### PR TITLE
ci(sdk): make sure we dont shutdown test cluster before grabbing results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,10 +715,10 @@ jobs:
               terminated_pods=`kubectl get pods --field-selector=status.phase!=Succeeded,status.phase!=Failed 2>&1`
               all_pods_terminated=`echo $(echo $terminated_pods | grep -c "No resources found")`
               if [ "$all_pods_terminated" -eq "1" ]; then
-                echo "All pods have terminated"
                 count_all_pods_terminated=$((count_all_pods_terminated + 1))
+                echo "All pods have terminated ($count_all_pods_terminated)"
                 # make sure we have seen all pods terminated twice to give pod attach a chance to run
-                if [ count_all_pods_terminated -ge 2 ]; then break; fi
+                if [ $count_all_pods_terminated -ge 2 ]; then break; fi
               fi
               sleep << parameters.sleep_time >>
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,13 +709,16 @@ jobs:
           command: |
             echo "Waiting for pods to finish"
             sleep 300
+            count_all_pods_terminated=0
             while true; do
               kubectl get pods
               terminated_pods=`kubectl get pods --field-selector=status.phase!=Succeeded,status.phase!=Failed 2>&1`
               all_pods_terminated=`echo $(echo $terminated_pods | grep -c "No resources found")`
               if [ "$all_pods_terminated" -eq "1" ]; then
                 echo "All pods have terminated"
-                break
+                count_all_pods_terminated=$((count_all_pods_terminated + 1))
+                # make sure we have seen all pods terminated twice to give pod attach a chance to run
+                if [ count_all_pods_terminated -ge 2 ]; then break; fi
               fi
               sleep << parameters.sleep_time >>
             done


### PR DESCRIPTION
Description
-----------
Fix race in nightly testing where we could shutdown the cluster before getting a chance to grab results.   This makes the race much less likely.

Testing
-------
Manually
https://app.circleci.com/pipelines/github/wandb/wandb/15966/workflows/52e33dc6-d28c-414e-bcc7-a37a441dcf36

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
