### PR TITLE
[DRAFT] Do not use service for thread mode

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -148,15 +148,21 @@ class _WandbInit:
                 )
                 self.printer.display(line, level="warn")
 
-        self._wl = wandb_setup.setup()
+        # pop local setings
+        settings_param = kwargs.pop("settings", None)
+
+        # defer setting up the manager until we have processed more settings
+        self._wl = wandb_setup._setup(_disable_manager=True)
         # Make sure we have a logger setup (might be an early logger)
         _set_logger(self._wl._get_logger())
 
         # Start with settings from wandb library singleton
         settings: Settings = self._wl.settings.copy()
-        settings_param = kwargs.pop("settings", None)
         if settings_param is not None and isinstance(settings_param, (Settings, dict)):
             settings.update(settings_param, source=Source.INIT)
+
+        # now that we have our settings more finalized, lets setup the manager
+        self._wl._setup_manager()
 
         self._reporter = reporting.setup_reporter(settings=settings)
 


### PR DESCRIPTION
Description
-----------
This change disables service for users who choose to use thread mode.   This is a possible risk mitigation if service doesnt work in all the cases that thread mode works.

There are a few subtleties here.   If the user ran wandb.setup() before wandb.init() without changing to thread mode. we will still use service.    If the user calls wandb.init() in the process without thread mode and then later with thread mode, we will still use service.   This is all because service is process wide choice -- it could be made to not be process wide, but this would complicate the parts of the code which were simplified with service (atexit etc).

This might be a bad idea as implemented
It could cause users running with service in the past couple releases to start seeing problems that were masked by us not respecting thread mode with service turned on. 


Testing
-------
completely untested

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
