### PR TITLE
chore(sdk): fix docker testimage to pull amd64 version

### DIFF
--- a/tests/pytest_tests/system_tests/conftest.py
+++ b/tests/pytest_tests/system_tests/conftest.py
@@ -587,6 +587,8 @@ def check_server_up(
             "WANDB_ENABLE_TEST_CONTAINER=true",
             "--name",
             "wandb-local",
+            "--platform",
+            "linux/amd64",
             f"gcr.io/wandb-production/local-testcontainer:{wandb_server_tag}",
         ]
         subprocess.Popen(command)


### PR DESCRIPTION
Description
-----------
Pull x86 image until core publishes amd64 images reliably.

Future:
- revert this when core is updated

Testing
-------
locally tested