### PR TITLE
fix(sdk): address numpy-related mypy errors

### DIFF
--- a/wandb/integration/tensorboard/log.py
+++ b/wandb/integration/tensorboard/log.py
@@ -9,7 +9,7 @@ from wandb.sdk.lib import telemetry
 from wandb.viz import custom_chart
 
 if TYPE_CHECKING:
-    import numpy as np  # type: ignore
+    import numpy as np
 
     from wandb.sdk.internal.tb_watcher import TBHistory
 
@@ -42,7 +42,7 @@ def make_ndarray(tensor: Any) -> Optional["np.ndarray"]:
         if res.dtype == "object":
             return None
         else:
-            return res
+            return res  # type: ignore
     else:
         wandb.termwarn(
             "Can't convert tensor summary, upgrade tensorboard with `pip"
@@ -167,7 +167,7 @@ def tf_summary_to_dict(  # noqa: C901
                     try:
                         # TODO: we should just re-bin if there are too many buckets
                         values[namespaced_tag(value.tag, namespace)] = wandb.Histogram(
-                            np_histogram=(counts, bins)
+                            np_histogram=(counts, bins)  # type: ignore
                         )
                     except ValueError:
                         wandb.termwarn(
@@ -238,7 +238,7 @@ def tf_summary_to_dict(  # noqa: C901
                 )
                 try:
                     # TODO: we should just re-bin if there are too many buckets
-                    values[tag] = wandb.Histogram(np_histogram=np_histogram)
+                    values[tag] = wandb.Histogram(np_histogram=np_histogram)  # type: ignore
                 except ValueError:
                     wandb.termwarn(
                         f"Not logging key {tag!r}. "

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -14,7 +14,7 @@ from wandb.sdk.lib.paths import LogicalPath
 from .wb_value import WBValue
 
 if TYPE_CHECKING:  # pragma: no cover
-    import numpy as np  # type: ignore
+    import numpy as np
 
     from wandb.sdk.artifacts.local_artifact import Artifact as LocalArtifact
     from wandb.sdk.artifacts.public_artifact import Artifact as PublicArtifact
@@ -316,4 +316,4 @@ def _numpy_arrays_to_lists(
     # Protects against logging non serializable objects
     elif isinstance(payload, Media):
         return str(payload.__class__.__name__)
-    return payload
+    return payload  # type: ignore

--- a/wandb/sdk/data_types/histogram.py
+++ b/wandb/sdk/data_types/histogram.py
@@ -6,7 +6,7 @@ from wandb import util
 from .base_types.wb_value import WBValue
 
 if TYPE_CHECKING:  # pragma: no cover
-    import numpy as np  # type: ignore
+    import numpy as np
 
     from wandb.sdk.artifacts.local_artifact import Artifact as LocalArtifact
 

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -18,7 +18,7 @@ from .helper_types.image_mask import ImageMask
 
 if TYPE_CHECKING:  # pragma: no cover
     import matplotlib  # type: ignore
-    import numpy as np  # type: ignore
+    import numpy as np
     import torch  # type: ignore
     from PIL.Image import Image as PILImage
 

--- a/wandb/sdk/data_types/object_3d.py
+++ b/wandb/sdk/data_types/object_3d.py
@@ -30,7 +30,7 @@ from ._private import MEDIA_TMP
 from .base_types.media import BatchableMedia
 
 if TYPE_CHECKING:  # pragma: no cover
-    import numpy as np  # type: ignore
+    import numpy as np
 
     from wandb.sdk.artifacts.local_artifact import Artifact as LocalArtifact
 

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -13,7 +13,7 @@ from .base_types.media import BatchableMedia
 if TYPE_CHECKING:  # pragma: no cover
     from typing import TextIO
 
-    import numpy as np  # type: ignore
+    import numpy as np
 
     from wandb.sdk.artifacts.local_artifact import Artifact as LocalArtifact
 
@@ -133,7 +133,7 @@ class Video(BatchableMedia):
             required='wandb.Video requires moviepy and imageio when passing raw data.  Install with "pip install moviepy imageio"',
         )
         tensor = self._prepare_video(self.data)
-        _, self._height, self._width, self._channels = tensor.shape
+        _, self._height, self._width, self._channels = tensor.shape  # type: ignore
 
         # encode sequence of images into gif string
         clip = mpy.ImageSequenceClip(list(tensor), fps=self._fps)


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e820760</samp>

This pull request fixes and updates the type checking comments in several modules under `wandb/sdk/data_types` and `wandb/integration/tensorboard`. The changes are based on the latest versions of numpy and torch and aim to improve the code quality and avoid mypy errors.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e820760</samp>

> _We defy the errors of the mypy lord_
> _We remove the `# type: ignore` chains_
> _We update the comments with the latest sword_
> _We improve the code quality in our veins_
