### PR TITLE
fix(launch): docker runner always pull for image sourced jobs

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_launch_local_container.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_local_container.py
@@ -20,10 +20,6 @@ def test_local_container_entrypoint(relay_server, monkeypatch):
         lambda x: None,
     )
     monkeypatch.setattr(
-        "wandb.sdk.launch.runner.local_container.docker_image_exists",
-        lambda x: False,
-    )
-    monkeypatch.setattr(
         "wandb.sdk.launch.builder.noop.NoOpBuilder.build_image",
         lambda *args, **kwargs: "testimage",
     )

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -17,7 +17,6 @@ from ..utils import (
     PROJECT_SYNCHRONOUS,
     _is_wandb_dev_uri,
     _is_wandb_local_uri,
-    docker_image_exists,
     pull_docker_image,
     sanitize_wandb_api_key,
 )
@@ -112,8 +111,7 @@ class LocalContainerRunner(AbstractRunner):
         if launch_project.docker_image:
             # user has provided their own docker image
             image_uri = launch_project.image_name
-            if not docker_image_exists(image_uri):
-                pull_docker_image(image_uri)
+            pull_docker_image(image_uri)
             entry_cmd = []
             if entry_point is not None:
                 entry_cmd = entry_point.command


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 012d9fb</samp>

### Summary
🔧🗑️🚀

<!--
1.  🔧 - This emoji represents refactoring or fixing code, which is the main purpose of the changes.
2.  🗑️ - This emoji represents removing or deleting code, which is what the changes do to the `docker_image_exists` function and check.
3.  🚀 - This emoji represents launching or deploying code, which is related to the docker image logic for launch projects.
-->
Simplify docker image handling for launch projects. Remove `docker_image_exists` function and check from `local_container.py`.

> _To launch projects with docker images_
> _We refactored some logic with fixes_
> _We removed a function_
> _That caused some obstruction_
> _And checked for existence with prefixes_

### Walkthrough
*  Remove unused `docker_image_exists` function from imports ([link](https://github.com/wandb/wandb/pull/5531/files?diff=unified&w=0#diff-03853de6b6ac99be1dc94a98df47da16d8d172f5870a0fbbe5aa39e59e89df83L20))
*  Simplify docker image logic by removing redundant check for local image existence ([link](https://github.com/wandb/wandb/pull/5531/files?diff=unified&w=0#diff-03853de6b6ac99be1dc94a98df47da16d8d172f5870a0fbbe5aa39e59e89df83L115-R114))




Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 012d9fb</samp>

> _To launch projects with docker images_
> _We refactored some logic with fixes_
> _We removed a function_
> _That caused some obstruction_
> _And checked for existence with prefixes_