### PR TITLE
fixup to #3975: make Artifact metadata JSON-encoding accept more types

### DIFF
--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1420,8 +1420,11 @@ class TestArtifactChecksMetadata:
     def test_validates_metadata_ok(
         self, create_artifact: Callable[..., wandb.Artifact]
     ):
-        assert create_artifact(metadata=None).metadata == {}
+        assert create_artifact(metadata=None).metadata in (None, {})
         assert create_artifact(metadata={"foo": "bar"}).metadata == {"foo": "bar"}
+        assert create_artifact(metadata={"foo": {"bar": [1, 2, (3, None)]}}).metadata == {"foo": {"bar": [1, 2, (3, None)]}}
+        assert create_artifact(metadata={"foo": np.arange(3)}).metadata == {"foo": [0, 1, 2]}
+        assert create_artifact(metadata={"foo": slice(4, 9, 2)}).metadata == {"foo": {"slice_start": 4, "slice_stop": 9, "slice_step": 2}}
 
     def test_validates_metadata_err(
         self, create_artifact: Callable[..., wandb.Artifact]

--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import os
+from typing import Any, Callable, Optional, Type
 import pytest
 from wandb import util
 import wandb
@@ -1335,7 +1336,7 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
 
         for setter in testable_setters_valid + testable_setters_invalid:
             with pytest.raises(ValueError):
-                setattr(art, setter, "TEST")
+                setattr(art, setter, setter_data.get(setter, setter))
 
         for method in testable_methods_valid + testable_methods_invalid:
             attr_method = getattr(art, method)
@@ -1349,7 +1350,7 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
             _ = getattr(art, getter)
 
         for setter in testable_setters_valid + testable_setters_invalid:
-            setattr(art, setter, "TEST")
+            setattr(art, setter, setter_data.get(setter, setter))
 
         for method in testable_methods_valid + testable_methods_invalid:
             attr_method = getattr(art, method)
@@ -1396,3 +1397,54 @@ def test_communicate_artifact(runner, publish_util, mocked_run):
         artifact_publish = dict(run=mocked_run, artifact=artifact, aliases=["latest"])
         ctx_util = publish_util(artifacts=[artifact_publish])
         assert len(set(ctx_util.manifests_created_ids)) == 1
+
+
+def _create_artifact_and_set_metadata(metadata):
+    artifact = wandb.Artifact("foo", "dataset")
+    artifact.metadata = metadata
+    return artifact
+
+
+# All these metadata-validation tests should behave identically
+# regardless of whether we set the metadata by passing it into the constructor
+# or by setting the attribute after creation; so, parametrize how we build the
+# artifact, and run tests both ways.
+@pytest.mark.parametrize(
+    "create_artifact",
+    [
+        lambda metadata: wandb.Artifact("foo", "dataset", metadata=metadata),
+        _create_artifact_and_set_metadata,
+    ],
+)
+class TestArtifactChecksMetadata:
+    def test_validates_metadata_ok(
+        self, create_artifact: Callable[..., wandb.Artifact]
+    ):
+        assert create_artifact(metadata=None).metadata == {}
+        assert create_artifact(metadata={"foo": "bar"}).metadata == {"foo": "bar"}
+
+    def test_validates_metadata_err(
+        self, create_artifact: Callable[..., wandb.Artifact]
+    ):
+        with pytest.raises(TypeError):
+            create_artifact(metadata=123)
+
+        with pytest.raises(TypeError):
+            create_artifact(metadata=[])
+
+        with pytest.raises(TypeError):
+            create_artifact(metadata={"unserializable": object()})
+
+    def test_deepcopies_metadata(self, create_artifact: Callable[..., wandb.Artifact]):
+        orig_metadata = {"foo": ["original"]}
+        artifact = create_artifact(metadata=orig_metadata)
+
+        # ensure `artifact.metadata` isn't just a reference to the argument
+        assert artifact.metadata is not orig_metadata
+        orig_metadata["bar"] = "modifying the top-level value"
+        assert "bar" not in artifact.metadata
+
+        # ensure that any mutable sub-values are also copies
+        assert artifact.metadata["foo"] is not orig_metadata["foo"]
+        orig_metadata["foo"].append("modifying the sub-value")
+        assert artifact.metadata["foo"] == ["original"]

--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1422,9 +1422,15 @@ class TestArtifactChecksMetadata:
     ):
         assert create_artifact(metadata=None).metadata in (None, {})
         assert create_artifact(metadata={"foo": "bar"}).metadata == {"foo": "bar"}
-        assert create_artifact(metadata={"foo": {"bar": [1, 2, (3, None)]}}).metadata == {"foo": {"bar": [1, 2, (3, None)]}}
-        assert create_artifact(metadata={"foo": np.arange(3)}).metadata == {"foo": [0, 1, 2]}
-        assert create_artifact(metadata={"foo": slice(4, 9, 2)}).metadata == {"foo": {"slice_start": 4, "slice_stop": 9, "slice_step": 2}}
+        assert create_artifact(
+            metadata={"foo": {"bar": [1, 2, (3, None)]}}
+        ).metadata == {"foo": {"bar": [1, 2, (3, None)]}}
+        assert create_artifact(metadata={"foo": np.arange(3)}).metadata == {
+            "foo": [0, 1, 2]
+        }
+        assert create_artifact(metadata={"foo": slice(4, 9, 2)}).metadata == {
+            "foo": {"slice_start": 4, "slice_stop": 9, "slice_step": 2}
+        }
 
     def test_validates_metadata_err(
         self, create_artifact: Callable[..., wandb.Artifact]

--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1420,7 +1420,7 @@ class TestArtifactChecksMetadata:
     def test_validates_metadata_ok(
         self, create_artifact: Callable[..., wandb.Artifact]
     ):
-        assert create_artifact(metadata=None).metadata in (None, {})
+        assert create_artifact(metadata=None).metadata == {}
         assert create_artifact(metadata={"foo": "bar"}).metadata == {"foo": "bar"}
         assert create_artifact(
             metadata={"foo": {"bar": [1, 2, (3, None)]}}

--- a/tests/unit_tests/wandb_artifacts_test.py
+++ b/tests/unit_tests/wandb_artifacts_test.py
@@ -1424,7 +1424,7 @@ class TestArtifactChecksMetadata:
         assert create_artifact(metadata={"foo": "bar"}).metadata == {"foo": "bar"}
         assert create_artifact(
             metadata={"foo": {"bar": [1, 2, (3, None)]}}
-        ).metadata == {"foo": {"bar": [1, 2, (3, None)]}}
+        ).metadata == {"foo": {"bar": [1, 2, [3, None]]}}
         assert create_artifact(metadata={"foo": np.arange(3)}).metadata == {
             "foo": [0, 1, 2]
         }

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -83,7 +83,7 @@ def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         return {}
     if not isinstance(metadata, dict):
         raise TypeError(f"metadata must be dict, not {type(metadata)}")
-    return cast(Dict[str, Any], json.loads(json.dumps(metadata)))
+    return cast(Dict[str, Any], json.loads(json.dumps(util.json_friendly_val(metadata))))
 
 
 class Artifact(ArtifactInterface):

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1,6 +1,7 @@
 import base64
 import contextlib
 import hashlib
+import json
 import os
 import pathlib
 import re
@@ -9,6 +10,7 @@ import tempfile
 import time
 from typing import (
     Any,
+    cast,
     Dict,
     Generator,
     IO,
@@ -76,6 +78,14 @@ class _AddedObj:
         self.obj = obj
 
 
+def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, dict):
+        raise TypeError(f"metadata must be dict, not {type(metadata)}")
+    return cast(Dict[str, Any], json.loads(json.dumps(metadata)))
+
+
 class Artifact(ArtifactInterface):
     """
     Flexible and lightweight building block for dataset and model versioning.
@@ -138,6 +148,7 @@ class Artifact(ArtifactInterface):
                 "Artifact name may only contain alphanumeric characters, dashes, underscores, and dots. "
                 'Invalid name: "%s"' % name
             )
+        metadata = _normalize_metadata(metadata)
         # TODO: this shouldn't be a property of the artifact. It's a more like an
         # argument to log_artifact.
         storage_layout = StorageLayout.V2
@@ -163,7 +174,7 @@ class Artifact(ArtifactInterface):
         self._type = type
         self._name = name
         self._description = description
-        self._metadata = metadata or {}
+        self._metadata = metadata
         self._distributed_id = None
         self._logged_artifact = None
         self._incremental = False
@@ -289,6 +300,7 @@ class Artifact(ArtifactInterface):
 
     @metadata.setter
     def metadata(self, metadata: dict) -> None:
+        metadata = _normalize_metadata(metadata)
         if self._logged_artifact:
             self._logged_artifact.metadata = metadata
             return

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -83,7 +83,9 @@ def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         return {}
     if not isinstance(metadata, dict):
         raise TypeError(f"metadata must be dict, not {type(metadata)}")
-    return cast(Dict[str, Any], json.loads(json.dumps(util.json_friendly_val(metadata))))
+    return cast(
+        Dict[str, Any], json.loads(json.dumps(util.json_friendly_val(metadata)))
+    )
 
 
 class Artifact(ArtifactInterface):


### PR DESCRIPTION
Description
-----------

Repro:
```python
import wandb, numpy as np
with wandb.init() as r:
  art = wandb.Artifact("foo", "bar", metadata={"a": np.arange(3)})
  r.log_artifact(art)
```

In v0.12.9: works as you’d expect, with the ndarray being turned into a… a list, I think ([example](https://wandb.ai/spencerpearson-wandb/client/artifacts/bar/foo/65cab3d178cdaa45648d)).

In v0.13.0rc6: `TypeError: Object of type ndarray is not JSON serializable`

This is because #3975 simply calls `json.dumps(metadata)` when it's normalizing the artifact metadata, which can't handle ndarrays; the "canonical" way for the metadata to get serialized is [here](https://github.com/wandb/client/blob/30f647881c3f46397fd90461b14a2531a9e04188/wandb/sdk/interface/interface.py#L380), using our `json_friendly_val` helper-function which can handle nonstandard types like that.

Testing
-------
Wrote some extra unit tests with non-JSON-serializable types to ensure they're normalized correctly.
