### PR TITLE
chore(launch): fix for run spec handling in sdk

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1201,7 +1201,7 @@ def launch(
     else:
         config = {}
 
-    resource = resource or config.get("resource")
+    resource = resource or config.get("resource") or "local-container"
 
     if build and queue is None:
         raise LaunchError("Build flag requires a queue to be set")

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1201,7 +1201,7 @@ def launch(
     else:
         config = {}
 
-    resource = resource or config.get("resource") or "local-container"
+    resource = resource or config.get("resource")
 
     if build and queue is None:
         raise LaunchError("Build flag requires a queue to be set")

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1076,6 +1076,11 @@ class Api:
             result: Optional[Dict[str, Any]] = self.gql(
                 mutation, variables, check_retry_fn=util.no_retry_4xx
             ).get("pushToRunQueueByName")
+
+            runSpec = json.loads(result.get("runSpec"))
+            if runSpec and runSpec != "{}":
+                result["runSpec"] = runSpec
+            return result
         except Exception as e:
             if (
                 'Cannot query field "runSpec" on type "PushToRunQueueByNamePayload"'

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1077,9 +1077,13 @@ class Api:
                 mutation, variables, check_retry_fn=util.no_retry_4xx
             ).get("pushToRunQueueByName")
 
-            run_spec = json.loads(result.get("runSpec"))
-            if run_spec and run_spec != "{}":
+            if not result:
+                return None
+
+            if result.get("runSpec"):
+                run_spec = json.loads(str(result["runSpec"]))
                 result["runSpec"] = run_spec
+
             return result
         except Exception as e:
             if (

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1077,9 +1077,9 @@ class Api:
                 mutation, variables, check_retry_fn=util.no_retry_4xx
             ).get("pushToRunQueueByName")
 
-            runSpec = json.loads(result.get("runSpec"))
-            if runSpec and runSpec != "{}":
-                result["runSpec"] = runSpec
+            run_spec = json.loads(result.get("runSpec"))
+            if run_spec and run_spec != "{}":
+                result["runSpec"] = run_spec
             return result
         except Exception as e:
             if (

--- a/wandb/sdk/launch/launch_add.py
+++ b/wandb/sdk/launch/launch_add.py
@@ -187,7 +187,10 @@ def _launch_add(
 
     updated_spec = res.get("runSpec")
     if updated_spec:
-        launch_spec = updated_spec
+        if updated_spec.get("resource_args"):
+            launch_spec["resource_args"] = updated_spec.get("resource_args")
+        if updated_spec.get("resource"):
+            launch_spec["resource"] = updated_spec.get("resource")
 
     wandb.termlog(f"{LOG_PREFIX}Added run to queue {queue_name}.")
     wandb.termlog(f"{LOG_PREFIX}Launch spec:\n{pprint.pformat(launch_spec)}\n")


### PR DESCRIPTION
misplaced return statement allow for double queries, adding TWO instead of ONE to the queue