### PR TITLE
docs(artifacts): correct parameter name in docstring example

### DIFF
--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -446,7 +446,7 @@ class Artifact:
 
             Adding a directory without an explicit name:
             ```
-            artifact.add_dir('my_dir/', path='destination') # All files in `my_dir/` are added under `destination/`.
+            artifact.add_dir('my_dir/', name='destination') # All files in `my_dir/` are added under `destination/`.
             ```
 
         Raises:


### PR DESCRIPTION
docs(artifacts): corrected parameter name in docstring example for `.add_dir` method. The correct paramater name is `name`, not `path`.

Fixes: https://github.com/wandb/wandb/issues/4443

Description
-----------
What does the PR do?
Corrects parameter name in docstring example for `.add_dir` method. The correct paramater name is `name`, not `path`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ X] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
