### PR TITLE
Tests/Examples for using define metric with gradients

### DIFF
--- a/tests/functional_tests/t0_main/torch/t4_mnist.yea
+++ b/tests/functional_tests/t0_main/torch/t4_mnist.yea
@@ -1,0 +1,28 @@
+plugin:
+  - wandb
+command:
+  program: train_mnist.py
+  args:
+    - --use-wandb
+    - --epochs
+    - "1"
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][config]: {}
+  - :op:>:
+    - :wandb:runs[0][summary][batch_loss]
+    - 0
+  - :wandb:runs[0][summary][gradients/embeddings.weight][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear1.bias][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear1.weight][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear2.bias][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear2.weight][_type]: histogram
+  - :wandb:runs[0][summary][parameters/embeddings.weight][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear1.bias][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear1.weight][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear2.bias][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear2.weight][_type]: histogram
+  - :wandb:runs[0][exitcode]: 0
+  - :op:contains:
+    - :wandb:runs[0][telemetry][3]  # feature
+    - 1  # watch

--- a/tests/functional_tests/t0_main/torch/t5_mnist_metric_grads.yea
+++ b/tests/functional_tests/t0_main/torch/t5_mnist_metric_grads.yea
@@ -1,0 +1,29 @@
+plugin:
+  - wandb
+command:
+  program: train_mnist.py
+  args:
+    - --use-wandb
+    - --use-wandb-define-metric
+    - --epochs
+    - "1"
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][config]: {}
+  - :op:>:
+    - :wandb:runs[0][summary][batch_loss]
+    - 0
+  - :wandb:runs[0][summary][gradients/embeddings.weight][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear1.bias][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear1.weight][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear2.bias][_type]: histogram
+  - :wandb:runs[0][summary][gradients/linear2.weight][_type]: histogram
+  - :wandb:runs[0][summary][parameters/embeddings.weight][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear1.bias][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear1.weight][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear2.bias][_type]: histogram
+  - :wandb:runs[0][summary][parameters/linear2.weight][_type]: histogram
+  - :wandb:runs[0][exitcode]: 0
+  - :op:contains:
+    - :wandb:runs[0][telemetry][3]  # feature
+    - 1  # watch

--- a/tests/functional_tests/t0_main/torch/train_mnist.py
+++ b/tests/functional_tests/t0_main/torch/train_mnist.py
@@ -1,0 +1,169 @@
+# torch example from:
+# https://github.com/pytorch/examples/blob/main/mnist/main.py
+from __future__ import print_function
+import argparse
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torchvision import datasets, transforms
+from torch.optim.lr_scheduler import StepLR
+import wandb
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def train(args, model, device, train_loader, optimizer, epoch):
+    model.train()
+    interval_step = 0
+    interval_losses = []
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+
+        if args.use_wandb:
+            wandb.log({"batch_loss": loss.item()})
+            interval_losses.append(loss.item())
+                
+        if batch_idx % args.log_interval == 0:
+            interval_step += 1
+            if args.use_wandb:
+                interval_loss = sum(interval_losses) / len(interval_losses)
+                wandb.log({"interval_loss": interval_loss, "interval_step": interval_step})
+                interval_losses = []
+            print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+                epoch, batch_idx * len(data), len(train_loader.dataset),
+                100. * batch_idx / len(train_loader), loss.item()))
+            if args.dry_run:
+                break
+
+
+def test(model, device, test_loader):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            test_loss += F.nll_loss(output, target, reduction='sum').item()  # sum up batch loss
+            pred = output.argmax(dim=1, keepdim=True)  # get the index of the max log-probability
+            correct += pred.eq(target.view_as(pred)).sum().item()
+
+    test_loss /= len(test_loader.dataset)
+
+    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
+        test_loss, correct, len(test_loader.dataset),
+        100. * correct / len(test_loader.dataset)))
+
+
+def main():
+    # Training settings
+    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for training (default: 64)')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing (default: 1000)')
+    parser.add_argument('--epochs', type=int, default=14, metavar='N',
+                        help='number of epochs to train (default: 14)')
+    parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
+                        help='learning rate (default: 1.0)')
+    parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
+                        help='Learning rate step gamma (default: 0.7)')
+    parser.add_argument('--no-cuda', action='store_true', default=False,
+                        help='disables CUDA training')
+    parser.add_argument('--dry-run', action='store_true', default=False,
+                        help='quickly check a single pass')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    parser.add_argument('--log-interval', type=int, default=10, metavar='N',
+                        help='how many batches to wait before logging training status')
+    parser.add_argument('--save-model', action='store_true', default=False,
+                        help='For Saving the current Model')
+    parser.add_argument('--use-wandb', action='store_true', default=False,
+                        help='Use W&B Experiment tracking')
+    parser.add_argument('--use-wandb-define-metric', action='store_true', default=False,
+                        help='Use W&B Experiment tracking')
+    args = parser.parse_args()
+    use_cuda = not args.no_cuda and torch.cuda.is_available()
+
+    torch.manual_seed(args.seed)
+
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    train_kwargs = {'batch_size': args.batch_size}
+    test_kwargs = {'batch_size': args.test_batch_size}
+    if use_cuda:
+        cuda_kwargs = {'num_workers': 1,
+                       'pin_memory': True,
+                       'shuffle': True}
+        train_kwargs.update(cuda_kwargs)
+        test_kwargs.update(cuda_kwargs)
+
+    transform=transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+        ])
+    dataset1 = datasets.MNIST('../data', train=True, download=True,
+                       transform=transform)
+    dataset2 = datasets.MNIST('../data', train=False,
+                       transform=transform)
+    train_loader = torch.utils.data.DataLoader(dataset1,**train_kwargs)
+    test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
+
+
+    model = Net().to(device)
+    optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
+
+    if args.use_wandb:
+        run = wandb.init()
+
+        if args.use_wandb_define_metric:
+            # no need to display interval_step chart
+            run.define_metric("interval_step", hidden=True)
+            # gradients and interval_loss are output aligned with intervals
+            run.define_metric("interval_loss", step_metric="interval_step")
+            run.define_metric("gradients/*", step_metric="interval_step", step_sync=True)
+
+        run.watch(model, log="gradients", log_freq=args.log_interval)
+
+    scheduler = StepLR(optimizer, step_size=1, gamma=args.gamma)
+    for epoch in range(1, args.epochs + 1):
+        train(args, model, device, train_loader, optimizer, epoch)
+        test(model, device, test_loader)
+        scheduler.step()
+
+    if args.save_model:
+        torch.save(model.state_dict(), "mnist_cnn.pt")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
Create an example that uses define_metric to control how W&B displays gradients.

Usage:
```
python train_mnist.py --use-wandb --use-wandb-define-metric --epochs 1 
```

The above script will train mnist for a single epoch, logging loss every batch.   But every log_interval (by default 10) it will log interval_loss metric (average for those 10 batches) as well as the gradients at that batch.

Simple metrics:
<img width="1122" alt="Screen Shot 2022-08-05 at 8 22 39 AM" src="https://user-images.githubusercontent.com/1832511/183109160-bd6d9627-32ff-47a0-9e46-8f7b364e05a7.png">

- ✅ The left most plot shows the x-axis being interval_step instead of step
- ❌ The middle plot shows interval_step being plotted against step, this should have been hidden

Gradient metrics:
<img width="778" alt="Screen Shot 2022-08-05 at 8 23 53 AM" src="https://user-images.githubusercontent.com/1832511/183109439-e84a1470-003b-4f88-8882-313f3ce7f51b.png">

- ❌ Both gradient plots are shown plotted against step, they should be plotted against interval_step

Manually editing the panel, you can change the step axis to be correct:
<img width="468" alt="Screen Shot 2022-08-05 at 8 26 10 AM" src="https://user-images.githubusercontent.com/1832511/183109928-fcd0a7e1-aa2c-4139-9730-a942743e4cf5.png">

Here it is with only the first plot manually changed:
<img width="784" alt="Screen Shot 2022-08-05 at 8 26 23 AM" src="https://user-images.githubusercontent.com/1832511/183109995-54d18307-5342-4070-a66f-17f751b08e26.png">

Here is the run that was generated and manually edited to generate the above screen shots:
https://wandb.ai/jeffr/wandb-tests_functional_tests_t0_main_torch/runs/ehe3cmm1

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
