### PR TITLE
feat(sweeps): Move run configs from entrypoint into params

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -209,7 +209,7 @@ class Scheduler(ABC):
         self,
         run_id: Optional[str] = None,
         entry_point: Optional[List[str]] = None,
-        params: Optional[Dict[str, Any]] = None,
+        config: Optional[Dict[str, Any]] = None,
     ) -> "public.QueuedRun":
         """Add a launch job to the Launch RunQueue."""
         run_id = run_id or generate_id()
@@ -224,7 +224,7 @@ class Scheduler(ABC):
         queued_run = launch_add(
             run_id=run_id,
             entry_point=entry_point,
-            params=params,
+            config=config,
             uri=_uri,
             job=_job,
             project=self._project,

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -207,8 +207,9 @@ class Scheduler(ABC):
 
     def _add_to_launch_queue(
         self,
-        entry_point: Optional[List[str]] = None,
         run_id: Optional[str] = None,
+        entry_point: Optional[List[str]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> "public.QueuedRun":
         """Add a launch job to the Launch RunQueue."""
         run_id = run_id or generate_id()
@@ -223,6 +224,7 @@ class Scheduler(ABC):
         queued_run = launch_add(
             run_id=run_id,
             entry_point=entry_point,
+            params=params,
             uri=_uri,
             job=_job,
             project=self._project,

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -144,22 +144,10 @@ class SweepScheduler(Scheduler):
         wandb.termlog(
             f"{LOG_PREFIX}Converting Sweep Run (RunID:{run.id}) to Launch Job"
         )
-        # This is actually what populates the wandb config
-        # since it is used in wandb.init()
-        sweep_param_path = os.path.join(
-            os.environ.get(wandb.env.DIR, os.getcwd()),
-            "wandb",
-            f"sweep-{self._sweep_id}",
-            f"config-{run.id}.yaml",
-        )
-        wandb.termlog(f"{LOG_PREFIX}Saving params to {sweep_param_path}")
-        wandb_lib.config_util.save_config_file_from_dict(sweep_param_path, run.args)
-        # Construct entry point using legacy sweeps utilities
-        command_args = LegacySweepAgent._create_command_args({"args": run.args})["args"]
-        entry_point = ["python", run.program] + command_args
         _ = self._add_to_launch_queue(
-            entry_point=entry_point,
+            entry_point=["python", run.program],
             run_id=run.id,
+            params=run.args,
         )
 
     def _exit(self) -> None:

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -1,6 +1,5 @@
 """Scheduler for classic wandb Sweeps."""
 import logging
-import os
 import pprint
 import queue
 import socket
@@ -9,7 +8,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 import wandb
-from wandb import wandb_lib  # type: ignore
 from wandb.sdk.launch.sweeps import SchedulerError
 from wandb.sdk.launch.sweeps.scheduler import (
     LOG_PREFIX,
@@ -18,7 +16,6 @@ from wandb.sdk.launch.sweeps.scheduler import (
     SimpleRunState,
     SweepRun,
 )
-from wandb.wandb_agent import Agent as LegacySweepAgent
 
 logger = logging.getLogger(__name__)
 
@@ -145,8 +142,8 @@ class SweepScheduler(Scheduler):
             f"{LOG_PREFIX}Converting Sweep Run (RunID:{run.id}) to Launch Job"
         )
         _ = self._add_to_launch_queue(
-            entry_point=["python", run.program],
             run_id=run.id,
+            entry_point=["python", run.program] if run.program else None,
             params=run.args,
         )
 

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -144,7 +144,7 @@ class SweepScheduler(Scheduler):
         _ = self._add_to_launch_queue(
             run_id=run.id,
             entry_point=["python", run.program] if run.program else None,
-            params=run.args,
+            config={"overrides": {"run_config": run.args}},
         )
 
     def _exit(self) -> None:


### PR DESCRIPTION
Fixes WB-10661

Description
-----------
Moves run configs from going through entrypoint in `launch_add` to going through the `params` kwarg.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
