### PR TITLE
chore(sdk): bump version to 0.15.2.dev1 and update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## 0.15.1 (May 2, 2023)
+
+### :magic_wand: Enhancements
+* feat(launch): implement new Kubernetes runner config schema by @TimH98 in https://github.com/wandb/wandb/pull/5231
+* feat(launch): allow platform override for docker builder by @TimH98 in https://github.com/wandb/wandb/pull/5330
+* feat(artifacts): get full name of artifact for easier artifact retrieval by @estellazx in https://github.com/wandb/wandb/pull/5314
+* feat(artifacts): make default root for artifacts download configurable by @moredatarequired in https://github.com/wandb/wandb/pull/5366
+* feat(artifacts): add Azure storage handler in SDK by @szymon-piechowicz-wandb in https://github.com/wandb/wandb/pull/5317
+* feat(media): add method to convert wandb.Table to pandas.DataFrame by @brunnelu in https://github.com/wandb/wandb/pull/5301
+* feat(launch): sweeps on launch command args passed as params by @gtarpenning in https://github.com/wandb/wandb/pull/5315
+### :hammer: Fixes
+* fix(launch): don't assume keys in args and config refer to the same thing by @szymon-piechowicz-wandb in https://github.com/wandb/wandb/pull/5183
+* fix(launch): make ElasticContainerRegistry environment handle "ImageNotFoundException" gracefully by @bcsherma in https://github.com/wandb/wandb/pull/5159
+* fix(launch): disable kaniko builder retry by @TimH98 in https://github.com/wandb/wandb/pull/5318
+* fix(sdk): refine error message for auth error by @kptkin in https://github.com/wandb/wandb/pull/5341
+* fix(launch): kubernetes runner does not respect override args by @KyleGoyette in https://github.com/wandb/wandb/pull/5303
+* fix(sweeps): allow attr-dicts as sweeps configs by @moredatarequired in https://github.com/wandb/wandb/pull/5268
+* fix(artifacts): checksum the read-only staging copy instead of the original file by @moredatarequired in https://github.com/wandb/wandb/pull/5346
+* fix(launch): skip getting run info if run completes successfully or is from a different entity by @TimH98 in https://github.com/wandb/wandb/pull/5379
+* fix(artifacts): default to project "uncategorized" instead of "None" when fetching artifacts by @szymon-piechowicz-wandb in https://github.com/wandb/wandb/pull/5375
+* fix(integrations): add enabled check to gym VideoRecorder by @younik in https://github.com/wandb/wandb/pull/5230
+* fix(artifacts): fix handling of default project and entity by @dmitryduev in https://github.com/wandb/wandb/pull/5395
+* fix(sdk): update  import_hook.py with latest changes in the wrapt repository by @kptkin in https://github.com/wandb/wandb/pull/5321
+* fix(launch): fix support for local urls in k8s launch agent by @KyleGoyette in https://github.com/wandb/wandb/pull/5413
+* fix(sdk): improve notebook environment detection and testing by @dmitryduev in https://github.com/wandb/wandb/pull/4982
+* fix(sdk): implement recursive isinstance check utility for the Settings object by @dmitryduev in https://github.com/wandb/wandb/pull/5436
+* fix(sdk): correctly parse edge cases in OpenMetrics filter definitions in System Monitor by @dmitryduev in https://github.com/wandb/wandb/pull/5329
+* fix(sdk): update debug logs to include SDK's version by @kptkin in https://github.com/wandb/wandb/pull/5344
+* fix(sdk): filter AWS Trainium metrics by local rank if executed with torchrun by @dmitryduev in https://github.com/wandb/wandb/pull/5142
+* fix(integrations): inform users about WandbTracer incompatibility with LangChain > 0.0.153 by @hwchase17 in https://github.com/wandb/wandb/pull/5453
+### :books: Docs
+* docs(sdk): update README.md by @thanos-wandb in https://github.com/wandb/wandb/pull/5386
+* docs(integrations): update docstrings of the Keras callbacks by @ayulockin in https://github.com/wandb/wandb/pull/5198
+* docs(sdk): update the images in `README.md` by @ngrayluna in https://github.com/wandb/wandb/pull/5399
+
+## New Contributors
+* @szymon-piechowicz-wandb made their first contribution in https://github.com/wandb/wandb/pull/5183
+* @thanos-wandb made their first contribution in https://github.com/wandb/wandb/pull/5386
+* @brunnelu made their first contribution in https://github.com/wandb/wandb/pull/5301
+* @younik made their first contribution in https://github.com/wandb/wandb/pull/5230
+* @hwchase17 made their first contribution in https://github.com/wandb/wandb/pull/5453
+
+**Full Changelog**: https://github.com/wandb/wandb/compare/v0.15.0...v0.15.1
+
 ## 0.15.0 (April 19, 2023)
 
 ### :magic_wand: Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip_gitignore = "True"
 [tool.commitizen]
 name = "cz_conventional_commits"
 major_version_zero = true
-version = "0.15.1"
+version = "0.15.2.dev1"
 version_files = ["setup.py", "setup.cfg", "wandb/__init__.py"]
 tag_format = "v$major.$minor.$patch$prerelease"
 changelog_incremental = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip_gitignore = "True"
 [tool.commitizen]
 name = "cz_conventional_commits"
 major_version_zero = true
-version = "0.15.1.dev1"
+version = "0.15.1"
 version_files = ["setup.py", "setup.cfg", "wandb/__init__.py"]
 tag_format = "v$major.$minor.$patch$prerelease"
 changelog_incremental = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.15.1.dev1
+current_version = 0.15.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{prekind}{pre}.{devkind}{dev}
 	{major}.{minor}.{patch}.{devkind}{dev}
 	{major}.{minor}.{patch}{prekind}{pre}
@@ -14,7 +14,7 @@ first_value = 1
 
 [bumpversion:part:prekind]
 optional_value = _
-values = 
+values =
 	_
 	rc
 	_
@@ -24,7 +24,7 @@ first_value = 1
 
 [bumpversion:part:devkind]
 optional_value = _
-values = 
+values =
 	_
 	dev
 	_
@@ -42,7 +42,7 @@ search = version = "{current_version}"
 replace = version = "{new_version}"
 
 [tool:pytest]
-norecursedirs = 
+norecursedirs =
 	vendor
 	wandb/vendor
 open_files_ignore = "*.ttf"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.1
+current_version = 0.15.2.dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ async_requirements = [
 
 setup(
     name="wandb",
-    version="0.15.1",
+    version="0.15.2.dev1",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ async_requirements = [
 
 setup(
     name="wandb",
-    version="0.15.1.dev1",
+    version="0.15.1",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.1"
+__version__ = "0.15.2.dev1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.1.dev1"
+__version__ = "0.15.1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"


### PR DESCRIPTION
Description
-----------
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5197521</samp>

This pull request updates the version number and the changelog for the new release 0.15.1 of the wandb SDK. It also sets the development version to 0.15.2.dev1 in the `pyproject.toml`, `setup.py`, and `wandb/__init__.py` files.


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5197521</samp>

> _Oh we are the wandb crew and we have a job to do_
> _We bump the version up and we write it down_
> _`pyproject.toml` and `setup.py` and `__init__.py`_
> _And don't forget the `CHANGELOG.md`_