### PR TITLE
Fix type hint for `filters` argument

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -23,7 +23,7 @@ import time
 import urllib
 from collections import namedtuple
 from functools import partial
-from typing import Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 import requests
 from wandb_gql import Client, gql
@@ -758,7 +758,7 @@ class Api:
     def runs(
         self,
         path: Optional[str] = None,
-        filters: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
         order: str = "-created_at",
         per_page: int = 50,
         include_sweeps: bool = True,
@@ -1543,7 +1543,7 @@ class Runs(Paginator):
         client: "RetryingClient",
         entity: str,
         project: str,
-        filters: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
         order: Optional[str] = None,
         per_page: int = 50,
         include_sweeps: bool = True,


### PR DESCRIPTION
Fixes the incorrect type hint introduced in https://github.com/wandb/wandb/commit/643b25da062e79abf498b4eaf33c09f2c462837e