### PR TITLE
Fix func sklearn (need kwargs)

### DIFF
--- a/tests/functional_tests/t0_main/sacred/t1_regression.py
+++ b/tests/functional_tests/t0_main/sacred/t1_regression.py
@@ -20,6 +20,6 @@ def run(c, gamma):
     per = permutation(iris.target.size)
     iris.data = iris.data[per]
     iris.target = iris.target[per]
-    clf = svm.SVC(c, "rbf", gamma=gamma)
+    clf = svm.SVC(C=c, kernel="rbf", gamma=gamma)
     clf.fit(iris.data[:90], iris.target[:90])
     return clf.score(iris.data[90:], iris.target[90:])


### PR DESCRIPTION
Description
-----------
Fix failure due to sklearn update:
```
INFO - iris_rbf_svm - Running command 'run'
INFO - iris_rbf_svm - Started
ERROR - iris_rbf_svm - Failed after 0:00:00!
Traceback (most recent calls WITHOUT Sacred internals):
  File "./t1_regression.py", line 23, in run
    clf = svm.SVC(c, "rbf", gamma=gamma)
TypeError: __init__() takes 1 positional argument but 3 positional arguments (and 1 keyword-only argument) were given
```

Testing
-------
Tested manually:
```
Results:
--------
  0.sacred.1: 😃

Test durations (sec):
---------------------
  0.sacred.1: 21.1
```