### PR TITLE
fix(sdk): pin tensorflow<2.11.0 to prevent errors caused by API changes

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,8 +15,8 @@ ipython
 ipykernel
 nbclient
 scikit-learn
-tensorflow>=1.15.2; sys_platform != 'darwin'
-tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and platform.machine != 'arm64'
+tensorflow>=1.15.2,<2.11; sys_platform != 'darwin'
+tensorflow>=1.15.2,<2.11; python_version > '3.6' and sys_platform == 'darwin' and platform.machine != 'arm64'
 tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_platform == 'darwin' and platform.machine == 'arm64'
 torch
 torchvision


### PR DESCRIPTION
Addresses (but **does not** fix) [WB-11570](https://wandb.atlassian.net/browse/WB-11570)

Description
-----------
CI is failing for all new PRs because of a change in the recently-released tensorflow 2.11.

There is probably a real issue here that we need to look into and most likely fix, but in the meantime this pins tensorflow in `requirements_dev.txt` to avoid installing the newest release to unblock unrelated PRs.

Testing
-------
CI actually passes for the PR, unlike for all the others 😅 
Albeit with a few re-runs to deal with flaky tests 😕 

Checklist
-------
- [X] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
