### PR TITLE
[WB-10429] Fix issue where patch is none

### DIFF
--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -295,13 +295,11 @@ class LaunchProject:
                 patch = utils.fetch_project_diff(
                     source_entity, source_project, source_run_name, internal_api
                 )
-
+                tag_string = run_info["git"]["remote"] + run_info["git"]["commit"]
                 if patch:
                     utils.apply_patch(patch, self.project_dir)
+                    tag_string += patch
 
-                tag_string = (
-                    run_info["git"]["remote"] + run_info["git"]["commit"] + patch
-                )
                 self._image_tag = binascii.hexlify(tag_string.encode()).decode()
 
                 # For cases where the entry point wasn't checked into git


### PR DESCRIPTION
[Fixes WB-10429](https://wandb.atlassian.net/browse/WB-10429)
Fixes #NNNN

Description
-----------
Fixes a type error where we can try to add a None type to a string if the git repo had no patch file

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
