### PR TITLE
Adds custom model naming and ending period to wandb.watch()

### DIFF
--- a/wandb/sdk/wandb_watch.py
+++ b/wandb/sdk/wandb_watch.py
@@ -15,7 +15,13 @@ _global_watch_idx = 0
 
 
 def watch(
-    models, criterion=None, log="gradients", log_freq=1000, idx=None, log_graph=False, model_names=None
+    models,
+    criterion=None,
+    log="gradients",
+    log_freq=1000,
+    idx=None,
+    log_graph=False,
+    model_names=None,
 ):
     """Hooks into the torch model to collect gradients and the topology.
 
@@ -87,8 +93,7 @@ def watch(
         global_idx = idx + local_idx
         _global_watch_idx += 1
         if model_names is not None:
-            print(model_names)
-            prefix = model_names[local_idx] + '.'
+            prefix = model_names[local_idx] + "."
         elif global_idx > 0:
             prefix = "graph_%i." % global_idx
 


### PR DESCRIPTION
This commit adds the `model_names` parameter to `watch()`. It also adds a period at the end of the prefix for cleanliness and consistency.

Description
-----------

**Issue:** Calling `wandb.watch()` on multiple models led to confusing naming - an issue for me as I want to easily track the NNs of my agents in an MARL setting. There's no easy way to add custom names here (see [this todo](https://github.com/WillDudley/client/blob/bac700f0259cec1e02bb766a2827700539cc3667/wandb/sdk/wandb_watch.py#L86)). 

This PR attempts to fix this.

Testing
-------

This PR was tested manually with one and multiple models passed into `wandb.watch()`, with and without `model_names` being also passed in.

Release Notes
-------------

------------- BEGIN RELEASE NOTES ------------------

- Added custom model naming capability for `wandb.watch()`.

------------- END RELEASE NOTES --------------------
