### PR TITLE
chore(launch): clean up run when rqi-state is failed

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -248,13 +248,20 @@ class Scheduler(ABC):
         for run_id, run in self._yield_runs():
             try:
                 _state = self._api.get_run_state(self._entity, self._project, run_id)
-                if _state is None or _state in [
-                    "crashed",
-                    "failed",
-                    "killed",
-                    "finished",
-                ]:
-                    _logger.debug(f"Got runstate: {_state} for run: {run_id}")
+                if (
+                    not _state
+                    or _state
+                    in [
+                        "crashed",
+                        "failed",
+                        "killed",
+                        "finished",
+                    ]
+                    or run.queued_run.state == "failed"
+                ):
+                    _logger.debug(
+                        f"({run_id}) run-state:{_state}, rqi-state:{run.queued_run.state}"
+                    )
                     run.state = RunState.DEAD
                     _runs_to_remove.append(run_id)
                 elif _state in [

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -248,6 +248,7 @@ class Scheduler(ABC):
         for run_id, run in self._yield_runs():
             try:
                 _state = self._api.get_run_state(self._entity, self._project, run_id)
+                _rqi_state = run.queued_run.state if run.queued_run else None
                 if (
                     not _state
                     or _state
@@ -257,10 +258,10 @@ class Scheduler(ABC):
                         "killed",
                         "finished",
                     ]
-                    or (run.queued_run and run.queued_run.state == "failed")
+                    or _rqi_state == "failed"
                 ):
                     _logger.debug(
-                        f"({run_id}) run-state:{_state}, rqi-state:{run.queued_run.state}"
+                        f"({run_id}) run-state:{_state}, rqi-state:{_rqi_state}"
                     )
                     run.state = RunState.DEAD
                     _runs_to_remove.append(run_id)

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -257,7 +257,7 @@ class Scheduler(ABC):
                         "killed",
                         "finished",
                     ]
-                    or run.queued_run.state == "failed"
+                    or (run.queued_run and run.queued_run.state == "failed")
                 ):
                     _logger.debug(
                         f"({run_id}) run-state:{_state}, rqi-state:{run.queued_run.state}"


### PR DESCRIPTION
Fixes: [WB-12864](https://wandb.atlassian.net/browse/WB-12864)

Description
-----------
When runs fail before they start, runstatus doesn't change, so we should check the runqueueitem state.

Master:
<img width="576" alt="Screen Shot 2023-03-10 at 1 51 59 PM" src="https://user-images.githubusercontent.com/19414170/224436251-b92547dc-1b53-47a7-96e6-fc0e85a064eb.png">

This branch:
<img width="1226" alt="Screen Shot 2023-03-10 at 1 57 09 PM" src="https://user-images.githubusercontent.com/19414170/224436220-3904ff33-fb0c-48e3-bfb7-aef7164f4488.png">

[WB-12864]: https://wandb.atlassian.net/browse/WB-12864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ