### PR TITLE
feat(integrations): add `plot_bboxes` callback for ultralytics

### DIFF
--- a/tools/pr-title-bot.py
+++ b/tools/pr-title-bot.py
@@ -124,7 +124,7 @@ def check_pr_title(
         messages=messages,
     )
     print(response.choices[0]["message"]["content"])
-    is_compliant = response.choices[0]["message"]["content"]
+    is_compliant = response.choices[0]["message"]["content"].lower()
 
     return is_compliant == "yes"
 

--- a/wandb/integration/yolov8/__init__.py
+++ b/wandb/integration/yolov8/__init__.py
@@ -1,7 +1,1 @@
-"""Tools for integrating `wandb` with [`ultralytics YOLOv8`](https://docs.ultralytics.com/).
-
-YOLOv8 is a computer vision framework for training and deploying YOLOv8 models.
-"""
-__all__ = ("add_callbacks",)
-
-from .yolov8 import add_callbacks
+from .yolov8 import plot_bboxes

--- a/wandb/integration/yolov8/bbox_utils.py
+++ b/wandb/integration/yolov8/bbox_utils.py
@@ -75,7 +75,7 @@ def create_prediction_metadata_map(model_predictions):
     """Create metadata map for model predictions by groupings them based on image ID."""
     pred_metadata_map = {}
     for prediction in model_predictions:
-        pred_metadata_map.setdefault(prediction['image_id'], [])
-        pred_metadata_map[prediction['image_id']].append(prediction)
+        pred_metadata_map.setdefault(prediction["image_id"], [])
+        pred_metadata_map[prediction["image_id"]].append(prediction)
 
     return pred_metadata_map

--- a/wandb/integration/yolov8/bbox_utils.py
+++ b/wandb/integration/yolov8/bbox_utils.py
@@ -35,6 +35,8 @@ def get_ground_truth_annotations(img_idx, image_path, batch, class_name_map=None
     bboxes = batch["bboxes"][indices]
     cls_labels = batch["cls"][indices].squeeze(1).tolist()
 
+    class_name_map_reverse = {v: k for k, v in class_name_map.items()}
+
     if len(bboxes) == 0:
         wandb.termwarn(f"Image: {image_path} has no bounding boxes labels")
         return None
@@ -64,7 +66,7 @@ def get_ground_truth_annotations(img_idx, image_path, batch, class_name_map=None
                     "height": int(box[3]),
                 },
                 "domain": "pixel",
-                "class_id": cls_labels.index(label),
+                "class_id": class_name_map_reverse[label],
                 "box_caption": label,
             }
         )
@@ -83,9 +85,6 @@ def create_prediction_metadata_map(model_predictions):
 
 
 def plot_validation_results(dataloader, class_label_map):
-    class_label_dict = {
-        idx: class_label_map[idx] for idx in range(len(class_label_map))
-    }
     table = wandb.Table(columns=["Index", "Images"])
     images, data_idx = [], 0
     for batch_idx, batch in enumerate(dataloader):
@@ -99,7 +98,7 @@ def plot_validation_results(dataloader, class_label_map):
                     boxes={
                         "ground_truth": {
                             "box_data": ground_truth_data,
-                            "class_labels": class_label_dict,
+                            "class_labels": class_label_map,
                         }
                     },
                 )

--- a/wandb/integration/yolov8/bbox_utils.py
+++ b/wandb/integration/yolov8/bbox_utils.py
@@ -1,6 +1,7 @@
 import wandb
 
 from ultralytics.yolo.utils import RANK, ops
+from ultralytics.yolo.engine.results import Results
 
 
 def scale_bounding_box_to_original_image_shape(
@@ -79,3 +80,64 @@ def create_prediction_metadata_map(model_predictions):
         pred_metadata_map[prediction["image_id"]].append(prediction)
 
     return pred_metadata_map
+
+
+def plot_ground_truth(dataloader, class_label_map):
+    class_label_dict = {
+        idx: class_label_map[idx] for idx in range(len(class_label_map))
+    }
+    images = []
+    for batch_idx, batch in enumerate(dataloader):
+        for img_idx, image_path in enumerate(batch["im_file"]):
+            try:
+                ground_truth_data = get_ground_truth_annotations(
+                    img_idx, image_path, batch, class_label_map
+                )
+                images.append(
+                    wandb.Image(
+                        image_path,
+                        boxes={
+                            "ground_truth": {
+                                "box_data": ground_truth_data,
+                                "class_labels": class_label_dict,
+                            }
+                        },
+                    )
+                )
+            except TypeError:
+                pass
+        if batch_idx + 1 == 1:
+            break
+    wandb.log({"ground_truth": images}, commit=False)
+
+
+def plot_predictions(result: Results, table: wandb.Table) -> wandb.Table:
+    boxes = result.boxes.xywh.to("cpu").long().numpy()
+    classes = result.boxes.cls.to("cpu").long().numpy()
+    confidence = result.boxes.conf.to("cpu").numpy()
+    class_id_to_label = {int(k): str(v) for k, v in result.names.items()}
+    box_data, total_confidence = [], 0.0
+    for idx in range(len(boxes)):
+        box_data.append(
+            {
+                "position": {
+                    "middle": [int(boxes[idx][0]), int(boxes[idx][1])],
+                    "width": int(boxes[idx][2]),
+                    "height": int(boxes[idx][3]),
+                },
+                "domain": "pixel",
+                "class_id": int(classes[idx]),
+                "box_caption": class_id_to_label[int(classes[idx])],
+                "scores": {"confidence": float(confidence[idx])},
+            }
+        )
+        total_confidence += float(confidence[idx])
+    boxes = {
+        "predictions": {
+            "box_data": box_data,
+            "class_labels": class_id_to_label,
+        },
+    }
+    image = wandb.Image(result.orig_img[:, :, ::-1], boxes=boxes)
+    table.add_data(image, len(box_data), total_confidence / len(box_data))
+    return table

--- a/wandb/integration/yolov8/bbox_utils.py
+++ b/wandb/integration/yolov8/bbox_utils.py
@@ -69,3 +69,13 @@ def get_ground_truth_annotations(img_idx, image_path, batch, class_name_map=None
         )
 
     return data
+
+
+def create_prediction_metadata_map(model_predictions):
+    """Create metadata map for model predictions by groupings them based on image ID."""
+    pred_metadata_map = {}
+    for prediction in model_predictions:
+        pred_metadata_map.setdefault(prediction['image_id'], [])
+        pred_metadata_map[prediction['image_id']].append(prediction)
+
+    return pred_metadata_map

--- a/wandb/integration/yolov8/bbox_utils.py
+++ b/wandb/integration/yolov8/bbox_utils.py
@@ -1,0 +1,71 @@
+import wandb
+
+from ultralytics.yolo.utils import RANK, ops
+
+
+def scale_bounding_box_to_original_image_shape(
+    box, resized_image_shape, original_image_shape, ratio_pad
+):
+    """
+    YOLOv8 resizes images during training and the label values
+    are normalized based on this resized shape. This function rescales the
+    bounding box labels to the original image shape.
+
+    Reference: https://github.com/ultralytics/ultralytics/blob/main/ultralytics/yolo/utils/callbacks/comet.py#L105
+    """
+
+    resized_image_height, resized_image_width = resized_image_shape
+
+    # Convert normalized xywh format predictions to xyxy in resized scale format
+    box = ops.xywhn2xyxy(box, h=resized_image_height, w=resized_image_width)
+    # Scale box predictions from resized image scale back to original image scale
+    box = ops.scale_boxes(resized_image_shape, box, original_image_shape, ratio_pad)
+    # # Convert bounding box format from xyxy to xywh for Comet logging
+    box = ops.xyxy2xywh(box)
+    # # Adjust xy center to correspond top-left corner
+    # box[:2] -= box[2:] / 2
+    box = box.tolist()
+
+    return box
+
+
+def get_ground_truth_annotations(img_idx, image_path, batch, class_name_map=None):
+    indices = batch["batch_idx"] == img_idx
+    bboxes = batch["bboxes"][indices]
+    cls_labels = batch["cls"][indices].squeeze(1).tolist()
+
+    if len(bboxes) == 0:
+        wandb.termwarn(f"Image: {image_path} has no bounding boxes labels")
+        return None
+
+    cls_labels = batch["cls"][indices].squeeze(1).tolist()
+    if class_name_map:
+        cls_labels = [str(class_name_map[label]) for label in cls_labels]
+
+    original_image_shape = batch["ori_shape"][img_idx]
+    resized_image_shape = batch["resized_shape"][img_idx]
+    ratio_pad = batch["ratio_pad"][img_idx]
+
+    original_image_shape = batch["ori_shape"][img_idx]
+    resized_image_shape = batch["resized_shape"][img_idx]
+    ratio_pad = batch["ratio_pad"][img_idx]
+
+    data = []
+    for box, label in zip(bboxes, cls_labels):
+        box = scale_bounding_box_to_original_image_shape(
+            box, resized_image_shape, original_image_shape, ratio_pad
+        )
+        data.append(
+            {
+                "position": {
+                    "middle": [int(box[0]), int(box[1])],
+                    "width": int(box[2]),
+                    "height": int(box[3]),
+                },
+                "domain": "pixel",
+                "class_id": cls_labels.index(label),
+                "box_caption": label,
+            }
+        )
+
+    return data

--- a/wandb/integration/yolov8/yolov8.py
+++ b/wandb/integration/yolov8/yolov8.py
@@ -1,15 +1,16 @@
 import wandb
 
 from ultralytics.yolo.v8.detect.train import DetectionTrainer
+from ultralytics.yolo.v8.detect.val import DetectionValidator
 
-from .bbox_utils import get_ground_truth_annotations
+from .bbox_utils import get_ground_truth_annotations, create_prediction_metadata_map
 
 
 def plot_bboxes(trainer: DetectionTrainer):
     if isinstance(trainer, DetectionTrainer):
-        print("CALLBACK HERE!!!")
         dataloader = trainer.validator.dataloader
         class_label_map = trainer.validator.names
+        predictions_metadata_map = create_prediction_metadata_map(trainer.validator.jdict)
         class_label_dict = {
             idx: class_label_map[idx] for idx in range(len(class_label_map))
         }
@@ -35,4 +36,4 @@ def plot_bboxes(trainer: DetectionTrainer):
                     pass
             if batch_idx + 1 == 1:
                 break
-        wandb.log({"sample_images": images}, commit=False)
+        wandb.log({"ground_truth": images}, commit=False)

--- a/wandb/integration/yolov8/yolov8.py
+++ b/wandb/integration/yolov8/yolov8.py
@@ -3,77 +3,22 @@ from typing import Union
 import wandb
 
 from ultralytics.yolo.v8.detect.train import DetectionTrainer
+from ultralytics.yolo.v8.detect.val import DetectionValidator
 from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 
-from .bbox_utils import get_ground_truth_annotations, create_prediction_metadata_map
+from .bbox_utils import plot_ground_truth, plot_predictions
 
 
 def plot_bboxes(trainer: Union[DetectionTrainer, DetectionPredictor]):
     if isinstance(trainer, DetectionTrainer):
         dataloader = trainer.validator.dataloader
         class_label_map = trainer.validator.names
-        predictions_metadata_map = create_prediction_metadata_map(
-            trainer.validator.jdict
-        )
-        class_label_dict = {
-            idx: class_label_map[idx] for idx in range(len(class_label_map))
-        }
-        images = []
-        for batch_idx, batch in enumerate(dataloader):
-            for img_idx, image_path in enumerate(batch["im_file"]):
-                try:
-                    ground_truth_data = get_ground_truth_annotations(
-                        img_idx, image_path, batch, class_label_map
-                    )
-                    images.append(
-                        wandb.Image(
-                            image_path,
-                            boxes={
-                                "ground_truth": {
-                                    "box_data": ground_truth_data,
-                                    "class_labels": class_label_dict,
-                                }
-                            },
-                        )
-                    )
-                except TypeError:
-                    pass
-            if batch_idx + 1 == 1:
-                break
-        wandb.log({"ground_truth": images}, commit=False)
+        plot_ground_truth(dataloader, class_label_map)
 
     elif isinstance(trainer, DetectionPredictor):
         predictor = trainer
         results = predictor.results
         table = wandb.Table(columns=["Image", "Num-Objects", "Mean-Confidence"])
         for idx, result in enumerate(results):
-            boxes = result.boxes.xywh.to("cpu").long().numpy()
-            classes = result.boxes.cls.to("cpu").long().numpy()
-            confidence = result.boxes.conf.to("cpu").numpy()
-            class_id_to_label = {int(k): str(v) for k, v in result.names.items()}
-            box_data, total_confidence = [], 0.0
-            for idx in range(len(boxes)):
-                box_data.append(
-                    {
-                        "position": {
-                            "middle": [int(boxes[idx][0]), int(boxes[idx][1])],
-                            "width": int(boxes[idx][2]),
-                            "height": int(boxes[idx][3]),
-                        },
-                        "domain": "pixel",
-                        "class_id": int(classes[idx]),
-                        "box_caption": class_id_to_label[int(classes[idx])],
-                        "scores": {"confidence": float(confidence[idx])},
-                    }
-                )
-                total_confidence += float(confidence[idx])
-            boxes = {
-                "predictions": {
-                    "box_data": box_data,
-                    "class_labels": class_id_to_label,
-                },
-            }
-            image = wandb.Image(result.orig_img[:, :, ::-1], boxes=boxes)
-            table.add_data(image, len(box_data), total_confidence / len(box_data))
-
+            table = plot_predictions(result, table)
         wandb.log({"Object-Detection-Table": table})

--- a/wandb/integration/yolov8/yolov8.py
+++ b/wandb/integration/yolov8/yolov8.py
@@ -1,250 +1,38 @@
-from typing import Any, Callable, Dict, List, Optional
-
-from ultralytics.yolo.engine.model import YOLO
-from ultralytics.yolo.engine.trainer import BaseTrainer
-from ultralytics.yolo.utils import RANK
-from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
-from ultralytics.yolo.v8.classify.train import ClassificationTrainer
-
 import wandb
-from wandb.sdk.lib import telemetry
+
+from ultralytics.yolo.v8.detect.train import DetectionTrainer
+
+from .bbox_utils import get_ground_truth_annotations
 
 
-class WandbCallback:
-    """An internal YOLO model wrapper that tracks metrics, and logs models to Weights & Biases.
-
-    Usage:
-    ```python
-    from wandb.integration.yolov8.yolov8 import WandbCallback
-    model = YOLO("yolov8n.pt")
-    wandb_logger = WandbCallback(model,)
-    for event, callback_fn in wandb_logger.callbacks.items():
-        model.add_callback(event, callback_fn)
-    ```
-    """
-
-    def __init__(
-        self,
-        yolo: YOLO,
-        run_name: Optional[str] = None,
-        project: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-        resume: Optional[str] = None,
-        **kwargs: Optional[Any],
-    ) -> None:
-        """A utility class to manage wandb run and various callbacks for the ultralytics YOLOv8 framework.
-
-        Args:
-            yolo: A YOLOv8 model that's inherited from `:class:ultralytics.yolo.engine.model.YOLO`
-            run_name, str: The name of the Weights & Biases run, defaults to an auto generated run_name if `trainer.args.name` is not defined.
-            project, str: The name of the Weights & Biases project, defaults to `"YOLOv8"` if `trainer.args.project` is not defined.
-            tags, List[str]: A list of tags to be added to the Weights & Biases run, defaults to `["YOLOv8"]`.
-            resume, str: Whether to resume a previous run on Weights & Biases, defaults to `None`.
-            **kwargs: Additional arguments to be passed to `wandb.init()`.
-        """
-        self.yolo = yolo
-        self.run_name = run_name
-        self.project = project
-        self.tags = tags
-        self.resume = resume
-        self.kwargs = kwargs
-
-    def on_pretrain_routine_start(self, trainer: BaseTrainer) -> None:
-        """Starts a new wandb run to track the training process and log to Weights & Biases.
-
-        Args:
-            trainer: A task trainer that's inherited from `:class:ultralytics.yolo.engine.trainer.BaseTrainer`
-                    that contains the model training and optimization routine.
-        """
-        if wandb.run is None:
-            self.run = wandb.init(
-                name=self.run_name if self.run_name else trainer.args.name,
-                project=self.project
-                if self.project
-                else trainer.args.project or "YOLOv8",
-                tags=self.tags if self.tags else ["YOLOv8"],
-                config=vars(trainer.args),
-                resume=self.resume if self.resume else None,
-                **self.kwargs,
-            )
-        else:
-            self.run = wandb.run
-        self.run.define_metric("epoch", hidden=True)
-        self.run.define_metric(
-            "train/*", step_metric="epoch", step_sync=True, summary="min"
-        )
-
-        self.run.define_metric(
-            "val/*", step_metric="epoch", step_sync=True, summary="min"
-        )
-
-        self.run.define_metric(
-            "metrics/*", step_metric="epoch", step_sync=True, summary="max"
-        )
-        self.run.define_metric(
-            "lr/*", step_metric="epoch", step_sync=True, summary="last"
-        )
-
-        with telemetry.context(run=wandb.run) as tel:
-            tel.feature.ultralytics_yolov8 = True
-
-    def on_pretrain_routine_end(self, trainer: BaseTrainer) -> None:
-        self.run.summary.update(
-            {
-                "model/parameters": get_num_params(trainer.model),
-                "model/GFLOPs": round(get_flops(trainer.model), 3),
-            }
-        )
-
-    def on_train_epoch_start(self, trainer: BaseTrainer) -> None:
-        """On train epoch start we only log epoch number to the Weights & Biases run."""
-        # We log the epoch number here to commit the previous step,
-        self.run.log({"epoch": trainer.epoch + 1})
-
-    def on_train_epoch_end(self, trainer: BaseTrainer) -> None:
-        """On train epoch end we log all the metrics to the Weights & Biases run."""
-        self.run.log(
-            {
-                **trainer.metrics,
-                **trainer.label_loss_items(trainer.tloss, prefix="train"),
-                **trainer.lr,
-            },
-        )
-        # Currently only the detection and segmentation trainers save images to the save_dir
-        if not isinstance(trainer, ClassificationTrainer):
-            self.run.log(
-                {
-                    "train_batch_images": [
-                        wandb.Image(str(image_path), caption=image_path.stem)
-                        for image_path in trainer.save_dir.glob("train_batch*.jpg")
-                    ]
-                }
-            )
-
-    def on_fit_epoch_end(self, trainer: BaseTrainer) -> None:
-        """On fit epoch end we log all the best metrics and model detail to Weights & Biases run summary."""
-        if trainer.epoch == 0:
-            speeds = [
-                trainer.validator.speed.get(
-                    key,
-                )
-                for key in (1, "inference")
-            ]
-            speed = speeds[0] if speeds[0] else speeds[1]
-            if speed:
-                self.run.summary.update(
-                    {
-                        "model/speed(ms/img)": round(speed, 3),
-                    }
-                )
-        if trainer.best_fitness == trainer.fitness:
-            self.run.summary.update(
-                {
-                    "best/epoch": trainer.epoch + 1,
-                    **{f"best/{key}": val for key, val in trainer.metrics.items()},
-                }
-            )
-
-    def on_train_end(self, trainer: BaseTrainer) -> None:
-        """On train end we log all the media, including plots, images and best model artifact to Weights & Biases."""
-        # Currently only the detection and segmentation trainers save images to the save_dir
-        if not isinstance(trainer, ClassificationTrainer):
-            self.run.log(
-                {
-                    "plots": [
-                        wandb.Image(str(image_path), caption=image_path.stem)
-                        for image_path in trainer.save_dir.glob("*.png")
-                    ],
-                    "val_images": [
-                        wandb.Image(str(image_path), caption=image_path.stem)
-                        for image_path in trainer.validator.save_dir.glob("val*.jpg")
-                    ],
-                },
-            )
-
-        if trainer.best.exists():
-            self.run.log_artifact(
-                str(trainer.best),
-                type="model",
-                name=f"{self.run.name}_{trainer.args.task}.pt",
-                aliases=["best", f"epoch_{trainer.epoch + 1}"],
-            )
-
-    def on_model_save(self, trainer: BaseTrainer) -> None:
-        """On model save we log the model as an artifact to Weights & Biases."""
-        self.run.log_artifact(
-            str(trainer.last),
-            type="model",
-            name=f"{self.run.name}_{trainer.args.task}.pt",
-            aliases=["last", f"epoch_{trainer.epoch + 1}"],
-        )
-
-    def teardown(self, _trainer: BaseTrainer) -> None:
-        """On teardown, we finish the Weights & Biases run and set it to None."""
-        self.run.finish()
-        self.run = None
-
-    @property
-    def callbacks(
-        self,
-    ) -> Dict[str, Callable]:
-        """Property contains all the relevant callbacks to add to the YOLO model for the Weights & Biases logging."""
-        return {
-            "on_pretrain_routine_start": self.on_pretrain_routine_start,
-            "on_pretrain_routine_end": self.on_pretrain_routine_end,
-            "on_train_epoch_start": self.on_train_epoch_start,
-            "on_train_epoch_end": self.on_train_epoch_end,
-            "on_fit_epoch_end": self.on_fit_epoch_end,
-            "on_train_end": self.on_train_end,
-            "on_model_save": self.on_model_save,
-            "teardown": self.teardown,
+def plot_bboxes(trainer: DetectionTrainer):
+    if isinstance(trainer, DetectionTrainer):
+        print("CALLBACK HERE!!!")
+        dataloader = trainer.validator.dataloader
+        class_label_map = trainer.validator.names
+        class_label_dict = {
+            idx: class_label_map[idx] for idx in range(len(class_label_map))
         }
-
-
-def add_callbacks(
-    yolo: YOLO,
-    run_name: Optional[str] = None,
-    project: Optional[str] = None,
-    tags: Optional[List[str]] = None,
-    resume: Optional[str] = None,
-    **kwargs: Optional[Any],
-) -> YOLO:
-    """A YOLO model wrapper that tracks metrics, and logs models to Weights & Biases.
-
-    Args:
-        yolo: A YOLOv8 model that's inherited from `:class:ultralytics.yolo.engine.model.YOLO`
-        run_name, str: The name of the Weights & Biases run, defaults to an auto generated name if `trainer.args.name` is not defined.
-        project, str: The name of the Weights & Biases project, defaults to `"YOLOv8"` if `trainer.args.project` is not defined.
-        tags, List[str]: A list of tags to be added to the Weights & Biases run, defaults to `["YOLOv8"]`.
-        resume, str: Whether to resume a previous run on Weights & Biases, defaults to `None`.
-        **kwargs: Additional arguments to be passed to `wandb.init()`.
-
-    Usage:
-    ```python
-    from wandb.integration.yolov8 import add_callbacks as add_wandb_callbacks
-    model = YOLO("yolov8n.pt")
-    add_wandb_callbacks(model,)
-    model.train(data="coco128.yaml", epochs=3, imgsz=640,)
-    ```
-    """
-    wandb.termwarn(
-        """The wandb callback is currently in beta and is subject to change based on updates to `ultralytics yolov8`.
-        The callback is tested and supported for ultralytics v8.0.43 and above.
-        Please report any issues to https://github.com/wandb/wandb/issues with the tag `yolov8`.
-        """,
-        repeat=False,
-    )
-
-    if RANK in [-1, 0]:
-        wandb_logger = WandbCallback(
-            yolo, run_name=run_name, project=project, tags=tags, resume=resume, **kwargs
-        )
-        for event, callback_fn in wandb_logger.callbacks.items():
-            yolo.add_callback(event, callback_fn)
-        return yolo
-    else:
-        wandb.termerror(
-            "The RANK of the process to add the callbacks was neither 0 or -1."
-            "No Weights & Biases callbacks were added to this instance of the YOLO model."
-        )
-    return yolo
+        images = []
+        for batch_idx, batch in enumerate(dataloader):
+            for img_idx, image_path in enumerate(batch["im_file"]):
+                try:
+                    ground_truth_data = get_ground_truth_annotations(
+                        img_idx, image_path, batch, class_label_map
+                    )
+                    images.append(
+                        wandb.Image(
+                            image_path,
+                            boxes={
+                                "ground_truth": {
+                                    "box_data": ground_truth_data,
+                                    "class_labels": class_label_dict,
+                                }
+                            },
+                        )
+                    )
+                except TypeError:
+                    pass
+            if batch_idx + 1 == 1:
+                break
+        wandb.log({"sample_images": images}, commit=False)

--- a/wandb/integration/yolov8/yolov8.py
+++ b/wandb/integration/yolov8/yolov8.py
@@ -1,16 +1,20 @@
+from typing import Union
+
 import wandb
 
 from ultralytics.yolo.v8.detect.train import DetectionTrainer
-from ultralytics.yolo.v8.detect.val import DetectionValidator
+from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 
 from .bbox_utils import get_ground_truth_annotations, create_prediction_metadata_map
 
 
-def plot_bboxes(trainer: DetectionTrainer):
+def plot_bboxes(trainer: Union[DetectionTrainer, DetectionPredictor]):
     if isinstance(trainer, DetectionTrainer):
         dataloader = trainer.validator.dataloader
         class_label_map = trainer.validator.names
-        predictions_metadata_map = create_prediction_metadata_map(trainer.validator.jdict)
+        predictions_metadata_map = create_prediction_metadata_map(
+            trainer.validator.jdict
+        )
         class_label_dict = {
             idx: class_label_map[idx] for idx in range(len(class_label_map))
         }
@@ -37,3 +41,39 @@ def plot_bboxes(trainer: DetectionTrainer):
             if batch_idx + 1 == 1:
                 break
         wandb.log({"ground_truth": images}, commit=False)
+
+    elif isinstance(trainer, DetectionPredictor):
+        predictor = trainer
+        results = predictor.results
+        table = wandb.Table(columns=["Image", "Num-Objects", "Mean-Confidence"])
+        for idx, result in enumerate(results):
+            boxes = result.boxes.xywh.to("cpu").long().numpy()
+            classes = result.boxes.cls.to("cpu").long().numpy()
+            confidence = result.boxes.conf.to("cpu").numpy()
+            class_id_to_label = {int(k): str(v) for k, v in result.names.items()}
+            box_data, total_confidence = [], 0.0
+            for idx in range(len(boxes)):
+                box_data.append(
+                    {
+                        "position": {
+                            "middle": [int(boxes[idx][0]), int(boxes[idx][1])],
+                            "width": int(boxes[idx][2]),
+                            "height": int(boxes[idx][3]),
+                        },
+                        "domain": "pixel",
+                        "class_id": int(classes[idx]),
+                        "box_caption": class_id_to_label[int(classes[idx])],
+                        "scores": {"confidence": float(confidence[idx])},
+                    }
+                )
+                total_confidence += float(confidence[idx])
+            boxes = {
+                "predictions": {
+                    "box_data": box_data,
+                    "class_labels": class_id_to_label,
+                },
+            }
+            image = wandb.Image(result.orig_img[:, :, ::-1], boxes=boxes)
+            table.add_data(image, len(box_data), total_confidence / len(box_data))
+
+        wandb.log({"Object-Detection-Table": table})

--- a/wandb/integration/yolov8/yolov8.py
+++ b/wandb/integration/yolov8/yolov8.py
@@ -2,18 +2,18 @@ from typing import Union
 
 import wandb
 
-from ultralytics.yolo.v8.detect.train import DetectionTrainer
 from ultralytics.yolo.v8.detect.val import DetectionValidator
 from ultralytics.yolo.v8.detect.predict import DetectionPredictor
 
-from .bbox_utils import plot_ground_truth, plot_predictions
+from .bbox_utils import plot_validation_results, plot_predictions
 
 
-def plot_bboxes(trainer: Union[DetectionTrainer, DetectionPredictor]):
-    if isinstance(trainer, DetectionTrainer):
-        dataloader = trainer.validator.dataloader
-        class_label_map = trainer.validator.names
-        plot_ground_truth(dataloader, class_label_map)
+def plot_bboxes(trainer: Union[DetectionValidator, DetectionPredictor]):
+    if isinstance(trainer, DetectionValidator):
+        validator = trainer
+        dataloader = validator.dataloader
+        class_label_map = validator.names
+        plot_validation_results(dataloader, class_label_map)
 
     elif isinstance(trainer, DetectionPredictor):
         predictor = trainer


### PR DESCRIPTION
Description
-----------
Add `plot_bboxes` callback for `ultralytics`

## Sample Usage for Validation

```python
from ultralytics.yolo.engine.model import YOLO
from wandb.integration.yolov8 import plot_bboxes


model = YOLO("yolov8n.pt")

model.add_callback("on_val_end", plot_bboxes)
model.train(
    data="coco128.yaml",
    epochs=2,
    imgsz=640,
)
model.val()
```

This currently logs a single validation batch with the interactive bounding box overlay corresponding to ground-truth lables in a table during the validation step.

Sample Run: https://wandb.ai/geekyrakshit/YOLOv8/runs/4yrnxnoi

**Note:** Plotting predictions is a work-in-progress.

## Sample Usage for Prediction

```python
from ultralytics import YOLO

import wandb
from wandb.integration.yolov8 import plot_bboxes


wandb.init(project='YOLOv8', entity="geekyrakshit")

model = YOLO('yolov8n.pt')

model.add_callback("on_predict_postprocess_end", plot_bboxes)
model(['https://ultralytics.com/images/bus.jpg', 'dove-2516641_1280.jpg'])
```

This currently logs the prediction batch with the interactive bounding box overlay corresponding to prediced lables in a table.

Sample Run: https://wandb.ai/geekyrakshit/YOLOv8/runs/vx1x2yiq