### PR TITLE
fix(launch): Skip getting run info if run completes successfully or is from a different entity

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -238,3 +238,22 @@ def test_thread_finish_run_fail_start_old_server(mocker):
     agent.finish_thread_id("thread_1")
     assert len(agent._jobs) == 0
     assert not mocker.api.fail_run_queue_item.called
+
+
+def test_thread_finish_run_fail_different_entity(mocker):
+    _setup_thread_finish(mocker)
+    mock_config = {
+        "entity": "test-entity",
+        "project": "test-project",
+    }
+
+    agent = LaunchAgent(api=mocker.api, config=mock_config)
+    job = JobAndRunStatus("run_queue_item_id")
+    job.run_id = "test_run_id"
+    job.project = "test-project"
+    job.entity = "other-entity"
+    agent._jobs = {"thread_1": job}
+    agent._jobs_lock = MagicMock()
+    agent.finish_thread_id("thread_1")
+    assert len(agent._jobs) == 0
+    assert not mocker.api.fail_run_queue_item.called


### PR DESCRIPTION
Fixes
-----
Item 10 [here](https://www.notion.so/wandbai/Easy-way-to-Launch-OpenAI-Evals-job-8936b3b8d51c4310bb1f1ee244a8e348?pvs=4#23a604f611c94dd88bbdca3497408a0d)

Description
-----------
Launch agent would incorrectly mark a run as failed if the run exists on a different entity than the agent.

Testing
-------
Unit test was added


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5b9df4d</samp>

> _Sing, O Muse, of the valiant LaunchAgent, swift and wise,_
> _Who faced the challenge of different run entities and statuses,_
> _And with skillful code and tests, he forged a robust solution,_
> _Like Hephaestus, who shapes the metal with his fiery hands._