### PR TITLE
fix(artifacts): default link artifact project to model-registry

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2568,6 +2568,11 @@ class Run:
 
         """
         portfolio, project, entity = wandb.util._parse_entity_project_item(target_path)
+        if project != 'model-registry':
+            project = 'model-registry'
+            wandb.termwarn(
+                "Projects other than model-registry are not supported to create registerd models. Resetting to default."
+            )
         if aliases is None:
             aliases = []
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2568,8 +2568,8 @@ class Run:
 
         """
         portfolio, project, entity = wandb.util._parse_entity_project_item(target_path)
-        if project != 'model-registry':
-            project = 'model-registry'
+        if project != "model-registry":
+            project = "model-registry"
             wandb.termwarn(
                 "Projects other than model-registry are not supported to create registerd models. Resetting to default."
             )


### PR DESCRIPTION
Fixes [WB-12633](https://wandb.atlassian.net/browse/WB-12633)
Fixes #NNNN

Description
-----------
defaults the project while using `link_artifact()` to model-registry. If this is not done then it creates a loop hole around model registry restrictions as we now check only for number of registered models in the model-registry project.

WIP: Need to update tests

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12633]: https://wandb.atlassian.net/browse/WB-12633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ