### PR TITLE
chore(sdk): improve file descriptor management

### DIFF
--- a/tests/unit_tests_old/test_summary.py
+++ b/tests/unit_tests_old/test_summary.py
@@ -1,5 +1,6 @@
 import pytest
 import wandb
+import wandb.old.summary
 
 
 @pytest.fixture

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -54,7 +54,7 @@ from wandb.errors import CommError, UsageError
 _preinit = wandb.wandb_lib.preinit
 _lazyloader = wandb.wandb_lib.lazyloader
 
-# Call import module hook to setup any needed require hooks
+# Call import module hook to set up any needed require hooks
 wandb.sdk.wandb_require._import_module_hook()
 
 from wandb import wandb_torch

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -48,7 +48,6 @@ from wandb.apis.normalize import normalize_exceptions
 from wandb.data_types import WBValue
 from wandb.errors import CommError, LaunchError
 from wandb.errors.term import termlog
-from wandb.old.summary import HTTPSummary
 from wandb.sdk.data_types._dtypes import InvalidType, Type, TypeRegistry
 from wandb.sdk.interface import artifacts
 from wandb.sdk.launch.utils import _fetch_git_repo, apply_patch
@@ -2200,6 +2199,8 @@ class Run(Attrs):
     @property
     def summary(self):
         if self._summary is None:
+            from wandb.old.summary import HTTPSummary
+
             # TODO: fix the outdir issue
             self._summary = HTTPSummary(self, self.client, summary=self.summary_metrics)
         return self._summary

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1556,7 +1556,7 @@ class Node(WBValue):
         self._attributes = {"name": None}
         self.in_edges = {}  # indexed by source node id
         self.out_edges = {}  # indexed by dest node id
-        # optional object (eg. PyTorch Parameter or Module) that this Node represents
+        # optional object (e.g. PyTorch Parameter or Module) that this Node represents
         self.obj = None
 
         if node is not None:

--- a/wandb/sdk/internal/internal.py
+++ b/wandb/sdk/internal/internal.py
@@ -156,6 +156,12 @@ def wandb_internal(
     for thread in threads:
         thread.join()
 
+    def close_internal_log():
+        root = logging.getLogger("wandb")
+        for _handler in root.handlers[:]:
+            _handler.close()
+            root.removeHandler(_handler)
+
     for thread in threads:
         exc_info = thread.get_exception()
         if exc_info:
@@ -169,6 +175,8 @@ def wandb_internal(
                 # and potentially just fail the one stream.
                 os._exit(-1)
             sys.exit(-1)
+
+    close_internal_log()
 
 
 def _setup_tracelog() -> None:

--- a/wandb/sdk/internal/internal.py
+++ b/wandb/sdk/internal/internal.py
@@ -156,7 +156,7 @@ def wandb_internal(
     for thread in threads:
         thread.join()
 
-    def close_internal_log():
+    def close_internal_log() -> None:
         root = logging.getLogger("wandb")
         for _handler in root.handlers[:]:
             _handler.close()

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -348,6 +348,7 @@ def import_module_lazy(name: str) -> Any:
         module = importlib.util.module_from_spec(module_spec)
         sys.modules[name] = module
 
+        assert module_spec.loader is not None
         lazy_loader = importlib.util.LazyLoader(module_spec.loader)
         lazy_loader.exec_module(module)
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -8,6 +8,7 @@ import functools
 import gzip
 import hashlib
 import importlib
+import importlib.util
 import json
 import logging
 import math
@@ -331,16 +332,47 @@ def vendor_import(name: str) -> Any:
     return module
 
 
-def get_module(name: str, required: Optional[Union[str, bool]] = None) -> Any:
+def import_module_lazy(name: str) -> Any:
+    """
+    Import a module lazily, only when it is used.
+
+    :param (str) name: Dot-separated module path. E.g., 'scipy.stats'.
+    """
+    try:
+        return sys.modules[name]
+    except KeyError:
+        module_spec = importlib.util.find_spec(name)
+        if not module_spec:
+            raise ModuleNotFoundError
+
+        module = importlib.util.module_from_spec(module_spec)
+        sys.modules[name] = module
+
+        lazy_loader = importlib.util.LazyLoader(module_spec.loader)
+        lazy_loader.exec_module(module)
+
+        return module
+
+
+def get_module(
+    name: str,
+    required: Optional[Union[str, bool]] = None,
+    lazy: bool = True,
+) -> Any:
     """
     Return module or None. Absolute import is required.
+
     :param (str) name: Dot-separated module path. E.g., 'scipy.stats'.
     :param (str) required: A string to raise a ValueError if missing
+    :param (bool) lazy: If True, return a lazy loader for the module.
     :return: (module|None) If import succeeds, the module will be returned.
     """
     if name not in _not_importable:
         try:
-            return import_module(name)
+            if not lazy:
+                return import_module(name)
+            else:
+                return import_module_lazy(name)
         except Exception:
             _not_importable.add(name)
             msg = f"Error importing optional module {name}"


### PR DESCRIPTION
Fixes WB-11427 (probably not fully, but this should be a good starting point)

Description
-----------
Reduce the default number of open file descriptors: 

- default to lazily loading optional external modules:
  - make `wandb.util.get_module` lazily load modules by default
  - `wandb.old.summary` was loading `h5py`, which many users will never need. It was accounting for ~40% of open file descriptors when you simply say `import wandb`.

With the above two improvements, for a simple script `junk.py` like this:
```python
import time

import wandb

run = wandb.init()
time.sleep(5)
run.finish()
```

```shell
p=`ps -ef | grep "junk" | awk 'NR==1 {print $2}'`
lsof -p $p | wc -l 
```

goes down from ~115 to ~70.

- Make sure to close the internal log file when finishing the internal process

Currently, for a script like this:
```python
import wandb

for i in range(20):
    print(i)
    with wandb.init():
        pass

```

All the `debug-internal.log` files stay open until the service process exits -- fixed this.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
