### PR TITLE
fix default test container tag

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -630,8 +630,7 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--wandb-server-tag",
-        # default="master",
-        default="fix-fixture-teardown",
+        default="master",
         help="Image tag to use for the wandb server",
     )
 


### PR DESCRIPTION
Description
-----------
What does the PR do?

This PR fixes an oversight from the unit test conftest, so the default value of the dev test container point to the lates version from master (affected only tests locally)

Testing
-------
How was this PR tested?

Shouldn't make a difference