### PR TITLE
chore(public-api): Upgrade Node 12 based GitHub Actions

### DIFF
--- a/.github/workflows/check-mocks-synced-with-yea-wandb.yml
+++ b/.github/workflows/check-mocks-synced-with-yea-wandb.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check if mock_requests is up to date with wandb/wandb:master
         id: mock_requests
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   cc:
-    name: Check conventional commit compliance
+    name: check conventional commit compliance
     runs-on: ubuntu-latest
     steps:
       # https://github.com/amannn/action-semantic-pull-request/releases

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Validate PR
+name: Validate PR title
 
 on:
   pull_request:
@@ -6,11 +6,11 @@ on:
 
 jobs:
   cc:
-    name: Validate PR title
+    name: Check conventional commit compliance
     runs-on: ubuntu-latest
     steps:
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v4.5.0
+      - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
GitHub has deprecated Node 12 based Actions; the two actions we need to update to comply with this are:
- Update semantic-pull-requests to v5.0.2
- Checkout to v3 (actually 2.5.0 which is called v3 🙃 )

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
