### PR TITLE
fix(sdk): fix `wandb docker` with local image

### DIFF
--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -203,7 +203,7 @@ def image_id(image_name: str) -> Optional[str]:
         return image_name
     else:
         return shell(
-            ["inspect", image_name, "--format", "{{index .RepoDigests 0}}"]
+            ["inspect", image_name, "--format", "{{.Id}}"]
         ) or image_id_from_registry(image_name)
 
 


### PR DESCRIPTION
Fixes #3442

Description
-----------
Fixes `wandb docker` for local images

Testing
-------
Was able to successfully use `wandb docker` with a local image

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
