### PR TITLE
feat(artifacts): add Azure storage handler in SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_requirements = ["mock>=2.0.0", "tox-pyenv>=1.0.3"]
 
 gcp_requirements = ["google-cloud-storage"]
 aws_requirements = ["boto3"]
-azure_requirements = ["azure-storage-blob"]
+azure_requirements = ["azure-identity", "azure-storage-blob"]
 grpc_requirements = ["grpcio>=1.27.2"]
 service_requirements = []
 kubeflow_requirements = ["kubernetes", "minio", "google-cloud-storage", "sh"]

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -3,6 +3,7 @@ import base64
 import os
 import random
 from multiprocessing import Pool
+from urllib.parse import urlparse
 
 import pytest
 import wandb
@@ -351,7 +352,7 @@ def test_storage_handler_incomplete():
     ush = UnfinishedStorageHandler()
 
     with pytest.raises(NotImplementedError):
-        ush.scheme()
+        ush.can_handle(parsed_url=urlparse("https://wandb.com"))
     with pytest.raises(NotImplementedError):
         ush.load_path(manifest_entry=None)
     with pytest.raises(NotImplementedError):

--- a/wandb/sdk/interface/artifacts/artifact.py
+++ b/wandb/sdk/interface/artifacts/artifact.py
@@ -322,6 +322,9 @@ class Artifact:
           versioning is enabled, then the version ID is also tracked.
         - gs: The checksum and size will be pulled from the object metadata. If bucket
           versioning is enabled, then the version ID is also tracked.
+        - https, domain matching *.blob.core.windows.net (Azure): The checksum and size
+          will be pulled from the blob metadata. If storage account versioning is
+          enabled, then the version ID is also tracked.
         - file: The checksum and size will be pulled from the file system. This scheme
           is useful if you have an NFS share or other externally mounted volume
           containing files you wish to track but not necessarily upload.
@@ -331,19 +334,17 @@ class Artifact:
 
         Arguments:
             uri: (str) The URI path of the reference to add. Can be an object returned
-            from
-                Artifact.get_path to store a reference to another artifact's entry.
+                from Artifact.get_path to store a reference to another artifact's entry.
             name: (str) The path within the artifact to place the contents of this
-            reference checksum: (bool, optional) Whether or not to checksum the
-            resource(s) located at the
-                reference URI. Checksumming is strongly recommended as it enables
-                automatic integrity validation, however it can be disabled to speed up
-                artifact creation. (default: True)
+                reference
+            checksum: (bool, optional) Whether or not to checksum the resource(s)
+                located at the reference URI. Checksumming is strongly recommended as it
+                enables automatic integrity validation, however it can be disabled to
+                speed up artifact creation. (default: True)
             max_objects: (int, optional) The maximum number of objects to consider when
-            adding a
-                reference that points to directory or bucket store prefix. For S3 and
-                GCS, this limit is 10,000 by default but is uncapped for other URI
-                schemes. (default: None)
+                adding a reference that points to directory or bucket store prefix. For
+                S3 and GCS, this limit is 10,000 by default but is uncapped for other
+                URI schemes. (default: None)
 
         Raises:
             ArtifactFinalizedError: if the artifact has already been finalized.

--- a/wandb/sdk/interface/artifacts/artifact_storage.py
+++ b/wandb/sdk/interface/artifacts/artifact_storage.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Dict, Optional, Sequence, Type, Union
 from wandb.util import FilePathStr, URIStr
 
 if TYPE_CHECKING:
+    from urllib.parse import ParseResult
+
     from wandb.filesync.step_prepare import StepPrepare
     from wandb.sdk.interface.artifacts import Artifact, ArtifactManifestEntry
     from wandb.sdk.internal.progress import ProgressFn
@@ -77,12 +79,11 @@ class StoragePolicy:
 
 
 class StorageHandler:
-    @property
-    def scheme(self) -> str:
-        """The scheme this handler applies to.
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        """Checks whether this handler can handle the given url.
 
         Returns:
-            The scheme to which this handler applies.
+            Whether this handler can handle the given url.
         """
         raise NotImplementedError
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import tempfile
 import time
+from types import ModuleType
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -63,6 +64,10 @@ from wandb.sdk.lib.hashutil import (
 from wandb.util import FilePathStr, LogicalFilePathStr, URIStr
 
 if TYPE_CHECKING:
+    from urllib.parse import ParseResult
+
+    import azure.storage.blob  # type: ignore
+
     # We could probably use https://pypi.org/project/boto3-stubs/ or something
     # instead of `type:ignore`ing these boto imports, but it's nontrivial:
     # for some reason, despite being actively maintained as of 2022-09-30,
@@ -847,6 +852,7 @@ class WandbStoragePolicy(StoragePolicy):
 
         s3 = S3Handler()
         gcs = GCSHandler()
+        azure = AzureHandler()
         http = HTTPHandler(self._session)
         https = HTTPHandler(self._session, scheme="https")
         artifact = WBArtifactHandler()
@@ -858,6 +864,7 @@ class WandbStoragePolicy(StoragePolicy):
             handlers=[
                 s3,
                 gcs,
+                azure,
                 http,
                 https,
                 artifact,
@@ -1086,37 +1093,33 @@ class __S3BucketPolicy(StoragePolicy):  # noqa: N801
 
 
 class MultiHandler(StorageHandler):
-    _handlers: Dict[str, StorageHandler]
+    _handlers: List[StorageHandler]
 
     def __init__(
         self,
         handlers: Optional[List[StorageHandler]] = None,
         default_handler: Optional[StorageHandler] = None,
     ) -> None:
-        self._handlers = {}
+        self._handlers = handlers or []
         self._default_handler = default_handler
 
-        handlers = handlers or []
-        for handler in handlers:
-            self._handlers[handler.scheme] = handler
-
-    @property
-    def scheme(self) -> str:
-        raise NotImplementedError
+    def _get_handler(self, url: Union[FilePathStr, URIStr]) -> StorageHandler:
+        parsed_url = urlparse(url)
+        for handler in self._handlers:
+            if handler.can_handle(parsed_url):
+                return handler
+        if self._default_handler is not None:
+            return self._default_handler
+        raise ValueError('No storage handler registered for url "%s"' % str(url))
 
     def load_path(
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
     ) -> Union[URIStr, FilePathStr]:
-        url = urlparse(manifest_entry.ref)
-        if url.scheme not in self._handlers:
-            if self._default_handler is not None:
-                return self._default_handler.load_path(manifest_entry, local=local)
-            raise ValueError(
-                'No storage handler registered for scheme "%s"' % str(url.scheme)
-            )
-        return self._handlers[str(url.scheme)].load_path(manifest_entry, local=local)
+        assert manifest_entry.ref is not None
+        handler = self._get_handler(manifest_entry.ref)
+        return handler.load_path(manifest_entry, local=local)
 
     def store_path(
         self,
@@ -1126,21 +1129,7 @@ class MultiHandler(StorageHandler):
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
-        url = urlparse(path)
-        if url.scheme not in self._handlers:
-            if self._default_handler is not None:
-                return self._default_handler.store_path(
-                    artifact,
-                    path,
-                    name=name,
-                    checksum=checksum,
-                    max_objects=max_objects,
-                )
-            raise ValueError(
-                'No storage handler registered for scheme "%s"' % url.scheme
-            )
-        handler: StorageHandler
-        handler = self._handlers[url.scheme]
+        handler = self._get_handler(path)
         return handler.store_path(
             artifact, path, name=name, checksum=checksum, max_objects=max_objects
         )
@@ -1158,9 +1147,8 @@ class TrackingHandler(StorageHandler):
         """
         self._scheme = scheme or ""
 
-    @property
-    def scheme(self) -> str:
-        return self._scheme
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == self._scheme
 
     def load_path(
         self,
@@ -1215,9 +1203,8 @@ class LocalFileHandler(StorageHandler):
         self._scheme = scheme or "file"
         self._cache = get_artifacts_cache()
 
-    @property
-    def scheme(self) -> str:
-        return self._scheme
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == self._scheme
 
     def load_path(
         self,
@@ -1332,9 +1319,8 @@ class S3Handler(StorageHandler):
         self._versioning_enabled = None
         self._cache = get_artifacts_cache()
 
-    @property
-    def scheme(self) -> str:
-        return self._scheme
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == self._scheme
 
     def init_boto(self) -> "boto3.resources.base.ServiceResource":
         if self._s3 is not None:
@@ -1450,7 +1436,7 @@ class S3Handler(StorageHandler):
         # parsing. Once we have that, we can store the rest of the
         # metadata in the artifact entry itself.
         bucket, key, version = self._parse_uri(path)
-        path = URIStr(f"{self.scheme}://{bucket}/{key}")
+        path = URIStr(f"{self._scheme}://{bucket}/{key}")
         if not self.versioning_enabled(bucket) and version:
             raise ValueError(
                 f"Specifying a versionId is not valid for s3://{bucket} as it does not have versioning enabled."
@@ -1564,7 +1550,7 @@ class S3Handler(StorageHandler):
             posix_ref = posix_path / relpath
         return ArtifactManifestEntry(
             path=LogicalFilePathStr(str(posix_name)),
-            ref=URIStr(f"{self.scheme}://{str(posix_ref)}"),
+            ref=URIStr(f"{self._scheme}://{str(posix_ref)}"),
             digest=ETag(self._etag_from_obj(obj)),
             size=self._size_from_obj(obj),
             extra=self._extra_from_obj(obj),
@@ -1616,9 +1602,8 @@ class GCSHandler(StorageHandler):
         self._versioning_enabled = bucket.versioning_enabled
         return self._versioning_enabled
 
-    @property
-    def scheme(self) -> str:
-        return self._scheme
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == self._scheme
 
     def init_gcs(self) -> "gcs_module.client.Client":
         if self._client is not None:
@@ -1697,7 +1682,7 @@ class GCSHandler(StorageHandler):
         # such as version identifiers, pare down the path to just the bucket
         # and key.
         bucket, key, version = self._parse_uri(path)
-        path = URIStr(f"{self.scheme}://{bucket}/{key}")
+        path = URIStr(f"{self._scheme}://{bucket}/{key}")
         max_objects = max_objects or DEFAULT_MAX_OBJECTS
         if not self.versioning_enabled(bucket) and version:
             raise ValueError(
@@ -1783,7 +1768,7 @@ class GCSHandler(StorageHandler):
             posix_ref = posix_path / relpath
         return ArtifactManifestEntry(
             path=LogicalFilePathStr(str(posix_name)),
-            ref=URIStr(f"{self.scheme}://{str(posix_ref)}"),
+            ref=URIStr(f"{self._scheme}://{str(posix_ref)}"),
             digest=obj.md5_hash,
             size=obj.size,
             extra=self._extra_from_obj(obj),
@@ -1806,15 +1791,183 @@ class GCSHandler(StorageHandler):
         )
 
 
+class AzureHandler(StorageHandler):
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == "https" and parsed_url.netloc.endswith(
+            ".blob.core.windows.net"
+        )
+
+    def load_path(
+        self,
+        manifest_entry: "ArtifactManifestEntry",
+        local: bool = False,
+    ) -> Union[URIStr, FilePathStr]:
+        assert manifest_entry.ref is not None
+        if not local:
+            return manifest_entry.ref
+
+        path, hit, cache_open = get_artifacts_cache().check_etag_obj_path(
+            URIStr(manifest_entry.ref),
+            ETag(manifest_entry.digest),
+            manifest_entry.size or 0,
+        )
+        if hit:
+            return path
+
+        account_url, container_name, blob_name, query = self._parse_uri(
+            manifest_entry.ref
+        )
+        version_id = manifest_entry.extra.get("versionID")
+        blob_service_client = self._get_module("azure.storage.blob").BlobServiceClient(
+            account_url,
+            credential=self._get_module("azure.identity").DefaultAzureCredential(),
+        )
+        blob_client = blob_service_client.get_blob_client(
+            container=container_name, blob=blob_name
+        )
+        if version_id is None:
+            # Try current version, then all versions.
+            try:
+                downloader = blob_client.download_blob(
+                    etag=manifest_entry.digest,
+                    match_condition=self._get_module(
+                        "azure.core"
+                    ).MatchConditions.IfNotModified,
+                )
+            except self._get_module("azure.core.exceptions").ResourceModifiedError:
+                container_client = blob_service_client.get_container_client(
+                    container_name
+                )
+                for blob_properties in container_client.walk_blobs(
+                    name_starts_with=blob_name, include=["versions"]
+                ):
+                    if (
+                        blob_properties.name == blob_name
+                        and blob_properties.etag == manifest_entry.digest
+                        and blob_properties.version_id is not None
+                    ):
+                        downloader = blob_client.download_blob(
+                            version_id=blob_properties.version_id
+                        )
+                        break
+                else:  # didn't break
+                    raise ValueError(
+                        f"Couldn't find blob version for {manifest_entry.ref} matching "
+                        f"etag {manifest_entry.digest}."
+                    )
+        else:
+            downloader = blob_client.download_blob(version_id=version_id)
+        with cache_open(mode="wb") as f:
+            downloader.readinto(f)
+        return path
+
+    def store_path(
+        self,
+        artifact: ArtifactInterface,
+        path: Union[URIStr, FilePathStr],
+        name: Optional[str] = None,
+        checksum: bool = True,
+        max_objects: Optional[int] = None,
+    ) -> Sequence["ArtifactManifestEntry"]:
+        account_url, container_name, blob_name, query = self._parse_uri(path)
+        path = URIStr(f"{account_url}/{container_name}/{blob_name}")
+
+        if not checksum:
+            return [
+                ArtifactManifestEntry(
+                    path=LogicalFilePathStr(name or blob_name), digest=path, ref=path
+                )
+            ]
+
+        blob_service_client = self._get_module("azure.storage.blob").BlobServiceClient(
+            account_url,
+            credential=self._get_module("azure.identity").DefaultAzureCredential(),
+        )
+        blob_client = blob_service_client.get_blob_client(
+            container=container_name, blob=blob_name
+        )
+        if blob_client.exists(version_id=query.get("versionId")):
+            blob_properties = blob_client.get_blob_properties(
+                version_id=query.get("versionId")
+            )
+            return [
+                self._create_entry(
+                    blob_properties,
+                    path=LogicalFilePathStr(
+                        name or pathlib.PurePosixPath(blob_name).name
+                    ),
+                    ref=URIStr(
+                        f"{account_url}/{container_name}/{blob_properties.name}"
+                    ),
+                )
+            ]
+
+        entries = []
+        container_client = blob_service_client.get_container_client(container_name)
+        max_objects = max_objects or DEFAULT_MAX_OBJECTS
+        for i, blob_properties in enumerate(
+            container_client.list_blobs(name_starts_with=f"{blob_name}/")
+        ):
+            if i >= max_objects:
+                raise ValueError(
+                    f"Exceeded {max_objects} objects tracked, pass max_objects to "
+                    f"add_reference"
+                )
+            suffix = pathlib.PurePosixPath(blob_properties.name).relative_to(blob_name)
+            entries.append(
+                self._create_entry(
+                    blob_properties,
+                    path=LogicalFilePathStr(str(name / suffix if name else suffix)),
+                    ref=URIStr(
+                        f"{account_url}/{container_name}/{blob_properties.name}"
+                    ),
+                )
+            )
+        return entries
+
+    def _get_module(self, name: str) -> ModuleType:
+        module = util.get_module(
+            name,
+            lazy=False,
+            required="Azure references require the azure library, run "
+            "pip install wandb[azure]",
+        )
+        assert isinstance(module, ModuleType)
+        return module
+
+    def _parse_uri(self, uri: str) -> Tuple[str, str, str, Dict[str, str]]:
+        parsed_url = urlparse(uri)
+        query = dict(parse_qsl(parsed_url.query))
+        account_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        _, container_name, blob_name = parsed_url.path.split("/", 2)
+        return account_url, container_name, blob_name, query
+
+    def _create_entry(
+        self,
+        blob_properties: "azure.storage.blob.BlobProperties",
+        path: LogicalFilePathStr,
+        ref: URIStr,
+    ) -> ArtifactManifestEntry:
+        extra = {"etag": blob_properties.etag.strip('"')}
+        if blob_properties.version_id:
+            extra["versionID"] = blob_properties.version_id
+        return ArtifactManifestEntry(
+            path=path,
+            ref=ref,
+            digest=blob_properties.etag.strip('"'),
+            size=blob_properties.size,
+            extra=extra,
+        )
+
+
 class HTTPHandler(StorageHandler):
     def __init__(self, session: requests.Session, scheme: Optional[str] = None) -> None:
         self._scheme = scheme or "http"
         self._cache = get_artifacts_cache()
         self._session = session
 
-    @property
-    def scheme(self) -> str:
-        return self._scheme
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == self._scheme
 
     def load_path(
         self,
@@ -1901,10 +2054,8 @@ class WBArtifactHandler(StorageHandler):
         self._cache = get_artifacts_cache()
         self._client = None
 
-    @property
-    def scheme(self) -> str:
-        """Scheme this handler applies to."""
-        return self._scheme
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == self._scheme
 
     @property
     def client(self) -> PublicApi:
@@ -2011,10 +2162,8 @@ class WBLocalArtifactHandler(StorageHandler):
         self._scheme = "wandb-client-artifact"
         self._cache = get_artifacts_cache()
 
-    @property
-    def scheme(self) -> str:
-        """Scheme this handler applies to."""
-        return self._scheme
+    def can_handle(self, parsed_url: "ParseResult") -> bool:
+        return parsed_url.scheme == self._scheme
 
     def load_path(
         self,


### PR DESCRIPTION
Fixes WB-13212

## Description

Added Azure storage handler to allow adding references to Azure storage blobs to artifacts.

Azure storage blobs summary:
- Organized into storage accounts, containers, blobs
- Example blob URLs:
  - https://tmpszymon.blob.core.windows.net/tmp-szymon/test.txt
  - https://tmpszymon.blob.core.windows.net/tmp-szymon/test.txt?versionId=2023-04-11T18:55:32.1517815Z
  - https://tmpszymon.blob.core.windows.net/tmp-szymon/test.txt?snapshot=2023-04-11T21:27:44.5716794Z
- [Quickstart](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python)
- [API](https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob)

## Testing

- Created `tmpszymon/tmp-szymon` container in Azure with:
  - `a/b/test.txt`
  - `test.txt` with multiple versions
- Started a Jupyter notebook:
```
$ tox -e py39 --notest
$ source .tox/py39/bin/activate
$ pip install azure-identity azure-storage-blob jupyter
$ jupyter notebook
```
- Created an artifact with
  - a file
  - a versioned file
  - a directory
 and fetched it back:
<img width="1159" alt="Untitled" src="https://user-images.githubusercontent.com/127154459/233048121-ed95c5be-af01-480c-9e4d-306d983b7483.png">