### PR TITLE
chore(launch): remove requirement to make target project match queue

### DIFF
--- a/tests/unit_tests_old/tests_launch/test_launch.py
+++ b/tests/unit_tests_old/tests_launch/test_launch.py
@@ -743,39 +743,6 @@ def test_launch_agent_instance(test_settings, live_mock_server):
     assert get_agent_response["name"] == "test_agent"
 
 
-@pytest.mark.flaky
-# @pytest.mark.xfail(reason="test goes through flaky periods. Re-enable with WB7616")
-@pytest.mark.timeout(240)
-def test_launch_agent_different_project_in_spec(
-    test_settings,
-    live_mock_server,
-    mocked_fetchable_git_repo,
-    monkeypatch,
-    # mock_load_backend_agent,
-    capsys,
-):
-    live_mock_server.set_ctx({"invalid_launch_spec_project": True})
-    monkeypatch.setattr(
-        wandb.sdk.launch.agent.LaunchAgent,
-        "pop_from_queue",
-        lambda c, queue: patched_pop_from_queue(c, queue),
-    )
-    api = wandb.sdk.internal.internal_api.Api(
-        default_settings=test_settings, load_settings=False
-    )
-    config = {
-        "entity": "mock_server_entity",
-        "project": "test_project",
-    }
-    launch.create_and_run_agent(api, config)
-    _, err = capsys.readouterr()
-
-    assert (
-        "Launch agents only support sending runs to their own project and entity. This run will be sent to mock_server_entity/test_project"
-        in err
-    )
-
-
 def test_agent_queues_notfound(test_settings, live_mock_server):
     api = wandb.sdk.internal.internal_api.Api(
         default_settings=test_settings, load_settings=False

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -126,23 +126,6 @@ class LaunchAgent:
         except Exception:
             self.finish_job_id(job_id)
 
-    def _validate_and_fix_spec_project_entity(
-        self, launch_spec: Dict[str, Any]
-    ) -> None:
-        """Checks if launch spec target project/entity differs from agent. Forces these values to agent's if they are set."""
-        if (
-            launch_spec.get("project") is not None
-            and launch_spec.get("project") != self._project
-        ) or (
-            launch_spec.get("entity") is not None
-            and launch_spec.get("entity") != self._entity
-        ):
-            wandb.termwarn(
-                f"Launch agents only support sending runs to their own project and entity. This run will be sent to {self._entity}/{self._project}"
-            )
-            launch_spec["entity"] = self._entity
-            launch_spec["project"] = self._project
-
     def run_job(self, job: Dict[str, Any]) -> None:
         """Sets up project and runs the job."""
         _msg = f"{LOG_PREFIX}Launch agent received job:\n{pprint.pformat(job)}\n"
@@ -160,7 +143,6 @@ class LaunchAgent:
             launch_spec["overrides"]["args"] = util._user_args_to_dict(
                 launch_spec["overrides"].get("args", [])
             )
-        self._validate_and_fix_spec_project_entity(launch_spec)
 
         project = create_project_from_spec(launch_spec, self._api)
         _logger.info("Fetching and validating project...")


### PR DESCRIPTION
[Fixes WB-11511](https://wandb.atlassian.net/browse/WB-11511)
Fixes #NNNN

Description
-----------
Removes the requirement to send the project to the same project as the queue

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
