### PR TITLE
[WB-4563] Support using wandb.watch() without wandb.log()

### DIFF
--- a/wandb/sdk/wandb_history.py
+++ b/wandb/sdk/wandb_history.py
@@ -47,6 +47,8 @@ class History(object):
     def _update_step(self):
         """Called after receiving the run from the internal process"""
         self._step = self._run.starting_step
+        if self._torch:
+            self._torch._step = self._step
 
     def _flush(self):
         if len(self._data) > 0:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1066,7 +1066,7 @@ class Run(object):
             tel.feature.finish = True
         if (
             wandb.run.history._torch
-            and wandb.run.history._torch.mode == "manual"
+            and wandb.run.history._torch._mode == "manual"
             and not wandb.run.history._torch._step_changed
         ):
             wandb.termwarn(

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1064,6 +1064,14 @@ class Run(object):
         """
         with telemetry.context(run=self) as tel:
             tel.feature.finish = True
+        if (
+            wandb.run.history._torch
+            and wandb.run.history._torch.mode == "manual"
+            and not wandb.run.history._torch._step_changed
+        ):
+            wandb.termwarn(
+                "Gradients and/or parameters not logged. Use wandb.watch(..., mode='auto') when wandb.watch() is used without wandb.log()."
+            )
         # detach logger, other setup cleanup
         logger.info("finishing run %s", self.path)
         for hook in self._teardown_hooks:

--- a/wandb/sdk/wandb_watch.py
+++ b/wandb/sdk/wandb_watch.py
@@ -58,6 +58,8 @@ def watch(
         log_gradients = False
     elif log is None:
         log_gradients = False
+    elif log == "gradients":
+        pass
     else:
         raise ValueError(
             "Invalid value for `log` argument. Expected one of 'gradients', 'parameters', 'all' or None. Received "

--- a/wandb/sdk_py27/wandb_history.py
+++ b/wandb/sdk_py27/wandb_history.py
@@ -47,6 +47,8 @@ class History(object):
     def _update_step(self):
         """Called after receiving the run from the internal process"""
         self._step = self._run.starting_step
+        if self._torch:
+            self._torch._step = self._step
 
     def _flush(self):
         if len(self._data) > 0:

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -1066,7 +1066,7 @@ class Run(object):
             tel.feature.finish = True
         if (
             wandb.run.history._torch
-            and wandb.run.history._torch.mode == "manual"
+            and wandb.run.history._torch._mode == "manual"
             and not wandb.run.history._torch._step_changed
         ):
             wandb.termwarn(

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -1064,6 +1064,14 @@ class Run(object):
         """
         with telemetry.context(run=self) as tel:
             tel.feature.finish = True
+        if (
+            wandb.run.history._torch
+            and wandb.run.history._torch.mode == "manual"
+            and not wandb.run.history._torch._step_changed
+        ):
+            wandb.termwarn(
+                "Gradients and/or parameters not logged. Use wandb.watch(..., mode='auto') when wandb.watch() is used without wandb.log()."
+            )
         # detach logger, other setup cleanup
         logger.info("finishing run %s", self.path)
         for hook in self._teardown_hooks:

--- a/wandb/sdk_py27/wandb_watch.py
+++ b/wandb/sdk_py27/wandb_watch.py
@@ -58,6 +58,8 @@ def watch(
         log_gradients = False
     elif log is None:
         log_gradients = False
+    elif log == "gradients":
+        pass
     else:
         raise ValueError(
             "Invalid value for `log` argument. Expected one of 'gradients', 'parameters', 'all' or None. Received "

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -82,6 +82,7 @@ class TorchHistory(object):
         self._is_cuda_histc_supported = None
         self._jupyter_run = None
         self._mode = "manual"
+        self._step = history._step
 
     def add_log_hooks_to_pytorch_module(
         self,
@@ -265,9 +266,14 @@ class TorchHistory(object):
                 {name: wandb.Histogram(np_histogram=(tensor.tolist(), bins.tolist()))}
             )
         elif self._mode == "auto":
+            if self._step != history._step:
+                wandb.termwarn(
+                    "Use wandb.watch(..., mode='manual') if metrics are logged manually using wandb.log()."
+                )
             history._row_add(
                 {name: wandb.Histogram(np_histogram=(tensor.tolist(), bins.tolist()))}
             )
+            self._step = history._step
 
     def _hook_variable_gradient_stats(self, var, name, log_track):
         """Logs a Variable's gradient's distribution statistics next time backward()

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -83,6 +83,7 @@ class TorchHistory(object):
         self._jupyter_run = None
         self._mode = "manual"
         self._step = history._step
+        self._step_changed = False
 
     def add_log_hooks_to_pytorch_module(
         self,
@@ -265,6 +266,8 @@ class TorchHistory(object):
             history._row_update(
                 {name: wandb.Histogram(np_histogram=(tensor.tolist(), bins.tolist()))}
             )
+            if history._step != self._step:
+                self._step_changed = True
         elif self._mode == "auto":
             if self._step != history._step:
                 wandb.termwarn(


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-4563

Adds an arg `mode` to `wandb.watch()` which allows grad/param logging without `wandb.log()` calls.


Testing
-------

How was this PR tested? Manually
