### PR TITLE
fix(artifacts): write to the cache defensively (catch OSError)

### DIFF
--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -462,12 +462,12 @@ def test_invalid_artifact_type(type):
         Artifact("foo", type=type)
 
 
-def test_cache_write_failure_is_ignored(api, monkeypatch, capsys):
+def test_cache_write_failure_is_ignored(monkeypatch, capsys):
     def bad_write(*args, **kwargs):
         raise FileNotFoundError("unable to copy from source file")
 
     monkeypatch.setattr(shutil, "copyfile", bad_write)
-    policy = WandbStoragePolicy(api=api)
+    policy = WandbStoragePolicy()
     path = Path("foo.txt")
     path.write_text("hello")
 

--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -473,7 +473,7 @@ def test_cache_write_failure_is_ignored(monkeypatch, capsys):
 
     entry = ArtifactManifestEntry(
         path=str(path),
-        digest="abc123",
+        digest="NWQ0MTQwMmFiYzRiMmE3NmI5NzE5ZDkxMTAxN2M1OTI=",
         local_path=str(path),
         size=path.stat().st_size,
     )

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1147,8 +1147,11 @@ class WandbStoragePolicy(StoragePolicy):
             entry.size if entry.size is not None else 0,
         )
         if not hit:
-            with cache_open() as f:
-                shutil.copyfile(entry.local_path, f.name)
+            try:
+                with cache_open() as f:
+                    shutil.copyfile(entry.local_path, f.name)
+            except OSError as e:
+                termwarn(f"Failed to cache {entry.local_path}, ignoring {e}")
 
 
 # Don't use this yet!


### PR DESCRIPTION
Fixes
-----
Fixes [WB-13769](https://wandb.atlassian.net/browse/WB-13769)

Description
-----------
Catch OSError when writing into the cache (failure to cache shouldn't be a critical error); issue a warning but ignore the error.

Testing
-------
Adds a unit test to check behavior.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fbed597</samp>

> _To copy files to the cache_
> _The `_write_cache` method may crash_
> _But it catches `OSError`_
> _And logs a warning there_
> _So the cache policy won't be trashed_

[WB-13769]: https://wandb.atlassian.net/browse/WB-13769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ