### PR TITLE
chore(launch): improved git fetch time by specifying a `refspec` and `depth=1`

### DIFF
--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -419,17 +419,9 @@ def _make_refspec_from_version(version: Optional[str]) -> List[str]:
     Helper to create a refspec that checks for the existence of origin/main
     and the version, if provided.
     """
-
-    def _is_sha1(version: str):
-        if len(version) == 40:
-            return True
-        return False
-
     if version:
-        if _is_sha1(version):
-            return [f"+{version}"]
-        else:
-            return [f"+refs/heads/{version}*:refs/remotes/origin/{version}*"]
+        return [f"+{version}"]
+
     return [
         "+refs/heads/main*:refs/remotes/origin/main*",
         "+refs/heads/master*:refs/remotes/origin/master*",
@@ -447,17 +439,11 @@ def _fetch_git_repo(dst_dir: str, uri: str, version: Optional[str]) -> str:
     # executable is available on the PATH, so we only want to fail if we actually need it.
     import git  # type: ignore
 
-    import time
-
     _logger.info("Fetching git repo")
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
     refspec = _make_refspec_from_version(version)
-
-    tic = time.perf_counter()
     origin.fetch(refspec=refspec, depth=1)
-    toc = time.perf_counter()
-    wandb.termlog(f"fetched: {[x.name for x in origin.refs]} in {toc-tic:0.4f} seconds")
 
     if version is not None:
         try:


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-11392

Description
-----------
Changes the origin.fetch command to only look for specific head object. master, main, and the optional passed in version.

This leads to 2-10x improvement in clone speed, depending on how many branches the target remote repo has and if the version is specified. 

For example, using the wandb/examples repo had the following results. 

| branch | command     | origin.fetch duration (s) |
| ----------- | ----------- | ----------- |
| master | `wandb launch https://github.com/wandb/examples`      |  85.6     |
| this PR | `wandb launch https://github.com/wandb/examples`      |  22.5     |
| this PR | `wandb launch https://github.com/wandb/examples --git-version=xyz`      |  10.5     |


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
