### PR TITLE
Added explicit error message for double uri/docker-image [WB-10302]

### DIFF
--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -187,6 +187,8 @@ def validate_launch_spec_source(launch_spec: Dict[str, Any]) -> None:
 
     if not bool(uri) and not bool(job) and not bool(docker_image):
         raise LaunchError("Must specify a uri, job or docker image")
+    elif bool(uri) and bool(docker_image):
+        raise LaunchError("Found both uri and docker-image, only one can be set")
     elif sum(map(bool, [uri, job, docker_image])) > 1:
         raise LaunchError("Must specify exactly one of uri, job or image")
 


### PR DESCRIPTION
Fixes WB-10302

Description
-----------
One-Liner improved error messaging for entering both a URI and docker image path

Testing
-------
Sending both or one or none and getting my fancy new error message. 