### PR TITLE
feat(sweeps): Look for launch job in sweep config

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -884,6 +884,15 @@ def sweep(
             wandb.termerror(_msg)
             raise LaunchError(_msg)
 
+        # Try and get job from sweep config
+        _job = config.get("job", None)
+        if _job is None:
+            wandb.termlog("No job found in sweep config, looking in launch config.")
+            _job = launch_config.get("job", None)
+            if _job is None:
+                wandb.termlog("No job found in launch config, using placeholder.")
+                _job = "placeholder-job"
+
         # Launch job spec for the Scheduler
         _launch_scheduler_spec = json.dumps(
             {
@@ -911,7 +920,7 @@ def sweep(
                             "--project",
                             project,
                             "--job",
-                            launch_config.get("job", "placeholder-job"),
+                            _job,
                             "--resource",
                             launch_config.get("resource", "local-process"),
                             # TODO(hupo): Add num-workers as option in launch config


### PR DESCRIPTION
Fixes WB-10606

Description
-----------
When running a sweep via the CLI, the `job` field can now be specified both in the sweep config and the launch config (with the sweep config taking precedence).

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
