### PR TITLE
Fix `ArtifactFiles.__repr__` as using non-implemented properties

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -4101,6 +4101,10 @@ class Artifact(artifacts.Artifact):
         return f"{self._sequence_name}:v{self._version_index}"
 
     @property
+    def path(self):
+        return [self.entity, self.project, self.name]
+
+    @property
     def aliases(self):
         """
         The aliases associated with this artifact.

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -4909,8 +4909,10 @@ class ArtifactFiles(Paginator):
 
     @property
     def length(self):
-        # TODO
-        return None
+        if self.last_response:
+            return len(self.last_response["project"]["artifactType"]["artifact"]["files"])
+        else:
+            return None
 
     @property
     def more(self):
@@ -4946,7 +4948,6 @@ class ArtifactFiles(Paginator):
 
 
 class Job:
-
     _name: str
     _input_types: Type
     _output_types: Type


### PR DESCRIPTION
Description
-----------
This PR basically addressed the review comment left in https://github.com/wandb/wandb/pull/3969, as when printing `ArtifactFiles` it was failing as the implemented `def __repr__` was using both `self.artifact.path` and `len(self)` and neither of those was implemented as a class property, so it was failing.

Testing
-------
In order to test this PR I've used the following code, which is still failing in the base branch of this PR:

```python
import wandb

api = wandb.Api()

entity, project, artifact_type, artifact_name, artifact_version = "wandb/yolo-chess/dataset/train/v0".split("/")

artifact = api.artifact(name=f"{entity}/{project}/{artifact_name}:{artifact_version}", type=artifact_type)
print(artifact.files())
```
