### PR TITLE
test(artifacts): fix flaky tests on windows (re-open file handle)

### DIFF
--- a/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
@@ -360,6 +360,7 @@ def test_safe_copy_different_file_systems(fs, fs_type: OSType):
     assert target_path.read_text("utf-8") == source_content
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows locks active files")
 def test_safe_copy_target_file_changes_during_copy(tmp_path: Path, monkeypatch):
     source_path = tmp_path / "source.txt"
     target_path = tmp_path / "target.txt"


### PR DESCRIPTION
Description
-----------
The test `test_safe_copy_target_file_changes_during_copy` introduced in #5279 doesn't always work on Windows, which generally prevents re-opening files that already have an open file handle. This just skips it on win32.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 211f066</samp>

> _`skip_if_windows`_
> _A file locked by wandb_
> _Fall leaves permission_