### PR TITLE
fix(integrations): date parsed as int/float in SM config

### DIFF
--- a/wandb/integration/sagemaker/config.py
+++ b/wandb/integration/sagemaker/config.py
@@ -20,9 +20,9 @@ def parse_sm_config() -> Dict[str, Any]:
         # Hyperparameter searches quote configs...
         for k, v in json.load(open(sm_files.SM_PARAM_CONFIG)).items():
             cast = v.strip('"')
-            if re.match(r"^[-\d]+$", cast):
+            if re.match(r"^-?[\d]+$", cast):
                 cast = int(cast)
-            elif re.match(r"^[-.\d]+$", cast):
+            elif re.match(r"^-?[.\d]+$", cast):
                 cast = float(cast)
             conf[k] = cast
     return conf


### PR DESCRIPTION

Fixes
-----
- Fixes [WB-6027](https://wandb.atlassian.net/browse/WB-6027)

Description
-----------
What does the PR do?
This fixes an issue where date strings such as "1625476886401-2021-02-01-2021-05-14" are parsed as ints due to the regex.

The new regex allows zero or one instance of "-" before each number whereas the previous allows the matching of more than one "-" within the string. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4488f36</samp>

Fixed a bug in `parse_sm_config` that prevented negative hyperparameters from being parsed correctly. Updated the regex patterns for integers and floats in `wandb/integration/sagemaker/config.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4488f36</samp>

> _`parse_sm_config`_
> _now accepts negative nums_
> _a winter bug fixed_


[WB-6027]: https://wandb.atlassian.net/browse/WB-6027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ