### PR TITLE
test(sdk): use `USER` env variable instead of `METAFLOW_USER` variable

### DIFF
--- a/tests/functional_tests/t0_main/metaflow/wandb-example-flow-decoboth.py
+++ b/tests/functional_tests/t0_main/metaflow/wandb-example-flow-decoboth.py
@@ -13,6 +13,7 @@ from wandb.integration.metaflow import wandb_log
 
 os.environ["WANDB_SILENT"] = "true"
 os.environ["METAFLOW_USER"] = "test_user"
+os.environ["USER"] = os.environ["METAFLOW_USER"]
 
 
 @wandb_log(datasets=False, models=False, others=False)

--- a/tests/functional_tests/t0_main/metaflow/wandb-example-flow-decoclass.py
+++ b/tests/functional_tests/t0_main/metaflow/wandb-example-flow-decoclass.py
@@ -13,6 +13,7 @@ from wandb.integration.metaflow import wandb_log
 
 os.environ["WANDB_SILENT"] = "true"
 os.environ["METAFLOW_USER"] = "test_user"
+os.environ["USER"] = os.environ["METAFLOW_USER"]
 
 
 @wandb_log(datasets=True, models=True, others=True)

--- a/tests/functional_tests/t0_main/metaflow/wandb-example-flow-decostep.py
+++ b/tests/functional_tests/t0_main/metaflow/wandb-example-flow-decostep.py
@@ -13,6 +13,7 @@ from wandb.integration.metaflow import wandb_log
 
 os.environ["WANDB_SILENT"] = "true"
 os.environ["METAFLOW_USER"] = "test_user"
+os.environ["USER"] = os.environ["METAFLOW_USER"]
 
 
 class WandbExampleFlowDecoStep(FlowSpec):

--- a/tests/functional_tests/t0_main/metaflow/wandb-foreach-flow.py
+++ b/tests/functional_tests/t0_main/metaflow/wandb-foreach-flow.py
@@ -16,6 +16,7 @@ from wandb.integration.metaflow import wandb_log
 
 os.environ["WANDB_SILENT"] = "true"
 os.environ["METAFLOW_USER"] = "test_user"
+os.environ["USER"] = os.environ["METAFLOW_USER"]
 
 
 def setup_model(name, *args, **kwargs):

--- a/tests/functional_tests/t0_main/metaflow/wandb-pytorch-flow.py
+++ b/tests/functional_tests/t0_main/metaflow/wandb-pytorch-flow.py
@@ -17,6 +17,7 @@ from wandb.integration.metaflow import wandb_log
 
 os.environ["WANDB_SILENT"] = "true"
 os.environ["METAFLOW_USER"] = "test_user"
+os.environ["USER"] = os.environ["METAFLOW_USER"]
 
 
 @wandb_log


### PR DESCRIPTION
Description
-----------
What does the PR do?

In release 2.8.6 of `metaflow` the `METAFLOW_USER` env variable was removed causing all the metaflow functional tests to fail. This PR adds the `USER` env variable instead as it still part of the variables used to discover the user. 

See [this PR](https://github.com/Netflix/metaflow/pull/1400) for more details on the change.


Testing
-------
How was this PR tested?

Should only fix broken tests.

Checklist
-------
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c46ff6d</samp>

> _`wandb` decorates_
> _metaflow scripts with `USER`_
> _autumn of logging_