### PR TITLE
Add dataclasses to requirements for py3.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,13 @@ You can install `ffmpeg` with the following command using [homebrew](https://bre
 $ brew install ffmpeg
 ```
 
+- The `lightgbm` package might require build packages `cmake` and `libomp` to be installed.
+You can install `cmake` and `libomp` with the following command using [homebrew](https://brew.sh/):
+
+```shell
+$ brew install cmake libomp
+```
+
 ## Code organization
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyYAML
 pathtools # supports vendored version of watchdog 0.9.0
 setproctitle
 setuptools
+dataclasses; python_version < '3.7'


### PR DESCRIPTION
Description
-----------
One of our requirements is probably pulling this in and saving us, but we should be explicit if we use it, which we do in sweeps on launch.

Bonus: update contributing with a new m1 issue that popped up (might not be strictly required)

Testing
-------
not tested