### PR TITLE
fix(launch): Disable kaniko builder retry

### DIFF
--- a/wandb/sdk/launch/builder/kaniko_builder.py
+++ b/wandb/sdk/launch/builder/kaniko_builder.py
@@ -407,7 +407,7 @@ class KanikoBuilder(AbstractBuilder):
             ),
         )
         # Create the specification of job
-        spec = client.V1JobSpec(template=template, backoff_limit=1)
+        spec = client.V1JobSpec(template=template, backoff_limit=0)
         job = client.V1Job(
             api_version="batch/v1",
             kind="Job",


### PR DESCRIPTION
Fixes [WB-12913](https://wandb.atlassian.net/browse/WB-12913)

Description
-----------
Set `backoff_limit` to 0 when attempting to build a Kaniko job



[WB-12913]: https://wandb.atlassian.net/browse/WB-12913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ