### PR TITLE
avoid crashing when a run cannot be sync (issue 1297)

### DIFF
--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -112,7 +112,11 @@ class SyncThread(threading.Thread):
                 interface=publish_interface,
             )
             ds = datastore.DataStore()
-            ds.open_for_scan(sync_item)
+            try:
+                ds.open_for_scan(sync_item)
+            except Exception:
+                print("Error for record {sync_item}. Skipping")
+                continue
 
             # save exit for final send
             exit_pb = None


### PR DESCRIPTION
Description
-----------

This is a workaround for issue #1297.

It will just skip a run if it failed to open the wand log file.

Before I applied this, the following error happened, when a run was either not done, or when a run crashed before being done

```
Traceback (most recent call last):
  File "/gpfswork/rech/dur/uzb95vd/envs/murel/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/gpfswork/rech/dur/uzb95vd/envs/murel/lib/python3.7/site-packages/wandb/sync/sync.py", line 115, in run
    ds.open_for_scan(sync_item)
  File "/gpfswork/rech/dur/uzb95vd/envs/murel/lib/python3.7/site-packages/wandb/sdk/internal/datastore.py", line 100, in open_for_scan
    self._read_header()
  File "/gpfswork/rech/dur/uzb95vd/envs/murel/lib/python3.7/site-packages/wandb/sdk/internal/datastore.py", line 170, in _read_header
    ident, magic, version = struct.unpack("<4sHB", header)
struct.error: unpack requires a buffer of 7 bytes
```
