### PR TITLE
refactor(artifacts): remove duplicated cache check/write

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -997,15 +997,6 @@ class WandbStoragePolicy(StoragePolicy):
         preparer: "StepPrepare",
         progress_callback: Optional["progress.ProgressFn"] = None,
     ) -> bool:
-        # write-through cache
-        cache_path, hit, cache_open = self._cache.check_md5_obj_path(
-            util.B64MD5(entry.digest),  # TODO(spencerpearson): unsafe cast
-            entry.size if entry.size is not None else 0,
-        )
-        if not hit and entry.local_path is not None:
-            with cache_open() as f:
-                shutil.copyfile(entry.local_path, f.name)
-            entry.local_path = cache_path
 
         def _prepare_fn() -> "internal_api.CreateArtifactFileSpecInput":
             return {

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -997,7 +997,7 @@ class WandbStoragePolicy(StoragePolicy):
         preparer: "StepPrepare",
         progress_callback: Optional["progress.ProgressFn"] = None,
     ) -> bool:
-
+        # TODO: document the purpose of the return value.
         def _prepare_fn() -> "internal_api.CreateArtifactFileSpecInput":
             return {
                 "artifactID": artifact_id,

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1009,22 +1009,22 @@ class WandbStoragePolicy(StoragePolicy):
         resp = preparer.prepare(_prepare_fn)
 
         entry.birth_artifact_id = resp.birth_artifact_id
-        exists = resp.upload_url is None
-        if not exists:
-            if entry.local_path is not None:
-                with open(entry.local_path, "rb") as file:
-                    # This fails if we don't send the first byte before the signed URL
-                    # expires.
-                    self._api.upload_file_retry(
-                        resp.upload_url,
-                        file,
-                        progress_callback,
-                        extra_headers={
-                            header.split(":", 1)[0]: header.split(":", 1)[1]
-                            for header in (resp.upload_headers or {})
-                        },
-                    )
-        return exists
+        if not resp.upload_url:
+            return True
+        if entry.local_path is None:
+            return False
+        with open(entry.local_path, "rb") as file:
+            # This fails if we don't send the first byte before the signed URL expires.
+            self._api.upload_file_retry(
+                resp.upload_url,
+                file,
+                progress_callback,
+                extra_headers={
+                    header.split(":", 1)[0]: header.split(":", 1)[1]
+                    for header in (resp.upload_headers or {})
+                },
+            )
+        return False
 
 
 # Don't use this yet!


### PR DESCRIPTION
This PR is mostly just a tool for me to ask a few questions.

1. I _think_ that there's no purpose for having a cache check/write here. We only cache if `local_file` is set, which means that the file was created by `_add_local_file`, which means `local_file` already points to a cache location. Please interrogate this and tell me if I'm wrong.
2. The refactor at the end is just reordering/rewording the existing logic; I feel like it's clearer this way. But one thing that is clearer is that I don't know the meaning of the return value; what are we doing with it anyway?