### PR TITLE
fix(launch): custom k8s objects respect command/args overrides

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -553,6 +553,14 @@ class KubernetesRunner(AbstractRunner):
             add_label_to_pods(
                 launch_project.resource_args, "wandb/run-id", launch_project.run_id
             )
+            # Add overrides of the container entrypoint and args.
+            if launch_project.override_entrypoint or launch_project.override_args:
+                inject_entrypoint_and_args(
+                    launch_project.resource_args.get("containers", []),
+                    launch_project.override_entrypoint,
+                    launch_project.override_args,
+                    launch_project.override_entrypoint is not None,
+                )
             api = client.CustomObjectsApi(api_client)
             # Infer the attributes of a custom object from the apiVersion and/or
             # a kind: attribute in the resource args.
@@ -756,3 +764,31 @@ def add_label_to_pods(
             labels[label_key] = label_value
         for value in manifest.values():
             add_label_to_pods(value, label_key, label_value)
+
+
+def add_entrypoint_args_overrides(manifest: Union[dict, list], overrides: dict) -> None:
+    """Add entrypoint and args overrides to all containers in a manifest.
+
+    Recursively traverses the manifest and adds the entrypoint and args overrides
+    to all containers. Containers are identified by the presence of a "spec" key
+    with a "containers" key in the value.
+
+    Arguments:
+        manifest: The manifest to modify.
+        overrides: Dictionary with args and entrypoint keys.
+
+    Returns: None.
+    """
+    if isinstance(manifest, list):
+        for item in manifest:
+            add_entrypoint_args_overrides(item, overrides)
+    elif isinstance(manifest, dict):
+        if "spec" in manifest and "containers" in manifest["spec"]:
+            containers = manifest["spec"]["containers"]
+            for container in containers:
+                if "command" in overrides:
+                    container["command"] = overrides["command"]
+                if "args" in overrides:
+                    container["args"] = overrides["args"]
+        for value in manifest.values():
+            add_entrypoint_args_overrides(value, overrides)

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -553,14 +553,15 @@ class KubernetesRunner(AbstractRunner):
             add_label_to_pods(
                 launch_project.resource_args, "wandb/run-id", launch_project.run_id
             )
-            # Add overrides of the container entrypoint and args.
-            if launch_project.override_entrypoint or launch_project.override_args:
-                inject_entrypoint_and_args(
-                    launch_project.resource_args.get("containers", []),
-                    launch_project.override_entrypoint,
-                    launch_project.override_args,
-                    launch_project.override_entrypoint is not None,
-                )
+            overrides = {}
+            if launch_project.override_args:
+                overrides["args"] = launch_project.override_args
+            if launch_project.override_entrypoint:
+                overrides["command"] = launch_project.override_entrypoint.command
+            add_entrypoint_args_overrides(
+                launch_project.resource_args,
+                overrides,
+            )
             api = client.CustomObjectsApi(api_client)
             # Infer the attributes of a custom object from the apiVersion and/or
             # a kind: attribute in the resource args.


### PR DESCRIPTION
Fixes
-----

Fixes WB-13703

Description
-----------

This makes the launching of custom k8s objects respect our args and command overrides in containers.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa0e2d9</samp>

### Summary
🚀🛠️✅

<!--
1.  🚀 - This emoji represents the new feature of being able to override the entrypoint and args of containers in Kubernetes resources, which can be useful for launching different experiments or customizing the execution of a project.
2.  🛠️ - This emoji represents the modification of the existing `KubernetesRunner` class and the addition of a new helper function, which are both related to implementing the new feature and enhancing the functionality of the `wandb launch` command.
3.  ✅ - This emoji represents the addition and modification of test functions, which are important for ensuring the quality and correctness of the new feature and the existing code.
-->
This pull request enables entrypoint and args overrides for Kubernetes containers when using `wandb launch`. It updates the `KubernetesRunner` class and the corresponding tests in `test_kubernetes.py`.

> _To launch projects with `wandb` tool_
> _You can now tweak the containers' rule_
> _With `add_entrypoint_args_overrides`_
> _You can change how each pod behaves_
> _And test it with `KubernetesRunner` cool_

### Walkthrough
*  Add entrypoint and args overrides feature to KubernetesRunner ([link](https://github.com/wandb/wandb/pull/5538/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86R556-R563), [link](https://github.com/wandb/wandb/pull/5538/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86R767-R794))
  - Check for overrides in launch_project object and call inject_entrypoint_and_args helper function ([link](https://github.com/wandb/wandb/pull/5538/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86R556-R563))
  - Define add_entrypoint_args_overrides function to recursively modify manifest with overrides ([link](https://github.com/wandb/wandb/pull/5538/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86R767-R794))
*  Import add_entrypoint_args_overrides function to test module ([link](https://github.com/wandb/wandb/pull/5538/files?diff=unified&w=0#diff-a1c99a9aafd44b94d56556ed6142736d658582e5f917e79b8bf60a0540b97df9R9))
*  Add test function for add_entrypoint_args_overrides ([link](https://github.com/wandb/wandb/pull/5538/files?diff=unified&w=0#diff-a1c99a9aafd44b94d56556ed6142736d658582e5f917e79b8bf60a0540b97df9R74-R93))
*  Modify test function for launch_custom to include overrides ([link](https://github.com/wandb/wandb/pull/5538/files?diff=unified&w=0#diff-a1c99a9aafd44b94d56556ed6142736d658582e5f917e79b8bf60a0540b97df9L156-R180))





Testing
-------
Unit tests.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)