### PR TITLE
chore(sdk): Pin KFPv1 dependencies in yea

### DIFF
--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-helper.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-helper.yea
@@ -6,6 +6,8 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
+    - urllib3==1.26.15
+    - requests-toolbelt==0.10.1
 assert:
     - :wandb:runs_len: 3
     - :wandb:runs[0][summary]: {}

--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-helper.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-helper.yea
@@ -6,8 +6,7 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
-    - urllib3==1.26.15
-    - requests-toolbelt==0.10.1
+    - appengine-python-standard
 assert:
     - :wandb:runs_len: 3
     - :wandb:runs[0][summary]: {}

--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-pytorch.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-pytorch.yea
@@ -6,6 +6,8 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
+    - urllib3==1.26.15
+    - requests-toolbelt==0.10.1
 assert:
     - :wandb:runs_len: 3
     - :wandb:runs[0][job_type]: setup_data

--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-pytorch.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-pytorch.yea
@@ -6,8 +6,7 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
-    - urllib3==1.26.15
-    - requests-toolbelt==0.10.1
+    - appengine-python-standard
 assert:
     - :wandb:runs_len: 3
     - :wandb:runs[0][job_type]: setup_data

--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-simple.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-simple.yea
@@ -6,8 +6,7 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
-    - urllib3==1.26.15
-    - requests-toolbelt==0.10.1
+    - appengine-python-standard
 assert:
     - :wandb:runs_len: 2
     - :wandb:runs[0][job_type]: add

--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-simple.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-simple.yea
@@ -6,6 +6,8 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
+    - urllib3==1.26.15
+    - requests-toolbelt==0.10.1
 assert:
     - :wandb:runs_len: 2
     - :wandb:runs[0][job_type]: add

--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-sklearn.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-sklearn.yea
@@ -6,8 +6,7 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
-    - urllib3==1.26.15
-    - requests-toolbelt==0.10.1
+    - appengine-python-standard
 assert:
     - :wandb:runs_len: 3
     - :wandb:runs[0][job_type]: preprocess_data

--- a/tests/functional_tests/t0_main/kfp/kfp-pipeline-sklearn.yea
+++ b/tests/functional_tests/t0_main/kfp/kfp-pipeline-sklearn.yea
@@ -6,6 +6,8 @@ plugin:
 depend:
   requirements:
     - kfp==1.8.11
+    - urllib3==1.26.15
+    - requests-toolbelt==0.10.1
 assert:
     - :wandb:runs_len: 3
     - :wandb:runs[0][job_type]: preprocess_data


### PR DESCRIPTION
Fixes
-----
Pins dependencies in yea to prevent flake issues (see [related issue](https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli))

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b80e3a</samp>

Add `appengine-python-standard` dependency to four KFP test files. This enables the tests to run on Google App Engine, the platform used by KFP.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b80e3a</samp>

> _`appengine` needed_
> _to run KFP pipelines_
> _on Google's cloud_
