### PR TITLE
ensure `metadata` passed to `Artifact()` is a legal dict

### DIFF
--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1408,9 +1408,7 @@ def _create_artifact_and_set_metadata(metadata):
 @pytest.mark.parametrize(
     "create_artifact",
     [
-        lambda *args, metadata, **kwargs: wandb.Artifact(
-            *args, metadata=metadata, **kwargs
-        ),
+        lambda metadata: wandb.Artifact("foo", "dataset", metadata=metadata),
         _create_artifact_and_set_metadata,
     ],
 )

--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1405,6 +1405,10 @@ def _create_artifact_and_set_metadata(metadata):
     return artifact
 
 
+# All these metadata-validation tests should behave identically
+# regardless of whether we set the metadata by passing it into the constructor
+# or by setting the attribute after creation; so, parametrize how we build the
+# artifact, and run tests both ways.
 @pytest.mark.parametrize(
     "create_artifact",
     [

--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1336,7 +1336,7 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
 
         for setter in testable_setters_valid + testable_setters_invalid:
             with pytest.raises(ValueError):
-                setattr(art, setter, "TEST")
+                setattr(art, setter, setter_data.get(setter, setter))
 
         for method in testable_methods_valid + testable_methods_invalid:
             attr_method = getattr(art, method)
@@ -1350,7 +1350,7 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
             _ = getattr(art, getter)
 
         for setter in testable_setters_valid + testable_setters_invalid:
-            setattr(art, setter, "TEST")
+            setattr(art, setter, setter_data.get(setter, setter))
 
         for method in testable_methods_valid + testable_methods_invalid:
             attr_method = getattr(art, method)

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 from typing import (
     Any,
+    cast,
     Dict,
     Generator,
     IO,
@@ -82,7 +83,8 @@ def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         return {}
     if not isinstance(metadata, dict):
         raise TypeError(f"metadata must be dict, not {type(metadata)}")
-    return json.loads(json.dumps(metadata))
+    return cast(Dict[str, Any], json.loads(json.dumps(metadata)))
+
 
 class Artifact(ArtifactInterface):
     """
@@ -298,6 +300,7 @@ class Artifact(ArtifactInterface):
 
     @metadata.setter
     def metadata(self, metadata: dict) -> None:
+        metadata = _normalize_metadata(metadata)
         if self._logged_artifact:
             self._logged_artifact.metadata = metadata
             return

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1,6 +1,7 @@
 import base64
 import contextlib
 import hashlib
+import json
 import os
 import pathlib
 import re
@@ -76,6 +77,13 @@ class _AddedObj:
         self.obj = obj
 
 
+def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, dict):
+        raise TypeError(f"metadata must be dict, not {type(metadata)}")
+    return json.loads(json.dumps(metadata))
+
 class Artifact(ArtifactInterface):
     """
     Flexible and lightweight building block for dataset and model versioning.
@@ -138,6 +146,7 @@ class Artifact(ArtifactInterface):
                 "Artifact name may only contain alphanumeric characters, dashes, underscores, and dots. "
                 'Invalid name: "%s"' % name
             )
+        metadata = _normalize_metadata(metadata)
         # TODO: this shouldn't be a property of the artifact. It's a more like an
         # argument to log_artifact.
         storage_layout = StorageLayout.V2
@@ -163,7 +172,7 @@ class Artifact(ArtifactInterface):
         self._type = type
         self._name = name
         self._description = description
-        self._metadata = metadata or {}
+        self._metadata = metadata
         self._distributed_id = None
         self._logged_artifact = None
         self._incremental = False


### PR DESCRIPTION
Fixes WB-6275

Description
-----------

- in `Artifact(metadata=...)`, and `my_artifact.metadata = ...`, verify that the metadata is a JSON-serializable dict (or None); raise TypeError if not
- previously, `Artifact(metadata=None)` resulted in metadata `{}`, while `a = Artifact(); a.metadata = None` resulted in metadata `None`; changed the second case to `{}`
- while I was in the neighborhood, I changed both metadata (`Artifact(metadata=...)` and `art.metadata = ...`) to deepcopy the given`metadata`; I doubt we want to pick up future modifications


Testing
-------
Unit tests!
