### PR TITLE
Make download_async a thing

### DIFF
--- a/tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_wandb_artifacts.py
@@ -5,6 +5,7 @@ import shutil
 from datetime import datetime, timezone
 
 import numpy as np
+import platform
 import pytest
 import wandb
 import wandb.data_types as data_types

--- a/tests/unit_tests_old/test_public_api.py
+++ b/tests/unit_tests_old/test_public_api.py
@@ -356,6 +356,20 @@ def test_artifact_download(runner, mock_server, api):
         assert os.listdir(path) == ["digits.h5"]
 
 
+@pytest.mark.asyncio
+async def test_artifact_download_async(runner, mock_server, api):
+    with runner.isolated_filesystem():
+        art = api.artifact("entity/project/mnist:v0", type="dataset")
+        future = art.download_async()
+        if platform.system() == "Windows":
+            part = "mnist-v0"
+        else:
+            part = "mnist:v0"
+        path = await future
+        assert path == os.path.join(".", "artifacts", part)
+        assert os.listdir(path) == ["digits.h5"]
+
+
 def test_artifact_delete(runner, mock_server, api):
     with runner.isolated_filesystem():
         art = api.artifact("entity/project/mnist:v0", type="dataset")

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements.txt
     pytest
+    pytest-asyncio
     pytest-cov
     pytest-xdist
     pytest-flask

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -1,3 +1,4 @@
+from asyncio import Future
 import base64
 import binascii
 import codecs
@@ -614,6 +615,26 @@ class Artifact:
 
         Returns:
             (str): The path to the downloaded contents.
+        """
+        raise NotImplementedError
+
+    def download_async(
+        self, root: Optional[str] = None, recursive: bool = False
+    ) -> Future:
+        """
+        Downloads the contents of the artifact to the specified root directory asynchronously.
+
+        NOTE: Any existing files at `root` are left untouched. Explicitly delete
+        root before calling `download` if you want the contents of `root` to exactly
+        match the artifact.
+
+        Arguments:
+            root: (str, optional) The directory in which to download this artifact's files.
+            recursive: (bool, optional) If true, then all dependent artifacts are eagerly
+                downloaded. Otherwise, the dependent artifacts are downloaded as needed.
+
+        Returns:
+            (Future): A future that can be awaited returning the directory
         """
         raise NotImplementedError
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1,3 +1,4 @@
+from asyncio import Future
 import base64
 import contextlib
 import hashlib
@@ -577,6 +578,14 @@ class Artifact(ArtifactInterface):
         )
 
     def download(self, root: str = None, recursive: bool = False) -> str:
+        if self._logged_artifact:
+            return self._logged_artifact.download(root=root, recursive=recursive)
+
+        raise ValueError(
+            "Cannot call download on an artifact before it has been logged or in offline mode"
+        )
+
+    def download_async(self, root: str = None, recursive: bool = False) -> Future:
         if self._logged_artifact:
             return self._logged_artifact.download(root=root, recursive=recursive)
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1,4 +1,5 @@
 import _thread as thread
+from asyncio import Future
 import atexit
 import functools
 import glob
@@ -3716,6 +3717,11 @@ class _LazyArtifact(ArtifactInterface):
 
     def download(self, root: Optional[str] = None, recursive: bool = False) -> str:
         return self._assert_instance().download(root, recursive)
+
+    def download_async(
+        self, root: Optional[str] = None, recursive: bool = False
+    ) -> Future:
+        return self._assert_instance().download_async(root, recursive)
 
     def checkout(self, root: Optional[str] = None) -> str:
         return self._assert_instance().checkout(root)


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
This adds a download_async to artifacts in response to a user request.

Testing
-------
Unit test.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
