### PR TITLE
Push test-results to circle for nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -832,7 +832,7 @@ jobs:
                   # grab result data
                   echo "Grab results"
                   echo "DEBUG cp << parameters.pod_name >>:/home/sdk/wandb/test-results"
-                  kublectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
+                  kubectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
                   echo "Grab results done"
 
                   kubectl logs << parameters.pod_name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -883,6 +883,10 @@ jobs:
                   echo "Pod for << parameters.image_name >> exited with code ${exit_code}"
                   exit ${exit_code}
                 no_output_timeout: "20m"
+            - store_test_results:
+                path: test-results
+            - store_artifacts:
+                path: test-results
             - run:
                 name: "Delete the pod"
                 when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,8 +806,7 @@ jobs:
                   done
                 no_output_timeout: "5m"
             - run:
-                # todo: make getting the exit_code more robust: add check for "commands succeeded"
-                name: "Wait for tests to finish, get pod logs, and parse exit code"
+                name: "Wait for tests to finish"
                 command: |
                   sleep 30
 
@@ -828,30 +827,16 @@ jobs:
                     echo
                     sleep << parameters.sleep_time >>
                   done
-
+                no_output_timeout: "20m"
+            - run:
+                name: "Grab results"
+                command: |
                   # grab result data
-                  echo "Grab results"
-                  echo "DEBUG cp << parameters.pod_name >>:/home/sdk/wandb/test-results"
-                  kubectl describe po
-                  kubectl describe pv
-                  kubectl describe pvc
-                  bash -c pwd
-                  ls -l
-                  echo "hello0"
+                  echo "Launch attach pod to get results..."
                   kubectl create -f << parameters.path >>/attach.yaml
-                  echo "hello"
-                  kubectl describe po
-                  kubectl describe pv
-                  kubectl describe pvc
-                  echo "hello2"
-                  kubectl describe po
-                  echo "hello33"
-                  kubectl get pods | grep attachpod
-                  echo "hello44"
-
                   while true; do
                     kubectl get pods
-                    pod_state=$(kubectl get pods | grep attachpod)
+                    pod_state=$(kubectl get pods | grep attach-pod)
                     if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
                       echo "Attach Pod for << parameters.image_name >> is running"
                       break
@@ -860,7 +845,7 @@ jobs:
                       break
                     elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
                       echo "Attach Pod for << parameters.image_name >> is in an error state"
-                      kubectl logs attachpod
+                      kubectl logs attach-pod
                       echo "About to exit"
                       exit 1
                     fi
@@ -868,15 +853,14 @@ jobs:
                     echo
                     sleep << parameters.sleep_time >>
                   done
-
-                  echo "hello3"
-                  kubectl cp attachpod:/wandb-store/test-results .
-                  echo "cp_done"
-                  kubectl delete pod attachpod
-                  ls -l
-                  # kubectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
-                  echo "Grab results done"
-
+                  echo "Copy results from pod..."
+                  kubectl cp attach-pod:/wandb-store/test-results .
+                no_output_timeout: "10m"
+            - run:
+                # todo: make getting the exit_code more robust: add check for "commands succeeded"
+                name: "Get pod logs and parse exit code"
+                command: |
+                  kubectl delete pod attach-pod
                   kubectl logs << parameters.pod_name >>
                   logs=`kubectl logs << parameters.pod_name >>`
                   exit_code=`echo $(echo $logs | grep -c "commands failed")`
@@ -892,7 +876,8 @@ jobs:
                 when: always
                 command: |
                   kubectl get pods
-                  kubectl delete -f << parameters.path >>/<< parameters.pod_config_name >>
+                  kubectl delete -f << parameters.path >>/<< parameters.pod_config_name >> || echo "Problem deleting pod"
+                  kubectl delete -f << parameters.path >>/attach.pod || echo "Problem deleting attach pod"
             # conditionally post a notification to slack if the job failed/succeeded
             - when:
                 condition: << parameters.notify_on_failure >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,10 @@ jobs:
                   done
 
                   # grab result data
+                  echo "Grab results"
+                  echo "DEBUG cp << parameters.pod_name >>:/home/sdk/wandb/test-results"
                   kublectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
+                  echo "Grab results done"
 
                   kubectl logs << parameters.pod_name >>
                   logs=`kubectl logs << parameters.pod_name >>`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,7 +851,7 @@ jobs:
 
                   while true; do
                     kubectl get pods
-                    pod_state=$(kubectl get pods | grep attachpod
+                    pod_state=$(kubectl get pods | grep attachpod)
                     if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
                       echo "Pod for << parameters.image_name >> is running"
                       break

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -841,7 +841,10 @@ jobs:
                   echo "Pod for << parameters.image_name >> exited with code ${exit_code}"
                   exit ${exit_code}
                 no_output_timeout: "20m"
-            - save-test-results
+            - store_artifacts:
+                path: "/tmp/store-cpu/test-results"
+            - store_test_results:
+                path: "/tmp/store-cpu/test-results"
             - run:
                 name: "Delete the pod"
                 when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,12 +829,16 @@ jobs:
                     sleep << parameters.sleep_time >>
                   done
 
+                  # grab result data
+                  kublectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
+
                   kubectl logs << parameters.pod_name >>
                   logs=`kubectl logs << parameters.pod_name >>`
                   exit_code=`echo $(echo $logs | grep -c "commands failed")`
                   echo "Pod for << parameters.image_name >> exited with code ${exit_code}"
                   exit ${exit_code}
                 no_output_timeout: "20m"
+            - save-test-results
             - run:
                 name: "Delete the pod"
                 when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,10 +830,10 @@ jobs:
                   done
 
                   # grab result data
-                  echo "Grab results"
-                  echo "DEBUG cp << parameters.pod_name >>:/home/sdk/wandb/test-results"
-                  kubectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
-                  echo "Grab results done"
+                  # echo "Grab results"
+                  # echo "DEBUG cp << parameters.pod_name >>:/home/sdk/wandb/test-results"
+                  # kubectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
+                  # echo "Grab results done"
 
                   kubectl logs << parameters.pod_name >>
                   logs=`kubectl logs << parameters.pod_name >>`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -838,8 +838,14 @@ jobs:
                   bash -c pwd
                   ls -l
                   kubectl create -f << parameters.path >>/attach.yaml
-                  kubectl cp attach-pvc:/wandb-store/test-results .
-                  kubectl delete pod attach-pvc
+                  echo "hello"
+                  kubectl describe po
+                  kubectl describe pv
+                  kubectl describe pvc
+                  echo "hello2"
+                  kubectl cp attachpod:/wandb-store/test-results .
+                  echo "cp_done"
+                  kubectl delete pod attachpod
                   ls -l
                   # kubectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
                   echo "Grab results done"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -836,7 +836,7 @@ jobs:
                   kubectl create -f << parameters.path >>/attach.yaml
                   while true; do
                     kubectl get pods
-                    pod_state=$(kubectl get pods | grep cpu-pod-attach-pod)
+                    pod_state=$(kubectl get pods | grep << parameters.pod_name >>-attach-pod)
                     if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
                       echo "Attach Pod for << parameters.image_name >> is running"
                       break
@@ -845,7 +845,7 @@ jobs:
                       break
                     elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
                       echo "Attach Pod for << parameters.image_name >> is in an error state"
-                      kubectl logs cpu-pod-attach-pod
+                      kubectl logs << parameters.pod_name >>-attach-pod
                       echo "About to exit"
                       exit 1
                     fi
@@ -855,13 +855,14 @@ jobs:
                   done
                   echo "Copy results from pod..."
                   mkdir -p results/<< parameters.pod_name >>
-                  kubectl cp cpu-pod-attach-pod:/wandb-store/test-results results/<< parameters.pod_name >>
+                  kubectl cp << parameters.pod_name >>-attach-pod:/wandb-store/test-results results/<< parameters.pod_name >>
+                  echo "Delete attach pod..."
+                  kubectl delete pod << parameters.pod_name >>-attach-pod
                 no_output_timeout: "10m"
             - run:
                 # todo: make getting the exit_code more robust: add check for "commands succeeded"
                 name: "Get pod logs and parse exit code"
                 command: |
-                  kubectl delete pod cpu-pod-attach-pod
                   kubectl logs << parameters.pod_name >>
                   logs=`kubectl logs << parameters.pod_name >>`
                   exit_code=`echo $(echo $logs | grep -c "commands failed")`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,6 +837,7 @@ jobs:
                   kubectl describe pvc
                   bash -c pwd
                   ls -l
+                  echo "hello0"
                   kubectl create -f << parameters.path >>/attach.yaml
                   echo "hello"
                   kubectl describe po

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -836,7 +836,7 @@ jobs:
                   kubectl create -f << parameters.path >>/attach.yaml
                   while true; do
                     kubectl get pods
-                    pod_state=$(kubectl get pods | grep attach-pod)
+                    pod_state=$(kubectl get pods | grep cpu-pod-attach-pod)
                     if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
                       echo "Attach Pod for << parameters.image_name >> is running"
                       break
@@ -845,7 +845,7 @@ jobs:
                       break
                     elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
                       echo "Attach Pod for << parameters.image_name >> is in an error state"
-                      kubectl logs attach-pod
+                      kubectl logs cpu-pod-attach-pod
                       echo "About to exit"
                       exit 1
                     fi
@@ -854,14 +854,14 @@ jobs:
                     sleep << parameters.sleep_time >>
                   done
                   echo "Copy results from pod..."
-                  mkdir results/<< parameters.pod_name >>
-                  kubectl cp attach-pod:/wandb-store/test-results results/<< parameters.pod_name >>
+                  mkdir -p results/<< parameters.pod_name >>
+                  kubectl cp cpu-pod-attach-pod:/wandb-store/test-results results/<< parameters.pod_name >>
                 no_output_timeout: "10m"
             - run:
                 # todo: make getting the exit_code more robust: add check for "commands succeeded"
                 name: "Get pod logs and parse exit code"
                 command: |
-                  kubectl delete pod attach-pod
+                  kubectl delete pod cpu-pod-attach-pod
                   kubectl logs << parameters.pod_name >>
                   logs=`kubectl logs << parameters.pod_name >>`
                   exit_code=`echo $(echo $logs | grep -c "commands failed")`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -861,6 +861,7 @@ jobs:
                     elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
                       echo "Attach Pod for << parameters.image_name >> is in an error state"
                       kubectl logs attachpod
+                      echo "About to exit"
                       exit 1
                     fi
                     echo "Sleeping for << parameters.sleep_time >> seconds"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,7 +837,9 @@ jobs:
                   kubectl describe pvc
                   bash -c pwd
                   ls -l
-                  kubectl cp << parameters.pod_name >>:pv-demo:test-results .
+                  kubectl create -f << parameters.path >>/attach.yaml
+                  kubectl cp attach-pvc:/wandb-store/test-results .
+                  kubectl delete pod attach-pvc
                   ls -l
                   # kubectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
                   echo "Grab results done"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -854,7 +854,8 @@ jobs:
                     sleep << parameters.sleep_time >>
                   done
                   echo "Copy results from pod..."
-                  kubectl cp attach-pod:/wandb-store/test-results .
+                  mkdir results/<< parameters.pod_name >>
+                  kubectl cp attach-pod:/wandb-store/test-results results/<< parameters.pod_name >>
                 no_output_timeout: "10m"
             - run:
                 # todo: make getting the exit_code more robust: add check for "commands succeeded"
@@ -868,9 +869,10 @@ jobs:
                   exit ${exit_code}
                 no_output_timeout: "20m"
             - store_test_results:
-                path: test-results
+                path: results/<< parameters.pod_name >>/test-results
             - store_artifacts:
-                path: test-results
+                path: results/<< parameters.pod_name >>/test-results
+                destination: test-results
             - run:
                 name: "Delete the pod"
                 when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,10 +830,17 @@ jobs:
                   done
 
                   # grab result data
-                  # echo "Grab results"
-                  # echo "DEBUG cp << parameters.pod_name >>:/home/sdk/wandb/test-results"
+                  echo "Grab results"
+                  echo "DEBUG cp << parameters.pod_name >>:/home/sdk/wandb/test-results"
+                  kubectl describe po
+                  kubectl describe pv
+                  kubectl describe pvc
+                  bash -c pwd
+                  ls -l
+                  kubectl cp << parameters.pod_name >>:pv-demo:test-results .
+                  ls -l
                   # kubectl cp << parameters.pod_name >>:/home/sdk/wandb/test-results .
-                  # echo "Grab results done"
+                  echo "Grab results done"
 
                   kubectl logs << parameters.pod_name >>
                   logs=`kubectl logs << parameters.pod_name >>`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,14 +853,14 @@ jobs:
                     kubectl get pods
                     pod_state=$(kubectl get pods | grep attachpod)
                     if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
-                      echo "Pod for << parameters.image_name >> is running"
+                      echo "Attach Pod for << parameters.image_name >> is running"
                       break
                     elif [ "$(echo "$pod_state" | grep -c 'Completed')" -eq "1" ]; then
-                      echo "Pod for << parameters.image_name >> has completed"
+                      echo "Attach Pod for << parameters.image_name >> has completed"
                       break
                     elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
-                      echo "Pod for << parameters.image_name >> is in an error state"
-                      kubectl logs << parameters.pod_name >>
+                      echo "Attach Pod for << parameters.image_name >> is in an error state"
+                      kubectl logs attachpod
                       exit 1
                     fi
                     echo "Sleeping for << parameters.sleep_time >> seconds"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -841,10 +841,6 @@ jobs:
                   echo "Pod for << parameters.image_name >> exited with code ${exit_code}"
                   exit ${exit_code}
                 no_output_timeout: "20m"
-            - store_artifacts:
-                path: "/tmp/store-cpu/test-results"
-            - store_test_results:
-                path: "/tmp/store-cpu/test-results"
             - run:
                 name: "Delete the pod"
                 when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -844,6 +844,31 @@ jobs:
                   kubectl describe pv
                   kubectl describe pvc
                   echo "hello2"
+                  kubectl describe po
+                  echo "hello33"
+                  kubectl get pods | grep attachpod
+                  echo "hello44"
+
+                  while true; do
+                    kubectl get pods
+                    pod_state=$(kubectl get pods | grep attachpod
+                    if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> is running"
+                      break
+                    elif [ "$(echo "$pod_state" | grep -c 'Completed')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> has completed"
+                      break
+                    elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> is in an error state"
+                      kubectl logs << parameters.pod_name >>
+                      exit 1
+                    fi
+                    echo "Sleeping for << parameters.sleep_time >> seconds"
+                    echo
+                    sleep << parameters.sleep_time >>
+                  done
+
+                  echo "hello3"
                   kubectl cp attachpod:/wandb-store/test-results .
                   echo "cp_done"
                   kubectl delete pod attachpod

--- a/tests/functional_tests/t0_main/perf/t1_basic.yea
+++ b/tests/functional_tests/t0_main/perf/t1_basic.yea
@@ -1,7 +1,7 @@
 plugin:
   - wandb
 tag:
-  shard: standalone-cpu-perf
+  shard: standalone-cpu
 profile:
   - :wandb:import
   - :wandb:init

--- a/tests/functional_tests/t0_main/perf/t1_basic.yea
+++ b/tests/functional_tests/t0_main/perf/t1_basic.yea
@@ -1,7 +1,7 @@
 plugin:
   - wandb
 tag:
-  shard: standalone-cpu
+  shard: standalone-cpu-perf
 profile:
   - :wandb:import
   - :wandb:init

--- a/tests/standalone_tests/shards/gke_cpu/Dockerfile
+++ b/tests/standalone_tests/shards/gke_cpu/Dockerfile
@@ -46,4 +46,4 @@ RUN PATH=/home/sdk/.local/bin:$PATH
 WORKDIR /wandb/wandb
 ENV DATE=$UTC_DATE
 #CMD ["tail", "-f", "/dev/null"]
-CMD ["python", "-m", "tox", "-v", "-e", "standalone-cpu-py38,store"]
+CMD ["python", "-m", "tox", "-v", "-e", "standalone-cpu-py38,pod-store"]

--- a/tests/standalone_tests/shards/gke_cpu/Dockerfile
+++ b/tests/standalone_tests/shards/gke_cpu/Dockerfile
@@ -46,4 +46,4 @@ RUN PATH=/home/sdk/.local/bin:$PATH
 WORKDIR /wandb/wandb
 ENV DATE=$UTC_DATE
 #CMD ["tail", "-f", "/dev/null"]
-CMD ["python", "-m", "tox", "-v", "-e", "standalone-cpu-py38"]
+CMD ["python", "-m", "tox", "-v", "-e", "standalone-cpu-py38,store"]

--- a/tests/standalone_tests/shards/gke_cpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/attach.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "attach-pod"
+  name: "cpu-pod-attach-pod"
 spec:
   restartPolicy: Never
   containers:
-  - name: "attach-container"
+  - name: "cpu-pod-attach-container"
     image: "alpine:latest"
     command: ["/bin/sh"]
     args: ["-c", "sleep 600"]
     volumeMounts:
-    - name: my-persistent-volumeclaim-name
+    - name: cpu-pod-results-volumeclaim-name
       mountPath: "/wandb-store"
   volumes:
-    - name: my-persistent-volumeclaim-name
+    - name: cpu-pod-results-volumeclaim-name
       persistentVolumeClaim:
-       claimName: my-persistent-volumeclaim
+       claimName: cpu-pod-results-volumeclaim

--- a/tests/standalone_tests/shards/gke_cpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/attach.yaml
@@ -6,7 +6,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: "attachcont"
-    image: "debian"
+    image: "alpine:latest"
     command: ["/bin/sh"]
     args: ["-c", "sleep 600"]
     volumeMounts:

--- a/tests/standalone_tests/shards/gke_cpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/attach.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "attachpod"
+  name: "attach-pod"
 spec:
   restartPolicy: Never
   containers:
-  - name: "attachcont"
+  - name: "attach-container"
     image: "alpine:latest"
     command: ["/bin/sh"]
     args: ["-c", "sleep 600"]

--- a/tests/standalone_tests/shards/gke_cpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/attach.yaml
@@ -6,8 +6,9 @@ spec:
   restartPolicy: Never
   containers:
   - name: "attachcont"
-    image: "alpine:latest"
-    command: ["/bin/bash", "-c", "sleep infinity"]   
+    image: "debian"
+    command: ["/bin/sh"]
+    args: ["-c", "sleep 600"]
     volumeMounts:
     - name: my-persistent-volumeclaim-name
       mountPath: "/wandb-store"

--- a/tests/standalone_tests/shards/gke_cpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/attach.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "attach-pvc"
+  name: "attachpod"
 spec:
   containers:
   - name: attach

--- a/tests/standalone_tests/shards/gke_cpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/attach.yaml
@@ -3,8 +3,9 @@ kind: Pod
 metadata:
   name: "attachpod"
 spec:
+  restartPolicy: Never
   containers:
-  - name: attach
+  - name: "attachcont"
     image: "alpine:latest"
     command: ["/bin/bash", "-c", "sleep infinity"]   
     volumeMounts:

--- a/tests/standalone_tests/shards/gke_cpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/attach.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "attach-pvc"
+spec:
+  containers:
+  - name: attach
+    image: "alpine:latest"
+    command: ["/bin/bash", "-c", "sleep infinity"]   
+    volumeMounts:
+    - name: my-persistent-volumeclaim-name
+      mountPath: "/wandb-store"
+  volumes:
+    - name: my-persistent-volumeclaim-name
+      persistentVolumeClaim:
+       claimName: my-persistent-volumeclaim

--- a/tests/standalone_tests/shards/gke_cpu/pod.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/pod.yaml
@@ -17,12 +17,18 @@ spec:
         requests:
           cpu: 3.5
       volumeMounts:
-        - mountPath: /tmp/store
-          name: results-volume-cpu
+        - mountPath: /wandb-store
+          name: wandb-store-cpu
   volumes:
-    - name: results-volume-cpu
-      hostPath:
-        # directory location on host
-        path: /tmp/store-cpu
-        # this field is optional
-        type: DirectoryOrCreate
+    - name: wandb-store-cpu
+      ephemeral:
+        volumeClaimTemplate:
+          metadata:
+            labels:
+              type: my-frontend-volume
+          spec:
+            accessModes: [ "ReadWriteOnce" ]
+            storageClassName: "scratch-storage-class"
+            resources:
+              requests:
+                storage: 1Gi

--- a/tests/standalone_tests/shards/gke_cpu/pod.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/pod.yaml
@@ -16,3 +16,13 @@ spec:
           cpu: 3.999
         requests:
           cpu: 3.5
+      volumeMounts:
+        - mountPath: /results
+          name: results-volume-cpu
+  volumes:
+    - name: results-volume-cpu
+      hostPath:
+        # directory location on host
+        path: /results-cpu
+        # this field is optional
+        type: DirectoryOrCreate

--- a/tests/standalone_tests/shards/gke_cpu/pod.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/pod.yaml
@@ -3,10 +3,8 @@ kind: PersistentVolume
 apiVersion: v1
 metadata:
   name: cpu-pod-results-volume
-  labels:
-    type: nfs
 spec:
-  storageClassName: pv-demo
+  storageClassName: cpu-pod-pv
   capacity:
     storage: 1Gi
   accessModes:
@@ -20,7 +18,7 @@ apiVersion: v1
 metadata:
   name: cpu-pod-results-volumeclaim
 spec:
-  storageClassName: pv-demo
+  storageClassName: cpu-pod-pv
   accessModes:
     - ReadWriteOnce
   resources:
@@ -40,7 +38,6 @@ spec:
       env:
         - name: WANDB_API_KEY
           value: WANDB_API_KEY_PLACEHOLDER
-#      command: ["tail", "-f", "/dev/null"]
       resources:
         limits:
           cpu: 3.999

--- a/tests/standalone_tests/shards/gke_cpu/pod.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/pod.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: my-persistent-volume
+  name: cpu-pod-results-volume
   labels:
     type: nfs
 spec:
@@ -18,7 +18,7 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: my-persistent-volumeclaim
+  name: cpu-pod-results-volumeclaim
 spec:
   storageClassName: pv-demo
   accessModes:
@@ -48,8 +48,8 @@ spec:
           cpu: 3.5
       volumeMounts:
         - mountPath: "/wandb-store"
-          name: my-persistent-volumeclaim-name
+          name: cpu-pod-results-volumeclaim-name
   volumes:
-    - name: my-persistent-volumeclaim-name
+    - name: cpu-pod-results-volumeclaim-name
       persistentVolumeClaim:
-       claimName: my-persistent-volumeclaim
+       claimName: cpu-pod-results-volumeclaim

--- a/tests/standalone_tests/shards/gke_cpu/pod.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/pod.yaml
@@ -17,12 +17,12 @@ spec:
         requests:
           cpu: 3.5
       volumeMounts:
-        - mountPath: /results
+        - mountPath: /tmp/store
           name: results-volume-cpu
   volumes:
     - name: results-volume-cpu
       hostPath:
         # directory location on host
-        path: /results-cpu
+        path: /tmp/store-cpu
         # this field is optional
         type: DirectoryOrCreate

--- a/tests/standalone_tests/shards/gke_cpu/pod.yaml
+++ b/tests/standalone_tests/shards/gke_cpu/pod.yaml
@@ -1,5 +1,35 @@
+---
+kind: PersistentVolume
 apiVersion: v1
+metadata:
+  name: my-persistent-volume
+  labels:
+    type: nfs
+spec:
+  storageClassName: pv-demo
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: my-persistent-volumeclaim
+spec:
+  storageClassName: pv-demo
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+
+---
 kind: Pod
+apiVersion: v1
 metadata:
   name: cpu-pod
 spec:
@@ -17,18 +47,9 @@ spec:
         requests:
           cpu: 3.5
       volumeMounts:
-        - mountPath: /wandb-store
-          name: wandb-store-cpu
+        - mountPath: "/wandb-store"
+          name: my-persistent-volumeclaim-name
   volumes:
-    - name: wandb-store-cpu
-      ephemeral:
-        volumeClaimTemplate:
-          metadata:
-            labels:
-              type: my-frontend-volume
-          spec:
-            accessModes: [ "ReadWriteOnce" ]
-            storageClassName: "scratch-storage-class"
-            resources:
-              requests:
-                storage: 1Gi
+    - name: my-persistent-volumeclaim-name
+      persistentVolumeClaim:
+       claimName: my-persistent-volumeclaim

--- a/tests/standalone_tests/shards/gke_gpu/Dockerfile
+++ b/tests/standalone_tests/shards/gke_gpu/Dockerfile
@@ -55,4 +55,4 @@ WORKDIR /wandb/wandb
 RUN sed -i -e 's/whl\/cpu/whl\/cu113/g' tox.ini
 ENV DATE=$UTC_DATE
 #CMD ["tail", "-f", "/dev/null"]
-CMD ["python", "-m", "tox", "-v", "-e", "standalone-gpu-py38"]
+CMD ["python", "-m", "tox", "-v", "-e", "standalone-gpu-py38,pod-store"]

--- a/tests/standalone_tests/shards/gke_gpu/attach.yaml
+++ b/tests/standalone_tests/shards/gke_gpu/attach.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "gpu-pod-attach-pod"
+spec:
+  restartPolicy: Never
+  containers:
+  - name: "gpu-pod-attach-container"
+    image: "alpine:latest"
+    command: ["/bin/sh"]
+    args: ["-c", "sleep 600"]
+    volumeMounts:
+    - name: gpu-pod-results-volumeclaim-name
+      mountPath: "/wandb-store"
+  volumes:
+    - name: gpu-pod-results-volumeclaim-name
+      persistentVolumeClaim:
+       claimName: gpu-pod-results-volumeclaim

--- a/tests/standalone_tests/shards/gke_gpu/pod.yaml
+++ b/tests/standalone_tests/shards/gke_gpu/pod.yaml
@@ -1,5 +1,33 @@
+---
+kind: PersistentVolume
 apiVersion: v1
+metadata:
+  name: gpu-pod-results-volume
+spec:
+  storageClassName: gpu-pod-pv
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: gpu-pod-results-volumeclaim
+spec:
+  storageClassName: gpu-pod-pv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+
+---
 kind: Pod
+apiVersion: v1
 metadata:
   name: gpu-pod
 spec:
@@ -10,13 +38,16 @@ spec:
       env:
         - name: WANDB_API_KEY
           value: WANDB_API_KEY_PLACEHOLDER
-  #    command: ["tail", "-f", "/dev/null"]
-      # do not restart the container if it exits
       resources:
         limits:
           cpu: 3.999
           nvidia.com/gpu: 2
         requests:
           cpu: 3.5
-  #    ports:
-  #    - containerPort: 80
+      volumeMounts:
+        - mountPath: "/wandb-store"
+          name: gpu-pod-results-volumeclaim-name
+  volumes:
+    - name: gpu-pod-results-volumeclaim-name
+      persistentVolumeClaim:
+       claimName: gpu-pod-results-volumeclaim

--- a/tox.ini
+++ b/tox.ini
@@ -516,7 +516,7 @@ whitelist_externals =
 commands =
     mkdir -p test-results
     wandb login --relogin {env:WANDB_API_KEY}
-    standalone-cpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu-perf run {posargs:--all}
+    standalone-cpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
     standalone-gpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
     standalone-tpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
     standalone-local-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}

--- a/tox.ini
+++ b/tox.ini
@@ -447,7 +447,7 @@ commands =
     func-s_noml-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard noml run {posargs:--all}
     func-s_kfp-py{37}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard kfp run {posargs:--all}
 
-[testenv:store]
+[testenv:pod-store]
 whitelist_externals =
     mkdir
     cp

--- a/tox.ini
+++ b/tox.ini
@@ -447,6 +447,12 @@ commands =
     func-s_noml-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard noml run {posargs:--all}
     func-s_kfp-py{37}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard kfp run {posargs:--all}
 
+[testenv:store]
+whitelist_externals =
+    cp
+commands =
+    cp -rp test-results /tmp/store/test-results
+
 [testenv:func-cover]
 skip_install = true
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -522,7 +522,7 @@ whitelist_externals =
 commands =
     mkdir -p test-results
     wandb login --relogin {env:WANDB_API_KEY}
-    standalone-cpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
+    standalone-cpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu-perf run {posargs:--all}
     standalone-gpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
     standalone-tpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
     standalone-local-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}

--- a/tox.ini
+++ b/tox.ini
@@ -450,14 +450,8 @@ commands =
 [testenv:store]
 whitelist_externals =
     mkdir
-    ls
     cp
-    bash
 commands =
-    bash -c pwd
-    ls -l
-    ls /
-    ls /tmp
     mkdir -p /wandb-store/test-results
     cp -rp test-results /wandb-store/test-results
 

--- a/tox.ini
+++ b/tox.ini
@@ -452,11 +452,14 @@ whitelist_externals =
     mkdir
     ls
     cp
+    bash
 commands =
+    bash -c pwd
+    ls -l
     ls /
     ls /tmp
-    mkdir -p /tmp/store/test-results
-    cp -rp test-results /tmp/store/test-results
+    mkdir -p /wandb-store/test-results
+    cp -rp test-results /wandb-store/test-results
 
 [testenv:func-cover]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -449,8 +449,13 @@ commands =
 
 [testenv:store]
 whitelist_externals =
+    mkdir
+    ls
     cp
 commands =
+    ls /
+    ls /tmp
+    mkdir -p /tmp/store/test-results
     cp -rp test-results /tmp/store/test-results
 
 [testenv:func-cover]


### PR DESCRIPTION
Description
-----------
We want to save the junit-xml files for nightly tests so we can use circleci test insights and we want to push it as an artifact so we can do our own test insight pipeline.

To accomplish this:
- A Persistent volume needed to be created for cloud-test pods
- At the conclusion of the test in tox.ini we run `pod-store` which copies data to the persistent volume
- The circleci job needs to grab this data to a local dir but the pod is already complete so it has to launch a new `attach-pod` to access the persistent volume
- Use kubectl to copy data out
- Use circleci store_* flows to save the test results and the artifacts
- profit

<img width="499" alt="Screen Shot 2022-08-21 at 5 47 24 PM" src="https://user-images.githubusercontent.com/1832511/185819037-2f5bdfb8-216b-4293-8436-8c62e86a0db6.png">

Testing
-------
Tested with:
```
./tools/circleci-tool.py trigger-nightly --shards standalone-cpu
```

Successful nightly full trigger:
https://app.circleci.com/pipelines/github/wandb/wandb/15130/workflows/32637510-9d52-4e06-9ff3-9f3ff3264f11