### PR TITLE
fix(artifacts): catch FileNotFoundError and PermissionError during cache.cleanup()

### DIFF
--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -908,17 +908,15 @@ class ArtifactsCache:
         total_size: int = 0
         for root, _, files in os.walk(self._cache_dir):
             for file in files:
-                path = os.path.join(root, file)
-                stat = os.stat(path)
+                try:
+                    path = os.path.join(root, file)
+                    stat = os.stat(path)
 
-                if file.startswith(ArtifactsCache._TMP_PREFIX):
-                    try:
+                    if file.startswith(ArtifactsCache._TMP_PREFIX):
                         os.remove(path)
                         bytes_reclaimed += stat.st_size
-                    except OSError:
-                        pass
+                except OSError:
                     continue
-
                 paths[path] = stat
                 total_size += stat.st_size
 

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -915,6 +915,7 @@ class ArtifactsCache:
                     if file.startswith(ArtifactsCache._TMP_PREFIX):
                         os.remove(path)
                         bytes_reclaimed += stat.st_size
+                        continue
                 except OSError:
                     continue
                 paths[path] = stat


### PR DESCRIPTION
Fixes [WB-12210](https://wandb.atlassian.net/browse/WB-12210)

Description
-----------
Expand the `try/except` block in `ArtifactsCache.cleanup` to ensure that if the file has been deleted by another process cleanup will skip over it rather than crashing.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12210]: https://wandb.atlassian.net/browse/WB-12210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ