### PR TITLE
fix(artifacts): default to project "uncategorized" instead of "None" when fetching artifacts

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -663,8 +663,8 @@ class Api:
 
     def _parse_artifact_path(self, path):
         """Return project, entity and artifact name for project specified by path."""
-        project = self.settings["project"]
-        entity = self.settings["entity"] or self.default_entity
+        project = self.settings.get("project", "uncategorized")
+        entity = self.settings.get("entity", self.default_entity)
         if path is None:
             return entity, project
         parts = path.split("/")


### PR DESCRIPTION
Fixes WB-13393

## Description

When creating an artifact, we default to project "uncategorized". When fetching an artifact, we default to project "None".

![Untitled (1)](https://user-images.githubusercontent.com/127154459/233065752-af9a803c-bb24-493e-a0b6-0ff2ccb98a38.png)

I changed the latter to also use "uncategorized".

## Test plan

- Started a Jupyter notebook:
```
$ tox -e py39 --notest
$ source .tox/py39/bin/activate
$ pip install jupyter
$ jupyter notebook
```
- Fetched an artifact from "uncategorized" project:
<img width="1152" alt="Untitled" src="https://user-images.githubusercontent.com/127154459/233064991-3ec8deb5-67d0-4755-8a91-259d46c6e3e5.png">