### PR TITLE
docs(sdk): Artifact docstring code corrected

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1457,7 +1457,7 @@ class Artifact:
             # Run using the artifact
             with wandb.init() as r:
                 artifact = r.use_artifact('my_dataset:latest')
-                table = r.get('my_table')
+                table = artifact.get('my_table')
             ```
         """
         if self._state == ArtifactState.PENDING:


### PR DESCRIPTION
Fixes
-----
- Fixes https://wandb.atlassian.net/browse/DOCS-591?atlOrigin=eyJpIjoiNjRhYTQ1YzRiM2Q2NDcwYTkwNGFlOTQ0MDBiYWZmYzIiLCJwIjoiaiJ9
- Fixes #NNNN

Description
-----------
What does the PR do?
Fixes docstring code example in artifacts. The `r.get('my_table')`  should actually be `artifact.get('my_table')`. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1728dda</samp>

Fixed a typo in the code example of the `get` method in `wandb/sdk/artifacts/artifact.py`. This improves the clarity and accuracy of the documentation for accessing artifact contents.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [X] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1728dda</samp>

> _`get` docstring fixed_
> _`artifact` instead of `r`_
> _Clearer example now_
