### PR TITLE
fix(launch): Ensure job names do not exceed maximum allowable for artifacts

### DIFF
--- a/tests/pytest_tests/unit_tests/test_job_builder.py
+++ b/tests/pytest_tests/unit_tests/test_job_builder.py
@@ -1,13 +1,19 @@
 import json
+import string
+import random
 
-from wandb.sdk.internal.job_builder import JobBuilder
+from wandb.sdk.internal.job_builder import MAX_ARTIFACT_NAME_LENGTH, JobBuilder
 from wandb.sdk.internal.settings_static import SettingsStatic
 
 
-def test_build_repo_job(runner):
+def str_of_length(n):
+    return "".join(random.choices(string.ascii_uppercase + string.digits, k=n))
 
+
+def test_build_repo_job(runner):
+    remote_name = str_of_length(129)
     metadata = {
-        "git": {"remote": "testtest", "commit": "testtestcommit"},
+        "git": {"remote": remote_name, "commit": "testtestcommit"},
         "codePath": "blah/test.py",
         "args": ["--test", "test"],
         "python": "3.7",
@@ -20,9 +26,11 @@ def test_build_repo_job(runner):
             f.write(json.dumps(metadata))
         settings = SettingsStatic({"files_dir": "./"})
         job_builder = JobBuilder(settings)
+        max_len_remote = MAX_ARTIFACT_NAME_LENGTH - len("job-") - len("_blah_test.py")
+        truncated_name = remote_name[:max_len_remote]
         artifact = job_builder.build()
         assert artifact is not None
-        assert artifact.name == "job-testtest_blah_test.py"
+        assert artifact.name == f"job-{truncated_name}_blah_test.py"
         assert artifact.type == "job"
         assert artifact._manifest.entries["wandb-job.json"]
         assert artifact._manifest.entries["requirements.frozen.txt"]
@@ -34,6 +42,7 @@ def test_build_artifact_job(runner):
         "args": ["--test", "test"],
         "python": "3.7",
     }
+    artifact_name = str_of_length(129)
     with runner.isolated_filesystem():
         with open("requirements.txt", "w") as f:
             f.write("numpy==1.19.0")
@@ -42,21 +51,27 @@ def test_build_artifact_job(runner):
             f.write(json.dumps(metadata))
         settings = SettingsStatic({"files_dir": "./"})
         job_builder = JobBuilder(settings)
-        job_builder._logged_code_artifact = {"id": "testtest", "name": "artifact_name"}
+        job_builder._logged_code_artifact = {
+            "id": "testtest",
+            "name": artifact_name,
+        }
+        max_name_len = MAX_ARTIFACT_NAME_LENGTH - len("job-")
+        truncated_name = artifact_name[-max_name_len:]
         artifact = job_builder.build()
         assert artifact is not None
-        assert artifact.name == "job-artifact_name"
+        assert artifact.name == f"job-{truncated_name}"
         assert artifact.type == "job"
         assert artifact._manifest.entries["wandb-job.json"]
         assert artifact._manifest.entries["requirements.frozen.txt"]
 
 
 def test_build_image_job(runner):
+    image_name = str_of_length(129)
     metadata = {
         "codePath": "blah/test.py",
         "args": ["--test", "test"],
         "python": "3.7",
-        "docker": "mydockerimage",
+        "docker": image_name,
     }
     with runner.isolated_filesystem():
         with open("requirements.txt", "w") as f:
@@ -68,7 +83,8 @@ def test_build_image_job(runner):
         job_builder = JobBuilder(settings)
         artifact = job_builder.build()
         assert artifact is not None
-        assert artifact.name == "job-mydockerimage"
+        truncated_name = image_name[: MAX_ARTIFACT_NAME_LENGTH - len("job-")]
+        assert artifact.name == truncated_name
         assert artifact.type == "job"
         assert artifact._manifest.entries["wandb-job.json"]
         assert artifact._manifest.entries["requirements.frozen.txt"]

--- a/tests/pytest_tests/unit_tests/test_job_builder.py
+++ b/tests/pytest_tests/unit_tests/test_job_builder.py
@@ -84,7 +84,7 @@ def test_build_image_job(runner):
         artifact = job_builder.build()
         assert artifact is not None
         truncated_name = image_name[: MAX_ARTIFACT_NAME_LENGTH - len("job-")]
-        assert artifact.name == truncated_name
+        assert artifact.name == f"job-{truncated_name}"
         assert artifact.type == "job"
         assert artifact._manifest.entries["wandb-job.json"]
         assert artifact._manifest.entries["requirements.frozen.txt"]

--- a/tests/pytest_tests/unit_tests/test_job_builder.py
+++ b/tests/pytest_tests/unit_tests/test_job_builder.py
@@ -1,6 +1,6 @@
 import json
-import string
 import random
+import string
 
 from wandb.sdk.internal.job_builder import JobBuilder
 from wandb.sdk.internal.settings_static import SettingsStatic

--- a/tests/pytest_tests/unit_tests/test_job_builder.py
+++ b/tests/pytest_tests/unit_tests/test_job_builder.py
@@ -2,9 +2,9 @@ import json
 import string
 import random
 
-from wandb.util import make_artifact_name_safe
 from wandb.sdk.internal.job_builder import JobBuilder
 from wandb.sdk.internal.settings_static import SettingsStatic
+from wandb.util import make_artifact_name_safe
 
 
 def str_of_length(n):

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -121,8 +121,9 @@ class JobBuilder:
                 "commit": commit,
             },
         }
-
-        name = make_artifact_name_safe(f"job-{remote}_{program_relpath}")
+        max_remote_name = 128 - len("job-") - len("_" + program_relpath)
+        truncated_remote_name = remote[:max_remote_name]
+        name = make_artifact_name_safe(f"job-{truncated_remote_name}_{program_relpath}")
 
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
         if os.path.exists(os.path.join(self._settings.files_dir, DIFF_FNAME)):
@@ -144,8 +145,9 @@ class JobBuilder:
             ],
             "artifact": f"wandb-artifact://_id/{self._logged_code_artifact['id']}",
         }
-
-        name = f"job-{self._logged_code_artifact['name']}"
+        max_name = 128 - len("job-")
+        truncated_name = self._logged_code_artifact["name"][:max_name]
+        name = f"job-{truncated_name}"
 
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
         return artifact, source
@@ -155,7 +157,9 @@ class JobBuilder:
     ) -> Tuple[Artifact, ImageSourceDict]:
         image_name = metadata.get("docker")
         assert isinstance(image_name, str)
-        name = make_artifact_name_safe(f"job-{image_name}")
+        max_name = 128 - len("job-")
+        truncated_image_name = image_name[:max_name]
+        name = make_artifact_name_safe(f"job-{truncated_image_name}")
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
         source: ImageSourceDict = {
             "image": image_name,

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 FROZEN_REQUIREMENTS_FNAME = "requirements.frozen.txt"
 JOB_FNAME = "wandb-job.json"
 JOB_ARTIFACT_TYPE = "job"
+MAX_ARTIFACT_NAME_LENGTH = 128
 
 
 class GitInfo(TypedDict):
@@ -121,8 +122,10 @@ class JobBuilder:
                 "commit": commit,
             },
         }
-        max_remote_name = 128 - len("job-") - len("_" + program_relpath)
-        truncated_remote_name = remote[:max_remote_name]
+        max_remote_name_length = (
+            MAX_ARTIFACT_NAME_LENGTH - len("job-") - len("_" + program_relpath)
+        )
+        truncated_remote_name = remote[:max_remote_name_length]
         name = make_artifact_name_safe(f"job-{truncated_remote_name}_{program_relpath}")
 
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
@@ -145,8 +148,9 @@ class JobBuilder:
             ],
             "artifact": f"wandb-artifact://_id/{self._logged_code_artifact['id']}",
         }
-        max_name = 128 - len("job-")
-        truncated_name = self._logged_code_artifact["name"][:max_name]
+        max_name_length = MAX_ARTIFACT_NAME_LENGTH - len("job-")
+        # left truncate to preserve code path
+        truncated_name = self._logged_code_artifact["name"][-max_name_length:]
         name = f"job-{truncated_name}"
 
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
@@ -157,8 +161,8 @@ class JobBuilder:
     ) -> Tuple[Artifact, ImageSourceDict]:
         image_name = metadata.get("docker")
         assert isinstance(image_name, str)
-        max_name = 128 - len("job-")
-        truncated_image_name = image_name[:max_name]
+        max_name_length = MAX_ARTIFACT_NAME_LENGTH - len("job-")
+        truncated_image_name = image_name[:max_name_length]
         name = make_artifact_name_safe(f"job-{truncated_image_name}")
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
         source: ImageSourceDict = {

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
 FROZEN_REQUIREMENTS_FNAME = "requirements.frozen.txt"
 JOB_FNAME = "wandb-job.json"
 JOB_ARTIFACT_TYPE = "job"
-MAX_ARTIFACT_NAME_LENGTH = 128
 
 
 class GitInfo(TypedDict):
@@ -122,11 +121,7 @@ class JobBuilder:
                 "commit": commit,
             },
         }
-        max_remote_name_length = (
-            MAX_ARTIFACT_NAME_LENGTH - len("job-") - len("_" + program_relpath)
-        )
-        truncated_remote_name = remote[:max_remote_name_length]
-        name = make_artifact_name_safe(f"job-{truncated_remote_name}_{program_relpath}")
+        name = make_artifact_name_safe(f"job-{remote}_{program_relpath}")
 
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
         if os.path.exists(os.path.join(self._settings.files_dir, DIFF_FNAME)):
@@ -148,10 +143,7 @@ class JobBuilder:
             ],
             "artifact": f"wandb-artifact://_id/{self._logged_code_artifact['id']}",
         }
-        max_name_length = MAX_ARTIFACT_NAME_LENGTH - len("job-")
-        # left truncate to preserve code path
-        truncated_name = self._logged_code_artifact["name"][-max_name_length:]
-        name = f"job-{truncated_name}"
+        name = make_artifact_name_safe(f"job-{self._logged_code_artifact['name']}")
 
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
         return artifact, source
@@ -161,9 +153,7 @@ class JobBuilder:
     ) -> Tuple[Artifact, ImageSourceDict]:
         image_name = metadata.get("docker")
         assert isinstance(image_name, str)
-        max_name_length = MAX_ARTIFACT_NAME_LENGTH - len("job-")
-        truncated_image_name = image_name[:max_name_length]
-        name = make_artifact_name_safe(f"job-{truncated_image_name}")
+        name = make_artifact_name_safe(f"job-{image_name}")
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)
         source: ImageSourceDict = {
             "image": image_name,

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -121,6 +121,7 @@ class JobBuilder:
                 "commit": commit,
             },
         }
+
         name = make_artifact_name_safe(f"job-{remote}_{program_relpath}")
 
         artifact = Artifact(name, JOB_ARTIFACT_TYPE)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1872,7 +1872,9 @@ def ensure_text(
 def make_artifact_name_safe(name: str) -> str:
     """Make an artifact name safe for use in artifacts"""
     # artifact names may only contain alphanumeric characters, dashes, underscores, and dots.
-    return re.sub(r"[^a-zA-Z0-9_\-.]", "_", name)
+    cleaned = re.sub(r"[^a-zA-Z0-9_\-.]", "_", name)
+    # truncate with dots in the middle using regex
+    return re.sub(r"(^.{63}).*(.{63}$)", r"\g<1>..\g<2>", cleaned)
 
 
 def make_docker_image_name_safe(name: str) -> str:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1873,6 +1873,8 @@ def make_artifact_name_safe(name: str) -> str:
     """Make an artifact name safe for use in artifacts"""
     # artifact names may only contain alphanumeric characters, dashes, underscores, and dots.
     cleaned = re.sub(r"[^a-zA-Z0-9_\-.]", "_", name)
+    if len(cleaned) <= 128:
+        return cleaned
     # truncate with dots in the middle using regex
     return re.sub(r"(^.{63}).*(.{63}$)", r"\g<1>..\g<2>", cleaned)
 


### PR DESCRIPTION
Fixes WB-NNNN
[Fixes #4888](https://github.com/wandb/wandb/issues/4888)

Description
-----------
- truncates the job artifact names to 128 characters

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
