### PR TITLE
Fix summary handling in conftest.py

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -945,8 +945,6 @@ class Context:
         # we can have multiple runs saved to context,
         # so we need to group by run id and take the
         # last one for each run.
-        print(_summary)
-        print(_summary.groupby("__run_id").last())
         self._summary = (
             _summary.groupby("__run_id").last().reset_index(level=["__run_id"])
         )
@@ -989,11 +987,12 @@ class Context:
         # and extract the first (and only) row.
         mask_run = self.summary["__run_id"] == run_id
         run_summary = self.summary[mask_run]
-        return (
+        ret = (
             run_summary.filter(regex="^[^_]", axis=1)
             if not include_private
             else run_summary
-        ).to_dict(orient="records")[0]
+        ).to_dict(orient="records")
+        return ret[0] if len(ret) > 0 else {}
 
     def get_run_history(
         self, run_id: str, include_private: bool = False

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -945,11 +945,10 @@ class Context:
         # we can have multiple runs saved to context,
         # so we need to group by run id and take the
         # last one for each run.
+        print(_summary)
+        print(_summary.groupby("__run_id").last())
         self._summary = (
-            _summary.groupby("__run_id")
-            .apply(lambda x: x.tail(1))
-            .droplevel("__run_id")
-            .reset_index(drop=True)
+            _summary.groupby("__run_id").last().reset_index(level=["__run_id"])
         )
 
         return deepcopy(self._summary)

--- a/tests/unit_tests/test_keras_full.py
+++ b/tests/unit_tests/test_keras_full.py
@@ -68,7 +68,7 @@ def test_basic_keras(dummy_model, dummy_data, relay_server, wandb_init):
     summary = relay.context.get_run_summary(run_id)
 
     assert history["epoch"][0] == 0
-    assert len(graph_json(run_dir, summary["graph"][0])["nodes"]) == 3
+    assert len(graph_json(run_dir, summary["graph"])["nodes"]) == 3
 
 
 def test_keras_telemetry(dummy_model, dummy_data, relay_server, wandb_init):

--- a/tests/unit_tests/test_keras_full.py
+++ b/tests/unit_tests/test_keras_full.py
@@ -249,8 +249,7 @@ def test_dataset_functional(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run.id)
     assert (
-        graph_json(run_dir, summary["graph"][0])["nodes"][0]["class_name"]
-        == "InputLayer"
+        graph_json(run_dir, summary["graph"])["nodes"][0]["class_name"] == "InputLayer"
     )
 
 

--- a/tests/unit_tests/test_metric_full.py
+++ b/tests/unit_tests/test_metric_full.py
@@ -1,7 +1,6 @@
 """
 metric full tests.
 """
-import pytest
 
 
 def test_metric_default(relay_server, wandb_init):

--- a/tests/unit_tests/test_metric_full.py
+++ b/tests/unit_tests/test_metric_full.py
@@ -4,7 +4,6 @@ metric full tests.
 import pytest
 
 
-@pytest.mark.xfail(reason="TODO: fix this test")
 def test_metric_default(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -19,10 +18,10 @@ def test_metric_default(relay_server, wandb_init):
     summary = relay.context.get_run_summary(run_id)
 
     # by default, we use last value
-    assert summary["val"][0] == 3
-    assert summary["val2"][0] == 1
-    assert summary["mystep"][0] == 3
-    assert len(summary.columns) == 3
+    assert summary["val"] == 3
+    assert summary["val2"] == 1
+    assert summary["mystep"] == 3
+    assert len(summary) == 3
 
 
 def test_metric_copy(relay_server, wandb_init):
@@ -39,10 +38,10 @@ def test_metric_copy(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val"][0] == 3
-    assert summary["val2"][0] == 1
-    assert summary["mystep"][0] == 3
-    assert len(summary.columns) == 3
+    assert summary["val"] == 3
+    assert summary["val2"] == 1
+    assert summary["mystep"] == 3
+    assert len(summary) == 3
 
 
 def test_metric_glob_none(relay_server, wandb_init):
@@ -60,10 +59,10 @@ def test_metric_glob_none(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val2"][0] == 1
-    assert summary["mystep"][0] == 3
-    assert len(summary.columns) == 2
-    assert "val" not in summary.columns
+    assert summary["val2"] == 1
+    assert summary["mystep"] == 3
+    assert len(summary) == 2
+    assert "val" not in summary
 
 
 def test_metric_glob(relay_server, wandb_init):
@@ -76,9 +75,9 @@ def test_metric_glob(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val"][0] == 2
-    assert summary["mystep"][0] == 1
-    assert len(summary.columns) == 2
+    assert summary["val"] == 2
+    assert summary["mystep"] == 1
+    assert len(summary) == 2
 
 
 def test_metric_nosummary(relay_server, wandb_init):
@@ -92,8 +91,8 @@ def test_metric_nosummary(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val2"][0] == 1
-    assert len(summary.columns) == 1
+    assert summary["val2"] == 1
+    assert len(summary) == 1
 
 
 def test_metric_none(relay_server, wandb_init):
@@ -107,8 +106,8 @@ def test_metric_none(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert "val2" not in summary.columns
-    assert len(summary.columns) == 0
+    assert "val2" not in summary
+    assert len(summary) == 0
 
 
 def test_metric_sum_none(relay_server, wandb_init):
@@ -126,10 +125,10 @@ def test_metric_sum_none(relay_server, wandb_init):
     summary = relay.context.get_run_summary(run_id)
 
     # if we set a metric, last is NOT disabled
-    assert summary["val"][0] == 3
-    assert summary["val2"][0] == 1
-    assert summary["mystep"][0] == 1
-    assert len(summary.columns) == 3
+    assert summary["val"] == 3
+    assert summary["val2"] == 1
+    assert summary["mystep"] == 1
+    assert len(summary) == 3
 
 
 def test_metric_max(relay_server, wandb_init):
@@ -145,9 +144,9 @@ def test_metric_max(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val"][0] == {"max": 8}
-    assert summary["mystep"][0] == 1
-    assert len(summary.columns) == 2
+    assert summary["val"] == {"max": 8}
+    assert summary["mystep"] == 1
+    assert len(summary) == 2
 
 
 def test_metric_min(relay_server, wandb_init):
@@ -163,9 +162,9 @@ def test_metric_min(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val"][0] == {"min": 2}
-    assert summary["mystep"][0] == 1
-    assert len(summary.columns) == 2
+    assert summary["val"] == {"min": 2}
+    assert summary["mystep"] == 1
+    assert len(summary) == 2
 
 
 def test_metric_last(relay_server, wandb_init):
@@ -181,9 +180,9 @@ def test_metric_last(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val"][0] == {"last": 3}
-    assert summary["mystep"][0] == 1
-    assert len(summary.columns) == 2
+    assert summary["val"] == {"last": 3}
+    assert summary["mystep"] == 1
+    assert len(summary) == 2
 
 
 def _gen_metric_sync_step(run):
@@ -207,9 +206,9 @@ def test_metric_no_sync_step(relay_server, wandb_init):
     history = relay.context.get_run_history(run_id)
     metrics = relay.context.get_run_metrics(run_id)
 
-    assert summary["val"][0] == {"min": 2}
-    assert summary["val2"][0] == 8
-    assert summary["mystep"][0] == 5
+    assert summary["val"] == {"min": 2}
+    assert summary["val2"] == 8
+    assert summary["mystep"] == 5
 
     history_val = history[history["val"].notnull()][["val", "mystep"]].reset_index(
         drop=True
@@ -234,9 +233,9 @@ def test_metric_sync_step(relay_server, wandb_init):
     metrics = relay.context.get_run_metrics(run_id)
     telemetry = relay.context.get_run_telemetry(run_id)
 
-    assert summary["val"][0] == {"min": 2}
-    assert summary["val2"][0] == 8
-    assert summary["mystep"][0] == 5
+    assert summary["val"] == {"min": 2}
+    assert summary["val2"] == 8
+    assert summary["mystep"] == 5
 
     history_val = history[history["val"].notnull()][["val", "mystep"]].reset_index(
         drop=True
@@ -292,7 +291,7 @@ def test_metric_nan_mean(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val"][0] == {"mean": 3}
+    assert summary["val"] == {"mean": 3}
 
 
 def test_metric_nan_min_norm(relay_server, wandb_init):
@@ -319,7 +318,7 @@ def test_metric_nan_min_more(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["val"][0] == {"min": 4}
+    assert summary["val"] == {"min": 4}
 
 
 def test_metric_nested_default(relay_server, wandb_init):
@@ -333,7 +332,7 @@ def test_metric_nested_default(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["this"][0] == {"that": 4}
+    assert summary["this"] == {"that": 4}
 
 
 def test_metric_nested_copy(relay_server, wandb_init):
@@ -348,7 +347,7 @@ def test_metric_nested_copy(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["this"][0] == {"that": 4}
+    assert summary["this"] == {"that": 4}
 
 
 def test_metric_nested_min(relay_server, wandb_init):
@@ -363,7 +362,7 @@ def test_metric_nested_min(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
 
-    assert summary["this"][0] == {"that": {"min": 2}}
+    assert summary["this"] == {"that": {"min": 2}}
 
 
 def test_metric_nested_mult(relay_server, wandb_init):
@@ -379,7 +378,7 @@ def test_metric_nested_mult(relay_server, wandb_init):
     summary = relay.context.get_run_summary(run_id)
     metrics = relay.context.get_run_metrics(run_id)
 
-    assert summary["this"][0] == {"that": {"min": 2, "max": 4}}
+    assert summary["this"] == {"that": {"min": 2, "max": 4}}
     assert metrics and len(metrics) == 1
     assert metrics[0] == {"1": "this.that", "7": [1, 2], "6": [3]}
 
@@ -398,7 +397,7 @@ def test_metric_dotted(relay_server, wandb_init):
     summary = relay.context.get_run_summary(run_id)
     metrics = relay.context.get_run_metrics(run_id)
 
-    assert summary["this.that"][0] == {"min": 2}
+    assert summary["this.that"] == {"min": 2}
     assert len(metrics) == 1
     assert metrics[0] == {"1": "this\\.that", "7": [1], "6": [3]}
 
@@ -416,7 +415,7 @@ def test_metric_nested_glob(relay_server, wandb_init):
     summary = relay.context.get_run_summary(run_id)
     metrics = relay.context.get_run_metrics(run_id)
 
-    assert summary["this"][0] == {"that": {"min": 2, "max": 4}}
+    assert summary["this"] == {"that": {"min": 2, "max": 4}}
     assert len(metrics) == 1
     assert metrics[0] == {"1": "this.that", "7": [1, 2]}
 

--- a/tests/unit_tests/test_metric_internal.py
+++ b/tests/unit_tests/test_metric_internal.py
@@ -29,11 +29,11 @@ def test_metric_none(relay_server, user, publish_util, mock_run):
         publish_util(run=run, history=history)
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == 3
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == 3
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_step(relay_server, user, publish_util, mock_run):
@@ -47,11 +47,11 @@ def test_metric_step(relay_server, user, publish_util, mock_run):
         publish_util(run=run, metrics=metrics, history=history)
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == 3
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == 3
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_max(relay_server, user, publish_util, mock_run):
@@ -65,11 +65,11 @@ def test_metric_max(relay_server, user, publish_util, mock_run):
         publish_util(run=run, metrics=metrics, history=history)
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == {"max": 8}
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == {"max": 8}
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_min(relay_server, user, publish_util, mock_run):
@@ -83,11 +83,11 @@ def test_metric_min(relay_server, user, publish_util, mock_run):
         publish_util(run=run, metrics=metrics, history=history)
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == {"min": 2}
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == {"min": 2}
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_min_str(relay_server, user, publish_util, mock_run):
@@ -101,10 +101,10 @@ def test_metric_min_str(relay_server, user, publish_util, mock_run):
         publish_util(run=run, metrics=metrics, history=history)
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == 3
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == 3
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_sum_none(relay_server, user, publish_util, mock_run):
@@ -116,12 +116,11 @@ def test_metric_sum_none(relay_server, user, publish_util, mock_run):
         publish_util(run=run, history=history, metrics=metrics)
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
-
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == 3
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == 3
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_mult(relay_server, user, publish_util, mock_run):
@@ -138,11 +137,11 @@ def test_metric_mult(relay_server, user, publish_util, mock_run):
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
 
-    assert summary.v1[0] == {"max": 3}
-    assert summary.v2[0] == {"min": 2}
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == {"max": 3}
+    assert summary["v2"] == {"min": 2}
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_again(relay_server, user, publish_util, mock_run):
@@ -159,11 +158,11 @@ def test_metric_again(relay_server, user, publish_util, mock_run):
     summary = relay.context.get_run_summary(run.id, include_private=True)
     metrics = relay.context.get_run_metrics(run.id)
 
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == 3
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == 3
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
     assert metrics and len(metrics) == 3
 
 
@@ -179,11 +178,11 @@ def test_metric_mean(relay_server, user, publish_util, mock_run):
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
 
-    assert summary.v1[0] == 2
-    assert summary.v2[0] == {"mean": 13.0 / 3}
-    assert summary.v3[0] == "pizza"
-    assert summary.mystep[0] == 3
-    assert summary._step[0] == 2
+    assert summary["v1"] == 2
+    assert summary["v2"] == {"mean": 13.0 / 3}
+    assert summary["v3"] == "pizza"
+    assert summary["mystep"] == 3
+    assert summary["_step"] == 2
 
 
 def test_metric_stepsync(relay_server, user, publish_util, mock_run):
@@ -309,8 +308,8 @@ def test_metric_glob_twice_over(relay_server, user, publish_util, mock_run):
     assert metrics and len(metrics) == 1
     assert metrics[0] == {"1": "metric", "7": [1]}
 
-    assert summary.metric[0] == {"min": 1}
-    assert summary._step[0] == 0
+    assert summary["metric"] == {"min": 1}
+    assert summary["_step"] == 0
 
 
 def test_metric_nan_max(relay_server, user, publish_util, mock_run):
@@ -328,7 +327,7 @@ def test_metric_nan_max(relay_server, user, publish_util, mock_run):
         publish_util(run=run, metrics=metrics, history=history)
 
     summary = relay.context.get_run_summary(run.id)
-    assert summary.v2[0] == {"max": 8}
+    assert summary["v2"] == {"max": 8}
 
 
 def test_metric_dot_flat_escaped(relay_server, user, publish_util, mock_run):
@@ -356,7 +355,7 @@ def test_metric_dot_flat_escaped(relay_server, user, publish_util, mock_run):
     assert summary["this.also"][0] == {"max": 2}
     assert summary["nodots"][0] == 2
     assert summary["this.has.dots"][0] == 2
-    assert summary._step[0] == 3
+    assert summary["_step"] == 3
 
 
 def test_metric_dot_flat_notescaped(relay_server, user, publish_util, mock_run):
@@ -381,10 +380,10 @@ def test_metric_dot_flat_notescaped(relay_server, user, publish_util, mock_run):
     assert metrics and len(metrics) == 1
     assert metrics[0] == {"1": "this.also", "7": [2]}
 
-    assert summary["this.also"][0] == 1
-    assert summary["nodots"][0] == 2
-    assert summary["this.has.dots"][0] == 2
-    assert summary._step[0] == 3
+    assert summary["this.also"] == 1
+    assert summary["nodots"] == 2
+    assert summary["this.has.dots"] == 2
+    assert summary["_step"] == 3
 
 
 # def test_metric_dot_step_sync(publish_util):
@@ -425,7 +424,7 @@ def test_metric_dot_glob(relay_server, user, publish_util, mock_run):
     assert metrics[0] == {"1": "this\\.also", "7": [2], "6": [3]}
     assert metrics[1] == {"1": "this\\.has\\.dots", "7": [1]}
     assert metrics[2] == {"1": "nodots", "7": [1]}
-    assert summary["this.also"][0] == {"max": 2}
-    assert summary["this.has.dots"][0] == {"min": 2}
-    assert summary["nodots"][0] == {"min": 3}
-    assert summary["_step"][0] == 3
+    assert summary["this.also"] == {"max": 2}
+    assert summary["this.has.dots"] == {"min": 2}
+    assert summary["nodots"] == {"min": 3}
+    assert summary["_step"] == 3

--- a/tests/unit_tests/test_metric_internal.py
+++ b/tests/unit_tests/test_metric_internal.py
@@ -229,9 +229,9 @@ def test_metric_stepsync(relay_server, user, publish_util, mock_run):
     summary = relay.context.get_run_summary(run.id, include_private=True)
     history = relay.context.get_run_history(run.id)
 
-    assert summary.s1[0] == 8
-    assert summary.a1[0] == 9
-    assert summary._step[0] == 5
+    assert summary["s1"] == 8
+    assert summary["a1"] == 9
+    assert summary["_step"] == 5
 
     history_val = history[history["a1"].notnull()].reset_index(drop=True)
     assert history_val.a1.tolist() == [1, 3, 5, 7, 9]
@@ -352,9 +352,9 @@ def test_metric_dot_flat_escaped(relay_server, user, publish_util, mock_run):
     assert metrics and len(metrics) == 1
     assert metrics[0] == {"1": r"this\.also", "7": [2]}
 
-    assert summary["this.also"][0] == {"max": 2}
-    assert summary["nodots"][0] == 2
-    assert summary["this.has.dots"][0] == 2
+    assert summary["this.also"] == {"max": 2}
+    assert summary["nodots"] == 2
+    assert summary["this.has.dots"] == 2
     assert summary["_step"] == 3
 
 

--- a/tests/unit_tests/test_mp_full.py
+++ b/tests/unit_tests/test_mp_full.py
@@ -30,9 +30,9 @@ def test_multiproc_default(relay_server, wandb_init):
         run.finish()
 
     summary = relay.context.get_run_summary(run.id)
-    assert summary.val.values[-1] == 3
-    assert summary.val2.values[-1] == 1
-    assert summary.mystep.values[-1] == 3
+    assert summary["val"] == 3
+    assert summary["val2"] == 1
+    assert summary["mystep"] == 3
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="fork needed")
@@ -69,9 +69,9 @@ def test_multiproc_ignore(relay_server, wandb_init):
         run.finish()
 
     summary = relay.context.get_run_summary(run.id)
-    assert summary.val.values[-1] == 3
-    assert summary.val2.values[-1] == 1
-    assert summary.mystep.values[-1] == 3
+    assert summary["val"] == 3
+    assert summary["val2"] == 1
+    assert summary["mystep"] == 3
 
 
 @pytest.mark.flaky
@@ -110,9 +110,9 @@ def test_multiproc_strict(relay_server, wandb_init):
         run.finish()
 
     summary = relay.context.get_run_summary(run.id)
-    assert summary.val.values[-1] == 3
-    assert summary.val2.values[-1] == 1
-    assert summary.mystep.values[-1] == 3
+    assert summary["val"] == 3
+    assert summary["val2"] == 1
+    assert summary["mystep"] == 3
 
 
 def test_multiproc_strict_bad(test_settings):

--- a/tests/unit_tests/test_runtime.py
+++ b/tests/unit_tests/test_runtime.py
@@ -56,4 +56,4 @@ def test_runtime(relay_server, publish_util, mock_run, end_cb, lower_bound, user
         publish_util(run=run, end_cb=end_cb, initial_start=True)
 
     summary = relay.context.get_run_summary(run.id, include_private=True)
-    assert summary["_wandb"].values[-1]["runtime"] >= lower_bound
+    assert summary["_wandb"]["runtime"] >= lower_bound

--- a/tests/unit_tests/test_start_method.py
+++ b/tests/unit_tests/test_start_method.py
@@ -17,7 +17,7 @@ def test_default(relay_server, wandb_init):
 
     summary = relay.context.get_run_summary(run_id)
     telemetry = relay.context.get_run_telemetry(run_id)
-    assert summary["val"][0] == 1
+    assert summary["val"] == 1
     assert telemetry and 5 in telemetry.get("8", [])
 
 


### PR DESCRIPTION
Description
-----------
This PR addresses a major source of flake in the refactored (`pytest`) unit tests.

TLDR:
Run summary may be updated multiple times during a test, but we are only interested in the last one.
We can have multiple runs saved to the relay server context, so we need to group by run id and take the last one for each run.

The `pandas` magic applied is the following:
```python
>>> import pandas as pd
>>> df = pd.DataFrame.from_records([{"_run": 1}, {"_run": 1, "a": 1}, {"_run": 2},{"_run": 2, "a": 2}])
>>> df
   _run    a
0     1  NaN
1     1  1.0
2     2  NaN
3     2  2.0
>>> df.groupby("_run").last().reset_index(level=["_run"])
   _run    a
0     1  1.0
1     2  2.0
```

Finally, run summary DataFrame must have only one row for the given run id, so in `Context.get_run_summary` we convert the summary to dict and extract the first (and only) row.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
