### PR TITLE
fix(launch): Correctly set gcp artifact registry repo URI for vertex runner

### DIFF
--- a/tests/unit_tests_old/tests_launch/test_launch_docker.py
+++ b/tests/unit_tests_old/tests_launch/test_launch_docker.py
@@ -13,7 +13,6 @@ from wandb.sdk.launch._project_spec import (
     fetch_and_validate_project,
 )
 from wandb.sdk.launch.builder.build import (
-    construct_gcp_image_uri,
     docker_image_exists,
     generate_dockerfile,
     get_base_setup,
@@ -212,30 +211,6 @@ def test_buildx_not_installed(
     )
 
     assert "RUN WANDB_DISABLE_CACHE=true" in dockerfile
-
-
-def test_gcp_uri(test_settings, live_mock_server, mocked_fetchable_git_repo):
-    api = wandb.sdk.internal.internal_api.Api(
-        default_settings=test_settings, load_settings=False
-    )
-    test_spec = {
-        "uri": "https://wandb.ai/mock_server_entity/test/runs/1",
-        "entity": "mock_server_entity",
-        "project": "test",
-        "cuda": None,
-        "resource": "local",
-        "resource_args": {},
-    }
-    test_project = create_project_from_spec(test_spec, api)
-    test_project = fetch_and_validate_project(test_project, api)
-
-    uri = construct_gcp_image_uri(
-        test_project, "test-repo", "test-project", "test-registry"
-    )
-    assert (
-        "test-registry/test-project/test-repo/wandb.ai__mock_server_entity__test__runs__1:68747470733a2f2f666f6f3a62617240"
-        in uri
-    )
 
 
 def test_docker_image_exists(

--- a/tests/unit_tests_old/tests_launch/test_launch_gcp.py
+++ b/tests/unit_tests_old/tests_launch/test_launch_gcp.py
@@ -8,6 +8,11 @@ from wandb.errors import LaunchError
 from wandb.sdk.launch.runner.gcp_vertex import get_gcp_config, run_shell
 
 from .test_launch import mock_load_backend, mocked_fetchable_git_repo  # noqa: F401
+from wandb.sdk.launch.runner.gcp_vertex import construct_gcp_repo_uri
+from wandb.sdk.launch._project_spec import (
+    create_project_from_spec,
+    fetch_and_validate_project,
+)
 
 SUCCEEDED = "PipelineState.PIPELINE_STATE_SUCCEEDED"
 FAILED = "PipelineState.PIPELINE_STATE_FAILED"
@@ -100,6 +105,30 @@ def setup_mock_aiplatform(status, monkeypatch):
         lambda config: patched_get_gcp_config(config),
     )
     return job_dict
+
+
+def test_gcp_uri(test_settings, live_mock_server, mocked_fetchable_git_repo):
+    api = wandb.sdk.internal.internal_api.Api(
+        default_settings=test_settings, load_settings=False
+    )
+    test_spec = {
+        "uri": "https://wandb.ai/mock_server_entity/test/runs/1",
+        "entity": "mock_server_entity",
+        "project": "test",
+        "cuda": None,
+        "resource": "local",
+        "resource_args": {},
+    }
+    test_project = create_project_from_spec(test_spec, api)
+    test_project = fetch_and_validate_project(test_project, api)
+
+    uri = construct_gcp_repo_uri(
+        test_project, "test-repo", "test-project", "test-registry"
+    )
+    assert (
+        "test-registry/test-project/test-repo/wandb.ai__mock_server_entity__test__runs__1"
+        in uri
+    )
 
 
 @pytest.mark.timeout(320)

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -417,22 +417,6 @@ def pull_docker_image(docker_image: str) -> None:
         raise LaunchError(f"Docker server returned error: {e}")
 
 
-def construct_gcp_image_uri(
-    launch_project: LaunchProject,
-    gcp_repo: str,
-    gcp_project: str,
-    gcp_registry: str,
-) -> str:
-    base_uri = launch_project.image_uri
-    return "/".join([gcp_registry, gcp_project, gcp_repo, base_uri])
-
-
-def construct_gcp_registry_uri(
-    gcp_repo: str, gcp_project: str, gcp_registry: str
-) -> str:
-    return "/".join([gcp_registry, gcp_project, gcp_repo])
-
-
 def _parse_existing_requirements(launch_project: LaunchProject) -> str:
     requirements_line = ""
     assert launch_project.project_dir is not None

--- a/wandb/sdk/launch/runner/gcp_vertex.py
+++ b/wandb/sdk/launch/runner/gcp_vertex.py
@@ -15,7 +15,7 @@ from wandb.util import get_module
 
 from .._project_spec import LaunchProject, get_entry_point_command
 from ..builder.abstract import AbstractBuilder
-from ..builder.build import construct_gcp_registry_uri, get_env_vars_dict
+from ..builder.build import get_env_vars_dict
 from ..utils import LOG_PREFIX, PROJECT_DOCKER_ARGS, PROJECT_SYNCHRONOUS, run_shell
 from .abstract import AbstractRun, AbstractRunner, Status
 
@@ -141,7 +141,8 @@ class VertexRunner(AbstractRunner):
             image_uri = launch_project.docker_image
         else:
 
-            repository = construct_gcp_registry_uri(
+            repository = construct_gcp_repo_uri(
+                launch_project,
                 gcp_artifact_repo,
                 gcp_project,
                 gcp_docker_host,
@@ -209,6 +210,15 @@ class VertexRunner(AbstractRunner):
             os._exit(0)
 
         return submitted_run
+
+
+def construct_gcp_repo_uri(
+    launch_project: LaunchProject,
+    gcp_repo: str,
+    gcp_project: str,
+    gcp_registry: str,
+) -> str:
+    return "/".join([gcp_registry, gcp_project, gcp_repo, launch_project.image_name])
 
 
 def get_gcp_config(config: str = "default") -> Any:


### PR DESCRIPTION
Fixes WB-11869

Description
-----------
Fixes the setting of the gcp artifact registry repo URI in the vertex runner. There were previously two functions written for this, one which returns the full image path and one that returns the registry URI, but what is actually needed for the docker build is a repo URI.

Moves the function that constructs that URI from the docker build implementation to the vertex runner implementation. Also moves the tests from test_launch_docker to test_launch_gcp.

Testing
-------
Modified original tests to verify that the launch repository URI is constructed properly.
@KyleGoyette mentioned that we should also test that the image tag is set correctly, but that setting the image tag is actually handled in the docker builder implementation and covered by the tests already written for that.

Checklist
-------
- [ x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
