### PR TITLE
test(sdk): use pre release for sb3 that replaces gym with gymnasium

### DIFF
--- a/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.py
+++ b/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 """Test stable_baselines3 integration."""
 
-import gym
+
+import gymnasium as gym
 import wandb
 from stable_baselines3 import PPO
 from stable_baselines3.common.monitor import Monitor

--- a/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
+++ b/tests/functional_tests/t0_main/sb3/t1_stable_baselines3.yea
@@ -6,9 +6,7 @@ tag:
     - platform: win
 depend:
   requirements:
-    - setuptools==65.5.0 # 20230202: issue with later versions of setuptools cause install errors
-    - importlib-metadata<5.0  # 20221003: sb3 needs to fix this on their side
-    - stable-baselines3
+    - --pre stable-baselines3
     - tensorboard
 assert:
   - :wandb:runs_len: 1


### PR DESCRIPTION
Description
-----------
What does the PR do?

gym is a dependency of stable-baselines3, but it is not maintained any more and the requirements specification is totally broken with newer versions of setuptools and it's dependencies. So we are installing the release candidate from stable-baselines3 that uses gymnasium instead of gym. 

Future action: once stable-baselines3 release the new version we should remove the `--pre` from the yea install tags.


Testing
-------
How was this PR tested?

Fixing broken test, so if it passes the fix worked

Checklist
-------
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7d5f2ab</samp>

> _`gym` is now `gymnasium`_
> _A fork that works with `stable-baselines3` - ah!_
> _Simplified `requirements`_