### PR TITLE
fix(artifacts): fix handling of default project and entity

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -663,8 +663,8 @@ class Api:
 
     def _parse_artifact_path(self, path):
         """Return project, entity and artifact name for project specified by path."""
-        project = self.settings.get("project", "uncategorized")
-        entity = self.settings.get("entity", self.default_entity)
+        project = self.settings["project"] or "uncategorized"
+        entity = self.settings["entity"] or self.default_entity
         if path is None:
             return entity, project
         parts = path.split("/")


### PR DESCRIPTION
Description
-----------
Fix regression introduced in #5375.
The issue there is that the settings always have the "project" and "entity" attributes, so settings.get("project", "something") will never return "something", as in
<img width="209" alt="image" src="https://user-images.githubusercontent.com/7557205/233516934-f68b03ca-63db-411e-ba91-0e8c18816282.png">

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


copilot:poem