### PR TITLE
fix(launch): torch installs fixes

### DIFF
--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -67,7 +67,10 @@ def install_deps(
             return failed
         elif len(failed) > num_failed:
             return install_deps(
-                list(set(clean_deps) - failed), failed, extra_index=extra_index
+                list(set(clean_deps) - failed),
+                failed,
+                extra_index=extra_index,
+                opts=opts,
             )
         else:
             return failed

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -27,7 +27,7 @@ def install_deps(
     deps: List[str],
     failed: Optional[Set[str]] = None,
     extra_index: Optional[str] = None,
-    opts: List[str] = [],
+    opts: Optional[List[str]] = None,
 ) -> Optional[Set[str]]:
     """Install pip dependencies.
 
@@ -43,6 +43,7 @@ def install_deps(
         clean_deps = [d.split("@")[-1].strip() if "@" in d else d for d in deps]
         index_args = ["--extra-index-url", extra_index] if extra_index else []
         print("installing {}...".format(", ".join(clean_deps)))
+        opts = opts or []
         args = ["pip", "install"] + opts + clean_deps + index_args
         sys.stdout.flush()
         subprocess.check_output(args, stderr=subprocess.STDOUT)

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -88,9 +88,9 @@ def main() -> None:
                         r"torch(vision|audio)?==\d+\.\d+\.\d+(\+(?:cu[\d]{2,3})|(?:cpu))?",
                         req,
                     )
-                    if match:
-                        variant = match.group(2)[1:]
-                        extra_index = f"https://download.pytorch.org/whl/{variant}"
+                    variant = match.group(2)
+                    if variant:
+                        extra_index = f"https://download.pytorch.org/whl/{variant[1:]}"
                     reqs.append(req.strip().replace(" ", ""))
                 else:
                     print(f"Ignoring requirement: {req} from frozen requirements")

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -88,9 +88,12 @@ def main() -> None:
                         r"torch(vision|audio)?==\d+\.\d+\.\d+(\+(?:cu[\d]{2,3})|(?:cpu))?",
                         req,
                     )
-                    variant = match.group(2)
-                    if variant:
-                        extra_index = f"https://download.pytorch.org/whl/{variant[1:]}"
+                    if match:
+                        variant = match.group(2)
+                        if variant:
+                            extra_index = (
+                                f"https://download.pytorch.org/whl/{variant[1:]}"
+                            )
                     reqs.append(req.strip().replace(" ", ""))
                 else:
                     print(f"Ignoring requirement: {req} from frozen requirements")

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -40,10 +40,9 @@ def install_deps(
     try:
         # Include only uri if @ is present
         clean_deps = [d.split("@")[-1].strip() if "@" in d else d for d in deps]
-        if extra_index:
-            extra_index = ["--extra-index-url", extra_index]
+        index_args = ["--extra-index-url", extra_index] if extra_index else []
         print("installing {}...".format(", ".join(clean_deps)))
-        args = ["pip", "install"] + OPTS + clean_deps + (extra_index or [])
+        args = ["pip", "install"] + OPTS + clean_deps + index_args
         sys.stdout.flush()
         subprocess.check_output(args, stderr=subprocess.STDOUT)
         return failed


### PR DESCRIPTION
Description
-----------
This PR adds an extra index URL for specific pytorch wheels in our launch dependency installer when we encounter frozen dependency strings of the form torch(vision|audio)==0.0.0+cu116 for example.


Testing
-------

I created a job with weird dependency strings https://wandb.ai/bcanfieldsherman/fmnist/artifacts/job/fmnist-cu116/v3 and was able to successfully reinstall the correct dependencies and run with gpu on local container runner. The changes didn't break any old pytest tests and I haven't added any new pytest tests.


Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
