### PR TITLE
Update import_hook.py with latest changes in the wrapt repository [draft]

### DIFF
--- a/wandb/sdk/lib/import_hooks.py
+++ b/wandb/sdk/lib/import_hooks.py
@@ -4,7 +4,7 @@ Styled as per PEP-369. Note that it doesn't cope with modules being reloaded.
 
 Note: This file is based on
 https://github.com/GrahamDumpleton/wrapt/blob/1.12.1/src/wrapt/importer.py
-and manual backports of later patches up to 1.14.0 in the wrapt repository
+and manual backports of later patches up to 1.14.1 in the wrapt repository
 (with slight modifications).
 """
 
@@ -191,6 +191,14 @@ class _ImportHookChainedLoader:
         self.loader = loader
 
     def load_module(self, fullname: str) -> Any:
+        if hasattr(loader, "load_module"):
+          self.load_module = self._load_module
+        if hasattr(loader, "create_module"):
+          self.create_module = self._create_module
+        if hasattr(loader, "exec_module"):
+          self.exec_module = self._exec_module
+
+    def _load_module(self, fullname):
         module = self.loader.load_module(fullname)
         notify_module_loaded(module)
 
@@ -200,10 +208,10 @@ class _ImportHookChainedLoader:
     # Python 3.4 introduced create_module() and exec_module() instead of
     # load_module() alone. Splitting the two steps.
 
-    def create_module(self, spec):
+    def _create_module(self, spec):
         return self.loader.create_module(spec)
 
-    def exec_module(self, module):
+    def _exec_module(self, module):
         self.loader.exec_module(module)
         notify_module_loaded(module)
 

--- a/wandb/sdk/lib/import_hooks.py
+++ b/wandb/sdk/lib/import_hooks.py
@@ -170,12 +170,22 @@ class _ImportHookChainedLoader:
         # Set module's loader to self.loader unless it's already set to
         # something else. Import machinery will set it to spec.loader if it is
         # None, so handle None as well. The module may not support attribute
-        # assignment, in which case we simply skip it.
-        if getattr(module, "__loader__", None) in (None, self):
+        # assignment, in which case we simply skip it. Note that we also deal
+        # with __loader__ not existing at all. This is to future proof things
+        # due to proposal to remove the attribue as described in the GitHub
+        # issue at https://github.com/python/cpython/issues/77458. Also prior
+        # to Python 3.3, the __loader__ attribute was only set if a custom
+        # module loader was used. It isn't clear whether the attribute still
+        # existed in that case or was set to None.
+
+        class UNDEFINED: pass
+
+        if getattr(module, "__loader__", UNDEFINED) in (None, self):
             try:
                 module.__loader__ = self.loader
             except AttributeError:
                 pass
+
         if (getattr(module, "__spec__", None) is not None
                 and getattr(module.__spec__, "loader", None) is self):
             module.__spec__.loader = self.loader

--- a/wandb/sdk/lib/import_hooks.py
+++ b/wandb/sdk/lib/import_hooks.py
@@ -166,8 +166,23 @@ class _ImportHookChainedLoader:
         if hasattr(loader, "exec_module"):
           self.exec_module = self._exec_module
 
+    def _set_loader(self, module):
+        # Set module's loader to self.loader unless it's already set to
+        # something else. Import machinery will set it to spec.loader if it is
+        # None, so handle None as well. The module may not support attribute
+        # assignment, in which case we simply skip it.
+        if getattr(module, "__loader__", None) in (None, self):
+            try:
+                module.__loader__ = self.loader
+            except AttributeError:
+                pass
+        if (getattr(module, "__spec__", None) is not None
+                and getattr(module.__spec__, "loader", None) is self):
+            module.__spec__.loader = self.loader
+
     def _load_module(self, fullname):
         module = self.loader.load_module(fullname)
+        self._set_loader(module)
         notify_module_loaded(module)
 
         return module
@@ -180,6 +195,7 @@ class _ImportHookChainedLoader:
         return self.loader.create_module(spec)
 
     def _exec_module(self, module):
+        self._set_loader(module)
         self.loader.exec_module(module)
         notify_module_loaded(module)
 

--- a/wandb/sdk/lib/import_hooks.py
+++ b/wandb/sdk/lib/import_hooks.py
@@ -30,7 +30,7 @@ def synchronized(lock: "threading.RLock") -> Callable:
 # The dictionary registering any post import hooks to be triggered once
 # the target module has been imported. Once a module has been imported
 # and the hooks fired, the list of hooks recorded against the target
-# module will be truncacted but the list left in the dictionary. This
+# module will be truncated but the list left in the dictionary. This
 # acts as a flag to indicate that the module had already been imported.
 
 _post_import_hooks: Dict = {}


### PR DESCRIPTION

Description
-----------
When running an internal test suite with higher concurrency levels (e.g. `pytest -n 15`) we see test failures which only occur when importing wandb. There is a deep chain of multiple exceptions so I can't post the full traceback here. However the issue disappears once we update wandb's copy of `import_hook.py` to the latest version available in the wrapt repository.

I strongly suspect that the actual fix is in [upstream commit c5173c95](https://github.com/GrahamDumpleton/wrapt/commit/c5173c954e8c045702d697a8aeeda6169ca4a282) but when looking at the wrapt file history there are also a lot of other changes which seem to be useful in general.

Therefore I manually applied the changes in the wrapt repository to wand's copy, maintaining the individual commits. I did not add the upstream authors in the git commits as I did not want to misrepresent their work. However besides putting the changes in the right place there is no original work of mine involved.

I'm using this PR as a way to start a discussion about how to best update `import_hook.py` in wandb. If you prefer you can also just "sync" the file in one commit without maintaining a commit history which will destroy the type annotations you added.


Testing
-------
Ran our internal test suite which passes after applying this PR locally.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
