### PR TITLE
refactor(artifacts): extract prepare_response from the body of the event loop

### DIFF
--- a/wandb/filesync/step_prepare.py
+++ b/wandb/filesync/step_prepare.py
@@ -92,6 +92,21 @@ def gather_batch(
     return False, batch
 
 
+def prepare_response(response: "CreateArtifactFilesResponseFile") -> ResponsePrepare:
+    multipart_resp = response.get("uploadMultipartUrls")
+    part_list = multipart_resp["uploadUrlParts"] if multipart_resp else []
+    multipart_parts = {u["partNumber"]: u["uploadUrl"] for u in part_list} or None
+
+    return ResponsePrepare(
+        upload_url=response["uploadUrl"],
+        multipart_upload_url=multipart_parts,
+        upload_id=multipart_resp and multipart_resp.get("uploadID"),
+        storage_path=response.get("storagePath"),
+        upload_headers=response["uploadHeaders"],
+        birth_artifact_id=response["artifact"]["id"],
+    )
+
+
 class StepPrepare:
     """A thread that batches requests to our file prepare API.
 
@@ -124,39 +139,12 @@ class StepPrepare:
                 max_batch_size=self._max_batch_size,
             )
             if batch:
-                prepare_response = self._prepare_batch(batch)
+                batch_response = self._prepare_batch(batch)
                 # send responses
                 for prepare_request in batch:
                     name = prepare_request.file_spec["name"]
-                    response_file = prepare_response[name]
-                    upload_url = response_file["uploadUrl"]
-                    upload_headers = response_file["uploadHeaders"]
-                    birth_artifact_id = response_file["artifact"]["id"]
-                    multipart_upload_url = None
-                    upload_id = None
-                    storage_path = None
-                    if (
-                        "uploadMultipartUrls" in response_file
-                        and response_file["uploadMultipartUrls"] is not None
-                    ):
-                        multipart_resp = response_file["uploadMultipartUrls"][
-                            "uploadUrlParts"
-                        ]
-                        multipart_upload_url = {
-                            u["partNumber"]: u["uploadUrl"] for u in multipart_resp
-                        }
-                        upload_id = response_file["uploadMultipartUrls"]["uploadID"]
-                    if "storagePath" in response_file:
-                        storage_path = response_file["storagePath"]
-
-                    response = ResponsePrepare(
-                        upload_url,
-                        multipart_upload_url,
-                        upload_id,
-                        storage_path,
-                        upload_headers,
-                        birth_artifact_id,
-                    )
+                    response_file = batch_response[name]
+                    response = prepare_response(response_file)
                     if isinstance(prepare_request.response_channel, queue.Queue):
                         prepare_request.response_channel.put(response)
                     else:


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
What does the PR do?


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aff98c8</samp>

> _To sync files with artifacts, we need_
> _To upload requests with some speed_
> _But the code was a mess_
> _So we had to address_
> _The logic of `prepare_response` indeed_