### PR TITLE
fix(integrations): Add importer support for older versions of mlflow (1.18)

### DIFF
--- a/tests/pytest_tests/system_tests/test_importers/conftest.py
+++ b/tests/pytest_tests/system_tests/test_importers/conftest.py
@@ -100,15 +100,31 @@ def make_tags():
 
 
 def make_params():
+    # Older versions have trouble handling certain kinds of strings and larger dicts
+    if mlflow_version < Version("2.0.0"):
+        param_str = st.text(
+            max_size=20, alphabet="abcdefghijklmnopqrstuvwxyz1234567890_- "
+        ).example()
+        param_dict = st.dictionaries(
+            st.text(max_size=4, alphabet="abcdefghijklmnopqrstuvwxyz1234567890_- "),
+            st.integers(),
+            max_size=2,
+        ).example()
+    else:
+        param_str = st.text(max_size=20).example()
+        param_dict = st.dictionaries(
+            st.text(max_size=20),
+            st.integers(),
+            max_size=10,
+        ).example()
+
     return {
         "param_int": st.integers().example(),
         "param_float": st.floats().example(),
-        # "param_str": st.text(max_size=20).example(),
+        "param_str": param_str,
         "param_bool": st.booleans().example(),
         "param_list": st.lists(st.integers()).example(),
-        # "param_dict": st.dictionaries(
-        #     st.text(max_size=20), st.integers(), max_size=10
-        # ).example(),
+        "param_dict": param_dict,
         "param_tuple": st.tuples(st.integers(), st.integers()).example(),
         "param_set": st.sets(st.integers()).example(),
         "param_none": None,

--- a/tests/pytest_tests/system_tests/test_importers/conftest.py
+++ b/tests/pytest_tests/system_tests/test_importers/conftest.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import subprocess
 import tempfile
@@ -6,7 +7,7 @@ import urllib.parse
 import uuid
 import warnings
 from itertools import islice
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import hypothesis.strategies as st
 import mlflow
@@ -22,8 +23,11 @@ MLFLOW_BASE_URL = "http://localhost:4040"
 MLFLOW_HEALTH_ENDPOINT = "health"
 EXPERIMENTS = 2
 RUNS_PER_EXPERIMENT = 3
-N_ARTIFACTS_PER_RUN = 10
 STEPS = 1000
+N_ROOT_FILES = 5
+N_SUBDIRS = 3
+N_SUBDIR_FILES = 2
+LOGGING_BATCH_SIZE = 50
 
 SECONDS_FROM_2023_01_01 = 1672549200
 
@@ -37,7 +41,7 @@ def _make_run(
     tags: Optional[Dict[str, Any]] = None,
     params: Optional[Dict[str, float]] = None,
     metrics: Optional[Iterable[Dict[str, float]]] = None,
-    make_artifact_fns: Optional[Iterable[Callable[[], Path]]] = None,
+    artifacts_dir: Optional[Path] = None,
     batch_size: Optional[int] = None,
 ):
     client = MlflowClient()
@@ -55,10 +59,8 @@ def _make_run(
             else:
                 for m in metrics:
                     mlflow.log_metrics(m)
-        if make_artifact_fns:
-            for f in make_artifact_fns:
-                path = f()
-                mlflow.log_artifact(path)
+        if artifacts_dir:
+            mlflow.log_artifact(artifacts_dir)
 
 
 # def make_nested_run():
@@ -139,40 +141,60 @@ def make_metrics(n_steps):
         }
 
 
-def make_artifact_fns(
-    temp_path: Path, n_artifacts: int
-) -> Iterable[Callable[[], Path]]:
-    def artifact_fn():
-        fname = str(uuid.uuid4())
-        file_path = f"{temp_path}/{fname}.txt"
+def make_artifacts_dir(
+    root_dir: Path, n_root_files: int, n_subdirs: int, n_subdir_files: int
+) -> Path:
+    # Ensure root_dir exists
+    os.makedirs(root_dir, exist_ok=True)
+
+    for i in range(n_root_files):
+        file_path = os.path.join(root_dir, f"file{i}.txt")
         with open(file_path, "w") as f:
             f.write(f"text from {file_path}")
-        return file_path
 
-    for _ in range(n_artifacts):
-        yield artifact_fn
+    for i in range(n_subdirs):
+        subdir_path = os.path.join(root_dir, f"subdir{i}")
+        os.makedirs(subdir_path, exist_ok=True)
+
+        for j in range(n_subdir_files):
+            file_path = os.path.join(subdir_path, f"file{j}.txt")
+            with open(file_path, "w") as f:
+                f.write(f"text from {file_path}")
+
+    return root_dir
 
 
-def make_run(name, n_steps, mlflow_batch_size, n_artifacts):
+def make_run(name, n_steps, mlflow_batch_size, n_root_files, n_subdirs, n_subdir_files):
     with tempfile.TemporaryDirectory() as temp_path:
         _make_run(
             name=name,
             tags=make_tags(),
             params=make_params(),
             metrics=make_metrics(n_steps),
-            make_artifact_fns=make_artifact_fns(temp_path, n_artifacts),
+            artifacts_dir=make_artifacts_dir(
+                temp_path, n_root_files, n_subdirs, n_subdir_files
+            ),
             batch_size=mlflow_batch_size,
         )
 
 
-def make_exp(n_runs, n_steps, mlflow_batch_size, n_artifacts_per_run):
+def make_exp(
+    n_runs, n_steps, mlflow_batch_size, n_root_files, n_subdirs, n_subdir_files
+):
     exp_name = "Experiment " + str(uuid.uuid4())
     mlflow.set_experiment(exp_name)
 
     # Can't use ProcessPoolExecutor -- it seems to always fail in tests!
     for _ in range(n_runs):
         run_name = "Run :/" + str(uuid.uuid4())
-        make_run(run_name, n_steps, mlflow_batch_size, n_artifacts_per_run)
+        make_run(
+            run_name,
+            n_steps,
+            mlflow_batch_size,
+            n_root_files,
+            n_subdirs,
+            n_subdir_files,
+        )
 
 
 def log_to_mlflow(
@@ -181,7 +203,9 @@ def log_to_mlflow(
     n_runs_per_exp: int = 3,
     n_steps: int = 1000,
     mlflow_batch_size: int = 50,
-    n_artifacts_per_run: int = 10,
+    n_root_files: int = 3,
+    n_subdirs: int = 3,
+    n_subdir_files: int = 2,
 ):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=NonInteractiveExampleWarning)
@@ -189,7 +213,14 @@ def log_to_mlflow(
 
         # Can't use ProcessPoolExecutor -- it seems to always fail in tests!
         for _ in range(n_exps):
-            make_exp(n_runs_per_exp, n_steps, mlflow_batch_size, n_artifacts_per_run)
+            make_exp(
+                n_runs_per_exp,
+                n_steps,
+                mlflow_batch_size,
+                n_root_files,
+                n_subdirs,
+                n_subdir_files,
+            )
 
 
 def check_mlflow_server_health(
@@ -325,6 +356,17 @@ def mlflow_server(mlflow_backend, mlflow_artifacts_destination):
 @pytest.fixture
 def prelogged_mlflow_server(mlflow_server):
     log_to_mlflow(
-        mlflow_server, EXPERIMENTS, RUNS_PER_EXPERIMENT, STEPS, N_ARTIFACTS_PER_RUN
+        mlflow_server,
+        EXPERIMENTS,
+        RUNS_PER_EXPERIMENT,
+        STEPS,
+        LOGGING_BATCH_SIZE,
+        N_ROOT_FILES,
+        N_SUBDIRS,
+        N_SUBDIR_FILES,
     )
-    yield mlflow_server, EXPERIMENTS, RUNS_PER_EXPERIMENT, STEPS, N_ARTIFACTS_PER_RUN
+
+    total_runs = EXPERIMENTS * RUNS_PER_EXPERIMENT
+    total_files = N_ROOT_FILES + N_SUBDIRS * N_SUBDIR_FILES
+
+    yield mlflow_server, total_runs, total_files, STEPS

--- a/tests/pytest_tests/system_tests/test_importers/test_import_mlflow.py
+++ b/tests/pytest_tests/system_tests/test_importers/test_import_mlflow.py
@@ -10,10 +10,9 @@ from wandb.apis.importers import MlflowImporter
 def test_mlflow(prelogged_mlflow_server, user):
     (
         mlflow_server,
-        exps,
-        runs_per_exp,
+        total_runs,
+        total_files,
         steps,
-        n_artifacts_per_run,
     ) = prelogged_mlflow_server
 
     project = "mlflow-import-testing"
@@ -25,10 +24,11 @@ def test_mlflow(prelogged_mlflow_server, user):
     importer.import_all_parallel(overrides=overrides)
 
     runs = list(wandb.Api().runs(f"{user}/{project}"))
-    assert len(runs) == exps * runs_per_exp
+    assert len(runs) == total_runs
     for run in runs:
         # https://stackoverflow.com/a/50645935
         assert len(list(run.scan_history())) == steps
 
+        # only one artifact containing everything in mlflow
         art = list(run.logged_artifacts())[0]
-        assert len(list(art.files())) == n_artifacts_per_run
+        assert len(art.files()) == total_files

--- a/wandb/apis/importers/base.py
+++ b/wandb/apis/importers/base.py
@@ -4,7 +4,7 @@ import re
 from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from contextlib import contextmanager
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional
 
 from tqdm.auto import tqdm
 
@@ -316,7 +316,8 @@ class Importer(ABC):
             sm.send(run._make_metadata_files_record())
             for history_record in run._make_history_records():
                 sm.send(history_record)
-            if run.artifacts() is not None:
-                for artifact in run.artifacts():
+            artifacts = run.artifacts()
+            if artifacts is not None:
+                for artifact in artifacts:
                     sm.send(run._make_artifact_record(artifact))
             sm.send(run._make_telem_record())

--- a/wandb/apis/importers/mlflow.py
+++ b/wandb/apis/importers/mlflow.py
@@ -59,7 +59,7 @@ class MlflowRun(ImporterRun):
         return f"User {self.run.info.user_id}"
 
     def display_name(self):
-        if mlflow_version < Version("2.0.0"):
+        if mlflow_version < Version("1.30.0"):
             return self.run.data.tags["mlflow.runName"]
 
         return self.run.info.run_name
@@ -123,7 +123,7 @@ class MlflowImporter(Importer):
         super().import_one(run, overrides)
 
     def download_all_runs(self) -> Iterable[MlflowRun]:
-        if mlflow_version < Version("2.0.0"):
+        if mlflow_version < Version("1.28.0"):
             experiments = self.mlflow_client.list_experiments()
         else:
             experiments = self.mlflow_client.search_experiments()

--- a/wandb/apis/importers/mlflow.py
+++ b/wandb/apis/importers/mlflow.py
@@ -89,7 +89,6 @@ class MlflowRun(ImporterRun):
 
     def artifacts(self):
         for f in self.mlflow_client.list_artifacts(self.run.info.run_id):
-            wandb.termlog(f"Downloading {f.path}")
             if mlflow_version < Version("2.0.0"):
                 dir_path = self.mlflow_client.download_artifacts(
                     run_id=self.run.info.run_id, path=""

--- a/wandb/apis/importers/mlflow.py
+++ b/wandb/apis/importers/mlflow.py
@@ -95,15 +95,6 @@ class MlflowRun(ImporterRun):
         else:
             dir_path = mlflow.artifacts.download_artifacts(run_id=self.run.info.run_id)
 
-        # import os
-
-        # everything = list(os.walk(dir_path))
-        # all_files = []
-        # for root, dirs, files in everything:
-        #     for file in files:
-        #         all_files.append(file)
-        # wandb.termlog(f"len: {len(all_files)} **** all files in dir: {all_files}")
-
         artifact_name = self._handle_incompatible_strings(self.display_name())
         art = wandb.Artifact(artifact_name, "imported-artifacts")
         art.add_dir(dir_path)

--- a/wandb/apis/importers/mlflow.py
+++ b/wandb/apis/importers/mlflow.py
@@ -1,5 +1,9 @@
+from collections import defaultdict
 from typing import Any, Dict, Iterable, Optional
 
+from packaging.version import Version
+
+import wandb
 from wandb.util import get_module
 
 from .base import Importer, ImporterRun
@@ -8,6 +12,8 @@ mlflow = get_module(
     "mlflow",
     required="To use the MlflowImporter, please install mlflow: `pip install mlflow`",
 )
+
+mlflow_version = Version(mlflow.__version__)
 
 
 class MlflowRun(ImporterRun):
@@ -32,25 +38,17 @@ class MlflowRun(ImporterRun):
         return self.run.data.metrics
 
     def metrics(self):
-        def wandbify(metrics):
-            for step, t in enumerate(metrics):
-                d = {m.key: m.value for m in t}
-                d["_step"] = step
-                yield d
-
-        metrics = [
+        d = defaultdict(dict)
+        metrics = (
             self.mlflow_client.get_metric_history(self.run.info.run_id, k)
             for k in self.run.data.metrics.keys()
-        ]
-        metrics = zip(*metrics)  # transpose
-        return wandbify(metrics)
+        )
+        for metric in metrics:
+            for item in metric:
+                d[item.step][item.key] = item.value
 
-        # Alternate: Might be slower but use less mem
-        # Can't make this a generator.  See mlflow get_metric_history internals
-        # https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/_tracking_service/client.py#L74-L93
-        # for k in self.run.data.metrics.keys():
-        #     history = self.mlflow_client.get_metric_history(self.run.info.run_id, k)
-        #     yield wandbify(history)
+        flattened = ({"_step": k, **v} for k, v in d.items())
+        return flattened
 
     def run_group(self):
         # this is nesting?  Parent at `run.info.tags.get("mlflow.parentRunId")`
@@ -61,6 +59,9 @@ class MlflowRun(ImporterRun):
         return f"User {self.run.info.user_id}"
 
     def display_name(self):
+        if mlflow_version < Version("2.0.0"):
+            return self.run.data.tags["mlflow.runName"]
+
         return self.run.info.run_name
 
     def notes(self):
@@ -88,8 +89,17 @@ class MlflowRun(ImporterRun):
 
     def artifacts(self):
         for f in self.mlflow_client.list_artifacts(self.run.info.run_id):
-            dir_path = mlflow.artifacts.download_artifacts(run_id=self.run.info.run_id)
-            full_path = dir_path + f.path
+            wandb.termlog(f"Downloading {f.path}")
+            if mlflow_version < Version("2.0.0"):
+                dir_path = self.mlflow_client.download_artifacts(
+                    run_id=self.run.info.run_id, path=""
+                )
+                full_path = dir_path + "/" + f.path
+            else:
+                dir_path = mlflow.artifacts.download_artifacts(
+                    run_id=self.run.info.run_id
+                )
+                full_path = dir_path + f.path
             yield (f.path, full_path)
 
 
@@ -114,6 +124,11 @@ class MlflowImporter(Importer):
         super().import_one(run, overrides)
 
     def download_all_runs(self) -> Iterable[MlflowRun]:
-        for exp in self.mlflow_client.search_experiments():
+        if mlflow_version < Version("2.0.0"):
+            experiments = self.mlflow_client.list_experiments()
+        else:
+            experiments = self.mlflow_client.search_experiments()
+
+        for exp in experiments:
             for run in self.mlflow_client.search_runs(exp.experiment_id):
                 yield MlflowRun(run, self.mlflow_client)

--- a/wandb/apis/importers/mlflow.py
+++ b/wandb/apis/importers/mlflow.py
@@ -88,18 +88,27 @@ class MlflowRun(ImporterRun):
         ...
 
     def artifacts(self):
-        for f in self.mlflow_client.list_artifacts(self.run.info.run_id):
-            if mlflow_version < Version("2.0.0"):
-                dir_path = self.mlflow_client.download_artifacts(
-                    run_id=self.run.info.run_id, path=""
-                )
-                full_path = dir_path + "/" + f.path
-            else:
-                dir_path = mlflow.artifacts.download_artifacts(
-                    run_id=self.run.info.run_id
-                )
-                full_path = dir_path + f.path
-            yield (f.path, full_path)
+        if mlflow_version < Version("2.0.0"):
+            dir_path = self.mlflow_client.download_artifacts(
+                run_id=self.run.info.run_id, path=""
+            )
+        else:
+            dir_path = mlflow.artifacts.download_artifacts(run_id=self.run.info.run_id)
+
+        # import os
+
+        # everything = list(os.walk(dir_path))
+        # all_files = []
+        # for root, dirs, files in everything:
+        #     for file in files:
+        #         all_files.append(file)
+        # wandb.termlog(f"len: {len(all_files)} **** all files in dir: {all_files}")
+
+        artifact_name = self._handle_incompatible_strings(self.display_name())
+        art = wandb.Artifact(artifact_name, "imported-artifacts")
+        art.add_dir(dir_path)
+
+        return [art]
 
 
 class MlflowImporter(Importer):

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2427,7 +2427,10 @@ def importer():
     help="Override default project to import data into",
 )
 def mlflow(mlflow_tracking_uri, target_entity, target_project):
-    from wandb.apis.importers import MlflowImporter
+    from wandb.util import get_module
+
+    if get_module("mlflow"):
+        from wandb.apis.importers import MlflowImporter
 
     importer = MlflowImporter(mlflow_tracking_uri=mlflow_tracking_uri)
     overrides = {


### PR DESCRIPTION
- only import mlflow if exists
- test

Fixes
-----

Fixes WB-NNNN

Fixes #NNNN

Description
-----------
What does the PR do?


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1bfdc4e</samp>

> _Sing, O Muse, of the crafty wandb CLI_
> _That imports the glorious runs of mlflow_
> _And adapts to its changing versions with skill_
> _Converting artifacts to wandb's own show_