### PR TITLE
Try reducing the number of training iterations

### DIFF
--- a/tests/functional_tests/t0_main/raytune/t5_colab.py
+++ b/tests/functional_tests/t0_main/raytune/t5_colab.py
@@ -29,7 +29,7 @@ def train_mnist(config):
         model.parameters(), lr=config["lr"], momentum=config["momentum"]
     )
 
-    for _i in range(10):
+    for _i in range(5):
         train(model, optimizer, train_loader, device=device)
         acc = test(model, test_loader, device=device)
 


### PR DESCRIPTION
Fixes [WB-12711](https://wandb.atlassian.net/browse/WB-12711)

Description
-----------
This test is timing out (exceeding 10 minutes and getting a `SIGTERM` error) quite frequently for me. I think since it's just a functional test doing 5 epochs of training instead of 10 should be fine? On my fast M1 Max even 5 epochs takes 2.5 minutes so I suspect this is a reasonable change.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
