### PR TITLE
fix(public-api): Job uses queue_name keyword arg (instead of queue) when calling launch_add

### DIFF
--- a/tests/unit_tests/tests_launch/test_job.py
+++ b/tests/unit_tests/tests_launch/test_job.py
@@ -1,0 +1,21 @@
+from wandb.apis.public import Api as PublicApi
+
+
+def test_job_call(user, wandb_init, test_settings):
+    proj = "TEST_PROJECT"
+    public_api = PublicApi()
+    settings = test_settings({"project": proj})
+    run = wandb_init(settings=settings)
+
+    docker_image = "TEST_IMAGE"
+    job_artifact = run._log_job_artifact_with_image(docker_image)
+    job_name = job_artifact.wait().name
+    job = public_api.job(f"{user}/{proj}/{job_name}")
+
+    queued_run = job.call(config={}, project=proj)
+    run.finish()
+
+    assert queued_run.state == "pending"
+    assert queued_run.entity == user
+    assert queued_run.project == proj
+    assert queued_run.container_job is True

--- a/tests/unit_tests/tests_launch/test_job.py
+++ b/tests/unit_tests/tests_launch/test_job.py
@@ -1,21 +1,35 @@
 from wandb.apis.public import Api as PublicApi
+from wandb.sdk.internal.internal_api import Api as InternalApi
 
 
-def test_job_call(user, wandb_init, test_settings):
+def test_job_call(relay_server, user, wandb_init, test_settings):
     proj = "TEST_PROJECT"
+    queue = "TEST_QUEUE"
     public_api = PublicApi()
+    internal_api = InternalApi()
     settings = test_settings({"project": proj})
-    run = wandb_init(settings=settings)
 
-    docker_image = "TEST_IMAGE"
-    job_artifact = run._log_job_artifact_with_image(docker_image)
-    job_name = job_artifact.wait().name
-    job = public_api.job(f"{user}/{proj}/{job_name}")
+    with relay_server():
+        run = wandb_init(settings=settings)
 
-    queued_run = job.call(config={}, project=proj)
-    run.finish()
+        docker_image = "TEST_IMAGE"
+        job_artifact = run._log_job_artifact_with_image(docker_image)
+        job_name = job_artifact.wait().name
+        job = public_api.job(f"{user}/{proj}/{job_name}")
 
-    assert queued_run.state == "pending"
-    assert queued_run.entity == user
-    assert queued_run.project == proj
-    assert queued_run.container_job is True
+        internal_api.create_run_queue(
+            entity=user, project=proj, queue_name=queue, access="PROJECT"
+        )
+
+        queued_run = job.call(config={}, project=proj, queue=queue)
+
+        assert queued_run.state == "pending"
+        assert queued_run.entity == user
+        assert queued_run.project == proj
+        assert queued_run.container_job is True
+
+        rqi = internal_api.pop_from_run_queue(queue, user, proj)
+
+        assert rqi["runSpec"]["job"].split("/")[-1] == f"job-{docker_image}:v0"
+        assert rqi["runSpec"]["project"] == proj
+        run.finish()

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -5532,7 +5532,7 @@ class Job:
             config={"overrides": {"run_config": run_config}},
             project=project or self._project,
             entity=entity or self._entity,
-            queue=queue,
+            queue_name=queue,
             resource=resource,
             resource_args=resource_args,
             cuda=cuda,


### PR DESCRIPTION
Job uses queue_name keyword arg (instead of queue) when calling launch_add

Fixes WB-11748

Description
-----------
Fixes `Job.call()` using the wrong keyword (`queue` vs `queue_name`) when calling launch_add.

Testing
-------
Unit test was added to verify `Job.call()`. Run `tox -e pylaunch38 tests/unit_tests/tests_launch/test_job.py`

