### PR TITLE
fix(integrations): update gym integration to match last version

### DIFF
--- a/wandb/integration/gym/__init__.py
+++ b/wandb/integration/gym/__init__.py
@@ -19,10 +19,10 @@ def monitor():
             key = "videos"
         wandb.log({key: wandb.Video(self.path)})
 
-    def __del__(self):
+    def del_(self):
         self.orig_close()
 
-    vcr.VideoRecorder.__del__ = __del__
+    vcr.VideoRecorder.__del__ = del_
     vcr.VideoRecorder.close = close
     wandb.patched["gym"].append(
         ["gym.wrappers.monitoring.video_recorder.VideoRecorder", "close"]


### PR DESCRIPTION
Fixes https://github.com/wandb/wandb/issues/4305

Description
-----------
This PR fixes the gym integration after breaking changes in gym 0.26.

Testing
-------
```python
wandb.init(project="test",  monitor_gym=True)

env = RecordVideo(
    gym.make("CartPole-v1", render_mode="rgb_array"),
    "video"
)

env.reset()
for _ in range(100):
    env.step(env.action_space.sample())
```

Checklist
-------
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
