### PR TITLE
Replce remaining instances of util.to_forward_slash_path with LogicalPath

### DIFF
--- a/tests/functional_tests/t0_main/jobs/job_repo_end_to_end.py
+++ b/tests/functional_tests/t0_main/jobs/job_repo_end_to_end.py
@@ -6,7 +6,7 @@ import wandb
 from wandb.apis.internal import InternalApi
 from wandb.sdk.data_types._dtypes import TypeRegistry
 from wandb.sdk.launch._project_spec import LaunchProject
-from wandb.util import to_forward_slash_path
+from wandb.sdk.lib.paths import LogicalPath
 
 # this test is kind of hacky, it piggy backs off of the existing wandb/client git repo to construct the job
 # should probably have it use wandb_examples or something
@@ -51,9 +51,9 @@ lp = LaunchProject(**kwargs)
 
 job.configure_launch_project(lp)
 command = lp.get_single_entry_point().compute_command({})
-print(to_forward_slash_path(command[1]))
+print(LogicalPath(command[1]))
 assert (
-    to_forward_slash_path(command[1])
+    LogicalPath(command[1])
     == "tests/functional_tests/t0_main/jobs/job_repo_creation.py"
 )
 assert "requirements.frozen.txt" in os.listdir(lp.project_dir)


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
What does the PR do?


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 46f560d</samp>

> _To handle paths in the wandb SDK_
> _They introduced a new class called `LogicalPath`_
> _It normalizes and compares with ease_
> _Across different platforms and OSes_
> _And the tests use it instead of `to_forward_slash_path`_