### PR TITLE
implement __getattribute__ in wandb.Config

### DIFF
--- a/tests/wandb_config_test.py
+++ b/tests/wandb_config_test.py
@@ -53,6 +53,8 @@ def test_locked_set_attr(consolidated, config):
 def test_getattribute(config):
     config.this = 8
     assert config.__getattribute__("this") == 8
+    with pytest.raises(AttributeError):
+        config.__getattribute__("that")
 
 
 def test_locked_set_key(consolidated, config):

--- a/tests/wandb_config_test.py
+++ b/tests/wandb_config_test.py
@@ -50,6 +50,11 @@ def test_locked_set_attr(consolidated, config):
     assert consolidated == dict(config)
 
 
+def test_getattribute(config):
+    config.this = 8
+    assert config.__getattribute__("this") == 8
+
+
 def test_locked_set_key(consolidated, config):
     config.update_locked(dict(this=2, that=4), "sweep")
     config["this"] = 8

--- a/tests/wandb_config_test.py
+++ b/tests/wandb_config_test.py
@@ -53,7 +53,7 @@ def test_locked_set_attr(consolidated, config):
 def test_getattribute(config):
     config.this = 8
     assert config.__getattribute__("this") == 8
-    with pytest.raises(AttributeError):
+    with pytest.raises(KeyError):
         config.__getattribute__("that")
 
 

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -150,6 +150,8 @@ class Config(object):
     def __getattr__(self, key):
         return self.__getitem__(key)
 
+    __getattribute__ = __getattr__
+
     def __contains__(self, key):
         return key in self._items
 

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -150,11 +150,8 @@ class Config(object):
     def __getattribute__(self, item):
         try:
             return super().__getattribute__(item)
-        except AttributeError as e:
-            try:
-                return self._items[item]
-            except KeyError:
-                raise e
+        except AttributeError:
+            return self._items[item]
 
     def __getattr__(self, key):
         return self.__getitem__(key)

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -150,11 +150,11 @@ class Config(object):
     def __getattribute__(self, item):
         try:
             return super().__getattribute__(item)
-        except AttributeError:
+        except AttributeError as e:
             try:
                 return self._items[item]
             except KeyError:
-                return super().__getattribute__(item)
+                raise e
 
     def __getattr__(self, key):
         return self.__getitem__(key)

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -147,10 +147,14 @@ class Config(object):
 
     __setattr__ = __setitem__
 
+    def __getattribute__(self, item):
+        try:
+            return super().__getattribute__(item)
+        except AttributeError:
+            return self._items[item]
+
     def __getattr__(self, key):
         return self.__getitem__(key)
-
-    __getattribute__ = __getattr__
 
     def __contains__(self, key):
         return key in self._items

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -151,7 +151,10 @@ class Config(object):
         try:
             return super().__getattribute__(item)
         except AttributeError:
-            return self._items[item]
+            try:
+                return self._items[item]
+            except KeyError:
+                return super().__getattribute__(item)
 
     def __getattr__(self, key):
         return self.__getitem__(key)

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -147,10 +147,14 @@ class Config(object):
 
     __setattr__ = __setitem__
 
+    def __getattribute__(self, item):
+        try:
+            return object.__getattribute__(self, item)
+        except AttributeError:
+            return self._items[item]
+
     def __getattr__(self, key):
         return self.__getitem__(key)
-
-    __getattribute__ = __getattr__
 
     def __contains__(self, key):
         return key in self._items

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -150,6 +150,8 @@ class Config(object):
     def __getattr__(self, key):
         return self.__getitem__(key)
 
+    __getattribute__ = __getattr__
+
     def __contains__(self, key):
         return key in self._items
 

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -149,9 +149,12 @@ class Config(object):
 
     def __getattribute__(self, item):
         try:
-            return object.__getattribute__(self, item)
+            return super().__getattribute__(item)
         except AttributeError:
-            return self._items[item]
+            try:
+                return self._items[item]
+            except KeyError:
+                return super().__getattribute__(item)
 
     def __getattr__(self, key):
         return self.__getitem__(key)

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -150,11 +150,8 @@ class Config(object):
     def __getattribute__(self, item):
         try:
             return super().__getattribute__(item)
-        except AttributeError as e:
-            try:
-                return self._items[item]
-            except KeyError:
-                raise e
+        except AttributeError:
+            return self._items[item]
 
     def __getattr__(self, key):
         return self.__getitem__(key)

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -150,11 +150,11 @@ class Config(object):
     def __getattribute__(self, item):
         try:
             return super().__getattribute__(item)
-        except AttributeError:
+        except AttributeError as e:
             try:
                 return self._items[item]
             except KeyError:
-                return super().__getattribute__(item)
+                raise e
 
     def __getattr__(self, key):
         return self.__getitem__(key)


### PR DESCRIPTION
A user ran into the issue that

```python
# All these work fine
wandb.config.embed_dims
wandb.config['embed_dims'] 
getattr(wandb.config, 'embed_dims')
wandb.config.__getattr__('embed_dims')

# But this throws an AttributeError 
wandb.config.__getattribute__('embed_dims')
```

This PR adds `__getattribute__` to `wandb.Config` to fix this issue.

Testing
-------

Unittest

Release Notes
-------------

------------- BEGIN RELEASE NOTES ------------------
Adds `__getattribute__` to `wandb.Config`
------------- END RELEASE NOTES --------------------
