### PR TITLE
refactor(launch): Add more robust uri parsing

### DIFF
--- a/tests/unit_tests/tests_launch/test_github_reference.py
+++ b/tests/unit_tests/tests_launch/test_github_reference.py
@@ -1,0 +1,132 @@
+from wandb.sdk.launch.github_reference import GitHubReference
+
+
+def test_parse_bad() -> None:
+    """Expected parse failures, None result."""
+    ref = GitHubReference.parse("not a url")
+    assert ref is None
+    ref = GitHubReference.parse("http://github.com")  # Not HTTPS
+    assert ref is None
+
+
+def test_parse_ssh() -> None:
+    """We should be able to parse and reconstruct an SSH reference."""
+    case = "git@github.com:wandb/examples.git"
+    ref = GitHubReference.parse(case)
+    assert ref.host == "github.com"
+    assert ref.organization == "wandb"
+    assert ref.repo == "examples"
+    assert ref.path is None
+    assert ref.repo_ssh() == case
+
+
+def test_parse_organization() -> None:
+    """Should parse URLs that only have an organization."""
+    cases = [
+        "https://github.com/wandb",
+        # Only half-heartedly parsing non-repo URLs for now - don't support reconstructing this
+        "https://github.com/orgs/wandb/people",
+    ]
+    for case in cases:
+        ref = GitHubReference.parse(case)
+        assert ref.host == "github.com"
+        assert ref.organization == "wandb"
+
+
+def test_parse_enterprise() -> None:
+    """Should support non-github.com hosts."""
+    case = "https://github.foo.bar.com/wandb/examples"
+    ref = GitHubReference.parse(case)
+    assert ref.host == "github.foo.bar.com"
+    assert ref.organization == "wandb"
+    assert ref.repo == "examples"
+    assert ref.url() == case
+
+
+def test_parse_repo() -> None:
+    """Should parse URLs that have an organization and a repo."""
+    # This case is special because we don't want to reconstruct url with the .git extension
+    case = "https://github.com/wandb/examples.git"
+    ref = GitHubReference.parse(case)
+    assert ref.host == "github.com"
+    assert ref.organization == "wandb"
+    assert ref.repo == "examples"
+
+    cases = [
+        "https://github.com/wandb/examples",
+        "https://github.com/wandb/examples/pulls",
+        "https://github.com/wandb/examples/tree/master/examples/launch/launch-quickstart",
+        "https://github.com/wandb/examples/blob/master/examples/launch/launch-quickstart/README.md",
+    ]
+    for case in cases:
+        ref = GitHubReference.parse(case)
+        assert ref.host == "github.com"
+        assert ref.organization == "wandb"
+        assert ref.repo == "examples"
+        assert ref.url() == case
+
+
+def test_parse_tree() -> None:
+    """Should parse a URL for viewing a dir."""
+    case = "https://github.com/wandb/examples/tree/master/examples/launch/launch-quickstart"
+    ref = GitHubReference.parse(case)
+    assert ref.host == "github.com"
+    assert ref.organization == "wandb"
+    assert ref.repo == "examples"
+    assert ref.view == "tree"
+    assert ref.path == "master/examples/launch/launch-quickstart"
+    assert ref.url() == case
+
+
+def test_parse_blob() -> None:
+    """Should parse a URL for viewing a file."""
+    case = "https://github.com/wandb/examples/blob/master/examples/launch/launch-quickstart/README.md"
+    ref = GitHubReference.parse(case)
+    assert ref.host == "github.com"
+    assert ref.organization == "wandb"
+    assert ref.repo == "examples"
+    assert ref.view == "blob"
+    assert ref.path == "master/examples/launch/launch-quickstart/README.md"
+    assert ref.url() == case
+
+
+def test_parse_auth() -> None:
+    """Should parse a URL that includes a username/password."""
+    case = "https://username@github.com/wandb/examples/blob/commit/path/entry.py"
+    ref = GitHubReference.parse(case)
+    assert ref.username == "username"
+    assert ref.password is None
+    assert ref.host == "github.com"
+    assert ref.organization == "wandb"
+    assert ref.repo == "examples"
+    assert ref.view == "blob"
+    assert ref.path == "commit/path/entry.py"
+    assert ref.url() == case
+
+    case = "https://username:pword@github.com/wandb/examples/blob/commit/path/entry.py"
+    ref = GitHubReference.parse(case)
+    assert ref.username == "username"
+    assert ref.password == "pword"
+    assert ref.host == "github.com"
+    assert ref.organization == "wandb"
+    assert ref.repo == "examples"
+    assert ref.view == "blob"
+    assert ref.path == "commit/path/entry.py"
+    assert ref.url() == case
+
+
+def test_update_ref() -> None:
+    """Test reference updating."""
+    case = "https://github.com/jamie-rasmussen/launch-test-private/blob/main/haspyenv/today.py"
+    ref = GitHubReference.parse(case)
+    # Simulate parsing refinement after fetch
+    ref.path = None
+    ref.ref = "main"
+    ref.directory = "haspyenv"
+    ref.file = "today.py"
+
+    ref.update_ref("jamie/testing-a-branch")
+    assert ref.ref_type is None
+    assert ref.ref == "jamie/testing-a-branch"
+    expected = "https://github.com/jamie-rasmussen/launch-test-private/blob/jamie/testing-a-branch/haspyenv/today.py"
+    assert ref.url() == expected

--- a/tests/unit_tests/tests_launch/test_wandb_reference.py
+++ b/tests/unit_tests/tests_launch/test_wandb_reference.py
@@ -1,0 +1,153 @@
+from wandb.sdk.launch.wandb_reference import WandbReference
+
+
+def test_parse_bad() -> None:
+    ref = WandbReference.parse("not a url")
+    assert ref is None
+
+
+def test_parse_hostonly() -> None:
+    test_cases = [
+        "https://wandb.ai",
+        "https://wandb.ai/",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.host == "wandb.ai"
+        assert ref.url_host() == "https://wandb.ai"
+
+
+def test_parse_beta() -> None:
+    test_cases = [
+        "https://beta.wandb.ai",
+        "https://beta.wandb.ai/settings",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.host == "beta.wandb.ai"
+        assert ref.entity is None
+
+
+def test_parse_run() -> None:
+    test_cases = [
+        "https://wandb.ai/my-entity/my-project/runs/2aqbwbek",
+        "https://wandb.ai/my-entity/my-project/runs/2aqbwbek?workspace=user-my-entity",
+        "https://wandb.ai/my-entity/my-project/runs/2aqbwbek/logs?workspace=user-my-entity",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.is_run()
+        assert ref.host == "wandb.ai"
+        assert ref.entity == "my-entity"
+        assert ref.project == "my-project"
+        assert ref.run_id == "2aqbwbek"
+
+
+def test_parse_run_localhost() -> None:
+    """This format can be seen when running old unit tests."""
+    test_case = "http://localhost:42051/mock_server_entity/test/runs/12345678"
+    ref = WandbReference.parse(test_case)
+    assert ref.is_run()
+    assert ref.host == "localhost:42051"
+    assert ref.entity == "mock_server_entity"
+    assert ref.project == "test"
+    assert ref.run_id == "12345678"
+
+
+def test_parse_run_bare() -> None:
+    test_cases = [
+        "/my-entity/my-project/runs/2aqbwbek",
+        "/my-entity/my-project/runs/2aqbwbek?workspace=user-my-entity",
+        "/my-entity/my-project/runs/2aqbwbek/logs?workspace=user-my-entity",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.is_bare()
+        assert ref.is_run()
+        assert ref.host is None
+        assert ref.entity == "my-entity"
+        assert ref.project == "my-project"
+        assert ref.run_id == "2aqbwbek"
+
+
+def test_parse_job() -> None:
+    test_cases = [
+        "https://wandb.ai/my-entity/my-project/artifacts/job/my-job.py",
+        "https://wandb.ai/my-entity/my-project/artifacts/job/my-job.py/_view/versions",
+        "https://wandb.ai/my-entity/my-project/artifacts/job/my-job.py/latest/lineage",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.is_job()
+        assert ref.host == "wandb.ai"
+        assert ref.entity == "my-entity"
+        assert ref.project == "my-project"
+        assert ref.job_name == "my-job.py"
+        assert ref.job_alias == "latest"
+        assert ref.job_reference() == "my-job.py:latest"
+        assert ref.job_reference_scoped() == "my-entity/my-project/my-job.py:latest"
+    test_cases = [
+        "https://wandb.ai/my-entity/my-project/artifacts/job/my-job.py/v0",
+        "https://wandb.ai/my-entity/my-project/artifacts/job/my-job.py/v0/",
+        "https://wandb.ai/my-entity/my-project/artifacts/job/my-job.py/v0/files",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.is_job()
+        assert ref.host == "wandb.ai"
+        assert ref.entity == "my-entity"
+        assert ref.project == "my-project"
+        assert ref.job_name == "my-job.py"
+        assert ref.job_alias == "v0"
+        assert ref.job_reference() == "my-job.py:v0"
+        assert ref.job_reference_scoped() == "my-entity/my-project/my-job.py:v0"
+
+
+def test_parse_job_bare() -> None:
+    test_cases = [
+        "/my-entity/my-project/artifacts/job/my-job.py",
+        "/my-entity/my-project/artifacts/job/my-job.py/_view/versions",
+        "/my-entity/my-project/artifacts/job/my-job.py/latest/lineage",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.is_bare()
+        assert ref.is_job()
+        assert ref.host is None
+        assert ref.entity == "my-entity"
+        assert ref.project == "my-project"
+        assert ref.job_name == "my-job.py"
+        assert ref.job_alias == "latest"
+    test_cases = [
+        "/my-entity/my-project/artifacts/job/my-job.py/v0",
+        "/my-entity/my-project/artifacts/job/my-job.py/v0/",
+        "/my-entity/my-project/artifacts/job/my-job.py/v0/files",
+    ]
+    for test_case in test_cases:
+        ref = WandbReference.parse(test_case)
+        assert ref.is_bare()
+        assert ref.is_job()
+        assert ref.host is None
+        assert ref.entity == "my-entity"
+        assert ref.project == "my-project"
+        assert ref.job_name == "my-job.py"
+        assert ref.job_alias == "v0"
+
+
+def test_is_uri_job_or_run() -> None:
+    test_cases = [
+        "https://wandb.ai/my-entity/my-project/runs/2aqbwbek?workspace=user-my-entity",
+        "/my-entity/my-project/runs/2aqbwbek",
+        "/my-entity/my-project/artifacts/job/my-job.py/_view/versions",
+        "https://wandb.ai/my-entity/my-project/artifacts/job/my-job.py/latest/lineage",
+    ]
+    for test_case in test_cases:
+        assert WandbReference.is_uri_job_or_run(test_case)
+    test_cases = [
+        "",
+        "https://wandb.ai/",
+        "https://beta.wandb.ai/settings",
+        "https://github.com/wandb/examples/pull/123/files",
+    ]
+    for test_case in test_cases:
+        assert not WandbReference.is_uri_job_or_run(test_case)

--- a/wandb/sdk/launch/github_reference.py
+++ b/wandb/sdk/launch/github_reference.py
@@ -1,0 +1,237 @@
+"""
+Support for parsing GitHub URLs (which might be user provided) into constituent parts.
+"""
+
+import re
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+from wandb.errors import LaunchError
+
+PREFIX_HTTPS = "https://"
+PREFIX_SSH = "git@"
+SUFFIX_GIT = ".git"
+
+
+GIT_COMMIT_REGEX = re.compile(r"[0-9a-f]{40}")
+
+
+class ReferenceType(IntEnum):
+    BRANCH = 1
+    COMMIT = 2
+
+
+def _parse_netloc(netloc: str) -> Tuple[Optional[str], Optional[str], str]:
+    """Parse netloc into username, password, and host.
+
+    github.com => None, None, "@github.com"
+    username@github.com => "username", None, "github.com"
+    username:password@github.com => "username", "password", "github.com"
+    """
+    parts = netloc.split("@", 1)
+    if len(parts) == 1:
+        return None, None, parts[0]
+    auth, host = parts
+    parts = auth.split(":", 1)
+    if len(parts) == 1:
+        return parts[0], None, host
+    return parts[0], parts[1], host
+
+
+@dataclass
+class GitHubReference:
+
+    username: Optional[str] = None
+    password: Optional[str] = None
+    host: Optional[str] = None
+
+    organization: Optional[str] = None
+    repo: Optional[str] = None
+
+    view: Optional[str] = None  # tree or blob
+
+    # Set when we don't know how to parse yet
+    path: Optional[str] = None
+
+    # Set when we do know
+    default_branch: Optional[str] = None
+
+    ref: Optional[str] = None  # branch or commit
+    ref_type: Optional[ReferenceType] = None
+
+    directory: Optional[str] = None
+    file: Optional[str] = None
+
+    def update_ref(self, ref: Optional[str]) -> None:
+        if ref:
+            # We no longer know what this refers to
+            self.ref_type = None
+            self.ref = ref
+
+    def url_host(self) -> str:
+        assert self.host
+        auth = self.username or ""
+        if self.password:
+            auth += f":{self.password}"
+        if auth:
+            auth += "@"
+        return f"{PREFIX_HTTPS}{auth}{self.host}"
+
+    def url_organization(self) -> str:
+        assert self.organization
+        return f"{self.url_host()}/{self.organization}"
+
+    def url_repo(self) -> str:
+        assert self.repo
+        return f"{self.url_organization()}/{self.repo}"
+
+    def repo_ssh(self) -> str:
+        return f"{PREFIX_SSH}{self.host}:{self.organization}/{self.repo}{SUFFIX_GIT}"
+
+    def url(self) -> str:
+        url = self.url_repo()
+        if self.view:
+            url += f"/{self.view}"
+        if self.ref:
+            url += f"/{self.ref}"
+            if self.directory:
+                url += f"/{self.directory}"
+            if self.file:
+                url += f"/{self.file}"
+        elif self.path:
+            url += f"/{self.path}"
+        return url
+
+    @staticmethod
+    def parse(uri: str) -> Optional["GitHubReference"]:
+        """
+        Attempt to parse a string as a GitHub URL.
+        """
+        # Special case: git@github.com:wandb/wandb.git
+        ref = GitHubReference()
+        if uri.startswith(PREFIX_SSH):
+            index = uri.find(":", len(PREFIX_SSH))
+            if index > 0:
+                ref.host = uri[len(PREFIX_SSH) : index]
+                parts = uri[index + 1 :].split("/", 1)
+                if len(parts) < 2 or not parts[1].endswith(SUFFIX_GIT):
+                    return None
+                ref.organization = parts[0]
+                ref.repo = parts[1][: -len(SUFFIX_GIT)]
+                return ref
+            else:
+                # Could not parse host name
+                return None
+
+        parsed = urlparse(uri)
+        if parsed.scheme != "https":
+            return None
+        ref.username, ref.password, ref.host = _parse_netloc(parsed.netloc)
+
+        parts = parsed.path.split("/")
+        if len(parts) > 1:
+            if parts[1] == "orgs" and len(parts) > 2:
+                ref.organization = parts[2]
+            else:
+                ref.organization = parts[1]
+                if len(parts) > 2:
+                    repo = parts[2]
+                    if repo.endswith(SUFFIX_GIT):
+                        repo = repo[: -len(SUFFIX_GIT)]
+                    ref.repo = repo
+                    ref.view = parts[3] if len(parts) > 3 else None
+                    ref.path = "/".join(parts[4:])
+        return ref
+
+    def fetch(self, dst_dir: str) -> None:
+        """Fetch the repo into dst_dir and refine githubref based on what we learn."""
+        # We defer importing git until the last moment, because the import requires that the git
+        # executable is available on the PATH, so we only want to fail if we actually need it.
+        import git  # type: ignore
+
+        repo = git.Repo.init(dst_dir)
+        origin = repo.create_remote("origin", self.url_repo())
+
+        # We fetch the origin so that we have branch and tag references
+        origin.fetch(depth=1)
+
+        # Guess if this is a commit
+        commit = None
+        first_segment = self.ref or (self.path.split("/")[0] if self.path else "")
+        if GIT_COMMIT_REGEX.fullmatch(first_segment):
+            try:
+                commit = repo.commit(first_segment)
+                self.ref_type = ReferenceType.COMMIT
+                self.ref = first_segment
+                if self.path:
+                    self.path = self.path[len(first_segment) + 1 :]
+                head = repo.create_head(first_segment, commit)
+                head.checkout()
+            except ValueError:
+                # Apparently it just looked like a commit
+                pass
+
+        # If not a commit, check to see if path indicates a branch name
+        branch = None
+        check_branch = self.ref or self.path
+        if not commit and check_branch:
+            for ref in repo.references:
+                if hasattr(ref, "tag"):
+                    # Skip tag references.
+                    # Using hasattr instead of isinstance because it works better with mocks.
+                    continue
+                refname = ref.name
+                if refname.startswith("origin/"):  # Trim off "origin/"
+                    refname = refname[7:]
+                if check_branch.startswith(refname):
+                    self.ref_type = ReferenceType.BRANCH
+                    self.ref = branch = refname
+                    if self.path:
+                        self.path = self.path[len(refname) + 1 :]
+                    head = repo.create_head(branch, origin.refs[branch])
+                    head.checkout()
+                    break
+
+        # Must be on default branch. Try to figure out what that is.
+        # TODO: Is there a better way to do this?
+        default_branch = None
+        if not commit and not branch:
+            for ref in repo.references:
+                if hasattr(ref, "tag"):  # Skip tag references
+                    continue
+                refname = ref.name
+                if refname.startswith("origin/"):  # Trim off "origin/"
+                    refname = refname[7:]
+                if refname == "main":
+                    default_branch = "main"
+                    break
+                if refname == "master":
+                    default_branch = "master"
+                    # Keep looking in case we also have a main, which we let take precedence
+                    # (While the references appear to be sorted, not clear if that's guaranteed.)
+            if not default_branch:
+                raise LaunchError(
+                    f"Unable to determine branch or commit to checkout from {self.url()}"
+                )
+            self.default_branch = default_branch
+            head = repo.create_head(default_branch, origin.refs[default_branch])
+            head.checkout()
+
+        # Now that we've checked something out, try to extract directory and file from what remains
+        self._update_path(dst_dir)
+
+    def _update_path(self, dst_dir: str) -> None:
+        """Set directory and file fields based on what remains in path."""
+        if not self.path:
+            return
+        path = Path(dst_dir, self.path)
+        if path.is_file():
+            self.directory = str(path.parent.absolute())
+            self.file = path.name
+            self.path = None
+        elif path.is_dir():
+            self.directory = self.path
+            self.path = None

--- a/wandb/sdk/launch/wandb_reference.py
+++ b/wandb/sdk/launch/wandb_reference.py
@@ -1,0 +1,143 @@
+"""
+Support for parsing W&B URLs (which might be user provided) into constituent parts.
+"""
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Optional
+from urllib.parse import urlparse
+
+PREFIX_HTTP = "http://"
+PREFIX_HTTPS = "https://"
+
+
+class ReferenceType(IntEnum):
+    RUN = 1
+    JOB = 2
+
+
+# Ideally we would not overload the URL paths as we do.
+# TODO: Not sure these are exhaustive, and even if so more special paths might get added.
+#       Would be good to have restrictions that we could check.
+RESERVED_NON_ENTITIES = (
+    "create-team",
+    "fully-connected",
+    "registry",
+    "settings",
+    "subscriptions",
+)
+RESERVED_NON_PROJECTS = (
+    "likes",
+    "projects",
+)
+RESERVED_JOB_PATHS = ("_view",)
+
+
+@dataclass
+class WandbReference:
+
+    # TODO: This will include port, should we separate that out?
+    host: Optional[str] = None
+
+    entity: Optional[str] = None
+    project: Optional[str] = None
+
+    # Set when we don't know how to parse yet
+    path: Optional[str] = None
+
+    # Reference type will determine what other fields are set
+    ref_type: Optional[ReferenceType] = None
+
+    run_id: Optional[str] = None
+
+    job_name: Optional[str] = None
+    job_alias: str = "latest"  # In addition to an alias can be a version specifier
+
+    def is_bare(self) -> bool:
+        return self.host is None
+
+    def is_job(self) -> bool:
+        return self.ref_type == ReferenceType.JOB
+
+    def is_run(self) -> bool:
+        return self.ref_type == ReferenceType.RUN
+
+    def is_job_or_run(self) -> bool:
+        return self.is_job() or self.is_run()
+
+    def job_reference(self) -> str:
+        assert self.is_job()
+        return f"{self.job_name}:{self.job_alias}"
+
+    def job_reference_scoped(self) -> str:
+        assert self.entity
+        assert self.project
+        unscoped = self.job_reference()
+        return f"{self.entity}/{self.project}/{unscoped}"
+
+    def url_host(self) -> str:
+        return f"{PREFIX_HTTPS}{self.host}" if self.host else ""
+
+    def url_entity(self) -> str:
+        assert self.entity
+        return f"{self.url_host()}/{self.entity}"
+
+    def url_project(self) -> str:
+        assert self.project
+        return f"{self.url_entity()}/{self.project}"
+
+    @staticmethod
+    def parse(uri: str) -> Optional["WandbReference"]:
+        """
+        Attempt to parse a string as a W&B URL.
+        """
+        # TODO: Error if HTTP and host is not localhost?
+        if (
+            not uri.startswith("/")
+            and not uri.startswith(PREFIX_HTTP)
+            and not uri.startswith(PREFIX_HTTPS)
+        ):
+            return None
+
+        ref = WandbReference()
+
+        # This takes care of things like query and fragment
+        parsed = urlparse(uri)
+        if parsed.netloc:
+            ref.host = parsed.netloc
+
+        if not parsed.path.startswith("/"):
+            return ref
+
+        ref.path = parsed.path[1:]
+        parts = ref.path.split("/")
+        if len(parts) > 0:
+            if parts[0] not in RESERVED_NON_ENTITIES:
+                ref.path = None
+                ref.entity = parts[0]
+                if len(parts) > 1:
+                    if parts[1] not in RESERVED_NON_PROJECTS:
+                        ref.project = parts[1]
+                        if len(parts) > 3 and parts[2] == "runs":
+                            ref.ref_type = ReferenceType.RUN
+                            ref.run_id = parts[3]
+                        elif (
+                            len(parts) > 4
+                            and parts[2] == "artifacts"
+                            and parts[3] == "job"
+                        ):
+                            ref.ref_type = ReferenceType.JOB
+                            ref.job_name = parts[4]
+                            if len(parts) > 5 and parts[5] not in RESERVED_JOB_PATHS:
+                                ref.job_alias = parts[5]
+                        # TODO: Right now we are not tracking selection as part of URL state in the Jobs tab.
+                        #       If that changes we'll want to update this.
+
+        return ref
+
+    @staticmethod
+    def is_uri_job_or_run(uri: str) -> bool:
+        ref = WandbReference.parse(uri)
+        if ref and ref.is_job_or_run():
+            return True
+        return False


### PR DESCRIPTION
Part of https://wandb.atlassian.net/browse/WB-7626

Description
-----------
Breaking up some changes into multiple PRs for easier review. This one adds some classes that parse W&B and GitHub URLs into constituent parts. A subsequent PR will use these to make more URI formats launchable.

Testing
-------
Includes unit tests.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
