### PR TITLE
enable custom labels for watching multiple models in pytorch

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -109,7 +109,7 @@ def hook_torch(*args, **kwargs):
 _global_watch_idx = 0
 
 
-def watch(models, criterion=None, log="gradients", log_freq=100, idx=None):
+def watch(models, criterion=None, log="gradients", log_freq=100, idx=None, labels=None):
     """
     Hooks into the torch model to collect gradients and the topology.  Should be extended
     to accept arbitrary ML models.
@@ -149,9 +149,11 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=None):
         global_idx = idx + local_idx
         _global_watch_idx += 1
         if global_idx > 0:
-            # TODO: this makes ugly chart names like gradients/graph_1conv1d.bias
             prefix = "graph_%i" % global_idx
-
+        # allow for custom names for each model, otherwise at least separate
+        # names from the rest of the details with a "/"
+        if labels:
+            prefix = labels[local_idx]
         run.history.torch.add_log_hooks_to_pytorch_module(
             model, log_parameters=log_parameters, log_gradients=log_gradients, prefix=prefix, log_freq=log_freq,
             jupyter_run=run if in_jupyter else None)

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -86,7 +86,7 @@ class TorchHistory(object):
         log_freq - log gradients/parameters every N batches
         """
         if name is not None:
-            prefix = prefix + name
+            prefix = prefix + "/" +  name
 
         if jupyter_run:
             self._jupyter_run = weakref.ref(jupyter_run)
@@ -104,7 +104,7 @@ class TorchHistory(object):
                     else:
                         data = parameter
                     self.log_tensor_stats(
-                        data.cpu(), 'parameters/' + prefix + name)
+                        data.cpu(), 'parameters/' + prefix + "/" + name)
             log_track_params = log_track_init(log_freq)
             hook = module.register_forward_hook(
                 lambda mod, inp, outp: parameter_log_hook(mod, inp, outp, log_track_params))
@@ -115,9 +115,9 @@ class TorchHistory(object):
             for name, parameter in module.named_parameters():
                 if parameter.requires_grad:
                     log_track_grad = log_track_init(log_freq)
-                    module._wandb_hook_names.append('gradients/' + prefix + name)
+                    module._wandb_hook_names.append('gradients/' + prefix + "/" + name)
                     self._hook_variable_gradient_stats(
-                        parameter, 'gradients/' + prefix + name, log_track_grad)
+                        parameter, 'gradients/' + prefix + "/" +  name, log_track_grad)
 
     def log_tensor_stats(self, tensor, name):
         """Add distribution statistics on a tensor's elements to the current History entry


### PR DESCRIPTION
(not urgent at all)
a very quick option to let folks label their sub-models explicitly in pytorch with an optional "labels" argument to model.watch():
model.watch(labels=["gen_A", "disc_B"...])
Makes it much easier to read!
Also added separating slashes in wandb/wandb_torch.py for clarity--let me know if there's a reason to avoid that.