### PR TITLE
fix(sdk): Ensure empty string logs as empty string and not list

### DIFF
--- a/tests/pytest_tests/system_tests/test_core/test_wandb.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb.py
@@ -429,6 +429,15 @@ def test_log_step_committed_same_dropped(relay_server, wandb_init):
     assert len(history.columns) == 1
 
 
+def test_log_empty_string(relay_server, wandb_init):
+    with relay_server() as relay:
+        run = wandb_init()
+        run.log(dict(cool=""))
+        run.finish()
+
+    assert relay.context.history["cool"][0] == ""
+
+
 # ----------------------------------
 # wandb.save
 # ----------------------------------

--- a/wandb/sdk/data_types/utils.py
+++ b/wandb/sdk/data_types/utils.py
@@ -78,7 +78,11 @@ def val_to_json(
 
     elif util.is_matplotlib_typename(typename) or util.is_plotly_typename(typename):
         val = Plotly.make_plot_media(val)
-    elif isinstance(val, Sequence) and all(isinstance(v, WBValue) for v in val):
+    elif (
+        isinstance(val, Sequence)
+        and not isinstance(val, str)
+        and all(isinstance(v, WBValue) for v in val)
+    ):
         assert run
         # This check will break down if Image/Audio/... have child classes.
         if (


### PR DESCRIPTION
Description
-----------
Currently logging `wandb.log({"somekey": ""})` sends the value of somekey to gorilla as `[]` instead of `""`. This fixes that and adds a test. 

Testing
-------
How was this PR tested? Unit test

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
