### PR TITLE
feat(launch): don't install frozen reqs if there is a reqs file

### DIFF
--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -288,7 +288,7 @@ def get_requirements_section(launch_project: LaunchProject, builder_type: str) -
         ):
             requirements_files += ["src/requirements.txt"]
             pip_install_line = "pip install -r requirements.txt"
-        if launch_project.project_dir is not None and os.path.exists(
+        elif launch_project.project_dir is not None and os.path.exists(
             os.path.join(launch_project.project_dir, "requirements.frozen.txt")
         ):
             # if we have frozen requirements stored, copy those over and have them take precedence


### PR DESCRIPTION
Fixes
-----




Description
-----------
What does the PR do?

Makes it so that the build will ignore frozen requirements and simply pip install a requirements.txt if one is in the root of the build context.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 36af901</samp>

### Summary
🐛🐳🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It conveys that the change addresses an issue that caused unexpected or incorrect behavior in the launch project.
2.  🐳 - This emoji represents Docker, which is the technology used to build and run the launch project as a container. It conveys that the change affects the Dockerfile and the image creation process.
3.  🚀 - This emoji represents launch, which is the name of the product that the pull request is related to. It conveys that the change is relevant for the launch project and its users.
-->
Fix bug where `requirements.frozen.txt` was ignored in launch image build. Change `if` to `elif` in `get_requirements_section` to avoid duplicate requirements in Dockerfile.

> _`elif` fixes bug_
> _frozen requirements now work_
> _winter image built_

### Walkthrough
* Fix bug where frozen requirements file was ignored when building Docker image for launch project ([link](https://github.com/wandb/wandb/pull/5548/files?diff=unified&w=0#diff-c24243e202a8bfb8b51dd0d8716256835ffa58e7712edfb9098ebc737a0adfbfL291-R291))



Testing
-------
How was this PR tested?


This was tested manually.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 36af901</samp>

> _`elif` fixes bug_
> _frozen requirements now work_
> _winter image built_