### PR TITLE
fix(sweeps): Parse heartbeat run args using legacy agent

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -16,6 +16,7 @@ from wandb.sdk.launch.sweeps.scheduler import (
     SimpleRunState,
     SweepRun,
 )
+from wandb.wandb_agent import Agent as LegacySweepAgent
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,14 @@ class SweepScheduler(Scheduler):
         _ = self._add_to_launch_queue(
             run_id=run.id,
             entry_point=["python", run.program] if run.program else None,
-            config={"overrides": {"run_config": run.args}},
+            # Use legacy sweep utilities to extract args dict from agent heartbeat run.args
+            config={
+                "overrides": {
+                    "run_config": LegacySweepAgent._create_command_args(
+                        {"args": run.args}
+                    )["args_dict"]
+                }
+            },
         )
 
     def _exit(self) -> None:

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -35,7 +35,7 @@ class SweepScheduler(Scheduler):
     def __init__(
         self,
         *args: Any,
-        num_workers: int = 4,
+        num_workers: int = 8,
         heartbeat_queue_timeout: float = 1.0,
         heartbeat_queue_sleep: float = 1.0,
         **kwargs: Any,
@@ -144,7 +144,7 @@ class SweepScheduler(Scheduler):
         )
         _ = self._add_to_launch_queue(
             run_id=run.id,
-            entry_point=["python", run.program] if run.program else None,
+            entry_point=["python3", run.program] if run.program else None,
             # Use legacy sweep utilities to extract args dict from agent heartbeat run.args
             config={
                 "overrides": {

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -370,6 +370,7 @@ class Agent:
             "args_no_hyphens": flags_no_hyphens,
             "args_no_boolean_flags": flags_no_booleans,
             "args_json": [json.dumps(flags_dict)],
+            "args_dict": flags_dict,
         }
 
     def _command_run(self, command):


### PR DESCRIPTION
Description
-----------
Fixes an issue where `run.args` coming from an AgentHeartbeat call were not formatted correctly for launch agents. Uses legacy sweep function to parse (to avoid code duplication).

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
