### PR TITLE
refactor(artifacts): Artifacts: add missing type annotations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -175,8 +175,8 @@ implicit_reexport = False
 [mypy-wandb.sdk.artifacts.*]
 disallow_untyped_calls = False
 
-[mypy-wandb.sdk.artifacts.artifact_download_logger,wandb.sdk.artifacts.downloaded_artifact_entry,wandb.sdk.artifacts.public_artifact]
-ignore_errors = True
+[mypy-wandb.sdk.artifacts.public_artifact]
+warn_return_any = False
 
 [mypy-wandb.sdk.backend.*]
 

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -286,6 +286,12 @@ def test_gcs_storage_handler_load_path_uses_cache(cache):
     assert local_path == path
 
 
+class FakePublicApi:
+    @property
+    def client(self):
+        return None
+
+
 def test_wbartifact_handler_load_path_nonlocal(monkeypatch):
     path = "foo/bar"
     uri = "wandb-artifact://deadbeef/path/to/file.json"
@@ -298,7 +304,7 @@ def test_wbartifact_handler_load_path_nonlocal(monkeypatch):
     )
 
     handler = WBArtifactHandler()
-    handler._client = lambda: None
+    handler._client = FakePublicApi()
     monkeypatch.setattr(PublicArtifact, "from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.ref_target = lambda: uri
@@ -319,7 +325,7 @@ def test_wbartifact_handler_load_path_local(monkeypatch):
     )
 
     handler = WBArtifactHandler()
-    handler._client = lambda: None
+    handler._client = FakePublicApi()
     monkeypatch.setattr(PublicArtifact, "from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.download = lambda: path

--- a/tests/pytest_tests/unit_tests_old/test_public_api.py
+++ b/tests/pytest_tests/unit_tests_old/test_public_api.py
@@ -365,8 +365,7 @@ def test_artifact_delete(runner, mock_server, api):
         # with pytest.raises(Exception):
         #    art.delete()
 
-        success = art.delete(delete_aliases=True)
-        assert success
+        art.delete(delete_aliases=True)
 
 
 def test_artifact_checkout(runner, mock_server, api):

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1,5 +1,6 @@
 """Artifact interface."""
-from typing import IO, TYPE_CHECKING, ContextManager, List, Optional, Sequence, Union
+import contextlib
+from typing import IO, TYPE_CHECKING, Generator, List, Optional, Sequence, Union
 
 import wandb
 from wandb.data_types import WBValue
@@ -191,13 +192,14 @@ class Artifact:
         """Get a list of the runs that have used this artifact."""
         raise NotImplementedError
 
-    def logged_by(self) -> "wandb.apis.public.Run":
+    def logged_by(self) -> Optional["wandb.apis.public.Run"]:
         """Get the run that first logged this artifact."""
         raise NotImplementedError
 
+    @contextlib.contextmanager
     def new_file(
         self, name: str, mode: str = "w", encoding: Optional[str] = None
-    ) -> ContextManager[IO]:
+    ) -> Generator[IO, None, None]:
         """Open a new temporary file that will be automatically added to the artifact.
 
         Arguments:
@@ -291,7 +293,7 @@ class Artifact:
     def add_reference(
         self,
         uri: Union["ArtifactManifestEntry", str],
-        name: Optional[str] = None,
+        name: Optional[StrPath] = None,
         checksum: bool = True,
         max_objects: Optional[int] = None,
     ) -> Sequence["ArtifactManifestEntry"]:
@@ -360,7 +362,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def add(self, obj: WBValue, name: str) -> "ArtifactManifestEntry":
+    def add(self, obj: WBValue, name: StrPath) -> "ArtifactManifestEntry":
         """Add wandb.WBValue `obj` to the artifact.
 
         ```
@@ -443,7 +445,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def get(self, name: str) -> WBValue:
+    def get(self, name: str) -> Optional[WBValue]:
         """Get the WBValue object located at the artifact relative `name`.
 
         Arguments:
@@ -503,7 +505,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def verify(self, root: Optional[str] = None) -> bool:
+    def verify(self, root: Optional[str] = None) -> None:
         """Verify that the actual contents of an artifact match the manifest.
 
         All files in the directory are checksummed and the checksums are then
@@ -542,7 +544,7 @@ class Artifact:
         """
         raise NotImplementedError
 
-    def delete(self) -> None:
+    def delete(self, delete_aliases: bool = False) -> None:
         """Delete this artifact, cleaning up all files associated with it.
 
         NOTE: Deletion is permanent and CANNOT be undone.

--- a/wandb/sdk/artifacts/artifact_download_logger.py
+++ b/wandb/sdk/artifacts/artifact_download_logger.py
@@ -11,7 +11,7 @@ class ArtifactDownloadLogger:
         self,
         nfiles: int,
         clock_for_testing: Callable[[], float] = time.monotonic,
-        termlog_for_testing=termlog,
+        termlog_for_testing: Callable[..., None] = termlog,
     ) -> None:
         self._nfiles = nfiles
         self._clock = clock_for_testing

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -60,7 +60,7 @@ class ArtifactManifestEntry:
         """
         raise NotImplementedError
 
-    def ref_target(self) -> str:
+    def ref_target(self) -> Union[FilePathStr, URIStr]:
         """Get the reference URL that is targeted by this artifact entry.
 
         Returns:

--- a/wandb/sdk/artifacts/lazy_artifact.py
+++ b/wandb/sdk/artifacts/lazy_artifact.py
@@ -38,7 +38,9 @@ class LazyArtifact(ArtifactInterface):
             resp = future_get.response.log_artifact_response
             if resp.error_message:
                 raise ValueError(resp.error_message)
-            self._instance = PublicArtifact.from_id(resp.artifact_id, self._api.client)
+            instance = PublicArtifact.from_id(resp.artifact_id, self._api.client)
+            assert instance is not None
+            self._instance = instance
         assert isinstance(
             self._instance, ArtifactInterface
         ), "Insufficient permissions to fetch Artifact with id {} from {}".format(
@@ -133,13 +135,13 @@ class LazyArtifact(ArtifactInterface):
     def used_by(self) -> List["wandb.apis.public.Run"]:
         return self._instance.used_by()
 
-    def logged_by(self) -> "wandb.apis.public.Run":
+    def logged_by(self) -> Optional["wandb.apis.public.Run"]:
         return self._instance.logged_by()
 
     def get_path(self, name: StrPath) -> "ArtifactManifestEntry":
         return self._instance.get_path(name)
 
-    def get(self, name: str) -> "WBValue":
+    def get(self, name: str) -> Optional["WBValue"]:
         return self._instance.get(name)
 
     def download(
@@ -150,11 +152,11 @@ class LazyArtifact(ArtifactInterface):
     def checkout(self, root: Optional[str] = None) -> str:
         return self._instance.checkout(root)
 
-    def verify(self, root: Optional[str] = None) -> Any:
-        return self._instance.verify(root)
+    def verify(self, root: Optional[str] = None) -> None:
+        self._instance.verify(root)
 
     def save(self) -> None:
         self._instance.save()
 
-    def delete(self) -> None:
-        self._instance.delete()
+    def delete(self, delete_aliases: bool = False) -> None:
+        self._instance.delete(delete_aliases=delete_aliases)

--- a/wandb/sdk/artifacts/local_artifact.py
+++ b/wandb/sdk/artifacts/local_artifact.py
@@ -340,7 +340,7 @@ class Artifact(ArtifactInterface):
 
         raise ArtifactNotLoggedError(self, "used_by")
 
-    def logged_by(self) -> "wandb.apis.public.Run":
+    def logged_by(self) -> Optional["wandb.apis.public.Run"]:
         if self._logged_artifact:
             return self._logged_artifact.logged_by()
 
@@ -568,7 +568,7 @@ class Artifact(ArtifactInterface):
 
         raise ArtifactNotLoggedError(self, "get_path")
 
-    def get(self, name: str) -> data_types.WBValue:
+    def get(self, name: str) -> Optional[data_types.WBValue]:
         if self._logged_artifact:
             return self._logged_artifact.get(name)
 
@@ -588,7 +588,7 @@ class Artifact(ArtifactInterface):
 
         raise ArtifactNotLoggedError(self, "checkout")
 
-    def verify(self, root: Optional[str] = None) -> bool:
+    def verify(self, root: Optional[str] = None) -> None:
         if self._logged_artifact:
             return self._logged_artifact.verify(root=root)
 
@@ -635,9 +635,9 @@ class Artifact(ArtifactInterface):
             else:
                 wandb.run.log_artifact(self)
 
-    def delete(self) -> None:
+    def delete(self, delete_aliases: bool = False) -> None:
         if self._logged_artifact:
-            return self._logged_artifact.delete()
+            return self._logged_artifact.delete(delete_aliases=delete_aliases)
 
         raise ArtifactNotLoggedError(self, "delete")
 

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -106,7 +106,7 @@ class WandbStoragePolicy(StoragePolicy):
         self,
         artifact: "ArtifactInterface",
         manifest_entry: "ArtifactManifestEntry",
-    ) -> str:
+    ) -> FilePathStr:
         path, hit, cache_open = self._cache.check_md5_obj_path(
             B64MD5(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
@@ -142,7 +142,7 @@ class WandbStoragePolicy(StoragePolicy):
         self,
         manifest_entry: "ArtifactManifestEntry",
         local: bool = False,
-    ) -> str:
+    ) -> Union[FilePathStr, URIStr]:
         return self._handler.load_path(manifest_entry, local)
 
     def _file_url(

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -31,7 +31,7 @@ class StoragePolicy:
 
     def load_file(
         self, artifact: "ArtifactInterface", manifest_entry: "ArtifactManifestEntry"
-    ) -> str:
+    ) -> FilePathStr:
         raise NotImplementedError
 
     def store_file_sync(
@@ -69,5 +69,5 @@ class StoragePolicy:
         self,
         manifest_entry: "ArtifactManifestEntry",
         local: bool = False,
-    ) -> str:
+    ) -> Union[FilePathStr, URIStr]:
         raise NotImplementedError

--- a/wandb/sdk/data_types/helper_types/classes.py
+++ b/wandb/sdk/data_types/helper_types/classes.py
@@ -148,6 +148,7 @@ class _ClassesIdType(_dtypes.Type):
                 classes_obj = artifact.get(
                     json_dict.get("params", {}).get("classes_obj", {}).get("path")
                 )
+                assert classes_obj is None or isinstance(classes_obj, Classes)
             else:
                 raise RuntimeError("Expected artifact to be non-null.")
         else:

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -311,9 +311,11 @@ class Image(BatchableMedia):
     def from_json(
         cls: Type["Image"], json_obj: dict, source_artifact: "PublicArtifact"
     ) -> "Image":
-        classes = None
+        classes: Optional[Classes] = None
         if json_obj.get("classes") is not None:
-            classes = source_artifact.get(json_obj["classes"]["path"])
+            value = source_artifact.get(json_obj["classes"]["path"])
+            assert isinstance(value, (type(None), Classes))
+            classes = value
 
         masks = json_obj.get("masks")
         _masks: Optional[Dict[str, ImageMask]] = None

--- a/wandb/sdk/data_types/saved_model.py
+++ b/wandb/sdk/data_types/saved_model.py
@@ -133,7 +133,7 @@ class _SavedModel(WBValue, Generic[SavedModelObjType]):
         # First, if the entry is a file, the download it.
         entry = source_artifact.manifest.entries.get(path)
         if entry is not None:
-            dl_path = source_artifact.get_path(path).download()
+            dl_path = str(source_artifact.get_path(path).download())
         else:
             # If not, assume it is directory.
             # FUTURE: Add this functionality to the artifact loader


### PR DESCRIPTION
Fixes WB-13437

# Description

Type checking is disabled under `wandb/apis/`. I moved code from there in https://github.com/wandb/wandb/pull/5534. In this PR, I added missing type annotations and enabled type checking for the code I moved.

# Test plan

mypy in CI