### PR TITLE
chore(sdk): Correct 'exclude'->'ignore-paths' in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-exclude =
+ignore-paths =
     wandb/vendor
 
 max-line-length = 180


### PR DESCRIPTION
Description
-----------
The current line in `.pylintrc` is incorrect, and causes an error
```
pylint: error: ambiguous option: --exclude could match --exclude-protected, --exclude-too-few-public-methods
```
when `pylint` runs and tries to pick up its config from that file; this just fixes that.

Testing
-------
Tested locally, that `pytest` is able to run correctly.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
