### PR TITLE
make standalone_tests/artifact_load.py overlap written files by default

### DIFF
--- a/tests/standalone_tests/artifact_load.py
+++ b/tests/standalone_tests/artifact_load.py
@@ -57,7 +57,7 @@ parser.add_argument("--test_phase_seconds", type=int, required=True)
 parser.add_argument("--num_writers", type=int, required=True)
 parser.add_argument("--files_per_version_min", type=int, required=True)
 parser.add_argument("--files_per_version_max", type=int, required=True)
-parser.add_argument("--non_overlapping_writers", default=True, action="store_true")
+parser.add_argument("--non_overlapping_writers", action="store_true")
 parser.add_argument("--distributed_fanout", type=int, default=1)
 parser.add_argument("--blocking", type=bool, default=False)
 


### PR DESCRIPTION
Description
-----------
Currently, the default is that no two artifact-writers will ever try to concurrently commit the same file to a new version of an artifact.

This PR changes that default so that collisions _can_ happen by default. I think this makes the test more realistic! (It also reveals bugs like [this](https://wandb.atlassian.net/browse/WB-10888).)

Testing
-------
n/a; is tests
