### PR TITLE
feat(integrations): add a `sep` argument to modify the metric name format (lightgbm, xgboost)

### DIFF
--- a/wandb/integration/xgboost/xgboost.py
+++ b/wandb/integration/xgboost/xgboost.py
@@ -61,6 +61,7 @@ class WandbCallback(xgb.callback.TrainingCallback):
         importance_type: (str) one of {weight, gain, cover, total_gain, total_cover} for tree model. weight for linear model.
         define_metric: (boolean) if True (default) capture model performance at the best step, instead of the last step, of training in your `wandb.summary`.
         sep: (str) separator that combines the validation set name and metric name.
+
     Passing `WandbCallback` to XGBoost will:
 
     - log the booster model configuration to Weights & Biases


### PR DESCRIPTION
Description
-----------
What does the PR do?

In the xgboost and lightgbm integration, the metric name is constructed by the hard coded format f"{data}-{metrics}" or "{data}_{metrics}". But it is useful if we can specify the separator like "/" because the wandb recognizes "/" as a section separator and we can make plots neat and tidy.

Testing
-------
How was this PR tested?

I actually ran the following simple example and got the expected results on the wandb page.
The image is an actual result where the new sections ('xgb_valid', 'lgb_valid') were automatically created.

I am not sure how to write unit tests for this type of feature, but I would appreciate any suggestion or advice about that.

```py
from sklearn.datasets import load_iris
from sklearn.model_selection import train_test_split
import xgboost as xgb
import lightgbm as lgb
import wandb.integration.xgboost as xgb_integ
import wandb.integration.lightgbm as lgb_integ
import wandb

wandb.init(project="dev-wandb")

data = load_iris()
X_train, X_valid, y_train, y_valid = train_test_split(data['data'], data['target'], test_size=.2)

# xgb
xgb_train = xgb.DMatrix(X_train, y_train)
xgb_valid = xgb.DMatrix(X_valid, y_valid)
xgb_params = dict(max_depth=2, learning_rate=1, objective='multi:softmax', num_class=3, eval_metric="mlogloss")
xgb.train(
    xgb_params,
    xgb_train,
    evals=[(xgb_valid, "xgb_valid"), (xgb_train, "xgb_train")],
    num_boost_round=10,
    callbacks=[xgb_integ.WandbCallback()]
)

# lgb
lgb_params = dict(max_depth=2, learning_rate=1, objective='multiclass', num_class=3, metric="multi_logloss")
lgb_train = lgb.Dataset(X_train, y_train)
lgb_valid = lgb.Dataset(X_valid, y_valid)
lgb.train(
    lgb_params,
    lgb_train,
    valid_sets=[lgb_train, lgb_valid],
    valid_names=["lgb_train", "lgb_valid"],
    num_boost_round=10,
    callbacks=[lgb_integ.wandb_callback(), lgb.log_evaluation(period=1)],
)
```

<img width="583" alt="wandb_plot" src="https://user-images.githubusercontent.com/9190086/212628707-f26d6240-8ce2-48d4-89b7-f25033a8cad8.png">

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
