### PR TITLE
ci(sdk): test a GH action to automate parts of the release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,13 +2,28 @@ changelog:
   exclude:
     labels:
       - changelog-ignore
+      - ignore-for-release
+      - cc-revert
+    authors:
+      - octocat
   categories:
-    - title: ":nail_care: Enhancement"
+    - title: ":magic_wand: Enhancements"
       labels:
-        - changelog-enhancement
-    - title: ":broom: Cleanup"
+        - cc-feat
+        - cc-perf
+    - title: ":hammer: Fixes"
       labels:
-        - changelog-cleanup
-    - title: ":bug: Bug Fix"
+        - cc-fix
+        - cc-security
+    - title: ":books: Docs"
+      labels:
+        - cc-docs
+    - title: ":toolbox: Dev"
+      labels:
+        - cc-build
+        - cc-ci
+        - cc-test
+        - cc-chore
+    - title: ":nail_care: Cleanup"
       labels:
         - "*"

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -1,0 +1,13 @@
+# Warning, do not check out untrusted code with
+# the pull_request_target event.
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1
+#        with:
+#          type_labels: '{"feat": "feature", "fix": "fix"}'

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -9,5 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: bcoe/conventional-release-labels@v1
-#        with:
-#          type_labels: '{"feat": "feature", "fix": "fix"}'
+        with:
+          ignored_types: "[]"
+          type_labels: '{"feat": "cc-feat", "fix": "cc-fix", "docs": "cc-docs", "style": "cc-style", "refactor": "cc-refactor", "perf": "cc-perf", "test": "cc-test", "build": "cc-build", "ci": "cc-ci", "chore": "cc-chore", "revert": "cc-revert", "security": "cc-security"}'


### PR DESCRIPTION
Description
-----------
- Use the `bcoe/conventional-release-labels` GitHub Action to auto-assign labels to PRs based on the conventional commits types.
- Reorganize the automated release note generation based on that.

Testing
-------
Tested manually, but thoroughly ;)

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
