### PR TITLE
feat(media): add method to convert wandb.Table to pandas.DataFrame

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -901,6 +901,10 @@ class Table(Media):
             ndxs.append(index)
         return ndxs
 
+    def get_df(self):
+        """Returns a pandas.DataFrame of the table."""
+        return pd.DataFrame.from_records(self.data, columns = self.columns)
+
     def index_ref(self, index):
         """Get a reference to a particular row index in the table."""
         assert index < len(self.data)


### PR DESCRIPTION

Description
-----------
Adding functionality to wandb.Table to access the contents of the table though a pandas DataFrame. This is useful not to rely on the wandb.joinTable functionality,...


Testing
-------
Not tested. I was hoping you have your pipelines set up ;)

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
