### PR TITLE
docs(cli): Formatted wandb.apis.public.Run.history docstring

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2050,15 +2050,15 @@ class Run(Attrs):
         the history records being sampled.
 
         Arguments:
-            samples (int, optional): The number of samples to return
-            pandas (bool, optional): Return a pandas dataframe
-            keys (list, optional): Only return metrics for specific keys
-            x_axis (str, optional): Use this metric as the xAxis defaults to _step
-            stream (str, optional): "default" for metrics, "system" for machine metrics
+            samples : (int, optional) The number of samples to return
+            pandas : (bool, optional) Return a pandas dataframe
+            keys : (list, optional) Only return metrics for specific keys
+            x_axis : (str, optional) Use this metric as the xAxis defaults to _step
+            stream : (str, optional) "default" for metrics, "system" for machine metrics
 
         Returns:
-            If pandas=True returns a `pandas.DataFrame` of history metrics.
-            If pandas=False returns a list of dicts of history metrics.
+            pandas.DataFrame: If pandas=True returns a `pandas.DataFrame` of history metrics.
+            list of dicts: If pandas=False returns a list of dicts of history metrics.
         """
         if keys is not None and not isinstance(keys, list):
             wandb.termerror("keys must be specified in a list")


### PR DESCRIPTION
Fixes https://wandb.atlassian.net/browse/DOCS-534

Description
-----------
What does the PR do?
Fixes docstring format for [wandb.apis.public.Runs history](https://docs.wandb.ai/ref/python/public-api/run#history) Arguments and Returns. Re: The autogenerated docs requires specific format for it to properly render. 

Testing
-------
How was this PR tested?
N/A . Changed a docstring.

Checklist
-------
- [X] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
