### PR TITLE
Fix for coverage tool and new circle config

### DIFF
--- a/tools/coverage-tool.py
+++ b/tools/coverage-tool.py
@@ -76,14 +76,14 @@ def matrix_expand(loc_dict_tuple_list):
             product = itertools.product(*groups)
             product = list(product)
             for subs in product:
+                data = copy.deepcopy(containing_dict)
+                toxenv = data["toxenv"]
                 for k, v in subs:
-                    data = copy.deepcopy(containing_dict)
-                    toxenv = data["toxenv"]
                     replace = f"<<matrix.{k}>>"
                     assert replace in toxenv, f"Cant find {replace} in {toxenv}"
-                    toxenv = toxenv.replace(replace, v)
-                    data["toxenv"] = toxenv
-                    ret.append((location, data))
+                    toxenv = toxenv.replace(replace, str(v))
+                data["toxenv"] = toxenv
+                ret.append((location, data))
         else:
             ret.append((location, containing_dict))
     return ret


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
What does the PR do?

jobs list:
```
% ./tools/coverage-tool.py jobs                                                                                                                                                                                         (unmock-server-coverage-tool)wandb
workflows.main.jobs.1.pytest   py36,covercircle
workflows.main.jobs.1.pytest   py37,covercircle
workflows.main.jobs.1.pytest   py38,covercircle
workflows.main.jobs.1.pytest   py39,covercircle
workflows.main.jobs.1.pytest   py310,covercircle
workflows.main.jobs.2.tox-base py36,covercircle
workflows.main.jobs.2.tox-base py37,covercircle
workflows.main.jobs.2.tox-base py38,covercircle
workflows.main.jobs.2.tox-base py39,covercircle
workflows.main.jobs.2.tox-base py310,covercircle
workflows.main.jobs.3.tox-base func-s_base-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_sklearn-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_metaflow-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_tf115-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_tf21-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_tf25-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_tf26-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_ray112-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_ray2-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_service-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_noml-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_grpc-py37,func-covercircle
workflows.main.jobs.3.tox-base func-s_docs-py37,func-covercircle
workflows.main.jobs.6.win.0    py37,wincovercircle -- --timeout 300 tests/unit_tests_new
workflows.main.jobs.6.win.1    py37,wincovercircle -- --timeout 300 tests/unit_tests_new
workflows.main.jobs.6.win.2    py37,wincovercircle -- --timeout 300 tests/unit_tests_new
workflows.main.jobs.6.win.3    py37,wincovercircle -- --timeout 300 tests/unit_tests_new
workflows.main.jobs.7.mac.0    py39,covercircle
workflows.main.jobs.7.mac.1    py39,covercircle
workflows.main.jobs.7.mac.2    py39,covercircle
workflows.main.jobs.7.mac.3    py39,covercircle
workflows.main.jobs.8.launch   pylaunch,covercircle
workflows.main.jobs.9.tox-base unit-s_nb-py36,unit-covercircle
```

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
