### PR TITLE
test(integrations): fix sb3 test by pinning upstream requirement

### DIFF
--- a/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
+++ b/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
@@ -4,6 +4,9 @@ plugin:
 tag:
   skips:
     - platform: win
+depend:
+  requirements:
+    - importlib-metadata<5.0  # 20221003: sb3 needs to fix this on their side
 assert:
   - :wandb:runs_len: 1
   - :wandb:runs[0][config][policy_type]: MlpPolicy


### PR DESCRIPTION
Description
-----------
A recent `importlib-metadata` release (5.0.0) removed a deprecated API that `sb3` has been apparently using. Fixed our test by pinning a corresponding requirement until they fix it upstream.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
