### PR TITLE
fix(launch): Only log the received job when launching something sourced from a job

### DIFF
--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -68,7 +68,8 @@ class LaunchProject:
             _logger.info(f"{LOG_PREFIX}Updating uri with base uri: {uri}")
         self.uri = uri
         self.job = job
-        wandb.termlog(f"{LOG_PREFIX}Launch project got job {job}")
+        if job is not None:
+            wandb.termlog(f"{LOG_PREFIX}Launching job: {job}")
         self._job_artifact: Optional[PublicArtifact] = None
         self.api = api
         self.launch_spec = launch_spec


### PR DESCRIPTION
[Fixes WB-12200
](https://wandb.atlassian.net/browse/WB-12200)Fixes #NNNN

Description
-----------
Only log the job that's going to be launched if a job was received

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
