### PR TITLE
Improve naming of standalone tests

### DIFF
--- a/tests/functional_tests/t0_main/lightning/train_gpu_ddp.py
+++ b/tests/functional_tests/t0_main/lightning/train_gpu_ddp.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import pathlib
 
 from pl_base import BoringModel, RandomDataset
 from pytorch_lightning import Trainer
@@ -30,7 +31,10 @@ def main():
     # set up wandb
     config = dict(some_hparam="Logged Before Trainer starts DDP")
     wandb_logger = WandbLogger(
-        log_model=True, config=config, save_code=True, name=__file__
+        log_model=True,
+        config=config,
+        save_code=True,
+        name=pathlib.Path(__file__).stem,
     )
 
     # Initialize a trainer

--- a/tests/standalone_tests/artifact_tests.py
+++ b/tests/standalone_tests/artifact_tests.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import shutil
 import time
 
@@ -6,6 +7,7 @@ import numpy as np
 import wandb
 
 
+run_name_base = pathlib.Path(__file__).stem
 init_count = 1
 
 
@@ -41,7 +43,7 @@ def test_artifact_run_lookup_apis():
     artifact_2_name = f"a2-{str(time.time())}"
 
     # Initial setup
-    run_1 = wandb.init(name=f"{__file__}-{get_init_count()}")
+    run_1 = wandb.init(name=f"{run_name_base}-{get_init_count()}")
     artifact = wandb.Artifact(artifact_1_name, "test_type")
     artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image")
     run_1.log_artifact(artifact)
@@ -51,14 +53,14 @@ def test_artifact_run_lookup_apis():
     run_1.finish()
 
     # Create a second version for a1
-    run_2 = wandb.init(name=f"{__file__}-{get_init_count()}")
+    run_2 = wandb.init(name=f"{run_name_base}-{get_init_count()}")
     artifact = wandb.Artifact(artifact_1_name, "test_type")
     artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image")
     run_2.log_artifact(artifact)
     run_2.finish()
 
     # Use both
-    run_3 = wandb.init(name=f"{__file__}-{get_init_count()}")
+    run_3 = wandb.init(name=f"{run_name_base}-{get_init_count()}")
     a1 = run_3.use_artifact(artifact_1_name + ":latest")
     assert _runs_eq(a1.used_by(), [run_3])
     assert _run_eq(a1.logged_by(), run_2)
@@ -68,7 +70,7 @@ def test_artifact_run_lookup_apis():
     run_3.finish()
 
     # Use both
-    run_4 = wandb.init(name=f"{__file__}-{get_init_count()}")
+    run_4 = wandb.init(name=f"{run_name_base}-{get_init_count()}")
     a1 = run_4.use_artifact(artifact_1_name + ":latest")
     assert _runs_eq(a1.used_by(), [run_3, run_4])
     a2 = run_4.use_artifact(artifact_2_name + ":latest")
@@ -80,19 +82,19 @@ def test_artifact_creation_with_diff_type():
     artifact_name = f"a1-{str(time.time())}"
 
     # create
-    with wandb.init(name=f"{__file__}-{get_init_count()}") as run:
+    with wandb.init(name=f"{run_name_base}-{get_init_count()}") as run:
         artifact = wandb.Artifact(artifact_name, "artifact_type_1")
         artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image")
         run.log_artifact(artifact)
 
     # update
-    with wandb.init(name=f"{__file__}-{get_init_count()}") as run:
+    with wandb.init(name=f"{run_name_base}-{get_init_count()}") as run:
         artifact = wandb.Artifact(artifact_name, "artifact_type_1")
         artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image")
         run.log_artifact(artifact)
 
     # invalid
-    with wandb.init(name=f"{__file__}-{get_init_count()}") as run:
+    with wandb.init(name=f"{run_name_base}-{get_init_count()}") as run:
         artifact = wandb.Artifact(artifact_name, "artifact_type_2")
         artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image_2")
         did_err = False
@@ -106,7 +108,7 @@ def test_artifact_creation_with_diff_type():
             )
         assert did_err
 
-    with wandb.init(name=f"{__file__}-{get_init_count()}") as run:
+    with wandb.init(name=f"{run_name_base}-{get_init_count()}") as run:
         artifact = run.use_artifact(artifact_name + ":latest")
         # should work
         image = artifact.get("image")

--- a/tests/standalone_tests/basic.py
+++ b/tests/standalone_tests/basic.py
@@ -1,8 +1,10 @@
+import pathlib
+
 import wandb
 
 
 def main():
-    run = wandb.init(name=__file__)
+    run = wandb.init(name=pathlib.Path(__file__).stem)
     run.log({"boom": 1})
     run.finish()
 

--- a/tests/standalone_tests/basic_plots.py
+++ b/tests/standalone_tests/basic_plots.py
@@ -1,4 +1,5 @@
 import math
+import pathlib
 import random
 import sys
 
@@ -7,7 +8,7 @@ import wandb
 
 def main(argv):
     # wandb.init(entity="wandb", project="new-plots-test-5")
-    wandb.init(name=__file__)
+    wandb.init(name=pathlib.Path(__file__).stem)
     data = [[i, random.random() + math.sin(i / 10)] for i in range(100)]
     table = wandb.Table(data=data, columns=["step", "height"])
     line_plot = wandb.plot.line(

--- a/tests/standalone_tests/mixed_keras.py
+++ b/tests/standalone_tests/mixed_keras.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import keras  # noqa: F401
 import numpy as np
 import tensorflow as tf
@@ -6,7 +8,7 @@ from wandb.keras import WandbCallback
 
 
 def main():
-    wandb.init(name=__file__)
+    wandb.init(name=pathlib.Path(__file__).stem)
 
     model = tf.keras.models.Sequential()
     model.add(tf.keras.layers.Conv2D(3, 3, activation="relu", input_shape=(28, 28, 1)))

--- a/tests/standalone_tests/pytorch_cuda.py
+++ b/tests/standalone_tests/pytorch_cuda.py
@@ -1,9 +1,11 @@
+import pathlib
+
 import numpy as np
 import torch
 import wandb
 
 
-run = wandb.init(name=__file__)
+run = wandb.init(name=pathlib.Path(__file__).stem)
 run.log({"cuda_available": torch.cuda.is_available()})
 x = np.random.random((32, 100)).astype("f")
 t_cpu = torch.Tensor(x)

--- a/tests/standalone_tests/table_mem_test.py
+++ b/tests/standalone_tests/table_mem_test.py
@@ -1,3 +1,4 @@
+import pathlib
 import time
 
 from memory_profiler import profile
@@ -17,7 +18,7 @@ def main(count: int, size=(32, 32, 3)) -> wandb.Table:
 
 
 if __name__ == "__main__":
-    run = wandb.init(name=__file__)
+    run = wandb.init(name=pathlib.Path(__file__).stem)
     for c in range(4):
         cnt = 2 * (10**c)
         start = time.time()

--- a/tests/standalone_tests/tweets.py
+++ b/tests/standalone_tests/tweets.py
@@ -5,7 +5,7 @@ import wandb
 
 
 def main():
-    wandb.init(name=__file__)
+    wandb.init(name=pathlib.Path(__file__).stem)
 
     # Get a pandas DataFrame object of all the data in the csv file:
     df = pd.read_csv(pathlib.Path(__file__).parent.resolve() / "tweets.csv")


### PR DESCRIPTION
Description
-----------
This is triggered by this failure: https://app.circleci.com/pipelines/github/wandb/wandb/14444/workflows/5d5690eb-965b-4610-b388-cde425f3a81a/jobs/251907?invite=true#step-117-1693

Separately from this, this commit in PL https://github.com/Lightning-AI/lightning/commit/749709fb4fd467474b610cab7b70d6d02aa4789c would create pain for those using, say, slashes in their run names, so we should submit a PR to PL with a fix.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
