### PR TITLE
chore(launch): let max_schedulers shadow max_jobs, 1:1 relationship

### DIFF
--- a/tests/pytest_tests/unit_tests/test_step_prepare.py
+++ b/tests/pytest_tests/unit_tests/test_step_prepare.py
@@ -1,0 +1,314 @@
+import dataclasses
+import queue
+from typing import TYPE_CHECKING, Iterable, Mapping, Tuple
+from unittest.mock import Mock, call
+
+import pytest
+from wandb.filesync.step_prepare import (
+    Request,
+    RequestFinish,
+    RequestPrepare,
+    ResponsePrepare,
+    StepPrepare,
+    gather_batch,
+)
+
+if TYPE_CHECKING:
+    from wandb.sdk.internal.internal_api import (
+        CreateArtifactFileSpecInput,
+        CreateArtifactFilesResponseFile,
+    )
+
+
+def simple_file_spec(name: str) -> "CreateArtifactFileSpecInput":
+    return {
+        "name": name,
+        "artifactID": "some-artifact-id",
+        "md5": "some-md5",
+    }
+
+
+def simple_request_prepare(name: str) -> RequestPrepare:
+    return RequestPrepare(simple_file_spec(name=name), queue.Queue())
+
+
+def mock_create_artifact_files_result(
+    names: Iterable[str],
+) -> Mapping[str, "CreateArtifactFilesResponseFile"]:
+    return {
+        name: {
+            "id": f"file-id-{name}",
+            "name": name,
+            "displayName": f"file-displayname-{name}",
+            "uploadUrl": f"http://wandb-test/upload-url-{name}",
+            "uploadHeaders": ["x-my-header-key:my-header-val"],
+            "artifact": {
+                "id": f"artifact-id-{name}",
+            },
+        }
+        for name in names
+    }
+
+
+@dataclasses.dataclass
+class MockClock:
+    now: float = 0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, duration: float) -> None:
+        self.now += duration
+
+
+class MockRequestQueue(Mock):
+    def __init__(
+        self,
+        clock: MockClock,
+        schedule: Iterable[Tuple[float, Request]],
+    ):
+        super().__init__(
+            get=Mock(wraps=self._get),
+        )
+        self._clock = clock
+        self._remaining_events = list(schedule)
+
+    def _get(self, timeout: float = 0) -> Request:
+        assert self._remaining_events, "ran out of events in mock queue"
+
+        next_event_time, next_event = self._remaining_events[0]
+        time_to_next_event = next_event_time - self._clock()
+        if 0 < timeout < time_to_next_event:
+            self._clock.sleep(timeout)
+            raise queue.Empty()
+
+        self._remaining_events.pop(0)
+        if time_to_next_event > 0:
+            self._clock.sleep(time_to_next_event)
+        return next_event
+
+
+class TestMockRequestQueue:
+    def test_smoke(self):
+        clock = MockClock()
+        q = MockRequestQueue(
+            clock,
+            [
+                (t, RequestPrepare(simple_file_spec(f"req-{t}"), queue.Queue()))
+                for t in [1, 3, 10, 30]
+            ],
+        )
+        assert q.get().file_spec["name"] == "req-1"
+        assert clock() == 1
+        assert q.get().file_spec["name"] == "req-3"
+        assert clock() == 3
+        assert q.get().file_spec["name"] == "req-10"
+        assert clock() == 10
+        assert q.get().file_spec["name"] == "req-30"
+        assert clock() == 30
+
+    def test_raises_assertion_error_if_out_of_events(self):
+        q = MockRequestQueue(MockClock(), [(1, RequestFinish())])
+        q.get()
+        with pytest.raises(AssertionError):
+            q.get()
+
+    def test_ticks_clock_forward(self):
+        clock = MockClock()
+        q = MockRequestQueue(clock, [(123, RequestFinish())])
+        q.get()
+        assert clock() == 123
+
+    def test_does_not_tick_clock_backward(self):
+        clock = MockClock(now=99999)
+        q = MockRequestQueue(clock, [(123, RequestFinish())])
+        q.get()
+        assert clock() == 99999
+
+    def test_respects_timeout(self):
+        clock = MockClock()
+        q = MockRequestQueue(clock, [(123, RequestFinish())])
+        with pytest.raises(queue.Empty):
+            q.get(timeout=8)
+        assert clock() == 8
+        assert q.get() == RequestFinish()
+        assert clock() == 123
+
+
+class TestGatherBatch:
+    def test_smoke(self):
+        q = Mock(
+            get=Mock(
+                side_effect=[
+                    simple_request_prepare("a"),
+                    simple_request_prepare("b"),
+                    simple_request_prepare("c"),
+                    RequestFinish(),
+                ]
+            )
+        )
+        done, batch = gather_batch(q, 0.1, 0.1, 100)
+        assert done
+        assert [f.file_spec["name"] for f in batch] == ["a", "b", "c"]
+
+    def test_returns_empty_if_first_request_is_finish(self):
+        q = Mock(
+            get=Mock(
+                side_effect=[
+                    RequestFinish(),
+                ]
+            )
+        )
+        done, batch = gather_batch(q, 0.1, 0.1, 100)
+        assert done
+        assert len(batch) == 0
+
+    def test_respects_batch_size(self):
+        q = Mock(
+            get=Mock(
+                side_effect=[
+                    simple_request_prepare("a"),
+                    simple_request_prepare("b"),
+                    simple_request_prepare("c"),
+                ]
+            )
+        )
+        _, batch = gather_batch(q, 0.1, 0.1, 2)
+        assert len(batch) == 2
+        assert q.get.call_count == 2
+
+    def test_respects_batch_time(self):
+
+        clock = MockClock()
+        q = MockRequestQueue(
+            clock=clock,
+            schedule=[(t, simple_request_prepare(f"req-{t}")) for t in [5, 15, 25, 35]],
+        )
+
+        _, batch = gather_batch(
+            q,
+            batch_time=33,
+            inter_event_time=12,
+            max_batch_size=100,
+            clock=clock,
+        )
+
+        assert q.get.call_args_list == [
+            call(),  # finishes at t=5; 28s left in batch
+            call(timeout=12),  # finishes at t=15; 18s left in batch
+            call(timeout=12),  # finishes at t=25; 8s left in batch
+            call(timeout=8),
+        ]
+        assert len(batch) == 3
+
+    def test_respects_inter_event_time(self):
+
+        clock = MockClock()
+        q = MockRequestQueue(
+            clock=clock,
+            schedule=[
+                (t, simple_request_prepare(f"req-{t}"))
+                for t in [10, 30, 60, 100, 150, 210, 280]
+                # diffs:    20  30  40   50   60   70
+            ],
+        )
+
+        _, batch = gather_batch(
+            q,
+            batch_time=1000,
+            inter_event_time=33,
+            max_batch_size=100,
+            clock=clock,
+        )
+
+        assert q.get.call_args_list == [
+            call(),  # waited 10s, next wait is 20s
+            call(timeout=33),  # waited 20s, next wait is 30s
+            call(timeout=33),  # waited 30s, next wait is 40s
+            call(timeout=33),  # waited 33s, then raised Empty
+        ]
+        assert len(batch) == 3
+
+    def test_ends_early_if_request_finish(self):
+        q = Mock(
+            get=Mock(
+                side_effect=[
+                    simple_request_prepare("a"),
+                    RequestFinish(),
+                    simple_request_prepare("b"),
+                ]
+            )
+        )
+        done, batch = gather_batch(q, 0.1, 0.1, 100)
+        assert done
+        assert [f.file_spec["name"] for f in batch] == ["a"]
+        assert q.get.call_count == 2
+
+
+class TestStepPrepare:
+    def test_smoke(self):
+        caf_result = mock_create_artifact_files_result(["foo"])
+        api = Mock(create_artifact_files=Mock(return_value=caf_result))
+
+        step_prepare = StepPrepare(
+            api=api, batch_time=1e-12, inter_event_time=1e-12, max_batch_size=1
+        )
+        step_prepare.start()
+
+        res = step_prepare.prepare(simple_file_spec(name="foo"))
+        step_prepare.finish()
+
+        assert res == ResponsePrepare(
+            upload_url=caf_result["foo"]["uploadUrl"],
+            upload_headers=caf_result["foo"]["uploadHeaders"],
+            birth_artifact_id=caf_result["foo"]["artifact"]["id"],
+        )
+
+    def test_batches_requests(self):
+        caf_result = mock_create_artifact_files_result(["a", "b"])
+        api = Mock(create_artifact_files=Mock(return_value=caf_result))
+
+        step_prepare = StepPrepare(
+            api=api, batch_time=1, inter_event_time=1, max_batch_size=10
+        )
+        step_prepare.start()
+
+        queue_a = step_prepare.prepare_async(simple_file_spec(name="a"))
+        queue_b = step_prepare.prepare_async(simple_file_spec(name="b"))
+        step_prepare.finish()
+
+        res_a = queue_a.get()
+        res_b = queue_b.get()
+
+        assert res_a.upload_url == caf_result["a"]["uploadUrl"]
+        assert res_b.upload_url == caf_result["b"]["uploadUrl"]
+
+        # make sure the URLs are different, just in case the fixture returns a constant
+        assert res_a.upload_url != res_b.upload_url
+
+        api.create_artifact_files.assert_called_once()
+
+    def test_finish_waits_for_pending_requests(self):
+        caf_result = mock_create_artifact_files_result(["a", "b"])
+        api = Mock(create_artifact_files=Mock(return_value=caf_result))
+
+        step_prepare = StepPrepare(
+            api=api, batch_time=1, inter_event_time=1, max_batch_size=10
+        )
+        step_prepare.start()
+
+        res_q = step_prepare.prepare_async(simple_file_spec(name="a"))
+
+        with pytest.raises(queue.Empty):
+            res_q.get(timeout=1e-12)
+
+        assert step_prepare.is_alive()
+
+        step_prepare.finish()
+
+        res = res_q.get(timeout=5)
+
+        assert res.upload_url == caf_result["a"]["uploadUrl"]
+
+        step_prepare._thread.join()
+        assert not step_prepare.is_alive()

--- a/wandb/sdk/internal/system/assets/interfaces.py
+++ b/wandb/sdk/internal/system/assets/interfaces.py
@@ -179,6 +179,7 @@ class MetricsMonitor:
         if (self._process is not None) or self._shutdown_event.is_set():
             return None
 
+        thread_name = f"{self.asset_name[:15]}"  # thread names are limited to 15 chars
         try:
             for metric in self.metrics:
                 if isinstance(metric, SetupTeardown):
@@ -186,25 +187,26 @@ class MetricsMonitor:
             self._process = threading.Thread(
                 target=self.monitor,
                 daemon=True,
-                name=self.asset_name,
+                name=thread_name,
             )
             self._process.start()
-            logger.info(f"Started {self.asset_name} monitoring")
+            logger.info(f"Started {thread_name} monitoring")
         except Exception as e:
-            logger.warning(f"Failed to start {self.asset_name} monitoring: {e}")
+            logger.warning(f"Failed to start {thread_name} monitoring: {e}")
             self._process = None
 
     def finish(self) -> None:
         if self._process is None:
             return None
 
+        thread_name = f"{self.asset_name[:15]}"
         try:
             self._process.join()
-            logger.info(f"Joined {self.asset_name} monitor")
+            logger.info(f"Joined {thread_name} monitor")
             for metric in self.metrics:
                 if isinstance(metric, SetupTeardown):
                     metric.teardown()
         except Exception as e:
-            logger.warning(f"Failed to finish {self.asset_name} monitoring: {e}")
+            logger.warning(f"Failed to finish {thread_name} monitoring: {e}")
         finally:
             self._process = None

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -70,7 +70,10 @@ class LaunchAgent:
         # Max sweep schedulers is `max_schedulers` or `max_jobs` or 1
         # Unless explicitly specified, can't run more schedulers than jobs
         # if max_jobs = 8, we can have 8 schedulers and 8 jobs simulataneously
-        self._max_scheduler_jobs = int(config.get("max_schedulers", self._max_jobs))
+        if config.get("max_schedulers"):
+            self._max_scheduler_jobs = int(config.get("max_schedulers"))
+        else:
+            self._max_scheduler_jobs = self._max_jobs
         self.default_config: Dict[str, Any] = config
 
         # serverside creation

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -71,7 +71,7 @@ class LaunchAgent:
         # Unless explicitly specified, can't run more schedulers than jobs
         # if max_jobs = 8, we can have 8 schedulers and 8 jobs simulataneously
         if config.get("max_schedulers"):
-            self._max_scheduler_jobs = int(config.get("max_schedulers"))
+            self._max_scheduler_jobs: Union[int, float] = int(config["max_schedulers"])
         else:
             self._max_scheduler_jobs = self._max_jobs
         self.default_config: Dict[str, Any] = config

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -241,13 +241,19 @@ class LaunchAgent:
                         if job:
                             if job.get("runSpec", {}).get("uri") == SCHEDULER_URI:
                                 # Should we run the scheduler job?
-                                if len(self._scheduler_jobs) >= self._max_schedulers:
+                                if (
+                                    len(self._scheduler_jobs)
+                                    >= self._max_scheduler_jobs
+                                ):
                                     # spit back out, can't run any more schedulers
                                     push_to_queue(
                                         self._api,
                                         queue,
                                         job.get["runSpec"],
-                                        # project_queue=job['runSpec'].get("project_queue")
+                                        project_queue=job["runSpec"].get(
+                                            "project_queue"
+                                        )
+                                        # always None? ^^
                                     )
                             try:
                                 self.run_job(job)

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -75,7 +75,6 @@ if TYPE_CHECKING:
 
     import wandb.apis.public
     from wandb.filesync.step_prepare import StepPrepare
-    from wandb.sdk.internal import internal_api
 
 # This makes the first sleep 1s, and then doubles it up to total times,
 # which makes for ~18 hours.
@@ -981,15 +980,14 @@ class WandbStoragePolicy(StoragePolicy):
             False if it needed to be uploaded or was a reference (nothing to dedupe).
         """
 
-        def _prepare_fn() -> "internal_api.CreateArtifactFileSpecInput":
-            return {
+        resp = preparer.prepare(
+            {
                 "artifactID": artifact_id,
                 "artifactManifestID": artifact_manifest_id,
                 "name": entry.path,
                 "md5": entry.digest,
             }
-
-        resp = preparer.prepare(_prepare_fn)
+        )
 
         entry.birth_artifact_id = resp.birth_artifact_id
         if resp.upload_url is None:


### PR DESCRIPTION
Possible solution where we allow as many schedulers as we allow max_jobs, counted separately.

If a user specifies nothing, we would allow 1 scheduler and 1 job. 
If a user specifies -1, we would allow inf schedulers and inf jobs. 
if a user specifies 4, we would allow 4 schedulers AND 4 jobs.
