### PR TITLE
[WB-10593] Launch kubernetes support taints and tolerations

### DIFF
--- a/tests/unit_tests_old/tests_launch/test_launch_kubernetes.py
+++ b/tests/unit_tests_old/tests_launch/test_launch_kubernetes.py
@@ -245,6 +245,7 @@ def test_launch_kube(
                 "preemption_policy": "Never",
                 "node_name": "test-node-name",
                 "node_selectors": {"test-selector": "test-value"},
+                "tolerations": [{"key": "test-key", "value": "test-value"}],
             },
         },
     }
@@ -269,6 +270,7 @@ def test_launch_kube(
     assert job.spec.template.spec.restart_policy == args["restart_policy"]
     assert job.spec.template.spec.preemption_policy == args["preemption_policy"]
     assert job.spec.template.spec.node_name == args["node_name"]
+    assert job.spec.template.spec.tolerations == args["tolerations"]
     assert (
         job.spec.template.spec.node_selector["test-selector"]
         == args["node_selectors"]["test-selector"]

--- a/wandb/sdk/launch/runner/kubernetes.py
+++ b/wandb/sdk/launch/runner/kubernetes.py
@@ -167,6 +167,8 @@ class KubernetesRunner(AbstractRunner):
             pod_spec["nodeName"] = resource_args.get("node_name")
         if resource_args.get("node_selectors"):
             pod_spec["nodeSelectors"] = resource_args.get("node_selectors")
+        if resource_args.get("tolerations"):
+            pod_spec["tolerations"] = resource_args.get("tolerations")
 
     def populate_container_resources(
         self, containers: List[Dict[str, Any]], resource_args: Dict[str, Any]


### PR DESCRIPTION
[Fixes WB-10593](https://wandb.atlassian.net/browse/WB-10593)
Fixes #NNNN

Description
-----------
Adds handling for a tolerations key in the kubernetes runner which can be used for taints and tolerations

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
