### PR TITLE
[DO NOT MERGE] Add sqlite checksum cache

### DIFF
--- a/tests/wandb_artifacts_cache_test.py
+++ b/tests/wandb_artifacts_cache_test.py
@@ -15,6 +15,29 @@ def _cache_writer(cache_path):
         f.write("".join(random.choice("0123456") for _ in range(10)))
 
 
+def test_get_cached_checksum(runner):
+    with runner.isolated_filesystem():
+        os.mkdir("cache")
+        cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+
+        path = os.path.join("test")
+        with open(path, "w") as f:
+            f.write("hi")
+
+        stat = os.stat(path)
+
+        expected_digest = "abc"
+        cold_digest = cache.get_cached_checksum(
+            path, stat.st_size, stat.st_mtime, lambda: expected_digest
+        )
+        warm_digest = cache.get_cached_checksum(
+            path, stat.st_size, stat.st_mtime, lambda: "wrong"
+        )
+
+        assert cold_digest == expected_digest
+        assert warm_digest == expected_digest
+
+
 def test_check_md5_obj_path(runner):
     with runner.isolated_filesystem():
         os.mkdir("cache")

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -837,7 +837,7 @@ class ArtifactsCache(object):
         self._init_checksum_db()
 
     def get_cached_checksum(
-        self, path: str, size: int, updated_at: int, checksum_getter: Callable
+        self, path: str, size: int, updated_at: float, checksum_getter: Callable
     ) -> str:
         with self._db() as conn:
             try:
@@ -962,7 +962,7 @@ class ArtifactsCache(object):
                         CREATE TABLE checksums(
                             path TEXT PRIMARY KEY,
                             size INT,
-                            updated_at INT,
+                            updated_at REAL,
                             checksum TEXT
                         )
                     """

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -4,8 +4,8 @@ import codecs
 import contextlib
 import hashlib
 import os
-import sqlite3
 import random
+import sqlite3
 from typing import (
     Callable,
     Dict,

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -943,33 +943,40 @@ class ArtifactsCache(object):
             with self._txn(conn, is_exclusive=True):
                 # Primitive schema management, could eventually do something
                 # more sophisticated.
-                conn.execute("""
+                conn.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS schema_migrations(
                         version INTEGER PRIMARY KEY,
                         dirty BOOLEAN
                     )
-                """)
+                """
+                )
 
-            with self._txn(conn, is_exclusive=True):
                 version = 0
                 for row in conn.execute("SELECT version FROM schema_migrations"):
                     version = row
 
                 if version == 0:
-                    conn.execute("""
+                    conn.execute(
+                        """
                         CREATE TABLE checksums(
                             path TEXT PRIMARY KEY,
                             size INT,
                             updated_at INT,
                             checksum TEXT
                         )
-                    """)
+                    """
+                    )
 
-                    conn.execute("""
+                    conn.execute(
+                        """
                         CREATE INDEX checksums_by_updated ON checksums (updated_at DESC)
-                    """)
+                    """
+                    )
 
-                    conn.execute("INSERT INTO schema_migrations (version) VALUES (?)", (1,))
+                    conn.execute(
+                        "INSERT INTO schema_migrations (version) VALUES (?)", (1,)
+                    )
 
     @contextlib.contextmanager
     def _db(self):
@@ -978,10 +985,12 @@ class ArtifactsCache(object):
 
     @contextlib.contextmanager
     def _txn(self, conn, is_exclusive=False):
-        conn.execute('BEGIN TRANSACTION' if not is_exclusive else 'BEGIN EXCLUSIVE TRANSACTION')
+        conn.execute(
+            "BEGIN TRANSACTION" if not is_exclusive else "BEGIN EXCLUSIVE TRANSACTION"
+        )
         try:
             yield
-        except:
+        except Exception:
             conn.rollback()
             raise
         else:

--- a/wandb/sdk/lib/sqlite.py
+++ b/wandb/sdk/lib/sqlite.py
@@ -8,10 +8,9 @@ from typing import (
     Tuple,
 )
 
+Error = sqlite3.Error
 Migration = List[str]
 Migrations = List[Migration]
-
-Error = sqlite3.Error
 
 
 @contextlib.contextmanager

--- a/wandb/sdk/lib/sqlite.py
+++ b/wandb/sdk/lib/sqlite.py
@@ -1,0 +1,84 @@
+import contextlib
+import os
+import sqlite3
+from typing import (
+    Any,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+)
+
+Migration = List[str]
+Migrations = List[Migration]
+
+Error = sqlite3.Error
+
+
+@contextlib.contextmanager
+def open_db(path: str) -> sqlite3.Connection:
+    with sqlite3.connect(os.path.join(path)) as db:
+        yield db
+
+
+@contextlib.contextmanager
+def txn(conn: sqlite3.Connection, is_exclusive=False):
+    conn.execute(
+        "BEGIN TRANSACTION" if not is_exclusive else "BEGIN EXCLUSIVE TRANSACTION"
+    )
+    try:
+        yield
+    except Exception:
+        conn.rollback()
+        raise
+    else:
+        conn.commit()
+
+
+def fetch(conn: sqlite3.Connection, sql: str, args: Tuple = ()) -> Iterator[Tuple]:
+    cur = conn.cursor()
+    for row in cur.execute(sql, args):
+        yield row
+
+
+def fetch_one(conn: sqlite3.Connection, sql: str, args: Tuple = ()) -> Any:
+    cur = conn.cursor()
+    cur.execute(sql, args)
+    return cur.fetchone()
+
+
+def migrate(conn: sqlite3.Connection, migrations: Migrations) -> None:
+    with txn(conn, is_exclusive=True):
+        (count,) = fetch_one(conn, """
+            SELECT COUNT(*)
+            FROM sqlite_master
+            WHERE
+                type ='table' AND
+                name = ?
+        """, ("schema_migrations",))
+        if count == 0:
+            # Primitive schema management, could eventually do something
+            # more sophisticated.
+            conn.execute(
+                """
+                CREATE TABLE schema_migrations(
+                    version INTEGER PRIMARY KEY,
+                    dirty BOOLEAN
+                )
+            """
+            )
+
+            conn.execute("""
+                INSERT INTO schema_migrations (version) VALUES (0);
+            """)
+
+    with txn(conn, is_exclusive=True):
+        (version,) = fetch_one(conn, "SELECT version FROM schema_migrations") or (0,)
+        for migration_idx, migration in enumerate(migrations):
+            if version > migration_idx:
+                continue
+            for stmt in migration:
+                conn.execute(stmt)
+            conn.execute(
+                "UPDATE schema_migrations SET version = ?", (migration_idx + 1,)
+            )

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -688,9 +688,13 @@ class Artifact(ArtifactInterface):
     def _add_local_file(
         self, name: str, path: str, digest: Optional[str] = None
     ) -> ArtifactEntry:
-        digest = digest or md5_file_b64(path)
-        size = os.path.getsize(path)
         name = util.to_forward_slash_path(name)
+        stat = os.stat(path)
+        size = stat.st_size
+        updated_at = stat.st_mtime
+        digest = self._cache.get_cached_checksum(
+            path, size, updated_at, lambda: digest or md5_file_b64(path)
+        )
 
         cache_path, hit, cache_open = self._cache.check_md5_obj_path(digest, size)
         if not hit:


### PR DESCRIPTION
Description
-----------
Adds a persistent, checksum cache to the artifacts cache dir. This significantly speeds up adding large directories to an artifact as we can just `stat` the filesystem which is significantly cheaper than checksumming the whole file.

❗ Merge checklist❗
- [ ] `WANDB_ENABLE_ARTIFACT_CHECKSUM_CACHE` settings
- [ ] Look into shared filesystems
- [ ] Multi-process / distributed training locking

Testing
-------
TODO.
⚠️  WE NEED TO ACCOUNT FOR SHARED FILESYSTEMS! SQLITE WILL NOT WORK THERE. ⚠️ 

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
