### PR TITLE
fix(artifacts): in `wandb artifact put`, wait for artifact to commit before telling the user it's ready

### DIFF
--- a/tests/unit_tests_old/test_cli.py
+++ b/tests/unit_tests_old/test_cli.py
@@ -58,9 +58,12 @@ def test_artifact_upload(runner, git_repo, mock_server, mocker, mocked_run):
     with open("artifact.txt", "w") as f:
         f.write("My Artifact")
     mocker.patch("wandb.init", lambda *args, **kwargs: mocked_run)
-    mocker.patch("wandb.Artifact.wait", lambda *args, **kwargs: wandb_internal_pb2.LogArtifactResponse(
-        artifact_id='some-artifact-id',
-    ))
+    mocker.patch(
+        "wandb.Artifact.wait",
+        lambda *args, **kwargs: wandb_internal_pb2.LogArtifactResponse(
+            artifact_id="some-artifact-id",
+        ),
+    )
     result = runner.invoke(cli.artifact, ["put", "artifact.txt", "-n", "test/simple"])
     print(result.output)
     print(result.exception)

--- a/tests/unit_tests_old/test_cli.py
+++ b/tests/unit_tests_old/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 import wandb
 from wandb.apis.internal import InternalApi
 from wandb.cli import cli
+from wandb.proto import wandb_internal_pb2
 
 
 @pytest.fixture
@@ -57,6 +58,9 @@ def test_artifact_upload(runner, git_repo, mock_server, mocker, mocked_run):
     with open("artifact.txt", "w") as f:
         f.write("My Artifact")
     mocker.patch("wandb.init", lambda *args, **kwargs: mocked_run)
+    mocker.patch("wandb.Artifact.wait", lambda *args, **kwargs: wandb_internal_pb2.LogArtifactResponse(
+        artifact_id='some-artifact-id',
+    ))
     result = runner.invoke(cli.artifact, ["put", "artifact.txt", "-n", "test/simple"])
     print(result.output)
     print(result.exception)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1742,6 +1742,8 @@ def put(path, name, description, type, alias):
     artifact_path = artifact_path.split(":")[0] + ":" + res.get("version", "latest")
     # Re-create the artifact and actually upload any files needed
     run.log_artifact(artifact, aliases=alias)
+    artifact.wait()
+
     wandb.termlog(
         "Artifact uploaded, use this artifact in a run by adding:\n", prefix=False
     )


### PR DESCRIPTION
Fixes WB-11275

Description
-----------
wandb artifact put ... prints out “Artifact uploaded” after the artifact is created, but before it’s committed (and therefore visible to the rest of the world):

![61b2436b-b6f3-4d3c-9e96-eb478c6f7182](https://user-images.githubusercontent.com/1899701/196520841-e7c271ed-aca8-4374-bf42-8a9c3aa43ad0.png)

If I try to use ^that artifact before the process completes, I get:
```
CommError: Project wandb/spencerpearson-artifacts does not contain artifact: "benchmark-251:latest"
```

Testing
-------
I ran `wandb artifact put <...snip...> /tmp/10e3-10B-files/` and verified that the `Artifact uploaded, use this artifact in a run by adding` message doesn't get printed until right before the process exits.
