### PR TITLE
chore(artifacts): require Run.files(names) to be non-null

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -23,7 +23,7 @@ import time
 import urllib
 from collections import namedtuple
 from functools import partial
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 import requests
 from wandb_gql import Client, gql
@@ -2600,7 +2600,7 @@ class Files(Paginator):
     QUERY = gql(
         """
         query RunFiles($project: String!, $entity: String!, $name: String!, $fileCursor: String,
-            $fileLimit: Int = 50, $fileNames: [String] = [], $upload: Boolean = false) {
+            $fileLimit: Int = 50, $fileNames: [String!] = [], $upload: Boolean = false) {
             project(name: $project, entityName: $entity) {
                 run(name: $name) {
                     fileCount
@@ -2613,7 +2613,14 @@ class Files(Paginator):
         % FILE_FRAGMENT
     )
 
-    def __init__(self, client, run, names=None, per_page=50, upload=False):
+    def __init__(
+        self,
+        client: Client,
+        run: Run,
+        names: Optional[Sequence[str]] = None,
+        per_page: int = 50,
+        upload: bool = False,
+    ):
         self.run = run
         variables = {
             "project": run.project,

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -7,7 +7,6 @@ import os
 import re
 import socket
 import sys
-from abc import ABC
 from copy import deepcopy
 from typing import (
     IO,
@@ -1568,7 +1567,7 @@ class Api:
     def upload_urls(
         self,
         project: str,
-        files: Union[List[str], Dict[str, IO]],
+        files: Iterable[str],
         run: Optional[str] = None,
         entity: Optional[str] = None,
         description: Optional[str] = None,
@@ -1593,7 +1592,7 @@ class Api:
         """
         query = gql(
             """
-        query RunUploadUrls($name: String!, $files: [String]!, $entity: String, $run: String!, $description: String) {
+        query RunUploadUrls($name: String!, $files: [String!]!, $entity: String, $run: String!, $description: String) {
             model(name: $name, entityName: $entity) {
                 bucket(name: $run, desc: $description) {
                     id


### PR DESCRIPTION
Description
-----------

In our GraphQL API, `Run.files(names=...)` should have `names` of type `[String!]` rather than `[String]` -- the server will reject any request with a `null` entry in `names`. But the schema on the server can't tighten up, because the the SDK makes requests that declare `names: $fileNames` with `$filenames: [String]`; and that looks ill-typed to the server even if the _concrete value_ doesn't contain any nulls. So we need to fix the SDK to stop making those requests, and _then_, after waiting months for people to upgrade, we can update the schema on the server.

Testing
-------

Ran the new query against production, verified it succeeded:

```python
In [6]: gql = '''
   ...: query RunFiles($project: String!, $entity: String!, $name: String!, $fileCursor: String, $fileLimit: Int = 50, $fileNames: [String!] = [], $upload: Boolean = false) {
   ...:     project(name: $project, entityName: $entity) {
   ...:         run(name: $name) {
   ...:             fileCount
   ...:             ...RunFilesFragment
   ...:         }
   ...:     }
   ...: }
   ...: fragment RunFilesFragment on Run {
   ...:     files(names: $fileNames, after: $fileCursor, first: $fileLimit) {
   ...:         edges {
   ...:             node {
   ...:                 id
   ...:                 name
   ...:                 url(upload: $upload)
   ...:                 directUrl
   ...:                 sizeBytes
   ...:                 mimetype
   ...:                 updatedAt
   ...:                 md5
   ...:             }
   ...:             cursor
   ...:         }
   ...:         pageInfo {
   ...:             endCursor
   ...:             hasNextPage
   ...:         }
   ...:     }
   ...: }
   ...: '''

In [7]: variables = {"project": "my-public-project", "entity": "spencerpearson-wandb", "name": "zo9p1hdf", "fileNames": "[]"}

In [8]: import requests

In [9]: print(requests.post("https://api.wandb.ai/graphql", json={"query":gql, "variables":variables}).json())
{'data': {'project': {'run': {'fileCount': 6, 'files': {'edges': [{'node': {'id': 'RmlsZTpzcGVuY2VycGVhcnNvbi13YW5kYjpteS1wdWJsaWMtcHJvamVjdDp6bzlwMWhkZjpbXQ==', 'name': '[]', 'url': 'https://api.wandb.ai/files/spencerpearson-wandb/my-public-project/zo9p1hdf/[]', 'directUrl': 'https://storage.googleapis.com/wandb-production.appspot.com/spencerpearson-wandb/my-public-project/zo9p1hdf/[]', 'sizeBytes': 0, 'mimetype': None, 'updatedAt': None, 'md5': '0'}, 'cursor': 'YXJyYXljb25uZWN0aW9uOjA='}], 'pageInfo': {'endCursor': 'YXJyYXljb25uZWN0aW9uOjA=', 'hasNextPage': False}}}}}}
```

Whereas, if I tweak the query to not match the server's schema (specifically, changing `$name: String!` to `$name: String`), I get an error:

```python
In [11]: print(requests.post("https://api.wandb.ai/graphql", json={"query":gql, "variables":variables}).json())
{'errors': [{'message': 'Variable "$name" of type "String" used in position expecting type "String!".', 'locations': [{'line': 2, 'column': 53}, {'line': 4, 'column': 19}]}]}
```

I regard this as pretty strong evidence that I haven't botched the query.