### PR TITLE
fix mailbox locking issue

### DIFF
--- a/wandb/sdk/lib/mailbox.py
+++ b/wandb/sdk/lib/mailbox.py
@@ -32,8 +32,8 @@ class _MailboxSlot:
 
     def _get_and_clear(self, timeout: float) -> Optional[pb.Result]:
         found = None
-        with self._lock:
-            if self._event.wait(timeout=timeout):
+        if self._event.wait(timeout=timeout):
+            with self._lock:
                 found = self._result
                 self._event.clear()
         return found


### PR DESCRIPTION
Fixes #4212

Description
-----------
Locking mistake..  We dont want to lock during the wait.  This was ported from mailbox phase2 PR, hopefully it is sufficient fix: https://github.com/wandb/wandb/pull/4169

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
