### PR TITLE
refactor(artifacts): use PurePosixPath instead of LogicalFilePathStr

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -60,6 +60,7 @@ from wandb.sdk.launch.utils import (
 from wandb.sdk.lib import filesystem, ipython, retry, runid
 from wandb.sdk.lib.gql_request import GraphQLSession
 from wandb.sdk.lib.hashutil import b64_to_hex_id, hex_to_b64_id, md5_file_b64
+from wandb.util import StrPath
 
 if TYPE_CHECKING:
     import wandb.apis.reports
@@ -4685,7 +4686,8 @@ class Artifact(artifacts.Artifact):
                 return entry, wb_class
         return None, None
 
-    def get_path(self, name):
+    def get_path(self, name: StrPath):
+        name = util.to_forward_slash_path(name)
         manifest = self._load_manifest()
         entry = manifest.entries.get(name)
         if entry is None:
@@ -4777,9 +4779,7 @@ class Artifact(artifacts.Artifact):
         for root, _, files in os.walk(dirpath):
             for file in files:
                 full_path = os.path.join(root, file)
-                artifact_path = util.to_forward_slash_path(
-                    os.path.relpath(full_path, start=dirpath)
-                )
+                artifact_path = os.path.relpath(full_path, start=dirpath)
                 try:
                     self.get_path(artifact_path)
                 except KeyError:
@@ -4796,9 +4796,7 @@ class Artifact(artifacts.Artifact):
         for root, _, files in os.walk(dirpath):
             for file in files:
                 full_path = os.path.join(root, file)
-                artifact_path = util.to_forward_slash_path(
-                    os.path.relpath(full_path, start=dirpath)
-                )
+                artifact_path = os.path.relpath(full_path, start=dirpath)
                 try:
                     self.get_path(artifact_path)
                 except KeyError:

--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -46,8 +46,7 @@ class FileEventHandler(abc.ABC):
     ) -> None:
         self.file_path = file_path
         # Convert windows paths to unix paths
-        save_name = SaveName(util.to_forward_slash_path(save_name))
-        self.save_name = save_name
+        self.save_name = SaveName(util.to_forward_slash_path(save_name))
         self._file_pusher = file_pusher
         self._last_sync: Optional[float] = None
 

--- a/wandb/filesync/stats.py
+++ b/wandb/filesync/stats.py
@@ -2,6 +2,7 @@ import threading
 from typing import MutableMapping, NamedTuple
 
 import wandb
+from wandb.util import StrPath
 
 
 class FileStats(NamedTuple):
@@ -31,8 +32,12 @@ class Stats:
         self._lock = threading.Lock()
 
     def init_file(
-        self, save_name: str, size: int, is_artifact_file: bool = False
+        self,
+        save_name: StrPath,
+        size: int,
+        is_artifact_file: bool = False,
     ) -> None:
+        save_name = str(save_name)
         with self._lock:
             self._stats[save_name] = FileStats(
                 deduped=False,
@@ -42,7 +47,8 @@ class Stats:
                 artifact_file=is_artifact_file,
             )
 
-    def set_file_deduped(self, save_name: str) -> None:
+    def set_file_deduped(self, save_name: StrPath) -> None:
+        save_name = str(save_name)
         with self._lock:
             orig = self._stats[save_name]
             self._stats[save_name] = orig._replace(
@@ -50,13 +56,15 @@ class Stats:
                 uploaded=orig.total,
             )
 
-    def update_uploaded_file(self, save_name: str, total_uploaded: int) -> None:
+    def update_uploaded_file(self, save_name: StrPath, total_uploaded: int) -> None:
+        save_name = str(save_name)
         with self._lock:
             self._stats[save_name] = self._stats[save_name]._replace(
                 uploaded=total_uploaded,
             )
 
-    def update_failed_file(self, save_name: str) -> None:
+    def update_failed_file(self, save_name: StrPath) -> None:
+        save_name = str(save_name)
         with self._lock:
             self._stats[save_name] = self._stats[save_name]._replace(
                 uploaded=0,

--- a/wandb/integration/keras/callbacks/model_checkpoint.py
+++ b/wandb/integration/keras/callbacks/model_checkpoint.py
@@ -9,6 +9,7 @@ from tensorflow.keras import callbacks  # type: ignore
 
 import wandb
 from wandb.sdk.lib import telemetry
+from wandb.util import StrPath
 
 from ..keras import patch_tf_keras
 
@@ -72,7 +73,7 @@ class WandbModelCheckpoint(callbacks.ModelCheckpoint):
 
     def __init__(
         self,
-        filepath: Union[str, os.PathLike],
+        filepath: StrPath,
         monitor: str = "val_loss",
         verbose: int = 0,
         save_best_only: bool = False,

--- a/wandb/sdk/data_types/base_types/wb_value.py
+++ b/wandb/sdk/data_types/base_types/wb_value.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Type, Union
 
 from wandb import util
+from wandb.util import StrPath
 
 if TYPE_CHECKING:  # pragma: no cover
     from wandb.apis.public import Artifact as PublicArtifact
@@ -39,18 +40,22 @@ class _WBValueArtifactSource:
     artifact: "PublicArtifact"
     name: Optional[str]
 
-    def __init__(self, artifact: "PublicArtifact", name: Optional[str] = None) -> None:
+    def __init__(
+        self, artifact: "PublicArtifact", name: Optional[StrPath] = None
+    ) -> None:
         self.artifact = artifact
-        self.name = name
+        self.name = util.to_forward_slash_path(name) if name else None
 
 
 class _WBValueArtifactTarget:
     artifact: "LocalArtifact"
     name: Optional[str]
 
-    def __init__(self, artifact: "LocalArtifact", name: Optional[str] = None) -> None:
+    def __init__(
+        self, artifact: "LocalArtifact", name: Optional[StrPath] = None
+    ) -> None:
         self.artifact = artifact
-        self.name = name
+        self.name = util.to_forward_slash_path(name) if name else None
 
 
 class WBValue:
@@ -105,7 +110,7 @@ class WBValue:
         raise NotImplementedError
 
     @classmethod
-    def with_suffix(cls: Type["WBValue"], name: str, filetype: str = "json") -> str:
+    def with_suffix(cls: Type["WBValue"], name: StrPath, filetype: str = "json") -> str:
         """Get the name with the appropriate suffix.
 
         Args:
@@ -116,6 +121,7 @@ class WBValue:
             str: a filename which is suffixed with it's `_log_type` followed by the
                 filetype.
         """
+        name = str(name)
         if cls._log_type is not None:
             suffix = cls._log_type + "." + filetype
         else:
@@ -186,7 +192,7 @@ class WBValue:
         raise NotImplementedError
 
     def _set_artifact_source(
-        self, artifact: "PublicArtifact", name: Optional[str] = None
+        self, artifact: "PublicArtifact", name: Optional[StrPath] = None
     ) -> None:
         assert (
             self._artifact_source is None
@@ -196,7 +202,7 @@ class WBValue:
         self._artifact_source = _WBValueArtifactSource(artifact, name)
 
     def _set_artifact_target(
-        self, artifact: "LocalArtifact", name: Optional[str] = None
+        self, artifact: "LocalArtifact", name: Optional[StrPath] = None
     ) -> None:
         assert (
             self._artifact_target is None

--- a/wandb/sdk/interface/artifacts/artifact.py
+++ b/wandb/sdk/interface/artifacts/artifact.py
@@ -2,7 +2,7 @@ from typing import IO, TYPE_CHECKING, ContextManager, List, Optional, Sequence, 
 
 import wandb
 from wandb.data_types import WBValue
-from wandb.util import FilePathStr
+from wandb.util import FilePathStr, StrPath
 
 if TYPE_CHECKING:
     import wandb.apis.public
@@ -23,7 +23,7 @@ class ArtifactStatusError(AttributeError):
         super().__init__(msg.format(artifact=artifact, attr=attr, method_id=method_id))
         # Follow the same pattern as AttributeError.
         self.obj = artifact
-        self.name = attr
+        self.name = str(attr) or ""
 
 
 class ArtifactNotLoggedError(ArtifactStatusError):
@@ -209,7 +209,10 @@ class Artifact:
         raise NotImplementedError
 
     def new_file(
-        self, name: str, mode: str = "w", encoding: Optional[str] = None
+        self,
+        name: StrPath,
+        mode: str = "w",
+        encoding: Optional[str] = None,
     ) -> ContextManager[IO]:
         """Open a new temporary file that will be automatically added to the artifact.
 
@@ -238,7 +241,7 @@ class Artifact:
     def add_file(
         self,
         local_path: str,
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         is_tmp: Optional[bool] = False,
     ) -> "ArtifactManifestEntry":
         """Add a local file to the artifact.
@@ -272,7 +275,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def add_dir(self, local_path: str, name: Optional[str] = None) -> None:
+    def add_dir(self, local_path: str, name: Optional[StrPath] = None) -> None:
         """Add a local directory to the artifact.
 
         Arguments:
@@ -304,7 +307,7 @@ class Artifact:
     def add_reference(
         self,
         uri: Union["ArtifactManifestEntry", str],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence["ArtifactManifestEntry"]:
@@ -373,7 +376,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def add(self, obj: WBValue, name: str) -> "ArtifactManifestEntry":
+    def add(self, obj: WBValue, name: StrPath) -> "ArtifactManifestEntry":
         """Add wandb.WBValue `obj` to the artifact.
 
         ```
@@ -410,7 +413,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def get_path(self, name: str) -> "ArtifactManifestEntry":
+    def get_path(self, name: StrPath) -> "ArtifactManifestEntry":
         """Get the path to the file located at the artifact relative `name`.
 
         Arguments:
@@ -439,7 +442,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def get(self, name: str) -> WBValue:
+    def get(self, name: StrPath) -> WBValue:
         """Get the WBValue object located at the artifact relative `name`.
 
         Arguments:
@@ -556,7 +559,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def __getitem__(self, name: str) -> Optional[WBValue]:
+    def __getitem__(self, name: StrPath) -> Optional[WBValue]:
         """Get the WBValue object located at the artifact relative `name`.
 
         Arguments:
@@ -583,7 +586,7 @@ class Artifact:
         """
         return self.get(name)
 
-    def __setitem__(self, name: str, item: WBValue) -> "ArtifactManifestEntry":
+    def __setitem__(self, name: StrPath, item: WBValue) -> "ArtifactManifestEntry":
         """Add `item` to the artifact at path `name`.
 
         Arguments:

--- a/wandb/sdk/interface/artifacts/artifact_cache.py
+++ b/wandb/sdk/interface/artifacts/artifact_cache.py
@@ -6,9 +6,9 @@ from typing import IO, TYPE_CHECKING, ContextManager, Dict, Generator, Optional,
 
 from wandb import env, util
 from wandb.sdk.interface.artifacts import Artifact, ArtifactNotLoggedError
-from wandb.sdk.lib.filesystem import StrPath, mkdir_exists_ok
+from wandb.sdk.lib.filesystem import mkdir_exists_ok
 from wandb.sdk.lib.hashutil import B64MD5, ETag, b64_to_hex_id
-from wandb.util import FilePathStr, URIStr
+from wandb.util import FilePathStr, StrPath, URIStr
 
 if TYPE_CHECKING:
     import sys
@@ -89,7 +89,7 @@ class ArtifactsCache:
         for root, _, files in os.walk(self._cache_dir):
             for file in files:
                 try:
-                    path = str(os.path.join(root, file))
+                    path = os.path.join(root, file)
                     stat = os.stat(path)
 
                     if file.startswith(ArtifactsCache._TMP_PREFIX):

--- a/wandb/sdk/interface/artifacts/artifact_manifest.py
+++ b/wandb/sdk/interface/artifacts/artifact_manifest.py
@@ -2,7 +2,14 @@ from dataclasses import field
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
 
 from wandb.sdk.lib.hashutil import B64MD5, ETag, HexMD5
-from wandb.util import FilePathStr, StrPath, URIStr, to_forward_slash_path
+from wandb.util import (
+    FilePathStr,
+    LogicalFilePathStr,
+    StrPath,
+    URIStr,
+    to_forward_slash_path,
+    to_native_slash_path,
+)
 
 if TYPE_CHECKING:
     from wandb.sdk import wandb_artifacts
@@ -10,13 +17,13 @@ if TYPE_CHECKING:
 
 
 class ArtifactManifestEntry:
-    path: str  # The artifact-relative path.
+    path: LogicalFilePathStr  # The artifact-relative path.
     digest: Union[B64MD5, URIStr, FilePathStr, ETag]
     ref: Optional[Union[FilePathStr, URIStr]] = None
     birth_artifact_id: Optional[str] = None
     size: Optional[int] = None
     extra: Dict = field(default_factory=dict)
-    local_path: Optional[str] = None
+    local_path: Optional[FilePathStr] = None
 
     def __init__(
         self,
@@ -26,16 +33,16 @@ class ArtifactManifestEntry:
         birth_artifact_id: Optional[str] = None,
         size: Optional[int] = None,
         extra: Optional[Dict] = None,
-        local_path: Optional[str] = None,
+        local_path: Optional[StrPath] = None,
     ) -> None:
-        # For backwards compatibility we always store the path as a string.
+        # For backwards compatibility we always store paths as str.
         self.path = to_forward_slash_path(path)
         self.digest = digest
         self.ref = ref
         self.birth_artifact_id = birth_artifact_id
         self.size = size
         self.extra = extra or {}
-        self.local_path = local_path
+        self.local_path = to_native_slash_path(local_path) if local_path else None
         if self.local_path and self.size is None:
             raise ValueError("size required when local_path specified")
 

--- a/wandb/sdk/interface/artifacts/artifact_manifest.py
+++ b/wandb/sdk/interface/artifacts/artifact_manifest.py
@@ -1,18 +1,16 @@
-from dataclasses import dataclass, field
-from pathlib import PurePosixPath
+from dataclasses import field
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
 
 from wandb.sdk.lib.hashutil import B64MD5, ETag, HexMD5
-from wandb.util import FilePathStr, URIStr, to_forward_slash_path
+from wandb.util import FilePathStr, StrPath, URIStr, to_forward_slash_path
 
 if TYPE_CHECKING:
     from wandb.sdk import wandb_artifacts
     from wandb.sdk.interface.artifacts import Artifact
 
 
-@dataclass
 class ArtifactManifestEntry:
-    path: Union[str, PurePosixPath]  # The artifact-relative path.
+    path: str  # The artifact-relative path.
     digest: Union[B64MD5, URIStr, FilePathStr, ETag]
     ref: Optional[Union[FilePathStr, URIStr]] = None
     birth_artifact_id: Optional[str] = None
@@ -20,10 +18,24 @@ class ArtifactManifestEntry:
     extra: Dict = field(default_factory=dict)
     local_path: Optional[str] = None
 
-    def __post_init__(self) -> None:
+    def __init__(
+        self,
+        path: StrPath,
+        digest: Union[B64MD5, URIStr, FilePathStr, ETag],
+        ref: Optional[Union[FilePathStr, URIStr]] = None,
+        birth_artifact_id: Optional[str] = None,
+        size: Optional[int] = None,
+        extra: Optional[Dict] = None,
+        local_path: Optional[str] = None,
+    ) -> None:
         # For backwards compatibility we always store the path as a string.
-        self.path = to_forward_slash_path(self.path)
-        self.extra = self.extra or {}
+        self.path = to_forward_slash_path(path)
+        self.digest = digest
+        self.ref = ref
+        self.birth_artifact_id = birth_artifact_id
+        self.size = size
+        self.extra = extra or {}
+        self.local_path = local_path
         if self.local_path and self.size is None:
             raise ValueError("size required when local_path specified")
 

--- a/wandb/sdk/interface/artifacts/artifact_storage.py
+++ b/wandb/sdk/interface/artifacts/artifact_storage.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Type, Union
 
-from wandb.util import FilePathStr, URIStr
+from wandb.util import FilePathStr, StrPath, URIStr
 
 if TYPE_CHECKING:
     from urllib.parse import ParseResult
@@ -107,7 +107,7 @@ class StorageHandler:
         self,
         artifact: "Artifact",
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence["ArtifactManifestEntry"]:

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -132,11 +132,7 @@ class FilePusher:
             return
 
         save_name = dir_watcher.SaveName(wandb.util.to_forward_slash_path(save_name))
-        event = step_checksum.RequestUpload(
-            path,
-            dir_watcher.SaveName(save_name),
-            copy,
-        )
+        event = step_checksum.RequestUpload(path, save_name, copy)
         self._incoming_queue.put(event)
 
     def store_manifest_files(

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -41,6 +41,7 @@ from wandb.integration.sagemaker import parse_sm_secrets
 from wandb.old.settings import Settings
 from wandb.sdk.lib.gql_request import GraphQLSession
 from wandb.sdk.lib.hashutil import B64MD5, md5_file_b64
+from wandb.util import StrPath
 
 from ..lib import retry
 from ..lib.filenames import DIFF_FNAME, METADATA_FNAME
@@ -1798,7 +1799,7 @@ class Api:
     def upload_urls(
         self,
         project: str,
-        files: Union[List[str], Dict[str, IO]],
+        files: Union[List[StrPath], Dict[StrPath, IO]],
         run: Optional[str] = None,
         entity: Optional[str] = None,
         description: Optional[str] = None,
@@ -1852,7 +1853,7 @@ class Api:
                 "run": run_id,
                 "entity": entity,
                 "description": description,
-                "files": [file for file in files],
+                "files": [str(file) for file in files],
             },
         )
 
@@ -2574,7 +2575,7 @@ class Api:
     @normalize_exceptions
     def push(
         self,
-        files: Union[List[str], Dict[str, IO]],
+        files: Union[List[StrPath], Dict[StrPath, IO]],
         run: Optional[str] = None,
         entity: Optional[str] = None,
         project: Optional[str] = None,
@@ -3016,7 +3017,7 @@ class Api:
 
     def create_artifact_manifest(
         self,
-        name: str,
+        name: StrPath,
         digest: str,
         artifact_id: Optional[str],
         base_artifact_id: Optional[str] = None,
@@ -3074,7 +3075,7 @@ class Api:
         response = self.gql(
             mutation,
             variable_values={
-                "name": name,
+                "name": str(name),
                 "digest": digest,
                 "artifactID": artifact_id,
                 "baseArtifactID": base_artifact_id,

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -14,6 +14,7 @@ import wandb
 from wandb import util
 from wandb.sdk.interface.interface import GlobStr
 from wandb.sdk.lib import filesystem
+from wandb.util import StrPath
 from wandb.viz import CustomChart
 
 from . import run as internal_run
@@ -145,7 +146,7 @@ class TBWatcher:
 
         return namespace
 
-    def add(self, logdir: str, save: bool, root_dir: str) -> None:
+    def add(self, logdir: StrPath, save: bool, root_dir: StrPath) -> None:
         logdir = util.to_forward_slash_path(logdir)
         root_dir = util.to_forward_slash_path(root_dir)
         if logdir in self._logdirs:

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -8,16 +8,18 @@ import stat
 import tempfile
 import threading
 from pathlib import Path
-from typing import IO, Any, BinaryIO, Generator, Union
+from typing import IO, TYPE_CHECKING, Any, BinaryIO, Generator
 
-StrPath = Union[str, "os.PathLike[str]"]
+if TYPE_CHECKING:
+    from wandb.util import StrPath
+
 
 logger = logging.getLogger(__name__)
 
 WRITE_PERMISSIONS = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH | stat.S_IWRITE
 
 
-def mkdir_exists_ok(dir_name: StrPath) -> None:
+def mkdir_exists_ok(dir_name: "StrPath") -> None:
     """Create `dir_name` and any parent directories if they don't exist.
 
     Raises:
@@ -84,7 +86,9 @@ class CRDedupedFile(WriteSerializingFile):
         super().close()
 
 
-def copy_or_overwrite_changed(source_path: StrPath, target_path: StrPath) -> StrPath:
+def copy_or_overwrite_changed(
+    source_path: "StrPath", target_path: "StrPath"
+) -> "StrPath":
     """Copy source_path to target_path, unless it already exists with the same mtime.
 
     We liberally add write permissions to deal with the case of multiple users needing
@@ -131,7 +135,7 @@ def copy_or_overwrite_changed(source_path: StrPath, target_path: StrPath) -> Str
 
 @contextlib.contextmanager
 def safe_open(
-    path: StrPath, mode: str = "r", *args: Any, **kwargs: Any
+    path: "StrPath", mode: str = "r", *args: Any, **kwargs: Any
 ) -> Generator[IO, None, None]:
     """Open a file, ensuring any changes only apply atomically after close.
 
@@ -180,7 +184,7 @@ def safe_open(
             tmp_path.replace(path)
 
 
-def safe_copy(source_path: StrPath, target_path: StrPath) -> StrPath:
+def safe_copy(source_path: "StrPath", target_path: "StrPath") -> "StrPath":
     """Copy a file, ensuring any changes only apply atomically once finished."""
     # TODO (hugh): check that there is enough free space.
     output_path = Path(target_path).resolve()

--- a/wandb/sdk/lib/hashutil.py
+++ b/wandb/sdk/lib/hashutil.py
@@ -1,8 +1,10 @@
 import base64
 import hashlib
 import sys
-from os import PathLike
-from typing import NewType, Union
+from typing import TYPE_CHECKING, NewType, Union
+
+if TYPE_CHECKING:
+    from wandb.util import StrPath
 
 ETag = NewType("ETag", str)
 HexMD5 = NewType("HexMD5", str)
@@ -36,15 +38,15 @@ def hex_to_b64_id(encoded_string: Union[str, bytes]) -> B64MD5:
     return B64MD5(base64.standard_b64encode(as_str).decode("utf-8"))
 
 
-def md5_file_b64(*paths: Union[str, PathLike]) -> B64MD5:
+def md5_file_b64(*paths: "StrPath") -> B64MD5:
     return _b64_from_hasher(_md5_file_hasher(*paths))
 
 
-def md5_file_hex(*paths: Union[str, PathLike]) -> HexMD5:
+def md5_file_hex(*paths: "StrPath") -> HexMD5:
     return HexMD5(_md5_file_hasher(*paths).hexdigest())
 
 
-def _md5_file_hasher(*paths: Union[str, PathLike]) -> "hashlib._Hash":
+def _md5_file_hasher(*paths: "StrPath") -> "hashlib._Hash":
     md5_hash = _md5()
     for path in sorted(str(p) for p in paths):
         with open(path, "rb") as f:

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1157,7 +1157,7 @@ class TrackingHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
-    ) -> str:
+    ) -> Union[URIStr, FilePathStr]:
         if local:
             # Likely a user error. The tracking handler is
             # oblivious to the underlying paths, so it has
@@ -1168,7 +1168,7 @@ class TrackingHandler(StorageHandler):
             )
         # TODO(spencerpearson): should this go through util.to_native_slash_path
         # instead of just getting typecast?
-        return manifest_entry.path
+        return FilePathStr(manifest_entry.path)
 
     def store_path(
         self,

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -421,7 +421,7 @@ class Artifact(ArtifactInterface):
         if not os.path.isfile(local_path):
             raise ValueError("Path is not a file: %s" % local_path)
 
-        name = util.to_forward_slash_path(name or os.path.basename(local_path))
+        name = name or os.path.basename(local_path)
         digest = md5_file_b64(local_path)
 
         if is_tmp:
@@ -475,7 +475,6 @@ class Artifact(ArtifactInterface):
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
         self._ensure_can_add()
-        name = util.to_forward_slash_path(name) if name else None
 
         # This is a bit of a hack, we want to check if the uri is a of the type
         # ArtifactManifestEntry which is a private class returned by Artifact.get_path in
@@ -1280,9 +1279,9 @@ class LocalFileHandler(StorageHandler):
                             % max_objects
                         )
                     physical_path = os.path.join(root, sub_path)
-                    # TODO(spencerpearson): this is not a "logical path" in the sense that
-                    # `util.to_forward_slash_path` returns a "logical path"; it's a relative path
-                    # **on the local filesystem**.
+                    # TODO(spencerpearson): this is not a "logical path" in the sense
+                    # that `util.to_forward_slash_path` returns a "logical path"; it's a
+                    # relative path **on the local filesystem**.
                     logical_path = os.path.relpath(physical_path, start=local_path)
                     if name is not None:
                         logical_path = os.path.join(name, logical_path)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -47,12 +47,12 @@ from wandb.proto.wandb_internal_pb2 import (
     RunRecord,
     ServerInfoResponse,
 )
-from wandb.sdk.lib.filesystem import StrPath
 from wandb.sdk.lib.import_hooks import (
     register_post_import_hook,
     unregister_post_import_hook,
 )
 from wandb.util import (
+    StrPath,
     _is_artifact_object,
     _is_artifact_string,
     _is_artifact_version_weave_dict,
@@ -3849,10 +3849,10 @@ class _LazyArtifact(ArtifactInterface):
     def logged_by(self) -> "wandb.apis.public.Run":
         return self._instance.logged_by()
 
-    def get_path(self, name: str) -> "ArtifactManifestEntry":
+    def get_path(self, name: StrPath) -> "ArtifactManifestEntry":
         return self._instance.get_path(name)
 
-    def get(self, name: str) -> "WBValue":
+    def get(self, name: StrPath) -> "WBValue":
         return self._instance.get(name)
 
     def download(

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -63,10 +63,14 @@ if TYPE_CHECKING:
 CheckRetryFnType = Callable[[Exception], Union[bool, timedelta]]
 
 
-# Path inputs should generally accept any kind of path. This is named the same and
+# Path _inputs_ should generally accept any kind of path. This is named the same and
 # modeled after the hint defined in the Python standard library's `typeshed`:
 # https://github.com/python/typeshed/blob/0b1cd5989669544866213807afa833a88f649ee7/stdlib/_typeshed/__init__.pyi#L56-L65
 StrPath = Union[str, "os.PathLike[str]"]
+
+# This *should* be a PurePosixPath, but changing now it would change the public API.
+# It represents an artifact-relative or run-relative path and is always POSIX-style.
+LogicalFilePathStr = NewType("LogicalFilePathStr", str)
 
 # `FilePathStr` represents a path to a file on the local filesystem.
 #
@@ -1302,11 +1306,11 @@ def auto_project_name(program: Optional[str]) -> str:
     return str(project.replace(os.sep, "_"))
 
 
-def to_forward_slash_path(path: StrPath) -> str:
+def to_forward_slash_path(path: StrPath) -> LogicalFilePathStr:
     path = str(path)
     if platform.system() == "Windows":
         path = path.replace("\\", "/")
-    return path
+    return LogicalFilePathStr(path)
 
 
 def to_posixpath(path: StrPath) -> PurePosixPath:


### PR DESCRIPTION
Fixes
-----
Fixes WB-NNNN

Fixes #NNNN

Description
-----------
What does the PR do?


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at be9b2e5</samp>

> _To use pathlib was the goal_
> _For paths in the `job_repo` module_
> _They refactored the code_
> _And removed the old load_
> _Of custom string types that were awful_