### PR TITLE
fix(artifacts): when artifact-commit 409s, retry entire artifact-creation, not just commit

### DIFF
--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
             pass
 
 
-def _manifest_json_from_proto(manifest: "wandb_internal_pb2.ArtifactManifest") -> Dict:
+def manifest_json_from_proto(manifest: "wandb_internal_pb2.ArtifactManifest") -> Dict:
     if manifest.version == 1:
         contents = {
             content.path: {

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1256,7 +1256,7 @@ class SendManager:
         saver = artifacts.ArtifactSaver(
             api=self._api,
             digest=artifact.digest,
-            manifest_json=artifacts._manifest_json_from_proto(artifact.manifest),
+            manifest_json=artifacts.manifest_json_from_proto(artifact.manifest),
             file_pusher=self._pusher,
             is_user_created=artifact.user_created,
         )


### PR DESCRIPTION
Fixes WB-10946

Description
-----------

After #4260 merges, when the SDK tries to commit an artifact and gets back a "409 Conflict" status code, it will fail. That's better than what we do now, which is retry the `commitArtifact` request indefinitely even if there's no hope of success (see [WB-10888](https://wandb.atlassian.net/browse/WB-10888)); but it'd be even better to retry the operation at a higher level to resolve the conflict.

The _right_ way to do this would be to have the SDK somehow figure out which files are responsible for the conflict (probably by asking the server); but, as a hopefully-temporary fix, we can just restart the entire "create-upload-commit" process from the beginning.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
