### PR TITLE
test(artifacts): flush writes instead of sleeping to wait on file writes

### DIFF
--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -2,7 +2,6 @@ import base64
 import os
 import pathlib
 import random
-import time
 from multiprocessing import Pool
 
 import pytest
@@ -162,13 +161,13 @@ def test_artifacts_cache_cleanup():
     os.makedirs(path_1)
     with open(os.path.join(path_1, "aardvark"), "w") as f:
         f.truncate(5000)
-    time.sleep(0.1)
+        f.flush()
 
     path_2 = os.path.join(cache_root, "ab")
     os.makedirs(path_2)
     with open(os.path.join(path_2, "absolute"), "w") as f:
         f.truncate(2000)
-    time.sleep(0.1)
+        f.flush()
 
     path_3 = os.path.join(cache_root, "ac")
     os.makedirs(path_3)

--- a/tests/unit_tests/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/test_wandb_artifacts_cache.py
@@ -162,17 +162,21 @@ def test_artifacts_cache_cleanup():
     with open(os.path.join(path_1, "aardvark"), "w") as f:
         f.truncate(5000)
         f.flush()
+        os.fsync(f)
 
     path_2 = os.path.join(cache_root, "ab")
     os.makedirs(path_2)
     with open(os.path.join(path_2, "absolute"), "w") as f:
         f.truncate(2000)
         f.flush()
+        os.fsync(f)
 
     path_3 = os.path.join(cache_root, "ac")
     os.makedirs(path_3)
     with open(os.path.join(path_3, "accelerate"), "w") as f:
         f.truncate(1000)
+        f.flush()
+        os.fsync(f)
 
     cache = wandb_sdk.wandb_artifacts.ArtifactsCache("cache")
     reclaimed_bytes = cache.cleanup(5000)


### PR DESCRIPTION
Description
-----------
Replace flaky calls to `time.sleep(0.1)` with calls to `flush` when waiting on a file to write.

For some reason on my machine the calls to `time.sleep` often do nothing. Regardless, this is a faster and more reliable way to ensure files are written with sequential c/m/a times.

Testing
-------
[test only PR, no behavior change]

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
