### PR TITLE
revert(sdk): accidental checkin of two fixes without a PR

### DIFF
--- a/wandb/analytics/sentry.py
+++ b/wandb/analytics/sentry.py
@@ -222,41 +222,36 @@ class Sentry:
                 return None
 
             for tag in settings_tags:
-                val = getattr(settings, tag, None)
+                val = settings[tag]
                 if val not in (None, ""):
                     scope.set_tag(tag, val)
 
             # todo: update once #4982 is merged
             python_runtime = (
                 "colab"
-                if getattr(settings, "_colab", None)
-                else ("jupyter" if getattr(settings, "_jupyter", None) else "python")
+                if settings["_colab"]
+                else ("jupyter" if settings["_jupyter"] else "python")
             )
             scope.set_tag("python_runtime", python_runtime)
 
             # Hack for constructing run_url and sweep_url given run_id and sweep_id
             required = ("entity", "project", "base_url")
-            params = {key: getattr(settings, key, None) for key in required}
+            params = {key: settings[key] for key in required}
             if all(params.values()):
                 # here we're guaranteed that entity, project, base_url all have valid values
-                app_url = wandb.util.app_url(params["base_url"])  # type: ignore
-                ent, proj = (quote(params[k]) for k in ("entity", "project"))  # type: ignore
+                app_url = wandb.util.app_url(params["base_url"])
+                ent, proj = (quote(params[k]) for k in ("entity", "project"))
 
                 # TODO: the settings object will be updated to contain run_url and sweep_url
                 # This is done by passing a settings_map in the run_start protocol buffer message
                 for word in ("run", "sweep"):
                     _url, _id = f"{word}_url", f"{word}_id"
-                    if not getattr(settings, _url, None) and getattr(
-                        settings, _id, None
-                    ):
+                    if not settings[_url] and settings[_id]:
                         scope.set_tag(
-                            _url,
-                            f"{app_url}/{ent}/{proj}/{word}s/{getattr(settings, _id, None)}",
+                            _url, f"{app_url}/{ent}/{proj}/{word}s/{settings[_id]}"
                         )
 
             if hasattr(settings, "email"):
                 scope.user = {"email": settings.email}  # noqa
-
-        # todo: add back the option to pass general tags see: c645f625d1c1a3db4a6b0e2aa8e924fee101904c (wandb/util.py)
 
         self.start_session()

--- a/wandb/sdk/data_types/plotly.py
+++ b/wandb/sdk/data_types/plotly.py
@@ -12,7 +12,7 @@ from .image import Image
 
 if TYPE_CHECKING:  # pragma: no cover
     import matplotlib  # type: ignore
-    import pandas as pd
+    import pandas as pd  # type: ignore
     import plotly  # type: ignore
 
     from ..wandb_artifacts import Artifact as LocalArtifact

--- a/wandb/sdk/data_types/utils.py
+++ b/wandb/sdk/data_types/utils.py
@@ -13,7 +13,7 @@ from .plotly import Plotly
 
 if TYPE_CHECKING:  # pragma: no cover
     import matplotlib  # type: ignore
-    import pandas as pd
+    import pandas as pd  # type: ignore
     import plotly  # type: ignore
 
     from ..wandb_run import Run as LocalRun
@@ -90,6 +90,7 @@ def val_to_json(
             and isinstance(val[0], BatchableMedia)
             and all(isinstance(v, type(val[0])) for v in val)
         ):
+
             if TYPE_CHECKING:
                 val = cast(Sequence["BatchableMedia"], val)
 
@@ -142,6 +143,7 @@ def val_to_json(
                 "partitioned-table",
                 "joined-table",
             ]:
+
                 # Special conditional to log tables as artifact entries as well.
                 # I suspect we will generalize this as we transition to storing all
                 # files in an artifact


### PR DESCRIPTION
Description
-----------
Revert "weird mypy demands"
This reverts commit https://github.com/wandb/wandb/commit/12e2905c311203dba7bd2669443e5a91f7cfdbf8.

Revert "safer access to settings attributes in sentry"
This reverts commit https://github.com/wandb/wandb/commit/b440c0be9d750445949939145bcc66b7b41e4ec9.


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
