### PR TITLE
feat(artifacts): reserve space on disk and prevent out of space errors from the filesystem

### DIFF
--- a/wandb/env.py
+++ b/wandb/env.py
@@ -73,6 +73,7 @@ CONFIG_DIR = "WANDB_CONFIG_DIR"
 DATA_DIR = "WANDB_DATA_DIR"
 ARTIFACT_DIR = "WANDB_ARTIFACT_DIR"
 CACHE_DIR = "WANDB_CACHE_DIR"
+MINIMUM_FREE_SPACE = "WANDB_MINIMUM_FREE_SPACE"
 DISABLE_SSL = "WANDB_INSECURE_DISABLE_SSL"
 SERVICE = "WANDB_SERVICE"
 _DISABLE_SERVICE = "WANDB_DISABLE_SERVICE"
@@ -119,6 +120,7 @@ def immutable_keys() -> List[str]:
         DATA_DIR,
         ARTIFACT_DIR,
         CACHE_DIR,
+        MINIMUM_FREE_SPACE,
         USE_V1_ARTIFACTS,
         DISABLE_SSL,
     ]
@@ -370,6 +372,19 @@ def get_cache_dir(env: Optional[Env] = None) -> str:
     if env is None:
         env = os.environ
     val = env.get(CACHE_DIR, default_dir)
+    return val
+
+
+def get_minimum_free_space(env: Optional[Env] = None, default: int = 1_000_000) -> int:
+    if env is None:
+        env = os.environ
+    val = env.get(MINIMUM_FREE_SPACE, default)
+    try:
+        val = int(val)
+    except ValueError:
+        val = default
+    if val < 0:
+        val = default
     return val
 
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -737,6 +737,11 @@ class Artifact(ArtifactInterface):
     def _add_local_file(
         self, name: StrPath, path: StrPath, digest: Optional[B64MD5] = None
     ) -> ArtifactManifestEntry:
+        # Verify that we have enough space to copy the file.
+        reserve_bytes = env.get_minimum_free_space()
+        size = os.path.getsize(path)
+        filesystem.check_available_space(path, reserve=reserve_bytes, size=size)
+
         with tempfile.NamedTemporaryFile(dir=get_staging_dir(), delete=False) as f:
             staging_path = f.name
             shutil.copyfile(path, staging_path)


### PR DESCRIPTION
Fixes [WB-12643](https://wandb.atlassian.net/browse/WB-12643)

Description
-----------
Adds a new environment variable `WANDB_MINIMUM_FREE_SPACE`, set to a default of 1GB; the intention is that `wandb` will not write to disk (and will raise an exception) if it needs to write and there is less than that many bytes free.

Adds a `filesystem.check_available_space` function that raises an error if there is not enough space; or logs a warning if there is not enough space for two such writes.

Checks space available when copying files to the upload staging area and to the cache.

Note that this doesn't really change the fundamental behavior of `wandb`; if it's going to run out of space, it still does so, and in fact does so sooner. The point is that the error is raised in the user process rather than by the kernel when a sys call fails; actually consuming all available disk space can significantly mess up a system and be somewhat difficult to recover from. It also should provide an early warning and more informative error messages.

Testing
-------
Added unit tests by patching `shutil.disk_usage`; no functional tests, because it's annoying to _actually_ use up all your disk space for a test.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-12643]: https://wandb.atlassian.net/browse/WB-12643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ