### PR TITLE
Adds a hack to make `t3_sentry_userproc` func test less flaky

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
           no_output_timeout: 5m
       - run:
           name: Run tests
-          no_output_timeout: 10m
+          no_output_timeout: 15m
           command: |
             CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e << parameters.toxenv >>
       - save-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
         default: "default"  # "default" or "server-2019-cuda"
       executor_size:
         type: string
-        default: "large"  # could only be "medium" for "server-2019-cuda"
+        default: "xlarge"  # could only be "medium" for "server-2019-cuda"
       execute:
         type: boolean
         default: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,11 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        args: [--resolve-all-config]
+#  - repo: https://github.com/pycqa/isort
+#    rev: 5.10.1
+#    hooks:
+#      - id: isort
+#        args: [--resolve-all-config]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -15,6 +15,6 @@ with mock.patch(
     import wandb
 
     wandb.sdk.wandb_init._WandbInit.init.sentry_repr = None
-    print(wandb.util.sentry_client)
-    print(wandb.util.sentry_hub)
+    wandb.termwarn(wandb.util.sentry_client)
+    wandb.termwarn(wandb.util.sentry_hub)
     run = wandb.init()

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python
+import sys
+import time
 from unittest import mock
 
 import wandb
 
-with mock.patch(
-    "wandb.sdk.wandb_init._WandbInit.init", mock.Mock(side_effect=Exception("injected"))
-):
-    wandb.sdk.wandb_init._WandbInit.init.sentry_repr = None
-    run = wandb.init()
+try:
+    with mock.patch(
+        "wandb.sdk.wandb_init._WandbInit.init",
+        mock.Mock(side_effect=Exception("injected")),
+    ):
+        wandb.sdk.wandb_init._WandbInit.init.sentry_repr = None
+        run = wandb.init()
+except Exception as e:
+    # todo: this is a hack to reduce flake
+    #  (sometimes, it takes time for the mock server to pick up the sentry event)
+    time.sleep(5)
+    sys.exit(4294967295)

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import platform
 import sys
 import time
 from unittest import mock
@@ -16,4 +17,7 @@ except Exception as e:
     # todo: this is a hack to reduce flake
     #  (sometimes, it takes time for the mock server to pick up the sentry event)
     time.sleep(5)
-    sys.exit(4294967295)
+    if platform.system() == "Windows":
+        sys.exit(4294967295)
+    else:
+        sys.exit(1)

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -5,7 +5,7 @@ from unittest import mock
 def sentry_exc(exc, delay):  # type: ignore
     import wandb.util
 
-    return wandb.util.sentry_exc(exc, delay=2)
+    return wandb.util.sentry_exc(exc, delay=5)
 
 
 with mock.patch(
@@ -15,6 +15,6 @@ with mock.patch(
     import wandb
 
     wandb.sdk.wandb_init._WandbInit.init.sentry_repr = None
-    wandb.termwarn(wandb.util.sentry_client)
-    wandb.termwarn(wandb.util.sentry_hub)
+    wandb.termwarn(str(wandb.util.sentry_client))
+    wandb.termwarn(str(wandb.util.sentry_hub))
     run = wandb.init()

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python
 from unittest import mock
 
-import wandb
-import wandb.util
-
 
 def sentry_exc(exc, delay):  # type: ignore
-    return wandb.util.sentry_exc(exc, delay=0.5)
+    import wandb.util
+
+    return wandb.util.sentry_exc(exc, delay=2)
 
 
 with mock.patch(
     "wandb.sdk.wandb_init._WandbInit.init",
     mock.Mock(side_effect=Exception("injected")),
 ), mock.patch("wandb.util.sentry_exc", sentry_exc):
+    import wandb
+
     wandb.sdk.wandb_init._WandbInit.init.sentry_repr = None
     print(wandb.util.sentry_client)
     print(wandb.util.sentry_hub)

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -8,10 +8,21 @@ def sentry_exc(exc, delay):  # type: ignore
     return wandb.util.sentry_exc(exc, delay=5)
 
 
+def _send_request(self, body, headers, endpoint_type="store", envelope=None):  # type: ignore
+    # unzip bytes and decode to string
+    import gzip
+
+    data = gzip.decompress(body).decode("utf-8")
+    print(data)
+
+
 with mock.patch(
     "wandb.sdk.wandb_init._WandbInit.init",
     mock.Mock(side_effect=Exception("injected")),
-), mock.patch("wandb.util.sentry_exc", sentry_exc):
+), mock.patch("wandb.util.sentry_exc", sentry_exc,), mock.patch(
+    "sentry_sdk.transport.HttpTransport._send_request",
+    _send_request,
+):
     import wandb
 
     wandb.sdk.wandb_init._WandbInit.init.sentry_repr = None

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -13,7 +13,7 @@ try:
     ):
         wandb.sdk.wandb_init._WandbInit.init.sentry_repr = None
         run = wandb.init()
-except Exception as e:
+except Exception:
     # todo: this is a hack to reduce flake
     #  (sometimes, it takes time for the mock server to pick up the sentry event)
     time.sleep(5)

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -6,7 +6,7 @@ import wandb.util
 
 
 def sentry_exc(exc, delay):  # type: ignore
-    return wandb.util.sentry_exc(exc, delay=False)
+    return wandb.util.sentry_exc(exc, delay=0.5)
 
 
 with mock.patch(

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc.py
@@ -16,7 +16,7 @@ try:
 except Exception:
     # todo: this is a hack to reduce flake
     #  (sometimes, it takes time for the mock server to pick up the sentry event)
-    time.sleep(5)
+    time.sleep(20)
     if platform.system() == "Windows":
         sys.exit(4294967295)
     else:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -164,7 +164,7 @@ def sentry_exc(
         else:
             sentry_hub.capture_exception(exc)  # type: ignore
     if delay:
-        time.sleep(2)
+        time.sleep(delay * 2)
     return None
 
 


### PR DESCRIPTION
Description
-----------
The flake we've been observing (and being annoyed by...) recently on Windows in `tests/functional_tests/t0_main/debug/t3_sentry_userproc.py` is apparently caused by the mock_server taking too much time to pick up the sentry event when the system is under load. The hack is to simply give it a bit more time to process the data. Once we switch yea to local-testcontainer+relay_server, this will no longer be necessary (won't exit context before the data are fully processed).

Testing
-------
Generated load on the Win VM in Circle with this script:
```python
import numpy as np


def load():
    # multiple two large random matrices
    a = np.random.rand(10000, 10000)
    b = np.random.rand(10000, 10000)
    c = np.dot(a, b)
    return c


if __name__ == "__main__":
    while True:
        load()
```
And ran the following in a loop
```shell
cd project
tox -e func-s_base-py39 -- tests/functional_tests/t0_main/debug/t3_sentry_userproc_win.yea
```

With the hack in place, have not observed flake, while did observe it without the hack.

Notes
-------
A nice `htop` alternative for Windows (https://github.com/gsass1/NTop):
```shell
pip install choco
choco install ntop.portable
ntop
```
(Use `:sort CPU%` to sort by a column name)

<img width="1506" alt="image" src="https://user-images.githubusercontent.com/7557205/186188788-4962cdfc-6d00-4144-abd2-7c81aeacf7f7.png">


Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
