### PR TITLE
fix(sdk): add special Exceptions for the manager logic, when trying to connect to a gone service

### DIFF
--- a/wandb/errors/__init__.py
+++ b/wandb/errors/__init__.py
@@ -156,6 +156,7 @@ class ServiceStartPortError(Error):
 
     pass
 
+
 class ServiceProcessExistsError(Error):
     """Raised when service process is not running"""
 

--- a/wandb/errors/__init__.py
+++ b/wandb/errors/__init__.py
@@ -15,9 +15,6 @@ __all__ = [
     "ServiceStartProcessError",
     "ServiceStartTimeoutError",
     "ServiceStartPortError",
-    "ServiceConnectProcessExistsError",
-    "ServiceConnectRefusedError",
-    "ServiceConnectError",
 ]
 
 from typing import List, Optional
@@ -138,41 +135,5 @@ class MailboxError(Error):
 
 class ContextCancelledError(Error):
     """Context cancelled Exception"""
-
-    pass
-
-
-class ServiceStartProcessError(Error):
-    """Raised when a known error occurs when launching wandb service"""
-
-    pass
-
-
-class ServiceStartTimeoutError(Error):
-    """Raised when service start times out"""
-
-    pass
-
-
-class ServiceStartPortError(Error):
-    """Raised when service start fails to find a port"""
-
-    pass
-
-
-class ServiceConnectError(Error):
-    """Raised when service process is not running"""
-
-    pass
-
-
-class ServiceConnectRefusedError(Error):
-    """Raised when service process is not running"""
-
-    pass
-
-
-class ServiceConnectProcessExistsError(Error):
-    """Raised when service process is not running, but WANDB_SERVICE exists"""
 
     pass

--- a/wandb/errors/__init__.py
+++ b/wandb/errors/__init__.py
@@ -12,9 +12,6 @@ __all__ = [
     "SweepError",
     "WaitTimeoutError",
     "ContextCancelledError",
-    "ServiceStartProcessError",
-    "ServiceStartTimeoutError",
-    "ServiceStartPortError",
 ]
 
 from typing import List, Optional

--- a/wandb/errors/__init__.py
+++ b/wandb/errors/__init__.py
@@ -155,3 +155,8 @@ class ServiceStartPortError(Error):
     """Raised when service start fails to find a port"""
 
     pass
+
+class ServiceProcessExistsError(Error):
+    """Raised when service process is not running"""
+
+    pass

--- a/wandb/errors/__init__.py
+++ b/wandb/errors/__init__.py
@@ -15,6 +15,9 @@ __all__ = [
     "ServiceStartProcessError",
     "ServiceStartTimeoutError",
     "ServiceStartPortError",
+    "ServiceConnectProcessExistsError",
+    "ServiceConnectRefusedError",
+    "ServiceConnectError",
 ]
 
 from typing import List, Optional
@@ -157,7 +160,19 @@ class ServiceStartPortError(Error):
     pass
 
 
-class ServiceProcessExistsError(Error):
+class ServiceConnectError(Error):
     """Raised when service process is not running"""
+
+    pass
+
+
+class ServiceConnectRefusedError(Error):
+    """Raised when service process is not running"""
+
+    pass
+
+
+class ServiceConnectProcessExistsError(Error):
+    """Raised when service process is not running, but WANDB_SERVICE exists"""
 
     pass

--- a/wandb/errors/__init__.py
+++ b/wandb/errors/__init__.py
@@ -20,9 +20,12 @@ from typing import List, Optional
 class Error(Exception):
     """Base W&B Error"""
 
-    def __init__(self, message) -> None:
+    def __init__(self, message, context: Optional[dict] = None) -> None:
         super().__init__(message)
         self.message = message
+        # sentry context capture
+        if context:
+            self.context = context
 
     # For python 2 support
     def encode(self, encoding):

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -23,19 +23,19 @@ if TYPE_CHECKING:
     from wandb.sdk.wandb_settings import Settings
 
 
-class ServiceStartProcessError(Exception):
+class ServiceStartProcessError(Error):
     """Raised when a known error occurs when launching wandb service"""
 
     pass
 
 
-class ServiceStartTimeoutError(Exception):
+class ServiceStartTimeoutError(Error):
     """Raised when service start times out"""
 
     pass
 
 
-class ServiceStartPortError(Exception):
+class ServiceStartPortError(Error):
     """Raised when service start fails to find a port"""
 
     pass

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -102,14 +102,24 @@ class _Service:
             if proc and proc.poll():
                 # process finished
                 # define these variables for sentry context grab:
-                command = proc.args  # noqa: F841
-                sys_executable = sys.executable  # noqa: F841
-                which_python = shutil.which("python3")  # noqa: F841
+                # command = proc.args  # noqa: F841
+                # sys_executable = sys.executable  # noqa: F841
+                # which_python = shutil.which("python3")  # noqa: F841
+                # proc_out = proc.stdout.read()  # noqa: F841
+                # proc_err = proc.stderr.read()  # noqa: F841
+                context = dict(
+                    command=proc.args,
+                    sys_executable=sys.executable,
+                    which_python=shutil.which("python3"),
+                    proc_out=proc.stdout.read() if proc.stdout else "",
+                    proc_err=proc.stderr.read() if proc.stderr else "",
+                )
                 raise ServiceStartProcessError(
                     f"The wandb service process exited with {proc.returncode}. "
                     "Ensure that `sys.executable` is a valid python interpreter. "
                     "You can override it with the `_executable` setting "
-                    "or with the `WANDB__EXECUTABLE` environment variable."
+                    "or with the `WANDB__EXECUTABLE` environment variable.",
+                    context=context,
                 )
             if not os.path.isfile(fname):
                 time.sleep(0.2)

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -12,18 +12,33 @@ import tempfile
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from ...errors import (
-    ServiceStartPortError,
-    ServiceStartProcessError,
-    ServiceStartTimeoutError,
-)
-from ...util import sentry_reraise, sentry_set_scope
+from wandb.errors import Error
+from wandb.util import sentry_reraise, sentry_set_scope
+
 from . import _startup_debug, port_file
 from .service_base import ServiceInterface
 from .service_sock import ServiceSockInterface
 
 if TYPE_CHECKING:
     from wandb.sdk.wandb_settings import Settings
+
+
+class ServiceStartProcessError(Error):
+    """Raised when a known error occurs when launching wandb service"""
+
+    pass
+
+
+class ServiceStartTimeoutError(Error):
+    """Raised when service start times out"""
+
+    pass
+
+
+class ServiceStartPortError(Error):
+    """Raised when service start fails to find a port"""
+
+    pass
 
 
 class _Service:

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from wandb.errors import Error
 from wandb.util import sentry_reraise, sentry_set_scope
 
 from . import _startup_debug, port_file

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -12,7 +12,6 @@ import tempfile
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from wandb.errors import Error
 from wandb.util import sentry_reraise, sentry_set_scope
 
 from . import _startup_debug, port_file
@@ -23,19 +22,19 @@ if TYPE_CHECKING:
     from wandb.sdk.wandb_settings import Settings
 
 
-class ServiceStartProcessError(Error):
+class ServiceStartProcessError(Exception):
     """Raised when a known error occurs when launching wandb service"""
 
     pass
 
 
-class ServiceStartTimeoutError(Error):
+class ServiceStartTimeoutError(Exception):
     """Raised when service start times out"""
 
     pass
 
 
-class ServiceStartPortError(Error):
+class ServiceStartPortError(Exception):
     """Raised when service start fails to find a port"""
 
     pass

--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -11,10 +11,10 @@ import psutil
 
 import wandb
 from wandb import env, trigger
+from wandb.errors import Error
 from wandb.sdk.lib.exit_hooks import ExitHooks
 from wandb.sdk.lib.import_hooks import unregister_all_post_import_hooks
 from wandb.sdk.lib.proto_util import settings_dict_from_pbmap
-from wandb.errors import Error
 from wandb.util import sentry_reraise
 
 if TYPE_CHECKING:

--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -14,6 +14,7 @@ from wandb import env, trigger
 from wandb.sdk.lib.exit_hooks import ExitHooks
 from wandb.sdk.lib.import_hooks import unregister_all_post_import_hooks
 from wandb.sdk.lib.proto_util import settings_dict_from_pbmap
+from wandb.errors import Error
 from wandb.util import sentry_reraise
 
 if TYPE_CHECKING:
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     from wandb.sdk.wandb_settings import Settings
 
 
-class ManagerConnectionError(Exception):
+class ManagerConnectionError(Error):
     """Raised when service process is not running"""
 
     pass

--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -11,7 +11,6 @@ import psutil
 
 import wandb
 from wandb import env, trigger
-from wandb.errors import Error
 from wandb.sdk.lib.exit_hooks import ExitHooks
 from wandb.sdk.lib.import_hooks import unregister_all_post_import_hooks
 from wandb.sdk.lib.proto_util import settings_dict_from_pbmap
@@ -23,7 +22,7 @@ if TYPE_CHECKING:
     from wandb.sdk.wandb_settings import Settings
 
 
-class ManagerConnectionError(Error):
+class ManagerConnectionError(Exception):
     """Raised when service process is not running"""
 
     pass

--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -120,7 +120,6 @@ class _Manager:
                 message = (
                     "Connection to wandb service failed "
                     "since the process is not available. "
-                    # "See [TODO] for more details"
                 )
             else:
                 message = f"Connection to wandb service failed: {e}. "

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -396,7 +396,7 @@ class Settings:
     _runqueue_item_id: str
     _save_requirements: bool
     _service_transport: str
-    _service_wait: int
+    _service_wait: float
     _start_datetime: datetime
     _start_time: float
     _stats_pid: int  # (internal) base pid for system stats
@@ -540,9 +540,21 @@ class Settings:
             _sync={"value": False},
             _platform={"value": util.get_platform_name()},
             _save_requirements={"value": True, "preprocessor": _str_as_bool},
-            _service_wait={"value": 30, "preprocessor": int},
-            _stats_sample_rate_seconds={"value": 2.0, "preprocessor": float},
-            _stats_samples_to_average={"value": 15},
+            _service_wait={
+                "value": 30,
+                "preprocessor": float,
+                "validator": self._validate__service_wait,
+            },
+            _stats_sample_rate_seconds={
+                "value": 2.0,
+                "preprocessor": float,
+                "validator": self._validate__stats_sample_rate_seconds,
+            },
+            _stats_samples_to_average={
+                "value": 15,
+                "preprocessor": int,
+                "validator": self._validate__stats_samples_to_average,
+            },
             _stats_join_assets={"value": True, "preprocessor": _str_as_bool},
             _stats_neuron_monitor_config_path={
                 "hook": lambda x: self._path_convert(x),
@@ -925,6 +937,24 @@ class Settings:
         elif split_url.hostname is None or len(split_url.hostname) > 253:
             raise UsageError("hostname is invalid")
 
+        return True
+
+    @staticmethod
+    def _validate__service_wait(value: float) -> bool:
+        if value <= 0:
+            raise UsageError("_service_wait must be a positive number")
+        return True
+
+    @staticmethod
+    def _validate__stats_sample_rate_seconds(value: float) -> bool:
+        if value < 0.1:
+            raise UsageError("_stats_sample_rate_seconds must be >= 0.1")
+        return True
+
+    @staticmethod
+    def _validate__stats_samples_to_average(value: int) -> bool:
+        if value < 1 or value > 30:
+            raise UsageError("_stats_samples_to_average must be between 1 and 30")
         return True
 
     # other helper methods


### PR DESCRIPTION
Fixes WB-12268

Description
-----------
What does the PR do?

- Adds more fine grained errors to the manager to help debug cases where the token is stale (since the service closed) vs real manager issues
- capture error context more cleanly and verbose 
- add validators to time-based settings

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
