### PR TITLE
feat(integrations): add ability to log learning rate using WandbMetricsLogger

### DIFF
--- a/tests/functional_tests/t0_main/keras/keras_metrics_logger_tf_2.6.yea
+++ b/tests/functional_tests/t0_main/keras/keras_metrics_logger_tf_2.6.yea
@@ -16,6 +16,7 @@ assert:
     - :wandb:runs[0][summary][batch/loss]: 2.302401065826416
     - :wandb:runs[0][summary][epoch]: 1
     - :wandb:runs[0][summary][val_accuracy]: 0.14000000059604645
+    - :wandb:runs[0][summary][batch/learning_rate]: 0.0001
     - :op:contains:
         - :wandb:runs[0][telemetry][3]  # feature
         - 38  # keras

--- a/wandb/integration/keras/callbacks/metrics_logger.py
+++ b/wandb/integration/keras/callbacks/metrics_logger.py
@@ -67,7 +67,8 @@ class WandbMetricsLogger(callbacks.Callback):
     def on_epoch_end(self, epoch: int, logs: Optional[Dict[str, Any]] = None) -> None:
         """Called at the end of an epoch."""
         wandb.log({"epoch": epoch}, commit=False)
-        logs["learning_rate"] = self._get_lr()
+        if not isinstance(self.log_freq, int):
+            logs["learning_rate"] = self._get_lr()
         wandb.log(logs or {}, commit=True)
 
     def on_batch_end(self, batch: int, logs: Optional[Dict[str, Any]] = None) -> None:

--- a/wandb/integration/keras/callbacks/metrics_logger.py
+++ b/wandb/integration/keras/callbacks/metrics_logger.py
@@ -23,7 +23,10 @@ class WandbMetricsLogger(callbacks.Callback):
     """`WandbMetricsLogger` automatically logs the `logs` dictionary
     that callback methods take as argument to wandb.
 
-    It also logs the system metrics to wandb.
+    This callback logs events for TensorBoard, including:
+    * Metrics summary plots
+    * System metrics plots
+    * Learning rate (both for a fixed value or a learning rate scheduler)
 
     Arguments:
         log_freq ("epoch", "batch", or int): if "epoch", logs metrics


### PR DESCRIPTION
Adds [GROWTH2-77](https://wandb.atlassian.net/browse/GROWTH2-77)

Description
-----------
Add support for tracking learning rate with [`WandbMetricsLogger `](https://github.com/wandb/wandb/blob/main/wandb/integration/keras/callbacks/metrics_logger.py)

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)

cc: @ayulockin 