### PR TITLE
feat(artifacts): don't remove temp files from artifacts cache by default

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1949,11 +1949,12 @@ def cache():
     help="Clean up less frequently used files from the artifacts cache",
 )
 @click.argument("target_size")
+@click.option("--remove-temp/--no-remove-temp", default=False, help="Remove temp files")
 @display_error
-def cleanup(target_size):
+def cleanup(target_size, remove_temp):
     target_size = util.from_human_size(target_size)
     cache = wandb_sdk.wandb_artifacts.get_artifacts_cache()
-    reclaimed_bytes = cache.cleanup(target_size)
+    reclaimed_bytes = cache.cleanup(target_size, remove_temp)
     print(f"Reclaimed {util.to_human_size(reclaimed_bytes)} of space")
 
 

--- a/wandb/sdk/interface/artifacts/artifact_cache.py
+++ b/wandb/sdk/interface/artifacts/artifact_cache.py
@@ -107,7 +107,7 @@ class ArtifactsCache:
 
         if temp_size:
             termwarn(
-                f"Cache contains {util.to_human_size(temp_size)} of temporary files."
+                f"Cache contains {util.to_human_size(temp_size)} of temporary files. "
                 "Run `wandb artifact cleanup --remove-temp` to remove them."
             )
 

--- a/wandb/sdk/interface/artifacts/artifact_cache.py
+++ b/wandb/sdk/interface/artifacts/artifact_cache.py
@@ -82,7 +82,7 @@ class ArtifactsCache:
     def store_client_artifact(self, artifact: "wandb_artifacts.Artifact") -> None:
         self._artifacts_by_client_id[artifact._client_id] = artifact
 
-    def cleanup(self, target_size: int, remove_temp=False) -> int:
+    def cleanup(self, target_size: int, remove_temp: bool = False) -> int:
         bytes_reclaimed = 0
         paths = {}
         total_size = 0

--- a/wandb/sdk/interface/artifacts/artifact_cache.py
+++ b/wandb/sdk/interface/artifacts/artifact_cache.py
@@ -4,7 +4,7 @@ import os
 import secrets
 from typing import IO, TYPE_CHECKING, ContextManager, Dict, Generator, Optional, Tuple
 
-from wandb import env, util
+from wandb import env, termwarn, util
 from wandb.sdk.interface.artifacts import Artifact, ArtifactNotLoggedError
 from wandb.sdk.lib.filesystem import mkdir_exists_ok
 from wandb.sdk.lib.hashutil import B64MD5, ETag, b64_to_hex_id
@@ -82,10 +82,11 @@ class ArtifactsCache:
     def store_client_artifact(self, artifact: "wandb_artifacts.Artifact") -> None:
         self._artifacts_by_client_id[artifact._client_id] = artifact
 
-    def cleanup(self, target_size: int) -> int:
+    def cleanup(self, target_size: int, remove_temp=False) -> int:
         bytes_reclaimed = 0
         paths = {}
         total_size = 0
+        temp_size = 0
         for root, _, files in os.walk(self._cache_dir):
             for file in files:
                 try:
@@ -93,13 +94,22 @@ class ArtifactsCache:
                     stat = os.stat(path)
 
                     if file.startswith(ArtifactsCache._TMP_PREFIX):
-                        os.remove(path)
-                        bytes_reclaimed += stat.st_size
+                        if remove_temp:
+                            os.remove(path)
+                            bytes_reclaimed += stat.st_size
+                        else:
+                            temp_size += stat.st_size
                         continue
                 except OSError:
                     continue
                 paths[path] = stat
                 total_size += stat.st_size
+
+        if temp_size:
+            termwarn(
+                f"Cache contains {util.to_human_size(temp_size)} of temporary files."
+                "Run `wandb artifact cleanup --remove-temp` to remove them."
+            )
 
         sorted_paths = sorted(paths.items(), key=lambda x: x[1].st_atime)
         for path, stat in sorted_paths:


### PR DESCRIPTION
Fixes
-----
Maybe fixes [WB-13769](https://wandb.atlassian.net/browse/WB-13769)

Description
-----------
- Require a `remove_temp=True` flag to `cache.cleanup()` to delete temp files.
- Add a term warning if there are temp files taking up space in the cache
- Add a CLI flag for forcing the delete of these temp files

Context: Under normal circumstances temp files in the cache are in use; only if runs crash after the cache write has started but before it completes should garbage be left, so deleting temp files by default is probably more dangerous than helpful.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b8a1bc</samp>

> _Oh, we're the crew of the CLI ship_
> _And we sail the code with skill and wit_
> _We clean up the cache with the `--remove-temp` flag_
> _And we warn of the files that make it drag_

[WB-13769]: https://wandb.atlassian.net/browse/WB-13769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ