### PR TITLE
chore(sdk): fix codecov download as it was removed from pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1372,7 +1372,7 @@ workflows:
               python_version_major: [3]
               python_version_minor: [9]
           name: "unit-macos-mock_server-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,covercircle"
+          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,maccovercircle"
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/tests_launch --ignore=tests/pytest_tests/unit_tests_old/tests_s_nb"
 
       - mac:
@@ -1381,7 +1381,7 @@ workflows:
               python_version_major: [3]
               python_version_minor: [9]
           name: "unit-macos-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,covercircle"
+          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,maccovercircle"
           tox_args: "tests/pytest_tests/unit_tests"
 
       #

--- a/tox.ini
+++ b/tox.ini
@@ -406,7 +406,7 @@ commands =
 
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
-    codecov -e TOXENV -F unittest
+    ./codecov -e TOXENV -F unittest
 
 # temporary until we can consolidate coverage collection paths
 [testenv:unit-cover]

--- a/tox.ini
+++ b/tox.ini
@@ -447,9 +447,11 @@ commands =
     bash.exe -c '~/project/.tox/wincovercircle/Scripts/python.exe -m coverage report --ignore-errors --skip-covered --omit "wandb/vendor/*"'
     ; bash.exe -c '~/project/.tox/wincovercircle/Scripts/python.exe -m codecov -e TOXENV -F unittest'
 
-    $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
-    .\codecov.exe -e TOXENV -F unittest
+    ; $ProgressPreference = 'SilentlyContinue'
+    ; Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+    curl -o codecov.exe https://uploader.codecov.io/latest/windows/codecov.exe
+    chmod +x codecov.exe
+    ./codecov.exe -e TOXENV -F unittest
 
 [testenv:cover]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -338,19 +338,48 @@ passenv = CI CIRCLECI CIRCLE_* CODECOV_* TOXENV
 deps =
     pytest
     coverage
-    ; codecov
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
 whitelist_externals =
     mkdir
     cp
+    curl
+    chmod
 commands =
     mkdir -p cover-results
     /usr/bin/env bash -c '{envpython} -m coverage combine {toxworkdir}/py*/.coverage*'
     coverage xml --ignore-errors
     cp .coverage coverage.xml cover-results/
     coverage report --ignore-errors --skip-covered --omit "wandb/vendor/*"
-    ; codecov -e TOXENV -F unittest
+
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    codecov -e TOXENV -F unittest
+
+[testenv:maccovercircle]
+skip_install = true
+basepython = python3
+passenv = CI CIRCLECI CIRCLE_* CODECOV_* TOXENV
+deps =
+    pytest
+    coverage
+setenv =
+    CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
+whitelist_externals =
+    mkdir
+    cp
+    curl
+    chmod
+commands =
+    mkdir -p cover-results
+    /usr/bin/env bash -c '{envpython} -m coverage combine {toxworkdir}/py*/.coverage*'
+    coverage xml --ignore-errors
+    cp .coverage coverage.xml cover-results/
+    coverage report --ignore-errors --skip-covered --omit "wandb/vendor/*"
+
+    curl -Os https://uploader.codecov.io/latest/macos/codecov
+    chmod +x codecov
+    ./codecov -t ${CODECOV_TOKEN}
 
 # temporary until we can consolidate coverage collection paths
 [testenv:unit-covercircle]
@@ -360,20 +389,24 @@ passenv = CI CIRCLECI CIRCLE_* CODECOV_* TOXENV
 deps =
     pytest
     coverage
-    ; codecov
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
 whitelist_externals =
     mkdir
     bash
     cp
+    curl
+    chmod
 commands =
     mkdir -p cover-results
     /usr/bin/env bash -c '{envpython} -m coverage combine {toxworkdir}/unit-s*-py*/.coverage*'
     /usr/bin/env bash -c '{envpython} -m coverage xml --ignore-errors'
     cp .coverage coverage.xml cover-results/
     coverage report --ignore-errors --skip-covered --include "wandb/*" --omit "wandb/vendor/*"
-    ; codecov -e TOXENV -F unittest
+    
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    codecov -e TOXENV -F unittest
 
 # temporary until we can consolidate coverage collection paths
 [testenv:unit-cover]
@@ -400,7 +433,6 @@ passenv = CI CIRCLECI CIRCLE_* CODECOV_* TOXENV
 deps =
     pytest
     coverage
-    ; codecov
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
 whitelist_externals =
@@ -414,6 +446,10 @@ commands =
     bash.exe -c 'cp .coverage coverage.xml cover-results/'
     bash.exe -c '~/project/.tox/wincovercircle/Scripts/python.exe -m coverage report --ignore-errors --skip-covered --omit "wandb/vendor/*"'
     ; bash.exe -c '~/project/.tox/wincovercircle/Scripts/python.exe -m codecov -e TOXENV -F unittest'
+
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+    .\codecov.exe -e TOXENV -F unittest
 
 [testenv:cover]
 skip_install = true
@@ -513,19 +549,23 @@ passenv = CI CIRCLECI CIRCLE_* CODECOV_* TOXENV
 deps =
     pytest
     coverage
-    ; codecov
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
 whitelist_externals =
     mkdir
     cp
+    curl
+    chmod
 commands =
     mkdir -p cover-results
     /usr/bin/env bash -c '{envpython} -m coverage combine {toxworkdir}/func-s*-py*/.coverage*'
     /usr/bin/env bash -c '{envpython} -m coverage xml --ignore-errors'
     cp .coverage coverage.xml cover-results/
     coverage report --ignore-errors --skip-covered --include "wandb/*" --omit "wandb/vendor/*"
-    ; codecov -e TOXENV -F functest
+
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    ./codecov -e TOXENV -F functest
 
 [testenv:standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}]
 install_command = pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -379,7 +379,7 @@ commands =
 
     curl -Os https://uploader.codecov.io/latest/macos/codecov
     chmod +x codecov
-    ./codecov -t ${CODECOV_TOKEN}
+    ./codecov -e TOXENV -F unittest
 
 # temporary until we can consolidate coverage collection paths
 [testenv:unit-covercircle]
@@ -403,7 +403,7 @@ commands =
     /usr/bin/env bash -c '{envpython} -m coverage xml --ignore-errors'
     cp .coverage coverage.xml cover-results/
     coverage report --ignore-errors --skip-covered --include "wandb/*" --omit "wandb/vendor/*"
-    
+
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
     codecov -e TOXENV -F unittest

--- a/tox.ini
+++ b/tox.ini
@@ -354,7 +354,7 @@ commands =
 
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
-    codecov -e TOXENV -F unittest
+    ./codecov -e TOXENV -F unittest
 
 [testenv:maccovercircle]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -451,7 +451,7 @@ commands =
     ; Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
     curl -o codecov.exe https://uploader.codecov.io/latest/windows/codecov.exe
     chmod +x codecov.exe
-    ./codecov.exe -e TOXENV -F unittest
+    codecov.exe -e TOXENV -F unittest
 
 [testenv:cover]
 skip_install = true


### PR DESCRIPTION
Description
-----------
What does the PR do?

This PR fixes the codecov call. The tool used to available using pypi but recently the tool was removed from the pypi repo and we need to curl it from a specific location. [see here](https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader) for additional details.


Testing
-------
How was this PR tested?

If CI passes, it means the change worked!

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9019b33</samp>

> _Oh, we are the coders of the CircleCI_
> _We run our tests on Mac and Windows, aye_
> _We heave and we ho, and we set `toxenv`_
> _To upload our coverage to Codecov, my friends_