### PR TITLE
docs(sdk): Fixed typo in docstring for data_types.Objects3D

### DIFF
--- a/wandb/sdk/data_types/object_3d.py
+++ b/wandb/sdk/data_types/object_3d.py
@@ -88,7 +88,7 @@ class Object3D(BatchableMedia):
     ```
     [[x y z],       ...] nx3
     [[x y z c],     ...] nx4 where c is a category with supported range [1, 14]
-    [[x y z r g b], ...] nx4 where is rgb is color
+    [[x y z r g b], ...] nx6 where is rgb is color
     ```
     """
 


### PR DESCRIPTION
Fixes [DOCS-458](https://wandb.atlassian.net/browse/DOCS-458?atlOrigin=eyJpIjoiOTY0MWI4ZDdjZjE0NDI2Yjk3NGMyZDlhYmMwMGM0YWIiLCJwIjoiaiJ9)
Fixes #NNNN

-----------
Fixed typo in python docstring for data_types.Objects3D

Testing
-------
How was this PR tested? 
N/A

Checklist
-------
- [X] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
