### PR TITLE
test(sdk): make a test's @skipif more precise

### DIFF
--- a/tests/pytest_tests/unit_tests/test_ssl.py
+++ b/tests/pytest_tests/unit_tests/test_ssl.py
@@ -101,8 +101,9 @@ def test_disable_ssl(
         lambda certpath: {"REQUESTS_CA_BUNDLE": str(certpath.parent)},
     ],
 )
-@pytest.mark.skipif(
-    platform.system() == "Windows" and sys.version_info[:2] == (3, 9),
+@pytest.mark.xfail(
+    condition=platform.system() == "Windows" and sys.version_info[:2] == (3, 9),
+    raises=requests.exceptions.SSLError,
     reason="Fails on Windows with Python 3.9",
 )
 def test_uses_userspecified_custom_ssl_certs(

--- a/tests/pytest_tests/unit_tests/test_ssl.py
+++ b/tests/pytest_tests/unit_tests/test_ssl.py
@@ -114,15 +114,19 @@ def test_uses_userspecified_custom_ssl_certs(
     ssl_server: http.server.HTTPServer,
     make_env: Callable[[Path], Mapping[str, str]],
 ):
-    url = f"https://{ssl_server.server_address[0]}:{ssl_server.server_address[1]}"
+    try:
+        url = f"https://{ssl_server.server_address[0]}:{ssl_server.server_address[1]}"
 
-    with pytest.raises(requests.exceptions.SSLError):
-        requests.get(url)
+        with pytest.raises(requests.exceptions.SSLError):
+            requests.get(url)
 
-    env = make_env(ssl_creds.cert)
-    srpdebug(f"SRP: url = {url}")
-    srpdebug(f"SRP: env = {env}")
-    srpdebug(f"SRP: listdir = {os.listdir(ssl_creds.cert.parent)}")
-    with patch.dict("os.environ", env):
-        srpdebug(f"env = {os.environ}")
-        assert requests.get(url).status_code == 200
+        env = make_env(ssl_creds.cert)
+        srpdebug(f"SRP: url = {url}")
+        srpdebug(f"SRP: env = {env}")
+        srpdebug(f"SRP: listdir = {os.listdir(ssl_creds.cert.parent)}")
+        with patch.dict("os.environ", env):
+            srpdebug(f"env = {os.environ}")
+            assert requests.get(url).status_code == 200
+    except Exception as e:
+        srpdebug(f"SRP: Exception = {e}")
+        assert False

--- a/tests/pytest_tests/unit_tests/test_ssl.py
+++ b/tests/pytest_tests/unit_tests/test_ssl.py
@@ -4,7 +4,6 @@ import http.server
 import os
 import platform
 import ssl
-import sys
 import threading
 from pathlib import Path
 from typing import Callable, Iterator, Mapping
@@ -102,9 +101,9 @@ def test_disable_ssl(
     ],
 )
 @pytest.mark.xfail(
-    condition=platform.system() == "Windows" and sys.version_info[:2] == (3, 9),
+    condition=platform.system() == "Windows",
     raises=requests.exceptions.SSLError,
-    reason="Fails on Windows with Python 3.9",
+    reason="Fails on Windows",
 )
 def test_uses_userspecified_custom_ssl_certs(
     ssl_creds: SSLCredPaths,


### PR DESCRIPTION
Description
-----------

- use `@xfail(raises=...)` instead of `@skipif` for this test: it's more precise
- only `xfail` on (windows AND py39): the test passes for _most_ Python versions. (I'm not yet sure why 3.9 fails.)
