### PR TITLE
test(sdk): make all potentially-stateful parametrize() args lazy, to avoid reusing them between tests

### DIFF
--- a/tests/unit_tests/artifacts/test_artifact_saver.py
+++ b/tests/unit_tests/artifacts/test_artifact_saver.py
@@ -1,3 +1,4 @@
+from typing import Callable
 from unittest.mock import Mock
 
 import pytest
@@ -82,28 +83,31 @@ class SomeCustomError(Exception):
 
 @pytest.mark.timeout(1)
 @pytest.mark.parametrize(
-    "api",
+    "make_api",
     [
-        make_api(use_artifact=Mock(side_effect=SomeCustomError("use_artifact failed"))),
-        make_api(
+        lambda: make_api(
+            use_artifact=Mock(side_effect=SomeCustomError("use_artifact failed"))
+        ),
+        lambda: make_api(
             create_artifact=Mock(side_effect=SomeCustomError("create_artifact failed"))
         ),
-        make_api(
+        lambda: make_api(
             create_artifact_manifest=Mock(
                 side_effect=SomeCustomError("create_artifact_manifest failed")
             )
         ),
-        make_api(
+        lambda: make_api(
             upload_file_retry=Mock(
                 side_effect=SomeCustomError("upload_file_retry failed")
             )
         ),
-        make_api(
+        lambda: make_api(
             commit_artifact=Mock(side_effect=SomeCustomError("commit_artifact failed"))
         ),
     ],
 )
-def test_reraises_err(api: internal_api.Api):
+def test_reraises_err(make_api: Callable[[], internal_api.Api]):
+    api = make_api()
     stream = Mock(spec=file_stream.FileStreamApi)
     pusher = file_pusher.FilePusher(api=api, file_stream=stream)
 

--- a/tests/unit_tests/test_step_upload.py
+++ b/tests/unit_tests/test_step_upload.py
@@ -135,27 +135,27 @@ class UploadBlockingMockApi(Mock):
 
 class TestFinish:
     @pytest.mark.parametrize(
-        ["api", "commands", "api_assert"],
+        ["make_api", "make_commands", "api_assert"],
         [
             (
-                make_api(),
+                lambda: make_api(),
                 lambda tmp_path: [],
                 lambda api: None,
             ),
             (
-                make_api(),
+                lambda: make_api(),
                 lambda tmp_path: [
                     make_request_upload(tmp_path / "nonexistent-file.txt")
                 ],
                 lambda api: api.upload_file_retry.assert_not_called(),
             ),
             (
-                make_api(),
+                lambda: make_api(),
                 lambda tmp_path: [make_request_upload(make_tmp_file(tmp_path))],
                 lambda api: api.upload_file_retry.assert_called(),
             ),
             (
-                make_api(),
+                lambda: make_api(),
                 lambda tmp_path: [
                     make_request_upload(make_tmp_file(tmp_path)),
                     make_request_upload(make_tmp_file(tmp_path)),
@@ -164,12 +164,14 @@ class TestFinish:
                 lambda api: api.upload_file_retry.assert_called(),
             ),
             (
-                make_api(upload_urls=Mock(side_effect=Exception("upload_urls failed"))),
+                lambda: make_api(
+                    upload_urls=Mock(side_effect=Exception("upload_urls failed"))
+                ),
                 lambda tmp_path: [make_request_upload(make_tmp_file(tmp_path))],
                 lambda api: api.upload_urls.assert_called(),
             ),
             (
-                make_api(
+                lambda: make_api(
                     upload_file_retry=Mock(
                         side_effect=Exception("upload_file_retry failed")
                     )
@@ -178,7 +180,7 @@ class TestFinish:
                 lambda api: api.upload_file_retry.assert_called(),
             ),
             (
-                make_api(
+                lambda: make_api(
                     upload_file_retry=Mock(
                         side_effect=Exception("upload_file_retry failed")
                     )
@@ -192,22 +194,28 @@ class TestFinish:
                 lambda api: api.upload_file_retry.assert_called(),
             ),
             (
-                make_api(),
+                lambda: make_api(),
                 lambda tmp_path: [make_request_commit("my-artifact")],
                 lambda api: api.commit_artifact.assert_called(),
             ),
             (
-                make_api(commit_artifact=Mock(side_effect=Exception("commit failed"))),
+                lambda: make_api(
+                    commit_artifact=Mock(side_effect=Exception("commit failed"))
+                ),
                 lambda tmp_path: [make_request_commit("my-artifact")],
                 lambda api: api.commit_artifact.assert_called(),
             ),
             (
-                make_api(commit_artifact=Mock(side_effect=Exception("commit failed"))),
+                lambda: make_api(
+                    commit_artifact=Mock(side_effect=Exception("commit failed"))
+                ),
                 lambda tmp_path: [make_request_commit("my-artifact")],
                 lambda api: api.commit_artifact.assert_called(),
             ),
             (
-                make_api(commit_artifact=Mock(side_effect=Exception("commit failed"))),
+                lambda: make_api(
+                    commit_artifact=Mock(side_effect=Exception("commit failed"))
+                ),
                 lambda tmp_path: [
                     make_request_upload(
                         make_tmp_file(tmp_path), artifact_id="my-artifact"
@@ -221,12 +229,14 @@ class TestFinish:
     def test_finishes(
         self,
         tmp_path: Path,
-        api: Mock,
-        commands: Callable[[Path], Iterable[Event]],
+        make_api: Callable[[], Mock],
+        make_commands: Callable[[Path], Iterable[Event]],
         api_assert: Callable[[Mock], None],
     ):
+        api = make_api()
+
         q = queue.Queue()
-        for cmd in commands(tmp_path):
+        for cmd in make_commands(tmp_path):
             q.put(cmd)
         step_upload = make_step_upload(api=api, event_queue=q)
         step_upload.start()
@@ -338,14 +348,14 @@ class TestUpload:
             assert f.exists()
 
     @pytest.mark.parametrize(
-        ["api", "bad_command"],
+        ["make_api", "make_bad_command"],
         [
             (
-                make_api(),
+                lambda: make_api(),
                 lambda tmp_path: make_request_upload(tmp_path / "nonexistent-file.txt"),
             ),
             (
-                make_api(
+                lambda: make_api(
                     upload_urls=Mock(
                         wraps=mock_upload_urls,
                         side_effect=[Exception("upload_urls failed"), DEFAULT],
@@ -354,7 +364,7 @@ class TestUpload:
                 lambda tmp_path: make_request_upload(make_tmp_file(tmp_path)),
             ),
             (
-                make_api(
+                lambda: make_api(
                     upload_file_retry=Mock(
                         wraps=mock_upload_file_retry,
                         side_effect=[Exception("upload_file_retry failed"), DEFAULT],
@@ -367,11 +377,12 @@ class TestUpload:
     def test_error_doesnt_stop_future_uploads(
         self,
         tmp_path: Path,
-        api: Mock,
-        bad_command: Callable[[Path], Event],
+        make_api: Callable[[], Mock],
+        make_bad_command: Callable[[Path], Event],
     ):
+        api = make_api()
         q = queue.Queue()
-        q.put(bad_command(tmp_path))
+        q.put(make_bad_command(tmp_path))
 
         good_command = make_request_upload(make_tmp_file(tmp_path))
         q.put(good_command)
@@ -417,17 +428,18 @@ class TestUpload:
             mock_stats.update_uploaded_file.assert_called_with(str(f), f.stat().st_size)
 
         @pytest.mark.parametrize(
-            "save_fn",
+            "make_save_fn",
             [
-                None,
-                Mock(side_effect=Exception("save_fn failed")),
+                lambda: None,
+                lambda: Mock(side_effect=Exception("save_fn failed")),
             ],
         )
         def test_updates_on_failure(
             self,
             tmp_path: Path,
-            save_fn: Optional[Callable[[int, int], None]],
+            make_save_fn: Callable[[], Optional[Callable[[int, int], None]]],
         ):
+            save_fn = make_save_fn()
             f = make_tmp_file(tmp_path)
 
             api = make_api(
@@ -474,21 +486,23 @@ class TestUpload:
                 mock_stats.set_file_deduped.assert_not_called()
 
     @pytest.mark.parametrize(
-        ["save_fn", "api", "success"],
+        ["make_save_fn", "make_api", "success"],
         [
             (
-                None,
-                make_api(),
+                lambda: None,
+                lambda: make_api(),
                 True,
             ),
             (
-                None,
-                make_api(upload_urls=Mock(side_effect=Exception("upload_urls failed"))),
+                lambda: None,
+                lambda: make_api(
+                    upload_urls=Mock(side_effect=Exception("upload_urls failed"))
+                ),
                 False,
             ),
             (
-                None,
-                make_api(
+                lambda: None,
+                lambda: make_api(
                     upload_file_retry=Mock(
                         side_effect=Exception("upload_file_retry failed")
                     ),
@@ -496,18 +510,18 @@ class TestUpload:
                 False,
             ),
             (
-                Mock(return_value=False),
-                make_api(),
+                lambda: Mock(return_value=False),
+                lambda: make_api(),
                 True,
             ),
             (
-                Mock(return_value=True),
-                make_api(),
+                lambda: Mock(return_value=True),
+                lambda: make_api(),
                 True,
             ),
             (
-                Mock(side_effect=Exception("save_fn failed")),
-                make_api(),
+                lambda: Mock(side_effect=Exception("save_fn failed")),
+                lambda: make_api(),
                 False,
             ),
         ],
@@ -515,10 +529,12 @@ class TestUpload:
     def test_notifies_file_stream_on_success(
         self,
         tmp_path: Path,
-        save_fn: Optional[Callable[[int, int], bool]],
-        api: Mock,
+        make_save_fn: Callable[[], Optional[Callable[[int, int], bool]]],
+        make_api: Callable[[], Mock],
         success: bool,
     ):
+        save_fn = make_save_fn()
+        api = make_api()
         f = make_tmp_file(tmp_path)
 
         q = queue.Queue()


### PR DESCRIPTION
Description
-----------

Here's a sneaky bug: consider this (slightly dumb, but correct) function.
```python
def retry_forever(f, *args, **kwargs):
    while True:
        try:
            return f(*args, **kwargs)
        except Exception:
            pass
```

Here's a simple test for it:

```python
@pytest.mark.parametrize(
    "fn",
    [
        Mock(),
        Mock(side_effect=[Exception(), None]),
        Mock(side_effect=[Exception()] * 100 + [None]),
    ],
)
def test_retry_eventually_succeeds(fn):
    retry_forever(fn)
```

I run this, and... it... hangs.

Why?



Hint: elsewhere, I defined...
```python
@pytest.fixture(autouse=True, params=[True, False])
def some_parametrized_fixture(request):
    return request.param
```


Solution: if there are multiple `@parametrize`s relevant to a test, then the parameters get reused between runs. Therefore, the parameters **must not** be stateful. `Mock`s are stateful (e.g. they have side-effect lists, and remember method calls).