### PR TITLE
Revert "[WB-6891] Include artifact references in bytes tracked (#2738)"

### DIFF
--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -1010,7 +1010,6 @@ def test_artifact_references_internal(
     mocked_run, mock_server, internal_sm, backend_interface, parse_ctx, test_settings,
 ):
     mock_server.set_context("max_cli_version", "0.11.0")
-    mock_server.set_context("emulate_artifacts", "true")
     run = wandb.init(settings=test_settings)
     t1 = wandb.Table(columns=[], data=[])
     art = wandb.Artifact("A", "dataset")

--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -81,10 +81,7 @@ class StepChecksum(object):
                 )
             elif isinstance(req, RequestStoreManifestFiles):
                 for entry in req.manifest.entries.values():
-                    local_path = entry.local_path
-                    if local_path is None:
-                        local_path = entry.ref
-                    if local_path:
+                    if entry.local_path:
                         # This stupid thing is needed so the closure works correctly.
                         def make_save_fn_with_entry(save_fn, entry):
                             return lambda progress_callback: save_fn(
@@ -92,11 +89,11 @@ class StepChecksum(object):
                             )
 
                         self._stats.init_file(
-                            local_path, entry.size, is_artifact_file=True
+                            entry.local_path, entry.size, is_artifact_file=True
                         )
                         self._output_queue.put(
                             step_upload.RequestUpload(
-                                local_path,
+                                entry.local_path,
                                 entry.path,
                                 req.artifact_id,
                                 entry.digest,


### PR DESCRIPTION
This reverts commit e85d501dbb7870da9d38882c32fa7aad69b6d2c8.

Description
-----------

Revert fix for WB-6891.

Testing
-------

Tested with:
```
./do-cloud-regression.sh  --cli_branch revert-wb-6891 --spec wandb-standalone-artifact-references:init:py36 tests/main/
```

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
