### PR TITLE
fix(sdk): clean up IPython's widget deprecation warning

### DIFF
--- a/wandb/sdk/lib/ipython.py
+++ b/wandb/sdk/lib/ipython.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import warnings
 from typing import Optional
 
 import wandb
@@ -103,7 +104,9 @@ def jupyter_progress_bar(min: float = 0, max: float = 1.0) -> Optional[ProgressW
     try:
         if widgets is None:
             # TODO: this currently works in iPython but it's deprecated since 4.0
-            from IPython.html import widgets  # type: ignore
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                from IPython.html import widgets  # type: ignore
 
         assert hasattr(widgets, "VBox")
         assert hasattr(widgets, "Label")


### PR DESCRIPTION
Fixes WB-5263

Description
-----------
What does the PR do?

This PR suppresses IPython's widget deprecation warning.

Before:
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/87335417/216962852-05a7f2c0-c5fa-4772-81b1-d21ce5119690.png">

After:
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/87335417/216963049-dc843bf2-a7b4-4980-8ce1-5d18173e55e4.png">


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
