### PR TITLE
refactor(artifacts): change artifact methods and attributes to private

### DIFF
--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -305,7 +305,7 @@ def test_wbartifact_handler_load_path_nonlocal(monkeypatch):
 
     handler = WBArtifactHandler()
     handler._client = FakePublicApi()
-    monkeypatch.setattr(Artifact, "from_id", lambda _1, _2: artifact)
+    monkeypatch.setattr(Artifact, "_from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.ref_target = lambda: uri
 
@@ -326,7 +326,7 @@ def test_wbartifact_handler_load_path_local(monkeypatch):
 
     handler = WBArtifactHandler()
     handler._client = FakePublicApi()
-    monkeypatch.setattr(Artifact, "from_id", lambda _1, _2: artifact)
+    monkeypatch.setattr(Artifact, "_from_id", lambda _1, _2: artifact)
     artifact.get_path = lambda _: artifact
     artifact.download = lambda: path
 

--- a/tests/pytest_tests/unit_tests/test_saved_model.py
+++ b/tests/pytest_tests/unit_tests/test_saved_model.py
@@ -85,7 +85,7 @@ class ArtifactPatch(Artifact):
 
 
 def make_local_artifact_public(art):
-    pub = ArtifactPatch.from_attrs(
+    pub = ArtifactPatch._from_attrs(
         "FAKE_ENTITY",
         "FAKE_PROJECT",
         "FAKE_NAME",

--- a/tests/pytest_tests/unit_tests/tests_launch/test_job.py
+++ b/tests/pytest_tests/unit_tests/tests_launch/test_job.py
@@ -43,7 +43,7 @@ def test_configure_notebook_repo_job(mocker, tmp_path):
     mock_code_artifact = MagicMock()
     mock_code_artifact.download.side_effect = mock_download_code
 
-    mocker.patch("wandb.sdk.artifacts.artifact.Artifact.from_id", mock_artifact)
+    mocker.patch("wandb.sdk.artifacts.artifact.Artifact._from_id", mock_artifact)
 
     mock_api = MagicMock()
     mock_api.artifact.return_value = mock_artifact
@@ -92,7 +92,7 @@ def test_configure_notebook_artifact_job(mocker, tmp_path):
         with open(os.path.join(root, "test.ipynb"), "w") as f:
             f.write("hello")
 
-    mocker.patch("wandb.sdk.artifacts.artifact.Artifact.from_id", mock_artifact)
+    mocker.patch("wandb.sdk.artifacts.artifact.Artifact._from_id", mock_artifact)
 
     mock_api = MagicMock()
     mock_api.artifact.return_value = mock_artifact

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -923,7 +923,9 @@ class Api:
         if name is None:
             raise ValueError("You must specify name= to fetch an artifact.")
         entity, project, artifact_name = self._parse_artifact_path(name)
-        artifact = wandb.Artifact.from_name(entity, project, artifact_name, self.client)
+        artifact = wandb.Artifact._from_name(
+            entity, project, artifact_name, self.client
+        )
         if type is not None and artifact.type != type:
             raise ValueError(
                 f"type {type} specified but this artifact is of type {artifact.type}"
@@ -3812,7 +3814,7 @@ class RunArtifacts(Paginator):
             }
             %s
             """
-            % wandb.Artifact.GQL_FRAGMENT
+            % wandb.Artifact._GQL_FRAGMENT
         )
 
         input_query = gql(
@@ -3840,7 +3842,7 @@ class RunArtifacts(Paginator):
             }
             %s
             """
-            % wandb.Artifact.GQL_FRAGMENT
+            % wandb.Artifact._GQL_FRAGMENT
         )
 
         self.run = run
@@ -3888,7 +3890,7 @@ class RunArtifacts(Paginator):
 
     def convert_objects(self):
         return [
-            wandb.Artifact.from_attrs(
+            wandb.Artifact._from_attrs(
                 self.run.entity,
                 self.run.project,
                 "{}:v{}".format(
@@ -4142,7 +4144,7 @@ class ArtifactVersions(Paginator):
                 artifact_collection_edge_name(
                     server_supports_artifact_collections_gql_edges(client)
                 ),
-                wandb.Artifact.GQL_FRAGMENT,
+                wandb.Artifact._GQL_FRAGMENT,
             )
         )
         super().__init__(client, variables, per_page)
@@ -4178,7 +4180,7 @@ class ArtifactVersions(Paginator):
         if self.last_response["project"]["artifactType"]["artifactCollection"] is None:
             return []
         return [
-            wandb.Artifact.from_attrs(
+            wandb.Artifact._from_attrs(
                 self.entity,
                 self.project,
                 self.collection_name + ":" + a["version"],
@@ -4333,7 +4335,7 @@ class Job:
     def _get_code_artifact(self, artifact_string):
         artifact_string, base_url, is_id = util.parse_artifact_string(artifact_string)
         if is_id:
-            code_artifact = wandb.Artifact.from_id(artifact_string, self._api._client)
+            code_artifact = wandb.Artifact._from_id(artifact_string, self._api._client)
         else:
             code_artifact = self._api.artifact(name=artifact_string, type="code")
         if code_artifact is None:

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -153,7 +153,7 @@ class ArtifactManifestEntry:
         return self.ref is not None and urlparse(self.ref).scheme == "wandb-artifact"
 
     def _get_referenced_artifact(self, client: "RetryingClient") -> "Artifact":
-        artifact: "Artifact" = wandb.Artifact.from_id(
+        artifact: "Artifact" = wandb.Artifact._from_id(
             hex_to_b64_id(util.host_from_path(self.ref)), client
         )
         assert artifact is not None

--- a/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
@@ -62,7 +62,7 @@ class WBArtifactHandler(StorageHandler):
         artifact_id = util.host_from_path(manifest_entry.ref)
         artifact_file_path = util.uri_from_path(manifest_entry.ref)
 
-        dep_artifact = wandb.Artifact.from_id(
+        dep_artifact = wandb.Artifact._from_id(
             hex_to_b64_id(artifact_id), self.client.client
         )
         assert dep_artifact is not None
@@ -100,7 +100,7 @@ class WBArtifactHandler(StorageHandler):
         while iter_path is not None and urlparse(iter_path).scheme == self._scheme:
             artifact_id = util.host_from_path(iter_path)
             artifact_file_path = util.uri_from_path(iter_path)
-            target_artifact = wandb.Artifact.from_id(
+            target_artifact = wandb.Artifact._from_id(
                 hex_to_b64_id(artifact_id), self.client.client
             )
             assert target_artifact is not None

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1291,7 +1291,7 @@ class Run:
         if _is_artifact_version_weave_dict(val):
             assert isinstance(val, dict)
             public_api = self._public_api()
-            artifact = Artifact.from_id(val["id"], public_api.client)
+            artifact = Artifact._from_id(val["id"], public_api.client)
             return self.use_artifact(artifact, use_as=key)
         elif _is_artifact_string(val):
             # this will never fail, but is required to make mypy happy
@@ -1304,7 +1304,7 @@ class Run:
             else:
                 public_api = self._public_api()
             if is_id:
-                artifact = Artifact.from_id(artifact_string, public_api._client)
+                artifact = Artifact._from_id(artifact_string, public_api._client)
             else:
                 artifact = public_api.artifact(name=artifact_string)
             # in the future we'll need to support using artifacts from
@@ -2952,7 +2952,7 @@ class Run:
         if not self._settings._offline:
             try:
                 public_api = self._public_api()
-                expected_type = Artifact.expected_type(
+                expected_type = Artifact._expected_type(
                     public_api.settings["entity"],
                     public_api.settings["project"],
                     artifact.name,


### PR DESCRIPTION
Fixes WB-13943

# Description

There's no way to make a method public to the rest of the wandb package, but not outside of it. I made methods that should not be exposed to users private. This means that we need to be more careful when modifying private methods, because they might be called by other classes in the wandb package.

# Test plan

Tested in https://github.com/wandb/docodile/pull/314