### PR TITLE
sklearn/plot_feature_importances: Allow `feature_names` to be of np.array type

### DIFF
--- a/tests/integrations/test_sklearn.py
+++ b/tests/integrations/test_sklearn.py
@@ -3,6 +3,7 @@ from sklearn.naive_bayes import MultinomialNB
 from sklearn.linear_model import ElasticNet
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.datasets import make_regression, make_hastie_10_2
+import numpy as np
 import sys
 
 if sys.version_info >= (3, 9):
@@ -175,5 +176,21 @@ def test_feature_importance_attribute_exists_for_random_forest(wandb_init_run):
     model.fit(X, y)
 
     result = plot_feature_importances(model, feature_names=ten_features)
+
+    assert isinstance(result, wandb.viz.Visualize)
+
+def test_feature_importance_attribute_type(wandb_init_run):
+    X, y = make_regression(n_features=2, random_state=42)
+    model = ElasticNet(random_state=42)
+    model.fit(X, y)
+
+    # input np.array instead of list
+    two_features = np.array(["a", "b"])
+
+    result = None
+    try:
+        result = plot_feature_importances(model, feature_names=two_features)
+    except ValueError:
+        pytest.fail('incorrect plot_feature_importances arguments: ValueError')
 
     assert isinstance(result, wandb.viz.Visualize)

--- a/wandb/sklearn/__init__.py
+++ b/wandb/sklearn/__init__.py
@@ -634,8 +634,14 @@ def plot_feature_importances(
 
         indices = np.argsort(importances)[::-1]
 
-        if not feature_names:
+        if feature_names is None or not len(feature_names) > 0:
             feature_names = indices
+        elif len(feature_names) != len(indices):
+            wandb.termwarn(
+                "incorrect feature_names length: got %d but should be %d."
+                % (len(feature_names), len(indices))
+            )
+            return
         else:
             feature_names = np.array(feature_names)[indices]
 


### PR DESCRIPTION
Allow `feature_names` in `plot_feature_importances` sklearn integration to be of `np.array` type. Now, it **only** accepts a list. e.g.

```python
# we can currently only input 'list'
two_features = ['f1', 'f2']
plot_feature_importances(model, feature_names=two_features)

# this PR allows also inputting `np.array`
two_features = np.array(["a", "b"])
plot_feature_importances(model, feature_names=two_features)
```

Description
-----------
See #2118.


Testing
-------
Added a new test called `test_feature_importance_attribute_type` in `tests/integrations/test_sklearn.py`
