### PR TITLE
chore(launch): fix push to run queue to also check launch proj WB-12359

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1174,7 +1174,10 @@ class Api:
             return push_result
 
         """ Legacy Method """
-        queues_found = self.get_project_run_queues(entity, project_queue)
+        project_queues = self.get_project_run_queues(entity, project_queue)
+        entity_queues = self.get_project_run_queues(entity, "model-registry")
+        queues_found = project_queues + entity_queues
+        
         matching_queues = [
             q
             for q in queues_found


### PR DESCRIPTION
Fixes WB-12359

Description
-----------
Push to run queue legacy method doesn't check for launch project queues

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
