### PR TITLE
refactor(artifacts): move _manifest_json_from_proto to sender.py

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -295,7 +295,6 @@ def test_add_reference_local_file_no_checksum(tmp_path):
 
 
 def test_add_reference_local_dir():
-
     with open("file1.txt", "w") as f:
         f.write("hello")
     os.mkdir("nest")
@@ -328,7 +327,6 @@ def test_add_reference_local_dir():
 
 
 def test_add_reference_local_dir_no_checksum():
-
     path_1 = os.path.join("file1.txt")
     with open(path_1, "w") as f:
         f.write("hello")
@@ -369,7 +367,6 @@ def test_add_reference_local_dir_no_checksum():
 
 
 def test_add_reference_local_dir_with_name():
-
     with open("file1.txt", "w") as f:
         f.write("hello")
     os.mkdir("nest")
@@ -419,7 +416,6 @@ def test_add_reference_local_dir_by_uri(tmp_path):
 
 
 def test_add_s3_reference_object():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact)
     artifact.add_reference("s3://my-bucket/my_object.pb")
@@ -435,7 +431,6 @@ def test_add_s3_reference_object():
 
 
 def test_add_s3_reference_object_with_version():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact)
     artifact.add_reference("s3://my-bucket/my_object.pb?versionId=2")
@@ -451,7 +446,6 @@ def test_add_s3_reference_object_with_version():
 
 
 def test_add_s3_reference_object_with_name():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact)
     artifact.add_reference("s3://my-bucket/my_object.pb", name="renamed.pb")
@@ -503,7 +497,6 @@ def test_add_s3_reference_path_with_content_type(runner, capsys):
 
 
 def test_add_s3_max_objects():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, path=True)
     with pytest.raises(ValueError):
@@ -511,7 +504,6 @@ def test_add_s3_max_objects():
 
 
 def test_add_reference_s3_no_checksum():
-
     with open("file1.txt", "w") as f:
         f.write("hello")
     artifact = wandb.Artifact(type="dataset", name="my-arty")
@@ -528,7 +520,6 @@ def test_add_reference_s3_no_checksum():
 
 
 def test_add_gs_reference_object():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb")
@@ -544,7 +535,6 @@ def test_add_gs_reference_object():
 
 
 def test_add_gs_reference_object_with_version():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb#2")
@@ -560,7 +550,6 @@ def test_add_gs_reference_object_with_version():
 
 
 def test_add_gs_reference_object_with_name():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb", name="renamed.pb")
@@ -594,7 +583,6 @@ def test_add_gs_reference_path(runner, capsys):
 
 
 def test_add_http_reference_path():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_http(
         artifact,
@@ -635,7 +623,6 @@ def test_add_reference_named_local_file(tmp_path):
 
 
 def test_add_reference_unknown_handler():
-
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_reference("ref://example.com/somefile.txt", name="ref")
 
@@ -995,7 +982,6 @@ def test_add_obj_wbtable_images_duplicate_name(assets_path):
 
 
 def test_add_partition_folder():
-
     table_name = "dataset"
     table_parts_dir = "dataset_parts"
     artifact_name = "simple_dataset"
@@ -1097,7 +1083,7 @@ def test_tracking_storage_handler():
 def test_manifest_json_version():
     pd_manifest = wandb.proto.wandb_internal_pb2.ArtifactManifest()
     pd_manifest.version = 1
-    manifest = wandb.sdk.internal.artifacts._manifest_json_from_proto(pd_manifest)
+    manifest = wandb.sdk.internal.sender._manifest_json_from_proto(pd_manifest)
     assert manifest["version"] == 1
 
 
@@ -1113,7 +1099,7 @@ def test_manifest_json_invalid_version(version):
     pd_manifest = wandb.proto.wandb_internal_pb2.ArtifactManifest()
     pd_manifest.version = version
     with pytest.raises(Exception) as e:
-        wandb.sdk.internal.artifacts._manifest_json_from_proto(pd_manifest)
+        wandb.sdk.internal.sender._manifest_json_from_proto(pd_manifest)
     assert "manifest version" in str(e.value)
 
 

--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -17,7 +17,6 @@ from ..interface.artifacts import (
 )
 
 if TYPE_CHECKING:
-    from wandb.proto import wandb_internal_pb2
     from wandb.sdk.internal.internal_api import Api as InternalApi
     from wandb.sdk.internal.progress import ProgressFn
 
@@ -39,37 +38,6 @@ if TYPE_CHECKING:
             self, entry: ArtifactManifestEntry, progress_callback: "ProgressFn"
         ) -> Awaitable[bool]:
             pass
-
-
-def _manifest_json_from_proto(manifest: "wandb_internal_pb2.ArtifactManifest") -> Dict:
-    if manifest.version == 1:
-        contents = {
-            content.path: {
-                "digest": content.digest,
-                "birthArtifactID": content.birth_artifact_id
-                if content.birth_artifact_id
-                else None,
-                "ref": content.ref if content.ref else None,
-                "size": content.size if content.size is not None else None,
-                "local_path": content.local_path if content.local_path else None,
-                "extra": {
-                    extra.key: json.loads(extra.value_json) for extra in content.extra
-                },
-            }
-            for content in manifest.contents
-        }
-    else:
-        raise Exception(f"unknown artifact manifest version: {manifest.version}")
-
-    return {
-        "version": manifest.version,
-        "storagePolicy": manifest.storage_policy,
-        "storagePolicyConfig": {
-            config.key: json.loads(config.value_json)
-            for config in manifest.storage_policy_config
-        },
-        "contents": contents,
-    }
 
 
 class ArtifactSaver:

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     import sys
 
     from wandb.proto.wandb_internal_pb2 import (
+        ArtifactManifest,
         ArtifactRecord,
         HttpResponse,
         LocalInfo,
@@ -98,6 +99,37 @@ def _framework_priority() -> Generator[Tuple[str, str], None, None]:
         ("tensorflow", "tensorflow"),
         ("sklearn", "sklearn"),
     ]
+
+
+def _manifest_json_from_proto(manifest: "ArtifactManifest") -> Dict:
+    if manifest.version == 1:
+        contents = {
+            content.path: {
+                "digest": content.digest,
+                "birthArtifactID": content.birth_artifact_id
+                if content.birth_artifact_id
+                else None,
+                "ref": content.ref if content.ref else None,
+                "size": content.size if content.size is not None else None,
+                "local_path": content.local_path if content.local_path else None,
+                "extra": {
+                    extra.key: json.loads(extra.value_json) for extra in content.extra
+                },
+            }
+            for content in manifest.contents
+        }
+    else:
+        raise ValueError(f"unknown artifact manifest version: {manifest.version}")
+
+    return {
+        "version": manifest.version,
+        "storagePolicy": manifest.storage_policy,
+        "storagePolicyConfig": {
+            config.key: json.loads(config.value_json)
+            for config in manifest.storage_policy_config
+        },
+        "contents": contents,
+    }
 
 
 class ResumeState:
@@ -1443,7 +1475,7 @@ class SendManager:
         saver = artifacts.ArtifactSaver(
             api=self._api,
             digest=artifact.digest,
-            manifest_json=artifacts._manifest_json_from_proto(artifact.manifest),
+            manifest_json=_manifest_json_from_proto(artifact.manifest),
             file_pusher=self._pusher,
             is_user_created=artifact.user_created,
         )


### PR DESCRIPTION
Supports [WB-12644](https://wandb.atlassian.net/browse/WB-12644)

Description
-----------
`_manifest_json_from_proto` is only used in `sender.py`, so move it there.

Testing
-------
Local/CI

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12644]: https://wandb.atlassian.net/browse/WB-12644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ