### PR TITLE
Fix 409 Conflict handling when GraphQL requests timeout

### DIFF
--- a/tests/functional_tests/t0_main/resume/t3_deleted.yea
+++ b/tests/functional_tests/t0_main/resume/t3_deleted.yea
@@ -1,0 +1,13 @@
+plugin:
+  - wandb
+tag:
+  shard: standalone-cpu
+  skip: true
+command:
+  program: two_runs.py
+  args:
+    - --delete_run
+assert:
+  - :op:!=:
+    - :yea:exit
+    - 0

--- a/tests/functional_tests/t0_main/resume/t3_deleted.yea
+++ b/tests/functional_tests/t0_main/resume/t3_deleted.yea
@@ -2,7 +2,6 @@ plugin:
   - wandb
 tag:
   shard: standalone-cpu
-  skip: true
 command:
   program: two_runs.py
   args:
@@ -11,3 +10,6 @@ assert:
   - :op:!=:
     - :yea:exit
     - 0
+  - :op:<:
+    - :yea:time
+    - 360

--- a/tests/functional_tests/t0_main/resume/two_runs.py
+++ b/tests/functional_tests/t0_main/resume/two_runs.py
@@ -33,7 +33,9 @@ def run_again(run_id: str, resume: Optional[str]) -> None:
 def delete_run(run_path: str) -> None:
     api = wandb.Api()
     run = api.run(run_path)
+    print(f"Deleting: {run_path}...")
     run.delete()
+    print("done.")
 
 
 def main() -> None:

--- a/tests/functional_tests/t0_main/resume/two_runs.py
+++ b/tests/functional_tests/t0_main/resume/two_runs.py
@@ -12,7 +12,8 @@ def run_first() -> str:
         wandb.log(dict(m2=2))
         wandb.log(dict(m3=3))
         run_id = run.id
-    return run_id
+        run_path = run.path
+    return run_id, run_path
 
 
 def run_again(run_id: str, resume: Optional[str]) -> None:
@@ -29,12 +30,22 @@ def run_again(run_id: str, resume: Optional[str]) -> None:
         wandb.log(dict(m4=44))
 
 
+def delete_run(run_path: str) -> None:
+    api = wandb.Api()
+    run = api.run(run_path)
+    run.delete()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--resume", type=str)
+    parser.add_argument("--delete_run", action="store_true")
     args = parser.parse_args()
 
-    run_id = run_first()
+    run_id, run_path = run_first()
+    if args.delete_run:
+        delete_run(run_path)
+
     run_again(run_id=run_id, resume=args.resume)
 
 

--- a/tests/unit_tests/test_retry.py
+++ b/tests/unit_tests/test_retry.py
@@ -1,5 +1,6 @@
 """retry tests"""
 
+import datetime
 from unittest import mock
 
 import pytest
@@ -87,3 +88,34 @@ def test_retry_respects_retryable_exceptions():
         retrier()
 
     assert func.call_count == 1
+
+
+def test_retry_respects_secondary_timeout():
+    func = mock.Mock()
+    func.side_effect = ValueError
+
+    now = datetime.datetime.now()
+    mock_datetime_now = mock.Mock()
+    mock_datetime_now.side_effect = [
+        now + datetime.timedelta(minutes=i) for i in range(30)
+    ]
+
+    def check_retry_timeout(e):
+        if isinstance(e, ValueError):
+            return datetime.timedelta(minutes=10)
+
+    retry_timedelta = datetime.timedelta(hours=7)
+    retrier = retry.Retry(
+        func,
+        retryable_exceptions=(ValueError,),
+        check_retry_fn=check_retry_timeout,
+        retry_timedelta=retry_timedelta,
+        num_retries=10000,
+        sleep_fn_for_testing=noop_sleep,
+        datetime_now_fn_for_testing=mock_datetime_now,
+    )
+    with pytest.raises(ValueError):
+        retrier()
+
+    # add some slop for other timeout calls, should be about 10 minutes of retries
+    assert 10 <= mock_datetime_now.call_count < 15

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -439,18 +439,18 @@ def test_no_retry_auth():
     assert util.no_retry_auth(e)
 
 
-def test_check_retry_commit_artifact_retries_on_conflict():
+def test_check_retry_conflict():
     e = mock.MagicMock(spec=requests.HTTPError)
     e.response = mock.MagicMock(spec=requests.Response)
 
     e.response.status_code = 400
-    assert not util.check_retry_commit_artifact(e)
+    assert util.is_conflict(e) is None
 
     e.response.status_code = 500
-    assert util.check_retry_commit_artifact(e)
+    assert util.is_conflict(e) is None
 
     e.response.status_code = 409
-    assert util.check_retry_commit_artifact(e)
+    assert util.is_conflict(e) is True
 
 
 def test_downsample():

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -445,13 +445,13 @@ def test_check_retry_conflict():
     e.response = mock.MagicMock(spec=requests.Response)
 
     e.response.status_code = 400
-    assert util.is_conflict(e) is None
+    assert util.check_retry_conflict(e) is None
 
     e.response.status_code = 500
-    assert util.is_conflict(e) is None
+    assert util.check_retry_conflict(e) is None
 
     e.response.status_code = 409
-    assert util.is_conflict(e) is True
+    assert util.check_retry_conflict(e) is True
 
 
 def test_make_check_reply_fn_timeout():
@@ -460,7 +460,7 @@ def test_make_check_reply_fn_timeout():
     e.response = mock.MagicMock(spec=requests.Response)
 
     check_retry_fn = util.make_check_retry_fn(
-        check_fn=util.is_conflict,
+        check_fn=util.check_retry_conflict,
         check_timedelta=datetime.timedelta(minutes=3),
         fallback_retry_fn=util.no_retry_auth,
     )

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1455,10 +1455,10 @@ class Api:
             "summaryMetrics": summary_metrics,
         }
 
-        # retry conflict errors for 8 minutes, default to no_auth_retry
+        # retry conflict errors for 2 minutes, default to no_auth_retry
         check_retry_fn = util.make_check_retry_fn(
             check_fn=util.is_conflict,
-            check_timedelta=datetime.timedelta(minutes=8),
+            check_timedelta=datetime.timedelta(minutes=2),
             fallback_retry_fn=util.no_retry_auth,
         )
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1457,7 +1457,7 @@ class Api:
 
         # retry conflict errors for 2 minutes, default to no_auth_retry
         check_retry_fn = util.make_check_retry_fn(
-            check_fn=util.is_conflict,
+            check_fn=util.check_retry_conflict_or_gone,
             check_timedelta=datetime.timedelta(minutes=2),
             fallback_retry_fn=util.no_retry_auth,
         )
@@ -2691,7 +2691,7 @@ class Api:
 
         # retry conflict errors for 2 minutes, default to no_auth_retry
         check_retry_fn = util.make_check_retry_fn(
-            check_fn=util.is_conflict,
+            check_fn=util.check_retry_conflict,
             check_timedelta=datetime.timedelta(minutes=2),
             fallback_retry_fn=util.no_retry_auth,
         )

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1455,10 +1455,10 @@ class Api:
             "summaryMetrics": summary_metrics,
         }
 
-        # retry conflict errors for 2 minutes, default to no_auth_retry
+        # retry conflict errors for 8 minutes, default to no_auth_retry
         check_retry_fn = util.make_check_retry_fn(
             check_fn=util.is_conflict,
-            check_timedelta=datetime.timedelta(minutes=2),
+            check_timedelta=datetime.timedelta(minutes=8),
             fallback_retry_fn=util.no_retry_auth,
         )
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1455,7 +1455,19 @@ class Api:
             "summaryMetrics": summary_metrics,
         }
 
-        response = self.gql(mutation, variable_values=variable_values, **kwargs)
+        # retry conflict errors for 2 minutes, default to no_auth_retry
+        check_retry_fn = util.make_check_retry_fn(
+            check_fn=util.is_conflict,
+            check_timedelta=datetime.timedelta(minutes=2),
+            fallback_retry_fn=util.no_retry_auth,
+        )
+
+        response = self.gql(
+            mutation,
+            variable_values=variable_values,
+            check_retry_fn=check_retry_fn,
+            **kwargs,
+        )
 
         run_obj: Dict[str, Dict[str, Dict[str, str]]] = response["upsertBucket"][
             "bucket"
@@ -2677,11 +2689,17 @@ class Api:
         """
         )
 
+        # retry conflict errors for 2 minutes, default to no_auth_retry
+        check_retry_fn = util.make_check_retry_fn(
+            check_fn=util.is_conflict,
+            check_timedelta=datetime.timedelta(minutes=2),
+            fallback_retry_fn=util.no_retry_auth,
+        )
+
         response: "_Response" = self.gql(  # type: ignore
             mutation,
             variable_values={"artifactID": artifact_id},
-            check_retry_fn=util.check_retry_commit_artifact,
-            retry_timedelta=datetime.timedelta(minutes=2),
+            check_retry_fn=check_retry_fn,
         )
         return response
 

--- a/wandb/sdk/lib/retry.py
+++ b/wandb/sdk/lib/retry.py
@@ -4,7 +4,7 @@ import logging
 import os
 import random
 import time
-from typing import Any, Callable, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Generic, Optional, Tuple, Type, TypeVar
 
 from requests import HTTPError
 import wandb

--- a/wandb/sdk/lib/retry.py
+++ b/wandb/sdk/lib/retry.py
@@ -8,8 +8,8 @@ from typing import Any, Callable, Generic, Optional, Tuple, Type, TypeVar, Union
 
 from requests import HTTPError
 import wandb
+from wandb.util import CheckRetryFnType
 
-ExceptionPredicate = Callable[[Exception], Union[bool, datetime.timedelta]]
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class Retry(Generic[_R]):
         call_fn: Callable[..., _R],
         retry_timedelta: Optional[datetime.timedelta] = None,
         num_retries: Optional[int] = None,
-        check_retry_fn: ExceptionPredicate = lambda e: True,
+        check_retry_fn: CheckRetryFnType = lambda e: True,
         retryable_exceptions: Optional[Tuple[Type[Exception], ...]] = None,
         error_prefix: str = "Network error",
         retry_callback: Optional[Callable[[int, str], Any]] = None,
@@ -97,7 +97,7 @@ class Retry(Generic[_R]):
         sleep_base: float = kwargs.pop("retry_sleep_base", 1)
 
         # an extra function to allow performing more logic on the filtered exception
-        check_retry_fn: ExceptionPredicate = kwargs.pop(
+        check_retry_fn: CheckRetryFnType = kwargs.pop(
             "check_retry_fn", self._check_retry_fn
         )
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -890,6 +890,13 @@ def no_retry_auth(e: Any) -> bool:
 
 
 def is_conflict(e: Any) -> Optional[bool]:
+    """Check if the exception is a conflict type so it can be retried.
+
+    Returns:
+        True - Should retry this operation
+        False - Should not retry this operation
+        None - No decision, let someone else decide
+    """
     if hasattr(e, "exception"):
         e = e.exception
     if (

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -913,6 +913,7 @@ def make_check_retry_fn(
         check_fn: Function which returns bool if retry should happen or None if unsure.
         check_timedelta: Optional retry timeout if we check_fn matches the exception
     """
+
     def check_retry_fn(e: Exception) -> Union[bool, timedelta]:
         check = check_fn(e)
         if check is None:


### PR DESCRIPTION
Fixes WB-10408

Description
-----------
- Fixes cases where the backend returns `409 Conflict` errors for some GraphQL requests.
- Added new handling for HTTP status `410 Gone` to never retry with the anticipation that this will be returned in the future so we don't have two classes of failures aliasing to the same code.

The scenario is:
```mermaid
sequenceDiagram
  participant SDK
  participant Server
  participant DB
  SDK->>Server: GraphQL(upsert_run)
  Server->>DB: INSERT run
  activate DB
  note right of DB: Database is slow as large project\nneeds to be loaded into cache
  note right of SDK: Client request timeout
  SDK->>Server: GraphQL(upsert_run) Retry
  Server->>DB: INSERT run
  DB->>Server: Duplicate entry for key 'PRIMARY'
  Server->>SDK: 409 Conflict
  DB->>Server: inserted
  deactivate DB
```

This happens when:
- a project is stale (not in the cache)
- a project is very large
- an `upsert_run` happens which takes longer than 10 seconds (to load all the project information?)
- a timeout occurs in the SDK
- the `upsert_run` is retried when the first `upsert_run` is still executing in the database

The fix is:
- retry 409 errors for upsert_run.   (retries were added for `commit_artifact` already)

Details:
- Introduce new `make_check_retry_fn` which takes arguments:
  - `check_fn`: is this an exception we want to handle in a special way?
  - `check_timedelta`: if so, how long should this be retried / or do not change default.
  - `fallback_retry_fn`: or if this isnt a special exception, fallback to this `check_retry_fn`
- Fix `commit_artifact` to not change the timedelta on 409, otherwise if gorilla is unresponsive for 2 minutes durring a `commit_artifact`, we will fail the run i think. (this was introduced in https://github.com/wandb/wandb/pull/3843)
- Add similar handling for `upsert_run` to retry 409 errors
- restructure the retry loop to have two possible timeout values, the longer default timeout, and a possibly shorter timeout if we are handling a special exception (like 409 errors)

Even more detail:  (lets walk through a case where the retry handler is dealing with two classes of retries):
- SDK sends an upsert_run
- But the network is down for 30 minutes
- The retry exponential backoff will be at its max (5 minutes).   By default we retry for 7 days.
- Now lets say a retried upsert_run gets delivered but the database is very slow so it hangs for a while
- Now the SDK resends the upsert_run yet again, and this time it hits the database which is still blocked on the previous attempt so a 409 Conflict is returned from the backend to the SDK. (this is pretty unlikely because it would mean that the database was busy for 5 minutes on the previous query)
- The SDK sees this 409 and continues to retry, but now with a new time limit of 2 minutes
- If we didnt rework the retry logic, the 2 minutes would be calculated from 30 minutes ago so there would be no retry at all
- But with the new logic. on the first 409 error, we would save an alternate start_time of the first time we saw a 409
- Now we keep going through the retry loop until the shorter timeout is exhausted on subsequent 409 errors or longer timeout is exhausted
- This logic means that we could have another 30 minutes of network outage after the first 409 error.   If we get another 409 error more than the timeout from the first 409 error, then we will give up retrying.

In the future:
- We might want a more sophisticated way of handling errors with a new retry abstraction.   The code needs to be careful in the case where we change the retry timeout when we find a specific exception.  The complication is that we might be in the middle of handling other types of network retries.   If that happens the exponential backoff delay might be already up to 5 minutes so we could miss a chance to retry the 409 because our timer expired.   To handle this case we sample a new start_time for when we first get this secondary error so we can make sure we give the server the minimum amount of time from the first 409 error (or whatever is triggered.
- We should introduce an idempotency key, either in the graphql payload or on the HTTP header (unfortunately gql doesnt have a great way of adding headers per request, so we might want to put it in the payload.) See https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-01 for a description of using HTTP header.
- Should this 409 handling be on all graphql requests in the future?  for now lets just do the ones we know of.

Tasks:
- [x] Document issue
- [x] Figure out some better tests

Testing
-------
- Running regressions that normally hit this error.
- Created new unittests to verify retry logic
- 100% patch coverage of changes
- Manually tested injecting 410 gone errors
- Created a nightly yea test to hit upsert after delete
-