### PR TITLE
test(integrations): fix executor-pex test

### DIFF
--- a/tests/standalone_tests/executor_tests/executor-pex.sh
+++ b/tests/standalone_tests/executor_tests/executor-pex.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
 
-pex -r $1 -o wandb.pex
+# todo: remove the urllib3 pin once requests, sentry and others are updated
+pex "urllib3<2.0.0" -r $1 -o wandb.pex
 WANDB__EXECUTABLE=./wandb.pex ./wandb.pex -c "import wandb; import os; wandb.init(mode='offline'); wandb.finish()"


### PR DESCRIPTION
Description
-----------
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3e4a5c</samp>

Pin `urllib3` version in `executor-pex.sh` to fix pex build. This avoids conflicts with other packages that use `urllib3`.


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d3e4a5c</samp>

> _`urllib3` pinned_
> _to avoid conflicts with `requests`_
> _a winter patch_