### PR TITLE
chore(sdk): add the 'build' type to our CC setup

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,7 @@ jobs:
             refactor
             perf
             test
+            build
             ci
             chore
             revert

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,7 @@ Examples can be found in the section below.
 | refactor | 📦 Code Refactor            | A code change that neither fixes a bug nor adds a feature                                    | No           |
 | perf     | 🚀 Performance Improvements | A code change that improves performance                                                      | No           |
 | test     | 🚨 Tests                    | Adding new or missing tests or correcting existing tests                                     | No           |
+| build    | 🛠 Builds                   | Changes that affect the build system (e.g. protobuf) or external dependencies                | Maybe        |
 | ci       | ⚙️ Continuous Integrations  | Changes to our CI configuration files and scripts                                            | No           |
 | chore    | ♻️ Chores                   | Other changes that don't modify source code files.                                           | No           |
 | revert   | 🗑 Reverts                  | Reverts a previous commit                                                                    | Maybe        |


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
I realized that it best describes the third-party-related stuff while working on the protobuf version upgrade stuff.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
