### PR TITLE
fix(artifacts): don't validate name of existing artifacts

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -288,8 +288,8 @@ class Artifact:
         attrs: Dict[str, Any],
         client: RetryingClient,
     ) -> "Artifact":
-        # type="placeholder" is required to skip validation.
-        artifact = cls(name.split(":")[0], type="placeholder")
+        # Placeholder is required to skip validation.
+        artifact = cls("placeholder", type="placeholder")
         artifact._client = client
         artifact._id = attrs["id"]
         artifact._entity = entity


### PR DESCRIPTION
Fixes WB-14064

# Description

- the SDK allows alphanumeric, dash, underscore, dot characters in artifact name ([code](https://github.com/wandb/wandb/blob/936aaf58f8e2d400894bb3997ead2809d1783783/wandb/sdk/artifacts/artifact.py#L148))
- the server allows any characters except slash, colon ([code](https://github.com/wandb/core/blob/c330e0fb922fbff9ce8f7da172a87c93cefc1df3/services/gorilla/validate.go#L77))
- after https://github.com/wandb/wandb/pull/5454 we started validating the name when loading an artifact in the SDK. This means that some artifacts created via the web app could not be loaded. In this PR, I'm removing that validation.

# Test plan

- created an artifact `my_artifact` from the SDK
- renamed the artifact to `my artifact 🙀` from the web app
- loaded the artifact from the SDK