### PR TITLE
style(artifacts): enable typechecking for interface.artifacts and add type hints / casts

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -254,7 +254,7 @@ ignore_errors = True
 # -----------------------------
 
 [mypy-wandb.sdk.interface.artifacts]
-ignore_errors = True
+disallow_untyped_calls = False
 
 [mypy-wandb.sdk.interface.summary_record]
 ignore_errors = True

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import random
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -104,7 +104,7 @@ class ArtifactManifestEntry:
     ref: Optional[Union[FilePathStr, URIStr]] = None
     birth_artifact_id: Optional[str] = None
     size: Optional[int] = None
-    extra: Optional[Dict] = None
+    extra: Dict = field(default_factory=dict)
     local_path: Optional[str] = None
 
     def __post_init__(self) -> None:

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import random
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -104,7 +104,7 @@ class ArtifactManifestEntry:
     ref: Optional[Union[FilePathStr, URIStr]] = None
     birth_artifact_id: Optional[str] = None
     size: Optional[int] = None
-    extra: Dict = field(default_factory=dict)
+    extra: Optional[Dict] = None
     local_path: Optional[str] = None
 
     def __post_init__(self) -> None:

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -756,10 +756,10 @@ class StoragePolicy:
         raise NotImplementedError
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: Dict) -> "StoragePolicy":
         raise NotImplementedError
 
-    def config(self):
+    def config(self) -> Dict:
         raise NotImplementedError
 
     def load_file(
@@ -778,8 +778,13 @@ class StoragePolicy:
         raise NotImplementedError
 
     def store_reference(
-        self, artifact, path, name=None, checksum=True, max_objects=None
-    ):
+        self,
+        artifact: Artifact,
+        path: Union[URIStr, FilePathStr],
+        name: Optional[str] = None,
+        checksum: bool = True,
+        max_objects: Optional[int] = None,
+    ) -> Sequence[ArtifactManifestEntry]:
         raise NotImplementedError
 
     def load_reference(

--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -954,7 +954,7 @@ def get_artifacts_cache() -> ArtifactsCache:
 def get_staging_dir() -> util.FilePathStr:
     path = os.path.join(env.get_data_dir(), "artifacts", "staging")
     filesystem.mkdir_exists_ok(path)
-    return os.path.abspath(os.path.expanduser(path))
+    return util.FilePathStr(os.path.abspath(os.path.expanduser(path)))
 
 
 def get_new_staging_file() -> IO:

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -395,7 +395,7 @@ class InterfaceBase:
         obj: Optional[pb.ArtifactManifest] = None,
     ) -> pb.ArtifactManifest:
         proto_manifest = obj or pb.ArtifactManifest()
-        proto_manifest.version = artifact_manifest.version()  # type: ignore
+        proto_manifest.version = artifact_manifest.version()
         proto_manifest.storage_policy = artifact_manifest.storage_policy.name()
 
         for k, v in artifact_manifest.storage_policy.config().items() or {}.items():

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -66,6 +66,7 @@ from wandb.viz import CustomChart, Visualize, custom_chart
 from . import wandb_artifacts, wandb_config, wandb_metric, wandb_summary
 from .data_types._dtypes import TypeRegistry
 from .interface.artifacts import Artifact as ArtifactInterface
+from .interface.artifacts import ArtifactNotLoggedError
 from .interface.interface import GlobStr, InterfaceBase
 from .interface.summary_record import SummaryRecord
 from .lib import (
@@ -86,7 +87,7 @@ from .lib.printer import get_printer
 from .lib.proto_util import message_to_dict
 from .lib.reporting import Reporter
 from .lib.wburls import wburls
-from .wandb_artifacts import Artifact, ArtifactNotLoggedError
+from .wandb_artifacts import Artifact
 from .wandb_settings import Settings, SettingsConsole
 from .wandb_setup import _WandbSetup
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1602,8 +1602,8 @@ def _has_internet() -> bool:
         return False
 
 
-def rand_alphanumeric(length: int = 8, rand: Optional[ModuleType] = None) -> str:
-    rand = rand or random
+def rand_alphanumeric(length: int = 8, rand: Optional[random.Random] = None) -> str:
+    rand = rand or random.Random()
     return "".join(rand.choice("0123456789ABCDEF") for _ in range(length))
 
 


### PR DESCRIPTION
Fixes [WB-12645](https://wandb.atlassian.net/browse/WB-12645)

Description
-----------
Remove the guard disabling `sdk/inferface/artifacts.py` from mypy checks, and add type hints, casts, and adjust signatures until we can pass typechecking.

Note that this involves a large number of changes in `wandb_artifact.py` as well, and reveals very tight coupling between them (e.g. the artifact cache defined in artifacts.py is imported into wandb_artifacts.py, but wandb_artifacts.py defines the only Artifact subclass that the cache relies on).

Testing
-------
CI. Should be almost no functional change, though there are a few casts added. Code that doesn't pass them should be invalid anyway though (e.g. passing a non-URI string to `add_reference`).

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12645]: https://wandb.atlassian.net/browse/WB-12645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ