### PR TITLE
fix(sdk): avoid lazy loading for tensorboard patching

### DIFF
--- a/wandb/integration/tensorboard/monkeypatch.py
+++ b/wandb/integration/tensorboard/monkeypatch.py
@@ -33,8 +33,6 @@ def patch(
             "Tensorboard already patched, remove `sync_tensorboard=True` "
             "from `wandb.init` or only call `wandb.tensorboard.patch` once."
         )
-    print(root_logdir)
-    print("patching tensorboard")
 
     # TODO: Some older versions of tensorflow don't require tensorboard to be present.
     # we may want to lift this requirement, but it's safer to have it for now

--- a/wandb/integration/tensorboard/monkeypatch.py
+++ b/wandb/integration/tensorboard/monkeypatch.py
@@ -17,7 +17,7 @@ TENSORBOARD_PYTORCH_MODULE = "torch.utils.tensorboard.writer"
 
 def unpatch() -> None:
     for module, method in wandb.patched["tensorboard"]:
-        writer = wandb.util.get_module(module)
+        writer = wandb.util.get_module(module, lazy=False)
         setattr(writer, method, getattr(writer, f"orig_{method}"))
     wandb.patched["tensorboard"] = []
 
@@ -33,15 +33,19 @@ def patch(
             "Tensorboard already patched, remove `sync_tensorboard=True` "
             "from `wandb.init` or only call `wandb.tensorboard.patch` once."
         )
+    print(root_logdir)
+    print("patching tensorboard")
 
     # TODO: Some older versions of tensorflow don't require tensorboard to be present.
     # we may want to lift this requirement, but it's safer to have it for now
-    wandb.util.get_module("tensorboard", required="Please install tensorboard package")
-    c_writer = wandb.util.get_module(TENSORBOARD_C_MODULE)
-    py_writer = wandb.util.get_module(TENSORFLOW_PY_MODULE)
-    tb_writer = wandb.util.get_module(TENSORBOARD_WRITER_MODULE)
-    pt_writer = wandb.util.get_module(TENSORBOARD_PYTORCH_MODULE)
-    tbx_writer = wandb.util.get_module(TENSORBOARD_X_MODULE)
+    wandb.util.get_module(
+        "tensorboard", required="Please install tensorboard package", lazy=False
+    )
+    c_writer = wandb.util.get_module(TENSORBOARD_C_MODULE, lazy=False)
+    py_writer = wandb.util.get_module(TENSORFLOW_PY_MODULE, lazy=False)
+    tb_writer = wandb.util.get_module(TENSORBOARD_WRITER_MODULE, lazy=False)
+    pt_writer = wandb.util.get_module(TENSORBOARD_PYTORCH_MODULE, lazy=False)
+    tbx_writer = wandb.util.get_module(TENSORBOARD_X_MODULE, lazy=False)
 
     if not pytorch and not tensorboard_x and c_writer:
         _patch_tensorflow2(


### PR DESCRIPTION
Description
-----------
What does the PR do?

This PR disables lazy loading for tensorboard patching, since it causes a regression when using in a notebook environment. 

Testing
-------
How was this PR tested?

Manually :/

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
