### PR TITLE
pure duct tape but otherwise is so annoying

### DIFF
--- a/wandb/sdk/internal/system/assets/interfaces.py
+++ b/wandb/sdk/internal/system/assets/interfaces.py
@@ -139,6 +139,7 @@ class MetricsMonitor:
                         metric.sample()
                     except Exception as e:
                         logger.error(f"Failed to sample metric: {e}")
+                        self._shutdown_event.set()
                 self._shutdown_event.wait(self.sampling_interval)
                 if self._shutdown_event.is_set():
                     break


### PR DESCRIPTION
Addresses, but does NOT fix: https://wandb.atlassian.net/browse/WB-12016 

Description
-----------
I can't figure out exactly which of the sender/handler processes is failing, but we except on this metrics polling forever currently. Sweeps on launch deterministically produces this error. 

This one-liner allows for only one exception, then manually sets the shutdown event to trigger stopping...
