### PR TITLE
docs(sdk): expose WBTraceTree as data_types.WBTraceTree

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -47,6 +47,7 @@ from .sdk.data_types.molecule import Molecule
 from .sdk.data_types.object_3d import Object3D
 from .sdk.data_types.plotly import Plotly
 from .sdk.data_types.saved_model import _SavedModel
+from .sdk.data_types.trace_tree import WBTraceTree
 from .sdk.data_types.video import Video
 from .sdk.lib import runid
 
@@ -67,6 +68,7 @@ __all__ = [
     "Object3D",
     "Plotly",
     "Video",
+    "WBTraceTree",
     "_SavedModel",
     # Typed Legacy Exports (I'd like to remove these)
     "ImageMask",

--- a/wandb/sdk/data_types/trace_tree.py
+++ b/wandb/sdk/data_types/trace_tree.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from wandb.data_types import _json_helper
+import wandb.data_types
 from wandb.sdk.data_types import _dtypes
 from wandb.sdk.data_types.base_types.media import Media
 
@@ -142,7 +142,7 @@ def _fallback_serialize(obj: Any) -> str:
 def _safe_serialize(obj: dict) -> str:
     try:
         return json.dumps(
-            _json_helper(obj, None),
+            wandb.data_types._json_helper(obj, None),
             skipkeys=True,
             default=_fallback_serialize,
         )


### PR DESCRIPTION
Fixes WB-13943

# Description

Exposed `WBTraceTree` as `data_types.WBTraceTree` so that we can generate docs for it automatically.

# Test plan

Tested in https://github.com/wandb/docugen/pull/32