### PR TITLE
fix(launch): generate more readable image names

### DIFF
--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -723,3 +723,17 @@ def test_sanitize_numpy_keys(dict_input, dict_output):
         dict_output.pop("_")
 
     assert output == (dict_output or dict_input)
+
+
+def test_make_docker_image_name_safe():
+    assert util.make_docker_image_name_safe("this-name-is-fine") == "this-name-is-fine"
+    assert util.make_docker_image_name_safe("also__ok") == "also__ok"
+    assert (
+        util.make_docker_image_name_safe("github.com/MyUsername/my_repo")
+        == "github.com__myusername__my_repo"
+    )
+    assert (
+        util.make_docker_image_name_safe("./abc.123___def-456---_.")
+        == "abc.123__def-456"
+    )
+    assert util.make_docker_image_name_safe("......") == "image"

--- a/tests/unit_tests_old/tests_launch/test_launch_docker.py
+++ b/tests/unit_tests_old/tests_launch/test_launch_docker.py
@@ -233,7 +233,7 @@ def test_gcp_uri(test_settings, live_mock_server, mocked_fetchable_git_repo):
         test_project, "test-repo", "test-project", "test-registry"
     )
     assert (
-        "test-registry/test-project/test-repo/wandb.aimock_server_entitytestruns1:68747470733a2f2f666f6f3a62617240"
+        "test-registry/test-project/test-repo/wandb.ai__mock_server_entity__test__runs__1:68747470733a2f2f666f6f3a62617240"
         in uri
     )
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1889,8 +1889,3 @@ def make_docker_image_name_safe(name: str) -> str:
     trimmed_start = RE_DOCKER_IMAGE_NAME_SEPARATOR_START.sub("", deduped)
     trimmed = RE_DOCKER_IMAGE_NAME_SEPARATOR_END.sub("", trimmed_start)
     return trimmed if trimmed else "image"
-
-
-def has_main_file(path: str) -> bool:
-    """Check if a directory has a main.py file"""
-    return path != "<python with no main file>"

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -95,6 +95,16 @@ MAX_LINE_BYTES = (10 << 20) - (100 << 10)  # imposed by back end
 IS_GIT = os.path.exists(os.path.join(os.path.dirname(__file__), "..", ".git"))
 RE_WINFNAMES = re.compile(r'[<>:"\\?*]')
 
+# From https://docs.docker.com/engine/reference/commandline/tag/
+# "Name components may contain lowercase letters, digits and separators.
+# A separator is defined as a period, one or two underscores, or one or more dashes.
+# A name component may not start or end with a separator."
+DOCKER_IMAGE_NAME_SEPARATOR = "(?:__|[._]|[-]+)"
+RE_DOCKER_IMAGE_NAME_SEPARATOR_START = re.compile("^" + DOCKER_IMAGE_NAME_SEPARATOR)
+RE_DOCKER_IMAGE_NAME_SEPARATOR_END = re.compile(DOCKER_IMAGE_NAME_SEPARATOR + "$")
+RE_DOCKER_IMAGE_NAME_SEPARATOR_REPEAT = re.compile(DOCKER_IMAGE_NAME_SEPARATOR + "{2,}")
+RE_DOCKER_IMAGE_NAME_CHARS = re.compile(r"[^a-z0-9._\-]")
+
 # these match the environments for gorilla
 if IS_GIT:
     SENTRY_ENV = "development"
@@ -1874,7 +1884,11 @@ def make_artifact_name_safe(name: str) -> str:
 
 def make_docker_image_name_safe(name: str) -> str:
     """Make a docker image name safe for use in artifacts"""
-    return re.sub(r"[^a-z0-9_\-.]", "", name)
+    safe_chars = RE_DOCKER_IMAGE_NAME_CHARS.sub("__", name.lower())
+    deduped = RE_DOCKER_IMAGE_NAME_SEPARATOR_REPEAT.sub("__", safe_chars)
+    trimmed_start = RE_DOCKER_IMAGE_NAME_SEPARATOR_START.sub("", deduped)
+    trimmed = RE_DOCKER_IMAGE_NAME_SEPARATOR_END.sub("", trimmed_start)
+    return trimmed if trimmed else "image"
 
 
 def has_main_file(path: str) -> bool:


### PR DESCRIPTION
Fixes WB-11092

Description
-----------
docker image names are automatically generated by launch. These names must conform to a few requirements, e.g. uppercase letters are not permitted. The previous algorithm for name generation just removed all invalid characters. This revised approach handles a few cases that could have led to invalid names being generated and generates more readable names.

Testing
-------
Tests added.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
