### PR TITLE
chore(sdk): reset permissions to allow test runner to clean up temp files

### DIFF
--- a/tests/pytest_tests/unit_tests/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_internal_api.py
@@ -122,6 +122,7 @@ def test_internal_api_with_no_write_global_config_dir(tmp_path):
     with patch.dict("os.environ", WANDB_CONFIG_DIR=str(tmp_path)):
         os.chmod(tmp_path, 0o444)
         internal.InternalApi()
+        os.chmod(tmp_path, 0o777)  # Allow the test runner to clean up.
 
 
 @pytest.fixture


### PR DESCRIPTION
Description
-----------
Previously running the tests caused un-removable files to accumulate in my pytest test directory, and I had to remove them manually with sudo. I think this is the cause, though to there might be another somewhere else too.
