### PR TITLE
build(sdk): temporarily pin jax in tests because of breaking changes

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,7 +27,7 @@ docker
 stable_baselines3
 tensorboard
 gym
-jax[cpu]; sys_platform == 'darwin' or sys_platform == 'linux'
+jax[cpu]<0.4; sys_platform == 'darwin' or sys_platform == 'linux'
 fastcore; python_version > '3.6'
 fastcore==1.3.29; python_version == '3.6'
 pyarrow


### PR DESCRIPTION
Description
-----------
jax 0.4.1 changed something which is breaking our tests... temporarily pin so we can keep tests passing while we figure it out

Testing
-------
circleci