### PR TITLE
build(sdk): pin pip and tox in development environments

### DIFF
--- a/tools/setup_dev_environment.py
+++ b/tools/setup_dev_environment.py
@@ -10,6 +10,7 @@ import sys
 from pkg_resources import parse_version
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+PIP_VERSION = "21.1.2"
 TOX_VERSION = "3.24.0"
 
 
@@ -30,15 +31,15 @@ class Console:
     END = "\033[0m"
 
 
-def pin_pip_version(python_version, pip_version='21.1.2'):
+def pin_version(python_version, package_name, package_version):
     p = subprocess.run(
-        f"eval \"$(pyenv init -)\"; "
+        f'eval "$(pyenv init -)"; '
         f"(pyenv shell {python_version}; "
-        f"python -m pip install --upgrade pip=={pip_version})",
-        shell=True
+        f"python -m pip install --upgrade {package_name}=={package_version})",
+        shell=True,
     )
     if p.returncode != 0:
-        print(f"Failed to install pip=={pip_version}")
+        print(f"Failed to install {package_name}=={package_version}")
 
 
 def main():
@@ -131,7 +132,8 @@ def main():
             )
             if p.returncode != 0:
                 print(f"Failed to install {latest}")
-        pin_pip_version(latest)
+        pin_version(latest, "pip", PIP_VERSION)
+        pin_version(latest, "tox", TOX_VERSION)
         installed_python_versions.append(latest)
 
     print(f"Setting local pyenv versions to: {' '.join(installed_python_versions)}")

--- a/tools/setup_dev_environment.py
+++ b/tools/setup_dev_environment.py
@@ -164,7 +164,7 @@ def main():
     print(f"{Console.CODE}  tox{Console.END}")
     print("Run a specific test in a specific environment:")
     print(
-        f"{Console.CODE}  tox -e py37 -- tests/test_public_api.py -k test_run_config{Console.END}"
+        f"{Console.CODE}  tox -e py37 -- tests/pytest_tests/unit_tests/test_public_api.py -k proj{Console.END}"
     )
     print("Lint code:")
     print(f"{Console.CODE}  tox -e format,flake8,mypy{Console.END}")

--- a/tools/setup_dev_environment.py
+++ b/tools/setup_dev_environment.py
@@ -33,7 +33,7 @@ class Console:
 def run_in_env(command, python_version=None):
     """Run a command in a pyenv environment."""
     if python_version:
-        command = f"eval \"$(pyenv init -)\"; (pyenv shell {python_version}; {command})"
+        command = f'eval "$(pyenv init -)"; (pyenv shell {python_version}; {command})'
     return subprocess.check_output(command, shell=True).decode("utf-8")
 
 

--- a/tools/setup_dev_environment.py
+++ b/tools/setup_dev_environment.py
@@ -30,6 +30,17 @@ class Console:
     END = "\033[0m"
 
 
+def pin_pip_version(python_version, pip_version='21.1.2'):
+    p = subprocess.run(
+        f"eval \"$(pyenv init -)\"; "
+        f"(pyenv shell {python_version}; "
+        f"python -m pip install --upgrade pip=={pip_version})",
+        shell=True
+    )
+    if p.returncode != 0:
+        print(f"Failed to install pip=={pip_version}")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -120,6 +131,7 @@ def main():
             )
             if p.returncode != 0:
                 print(f"Failed to install {latest}")
+        pin_pip_version(latest)
         installed_python_versions.append(latest)
 
     print(f"Setting local pyenv versions to: {' '.join(installed_python_versions)}")


### PR DESCRIPTION
Fixes [WB-12228](https://wandb.atlassian.net/browse/WB-12228)

Description
-----------
Pin `pip` to 21.1.2 and `tox` to 3.24.0 in each virtual environment installed by `setup_dev_environment.py`

Testing
-------
It works on my machine!

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12228]: https://wandb.atlassian.net/browse/WB-12228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ