### PR TITLE
fix(sweeps): sweeps schedulers handles multi word parameters

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -917,7 +917,7 @@ def sweep(
                             "scheduler",
                             "WANDB_SWEEP_ID",
                             "--queue",
-                            queue or launch_config.get("queue", "default"),
+                            f"\"{queue or launch_config.get('queue', 'default')}\"",
                             "--project",
                             project,
                             "--job",
@@ -1369,15 +1369,9 @@ def scheduler(
 
     # Future-proofing hack to pull any kwargs that get passed in through the CLI
     kwargs = {}
-    cur_key = ""
-    for _arg in ctx.args:
+    for i, _arg in enumerate(ctx.args):
         if isinstance(_arg, str) and _arg.startswith("--"):
-            cur_key = _arg[2:]
-            kwargs[cur_key] = ""
-        elif cur_key:
-            kwargs[cur_key] += _arg + " "
-    # clean up spaces
-    kwargs = {key: val.strip() for key, val in kwargs.items()}
+            kwargs[_arg[2:]] = ctx.args[i + 1]
 
     _scheduler = load_scheduler("sweep")(
         api,

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1369,9 +1369,15 @@ def scheduler(
 
     # Future-proofing hack to pull any kwargs that get passed in through the CLI
     kwargs = {}
-    for i, _arg in enumerate(ctx.args):
+    cur_key = ""
+    for _arg in ctx.args:
         if isinstance(_arg, str) and _arg.startswith("--"):
-            kwargs[_arg[2:]] = ctx.args[i + 1]
+            cur_key = _arg[2:]
+            kwargs[cur_key] = ""
+        elif cur_key:
+            kwargs[cur_key] += _arg + " "
+    # clean up spaces
+    kwargs = {key: val.strip() for key, val in kwargs.items()}
 
     _scheduler = load_scheduler("sweep")(
         api,


### PR DESCRIPTION
Fixes https://wandb.atlassian.net/browse/WB-11742

Description
-----------
We slightly modify an existing hack-y parameter ingesting mechanism to support multi-word params, exposed when pushing to a queue that had spaces in the name. 

This does not solve the case where backslashes are in the name, we escape them properly on the backend, but then assume they are already escaped when printing, resulting in half as many backslashes. We should probably just tell users in the frontend they can't use backslashes. I don't think XSS is possible here but why would anyone want a backslash in the name if they weren't doing something nefarious? 
