### PR TITLE
[Draft] Serialize artifact commits for versions with the same artifact name

### DIFF
--- a/standalone_tests/artifact_serialize_test.py
+++ b/standalone_tests/artifact_serialize_test.py
@@ -1,0 +1,31 @@
+import wandb
+import random
+import os
+import time
+
+PROJECT_NAME = 'serialize-artifact-test'
+FILE_NAME = 'contents.txt'
+NUM_VERSIONS = 50
+
+artifact_name = 'serialized-%s' % time.time()
+
+# write random artifacts serially
+with wandb.init(project=PROJECT_NAME) as run:
+    for i in range(NUM_VERSIONS):
+        art = wandb.Artifact(artifact_name, type='dataset')
+        open(FILE_NAME, 'w').write('%s %s' % (i, 'x' * random.randrange(50000)))
+        art.add_file(FILE_NAME)
+        run.log_artifact(art)
+
+# confirm that the versions end up in the order we sent them!
+api = wandb.Api()
+versions = api.artifact_versions('dataset', '%s/%s' % (PROJECT_NAME, artifact_name))
+print("VERSIONS", versions)
+for av in versions:
+    version = av.name.split(':')[1]  # e.g. v14
+    version = version[1:]  # strip leading v
+    ver_dir = av.download()
+    file_contents = open(os.path.join(ver_dir, FILE_NAME)).read()
+    file_version = file_contents.split()[0]
+    print('%s == %s' % (version, file_version))
+    assert version == file_version

--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -25,7 +25,7 @@ RequestStoreManifestFiles = collections.namedtuple(
     "RequestStoreManifestFiles", ("manifest", "artifact_id", "save_fn")
 )
 RequestCommitArtifact = collections.namedtuple(
-    "RequestCommitArtifact", ("artifact_id", "finalize", "before_commit", "on_commit")
+    "RequestCommitArtifact", ("artifact_id", "artifact_name", "finalize", "before_commit", "on_commit")
 )
 RequestFinish = collections.namedtuple("RequestFinish", ())
 
@@ -99,7 +99,7 @@ class StepChecksum(object):
             elif isinstance(req, RequestCommitArtifact):
                 self._output_queue.put(
                     step_upload.RequestCommitArtifact(
-                        req.artifact_id, req.finalize, req.before_commit, req.on_commit
+                        req.artifact_id, req.artifact_name, req.finalize, req.before_commit, req.on_commit
                     )
                 )
             elif isinstance(req, RequestFinish):

--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -185,6 +185,7 @@ class ArtifactSaver(object):
         # This will queue the commit. It will only happen after all the file uploads are done
         self._file_pusher.commit_artifact(
             artifact_id,
+            name,
             finalize=finalize,
             before_commit=before_commit,
             on_commit=on_commit,

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -165,10 +165,10 @@ class FilePusher(object):
         return f
 
     def commit_artifact(
-        self, artifact_id, finalize=True, before_commit=None, on_commit=None
+        self, artifact_id, artifact_name, finalize=True, before_commit=None, on_commit=None
     ):
         event = step_checksum.RequestCommitArtifact(
-            artifact_id, finalize, before_commit, on_commit
+            artifact_id, artifact_name, finalize, before_commit, on_commit
         )
         self._incoming_queue.put(event)
 


### PR DESCRIPTION
Description
-----------

Ensure that if the user logs versions of the same artifact name during a single wandb run, we serialize committing those versions so they end up in the correct order.

Note:
- This change does not serialize the artifact create & upload steps! Those can still happen out of order!
- This means that you will still get an error if you try to save multiple versions that include common files! (ie if you save version 1 and version 2, and they both share 'a.txt' with the same md5, you will get an error).
- Therefore I'm not really sure if this is even worth it, we may need to serialize the creation & upload steps as well, which will be a bit harder given the way this code is structured. Things like models _tend_ to be different from version to version, but there's no guarantee of that.

I included a standalone test that confirms the correct behavior (and fails without this change), as long as files always differ from version to version.

Also, this probably does not work with the finalize=False behavior! I didn't have time to look into that. Someone will need to fix this PR up to ensure it works with the parallel writer case.

Testing
-------

How was this PR tested?
