### PR TITLE
feat(sweeps): launch a scheduler as a job

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -982,7 +982,7 @@ def launch_sweep(
     else:
         parsed_sweep_config = parsed_config
 
-    # validate job existence, add :latest alias if not specified
+    # validate job existence
     job = parsed_sweep_config.get("job")
     if job:
         if not isinstance(job, str) or ":" not in job:
@@ -1002,6 +1002,7 @@ def launch_sweep(
         wandb.termwarn(
             "Using a scheduler job for launch sweeps is *experimental* and may change without warning"
         )
+        # validate scheduler job existence
         try:
             public_api = PublicApi()
             public_api.artifact(scheduler_args["job"], type="job")
@@ -1041,7 +1042,7 @@ def launch_sweep(
     if scheduler_is_job:
         # args is a dict here
         overrides["overrides"]["run_config"]["sweep_args"] = args
-    else:
+    else:  # scheduler uses raw entrypoint
         # args is list of parameters
         overrides["overrides"]["args"] = args
 

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -112,8 +112,9 @@ def _job_is_scheduler(run_spec: Dict[str, Any]) -> bool:
         return False
 
     if run_spec.get("resource") == "local-process":
-        # If a scheduler is a local-process (100%), also
+        # If a scheduler is a local-process, also
         #    confirm command is in format: [wandb scheduler <sweep>]
+        # This will FAIL for schedulers run as jobs
         cmd = run_spec.get("overrides", {}).get("entry_point", [])
         if len(cmd) < 3:
             return False


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-13667

Enables: https://wandb.atlassian.net/browse/WB-13289

Description
-----------
CLI and Agent changes to enable launching a sweep scheduler from a simple job. 


Testing
-------
TODO


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7431374</samp>

> _From the ashes of the scheduler job_
> _We unleash the launch sweeps of doom_
> _With `arguments` and `overrides` we shape our destiny_
> _And enter the `scheduler_job_creation` tomb_