### PR TITLE
fix(sdk): make error message during run initialization more actionable and fix uncaught exception  

### DIFF
--- a/tests/pytest_tests/unit_tests/test_util.py
+++ b/tests/pytest_tests/unit_tests/test_util.py
@@ -486,6 +486,7 @@ def test_no_retry_auth():
         e.response.status_code = status_code
         assert not util.no_retry_auth(e)
     e.response.status_code = 401
+    e.response.reason = "Unauthorized"
     with pytest.raises(wandb.CommError):
         util.no_retry_auth(e)
     e.response.status_code = 403

--- a/tests/pytest_tests/unit_tests/test_util.py
+++ b/tests/pytest_tests/unit_tests/test_util.py
@@ -490,6 +490,7 @@ def test_no_retry_auth():
     with pytest.raises(wandb.CommError):
         util.no_retry_auth(e)
     e.response.status_code = 403
+    e.response.reason = "Forbidden"
     with mock.patch("wandb.run", mock.MagicMock()):
         with pytest.raises(wandb.CommError):
             util.no_retry_auth(e)

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -933,7 +933,6 @@ class SendManager:
                 result = proto_util._result_from_record(record)
                 result.run_result.run.CopyFrom(run)
                 error = wandb_internal_pb2.ErrorInfo()
-                error.code = wandb_internal_pb2.ErrorInfo.ErrorCode.PERMISSION
                 error.message = str(e)
                 result.run_result.error.CopyFrom(error)
                 self._respond_result(result)

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -29,7 +29,7 @@ import requests
 
 import wandb
 from wandb import util
-from wandb.errors import ContextCancelledError, CommError
+from wandb.errors import CommError, ContextCancelledError
 from wandb.filesync.dir_watcher import DirWatcher
 from wandb.proto import wandb_internal_pb2
 from wandb.sdk.lib import redirect

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -936,6 +936,8 @@ class SendManager:
                 error.message = str(e)
                 result.run_result.error.CopyFrom(error)
                 self._respond_result(result)
+            else:
+                logger.error(e, exc_info=True)
             return
 
         assert self._run  # self._run is configured in _init_run()

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -929,6 +929,7 @@ class SendManager:
         try:
             self._init_run(run, config_value_dict)
         except CommError as e:
+            logger.error(e, exc_info=True)
             if record.control.req_resp or record.control.mailbox_slot:
                 result = proto_util._result_from_record(record)
                 result.run_result.run.CopyFrom(run)
@@ -936,8 +937,6 @@ class SendManager:
                 error.message = str(e)
                 result.run_result.error.CopyFrom(error)
                 self._respond_result(result)
-            else:
-                logger.error(e, exc_info=True)
             return
 
         assert self._run  # self._run is configured in _init_run()

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1009,7 +1009,7 @@ def no_retry_auth(e: Any) -> bool:
         raise CommError(
             "The API key is either invalid or missing, or the host is incorrect. "
             "To resolve this issue, you may try running the 'wandb login --host [hostname]' command. "
-            "The host defaults to 'https://wandb.ai' if not specified. "
+            "The host defaults to 'https://api.wandb.ai' if not specified. "
             f"(Error {e.response.status_code}: {e.response.reason})"
         )
     elif wandb.run:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1006,7 +1006,9 @@ def no_retry_auth(e: Any) -> bool:
         return True
     # Crash w/message on forbidden/unauthorized errors.
     if e.response.status_code == 401:
-        raise CommError("Invalid or missing api_key. Run `wandb login`")
+        raise CommError(
+            "Invalid or missing api_key. Run `wandb login` and make sure your host is configured correctly."
+        )
     elif wandb.run:
         raise CommError(f"Permission denied to access {wandb.run.path}")
     else:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1007,7 +1007,10 @@ def no_retry_auth(e: Any) -> bool:
     # Crash w/message on forbidden/unauthorized errors.
     if e.response.status_code == 401:
         raise CommError(
-            "Invalid or missing api_key. Run `wandb login` and make sure your host is configured correctly."
+            "The API key is either invalid or missing, or the host is incorrect. "
+            "To resolve this issue, you may try running the 'wandb login --host [hostname]' command. "
+            "The host defaults to 'https://wandb.ai' if not specified. "
+            f"(Error {e.response.status_code}: {e.response.reason})"
         )
     elif wandb.run:
         raise CommError(f"Permission denied to access {wandb.run.path}")

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1015,7 +1015,12 @@ def no_retry_auth(e: Any) -> bool:
     elif wandb.run:
         raise CommError(f"Permission denied to access {wandb.run.path}")
     else:
-        raise CommError("Permission denied, ask the project owner to grant you access")
+        raise CommError(
+            "It appears that you do not have permission to access the requested resource. "
+            "Please reach out to the project owner to grant you access. "
+            "If you have the correct permissions, verify that there are no issues with your networking setup."
+            f"(Error {e.response.status_code}: {e.response.reason})"
+        )
 
 
 def check_retry_conflict(e: Any) -> Optional[bool]:


### PR DESCRIPTION
Fixes WB-7611
Fixes WB-7854
Fixes WB-11936

Description
-----------
What does the PR do?

This PR catches a `CommError` when trying to init a run, before we would raise an Exception that would cause the socket to close and the entire program failed. Now we sends it the error as part of the message to the user process, so it could be printed for the user. The error message is now more informative and actionable including the information about local installs as was the case in this ticket. 

Screenshot (before the fix):
<img width="680" alt="image" src="https://user-images.githubusercontent.com/87335417/216911208-4e20109c-d0f0-4449-9079-694b481b9727.png">


Screenshot (after the fix):
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/87335417/216910893-d300c3bd-d69e-4853-8250-fee186cbd25a.png">


Screenshot (with rich installed - future):
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/87335417/216909769-2b9b9969-9ed0-416c-839e-33b1ba3c249a.png">


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
