### PR TITLE
Reduce the `pytest` job parallelism from 10 to 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
         default: false
       xdist:
         type: integer
-        default: 8
+        default: 6
     docker:
       - image: "python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>"
       - image: gcr.io/wandb-production/local-testcontainer:<< pipeline.parameters.wandb_server_tag >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,9 @@ jobs:
       notify_on_failure:
         type: boolean
         default: false
+      xdist:
+        type: integer
+        default: 8
     docker:
       - image: "python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>"
       - image: gcr.io/wandb-production/local-testcontainer:<< pipeline.parameters.wandb_server_tag >>
@@ -294,6 +297,7 @@ jobs:
           name: Run tests
           no_output_timeout: 10m
           command: |
+            CI_PYTEST_PARALLEL=<< parameters.xdist >> \
             tox -v -e <<parameters.toxenv>>  \
               -- --wandb-server-tag << pipeline.parameters.wandb_server_tag >> tests/unit_tests
       - save-test-results


### PR DESCRIPTION
Description
-----------
What does the PR do?

This PR reduces the `pytest` parallelism from 10 to 6 in the hopes to make CircleCi happier

Testing
-------
How was this PR tested?

Hopefully over time the flake should be reduced

