### PR TITLE
perf(artifacts): get download URLs in batches

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -176,7 +176,7 @@ setenv=
     ; Setting low network buffer so that we exercise flow control logic
     WANDB__NETWORK_BUFFER=1000
     COVERAGE_FILE={envdir}/.coverage
-    YEA_WANDB_VERSION=0.9.11
+    YEA_WANDB_VERSION=0.9.12
 passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -34,6 +34,7 @@ class ArtifactManifestEntry:
     local_path: Optional[str]
 
     _parent_artifact: Optional["Artifact"] = None
+    _download_url: Optional[str] = None
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes WB-13972

# Description

Before:
- 32 threads downloading files 1 at a time; we query gorilla which does a bunch of MySQL queries, generates a download URL and redirects to it ([code](https://github.com/wandb/core/blob/13079312727145231965f133f9a46e4a150fdd88/services/gorilla/api/handler/artifacts.go#L140)).

After:
- 1 thread getting download URLs for files in 5k batches; waiting for download threads to catch up (at most 5k files in download queue) before fetching the next batch
- 64 threads downloading files 1 at a time using the URL fetched above, falling back to getting the URL using the old method

Benchmark: downloading a 1 million file artifact went down from 5h 38min to 1h 11min ([thread](https://weightsandbiases.slack.com/archives/C04MNBGJDBN/p1686304602511269)).

Depends on server-side change: https://github.com/wandb/core/pull/15374
Corresponding yea-wandb change: https://github.com/wandb/yea-wandb/pull/115

# Test plan

Downloaded a 1 million file artifact with and without the server side change.