### PR TITLE
fix(sdk): Add tensorflow_datasets requirement to imports12

### DIFF
--- a/tests/functional_tests/t0_main/imports/12-batch12.py
+++ b/tests/functional_tests/t0_main/imports/12-batch12.py
@@ -11,6 +11,7 @@ depend:
   pip_install_timeout: 1500  # 25m
   requirements:
     - tensorflow
+    - tensorflow_datasets
     - "-r 12-batch12-requirements.txt"
 assert:
   - :wandb:runs_len: 1


### PR DESCRIPTION
Description
-----------
Add `tensorflow_datasets` requirement to imports12.

Testing
-------
`func-s_imports12-lin-py37`

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
