### PR TITLE
chore(launch): Agent logs full stack trace when catching exception

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+from wandb.sdk.launch.agent.agent import LaunchAgent
+
+
+class TermSetupSettings:
+    def __init__(self):
+        self.silent = True
+        self.show_info = True
+        self.show_warnings = True
+        self.show_errors = True
+
+
+def test_loop_capture_stack_trace(mocker):
+    _setup(mocker)
+    mock_config = {
+        "entity": "test-entity",
+        "project": "test-project",
+    }
+    agent = LaunchAgent(api=mocker.api, config=mock_config)
+    agent.run_job = MagicMock()
+    agent.run_job.side_effect = Exception("test exception")
+    agent.pop_from_queue = MagicMock(return_value=MagicMock())
+
+    agent.loop()
+
+    call_args = mocker.termerror.call_args.args
+    assert "Traceback (most recent call last):" in call_args[0]
+
+
+def _setup(mocker):
+    mocker.api = MagicMock()
+    mock_agent_response = {"name": "test-name", "stopPolling": False}
+    mocker.api.get_launch_agent = MagicMock(return_value=mock_agent_response)
+    mocker.api.ack_run_queue_item = MagicMock(side_effect=KeyboardInterrupt)
+    mocker.termlog = MagicMock()
+    mocker.termerror = MagicMock()
+    mocker.patch("wandb.termlog", mocker.termlog)
+    mocker.patch("wandb.termerror", mocker.termerror)

--- a/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -24,8 +24,7 @@ def test_loop_capture_stack_trace(mocker):
 
     agent.loop()
 
-    call_args = mocker.termerror.call_args.args
-    assert "Traceback (most recent call last):" in call_args[0]
+    assert "Traceback (most recent call last):" in mocker.termerror.call_args[0][0]
 
 
 def _setup(mocker):

--- a/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -3,14 +3,6 @@ from unittest.mock import MagicMock
 from wandb.sdk.launch.agent.agent import LaunchAgent
 
 
-class TermSetupSettings:
-    def __init__(self):
-        self.silent = True
-        self.show_info = True
-        self.show_warnings = True
-        self.show_errors = True
-
-
 def test_loop_capture_stack_trace(mocker):
     _setup(mocker)
     mock_config = {

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -6,6 +6,7 @@ import logging
 import os
 import pprint
 import time
+import traceback
 from typing import Any, Dict, List, Union
 
 import wandb
@@ -204,8 +205,10 @@ class LaunchAgent:
                         if job:
                             try:
                                 self.run_job(job)
-                            except Exception as e:
-                                wandb.termerror(f"Error running job: {e}")
+                            except Exception:
+                                wandb.termerror(
+                                    f"Error running job: {traceback.format_exc()}"
+                                )
                                 self._api.ack_run_queue_item(job["runQueueItemId"])
                 for job_id in self.job_ids:
                     self._update_finished(job_id)


### PR DESCRIPTION
Fixes [WB-11745](https://wandb.atlassian.net/browse/WB-11745)

Description
-----------
Previously, when an agent catches an exception, it would only log the error itself. Now it outputs a more comprehensive stack trace, showing where the error came from.

Testing
-------
A unit test was added, `test_loop_capture_stack_trace`, to ensure that the stack trace is being logged



[WB-11745]: https://wandb.atlassian.net/browse/WB-11745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ