### PR TITLE
test(artifacts): Use `tmp_path` fixture instead of writing local files during tests

### DIFF
--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -19,9 +19,8 @@ def _cache_writer(cache_path):
         f.write("".join(random.choice("0123456") for _ in range(10)))
 
 
-def test_opener_rejects_append_mode():
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_opener_rejects_append_mode(tmp_path):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
     path, exists, opener = cache.check_md5_obj_path(base64.b64encode(b"abcdef"), 10)
 
     with pytest.raises(ValueError):
@@ -33,13 +32,12 @@ def test_opener_rejects_append_mode():
         pass
 
 
-def test_check_md5_obj_path():
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_check_md5_obj_path(tmp_path):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
 
     md5 = base64.b64encode(b"abcdef")
     path, exists, opener = cache.check_md5_obj_path(md5, 10)
-    expected_path = os.path.join("cache", "obj", "md5", "61", "6263646566")
+    expected_path = os.path.join(tmp_path, "obj", "md5", "61", "6263646566")
     with opener() as f:
         f.write("hi")
     with open(path) as f:
@@ -50,9 +48,8 @@ def test_check_md5_obj_path():
     assert contents == "hi"
 
 
-def test_check_etag_obj_path_points_to_opener_dst():
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_check_etag_obj_path_points_to_opener_dst(tmp_path):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
 
     path, exists, opener = cache.check_etag_obj_path("http://my/url", "abc", 10)
 
@@ -64,9 +61,8 @@ def test_check_etag_obj_path_points_to_opener_dst():
     assert contents == "hi"
 
 
-def test_check_etag_obj_path_returns_exists_if_exists():
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_check_etag_obj_path_returns_exists_if_exists(tmp_path):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
 
     size = 123
     _, exists, opener = cache.check_etag_obj_path("http://my/url", "abc", size)
@@ -79,9 +75,8 @@ def test_check_etag_obj_path_returns_exists_if_exists():
     assert exists
 
 
-def test_check_etag_obj_path_returns_not_exists_if_incomplete():
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_check_etag_obj_path_returns_not_exists_if_incomplete(tmp_path):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
 
     size = 123
     _, exists, opener = cache.check_etag_obj_path("http://my/url", "abc", size)
@@ -100,9 +95,8 @@ def test_check_etag_obj_path_returns_not_exists_if_incomplete():
     assert exists
 
 
-def test_check_etag_obj_path_does_not_include_etag():
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_check_etag_obj_path_does_not_include_etag(tmp_path):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
 
     path, _, _ = cache.check_etag_obj_path("http://url/1", "abcdef", 10)
     assert "abcdef" not in path
@@ -116,9 +110,10 @@ def test_check_etag_obj_path_does_not_include_etag():
         ("http://url/1", "http://url/2", "abc", "abc", False),
     ],
 )
-def test_check_etag_obj_path_hashes_url_and_etag(url1, url2, etag1, etag2, path_equal):
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_check_etag_obj_path_hashes_url_and_etag(
+    url1, url2, etag1, etag2, path_equal, tmp_path
+):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
 
     path_1, _, _ = cache.check_etag_obj_path(url1, etag1, 10)
     path_2, _, _ = cache.check_etag_obj_path(url2, etag2, 10)
@@ -129,66 +124,61 @@ def test_check_etag_obj_path_hashes_url_and_etag(url1, url2, etag1, etag2, path_
         assert path_1 != path_2
 
 
-def test_check_write_parallel(runner):
-    with runner.isolated_filesystem() as t:
-        cache = os.path.join(t, "cache")
-        num_parallel = 5
+def test_check_write_parallel(tmp_path):
+    num_parallel = 5
 
-        p = Pool(num_parallel)
-        p.map(_cache_writer, [cache for _ in range(num_parallel)])
-        _cache_writer(cache)  # run in this process too for code coverage
-        p.close()
-        p.join()
+    p = Pool(num_parallel)
+    p.map(_cache_writer, [tmp_path for _ in range(num_parallel)])
+    _cache_writer(tmp_path)  # run in this process too for code coverage
+    p.close()
+    p.join()
 
-        # Regardless of the ordering, we should be left with one
-        # file at the end.
-        files = [
-            f for f in (pathlib.Path(cache) / "obj" / "etag").rglob("*") if f.is_file()
-        ]
-        assert len(files) == 1
+    # Regardless of the ordering, we should be left with one
+    # file at the end.
+    files = [f for f in (tmp_path / "obj" / "etag").rglob("*") if f.is_file()]
+    assert len(files) == 1
 
 
-def test_artifacts_cache_cleanup_empty():
-    os.mkdir("cache")
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+def test_artifacts_cache_cleanup_empty(tmp_path):
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
     reclaimed_bytes = cache.cleanup(100000)
     assert reclaimed_bytes == 0
 
 
-def test_artifacts_cache_cleanup():
-    cache_root = os.path.join("cache", "obj", "md5")
+def test_artifacts_cache_cleanup(tmp_path):
+    cache_root = os.path.join(tmp_path, "obj", "md5")
 
     path_1 = os.path.join(cache_root, "aa")
     os.makedirs(path_1)
     with open(os.path.join(path_1, "aardvark"), "w") as f:
         f.truncate(5000)
-    time.sleep(0.1)
+        f.flush()
 
     path_2 = os.path.join(cache_root, "ab")
     os.makedirs(path_2)
     with open(os.path.join(path_2, "absolute"), "w") as f:
         f.truncate(2000)
-    time.sleep(0.1)
+        f.flush()
 
     path_3 = os.path.join(cache_root, "ac")
     os.makedirs(path_3)
     with open(os.path.join(path_3, "accelerate"), "w") as f:
         f.truncate(1000)
 
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
     reclaimed_bytes = cache.cleanup(5000)
 
     # We should get rid of "aardvark" in this case
     assert reclaimed_bytes == 5000
 
 
-def test_artifacts_cache_cleanup_tmp_files():
-    path = os.path.join("cache", "obj", "md5", "aa")
+def test_artifacts_cache_cleanup_tmp_files(tmp_path):
+    path = os.path.join(tmp_path, "obj", "md5", "aa")
     os.makedirs(path)
     with open(os.path.join(path, "tmp_abc"), "w") as f:
         f.truncate(1000)
 
-    cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
+    cache = wandb_sdk.wandb_artifacts.ArtifactsCache(tmp_path)
 
     # Even if we are above our target size, the cleanup
     # should reclaim tmp files.

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -1,8 +1,6 @@
 import base64
 import os
-import pathlib
 import random
-import time
 from multiprocessing import Pool
 
 import pytest


### PR DESCRIPTION
Description
-----------
Replace `os.mkdir` calls inside test functions with accepting the pytest built-in `tmp_path` fixture.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
