### PR TITLE
fix(artifacts): check to see if the run is disabled when getting the cache directory

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_cache.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_cache.py
@@ -4,6 +4,7 @@ import platform
 import random
 from multiprocessing import Pool
 from unittest import mock
+from pathlib import Path
 
 import pytest
 import wandb
@@ -357,3 +358,9 @@ def test_artifacts_cache_location_init(tmp_path, wandb_init, test_settings):
         with mock.patch("wandb.sdk.interface.artifacts._artifacts_cache", None):
             cache = wandb_sdk.wandb_artifacts.get_artifacts_cache()
             assert cache._cache_dir == os.path.join(tmp_path, "artifacts")
+
+
+def test_artifacts_cache_when_disabled():
+    with mock.patch.dict("os.environ", WANDB_MODE="disabled"):
+        cache = wandb_sdk.wandb_artifacts.get_artifacts_cache()
+        assert Path(cache._cache_dir).is_dir()

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_cache.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_cache.py
@@ -3,8 +3,8 @@ import os
 import platform
 import random
 from multiprocessing import Pool
-from unittest import mock
 from pathlib import Path
+from unittest import mock
 
 import pytest
 import wandb


### PR DESCRIPTION
Fixes [WB-12226](https://wandb.atlassian.net/browse/WB-12226)
Fixes #4869 

Description
-----------
Since the `disabled.RunDisabled` object is a subclass of string that returns itself for all `__attr__` access, `wandb.run.settings.cache_dir` *appears* to return a valid path even when `wandb.run` is disabled and there is no settings object. This checks explicitly for that case to ensure we always return a proper directory.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12226]: https://wandb.atlassian.net/browse/WB-12226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ