### PR TITLE
Fix parse path behaviour when project isn't set

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -80,11 +80,17 @@ def test_parse_path_user_proj(mock_server, api):
     assert r == "run"
 
 
-def test_parse_path_proj(mock_server, api):
+def test_parse_path_run(mock_server, api):
     u, p, r = api._parse_path("run")
     assert u == "mock_server_entity"
     assert p == "test"
     assert r == "run"
+
+
+def test_parse_path_run_no_proj(mock_server, api):
+    api.settings["project"] = None
+    with pytest.assert_raises(ValueError):
+        api._parse_path("run")
 
 
 def test_from_path(mock_server, api):


### PR DESCRIPTION
Fixes #3830

Description
-----------
Based on the documentation for wandb.api.public.Api I expect that I could find a run given only the run_id if the entity and project are set in api.settings:

> path to run in the form entity/project/run_id. If api.entity is set, this can be in the form project/run_id and if api.project is set this can just be the run_id.

Testing
-------
Added tests that describe the expected behaviour