### PR TITLE
PoC: Add PL support to wandb magic

### DIFF
--- a/functional_tests/magic/03-lightning.py
+++ b/functional_tests/magic/03-lightning.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+import os
+
+import pytorch_lightning as pl
+from pytorch_lightning.loggers import WandbLogger
+from torch.utils.data import DataLoader
+
+from pytorch_lightning import LightningModule
+import torch
+from torch.utils.data import Dataset
+
+from wandb import magic
+
+
+class RandomDataset(Dataset):
+    def __init__(self, size, num_samples):
+        self.len = num_samples
+        self.data = torch.randn(num_samples, size)
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+    def __len__(self):
+        return self.len
+
+
+class BoringModel(LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(32, 2)
+
+    def forward(self, x):
+        return self.layer(x)
+
+    def loss(self, batch, prediction):
+        # An arbitrary loss to have a loss that updates the model weights during `Trainer.fit` calls
+        return torch.nn.functional.mse_loss(prediction, torch.ones_like(prediction))
+
+    def training_step(self, batch, batch_idx):
+        output = self.layer(batch)
+        loss = self.loss(batch, output)
+        self.log("loss", loss)
+        return {"loss": loss}
+
+    def training_step_end(self, training_step_outputs):
+        return training_step_outputs
+
+    def training_epoch_end(self, outputs) -> None:
+        torch.stack([x["loss"] for x in outputs]).mean()
+
+    def validation_step(self, batch, batch_idx):
+        output = self.layer(batch)
+        loss = self.loss(batch, output)
+        return {"x": loss}
+
+    def validation_epoch_end(self, outputs) -> None:
+        torch.stack([x["x"] for x in outputs]).mean()
+
+    def test_step(self, batch, batch_idx):
+        output = self.layer(batch)
+        loss = self.loss(batch, output)
+        self.log("fake_test_acc", loss)
+        return {"y": loss}
+
+    def test_epoch_end(self, outputs) -> None:
+        torch.stack([x["y"] for x in outputs]).mean()
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
+        lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+        return [optimizer], [lr_scheduler]
+
+
+def main():
+    # Use concurrency experiment
+    print("PIDPID", os.getpid())
+
+    # Set up data
+    num_samples = 100000
+    train = RandomDataset(32, num_samples)
+    train = DataLoader(train, batch_size=32)
+    val = RandomDataset(32, num_samples)
+    val = DataLoader(val, batch_size=32)
+    test = RandomDataset(32, num_samples)
+    test = DataLoader(test, batch_size=32)
+    # init model
+    model = BoringModel()
+
+    # set up wandb
+    # config = dict(some_hparam="Logged Before Trainer starts DDP")
+    # wandb_logger = WandbLogger(log_model=True, config=config, save_code=True)
+
+    # Initialize a trainer
+    trainer = pl.Trainer(
+        max_epochs=1,
+        num_processes=2,
+        accelerator="ddp",
+        # logger=wandb_logger,
+    )
+
+    # Train the model
+    trainer.fit(model, train, val)
+    trainer.test(dataloaders=test)
+
+
+if __name__ == "__main__":
+    main()

--- a/functional_tests/magic/03-lightning.yea
+++ b/functional_tests/magic/03-lightning.yea
@@ -1,0 +1,23 @@
+id: magic.03_lightning
+plugin:
+  - wandb
+tag:
+  shard: service
+depend:
+  requirements:
+    - pytorch-lightning
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][config][some_hparam]: Logged Before Trainer starts DDP
+  - :wandb:runs[0][summary][epoch]: 0
+  - :wandb:runs[0][history][30][trainer/global_step]: 1549
+  - :wandb:runs[0][exitcode]: 0
+  - :op:contains:
+    - :wandb:runs[0][telemetry][3]  # feature
+    - 23  # service
+  - :op:>=:
+    - :wandb:runs[0][summary][loss]
+    - 0
+  - :op:>=:
+    - :wandb:runs[0][summary][fake_test_acc]
+    - 0


### PR DESCRIPTION
Fixes  WB-9547

Description
-----------
Mock out trainer to add wandb logger

TODO:
- [ ] deal with loggers set to something else
- [ ] figure out how to deal with deferred wandb init.  right now it does this if PL is loaded.. maybe we dont defer wandb init and let the logger get the init that we did already?
- [ ] add hook to capture when PL is loaded
- [ ] add newer style magic telemetry
- [ ] pass config into logger if we do defer wandb init

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
