### PR TITLE
fix(sdk): update logical path handling in tb watcher for s3

### DIFF
--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -14,7 +14,6 @@ import wandb
 from wandb import util
 from wandb.sdk.interface.interface import GlobStr
 from wandb.sdk.lib import filesystem
-from wandb.sdk.lib.paths import LogicalPath
 from wandb.viz import CustomChart
 
 from . import run as internal_run
@@ -136,23 +135,16 @@ class TBWatcher:
             filename = ""
 
         if rootdir == "":
-            # rootdir = LogicalPath(os.path.dirname(os.path.commonprefix(dirs)))
-            rootdir = os.path.dirname(os.path.commonprefix(dirs))
-            print("NEWROOT:", rootdir, LogicalPath(rootdir))
+            rootdir = util.to_forward_slash_path(
+                os.path.dirname(os.path.commonprefix(dirs))
+            )
             # Tensorboard loads all tfevents files in a directory and prepends
             # their values with the path. Passing namespace to log allows us
             # to nest the values in wandb
             # Note that we strip '/' instead of os.sep, because elsewhere we've
             # converted paths to forward slash.
             namespace = logdir.replace(filename, "").replace(rootdir, "").strip("/")
-            print("NAMESPACE:", namespace)
-            print(
-                "NAMESPACE H:",
-                LogicalPath(logdir)
-                .replace(filename, "")
-                .replace(rootdir, "")
-                .strip("/"),
-            )
+
             # TODO: revisit this heuristic, it exists because we don't know the
             # root log directory until more than one tfevents file is written to
             if len(dirs) == 1 and namespace not in ["train", "validation"]:
@@ -163,17 +155,8 @@ class TBWatcher:
         return namespace
 
     def add(self, logdir: str, save: bool, root_dir: str) -> None:
-        # logdir = LogicalPath(logdir)
-        # root_dir = LogicalPath(root_dir)
-        print(
-            "LOGDIR:", logdir, util.to_forward_slash_path(logdir), LogicalPath(logdir)
-        )
-        print(
-            "ROOTDIR:",
-            root_dir,
-            util.to_forward_slash_path(root_dir),
-            LogicalPath(root_dir),
-        )
+        logdir = util.to_forward_slash_path(logdir)
+        root_dir = util.to_forward_slash_path(root_dir)
         if logdir in self._logdirs:
             return
         namespace = self._calculate_namespace(logdir, root_dir)

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -14,7 +14,6 @@ import wandb
 from wandb import util
 from wandb.sdk.interface.interface import GlobStr
 from wandb.sdk.lib import filesystem
-from wandb.sdk.lib.paths import LogicalPath
 from wandb.viz import CustomChart
 
 from . import run as internal_run
@@ -135,8 +134,9 @@ class TBWatcher:
         else:
             filename = ""
 
-        if rootdir == ".":
-            rootdir = LogicalPath(os.path.dirname(os.path.commonprefix(dirs)))
+        if rootdir == "":
+            # rootdir = LogicalPath(os.path.dirname(os.path.commonprefix(dirs)))
+            rootdir = os.path.dirname(os.path.commonprefix(dirs))
             # Tensorboard loads all tfevents files in a directory and prepends
             # their values with the path. Passing namespace to log allows us
             # to nest the values in wandb
@@ -153,8 +153,8 @@ class TBWatcher:
         return namespace
 
     def add(self, logdir: str, save: bool, root_dir: str) -> None:
-        logdir = LogicalPath(logdir)
-        root_dir = LogicalPath(root_dir)
+        # logdir = LogicalPath(logdir)
+        # root_dir = LogicalPath(root_dir)
         if logdir in self._logdirs:
             return
         namespace = self._calculate_namespace(logdir, root_dir)

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -138,6 +138,7 @@ class TBWatcher:
         if rootdir == "":
             # rootdir = LogicalPath(os.path.dirname(os.path.commonprefix(dirs)))
             rootdir = os.path.dirname(os.path.commonprefix(dirs))
+            print("NEWROOT:", rootdir, LogicalPath(rootdir))
             # Tensorboard loads all tfevents files in a directory and prepends
             # their values with the path. Passing namespace to log allows us
             # to nest the values in wandb

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -145,6 +145,14 @@ class TBWatcher:
             # Note that we strip '/' instead of os.sep, because elsewhere we've
             # converted paths to forward slash.
             namespace = logdir.replace(filename, "").replace(rootdir, "").strip("/")
+            print("NAMESPACE:", namespace)
+            print(
+                "NAMESPACE H:",
+                LogicalPath(logdir)
+                .replace(filename, "")
+                .replace(rootdir, "")
+                .strip("/"),
+            )
             # TODO: revisit this heuristic, it exists because we don't know the
             # root log directory until more than one tfevents file is written to
             if len(dirs) == 1 and namespace not in ["train", "validation"]:

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -156,8 +156,15 @@ class TBWatcher:
     def add(self, logdir: str, save: bool, root_dir: str) -> None:
         # logdir = LogicalPath(logdir)
         # root_dir = LogicalPath(root_dir)
-        print(logdir, util.to_forward_slash_path(logdir), LogicalPath(root_dir))
-        print(root_dir, util.to_forward_slash_path(root_dir), LogicalPath(root_dir))
+        print(
+            "LOGDIR:", logdir, util.to_forward_slash_path(logdir), LogicalPath(logdir)
+        )
+        print(
+            "ROOTDIR:",
+            root_dir,
+            util.to_forward_slash_path(root_dir),
+            LogicalPath(root_dir),
+        )
         if logdir in self._logdirs:
             return
         namespace = self._calculate_namespace(logdir, root_dir)

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -14,6 +14,7 @@ import wandb
 from wandb import util
 from wandb.sdk.interface.interface import GlobStr
 from wandb.sdk.lib import filesystem
+from wandb.sdk.lib.paths import LogicalPath
 from wandb.viz import CustomChart
 
 from . import run as internal_run
@@ -155,6 +156,8 @@ class TBWatcher:
     def add(self, logdir: str, save: bool, root_dir: str) -> None:
         # logdir = LogicalPath(logdir)
         # root_dir = LogicalPath(root_dir)
+        print(logdir, util.to_forward_slash_path(logdir), LogicalPath(root_dir))
+        print(root_dir, util.to_forward_slash_path(root_dir), LogicalPath(root_dir))
         if logdir in self._logdirs:
             return
         namespace = self._calculate_namespace(logdir, root_dir)


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0547ef3</samp>

Fixed a bug and simplified the code for watching TensorBoard logs by using `os.path` instead of `LogicalPath` in `tb_watcher.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0547ef3</samp>

> _We're sailing on the Python sea, with `tb_watcher.py`_
> _We found a bug that made us frown, so we had to fix it right away_
> _We tossed the `LogicalPath` overboard, and used `os.path` instead_
> _Now the code is simpler and cleaner, and we can sail ahead_
