### PR TITLE
Add AttributeError to the list of handled exceptions when saving a keras model

### DIFF
--- a/wandb/integration/keras/keras.py
+++ b/wandb/integration/keras/keras.py
@@ -1016,7 +1016,7 @@ class WandbCallback(tf.keras.callbacks.Callback):
                 self.model.save(self.filepath, overwrite=True)
         # Was getting `RuntimeError: Unable to create link` in TF 1.13.1
         # also saw `TypeError: can't pickle _thread.RLock objects`
-        except (ImportError, RuntimeError, TypeError) as e:
+        except (ImportError, RuntimeError, TypeError, AttributeError) as e:
             wandb.termerror(
                 "Can't save model in the h5py format. The model will be saved as "
                 "as an W&B Artifact in the 'tf' format."


### PR DESCRIPTION
Description
-----------
Handle `AttributeError` throw by TF-2.11 in some cases when saving a model

Testing
-------
Saving a model that uses `mixed_float16` policy

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
