### PR TITLE
Add performance profiling to nightly yea tests

### DIFF
--- a/.flake8-base
+++ b/.flake8-base
@@ -8,13 +8,17 @@ exclude =
     __pycache__
     build/
     dist/
-    tests/
     codemod/
     *.pyc
     *.egg-info
     .cache
     .eggs
-    ./functional_tests/metaflow/
+    ./tests/conftest.py
+    ./tests/utils/
+    ./tests/logs/
+    ./tests/unit_tests/
+    ./tests/functional_tests/t0_main/metaflow/
+    ./tests/functional_tests/t0_main/fastai/t1_v1.py
     ./wandb/__init__.py
     ./wandb/wandb_torch.py
     ./wandb/bin

--- a/.flake8-base
+++ b/.flake8-base
@@ -14,6 +14,7 @@ exclude =
     .cache
     .eggs
     ./tests/conftest.py
+    ./tests/assets/fixtures/train.py
     ./tests/utils/
     ./tests/logs/
     ./tests/unit_tests/

--- a/tests/functional_tests/t0_main/console/test_emoji.py
+++ b/tests/functional_tests/t0_main/console/test_emoji.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import sys
-import time
-import tqdm
+
 import wandb
 
 run = wandb.init()

--- a/tests/functional_tests/t0_main/console/test_tqdm.py
+++ b/tests/functional_tests/t0_main/console/test_tqdm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
 import time
+
 import tqdm
 import wandb
 

--- a/tests/functional_tests/t0_main/console/test_tqdm_nested.py
+++ b/tests/functional_tests/t0_main/console/test_tqdm_nested.py
@@ -9,7 +9,7 @@ run = wandb.init()
 wandb.log(dict(this=2))
 print("before progress")
 for outer in tqdm.tqdm([10, 20, 30, 40, 50], desc=" outer", position=0):
-    for inner in tqdm.tqdm(range(outer), desc=" inner loop", position=1, leave=False):
+    for _inner in tqdm.tqdm(range(outer), desc=" inner loop", position=1, leave=False):
         time.sleep(0.05)
 print("done!")
 print("after progress", file=sys.stderr)

--- a/tests/functional_tests/t0_main/imports/03-batch3-requirements.txt
+++ b/tests/functional_tests/t0_main/imports/03-batch3-requirements.txt
@@ -3,7 +3,7 @@
 # lightgbm
 lightning-flash
 openmim # handles dependencies for mmlab projects
-mmcv
+mmcv<1.6.1 # 1.6.1 breaks mmdet 2.25.0
 mmdet
 # mmf
 monai

--- a/tests/functional_tests/t0_main/perf/log_data.py
+++ b/tests/functional_tests/t0_main/perf/log_data.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import argparse
+
+import wandb
+import yea
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-epochs", type=int, default=10)
+    parser.add_argument("--num-scalers", type=int, default=10)
+    args = parser.parse_args()
+
+    run = wandb.init()
+    for i in range(args.num_epochs):
+        data = {}
+        for j in range(args.num_scalers):
+            data[f"m-{j}"] = j * i
+        wandb.log(data)
+    run.finish()
+
+
+if __name__ == "__main__":
+    yea.setup()
+    main()

--- a/tests/functional_tests/t0_main/perf/t1_basic.py
+++ b/tests/functional_tests/t0_main/perf/t1_basic.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python
-import sys
-import time
+import yea
 
 
 def main():
+    # import here so we can profile how long it takes
     import wandb
 
     run = wandb.init()
     wandb.log(dict(this=2))
-    wandb.finish()
+    run.finish()
 
 
 if __name__ == "__main__":
-    import yea
-
     yea.setup()
-
     main()

--- a/tests/functional_tests/t0_main/perf/t1_basic.py
+++ b/tests/functional_tests/t0_main/perf/t1_basic.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import sys
+import time
+
+
+def main():
+    import wandb
+
+    run = wandb.init()
+    wandb.log(dict(this=2))
+    wandb.finish()
+
+
+if __name__ == "__main__":
+    import yea
+    yea.setup()
+
+    main()

--- a/tests/functional_tests/t0_main/perf/t1_basic.py
+++ b/tests/functional_tests/t0_main/perf/t1_basic.py
@@ -13,6 +13,7 @@ def main():
 
 if __name__ == "__main__":
     import yea
+
     yea.setup()
 
     main()

--- a/tests/functional_tests/t0_main/perf/t1_basic.yea
+++ b/tests/functional_tests/t0_main/perf/t1_basic.yea
@@ -1,8 +1,7 @@
 plugin:
   - wandb
 tag:
-  shards:
-    - standalone-cpu
+  shard: standalone-cpu
 profile:
   - :wandb:import
   - :wandb:init

--- a/tests/functional_tests/t0_main/perf/t1_basic.yea
+++ b/tests/functional_tests/t0_main/perf/t1_basic.yea
@@ -1,5 +1,8 @@
 plugin:
   - wandb
+tag:
+  shards:
+    - standalone-cpu
 profile:
   - :wandb:import
   - :wandb:init

--- a/tests/functional_tests/t0_main/perf/t1_basic.yea
+++ b/tests/functional_tests/t0_main/perf/t1_basic.yea
@@ -19,7 +19,7 @@ assert:
     - 3
   - :op:<:
     - :yea:profile[:wandb:init][mean]
-    - 3
+    - 8
   - :op:<:
     - :yea:profile[:wandb:log][mean]
     - 0.001

--- a/tests/functional_tests/t0_main/perf/t1_basic.yea
+++ b/tests/functional_tests/t0_main/perf/t1_basic.yea
@@ -1,0 +1,25 @@
+plugin:
+  - wandb
+profile:
+  - :wandb:import
+  - :wandb:init
+  - :wandb:log
+  - :wandb:finish
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][exitcode]: 0
+  - :op:<:
+    - :yea:time
+    - 10
+  - :op:<:
+    - :yea:profile[:wandb:import][mean]
+    - 0.75
+  - :op:<:
+    - :yea:profile[:wandb:init][mean]
+    - 3
+  - :op:<:
+    - :yea:profile[:wandb:log][mean]
+    - 0.001
+  - :op:<:
+    - :yea:profile[:wandb:finish][mean]
+    - 5

--- a/tests/functional_tests/t0_main/perf/t2_log_scalers_offline.yea
+++ b/tests/functional_tests/t0_main/perf/t2_log_scalers_offline.yea
@@ -1,8 +1,7 @@
 plugin:
   - wandb
 tag:
-  shards:
-    - standalone-cpu
+  shard: standalone-cpu
 command:
   program: log_data.py
   args:

--- a/tests/functional_tests/t0_main/perf/t2_log_scalers_offline.yea
+++ b/tests/functional_tests/t0_main/perf/t2_log_scalers_offline.yea
@@ -3,27 +3,31 @@ plugin:
 tag:
   shards:
     - standalone-cpu
+command:
+  program: log_data.py
+  args:
+    - --num-epochs
+    - "1000"
+    - --num-scalers
+    - "1000"
+env:
+  - WANDB_MODE: offline
 profile:
-  - :wandb:import
   - :wandb:init
   - :wandb:log
   - :wandb:finish
 assert:
   - :yea:exit: 0
-  - :wandb:runs_len: 1
-  - :wandb:runs[0][exitcode]: 0
+  - :wandb:runs_len: 0
   - :op:<:
     - :yea:time
-    - 10
-  - :op:<:
-    - :yea:profile[:wandb:import][mean]
-    - 3
+    - 120
   - :op:<:
     - :yea:profile[:wandb:init][mean]
     - 3
   - :op:<:
     - :yea:profile[:wandb:log][mean]
-    - 0.001
+    - 0.100
   - :op:<:
     - :yea:profile[:wandb:finish][mean]
-    - 5
+    - 100

--- a/tests/standalone_tests/log_large_data.py
+++ b/tests/standalone_tests/log_large_data.py
@@ -1,5 +1,6 @@
 import argparse
 import timeit
+
 import wandb
 
 

--- a/tests/standalone_tests/table_mem_test.py
+++ b/tests/standalone_tests/table_mem_test.py
@@ -1,8 +1,7 @@
 import time
 
-import numpy as np
 from memory_profiler import profile
-
+import numpy as np
 import wandb
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.8.0
+    YEA_WANDB_VERSION = 0.8.1
 
 [unitbase]
 deps =
@@ -397,9 +397,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/add-profile.zip
-    https://github.com/wandb/yea-wandb/archive/add-profile.zip
-    ; yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
     func-s_grpc-py{36,37,38,39,310}: grpc
@@ -479,9 +477,7 @@ deps =
     -r{toxinidir}/requirements.txt
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/add-profile.zip
-    https://github.com/wandb/yea-wandb/archive/add-profile.zip
-    ; yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date
     echo

--- a/tox.ini
+++ b/tox.ini
@@ -491,7 +491,7 @@ whitelist_externals =
 commands =
     mkdir -p test-results
     wandb login --relogin {env:WANDB_API_KEY}
-    standalone-cpu-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
-    standalone-gpu-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
-    standalone-tpu-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
-    standalone-local-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}
+    standalone-cpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
+    standalone-gpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
+    standalone-tpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
+    standalone-local-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}

--- a/tox.ini
+++ b/tox.ini
@@ -397,7 +397,9 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    https://github.com/wandb/yea/archive/live-as-relay.zip
+    https://github.com/wandb/yea-wandb/archive/live-as-relay.zip
+    ; yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
     func-s_grpc-py{36,37,38,39,310}: grpc
@@ -477,7 +479,9 @@ deps =
     -r{toxinidir}/requirements.txt
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    https://github.com/wandb/yea/archive/live-as-relay.zip
+    https://github.com/wandb/yea-wandb/archive/live-as-relay.zip
+    ; yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date
     echo

--- a/tox.ini
+++ b/tox.ini
@@ -397,8 +397,8 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/live-as-relay.zip
-    https://github.com/wandb/yea-wandb/archive/live-as-relay.zip
+    https://github.com/wandb/yea/archive/add-profile.zip
+    https://github.com/wandb/yea-wandb/archive/add-profile.zip
     ; yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
@@ -479,8 +479,8 @@ deps =
     -r{toxinidir}/requirements.txt
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/live-as-relay.zip
-    https://github.com/wandb/yea-wandb/archive/live-as-relay.zip
+    https://github.com/wandb/yea/archive/add-profile.zip
+    https://github.com/wandb/yea-wandb/archive/add-profile.zip
     ; yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date


### PR DESCRIPTION
Description
-----------
Changes:
- Update to yea 0.8.1 / yea-wandb 0.8.1 (waiting on approvals before changing tox.ini)
- Add yea profile support
- Add some base nightly tests to start establishing baseline performance
- flake8 was accidentally turned off for test files -- turn back on and fix some tests

Will eventually replace this draft PR:
- https://github.com/wandb/wandb/pull/3652

Future:
- Add more tests
- Figure out the best way to track historical data
- add yea offline support and assert on records

Required PRs:
- https://github.com/wandb/yea/pull/31
- https://github.com/wandb/yea-wandb/pull/81

Testing
-------
These are tests