### PR TITLE
chore(artifacts): use absolute imports

### DIFF
--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -8,13 +8,12 @@ from typing import TYPE_CHECKING, Awaitable, Dict, List, Optional, Sequence
 import wandb
 import wandb.filesync.step_prepare
 from wandb import util
-from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
-
-from ..interface.artifacts import (
+from wandb.sdk.interface.artifacts import (
     ArtifactManifest,
     ArtifactManifestEntry,
     get_staging_dir,
 )
+from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
 
 if TYPE_CHECKING:
     from wandb.proto import wandb_internal_pb2

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1,6 +1,5 @@
 """sender."""
 
-
 import json
 import logging
 import os
@@ -30,26 +29,32 @@ from wandb import util
 from wandb.errors import CommError
 from wandb.filesync.dir_watcher import DirWatcher
 from wandb.proto import wandb_internal_pb2
-from wandb.sdk.lib import redirect
-from wandb.sdk.lib.mailbox import ContextCancelledError
-
-from ..interface import interface
-from ..interface.interface_queue import InterfaceQueue
-from ..lib import (
+from wandb.sdk.interface import interface
+from wandb.sdk.interface.interface_queue import InterfaceQueue
+from wandb.sdk.internal import (
+    artifacts,
+    context,
+    datastore,
+    file_stream,
+    internal_api,
+    update,
+)
+from wandb.sdk.internal.file_pusher import FilePusher
+from wandb.sdk.internal.job_builder import JobBuilder
+from wandb.sdk.internal.settings_static import SettingsDict, SettingsStatic
+from wandb.sdk.lib import (
     config_util,
     filenames,
     filesystem,
     printer,
     proto_util,
+    redirect,
     telemetry,
     tracelog,
 )
-from ..lib.proto_util import message_to_dict
-from ..wandb_settings import Settings
-from . import artifacts, context, datastore, file_stream, internal_api, update
-from .file_pusher import FilePusher
-from .job_builder import JobBuilder
-from .settings_static import SettingsDict, SettingsStatic
+from wandb.sdk.lib.mailbox import ContextCancelledError
+from wandb.sdk.lib.proto_util import message_to_dict
+from wandb.sdk.wandb_settings import Settings
 
 if TYPE_CHECKING:
     import sys
@@ -1176,7 +1181,7 @@ class SendManager:
             # shut down threads
             output_raw._writer_thr.join(timeout=5)
             if output_raw._writer_thr.is_alive():
-                logger.info("processing output...")
+                logger.info("processing outputwandb.sdk..")
                 output_raw._writer_thr.join()
             output_raw._reader_thr.join()
 

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1181,7 +1181,7 @@ class SendManager:
             # shut down threads
             output_raw._writer_thr.join(timeout=5)
             if output_raw._writer_thr.is_alive():
-                logger.info("processing outputwandb.sdk..")
+                logger.info("processing output...")
                 output_raw._writer_thr.join()
             output_raw._reader_thr.join()
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -34,13 +34,10 @@ from wandb.apis import InternalApi, PublicApi
 from wandb.apis.public import Artifact as PublicArtifact
 from wandb.errors import CommError
 from wandb.errors.term import termlog, termwarn
-from wandb.sdk.internal import progress
-from wandb.util import FilePathStr, LogicalFilePathStr, URIStr
-
-from . import lib as wandb_lib
-from .data_types._dtypes import Type, TypeRegistry
-from .interface.artifacts import Artifact as ArtifactInterface
-from .interface.artifacts import (
+from wandb.sdk import lib as wandb_lib
+from wandb.sdk.data_types._dtypes import Type, TypeRegistry
+from wandb.sdk.interface.artifacts import Artifact as ArtifactInterface
+from wandb.sdk.interface.artifacts import (
     ArtifactFinalizedError,
     ArtifactManifest,
     ArtifactManifestEntry,
@@ -52,8 +49,9 @@ from .interface.artifacts import (
     get_artifacts_cache,
     get_new_staging_file,
 )
-from .lib import filesystem, runid
-from .lib.hashutil import (
+from wandb.sdk.internal import progress
+from wandb.sdk.lib import filesystem, runid
+from wandb.sdk.lib.hashutil import (
     B64MD5,
     ETag,
     HexMD5,
@@ -62,6 +60,7 @@ from .lib.hashutil import (
     md5_file_b64,
     md5_string,
 )
+from wandb.util import FilePathStr, LogicalFilePathStr, URIStr
 
 if TYPE_CHECKING:
     # We could probably use https://pypi.org/project/boto3-stubs/ or something


### PR DESCRIPTION
Description
-----------
Stops using local/relative imports (`from ..foo import ...`) in favor of absolute imports (`from wandb.sdk.foo import ...`)

Separating out these changes rather than lump them in with my other refactoring PRs.
