### PR TITLE
chore(sdk): add ruff rules to replace pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,20 +7,10 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-#  - repo: https://github.com/pycqa/isort
-#    rev: 5.10.1
-#    hooks:
-#      - id: isort
-#        args: [--resolve-all-config]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
-      - id: black
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
-    hooks:
-      - id: pyupgrade
-        args: [--py36-plus, --keep-mock]
+      - id: black-jupyter
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,13 @@ security = ":lock: Security"
 
 
 [tool.ruff]
-select = ["F", "E", "W", "B", "I", "N", "C90"]
-ignore = ["B904", "E501"]
+select = ["F", "E", "W", "B", "I", "N", "C90", "UP"]
+ignore = [
+    "B904",
+    "E501",
+    "UP022",  # Only valid for Python 3.7+
+    "UP036",  # Only valid for Python 3.7+
+]
 exclude = [
     "tests/functional_tests/t0_main/fastai/t1_v1.py",
     "tests/functional_tests/t0_main/metaflow",

--- a/tests/standalone_tests/grpc_client.py
+++ b/tests/standalone_tests/grpc_client.py
@@ -16,8 +16,10 @@ from typing import TYPE_CHECKING, Any, Dict
 
 import grpc
 import wandb
-from wandb.proto import wandb_internal_pb2  # type: ignore
-from wandb.proto import wandb_server_pb2_grpc  # type: ignore
+from wandb.proto import (
+    wandb_internal_pb2,  # type: ignore
+    wandb_server_pb2_grpc,  # type: ignore
+)
 from wandb.proto import wandb_server_pb2 as spb  # type: ignore
 
 if TYPE_CHECKING:

--- a/tests/standalone_tests/grpc_client.py
+++ b/tests/standalone_tests/grpc_client.py
@@ -16,10 +16,8 @@ from typing import TYPE_CHECKING, Any, Dict
 
 import grpc
 import wandb
-from wandb.proto import (
-    wandb_internal_pb2,  # type: ignore
-    wandb_server_pb2_grpc,  # type: ignore
-)
+from wandb.proto import wandb_internal_pb2  # type: ignore
+from wandb.proto import wandb_server_pb2_grpc  # type: ignore
 from wandb.proto import wandb_server_pb2 as spb  # type: ignore
 
 if TYPE_CHECKING:

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -88,10 +88,9 @@ class ClickWandbException(ClickException):
         if issubclass(self.orig_type, Error):
             return click.style(str(self.message), fg="red")
         else:
-            return "An Exception was raised, see %s for full traceback.\n" "%s: %s" % (
-                log_file,
-                orig_type,
-                self.message,
+            return (
+                f"An Exception was raised, see {log_file} for full traceback.\n"
+                f"{orig_type}: {self.message}"
             )
 
 

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -470,10 +470,11 @@ def _fetch_git_repo(dst_dir: str, uri: str, version: Optional[str]) -> str:
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise LaunchError(
-                f"Unable to checkout version '{version}' of git repo {uri}"
+                "Unable to checkout version '{version}' of git repo {uri}"
                 "- please ensure that the version exists in the repo. "
-                f"Error: {e}"
-            )
+                "Error: {e}",
+                extras=dict(version=version, uri=uri, error=e),
+            ) from e
     else:
         if getattr(repo, "references", None) is not None:
             branches = [ref.name for ref in repo.references]
@@ -493,10 +494,11 @@ def _fetch_git_repo(dst_dir: str, uri: str, version: Optional[str]) -> str:
             )
         except (AttributeError, IndexError) as e:
             raise LaunchError(
-                f"Unable to checkout default version '{version}' of git repo {uri} "
+                "Unable to checkout default version '{version}' of git repo {uri} "
                 "- to specify a git version use: --git-version \n"
-                f"Error: {e}"
-            )
+                "Error: {e}",
+                extras=dict(version=version, uri=uri, error=e),
+            ) from e
 
     repo.submodule_update(init=True, recursive=True)
     return version

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -470,9 +470,9 @@ def _fetch_git_repo(dst_dir: str, uri: str, version: Optional[str]) -> str:
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise LaunchError(
-                "Unable to checkout version '%s' of git repo %s"
+                f"Unable to checkout version '{version}' of git repo {uri}"
                 "- please ensure that the version exists in the repo. "
-                "Error: %s" % (version, uri, e)
+                f"Error: {e}"
             )
     else:
         if getattr(repo, "references", None) is not None:
@@ -493,9 +493,9 @@ def _fetch_git_repo(dst_dir: str, uri: str, version: Optional[str]) -> str:
             )
         except (AttributeError, IndexError) as e:
             raise LaunchError(
-                "Unable to checkout default version '%s' of git repo %s "
+                f"Unable to checkout default version '{version}' of git repo {uri} "
                 "- to specify a git version use: --git-version \n"
-                "Error: %s" % (version, uri, e)
+                f"Error: {e}"
             )
 
     repo.submodule_update(init=True, recursive=True)
@@ -578,7 +578,6 @@ def get_kube_context_and_api_client(
     kubernetes: Any,  # noqa: F811
     resource_args: Dict[str, Any],  # noqa: F811
 ) -> Tuple[Any, Any]:
-
     config_file = resource_args.get("config_file", None)
     context = None
     if config_file is not None or os.path.exists(os.path.expanduser("~/.kube/config")):

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -470,10 +470,9 @@ def _fetch_git_repo(dst_dir: str, uri: str, version: Optional[str]) -> str:
             repo.git.checkout(version)
         except git.exc.GitCommandError as e:
             raise LaunchError(
-                "Unable to checkout version '{version}' of git repo {uri}"
+                f"Unable to checkout version '{version}' of git repo {uri}"
                 "- please ensure that the version exists in the repo. "
-                "Error: {e}",
-                extras=dict(version=version, uri=uri, error=e),
+                f"Error: {e}"
             ) from e
     else:
         if getattr(repo, "references", None) is not None:
@@ -494,10 +493,9 @@ def _fetch_git_repo(dst_dir: str, uri: str, version: Optional[str]) -> str:
             )
         except (AttributeError, IndexError) as e:
             raise LaunchError(
-                "Unable to checkout default version '{version}' of git repo {uri} "
+                f"Unable to checkout default version '{version}' of git repo {uri} "
                 "- to specify a git version use: --git-version \n"
-                "Error: {e}",
-                extras=dict(version=version, uri=uri, error=e),
+                f"Error: {e}"
             ) from e
 
     repo.submodule_update(init=True, recursive=True)


### PR DESCRIPTION
Description
-----------
- add the "UP" ruleset to Ruff's configuration to replace pyupgrade
- fix 3 lint errors that would otherwise appear
- disable the warnings that require 3.7 syntax
- remove commented-out isort block in pre-commit (ruff gets us this basically for free!)
- remove pyupgrade in pre-commit now that ruff handles that too
- upgrade black in pre-commit and let it check Jupyter notebooks*

\* mostly just so I stop being annoyed by the warning that there are ipynb files it can't check 


Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
