### PR TITLE
chore(sdk): remove test dependency on old fastparquet package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,11 +56,6 @@ setenv =
 whitelist_externals =
     mkdir
     bash
-    git
-# Workaround for bug with fastparquet and numpy<0.20 ("numpy.ndarray size changed, may indicate binary incompatibility")
-# fixme: fastparquet==0.8.0 fails locally, need to investigate
-commands_pre =
-    py{36,37,38}: pip install "fastparquet<0.8"
 commands =
     mkdir -p test-results
     py{36,37,38,39,310}:     python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:10} --durations=20 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/}


### PR DESCRIPTION
Description
-----------
fastparquet is having trouble installing on some systems and it looks like it isnt really needed anymore.

Testing
-------
CircleCI