### PR TITLE
Fix issue triggered by colab update by using default file and catching exceptions

### DIFF
--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -400,7 +400,11 @@ class Notebook:
         # TODO: likely only save if the code has changed
         colab_ipynb = attempt_colab_load_ipynb()
         if colab_ipynb:
-            nb_name = colab_ipynb["metadata"]["colab"]["name"]
+            nb_name = (
+                colab_ipynb.get("metadata", {})
+                .get("colab", {})
+                .get("name", "colab.ipynb")
+            )
             if ".ipynb" not in nb_name:
                 nb_name += ".ipynb"
             with open(

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -373,10 +373,18 @@ class Notebook:
 
         return
 
-    def save_ipynb(self):
+    def save_ipynb(self) -> bool:
         if not self.settings.save_code:
             logger.info("not saving jupyter notebook")
             return False
+        ret = False
+        try:
+            ret = self._save_ipynb()
+        except Exception as e:
+            logger.info(f"Problem saving notebook: {e}")
+        return ret
+
+    def _save_ipynb(self) -> bool:
         relpath = self.settings._jupyter_path
         logger.info("looking for notebook: %s", relpath)
         if relpath:
@@ -392,10 +400,6 @@ class Notebook:
         # TODO: likely only save if the code has changed
         colab_ipynb = attempt_colab_load_ipynb()
         if colab_ipynb:
-            print("DEBUG1", colab_ipynb)
-            print("DEBUG2", colab_ipynb.get("metadata"))
-            print("DEBUG3", colab_ipynb.get("metadata", {}).get("colab"))
-            print("DEBUG4", colab_ipynb.get("metadata", {}).get("colab", {}).get("name"))
             nb_name = colab_ipynb["metadata"]["colab"]["name"]
             if ".ipynb" not in nb_name:
                 nb_name += ".ipynb"

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -381,7 +381,7 @@ class Notebook:
         try:
             ret = self._save_ipynb()
         except Exception as e:
-            logger.info(f"Problem saving notebook: {e}")
+            logger.info(f"Problem saving notebook: {repr(e)}")
         return ret
 
     def _save_ipynb(self) -> bool:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -392,6 +392,7 @@ class Notebook:
         # TODO: likely only save if the code has changed
         colab_ipynb = attempt_colab_load_ipynb()
         if colab_ipynb:
+            print("DEBUG", colab_ipynb)
             nb_name = colab_ipynb["metadata"]["colab"]["name"]
             if ".ipynb" not in nb_name:
                 nb_name += ".ipynb"

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -392,7 +392,10 @@ class Notebook:
         # TODO: likely only save if the code has changed
         colab_ipynb = attempt_colab_load_ipynb()
         if colab_ipynb:
-            print("DEBUG", colab_ipynb)
+            print("DEBUG1", colab_ipynb)
+            print("DEBUG2", colab_ipynb.get("metadata"))
+            print("DEBUG3", colab_ipynb.get("metadata", {}).get("colab"))
+            print("DEBUG4", colab_ipynb.get("metadata", {}).get("colab", {}).get("name"))
             nb_name = colab_ipynb["metadata"]["colab"]["name"]
             if ".ipynb" not in nb_name:
                 nb_name += ".ipynb"


### PR DESCRIPTION
Description
-----------
Colab internals have changed and there were calls that were not robust to these changes.
<img width="703" alt="Screen Shot 2022-08-22 at 8 31 47 AM" src="https://user-images.githubusercontent.com/1832511/185969771-90ce8040-f6f7-4f21-ab58-f36d2a07e318.png">

Quick fix is to catch this exception.  Longer term fix is to be more strict about assumptions made about external interfaces.

Log will have:
```
2022-08-22 16:24:05,105 INFO    MainThread:56 [jupyter.py:save_ipynb():384] Problem saving notebook: KeyError('name')
```

Testing
-------
Manual:
```shell
pip install --upgrade git+https://github.com/wandb/wandb.git@fix-colab#egg=wandb
```