### PR TITLE
chore(sdk): use pytest tmp_path so we can inspect failures

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -151,8 +151,8 @@ def clean_up():
 
 
 @pytest.fixture(scope="function", autouse=True)
-def filesystem_isolate():
-    with CliRunner().isolated_filesystem():
+def filesystem_isolate(tmp_path):
+    with CliRunner().isolated_filesystem(temp_dir=tmp_path):
         yield
 
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -9,6 +9,7 @@ import shutil
 import socket
 import string
 import subprocess
+import sys
 import threading
 import time
 import unittest.mock
@@ -152,7 +153,9 @@ def clean_up():
 
 @pytest.fixture(scope="function", autouse=True)
 def filesystem_isolate(tmp_path):
-    with CliRunner().isolated_filesystem(temp_dir=tmp_path):
+    # Click>=8 implements temp_dir argument which depends on python>=3.7
+    kwargs = dict(temp_dir=tmp_path) if sys.version_info >= (3, 7) else {}
+    with CliRunner().isolated_filesystem(**kwargs):
         yield
 
 


### PR DESCRIPTION
Description
-----------
Once this pytest feature gets out, then we can use temp dir retention policies based on failures etc:
https://github.com/pytest-dev/pytest/pull/10442

Testing
-------
Manual test to make sure directory exists after pytest exit
By default pytest keeps around 3 sessions.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
