### PR TITLE
Improve wandb.init() error message

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -676,11 +676,7 @@ class _WandbInit:
                 logger.error("backend process timed out")
                 error_message = "Error communicating with wandb process"
                 if active_start_method != "fork":
-                    error_message += "\ntry: wandb.init(settings=wandb.Settings(start_method='fork'))"
-                    error_message += "\nor:  wandb.init(settings=wandb.Settings(start_method='thread'))"
-                    error_message += (
-                        f"\nFor more info see: {wburls.get('doc_start_err')}"
-                    )
+                    error_message += f"\nFor more info see: {wburls.get('doc_start_err')}"
             elif run_result.error:
                 error_message = run_result.error.message
             if error_message:

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -676,7 +676,9 @@ class _WandbInit:
                 logger.error("backend process timed out")
                 error_message = "Error communicating with wandb process"
                 if active_start_method != "fork":
-                    error_message += f"\nFor more info see: {wburls.get('doc_start_err')}"
+                    error_message += (
+                        f"\nFor more info see: {wburls.get('doc_start_err')}"
+                    )
             elif run_result.error:
                 error_message = run_result.error.message
             if error_message:


### PR DESCRIPTION
Description
-----------
thread mode and fork mode are often not useful right now.. wandb service should solve most of the conditions where this was required so lets not give an outdated suggestion but still point to the URL where we can update the content.

NOTE start_method != fork is the normal case.   We are not adding any more messaging for this release, instead just removing outdated messaging.

Testing
-------
Not tested