### PR TITLE
Skip the `t3_sentry_userproc` functional test on win

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,11 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        args: [--resolve-all-config]
+#  - repo: https://github.com/pycqa/isort
+#    rev: 5.10.1
+#    hooks:
+#      - id: isort
+#        args: [--resolve-all-config]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/tests/functional_tests/t0_main/debug/t3_sentry_userproc_win.yea
+++ b/tests/functional_tests/t0_main/debug/t3_sentry_userproc_win.yea
@@ -2,6 +2,9 @@ id: 0.debug.03-sentry-userproc-win
 plugin:
   - wandb
 tag:
+  skips:
+    - platform: win
+      reason: some sketchy flake going on with this test, gotta debug
   platforms:
     - win
 command:


### PR DESCRIPTION
Description
-----------
Some sketchy flake has been going on with it in Circle since we updated the base Win worker used for the functional tests. Spent a lot of time debugging it already, which might not even be necessary once yea is transferred onto the unmock server rails.

Also: comment out the isort pre-commit hook as takes up to 10 seconds to run, which is too much for a pre-commit hook. (we don't have mypy there for the same reason).

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
