### PR TITLE
refactor(artifacts): replace _cache_opener with safe_open/safe_copy

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -15,6 +15,7 @@ import wandb.data_types as data_types
 import wandb.sdk.interface as wandb_interface
 from wandb import util, wandb_sdk
 from wandb.sdk import wandb_artifacts
+from wandb.sdk.lib import filesystem
 from wandb.sdk.lib.hashutil import md5_string
 from wandb.sdk.wandb_artifacts import (
     ArtifactFinalizedError,
@@ -1294,8 +1295,8 @@ def test_s3_storage_handler_load_path_uses_cache(tmp_path):
     etag = "some etag"
 
     cache = wandb_artifacts.ArtifactsCache(tmp_path)
-    path, _, opener = cache.check_etag_obj_path(uri, etag, 123)
-    with opener() as f:
+    path, _, _ = cache.check_etag_obj_path(uri, etag, 123)
+    with filesystem.safe_open(path, "w") as f:
         f.write(123 * "a")
 
     handler = wandb_artifacts.S3Handler()

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -1295,7 +1295,7 @@ def test_s3_storage_handler_load_path_uses_cache(tmp_path):
     etag = "some etag"
 
     cache = wandb_artifacts.ArtifactsCache(tmp_path)
-    path, _, _ = cache.check_etag_obj_path(uri, etag, 123)
+    path, _ = cache.check_etag_obj_path(uri, etag, 123)
     with filesystem.safe_open(path, "w") as f:
         f.write(123 * "a")
 
@@ -1383,7 +1383,7 @@ def test_cache_cleanup_allows_upload(wandb_init, tmp_path, monkeypatch):
         artifact.wait()
 
     manifest_entry = artifact.manifest.entries["test-file"]
-    _, found, _ = cache.check_md5_obj_path(manifest_entry.digest, 2**20)
+    _, found = cache.check_md5_obj_path(manifest_entry.digest, 2**20)
 
     # Now the file should be in the cache.
     # Even though this works in production, the test often fails. I don't know why :(.

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -14,7 +14,7 @@ from wandb.sdk.lib import filesystem
 
 def test_check_md5_obj_path(cache):
     md5 = base64.b64encode(b"abcdef")
-    path, exists, _ = cache.check_md5_obj_path(md5, 10)
+    path, exists = cache.check_md5_obj_path(md5, 10)
     expected_path = os.path.join(cache._cache_dir, "obj", "md5", "61", "6263646566")
 
     with filesystem.safe_open(path, "w") as f:
@@ -29,36 +29,36 @@ def test_check_md5_obj_path(cache):
 
 def test_check_etag_obj_path_returns_exists_if_exists(cache):
     size = 123
-    path, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    path, exists = cache.check_etag_obj_path("http://my/url", "abc", size)
     assert not exists
 
     with filesystem.safe_open(path, "w") as f:
         f.write(size * "a")
 
-    _, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    _, exists = cache.check_etag_obj_path("http://my/url", "abc", size)
     assert exists
 
 
 def test_check_etag_obj_path_returns_not_exists_if_incomplete(cache):
     size = 123
-    path, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    path, exists = cache.check_etag_obj_path("http://my/url", "abc", size)
     assert not exists
 
     with filesystem.safe_open(path, "w") as f:
         f.write((size - 1) * "a")
 
-    _, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    _, exists = cache.check_etag_obj_path("http://my/url", "abc", size)
     assert not exists
 
     with filesystem.safe_open(path, "w") as f:
         f.write(size * "a")
 
-    _, exists, _ = cache.check_etag_obj_path("http://my/url", "abc", size)
+    _, exists = cache.check_etag_obj_path("http://my/url", "abc", size)
     assert exists
 
 
 def test_check_etag_obj_path_does_not_include_etag(cache):
-    path, _, _ = cache.check_etag_obj_path("http://url/1", "abcdef", 10)
+    path, _ = cache.check_etag_obj_path("http://url/1", "abcdef", 10)
     assert "abcdef" not in path
 
 
@@ -73,8 +73,8 @@ def test_check_etag_obj_path_does_not_include_etag(cache):
 def test_check_etag_obj_path_hashes_url_and_etag(
     url1, url2, etag1, etag2, path_equal, cache
 ):
-    path_1, _, _ = cache.check_etag_obj_path(url1, etag1, 10)
-    path_2, _, _ = cache.check_etag_obj_path(url2, etag2, 10)
+    path_1, _ = cache.check_etag_obj_path(url1, etag1, 10)
+    path_2, _ = cache.check_etag_obj_path(url2, etag2, 10)
 
     if path_equal:
         assert path_1 == path_2
@@ -161,7 +161,7 @@ def test_local_file_handler_load_path_uses_cache(cache, tmp_path):
     uri = file.as_uri()
     digest = "XUFAKrxLKna5cZ2REBfFkg=="
 
-    path, _, _ = cache.check_md5_obj_path(b64_md5=digest, size=123)
+    path, _ = cache.check_md5_obj_path(b64_md5=digest, size=123)
     with filesystem.safe_open(path, "w") as f:
         f.write(123 * "a")
 
@@ -184,7 +184,7 @@ def test_s3_storage_handler_load_path_uses_cache(cache):
     uri = "s3://some-bucket/path/to/file.json"
     etag = "some etag"
 
-    path, _, _ = cache.check_etag_obj_path(uri, etag, 123)
+    path, _ = cache.check_etag_obj_path(uri, etag, 123)
     with filesystem.safe_open(path, "w") as f:
         f.write(123 * "a")
 
@@ -224,7 +224,7 @@ def test_gcs_storage_handler_load_path_uses_cache(cache):
     uri = "gs://some-bucket/path/to/file.json"
     etag = "some etag"
 
-    path, _, _ = cache.check_md5_obj_path(etag, 123)
+    path, _ = cache.check_md5_obj_path(etag, 123)
     with filesystem.safe_open(path, "w") as f:
         f.write(123 * "a")
 

--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -62,7 +62,7 @@ def some_file(tmp_path: Path) -> Path:
 
 
 def is_cache_hit(cache: ArtifactsCache, digest: str, size: int) -> bool:
-    _, hit, _ = cache.check_md5_obj_path(digest, size)
+    _, hit = cache.check_md5_obj_path(digest, size)
     return hit
 
 

--- a/wandb/sdk/interface/artifacts/artifact_cache.py
+++ b/wandb/sdk/interface/artifacts/artifact_cache.py
@@ -28,10 +28,8 @@ class ArtifactsCache:
     ) -> Tuple[FilePathStr, bool]:
         hex_md5 = b64_to_hex_id(b64_md5)
         path = os.path.join(self._cache_dir, "obj", "md5", hex_md5[:2], hex_md5[2:])
-        if os.path.isfile(path) and os.path.getsize(path) == size:
-            return FilePathStr(path), True
-        mkdir_exists_ok(os.path.dirname(path))
-        return FilePathStr(path), False
+        hit = os.path.isfile(path) and os.path.getsize(path) == size
+        return FilePathStr(path), hit
 
     # TODO(spencerpearson): this method at least needs its signature changed.
     # An ETag is not (necessarily) a checksum.
@@ -46,10 +44,8 @@ class ArtifactsCache:
             + hashlib.sha256(etag.encode("utf-8")).digest()
         ).hexdigest()
         path = os.path.join(self._cache_dir, "obj", "etag", hexhash[:2], hexhash[2:])
-        if os.path.isfile(path) and os.path.getsize(path) == size:
-            return FilePathStr(path), True
-        mkdir_exists_ok(os.path.dirname(path))
-        return FilePathStr(path), False
+        hit = os.path.isfile(path) and os.path.getsize(path) == size
+        return FilePathStr(path), hit
 
     def get_artifact(self, artifact_id: str) -> Optional["Artifact"]:
         return self._artifacts_by_id.get(artifact_id)

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -892,7 +892,7 @@ class WandbStoragePolicy(StoragePolicy):
         artifact: ArtifactInterface,
         manifest_entry: ArtifactManifestEntry,
     ) -> str:
-        path, hit, _ = self._cache.check_md5_obj_path(
+        path, hit = self._cache.check_md5_obj_path(
             B64MD5(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
         )
@@ -1142,7 +1142,7 @@ class WandbStoragePolicy(StoragePolicy):
             return
 
         # Cache upon successful upload.
-        path, hit, _ = self._cache.check_md5_obj_path(
+        path, hit = self._cache.check_md5_obj_path(
             B64MD5(entry.digest),
             entry.size if entry.size is not None else 0,
         )
@@ -1325,7 +1325,7 @@ class LocalFileHandler(StorageHandler):
                 "Local file reference: Failed to find file at path %s" % local_path
             )
 
-        path, hit, _ = self._cache.check_md5_obj_path(
+        path, hit = self._cache.check_md5_obj_path(
             B64MD5(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
         )
@@ -1471,7 +1471,7 @@ class S3Handler(StorageHandler):
 
         assert manifest_entry.ref is not None
 
-        path, hit, _ = self._cache.check_etag_obj_path(
+        path, hit = self._cache.check_etag_obj_path(
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
@@ -1728,7 +1728,7 @@ class GCSHandler(StorageHandler):
             assert manifest_entry.ref is not None
             return manifest_entry.ref
 
-        path, hit, _ = self._cache.check_md5_obj_path(
+        path, hit = self._cache.check_md5_obj_path(
             B64MD5(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
         )
@@ -2070,7 +2070,7 @@ class HTTPHandler(StorageHandler):
 
         assert manifest_entry.ref is not None
 
-        path, hit, _ = self._cache.check_etag_obj_path(
+        path, hit = self._cache.check_etag_obj_path(
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,


### PR DESCRIPTION
Description
-----------
Use `filesystem.safe_copy` and `filesystem.safe_open` to replace the `ArtifactsCache._cache_opener` object that otherwise get returned.

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 62a428f</samp>

> _`cache_open` gone_
> _safe file operations now_
> _autumn of wandb_