### PR TITLE
Add `wandb.save` warning message for empty files to be uploaded to `wandb` remote

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1669,12 +1669,12 @@ class Run:
             warn = True
         for path in glob.glob(glob_str):
             file_name = os.path.relpath(path, base_path)
-            if os.path.getsize(file_name) == 0:
-                wandb.termlog(
-                    "%s is an empty file, it won't be uploaded to wandb." % file_nameS
+            abs_path = os.path.abspath(path)
+            if os.path.getsize(abs_path) == 0:
+                wandb.termwarn(
+                    "%s is an empty file, it won't be uploaded to wandb." % abs_path
                 )
                 continue
-            abs_path = os.path.abspath(path)
             wandb_path = os.path.join(self._settings.files_dir, file_name)
             wandb.util.mkdir_exists_ok(os.path.dirname(wandb_path))
             # We overwrite symlinks because namespaces can change in Tensorboard

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1669,6 +1669,11 @@ class Run:
             warn = True
         for path in glob.glob(glob_str):
             file_name = os.path.relpath(path, base_path)
+            if os.path.getsize(file_name) == 0:
+                wandb.termlog(
+                    "%s is an empty file, it won't be uploaded to wandb." % file_nameS
+                )
+                continue
             abs_path = os.path.abspath(path)
             wandb_path = os.path.join(self._settings.files_dir, file_name)
             wandb.util.mkdir_exists_ok(os.path.dirname(wandb_path))


### PR DESCRIPTION
Fixes #3931

Description
-----------
This PR adds a missing check in `wandb.save` as described in #3931, as empty files were not uploaded, but those weren't checked, which means that the user may expect an empty file to be uploaded when it's actually not. So before proceeding with the upload, we first check the file size, and if it's 0, we show a warning message from `wandb` so as to let the user know that the file won't be uploaded.

Testing
-------
In order to test this PR, I've used `wandb.save` over an empty file, a directory with empty files, a directory with both empty and not empty files, and some more tests like for hidden files (previously ignored by `glob.glob` so not even listed.