### PR TITLE
build(sdk): remove dependency on six by modifying vendored libs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ promise>=2.0,<3
 shortuuid>=0.5.0
 psutil>=5.0.0
 sentry-sdk>=1.0.0
-six>=1.13.0
 docker-pycreds>=0.4.0
 protobuf>=3.12.0,!=4.0.*,!=4.21.0,<5
 PyYAML

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1107,7 +1107,6 @@ def init(
         # mess with sentry's ability to send out errors before the program ends.
         sentry_exc(e, delay=True)
         # reraise(*sys.exc_info())
-        # six.raise_from(Exception("problem"), e)
     finally:
         if error_seen:
             wandb.termerror("Abnormal program exit")

--- a/wandb/vendor/gql-0.2.0/wandb-vendor.diff
+++ b/wandb/vendor/gql-0.2.0/wandb-vendor.diff
@@ -1,5 +1,5 @@
 diff --git a/wandb/vendor/gql-0.2.0/wandb_gql/client.py b/wandb/vendor/gql-0.2.0/wandb_gql/client.py
-index 95c565c4e..ab3ed7f0e 100644
+index 95c565c..ab3ed7f 100644
 --- a/wandb/vendor/gql-0.2.0/wandb_gql/client.py
 +++ b/wandb/vendor/gql-0.2.0/wandb_gql/client.py
 @@ -1,7 +1,7 @@
@@ -13,13 +13,16 @@ index 95c565c4e..ab3ed7f0e 100644
  from .transport.local_schema import LocalSchemaTransport
  
 diff --git a/wandb/vendor/gql-0.2.0/wandb_gql/dsl.py b/wandb/vendor/gql-0.2.0/wandb_gql/dsl.py
-index 39ff3c2ed..060543645 100644
+index 135d808..052e1eb 100644
 --- a/wandb/vendor/gql-0.2.0/wandb_gql/dsl.py
 +++ b/wandb/vendor/gql-0.2.0/wandb_gql/dsl.py
-@@ -3,9 +3,9 @@ import decimal
+@@ -1,11 +1,10 @@
+-import collections
++from collections.abc import Iterable
+ import decimal
  from functools import partial
  
- import six
+-import six
 -from graphql.language import ast
 -from graphql.language.printer import print_ast
 -from graphql.type import (GraphQLField, GraphQLList,
@@ -29,12 +32,30 @@ index 39ff3c2ed..060543645 100644
                            GraphQLNonNull, GraphQLEnumType)
  
  from .utils import to_camel_case
+@@ -61,7 +60,7 @@ def selections(*fields):
+ def get_ast_value(value):
+     if isinstance(value, ast.Node):
+         return value
+-    if isinstance(value, six.string_types):
++    if isinstance(value, str):
+         return ast.StringValue(value=value)
+     elif isinstance(value, bool):
+         return ast.BooleanValue(value=value)
+@@ -134,7 +133,7 @@ def query(*fields):
+ 
+ 
+ def serialize_list(serializer, values):
+-    assert isinstance(values, collections.Iterable), 'Expected iterable, received "{}"'.format(repr(values))
++    assert isinstance(values, Iterable), 'Expected iterable, received "{}"'.format(repr(values))
+     return [serializer(v) for v in values]
+ 
+ 
 diff --git a/wandb/vendor/gql-0.2.0/wandb_gql/gql.py b/wandb/vendor/gql-0.2.0/wandb_gql/gql.py
-index 782943f0e..39a8a5859 100644
+index 782943f..21edd39 100644
 --- a/wandb/vendor/gql-0.2.0/wandb_gql/gql.py
 +++ b/wandb/vendor/gql-0.2.0/wandb_gql/gql.py
-@@ -1,6 +1,6 @@
- import six
+@@ -1,10 +1,9 @@
+-import six
 -from graphql.language.parser import parse
 -from graphql.language.source import Source
 +from wandb_graphql.language.parser import parse
@@ -42,8 +63,13 @@ index 782943f0e..39a8a5859 100644
  
  
  def gql(request_string):
+-    if isinstance(request_string, six.string_types):
++    if isinstance(request_string, str):
+         source = Source(request_string, 'GraphQL request')
+         return parse(source)
+     else:
 diff --git a/wandb/vendor/gql-0.2.0/wandb_gql/transport/local_schema.py b/wandb/vendor/gql-0.2.0/wandb_gql/transport/local_schema.py
-index 30d577ec0..5bc7d33dc 100644
+index 30d577e..5bc7d33 100644
 --- a/wandb/vendor/gql-0.2.0/wandb_gql/transport/local_schema.py
 +++ b/wandb/vendor/gql-0.2.0/wandb_gql/transport/local_schema.py
 @@ -1,4 +1,4 @@
@@ -53,7 +79,7 @@ index 30d577ec0..5bc7d33dc 100644
  
  class LocalSchemaTransport(object):
 diff --git a/wandb/vendor/gql-0.2.0/wandb_gql/transport/requests.py b/wandb/vendor/gql-0.2.0/wandb_gql/transport/requests.py
-index 71399a55d..305ca8af9 100644
+index 71399a5..305ca8a 100644
 --- a/wandb/vendor/gql-0.2.0/wandb_gql/transport/requests.py
 +++ b/wandb/vendor/gql-0.2.0/wandb_gql/transport/requests.py
 @@ -1,8 +1,8 @@

--- a/wandb/vendor/gql-0.2.0/wandb_gql/dsl.py
+++ b/wandb/vendor/gql-0.2.0/wandb_gql/dsl.py
@@ -1,8 +1,7 @@
-from six.moves.collections_abc import Iterable
+from collections.abc import Iterable
 import decimal
 from functools import partial
 
-import six
 from wandb_graphql.language import ast
 from wandb_graphql.language.printer import print_ast
 from wandb_graphql.type import (GraphQLField, GraphQLList,
@@ -61,7 +60,7 @@ def selections(*fields):
 def get_ast_value(value):
     if isinstance(value, ast.Node):
         return value
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         return ast.StringValue(value=value)
     elif isinstance(value, bool):
         return ast.BooleanValue(value=value)

--- a/wandb/vendor/gql-0.2.0/wandb_gql/gql.py
+++ b/wandb/vendor/gql-0.2.0/wandb_gql/gql.py
@@ -1,10 +1,9 @@
-import six
 from wandb_graphql.language.parser import parse
 from wandb_graphql.language.source import Source
 
 
 def gql(request_string):
-    if isinstance(request_string, six.string_types):
+    if isinstance(request_string, str):
         source = Source(request_string, 'GraphQL request')
         return parse(source)
     else:

--- a/wandb/vendor/graphql-core-1.1/wandb-vendor.diff
+++ b/wandb/vendor/graphql-core-1.1/wandb-vendor.diff
@@ -1,5 +1,185 @@
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/error/base.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/error/base.py
+index 44126cd..74d6447 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/error/base.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/error/base.py
+@@ -1,4 +1,3 @@
+-import six
+ from ..language.location import get_location
+ 
+ 
+@@ -32,7 +31,7 @@ class GraphQLError(Exception):
+ 
+     def reraise(self):
+         if self.stack:
+-            six.reraise(type(self), self, self.stack)
++            raise self.with_traceback(self.stack)
+         else:
+             raise self
+ 
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/executor.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/executor.py
+index 202ba98..53a9f35 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/executor.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/executor.py
+@@ -1,9 +1,9 @@
+ import collections
++from collections.abc import Iterable
+ import functools
+ import logging
+ import sys
+ 
+-from six import string_types
+ from promise import Promise, promise_for_dict, is_thenable
+ 
+ from ..error import GraphQLError, GraphQLLocatedError
+@@ -294,7 +294,7 @@ def complete_list_value(exe_context, return_type, field_asts, info, result):
+     """
+     Complete a list value by completing each item in the list with the inner type
+     """
+-    assert isinstance(result, collections.Iterable), \
++    assert isinstance(result, Iterable), \
+         ('User Error: expected iterable, but did not find one ' +
+          'for field {}.{}.').format(info.parent_type, info.field_name)
+ 
+@@ -335,7 +335,7 @@ def complete_abstract_value(exe_context, return_type, field_asts, info, result):
+         else:
+             runtime_type = get_default_resolve_type_fn(result, exe_context.context_value, info, return_type)
+ 
+-    if isinstance(runtime_type, string_types):
++    if isinstance(runtime_type, str):
+         runtime_type = info.schema.get_type(runtime_type)
+ 
+     if not isinstance(runtime_type, GraphQLObjectType):
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/experimental/resolver.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/experimental/resolver.py
+index 75f5b7d..ab12110 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/experimental/resolver.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/experimental/resolver.py
+@@ -1,5 +1,5 @@
+ import sys
+-import collections
++from collections.abc import Iterable
+ from functools import partial
+ 
+ from promise import Promise, is_thenable
+@@ -37,7 +37,7 @@ def complete_list_value(inner_resolver, exe_context, info, on_error, result):
+     if result is None:
+         return None
+ 
+-    assert isinstance(result, collections.Iterable), \
++    assert isinstance(result, Iterable), \
+         ('User Error: expected iterable, but did not find one ' +
+          'for field {}.{}.').format(info.parent_type, info.field_name)
+ 
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/values.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/values.py
+index 5600846..473ada1 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/values.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/values.py
+@@ -1,8 +1,6 @@
+-import collections
++from collections.abc import Iterable
+ import json
+ 
+-from six import string_types
+-
+ from ..error import GraphQLError
+ from ..language.printer import print_ast
+ from ..type import (GraphQLEnumType, GraphQLInputObjectType, GraphQLList,
+@@ -121,7 +119,7 @@ def coerce_value(type, value):
+ 
+     if isinstance(type, GraphQLList):
+         item_type = type.of_type
+-        if not isinstance(value, string_types) and isinstance(value, collections.Iterable):
++        if not isinstance(value, str) and isinstance(value, Iterable):
+             return [coerce_value(item_type, item) for item in value]
+         else:
+             return [coerce_value(item_type, value)]
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/lexer.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/lexer.py
+index 711525e..c6909fb 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/lexer.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/lexer.py
+@@ -1,7 +1,5 @@
+ import json
+ 
+-from six import unichr
+-
+ from ..error import GraphQLSyntaxError
+ 
+ __all__ = ['Token', 'Lexer', 'TokenKind',
+@@ -134,7 +132,7 @@ def print_char_code(code):
+         return '<EOF>'
+ 
+     if code < 0x007F:
+-        return json.dumps(unichr(code))
++        return json.dumps(chr(code))
+ 
+     return '"\\u%04X"' % code
+ 
+@@ -368,12 +366,12 @@ def read_string(source, start):
+                         u'Invalid character escape sequence: \\u{}.'.format(body[position + 1: position + 5])
+                     )
+ 
+-                append(unichr(char_code))
++                append(chr(char_code))
+                 position += 4
+             else:
+                 raise GraphQLSyntaxError(
+                     source, position,
+-                    u'Invalid character escape sequence: \\{}.'.format(unichr(code))
++                    u'Invalid character escape sequence: \\{}.'.format(chr(code))
+                 )
+ 
+             position += 1
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/parser.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/parser.py
+index 21adac9..d2854a3 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/parser.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/parser.py
+@@ -1,5 +1,3 @@
+-from six import string_types
+-
+ from . import ast
+ from ..error import GraphQLSyntaxError
+ from .lexer import Lexer, TokenKind, get_token_desc, get_token_kind_desc
+@@ -14,7 +12,7 @@ def parse(source, **kwargs):
+     options.update(kwargs)
+     source_obj = source
+ 
+-    if isinstance(source, string_types):
++    if isinstance(source, str):
+         source_obj = Source(source)
+ 
+     parser = Parser(source_obj, options)
+@@ -26,7 +24,7 @@ def parse_value(source, **kwargs):
+     options.update(kwargs)
+     source_obj = source
+ 
+-    if isinstance(source, string_types):
++    if isinstance(source, str):
+         source_obj = Source(source)
+ 
+     parser = Parser(source_obj, options)
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/visitor.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/visitor.py
+index a77c36e..95cd69a 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/visitor.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/visitor.py
+@@ -1,7 +1,5 @@
+ from copy import copy
+ 
+-import six
+-
+ from . import ast
+ from .visitor_meta import QUERY_DOCUMENT_KEYS, VisitorMeta
+ 
+@@ -158,8 +156,7 @@ def visit(root, visitor, key_map=None):
+     return new_root
+ 
+ 
+-@six.add_metaclass(VisitorMeta)
+-class Visitor(object):
++class Visitor(metaclass=VisitorMeta):
+     __slots__ = ()
+ 
+     def enter(self, node, key, parent, path, ancestors):
 diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py
-index f73391199..614df9f57 100644
+index f733911..614df9f 100644
 --- a/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py
 +++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/pyutils/version.py
 @@ -42,7 +42,7 @@ def get_complete_version(version=None):
@@ -11,3 +191,226 @@ index f73391199..614df9f57 100644
      else:
          assert len(version) == 5
          assert version[3] in ('alpha', 'beta', 'rc', 'final')
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/definition.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/definition.py
+index 65e3a90..1d0c4b4 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/definition.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/definition.py
+@@ -1,3 +1,4 @@
++from collections.abc import Mapping, Hashable
+ import collections
+ import copy
+ 
+@@ -188,7 +189,7 @@ def define_field_map(type, field_map):
+     if callable(field_map):
+         field_map = field_map()
+ 
+-    assert isinstance(field_map, collections.Mapping) and len(field_map) > 0, (
++    assert isinstance(field_map, Mapping) and len(field_map) > 0, (
+         '{} fields must be a mapping (dict / OrderedDict) with field names as keys or a '
+         'function which returns such a mapping.'
+     ).format(type)
+@@ -198,7 +199,7 @@ def define_field_map(type, field_map):
+         field_args = getattr(field, 'args', None)
+ 
+         if field_args:
+-            assert isinstance(field_args, collections.Mapping), (
++            assert isinstance(field_args, Mapping), (
+                 '{}.{} args must be a mapping (dict / OrderedDict) with argument names as keys.'.format(type,
+                                                                                                         field_name)
+             )
+@@ -407,7 +408,7 @@ class GraphQLEnumType(GraphQLType):
+         self.values = define_enum_values(self, values)
+ 
+     def serialize(self, value):
+-        if isinstance(value, collections.Hashable):
++        if isinstance(value, Hashable):
+             enum_value = self._value_lookup.get(value)
+ 
+             if enum_value:
+@@ -416,7 +417,7 @@ class GraphQLEnumType(GraphQLType):
+         return None
+ 
+     def parse_value(self, value):
+-        if isinstance(value, collections.Hashable):
++        if isinstance(value, Hashable):
+             enum_value = self._name_lookup.get(value)
+ 
+             if enum_value:
+@@ -441,7 +442,7 @@ class GraphQLEnumType(GraphQLType):
+ 
+ 
+ def define_enum_values(type, value_map):
+-    assert isinstance(value_map, collections.Mapping) and len(value_map) > 0, (
++    assert isinstance(value_map, Mapping) and len(value_map) > 0, (
+         '{} values must be a mapping (dict / OrderedDict) with value names as keys.'.format(type)
+     )
+ 
+@@ -522,7 +523,7 @@ class GraphQLInputObjectType(GraphQLType):
+         if callable(fields):
+             fields = fields()
+ 
+-        assert isinstance(fields, collections.Mapping) and len(fields) > 0, (
++        assert isinstance(fields, Mapping) and len(fields) > 0, (
+             '{} fields must be a mapping (dict / OrderedDict) with field names as keys or a '
+             'function which returns such a mapping.'
+         ).format(self)
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/directives.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/directives.py
+index 06c920d..c566b4d 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/directives.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/directives.py
+@@ -1,4 +1,4 @@
+-import collections
++from collections.abc import Iterable, Mapping
+ 
+ from ..pyutils.ordereddict import OrderedDict
+ from ..utils.assert_valid_name import assert_valid_name
+@@ -52,14 +52,14 @@ class GraphQLDirective(object):
+     def __init__(self, name, description=None, args=None, locations=None):
+         assert name, 'Directive must be named.'
+         assert_valid_name(name)
+-        assert isinstance(locations, collections.Iterable), 'Must provide locations for directive.'
++        assert isinstance(locations, Iterable), 'Must provide locations for directive.'
+ 
+         self.name = name
+         self.description = description
+         self.locations = locations
+ 
+         if args:
+-            assert isinstance(args, collections.Mapping), '{} args must be a dict with argument names as keys.'.format(name)
++            assert isinstance(args, Mapping), '{} args must be a dict with argument names as keys.'.format(name)
+             for arg_name, _arg in args.items():
+                 assert_valid_name(arg_name)
+                 assert is_input_type(_arg.type), '{}({}) argument type must be Input Type but got {}.'.format(
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/scalars.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/scalars.py
+index bae7a9c..62955b5 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/scalars.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/scalars.py
+@@ -1,5 +1,3 @@
+-from six import string_types, text_type
+-
+ from ..language.ast import BooleanValue, FloatValue, IntValue, StringValue
+ from .definition import GraphQLScalarType
+ 
+@@ -68,20 +66,20 @@ GraphQLFloat = GraphQLScalarType(
+ 
+ 
+ def coerce_string(value):
+-    if isinstance(value, string_types):
++    if isinstance(value, str):
+         return value
+ 
+     if isinstance(value, bool):
+         return u'true' if value else u'false'
+ 
+-    return text_type(value)
++    return str(value)
+ 
+ 
+ def coerce_str(value):
+-    if isinstance(value, string_types):
++    if isinstance(value, str):
+         return value
+ 
+-    return text_type(value)
++    return str(value)
+ 
+ 
+ def parse_string_literal(ast):
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/schema.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/schema.py
+index 088183f..7f29b8f 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/schema.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/schema.py
+@@ -1,4 +1,4 @@
+-from collections import Iterable
++from collections.abc import Iterable
+ 
+ from .definition import GraphQLObjectType
+ from .directives import GraphQLDirective, specified_directives
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/typemap.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/typemap.py
+index 577a111..12733a6 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/typemap.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/typemap.py
+@@ -1,4 +1,5 @@
+-from collections import OrderedDict, Sequence, defaultdict
++from collections import OrderedDict, defaultdict
++from collections.abc import Sequence
+ from functools import reduce
+ 
+ from ..utils.type_comparators import is_equal_type, is_type_sub_type_of
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/ast_from_value.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/ast_from_value.py
+index d41a91d..1355ef5 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/ast_from_value.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/ast_from_value.py
+@@ -2,8 +2,6 @@ import json
+ import re
+ import sys
+ 
+-from six import string_types
+-
+ from ..language import ast
+ from ..type.definition import (GraphQLEnumType, GraphQLInputObjectType,
+                                GraphQLList, GraphQLNonNull)
+@@ -40,7 +38,7 @@ def ast_from_value(value, type=None):
+ 
+         return ast.FloatValue(string_num)
+ 
+-    if isinstance(value, string_types):
++    if isinstance(value, str):
+         if isinstance(type, GraphQLEnumType) and re.match(r'^[_a-zA-Z][_a-zA-Z0-9]*$', value):
+             return ast.EnumValue(value)
+ 
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/is_valid_value.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/is_valid_value.py
+index b3d5d05..eddce4f 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/is_valid_value.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/is_valid_value.py
+@@ -2,11 +2,9 @@
+     Implementation of isValidJSValue from graphql.s
+ """
+ 
+-import collections
++from collections.abc import Iterable, Mapping
+ import json
+ 
+-from six import string_types
+-
+ from ..type import (GraphQLEnumType, GraphQLInputObjectType, GraphQLList,
+                     GraphQLNonNull, GraphQLScalarType)
+ 
+@@ -27,7 +25,7 @@ def is_valid_value(value, type):
+ 
+     if isinstance(type, GraphQLList):
+         item_type = type.of_type
+-        if not isinstance(value, string_types) and isinstance(value, collections.Iterable):
++        if not isinstance(value, str) and isinstance(value, Iterable):
+             errors = []
+             for i, item in enumerate(value):
+                 item_errors = is_valid_value(item, item_type)
+@@ -40,7 +38,7 @@ def is_valid_value(value, type):
+             return is_valid_value(value, item_type)
+ 
+     if isinstance(type, GraphQLInputObjectType):
+-        if not isinstance(value, collections.Mapping):
++        if not isinstance(value, Mapping):
+             return [u'Expected "{}", found not an object.'.format(type)]
+ 
+         fields = type.fields
+diff --git a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/type_info.py b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/type_info.py
+index d81fd0d..6baf417 100644
+--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/type_info.py
++++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/type_info.py
+@@ -1,5 +1,3 @@
+-import six
+-
+ from ..language import visitor_meta
+ from ..type.definition import (GraphQLInputObjectType, GraphQLList,
+                                get_named_type, get_nullable_type,
+@@ -14,8 +12,7 @@ def pop(lst):
+ 
+ 
+ # noinspection PyPep8Naming
+-@six.add_metaclass(visitor_meta.VisitorMeta)
+-class TypeInfo(object):
++class TypeInfo(metaclass=visitor_meta.VisitorMeta):
+     __slots__ = '_schema', '_type_stack', '_parent_type_stack', '_input_type_stack', '_field_def_stack', '_directive', \
+                 '_argument', '_get_field_def_fn'
+ 

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/error/base.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/error/base.py
@@ -1,4 +1,3 @@
-import six
 from ..language.location import get_location
 
 
@@ -32,7 +31,7 @@ class GraphQLError(Exception):
 
     def reraise(self):
         if self.stack:
-            six.reraise(type(self), self, self.stack)
+            raise self.with_traceback(self.stack)
         else:
             raise self
 

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/executor.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/executor.py
@@ -1,10 +1,9 @@
 import collections
-from six.moves.collections_abc import Iterable
+from collections.abc import Iterable
 import functools
 import logging
 import sys
 
-from six import string_types
 from promise import Promise, promise_for_dict, is_thenable
 
 from ..error import GraphQLError, GraphQLLocatedError
@@ -336,7 +335,7 @@ def complete_abstract_value(exe_context, return_type, field_asts, info, result):
         else:
             runtime_type = get_default_resolve_type_fn(result, exe_context.context_value, info, return_type)
 
-    if isinstance(runtime_type, string_types):
+    if isinstance(runtime_type, str):
         runtime_type = info.schema.get_type(runtime_type)
 
     if not isinstance(runtime_type, GraphQLObjectType):

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/experimental/resolver.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/experimental/resolver.py
@@ -1,5 +1,5 @@
 import sys
-from six.moves.collections_abc import Iterable
+from collections.abc import Iterable
 from functools import partial
 
 from promise import Promise, is_thenable

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/values.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/execution/values.py
@@ -1,7 +1,5 @@
-from six.moves.collections_abc import Iterable
+from collections.abc import Iterable
 import json
-
-from six import string_types
 
 from ..error import GraphQLError
 from ..language.printer import print_ast
@@ -121,7 +119,7 @@ def coerce_value(type, value):
 
     if isinstance(type, GraphQLList):
         item_type = type.of_type
-        if not isinstance(value, string_types) and isinstance(value, Iterable):
+        if not isinstance(value, str) and isinstance(value, Iterable):
             return [coerce_value(item_type, item) for item in value]
         else:
             return [coerce_value(item_type, value)]

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/lexer.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/lexer.py
@@ -1,7 +1,5 @@
 import json
 
-from six import unichr
-
 from ..error import GraphQLSyntaxError
 
 __all__ = ['Token', 'Lexer', 'TokenKind',
@@ -134,7 +132,7 @@ def print_char_code(code):
         return '<EOF>'
 
     if code < 0x007F:
-        return json.dumps(unichr(code))
+        return json.dumps(chr(code))
 
     return '"\\u%04X"' % code
 
@@ -368,12 +366,12 @@ def read_string(source, start):
                         u'Invalid character escape sequence: \\u{}.'.format(body[position + 1: position + 5])
                     )
 
-                append(unichr(char_code))
+                append(chr(char_code))
                 position += 4
             else:
                 raise GraphQLSyntaxError(
                     source, position,
-                    u'Invalid character escape sequence: \\{}.'.format(unichr(code))
+                    u'Invalid character escape sequence: \\{}.'.format(chr(code))
                 )
 
             position += 1

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/parser.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/parser.py
@@ -1,5 +1,3 @@
-from six import string_types
-
 from . import ast
 from ..error import GraphQLSyntaxError
 from .lexer import Lexer, TokenKind, get_token_desc, get_token_kind_desc
@@ -14,7 +12,7 @@ def parse(source, **kwargs):
     options.update(kwargs)
     source_obj = source
 
-    if isinstance(source, string_types):
+    if isinstance(source, str):
         source_obj = Source(source)
 
     parser = Parser(source_obj, options)
@@ -26,7 +24,7 @@ def parse_value(source, **kwargs):
     options.update(kwargs)
     source_obj = source
 
-    if isinstance(source, string_types):
+    if isinstance(source, str):
         source_obj = Source(source)
 
     parser = Parser(source_obj, options)

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/language/visitor.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/language/visitor.py
@@ -1,7 +1,5 @@
 from copy import copy
 
-import six
-
 from . import ast
 from .visitor_meta import QUERY_DOCUMENT_KEYS, VisitorMeta
 
@@ -158,8 +156,7 @@ def visit(root, visitor, key_map=None):
     return new_root
 
 
-@six.add_metaclass(VisitorMeta)
-class Visitor(object):
+class Visitor(metaclass=VisitorMeta):
     __slots__ = ()
 
     def enter(self, node, key, parent, path, ancestors):

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/definition.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/definition.py
@@ -1,4 +1,4 @@
-from six.moves.collections_abc import Mapping, Hashable
+from collections.abc import Mapping, Hashable
 import collections
 import copy
 

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/directives.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/directives.py
@@ -1,4 +1,4 @@
-from six.moves.collections_abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 from ..pyutils.ordereddict import OrderedDict
 from ..utils.assert_valid_name import assert_valid_name

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/scalars.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/scalars.py
@@ -1,5 +1,3 @@
-from six import string_types, text_type
-
 from ..language.ast import BooleanValue, FloatValue, IntValue, StringValue
 from .definition import GraphQLScalarType
 
@@ -68,20 +66,20 @@ GraphQLFloat = GraphQLScalarType(
 
 
 def coerce_string(value):
-    if isinstance(value, string_types):
+    if isinstance(value, str):
         return value
 
     if isinstance(value, bool):
         return u'true' if value else u'false'
 
-    return text_type(value)
+    return str(value)
 
 
 def coerce_str(value):
-    if isinstance(value, string_types):
+    if isinstance(value, str):
         return value
 
-    return text_type(value)
+    return str(value)
 
 
 def parse_string_literal(ast):

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/schema.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/schema.py
@@ -1,4 +1,4 @@
-from six.moves.collections_abc import Iterable
+from collections.abc import Iterable
 
 from .definition import GraphQLObjectType
 from .directives import GraphQLDirective, specified_directives

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/type/typemap.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/type/typemap.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict, defaultdict
-from six.moves.collections_abc import Sequence
+from collections.abc import Sequence
 from functools import reduce
 
 from ..utils.type_comparators import is_equal_type, is_type_sub_type_of

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/ast_from_value.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/ast_from_value.py
@@ -2,8 +2,6 @@ import json
 import re
 import sys
 
-from six import string_types
-
 from ..language import ast
 from ..type.definition import (GraphQLEnumType, GraphQLInputObjectType,
                                GraphQLList, GraphQLNonNull)
@@ -40,7 +38,7 @@ def ast_from_value(value, type=None):
 
         return ast.FloatValue(string_num)
 
-    if isinstance(value, string_types):
+    if isinstance(value, str):
         if isinstance(type, GraphQLEnumType) and re.match(r'^[_a-zA-Z][_a-zA-Z0-9]*$', value):
             return ast.EnumValue(value)
 

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/is_valid_value.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/is_valid_value.py
@@ -2,10 +2,8 @@
     Implementation of isValidJSValue from graphql.s
 """
 
-from six.moves.collections_abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 import json
-
-from six import string_types
 
 from ..type import (GraphQLEnumType, GraphQLInputObjectType, GraphQLList,
                     GraphQLNonNull, GraphQLScalarType)
@@ -27,7 +25,7 @@ def is_valid_value(value, type):
 
     if isinstance(type, GraphQLList):
         item_type = type.of_type
-        if not isinstance(value, string_types) and isinstance(value, Iterable):
+        if not isinstance(value, str) and isinstance(value, Iterable):
             errors = []
             for i, item in enumerate(value):
                 item_errors = is_valid_value(item, item_type)

--- a/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/type_info.py
+++ b/wandb/vendor/graphql-core-1.1/wandb_graphql/utils/type_info.py
@@ -1,5 +1,3 @@
-import six
-
 from ..language import visitor_meta
 from ..type.definition import (GraphQLInputObjectType, GraphQLList,
                                get_named_type, get_nullable_type,
@@ -14,8 +12,7 @@ def pop(lst):
 
 
 # noinspection PyPep8Naming
-@six.add_metaclass(visitor_meta.VisitorMeta)
-class TypeInfo(object):
+class TypeInfo(metaclass=visitor_meta.VisitorMeta):
     __slots__ = '_schema', '_type_stack', '_parent_type_stack', '_input_type_stack', '_field_def_stack', '_directive', \
                 '_argument', '_get_field_def_fn'
 

--- a/wandb/vendor/watchdog_0_9_0/wandb_watchdog/utils/bricks.py
+++ b/wandb/vendor/watchdog_0_9_0/wandb_watchdog/utils/bricks.py
@@ -37,7 +37,7 @@ Classes
 """
 
 import sys
-from six.moves.collections_abc import MutableSet
+from collections.abc import MutableSet
 from .compat import queue
 
 class SkipRepeatsQueue(queue.Queue):


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
This PR removes dependency on `six` by modifying vendored libs `gql` and `graphql-core`.

Concretely what I did was:
- Downloaded the vendored versions of the libraries from PyPI (tar balls)
- Initialized git in the uncompressed directories, applied our wandb-vendor diff's (manually)
- Identified all files that used six with `git grep " six"` (to catch `import six` and `from six import ...`)
- Ran `pyupgrade --py36-plus <filename>` on each identified file and manually made sure the result was good.
- Generated new diffs with `git diff > wandb-vendor.diff`, ensured they looked good
- Copied stuff over to the SDK and checked the diffs once again.

Testing
-------
CI!

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
