### PR TITLE
build(sdk): update tox.ini and pytest.ini to ignore unit_tests_old

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,7 +359,7 @@ tox -e flake8,mypy
 
 We use the [`pytest`](https://docs.pytest.org/) framework. Tests can be found in `tests/`.
 
-By default, tests are run in parallel with 4 processes. This can be changed by setting the
+By default, tests are run in parallel with 10 processes. This can be changed by setting the
 `CI_PYTEST_PARALLEL` environment variable to a different value.
 
 To run specific tests in a specific environment:

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     {[unitbase]deps}
     -r{toxinidir}/requirements_dev.txt
 install_command =
-    py{36,37,38,39,launch,launch38}: pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
+    py{36,37,38,39,310,launch,launch38}: pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 passenv =
     USERNAME
     CI_PYTEST_SPLIT_ARGS


### PR DESCRIPTION
Description
-----------
- Fix `tox`'s default behavior (ignore the tests we know fail (and don't run on CI))
- Include Python 3.10 as a test environment (consistently)

Following `CONTRIBUTING.md` should work; now it does, at least for `tox -e py3x`

Testing
-------
Locally and on CI

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
