### PR TITLE
chore(launch): agent extra check when running sweep scheduler local-proc

### DIFF
--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -95,20 +95,20 @@ def _job_is_scheduler(run_spec: Dict[str, Any]) -> bool:
     """Determine whether a job/runSpec is a sweep scheduler."""
     if not run_spec:
         _logger.debug("Recieved runSpec in _job_is_scheduler that was empty")
-    
+
     if run_spec.get("uri") != SCHEDULER_URI:
         return False
 
-    if run_spec.get('resource') == 'local-process':
+    if run_spec.get("resource") == "local-process":
         # If a scheduler is a local-process (100%), also
         #    confirm command is in format: [wandb scheduler <sweep>]
-        cmd = run_spec.get('overrides', {}).get('entry_point', [])
+        cmd = run_spec.get("overrides", {}).get("entry_point", [])
         if len(cmd) < 3:
             return False
 
-        if cmd[:2] != ['wandb', 'scheduler']:
+        if cmd[:2] != ["wandb", "scheduler"]:
             return False
-    
+
     return True
 
 

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -95,8 +95,21 @@ def _job_is_scheduler(run_spec: Dict[str, Any]) -> bool:
     """Determine whether a job/runSpec is a sweep scheduler."""
     if not run_spec:
         _logger.debug("Recieved runSpec in _job_is_scheduler that was empty")
+    
+    if run_spec.get("uri") != SCHEDULER_URI:
+        return False
 
-    return run_spec.get("uri") == SCHEDULER_URI
+    if run_spec.get('resource') == 'local-process':
+        # If a scheduler is a local-process (100%), also
+        #    confirm command is in format: [wandb scheduler <sweep>]
+        cmd = run_spec.get('overrides', {}).get('entry_point', [])
+        if len(cmd) < 3:
+            return False
+
+        if cmd[:2] != ['wandb', 'scheduler']:
+            return False
+    
+    return True
 
 
 class LaunchAgent:


### PR DESCRIPTION
Fixes [WB-12816](https://wandb.atlassian.net/browse/WB-12816)

Description
-----------
Don't just check the image UI for the scheduler placeholder, which can be easily scammed, also check the actual command being run. This ensures local process execution is limited to a `wandb scheduler` command, rather than arbitrary execution. 


[WB-12816]: https://wandb.atlassian.net/browse/WB-12816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ