### PR TITLE
Fix requirements.txt parsing in nightly SDK installation checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,7 @@ jobs:
           name: "Install stable version of wandb with pre-release versions of dependencies"
           command: |
             wget https://raw.githubusercontent.com/wandb/wandb/$CIRCLE_BRANCH/requirements.txt
-            for r in `grep -o '^[^#]*' requirements.txt`; do pip install --upgrade --pre "$r"; done
+            for r in `grep -o '^[^(#,;)]*' requirements.txt`; do pip install --upgrade --pre "$r"; done
             pip install wandb
             python -c "import wandb"
             pip freeze > deps_wandb_deps_pre.txt
@@ -839,7 +839,7 @@ jobs:
       - run:
           name: "Install pre-release version of wandb with pre-release versions of dependencies"
           command: |
-            for r in `grep -o '^[^#]*' requirements.txt`; do pip install --upgrade --pre "$r"; done
+            for r in `grep -o '^[^(#,;)]*' requirements.txt`; do pip install --upgrade --pre "$r"; done
             pip install --pre wandb
             python -c "import wandb"
           when: always


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
We added `dataclasses` for py<3.6. We'll remove it once we sunset py3.6 support hopefully later this year.

Testing
-------
Ran nightly manually:
https://app.circleci.com/pipelines/github/wandb/wandb/14325/workflows/119b1c47-de21-410d-87a9-db434603bae9

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
