### PR TITLE
chore(artifacts): add a safe_open utility for atomic writes

### DIFF
--- a/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
@@ -2,12 +2,17 @@ import os
 import platform
 import shutil
 import stat
+import tempfile
 import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from wandb.sdk.lib.filesystem import copy_or_overwrite_changed, mkdir_exists_ok
+from wandb.sdk.lib.filesystem import (
+    copy_or_overwrite_changed,
+    mkdir_exists_ok,
+    safe_open,
+)
 
 
 def write_pause(path, content):
@@ -137,3 +142,145 @@ def test_copy_or_overwrite_changed_unfixable(tmp_path):
     with pytest.raises(PermissionError) as e:
         copy_or_overwrite_changed(source_path, target_path)
     assert "Unable to overwrite" in str(e.value)
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+@pytest.mark.parametrize("mode", ["w", "w+", "a", "a+"])
+def test_safe_write_interrupted_overwrites(binary, mode):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = Path(tmp_dir)
+        original_file = tmp_dir / "original.txt"
+        original_content = "Original content 🧐"
+        original_file.write_text(original_content, encoding="utf-8")
+
+        with pytest.raises(RuntimeError):
+            with safe_open(original_file, mode + binary) as f:
+                f.write(b"!!!" if binary == "b" else "!!!")
+                raise RuntimeError("Interrupted write")
+
+        assert original_file.read_text("utf-8") == original_content
+        assert list(tmp_dir.iterdir()) == [original_file]
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+@pytest.mark.parametrize("mode", ["w", "w+"])
+def test_safe_write_complete_overwrites(mode, binary):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = Path(tmp_dir)
+        original_file = tmp_dir / "original.txt"
+        original_file.write_text("Original content")
+        new_content = "New content 😐"  # Shorter than original.
+
+        encoding = "utf-8" if binary != "b" else None
+        with safe_open(original_file, mode + binary, encoding=encoding) as f:
+            f.write(new_content.encode("utf-8") if binary == "b" else new_content)
+
+        assert original_file.read_text("utf-8") == new_content
+        assert list(tmp_dir.iterdir()) == [original_file]
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+@pytest.mark.parametrize("mode", ["a", "a+"])
+def test_safe_write_complete_appends(binary, mode):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = Path(tmp_dir)
+        original_file = tmp_dir / "original.txt"
+        original_content = "Original content 🧐"
+        original_file.write_text(original_content, encoding="utf-8")
+        new_content = "New content❗"
+
+        encoding = "utf-8" if binary != "b" else None
+        with safe_open(original_file, mode + binary, encoding=encoding) as f:
+            f.write(new_content.encode("utf-8") if binary == "b" else new_content)
+
+        assert original_file.read_text("utf-8") == original_content + new_content
+        assert list(tmp_dir.iterdir()) == [original_file]
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+@pytest.mark.parametrize("mode", ["r", "r+"])
+def test_safe_read_missing_file(tmp_path, binary, mode):
+    missing_file = tmp_path / "missing.txt"
+
+    with pytest.raises(FileNotFoundError):
+        with safe_open(missing_file, mode + binary):
+            pass
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+def test_safe_read_existing_file(tmp_path, binary):
+    existing_file = tmp_path / "existing.txt"
+    original_content = "Original content 🧐"
+    existing_file.write_text(original_content, encoding="utf-8")
+
+    encoding = "utf-8" if binary != "b" else None
+    with safe_open(existing_file, "r" + binary, encoding=encoding) as f:
+        content = f.read()
+        if binary == "b":
+            content = content.decode("utf-8")
+        assert content == original_content
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+def test_safe_read_write_existing_file(binary):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = Path(tmp_dir)
+        original_file = tmp_dir / "original.txt"
+        original_content = "🔜Original content"
+        original_file.write_text(original_content, encoding="utf-8")
+        new_content = "More❗"
+
+        encoding = "utf-8" if binary != "b" else None
+        with safe_open(original_file, "r+" + binary, encoding=encoding) as f:
+            content = f.read()
+            if binary == "b":
+                content = content.decode("utf-8")
+            assert content == original_content
+            f.seek(5)
+            f.write(new_content.encode("utf-8") if binary == "b" else new_content)
+
+        assert original_file.read_text("utf-8") == "🔜OMore❗ content"
+        assert list(tmp_dir.iterdir()) == [original_file]
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+@pytest.mark.parametrize("mode", ["x", "x+"])
+def test_safe_exclusive_write_existing_file(tmp_path, binary, mode):
+    existing_file = tmp_path / "existing.txt"
+    existing_file.write_text("Existing content 🧐", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        with safe_open(existing_file, mode + binary):
+            pass
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+@pytest.mark.parametrize("mode", ["a", "a+", "x", "x+"])
+def test_safe_write_interrupted_exclusive_writes(binary, mode):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = Path(tmp_dir)
+        original_file = tmp_dir / "original.txt"
+
+        with pytest.raises(RuntimeError):
+            with safe_open(original_file, mode + binary) as f:
+                f.write(b"!!!" if binary == "b" else "!!!")
+                raise RuntimeError("Interrupted write")
+
+        assert not original_file.exists()
+        assert list(tmp_dir.iterdir()) == []
+
+
+@pytest.mark.parametrize("binary", ["", "b", "t"])
+@pytest.mark.parametrize("mode", ["a", "a+", "x", "x+"])
+def test_safe_write_complete_exclusive_writes(binary, mode):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir = Path(tmp_dir)
+        original_file = tmp_dir / "original.txt"
+        new_content = "New content 👾"
+
+        encoding = "utf-8" if binary != "b" else None
+        with safe_open(original_file, mode + binary, encoding=encoding) as f:
+            f.write(new_content.encode("utf-8") if binary == "b" else new_content)
+
+        assert original_file.read_text("utf-8") == new_content
+        assert list(tmp_dir.iterdir()) == [original_file]


### PR DESCRIPTION
Fixes [WB-13152](https://wandb.atlassian.net/browse/WB-13152)

Description
-----------
This adds a `safe_open` utility that operates like the `open()` built-in, but writes to a temp file and replaces the target only when a write is complete. This is modeled off `ArtifactsCache._cache_opener`, but has slightly broader applicability and is much more extensively tested.

Right now this PR adds the utility without doing anything else because it's actually a decent amount of surprisingly tricky code, but I will be using it to improve how the ArtifactsCache works.

Testing
-------
Yes.

Lots of tests. I think with all the various parameterizations it's 66 new test cases? This turned out to be very tricky to get exactly correct and most of these tests turned out to be important.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
