### PR TITLE
Revert "fix(sdk): pin tensorflow<2.11.0 to prevent errors caused by A…

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,8 +15,8 @@ ipython
 ipykernel
 nbclient
 scikit-learn
-tensorflow>=1.15.2,<2.11; sys_platform != 'darwin'
-tensorflow>=1.15.2,<2.11; python_version > '3.6' and sys_platform == 'darwin' and platform.machine != 'arm64'
+tensorflow>=1.15.2; sys_platform != 'darwin'
+tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and platform.machine != 'arm64'
 tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_platform == 'darwin' and platform.machine == 'arm64'
 torch
 torchvision


### PR DESCRIPTION
…PI changes (#4508)"

This reverts commit 7426e4905046202b5409d39ffc0c57d436d22c30.

Fixes WB-NNNN
Fixes #NNNN

Description
-----------
What does the PR do?

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
