### PR TITLE
fix(sdk): permit `LogicalPath` to strip trailing slashes

### DIFF
--- a/tests/pytest_tests/unit_tests/test_lib/test_paths.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_paths.py
@@ -28,9 +28,9 @@ def test_path_groups(target, posix, windows, _bytes):
 @example(b"")
 @example(".")
 @example("\\")
+@example(" /")
 @example(PureWindowsPath("C:/foo/bar.txt"))
 @example(PurePosixPath("x\\a/b.bin"))
-@pytest.mark.skip(reason="Fails on path = ' /', should fix")
 def test_path_conversion(path):
     logical_path = LogicalPath(path)
     assert isinstance(logical_path, str)
@@ -38,9 +38,11 @@ def test_path_conversion(path):
         assert "\\" not in logical_path
 
     # For compatibility, enforce output identical to `to_forward_slash_path`.
-    # One exception: we send both `'.'` and `''` to `'.'`.
+    # Two exceptions, neither affect the interpretation of the path:
+    # 1. We send both `'.'` and `''` to `'.'`
+    # 2. We strip trailing slashes
     if path and isinstance(path, str):
-        assert logical_path == to_forward_slash_path(path)
+        assert logical_path == to_forward_slash_path(path).rstrip("/")
 
 
 @given(fspaths())


### PR DESCRIPTION
Fixes
-----
Fixes [WB-13605](https://wandb.atlassian.net/browse/WB-13605)

Description
-----------
I love `hypothesis`, I can't count the number of times it's eventually caught a bug or a corner case I hadn't thought of. This is one of them.

`LogicalPath`, which I'm planning to use to replace & improve upon our former `LogicalFilePathStr` alias should normally produce string output identical to `to_forward_slash_path`, even when `to_forward_slash_path`'s behavior is suspect. One case it apparently doesn't is that it strips trailing slashes.

I'm changing the test to explicitly allow this because:
1. This is the correct behavior, the the extent possible we should only have one possible representation for the same path.
2. The output will still be interpreted the same way by `os.open` etc.

Testing
-------
Tests pass now; this explicitly adds the formerly failing example.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


copilot:poem

[WB-13605]: https://wandb.atlassian.net/browse/WB-13605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ