### PR TITLE
fix(sdk): remove duplicate generate_id functions, replace shortuuid with secrets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Click>=7.0,!=8.0.0  # click 8.0.0 is broken
 GitPython>=1.0.0
 requests>=2.0.0,<3
 promise>=2.0,<3
-shortuuid>=0.5.0
+shortuuid>=1.0.0
 psutil>=5.0.0
 sentry-sdk>=1.0.0
 docker-pycreds>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Click>=7.0,!=8.0.0  # click 8.0.0 is broken
 GitPython>=1.0.0
 requests>=2.0.0,<3
 promise>=2.0,<3
-shortuuid>=1.0.0
 psutil>=5.0.0
 sentry-sdk>=1.0.0
 docker-pycreds>=0.4.0

--- a/tests/standalone_tests/artifact_references.py
+++ b/tests/standalone_tests/artifact_references.py
@@ -4,11 +4,12 @@ import time
 from filecmp import dircmp
 
 import wandb
+from wandb.sdk.lib import runid
 
 # These should have bucket versioning enabled
 GCS_BUCKET = "gs://wandb-experiments"
 S3_BUCKET = "s3://kubeml"
-PREFIX = wandb.util.generate_id()
+PREFIX = runid.generate_id()
 GCS_NAME = f"gcs-artifact-{PREFIX}"
 S3_NAME = f"s3-artifact-{PREFIX}"
 GCS_REMOTE = f"{GCS_BUCKET}/artifact-versions/{PREFIX}"

--- a/tests/standalone_tests/resuming_and_reinit.py
+++ b/tests/standalone_tests/resuming_and_reinit.py
@@ -2,10 +2,11 @@ import sys
 import time
 
 import wandb
+from wandb.sdk.lib import runid
 
 
 def main(args):
-    run_id = wandb.util.generate_id()
+    run_id = runid.generate_id()
     try:
         wandb.init(project="resuming", resume="must", id=run_id)
     except wandb.Error:

--- a/tests/unit_tests/assets/wandb/offline-run-20210216_154407-g9dvvkua/files/requirements.txt
+++ b/tests/unit_tests/assets/wandb/offline-run-20210216_154407-g9dvvkua/files/requirements.txt
@@ -402,7 +402,6 @@ sentencepiece==0.1.86
 sentry-sdk==0.13.4
 setuptools==41.2.0
 sh==1.12.14
-shortuuid==0.5.0
 six==1.13.0
 smmap2==2.0.5
 sniffio==1.2.0

--- a/tests/unit_tests/assets/wandb/offline-run-20210216_154407-g9dvvkua/files/requirements.txt
+++ b/tests/unit_tests/assets/wandb/offline-run-20210216_154407-g9dvvkua/files/requirements.txt
@@ -402,6 +402,7 @@ sentencepiece==0.1.86
 sentry-sdk==0.13.4
 setuptools==41.2.0
 sh==1.12.14
+shortuuid==0.5.0
 six==1.13.0
 smmap2==2.0.5
 sniffio==1.2.0

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -48,7 +48,7 @@ from wandb.sdk.interface.interface_queue import InterfaceQueue
 from wandb.sdk.internal.handler import HandleManager
 from wandb.sdk.internal.sender import SendManager
 from wandb.sdk.internal.settings_static import SettingsStatic
-from wandb.sdk.lib import filesystem
+from wandb.sdk.lib import filesystem, runid
 from wandb.sdk.lib.git import GitRepo
 from wandb.sdk.lib.mailbox import Mailbox
 
@@ -407,7 +407,7 @@ def mock_run(test_settings, mocked_backend) -> Generator[Callable, None, None]:
         kwargs_settings = kwargs.pop("settings", dict())
         kwargs_settings = {
             **{
-                "run_id": wandb.util.generate_id(),
+                "run_id": runid.generate_id(),
             },
             **kwargs_settings,
         }

--- a/tests/unit_tests/lib/test_runid.py
+++ b/tests/unit_tests/lib/test_runid.py
@@ -1,0 +1,8 @@
+from wandb.sdk.lib import runid
+
+
+def test_generate_id_is_base36():
+    # Given reasonable randomness assumptions, generating an 1000-digit string should
+    # hit all 36 characters at least once >99.9999999999% of the time.
+    id = runid.generate_id(1000)
+    assert set(id) == set("0123456789abcdefghijklmnopqrstuvwxyz")

--- a/tests/unit_tests/lib/test_runid.py
+++ b/tests/unit_tests/lib/test_runid.py
@@ -4,5 +4,10 @@ from wandb.sdk.lib import runid
 def test_generate_id_is_base36():
     # Given reasonable randomness assumptions, generating an 1000-digit string should
     # hit all 36 characters at least once >99.9999999999% of the time.
-    id = runid.generate_id(1000)
-    assert set(id) == set("0123456789abcdefghijklmnopqrstuvwxyz")
+    new_id = runid.generate_id(1000)
+    assert len(new_id) == 1000
+    assert set(new_id) == set("0123456789abcdefghijklmnopqrstuvwxyz")
+
+
+def test_generate_id_default_8_chars():
+    assert len(runid.generate_id()) == 8

--- a/tests/unit_tests/test_offline_sync.py
+++ b/tests/unit_tests/test_offline_sync.py
@@ -2,7 +2,7 @@ import unittest.mock
 
 import pytest
 from wandb.cli import cli
-from wandb.util import generate_id
+from wandb.sdk.lib.runid import generate_id
 
 
 @pytest.mark.flaky

--- a/tests/unit_tests/test_public_api.py
+++ b/tests/unit_tests/test_public_api.py
@@ -8,6 +8,7 @@ import wandb
 import wandb.apis.public
 import wandb.util
 from wandb import Api
+from wandb.sdk.lib import runid
 
 from .test_wandb_sweep import (
     SWEEP_CONFIG_BAYES,
@@ -161,7 +162,7 @@ def test_run_from_tensorboard(runner, relay_server, user, api, copy_asset):
     with relay_server() as relay, runner.isolated_filesystem():
         tb_file_name = "events.out.tfevents.1585769947.cvp"
         copy_asset(tb_file_name)
-        run_id = wandb.util.generate_id()
+        run_id = runid.generate_id()
         api.sync_tensorboard(".", project="test", run_id=run_id)
         uploaded_files = relay.context.get_run_uploaded_files(run_id)
         assert uploaded_files[0].endswith(tb_file_name)

--- a/tests/unit_tests/test_redir_full.py
+++ b/tests/unit_tests/test_redir_full.py
@@ -10,6 +10,7 @@ import wandb.sdk.lib.redirect
 import wandb.util
 from click.testing import CliRunner
 from wandb.cli import cli
+from wandb.sdk.lib import runid
 
 console_modes = ["wrap"]
 if os.name != "nt":
@@ -93,7 +94,7 @@ def test_very_long_output(wandb_init, capfd, console, numpy):
                 settings={
                     "console": console,
                     "mode": "offline",
-                    "run_id": wandb.util.generate_id(),
+                    "run_id": runid.generate_id(),
                 }
             )
             run_dir, run_id = run.dir, run.id

--- a/tests/unit_tests_old/conftest.py
+++ b/tests/unit_tests_old/conftest.py
@@ -31,7 +31,7 @@ from wandb.sdk.interface.interface_queue import InterfaceQueue
 from wandb.sdk.internal.handler import HandleManager
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.internal.sender import SendManager
-from wandb.sdk.lib import filesystem
+from wandb.sdk.lib import filesystem, runid
 from wandb.sdk.lib.git import GitRepo
 from wandb.sdk.lib.mailbox import Mailbox
 from wandb.sdk.lib.module import unset_globals
@@ -249,7 +249,7 @@ def test_settings(test_dir, mocker, live_mock_server):
         host="test",
         project="test",
         root_dir=test_dir,
-        run_id=wandb.util.generate_id(),
+        run_id=runid.generate_id(),
         save_code=False,
     )
     settings._set_run_start_time()

--- a/tests/unit_tests_old/tests_launch/test_launch.py
+++ b/tests/unit_tests_old/tests_launch/test_launch.py
@@ -9,7 +9,6 @@ import pytest
 import wandb
 import wandb.sdk.launch._project_spec as _project_spec
 import wandb.sdk.launch.launch as launch
-import wandb.util as util
 import yaml
 from wandb.apis import PublicApi
 from wandb.errors import LaunchError
@@ -17,6 +16,7 @@ from wandb.sdk.launch.agent.agent import LaunchAgent
 from wandb.sdk.launch.builder.build import pull_docker_image
 from wandb.sdk.launch.builder.docker import DockerBuilder
 from wandb.sdk.launch.utils import PROJECT_DOCKER_ARGS, PROJECT_SYNCHRONOUS
+from wandb.sdk.lib import runid
 
 from tests.unit_tests_old.utils import fixture_open, notebook_path
 
@@ -828,7 +828,7 @@ def test_launch_full_build_new_image(
     api = wandb.sdk.internal.internal_api.Api(
         default_settings=test_settings, load_settings=False
     )
-    random_id = util.generate_id()
+    random_id = runid.generate_id()
     run = launch.run(
         api=api,
         uri="https://wandb.ai/mock_server_entity/test/runs/1",

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -51,7 +51,7 @@ from wandb.errors.term import termlog
 from wandb.sdk.data_types._dtypes import InvalidType, Type, TypeRegistry
 from wandb.sdk.interface import artifacts
 from wandb.sdk.launch.utils import _fetch_git_repo, apply_patch
-from wandb.sdk.lib import filesystem, ipython, retry
+from wandb.sdk.lib import filesystem, ipython, retry, runid
 
 if TYPE_CHECKING:
     import wandb.apis.reports
@@ -483,7 +483,7 @@ class Api:
         """Sync a local directory containing tfevent files to wandb"""
         from wandb.sync import SyncManager  # noqa: F401  TODO: circular import madness
 
-        run_id = run_id or util.generate_id()
+        run_id = run_id or runid.generate_id()
         project = project or self.settings.get("project") or "uncategorized"
         entity = entity or self.default_entity
         # TODO: pipe through log_path to inform the user how to debug
@@ -1743,7 +1743,7 @@ class Run(Attrs):
     @classmethod
     def create(cls, api, run_id=None, project=None, entity=None):
         """Create a run for the given project"""
-        run_id = run_id or util.generate_id()
+        run_id = run_id or runid.generate_id()
         project = project or api.settings.get("project") or "uncategorized"
         mutation = gql(
             """

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -47,6 +47,7 @@ from .sdk.data_types.object_3d import Object3D
 from .sdk.data_types.plotly import Plotly
 from .sdk.data_types.saved_model import _SavedModel
 from .sdk.data_types.video import Video
+from .sdk.lib import runid
 
 # Note: we are importing everything from the sdk/data_types to maintain a namespace for now.
 # Once we fully type this file and move it all into sdk, then we will need to clean up the
@@ -521,7 +522,7 @@ class Table(Media):
         # this code path will be ultimately removed. The 10k limit warning confuses
         # users given that we publicly say 200k is the limit.
         data = self._to_table_json(warn=False)
-        tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".table.json")
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".table.json")
         data = _numpy_arrays_to_lists(data)
         with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
             util.json_dump_safer(data, fp)
@@ -655,9 +656,7 @@ class Table(Media):
                         "numpy",
                         required="Serializing numpy requires numpy to be installed",
                     )
-                    file_name = "{}_{}.npz".format(
-                        str(col_name), str(util.generate_id())
-                    )
+                    file_name = f"{str(col_name)}_{runid.generate_id()}.npz"
                     npz_file_name = os.path.join(MEDIA_TMP.name, file_name)
                     np.savez_compressed(
                         npz_file_name,
@@ -1063,7 +1062,7 @@ class Audio(BatchableMedia):
                 required='Raw audio requires the soundfile package. To get it, run "pip install soundfile"',
             )
 
-            tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".wav")
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".wav")
             soundfile.write(tmp_path, data_or_path, sample_rate)
             self._duration = len(data_or_path) / float(sample_rate)
 
@@ -1338,7 +1337,7 @@ class Bokeh(Media):
             if "references" in b_json["roots"]:
                 b_json["roots"]["references"].sort(key=lambda x: x["id"])
 
-            tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".bokeh.json")
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".bokeh.json")
             with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
                 util.json_dump_safer(b_json, fp)
             self._set_file(tmp_path, is_tmp=True, extension=".bokeh.json")
@@ -1419,7 +1418,7 @@ class Graph(Media):
 
     def bind_to_run(self, *args, **kwargs):
         data = self._to_graph_json()
-        tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".graph.json")
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".graph.json")
         data = _numpy_arrays_to_lists(data)
         with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
             util.json_dump_safer(data, fp)
@@ -1985,7 +1984,7 @@ class _ForeignKeyType(_dtypes.Type):
     def to_json(self, artifact=None):
         res = super().to_json(artifact)
         if artifact is not None:
-            table_name = f"media/tables/t_{util.generate_id()}"
+            table_name = f"media/tables/t_{runid.generate_id()}"
             entry = artifact.add(self.params["table"], table_name)
             res["params"]["table"] = entry.path
         else:
@@ -2045,7 +2044,7 @@ class _ForeignIndexType(_dtypes.Type):
     def to_json(self, artifact=None):
         res = super().to_json(artifact)
         if artifact is not None:
-            table_name = f"media/tables/t_{util.generate_id()}"
+            table_name = f"media/tables/t_{runid.generate_id()}"
             entry = artifact.add(self.params["table"], table_name)
             res["params"]["table"] = entry.path
         else:

--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -6,7 +6,6 @@ import shutil
 import threading
 from typing import TYPE_CHECKING, NamedTuple, Optional, Union, cast
 
-import wandb.util
 from wandb.filesync import dir_watcher, step_upload
 from wandb.sdk.lib import filesystem, runid
 

--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, NamedTuple, Optional, Union, cast
 
 import wandb.util
 from wandb.filesync import dir_watcher, step_upload
-from wandb.sdk.lib import filesystem
+from wandb.sdk.lib import filesystem, runid
 
 if TYPE_CHECKING:
     import tempfile
@@ -73,7 +73,7 @@ class StepChecksum:
                 if req.copy:
                     path = os.path.join(
                         self._tempdir.name,
-                        f"{wandb.util.generate_id()}-{req.save_name}",
+                        f"{runid.generate_id()}-{req.save_name}",
                     )
                     filesystem.mkdir_exists_ok(os.path.dirname(path))
                     try:

--- a/wandb/sdk/data_types/base_types/json_metadata.py
+++ b/wandb/sdk/data_types/base_types/json_metadata.py
@@ -3,6 +3,7 @@ import os
 from typing import TYPE_CHECKING, Type, Union
 
 from wandb import util
+from wandb.sdk.lib import runid
 
 from .._private import MEDIA_TMP
 from .media import Media
@@ -31,7 +32,7 @@ class JSONMetadata(Media):
         self._val = val
 
         ext = "." + self.type_name() + ".json"
-        tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ext)
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ext)
         with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
             util.json_dump_uncompressed(self._val, fp)
         self._set_file(tmp_path, is_tmp=True, extension=ext)

--- a/wandb/sdk/data_types/helper_types/image_mask.py
+++ b/wandb/sdk/data_types/helper_types/image_mask.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional, Type, Union
 
 import wandb
 from wandb import util
+from wandb.sdk.lib import runid
 
 from .._private import MEDIA_TMP
 from ..base_types.media import Media
@@ -53,30 +54,21 @@ class ImageMask(Media):
         ground_truth_mask[:25, 25:] = 2
         ground_truth_mask[25:, 25:] = 3
 
-        class_labels = {
-            0: "person",
-            1: "tree",
-            2: "car",
-            3: "road"
-        }
+        class_labels = {0: "person", 1: "tree", 2: "car", 3: "road"}
 
-        masked_image = wandb.Image(image, masks={
-            "predictions": {
-                "mask_data": predicted_mask,
-                "class_labels": class_labels
+        masked_image = wandb.Image(
+            image,
+            masks={
+                "predictions": {"mask_data": predicted_mask, "class_labels": class_labels},
+                "ground_truth": {"mask_data": ground_truth_mask, "class_labels": class_labels},
             },
-            "ground_truth": {
-                "mask_data": ground_truth_mask,
-                "class_labels": class_labels
-            }
-        })
-        wandb.log({"img_with_masks" : masked_image})
+        )
+        wandb.log({"img_with_masks": masked_image})
         ```
 
         ### Log a masked image inside a Table
         <!--yeadoc-test:log-image-mask-table-->
         ```python
-
         import numpy as np
         import wandb
 
@@ -95,30 +87,25 @@ class ImageMask(Media):
         ground_truth_mask[:25, 25:] = 2
         ground_truth_mask[25:, 25:] = 3
 
-        class_labels = {
-            0: "person",
-            1: "tree",
-            2: "car",
-            3: "road"
-        }
+        class_labels = {0: "person", 1: "tree", 2: "car", 3: "road"}
 
-        class_set = wandb.Classes([
-            {"name" : "person", "id" : 0},
-            {"name" : "tree", "id" : 1},
-            {"name" : "car", "id" : 2},
-            {"name" : "road", "id" : 3}
-        ])
+        class_set = wandb.Classes(
+            [
+                {"name": "person", "id": 0},
+                {"name": "tree", "id": 1},
+                {"name": "car", "id": 2},
+                {"name": "road", "id": 3},
+            ]
+        )
 
-        masked_image = wandb.Image(image, masks={
-            "predictions": {
-                "mask_data": predicted_mask,
-                "class_labels": class_labels
+        masked_image = wandb.Image(
+            image,
+            masks={
+                "predictions": {"mask_data": predicted_mask, "class_labels": class_labels},
+                "ground_truth": {"mask_data": ground_truth_mask, "class_labels": class_labels},
             },
-            "ground_truth": {
-                "mask_data": ground_truth_mask,
-                "class_labels": class_labels
-            }
-        }, classes=class_set)
+            classes=class_set,
+        )
 
         table = wandb.Table(columns=["image"])
         table.add_data(masked_image)
@@ -160,7 +147,7 @@ class ImageMask(Media):
             self._key = key
 
             ext = "." + self.type_name() + ".png"
-            tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ext)
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ext)
 
             pil_image = util.get_module(
                 "PIL.Image",

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -1,8 +1,7 @@
 import os
 from typing import TYPE_CHECKING, Sequence, Type, Union
 
-from wandb import util
-from wandb.sdk.lib import filesystem
+from wandb.sdk.lib import filesystem, runid
 
 from . import _dtypes
 from ._private import MEDIA_TMP
@@ -51,7 +50,7 @@ class Html(BatchableMedia):
             self.inject_head()
 
         if inject or not data_is_path:
-            tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".html")
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".html")
             with open(tmp_path, "w") as out:
                 out.write(self.html)
 

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -7,6 +7,7 @@ from urllib import parse
 
 import wandb
 from wandb import util
+from wandb.sdk.lib import runid
 
 from ._private import MEDIA_TMP
 from .base_types.media import BatchableMedia, Media
@@ -296,7 +297,7 @@ class Image(BatchableMedia):
                 self.to_uint8(data), mode=mode or self.guess_mode(data)
             )
 
-        tmp_path = os.path.join(MEDIA_TMP.name, str(util.generate_id()) + ".png")
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".png")
         self.format = "png"
         assert self._image is not None
         self._image.save(tmp_path, transparency=None)

--- a/wandb/sdk/data_types/molecule.py
+++ b/wandb/sdk/data_types/molecule.py
@@ -4,6 +4,7 @@ import pathlib
 from typing import TYPE_CHECKING, Optional, Sequence, Type, Union
 
 from wandb import util
+from wandb.sdk.lib import runid
 
 from ._private import MEDIA_TMP
 from .base_types.media import BatchableMedia, Media
@@ -76,7 +77,7 @@ class Molecule(BatchableMedia):
                 )
 
             tmp_path = os.path.join(
-                MEDIA_TMP.name, util.generate_id() + "." + extension
+                MEDIA_TMP.name, runid.generate_id() + "." + extension
             )
             with open(tmp_path, "w") as f:
                 f.write(molecule)

--- a/wandb/sdk/data_types/object_3d.py
+++ b/wandb/sdk/data_types/object_3d.py
@@ -22,6 +22,7 @@ else:
 
 import wandb
 from wandb import util
+from wandb.sdk.lib import runid
 
 from . import _dtypes
 from ._private import MEDIA_TMP
@@ -132,7 +133,7 @@ class Object3D(BatchableMedia):
 
             extension = "." + extension
 
-            tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + extension)
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + extension)
             with open(tmp_path, "w") as f:
                 f.write(object_3d)
 
@@ -174,7 +175,7 @@ class Object3D(BatchableMedia):
                     "Type not supported, only 'lidar/beta' is currently supported"
                 )
 
-            tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".pts.json")
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".pts.json")
             with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
                 json.dump(
                     data,
@@ -205,7 +206,7 @@ class Object3D(BatchableMedia):
                 )
 
             list_data = np_data.tolist()
-            tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".pts.json")
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".pts.json")
             with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
                 json.dump(
                     list_data,

--- a/wandb/sdk/data_types/plotly.py
+++ b/wandb/sdk/data_types/plotly.py
@@ -3,6 +3,7 @@ import os
 from typing import TYPE_CHECKING, Sequence, Type, Union
 
 from wandb import util
+from wandb.sdk.lib import runid
 
 from ._private import MEDIA_TMP
 from .base_types.media import Media, _numpy_arrays_to_lists
@@ -65,7 +66,7 @@ class Plotly(Media):
                     "Logged plots must be plotly figures, or matplotlib plots convertible to plotly via mpl_to_plotly"
                 )
 
-        tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".plotly.json")
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".plotly.json")
         val = _numpy_arrays_to_lists(val.to_plotly_json())
         with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
             util.json_dump_safer(val, fp)

--- a/wandb/sdk/data_types/saved_model.py
+++ b/wandb/sdk/data_types/saved_model.py
@@ -17,6 +17,7 @@ from typing import (
 import wandb
 from wandb import util
 from wandb.sdk.interface.artifacts import b64_string_to_hex, md5_files_b64
+from wandb.sdk.lib import runid
 
 from ._private import MEDIA_TMP
 from .base_types.wb_value import WBValue
@@ -241,9 +242,7 @@ class _SavedModel(WBValue, Generic[SavedModelObjType]):
         # Generates a tmp path under our MEDIA_TMP directory which confirms to the file
         # or folder preferences of the class.
         assert isinstance(cls._path_extension, str), "_path_extension must be a string"
-        tmp_path = os.path.abspath(
-            os.path.join(MEDIA_TMP.name, str(util.generate_id()))
-        )
+        tmp_path = os.path.abspath(os.path.join(MEDIA_TMP.name, runid.generate_id()))
         if cls._path_extension != "":
             tmp_path += "." + cls._path_extension
         return tmp_path
@@ -300,7 +299,7 @@ class _PicklingSavedModel(_SavedModel[SavedModelObjType]):
         if dep_py_files is not None and len(dep_py_files) > 0:
             self._dep_py_files = dep_py_files
             self._dep_py_files_path = os.path.abspath(
-                os.path.join(MEDIA_TMP.name, str(util.generate_id()))
+                os.path.join(MEDIA_TMP.name, runid.generate_id())
             )
             os.makedirs(self._dep_py_files_path, exist_ok=True)
             for extra_file in self._dep_py_files:

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Type, Union
 
 from wandb import util
-from wandb.sdk.lib import filesystem
+from wandb.sdk.lib import filesystem, runid
 
 from . import _dtypes
 from ._private import MEDIA_TMP
@@ -101,7 +101,7 @@ class Video(BatchableMedia):
 
         if isinstance(data_or_path, BytesIO):
             filename = os.path.join(
-                MEDIA_TMP.name, util.generate_id() + "." + self._format
+                MEDIA_TMP.name, runid.generate_id() + "." + self._format
             )
             with open(filename, "wb") as f:
                 f.write(data_or_path.read())
@@ -137,7 +137,9 @@ class Video(BatchableMedia):
         # encode sequence of images into gif string
         clip = mpy.ImageSequenceClip(list(tensor), fps=self._fps)
 
-        filename = os.path.join(MEDIA_TMP.name, util.generate_id() + "." + self._format)
+        filename = os.path.join(
+            MEDIA_TMP.name, runid.generate_id() + "." + self._format
+        )
         if TYPE_CHECKING:
             kwargs: Dict[str, Optional[bool]] = {}
         try:  # older versions of moviepy do not support logger argument

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -12,6 +12,7 @@ import wandb
 import wandb.util as util
 from wandb.apis.internal import Api
 from wandb.sdk.launch.runner.local_container import LocalSubmittedRun
+from wandb.sdk.lib import runid
 
 from .._project_spec import create_project_from_spec, fetch_and_validate_project
 from ..builder.loader import load_builder
@@ -54,7 +55,7 @@ class LaunchAgent:
         self._ticks = 0
         self._running = 0
         self._cwd = os.getcwd()
-        self._namespace = wandb.util.generate_id()
+        self._namespace = runid.generate_id()
         self._access = _convert_access("project")
         max_jobs_from_config = int(config.get("max_jobs", 1))
         if max_jobs_from_config == -1:

--- a/wandb/sdk/launch/runner/abstract.py
+++ b/wandb/sdk/launch/runner/abstract.py
@@ -12,6 +12,7 @@ from wandb import Settings
 from wandb.apis.internal import Api
 from wandb.errors import CommError
 from wandb.sdk.launch.builder.abstract import AbstractBuilder
+from wandb.sdk.lib import runid
 
 from .._project_spec import LaunchProject
 
@@ -118,7 +119,7 @@ class AbstractRunner(ABC):
         self._api = api
         self.backend_config = backend_config
         self._cwd = os.getcwd()
-        self._namespace = wandb.util.generate_id()
+        self._namespace = runid.generate_id()
 
     def find_executable(
         self, cmd: str

--- a/wandb/sdk/lib/runid.py
+++ b/wandb/sdk/lib/runid.py
@@ -2,12 +2,13 @@
 runid util.
 """
 
-import shortuuid
+import secrets
+import string
 
 
 def generate_id(length: int = 8) -> str:
     """Generate a random base-36 string of `length` digits."""
     # There are ~2.8T base-36 8-digit strings. If we generate 210k ids,
     # we'll have a ~1% chance of collision.
-    run_gen = shortuuid.ShortUUID(alphabet="0123456789abcdefghijklmnopqrstuvwxyz")
-    return run_gen.random(length)
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for i in range(length))

--- a/wandb/sdk/lib/runid.py
+++ b/wandb/sdk/lib/runid.py
@@ -10,5 +10,5 @@ def generate_id(length: int = 8) -> str:
     """Generate a random base-36 string of `length` digits."""
     # There are ~2.8T base-36 8-digit strings. If we generate 210k ids,
     # we'll have a ~1% chance of collision.
-    alphabet = string.ascii_letters + string.digits
+    alphabet = string.ascii_lowercase + string.digits
     return "".join(secrets.choice(alphabet) for _ in range(length))

--- a/wandb/sdk/lib/runid.py
+++ b/wandb/sdk/lib/runid.py
@@ -11,4 +11,4 @@ def generate_id(length: int = 8) -> str:
     # There are ~2.8T base-36 8-digit strings. If we generate 210k ids,
     # we'll have a ~1% chance of collision.
     alphabet = string.ascii_letters + string.digits
-    return "".join(secrets.choice(alphabet) for i in range(length))
+    return "".join(secrets.choice(alphabet) for _ in range(length))

--- a/wandb/sdk/lib/runid.py
+++ b/wandb/sdk/lib/runid.py
@@ -1,14 +1,13 @@
-#
 """
 runid util.
 """
 
-from typing import cast
-
-import shortuuid  # type: ignore
+import shortuuid
 
 
-def generate_id() -> str:
-    # ~3t run ids (36**8)
-    run_gen = shortuuid.ShortUUID(alphabet=list("0123456789abcdefghijklmnopqrstuvwxyz"))
-    return cast(str, run_gen.random(8))
+def generate_id(length: int = 8) -> str:
+    """Generate a random base-36 string of `length` digits."""
+    # There are ~2.8T base-36 8-digit strings. If we generate 210k ids,
+    # we'll have a ~1% chance of collision.
+    run_gen = shortuuid.ShortUUID(alphabet="0123456789abcdefghijklmnopqrstuvwxyz")
+    return run_gen.random(length)

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -13,6 +13,7 @@ from pkg_resources import parse_version
 from wandb_gql import gql  # type: ignore
 
 import wandb
+from wandb.sdk.lib import runid
 
 from ...apis.internal import Api
 from ...apis.public import Artifact as ArtifactAPI
@@ -23,7 +24,7 @@ GET_RUN_MAX_TIME = 10
 MIN_RETRYS = 3
 CHECKMARK = "\u2705"
 RED_X = "\u274C"
-ID_PREFIX = wandb.util.generate_id()
+ID_PREFIX = runid.generate_id()
 
 
 def nice_id(name):

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -53,7 +53,7 @@ from .interface.artifacts import (  # noqa: F401
     md5_file_b64,
     md5_string,
 )
-from .lib import filesystem
+from .lib import filesystem, runid
 
 if TYPE_CHECKING:
 
@@ -194,8 +194,8 @@ class Artifact(ArtifactInterface):
         self._distributed_id = None
         self._logged_artifact = None
         self._incremental = False
-        self._client_id = util.generate_id(128)
-        self._sequence_client_id = util.generate_id(128)
+        self._client_id = runid.generate_id(128)
+        self._sequence_client_id = runid.generate_id(128)
         self._cache.store_client_artifact(self)
         self._use_as = use_as
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -18,13 +18,12 @@ import tempfile
 import traceback
 from typing import Any, Dict, Optional, Sequence, Union
 
-import shortuuid  # type: ignore
-
 import wandb
 from wandb import trigger
 from wandb.errors import UsageError
 from wandb.integration import sagemaker
 from wandb.integration.magic import magic_install
+from wandb.sdk.lib import runid
 from wandb.util import _is_artifact_representation, sentry_exc
 
 from . import wandb_login, wandb_setup
@@ -487,7 +486,7 @@ class _WandbInit:
         drun.step = 0
         drun.resumed = False
         drun.disabled = True
-        drun.id = shortuuid.uuid()
+        drun.id = runid.generate_id()
         drun.name = "dummy-" + drun.id
         drun.dir = tempfile.gettempdir()
         module.set_global(

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -16,7 +16,7 @@ import wandb
 from wandb.proto import wandb_internal_pb2  # type: ignore
 from wandb.sdk.interface.interface_queue import InterfaceQueue
 from wandb.sdk.internal import datastore, handler, sender, tb_watcher
-from wandb.sdk.lib import filesystem
+from wandb.sdk.lib import filesystem, runid
 from wandb.util import check_and_warn_old
 
 WANDB_SUFFIX = ".wandb"
@@ -139,7 +139,7 @@ class SyncThread(threading.Thread):
             viewer, server_info = send_manager._api.viewer_server_info()
             self._entity = viewer.get("entity")
         proto_run = wandb_internal_pb2.RunRecord()
-        proto_run.run_id = self._run_id or wandb.util.generate_id()
+        proto_run.run_id = self._run_id or runid.generate_id()
         proto_run.project = self._project or wandb.util.auto_project_name(None)
         proto_run.entity = self._entity
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -866,12 +866,6 @@ def launch_browser(attempt_launch_browser: bool = True) -> bool:
     return launch_browser
 
 
-def generate_id(length: int = 8) -> str:
-    # ~3t run ids (36**8)
-    run_gen = shortuuid.ShortUUID(alphabet=list("0123456789abcdefghijklmnopqrstuvwxyz"))
-    return str(run_gen.random(length))
-
-
 def parse_tfjob_config() -> Any:
     """Attempts to parse TFJob config, returning False if it can't find it"""
     if os.getenv("TF_CONFIG"):

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -53,7 +53,6 @@ from urllib.parse import quote
 
 import requests
 import sentry_sdk  # type: ignore
-import shortuuid  # type: ignore
 import yaml
 
 import wandb


### PR DESCRIPTION
Addresses [WB-7375](https://wandb.atlassian.net/browse/WB-7375)

Description
-----------
- Replace the dependency on `shortuuid` and prefer the built-in module `secrets` for token (run id) generation
- Consolidate the two nearly identical `generate_id` functions, move the callers depending on `util` to `lib.runid`

Testing
-------
No additional tests.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
