### PR TITLE
test(sdk): cache .git repo for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,20 +209,6 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
-  cached-checkout:
-    steps:
-      - restore_cache:
-          keys:
-            - &source-cache source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
-      - checkout
-      - save_cache:
-          key: *source-cache
-          paths:
-            - ".git"
-
-
 
 jobs:
   regression:
@@ -259,7 +245,7 @@ jobs:
     resource_class: xlarge
     working_directory: /mnt/ramdisk/wandb
     steps:
-      - cached-checkout
+      - checkout
       - add_ssh_keys:
           fingerprints:
       - when:
@@ -336,7 +322,7 @@ jobs:
     resource_class: xlarge
     working_directory: /mnt/ramdisk
     steps:
-      - cached-checkout
+      - checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -373,7 +359,16 @@ jobs:
     resource_class: small
     working_directory: /mnt/ramdisk
     steps:
+      - restore_cache:
+          keys:
+            - &source-cache source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
       - checkout
+      - save_cache:
+          key: *source-cache
+          paths:
+            - ".git"
 
   pytest:
     parameters:
@@ -406,7 +401,7 @@ jobs:
     resource_class: xlarge
     working_directory: /mnt/ramdisk
     steps:
-      - cached-checkout
+      - checkout
       - run:
           name: Install system deps
           command: |
@@ -450,7 +445,7 @@ jobs:
     resource_class: small
     working_directory: /mnt/ramdisk
     steps:
-      - cached-checkout
+      - checkout
       - run:
           name: Install system deps
           command: |
@@ -497,7 +492,7 @@ jobs:
       size: << parameters.executor_size >>
     parallelism: << parameters.parallelism >>
     steps:
-      - cached-checkout
+      - checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -558,7 +553,7 @@ jobs:
     resource_class: large
     parallelism: << parameters.parallelism >>
     steps:
-      - cached-checkout
+      - checkout
       - run:
           name: Install python dependencies
           command: |
@@ -583,7 +578,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - cached-checkout
+      - checkout
       - run:
           name: Install python dependencies, build r2d
           command: |
@@ -622,7 +617,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - cached-checkout
+      - checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -749,7 +744,7 @@ jobs:
     docker:
       - image: "google/cloud-sdk:alpine"
     steps:
-      - cached-checkout
+      - checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -809,7 +804,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - cached-checkout
+      - checkout
       - go/install
       - gcloud/install
       - gcloud/install
@@ -847,7 +842,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - cached-checkout
+      - checkout
       - go/install
       - gcloud/install
       - setup_gcloud
@@ -918,7 +913,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - cached-checkout
+      - checkout
       - when:
           condition: << parameters.execute >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,6 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
-
 jobs:
   regression:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,21 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
+  cached-checkout:
+    steps:
+      - restore_cache:
+          keys:
+            - &source-cache source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
+      - checkout
+      - save_cache:
+          key: *source-cache
+          paths:
+            - ".git"
+
+
+
 jobs:
   regression:
     parameters:
@@ -244,7 +259,7 @@ jobs:
     resource_class: xlarge
     working_directory: /mnt/ramdisk/wandb
     steps:
-      - checkout
+      - cached-checkout
       - add_ssh_keys:
           fingerprints:
       - when:
@@ -321,7 +336,7 @@ jobs:
     resource_class: xlarge
     working_directory: /mnt/ramdisk
     steps:
-      - checkout
+      - cached-checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -391,7 +406,7 @@ jobs:
     resource_class: xlarge
     working_directory: /mnt/ramdisk
     steps:
-      - checkout
+      - cached-checkout
       - run:
           name: Install system deps
           command: |
@@ -435,7 +450,7 @@ jobs:
     resource_class: small
     working_directory: /mnt/ramdisk
     steps:
-      - checkout
+      - cached-checkout
       - run:
           name: Install system deps
           command: |
@@ -482,7 +497,7 @@ jobs:
       size: << parameters.executor_size >>
     parallelism: << parameters.parallelism >>
     steps:
-      - checkout
+      - cached-checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -543,7 +558,7 @@ jobs:
     resource_class: large
     parallelism: << parameters.parallelism >>
     steps:
-      - checkout
+      - cached-checkout
       - run:
           name: Install python dependencies
           command: |
@@ -568,7 +583,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - checkout
+      - cached-checkout
       - run:
           name: Install python dependencies, build r2d
           command: |
@@ -607,7 +622,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - checkout
+      - cached-checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -734,7 +749,7 @@ jobs:
     docker:
       - image: "google/cloud-sdk:alpine"
     steps:
-      - checkout
+      - cached-checkout
       - when:
           condition: << parameters.execute >>
           steps:
@@ -794,7 +809,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - checkout
+      - cached-checkout
       - go/install
       - gcloud/install
       - gcloud/install
@@ -832,7 +847,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - checkout
+      - cached-checkout
       - go/install
       - gcloud/install
       - setup_gcloud
@@ -903,7 +918,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - checkout
+      - cached-checkout
       - when:
           condition: << parameters.execute >>
           steps:

--- a/tox.ini
+++ b/tox.ini
@@ -25,17 +25,7 @@ setenv =
 [unitbase]
 deps =
     -r{toxinidir}/requirements.txt
-    pytest
-    pytest-cov
-    pytest-xdist
-    pytest-flask
-    pytest-split
-    pytest-mock
-    pytest-timeout
-    pytest-openfiles
-    pytest-flakefinder
-    pytest-rerunfailures
-    parameterized
+    -r{toxinidir}/requirements_test.txt
 
 [unitshardbase]
 deps =


### PR DESCRIPTION
Fixes
-----
Fixes [WB-13490](https://wandb.atlassian.net/browse/WB-13490)

Description
-----------
Use CircleCI caching to cache our `.git` repo. This reduces the time it takes to checkout code from 15-30s down to 1-7s. Not that much of an improvement, but it's a trivial change.

(next step is caching .tox, which should have a much bigger impact)

Testing
-------
Run in CI and inspect cache restore + checkout + save time compared to former checkout time.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f75f70c</samp>

> _To simplify tox environments_
> _We use a file for requirements_
> _It's called `requirements_test.txt`_
> _And it avoids any context_
> _That might cause us some impediments_

[WB-13490]: https://wandb.atlassian.net/browse/WB-13490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ