### PR TITLE
fix(artifacts): in artifacts cache, use hash(etag+url) as key, not just etag

### DIFF
--- a/tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_wandb_artifacts.py
@@ -1000,6 +1000,32 @@ def test_http_storage_handler_uses_etag_for_digest(
         assert entry.digest == expected_digest
 
 
+def test_s3_storage_handler_load_path_uses_cache(tmp_path):
+    uri = "s3://some-bucket/path/to/file.json"
+    etag = "some etag"
+
+    cache = wandb.wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
+    path, _, opener = cache.check_etag_obj_path(uri, etag, 123)
+    with opener() as f:
+        f.write(123 * "a")
+
+    handler = wandb.wandb_sdk.wandb_artifacts.S3Handler()
+    handler._cache = cache
+
+    art = wandb.Artifact("test", type="dataset")
+    local_path = handler.load_path(
+        wandb.Artifact("test", type="dataset"),
+        wandb.wandb_sdk.wandb_artifacts.ArtifactManifestEntry(
+            path="foo/bar",
+            ref=uri,
+            digest=etag,
+            size=123,
+        ),
+        local=True,
+    )
+    assert local_path == path
+
+
 def test_tracking_storage_handler():
     art = wandb.wandb_sdk.wandb_artifacts.Artifact("test", "dataset")
     handler = wandb.wandb_sdk.wandb_artifacts.TrackingHandler()

--- a/tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_wandb_artifacts.py
@@ -1012,7 +1012,6 @@ def test_s3_storage_handler_load_path_uses_cache(tmp_path):
     handler = wandb.wandb_sdk.wandb_artifacts.S3Handler()
     handler._cache = cache
 
-    art = wandb.Artifact("test", type="dataset")
     local_path = handler.load_path(
         wandb.Artifact("test", type="dataset"),
         wandb.wandb_sdk.wandb_artifacts.ArtifactManifestEntry(

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -128,7 +128,9 @@ def test_check_write_parallel(runner):
 
         # Regardless of the ordering, we should be left with one
         # file at the end.
-        files = [f for f in (pathlib.Path(cache)/"obj"/"etag").rglob("*") if f.is_file()]
+        files = [
+            f for f in (pathlib.Path(cache) / "obj" / "etag").rglob("*") if f.is_file()
+        ]
         assert len(files) == 1
 
 

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -5,7 +5,6 @@ import time
 from multiprocessing import Pool
 
 import pytest
-
 from wandb import wandb_sdk
 
 
@@ -72,7 +71,7 @@ def test_check_etag_obj_path_returns_not_exists_if_incomplete():
     assert not exists
 
     with opener() as f:
-        f.write((size-1) * "a")
+        f.write((size - 1) * "a")
 
     _, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
     assert not exists
@@ -92,11 +91,14 @@ def test_check_etag_obj_path_does_not_include_etag():
     assert "abcdef" not in path
 
 
-@pytest.mark.parametrize(["url1","url2","etag1","etag2","path_equal"], [
-    ("http://url/1", "http://url/1", "abc", "abc", True),
-    ("http://url/1", "http://url/1", "abc", "def", False),
-    ("http://url/1", "http://url/2", "abc", "abc", False),
-])
+@pytest.mark.parametrize(
+    ["url1", "url2", "etag1", "etag2", "path_equal"],
+    [
+        ("http://url/1", "http://url/1", "abc", "abc", True),
+        ("http://url/1", "http://url/1", "abc", "def", False),
+        ("http://url/1", "http://url/2", "abc", "abc", False),
+    ],
+)
 def test_check_etag_obj_path_hashes_url_and_etag(url1, url2, etag1, etag2, path_equal):
     os.mkdir("cache")
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import pathlib
 import random
 import time
 from multiprocessing import Pool
@@ -8,6 +9,8 @@ import pytest
 from wandb import wandb_sdk
 
 
+# This function should only be used in `test_check_write_parallel`,
+# but it needs to be a global function for multiprocessing.
 def _cache_writer(cache_path):
     etag = "abcdef"
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache(cache_path)
@@ -125,8 +128,8 @@ def test_check_write_parallel(runner):
 
         # Regardless of the ordering, we should be left with one
         # file at the end.
-        path = os.path.join("cache", "obj", "etag", "ab")
-        assert os.listdir(path) == ["cdef"]
+        files = [f for f in (pathlib.Path(cache)/"obj"/"etag").rglob("*") if f.is_file()]
+        assert len(files) == 1
 
 
 def test_artifacts_cache_cleanup_empty():

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -4,6 +4,8 @@ import random
 import time
 from multiprocessing import Pool
 
+import pytest
+
 from wandb import wandb_sdk
 
 
@@ -32,23 +34,80 @@ def test_check_md5_obj_path():
     assert contents == "hi"
 
 
-def test_check_etag_obj_path():
+def test_check_etag_obj_path_points_to_opener_dst():
     os.mkdir("cache")
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
 
-    etag = "abcdef"
-    path, exists, opener = cache.check_etag_obj_path(
-        "http://wandb.example/foo", etag, 10
-    )
-    expected_path = os.path.join("cache", "obj", "etag", "ab", "cdef")
+    path, exists, opener = cache.check_etag_obj_path("http://my/url", "abc", 10)
+
     with opener() as f:
         f.write("hi")
     with open(path) as f:
         contents = f.read()
 
-    assert path == expected_path
-    assert exists is False
     assert contents == "hi"
+
+
+def test_check_etag_obj_path_returns_exists_if_exists():
+    os.mkdir("cache")
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+
+    size = 123
+    _, exists, opener = cache.check_etag_obj_path("http://my/url", "abc", size)
+    assert not exists
+
+    with opener() as f:
+        f.write(size * "a")
+
+    _, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    assert exists
+
+
+def test_check_etag_obj_path_returns_not_exists_if_incomplete():
+    os.mkdir("cache")
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+
+    size = 123
+    _, exists, opener = cache.check_etag_obj_path("http://my/url", "abc", size)
+    assert not exists
+
+    with opener() as f:
+        f.write((size-1) * "a")
+
+    _, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    assert not exists
+
+    with opener() as f:
+        f.write(size * "a")
+
+    _, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    assert exists
+
+
+def test_check_etag_obj_path_does_not_include_etag():
+    os.mkdir("cache")
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+
+    path, _, _ = cache.check_etag_obj_path("http://url/1", "abcdef", 10)
+    assert "abcdef" not in path
+
+
+@pytest.mark.parametrize(["url1","url2","etag1","etag2","path_equal"], [
+    ("http://url/1", "http://url/1", "abc", "abc", True),
+    ("http://url/1", "http://url/1", "abc", "def", False),
+    ("http://url/1", "http://url/2", "abc", "abc", False),
+])
+def test_check_etag_obj_path_hashes_url_and_etag(url1, url2, etag1, etag2, path_equal):
+    os.mkdir("cache")
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+
+    path_1, _, _ = cache.check_etag_obj_path(url1, etag1, 10)
+    path_2, _, _ = cache.check_etag_obj_path(url2, etag2, 10)
+
+    if path_equal:
+        assert path_1 == path_2
+    else:
+        assert path_1 != path_2
 
 
 def test_check_write_parallel(runner):

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -19,6 +19,20 @@ def _cache_writer(cache_path):
         f.write("".join(random.choice("0123456") for _ in range(10)))
 
 
+def test_opener_rejects_append_mode():
+    os.mkdir("cache")
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+    path, exists, opener = cache.check_md5_obj_path(base64.b64encode(b"abcdef"), 10)
+
+    with pytest.raises(ValueError):
+        with opener("a"):
+            pass
+
+    # make sure that the ValueError goes away if we use a valid mode
+    with opener("w"):
+        pass
+
+
 def test_check_md5_obj_path():
     os.mkdir("cache")
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -10,7 +10,7 @@ from wandb import wandb_sdk
 def _cache_writer(cache_path):
     etag = "abcdef"
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache(cache_path)
-    _, _, opener = cache.check_etag_obj_path('http://wandb.example/foo', etag, 10)
+    _, _, opener = cache.check_etag_obj_path("http://wandb.example/foo", etag, 10)
     with opener() as f:
         f.write("".join(random.choice("0123456") for _ in range(10)))
 
@@ -37,7 +37,9 @@ def test_check_etag_obj_path():
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
 
     etag = "abcdef"
-    path, exists, opener = cache.check_etag_obj_path('http://wandb.example/foo', etag, 10)
+    path, exists, opener = cache.check_etag_obj_path(
+        "http://wandb.example/foo", etag, 10
+    )
     expected_path = os.path.join("cache", "obj", "etag", "ab", "cdef")
     with opener() as f:
         f.write("hi")

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -10,7 +10,7 @@ from wandb import wandb_sdk
 def _cache_writer(cache_path):
     etag = "abcdef"
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache(cache_path)
-    _, _, opener = cache.check_etag_obj_path(etag, 10)
+    _, _, opener = cache.check_etag_obj_path('http://wandb.example/foo', etag, 10)
     with opener() as f:
         f.write("".join(random.choice("0123456") for _ in range(10)))
 
@@ -37,7 +37,7 @@ def test_check_etag_obj_path():
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
 
     etag = "abcdef"
-    path, exists, opener = cache.check_etag_obj_path(etag, 10)
+    path, exists, opener = cache.check_etag_obj_path('http://wandb.example/foo', etag, 10)
     expected_path = os.path.join("cache", "obj", "etag", "ab", "cdef")
     with opener() as f:
         f.write("hi")

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -911,7 +911,7 @@ class ArtifactsCache:
     ) -> Tuple[util.FilePathStr, bool, "Opener"]:
         hexhash = hashlib.sha256(
             hashlib.sha256(url.encode("utf-8")).digest()
-            + hashlib.sha256(url.encode("utf-8")).digest()
+            + hashlib.sha256(etag.encode("utf-8")).digest()
         ).hexdigest()
         path = os.path.join(self._cache_dir, "obj", "etag", hexhash[:2], hexhash[2:])
         opener = self._cache_opener(path)

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -904,9 +904,13 @@ class ArtifactsCache:
     # TODO(spencerpearson): this method at least needs its signature changed.
     # An ETag is not (necessarily) a checksum.
     def check_etag_obj_path(
-        self, etag: util.ETag, size: int
+        self,
+        url: util.URIStr,
+        etag: util.ETag,
+        size: int,
     ) -> Tuple[util.FilePathStr, bool, "Opener"]:
-        path = os.path.join(self._cache_dir, "obj", "etag", etag[:2], etag[2:])
+        hexhash = hashlib.sha256(hashlib.sha256(url.encode('utf-8')).digest() + etag.encode('utf-8')).hexdigest()
+        path = os.path.join(self._cache_dir, "obj", "etag", hexhash[:2], hexhash[2:])
         opener = self._cache_opener(path)
         if os.path.isfile(path) and os.path.getsize(path) == size:
             return path, True, opener

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -909,7 +909,10 @@ class ArtifactsCache:
         etag: util.ETag,
         size: int,
     ) -> Tuple[util.FilePathStr, bool, "Opener"]:
-        hexhash = hashlib.sha256(hashlib.sha256(url.encode('utf-8')).digest() + etag.encode('utf-8')).hexdigest()
+        hexhash = hashlib.sha256(
+            hashlib.sha256(url.encode("utf-8")).digest()
+            + hashlib.sha256(url.encode("utf-8")).digest()
+        ).hexdigest()
         path = os.path.join(self._cache_dir, "obj", "etag", hexhash[:2], hexhash[2:])
         opener = self._cache_opener(path)
         if os.path.isfile(path) and os.path.getsize(path) == size:

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -969,6 +969,10 @@ class ArtifactsCache:
     def _cache_opener(self, path):
         @contextlib.contextmanager
         def helper(mode="w"):
+
+            if "a" in mode:
+                raise ValueError("Appending to cache files is not supported")
+
             dirname = os.path.dirname(path)
             tmp_file = os.path.join(
                 dirname,

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -26,6 +26,7 @@ from urllib.parse import parse_qsl, quote, urlparse
 
 import requests
 import urllib3
+
 import wandb
 import wandb.data_types as data_types
 from wandb import env, util
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
     import boto3.s3  # type: ignore
     import boto3.session  # type: ignore
     import google.cloud.storage as gcs_module  # type: ignore
+
     import wandb.apis.public
     from wandb.filesync.step_prepare import StepPrepare
     from wandb.sdk.internal import internal_api
@@ -1838,7 +1840,7 @@ class HTTPHandler(StorageHandler):
         response = self._session.get(manifest_entry.ref, stream=True)
         response.raise_for_status()
 
-        digest: Optional[Union[util.ETag, util.FilePathStr]]
+        digest: Optional[Union[util.ETag, util.FilePathStr, util.URIStr]]
         digest, size, extra = self._entry_from_headers(response.headers)
         digest = digest or manifest_entry.ref
         if manifest_entry.digest != digest:

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1840,7 +1840,7 @@ class HTTPHandler(StorageHandler):
 
         digest: Optional[Union[util.ETag, util.FilePathStr]]
         digest, size, extra = self._entry_from_headers(response.headers)
-        digest = digest or path
+        digest = digest or manifest_entry.ref
         if manifest_entry.digest != digest:
             raise ValueError(
                 "Digest mismatch for url %s: expected %s but found %s"

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1387,6 +1387,8 @@ class S3Handler(StorageHandler):
             assert manifest_entry.ref is not None
             return manifest_entry.ref
 
+        assert manifest_entry.ref is not None
+
         path, hit, cache_open = self._cache.check_etag_obj_path(
             util.URIStr(manifest_entry.ref),
             util.ETag(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
@@ -1397,7 +1399,6 @@ class S3Handler(StorageHandler):
 
         self.init_boto()
         assert self._s3 is not None  # mypy: unwraps optionality
-        assert manifest_entry.ref is not None
         bucket, key, _ = self._parse_uri(manifest_entry.ref)
         version = manifest_entry.extra.get("versionID")
 
@@ -1824,6 +1825,8 @@ class HTTPHandler(StorageHandler):
             assert manifest_entry.ref is not None
             return manifest_entry.ref
 
+        assert manifest_entry.ref is not None
+
         path, hit, cache_open = self._cache.check_etag_obj_path(
             util.URIStr(manifest_entry.ref),
             util.ETag(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
@@ -1832,7 +1835,6 @@ class HTTPHandler(StorageHandler):
         if hit:
             return path
 
-        assert manifest_entry.ref is not None
         response = self._session.get(manifest_entry.ref, stream=True)
         response.raise_for_status()
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -26,7 +26,6 @@ from urllib.parse import parse_qsl, quote, urlparse
 
 import requests
 import urllib3
-
 import wandb
 import wandb.data_types as data_types
 from wandb import env, util
@@ -63,7 +62,6 @@ if TYPE_CHECKING:
     import boto3.s3  # type: ignore
     import boto3.session  # type: ignore
     import google.cloud.storage as gcs_module  # type: ignore
-
     import wandb.apis.public
     from wandb.filesync.step_prepare import StepPrepare
     from wandb.sdk.internal import internal_api

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1390,6 +1390,7 @@ class S3Handler(StorageHandler):
             return manifest_entry.ref
 
         path, hit, cache_open = self._cache.check_etag_obj_path(
+            util.URIStr(manifest_entry.ref),
             util.ETag(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
         )
@@ -1826,6 +1827,7 @@ class HTTPHandler(StorageHandler):
             return manifest_entry.ref
 
         path, hit, cache_open = self._cache.check_etag_obj_path(
+            util.URIStr(manifest_entry.ref),
             util.ETag(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
         )


### PR DESCRIPTION
Fixes WB-11066
Fixes WB-11042

Description
-----------

Our handling of ETags has problems:
- We cache the resource at `/path/to/cache/obj/etag/{etag}`.  This is super unsafe, since the ETag can contain arbitrary characters! We should hash it first.
- ^This scheme also assumes that two resources with the same ETag have the same content. This is not necessarily the case: the ETag is _often_ a hash of the resource content, but other times it's just, like, a version number, which might collide between different resources.

This PR changes the resource-cache location to `sha256(sha256(url) + sha256(etag))`. This should solve both problems at once.


Testing
-------
Existing unit tests; and ran the repro script in [WB-11042](https://wandb.atlassian.net/browse/WB-11042) to verify that I can now successfully download artifacts with HTTP-references, both with and without etags.
