### PR TITLE
test(sdk): strengthen StepUpload tests; make exception-handling more thorough in upload/commit

### DIFF
--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 
 PreCommitFn = Callable[[], None]
-PostCommitFn = Callable[[], None]
+PostCommitFn = Callable[[Optional[Exception]], None]
 OnRequestFinishFn = Callable[[], None]
 SaveFn = Callable[["progress.ProgressFn"], Any]
 
@@ -213,12 +213,20 @@ class StepUpload:
             artifact_status["pending_count"] == 0
             and artifact_status["commit_requested"]
         ):
-            for callback in artifact_status["pre_commit_callbacks"]:
-                callback()
+            for pre_callback in artifact_status["pre_commit_callbacks"]:
+                pre_callback()
+            exc = None
             if artifact_status["finalize"]:
-                self._api.commit_artifact(artifact_id)
-            for callback in artifact_status["post_commit_callbacks"]:
-                callback()
+                try:
+                    self._api.commit_artifact(artifact_id)
+                except Exception as e:
+                    exc = e
+                    termerror(
+                        f"Committing artifact failed. Artifact {artifact_id} won't be finalized."
+                    )
+                    termerror(str(e))
+            for post_callback in artifact_status["post_commit_callbacks"]:
+                post_callback(exc)
 
     def start(self) -> None:
         self._thread.start()

--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -4,6 +4,7 @@ import threading
 from typing import TYPE_CHECKING, NamedTuple, Optional
 
 import wandb
+import wandb.util
 
 if TYPE_CHECKING:
     import queue
@@ -64,7 +65,18 @@ class UploadJob(threading.Thread):
     def run(self) -> None:
         success = False
         try:
-            success = self.push()
+            self.push()
+            success = True
+        except Exception as e:
+            self._stats.update_failed_file(self.save_name)
+            logger.exception("Failed to upload file: %s", self.save_path)
+            wandb.util.sentry_exc(e)
+            if not self.silent:
+                wandb.termerror(
+                    'Error uploading "{}": {}, {}'.format(
+                        self.save_name, type(e).__name__, e
+                    )
+                )
         finally:
             if self.copied and os.path.isfile(self.save_path):
                 os.remove(self.save_path)
@@ -72,34 +84,20 @@ class UploadJob(threading.Thread):
             if success:
                 self._file_stream.push_success(self.artifact_id, self.save_name)  # type: ignore
 
-    def push(self) -> bool:
+    def push(self) -> None:
         if self.save_fn:
             # Retry logic must happen in save_fn currently
-            try:
-                deduped = self.save_fn(
-                    lambda _, t: self._stats.update_uploaded_file(self.save_path, t)
-                )
-            except Exception as e:
-                self._stats.update_failed_file(self.save_path)
-                logger.exception("Failed to upload file: %s", self.save_path)
-                wandb.util.sentry_exc(e)
-                message = str(e)
-                # TODO: this is usually XML, but could be JSON
-                if hasattr(e, "response"):
-                    message = e.response.content
-                wandb.termerror(
-                    'Error uploading "{}": {}, {}'.format(
-                        self.save_path, type(e).__name__, message
-                    )
-                )
-                return False
+            deduped = self.save_fn(
+                lambda _, t: self._stats.update_uploaded_file(self.save_path, t)
+            )
 
             if deduped:
                 logger.info("Skipped uploading %s", self.save_path)
                 self._stats.set_file_deduped(self.save_path)
             else:
                 logger.info("Uploaded file %s", self.save_path)
-            return True
+
+            return
 
         if self.md5:
             # This is the new artifact manifest upload flow, in which we create the
@@ -132,27 +130,14 @@ class UploadJob(threading.Thread):
             # since its a proxied file store like the on-prem VM.
             if upload_url.startswith("/"):
                 upload_url = f"{self._api.api_url}{upload_url}"
-            try:
-                with open(self.save_path, "rb") as f:
-                    self._api.upload_file_retry(
-                        upload_url,
-                        f,
-                        lambda _, t: self.progress(t),
-                        extra_headers=extra_headers,
-                    )
-                logger.info("Uploaded file %s", self.save_path)
-            except Exception as e:
-                self._stats.update_failed_file(self.save_name)
-                logger.exception("Failed to upload file: %s", self.save_path)
-                wandb.util.sentry_exc(e)
-                if not self.silent:
-                    wandb.termerror(
-                        'Error uploading "{}": {}, {}'.format(
-                            self.save_name, type(e).__name__, e
-                        )
-                    )
-                return False
-        return True
+            with open(self.save_path, "rb") as f:
+                self._api.upload_file_retry(
+                    upload_url,
+                    f,
+                    lambda _, t: self.progress(t),
+                    extra_headers=extra_headers,
+                )
+            logger.info("Uploaded file %s", self.save_path)
 
     def progress(self, total_bytes: int) -> None:
         self._stats.update_uploaded_file(self.save_name, total_bytes)

--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -271,8 +271,8 @@ class ArtifactSaver:
                     extra_headers=extra_headers,
                 )
 
-        def on_commit() -> None:
-            if finalize and use_after_commit:
+        def on_commit(exc: Optional[Exception]) -> None:
+            if exc is None and finalize and use_after_commit:
                 self._api.use_artifact(artifact_id)
             step_prepare.shutdown()
             commit_event.set()

--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -271,7 +271,12 @@ class ArtifactSaver:
                     extra_headers=extra_headers,
                 )
 
+        commit_exc: Optional[Exception] = None
+
         def on_commit(exc: Optional[Exception]) -> None:
+            nonlocal commit_exc
+            commit_exc = exc
+
             if exc is None and finalize and use_after_commit:
                 self._api.use_artifact(artifact_id)
             step_prepare.shutdown()
@@ -289,6 +294,9 @@ class ArtifactSaver:
         # artifact is committed.
         while not commit_event.is_set():
             commit_event.wait()
+
+        if commit_exc is not None:
+            raise commit_exc
 
         return self._server_artifact
 


### PR DESCRIPTION
Description
-----------

- **Improve tests.**
    - `test_finishes` wasn't quite testing what it meant to: UploadJob threads were hitting exceptions and dying in the background; that manifested as _warnings_ (which I somehow didn't notice earlier?), but it didn't make the test-assertions fail. So I split it into a bunch of tests for several different possible workloads / failure modes.
    - Added tests for more possible failure modes when StepUpload tries to upload a file or commit an artifact.

- **Improve exception-handling.** The ^new tests revealed:

    - If `api.commit_artifact` raises an exception, the entire StepUpload thread dies, making the process hang! (Easy to see for yourself: go [here](https://github.com/wandb/wandb/blob/cf7df1ded71b5a5b768234c7455f5073ce063cf0/wandb/sdk/internal/internal_api.py#L2757), insert a `raise Exception("oh no")`, then run `wandb artifact put -n spencerpearson-artifacts/foo -t bar $(mktemp)` and watch it print an error and hang indefinitely.)
        - Fixed by putting a `try/except` around `api.commit_artifact`, and passing the exception into the `on_commit` callback so that `ArtifactSaver.save` can raise it, propagating the failure info to the user process.
        - Fix verified by re-running `wandb artifact put -n spencerpearson-artifacts/foo -t bar $(mktemp)` and seeing that it (a) still prints out error details, but (b) doesn't hang forever, and (c; from debug-internal.log) continues to upload files even after the failed commit, unlike on main.

    - In an UploadJob, if `api.upload_urls` raises an exception, then the UploadJob dies in an uncontrolled manner, printing out a messy stack trace and _not_ reporting the issue to Sentry. (Easy to see for yourself: go [here](https://github.com/wandb/wandb/blob/cf7df1ded71b5a5b768234c7455f5073ce063cf0/wandb/sdk/internal/internal_api.py#L1674), insert a `raise Exception("oh no, something bad happened")`, then run `python3 -c 'import wandb; wandb.init()'`.)
        - Fixed by moving `UploadJob`'s exception-handling into its `.run()` method, so it captures _all_ errors `.push()` raises. (which also has the happy side effect of cleaning up its `.push()` method).
        - Fix verified by re-running `python3 -c 'import wandb; wandb.init()'`, seeing that it switched to printing out `wandb: ERROR Error uploading "wandb-metadata.json": CommError, oh no, something bad happened` instead of a stack trace, and verified that it [created a Sentry issue](https://sentry.io/organizations/weights-biases/issues/3828230178/?project=5288891&query=is%3Aunresolved+message%3A%22oh+no%22&referrer=issue-stream&statsPeriod=14d).
