### PR TITLE
Fix flaky tests (notebook, keras, perf oh my)

### DIFF
--- a/tests/assets/notebooks/magic.ipynb
+++ b/tests/assets/notebooks/magic.ipynb
@@ -37,6 +37,15 @@
    ],
    "outputs": [],
    "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "wandb.finish()"
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/tests/assets/notebooks/one_cell.ipynb
+++ b/tests/assets/notebooks/one_cell.ipynb
@@ -8,7 +8,16 @@
    "source": [
     "import wandb\n",
     "wandb.init()\n",
-    "wandb.log({\"test\": 1})"
+    "wandb.log({\"test\": 1})\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wandb.finish()"
    ]
   }
  ],

--- a/tests/functional_tests/t0_main/keras/test_keras_subclassed_model.py
+++ b/tests/functional_tests/t0_main/keras/test_keras_subclassed_model.py
@@ -51,6 +51,7 @@ api = wandb.Api()
 artifact = api.artifact(f"{run.project}/model-{run.name}:latest")
 download_dir = artifact.download()
 files = os.listdir(download_dir)
+print("FILES", files)
 assert files[0] == "variables"
 assert files[1] == "keras_metadata.pb"
 assert files[2] == "saved_model.pb"

--- a/tests/functional_tests/t0_main/keras/test_keras_subclassed_model.py
+++ b/tests/functional_tests/t0_main/keras/test_keras_subclassed_model.py
@@ -50,8 +50,8 @@ run.finish()
 api = wandb.Api()
 artifact = api.artifact(f"{run.project}/model-{run.name}:latest")
 download_dir = artifact.download()
-files = os.listdir(download_dir)
-print("FILES", files)
-assert files[0] == "variables"
-assert files[1] == "keras_metadata.pb"
-assert files[2] == "saved_model.pb"
+files = sorted(os.listdir(download_dir))
+print(f"FILES: {files}")
+assert files[0] == "keras_metadata.pb"
+assert files[1] == "saved_model.pb"
+assert files[2] == "variables"

--- a/tests/functional_tests/t0_main/perf/t1_basic.py
+++ b/tests/functional_tests/t0_main/perf/t1_basic.py
@@ -7,7 +7,8 @@ def main():
     import wandb
 
     run = wandb.init()
-    wandb.log(dict(this=2))
+    for _ in range(1000):
+        wandb.log(dict(this=2))
     run.finish()
 
 

--- a/tests/functional_tests/t0_main/perf/t1_basic.yea
+++ b/tests/functional_tests/t0_main/perf/t1_basic.yea
@@ -13,7 +13,7 @@ assert:
   - :wandb:runs[0][exitcode]: 0
   - :op:<:
     - :yea:time
-    - 10
+    - 25
   - :op:<:
     - :yea:profile[:wandb:import][mean]
     - 3
@@ -25,4 +25,4 @@ assert:
     - 0.001
   - :op:<:
     - :yea:profile[:wandb:finish][mean]
-    - 5
+    - 15

--- a/tests/unit_tests/tests_s_nb/test_notebooks.py
+++ b/tests/unit_tests/tests_s_nb/test_notebooks.py
@@ -55,7 +55,7 @@ def test_magic(notebook):
                 text += out["data"]["text/html"]
             iframes += 1
         assert notebook.base_url in text
-        assert iframes == 4
+        assert iframes == 5
 
 
 @pytest.mark.flaky

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ passenv =
 commands =
     s_nb: ipython kernel install --user --name=wandb_python
     mkdir -p test-results
-    python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:{env:WB_UNIT_PARALLEL:4}} --durations=20 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/unit_tests/tests_{env:WB_UNIT_SHARD}/}
+    python -m pytest -vv {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:{env:WB_UNIT_PARALLEL:4}} --durations=20 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/unit_tests/tests_{env:WB_UNIT_SHARD}/}
 
 [testenv:dev]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ passenv =
 commands =
     s_nb: ipython kernel install --user --name=wandb_python
     mkdir -p test-results
-    python -m pytest -vv {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:{env:WB_UNIT_PARALLEL:4}} --durations=20 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/unit_tests/tests_{env:WB_UNIT_SHARD}/}
+    python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:{env:WB_UNIT_PARALLEL:4}} --durations=20 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/unit_tests/tests_{env:WB_UNIT_SHARD}/}
 
 [testenv:dev]
 usedevelop = true


### PR DESCRIPTION
Description
-----------
changes:
- notebook tests were leaking into the next test, there should be a better way to shutdown runs between notebook tests but for now, i added an explicit finish
- keras subclass test was not sorting a list from the fs..
- perf tests were too strict right now..  relaxed and logged more data so we can get a mean rather than a single log which might have warm up time?

Not fixed:
- the following test is wrong as it might not improve on the second epoch so only 1 artifact wil be saved:
https://github.com/wandb/wandb/blame/master/tests/functional_tests/t0_main/keras/keras_subclassed_test_tf_2_6.yea#L15

Testing
-------
circle, manual flake repro with different xdist settings in a loop