### PR TITLE
chore(sweeps): Update scheduler and agent resource handling to allow DRC override

### DIFF
--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -445,7 +445,7 @@ def create_project_from_spec(launch_spec: Dict[str, Any], api: Api) -> LaunchPro
         launch_spec.get("docker", {}),
         launch_spec.get("git", {}),
         launch_spec.get("overrides", {}),
-        launch_spec.get("resource", "local"),
+        launch_spec.get("resource", None),  # "local"
         launch_spec.get("resource_args", {}),
         launch_spec.get("cuda", None),
         launch_spec.get("run_id", None),

--- a/wandb/sdk/launch/launch_add.py
+++ b/wandb/sdk/launch/launch_add.py
@@ -122,7 +122,7 @@ def _launch_add(
     run_id: Optional[str] = None,
 ) -> "public.QueuedRun":
 
-    resource = resource or "local"
+    resource = resource  # or "local"
     if config is not None:
         if isinstance(config, str):
             with open(config) as fp:

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -148,7 +148,7 @@ def construct_launch_spec(
         launch_spec["docker"]["docker_image"] = docker_image
 
     if "resource" not in launch_spec:
-        launch_spec["resource"] = resource or "local"
+        launch_spec["resource"] = resource  # or "local"
 
     if "git" not in launch_spec:
         launch_spec["git"] = {}


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-11447

Description
-----------
Currently there are hardcoded references to "local-process" and "local" when dealing with sweeps in the SDK. This is great for local sweeps, but for sweeps on launch we want the queues default resource config to dictate the resource. There are going to be some logic design decisions here to ensure existing functionality works as well as the new sweeps on launch. 

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
