### PR TITLE
chore(sdk): Add tox sections for ruff check/fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1309,7 +1309,7 @@ workflows:
       - tox-base:
           name: "code-check"
           python_version_minor: 8
-          toxenv: "protocheck3,protocheck4,generatecheck,codecovcheck,mypy,mypy-report,pyupgrade,black,isort-check,flake8,docstrings"
+          toxenv: "protocheck3,protocheck4,generatecheck,codecovcheck,mypy,mypy-report,pyupgrade,black,isort-check,ruff-check,flake8,docstrings"
 
       #
       # System tests with pytest on Linux, using real wandb server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1309,7 +1309,7 @@ workflows:
       - tox-base:
           name: "code-check"
           python_version_minor: 8
-          toxenv: "protocheck3,protocheck4,generatecheck,codecovcheck,mypy,mypy-report,pyupgrade,black,isort-check,ruff-check,flake8,docstrings"
+          toxenv: "protocheck3,protocheck4,generatecheck,codecovcheck,mypy,mypy-report,pyupgrade,black,isort-check,ruff,flake8,docstrings"
 
       #
       # System tests with pytest on Linux, using real wandb server

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:
+      - id: check-merge-conflict
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     hooks:
       - id: blacken-docs
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.252'
+    rev: "v0.0.252"
     hooks:
       - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ exclude = [
 ]
 target-version = "py37"
 
+[tool.ruff.isort]
+split-on-trailing-comma = false
+
 [tool.ruff.per-file-ignores]
 "wandb/cli/cli.py" = ["C901"]
 "wandb/wandb_controller.py" = ["N803", "N806"]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ minversion=3.24.0
 envlist=
     black,
     isort,
+    ruff,
     mypy,
     flake8,
     docstrings,
@@ -246,6 +247,26 @@ deps=
     {[isort]deps}
 commands=
     isort --resolve-all-configs --config-root {toxinidir} {toxinidir}
+
+[ruff]
+deps=
+    ruff==0.0.252
+
+[testenv:ruff-check]
+basepython = python3
+skip_install = true
+deps=
+    {[ruff]deps}
+commands=
+    ruff {toxinidir}
+
+[testenv:ruff-fix]
+basepython = python3
+skip_install = true
+deps=
+    {[ruff]deps}
+commands=
+    ruff --fix {toxinidir}
 
 [black]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -250,7 +250,7 @@ commands=
 
 [ruff]
 deps=
-    ruff==0.0.252
+    ruff
 
 [testenv:ruff]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -252,7 +252,7 @@ commands=
 deps=
     ruff==0.0.252
 
-[testenv:ruff-check]
+[testenv:ruff]
 basepython = python3
 skip_install = true
 deps=

--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -6,8 +6,8 @@ import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 import wandb
-import wandb.filesync.step_prepare
 from wandb import util
+import wandb.filesync.step_prepare
 from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
 
 from ..interface.artifacts import (
@@ -242,7 +242,7 @@ class ArtifactSaver:
                 _, resp = self._api.update_artifact_manifest(
                     artifact_manifest_id,
                     digest=digest,
-                )
+                );
             else:
                 # In the regular flow, we can recreate the full manifest with the
                 # updated digest.
@@ -263,6 +263,7 @@ class ArtifactSaver:
             for upload_header in upload_headers:
                 key, val = upload_header.split(":", 1)
                 extra_headers[key] = val
+            zz = set((1,))
             with open(path, "rb") as fp2:
                 self._api.upload_file_retry(
                     upload_url,

--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -6,8 +6,8 @@ import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 import wandb
-from wandb import util
 import wandb.filesync.step_prepare
+from wandb import util
 from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
 
 from ..interface.artifacts import (
@@ -242,7 +242,7 @@ class ArtifactSaver:
                 _, resp = self._api.update_artifact_manifest(
                     artifact_manifest_id,
                     digest=digest,
-                );
+                )
             else:
                 # In the regular flow, we can recreate the full manifest with the
                 # updated digest.
@@ -263,7 +263,6 @@ class ArtifactSaver:
             for upload_header in upload_headers:
                 key, val = upload_header.split(":", 1)
                 extra_headers[key] = val
-            zz = set((1,))
             with open(path, "rb") as fp2:
                 self._api.upload_file_retry(
                     upload_url,

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -65,12 +65,10 @@ def _convert_access(access: str) -> str:
 def _max_from_config(
     config: Dict[str, Any], key: str, default: int = 1
 ) -> Union[int, float]:
-    """
-    Utility for parsing integers from the agent config with
-    a default, infinity handling, and integer parsing.
-    Raises more informative error if parse error
+    """Get an integer from the config, or float.inf if -1.
 
-    returns parsed value as int or infinity
+    Utility for parsing integers from the agent config with a default, infinity
+    handling, and integer parsing. Raises more informative error if parse error.
     """
     try:
         val = config.get(key)
@@ -88,9 +86,7 @@ def _max_from_config(
 
 
 def _job_is_scheduler(run_spec: Dict[str, Any]) -> bool:
-    """
-    Utility for determining whether a job/runSpec is a sweep scheduler
-    """
+    """Determine whether a job/runSpec is a sweep scheduler."""
     if not run_spec:
         _logger.debug("Recieved runSpec in _job_is_scheduler that was empty")
 
@@ -144,13 +140,13 @@ class LaunchAgent:
 
     @property
     def num_running_schedulers(self) -> int:
-        """Returns just the number of schedulers"""
+        """Return just the number of schedulers."""
         with self._jobs_lock:
             return len([x for x in self._jobs if self._jobs[x].is_scheduler])
 
     @property
     def num_running_jobs(self) -> int:
-        """Returns the number of jobs not including schedulers"""
+        """Return the number of jobs not including schedulers."""
         with self._jobs_lock:
             return len([x for x in self._jobs if not self._jobs[x].is_scheduler])
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -104,9 +104,7 @@ def _str_as_bool(val: Union[str, bool]) -> bool:
 
 
 def _str_as_tuple(val: Union[str, Sequence[str]]) -> Tuple[str, ...]:
-    """
-    Parse a (potentially comma-separated) string as a tuple.
-    """
+    """Parse a (potentially comma-separated) string as a tuple."""
     if isinstance(val, str):
         return tuple(val.split(","))
     return tuple(val)


### PR DESCRIPTION
Fixes WB-NNNN

Description
-----------
- Add `ruff` and `ruff-fix` commands to tox
- Make ruff checks part of the code-check CI task

Eventually ruff should be able to replace isort, pyupgrade, and all of the flake8-* checks, but adding this as a parallel check should pave the way for that.

Testing
-------
If this is set up correctly then ruff should emit lint errors in parallel to pyupgrade and isort (and some but not all of flake8 errors). Once we're satisfied with that we can remove the other more expensive linters.

[9ae5d49](https://github.com/wandb/wandb/pull/5028/commits/9ae5d497bdfe94151420541773c48e1c2a4a8533) added in three errors that should have been caught, which they successfully were: [code-check job](https://app.circleci.com/pipelines/github/wandb/wandb/19638/workflows/6b2ef553-aab9-4e40-9caa-a199690efe3b/jobs/447938).

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
