### PR TITLE
feat(sdk): namespace filters applied by OpenMetrics endpoint consumer

### DIFF
--- a/tests/pytest_tests/unit_tests/test_system_metric/test_system_metrics_open_metrics.py
+++ b/tests/pytest_tests/unit_tests/test_system_metric/test_system_metrics_open_metrics.py
@@ -101,7 +101,6 @@ def test_dcgm_not_available(test_settings, mocked_requests_get_method):
         "get",
         mocked_requests_get_method,
     ):
-
         url = "http://localhost:9400/metrics"
 
         assert not OpenMetrics.is_available(url)
@@ -165,56 +164,82 @@ def test_dcgm(test_settings):
 
 
 @pytest.mark.parametrize(
-    "filters,metric_name,metric_labels,should_capture",
+    "filters,endpoint_name,metric_name,metric_labels,should_capture",
     [
         (
-            {"DCGM_FI_DEV_POWER_USAGE": {"pod": "wandb-.*"}},
+            {".*DCGM_FI_DEV_POWER_USAGE": {"pod": "wandb-.*"}},
+            "node1",
             "DCGM_FI_DEV_POWER_USAGE",
             {"pod": "wandb-1337"},
             True,
         ),
         (
-            {"DCGM_FI_DEV_POWER_USAGE": {"pod": "wandb-.*"}},
+            {".*DCGM_FI_DEV_POWER_USAGE": {"pod": "wandb-.*"}},
+            "node2",
             "DCGM_FI_DEV_POWER_USAGE",
             {"pod": "not-wandb-1337"},
             False,
         ),
         (
-            {"DCGM_FI_DEV_POWER_USAGE": {"pod": "wandb-.*"}},
+            {".*DCGM_FI_DEV_POWER_USAGE": {"pod": "wandb-.*"}},
+            "node3",
             "DCGM_FI_DEV_POWER_USAGE",
             {"pod": "wandb-1337", "container": "wandb"},
             True,
         ),
         (
-            {"DCGM_.*": {}},
+            {".*DCGM_.*": {}},
+            "node4",
             "DCGM_FI_DEV_POWER_USAGE",
             {"pod": "wandb-1337", "container": "not-wandb"},
             True,
         ),
         (
             {".*": {}},
+            "node5",
             "DCGM_FI_DEV_POWER_USAGE",
             {"pod": "wandb-1337", "container": "not-wandb"},
             True,
         ),
         (
-            {"DCGM_.*": {"pod": "wandb-.*"}},
+            {".*DCGM_.*": {"pod": "wandb-.*"}},
+            "node6",
             "DCGM_FI_DEV_POWER_USAGE",
             {"pod": "wandb-1337"},
             True,
         ),
         (
-            {"DCGM_.*": {"pod": "wandb-.*"}},
+            {".*DCGM_.*": {"pod": "wandb-.*"}},
+            "node7",
             "DCGM_FI_DEV_POWER_USAGE",
             {"pod": "not-wandb-1337"},
             False,
         ),
+        (
+            {"node[0-9].DCGM_.*": {"pod": "wandb-.*"}},
+            "node8",
+            "DCGM_FI_DEV_POWER_USAGE",
+            {"pod": "wandb-1337"},
+            True,
+        ),
+        (
+            {"node[0-7].DCGM_.*": {"pod": "wandb-.*"}},
+            "node8",
+            "DCGM_FI_DEV_POWER_USAGE",
+            {"pod": "wandb-1337"},
+            False,
+        ),
     ],
 )
-def test_metric_filters(filters, metric_name, metric_labels, should_capture):
+def test_metric_filters(
+    filters, endpoint_name, metric_name, metric_labels, should_capture
+):
     assert (
         _should_capture_metric(
-            metric_name, tuple(metric_labels.items()), _nested_dict_to_tuple(filters)
+            endpoint_name,
+            metric_name,
+            tuple(metric_labels.items()),
+            _nested_dict_to_tuple(filters),
         )
         is should_capture
     )

--- a/wandb/sdk/internal/system/assets/open_metrics.py
+++ b/wandb/sdk/internal/system/assets/open_metrics.py
@@ -79,6 +79,7 @@ def _tuple_to_nested_dict(
 
 @lru_cache(maxsize=128)
 def _should_capture_metric(
+    endpoint_name: str,
     metric_name: str,
     metric_labels: Tuple[str, ...],
     filters: Tuple[Tuple[str, Tuple[str, str]], ...],
@@ -97,7 +98,7 @@ def _should_capture_metric(
     metric_labels_dict = {t[0]: t[1] for t in metric_labels}
     filters_dict = _tuple_to_nested_dict(filters)
     for metric_name_regex, label_filters in filters_dict.items():
-        if not re.match(metric_name_regex, metric_name):
+        if not re.match(metric_name_regex, f"{endpoint_name}.{metric_name}"):
             continue
 
         should_capture = True
@@ -159,6 +160,7 @@ class OpenMetricsMetric:
                 name, labels, value = sample.name, sample.labels, sample.value
 
                 if not _should_capture_metric(
+                    self.name,
                     name,
                     tuple(labels.items()),
                     self.filters_tuple,

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    TypedDict,
     Union,
     no_type_check,
 )
@@ -178,14 +177,6 @@ def _get_program_relpath_from_gitrepo(
     if _logger is not None:
         _logger.warning(f"Could not find program at {program}")
     return None
-
-
-class OpenMetricsConfig(TypedDict):
-    """Configuration for OpenMetrics endpoint consumption."""
-
-    url: str  # open metrics endpoint url
-    # open metrics filters {"metric regex pattern": {"label": "label value regex pattern"}}
-    filters: Mapping[str, Mapping[str, str]]
 
 
 @enum.unique
@@ -434,7 +425,6 @@ class Settings:
     _stats_samples_to_average: int
     _stats_join_assets: bool  # join metrics from different assets before sending to backend
     _stats_neuron_monitor_config_path: str  # path to place config file for neuron-monitor (AWS Trainium)
-    # _stats_open_metrics: Mapping[str, OpenMetricsConfig]  # open metrics configs
     _stats_open_metrics_endpoints: Mapping[str, str]  # open metrics endpoint names/urls
     # open metrics filters
     # {"metric regex pattern, including endpoint name as prefix": {"label": "label value regex pattern"}}
@@ -602,18 +592,6 @@ class Settings:
             _stats_join_assets={"value": True, "preprocessor": _str_as_bool},
             _stats_neuron_monitor_config_path={
                 "hook": lambda x: self._path_convert(x),
-            },
-            _stats_open_metrics={
-                "value": {
-                    # NVIDIA DCGM Exporter
-                    "DCGM": {
-                        "url": "http://localhost:9400/metrics",
-                        "filters": {
-                            ".*": {},
-                        },
-                    }
-                },
-                "preprocessor": _str_as_dict,
             },
             _stats_open_metrics_endpoints={
                 "preprocessor": _str_as_dict,


### PR DESCRIPTION
...in SystemMonitor

Description
-----------
This PR slightly changes the meaning of the `_stats_open_metrics_filters` setting: it will now assume that the OpenMetric metric name is prefixed with the OM endpoint name, in line with how the consumed metrics are displayed in the app (`<endpoint name>.<metric name>...`). For example,

```python
run = wandb.init(
    project="dcgm",
    settings=wandb.Settings(
        _stats_sample_rate_seconds=1,
        _stats_samples_to_average=1,
        _stats_open_metrics_endpoints={
            "node1": "http://172.0.0.1:9400/metrics",
            "node2": "http://172.0.0.2:9400/metrics",
            "node3": "http://172.0.0.3:9400/metrics",
        },
        _stats_open_metrics_filters={
            "node[1-2].DCGM_FI_DEV_(POWER_USAGE|MEM_COPY_UTIL|TOTAL_ENERGY_CONSUMPTION)": {
                "gpu": "[0,1]",
            },
            "node3.DCGM.*": {},
        },
    ),
)
```

The first filter will only be applied to the matching metrics from `node1` and `node2`, and all metrics whose names start with DCGM from `node3` will be consumed.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
