### PR TITLE
[WB-10394] add detail to error message when uploading an artifact with the wrong type

### DIFF
--- a/tests/standalone_tests/artifact_tests.py
+++ b/tests/standalone_tests/artifact_tests.py
@@ -103,7 +103,7 @@ def test_artifact_creation_with_diff_type():
             did_err = True
             assert (
                 str(err)
-                == "Expected artifact type artifact_type_1, got artifact_type_2"
+                == f"Artifact {artifact_name} already exists with type artifact_type_1; cannot create another with type artifact_type_2"
             )
         assert did_err
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2796,9 +2796,7 @@ class Run:
                 return
             if expected_type is not None and artifact.type != expected_type:
                 raise ValueError(
-                    "Expected artifact type {}, got {}".format(
-                        expected_type, artifact.type
-                    )
+                    f"Artifact {artifact.name} already exists with type {expected_type}; cannot create another with type {artifact.type}"
                 )
 
     def _prepare_artifact(


### PR DESCRIPTION
Fixes WB-10394

Testing
-------
Shouldn't affect anything, so, relying on the existing test suite!
