### PR TITLE
refactor(artifacts): consistently order ResponsePrepare fields

### DIFF
--- a/tests/pytest_tests/unit_tests/test_step_prepare.py
+++ b/tests/pytest_tests/unit_tests/test_step_prepare.py
@@ -365,12 +365,12 @@ class TestStepPrepare:
         )
 
         assert res == ResponsePrepare(
+            birth_artifact_id=caf_result["foo"]["artifact"]["id"],
             upload_url=caf_result["foo"]["uploadUrl"],
             upload_headers=caf_result["foo"]["uploadHeaders"],
-            birth_artifact_id=caf_result["foo"]["artifact"]["id"],
+            upload_id=upload_id,
             storage_path=caf_result["foo"]["storagePath"],
             multipart_upload_url=caf_result["foo"]["uploadMultipartUrls"],
-            upload_id=upload_id,
         )
 
     def test_batches_requests(self, prepare: "PrepareFixture"):

--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -75,12 +75,12 @@ def singleton_queue(x):
 def dummy_response_prepare(spec):
     name = spec["name"]
     return ResponsePrepare(
+        birth_artifact_id=f"artifact-id-{name}",
         upload_url=f"http://wandb-test/upload-url-{name}",
         upload_headers=["x-my-header-key:my-header-val"],
-        birth_artifact_id=f"artifact-id-{name}",
-        multipart_upload_url=None,
         upload_id=None,
         storage_path="wandb_artifact/123456789",
+        multipart_upload_url=None,
     )
 
 

--- a/wandb/filesync/step_prepare.py
+++ b/wandb/filesync/step_prepare.py
@@ -40,12 +40,12 @@ class RequestFinish(NamedTuple):
 
 
 class ResponsePrepare(NamedTuple):
+    birth_artifact_id: str
     upload_url: Optional[str]
-    multipart_upload_url: Optional[Dict[int, str]]
+    upload_headers: Sequence[str]
     upload_id: Optional[str]
     storage_path: Optional[str]
-    upload_headers: Sequence[str]
-    birth_artifact_id: str
+    multipart_upload_url: Optional[Dict[int, str]]
 
 
 Request = Union[RequestPrepare, RequestFinish]
@@ -98,12 +98,12 @@ def prepare_response(response: "CreateArtifactFilesResponseFile") -> ResponsePre
     multipart_parts = {u["partNumber"]: u["uploadUrl"] for u in part_list} or None
 
     return ResponsePrepare(
+        birth_artifact_id=response["artifact"]["id"],
         upload_url=response["uploadUrl"],
-        multipart_upload_url=multipart_parts,
+        upload_headers=response["uploadHeaders"],
         upload_id=multipart_resp and multipart_resp.get("uploadID"),
         storage_path=response.get("storagePath"),
-        upload_headers=response["uploadHeaders"],
-        birth_artifact_id=response["artifact"]["id"],
+        multipart_upload_url=multipart_parts,
     )
 
 


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
What does the PR do?


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9c78932</samp>

> _To make the code more consistent_
> _The `ResponsePrepare` constructor was insistent_
> _On reordering its fields_
> _And adding some defaults_
> _To make it more readable and efficient_