### PR TITLE
feat(sdk): allow setting of extra headers for the gql client

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -194,12 +194,22 @@ class Api:
             "system_samples": 15,
             "heartbeat_seconds": 30,
         }
+
+        # FIXME allow the headers to be provided as dicts. For an easier PoC we
+        # put them in a Sequence[str] where header name and value are
+        # concatenated with a ":" as delimiter.
+        extra_http_headers = {}
+        for header in self.settings('extra_http_headers'):
+            name, value = header.split(':')
+            extra_http_headers[name] = value
+
         self.client = Client(
             transport=GraphQLSession(
                 headers={
                     "User-Agent": self.user_agent,
                     "X-WANDB-USERNAME": env.get_username(env=self._environ),
                     "X-WANDB-USER-EMAIL": env.get_user_email(env=self._environ),
+                    **extra_http_headers,
                 },
                 use_json=True,
                 # this timeout won't apply when the DNS lookup fails. in that case, it will be 60s

--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -62,6 +62,7 @@ class SettingsStatic:
     _flow_control_custom: bool
     disable_job_creation: bool
     _async_upload_concurrency_limit: Optional[int]
+    _extra_http_headers: Optional[Mapping[str, str]]
 
     # TODO(jhr): clean this up, it is only in SettingsStatic and not in Settings
     _log_level: int

--- a/wandb/sdk/lib/_settings_toposort_generated.py
+++ b/wandb/sdk/lib/_settings_toposort_generated.py
@@ -24,6 +24,7 @@ _Setting = Literal[
     "_disable_viewer",
     "_except_exit",
     "_executable",
+    "_extra_http_headers",
     "_flow_control_custom",
     "_flow_control_disabled",
     "_internal_check_process",

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -448,6 +448,7 @@ class Settings:
     docker: str
     email: str
     entity: str
+    extra_http_headers: Sequence[str]
     files_dir: str
     force: bool
     git_commit: str
@@ -632,6 +633,7 @@ class Settings:
             disable_git={"preprocessor": _str_as_bool},
             disable_job_creation={"value": False, "preprocessor": _str_as_bool},
             disabled={"value": False, "preprocessor": _str_as_bool},
+            extra_http_headers={"value": {}},
             files_dir={
                 "value": "files",
                 "hook": lambda x: self._path_convert(

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -634,7 +634,6 @@ class Settings:
             disable_git={"preprocessor": _str_as_bool},
             disable_job_creation={"value": False, "preprocessor": _str_as_bool},
             disabled={"value": False, "preprocessor": _str_as_bool},
-            extra_http_headers={"value": {}},
             files_dir={
                 "value": "files",
                 "hook": lambda x: self._path_convert(

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -395,6 +395,7 @@ class Settings:
     _disable_viewer: bool  # Prevent early viewer query
     _except_exit: bool
     _executable: str
+    _extra_http_headers: Mapping[str, str]
     _flow_control_custom: bool
     _flow_control_disabled: bool
     _internal_check_process: Union[int, float]
@@ -448,7 +449,6 @@ class Settings:
     docker: str
     email: str
     entity: str
-    extra_http_headers: Sequence[str]
     files_dir: str
     force: bool
     git_commit: str
@@ -541,6 +541,7 @@ class Settings:
             },
             _disable_stats={"preprocessor": _str_as_bool},
             _disable_viewer={"preprocessor": _str_as_bool},
+            _extra_http_headers={"preprocessor": _str_as_dict},
             _network_buffer={"preprocessor": int},
             _colab={
                 "hook": lambda _: "google.colab" in sys.modules,


### PR DESCRIPTION
Description
-----------
Provide a temporary way to pass extra headers to the GraphQL Client init.

TODO: Shall be refactored once the Settings refactor is complete.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
