### PR TITLE
fix(sdk): correct the type hint for wandb.run

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -121,7 +121,7 @@ def _assert_is_user_process():
 # globals
 Api = PublicApi
 api = InternalApi()
-run: Optional["wandb.sdk.wandb_run.Run"] = None
+run: Optional["wandb_sdk.wandb_run.Run"] = None
 config = _preinit.PreInitObject("wandb.config", wandb_sdk.wandb_config.Config)
 summary = _preinit.PreInitObject("wandb.summary", wandb_sdk.wandb_summary.Summary)
 log = _preinit.PreInitCallable("wandb.log", wandb_sdk.wandb_run.Run.log)


### PR DESCRIPTION
Fixes #4584 

Description
-----------
Fixes (speculatively?) the type hint for wandb.run, by referring to "wandb_sdk" instead of "wandb.sdk".