### PR TITLE
add obj.reload() in order to get the md5 hash

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1648,6 +1648,8 @@ class GCSHandler(StorageHandler):
             # We're listing a path and user provided name, just prepend it
             name = os.path.join(name, os.path.basename(obj.name))
             ref = os.path.join(path, name)
+        # Retrieve the md5 hash of blob
+        obj.reload()
         return ArtifactManifestEntry(
             name, ref, obj.md5_hash, size=obj.size, extra=self._extra_from_obj(obj)
         )


### PR DESCRIPTION
Fix issue #3156 since GCS client don't return md5_hash of objects the method add_reference didn't work
But as you can see in the documentation of the blob object, is possible using the method reload, to obtain the hash
<img width="697" alt="Schermata 2022-01-26 alle 10 41 16" src="https://user-images.githubusercontent.com/46601193/151139698-71b62489-039e-40ab-9b56-89f9c22ffe8c.png">

