### PR TITLE
fix(artifacts): get digest directly instead of from the manifests' manifest

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1250,9 +1250,9 @@ class JoinedTable(Media):
         # Check if this is an ArtifactManifestEntry
         elif hasattr(table, "ref_url"):
             # Give the new object a unique, yet deterministic name
-            name = binascii.hexlify(
-                base64.standard_b64decode(table.entry.digest)
-            ).decode("ascii")[:20]
+            name = binascii.hexlify(base64.standard_b64decode(table.digest)).decode(
+                "ascii"
+            )[:20]
             entry = artifact.add_reference(
                 table.ref_url(), "{}.{}.json".format(name, table.name.split(".")[-2])
             )[0]


### PR DESCRIPTION
Fixes [WB-11885](https://wandb.atlassian.net/browse/WB-11885)

Description
-----------
Fixes missed field from #4649 causing regression error in the standalone test suite

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
