### PR TITLE
[POC][WB-8516] Lambda thread mode

### DIFF
--- a/wandb/sdk/backend/backend.py
+++ b/wandb/sdk/backend/backend.py
@@ -10,6 +10,7 @@ import importlib.machinery
 import logging
 import multiprocessing
 import os
+import queue
 import sys
 import threading
 from typing import Any, Callable, Dict, Optional
@@ -185,11 +186,11 @@ class Backend(object):
             self._ensure_launched_manager()
             return
 
-        self.record_q = self._multiprocessing.Queue()
-        self.result_q = self._multiprocessing.Queue()
         user_pid = os.getpid()
 
         if start_method == "thread":
+            self.record_q = queue.Queue()
+            self.result_q = queue.Queue()
             wandb._set_internal_process(disable=True)  # type: ignore
             wandb_thread = BackendThread(
                 target=wandb_internal,
@@ -203,6 +204,8 @@ class Backend(object):
             # TODO: risky cast, assumes BackendThread Process ducktyping
             self.wandb_process = wandb_thread  # type: ignore
         else:
+            self.record_q = self._multiprocessing.Queue()
+            self.result_q = self._multiprocessing.Queue()
             self.wandb_process = self._multiprocessing.Process(
                 target=wandb_internal,
                 kwargs=dict(
@@ -249,8 +252,8 @@ class Backend(object):
         if self.wandb_process:
             self.wandb_process.join()
 
-        if self.record_q:
+        if self.record_q and hasattr(self.record_q, "close"):
             self.record_q.close()
-        if self.result_q:
+        if self.result_q and hasattr(self.result_q, "close"):
             self.result_q.close()
         # No printing allowed from here until redirect restore!!!


### PR DESCRIPTION
WB-8516

Description
-----------
This is a quick POC off of the 0.12.10 release to support using wandb.init() with lambdas using the thread start method.

To install:
```
pip install --upgrade git+https://github.com/wandb/client.git@lambda-thread-mode#egg=wandb
```

To use this:
```
os.environ["WANDB_START_METHOD"] = "thread"
wandb.init()
```

Testing
-------
Manually tested.

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
