### PR TITLE
test(sdk): update mock_server.py to match yea-wandb==0.9.6

### DIFF
--- a/tests/pytest_tests/unit_tests_old/utils/mock_server.py
+++ b/tests/pytest_tests/unit_tests_old/utils/mock_server.py
@@ -114,7 +114,10 @@ def mock_server(mocker):
     mock = RequestsMock(app, ctx)
     # We mock out all requests libraries, couldn't find a way to mock the core lib
     sdk_path = "wandb.sdk"
+    # From previous wandb_gql transport library.
     mocker.patch("wandb_gql.transport.requests.requests", mock)
+
+    mocker.patch("wandb.wandb_sdk.lib.gql_request.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.file_stream.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.internal_api.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.update.requests", mock)
@@ -372,7 +375,6 @@ class HttpException(Exception):
 
 
 class SnoopRelay:
-
     _inject_count: int
     _inject_time: float
 
@@ -383,7 +385,6 @@ class SnoopRelay:
     def relay(self, func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-
             # Normal mockserver mode, disable live relay and call next function
             if not os.environ.get("MOCKSERVER_RELAY"):
                 return func(*args, **kwargs)
@@ -1659,7 +1660,6 @@ def create_app(user_ctx=None):
                 c["alerts"].append(adict)
             return {"data": {"notifyScriptableRunAlert": {"success": True}}}
         if "query SearchUsers" in body["query"]:
-
             return {
                 "data": {
                     "users": {

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist=
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.9.5
+    YEA_WANDB_VERSION = 0.9.6
     ; Setting low network buffer so that we exercise flow control logic
     WANDB__NETWORK_BUFFER = 1000
 


### PR DESCRIPTION
Required for [WB-12747](https://wandb.atlassian.net/browse/WB-12747)

Description
-----------
Needed for #5075, this matches the updates from https://github.com/wandb/yea-wandb/pull/104. The functional tests won't pass until 0.9.6 has been released.

Testing
-------


Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12747]: https://wandb.atlassian.net/browse/WB-12747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ