### PR TITLE
chore(sdk): fix flake8 output coloring

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -232,7 +232,7 @@ deps=
 
 [testenv:isort-check]
 basepython = python3
-skip_install = truecommit
+skip_install = true
 deps=
     {[isort]deps}
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -166,8 +166,7 @@ commands=
 
 [flake8base]
 deps =
-    flake8
-    flake8-colors
+    flake8>=5.0.0
     grpcio>=1.46.3
 
 [testenv:flake8]
@@ -180,7 +179,7 @@ deps =
     flake8-fixme
     flake8-typing-imports>=1.1
 commands =
-    flake8 --append-config={toxinidir}/.flake8-base {posargs}
+    flake8 --append-config={toxinidir}/.flake8-base --color=always {posargs}
 
 [testenv:docstrings]
 basepython=python3
@@ -230,12 +229,10 @@ commands=
 [isort]
 deps=
     isort
-commands=
-    isort --resolve-all-configs --config-root {toxinidir} {toxinidir}
 
 [testenv:isort-check]
 basepython = python3
-skip_install = true
+skip_install = truecommit
 deps=
     {[isort]deps}
 commands=
@@ -304,7 +301,6 @@ ignore =
     DAR103,
 # select = C,E,F,W,B,B901,I,N
 max-complexity = 18
-format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
 # docstring checking
 docstring-convention = all
 docstring-style = google


### PR DESCRIPTION
Description
-----------
`flake8-color` has been integrated upstream and is now obsolete; they also changed some formatting so that our old format broke.

Testing
-------
"Well, it works on my machine..."

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
