### PR TITLE
Hotfix Again: Fix issue where tests didn't catch error, and allowed nested artifacts if inserted in one way

### DIFF
--- a/tests/wandb_run_test.py
+++ b/tests/wandb_run_test.py
@@ -241,6 +241,26 @@ def test_artifacts_in_config(live_mock_server, test_settings, parse_ctx):
     run.config.dataset = artifact
     run.config.logged_artifact = logged_artifact
     run.config.update({"myarti": artifact})
+    with pytest.raises(ValueError) as e_info:
+        run.config.nested_dataset = {"nested": artifact}
+        assert (
+            str(e_info.value)
+            == "Instances of wandb.Artifact and wandb.apis.public.Artifact can only be top level keys in wandb.config"
+        )
+
+    with pytest.raises(ValueError) as e_info:
+        run.config.dict_nested = {"one_nest": {"two_nest": artifact}}
+        assert (
+            str(e_info.value)
+            == "Instances of wandb.Artifact and wandb.apis.public.Artifact can only be top level keys in wandb.config"
+        )
+
+    with pytest.raises(ValueError) as e_info:
+        run.config.update({"one_nest": {"two_nest": artifact}})
+        assert (
+            str(e_info.value)
+            == "Instances of wandb.Artifact and wandb.apis.public.Artifact can only be top level keys in wandb.config"
+        )
     run.finish()
     ctx = parse_ctx(live_mock_server.get_ctx())
     assert ctx.config_user["dataset"] == {
@@ -269,26 +289,6 @@ def test_artifacts_in_config(live_mock_server, test_settings, parse_ctx):
         "sequenceName": logged_artifact.name.split(":")[0],
         "usedAs": None,
     }
-    with pytest.raises(Exception) as e_info:
-        run.config.nested_dataset = {"nested": artifact}
-        assert (
-            str(e_info.value)
-            == "Instances of wandb.Artifact and wandb.apis.public.Artifact can only be top level keys in wandb.config"
-        )
-
-    with pytest.raises(Exception) as e_info:
-        run.config.dict_nested = {"one_nest": {"two_nest": artifact}}
-        assert (
-            str(e_info.value)
-            == "Instances of wandb.Artifact and wandb.apis.public.Artifact can only be top level keys in wandb.config"
-        )
-
-    with pytest.raises(Exception) as e_info:
-        run.config.update({"one_nest": {"two_nest": artifact}})
-        assert (
-            str(e_info.value)
-            == "Instances of wandb.Artifact and wandb.apis.public.Artifact can only be top level keys in wandb.config"
-        )
 
 
 def test_unlogged_artifact_in_config(live_mock_server, test_settings):

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -215,11 +215,10 @@ class Config(object):
         self, config_dict, allow_val_change=None, ignore_keys: set = None,
     ):
         sanitized = {}
+        self._raise_value_error_on_nested_artifact(config_dict)
         for k, v in six.iteritems(config_dict):
             if ignore_keys and k in ignore_keys:
                 continue
-
-            self._raise_value_error_on_nested_artifact(v)
             k, v = self._sanitize(k, v, allow_val_change)
             sanitized[k] = v
         return sanitized


### PR DESCRIPTION
Description
-----------

- changes the tests to check for a ValueError
- modifies the check of the config_dict for nested arrays to check at the top level. Catching second level nesting when used with update

Testing
-------

How was this PR tested?

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES


------------- END RELEASE NOTES --------------------
