### PR TITLE
Some improvements for `wandb.apis.public.File.download`

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2656,11 +2656,9 @@ class File:
         Raises:
             `ValueError` if file already exists and replace=False
         """
-        if not os.path.isfile(self.name):
-            raise Exception(f"Either the file {path} doesn't exist or it's a directory!")
         path_ext = os.path.splitext(self.name)[1]
         if path_ext == "":
-            raise Exception(f"File {path} must contain a file extension, otherwise it won't be downloaded!")
+            raise Exception(f"File {self.name} must contain a file extension, otherwise it won't be downloaded!")
         if root == "/":
             raise Exception("'/' is not a valid directory, to use the root directory use '.' instead.")
         root_ext = os.path.splitext(root)[1]


### PR DESCRIPTION
Description
-----------

This PR improves `wandb.apis.public.File.download` as described in https://github.com/wandb/client/issues/3923

Testing
-------

The use-cases from the original issue at https://github.com/wandb/client/issues/3923 were replicated so as to make sure that the `root` parameter in `wandb.apis.public.File.download` can either be a directory or a file path, and that we can overwrite both if `replace=True`. And, also that an exception is properly triggered whenever we try to download a directory as that feature is not supported.

Checklist
-------
- Fixes #3923 
