### PR TITLE
fix(sdk): improve lazy import to be thread-safe

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 import traceback
+import types
 import urllib
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, timedelta
@@ -180,25 +181,59 @@ def vendor_import(name: str) -> Any:
     return module
 
 
-def import_module_lazy(name: str) -> Any:
+class LazyModuleState:
+    def __init__(self, module: types.ModuleType) -> None:
+        self.module = module
+        self.load_started = False
+        self.lock = threading.RLock()
+
+    def load(self) -> None:
+        with self.lock:
+            if self.load_started:
+                return
+            self.load_started = True
+            assert self.module.__spec__ is not None
+            assert self.module.__spec__.loader is not None
+            self.module.__spec__.loader.exec_module(self.module)
+            self.module.__class__ = types.ModuleType
+
+
+class LazyModule(types.ModuleType):
+    def __getattribute__(self, name: str) -> Any:
+        state = object.__getattribute__(self, "__lazy_module_state__")
+        state.load()
+        return object.__getattribute__(self, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        state = object.__getattribute__(self, "__lazy_module_state__")
+        state.load()
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        state = object.__getattribute__(self, "__lazy_module_state__")
+        state.load()
+        object.__delattr__(self, name)
+
+
+def import_module_lazy(name: str) -> types.ModuleType:
     """Import a module lazily, only when it is used.
+
+    Inspired by importlib.util.LazyLoader, but improved so that the module loading is
+    thread-safe. Circular dependency between modules can lead to a deadlock if the two
+    modules are loaded from different threads.
 
     :param (str) name: Dot-separated module path. E.g., 'scipy.stats'.
     """
     try:
         return sys.modules[name]
     except KeyError:
-        module_spec = importlib.util.find_spec(name)
-        if not module_spec:
+        spec = importlib.util.find_spec(name)
+        if spec is None:
             raise ModuleNotFoundError
-
-        module = importlib.util.module_from_spec(module_spec)
+        module = importlib.util.module_from_spec(spec)
+        module.__lazy_module_state__ = LazyModuleState(module)  # type: ignore
+        module.__class__ = LazyModule
         sys.modules[name] = module
-
-        assert module_spec.loader is not None
-        lazy_loader = importlib.util.LazyLoader(module_spec.loader)
-        lazy_loader.exec_module(module)
-
         return module
 
 


### PR DESCRIPTION
Fixes WB-13942

# Description

We use `multiprocessing.util.LazyLoader` to import modules lazily, i.e. when an attribute of the module is accessed. However, `LazyLoader` is not thread-safe: while one thread is loading the module, another thread will see a partially-loaded module. I replaced it with a custom implementation that is thread-safe.

# Test plan

Before:
<img width="1155" alt="before" src="https://github.com/wandb/wandb/assets/127154459/065f5d67-3ad5-4d54-be65-f3e1947723c9">

After:
<img width="953" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/d1802291-16e9-448d-a9cd-cc87ed679946">