### PR TITLE
Deflake: bump timeout for another launch test

### DIFF
--- a/tests/unit_tests/tests_launch/test_launch.py
+++ b/tests/unit_tests/tests_launch/test_launch.py
@@ -797,6 +797,7 @@ def test_launch_agent_instance(test_settings, live_mock_server):
 
 @pytest.mark.flaky
 # @pytest.mark.xfail(reason="test goes through flaky periods. Re-enable with WB7616")
+@pytest.mark.timeout(240)
 def test_launch_agent_different_project_in_spec(
     test_settings,
     live_mock_server,


### PR DESCRIPTION
Description
-----------
Attempt to fix:
- https://app.circleci.com/pipelines/github/wandb/wandb/14248/workflows/cce6c5ac-c1f1-4d45-b887-f024e3171881/jobs/244087/steps?invite=true#step-106-564

Testing
-------
circleci