### PR TITLE
refactor(sdk): add thread local api settings for authentication

### DIFF
--- a/tests/pytest_tests/unit_tests/test_public_api.py
+++ b/tests/pytest_tests/unit_tests/test_public_api.py
@@ -4,11 +4,30 @@ import pytest
 import wandb
 from wandb import Api
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
+from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 
 
 def test_api_auto_login_no_tty():
     with pytest.raises(wandb.UsageError):
         Api()
+
+
+def test_thread_local_cookies():
+    try:
+        _thread_local_api_settings.cookies = {"foo": "bar"}
+        api = Api()
+        assert api._base_client.transport.cookies == {"foo": "bar"}
+    finally:
+        _thread_local_api_settings.cookies = None
+
+
+def test_thread_local_api_key():
+    try:
+        _thread_local_api_settings.api_key = "XXXX"
+        api = Api()
+        assert api.api_key == "XXXX"
+    finally:
+        _thread_local_api_settings.api_key = None
 
 
 @pytest.mark.usefixtures("patch_apikey", "patch_prompt")

--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -105,6 +105,14 @@ def mock_preparer(**kwargs):
     return Mock(**kwargs)
 
 
+def test_capped_cache(artifact_cache):
+    for i in range(51):
+        art = Artifact(f"foo-{i}", type="test")
+        art._logged_artifact = Mock(id=f"foo-{i}")
+        artifact_cache.store_artifact(art)
+    assert len(artifact_cache._artifacts_by_id) == 50
+
+
 class TestStoreFile:
     @staticmethod
     def _fixture_kwargs_to_kwargs(

--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -105,12 +105,12 @@ def mock_preparer(**kwargs):
     return Mock(**kwargs)
 
 
-def test_capped_cache(artifact_cache):
+def test_capped_cache(artifacts_cache):
     for i in range(51):
         art = Artifact(f"foo-{i}", type="test")
         art._logged_artifact = Mock(id=f"foo-{i}")
-        artifact_cache.store_artifact(art)
-    assert len(artifact_cache._artifacts_by_id) == 50
+        artifacts_cache.store_artifact(art)
+    assert len(artifacts_cache._artifacts_by_id) == 50
 
 
 class TestStoreFile:

--- a/tests/pytest_tests/unit_tests_old/utils/mock_requests.py
+++ b/tests/pytest_tests/unit_tests_old/utils/mock_requests.py
@@ -92,6 +92,10 @@ class RequestsMock:
         return {}
 
     @property
+    def cookies(self):
+        return {}
+
+    @property
     def __version__(self):
         return requests.__version__
 

--- a/tests/pytest_tests/unit_tests_old/utils/mock_requests.py
+++ b/tests/pytest_tests/unit_tests_old/utils/mock_requests.py
@@ -143,7 +143,7 @@ class RequestsMock:
             del kwargs["location_mode"]
         if "headers" in kwargs:
             # We convert our headers to a dict to avoid requests mocking madness
-            kwargs["headers"] = dict(kwargs["headers"])
+            kwargs["headers"] = dict(kwargs["headers"] or {})
         return kwargs
 
     def _store_request(self, url, body):

--- a/tox.ini
+++ b/tox.ini
@@ -176,7 +176,7 @@ setenv=
     ; Setting low network buffer so that we exercise flow control logic
     WANDB__NETWORK_BUFFER=1000
     COVERAGE_FILE={envdir}/.coverage
-    YEA_WANDB_VERSION=0.9.9
+    YEA_WANDB_VERSION=0.9.10
 passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS

--- a/tox.ini
+++ b/tox.ini
@@ -176,7 +176,7 @@ setenv=
     ; Setting low network buffer so that we exercise flow control logic
     WANDB__NETWORK_BUFFER=1000
     COVERAGE_FILE={envdir}/.coverage
-    YEA_WANDB_VERSION=https://github.com/wandb/yea-wandb/archive/task/weave-compat.zip
+    YEA_WANDB_VERSION=0.9.9
 passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS

--- a/tox.ini
+++ b/tox.ini
@@ -176,7 +176,7 @@ setenv=
     ; Setting low network buffer so that we exercise flow control logic
     WANDB__NETWORK_BUFFER=1000
     COVERAGE_FILE={envdir}/.coverage
-    YEA_WANDB_VERSION=0.9.9
+    YEA_WANDB_VERSION=https://github.com/wandb/yea-wandb/archive/task/weave-compat.zip
 passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS

--- a/wandb/sdk/artifacts/artifacts_cache.py
+++ b/wandb/sdk/artifacts/artifacts_cache.py
@@ -3,7 +3,7 @@ import contextlib
 import hashlib
 import os
 import secrets
-from typing import IO, TYPE_CHECKING, ContextManager, Generator, Optional, Tuple
+from typing import IO, TYPE_CHECKING, ContextManager, Dict, Generator, Optional, Tuple
 
 from wandb import env, termwarn, util
 from wandb.sdk.artifacts.exceptions import ArtifactNotLoggedError
@@ -36,8 +36,8 @@ class ArtifactsCache:
         mkdir_exists_ok(self._cache_dir)
         self._md5_obj_dir = os.path.join(self._cache_dir, "obj", "md5")
         self._etag_obj_dir = os.path.join(self._cache_dir, "obj", "etag")
-        self._artifacts_by_id: CappedDict[str, "ArtifactInterface"] = CappedDict()
-        self._artifacts_by_client_id: CappedDict[str, "LocalArtifact"] = CappedDict()
+        self._artifacts_by_id: Dict[str, "ArtifactInterface"] = CappedDict()
+        self._artifacts_by_client_id: Dict[str, "LocalArtifact"] = CappedDict()
 
     def check_md5_obj_path(
         self, b64_md5: B64MD5, size: int

--- a/wandb/sdk/artifacts/artifacts_cache.py
+++ b/wandb/sdk/artifacts/artifacts_cache.py
@@ -3,10 +3,11 @@ import contextlib
 import hashlib
 import os
 import secrets
-from typing import IO, TYPE_CHECKING, ContextManager, Dict, Generator, Optional, Tuple
+from typing import IO, TYPE_CHECKING, ContextManager, Generator, Optional, Tuple
 
 from wandb import env, termwarn, util
 from wandb.sdk.artifacts.exceptions import ArtifactNotLoggedError
+from wandb.sdk.lib.capped_dict import CappedDict
 from wandb.sdk.lib.filesystem import mkdir_exists_ok
 from wandb.sdk.lib.hashutil import B64MD5, ETag, b64_to_hex_id
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
@@ -35,8 +36,8 @@ class ArtifactsCache:
         mkdir_exists_ok(self._cache_dir)
         self._md5_obj_dir = os.path.join(self._cache_dir, "obj", "md5")
         self._etag_obj_dir = os.path.join(self._cache_dir, "obj", "etag")
-        self._artifacts_by_id: Dict[str, "ArtifactInterface"] = {}
-        self._artifacts_by_client_id: Dict[str, "LocalArtifact"] = {}
+        self._artifacts_by_id: CappedDict[str, "ArtifactInterface"] = CappedDict()
+        self._artifacts_by_client_id: CappedDict[str, "LocalArtifact"] = CappedDict()
 
     def check_md5_obj_path(
         self, b64_md5: B64MD5, size: int

--- a/wandb/sdk/artifacts/public_artifact.py
+++ b/wandb/sdk/artifacts/public_artifact.py
@@ -651,13 +651,13 @@ class Artifact(ArtifactInterface):
         download_logger = ArtifactDownloadLogger(nfiles=nfiles)
 
         def _download_file_with_thread_local_api_settings(
-            name,
-            root,
+            name: str,
+            root: str,
             download_logger: ArtifactDownloadLogger,
             tlas_api_key: Optional[str],
             tlas_cookies: Optional[Dict],
             tlas_headers: Optional[Dict],
-        ):
+        ) -> StrPath:
             _thread_local_api_settings.api_key = tlas_api_key
             _thread_local_api_settings.cookies = tlas_cookies
             _thread_local_api_settings.headers = tlas_headers

--- a/wandb/sdk/artifacts/public_artifact.py
+++ b/wandb/sdk/artifacts/public_artifact.py
@@ -37,6 +37,7 @@ from wandb.sdk.artifacts.artifact import Artifact as ArtifactInterface
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
 from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
+from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.lib.hashutil import hex_to_b64_id, md5_file_b64
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath
 
@@ -649,9 +650,30 @@ class Artifact(ArtifactInterface):
 
         download_logger = ArtifactDownloadLogger(nfiles=nfiles)
 
+        def _download_file_with_thread_local_api_settings(
+            name,
+            root,
+            download_logger: ArtifactDownloadLogger,
+            tlas_api_key: Optional[str],
+            tlas_cookies: Optional[Dict],
+            tlas_headers: Optional[Dict],
+        ):
+            _thread_local_api_settings.api_key = tlas_api_key
+            _thread_local_api_settings.cookies = tlas_cookies
+            _thread_local_api_settings.headers = tlas_headers
+
+            return self._download_file(name, root, download_logger)
+
         pool = multiprocessing.dummy.Pool(32)
         pool.map(
-            partial(self._download_file, root=dirpath, download_logger=download_logger),
+            partial(
+                _download_file_with_thread_local_api_settings,
+                root=dirpath,
+                download_logger=download_logger,
+                tlas_api_key=_thread_local_api_settings.api_key,
+                tlas_headers={**(_thread_local_api_settings.headers or {})},
+                tlas_cookies={**(_thread_local_api_settings.cookies or {})},
+            ),
             manifest.entries,
         )
         if recursive:

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -338,7 +338,7 @@ class FileStreamApi:
         # self._client.post = functools.partial(self._client.post, timeout=self.HTTP_TIMEOUT)
         self._client.auth = api.client.transport.session.auth
         self._client.headers.update(api.client.transport.headers or {})
-        self._client.cookies.update(api.client.transport.cookies or {})
+        self._client.cookies.update(api.client.transport.cookies or {})  # type: ignore[no-untyped-call]
         self._file_policies: Dict[str, "DefaultFilePolicy"] = {}
         self._dropped_chunks: int = 0
         self._queue: queue.Queue = queue.Queue()

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -336,14 +336,9 @@ class FileStreamApi:
         self._client = requests.Session()
         # todo: actually use the timeout once more thorough error injection in testing covers it
         # self._client.post = functools.partial(self._client.post, timeout=self.HTTP_TIMEOUT)
-        self._client.auth = ("api", api.api_key or "")
-        self._client.headers.update(
-            {
-                "User-Agent": api.user_agent,
-                "X-WANDB-USERNAME": env.get_username() or "",
-                "X-WANDB-USER-EMAIL": env.get_user_email() or "",
-            }
-        )
+        self._client.auth = api.client.transport.auth
+        self._client.headers.update(api.client.transport.headers or {})
+        self._client.cookies.update(api.client.transport.cookies or {})
         self._file_policies: Dict[str, "DefaultFilePolicy"] = {}
         self._dropped_chunks: int = 0
         self._queue: queue.Queue = queue.Queue()

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -336,7 +336,7 @@ class FileStreamApi:
         self._client = requests.Session()
         # todo: actually use the timeout once more thorough error injection in testing covers it
         # self._client.post = functools.partial(self._client.post, timeout=self.HTTP_TIMEOUT)
-        self._client.auth = api.client.transport.auth
+        self._client.auth = api.client.transport.session.auth
         self._client.headers.update(api.client.transport.headers or {})
         self._client.cookies.update(api.client.transport.cookies or {})
         self._file_policies: Dict[str, "DefaultFilePolicy"] = {}

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -39,6 +39,7 @@ from wandb.apis.normalize import normalize_exceptions, parse_backend_error_messa
 from wandb.errors import CommError, UsageError
 from wandb.integration.sagemaker import parse_sm_secrets
 from wandb.old.settings import Settings
+from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.lib.gql_request import GraphQLSession
 from wandb.sdk.lib.hashutil import B64MD5, md5_file_b64
 
@@ -229,6 +230,10 @@ class Api:
             self._environ.get("WANDB__EXTRA_HTTP_HEADERS", {})
         )
 
+        auth = None
+        if _thread_local_api_settings.cookies is None:
+            auth = ("api", self.api_key)
+        extra_http_headers.update(_thread_local_api_settings.headers or {})
         self.client = Client(
             transport=GraphQLSession(
                 headers={
@@ -241,8 +246,9 @@ class Api:
                 # this timeout won't apply when the DNS lookup fails. in that case, it will be 60s
                 # https://bugs.python.org/issue22889
                 timeout=self.HTTP_TIMEOUT,
-                auth=("api", self.api_key or ""),
+                auth=auth,
                 url=f"{self.settings('base_url')}/graphql",
+                cookies=_thread_local_api_settings.cookies,
             )
         )
 
@@ -336,6 +342,8 @@ class Api:
 
     @property
     def api_key(self) -> Optional[str]:
+        if _thread_local_api_settings.api_key:
+            return _thread_local_api_settings.api_key
         auth = requests.utils.get_netrc_auth(self.api_url)
         key = None
         if auth:
@@ -2021,7 +2029,16 @@ class Api:
         Returns:
             A tuple of the content length and the streaming response
         """
-        response = requests.get(url, auth=("user", self.api_key), stream=True)  # type: ignore
+        auth = None
+        if _thread_local_api_settings.cookies is None:
+            auth = ("user", self.api_key)
+        response = requests.get(
+            url,
+            auth=auth,
+            cookies=_thread_local_api_settings.cookies or {},
+            headers=_thread_local_api_settings.headers or {},
+            stream=True,
+        )
         response.raise_for_status()
         return int(response.headers.get("content-length", 0)), response
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -308,7 +308,7 @@ class Api:
 
     def reauth(self) -> None:
         """Ensure the current api key is set in the transport."""
-        self.client.transport.auth = ("api", self.api_key or "")
+        self.client.transport.session.auth = ("api", self.api_key or "")
 
     def relocate(self) -> None:
         """Ensure the current api points to the right server."""

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -232,7 +232,7 @@ class Api:
 
         auth = None
         if _thread_local_api_settings.cookies is None:
-            auth = ("api", self.api_key)
+            auth = ("api", self.api_key or "")
         extra_http_headers.update(_thread_local_api_settings.headers or {})
         self.client = Client(
             transport=GraphQLSession(
@@ -2031,7 +2031,7 @@ class Api:
         """
         auth = None
         if _thread_local_api_settings.cookies is None:
-            auth = ("user", self.api_key)
+            auth = ("user", self.api_key or "")
         response = requests.get(
             url,
             auth=auth,

--- a/wandb/sdk/internal/thread_local_settings.py
+++ b/wandb/sdk/internal/thread_local_settings.py
@@ -1,0 +1,18 @@
+import threading
+from typing import Dict, Optional
+
+
+# Context variable for setting API settings (api keys, etc.) for internal and public apis thread-locally
+# TODO: move this into actual settings
+class _ThreadLocalApiSettings(threading.local):
+    api_key: Optional[str]
+    cookies: Optional[Dict]
+    headers: Optional[Dict]
+
+    def __init__(self) -> None:
+        self.api_key = None
+        self.cookies = None
+        self.headers = None
+
+
+_thread_local_api_settings: _ThreadLocalApiSettings = _ThreadLocalApiSettings()

--- a/wandb/sdk/lib/capped_dict.py
+++ b/wandb/sdk/lib/capped_dict.py
@@ -1,0 +1,25 @@
+import collections
+
+
+class CappedDict(collections.OrderedDict):
+    default_max_size = 50
+
+    def __init__(self, *args, **kwargs):
+        self.max_size = kwargs.pop("max_size", self.default_max_size)
+        super().__init__(*args, **kwargs)
+
+    def __setitem__(self, key, val):
+        if key not in self:
+            max_size = self.max_size - 1
+            self._prune_dict(max_size)
+        super().__setitem__(key, val)
+
+    def update(self, **kwargs):
+        super().update(**kwargs)
+        self._prune_dict(self.max_size)
+
+    def _prune_dict(self, max_size):
+        if len(self) >= max_size:
+            diff = len(self) - max_size
+            for k in list(self.keys())[:diff]:
+                del self[k]

--- a/wandb/sdk/lib/capped_dict.py
+++ b/wandb/sdk/lib/capped_dict.py
@@ -1,24 +1,25 @@
 import collections
+from typing import Any, Optional
 
 
 class CappedDict(collections.OrderedDict):
     default_max_size = 50
 
-    def __init__(self, *args, **kwargs):
-        self.max_size = kwargs.pop("max_size", self.default_max_size)
-        super().__init__(*args, **kwargs)
+    def __init__(self, max_size: Optional[int] = None) -> None:
+        self.max_size = max_size or self.default_max_size
+        super().__init__()
 
-    def __setitem__(self, key, val):
+    def __setitem__(self, key: str, val: Any) -> None:
         if key not in self:
             max_size = self.max_size - 1
             self._prune_dict(max_size)
         super().__setitem__(key, val)
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: Any) -> None:  # type: ignore[override]
         super().update(**kwargs)
         self._prune_dict(self.max_size)
 
-    def _prune_dict(self, max_size):
+    def _prune_dict(self, max_size: int) -> None:
         if len(self) >= max_size:
             diff = len(self) - max_size
             for k in list(self.keys())[:diff]:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -50,6 +50,7 @@ import yaml
 import wandb
 import wandb.env
 from wandb.errors import AuthenticationError, CommError, UsageError, term
+from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.lib import filesystem, runid
 from wandb.sdk.lib.paths import FilePathStr, StrPath
 
@@ -1246,7 +1247,17 @@ def guess_data_type(shape: Sequence[int], risky: bool = False) -> Optional[str]:
 def download_file_from_url(
     dest_path: str, source_url: str, api_key: Optional[str] = None
 ) -> None:
-    response = requests.get(source_url, auth=("api", api_key), stream=True, timeout=5)  # type: ignore
+    auth = None
+    if not _thread_local_api_settings.cookies:
+        auth = ("api", api_key)
+    response = requests.get(
+        source_url,
+        auth=auth,
+        headers=_thread_local_api_settings.headers,
+        cookies=_thread_local_api_settings.cookies,
+        stream=True,
+        timeout=5,
+    )  # type: ignore
     response.raise_for_status()
 
     if os.sep in dest_path:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1249,7 +1249,7 @@ def download_file_from_url(
 ) -> None:
     auth = None
     if not _thread_local_api_settings.cookies:
-        auth = ("api", api_key)
+        auth = ("api", api_key or "")
     response = requests.get(
         source_url,
         auth=auth,
@@ -1257,7 +1257,7 @@ def download_file_from_url(
         cookies=_thread_local_api_settings.cookies,
         stream=True,
         timeout=5,
-    )  # type: ignore
+    )
     response.raise_for_status()
 
     if os.sep in dest_path:


### PR DESCRIPTION
Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
This adds a thread local api settings object, primarily for use by weave.  It also fixes a memory leak in the artifacts cache by capping the map of artifacts to the most recent 50.


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 819fee3</samp>

> _Sing, O Muse, of the cunning wandb developers_
> _Who devised many ways to improve their artifacts cache_
> _And threaded their API settings with skill and care_
> _To handle requests with cookies and headers in a flash_