### PR TITLE
chore(launch): Use _wandb_api_key to set env var

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
@@ -25,6 +25,27 @@ def test_get_env_vars_dict(mocker):
     }
 
 
+def test_get_env_vars_dict_api_key_override(mocker):
+    _setup(mocker)
+    mocker.launch_project.launch_spec = {"_wandb_api_key": "override-api-key"}
+
+    resp = build.get_env_vars_dict(mocker.launch_project, mocker.api)
+
+    assert resp == {
+        "WANDB_API_KEY": "override-api-key",
+        "WANDB_ARTIFACTS": "test-wandb-artifacts",
+        "WANDB_BASE_URL": "base_url",
+        "WANDB_CONFIG": "test-wandb-artifacts",
+        "WANDB_DOCKER": "test-docker-image",
+        "WANDB_ENTITY": "test-entity",
+        "WANDB_ENTRYPOINT_COMMAND": "",
+        "WANDB_LAUNCH": "True",
+        "WANDB_NAME": "test-name",
+        "WANDB_PROJECT": "test-project",
+        "WANDB_RUN_ID": "test-run-id",
+    }
+
+
 def test_image_tag_from_dockerfile_and_source(mocker):
     _setup(mocker)
     source_string = "test-docker-image"

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -234,7 +234,8 @@ def get_env_vars_dict(launch_project: LaunchProject, api: Api) -> Dict[str, str]
     """
     env_vars = {}
     env_vars["WANDB_BASE_URL"] = api.settings("base_url")
-    env_vars["WANDB_API_KEY"] = api.api_key
+    override_api_key = launch_project.launch_spec.get("_wandb_api_key")
+    env_vars["WANDB_API_KEY"] = override_api_key or api.api_key
     env_vars["WANDB_PROJECT"] = launch_project.target_project
     env_vars["WANDB_ENTITY"] = launch_project.target_entity
     env_vars["WANDB_LAUNCH"] = "True"
@@ -243,7 +244,7 @@ def get_env_vars_dict(launch_project: LaunchProject, api: Api) -> Dict[str, str]
         env_vars["WANDB_DOCKER"] = launch_project.docker_image
     if launch_project.name is not None:
         env_vars["WANDB_NAME"] = launch_project.name
-    if "author" in launch_project.launch_spec:
+    if "author" in launch_project.launch_spec and not override_api_key:
         env_vars["WANDB_USERNAME"] = launch_project.launch_spec["author"]
 
     # TODO: handle env vars > 32760 characters


### PR DESCRIPTION
Fixes
-----
Second half of [WB-13355](https://wandb.atlassian.net/browse/WB-13355), [PR](https://github.com/wandb/core/pull/14342)

Description
-----------
Make use of `_wandb_api_key` if present, to override the `WANDB_API_KEY` environment variable.


Testing
-------
Added unit test


[WB-13355]: https://wandb.atlassian.net/browse/WB-13355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ