### PR TITLE
chore(sdk): Bump version: 0.15.4.dev1 → 0.15.5.dev1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip_gitignore = "True"
 [tool.commitizen]
 name = "cz_conventional_commits"
 major_version_zero = true
-version = "0.15.4.dev1"
+version = "0.15.5"
 version_files = ["setup.py", "setup.cfg", "wandb/__init__.py"]
 tag_format = "v$major.$minor.$patch$prerelease"
 changelog_incremental = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip_gitignore = "True"
 [tool.commitizen]
 name = "cz_conventional_commits"
 major_version_zero = true
-version = "0.15.5"
+version = "0.15.5.dev1"
 version_files = ["setup.py", "setup.cfg", "wandb/__init__.py"]
 tag_format = "v$major.$minor.$patch$prerelease"
 changelog_incremental = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.5
+current_version = 0.15.5.dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.15.4.dev1
+current_version = 0.15.5
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prekind}{pre}.{devkind}{dev}
 	{major}.{minor}.{patch}.{devkind}{dev}
 	{major}.{minor}.{patch}{prekind}{pre}
@@ -14,7 +14,7 @@ first_value = 1
 
 [bumpversion:part:prekind]
 optional_value = _
-values =
+values = 
 	_
 	rc
 	_
@@ -24,7 +24,7 @@ first_value = 1
 
 [bumpversion:part:devkind]
 optional_value = _
-values =
+values = 
 	_
 	dev
 	_
@@ -42,7 +42,7 @@ search = version = "{current_version}"
 replace = version = "{new_version}"
 
 [tool:pytest]
-norecursedirs =
+norecursedirs = 
 	vendor
 	wandb/vendor
 open_files_ignore = "*.ttf"

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ async_requirements = [
 
 setup(
     name="wandb",
-    version="0.15.5",
+    version="0.15.5.dev1",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ async_requirements = [
 
 setup(
     name="wandb",
-    version="0.15.4.dev1",
+    version="0.15.5",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.4.dev1"
+__version__ = "0.15.5"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.5"
+__version__ = "0.15.5.dev1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"


### PR DESCRIPTION
Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9411841</samp>

Bump the version number to 0.15.5.dev1 in `pyproject.toml`, `setup.cfg`, `setup.py`, and `wandb/__init__.py`. This prepares the wandb Python package for a new development release.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9411841</samp>

> _Oh we are the wandb crew and we have a job to do_
> _We bump the version number in every file we touch_
> _`pyproject.toml`, `setup.py`, and `__init__.py`_
> _And don't forget `setup.cfg`, we'll make it nice and flush_
