### PR TITLE
Fix service teardown handling if user process has been terminated

### DIFF
--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -243,7 +243,11 @@ class StreamMux:
             )
 
         streams_to_join, poll_exit_responses = {}, {}
-        while streams:
+        while streams and not self._stopped.is_set():
+            # Stop trying to sync data if our parent process has terminated
+            if self._check_orphaned():
+                self._stopped.set()
+                return
             # Note that we materialize the generator so we can modify the underlying list
             for sid, stream in list(streams.items()):
                 poll_exit_response = stream.interface.communicate_poll_exit()


### PR DESCRIPTION
Description
-----------
Fix orphaned wandb-service process by shutting down if the parent process has been terminated.

Walk through of what can happen (one case is control-C):
- wandb.init() spins up wandb-service
- user process is in the process of crashing, handling control-c, etc
- atexit of the wandb_manager is called
- wandb_manager attempts to finish all runs that are active
- wandb-service is handling this finish_all request
- while trying to finish syncing all runs the parent process gets killed somehow
- if the parent process is gone, there is no reason to continue syncing, we could be in a network retry loop of up to 7 days.

We have other places where we check for orphaned... namely in the stream mux loop.  But since we are handling a request on behalf of the mux, the mux doesnt get a chance to shutdown.   In the future we might want to fix all stream actions to not block the stream loop (this is possibly required for grpc as things are currently implemented).

Testing
-------
Manual tested.