### PR TITLE
fix(artifacts): load boto3 eagerly to avoid crashing when downloading reference artifact

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1331,6 +1331,7 @@ class S3Handler(StorageHandler):
         boto: "boto3" = util.get_module(
             "boto3",
             required="s3:// references requires the boto3 library, run pip install wandb[aws]",
+            lazy=False,
         )
         self._s3 = boto.session.Session().resource(
             "s3",


### PR DESCRIPTION
Fixes [WB-12548](https://wandb.atlassian.net/browse/WB-12548)

Description
-----------
This is @fdsig's change https://github.com/wandb/wandb/pull/5018; just moving to my own branch to enable all tests to run (they aren't authorized on all CircleCI resources) 

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12548]: https://wandb.atlassian.net/browse/WB-12548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ