### PR TITLE
test(sdk): always mock out `requests` in all tests

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -119,6 +119,11 @@ def copy_asset(assets_path) -> Callable:
 # --------------------------------
 
 
+@pytest.fixture(autouse=True)
+def mock_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
 @pytest.fixture(scope="function", autouse=True)
 def unset_global_objects():
     from wandb.sdk.lib.module import unset_globals

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -292,14 +292,8 @@ def test_max_images(mock_run):
     assert os.path.exists(path)
 
 
-@pytest.fixture
-def mock_reference_get_responses():
-    with responses.RequestsMock() as rsps:
-        yield rsps
-
-
-def test_image_refs(mock_reference_get_responses):
-    mock_reference_get_responses.add(
+def test_image_refs(mock_responses: responses.RequestsMock):
+    mock_responses.add(
         method="GET",
         url="http://nonexistent/puppy.jpg",
         body=b"test",

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -40,14 +40,15 @@ def test_get_run_state_invalid_kwargs():
 def test_download_write_file_fetches_iff_file_checksum_mismatched(
     existing_contents: Optional[str],
     expect_download: bool,
+    mock_responses: responses.RequestsMock,
 ):
     url = "https://example.com/path/to/file.txt"
     current_contents = "current contents"
-    with responses.RequestsMock() as rsps, tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         filepath = os.path.join(tmpdir, "file.txt")
 
         if expect_download:
-            rsps.add(
+            mock_responses.add(
                 responses.GET,
                 url,
                 body=current_contents,

--- a/tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_wandb_artifacts.py
@@ -980,10 +980,12 @@ def test_interface_commit_hash():
     ],
 )
 def test_http_storage_handler_uses_etag_for_digest(
-    headers: Optional[Mapping[str, str]], expected_digest: Optional[str]
+    headers: Optional[Mapping[str, str]],
+    expected_digest: Optional[str],
+    mock_responses: responses.RequestsMock,
 ):
-    with responses.RequestsMock() as rsps, requests.Session() as session:
-        rsps.add(
+    with requests.Session() as session:
+        mock_responses.add(
             "GET",
             "https://example.com/foo.json?bar=abc",
             json={"result": 1},


### PR DESCRIPTION
Description
-----------

Until recently, we had some unit tests which made real-life network requests. That seems like it's begging for flakiness, so I added an `autouse=True` Pytest fixture that activates the `responses` library, which fails all unexpected requests.


Testing
---------

Wrote a new test:
```python
def test_that_makes_an_unmocked_request():
    import requests
    assert requests.get('https://example.com').status_code == 200
```

It passes on `main`, and it fails on this branch, as desired:

```
$ pytest tests/unit_tests/test_reqmock.py -k test_that_makes_an_unmocked_request
<...snip...>
E           requests.exceptions.ConnectionError: Connection refused by Responses - the call doesn't match any registered mock.
E
E           Request:
E           - GET https://example.com/
E
E           Available matches:

/Users/pears/.pyenv/versions/3.9.13/envs/example/lib/python3.9/site-packages/responses/__init__.py:993: ConnectionError
```