### PR TITLE
fix(artifacts): fix handling of references when downloading

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1602,7 +1602,6 @@ class Artifact:
 
         with concurrent.futures.ThreadPoolExecutor(64) as executor:
             active_futures = set()
-            # Download files.
             has_next_page = True
             cursor = None
             while has_next_page:
@@ -1621,10 +1620,6 @@ class Artifact:
                         active_futures.remove(future)
                         if len(active_futures) <= max_backlog:
                             break
-            # Download references.
-            for entry in self.manifest.entries.values():
-                if entry.ref is not None:
-                    active_futures.add(executor.submit(download_entry, entry))
             # Check for errors.
             for future in concurrent.futures.as_completed(active_futures):
                 future.result()


### PR DESCRIPTION
Fixes WB-13972

# Description

This fixes a bug introduced in https://github.com/wandb/wandb/pull/5692. I assumed `Artifact.files()` in GraphQL doesn't include references, but it does.

# Test plan

Downloaded an artifact with 500 references, made sure the counter correctly said 500 / 500:
![Untitled](https://github.com/wandb/wandb/assets/127154459/bb033e4a-a33f-4ec0-89f3-e2e3e832a724)