### PR TITLE
Remove Slack orb usage from Win job on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,6 +393,7 @@ jobs:
                 condition: << parameters.notify_on_failure >>
                 steps:
                   - slack/notify:
+                      shell: bash.exe
                       event: fail
                       template: basic_fail_1
                       mentions: "@channel"
@@ -1004,6 +1005,7 @@ workflows:
       - win:
           machine_executor: "server-2019-cuda"
           executor_size: "medium"
+          context: slack-secrets
           matrix:
             parameters:
               python_version_major: [ 3 ]
@@ -1296,6 +1298,7 @@ workflows:
       - win:
           machine_executor: "server-2019-cuda"
           executor_size: "medium"
+          context: slack-secrets
           execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_gpu_win >>
           matrix:
             parameters:
@@ -1307,7 +1310,7 @@ workflows:
           xdist: 1
           notify_on_failure: true
       #
-      # stanalone tests on gke
+      # standalone tests on gke
       #
       - slack_notify:
           name: "slack-notify-on-start"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,9 +344,6 @@ jobs:
       execute:
         type: boolean
         default: true
-      notify_on_failure:
-        type: boolean
-        default: false
     executor:
       name: win/<< parameters.machine_executor >>
       size: << parameters.executor_size >>
@@ -388,17 +385,6 @@ jobs:
                   DATE=$(date -u +%Y%m%d) CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e << parameters.toxenv >>
                 no_output_timeout: 10m
             - save-test-results
-            # conditionally post a notification to slack if the job failed
-            - when:
-                condition: << parameters.notify_on_failure >>
-                steps:
-                  - slack/notify:
-                      shell: bash.exe
-                      event: fail
-                      template: basic_fail_1
-                      mentions: "@channel"
-                      # taken from slack-secrets context
-                      channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
   mac:
     parameters:
@@ -1005,7 +991,6 @@ workflows:
       - win:
           machine_executor: "server-2019-cuda"
           executor_size: "medium"
-          context: slack-secrets
           matrix:
             parameters:
               python_version_major: [ 3 ]
@@ -1014,7 +999,6 @@ workflows:
           toxenv: "standalone-gpu-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           parallelism: 2
           xdist: 1
-          notify_on_failure: true
       #
       # standalone tests on gke
       #
@@ -1298,7 +1282,6 @@ workflows:
       - win:
           machine_executor: "server-2019-cuda"
           executor_size: "medium"
-          context: slack-secrets
           execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_gpu_win >>
           matrix:
             parameters:
@@ -1308,7 +1291,6 @@ workflows:
           toxenv: "standalone-gpu-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           parallelism: 2
           xdist: 1
-          notify_on_failure: true
       #
       # standalone tests on gke
       #


### PR DESCRIPTION
Description
-----------
...because Windows is currently not supported by the Slack orb, see https://github.com/CircleCI-Public/slack-orb/pull/282.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
