### PR TITLE
Bump version: → 0.13.1.dev1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.13.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.1
+current_version = 0.13.1.dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0rc6.dev1
+current_version = 0.13.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ models_requirements = [
 
 setup(
     name="wandb",
-    version="0.13.1",
+    version="0.13.1.dev1",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ models_requirements = [
 
 setup(
     name="wandb",
-    version="0.13.0",
+    version="0.13.1",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ models_requirements = [
 
 setup(
     name="wandb",
-    version="0.13.0rc6.dev1",
+    version="0.13.0",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -72,7 +72,7 @@ def default_ctx():
         "run_queues": {"1": []},
         "num_popped": 0,
         "num_acked": 0,
-        "max_cli_version": "0.13.0",
+        "max_cli_version": "0.14.0",
         "runs": {},
         "run_ids": [],
         "file_names": [],

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.8.5
+    YEA_WANDB_VERSION = 0.8.6
 
 [unitbase]
 deps =

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.13.1"
+__version__ = "0.13.1.dev1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.13.0rc6.dev1"
+__version__ = "0.13.0"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"


### PR DESCRIPTION
Description
-----------
Bump to dev version

Requires:
https://github.com/wandb/yea-wandb/pull/88

Testing
-------
None