### PR TITLE
Corrected wandb.Artifacts.artifact.version attribute. The version ret…

### DIFF
--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -196,7 +196,7 @@ class Artifact:
     def version(self) -> str:
         """
         Returns:
-            (int): The version of this artifact. For example, if this
+            (str): The version of this artifact. For example, if this
                 is the first version of an artifact, its `version` will
                 be 'v0'.
         """


### PR DESCRIPTION
…urns a string (str) not an integer (int).

Fixes WB-NNNN
Fixes #NNNN

Description
-----------
Docstring error in Artifacts Class, version attribute. Artifacts.version return a string, not an integer.

Testing
-------
How was this PR tested?
Created an artifact object and confirmed version attribute is a string type, not int.

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
