### PR TITLE
Adjust root_dir setting processing logic

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -11,6 +11,7 @@ import copy
 import json
 import logging
 import os
+import pathlib
 import platform
 import sys
 import tempfile
@@ -813,7 +814,7 @@ def _attach(
 
 def init(
     job_type: Optional[str] = None,
-    dir=None,
+    dir: Union[str, pathlib.Path, None] = None,
     config: Union[Dict, str, None] = None,
     project: Optional[str] = None,
     entity: Optional[str] = None,
@@ -844,7 +845,7 @@ def init(
     script, and each piece would be tracked as a run in W&B.
 
     `wandb.init()` spawns a new background process to log data to a run, and it
-    also syncs data to wandb.ai by default so you can see live visualizations.
+    also syncs data to wandb.ai by default, so you can see live visualizations.
 
     Call `wandb.init()` to start a run before logging data with `wandb.log()`:
     <!--yeadoc-test:init-method-log-->
@@ -928,10 +929,10 @@ def init(
         notes: (str, optional) A longer description of the run, like a `-m` commit
             message in git. This helps you remember what you were doing when you
             ran this run.
-        dir: (str, optional) An absolute path to a directory where metadata will
-            be stored. When you call `download()` on an artifact, this is the
-            directory where downloaded files will be saved. By default, this is
-            the `./wandb` directory.
+        dir: (str or pathlib.Path, optional) An absolute path to a directory where
+            metadata will be stored. When you call `download()` on an artifact,
+            this is the directory where downloaded files will be saved. By default,
+            this is the `./wandb` directory.
         resume: (bool, str, optional) Sets the resuming behavior. Options:
             `"allow"`, `"must"`, `"never"`, `"auto"` or `None`. Defaults to `None`.
             Cases:
@@ -964,7 +965,7 @@ def init(
             `wandb.config`.
         anonymous: (str, optional) Controls anonymous data logging. Options:
             - `"never"` (default): requires you to link your W&B account before
-                tracking the run so you don't accidentally create an anonymous
+                tracking the run, so you don't accidentally create an anonymous
                 run.
             - `"allow"`: lets a logged-in user track runs with their account, but
                 lets someone who is running the script without a W&B account see

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -605,6 +605,10 @@ class Settings:
                 "hook": lambda x: self._path_convert(self.wandb_dir, x),
             },
             resumed={"value": "False", "preprocessor": _str_as_bool},
+            root_dir={
+                "preprocessor": lambda x: str(x),
+                "value": os.path.abspath(os.getcwd()),
+            },
             run_mode={
                 "hook": lambda _: "offline-run" if self._offline else "run",
                 "auto_hook": True,
@@ -1072,10 +1076,6 @@ class Settings:
         # setup private attributes
         object.__setattr__(self, "_Settings_start_datetime", None)
         object.__setattr__(self, "_Settings_start_time", None)
-
-        if os.environ.get(wandb.env.DIR) is None:
-            # todo: double-check source, shouldn't it be Source.ENV?
-            self.update({"root_dir": os.path.abspath(os.getcwd())}, source=Source.BASE)
 
         # done with init, use self.update() to update attributes from now on
         self.__initialized = True


### PR DESCRIPTION
Description
-----------
Found in Sentry: https://sentry.io/organizations/weights-biases/issues/3167782210/?project=5288891&query=is%3Aunresolved+release%3A0.13.0&statsPeriod=14d

Apparently, two independent issues:
- We could be more forgiving and preprocess root_dir as a str so that people can use, e.g., pathlib.Path's
- We have some dubious logic in how we set up the default value for root_dir in Settings.

Repro:

```python
import pathlib

import wandb

run = wandb.init(dir=pathlib.Path("/Users/dimaduev/dev/rubbish"))
run.finish()

# or also:

run = wandb.init(settings=wandb.Settings(root_dir=pathlib.Path("/Users/dimaduev/dev/rubbish")))
run.finish()
```

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
