### PR TITLE
fix(launch): mkdir_exists_ok now (again) checks permission on existence

### DIFF
--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -13,6 +13,9 @@ def mkdir_exists_ok(dir_name: AnyPath) -> None:
         FileExistsError: if `dir_name` exists and is not a directory.
         PermissionError: if `dir_name` is not writable.
     """
+    if not os.access(dir_name, os.W_OK):
+        raise PermissionError(f"{dir_name!s} is not writable")
+
     os.makedirs(dir_name, exist_ok=True)
     if not os.access(dir_name, os.W_OK):
         raise PermissionError(f"{dir_name!s} is not writable")

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -13,12 +13,12 @@ def mkdir_exists_ok(dir_name: AnyPath) -> None:
         FileExistsError: if `dir_name` exists and is not a directory.
         PermissionError: if `dir_name` is not writable.
     """
-    if not os.access(dir_name, os.W_OK):
-        raise PermissionError(f"{dir_name!s} is not writable")
-
-    os.makedirs(dir_name, exist_ok=True)
-    if not os.access(dir_name, os.W_OK):
-        raise PermissionError(f"{dir_name!s} is not writable")
+    try:
+        os.makedirs(dir_name, exist_ok=True)
+    except FileExistsError as e:
+        raise FileExistsError(f"{dir_name!s} exists and is not a directory") from e
+    except PermissionError as e:
+        raise PermissionError(f"{dir_name!s} is not writable") from e
 
 
 class WriteSerializingFile:


### PR DESCRIPTION
Fixes WB-12199

Description
-----------
Launch relies on `run.log_code()` to create jobs, recent refactor breaks this when artifacts directory doesn't have the correct permissions. 

TODO: Figure out how to surface the actual directory that isn't writable. 

Current: 
![Screen Shot 2023-02-08 at 2 45 07 PM](https://user-images.githubusercontent.com/19414170/217669118-01bc7efc-e696-4e82-afbe-23b304d6566b.png)