### PR TITLE
Add support for wandb tags for offline sync

### DIFF
--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -702,6 +702,8 @@ class Api(object):
             commit (str, optional): The Git SHA to associate the run with
             summary_metrics (str, optional): The JSON summary metrics
         """
+        if tags is None:
+            tags = os.environ['WANDB_TAGS']
         mutation = gql('''
         mutation UpsertBucket(
             $id: String, $name: String,

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1289,6 +1289,10 @@ class Plotly(Media):
             tools = util.get_module(
                 "plotly.tools", required="plotly is required to log interactive plots, install with: pip install plotly or convert the plot to an image with `wandb.Image(plt)`")
             val = tools.mpl_to_plotly(val)
+            for p in val.data:
+                if '_line' not in p.name:
+                    val.update_layout(showlegend=True)
+                    break
         return cls(val)
 
     def __init__(self, val, **kwargs):


### PR DESCRIPTION
**Objective:**

I have multiple runs saved in wandb directory in a server. The plan is to transfer those to a server having internet and push those results to wandb. However, in doing so, I am unable to push the tags associated with each run using `wandb sync` command. I tried setting env variable WANDB_TAGS, but the issue still persists.

**Resolution**
1. One approach is to save the tags in the metafile and restore it in the internal.py. 
2. A quick fix would be to fetch tags from the environment variable if the tags options are set to None.

This merge enables quick fix and is tested against working offline and online sync for wandb project.
