### PR TITLE
chore(sdk): removing duplicate docstring

### DIFF
--- a/wandb/integration/keras/callbacks/model_checkpoint.py
+++ b/wandb/integration/keras/callbacks/model_checkpoint.py
@@ -56,7 +56,6 @@ class WandbModelCheckpoint(callbacks.ModelCheckpoint):
         save_weights_only (bool): if True, then only the model's weights will be saved.
         mode (Mode): one of {'auto', 'min', 'max'}. For `val_acc`, this should be `max`,
             for `val_loss` this should be `min`, etc.
-        save_weights_only (bool): if True, then only the model's weights will be saved
         save_freq (Union[SaveStrategy, int]): `epoch` or integer. When using `'epoch'`,
             the callback saves the model after each epoch. When using an integer, the
             callback saves the model at end of this many batches.


### PR DESCRIPTION
Description:
There used to be two copies of `save_weights_only` and its description, now there is only one.

Fixes WB-NNNN
Fixes #NNNN

Description
-----------
Fixes this ticket:
https://github.com/wandb/wandb/issues/5241

What does the PR do?

This pr removes duplicate entries of docstring for `save_weights_only` located in `wandb/wandb/integration/keras/callbacks/model_checkpoint.py`. There used to be two entries and now there is one. 

<img width="1728" alt="Screenshot 2023-04-04 at 12 24 42 AM" src="https://user-images.githubusercontent.com/115654725/229706153-e26f8ff8-b9a3-4b71-8461-c78fb655d327.png">


Testing
-------
How was this PR tested?
- This pr wasn't tested since, it only edits the documentation in this case

Checklist
-------
- [✓] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [✓] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
