### PR TITLE
feat(artifacts): raise ArtifactNotLoggedError instead of ValueError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ wandb/run-202*
 .idea/
 .yea-requirements.txt
 .yeadoc/
+logs/

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -14,6 +14,7 @@ import wandb.sdk.interface as wandb_interface
 from wandb import util
 from wandb.sdk import wandb_artifacts
 from wandb.sdk.lib.hashutil import md5_string
+from wandb.sdk.wandb_artifacts import ArtifactNotLoggedError
 
 
 def mock_boto(artifact, path=False, content_type=None):
@@ -779,7 +780,7 @@ def test_add_obj_using_brackets(assets_path):
         },
     }
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ArtifactNotLoggedError):
         _ = artifact["my-image"]
 
 

--- a/tests/pytest_tests/unit_tests_old/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests_old/test_wandb_artifacts.py
@@ -282,7 +282,6 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
             "checkout",
             "verify",
             "delete",
-            "wait",
             "json_encode",
         ]
 
@@ -293,6 +292,8 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
         special_errors = {
             "save": wandb.errors.CommError,
             "delete": wandb.errors.CommError,
+            "verify": ValueError,
+            "logged_by": KeyError,
         }
 
         for valid_getter in testable_getters_valid + testable_getters_always_valid:

--- a/tests/pytest_tests/unit_tests_old/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests_old/test_wandb_artifacts.py
@@ -1,5 +1,3 @@
-import base64
-import hashlib
 from typing import Callable
 
 import numpy as np
@@ -7,6 +5,7 @@ import pytest
 import wandb
 from wandb import util
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.wandb_artifacts import ArtifactNotLoggedError
 
 sm = wandb.wandb_sdk.internal.sender.SendManager
 
@@ -170,7 +169,7 @@ def test_artifact_incremental_internal(
 
     with backend_interface() as interface:
         proto_run = interface._make_run(mocked_run)
-        r = internal_sm.send_run(interface._make_record(run=proto_run))
+        internal_sm.send_run(interface._make_record(run=proto_run))
 
         proto_artifact = interface._make_artifact(artifact)
         proto_artifact.run_id = proto_run.run_id
@@ -212,7 +211,7 @@ def test_artifact_references_internal(
 
         with backend_interface() as interface:
             proto_run = interface._make_run(mocked_run)
-            r = internal_sm.send_run(interface._make_record(run=proto_run))
+            internal_sm.send_run(interface._make_record(run=proto_run))
 
             proto_artifact = interface._make_artifact(art)
             proto_artifact.run_id = proto_run.run_id
@@ -283,6 +282,8 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
             "checkout",
             "verify",
             "delete",
+            "wait",
+            "json_encode",
         ]
 
         setter_data = {"metadata": {}}
@@ -292,22 +293,20 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
         special_errors = {
             "save": wandb.errors.CommError,
             "delete": wandb.errors.CommError,
-            "verify": ValueError,
-            "logged_by": KeyError,
         }
 
         for valid_getter in testable_getters_valid + testable_getters_always_valid:
             _ = getattr(art, valid_getter)
 
         for invalid_getter in testable_getters_invalid:
-            with pytest.raises(ValueError):
+            with pytest.raises(ArtifactNotLoggedError):
                 _ = getattr(art, invalid_getter)
 
         for valid_setter in testable_setters_valid + testable_setters_always_valid:
             setattr(art, valid_setter, setter_data.get(valid_setter, valid_setter))
 
         for invalid_setter in testable_setters_invalid:
-            with pytest.raises(ValueError):
+            with pytest.raises(ArtifactNotLoggedError):
                 setattr(
                     art, invalid_setter, setter_data.get(invalid_setter, invalid_setter)
                 )
@@ -321,23 +320,23 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
 
         for invalid_method in testable_methods_invalid:
             attr_method = getattr(art, invalid_method)
-            with pytest.raises(ValueError):
+            with pytest.raises(ArtifactNotLoggedError):
                 _ = attr_method(*params.get(invalid_method, []))
 
         # THE LOG
         run.log_artifact(art)
 
         for getter in testable_getters_valid + testable_getters_invalid:
-            with pytest.raises(ValueError):
+            with pytest.raises(ArtifactNotLoggedError):
                 _ = getattr(art, getter)
 
         for setter in testable_setters_valid + testable_setters_invalid:
-            with pytest.raises(ValueError):
+            with pytest.raises(ArtifactNotLoggedError):
                 setattr(art, setter, setter_data.get(setter, setter))
 
         for method in testable_methods_valid + testable_methods_invalid:
             attr_method = getattr(art, method)
-            with pytest.raises(ValueError):
+            with pytest.raises(ArtifactNotLoggedError):
                 _ = attr_method(*params.get(method, []))
 
         # THE ALL IMPORTANT WAIT

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -107,6 +107,20 @@ def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     )
 
 
+class ArtifactNotLoggedError(Exception):
+    """Raised for Artifact methods or attributes that require the logged artifact."""
+
+    def __init__(self, artifact: "Artifact" = None, attr: str = None):
+        desc = artifact.__class__.__name__ if artifact else "Artifact"
+        desc += f".{attr}" if attr else ""
+        super().__init__(
+            f"'{desc}' used prior to logging artifact or while in offline mode"
+        )
+        # Follow the same pattern as AttributeError.
+        self.obj = artifact
+        self.name = attr
+
+
 class Artifact(ArtifactInterface):
     """
     Flexible and lightweight building block for dataset and model versioning.
@@ -228,9 +242,7 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.version
 
-        raise ValueError(
-            "Cannot call version on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "version")
 
     @property
     def entity(self) -> str:
@@ -300,9 +312,7 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.commit_hash
 
-        raise ValueError(
-            "Cannot access commit_hash on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "commit_hash")
 
     @property
     def description(self) -> Optional[str]:
@@ -340,9 +350,7 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.aliases
 
-        raise ValueError(
-            "Cannot call aliases on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "aliases")
 
     @aliases.setter
     def aliases(self, aliases: List[str]) -> None:
@@ -354,9 +362,7 @@ class Artifact(ArtifactInterface):
             self._logged_artifact.aliases = aliases
             return
 
-        raise ValueError(
-            "Cannot set aliases on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "aliases")
 
     @property
     def use_as(self) -> Optional[str]:
@@ -378,17 +384,13 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.used_by()
 
-        raise ValueError(
-            "Cannot call used_by on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "used_by()")
 
     def logged_by(self) -> "wandb.apis.public.Run":
         if self._logged_artifact:
             return self._logged_artifact.logged_by()
 
-        raise ValueError(
-            "Cannot call logged_by on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "logged_by()")
 
     @contextlib.contextmanager
     def new_file(
@@ -587,17 +589,13 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.get_path(name)
 
-        raise ValueError(
-            "Cannot load paths from an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "get_path()")
 
     def get(self, name: str) -> data_types.WBValue:
         if self._logged_artifact:
             return self._logged_artifact.get(name)
 
-        raise ValueError(
-            "Cannot call get on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "get()")
 
     def download(
         self, root: Optional[str] = None, recursive: bool = False
@@ -605,25 +603,19 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.download(root=root, recursive=recursive)
 
-        raise ValueError(
-            "Cannot call download on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "download()")
 
     def checkout(self, root: Optional[str] = None) -> str:
         if self._logged_artifact:
             return self._logged_artifact.checkout(root=root)
 
-        raise ValueError(
-            "Cannot call checkout on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "checkout()")
 
     def verify(self, root: Optional[str] = None) -> bool:
         if self._logged_artifact:
             return self._logged_artifact.verify(root=root)
 
-        raise ValueError(
-            "Cannot call verify on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "verify()")
 
     def save(
         self,
@@ -670,9 +662,7 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.delete()
 
-        raise ValueError(
-            "Cannot call delete on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "delete()")
 
     def wait(self, timeout: Optional[int] = None) -> ArtifactInterface:
         """
@@ -682,9 +672,7 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.wait(timeout)  # type: ignore [call-arg]
 
-        raise ValueError(
-            "Cannot call wait on an artifact before it has been logged or in offline mode"
-        )
+        raise ArtifactNotLoggedError(self, "wait()")
 
     def get_added_local_path_name(self, local_path: str) -> Optional[str]:
         """
@@ -729,9 +717,7 @@ class Artifact(ArtifactInterface):
 
     def json_encode(self) -> Dict[str, Any]:
         if not self._logged_artifact:
-            raise ValueError(
-                "Cannot json encode artifact before it has been logged or in offline mode."
-            )
+            raise ArtifactNotLoggedError(self, "json_encode()")
         return util.artifact_to_json(self)
 
     def _ensure_can_add(self) -> None:

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -110,11 +110,12 @@ def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 class ArtifactNotLoggedError(Exception):
     """Raised for Artifact methods or attributes that require the logged artifact."""
 
-    def __init__(self, artifact: "Artifact" = None, attr: str = None):
+    def __init__(self, artifact: "Artifact" = None, attr: Optional[str] = None):
         desc = artifact.__class__.__name__ if artifact else "Artifact"
         desc += f".{attr}" if attr else ""
         super().__init__(
-            f"'{desc}' used prior to logging artifact or while in offline mode"
+            f"'{desc}' used prior to logging artifact or while in offline mode."
+            "Call wait() before accessing logged artifact properties."
         )
         # Follow the same pattern as AttributeError.
         self.obj = artifact

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -384,13 +384,13 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.used_by()
 
-        raise ArtifactNotLoggedError(self, "used_by()")
+        raise ArtifactNotLoggedError(self, "used_by")
 
     def logged_by(self) -> "wandb.apis.public.Run":
         if self._logged_artifact:
             return self._logged_artifact.logged_by()
 
-        raise ArtifactNotLoggedError(self, "logged_by()")
+        raise ArtifactNotLoggedError(self, "logged_by")
 
     @contextlib.contextmanager
     def new_file(
@@ -589,13 +589,13 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.get_path(name)
 
-        raise ArtifactNotLoggedError(self, "get_path()")
+        raise ArtifactNotLoggedError(self, "get_path")
 
     def get(self, name: str) -> data_types.WBValue:
         if self._logged_artifact:
             return self._logged_artifact.get(name)
 
-        raise ArtifactNotLoggedError(self, "get()")
+        raise ArtifactNotLoggedError(self, "get")
 
     def download(
         self, root: Optional[str] = None, recursive: bool = False
@@ -603,19 +603,19 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.download(root=root, recursive=recursive)
 
-        raise ArtifactNotLoggedError(self, "download()")
+        raise ArtifactNotLoggedError(self, "download")
 
     def checkout(self, root: Optional[str] = None) -> str:
         if self._logged_artifact:
             return self._logged_artifact.checkout(root=root)
 
-        raise ArtifactNotLoggedError(self, "checkout()")
+        raise ArtifactNotLoggedError(self, "checkout")
 
     def verify(self, root: Optional[str] = None) -> bool:
         if self._logged_artifact:
             return self._logged_artifact.verify(root=root)
 
-        raise ArtifactNotLoggedError(self, "verify()")
+        raise ArtifactNotLoggedError(self, "verify")
 
     def save(
         self,

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -663,7 +663,7 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.delete()
 
-        raise ArtifactNotLoggedError(self, "delete()")
+        raise ArtifactNotLoggedError(self, "delete")
 
     def wait(self, timeout: Optional[int] = None) -> ArtifactInterface:
         """
@@ -673,7 +673,7 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.wait(timeout)  # type: ignore [call-arg]
 
-        raise ArtifactNotLoggedError(self, "wait()")
+        raise ArtifactNotLoggedError(self, "wait")
 
     def get_added_local_path_name(self, local_path: str) -> Optional[str]:
         """
@@ -718,7 +718,7 @@ class Artifact(ArtifactInterface):
 
     def json_encode(self) -> Dict[str, Any]:
         if not self._logged_artifact:
-            raise ArtifactNotLoggedError(self, "json_encode()")
+            raise ArtifactNotLoggedError(self, "json_encode")
         return util.artifact_to_json(self)
 
     def _ensure_can_add(self) -> None:

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -110,7 +110,9 @@ def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 class ArtifactNotLoggedError(Exception):
     """Raised for Artifact methods or attributes that require the logged artifact."""
 
-    def __init__(self, artifact: "Artifact" = None, attr: Optional[str] = None):
+    def __init__(
+        self, artifact: Optional["Artifact"] = None, attr: Optional[str] = None
+    ):
         desc = artifact.__class__.__name__ if artifact else "Artifact"
         desc += f".{attr}" if attr else ""
         super().__init__(

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3686,7 +3686,7 @@ class InvalidArtifact:
 
 class _LazyArtifact(ArtifactInterface):
     _api: PublicApi
-    _instance: Optional[ArtifactInterface] = None
+    _instance: Union[ArtifactInterface, InvalidArtifact]
     _future: Any
 
     def __init__(self, api: PublicApi, future: Any):

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3793,36 +3793,6 @@ class _LazyArtifact(ArtifactInterface):
     def logged_by(self) -> "wandb.apis.public.Run":
         return self._instance.logged_by()
 
-    # Commenting this block out since this code is unreachable since LocalArtifact
-    # overrides them and therefore untestable.
-    # Leaving behind as we may want to support these in the future.
-
-    # def new_file(self, name: str, mode: str = "w") -> Any:  # TODO: Refine Type
-    #     return self._instance.new_file(name, mode)
-
-    # def add_file(
-    #     self,
-    #     local_path: str,
-    #     name: Optional[str] = None,
-    #     is_tmp: Optional[bool] = False,
-    # ) -> Any:  # TODO: Refine Type
-    #     return self._instance.add_file(local_path, name, is_tmp)
-
-    # def add_dir(self, local_path: str, name: Optional[str] = None) -> None:
-    #     return self._instance.add_dir(local_path, name)
-
-    # def add_reference(
-    #     self,
-    #     uri: Union["ArtifactManifestEntry", str],
-    #     name: Optional[str] = None,
-    #     checksum: bool = True,
-    #     max_objects: Optional[int] = None,
-    # ) -> Any:  # TODO: Refine Type
-    #     return self._instance.add_reference(uri, name, checksum, max_objects)
-
-    # def add(self, obj: "WBValue", name: str) -> Any:  # TODO: Refine Type
-    #     return self._instance.add(obj, name)
-
     def get_path(self, name: str) -> "ArtifactManifestEntry":
         return self._instance.get_path(name)
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3811,7 +3811,7 @@ class _LazyArtifact(ArtifactInterface):
         return self._instance.verify(root)
 
     def save(self) -> None:
-        return self._instance.save()
+        self._instance.save()
 
     def delete(self) -> None:
-        return self._instance.delete()
+        self._instance.delete()


### PR DESCRIPTION
Fixes WB-NNNN

Description
-----------
Define `ArtifactNotLoggedError` and raise it rather than a generic `ValueError` when an attribute that requires a logged artifact is accessed. Minimal change, though it does alter error messages.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
