### PR TITLE
fix(sweeps): correct launch sweep author to personal username

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1036,7 +1036,7 @@ def launch_sweep(
         sweep_config=sweep_config,
         queue=queue,
         project=project,
-        author=entity,
+        author=wandb.Settings().get("username"),
     )
     if not args:
         return

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -949,6 +949,9 @@ def launch_sweep(
         wandb.termerror("A project must be configured when using launch")
         return
 
+    # get personal username, not team name or service account, default entity
+    author = api.viewer().get("username") or entity
+
     # if not sweep_config XOR resume_id
     if not (config or resume_id):
         wandb.termerror("'config' and/or 'resume_id' required")
@@ -1036,7 +1039,7 @@ def launch_sweep(
         sweep_config=sweep_config,
         queue=queue,
         project=project,
-        author=wandb.Settings().get("username"),
+        author=author,
     )
     if not args:
         return

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -949,7 +949,7 @@ def launch_sweep(
         wandb.termerror("A project must be configured when using launch")
         return
 
-    # get personal username, not team name or service account, default entity
+    # get personal username, not team name or service account, default to entity
     author = api.viewer().get("username") or entity
 
     # if not sweep_config XOR resume_id

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -711,6 +711,7 @@ class Api:
             viewer {
                 id
                 entity
+                username
                 flags
                 teams {
                     edges {


### PR DESCRIPTION
Prod defaults to the entity passed in, which in many cases is the team entity. Update viewer api call to get username, and use that if available.