### PR TITLE
fix(sdk): resume collecting system metrics on object restart

### DIFF
--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -742,7 +742,7 @@ class HandleManager:
             self._metric_defines[metric.step_metric] = m
             mr = Record()
             mr.metric.CopyFrom(m)
-            mr.control.local = True  # Dont store this, just send it
+            mr.control.local = True  # Don't store this, just send it
             self._dispatch_record(mr)
 
         self._dispatch_record(record)

--- a/wandb/sdk/internal/system/system_monitor.py
+++ b/wandb/sdk/internal/system/system_monitor.py
@@ -4,6 +4,7 @@ import queue
 import threading
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import wandb
 from .assets.asset_registry import asset_registry
 from .assets.interfaces import Asset, Interface
 from .system_info import SystemInfo
@@ -146,7 +147,8 @@ class SystemMonitor:
             logger.error(f"Error publishing last batch of metrics: {e}")
 
     def start(self) -> None:
-        if self._process is None and not self._shutdown_event.is_set():
+        self._shutdown_event.clear()
+        if self._process is None:
             logger.info("Starting system monitor")
             # self._process = mp.Process(target=self._start, name="SystemMonitor")
             self._process = threading.Thread(

--- a/wandb/sdk/internal/system/system_monitor.py
+++ b/wandb/sdk/internal/system/system_monitor.py
@@ -4,7 +4,6 @@ import queue
 import threading
 from typing import TYPE_CHECKING, List, Optional, Union
 
-import wandb
 from .assets.asset_registry import asset_registry
 from .assets.interfaces import Asset, Interface
 from .system_info import SystemInfo


### PR DESCRIPTION
Fixes WB-11669

Description
-----------
In jupyter-based environments, we pause system metrics collection when no cell is being executed. Resuming SM collection was broken in 0.13.5 because the internal `_shutdown_event` was never reset and the attempt to restart the system monitor didn't do anything. This PR fixes this.

Testing
-------
Tested locally in jupyter lab and in colab. Square brackets denote a cell
- [init + log a few steps] [log a few more steps] [finish]
- [init] [log a few steps] [log a few more steps] [finish]
- [init] [log a few steps, forcefully stop cell execution midway] [log a few more steps] [finish]

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
