### PR TITLE
feat(launch): Allow platform override for docker builder

### DIFF
--- a/tools/build_launch_agent.py
+++ b/tools/build_launch_agent.py
@@ -42,6 +42,9 @@ def parse_args():
         help="Push image after creation. This requires that you enter a tag that includes a registry via --tag",
     )
     parser.add_argument("--tag", default="wandb-launch-agent", help="Tag for the image")
+    parser.add_argument(
+        "--platform", default="linux/amd64", help="Platform to use, e.g. 'linux/amd64'"
+    )
     return parser.parse_args()
 
 
@@ -59,6 +62,7 @@ def main():
         tags=[args.tag],
         file=dockerfile_path,
         context_path=build_context,
+        platform=args.platform,
     )
     if args.push:
         image, tag = args.tag.split(":")

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -82,8 +82,12 @@ def is_buildx_installed() -> bool:
     return _buildx_installed
 
 
-def build(tags: List[str], file: str, context_path: str) -> str:
+def build(
+    tags: List[str], file: str, context_path: str, platform: Optional[str] = None
+) -> str:
     command = ["buildx", "build"] if is_buildx_installed() else ["build"]
+    if platform:
+        command += ["--platform", platform]
     build_tags = []
     for tag in tags:
         build_tags += ["-t", tag]

--- a/wandb/sdk/launch/builder/docker_builder.py
+++ b/wandb/sdk/launch/builder/docker_builder.py
@@ -50,6 +50,7 @@ class DockerBuilder(AbstractBuilder):
         self,
         environment: AbstractEnvironment,
         registry: AbstractRegistry,
+        config: Dict[str, Any],
         verify: bool = True,
         login: bool = True,
     ):
@@ -66,6 +67,7 @@ class DockerBuilder(AbstractBuilder):
         """
         self.environment = environment  # Docker builder doesn't actually use this.
         self.registry = registry
+        self.config = config
         if verify:
             self.verify()
         if login:
@@ -92,7 +94,7 @@ class DockerBuilder(AbstractBuilder):
         """
         # TODO the config for the docker builder as of yet is empty
         # but ultimately we should add things like target platform, base image, etc.
-        return cls(environment, registry)
+        return cls(environment, registry, config)
 
     def verify(self) -> None:
         """Verify the builder."""
@@ -153,7 +155,10 @@ class DockerBuilder(AbstractBuilder):
         dockerfile = os.path.join(build_ctx_path, _GENERATED_DOCKERFILE_NAME)
         try:
             output = docker.build(
-                tags=[image_uri], file=dockerfile, context_path=build_ctx_path
+                tags=[image_uri],
+                file=dockerfile,
+                context_path=build_ctx_path,
+                platform=self.config.get("platform"),
             )
             warn_failed_packages_from_build_logs(output, image_uri)
 


### PR DESCRIPTION
Fixes
-----
Fixes [WB-11692](https://wandb.atlassian.net/browse/WB-11692)

Description
-----------
Allow specifying the build platform using the `platform` key when using the Docker builder. See below for an example agent config that sets this value.


Testing
-------
- Start an agent on a Mac M1 with config:
```
{
    "builder": {
        "type": "docker",
        "platform": "windows/amd64"
    }
}
```
- Give the agent a job, confirm the job fails to start
- Start another agent, replacing `windows/amd64` with `linux/arm64`
- Give the agent a job and confirm it succeeds


[WB-11692]: https://wandb.atlassian.net/browse/WB-11692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ