### PR TITLE
Adds debug mode for `pytest` unit tests

### DIFF
--- a/tests/unit_tests/test_keras_full.py
+++ b/tests/unit_tests/test_keras_full.py
@@ -274,7 +274,6 @@ def test_keras_log_weights(dummy_model, dummy_data, relay_server, wandb_init):
     assert history["parameters/dense.weights"][0]["_type"] == "histogram"
 
 
-@pytest.mark.xfail(reason="flaky")
 def test_keras_log_gradients(dummy_model, dummy_data, relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()

--- a/tests/unit_tests/test_torch_full.py
+++ b/tests/unit_tests/test_torch_full.py
@@ -221,7 +221,6 @@ def test_sequence_net(wandb_init):
     run.finish()
 
 
-@pytest.mark.xfail(reason="TODO: [Errno 24] Too many open files on darwin")
 def test_multi_net(wandb_init):
     run = wandb_init()
     net1 = ConvNet()


### PR DESCRIPTION
Description
-----------
In this PR:
- Provision an admin user to use with the app when running `pytest` tests. Users generated per requesting test are not removed at the end of the test so that developers can inspect the app with the admin account at the end of the test session.
<img width="630" alt="image" src="https://user-images.githubusercontent.com/7557205/186047780-decf97bc-4be7-45e5-93e6-76de4a4b5f92.png">
- Unset global wandb objects at the end of each test to improve isolation.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
