### PR TITLE
build(sdk): unpin setuptools and tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ['setuptools<64']
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ["py36", "py37", "py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
-exclude = '''
+exclude = """
 wandb/vendor/
 | wandb/bin/
 | wandb/proto/
@@ -17,7 +17,7 @@ wandb/vendor/
 | __pycache__
 | .pyc
 | .tox/
-'''
+"""
 
 [tool.isort]
 profile = "black"

--- a/tools/setup_dev_environment.py
+++ b/tools/setup_dev_environment.py
@@ -9,7 +9,6 @@ import sys
 from pkg_resources import parse_version
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-TOX_VERSION = "3.24.0"
 
 
 # Python 3.6 is not installable on Macs with Apple silicon
@@ -27,31 +26,6 @@ class Console:
     YELLOW = "\033[93m"
     RED = "\033[91m"
     END = "\033[0m"
-
-
-def run_in_env(command, python_version=None):
-    """Run a command in a pyenv environment."""
-    if python_version:
-        command = f'eval "$(pyenv init -)"; (pyenv shell {python_version}; {command})'
-    return subprocess.check_output(command, shell=True).decode("utf-8")
-
-
-def installed_versions(python_version):
-    """List of installed package/versions."""
-    list_cmd = "pip list --format=freeze --disable-pip-version-check"
-    return run_in_env(list_cmd, python_version=python_version).split()
-
-
-def pin_version(package_name, package_version, python_version=None):
-    versioned_package = f"{package_name}=={package_version}"
-    if versioned_package in installed_versions(python_version):
-        return
-    print(f"Installing {versioned_package}", end=" ")
-    if python_version:
-        print(f"for Python {python_version}", end=" ")
-    print("...")
-    install_command = f"python -m pip install --upgrade {versioned_package} -qq"
-    return run_in_env(install_command, python_version=python_version)
 
 
 def main():
@@ -144,7 +118,6 @@ def main():
             )
             if p.returncode != 0:
                 print(f"Failed to install {latest}")
-        pin_version("tox", TOX_VERSION, python_version=latest)
         installed_python_versions.append(latest)
 
     print(f"Setting local pyenv versions to: {' '.join(installed_python_versions)}")
@@ -154,7 +127,6 @@ def main():
         stderr=subprocess.STDOUT,
         check=True,
     )
-    pin_version("tox", TOX_VERSION)
 
     print(f"{Console.GREEN}Development environment setup!{Console.END}")
     print()

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,12 @@ envlist=
     flake8,
     docstrings,
     py{36,37,38,39,launch},
-    func-s_{tf{115,21,24,25,26},imports{1,2,3,4,5,6,7,8,9,10,11,12}}-py37,
+    func-s_tf{115,21,24,25,26}-py37,
+    func-s_imports{1,2,3,4,5,6,7,8,9,10,11,12}-py37,
     func-s_{base,sklearn,metaflow,ray112,ray2,service,docs,noml,grpc}-py39,
     func-s_llm-py38,
     standalone-{cpu,gpu,tpu,local}-py38,
-    regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-wandb-examples,s3,sagemaker}-py{37,38,39,310},
+    regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-wandb-examples,s3,sagemaker}-py{37,38,39,310,311},
     func-cover,
     cover
 
@@ -44,7 +45,7 @@ deps =
     bokeh             # TODO: remove after conftest.py refactor
     nbclient          # TODO: remove after conftest.py refactor
 
-[testenv:py{36,37,38,39,310,launch}]
+[testenv:py{36,37,38,39,310,311,launch}]
 deps =
     {[unitbase]deps}
     -r{toxinidir}/requirements_dev.txt
@@ -56,18 +57,18 @@ passenv =
     CI_PYTEST_PARALLEL
     CI
 setenv =
-    py{36,37,38,39,310,launch}: COVERAGE_FILE={envdir}/.coverage
+    py{36,37,38,39,310,311,launch}: COVERAGE_FILE={envdir}/.coverage
     py{37,39}: WINDIR=C:\\Windows
 # Pytorch installations on non-darwin need the `-f`
-whitelist_externals =
+allowlist_externals =
     mkdir
     bash
 commands =
     mkdir -p test-results
-    py{36,37,38,39,310}:     python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:10} --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/pytest_tests}
-    pylaunch:                python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:4} --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/pytest_tests/unit_tests_old/tests_launch/}
+    py{36,37,38,39,310,311}: python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:10} --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/pytest_tests}
+    pylaunch:                python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:4}  --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/pytest_tests/unit_tests_old/tests_launch/}
 
-[testenv:nb-py{36,37,38,39,310}]
+[testenv:nb-py{36,37,38,39,310,311}]
 deps =
     {[unitshardbase]deps}
     nb: flask
@@ -78,10 +79,10 @@ deps =
     nb: ipykernel
     nb: nbclient
     nb: nbconvert
-whitelist_externals =
+allowlist_externals =
     mkdir
 setenv =
-    py{36,37,38,39,310,launch}: COVERAGE_FILE={envdir}/.coverage
+    py{36,37,38,39,310,311,launch}: COVERAGE_FILE={envdir}/.coverage
     py{37}: WINDIR=C:\\Windows
 passenv =
     USERNAME
@@ -136,7 +137,7 @@ commands=
 [testenv:protocheck{3,4}]
 basepython=python3
 skip_install = false
-whitelist_externals =
+allowlist_externals =
     cp
     rm
     diff
@@ -302,7 +303,7 @@ commands =
 
 [testenv:pyupgrade]
 basepython=python3
-whitelist_externals =
+allowlist_externals =
     sh
 deps=
     pyupgrade<=2.34.0
@@ -345,7 +346,7 @@ deps =
     coverage
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
-whitelist_externals =
+allowlist_externals =
     mkdir
     cp
     curl
@@ -370,7 +371,7 @@ deps =
     coverage
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
-whitelist_externals =
+allowlist_externals =
     mkdir
     cp
     curl
@@ -396,7 +397,7 @@ deps =
     coverage
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
-whitelist_externals =
+allowlist_externals =
     mkdir
     bash
     cp
@@ -419,7 +420,7 @@ skip_install = true
 deps =
     pytest
     coverage
-whitelist_externals =
+allowlist_externals =
     mkdir
     bash
     cp
@@ -440,7 +441,7 @@ deps =
     coverage
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
-whitelist_externals =
+allowlist_externals =
     mkdir
     cp
     bash.exe
@@ -463,7 +464,7 @@ skip_install = true
 deps =
     pytest
     coverage
-whitelist_externals =
+allowlist_externals =
     mkdir
     cp
 commands =
@@ -473,7 +474,7 @@ commands =
     cp .coverage coverage.xml cover-results/
     coverage report -m --ignore-errors --skip-covered --omit "wandb/vendor/*"
 
-[testenv:func-s_{base,sklearn,metaflow,tf115,tf21,tf24,tf25,tf26,ray112,ray2,service,py310,docs,imports1,imports2,imports3,imports4,imports5,imports6,imports7,imports8,imports9,imports10,imports11,imports12,noml,grpc,kfp}-{py36,py37,py38,py39,py310}]
+[testenv:func-s_{base,sklearn,metaflow,tf115,tf21,tf24,tf25,tf26,ray112,ray2,service,py310,py311,docs,imports1,imports2,imports3,imports4,imports5,imports6,imports7,imports8,imports9,imports10,imports11,imports12,noml,grpc,kfp}-{py36,py37,py38,py39,py310,py311}]
 install_command = pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 commands_pre =
 setenv =
@@ -486,46 +487,46 @@ passenv =
     CI_PYTEST_SPLIT_ARGS
 deps =
     -r{toxinidir}/requirements.txt
-    func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
+    func-s_{base,metaflow}-py{36,37,38,39,310,311}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
     yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
-    func-s_service-py{36,37,38,39,310}: service
-    func-s_grpc-py{36,37,38,39,310}: grpc
-whitelist_externals =
+    func-s_service-py{36,37,38,39,310,311}: service
+    func-s_grpc-py{36,37,38,39,310,311}: grpc
+allowlist_externals =
     mkdir
 commands =
     mkdir -p test-results
-    func-s_base-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard default run {posargs:--all}
-    func-s_sklearn-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard sklearn run {posargs:--all}
-    func-s_metaflow-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard metaflow run {posargs:--all}
-    func-s_tf115-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf115 run {posargs:--all}
-    func-s_tf21-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf21 run {posargs:--all}
-    func-s_tf24-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf24 run {posargs:--all}
-    func-s_tf25-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf25 run {posargs:--all}
-    func-s_tf26-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf26 run {posargs:--all}
-    func-s_ray112-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard ray112 run {posargs:--all}
-    func-s_ray2-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard ray2 run {posargs:--all}
-    func-s_service-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard service run {posargs:--all}
-    func-s_grpc-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard grpc run {posargs:--all}
-    func-s_py310-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard py310 run {posargs:--all}
-    func-s_docs-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --yeadoc --shard docs run {posargs:--all}
-    func-s_imports1-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports1 run {posargs:--all}
-    func-s_imports2-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports2 run {posargs:--all}
-    func-s_imports3-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports3 run {posargs:--all}
-    func-s_imports4-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports4 run {posargs:--all}
-    func-s_imports5-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports5 run {posargs:--all}
-    func-s_imports6-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports6 run {posargs:--all}
-    func-s_imports7-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports7 run {posargs:--all}
-    func-s_imports8-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports8 run {posargs:--all}
-    func-s_imports9-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports9 run {posargs:--all}
-    func-s_imports10-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports10 run {posargs:--all}
-    func-s_imports11-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports11 run {posargs:--all}
-    func-s_imports12-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports12 run {posargs:--all}
-    func-s_noml-py{36,37,38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard noml run {posargs:--all}
+    func-s_base-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard default run {posargs:--all}
+    func-s_sklearn-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard sklearn run {posargs:--all}
+    func-s_metaflow-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard metaflow run {posargs:--all}
+    func-s_tf115-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf115 run {posargs:--all}
+    func-s_tf21-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf21 run {posargs:--all}
+    func-s_tf24-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf24 run {posargs:--all}
+    func-s_tf25-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf25 run {posargs:--all}
+    func-s_tf26-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard tf26 run {posargs:--all}
+    func-s_ray112-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard ray112 run {posargs:--all}
+    func-s_ray2-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard ray2 run {posargs:--all}
+    func-s_service-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard service run {posargs:--all}
+    func-s_grpc-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard grpc run {posargs:--all}
+    func-s_py310-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard py310 run {posargs:--all}
+    func-s_docs-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --yeadoc --shard docs run {posargs:--all}
+    func-s_imports1-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports1 run {posargs:--all}
+    func-s_imports2-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports2 run {posargs:--all}
+    func-s_imports3-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports3 run {posargs:--all}
+    func-s_imports4-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports4 run {posargs:--all}
+    func-s_imports5-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports5 run {posargs:--all}
+    func-s_imports6-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports6 run {posargs:--all}
+    func-s_imports7-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports7 run {posargs:--all}
+    func-s_imports8-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports8 run {posargs:--all}
+    func-s_imports9-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports9 run {posargs:--all}
+    func-s_imports10-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports10 run {posargs:--all}
+    func-s_imports11-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports11 run {posargs:--all}
+    func-s_imports12-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard imports12 run {posargs:--all}
+    func-s_noml-py{36,37,38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard noml run {posargs:--all}
     func-s_kfp-py{37}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard kfp run {posargs:--all}
 
-[testenv:func-s_llm-{py36,py37,py38,py39,py310}]
+[testenv:func-s_llm-{py36,py37,py38,py39,py310,py311}]
 install_command = pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 commands_pre =
 setenv =
@@ -539,17 +540,17 @@ passenv =
     OPENAI_API_KEY
 deps =
     -r{toxinidir}/requirements.txt
-    func-s_llm-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
+    func-s_llm-py{36,37,38,39,310,311}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
     yea-wandb=={env:YEA_WANDB_VERSION}
-whitelist_externals =
+allowlist_externals =
     mkdir
 commands =
     mkdir -p test-results
-    func-s_llm-py{38,39,310}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard llm run {posargs:--all}
+    func-s_llm-py{38,39,310,311}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard llm run {posargs:--all}
 
 [testenv:pod-store]
-whitelist_externals =
+allowlist_externals =
     mkdir
     cp
 commands =
@@ -560,7 +561,7 @@ commands =
 skip_install = true
 deps =
     coverage
-whitelist_externals =
+allowlist_externals =
     mkdir
     cp
 commands =
@@ -579,7 +580,7 @@ deps =
     coverage
 setenv =
     CIRCLE_BUILD_NUM={env:CIRCLE_WORKFLOW_ID}
-whitelist_externals =
+allowlist_externals =
     mkdir
     cp
     curl
@@ -596,7 +597,7 @@ commands =
     chmod +x codecov
     ./codecov -e TOXENV -F functest
 
-[testenv:standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}]
+[testenv:standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310,311}]
 install_command = pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 commands_pre =
 setenv =
@@ -610,10 +611,10 @@ passenv =
     WANDB_API_KEY
 deps =
     -r{toxinidir}/requirements.txt
-    standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
+    standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310,311}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
     yea-wandb=={env:YEA_WANDB_VERSION}
-whitelist_externals =
+allowlist_externals =
     date
     echo
     export
@@ -622,12 +623,12 @@ whitelist_externals =
 commands =
     mkdir -p test-results
     wandb login --relogin {env:WANDB_API_KEY}
-    standalone-cpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
-    standalone-gpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
-    standalone-tpu-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
-    standalone-local-py{36,37,38,39,310}: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}
+    standalone-cpu-py{36,37,38,39,310,311}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
+    standalone-gpu-py{36,37,38,39,310,311}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
+    standalone-tpu-py{36,37,38,39,310,311}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
+    standalone-local-py{36,37,38,39,310,311}: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}
 
-[testenv:regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-other,s3,sagemaker}-py{37,38,39,310}]
+[testenv:regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-other,s3,sagemaker}-py{37,38,39,310,311}]
 install_command = pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 commands_pre =
 setenv =
@@ -635,7 +636,7 @@ setenv =
     COVERAGE_FILE={envdir}/.coverage
     TESTING_DIR={toxinidir}/wandb-testing/regression
 passenv = *
-whitelist_externals =
+allowlist_externals =
     git
     echo
     export
@@ -651,16 +652,16 @@ whitelist_externals =
 commands =
     git clone -b update-py-v https://github.com/wandb/wandb-testing.git
     python -m pip install pyyaml six wandb shortuuid
-    regression-yolov5-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/yolov5/ {posargs}
-    regression-huggingface-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/huggingface/ {posargs}
-    regression-keras-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/keras/ {posargs}
-    regression-tensorflow-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/tensorflow/ {posargs}
-    regression-pytorch-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/pytorch/ {posargs}
-    regression-wandb-sdk-standalone-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/wandb-git/client/standalone_tests {posargs}
-    regression-wandb-sdk-examples-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/wandb-git/examples {posargs}
-    regression-wandb-sdk-other-py{37,38,39,310}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/wandb-git/wandb-examples {posargs}
-    regression-s3-py{37,38,39,310}: {env:TESTING_DIR}/do-s3-regression.sh tests/s3-beta/ {posargs}
-    regression-sagemaker-py{37,38,39,310}: {env:TESTING_DIR}/do-sagemaker-regression.sh tests/sagemaker-beta/ {posargs}
+    regression-yolov5-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/yolov5/ {posargs}
+    regression-huggingface-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/huggingface/ {posargs}
+    regression-keras-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/keras/ {posargs}
+    regression-tensorflow-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/tensorflow/ {posargs}
+    regression-pytorch-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/pytorch/ {posargs}
+    regression-wandb-sdk-standalone-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/wandb-git/client/standalone_tests {posargs}
+    regression-wandb-sdk-examples-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/wandb-git/examples {posargs}
+    regression-wandb-sdk-other-py{37,38,39,310,311}: {env:TESTING_DIR}/do-cloud-regression.sh tests/main/wandb-git/wandb-examples {posargs}
+    regression-s3-py{37,38,39,310,311}: {env:TESTING_DIR}/do-s3-regression.sh tests/s3-beta/ {posargs}
+    regression-sagemaker-py{37,38,39,310,311}: {env:TESTING_DIR}/do-sagemaker-regression.sh tests/sagemaker-beta/ {posargs}
 
 
 [testenv:executor-{pex,uwsgi,gunicorn}]
@@ -676,7 +677,7 @@ deps =
 setenv =
     {[base]setenv}
 passenv = *
-whitelist_externals =
+allowlist_externals =
     bash
 commands =
     bash tests/standalone_tests/executor_tests/{envname}.sh {posargs}


### PR DESCRIPTION
Fixes
-----
Fixes WB-NNNN

Description
-----------
- unpin setuptools and tox
- change `whitelist_externals` to `allowlist_externals` to enable tox>=4
- add tox environments for Python 3.11 (not used in tests yet)
- remove extra pinning logic in `setup_dev_environment.py`


Impact
-------
The setuptools change should be benign, but the `whitelist` -> `allowlist` requires a migration to tox 4 (developers will need to update their tox install).


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e88810</samp>

> _We're breaking free from the old constraints_
> _We're testing on the edge of Python's fate_
> _We're cleaning up the code and the style_
> _We're `setuptools` rebels with a `pyproject` smile_