### PR TITLE
fix(artifacts): checksum the read-only staging copy instead of the original file

### DIFF
--- a/wandb/sdk/internal/artifacts.py
+++ b/wandb/sdk/internal/artifacts.py
@@ -297,6 +297,7 @@ class ArtifactSaver:
         for entry in self._manifest.entries.values():
             if entry.local_path and entry.local_path.startswith(staging_dir):
                 try:
+                    os.chmod(entry.local_path, 0o600)
                     os.remove(entry.local_path)
                 except OSError:
                     pass

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -719,18 +719,15 @@ class Artifact(ArtifactInterface):
     def _add_local_file(
         self, name: str, path: str, digest: Optional[B64MD5] = None
     ) -> ArtifactManifestEntry:
-        digest = digest or md5_file_b64(path)
-        size = os.path.getsize(path)
-        name = util.to_forward_slash_path(name)
-
         with tempfile.NamedTemporaryFile(dir=get_staging_dir(), delete=False) as f:
             staging_path = f.name
             shutil.copyfile(path, staging_path)
+            os.chmod(staging_path, 0o400)
 
         entry = ArtifactManifestEntry(
-            path=name,
-            digest=digest,
-            size=size,
+            path=util.to_forward_slash_path(name),
+            digest=digest or md5_file_b64(staging_path),
+            size=os.path.getsize(staging_path),
             local_path=staging_path,
         )
 


### PR DESCRIPTION
Fixes
-----
Fixes [WB-13354](https://wandb.atlassian.net/browse/WB-13354)

Description
-----------
- Check the size and MD5 checksum of a file _after_ copying it to our staging area so that we can't be affected by an in-progress write from another process
- Make the file read-only

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb38b7f</samp>

> _Copy `local_file`_
> _Compute `digest` and `size`_
> _Winter snow, no change_

[WB-13354]: https://wandb.atlassian.net/browse/WB-13354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ