### PR TITLE
fix(artifacts): WBArtifactHandler Client Passing

### DIFF
--- a/tests/functional_tests/t0_main/artifacts/log-reference-artifact-no-cache.py
+++ b/tests/functional_tests/t0_main/artifacts/log-reference-artifact-no-cache.py
@@ -20,6 +20,12 @@ def main():
             art1 = run.use_artifact("test-artifact-1:latest")
             local_entry = art1.get_path(file_name)
             local_ref_path = local_entry.ref_url()
+            # Blow away cache
+            # This ensures our references work without having pre-loaded cache
+            from wandb.sdk.interface import artifacts
+
+            artifacts._artifacts_cache = None
+            # End blow away
             artifact.add_reference(local_ref_path)
             run.log_artifact(artifact)
 

--- a/tests/functional_tests/t0_main/artifacts/log-reference-artifact-no-cache.yea
+++ b/tests/functional_tests/t0_main/artifacts/log-reference-artifact-no-cache.yea
@@ -1,4 +1,4 @@
-id: 0.artifacts.log-reference-artifact
+id: 0.artifacts.log-reference-artifact-no-cache
 plugin:
   - wandb
 assert:

--- a/tests/functional_tests/t0_main/artifacts/log-reference-artifact.py
+++ b/tests/functional_tests/t0_main/artifacts/log-reference-artifact.py
@@ -5,19 +5,20 @@ import wandb
 
 def main():
     with tempfile.TemporaryDirectory() as tmpdir:
-        local_path = tmpdir + "/hello.txt"
+        file_name = "hello.txt"
+        local_path = tmpdir + "/" + file_name
         with wandb.init() as run:
             artifact = wandb.Artifact("test-artifact", "test-type")
             with open(local_path, "w") as f:
                 f.write("hello world")
 
-            artifact.add_file(local_path)
+            artifact.add_file(local_path, file_name)
             run.log_artifact(artifact)
 
         with wandb.init() as run:
             artifact = wandb.Artifact("test-artifact-2", "test-type")
             art1 = run.use_artifact("test-artifact:latest")
-            local_entry = art1.get_path(local_path)
+            local_entry = art1.get_path(file_name)
             local_ref_path = local_entry.ref_url()
             artifact.add_reference(local_ref_path)
             run.log_artifact(artifact)
@@ -25,7 +26,7 @@ def main():
         with wandb.init() as run:
             artifact = wandb.Artifact("test-artifact-3", "test-type")
             art1 = run.use_artifact("test-artifact:latest")
-            local_entry = art1.get_path(local_path)
+            local_entry = art1.get_path(file_name)
             local_ref_path = local_entry.ref_url()
             # Blow away cache
             # This ensures our references work without having pre-loaded cache

--- a/tests/functional_tests/t0_main/artifacts/log-reference-artifact.py
+++ b/tests/functional_tests/t0_main/artifacts/log-reference-artifact.py
@@ -1,0 +1,45 @@
+import tempfile
+
+import wandb
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        local_path = tmpdir + "/hello.txt"
+        with wandb.init() as run:
+            artifact = wandb.Artifact("test-artifact", "test-type")
+            with open(local_path, "w") as f:
+                f.write("hello world")
+
+            artifact.add_file(local_path)
+            run.log_artifact(artifact)
+
+        with wandb.init() as run:
+            artifact = wandb.Artifact("test-artifact-2", "test-type")
+            art1 = run.use_artifact("test-artifact:latest")
+            local_entry = art1.get_path(local_path)
+            local_ref_path = local_entry.ref_url()
+            artifact.add_reference(local_ref_path)
+            run.log_artifact(artifact)
+
+        with wandb.init() as run:
+            artifact = wandb.Artifact("test-artifact-3", "test-type")
+            art1 = run.use_artifact("test-artifact:latest")
+            local_entry = art1.get_path(local_path)
+            local_ref_path = local_entry.ref_url()
+            # Blow away cache
+            # This ensures our references work without having pre-loaded cache
+            from wandb.sdk.interface import artifacts
+
+            artifacts._artifacts_cache = None
+            # End blow away
+            artifact.add_reference(local_ref_path)
+            run.log_artifact(artifact)
+
+        with wandb.init() as run:
+            art1 = run.use_artifact("test-artifact-3:latest")
+            art1.get_path(local_path).download()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/t0_main/artifacts/log-reference-artifact.yea
+++ b/tests/functional_tests/t0_main/artifacts/log-reference-artifact.yea
@@ -1,0 +1,12 @@
+id: 0.artifacts.log-reference-artifact
+plugin:
+  - wandb
+assert:
+  - :wandb:runs_len: 4
+  - :wandb:runs[0][exitcode]: 0
+  - :wandb:runs[1][exitcode]: 0
+  - :wandb:runs[2][exitcode]: 0
+  - :wandb:runs[3][exitcode]: 0
+  - :wandb:artifacts[test-artifact][type]: test-type
+  - :wandb:artifacts[test-artifact-2][type]: test-type
+  - :wandb:artifacts[test-artifact-3][type]: test-type

--- a/tests/unit_tests/artifacts/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/artifacts/test_wandb_artifacts_cache.py
@@ -302,7 +302,7 @@ def test_gcs_storage_handler_load_path_uses_cache(cache):
 
 
 class MockApi:
-    client = None
+    _client = None
 
 
 def test_wbartifact_handler_load_path_nonlocal(monkeypatch):

--- a/tests/unit_tests/artifacts/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/artifacts/test_wandb_artifacts_cache.py
@@ -301,6 +301,10 @@ def test_gcs_storage_handler_load_path_uses_cache(cache):
     assert local_path == path
 
 
+class MockApi:
+    client = None
+
+
 def test_wbartifact_handler_load_path_nonlocal(monkeypatch):
     path = "foo/bar"
     uri = "wandb-artifact://deadbeef/path/to/file.json"
@@ -313,7 +317,7 @@ def test_wbartifact_handler_load_path_nonlocal(monkeypatch):
     )
 
     handler = wandb_sdk.wandb_artifacts.WBArtifactHandler()
-    handler._client = lambda: None
+    handler._client = lambda: MockApi()
     monkeypatch.setattr(wandb.apis.public.Artifact, "from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.ref_target = lambda: uri
@@ -337,7 +341,7 @@ def test_wbartifact_handler_load_path_local(monkeypatch):
     )
 
     handler = wandb_sdk.wandb_artifacts.WBArtifactHandler()
-    handler._client = lambda: None
+    handler._client = lambda: MockApi()
     monkeypatch.setattr(wandb.apis.public.Artifact, "from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.download = lambda: path

--- a/tests/unit_tests/artifacts/test_wandb_artifacts_cache.py
+++ b/tests/unit_tests/artifacts/test_wandb_artifacts_cache.py
@@ -317,7 +317,7 @@ def test_wbartifact_handler_load_path_nonlocal(monkeypatch):
     )
 
     handler = wandb_sdk.wandb_artifacts.WBArtifactHandler()
-    handler._client = lambda: MockApi()
+    handler._client = MockApi()
     monkeypatch.setattr(wandb.apis.public.Artifact, "from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.ref_target = lambda: uri
@@ -341,7 +341,7 @@ def test_wbartifact_handler_load_path_local(monkeypatch):
     )
 
     handler = wandb_sdk.wandb_artifacts.WBArtifactHandler()
-    handler._client = lambda: MockApi()
+    handler._client = MockApi()
     monkeypatch.setattr(wandb.apis.public.Artifact, "from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.download = lambda: path

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1942,7 +1942,9 @@ class WBArtifactHandler(StorageHandler):
         artifact_id = util.host_from_path(manifest_entry.ref)
         artifact_file_path = util.uri_from_path(manifest_entry.ref)
 
-        dep_artifact = PublicArtifact.from_id(hex_to_b64_id(artifact_id), self.client)
+        dep_artifact = PublicArtifact.from_id(
+            hex_to_b64_id(artifact_id), self.client._client
+        )
         link_target_path: util.FilePathStr
         if local:
             link_target_path = dep_artifact.get_path(artifact_file_path).download()

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1981,7 +1981,7 @@ class WBArtifactHandler(StorageHandler):
             artifact_id = util.host_from_path(path)
             artifact_file_path = util.uri_from_path(path)
             target_artifact = PublicArtifact.from_id(
-                hex_to_b64_id(artifact_id), self.client
+                hex_to_b64_id(artifact_id), self.client._client
             )
 
             # this should only have an effect if the user added the reference by url


### PR DESCRIPTION
I am surprised here - this is almost a 2 year old bug! Let's break it down: The `WBArtifactHandler` has a `client` property (which is probably poorly named) that is actually of type `Api`. However, it calls `Artifact.from_id(..., self.client)` ... yet `from_id` expects a `Client` (which is basically a GQL client. This is totally incorrect and can cause crashes - as tested by the unit tests written. 

However, since `from_id` has a short circuit that returns early when the artifact is in the cache, this bug almost NEVER occurs. This is because to construct a reference entry (the case where this is triggered), the user is almost guaranteed to have already downloaded the artifact in question! Therefore it is always populated, and we always short circuit. While working on Weave, we killed the cache for performance and this caused us to see this bug! cc @dannygoldstein .

I added unit tests to test the happy path as well as a cache-less path. Also updated the stub for another test to be correct