### PR TITLE
fix(sdk): add deepcopy dunder method to the Run class

### DIFF
--- a/tests/pytest_tests/unit_tests/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_run.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import platform
 
@@ -213,3 +214,11 @@ def test_run_sweep_overlap():
     sw = dict(param2=8, param3=9)
     run = wandb_sdk.wandb_run.Run(settings=s, config=c, sweep_config=sw)
     assert dict(run.config) == dict(param1=2, param2=8, param3=9)
+
+
+def test_run_deepcopy():
+    s = wandb.Settings()
+    c = dict(param1=2, param2=4)
+    run = wandb_sdk.wandb_run.Run(settings=s, config=c)
+    run2 = copy.deepcopy(run)
+    assert id(run) == id(run2)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -770,7 +770,7 @@ class Run:
         except Exception:
             wandb.termwarn("Cannot find valid git repo associated with this directory.")
 
-    def __deepcopy__(self, memo) -> "Run":
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "Run":
         return self
 
     def __getstate__(self) -> Any:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -295,7 +295,6 @@ class RunStatusChecker:
 
 
 class _run_decorator:  # noqa: N801
-
     _is_attaching: str = ""
 
     class Dummy:
@@ -305,7 +304,6 @@ class _run_decorator:  # noqa: N801
     def _attach(cls, func: Callable) -> Callable:
         @functools.wraps(func)
         def wrapper(self: Type["Run"], *args: Any, **kwargs: Any) -> Any:
-
             # * `_attach_id` is only assigned in service hence for all non-service cases
             # it will be a passthrough.
             # * `_attach_pid` is only assigned in _init (using _attach_pid guarantees single attach):
@@ -315,7 +313,6 @@ class _run_decorator:  # noqa: N801
                 getattr(self, "_attach_id", None)
                 and getattr(self, "_attach_pid", None) != os.getpid()
             ):
-
                 if cls._is_attaching:
                     message = (
                         f"Trying to attach `{func.__name__}` "
@@ -528,7 +525,6 @@ class Run:
         sweep_config: Optional[Dict[str, Any]] = None,
         launch_config: Optional[Dict[str, Any]] = None,
     ) -> None:
-
         self._settings = settings
         self._config = wandb_config.Config()
         self._config._set_callback(self._config_callback)
@@ -773,6 +769,9 @@ class Run:
             self._remote_url, self._commit = repo.remote_url, repo.last_commit
         except Exception:
             wandb.termwarn("Cannot find valid git repo associated with this directory.")
+
+    def __deepcopy__(self, memo) -> "Run":
+        return self
 
     def __getstate__(self) -> Any:
         """Custom pickler."""
@@ -1749,7 +1748,6 @@ class Run:
         base_path: Optional[str] = None,
         policy: "PolicyName" = "live",
     ) -> Union[bool, List[str]]:
-
         if policy not in ("live", "end", "now"):
             raise ValueError(
                 'Only "live" "end" and "now" policies are currently supported.'
@@ -2129,7 +2127,6 @@ class Run:
             self._output_writer = None
 
     def _on_init(self) -> None:
-
         if self._backend and self._backend.interface:
             logger.info("communicating current version")
             version_handle = self._backend.interface.deliver_check_version(
@@ -3045,7 +3042,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if not check_version or settings._offline:
             return
 
@@ -3080,7 +3076,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         # printer = printer or get_printer(settings._jupyter)
         if settings._offline:
             printer.display(
@@ -3104,7 +3099,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if settings._offline or settings.silent:
             return
 
@@ -3120,13 +3114,11 @@ class Run:
         # printer = printer or get_printer(settings._jupyter)
         if printer._html:
             if not wandb.jupyter.maybe_display():
-
                 run_line = f"<strong>{printer.link(run_url, run_name)}</strong>"
                 project_line, sweep_line = "", ""
 
                 # TODO(settings): make settings the source of truth
                 if not wandb.jupyter.quiet():
-
                     doc_html = printer.link(wburls.get("doc_run"), "docs")
 
                     project_html = printer.link(project_url, "Weights & Biases")
@@ -3224,7 +3216,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if settings.silent:
             return
 
@@ -3320,7 +3311,6 @@ class Run:
         *,
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         # todo: is this same as settings._offline?
         if not all(poll_exit_responses):
             return
@@ -3374,7 +3364,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if settings.silent:
             return
 
@@ -3410,7 +3399,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if (quiet or settings.quiet) or settings.silent:
             return
 
@@ -3430,7 +3418,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if (quiet or settings.quiet) or settings.silent:
             return
 
@@ -3502,7 +3489,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if (quiet or settings.quiet) or settings.silent:
             return
 
@@ -3531,7 +3517,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if (quiet or settings.quiet) or settings.silent:
             return
 
@@ -3555,7 +3540,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if not check_version:
             return
 
@@ -3584,7 +3568,6 @@ class Run:
         settings: "Settings",
         printer: Union["PrinterTerm", "PrinterJupyter"],
     ) -> None:
-
         if (quiet or settings.quiet) or settings.silent:
             return
 
@@ -3687,7 +3670,6 @@ def finish(exit_code: Optional[int] = None, quiet: Optional[bool] = None) -> Non
 
 
 class _LazyArtifact(ArtifactInterface):
-
     _api: PublicApi
     _instance: Optional[ArtifactInterface] = None
     _future: Any


### PR DESCRIPTION
Fixes WB-12270

Description
-----------
What does the PR do?

This PR adds `__deepcopy__` dunder method to the `Run` class, for cases when the Run is part of another object that being copied. Currently, that would fails since python would resolve to the pickling mechanism (we don't allow to pickle/un-pickle in the same process, to avoid a case where we have 2 runs in the same process, not supported). With change cases like described above would work.

Testing
-------
How was this PR tested?

Added simple test (in `unit_tests/test_wandb_run.py`) that checks that we can deepcopy the Run object and that it returns the same instance of the Run.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
