### PR TITLE
chore(launch): remove default to project always in sweep

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -84,7 +84,7 @@ class Scheduler(ABC):
         self._runs: Dict[str, SweepRun] = {}
         # Threading lock to ensure thread-safe access to the runs dictionary
         self._threading_lock: threading.Lock = threading.Lock()
-        self._project_queue = project_queue or self._project
+        self._project_queue = project_queue
         # Scheduler may receive additional kwargs which will be piped into the launch command
         self._kwargs: Dict[str, Any] = kwargs
 


### PR DESCRIPTION
Fixes [WB-12359](https://wandb.atlassian.net/browse/WB-12359)

Description
-----------
Currently we always default to the project, but most queues are now in the launch project which breaks sweeps on launch.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
