### PR TITLE
test(artifacts): add standalone artifact test to nightly cpu suite

### DIFF
--- a/tests/standalone_tests/artifact_tests.yea
+++ b/tests/standalone_tests/artifact_tests.yea
@@ -1,7 +1,5 @@
-id: 0.standalone.04-artifact-tests
 tag:
   shard: standalone-cpu
-  skip: true
   platforms:
     - linux
     - mac

--- a/tests/standalone_tests/artifact_tests.yea
+++ b/tests/standalone_tests/artifact_tests.yea
@@ -7,4 +7,13 @@ tag:
 plugin:
   - wandb
 assert:
-  - :wandb:runs: None
+  - :yea:exit: 0
+  - :wandb:runs_len: 8
+  - :wandb:runs[0][exitcode]: 0
+  - :wandb:runs[1][exitcode]: 0
+  - :wandb:runs[2][exitcode]: 0
+  - :wandb:runs[3][exitcode]: 0
+  - :wandb:runs[4][exitcode]: 0
+  - :wandb:runs[5][exitcode]: 0
+  - :wandb:runs[6][exitcode]: 0
+  - :wandb:runs[7][exitcode]: 0


### PR DESCRIPTION
Partially Fixes WB-11204

Description
-----------
Adds artifact test to nightly
<img width="1301" alt="Screen Shot 2022-10-07 at 2 55 24 PM" src="https://user-images.githubusercontent.com/1832511/194668265-c3dd7f29-719e-405e-8fbc-72f27c943536.png">
https://app.circleci.com/pipelines/github/wandb/wandb/15962/workflows/07b79a66-3fb7-4d36-b404-a85579d9ac6f


Testing
-------
Run manually.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
