### PR TITLE
Add integrations functional tests

### DIFF
--- a/functional_tests/fastai/fastai.yea
+++ b/functional_tests/fastai/fastai.yea
@@ -1,0 +1,14 @@
+id: 0.fastai
+plugin:
+    - wandb
+command:
+    program: test_fastai.py
+depend:
+    requirements:
+        - fastai>=2.5.1
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][project]: wandb_integrations_testing
+  - :wandb:runs[0][config][lr_0]: 0.01
+  - :wandb:runs[0][summary][epoch]: 2
+  - :wandb:runs[0][exitcode]: 0

--- a/functional_tests/fastai/test_fastai.py
+++ b/functional_tests/fastai/test_fastai.py
@@ -1,0 +1,17 @@
+from fastai.callback.wandb import *
+from fastai.vision.all import *
+import wandb
+
+wandb.init(project="wandb_integrations_testing")
+path = untar_data(URLs.MNIST_TINY)
+mnist = DataBlock(
+    blocks=(ImageBlock(cls=PILImageBW), CategoryBlock),
+    get_items=get_image_files,
+    splitter=GrandparentSplitter(),
+    get_y=parent_label,
+)
+
+dls = mnist.dataloaders(path / "train", bs=32)
+learn = cnn_learner(dls, resnet18, metrics=error_rate)
+learn.fit(2, 1e-2, cbs=WandbCallback(log_preds=False, log_model=False))
+wandb.finish()

--- a/functional_tests/optuna/optuna.sh
+++ b/functional_tests/optuna/optuna.sh
@@ -1,0 +1,14 @@
+id: 0.optuna
+plugin:
+    - wandb
+command:
+    program: test_optuna.py
+depend:
+    requirements:
+        - optuna>=2.10
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][project]: integrations_testing
+  - :wandb:runs[0][config][a]: 2
+  - :wandb:runs[0][config][b]: testing
+  - :wandb:runs[0][exitcode]: 0

--- a/functional_tests/optuna/test_optuna.py
+++ b/functional_tests/optuna/test_optuna.py
@@ -1,0 +1,16 @@
+import optuna
+import wandb
+from optuna.integration.wandb import WeightsAndBiasesCallback
+
+
+def objective(trial):
+    x = trial.suggest_float("x", -10, 10)
+    return (x - 2) ** 2
+
+
+n_trials = 5
+wandb_kwargs = {"project": "integrations_testing", "config": {"a": 2, "b": "testing"}}
+wandbc = WeightsAndBiasesCallback(wandb_kwargs=wandb_kwargs)
+study = optuna.create_study(study_name="my_study")
+study.optimize(objective, n_trials=n_trials, callbacks=[wandbc])
+wandb.finish()

--- a/functional_tests/spacy/spacy.py
+++ b/functional_tests/spacy/spacy.py
@@ -1,0 +1,6 @@
+"""Tests wandb integration in spaCy"""
+
+import os
+
+os.system("spacy project clone integrations/wandb")
+os.system("cd wandb && spacy project assets && spacy project run log")

--- a/functional_tests/spacy/spacy.py
+++ b/functional_tests/spacy/spacy.py
@@ -1,6 +1,0 @@
-"""Tests wandb integration in spaCy"""
-
-import os
-
-os.system("spacy project clone integrations/wandb")
-os.system("cd wandb && spacy project assets && spacy project run log")

--- a/functional_tests/spacy/spacy.yea
+++ b/functional_tests/spacy/spacy.yea
@@ -2,11 +2,7 @@ id: 0.spacy
 plugin:
     - wandb
 command:
-    program: python3 -m spacy project clone integrations/wandb
-    program: cd wandb
-    program: python3 -m spacy project run install
-    program: python3 -m spacy project assets
-    program: python3 -m spacy project run log
+    program: test_spacy.sh
 depend:
     requirements:
         - spacy>=3.1

--- a/functional_tests/spacy/spacy.yea
+++ b/functional_tests/spacy/spacy.yea
@@ -1,0 +1,20 @@
+id: 0.spacy
+plugin:
+    - wandb
+command:
+    program: python3 -m spacy project clone integrations/wandb
+    program: cd wandb
+    program: python3 -m spacy project run install
+    program: python3 -m spacy project assets
+    program: python3 -m spacy project run log
+depend:
+    requirements:
+        - spacy>=3.1
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][project]: IMDB_sentiment
+  - :wandb:runs[0][config][training.batcher.size.start]: 100
+  - :op:>=:
+    - :wandb:runs[0][summary][score]
+    - 0.5
+  - :wandb:runs[0][exitcode]: 0

--- a/functional_tests/spacy/test_spacy.sh
+++ b/functional_tests/spacy/test_spacy.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+python3 -m spacy project clone integrations/wandb
+cd wandb
+python3 -m spacy project run install
+python3 -m spacy project assets
+python3 -m spacy project run log

--- a/functional_tests/transformers/test_transformers.py
+++ b/functional_tests/transformers/test_transformers.py
@@ -1,0 +1,64 @@
+import os
+import transformers
+import datasets
+from transformers import (
+    Trainer,
+    TrainingArguments,
+    AutoTokenizer,
+    AutoModelForSequenceClassification,
+)
+from datasets import load_dataset, load_metric, Dataset
+import numpy as np
+
+os.environ["WANDB_PROJECT"] = "integrations_testing"
+transformers.logging.set_verbosity_error()
+datasets.logging.set_verbosity_error()
+
+
+def tokenize_function(examples):
+    return tokenizer(examples["text"], padding=True, truncation=True, max_length=100)
+
+
+model_name = "google/mobilebert-uncased"
+tokenizer = AutoTokenizer.from_pretrained(model_name, num_labels=2)
+
+n_text = 50
+dummy_text = "The dog walked on the moon! " * n_text
+dummy_dict = {"text": [dummy_text] * n_text, "label": [1] * n_text}
+dataset = Dataset.from_dict(dummy_dict)
+tokenized_dataset = dataset.map(tokenize_function, batched=False)
+tokenized_dataset = tokenized_dataset.remove_columns(["text"])
+tokenized_dataset.set_format("torch")
+
+metric = load_metric("accuracy")
+
+
+def compute_metrics(eval_pred):
+    logits, labels = eval_pred
+    predictions = np.argmax(logits, axis=-1)
+    return metric.compute(predictions=predictions, references=labels)
+
+
+training_args = TrainingArguments(
+    "test_trainer",
+    evaluation_strategy="epoch",
+    num_train_epochs=2,
+    per_device_train_batch_size=32,
+    per_device_eval_batch_size=32,
+    logging_strategy="steps",
+    logging_steps=1,
+    report_to="wandb",
+    run_name="testing",
+)
+
+model = AutoModelForSequenceClassification.from_pretrained(model_name)
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=tokenized_dataset,
+    eval_dataset=tokenized_dataset,
+    compute_metrics=compute_metrics,
+)
+
+trainer.train()
+wandb.finish()

--- a/functional_tests/transformers/transformers.yea
+++ b/functional_tests/transformers/transformers.yea
@@ -1,0 +1,17 @@
+id: 0.transformers
+plugin:
+    - wandb
+command:
+    program: test_transformers.py
+depend:
+    requirements:
+        - transformers>=4.11.3
+        - datasets
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][project]: integrations_testing
+  - :wandb:runs[0][config][num_train_epochs]: 2
+  - :op:<=:
+    - :wandb:runs[0][summary][train/loss]
+    - 0.1
+  - :wandb:runs[0][exitcode]: 0


### PR DESCRIPTION
# Description
This PR adds additional functional tests for wandb integrations in the following libraries:

- [x] transformers
- [x] spaCy
- [x] Fastai
- [x] Optuna

Related to addition of wandb callbacks in external libraries to telemetry - [jira](https://wandb.atlassian.net/browse/WB-6132)

# Testing
- transformers: ran `test_transformers.py` on command line
- spaCy: ran `test_spacy.sh` on command line
- fastai: ran `test_fastai.py` on command line
- Optuna: ran `test_optuna.py` on command line

# Release

------------- BEGIN RELEASE NOTES ------------------
* Adds test for wandb integrations in transformers, spaCy, fastai, optuna
------------- END RELEASE NOTES --------------------