### PR TITLE
fix(artifacts): Catch retryable request timeout when uploading artifacts to AWS

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1889,7 +1889,9 @@ class Api:
             status_code = e.response.status_code if e.response is not None else 0
             # S3 reports retryable request timeouts out-of-band
             is_aws_retryable = (
-                status_code == 400 and "RequestTimeout" in response_content
+                "x-amz-meta-md5" in extra_headers
+                and status_code == 400
+                and "RequestTimeout" in response_content
             )
             # We need to rewind the file for the next retry (the file passed in is seeked to 0)
             progress.rewind()


### PR DESCRIPTION
Fixes WB-11059
Fixes #NNNN

Description
-----------

Instead of the standard `408` status code, S3 will respond with [code `400` and an XML payload](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html) containing an error string and detailed error message. This has been observed to happen intermittently for `PUT` (upload) requests, and more consistently when uploading larger artifacts.

This PR attempts to detect these out-of-band `RequestTimeout` errors and correctly retry the request.

Testing
-------
How was this PR tested? TBD

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
