### PR TITLE
fix(integrations): add function signature wrapper to patched openai methods

### DIFF
--- a/wandb/integration/openai/openai.py
+++ b/wandb/integration/openai/openai.py
@@ -50,6 +50,7 @@ class PatchOpenAIAPI:
             original = getattr(self.openai, symbol).create
 
             def method_factory(original_method: Any):
+                @functools.wraps(original_method)
                 def create(*args, **kwargs):
                     with Timer() as timer:
                         result = original_method(*args, **kwargs)
@@ -67,9 +68,7 @@ class PatchOpenAIAPI:
             # save original method
             self.original_methods[symbol] = original
             # monkeypatch
-            wrapper = method_factory(original)
-            wrapper = functools.update_wrapper(wrapper, original)
-            getattr(self.openai, symbol).create = wrapper
+            getattr(self.openai, symbol).create = method_factory(original)
 
     def unpatch(self) -> None:
         """Unpatches the OpenAI API."""

--- a/wandb/integration/openai/openai.py
+++ b/wandb/integration/openai/openai.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import sys
 from typing import Any, Dict, List, Optional
@@ -66,7 +67,9 @@ class PatchOpenAIAPI:
             # save original method
             self.original_methods[symbol] = original
             # monkeypatch
-            getattr(self.openai, symbol).create = method_factory(original)
+            wrapper = method_factory(original)
+            wrapper = functools.update_wrapper(wrapper, original)
+            getattr(self.openai, symbol).create = wrapper
 
     def unpatch(self) -> None:
         """Unpatches the OpenAI API."""


### PR DESCRIPTION
Summary
-----

This PR adds function signature wrapper to patched methods in the openai autologging integration. 

Testing
-------

locally

Checklist
-------
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a875b97</samp>

> _To patch OpenAI methods with ease_
> _We import `functools` if you please_
> _Then we use `update_wrapper`_
> _To avoid any dapper_
> _And keep the original metadata keys_