### PR TITLE
docs(sdk): fix missed docstring lint errors reported by ruff

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_environment/test_aws.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_environment/test_aws.py
@@ -177,8 +177,12 @@ def test_upload_directory(mocker):
 
 
 def test_upload_invalid_path(mocker):
-    """Test that we raise an error when the source path is not a directory or
-    the destination path is not a valid s3 URI."""
+    """Test that we raise an error for invalid paths.
+
+    The upload can't proceed if
+    - the source path is not a directory, or
+    - the destination path is not a valid S3 URI
+    """
     environment = _get_environment()
     with pytest.raises(LaunchError) as e:
         environment.upload_dir("invalid_path", "s3://bucket/key")

--- a/tests/pytest_tests/unit_tests/test_library_public.py
+++ b/tests/pytest_tests/unit_tests/test_library_public.py
@@ -2,7 +2,7 @@
 
 *NOTE*: If you need to add a symbol, make sure this has been discussed and the name of the object or method is agreed upon.
 
-TODO:
+Todo:
     - clean up / hide symbols, which shouldn't be public
     - deprecate ones that were public but we want to remove
 

--- a/tests/standalone_tests/artifact_load.py
+++ b/tests/standalone_tests/artifact_load.py
@@ -17,7 +17,7 @@ For a single artifact named A:
       - ensure files are available in bucket and match md5 / etag
       - ensure there are no dangling files in bucket
 
-TODO:
+Todo:
   - enabling the cache gc process causes errors, but the test doesn't fail, because
     wandb exits cleanly even if file pusher has errors
   - implement the deleter and bucket gc processes once we've built support for them

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -12,15 +12,19 @@ class Api:
         self._api = None
 
     def __getstate__(self):
-        """Used for serializing. self._api is not serializable,
-        so it's dropped"""
+        """Use for serializing.
+
+        self._api is not serializable, so it's dropped
+        """
         state = self.__dict__.copy()
         del state["_api"]
         return state
 
     def __setstate__(self, state):
-        """Used for deserializing. Don't need to set self._api because
-        it's constructed when needed"""
+        """Used for deserializing.
+
+        Don't need to set self._api because it's constructed when needed.
+        """
         self.__dict__.update(state)
         self._api = None
 

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -1,6 +1,4 @@
-"""
-Implementation of launch agent.
-"""
+"""Implementation of launch agent."""
 import logging
 import os
 import pprint


### PR DESCRIPTION
Description
-----------
#5036 was big enough that a bunch of its changes either got dropped in the merge queue or were overwritten by PRs inflight, so this fixes 12 lint errors that should have been covered by it but weren't. Gotta catch 'em all.

Testing
-------
Small documentation-only changes.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
