### PR TITLE
Don't set auth if its being overridden

### DIFF
--- a/tests/standalone_tests/table_mem_test.py
+++ b/tests/standalone_tests/table_mem_test.py
@@ -3,11 +3,11 @@ import time
 
 import numpy as np
 import wandb
-from memory_profiler import profile
+#from memory_profiler import profile
 
 
 # todo: yea seems to swallow memory_profiler.profile's output
-@profile
+#@profile
 def main(count: int, size=(32, 32, 3)) -> wandb.Table:
     table = wandb.Table(columns=["img_1", "img_2", "img_3"])
     for _ in range(count):
@@ -20,7 +20,7 @@ def main(count: int, size=(32, 32, 3)) -> wandb.Table:
 if __name__ == "__main__":
     run = wandb.init(name=pathlib.Path(__file__).stem)
     for c in range(4):
-        cnt = 2 * (10**c)
+        cnt = 10 #2 * (10**c)
         start = time.time()
         print(f"Starting count {cnt}")
         t = main(cnt, (32, 32, 3))

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -336,12 +336,15 @@ class FileStreamApi:
         self._client = requests.Session()
         # todo: actually use the timeout once more thorough error injection in testing covers it
         # self._client.post = functools.partial(self._client.post, timeout=self.HTTP_TIMEOUT)
-        self._client.auth = ("api", api.api_key or "")
+        extra_headers = self._settings._extra_http_headers or {}
+        if not extra_headers.get("Authorization"):
+            self._client.auth = ("api", api.api_key or "")
         self._client.headers.update(
             {
                 "User-Agent": api.user_agent,
                 "X-WANDB-USERNAME": env.get_username() or "",
                 "X-WANDB-USER-EMAIL": env.get_user_email() or "",
+                **extra_headers,
             }
         )
         self._file_policies: Dict[str, "DefaultFilePolicy"] = {}

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -228,6 +228,7 @@ class Api:
         ) or wandb.sdk.wandb_settings._str_as_json(
             self._environ.get("WANDB__EXTRA_HTTP_HEADERS", {})
         )
+        auth_override = extra_http_headers.get("Authorization")
 
         self.client = Client(
             transport=GraphQLSession(
@@ -241,7 +242,7 @@ class Api:
                 # this timeout won't apply when the DNS lookup fails. in that case, it will be 60s
                 # https://bugs.python.org/issue22889
                 timeout=self.HTTP_TIMEOUT,
-                auth=("api", self.api_key or ""),
+                auth=("api", self.api_key or "") if auth_override is None else None,
                 url=f"{self.settings('base_url')}/graphql",
             )
         )


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
This respects Authorization in extra headers over our own auth.


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


copilot:poem