### PR TITLE
chore(launch): Add secure mode for launch agent

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -35,6 +35,34 @@ def test_loop_capture_stack_trace(mocker):
     assert "Traceback (most recent call last):" in mocker.termerror.call_args[0][0]
 
 
+def test_run_job_secure_mode(mocker):
+    _setup(mocker)
+    mock_config = {
+        "entity": "test-entity",
+        "project": "test-project",
+        "secure_mode": True,
+    }
+    agent = LaunchAgent(api=mocker.api, config=mock_config)
+
+    k8s_specs = [
+        {"spec": {"template": {"spec": {"hostPID": True}}}},
+        {
+            "spec": {
+                "template": {
+                    "spec": {"containers": [{}, {"command": ["some", "code"]}]}
+                }
+            }
+        },
+    ]
+    errors = [
+        'This agent is configured to lock "hostPID" in pod spec but the job specification attempts to override it.',
+        'This agent is configured to lock "command" in container spec but the job specification attempts to override it.',
+    ]
+    for spec, error in zip(k8s_specs, errors):
+        with pytest.raises(ValueError, match=error):
+            agent.run_job({"runSpec": {"resource_args": {"kubernetes": spec}}})
+
+
 def test_team_entity_warning(mocker):
     _setup(mocker)
     mocker.api.entity_is_team = MagicMock(return_value=True)

--- a/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -67,7 +67,7 @@ def test_run_job_secure_mode(mocker):
                 }
             }
         },
-        {"overrides": {"entry_point": ["some", "code"]}},
+        {"runSpec": {"overrides": {"entry_point": ["some", "code"]}}},
     ]
     errors = [
         'This agent is configured to lock "hostPID" in pod spec but the job specification attempts to override it.',

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -303,31 +303,7 @@ class LaunchAgent:
         launch_spec = job["runSpec"]
 
         # Abort if this job attempts to override secure mode
-        if self._secure_mode:
-            k8s_config = launch_spec.get("resource_args", {}).get("kubernetes", {})
-
-            pod_secure_keys = ["hostPID", "hostIPC", "hostNetwork", "initContainers"]
-            pod_spec = k8s_config.get("spec", {}).get("template", {}).get("spec", {})
-            for key in pod_secure_keys:
-                if key in pod_spec:
-                    raise ValueError(
-                        f'This agent is configured to lock "{key}" in pod spec '
-                        "but the job specification attempts to override it."
-                    )
-
-            container_specs = pod_spec.get("containers", [])
-            for container_spec in container_specs:
-                if "command" in container_spec:
-                    raise ValueError(
-                        'This agent is configured to lock "command" in container spec '
-                        "but the job specification attempts to override it."
-                    )
-
-            if launch_spec.get("overrides", {}).get("entry_point"):
-                raise ValueError(
-                    'This agent is configured to lock the "entrypoint" override '
-                    "but the job specification attempts to override it."
-                )
+        self._assert_secure(launch_spec)
 
         self._pool.apply_async(
             self.thread_run_job,
@@ -338,6 +314,35 @@ class LaunchAgent:
                 self._api,
             ),
         )
+
+    def _assert_secure(self, launch_spec: Dict[str, Any]) -> None:
+        """If secure mode is set, make sure no vulnerable keys are overridden."""
+        if not self._secure_mode:
+            return
+        k8s_config = launch_spec.get("resource_args", {}).get("kubernetes", {})
+
+        pod_secure_keys = ["hostPID", "hostIPC", "hostNetwork", "initContainers"]
+        pod_spec = k8s_config.get("spec", {}).get("template", {}).get("spec", {})
+        for key in pod_secure_keys:
+            if key in pod_spec:
+                raise ValueError(
+                    f'This agent is configured to lock "{key}" in pod spec '
+                    "but the job specification attempts to override it."
+                )
+
+        container_specs = pod_spec.get("containers", [])
+        for container_spec in container_specs:
+            if "command" in container_spec:
+                raise ValueError(
+                    'This agent is configured to lock "command" in container spec '
+                    "but the job specification attempts to override it."
+                )
+
+        if launch_spec.get("overrides", {}).get("entry_point"):
+            raise ValueError(
+                'This agent is configured to lock the "entrypoint" override '
+                "but the job specification attempts to override it."
+            )
 
     def loop(self) -> None:
         """Loop infinitely to poll for jobs and run them.


### PR DESCRIPTION
Fixes
-----
Fixes [WB-13380](https://wandb.atlassian.net/browse/WB-13380)

Description
-----------
Add a "secure mode" key that can be supplied to an agent. If present, it locks some potentially vulnerable pod and container configs to arbitrary code execution. Attempting to override those configs raises a validation error.


Testing
-------
A unit test was added to make sure safe mode raises an error when specific keys are present.




[WB-13380]: https://wandb.atlassian.net/browse/WB-13380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ