### PR TITLE
feat(sdk): Add helper to reference other artifacts inside an artifact

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     Dict,
     Generator,
+    Iterable,
     List,
     Mapping,
     Optional,
@@ -505,6 +506,17 @@ class Artifact(ArtifactInterface):
             self._manifest.add_entry(entry)
 
         return manifest_entries
+
+    def add_artifact_reference(self, art: "Artifact"):
+        # Add the entire artifact as a reference
+        for name in art.manifest.entries:
+            ref = art.get_path(name)
+            namespaced_fname = f"{art.name}/{name}"
+            self.add_reference(ref, namespaced_fname)
+
+    def add_artifact_references(self, *arts: "Iterable[Artifact]"):
+        for art in arts:
+            self.add_artifact_reference(art)
 
     def add(self, obj: data_types.WBValue, name: str) -> ArtifactManifestEntry:
         self._ensure_can_add()

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -507,14 +507,14 @@ class Artifact(ArtifactInterface):
 
         return manifest_entries
 
-    def add_artifact_reference(self, art: "Artifact"):
+    def add_artifact_reference(self, art: "Artifact") -> None:
         # Add the entire artifact as a reference
         for name in art.manifest.entries:
             ref = art.get_path(name)
             namespaced_fname = f"{art.name}/{name}"
             self.add_reference(ref, namespaced_fname)
 
-    def add_artifact_references(self, *arts: "Iterable[Artifact]"):
+    def add_artifact_references(self, *arts: "Iterable[Artifact]") -> None:
         for art in arts:
             self.add_artifact_reference(art)
 


### PR DESCRIPTION
Fixes
-----
n/a

Description
-----------
The naming could probably be better here.

Previously, it wasn't obvious to me how to reference an entire artifact in another artifact.  This PR adds helper methods to make that easier.

In these screenshots, note how the entire artifact is a directory, and all files are actually refs to the files in the originating artifact
![image](https://user-images.githubusercontent.com/15385696/235563787-ccccaf10-d81f-4d16-9232-77ea868cd4ba.png)
![image](https://user-images.githubusercontent.com/15385696/235563846-d7c55c1e-65a4-488e-8e88-1d33fa003331.png)




Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c03fa1f</samp>

> _`Artifact` class grows_
> _Adding references to peers_
> _Winter of content_