### PR TITLE
Accept and return ordinary strings from to_forward_slash_path

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -1315,7 +1315,7 @@ def test_tracking_storage_handler():
     #
     # Empirically, this test fails with:
     #   AssertionError: assert 'some-file' == '/path/to/file.txt'
-    # But 'some-file' started out as a `name`, i.e. a LogicalFilePathStr,
+    # But 'some-file' started out as a `name`, i.e. a LogicalPath,
     # representing the location of the file *within the artifact*
     # rather than *on the filesystem*.
     #

--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -119,7 +119,7 @@ class TestStoreFile:
             entry=ArtifactManifestEntry(
                 path=entry_path,
                 digest=entry_digest,
-                local_path=str(entry_local_path) if entry_local_path else None,
+                local_path=entry_local_path,
                 size=entry_local_path.stat().st_size if entry_local_path else None,
             ),
             preparer=preparer if preparer else mock_preparer(),

--- a/wandb/sdk/interface/artifacts/artifact.py
+++ b/wandb/sdk/interface/artifacts/artifact.py
@@ -2,7 +2,7 @@ from typing import IO, TYPE_CHECKING, ContextManager, List, Optional, Sequence, 
 
 import wandb
 from wandb.data_types import WBValue
-from wandb.sdk.lib.paths import FilePathStr
+from wandb.sdk.lib.paths import FilePathStr, StrPath
 
 if TYPE_CHECKING:
     import wandb.apis.public
@@ -410,7 +410,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def get_path(self, name: str) -> "ArtifactManifestEntry":
+    def get_path(self, name: StrPath) -> "ArtifactManifestEntry":
         """Get the path to the file located at the artifact relative `name`.
 
         Arguments:

--- a/wandb/sdk/lib/paths.py
+++ b/wandb/sdk/lib/paths.py
@@ -9,9 +9,6 @@ from typing import Any, NewType, Union
 # https://github.com/python/typeshed/blob/0b1cd5989669544866213807afa833a88f649ee7/stdlib/_typeshed/__init__.pyi#L56-L65
 StrPath = Union[str, "os.PathLike[str]"]
 
-# An artifact-relative or run-relative path. It is always POSIX-style.
-LogicalFilePathStr = NewType("LogicalFilePathStr", str)
-
 # A native path to a file on a local filesystem.
 FilePathStr = NewType("FilePathStr", str)
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -2,11 +2,11 @@ import base64
 import contextlib
 import json
 import os
-import pathlib
 import re
 import shutil
 import tempfile
 import time
+from pathlib import PurePosixPath
 from types import ModuleType
 from typing import (
     IO,
@@ -61,7 +61,7 @@ from wandb.sdk.lib.hashutil import (
     md5_file_b64,
     md5_string,
 )
-from wandb.sdk.lib.paths import FilePathStr, LogicalFilePathStr, URIStr
+from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
 
 if TYPE_CHECKING:
     from urllib.parse import ParseResult
@@ -472,7 +472,7 @@ class Artifact(ArtifactInterface):
     def add_reference(
         self,
         uri: Union[ArtifactManifestEntry, str],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
@@ -506,7 +506,7 @@ class Artifact(ArtifactInterface):
 
         return manifest_entries
 
-    def add(self, obj: data_types.WBValue, name: str) -> ArtifactManifestEntry:
+    def add(self, obj: data_types.WBValue, name: StrPath) -> ArtifactManifestEntry:
         self._ensure_can_add()
         name = util.to_forward_slash_path(name)
 
@@ -589,7 +589,7 @@ class Artifact(ArtifactInterface):
 
         return entry
 
-    def get_path(self, name: str) -> ArtifactManifestEntry:
+    def get_path(self, name: StrPath) -> ArtifactManifestEntry:
         if self._logged_artifact:
             return self._logged_artifact.get_path(name)
 
@@ -728,7 +728,7 @@ class Artifact(ArtifactInterface):
             raise ArtifactFinalizedError(artifact=self)
 
     def _add_local_file(
-        self, name: str, path: str, digest: Optional[B64MD5] = None
+        self, name: StrPath, path: StrPath, digest: Optional[B64MD5] = None
     ) -> ArtifactManifestEntry:
         with tempfile.NamedTemporaryFile(dir=get_staging_dir(), delete=False) as f:
             staging_path = f.name
@@ -743,7 +743,7 @@ class Artifact(ArtifactInterface):
         )
 
         self._manifest.add_entry(entry)
-        self._added_local_paths[path] = entry
+        self._added_local_paths[os.fspath(path)] = entry
         return entry
 
 
@@ -773,7 +773,7 @@ class ArtifactManifestV1(ArtifactManifest):
         entries: Mapping[str, ArtifactManifestEntry]
         entries = {
             name: ArtifactManifestEntry(
-                path=LogicalFilePathStr(name),
+                path=name,
                 digest=val["digest"],
                 birth_artifact_id=val.get("birthArtifactID"),
                 ref=val.get("ref"),
@@ -1177,7 +1177,7 @@ class TrackingHandler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
@@ -1191,7 +1191,7 @@ class TrackingHandler(StorageHandler):
             "Artifact references with unsupported schemes cannot be checksummed: %s"
             % path
         )
-        name = LogicalFilePathStr(name or url.path[1:])  # strip leading slash
+        name = name or url.path[1:]  # strip leading slash
         return [ArtifactManifestEntry(path=name, ref=path, digest=path)]
 
 
@@ -1248,7 +1248,7 @@ class LocalFileHandler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
@@ -1284,14 +1284,14 @@ class LocalFileHandler(StorageHandler):
                         )
                     physical_path = os.path.join(root, sub_path)
                     # TODO(spencerpearson): this is not a "logical path" in the sense that
-                    # `util.to_forward_slash_path` returns a "logical path"; it's a relative path
+                    # `LogicalPath` returns a "logical path"; it's a relative path
                     # **on the local filesystem**.
                     logical_path = os.path.relpath(physical_path, start=local_path)
                     if name is not None:
                         logical_path = os.path.join(name, logical_path)
 
                     entry = ArtifactManifestEntry(
-                        path=LogicalFilePathStr(logical_path),
+                        path=logical_path,
                         ref=FilePathStr(os.path.join(path, logical_path)),
                         size=os.path.getsize(physical_path),
                         digest=md5(physical_path),
@@ -1302,7 +1302,7 @@ class LocalFileHandler(StorageHandler):
         elif os.path.isfile(local_path):
             name = name or os.path.basename(local_path)
             entry = ArtifactManifestEntry(
-                path=LogicalFilePathStr(name),
+                path=name,
                 ref=path,
                 size=os.path.getsize(local_path),
                 digest=md5(local_path),
@@ -1430,7 +1430,7 @@ class S3Handler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
@@ -1450,11 +1450,7 @@ class S3Handler(StorageHandler):
 
         max_objects = max_objects or DEFAULT_MAX_OBJECTS
         if not checksum:
-            return [
-                ArtifactManifestEntry(
-                    path=LogicalFilePathStr(name or key), ref=path, digest=path
-                )
-            ]
+            return [ArtifactManifestEntry(path=name or key, ref=path, digest=path)]
 
         # If an explicit version is specified, use that. Otherwise, use the head version.
         objs = (
@@ -1517,7 +1513,7 @@ class S3Handler(StorageHandler):
         self,
         obj: "boto3.s3.Object",
         path: str,
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         prefix: str = "",
         multi: bool = False,
     ) -> ArtifactManifestEntry:
@@ -1533,12 +1529,10 @@ class S3Handler(StorageHandler):
         bucket, key, _ = self._parse_uri(path)
 
         # Always use posix paths, since that's what S3 uses.
-        posix_key = pathlib.PurePosixPath(obj.key)  # the bucket key
-        posix_path = pathlib.PurePosixPath(bucket) / pathlib.PurePosixPath(
-            key
-        )  # the path, with the scheme stripped
-        posix_prefix = pathlib.PurePosixPath(prefix)  # the prefix, if adding a prefix
-        posix_name = pathlib.PurePosixPath(name or "")
+        posix_key = PurePosixPath(obj.key)  # the bucket key
+        posix_path = PurePosixPath(bucket) / key  # the path, with the scheme stripped
+        posix_prefix = PurePosixPath(prefix)  # the prefix, if adding a prefix
+        posix_name = PurePosixPath(name or "")
         posix_ref = posix_path
 
         if name is None:
@@ -1547,7 +1541,7 @@ class S3Handler(StorageHandler):
                 posix_name = posix_key.relative_to(posix_prefix)
                 posix_ref = posix_path / posix_name
             else:
-                posix_name = pathlib.PurePosixPath(posix_key.name)
+                posix_name = PurePosixPath(posix_key.name)
                 posix_ref = posix_path
         elif multi:
             # We're adding a directory with a name override.
@@ -1555,7 +1549,7 @@ class S3Handler(StorageHandler):
             posix_name = posix_name / relpath
             posix_ref = posix_path / relpath
         return ArtifactManifestEntry(
-            path=LogicalFilePathStr(str(posix_name)),
+            path=posix_name,
             ref=URIStr(f"{self._scheme}://{str(posix_ref)}"),
             digest=ETag(self._etag_from_obj(obj)),
             size=self._size_from_obj(obj),
@@ -1677,7 +1671,7 @@ class GCSHandler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
@@ -1696,11 +1690,7 @@ class GCSHandler(StorageHandler):
             )
 
         if not checksum:
-            return [
-                ArtifactManifestEntry(
-                    path=LogicalFilePathStr(name or key), ref=path, digest=path
-                )
-            ]
+            return [ArtifactManifestEntry(path=name or key, ref=path, digest=path)]
 
         start_time = None
         obj = self._client.bucket(bucket).get_blob(key, generation=version)
@@ -1735,7 +1725,7 @@ class GCSHandler(StorageHandler):
         self,
         obj: "gcs_module.blob.Blob",
         path: str,
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         prefix: str = "",
         multi: bool = False,
     ) -> ArtifactManifestEntry:
@@ -1751,12 +1741,12 @@ class GCSHandler(StorageHandler):
         bucket, key, _ = self._parse_uri(path)
 
         # Always use posix paths, since that's what S3 uses.
-        posix_key = pathlib.PurePosixPath(obj.name)  # the bucket key
-        posix_path = pathlib.PurePosixPath(bucket) / pathlib.PurePosixPath(
+        posix_key = PurePosixPath(obj.name)  # the bucket key
+        posix_path = PurePosixPath(bucket) / PurePosixPath(
             key
         )  # the path, with the scheme stripped
-        posix_prefix = pathlib.PurePosixPath(prefix)  # the prefix, if adding a prefix
-        posix_name = pathlib.PurePosixPath(name or "")
+        posix_prefix = PurePosixPath(prefix)  # the prefix, if adding a prefix
+        posix_name = PurePosixPath(name or "")
         posix_ref = posix_path
 
         if name is None:
@@ -1765,7 +1755,7 @@ class GCSHandler(StorageHandler):
                 posix_name = posix_key.relative_to(posix_prefix)
                 posix_ref = posix_path / posix_name
             else:
-                posix_name = pathlib.PurePosixPath(posix_key.name)
+                posix_name = PurePosixPath(posix_key.name)
                 posix_ref = posix_path
         elif multi:
             # We're adding a directory with a name override.
@@ -1773,7 +1763,7 @@ class GCSHandler(StorageHandler):
             posix_name = posix_name / relpath
             posix_ref = posix_path / relpath
         return ArtifactManifestEntry(
-            path=LogicalFilePathStr(str(posix_name)),
+            path=posix_name,
             ref=URIStr(f"{self._scheme}://{str(posix_ref)}"),
             digest=obj.md5_hash,
             size=obj.size,
@@ -1871,7 +1861,7 @@ class AzureHandler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence["ArtifactManifestEntry"]:
@@ -1880,9 +1870,7 @@ class AzureHandler(StorageHandler):
 
         if not checksum:
             return [
-                ArtifactManifestEntry(
-                    path=LogicalFilePathStr(name or blob_name), digest=path, ref=path
-                )
+                ArtifactManifestEntry(path=name or blob_name, digest=path, ref=path)
             ]
 
         blob_service_client = self._get_module("azure.storage.blob").BlobServiceClient(
@@ -1899,9 +1887,7 @@ class AzureHandler(StorageHandler):
             return [
                 self._create_entry(
                     blob_properties,
-                    path=LogicalFilePathStr(
-                        name or pathlib.PurePosixPath(blob_name).name
-                    ),
+                    path=name or PurePosixPath(blob_name).name,
                     ref=URIStr(
                         f"{account_url}/{container_name}/{blob_properties.name}"
                     ),
@@ -1919,11 +1905,11 @@ class AzureHandler(StorageHandler):
                     f"Exceeded {max_objects} objects tracked, pass max_objects to "
                     f"add_reference"
                 )
-            suffix = pathlib.PurePosixPath(blob_properties.name).relative_to(blob_name)
+            suffix = PurePosixPath(blob_properties.name).relative_to(blob_name)
             entries.append(
                 self._create_entry(
                     blob_properties,
-                    path=LogicalFilePathStr(str(name / suffix if name else suffix)),
+                    path=LogicalPath(name) / suffix if name else suffix,
                     ref=URIStr(
                         f"{account_url}/{container_name}/{blob_properties.name}"
                     ),
@@ -1951,7 +1937,7 @@ class AzureHandler(StorageHandler):
     def _create_entry(
         self,
         blob_properties: "azure.storage.blob.BlobProperties",
-        path: LogicalFilePathStr,
+        path: StrPath,
         ref: URIStr,
     ) -> ArtifactManifestEntry:
         extra = {"etag": blob_properties.etag.strip('"')}
@@ -2014,11 +2000,11 @@ class HTTPHandler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
-        name = LogicalFilePathStr(name or os.path.basename(path))
+        name = name or os.path.basename(path)
         if not checksum:
             return [ArtifactManifestEntry(path=name, ref=path, digest=path)]
 
@@ -2107,7 +2093,7 @@ class WBArtifactHandler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
@@ -2151,7 +2137,7 @@ class WBArtifactHandler(StorageHandler):
         # Return the new entry
         return [
             ArtifactManifestEntry(
-                path=LogicalFilePathStr(name or os.path.basename(path)),
+                path=name or os.path.basename(path),
                 ref=path,
                 size=0,
                 digest=entry.digest,
@@ -2184,7 +2170,7 @@ class WBLocalArtifactHandler(StorageHandler):
         self,
         artifact: ArtifactInterface,
         path: Union[URIStr, FilePathStr],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence[ArtifactManifestEntry]:
@@ -2210,7 +2196,7 @@ class WBLocalArtifactHandler(StorageHandler):
         # Return the new entry
         return [
             ArtifactManifestEntry(
-                path=LogicalFilePathStr(name or os.path.basename(path)),
+                path=name or os.path.basename(path),
                 ref=path,
                 size=0,
                 digest=target_entry.digest,

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -51,7 +51,7 @@ import wandb
 import wandb.env
 from wandb.errors import AuthenticationError, CommError, UsageError, term
 from wandb.sdk.lib import filesystem, runid
-from wandb.sdk.lib.paths import FilePathStr, LogicalFilePathStr, StrPath
+from wandb.sdk.lib.paths import FilePathStr, StrPath
 
 if TYPE_CHECKING:
     import wandb.apis.public
@@ -1289,10 +1289,10 @@ def auto_project_name(program: Optional[str]) -> str:
 
 
 # TODO(hugh): Deprecate version here and use wandb/sdk/lib/paths.py
-def to_forward_slash_path(path: str) -> LogicalFilePathStr:
+def to_forward_slash_path(path: str) -> str:
     if platform.system() == "Windows":
         path = path.replace("\\", "/")
-    return LogicalFilePathStr(path)
+    return path
 
 
 # TODO(hugh): Deprecate version here and use wandb/sdk/lib/paths.py


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
What does the PR do?


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a77004b</samp>

> _The type `LogicalFilePathStr` was a pain_
> _So they replaced it with `StrPath` in the main_
> _They also made `to_forward_slash_path`_
> _Return a plain `str` with no wrath_
> _And thus they simplified the code domain_