### PR TITLE
chore(sweeps): remove queue=default and add -q shortcut

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -917,7 +917,7 @@ def sweep(
             )
         else:
             # multi-word queues must be quoted for scheduler command
-            if launch_queue.count(' ') > 1:
+            if launch_queue.count(" ") > 1:
                 launch_queue = f"{launch_queue!r}"
 
         # Launch job spec for the Scheduler

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -702,6 +702,7 @@ def sync(
 )
 @click.option(
     "--queue",
+    "-q",
     default=None,
     help="The name of a launch queue (configured with a resource), available in the current user or team.",
 )
@@ -909,10 +910,16 @@ def sweep(
                     "No job found in sweep or launch config for launch-sweep."
                 )
 
+        launch_queue = queue or launch_config.get('queue')
+        if not launch_queue:
+            raise LaunchError(
+                "No queue passed from CLI or in launch config for launch-sweep."
+            )
+
         # Launch job spec for the Scheduler
         _launch_scheduler_spec = json.dumps(
             {
-                "queue": queue or launch_config.get("queue", "default"),
+                "queue": launch_queue,
                 "run_queue_project": project_queue,
                 "run_spec": json.dumps(
                     construct_launch_spec(
@@ -933,7 +940,7 @@ def sweep(
                             "scheduler",
                             "WANDB_SWEEP_ID",
                             "--queue",
-                            f"{(queue or launch_config.get('queue', 'default'))!r}",
+                            f"{launch_queue!r}",
                             "--project",
                             project,
                             "--job",

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -910,7 +910,7 @@ def sweep(
                     "No job found in sweep or launch config for launch-sweep."
                 )
 
-        launch_queue = queue or launch_config.get('queue')
+        launch_queue = queue or launch_config.get("queue")
         if not launch_queue:
             raise LaunchError(
                 "No queue passed from CLI or in launch config for launch-sweep."

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -915,6 +915,10 @@ def sweep(
             raise LaunchError(
                 "No queue passed from CLI or in launch config for launch-sweep."
             )
+        else:
+            # multi-word queues must be quoted for scheduler command
+            if launch_queue.count(' ') > 1:
+                launch_queue = f"{launch_queue!r}"
 
         # Launch job spec for the Scheduler
         _launch_scheduler_spec = json.dumps(
@@ -940,7 +944,7 @@ def sweep(
                             "scheduler",
                             "WANDB_SWEEP_ID",
                             "--queue",
-                            f"{launch_queue!r}",
+                            launch_queue,
                             "--project",
                             project,
                             "--job",

--- a/wandb/settings
+++ b/wandb/settings
@@ -1,5 +1,0 @@
-[default]
-entity = griffin_wb
-project = sweep-123
-base_url = https://api.wandb.ai
-

--- a/wandb/settings
+++ b/wandb/settings
@@ -1,0 +1,5 @@
+[default]
+entity = griffin_wb
+project = sweep-123
+base_url = https://api.wandb.ai
+


### PR DESCRIPTION
Fixes WB-12396
Fixes WB-12397
Fixes WB-12400

Description
-----------
Small CLI tweaks. We now error if a user doesn't input a queue. The weird shlex quoting thing should also be alleviated. Also adds a `-q` alias to `--queue` to mirror the launch-agent command.

Testing
-------
silly griffin, tests are for kids!

