### PR TITLE
Fix flake in keras subclass test (workaround)

### DIFF
--- a/tests/functional_tests/t0_main/keras/keras_subclassed_test_tf_2_6.yea
+++ b/tests/functional_tests/t0_main/keras/keras_subclassed_test_tf_2_6.yea
@@ -12,7 +12,15 @@ depend:
 assert:
     - :wandb:runs_len: 1
     - :wandb:artifacts[model-lovely-dawn-32][type]: model
-    - :wandb:artifacts[model-lovely-dawn-32][num]: 2
+    # Test doesnt always save 2 models since it might not improve
+    # on second epoch.  When test is made more determinstic, this
+    # should be changed back to a stricter check
+    - :op:>=:
+      - :wandb:artifacts[model-lovely-dawn-32][num]
+      - 1
+    - :op:<=:
+      - :wandb:artifacts[model-lovely-dawn-32][num]
+      - 2
     - :op:contains:
         - :wandb:runs[0][telemetry][3]  # feature
         - 8  # keras


### PR DESCRIPTION
Description
-----------
temporary workaround for a non deterministic test which might not improve on the second epoch so it will only store 1 artifact.

Testing
-------
Ran yea test in a loop.