### PR TITLE
feat(artifacts): Artifacts: allow saved artifacts to be modified and logged as a new version

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -65,6 +65,7 @@ from wandb.sdk.lib.paths import LogicalPath
 if TYPE_CHECKING:
     import wandb.apis.reports
     import wandb.apis.reports.util
+    from wandb import Artifact as LocalArtifact
 
 logger = logging.getLogger(__name__)
 
@@ -5244,6 +5245,19 @@ class Artifact(artifacts.Artifact):
                 run_obj["project"]["name"],
                 run_obj["name"],
             )
+
+    def new_draft(self) -> "LocalArtifact":
+        """Create a new draft artifact with the same content as this committed artifact.
+
+        The artifact returned can be extended or modified and logged as a new version.
+        """
+        artifact = wandb.Artifact(self.name.split(":")[0], self.type)
+        artifact._description = self.description
+        artifact._metadata = self.metadata
+        artifact._manifest = artifacts.ArtifactManifest.from_manifest_json(
+            self.manifest.to_manifest_json()
+        )
+        return artifact
 
 
 class ArtifactVersions(Paginator):


### PR DESCRIPTION
Fixes WB-12549

# Description

Added the ability to create a new draft artifact bootstrapped with an existing artifact.

Note on API design:
I decided to create a new `Artifact` instance instead of modifying an existing instance. Changing the identity of an existing instance would be error prone. Note that we keep references to `Artifact` instances in various places (e.g. [here](https://github.com/wandb/wandb/blob/8f9d25fee7df3cb5bd52a5d732d72486d306cedd/wandb/apis/public.py#L4127) and [here](https://github.com/wandb/wandb/blob/a87fb976c939052656e2cf6c1bcf885d03afdfbb/wandb/sdk/data_types/base_types/wb_value.py#L43)) and assume their identity doesn't change over time.

# Test plan

<img width="1154" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/9dd19e04-b4f5-4bd6-bf31-7ed8f20ea448">
<img width="1198" alt="1" src="https://github.com/wandb/wandb/assets/127154459/94995fed-a5c0-41c7-b9f1-617659a7831d">
<img width="1198" alt="2" src="https://github.com/wandb/wandb/assets/127154459/a6d92edc-8130-4623-898f-78ab11518439">