### PR TITLE
refactor(artifacts): move EventJobDone to its point of use

### DIFF
--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, NamedTuple, Optional
+from typing import TYPE_CHECKING, Optional
 
 import wandb
 from wandb.sdk.lib.paths import LogicalPath
@@ -9,11 +9,6 @@ from wandb.sdk.lib.paths import LogicalPath
 if TYPE_CHECKING:
     from wandb.filesync import dir_watcher, stats, step_upload
     from wandb.sdk.internal import file_stream, internal_api
-
-
-class EventJobDone(NamedTuple):
-    job: "step_upload.RequestUpload"
-    exc: Optional[BaseException]
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Description
-----------
Very small obvious refactor.

`EventJobDone` is used in only one file, step_upload.py but it is defined in a different file. This just moves it to the place where it's used.


Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 537c6be</samp>

> _No more circles of import hell_
> _We break the chains of file sync_
> _`EventJobDone` finds a new home_
> _We upload and complete our steps_