### PR TITLE
feat(launch): Include username of run author in environment variables

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from wandb.sdk.launch.builder import build
+
+
+def test_get_env_vars_dict(mocker):
+    _setup(mocker)
+
+    resp = build.get_env_vars_dict(mocker.launch_project, mocker.api)
+
+    assert resp == {
+        "WANDB_API_KEY": "test-api-key",
+        "WANDB_ARGS": "",
+        "WANDB_ARTIFACTS": "test-wandb-artifacts",
+        "WANDB_BASE_URL": "base_url",
+        "WANDB_CONFIG": "test-wandb-artifacts",
+        "WANDB_DOCKER": "test-docker-image",
+        "WANDB_ENTITY": "test-entity",
+        "WANDB_ENTRYPOINT_COMMAND": "",
+        "WANDB_LAUNCH": "True",
+        "WANDB_NAME": "test-name",
+        "WANDB_PROJECT": "test-project",
+        "WANDB_RUN_ID": "test-run-id",
+        "WANDB_USERNAME": "test-author",
+    }
+
+
+def _setup(mocker):
+    launch_project = MagicMock()
+    launch_project.target_project = "test-project"
+    launch_project.target_entity = "test-entity"
+    launch_project.run_id = "test-run-id"
+    launch_project.docker_image = "test-docker-image"
+    launch_project.name = "test-name"
+    launch_project.launch_spec = {"author": "test-author"}
+    launch_project.override_config = {}
+    launch_project.override_artifacts = {}
+    mocker.launch_project = launch_project
+
+    api = MagicMock()
+    api.settings = lambda x: x
+    api.api_key = "test-api-key"
+    mocker.api = api
+
+    mocker.patch("json.dumps", lambda x: "test-wandb-artifacts")

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -233,6 +233,8 @@ def get_env_vars_dict(launch_project: LaunchProject, api: Api) -> Dict[str, str]
         env_vars["WANDB_DOCKER"] = launch_project.docker_image
     if launch_project.name is not None:
         env_vars["WANDB_NAME"] = launch_project.name
+    if "author" in launch_project.launch_spec:
+        env_vars["WANDB_USERNAME"] = launch_project.launch_spec["author"]
 
     # TODO: handle env vars > 32760 characters
     env_vars["WANDB_CONFIG"] = json.dumps(launch_project.override_config)


### PR DESCRIPTION
Fixes [WB-11750](https://wandb.atlassian.net/browse/WB-11750)

Description
-----------
Pull the "Author" key from the launch spec to populate the "WANDB_USERNAME" environment variable

Testing
-------
A new unit test, `test_get_env_vars_dict`, was added to ensure all the environment variables are fetched correctly. 



[WB-11750]: https://wandb.atlassian.net/browse/WB-11750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ