### PR TITLE
update pypi package readme shields

### DIFF
--- a/package_readme.md
+++ b/package_readme.md
@@ -2,7 +2,7 @@
   <img src="https://i.imgur.com/RUtiVzH.png" width="600" /><br><br>
 </div>
 
-# Weights and Biases [![ci](https://circleci.com/gh/wandb/wandb.svg?style=svg)](https://circleci.com/gh/wandb/wandb) [![pypi](https://img.shields.io/pypi/v/wandb.svg)](https://pypi.python.org/pypi/wandb) [![codecov](https://codecov.io/gh/wandb/wandb/branch/master/graph/badge.svg?token=41Iw2WzViQ)](https://codecov.io/gh/wandb/wandb)
+# Weights and Biases [![PyPI](https://img.shields.io/pypi/v/wandb)](https://pypi.python.org/pypi/wandb) [![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/wandb)](https://anaconda.org/conda-forge/wandb) [![CircleCI](https://img.shields.io/circleci/build/github/wandb/wandb/master)](https://circleci.com/gh/wandb/wandb) [![Codecov](https://img.shields.io/codecov/c/gh/wandb/wandb)](https://codecov.io/gh/wandb/wandb)
 
 Use W&B to build better models faster. Track and visualize all the pieces of your machine learning pipeline, from datasets to production models.
 


### PR DESCRIPTION
Description
-----------
We have two separate files for our readme,  update shields for the other one.
Note, this only updates the shields.  there were other things that are different in the readme that we should sync up or consolidate the files in the future.

I noticed the broken images here:
https://pypi.org/project/wandb/0.12.21/

<img width="888" alt="Screen Shot 2022-08-02 at 8 28 11 AM" src="https://user-images.githubusercontent.com/1832511/182413165-a2fe804d-124a-41b0-be27-b19863506e46.png">

Testing
-------
Not tested