### PR TITLE
fix(integrations): fix type check for jax.Array introduced in jax==0.4.1

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@ docker
 stable_baselines3
 tensorboard
 gym
-jax[cpu]<0.4; sys_platform == 'darwin' or sys_platform == 'linux'
+jax[cpu]; sys_platform == 'darwin' or sys_platform == 'linux'
 fastcore; python_version > '3.6'
 fastcore==1.3.29; python_version == '3.6'
 pyarrow

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -543,7 +543,7 @@ def is_pytorch_tensor_typename(typename: str) -> bool:
 
 
 def is_jax_tensor_typename(typename: str) -> bool:
-    return typename.startswith("jaxlib.") and "DeviceArray" in typename
+    return typename.startswith("jaxlib.") and "Array" in typename
 
 
 def get_jax_tensor(obj: Any) -> Optional[Any]:


### PR DESCRIPTION
Description
-----------
See https://github.com/wandb/wandb/pull/4632#issuecomment-1368286125 -- the sdk is currently not working with `jax==0.4.1` bc of a jax API change.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
