### PR TITLE
feat(artifacts): support access key for Azure references

### DIFF
--- a/wandb/sdk/artifacts/storage_handlers/azure_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/azure_handler.py
@@ -4,6 +4,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple, Union
 from urllib.parse import ParseResult, parse_qsl, urlparse
 
+import wandb
 from wandb import util
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
@@ -12,6 +13,7 @@ from wandb.sdk.lib.hashutil import ETag
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
 
 if TYPE_CHECKING:
+    import azure.identity  # type: ignore
     import azure.storage.blob  # type: ignore
 
     from wandb.sdk.artifacts.artifact import Artifact
@@ -45,8 +47,7 @@ class AzureHandler(StorageHandler):
         )
         version_id = manifest_entry.extra.get("versionID")
         blob_service_client = self._get_module("azure.storage.blob").BlobServiceClient(
-            account_url,
-            credential=self._get_module("azure.identity").DefaultAzureCredential(),
+            account_url, credential=self._get_credential(account_url)
         )
         blob_client = blob_service_client.get_blob_client(
             container=container_name, blob=blob_name
@@ -104,8 +105,7 @@ class AzureHandler(StorageHandler):
             ]
 
         blob_service_client = self._get_module("azure.storage.blob").BlobServiceClient(
-            account_url,
-            credential=self._get_module("azure.identity").DefaultAzureCredential(),
+            account_url, credential=self._get_credential(account_url)
         )
         blob_client = blob_service_client.get_blob_client(
             container=container_name, blob=blob_name
@@ -156,6 +156,16 @@ class AzureHandler(StorageHandler):
         )
         assert isinstance(module, ModuleType)
         return module
+
+    def _get_credential(
+        self, account_url: str
+    ) -> Union["azure.identity.DefaultAzureCredential", str]:
+        if (
+            wandb.run
+            and account_url in wandb.run.settings.azure_account_url_to_access_key
+        ):
+            return wandb.run.settings.azure_account_url_to_access_key[account_url]
+        return self._get_module("azure.identity").DefaultAzureCredential()
 
     def _parse_uri(self, uri: str) -> Tuple[str, str, str, Dict[str, str]]:
         parsed_url = urlparse(uri)

--- a/wandb/sdk/lib/_settings_toposort_generated.py
+++ b/wandb/sdk/lib/_settings_toposort_generated.py
@@ -68,6 +68,7 @@ _Setting = Literal[
     "allow_val_change",
     "anonymous",
     "api_key",
+    "azure_account_url_to_access_key",
     "base_url",
     "code_dir",
     "config_paths",

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -509,6 +509,7 @@ class Settings:
     allow_val_change: bool
     anonymous: str
     api_key: str
+    azure_account_url_to_access_key: Dict[str, str]
     base_url: str  # The base url for the wandb api
     code_dir: str
     config_paths: Sequence[str]
@@ -702,6 +703,7 @@ class Settings:
             },
             anonymous={"validator": self._validate_anonymous},
             api_key={"validator": self._validate_api_key},
+            azure_account_url_to_access_key={"value": {}},
             base_url={
                 "value": "https://api.wandb.ai",
                 "preprocessor": lambda x: str(x).strip().rstrip("/"),


### PR DESCRIPTION
Fixes WB-14083

# Description

Azure blob storage has two authorization methods: Role-Based Access Control (RBAC) and access keys ([docs](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-data-operations-portal)). We currently support RBAC, this PR adds support for using access keys.

# Test plan

- Made sure default authorization works:
<img width="1154" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/689248c7-a9a6-4244-a312-f5930d97e356">

- Logged out of Azure with `$ az logout` and made sure authorization with access key works:
<img width="1151" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/61fd9292-8982-4b63-a454-eb095943a6c2">