### PR TITLE
docs(sdk): Removed less than, greater than characters from dosctrings…

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -4775,10 +4775,10 @@ class Artifact(artifacts.Artifact):
             print("Warning: skipped verification of %s refs" % ref_count)
 
     def file(self, root=None):
-        """Download a single file artifact to dir specified by the <root>
+        """Download a single file artifact to dir specified by the root
 
         Arguments:
-            root: (str, optional) The root directory in which to place the file. Defaults to './artifacts/<self.name>/'.
+            root: (str, optional) The root directory in which to place the file. Defaults to './artifacts/self.name/'.
 
         Returns:
             (str): The full path of the downloaded file.

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1009,14 +1009,14 @@ def sweep(
 
 @cli.command(
     help="Launch or queue a job from a uri (Experimental). A uri can be either a wandb "
-    "uri of the form https://wandb.ai/<entity>/<project>/runs/<run_id>, "
+    "uri of the form https://wandb.ai/entity/project/runs/run_id, "
     "or a git uri pointing to a remote repository, or path to a local directory.",
 )
 @click.argument("uri", nargs=1, required=False)
 @click.option(
     "--job",
     "-j",
-    metavar="<str>",
+    metavar="(str)",
     default=None,
     help="Name of the job to launch. If passed in, launch does not require a uri.",
 )
@@ -1054,7 +1054,7 @@ def sweep(
 @click.option(
     "--entity",
     "-e",
-    metavar="<str>",
+    metavar="(str)",
     default=None,
     help="Name of the target entity which the new run will be sent to. Defaults to using the entity set by local wandb/settings folder."
     "If passed in, will override the entity value passed in using a config file.",
@@ -1062,7 +1062,7 @@ def sweep(
 @click.option(
     "--project",
     "-p",
-    metavar="<str>",
+    metavar="(str)",
     default=None,
     help="Name of the target project which the new run will be sent to. Defaults to using the project name given by the source uri "
     "or for github runs, the git repo name. If passed in, will override the project value passed in using a config file.",

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -681,7 +681,7 @@ class Artifact:
 
         Arguments:
             root: (str, optional) The directory to verify. If None
-                artifact will be downloaded to './artifacts/<self.name>/'
+                artifact will be downloaded to './artifacts/self.name/'
 
         Raises:
             (ValueError): If the verification fails.


### PR DESCRIPTION
…. Re: It breaks the new doc engine Docusuarus.

Fixes WB-NNNN
Fixes #NNNN

Description
-----------
Removed less than, greater than characters from dosctrings. Re: It breaks the new doc engine Docusuarus.

Testing
-------
No test. Docstring changes only.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
