### PR TITLE
build(sdk): fix editable mode with latest version of pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools<=63.4.3']
+requires = ['setuptools==63.4.3']
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools==63.4.3']
+requires = ['setuptools<=63.4.3']
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools<=63.4.3']
+requires = ['setuptools<64']
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ['setuptools<=63.4.3']
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 88
 include = '\.pyi?$'

--- a/tools/setup_dev_environment.py
+++ b/tools/setup_dev_environment.py
@@ -9,7 +9,6 @@ import sys
 from pkg_resources import parse_version
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-PIP_VERSION = "21.1.2"
 TOX_VERSION = "3.24.0"
 
 
@@ -145,7 +144,6 @@ def main():
             )
             if p.returncode != 0:
                 print(f"Failed to install {latest}")
-        pin_version("pip", PIP_VERSION, python_version=latest)
         pin_version("tox", TOX_VERSION, python_version=latest)
         installed_python_versions.append(latest)
 


### PR DESCRIPTION
Fixes WB-11443

Description
-----------
What does the PR do?

Adds a build system section to workaround an issue introduce by setup tools (in version 64.0.0). The change broke the editable mode. 

Pinning the version based on the discussion here: https://github.com/pypa/setuptools/issues/3548

Testing
-------
How was this PR tested?

tested locally on my machine and was able to work in editable mode with this change (with the latest version of pip)

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
