### PR TITLE
test(sdk): fix gcloud sdk version requested in nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,8 +679,8 @@ jobs:
       - when:
           condition: << parameters.execute >>
           steps:
-            - gcloud/install:
-                version: "412.0.0"
+            - gcloud/install
+#                version: "413.0.0"
 #                components: "docker-credential-gcr"
             - setup_gcloud
             - setup_docker_buildx:


### PR DESCRIPTION
Description
-----------
The action of updating the gcloud sdk that is a part of the Circle orb seems to have been fixed to use the latest version, so this PR undoes a previous fix.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
