### PR TITLE
fix(launch): misc gcp fixes

### DIFF
--- a/wandb/sdk/launch/environment/gcp_environment.py
+++ b/wandb/sdk/launch/environment/gcp_environment.py
@@ -202,7 +202,7 @@ class GcpEnvironment(AbstractEnvironment):
             storage_client = google.cloud.storage.Client(
                 credentials=self.get_credentials()
             )
-            bucket = storage_client.post_bucket(bucket)
+            bucket = storage_client.get_bucket(bucket)
         except google.api_core.exceptions.NotFound as e:
             raise LaunchError(f"Bucket {bucket} does not exist.") from e
 
@@ -266,6 +266,4 @@ class GcpEnvironment(AbstractEnvironment):
                     blob = bucket.blob(gcs_path)
                     blob.upload_from_filename(local_path)
         except google.api_core.exceptions.GoogleAPICallError as e:
-            raise LaunchError(f"Could not upload directory to GCS: {e}") from e
-            raise LaunchError(f"Could not upload directory to GCS: {e}") from e
             raise LaunchError(f"Could not upload directory to GCS: {e}") from e

--- a/wandb/sdk/launch/registry/google_artifact_registry.py
+++ b/wandb/sdk/launch/registry/google_artifact_registry.py
@@ -99,7 +99,7 @@ class GoogleArtifactRegistry(AbstractRegistry):
         Arguments:
             config: A dictionary containing the following keys:
                 repository: The repository name.
-                image_name: The image name.
+                image-name: The image name.
             environment: A GcpEnvironment configured for access to this registry.
 
         Returns:
@@ -110,7 +110,7 @@ class GoogleArtifactRegistry(AbstractRegistry):
             raise LaunchError(
                 "The Google Artifact Registry repository must be specified."
             )
-        image_name = config.get("image_name")
+        image_name = config.get("image-name")
         if not image_name:
             raise LaunchError("The image name must be specified.")
         return cls(repository, image_name, environment, verify=verify)
@@ -182,22 +182,19 @@ class GoogleArtifactRegistry(AbstractRegistry):
         _logger.info(
             f"Checking if image {image_uri} exists. In Google Artifact Registry {self.uri}."
         )
-
-        return False
-        # TODO: Test GCP Artifact Registry image exists to get working
-        # repo_uri, _ = image_uri.split(":")
-        # if repo_uri != self.get_repo_uri():
-        #     raise LaunchError(
-        #         f"The image {image_uri} does not belong to the Google Artifact "
-        #         f"Repository {self.get_repo_uri()}."
-        #     )
-        # credentials = self.environment.get_credentials()
-        # request = google.cloud.artifactregistry.GetTagRequest(parent=image_uri)
-        # client = google.cloud.artifactregistry.ArtifactRegistryClient(
-        #     credentials=credentials
-        # )
-        # try:
-        #     client.get_tag(request=request)
-        #     return True
-        # except google.api_core.exceptions.NotFound:
-        #     return False
+        repo_uri, _ = image_uri.split(":")
+        if repo_uri != self.get_repo_uri():
+            raise LaunchError(
+                f"The image {image_uri} does not belong to the Google Artifact "
+                f"Repository {self.get_repo_uri()}."
+            )
+        credentials = self.environment.get_credentials()
+        request = google.cloud.artifactregistry.GetTagRequest(parent=image_uri)
+        client = google.cloud.artifactregistry.ArtifactRegistryClient(
+            credentials=credentials
+        )
+        try:
+            client.get_tag(request=request)
+            return True
+        except google.api_core.exceptions.NotFound:
+            return False


### PR DESCRIPTION
post_bucket doesn't exist in every version just using get_bucket

- vs _ mismatch against docs corrected in a config key

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 45c4114</samp>

### Summary
🐛🚫🖼️

<!--
1.  🐛 for fixing a bug in the `verify_storage_uri` function
2.  🚫 for removing a duplicated line of code that raises a `LaunchError`
3.  🖼️ for fixing the image name key and adding the image existence check in the `GoogleArtifactRegistry` class
-->
This pull request fixes some bugs and adds some features in the `wandb/sdk/launch` modules related to launching runs on Google Cloud Platform. It improves the `gcp_environment.py` and `google_artifact_registry.py` files to handle storage URIs, image names, and image existence checks more robustly and correctly.

> _Oh we're the coders of the cloud, and we work both hard and proud_
> _We fix the bugs and add the features, to make our modules shine_
> _We heave away on `verify_storage_uri`, and we pull the `LaunchError` line_
> _And we check the image name in the `GoogleArtifactRegistry`, on the count of three_

### Walkthrough
* Fix a typo in the `verify_storage_uri` function that used the wrong method to check if a bucket exists ([link](https://github.com/wandb/wandb/pull/5626/files?diff=unified&w=0#diff-1ac507743c7f5aaa35e85fa08eed6b3032fb25a166fa7f270f1855fc5cad6af2L205-R205))
* Remove a duplicated line of code that raised an error if the directory upload to GCS failed ([link](https://github.com/wandb/wandb/pull/5626/files?diff=unified&w=0#diff-1ac507743c7f5aaa35e85fa08eed6b3032fb25a166fa7f270f1855fc5cad6af2L270-L271))
* Update the docstring and the key name for the image name in the `from_config` function of the `GoogleArtifactRegistry` class to match the naming convention used in other parts of the code ([link](https://github.com/wandb/wandb/pull/5626/files?diff=unified&w=0#diff-e48f9a73317248f64c1316ead0a9b85822be710a1a737674e3182c55d510f357L102-R102), [link](https://github.com/wandb/wandb/pull/5626/files?diff=unified&w=0#diff-e48f9a73317248f64c1316ead0a9b85822be710a1a737674e3182c55d510f357L113-R113))
* Enable the functionality of checking if an image exists in the Google Artifact Registry using the `google.cloud.artifactregistry` module and the `get_tag` method ([link](https://github.com/wandb/wandb/pull/5626/files?diff=unified&w=0#diff-e48f9a73317248f64c1316ead0a9b85822be710a1a737674e3182c55d510f357L185-R200))



Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
What does the PR do?


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 45c4114</samp>

> _Oh we're the coders of the cloud, and we work both hard and proud_
> _We fix the bugs and add the features, to make our modules shine_
> _We heave away on `verify_storage_uri`, and we pull the `LaunchError` line_
> _And we check the image name in the `GoogleArtifactRegistry`, on the count of three_