### PR TITLE
chore(sdk): pass usedforsecurity=False when possible for FIPS support

### DIFF
--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -7,7 +7,7 @@ from urllib import parse
 
 import wandb
 from wandb import util
-from wandb.sdk.lib import runid
+from wandb.sdk.lib import hashutil, runid
 
 from ._private import MEDIA_TMP
 from .base_types.media import BatchableMedia, Media
@@ -409,7 +409,7 @@ class Image(BatchableMedia):
                 )
 
             if self._classes is not None:
-                class_id = hashlib.md5(
+                class_id = hashutil._md5(
                     str(self._classes._class_set).encode("utf-8")
                 ).hexdigest()
                 class_name = os.path.join(

--- a/wandb/sdk/internal/system/assets/open_metrics.py
+++ b/wandb/sdk/internal/system/assets/open_metrics.py
@@ -4,7 +4,6 @@ import sys
 import threading
 from collections import defaultdict, deque
 from functools import lru_cache
-from hashlib import md5
 from types import ModuleType
 from typing import TYPE_CHECKING, Dict, List, Mapping, Tuple, Union
 
@@ -18,7 +17,7 @@ import requests.adapters
 import urllib3
 
 import wandb
-from wandb.sdk.lib import telemetry
+from wandb.sdk.lib import hashutil, telemetry
 
 from .aggregators import aggregate_last, aggregate_mean
 from .interfaces import Interface, Metric, MetricsMonitor
@@ -168,7 +167,7 @@ class OpenMetricsMetric:
                     continue
 
                 # md5 hash of the labels
-                label_hash = md5(str(labels).encode("utf-8")).hexdigest()
+                label_hash = hashutil._md5(str(labels).encode("utf-8")).hexdigest()
                 if label_hash not in self.label_map[name]:
                     # store the index of the label hash in the label map
                     self.label_map[name][label_hash] = len(self.label_map[name])

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1,6 +1,5 @@
 import base64
 import contextlib
-import hashlib
 import json
 import os
 import pathlib
@@ -55,6 +54,7 @@ from wandb.sdk.lib.hashutil import (
     B64MD5,
     ETag,
     HexMD5,
+    _md5,
     b64_to_hex_id,
     hex_to_b64_id,
     md5_file_b64,
@@ -808,7 +808,7 @@ class ArtifactManifestV1(ArtifactManifest):
         }
 
     def digest(self) -> HexMD5:
-        hasher = hashlib.md5()
+        hasher = _md5()
         hasher.update(b"wandb-artifact-manifest-v1\n")
         for name, entry in sorted(self.entries.items(), key=lambda kv: kv[0]):
             hasher.update(f"{name}:{entry.digest}\n".encode())


### PR DESCRIPTION
Fixes [WB-13199](https://wandb.atlassian.net/browse/WB-13199)

Description
-----------
For Python >=3.9, FIPS-compliant Python needs `usedforsecurity=False` in order to allow the use of MD5 hashes.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


[WB-13199]: https://wandb.atlassian.net/browse/WB-13199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ