### PR TITLE
chore(sdk): update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ How was this PR tested?
 Checklist
 -------
 - [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
+- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


### PR DESCRIPTION
Description
-----------
We were still referencing master instead of main... and the redir looses the anchor point so it doesnt go directly to conventional commit info

Testing
-------
Untested
