### PR TITLE
test(sdk): fix broken dependencies in tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,9 +25,7 @@ plotly
 bokeh
 tqdm
 docker
-# stable_baselines3
 tensorboard
-# gym
 jax[cpu]; sys_platform == 'darwin' or sys_platform == 'linux'
 fastcore; python_version > '3.6'
 fastcore==1.3.29; python_version == '3.6'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,7 +27,7 @@ tqdm
 docker
 stable_baselines3
 tensorboard
-gym
+# gym
 jax[cpu]; sys_platform == 'darwin' or sys_platform == 'linux'
 fastcore; python_version > '3.6'
 fastcore==1.3.29; python_version == '3.6'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,7 +25,7 @@ plotly
 bokeh
 tqdm
 docker
-stable_baselines3
+# stable_baselines3
 tensorboard
 # gym
 jax[cpu]; sys_platform == 'darwin' or sys_platform == 'linux'

--- a/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
+++ b/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
@@ -6,6 +6,7 @@ tag:
     - platform: win
 depend:
   requirements:
+    - setuptools==65.5.0 # 20230202: issue with later versions of setuptools cause install errors
     - importlib-metadata<5.0  # 20221003: sb3 needs to fix this on their side
     - stable-baselines3
     - tensorboard

--- a/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
+++ b/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
@@ -7,6 +7,8 @@ tag:
 depend:
   requirements:
     - importlib-metadata<5.0  # 20221003: sb3 needs to fix this on their side
+    - stable-baselines3
+    - tensorboard
 assert:
   - :wandb:runs_len: 1
   - :wandb:runs[0][config][policy_type]: MlpPolicy

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 
 logger: Optional[logging.Logger] = None  # logger configured during wandb.init()
 
+#testing!!
 
 def _set_logger(log_object: logging.Logger) -> None:
     """Configure module logger."""

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -51,7 +51,6 @@ if TYPE_CHECKING:
 
 logger: Optional[logging.Logger] = None  # logger configured during wandb.init()
 
-#testing!!
 
 def _set_logger(log_object: logging.Logger) -> None:
     """Configure module logger."""


### PR DESCRIPTION
Description
-----------
What does the PR do?

Newer versions of `setuptools==67.0.0` has new enforcements on `extras` that seem to break with gym. The gym project is not maintained anymore and currently the gym project suggests moving to [gymnasium](https://github.com/openai/gym#the-team-that-has-been-maintaining-gym-since-2021-has-moved-all-future-development-to-gymnasium-a-drop-in-replacement-for-gym-import-gymnasium-as-gym-and-gym-will-not-be-receiving-any-future-updates-please-switch-over-to-gymnasium-as-soon-as-youre-able-to-do-so-if-youd-like-to-read-more-about-the-story-behind-this-switch-please-check-out-this-blog-post). 

Until we move to  gymnasium, we remove the gym requirement from `requirement_dev.txt` as it only tested in yea where we have isolated env. We also remove `stable_baselines3` since it depends on `gym` and causes issues as well (again only tests in yea)

It also seems that `grpc==1.52.0` is also breaking see [here](https://github.com/grpc/grpc/issues/31885), which causes ray to fail as well, this version has been yanked, so we should be good

Testing
-------
How was this PR tested?

N/A

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
