### PR TITLE
feat(integrations): add relay-server-based autolog for OpenAI's python library

### DIFF
--- a/wandb/integration/openai/__init__.py
+++ b/wandb/integration/openai/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ("Autolog", "Relay")
+
+from .openai import Autolog, Relay

--- a/wandb/integration/openai/openai.py
+++ b/wandb/integration/openai/openai.py
@@ -31,6 +31,9 @@ openai = wandb.util.get_module(
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 K = TypeVar("K", bound=str)
 V = TypeVar("V")
 
@@ -42,18 +45,6 @@ class OpenAIResponse(Protocol[K, V]):
     def __getitem__(self, key: K) -> V:
         ...  # pragma: no cover
 
-    def __setitem__(self, key: K, value: V) -> None:
-        ...  # pragma: no cover
-
-    def __delitem__(self, key: K) -> None:
-        ...  # pragma: no cover
-
-    def __iter__(self) -> Any:
-        ...  # pragma: no cover
-
-    def __len__(self) -> int:
-        ...  # pragma: no cover
-
     def get(self, key: K, default: Optional[V] = None) -> Optional[V]:
         ...  # pragma: no cover
 
@@ -63,15 +54,21 @@ class OpenAIRequestResponseResolver:
         self,
         request: Dict[str, Any],
         response: OpenAIResponse,
-    ):
-        if response["object"] == "edit":
-            return self._resolve_edit(request, response)
+        time_elapsed: float,
+    ) -> Optional[trace_tree.WBTraceTree]:
+        try:
+            if response["object"] == "edit":
+                return self._resolve_edit(request, response, time_elapsed)
+        except Exception as e:
+            logger.warning(f"Failed to resolve request/response: {e}")
+        return None
 
     @staticmethod
     def results_to_trace_tree(
         request: Dict[str, Any],
         response: OpenAIResponse,
         results: List[trace_tree.Result],
+        time_elapsed: float,
     ) -> trace_tree.WBTraceTree:
         """Converts the request, response, and results into a trace tree.
 
@@ -82,11 +79,13 @@ class OpenAIRequestResponseResolver:
         returns:
             A trace tree object.
         """
+        start_time_ms = int(round(response["created"] * 1000))
+        end_time_ms = start_time_ms + int(round(time_elapsed * 1000))
         span = trace_tree.Span(
             name=f"{response.get('model', 'openai')}_{response['object']}_{response.get('created')}",
             attributes=dict(response),  # type: ignore
-            start_time_ms=int(round(response["created"] * 1000)),
-            end_time_ms=int(round(response["created"] * 1000)) + 10,
+            start_time_ms=start_time_ms,
+            end_time_ms=end_time_ms,
             span_kind=trace_tree.SpanKind.LLM,
             results=results,
         )
@@ -97,6 +96,7 @@ class OpenAIRequestResponseResolver:
         self,
         request: Dict[str, Any],
         response: OpenAIResponse,
+        time_elapsed: float,
     ) -> trace_tree.WBTraceTree:
         def format_request(_request: Dict[str, Any]) -> str:
             """Formats the request object to a string.
@@ -104,7 +104,8 @@ class OpenAIRequestResponseResolver:
             params:
                 _request: The request object
             returns:
-                A string representation of the request object to be logged in a trace tree Result object.
+                A string representation of the request object to be logged
+                in a trace tree Result object.
             """
             prompt = (
                 f"\n\n**Instruction**: {_request['instruction']}\n\n"
@@ -118,7 +119,8 @@ class OpenAIRequestResponseResolver:
             params:
                 choice: The choice object
             returns:
-                A string representation of the choice object to be logged in a trace tree Result object.
+                A string representation of the choice object to be logged
+                in a trace tree Result object.
             """
             choice = f"\n\n**Edited**: {choice['text']}\n"
             return choice
@@ -130,7 +132,7 @@ class OpenAIRequestResponseResolver:
             )
             for choice in response["choices"]
         ]
-        trace = self.results_to_trace_tree(request, response, results)
+        trace = self.results_to_trace_tree(request, response, results, time_elapsed)
         return trace
 
 
@@ -256,7 +258,7 @@ class Relay:
         # todo: add context resolvers
         # todo: save parsed context to wandb
         #  if parsing fails, just save the raw data !!
-        trace = self.resolver(request_data, response_data)
+        trace = self.resolver(request_data, response_data, time_elapsed)
         print(trace)
 
     def snoopy(self, subpath) -> Mapping[str, str]:

--- a/wandb/integration/openai/openai.py
+++ b/wandb/integration/openai/openai.py
@@ -1,0 +1,176 @@
+import logging
+import socket
+import threading
+import urllib.parse
+from typing import Dict, List, Mapping, Optional
+
+import requests
+
+import wandb.util
+from wandb.testing.relay import RawRequestResponse, Timer
+
+flask = wandb.util.get_module(
+    name="flask",
+    required="To use the W&B OpenAI Autolog, you need to have the `flask` python "
+    "package installed. Please install it with `pip install flask`.",
+    lazy=False,
+)
+
+openai = wandb.util.get_module(
+    name="openai",
+    required="To use the W&B OpenAI Autolog, you need to have the `openai` python "
+    "package installed. Please install it with `pip install openai`.",
+    lazy=False,
+)
+
+
+class Relay:
+    def __init__(self) -> None:
+        self.app = flask.Flask(__name__)
+        self.app.logger.setLevel(logging.INFO)
+        # disable flask's default message:
+        flask.cli.show_server_banner = lambda *args: None
+
+        self.app.add_url_rule(
+            rule="/<path:subpath>",
+            endpoint="snoopy",
+            view_func=self.snoopy,
+            methods=["GET", "POST"],
+        )
+
+        self.port = self._get_free_port()
+        # self.base_url = openai.api_base
+        self.base_url = urllib.parse.urlparse(openai.api_base)
+        print(self.base_url)
+        self.session = requests.Session()
+        self.relay_url = f"http://127.0.0.1:{self.port}/{self.base_url.path}"
+
+        self._relay_server_thread: Optional[threading.Thread] = None
+
+        self.context: List[Dict[str, str]] = []
+
+        # useful for debugging:
+        # self.after_request_fn = self.app.after_request(self.after_request_fn)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+
+    @staticmethod
+    def _get_free_port() -> int:
+        sock = socket.socket()
+        sock.bind(("", 0))
+
+        _, port = sock.getsockname()
+        return port
+
+    def start(self) -> None:
+        if self._relay_server_thread is not None:
+            return
+        # run server in a separate thread
+        self._relay_server_thread = threading.Thread(
+            target=self.app.run,
+            kwargs={"port": self.port},
+            daemon=True,
+        )
+        self._relay_server_thread.start()
+        openai.api_base = self.relay_url
+
+    def stop(self) -> None:
+        if self._relay_server_thread is None:
+            return
+        # self._relay_server_thread.join()
+        self._relay_server_thread = None
+        openai.api_base = self.base_url.geturl()
+        # openai.api_base = str(self.base_url)
+
+    def after_request_fn(self, response: "requests.Response") -> "requests.Response":
+        # todo: this is useful for debugging, but should be removed in the future
+        # flask.request.url = self.relay_url + flask.request.url
+        print(flask.request)
+        print(flask.request.get_json())
+        print(response)
+        print(response.json())
+        return response
+
+    def relay(
+        self,
+        request: "flask.Request",
+    ) -> "requests.Response":
+        # replace the relay url with the real backend url (self.base_url)
+        url = (
+            urllib.parse.urlparse(request.url)
+            ._replace(netloc=self.base_url.netloc, scheme=self.base_url.scheme)
+            .geturl()
+        )
+        headers = {key: value for (key, value) in request.headers if key != "Host"}
+        prepared_relayed_request = requests.Request(
+            method=request.method,
+            url=url,
+            headers=headers,
+            data=request.get_data(),
+            json=request.get_json(),
+        ).prepare()
+
+        relayed_response = self.session.send(prepared_relayed_request)
+        return relayed_response
+
+    def save(
+        self,
+        request: "flask.Request",
+        response: "requests.Response",
+        time_elapsed: float,
+    ) -> None:
+        request_data = request.get_json()
+        response_data = response.json() or {}
+
+        # store raw data
+        raw_data: "RawRequestResponse" = {
+            "url": request.url,
+            "request": request_data,
+            "response": response_data,
+            "time_elapsed": time_elapsed,
+        }
+        self.context.append(raw_data)
+
+        # todo: add context resolvers
+        # todo: save parsed context to wandb
+        #  if parsing fails, just save the raw data !!
+
+    def snoopy(self, subpath) -> Mapping[str, str]:
+        request = flask.request
+        with Timer() as timer:
+            relayed_response = self.relay(request)
+        print("*****************")
+        print("REQUEST:")
+        print(request.get_json())
+        print("RESPONSE:")
+        print(relayed_response.status_code, relayed_response.json())
+        print("*****************")
+        # snoop work to extract the context
+        self.save(request, relayed_response, timer.elapsed)
+
+        return relayed_response.json()
+
+
+class Autolog:
+    def __init__(
+        self,
+        project: Optional[str] = None,
+        entity: Optional[str] = None,
+    ):
+        # autolog = Autolog()
+        # autolog.enable()
+        # # doo da ding...he don't miss!!!
+        # autolog.disable()
+        pass
+
+    # do the same thing as the context manager
+    def enable(self):
+        pass
+
+    def disable(self):
+        pass

--- a/wandb/testing/relay.py
+++ b/wandb/testing/relay.py
@@ -41,12 +41,6 @@ else:
 if TYPE_CHECKING:
     from typing import Deque
 
-    class RawRequestResponse(TypedDict):
-        url: str
-        request: Optional[Any]
-        response: Dict[str, Any]
-        time_elapsed: float  # seconds
-
     ResolverName = Literal[
         "upsert_bucket",
         "upload_files",
@@ -58,6 +52,13 @@ if TYPE_CHECKING:
     class Resolver(TypedDict):
         name: ResolverName
         resolver: Callable[[Any], Optional[Dict[str, Any]]]
+
+
+class RawRequestResponse(TypedDict):
+    url: str
+    request: Optional[Any]
+    response: Dict[str, Any]
+    time_elapsed: float  # seconds
 
 
 class DeliberateHTTPError(Exception):

--- a/wandb/testing/relay.py
+++ b/wandb/testing/relay.py
@@ -557,9 +557,9 @@ class RelayServer:
         self.session = requests.Session()
         self.relay_url = f"http://127.0.0.1:{self.port}"
 
-        # recursively merge-able object to store state
-        self.resolver = QueryResolver()
         # todo: add an option to add custom resolvers
+        self.resolver = QueryResolver()
+        # recursively merge-able object to store state
         self.context = Context()
 
         # injected responses


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
Example logged stuff: https://wandb.ai/dimaduev/snoopy/runs/nn7a2mrq


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fa1f231</samp>

> _To log OpenAI with W&B_
> _We added `Autolog` and `Relay`_
> _We also refactored_
> _The `RawRequestResponse` actor_
> _And moved it to `testing/relay.py`_