### PR TITLE
Update yea-wandb 0.8.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.8.1
+    YEA_WANDB_VERSION = 0.8.2
 
 [unitbase]
 deps =


### PR DESCRIPTION
Description
-----------
Updates yea and yea-wandb:
- add "--noskip" option
- fixes mockserver relay mode to return the right status message
- fix parse context to handle None in config and upsert bucket run

Corresponding yea-wandb change:
https://github.com/wandb/yea-wandb/pull/82

Testing
-------
circle