### PR TITLE
fix(sdk): correctly detect notebook name and fix code saving in Colab

### DIFF
--- a/tests/pytest_tests/unit_tests_old/tests_s_nb/test_notebooks.py
+++ b/tests/pytest_tests/unit_tests_old/tests_s_nb/test_notebooks.py
@@ -156,12 +156,17 @@ def test_notebook_metadata_kaggle(mocker, mocked_module):
         "source": json.dumps({"metadata": {}, "cells": []})
     }
     kaggle.UserSessionClient.return_value = kaggle_client
-    meta = wandb.jupyter.notebook_metadata(False)
-    assert meta == {
-        "root": "/kaggle/working",
-        "path": "kaggle.ipynb",
-        "name": "kaggle.ipynb",
-    }
+    with mock.patch.object(
+        wandb.jupyter,
+        "notebook_metadata_from_jupyter_servers_and_kernel_id",
+        lambda *args, **kwargs: {},
+    ):
+        meta = wandb.jupyter.notebook_metadata(False)
+        assert meta == {
+            "root": "/kaggle/working",
+            "path": "kaggle.ipynb",
+            "name": "kaggle.ipynb",
+        }
 
 
 def test_databricks_notebook_doesnt_hang_on_wandb_login(mocked_module):

--- a/tests/pytest_tests/unit_tests_old/tests_s_nb/test_notebooks.py
+++ b/tests/pytest_tests/unit_tests_old/tests_s_nb/test_notebooks.py
@@ -3,9 +3,12 @@ import os
 import platform
 import subprocess
 import sys
+from unittest import mock
 
 import pytest
 import wandb
+import wandb.jupyter
+import wandb.util
 from wandb.errors import UsageError
 
 from tests.pytest_tests.unit_tests_old import utils
@@ -126,14 +129,23 @@ def test_notebook_metadata_no_servers(mocker, mocked_module):
 def test_notebook_metadata_colab(mocked_module):
     colab = mocked_module("google.colab")
     colab._message.blocking_request.return_value = {
-        "ipynb": {"metadata": {"colab": {"name": "colab.ipynb"}}}
+        "ipynb": {"metadata": {"colab": {"name": "koalab.ipynb"}}}
     }
-    meta = wandb.jupyter.notebook_metadata(False)
-    assert meta == {
-        "root": "/content",
-        "path": "colab.ipynb",
-        "name": "colab.ipynb",
-    }
+    with mock.patch.object(
+        wandb.jupyter,
+        "notebook_metadata_from_jupyter_servers_and_kernel_id",
+        lambda *args, **kwargs: {
+            "path": "colab.ipynb",
+            "root": "/consent",
+            "name": "colab.ipynb",
+        },
+    ):
+        meta = wandb.jupyter.notebook_metadata(False)
+        assert meta == {
+            "root": "/content",
+            "path": "colab.ipynb",
+            "name": "colab.ipynb",
+        }
 
 
 def test_notebook_metadata_kaggle(mocker, mocked_module):

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -194,14 +194,11 @@ def notebook_metadata(silent) -> Dict[str, str]:
         "the WANDB_NOTEBOOK_NAME environment variable to enable code saving."
     )
     try:
-        print("notebook_metadata")
         jupyter_metadata = notebook_metadata_from_jupyter_servers_and_kernel_id()
-        print(jupyter_metadata)
+
         # Colab:
         # request the most recent contents
         ipynb = attempt_colab_load_ipynb()
-        print(ipynb)
-        print(ipynb is not None and jupyter_metadata is not None)
         if ipynb is not None and jupyter_metadata is not None:
             return {
                 "root": "/content",

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -195,10 +195,12 @@ def notebook_metadata(silent) -> Dict[str, str]:
     )
     try:
         jupyter_metadata = notebook_metadata_from_jupyter_servers_and_kernel_id()
-
+        print(jupyter_metadata)
         # Colab:
         # request the most recent contents
         ipynb = attempt_colab_load_ipynb()
+        print(ipynb)
+        print(ipynb is not None and jupyter_metadata is not None)
         if ipynb is not None and jupyter_metadata is not None:
             return {
                 "root": "/content",

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -199,7 +199,7 @@ def notebook_metadata(silent) -> Dict[str, str]:
         # Colab:
         # request the most recent contents
         ipynb = attempt_colab_load_ipynb()
-        if ipynb and jupyter_metadata:
+        if ipynb is not None and jupyter_metadata is not None:
             return {
                 "root": "/content",
                 "path": jupyter_metadata["path"],

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -11,6 +11,7 @@ import requests
 from requests.compat import urljoin
 
 import wandb
+import wandb.util
 from wandb.sdk.lib import filesystem
 
 try:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import sys
 from base64 import b64encode
+from typing import Dict
 
 import requests
 from requests.compat import urljoin
@@ -177,10 +178,10 @@ def notebook_metadata_from_jupyter_servers_and_kernel_id():
     return None
 
 
-def notebook_metadata(silent):
+def notebook_metadata(silent) -> Dict[str, str]:
     """Attempts to query jupyter for the path and name of the notebook file.
 
-    This can handle many different jupyter environments, specifically:
+    This can handle different jupyter environments, specifically:
 
     1. Colab
     2. Kaggle
@@ -193,30 +194,21 @@ def notebook_metadata(silent):
         "the WANDB_NOTEBOOK_NAME environment variable to enable code saving."
     )
     try:
-        # In colab we can request the most recent contents
+        jupyter_metadata = notebook_metadata_from_jupyter_servers_and_kernel_id()
+
+        # Colab:
+        # request the most recent contents
         ipynb = attempt_colab_load_ipynb()
-        if ipynb:
-            nb_name = ipynb["metadata"]["colab"]["name"]
-            if ".ipynb" not in nb_name:
-                nb_name += ".ipynb"
-            ret = {
+        if ipynb and jupyter_metadata:
+            return {
                 "root": "/content",
-                "path": nb_name,
-                "name": nb_name,
+                "path": jupyter_metadata["path"],
+                "name": jupyter_metadata["name"],
             }
 
-            try:
-                jupyter_metadata = (
-                    notebook_metadata_from_jupyter_servers_and_kernel_id()
-                )
-            except RuntimeError:
-                pass
-            else:
-                ret["path"] = jupyter_metadata["path"]
-            return ret
-
+        # Kaggle:
         if wandb.util._is_kaggle():
-            # In kaggle we can request the most recent contents
+            # request the most recent contents
             ipynb = attempt_kaggle_load_ipynb()
             if ipynb:
                 return {
@@ -225,7 +217,6 @@ def notebook_metadata(silent):
                     "name": ipynb["metadata"]["name"],
                 }
 
-        jupyter_metadata = notebook_metadata_from_jupyter_servers_and_kernel_id()
         if jupyter_metadata:
             return jupyter_metadata
         if not silent:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -194,6 +194,7 @@ def notebook_metadata(silent) -> Dict[str, str]:
         "the WANDB_NOTEBOOK_NAME environment variable to enable code saving."
     )
     try:
+        print("notebook_metadata")
         jupyter_metadata = notebook_metadata_from_jupyter_servers_and_kernel_id()
         print(jupyter_metadata)
         # Colab:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -392,12 +392,14 @@ class Notebook:
         # TODO: likely only save if the code has changed
         colab_ipynb = attempt_colab_load_ipynb()
         if colab_ipynb:
-            nb_name = (
-                colab_ipynb.get("metadata", {})
-                .get("colab", {})
-                .get("name", "colab.ipynb")
-            )
-            if ".ipynb" not in nb_name:
+            try:
+                jupyter_metadata = (
+                    notebook_metadata_from_jupyter_servers_and_kernel_id()
+                )
+                nb_name = jupyter_metadata["name"]
+            except Exception:
+                nb_name = "colab.ipynb"
+            if not nb_name.endswith(".ipynb"):
                 nb_name += ".ipynb"
             with open(
                 os.path.join(


### PR DESCRIPTION
Fixes WB-11023
Potentially fixes WB-12217 (@KyleGoyette could you verify please?)
Fixes #4962

Description
-----------
The API we've been relying on when detecting the notebook name in Colab has changed resulting in:
- The annoying `Failed to detect the name of this notebook, you can set it manually with the WANDB_NOTEBOOK_NAME environment variable to enable code saving.` message
- Broken code saving in Colab.

This PR fixes it. Turns out, the standard way of detecting the nb name now works in Colab, so just using that.

Testing
-------
[Manually](https://wandb.ai/dimaduev/colab/runs/41usa6l8/)

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
