### PR TITLE
chore(launch): hide entrypoint env var from actual entrypoint log

### DIFF
--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -528,7 +528,9 @@ def join(split_command: List[str]) -> str:
     Also remove quotes from double quoted strings. Ex:
     "'local container queue'" --> "local container queue"
     """
-    return " ".join(shlex.quote(arg.replace("'", "")) for arg in split_command)
+    clean = [arg.replace("'", "").replace('"', "") for arg in split_command]
+
+    return " ".join(shlex.quote(arg) for arg in clean)
 
 
 def construct_builder_args(

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -17,6 +17,7 @@ from ..utils import (
     PROJECT_SYNCHRONOUS,
     _is_wandb_dev_uri,
     _is_wandb_local_uri,
+    sanitize_entrypoint_key,
     sanitize_wandb_api_key,
 )
 from .abstract import AbstractRun, AbstractRunner, Status
@@ -148,6 +149,7 @@ class LocalContainerRunner(AbstractRunner):
         if not self.ack_run_queue_item(launch_project):
             return None
         sanitized_cmd_str = sanitize_wandb_api_key(command_str)
+        sanitized_cmd_str = sanitize_entrypoint_key(sanitized_cmd_str)
         _msg = f"{LOG_PREFIX}Launching run in docker with command: {sanitized_cmd_str}"
         wandb.termlog(_msg)
         run = _run_entry_point(command_str, launch_project.project_dir)

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -54,6 +54,7 @@ _WANDB_LOCAL_DEV_URI_REGEX = re.compile(
 )  # for testing, not sure if we wanna keep this
 
 API_KEY_REGEX = r"WANDB_API_KEY=\w+"
+ENTRYPOINT_KEY_REGEX = r"WANDB_ENTRYPOINT_COMMAND='.*'"
 
 PROJECT_SYNCHRONOUS = "SYNCHRONOUS"
 
@@ -89,6 +90,10 @@ def _is_git_uri(uri: str) -> bool:
 
 def sanitize_wandb_api_key(s: str) -> str:
     return str(re.sub(API_KEY_REGEX, "WANDB_API_KEY", s))
+
+
+def sanitize_entrypoint_key(s: str) -> str:
+    return str(re.sub(ENTRYPOINT_KEY_REGEX, "WANDB_ENTRYPOINT_COMMAND", s))
 
 
 def get_project_from_job(job: str) -> Optional[str]:


### PR DESCRIPTION
Uses the same logic as `sanitize_api_key` to remove the entrypoint env var from logging. purely cosmetic.

This: 
![Screen Shot 2023-03-08 at 4 51 54 PM](https://user-images.githubusercontent.com/19414170/223886738-2cafacde-f752-4121-8941-f34262d14281.png)


To: 

![Screen Shot 2023-03-08 at 4 52 19 PM](https://user-images.githubusercontent.com/19414170/223886794-5d726e09-dcc4-4aae-8830-ee450c669e59.png)

