### PR TITLE
fix(launch): Git URLs were failing if fsmonitor is enabled

### DIFF
--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -12,7 +12,7 @@ class Api:
 
     @property
     def api(self):
-        # This is a property in order ot delay construction of Internal API
+        # This is a property in order to delay construction of Internal API
         # for as long as possible. If constructed in constructor, then the
         # whole InternalAPI is started when simply importing wandb.
         if self._api is None:

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -479,6 +479,7 @@ def _create_docker_build_ctx(
         src=launch_project.project_dir,
         dst=dst_path,
         symlinks=True,
+        ignore=shutil.ignore_patterns("fsmonitor--daemon.ipc"),
     )
     shutil.copy(
         os.path.join(os.path.dirname(__file__), "templates", "_wandb_bootstrap.py"),


### PR DESCRIPTION
Fixes WB-11072

Description
-----------
Git now has an option to use a built-in filesystem monitor, which can improve performance. 
It can be enabled with `git config core.fsmonitor true`
When enabled, running launch with a git url would throw an exception while executing shutil.copytree:
`[Errno 102] Operation not supported on socket`
This change ignores the socket file.

Also fixed a typo.


Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
