### PR TITLE
[WB-6559] Fix colab urls

### DIFF
--- a/wandb/sdk/internal/meta.py
+++ b/wandb/sdk/internal/meta.py
@@ -219,7 +219,7 @@ class Meta(object):
                 if self._settings.notebook_name:
                     self.data["program"] = self._settings.notebook_name
                 elif self._settings._jupyter_path:
-                    if "fileId=" in self._settings._jupyter_path:
+                    if self._settings._jupyter_path.startswith("fileId="):
                         unescaped = unquote(self._settings._jupyter_path)
                         self.data["colab"] = (
                             "https://colab.research.google.com/notebook#"


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6559

Description
-----------

This PR fixes the colab urls that are now captured from #2572. The logic before this PR assumed that the colab urls always started with `https://colab.research.google.com/drive/"`. This is not the case. I found this nice SO discussion between a colab user and one of the colab devs on the colab URL scheme: 

https://stackoverflow.com/questions/49163985/google-colaboratory-url-scheme

There are now all of these url schemes:

```
https://colab.research.google.com/notebook#fileId=xxx This is the original one, now not used much.
https://colab.research.google.com/notebooks/xxx.ipynb This is for official notebooks, such as welcome.ipynb and other examples for newcomers.
https://colab.research.google.com/drive/xxxxxx This is the most common scheme. It refers to a specific notebook in Google Drive by fileId.
https://colab.research.google.com/github/tensorflow/path/to/notebook.ipynb The newest one. It can refer to any notebook hosted on github.
https://colab.research.google.com/gist/yourname/xxxxxx/notebook.ipynb A notebook on GitHub Gist. You can save any Colab notebook there with Save a copy as a GitHub Gist... menu.
```

However, since we have the `fileId`s, all we need is the first URL scheme:

`https://colab.research.google.com/notebook#fileId=xxx`

this will resolve to any of the above as long as we supply the `fileId`. 

For example, 

`https://colab.research.google.com/notebook#fileId=/v2/external/notebooks/intro.ipynb`

redirects to

`https://colab.research.google.com/notebooks/intro.ipynb`

and

`https://colab.research.google.com/notebook#fileId=1rT3Sfjo0nsnENUy6qFQS8frMUUtmuTNS`

redirects to

`https://colab.research.google.com/drive/1rT3Sfjo0nsnENUy6qFQS8frMUUtmuTNS#scrollTo=xmDtwZPE2gOV`

and

`https://colab.research.google.com/notebook#fileId=https%3A%2F%2Fgithub.com%2Fwandb%2Fexamples%2Fblob%2Fmaster%2Fcolabs%2Fkeras%2FSimple_Keras_Integration.ipynb`

redirects to

`https://colab.research.google.com/github/wandb/examples/blob/master/colabs/keras/Simple_Keras_Integration.ipynb`

I added the escaping for visual cleanliness in the URL we display. It doesn't affect the redirect.


Testing
-------

Manually

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
Fixes colab urls  to point to the correct notebooks
------------- END RELEASE NOTES --------------------
