### PR TITLE
chore(sdk): fix linguist rule to ignore grpc generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 wandb/vendor/** linguist-vendored
 wandb/proto/v*/*_pb2.py linguist-generated
 wandb/proto/v*/*_pb2.pyi linguist-generated
+wandb/proto/v*/*_pb2_grpc.py linguist-generated
+wandb/proto/v*/*_pb2_grpc.pyi linguist-generated
 *_generated.py linguist-generated


### PR DESCRIPTION
Description
-----------
gRPC files did not match wildcard for generated files

Testing
-------
Not tested.