### PR TITLE
fix(artifacts): fix json encoder to allow tensor datatypes for artifact metadata

### DIFF
--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -258,7 +258,7 @@ def test_make_safe_for_json_artifacts():
         "seq": ["NaN", 1],
         "str": "str",
         "numpyArr": [0] * 33,
-        "tf": [300, 300],
+        "tensor": [300, 300],
     }
     assert json.dumps(res)
     assert_deep_lists_equal(res, expected)

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -237,7 +237,7 @@ def test_app_url():
 ###############################################################################
 
 
-def test_safe_for_json():
+def test_make_safe_for_json_artifacts():
     res = util.make_safe_for_json(
         {
             "nan": float("nan"),
@@ -247,6 +247,7 @@ def test_safe_for_json():
             "seq": [float("nan"), 1],
             "map": {"foo": 1, "nan": float("nan")},
             "numpyArr": np.array([0] * 33),
+            "tensor": tf.convert_to_tensor((300,) * 2),
         }
     )
     expected = {
@@ -257,6 +258,7 @@ def test_safe_for_json():
         "seq": ["NaN", 1],
         "str": "str",
         "numpyArr": [0] * 33,
+        "tf": [300, 300],
     }
     assert json.dumps(res)
     assert_deep_lists_equal(res, expected)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -675,7 +675,7 @@ def _sanitize_numpy_keys(d: Dict) -> Tuple[Dict, bool]:
     return d, True
 
 
-def tensor_to_json_friendly_types(obj) -> Tuple[Any, bool]:
+def tensor_to_json_friendly_types(obj: Any) -> Tuple[Any, bool]:
     typename = get_full_typename(obj)
 
     if is_tf_eager_tensor_typename(typename):


### PR DESCRIPTION
https://github.com/wandb/wandb/issues/4500
https://wandb.atlassian.net/browse/WB-11691

Description
-----------
Fix issue where tensor datatypes weren't json serializable so that it can be set as the metadata. This is a hacky fix to the eventual fix of refactoring the json serialization across this repo

Testing
-------
Added small change to unit test as well as testing manually
