### PR TITLE
fix(sdk): refine error message for auth error

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -881,10 +881,11 @@ def no_retry_auth(e: Any) -> bool:
     # Crash w/message on forbidden/unauthorized errors.
     if e.response.status_code == 401:
         raise AuthenticationError(
-            "The API key is either invalid or missing, or the host is incorrect. "
+            "The API key you provided is either invalid or missing.  "
             f"If the `{wandb.env.API_KEY}` environment variable is set, make sure it is correct. "
-            "Otherwise, to resolve this issue, you may try running the 'wandb login --relogin --host [hostname]' command. "
-            "The host defaults to 'https://wandb.ai' if not specified. "
+            "Otherwise, to resolve this issue, you may try running the 'wandb login --relogin' command. "
+            "If you are using a local server, make sure that you're using the correct hostname. "
+            "If you're not sure, you can try logging in again using the 'wandb login --relogin --host [hostname]' command."
             f"(Error {e.response.status_code}: {e.response.reason})"
         )
     elif wandb.run:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -883,8 +883,8 @@ def no_retry_auth(e: Any) -> bool:
         raise AuthenticationError(
             "The API key is either invalid or missing, or the host is incorrect. "
             f"If the `{wandb.env.API_KEY}` environment variable is set, make sure it is correct. "
-            "Otherwise, to resolve this issue, you may try running the 'wandb login --host [hostname]' command. "
-            "The host defaults to 'https://api.wandb.ai' if not specified. "
+            "Otherwise, to resolve this issue, you may try running the 'wandb login --relogin --host [hostname]' command. "
+            "The host defaults to 'https://wandb.ai' if not specified. "
             f"(Error {e.response.status_code}: {e.response.reason})"
         )
     elif wandb.run:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -50,7 +50,7 @@ import requests
 import yaml
 
 import wandb
-from wandb.env import get_app_url
+import wandb.env
 from wandb.errors import AuthenticationError, CommError, UsageError, term
 from wandb.sdk.lib import filesystem, runid
 
@@ -256,7 +256,7 @@ VALUE_BYTES_LIMIT = 100000
 def app_url(api_url: str) -> str:
     """Return the frontend app url without a trailing slash."""
     # TODO: move me to settings
-    app_url = get_app_url()
+    app_url = wandb.env.get_app_url()
     if app_url is not None:
         return str(app_url.strip("/"))
     if "://api.wandb.test" in api_url:
@@ -882,7 +882,8 @@ def no_retry_auth(e: Any) -> bool:
     if e.response.status_code == 401:
         raise AuthenticationError(
             "The API key is either invalid or missing, or the host is incorrect. "
-            "To resolve this issue, you may try running the 'wandb login --host [hostname]' command. "
+            f"If the `{wandb.env.API_KEY}` environment variable is set, make sure it is correct. "
+            "Otherwise, to resolve this issue, you may try running the 'wandb login --host [hostname]' command. "
             "The host defaults to 'https://api.wandb.ai' if not specified. "
             f"(Error {e.response.status_code}: {e.response.reason})"
         )


### PR DESCRIPTION
Fixes
-----
Fixes #5319

Description
-----------
What does the PR do?

makes the error message more complete to handle cases where users have the api key set as env variable.


Testing
-------
How was this PR tested?

tested locally

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4eb81d2</samp>

> _To fix circular imports in `util`_
> _The code was refactored with skill_
> _They used `wandb.env`_
> _To store and retrieve_
> _The variables that set the config still_