### PR TITLE
fix(sdk): Allow pathlib.Path in ImageDataOrPathType

### DIFF
--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -151,10 +151,10 @@ class Image(BatchableMedia):
         if isinstance(data_or_path, Image):
             self._initialize_from_wbimage(data_or_path)
         elif isinstance(data_or_path, (str, Path)):
-            if self.path_is_reference(data_or_path):
-                self._initialize_from_reference(data_or_path)
+            if self.path_is_reference(str(data_or_path)):
+                self._initialize_from_reference(str(data_or_path))
             else:
-                self._initialize_from_path(data_or_path)
+                self._initialize_from_path(str(data_or_path))
         else:
             self._initialize_from_data(data_or_path, mode)
 

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -4,6 +4,7 @@ import os
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Type, Union, cast
 from urllib import parse
+from pathlib import Path
 
 import wandb
 from wandb import util
@@ -29,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
     ImageDataType = Union[
         "matplotlib.artist.Artist", "PILImage", "TorchTensorType", "np.ndarray"
     ]
-    ImageDataOrPathType = Union[str, "Image", ImageDataType]
+    ImageDataOrPathType = Union[str, Path, "Image", ImageDataType]
     TorchTensorType = Union["torch.Tensor", "torch.Variable"]
 
 
@@ -149,7 +150,7 @@ class Image(BatchableMedia):
         # only overriding additional metdata passed in. If this pattern is compelling, we can generalize.
         if isinstance(data_or_path, Image):
             self._initialize_from_wbimage(data_or_path)
-        elif isinstance(data_or_path, str):
+        elif isinstance(data_or_path, (str, Path)):
             if self.path_is_reference(data_or_path):
                 self._initialize_from_reference(data_or_path)
             else:


### PR DESCRIPTION
It's pretty common to pass `Path` objects around instead of `str`s these days, and as of right now you get a cryptic error, since the SDK tried to parse it as a tensor.


Description
-----------
What does the PR do?

Allows a user to pass a `Path` in (which can be safely cast to a `str`).

Checklist
-------
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
