### PR TITLE
chore(sdk): dont create universal py2/py3 package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,6 @@ replace = version="{new_version}"
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[bdist_wheel]
-universal = 1
-
 [tool:pytest]
 norecursedirs = 
 	vendor


### PR DESCRIPTION
Description
-----------
We dont need a universal package as we dont support py2 anymore.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
