### PR TITLE
chore(sdk): exercise extra caution when starting asset monitoring threads

### DIFF
--- a/wandb/sdk/internal/system/assets/interfaces.py
+++ b/wandb/sdk/internal/system/assets/interfaces.py
@@ -179,6 +179,7 @@ class MetricsMonitor:
         if (self._process is not None) or self._shutdown_event.is_set():
             return None
 
+        thread_name = f"{self.asset_name[:15]}"  # thread names are limited to 15 chars
         try:
             for metric in self.metrics:
                 if isinstance(metric, SetupTeardown):
@@ -186,25 +187,26 @@ class MetricsMonitor:
             self._process = threading.Thread(
                 target=self.monitor,
                 daemon=True,
-                name=self.asset_name,
+                name=thread_name,
             )
             self._process.start()
-            logger.info(f"Started {self.asset_name} monitoring")
+            logger.info(f"Started {thread_name} monitoring")
         except Exception as e:
-            logger.warning(f"Failed to start {self.asset_name} monitoring: {e}")
+            logger.warning(f"Failed to start {thread_name} monitoring: {e}")
             self._process = None
 
     def finish(self) -> None:
         if self._process is None:
             return None
 
+        thread_name = f"{self.asset_name[:15]}"
         try:
             self._process.join()
-            logger.info(f"Joined {self.asset_name} monitor")
+            logger.info(f"Joined {thread_name} monitor")
             for metric in self.metrics:
                 if isinstance(metric, SetupTeardown):
                     metric.teardown()
         except Exception as e:
-            logger.warning(f"Failed to finish {self.asset_name} monitoring: {e}")
+            logger.warning(f"Failed to finish {thread_name} monitoring: {e}")
         finally:
             self._process = None


### PR DESCRIPTION
Fixes #4903

Description
-----------
When starting/stopping asset monitoring threads, especially in notebook-based environments, some unfortunate timing could produce errors (where MetricsMonitor._process would be flipped to None, but some code in a different thread would try to access its attribute such as the name). 

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
