### PR TITLE
feat(artifacts): Artifacts: add .source_entity et al.

### DIFF
--- a/tests/pytest_tests/unit_tests_old/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests_old/test_wandb_run.py
@@ -125,7 +125,7 @@ def test_artifacts_in_config(live_mock_server, test_settings, parse_ctx):
         "_version": "v0",
         "id": artifact.id,
         "version": "v0",
-        "sequenceName": artifact._sequence_name,
+        "sequenceName": artifact.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -134,7 +134,7 @@ def test_artifacts_in_config(live_mock_server, test_settings, parse_ctx):
         "_version": "v0",
         "id": artifact.id,
         "version": "v0",
-        "sequenceName": artifact._sequence_name,
+        "sequenceName": artifact.source_name.split(":")[0],
         "usedAs": "myarti",
     }
 
@@ -159,7 +159,7 @@ def test_artifact_string_run_config_init(live_mock_server, test_settings, parse_
         "_version": "v0",
         "id": run.config.dataset.id,
         "version": "v0",
-        "sequenceName": run.config.dataset._sequence_name,
+        "sequenceName": run.config.dataset.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -178,7 +178,7 @@ def test_artifact_string_run_config_set_item(
         "_version": "v0",
         "id": run.config.dataset.id,
         "version": "v0",
-        "sequenceName": run.config.dataset._sequence_name,
+        "sequenceName": run.config.dataset.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -195,7 +195,7 @@ def test_artifact_string_digest_run_config_update(
         "_version": "v0",
         "id": run.config.dataset.id,
         "version": "v0",
-        "sequenceName": run.config.dataset._sequence_name,
+        "sequenceName": run.config.dataset.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -213,7 +213,7 @@ def test_artifact_string_digest_run_config_init(
         "_version": "v0",
         "id": run.config.dataset.id,
         "version": "v0",
-        "sequenceName": run.config.dataset._sequence_name,
+        "sequenceName": run.config.dataset.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -230,7 +230,7 @@ def test_artifact_string_digest_run_config_set_item(
         "_version": "v0",
         "id": run.config.dataset.id,
         "version": "v0",
-        "sequenceName": run.config.dataset._sequence_name,
+        "sequenceName": run.config.dataset.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -247,7 +247,7 @@ def test_artifact_string_run_config_update(
         "_version": "v0",
         "id": run.config.dataset.id,
         "version": "v0",
-        "sequenceName": run.config.dataset._sequence_name,
+        "sequenceName": run.config.dataset.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -266,7 +266,7 @@ def test_public_artifact_run_config_init(
         "_version": "v0",
         "id": art.id,
         "version": "v0",
-        "sequenceName": art._sequence_name,
+        "sequenceName": art.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -285,7 +285,7 @@ def test_public_artifact_run_config_set_item(
         "_version": "v0",
         "id": art.id,
         "version": "v0",
-        "sequenceName": art._sequence_name,
+        "sequenceName": art.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 
@@ -305,7 +305,7 @@ def test_public_artifact_run_config_update(
         "_version": "v0",
         "id": art.id,
         "version": "v0",
-        "sequenceName": art._sequence_name,
+        "sequenceName": art.source_name.split(":")[0],
         "usedAs": "dataset",
     }
 

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -4340,7 +4340,7 @@ class Artifact(artifacts.Artifact):
         self.client = client
         self._entity = entity
         self._project = project
-        self._artifact_name = name
+        self._name = name
         self._artifact_collection_name = name.split(":")[0]
         self._attrs = attrs
         if self._attrs is None:
@@ -4349,10 +4349,10 @@ class Artifact(artifacts.Artifact):
         # The entity and project above are taken from the passed-in artifact version path
         # so if the user is pulling an artifact version from an artifact portfolio, the entity/project
         # of that portfolio may be different than the birth entity/project of the artifact version.
-        self._birth_project = (
+        self._source_project = (
             self._attrs.get("artifactType", {}).get("project", {}).get("name")
         )
-        self._birth_entity = (
+        self._source_entity = (
             self._attrs.get("artifactType", {})
             .get("project", {})
             .get("entity", {})
@@ -4360,8 +4360,10 @@ class Artifact(artifacts.Artifact):
         )
         self._metadata = json.loads(self._attrs.get("metadata") or "{}")
         self._description = self._attrs.get("description", None)
-        self._sequence_name = self._attrs["artifactSequence"]["name"]
-        self._sequence_version_index = self._attrs.get("versionIndex", None)
+        self._source_name = "{}:v{}".format(
+            self._attrs["artifactSequence"]["name"], self._attrs.get("versionIndex")
+        )
+        self._source_version = "v{}".format(self._attrs.get("versionIndex"))
         # We will only show aliases under the Collection this artifact version is fetched from
         # _aliases will be a mutable copy on which the user can append or remove aliases
         self._aliases = [
@@ -4382,16 +4384,16 @@ class Artifact(artifacts.Artifact):
         return self._attrs["id"]
 
     @property
-    def file_count(self):
-        return self._attrs["fileCount"]
+    def entity(self):
+        return self._entity
 
     @property
-    def source_version(self):
-        """The artifact's version index under its parent artifact collection.
+    def project(self):
+        return self._project
 
-        A string with the format "v{number}".
-        """
-        return f"v{self._sequence_version_index}"
+    @property
+    def name(self):
+        return self._name
 
     @property
     def version(self):
@@ -4409,12 +4411,28 @@ class Artifact(artifacts.Artifact):
         return None
 
     @property
-    def entity(self):
-        return self._entity
+    def source_entity(self):
+        return self._source_entity
 
     @property
-    def project(self):
-        return self._project
+    def source_project(self):
+        return self._source_project
+
+    @property
+    def source_name(self):
+        return self._source_name
+
+    @property
+    def source_version(self):
+        """The artifact's version index under its parent artifact collection.
+
+        A string with the format "v{number}".
+        """
+        return self._source_version
+
+    @property
+    def file_count(self):
+        return self._attrs["fileCount"]
 
     @property
     def metadata(self):
@@ -4465,10 +4483,6 @@ class Artifact(artifacts.Artifact):
     @property
     def commit_hash(self):
         return self._attrs.get("commitHash", "")
-
-    @property
-    def name(self):
-        return self._artifact_name
 
     @property
     def aliases(self):
@@ -4726,7 +4740,7 @@ class Artifact(artifacts.Artifact):
             log = True
             termlog(
                 "Downloading large artifact {}, {:.2f}MB. {} files... ".format(
-                    self._artifact_name, size / (1024 * 1024), nfiles
+                    self.name, size / (1024 * 1024), nfiles
                 ),
             )
             start_time = datetime.datetime.now()
@@ -4835,7 +4849,7 @@ class Artifact(artifacts.Artifact):
         return downloaded_path
 
     def _default_root(self, include_version=True):
-        name = self.name if include_version else self._sequence_name
+        name = self.source_name if include_version else self.source_name.split(":")[0]
         root = os.path.join(get_artifact_dir(), name)
         if platform.system() == "Windows":
             head, tail = os.path.splitdrive(root)
@@ -5045,13 +5059,13 @@ class Artifact(artifacts.Artifact):
                 variable_values={
                     "entityName": self.entity,
                     "projectName": self.project,
-                    "name": self._artifact_name,
+                    "name": self.name,
                 },
             )
         except Exception:
             # we check for this after doing the call, since the backend supports raw digest lookups
             # which don't include ":" and are 32 characters long
-            if ":" not in self._artifact_name and len(self._artifact_name) != 32:
+            if ":" not in self.name and len(self.name) != 32:
                 raise ValueError(
                     'Attempted to fetch artifact without alias (e.g. "<artifact_name>:v3" or "<artifact_name>:latest")'
                 )
@@ -5061,7 +5075,7 @@ class Artifact(artifacts.Artifact):
             or response["project"].get("artifact") is None
         ):
             raise ValueError(
-                f'Project {self.entity}/{self.project} does not contain artifact: "{self._artifact_name}"'
+                f'Project {self.entity}/{self.project} does not contain artifact: "{self.name}"'
             )
         self._attrs = response["project"]["artifact"]
         return self._attrs
@@ -5107,7 +5121,7 @@ class Artifact(artifacts.Artifact):
                 variable_values={
                     "entityName": self.entity,
                     "projectName": self.project,
-                    "name": self._artifact_name,
+                    "name": self.name,
                 },
             )
 
@@ -5391,10 +5405,10 @@ class ArtifactFiles(Paginator):
     ):
         self.artifact = artifact
         variables = {
-            "entityName": artifact._birth_entity,
-            "projectName": artifact._birth_project,
+            "entityName": artifact.source_entity,
+            "projectName": artifact.source_project,
             "artifactTypeName": artifact.type,
-            "artifactName": artifact.name,
+            "artifactName": artifact.source_name,
             "fileNames": names,
         }
         # The server must advertise at least SDK 0.12.21

--- a/wandb/sdk/interface/artifacts/artifact.py
+++ b/wandb/sdk/interface/artifacts/artifact.py
@@ -60,45 +60,72 @@ class Artifact:
         raise NotImplementedError
 
     @property
-    def version(self) -> str:
-        """The version of this artifact.
+    def entity(self) -> str:
+        """The name of the entity of the secondary (portfolio) artifact collection."""
+        raise NotImplementedError
 
-        For example, if this is the first version of an artifact, its `version` will be
-        'v0'.
+    @property
+    def project(self) -> str:
+        """The name of the project of the secondary (portfolio) artifact collection."""
+        raise NotImplementedError
+
+    @property
+    def name(self) -> str:
+        """The artifact name and version in its secondary (portfolio) collection.
+
+        A string with the format {collection}:{alias}. Before the artifact is saved,
+        contains only the name since the version is not yet known.
         """
         raise NotImplementedError
 
     @property
-    def source_version(self) -> Optional[str]:
-        """The artifact's version index under its parent artifact collection.
+    def qualified_name(self) -> str:
+        """The entity/project/name of the secondary (portfolio) collection."""
+        return f"{self.entity}/{self.project}/{self.name}"
+
+    @property
+    def version(self) -> str:
+        """The artifact's version in its secondary (portfolio) collection.
 
         A string with the format "v{number}".
         """
         raise NotImplementedError
 
     @property
-    def name(self) -> str:
-        """The artifact's name."""
+    def source_entity(self) -> str:
+        """The name of the entity of the primary (sequence) artifact collection."""
         raise NotImplementedError
 
     @property
-    def qualified_name(self) -> str:
-        """The artifact's qualified name."""
+    def source_project(self) -> str:
+        """The name of the project of the primary (sequence) artifact collection."""
+        raise NotImplementedError
+
+    @property
+    def source_name(self) -> str:
+        """The artifact name and version in its primary (sequence) collection.
+
+        A string with the format {collection}:{alias}. Before the artifact is saved,
+        contains only the name since the version is not yet known.
+        """
+        raise NotImplementedError
+
+    @property
+    def source_qualified_name(self) -> str:
+        """The entity/project/name of the primary (sequence) collection."""
         return f"{self.entity}/{self.project}/{self.name}"
+
+    @property
+    def source_version(self) -> str:
+        """The artifact's version in its primary (sequence) collection.
+
+        A string with the format "v{number}".
+        """
+        raise NotImplementedError
 
     @property
     def type(self) -> str:
         """The artifact's type."""
-        raise NotImplementedError
-
-    @property
-    def entity(self) -> str:
-        """The name of the entity this artifact belongs to."""
-        raise NotImplementedError
-
-    @property
-    def project(self) -> str:
-        """The name of the project this artifact belongs to."""
         raise NotImplementedError
 
     @property

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -230,20 +230,6 @@ class Artifact(ArtifactInterface):
         return None
 
     @property
-    def source_version(self) -> Optional[str]:
-        if self._logged_artifact:
-            return self._logged_artifact.source_version
-
-        return None
-
-    @property
-    def version(self) -> str:
-        if self._logged_artifact:
-            return self._logged_artifact.version
-
-        raise ArtifactNotLoggedError(self, "version")
-
-    @property
     def entity(self) -> str:
         if self._logged_artifact:
             return self._logged_artifact.entity
@@ -254,6 +240,34 @@ class Artifact(ArtifactInterface):
         if self._logged_artifact:
             return self._logged_artifact.project
         raise ArtifactNotLoggedError(self, "project")
+
+    @property
+    def name(self) -> str:
+        if self._logged_artifact:
+            return self._logged_artifact.name
+        return self._name
+
+    @property
+    def version(self) -> str:
+        if self._logged_artifact:
+            return self._logged_artifact.version
+        raise ArtifactNotLoggedError(self, "version")
+
+    @property
+    def source_entity(self) -> str:
+        return self.entity
+
+    @property
+    def source_project(self) -> str:
+        return self.project
+
+    @property
+    def source_name(self) -> str:
+        return self.name
+
+    @property
+    def source_version(self) -> str:
+        return self.version
 
     @property
     def manifest(self) -> ArtifactManifest:
@@ -278,20 +292,6 @@ class Artifact(ArtifactInterface):
             return self._logged_artifact.type
 
         return self._type
-
-    @property
-    def name(self) -> str:
-        if self._logged_artifact:
-            return self._logged_artifact.name
-
-        return self._name
-
-    @property
-    def qualified_name(self) -> str:
-        if self._logged_artifact:
-            return self._logged_artifact.qualified_name
-
-        return super().qualified_name
 
     @property
     def state(self) -> str:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3760,32 +3760,40 @@ class _LazyArtifact(ArtifactInterface):
         return self._instance.id
 
     @property
-    def source_version(self) -> Optional[str]:
-        return self._instance.source_version
-
-    @property
-    def version(self) -> str:
-        return self._instance.version
-
-    @property
-    def name(self) -> str:
-        return self._instance.name
-
-    @property
-    def qualified_name(self) -> str:
-        return self._instance.qualified_name
-
-    @property
-    def type(self) -> str:
-        return self._instance.type
-
-    @property
     def entity(self) -> str:
         return self._instance.entity
 
     @property
     def project(self) -> str:
         return self._instance.project
+
+    @property
+    def name(self) -> str:
+        return self._instance.name
+
+    @property
+    def version(self) -> str:
+        return self._instance.version
+
+    @property
+    def source_entity(self) -> str:
+        return self._instance.source_entity
+
+    @property
+    def source_project(self) -> str:
+        return self._instance.source_project
+
+    @property
+    def source_name(self) -> str:
+        return self._instance.source_name
+
+    @property
+    def source_version(self) -> str:
+        return self._instance.source_version
+
+    @property
+    def type(self) -> str:
+        return self._instance.type
 
     @property
     def manifest(self) -> "ArtifactManifest":

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1490,19 +1490,12 @@ def check_windows_valid_filename(path: Union[int, str]) -> bool:
 def artifact_to_json(
     artifact: Union["wandb.sdk.wandb_artifacts.Artifact", "wandb.apis.public.Artifact"]
 ) -> Dict[str, Any]:
-    # public.Artifact has the _sequence name, instances of wandb.Artifact
-    # just have the name
-    if hasattr(artifact, "_sequence_name"):
-        sequence_name = artifact._sequence_name
-    else:
-        sequence_name = artifact.name.split(":")[0]
-
     return {
         "_type": "artifactVersion",
         "_version": "v0",
         "id": artifact.id,
         "version": artifact.source_version,
-        "sequenceName": sequence_name,
+        "sequenceName": artifact.source_name.split(":")[0],
         "usedAs": artifact._use_as,
     }
 


### PR DESCRIPTION
Fixes WB-13706

# Description

- added `artifact.source_entity`
- added `artifact.source_project`
- added `artifact.source_name`
- made `artifact.source_version` raise `ArtifactNotLoggedError` instead of returning `None` when the artifact is not saved. This is consistent with the other properties, in particular `artifact.version`.

See discussion [here](https://weightsandbiases.slack.com/archives/C04MNBGJDBN/p1683275620778489).

# Test plan

<img width="1154" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/7b9ad141-3208-4367-a26e-1c06f4f657f9">