### PR TITLE
feat(sweeps): launch sweeps init wandb run

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -119,6 +119,9 @@ class Scheduler(ABC):
         # Scheduler may receive additional kwargs which will be piped into the launch command
         self._kwargs: Dict[str, Any] = kwargs
 
+        # Init wandb run to manage scheduler
+        self._wandb_run: SdkRun = _init_wandb_run()
+
     @abstractmethod
     def _get_next_sweep_run(self, worker_id: int) -> Optional[SweepRun]:
         """Called when worker available."""


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
init a run in the sweeps on launch scheduler, can be stopped in the UI to stop the scheduler, can be inspected for logs. 


Testing
-------
major testing changes, our testing env doesn't like sub-wandb run inits, all are mocked. 


copilot:poem