### PR TITLE
Remove `buildx` version pin for nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ commands:
       - setup_remote_docker:
           version: 20.10.12
           docker_layer_caching: << parameters.docker_layer_caching >>
-      - run: apk add docker-cli-buildx=0.9.0-r0  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+      - run: apk add docker-cli-buildx --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
   setup_gcloud:
     parameters:


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
What does the PR do?

Testing
-------
Ran the manual nightly suite and it worked! :)
https://app.circleci.com/pipelines/github/wandb/wandb/15065/workflows/57f66cc8-bd8f-4843-8848-ac6a30b42356

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
