### PR TITLE
Addresses WB-10134, grabs environment var in  (probably not the best …

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1182,6 +1182,9 @@ def launch(
     elif resource is None:
         resource = "local-container"
 
+    # Grab WANDB_RUN_ID env var here? or in proj
+    run_id = config.get("run_id") or os.environ.get("WANDB_RUN_ID")
+
     if queue is None:
         # direct launch
         try:
@@ -1201,6 +1204,7 @@ def launch(
                 config=config,
                 synchronous=(not run_async),
                 cuda=cuda,
+                run_id=run_id,
             )
         except LaunchError as e:
             logger.error("=== %s ===", e)
@@ -1225,6 +1229,7 @@ def launch(
             args_dict,
             resource_args,
             cuda=cuda,
+            run_id=run_id,
         )
 
 

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -216,6 +216,7 @@ def get_env_vars_dict(launch_project: LaunchProject, api: Api) -> Dict[str, str]
     env_vars["WANDB_API_KEY"] = api.api_key
     env_vars["WANDB_PROJECT"] = launch_project.target_project
     env_vars["WANDB_ENTITY"] = launch_project.target_entity
+    env_vars["WANDB_NAME"] = launch_project.name
     env_vars["WANDB_LAUNCH"] = "True"
     env_vars["WANDB_RUN_ID"] = launch_project.run_id
     if launch_project.docker_image:


### PR DESCRIPTION
…place for it)

Fixes WB-10134

Description
-----------
Picks up `run_id` from environment variables (`WANDB_RUN_ID`) in the cli, not sure how to effectively confirm this works from launches in other locations...

Propagates the `WANDB_NAME` through to docker env vars so that it changes the display name of a run. 

Testing
-------
Testing suite + manual cli incantations, including from config file. 