### PR TITLE
feat(launch): put job into artifact slot, have run use it, dont produce a job in a launched run that is sourced from a job

### DIFF
--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -225,7 +225,14 @@ def get_env_vars_dict(launch_project: LaunchProject, api: Api) -> Dict[str, str]
 
     # TODO: handle env vars > 32760 characters
     env_vars["WANDB_CONFIG"] = json.dumps(launch_project.override_config)
-    env_vars["WANDB_ARTIFACTS"] = json.dumps(launch_project.override_artifacts)
+    artifacts = {}
+    # if we're spinning up a launch process from a job
+    # we should tell the run to use that artifact
+    if launch_project.job:
+        artifacts = {wandb.util.LAUNCH_JOB_ARTIFACT_SLOT_NAME: launch_project.job}
+    env_vars["WANDB_ARTIFACTS"] = json.dumps(
+        {**artifacts, **launch_project.override_artifacts}
+    )
     #  check if the user provided an override entrypoint, otherwise use the default
 
     if launch_project.override_entrypoint is not None:

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -752,6 +752,11 @@ class _WandbInit:
         # as the run is not upserted
         for k, v in self.init_artifact_config.items():
             run.config.update({k: v}, allow_val_change=True)
+        job_artifact = run._launch_artifact_mapping.get(
+            wandb.util.LAUNCH_JOB_ARTIFACT_SLOT_NAME
+        )
+        if job_artifact:
+            run.use_artifact(job_artifact)
 
         self.backend = backend
         self._reporter.set_context(run=run)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -355,6 +355,7 @@ class Run:
     _project: Optional[str]
     _group: Optional[str]
     _job_type: Optional[str]
+    _job_name: Optional[str]
     _name: Optional[str]
     _notes: Optional[str]
 
@@ -456,6 +457,7 @@ class Run:
         self._project = None
         self._group = None
         self._job_type = None
+        self._job_name = None
         self._run_id = self._settings.run_id
         self._starting_step = 0
         self._name = None
@@ -623,6 +625,8 @@ class Run:
             self._group = settings.run_group
         if settings.run_job_type is not None:
             self._job_type = settings.run_job_type
+        if settings.job_name is not None:
+            self._job_name = settings.job_name
         if settings.run_name is not None:
             self._name = settings.run_name
         if settings.run_notes is not None:
@@ -2040,6 +2044,12 @@ class Run:
         self._freeze()
 
     def _log_job(self) -> None:
+        # don't produce a job if the run is sourced from a job
+        if (
+            self._launch_artifact_mapping.get(wandb.util.LAUNCH_JOB_ARTIFACT_SLOT_NAME)
+            is not None
+        ):
+            return
         artifact = None
         input_types = TypeRegistry.type_of(self.config.as_dict()).to_json()
         output_types = TypeRegistry.type_of(self.summary._as_dict()).to_json()
@@ -2083,6 +2093,17 @@ class Run:
 
         return job_artifact
 
+    def _get_job_name(self, default_name: str) -> str:
+        if self._job_name is not None:
+            changed_name = wandb.util.make_artifact_name_safe(self._job_name)
+            if changed_name != self._job_name:
+                wandb.termwarn(
+                    f"Provided job name was not a valid artifact, changed to {changed_name}"
+                )
+                return changed_name
+            return self._job_name
+        return wandb.util.make_artifact_name_safe(default_name)
+
     def _create_repo_job(
         self,
         input_types: Dict[str, Any],
@@ -2096,9 +2117,7 @@ class Run:
             return None
         assert self._remote_url is not None
         assert self._commit is not None
-        name = wandb.util.make_artifact_name_safe(
-            f"job-{self._remote_url}_{program_relpath}"
-        )
+        name = self._get_job_name(f"job-{self._remote_url}_{program_relpath}")
         patch_path = os.path.join(self._settings.files_dir, DIFF_FNAME)
 
         source_info: JobSourceDict = {
@@ -2138,7 +2157,7 @@ class Run:
         ):
             return None
         artifact_client_id = self._code_artifact_info.get("client_id")
-        name = f"job-{self._code_artifact_info['name']}"
+        name = self._get_job_name(f"job-{self._code_artifact_info['name']}")
 
         source_info: JobSourceDict = {
             "_version": "v0",
@@ -2169,7 +2188,7 @@ class Run:
         docker_image_name = os.getenv("WANDB_DOCKER")
         if docker_image_name is None:
             return None
-        name = wandb.util.make_artifact_name_safe(f"job-{docker_image_name}")
+        name = self._get_job_name(f"job-{docker_image_name}")
 
         source_info: JobSourceDict = {
             "_version": "v0",

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2102,7 +2102,9 @@ class Run:
             return None
         assert self._remote_url is not None
         assert self._commit is not None
-        name = f"job-{self._remote_url}_{program_relpath}"
+        name = wandb.util.make_artifact_name_safe(
+            f"job-{self._remote_url}_{program_relpath}"
+        )
         patch_path = os.path.join(self._settings.files_dir, DIFF_FNAME)
 
         source_info: JobSourceDict = {
@@ -2173,7 +2175,7 @@ class Run:
         docker_image_name = os.getenv("WANDB_DOCKER")
         if docker_image_name is None:
             return None
-        name = f"job-{docker_image_name}"
+        name = wandb.util.make_artifact_name_safe(f"job-{docker_image_name}")
 
         source_info: JobSourceDict = {
             "_version": "v0",

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -355,7 +355,6 @@ class Run:
     _project: Optional[str]
     _group: Optional[str]
     _job_type: Optional[str]
-    _job_name: Optional[str]
     _name: Optional[str]
     _notes: Optional[str]
 
@@ -457,7 +456,6 @@ class Run:
         self._project = None
         self._group = None
         self._job_type = None
-        self._job_name = None
         self._run_id = self._settings.run_id
         self._starting_step = 0
         self._name = None
@@ -625,8 +623,6 @@ class Run:
             self._group = settings.run_group
         if settings.run_job_type is not None:
             self._job_type = settings.run_job_type
-        if settings.job_name is not None:
-            self._job_name = settings.job_name
         if settings.run_name is not None:
             self._name = settings.run_name
         if settings.run_notes is not None:
@@ -2093,17 +2089,6 @@ class Run:
 
         return job_artifact
 
-    def _get_job_name(self, default_name: str) -> str:
-        if self._job_name is not None:
-            changed_name = wandb.util.make_artifact_name_safe(self._job_name)
-            if changed_name != self._job_name:
-                wandb.termwarn(
-                    f"Provided job name was not a valid artifact, changed to {changed_name}"
-                )
-                return changed_name
-            return self._job_name
-        return wandb.util.make_artifact_name_safe(default_name)
-
     def _create_repo_job(
         self,
         input_types: Dict[str, Any],
@@ -2117,7 +2102,7 @@ class Run:
             return None
         assert self._remote_url is not None
         assert self._commit is not None
-        name = self._get_job_name(f"job-{self._remote_url}_{program_relpath}")
+        name = f"job-{self._remote_url}_{program_relpath}"
         patch_path = os.path.join(self._settings.files_dir, DIFF_FNAME)
 
         source_info: JobSourceDict = {
@@ -2157,7 +2142,7 @@ class Run:
         ):
             return None
         artifact_client_id = self._code_artifact_info.get("client_id")
-        name = self._get_job_name(f"job-{self._code_artifact_info['name']}")
+        name = f"job-{self._code_artifact_info['name']}"
 
         source_info: JobSourceDict = {
             "_version": "v0",
@@ -2188,7 +2173,7 @@ class Run:
         docker_image_name = os.getenv("WANDB_DOCKER")
         if docker_image_name is None:
             return None
-        name = self._get_job_name(f"job-{docker_image_name}")
+        name = f"job-{docker_image_name}"
 
         source_info: JobSourceDict = {
             "_version": "v0",

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -79,6 +79,8 @@ PLATFORM_BSD = "bsd"
 PLATFORM_DARWIN = "darwin"
 PLATFORM_UNKNOWN = "unknown"
 
+LAUNCH_JOB_ARTIFACT_SLOT_NAME = "_wandb_job"
+
 
 def get_platform_name() -> str:
     if sys.platform.startswith("win"):


### PR DESCRIPTION
[Fixes WB-10747](https://wandb.atlassian.net/browse/WB-10747)
[Fixes WB-10746](https://wandb.atlassian.net/browse/WB-10746)
Fixes #NNNN

Description
-----------
Puts the job in the artifacts dict and automatically uses it.
so 
1. We can now filter by jobs using this job
2. We dont try to produce a new job version when sourced from a job

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
