### PR TITLE
fix(launch): read kaniko pod sa name from env var

### DIFF
--- a/wandb/sdk/launch/builder/kaniko_builder.py
+++ b/wandb/sdk/launch/builder/kaniko_builder.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import os
 import tarfile
 import tempfile
 import time
@@ -46,6 +47,8 @@ from kubernetes import client  # noqa: E402
 _logger = logging.getLogger(__name__)
 
 _DEFAULT_BUILD_TIMEOUT_SECS = 1800  # 30 minute build timeout
+
+SERVICE_ACCOUNT_NAME = os.environ.get("WANDB_LAUNCH_SERVICE_ACCOUNT_NAME", "default")
 
 
 def _wait_for_completion(
@@ -404,6 +407,7 @@ class KanikoBuilder(AbstractBuilder):
                 active_deadline_seconds=_DEFAULT_BUILD_TIMEOUT_SECS,
                 containers=[container],
                 volumes=volumes,
+                service_account_name=SERVICE_ACCOUNT_NAME,
             ),
         )
         # Create the specification of job


### PR DESCRIPTION
Fixes
-----

Fixes WB-13765

Fixes #NNNN

Description
-----------
What does the PR do?

Configure kaniko pod to use the service account whose name is set in the WANDB_LAUNCH_SERVICE_ACCOUNT_NAME environment variable. This variable is set automatically to the name of the service account used by the launch agent in k8s deployments in our helm chart as of https://github.com/wandb/helm-charts/pull/8

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2bf3d00</samp>

### Summary
🚀🔧🛠️

<!--
1.  🚀 This emoji represents the new feature of allowing users to customize the service account for kaniko pods, which can enable them to use different permissions or credentials for building and pushing images.
2.  🔧 This emoji represents the configuration aspect of this feature, as users can set an environment variable to specify the service account name they want to use.
3.  🛠️ This emoji represents the improvement or enhancement of the wandb launch functionality, as users can now have more control and flexibility over how their images are built and pushed.
-->
Add custom service account support for kaniko pods in wandb launch. This allows users to specify the `WANDB_LAUNCH_SERVICE_ACCOUNT_NAME` environment variable or use a default value to control the permissions of the kaniko pods that build docker images from `wandb/sdk/launch/builder/kaniko_builder.py`.

> _To launch kaniko pods with wandb_
> _You can customize the service account_
> _Just set the env var `WANDB_LAUNCH_SERVICE_ACCOUNT_NAME`_
> _Or use the default if it's the same_
> _This pull request adds this feature to the branch_

### Walkthrough
* Import `os` module to access environment variables ([link](https://github.com/wandb/wandb/pull/5619/files?diff=unified&w=0#diff-3509017a43bb64af7d243649fa8cac7ce8c82737137b1005885cd04d07c2230bR4))
* Define `SERVICE_ACCOUNT_NAME` constant to store the name of the Kubernetes service account for the kaniko job ([link](https://github.com/wandb/wandb/pull/5619/files?diff=unified&w=0#diff-3509017a43bb64af7d243649fa8cac7ce8c82737137b1005885cd04d07c2230bL50-R53))
* Set `service_account_name` parameter for the kaniko pod spec to `SERVICE_ACCOUNT_NAME` ([link](https://github.com/wandb/wandb/pull/5619/files?diff=unified&w=0#diff-3509017a43bb64af7d243649fa8cac7ce8c82737137b1005885cd04d07c2230bR410))



Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2bf3d00</samp>

> _To launch kaniko pods with wandb_
> _You can customize the service account_
> _Just set the env var `WANDB_LAUNCH_SERVICE_ACCOUNT_NAME`_
> _Or use the default if it's the same_
> _This pull request adds this feature to the branch_