### PR TITLE
perf(artifacts): use __slots__ in ArtifactManifestEntry

### DIFF
--- a/wandb/sdk/interface/artifacts/artifact_manifest.py
+++ b/wandb/sdk/interface/artifacts/artifact_manifest.py
@@ -12,6 +12,16 @@ if TYPE_CHECKING:
 class ArtifactManifestEntry:
     """A single entry in an artifact manifest."""
 
+    __slots__ = (
+        "path",
+        "digest",
+        "ref",
+        "birth_artifact_id",
+        "size",
+        "extra",
+        "local_path",
+    )
+
     path: LogicalPath
     digest: Union[B64MD5, URIStr, FilePathStr, ETag]
     ref: Optional[Union[FilePathStr, URIStr]]


### PR DESCRIPTION
Fixes
-----
Fixes [WB-13701](https://wandb.atlassian.net/browse/WB-13701)


Description
-----------
Use `__slots__` to reduce the memory consumption of `ArtifactManifestEntry` objects.

This reduces baseline (minimum) memory consumption from 904 bytes per object to 224 (75% reduction). In practice most of the memory consumed by manifest entries comes from their strings (at least as many bytes as the length of a path, digest, id, etc.) so the actual savings are closer to 50% in the real world.

For most programs this won't make much of a difference; for every 1 million artifact files this saves 1.36GB (during artifact creation the artifact manifest is created 3 separate times) which isn't that considerable but also isn't trivial.

Note that this makes ArtifactManifestEntry objects less flexible; see how I needed to change the `ArtifactManifestEntryPatch` for testing purposes, since the methods can't be dynamically bound without a `__dict__` attribute.


Testing
-------
CI

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0dd2405</samp>

> _`__slots__` added_
> _to manifest entry class_
> _cutting memory_

[WB-13701]: https://wandb.atlassian.net/browse/WB-13701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ