### PR TITLE
feat(launch): Allow users to configure kaniko build job namespace

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
@@ -98,7 +98,8 @@ def _setup(mocker):
 def test_construct_builder_args(
     default_config, override_build_config, resolved_namespace
 ):
-    build_config, _ = build.construct_builder_args(
+    
+    build_config, registry_config = build.construct_builder_args(
         default_config, override_build_config
     )
     assert build_config.get("namespace") == resolved_namespace

--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
@@ -1,6 +1,7 @@
 import hashlib
 from unittest.mock import MagicMock
 
+import pytest
 from wandb.sdk.launch.builder import build
 
 
@@ -80,3 +81,24 @@ def _setup(mocker):
     mocker.api = api
 
     mocker.patch("json.dumps", lambda x: "test-wandb-artifacts")
+
+
+@pytest.mark.parametrize(
+    "default_config,override_build_config,resolved_namespace",
+    [
+        ({}, {}, None),
+        (
+            {"builder": {"namespace": "not-namespace"}},
+            {"namespace": "is-namespace"},
+            "is-namespace",
+        ),
+        ({"builder": {"namespace": "is-namespace"}}, {}, "is-namespace"),
+    ],
+)
+def test_construct_builder_args(
+    default_config, override_build_config, resolved_namespace
+):
+    build_config, _ = build.construct_builder_args(
+        default_config, override_build_config
+    )
+    assert build_config.get("namespace") == resolved_namespace

--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
@@ -98,7 +98,6 @@ def _setup(mocker):
 def test_construct_builder_args(
     default_config, override_build_config, resolved_namespace
 ):
-    
     build_config, registry_config = build.construct_builder_args(
         default_config, override_build_config
     )

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -461,21 +461,11 @@ def join(split_command: List[str]) -> str:
 
 
 def construct_builder_args(
-    launch_config: Optional[Dict] = None,
-    build_config: Optional[Dict] = None,
+    default_launch_config: Optional[Dict] = None,
+    override_build_config: Optional[Dict] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    registry_config = None
-    if launch_config is not None:
-        build_config = launch_config.get("builder")
-        registry_config = launch_config.get("registry")
-
-    default_launch_config = None
-    if os.path.exists(os.path.expanduser(LAUNCH_CONFIG_FILE)):
-        with open(os.path.expanduser(LAUNCH_CONFIG_FILE)) as f:
-            default_launch_config = yaml.safe_load(f)
-
     build_config, registry_config = resolve_build_and_registry_config(
-        default_launch_config, build_config, registry_config
+        default_launch_config, override_build_config
     )
 
     return build_config, registry_config

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -9,7 +9,6 @@ import tempfile
 from typing import Any, Dict, List, Optional, Tuple
 
 import pkg_resources
-import yaml
 from dockerpycreds.utils import find_executable  # type: ignore
 from six.moves import shlex_quote
 
@@ -29,7 +28,7 @@ from .._project_spec import (
     fetch_and_validate_project,
 )
 from ..errors import ExecutionError, LaunchError
-from ..utils import LAUNCH_CONFIG_FILE, LOG_PREFIX, resolve_build_and_registry_config
+from ..utils import LOG_PREFIX, resolve_build_and_registry_config
 from .abstract import AbstractBuilder
 
 _logger = logging.getLogger(__name__)

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -579,18 +579,15 @@ def get_kube_context_and_api_client(
 def resolve_build_and_registry_config(
     default_launch_config: Optional[Dict[str, Any]],
     build_config: Optional[Dict[str, Any]],
-    registry_config: Optional[Dict[str, Any]],
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     resolved_build_config: Dict[str, Any] = {}
-    if build_config is None and default_launch_config is not None:
+    if default_launch_config is not None:
         resolved_build_config = default_launch_config.get("builder", {})
-    elif build_config is not None:
-        resolved_build_config = build_config
+    if build_config is not None:
+        resolved_build_config.update(build_config)
     resolved_registry_config: Dict[str, Any] = {}
-    if registry_config is None and default_launch_config is not None:
+    if default_launch_config is not None:
         resolved_registry_config = default_launch_config.get("registry", {})
-    elif registry_config is not None:
-        resolved_registry_config = registry_config
     validate_build_and_registry_configs(resolved_build_config, resolved_registry_config)
     return resolved_build_config, resolved_registry_config
 


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 144960d</samp>

This pull request adds a new unit test for the `build` module and enhances the `KanikoBuilder` class to support custom Kubernetes namespaces. These changes improve the test coverage and flexibility of the wandb launch feature, which allows users to run and reproduce code from wandb artifacts.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 144960d</samp>

> _`KanikoBuilder` now_
> _accepts custom namespaces_
> _autumn of wandb_
