### PR TITLE
fix(artifacts): Never include colons in default file paths

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -794,7 +794,7 @@ def test_download_safe_pathname(wandb_init):
         run.log_artifact(artifact)
 
     with wandb_init() as run:
-        artifact = run.use_artifact("my-arty")
+        artifact = run.use_artifact("my-arty:v0")
         artifact_dir = Path(artifact.download()).resolve()
         no_anchor = artifact_dir.relative_to(artifact_dir.anchor)
         assert ":" not in str(no_anchor)

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -2,8 +2,8 @@ import os
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
-from typing import Mapping, Optional
 from pathlib import Path
+from typing import Mapping, Optional
 
 import numpy as np
 import pytest
@@ -786,7 +786,7 @@ def test_add_obj_using_brackets(assets_path):
 
 def test_download_safe_pathname(wandb_init):
     test_file = Path("test_file.txt")
-    test_file.write("hello")
+    test_file.write_text("hello")
 
     with wandb_init() as run:
         artifact = wandb.Artifact(type="dataset", name="my-arty")

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -3,6 +3,7 @@ import shutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Mapping, Optional
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -781,6 +782,22 @@ def test_add_obj_using_brackets(assets_path):
 
     with pytest.raises(ValueError):
         _ = artifact["my-image"]
+
+
+def test_download_safe_pathname(wandb_init):
+    test_file = Path("test_file.txt")
+    test_file.write("hello")
+
+    with wandb_init() as run:
+        artifact = wandb.Artifact(type="dataset", name="my-arty")
+        artifact.add_file(test_file)
+        run.log_artifact(artifact)
+
+    with wandb_init() as run:
+        artifact = run.use_artifact("my-arty")
+        artifact_dir = Path(artifact.download()).resolve()
+        no_anchor = artifact_dir.relative_to(artifact_dir.anchor)
+        assert ":" not in str(no_anchor)
 
 
 def test_artifact_interface_link():

--- a/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import shutil
 import stat
 import time

--- a/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
@@ -66,17 +66,14 @@ def test_mkdir_exists_ok_not_writable(tmp_path):
         mkdir_exists_ok(new_dir)
 
 
-def test_copy_or_overwrite_changed_windows_colon(tmp_path):
+def test_copy_or_overwrite_changed_colon(tmp_path):
     source_path = tmp_path / "new_file.txt"
     target_path = tmp_path / "file:with:colon.txt"
 
     source_path.write_text("original")
     final_path = copy_or_overwrite_changed(source_path, target_path)
 
-    if platform.system() == "Windows":
-        assert final_path == tmp_path / "file-with-colon.txt"
-    else:
-        assert final_path == target_path
+    assert final_path == tmp_path / "file-with-colon.txt"
     assert final_path.read_text() == "original"
 
 

--- a/tests/pytest_tests/unit_tests_old/test_cli.py
+++ b/tests/pytest_tests/unit_tests_old/test_cli.py
@@ -46,10 +46,7 @@ def test_artifact_download(runner, git_repo, mock_server):
     print(traceback.print_tb(result.exc_info[2]))
     assert result.exit_code == 0
     assert "Downloading dataset artifact" in result.output
-    path = os.path.join(".", "artifacts", "mnist:v0")
-    if platform.system() == "Windows":
-        head, tail = os.path.splitdrive(path)
-        path = head + tail.replace(":", "-")
+    path = os.path.join(".", "artifacts", "mnist-v0")
     assert "Artifact downloaded to %s" % path in result.output
     assert os.path.exists(path)
 

--- a/tests/pytest_tests/unit_tests_old/test_public_api.py
+++ b/tests/pytest_tests/unit_tests_old/test_public_api.py
@@ -304,9 +304,7 @@ def test_artifact_get_path(runner, mock_server, api):
     with runner.isolated_filesystem():
         path = art.get_path("digits.h5")
         res = path.download()
-        part = art.name
-        if platform.system() == "Windows":
-            part = "mnist-v0"
+        part = art.name.replace(":", "-")
         path = os.path.join(".", "artifacts", part, "digits.h5")
         assert res == path
 
@@ -323,10 +321,7 @@ def test_artifact_file(runner, mock_server, api):
     with runner.isolated_filesystem():
         art = api.artifact("entity/project/mnist:v0", type="dataset")
         path = art.file()
-        if platform.system() == "Windows":
-            part = "mnist-v0"
-        else:
-            part = "mnist:v0"
+        part = "mnist-v0"
         assert path == os.path.join(".", "artifacts", part, "digits.h5")
 
 
@@ -349,10 +344,7 @@ def test_artifact_download(runner, mock_server, api):
     with runner.isolated_filesystem():
         art = api.artifact("entity/project/mnist:v0", type="dataset")
         path = art.download()
-        if platform.system() == "Windows":
-            part = "mnist-v0"
-        else:
-            part = "mnist:v0"
+        part = "mnist-v0"
         assert path == os.path.join(".", "artifacts", part)
         assert os.listdir(path) == ["digits.h5"]
 

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -4873,10 +4873,8 @@ class Artifact(artifacts.Artifact):
             if include_version
             else os.path.join(".", "artifacts", self._sequence_name)
         )
-        if platform.system() == "Windows":
-            head, tail = os.path.splitdrive(root)
-            root = head + tail.replace(":", "-")
-        return root
+        head, tail = os.path.splitdrive(root)
+        return head + tail.replace(":", "-")
 
     def json_encode(self):
         return util.artifact_to_json(self)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1861,7 +1861,7 @@ def get(path, root, type):
             artifact_name = artifact_parts[0]
         else:
             version = "latest"
-        full_path = "{entity}/{project}/{artifact}:{version}".format(
+        full_path = "{entity}/{project}/{artifact}-{version}".format(
             entity=entity, project=project, artifact=artifact_name, version=version
         )
         wandb.termlog(

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -95,11 +95,12 @@ def copy_or_overwrite_changed(source_path: StrPath, target_path: StrPath) -> Str
     """
     return_type = type(target_path)
 
-    if platform.system() == "Windows":
-        head, tail = os.path.splitdrive(str(target_path))
-        if ":" in tail:
-            logger.warning("Replacing ':' in %s with '-'", tail)
-            target_path = os.path.join(head, tail.replace(":", "-"))
+    # Replace ':' with '-' to avoid Windows path issues. This needs to be done on Linux
+    # as well because it's still possible to run into problems with FUSE-mounted drives.
+    head, tail = os.path.splitdrive(str(target_path))
+    if ":" in tail:
+        logger.warning("Replacing ':' in %s with '-'", tail)
+        target_path = os.path.join(head, tail.replace(":", "-"))
 
     need_copy = (
         not os.path.isfile(target_path)

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import platform
 import re
 import shutil
 import stat


### PR DESCRIPTION
Fixes [WB-12064](https://wandb.atlassian.net/browse/WB-12064)

Description
-----------
Make replacing `:` with `-` universal rather than restricting to Windows, since non-Windows platforms sometimes still use NTFS file systems (e.g. NFS or FUSE-mounted drives).

The main risk of this PR is any user that assumes artifacts will be located at `artifact-name:vN` and manually constructs that path instead of retrieving the value returned by `Artifact.download()`

Testing
-------
In addition to unit tests, it seems like this does not cause a problem with upgrading from a version that uses `:` in file paths, at least in manual tests. I'd like some additional thought on this and the potential problems it could cause though.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12064]: https://wandb.atlassian.net/browse/WB-12064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ