### PR TITLE
chore(launch): clean up logging slightly

### DIFF
--- a/wandb/sdk/launch/launch.py
+++ b/wandb/sdk/launch/launch.py
@@ -15,6 +15,7 @@ from .runner.abstract import AbstractRun
 from .utils import (
     LAUNCH_CONFIG_FILE,
     LAUNCH_DEFAULT_PROJECT,
+    LOG_PREFIX,
     PROJECT_SYNCHRONOUS,
     ExecutionError,
     LaunchError,
@@ -189,6 +190,7 @@ def _run(
     builder = loader.builder_from_config(build_config, environment, registry)
     backend = loader.runner_from_config(resource, api, runner_config, environment)
     if backend:
+        wandb.termlog(f"{LOG_PREFIX}Launching run into {entity}/{project}")
         submitted_run = backend.run(launch_project, builder)
         # this check will always pass, run is only optional in the agent case where
         # a run queue id is present on the backend config

--- a/wandb/sdk/launch/launch.py
+++ b/wandb/sdk/launch/launch.py
@@ -190,7 +190,9 @@ def _run(
     builder = loader.builder_from_config(build_config, environment, registry)
     backend = loader.runner_from_config(resource, api, runner_config, environment)
     if backend:
-        wandb.termlog(f"{LOG_PREFIX}Launching run into {entity}/{project}")
+        wandb.termlog(
+            f"{LOG_PREFIX}Launching run into {launch_project.target_entity}/{launch_project.target_project}"
+        )
         submitted_run = backend.run(launch_project, builder)
         # this check will always pass, run is only optional in the agent case where
         # a run queue id is present on the backend config

--- a/wandb/sdk/launch/launch_add.py
+++ b/wandb/sdk/launch/launch_add.py
@@ -190,7 +190,9 @@ def _launch_add(
         project_queue = LAUNCH_DEFAULT_PROJECT
 
     validate_launch_spec_source(launch_spec)
-    wandb.termlog(f"{LOG_PREFIX}Launching run into {entity}/{project}")
+    wandb.termlog(
+        f"{LOG_PREFIX}Launching run into {launch_spec.get('entity')}/{launch_spec.get('project')}"
+    )
     res = push_to_queue(api, queue_name, launch_spec, project_queue)
 
     if res is None or "runQueueItemId" not in res:

--- a/wandb/sdk/launch/launch_add.py
+++ b/wandb/sdk/launch/launch_add.py
@@ -190,6 +190,7 @@ def _launch_add(
         project_queue = LAUNCH_DEFAULT_PROJECT
 
     validate_launch_spec_source(launch_spec)
+    wandb.termlog(f"{LOG_PREFIX}Launching run into {entity}/{project}")
     res = push_to_queue(api, queue_name, launch_spec, project_queue)
 
     if res is None or "runQueueItemId" not in res:

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -1,10 +1,8 @@
 # heavily inspired by https://github.com/mlflow/mlflow/blob/master/mlflow/projects/utils.py
 import logging
 import os
-import platform
 import re
 import subprocess
-import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import click
@@ -141,10 +139,6 @@ def set_project_entity_defaults(
         if launch_config:
             config_entity = launch_config.get("entity")
         entity = config_entity or api.default_entity
-    prefix = ""
-    if platform.system() != "Windows" and sys.stdout.encoding == "UTF-8":
-        prefix = "🚀 "
-    wandb.termlog(f"{LOG_PREFIX}{prefix}Launching run into {entity}/{project}")
     return project, entity
 
 


### PR DESCRIPTION
Not sure we even need this message, but now we don't log after creating a launchSpec, but rather right before actually launching. Should be in the exact same place for most paths. 


master/this branch:
![Screen Shot 2023-03-13 at 5 39 45 PM](https://user-images.githubusercontent.com/19414170/224862945-2d4b4457-7cee-442c-94f8-82a1a0a3c5e2.png)


