### PR TITLE
perf(artifacts): conserve memory when hashing files

### DIFF
--- a/wandb/sdk/lib/hashutil.py
+++ b/wandb/sdk/lib/hashutil.py
@@ -1,6 +1,9 @@
 import base64
 import hashlib
+import mmap
+import os
 import sys
+from pathlib import Path
 from typing import NewType, Union
 
 from wandb.sdk.lib.paths import StrPath
@@ -47,8 +50,13 @@ def md5_file_hex(*paths: StrPath) -> HexMD5:
 
 def _md5_file_hasher(*paths: StrPath) -> "hashlib._Hash":
     md5_hash = _md5()
-    for path in sorted(str(p) for p in paths):
-        with open(path, "rb") as f:
-            for chunk in iter(lambda: f.read(64 * 1024), b""):
-                md5_hash.update(chunk)
+
+    for path in sorted(Path(p) for p in paths):
+        with path.open("rb") as f:
+            if os.stat(f.fileno()).st_size <= 1024 * 1024:
+                md5_hash.update(f.read())
+            else:
+                with mmap.mmap(f.fileno(), length=0, access=mmap.ACCESS_READ) as mview:
+                    md5_hash.update(mview)
+
     return md5_hash


### PR DESCRIPTION
Fixes
-----
Fixes [WB-13694](https://wandb.atlassian.net/browse/WB-13694)

Description
-----------
Reduce the excess memory currently used when hashing files. In some microbenchmarks using a variety of file sizes (with the majority of bytes in larger files, but with most files substantially <1MB) this reduces memory consumption of the overall `wandb` process by almost 5x (from 3.65GB to 643MB for 20,000 files).

- For small files (anything under 1MB) read the entire file at once
- Otherwise, `mmap` the file and hash that buffer also in its entirety

Testing
-------
CI

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4649767</samp>

> _`LogicalPath` helps_
> _Hash files faster with `mmap`_
> _A crisp autumn task_

[WB-13694]: https://wandb.atlassian.net/browse/WB-13694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ