### PR TITLE
internal: more-precisely define the return-type of create_artifact

### DIFF
--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING
 import wandb
 from wandb import util
 import wandb.filesync.step_prepare
+from wandb.sdk.internal.internal_api import CreateArtifactResponse
 
 from ..interface.artifacts import ArtifactEntry, ArtifactManifest
 
@@ -62,7 +63,7 @@ def _manifest_json_from_proto(manifest: "wandb_internal_pb2.ArtifactManifest") -
 
 
 class ArtifactSaver:
-    _server_artifact: Optional[Dict]  # TODO better define this dict
+    _server_artifact: Optional[CreateArtifactResponse]
 
     def __init__(
         self,
@@ -94,7 +95,7 @@ class ArtifactSaver:
         use_after_commit: bool = False,
         incremental: bool = False,
         history_step: Optional[int] = None,
-    ) -> Optional[Dict]:
+    ) -> Optional[CreateArtifactResponse]:
         aliases = aliases or []
         alias_specs = []
         for alias in aliases:

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -70,6 +70,33 @@ if TYPE_CHECKING:
         mimetype: Optional[str]
         artifactManifestID: Optional[str]
 
+    class CreateArtifactResponseLatestArtifactInfo(TypedDict):
+        id: str
+        versionIndex: int
+
+    ArtifactState = Literal[
+        "PENDING",
+        "COMMITTED",
+        "DELETED",
+        "COMMITTING",  # removed from server in mid-2020
+        "FAILED",  # removed from server in mid-2020
+    ]
+
+    class CreateArtifactResponseArtifactAlias(TypedDict):
+        artifactCollectionName: str
+        alias: str
+
+    class CreateArtifactResponseArtifactSequence(TypedDict):
+        id: str
+        latestArtifact: CreateArtifactResponseLatestArtifactInfo
+
+    class CreateArtifactResponse(TypedDict):
+        id: str
+        digest: str
+        state: ArtifactState
+        aliases: Sequence[CreateArtifactResponseArtifactAlias]
+        artifactSequence: CreateArtifactResponseArtifactSequence
+
     class DefaultSettings(TypedDict):
         section: str
         git_remote: str
@@ -2520,7 +2547,7 @@ class Api:
         is_user_created: Optional[bool] = False,
         enable_digest_deduplication: Optional[bool] = False,
         history_step: Optional[int] = None,
-    ) -> Tuple[Dict, Dict]:
+    ) -> Tuple[CreateArtifactResponse, CreateArtifactResponseLatestArtifactInfo]:
         _, server_info = self.viewer_server_info()
         max_cli_version = server_info.get("cliVersionInfo", {}).get(
             "max_cli_version", None

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1247,7 +1247,7 @@ class SendManager:
 
     def _send_artifact(
         self, artifact: "ArtifactRecord", history_step: Optional[int] = None
-    ) -> Optional[Dict]:
+    ) -> Optional[internal_api.CreateArtifactResponse]:
         assert self._pusher
         saver = artifacts.ArtifactSaver(
             api=self._api,


### PR DESCRIPTION
Description
-----------

Our GraphQL API returns `Dict[str, Any]` all over the place, which makes me sad! Here's one way we could fix it.
