### PR TITLE
fix(launch): Clarify arguments in help text

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -994,7 +994,7 @@ def sweep(
     "-j",
     metavar="<str>",
     default=None,
-    help="Name of the job to launch. If passed in, launch does not require a uri.",
+    help="Job to launch in the format entity/project/job_name[:alias]. If passed in, launch does not require a uri.",
 )
 @click.option(
     "--entry-point",
@@ -1032,7 +1032,7 @@ def sweep(
     "-e",
     metavar="<str>",
     default=None,
-    help="Name of the target entity which the new run will be sent to. Defaults to using the entity set by local wandb/settings folder."
+    help="Name of the target entity which the new run will be sent to. Defaults to using the entity set by local wandb/settings folder. "
     "If passed in, will override the entity value passed in using a config file.",
 )
 @click.option(
@@ -1056,16 +1056,17 @@ def sweep(
     "--docker-image",
     "-d",
     default=None,
-    metavar="DOCKER IMAGE",
-    help="Specific docker image you'd like to use. In the form name:tag."
-    " If passed in, will override the docker image value passed in using a config file.",
+    metavar="IMAGE",
+    help="Specific docker image you'd like to use in the form name:tag."
+    " If passed in, will override the docker image value passed in using a config file"
+    " and launch does not require a uri.",
 )
 @click.option(
     "--config",
     "-c",
     metavar="FILE",
     help="Path to JSON file (must end in '.json') or JSON string which will be passed "
-    "as a launch config. Dictation how the launched run will be configured. ",
+    "as a launch config. Dictates how the launched run will be configured. ",
 )
 @click.option(
     "--queue",
@@ -1098,6 +1099,7 @@ def sweep(
     is_flag=False,
     flag_value=True,
     default=None,
+    metavar="BOOLEAN",
     help="Flag to build an image with CUDA enabled. If reproducing a previous wandb run that ran on GPU, a CUDA-enabled image will be "
     "built by default and you must set --cuda=False to build a CPU-only image.",
 )
@@ -1142,6 +1144,9 @@ def launch(
         raise LaunchError(
             "Cannot use both --async and --queue with wandb launch, see help for details."
         )
+
+    if job and ":" not in job:
+        job += ":latest"
 
     # we take a string for the `cuda` arg in order to accept None values, then convert it to a bool
     if cuda is not None:

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -171,7 +171,7 @@ class LaunchProject:
 
     def _initialize_image_job_tag(self) -> Optional[str]:
         if self.job is not None:
-            job_name, alias = self.job.split(":")
+            job_name, alias = utils.validate_job_name(self.job)
             # Alias is used to differentiate images between jobs of the same sequence
             _image_tag = f"{alias}-{job_name}"
             _logger.debug(f"{LOG_PREFIX}Setting image tag {_image_tag}")

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -606,3 +606,17 @@ def check_logged_in(api: Api) -> bool:
         )
 
     return True
+
+
+def validate_job_name(name: str) -> Tuple[str, str]:
+    """
+    Validate that we have a complete name reference, return a Tuple of name and alias.
+    """
+    name_parts = name.split(":", 1)
+    job_name = name_parts[0]
+    if job_name.count("/") != 2:
+        raise LaunchError(
+            "Job must be specified in the format entity/project/job_name[:alias]"
+        )
+    alias = name_parts[1] if len(name_parts) > 1 else "latest"
+    return (job_name, alias)


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
Several small cleanups to the `wandb launch` argument help text.
If --job is specified without a version, use "latest" instead of throwing exception.
Improved error message if user doesn't specify entity/project prefix when specifying job.

Testing
-------
How was this PR tested? - I'm having trouble running tests because of a tox/fastparquet issue, will add a unit test if I can get that resolved.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
