### PR TITLE
fix(artifacts): fix collection filtering when getting aliases

### DIFF
--- a/tests/pytest_tests/unit_tests/test_saved_model.py
+++ b/tests/pytest_tests/unit_tests/test_saved_model.py
@@ -94,7 +94,18 @@ def make_local_artifact_public(art):
             "artifactType": {
                 "name": "FAKE_TYPE_NAME",
             },
-            "aliases": [{"artifactCollectionName": "FAKE_NAME", "alias": "v0"}],
+            "aliases": [
+                {
+                    "artifactCollection": {
+                        "project": {
+                            "entityName": "FAKE_ENTITY",
+                            "name": "FAKE_PROJECT",
+                        },
+                        "name": "FAKE_NAME",
+                    },
+                    "alias": "v0",
+                }
+            ],
             "artifactSequence": {
                 "name": "FAKE_SEQUENCE_NAME",
                 "project": {

--- a/tests/pytest_tests/unit_tests_old/utils/mock_server.py
+++ b/tests/pytest_tests/unit_tests_old/utils/mock_server.py
@@ -295,7 +295,13 @@ def artifact2(
         "metadata": None,
         "aliases": [
             {
-                "artifactCollectionName": name,
+                "artifactCollection": {
+                    "project": {
+                        "entityName": entity,
+                        "name": project,
+                    },
+                    "name": name,
+                },
                 "alias": "v%i" % ctx["page_count"],
             },
         ],
@@ -1460,16 +1466,38 @@ def create_app(user_ctx=None):
             artifacts["totalCount"] = ctx["page_times"]
             return {"data": {"project": {"run": {key: artifacts}}}}
         if "query RunInputArtifacts(" in body["query"]:
-            artifacts = paginated(artifact2(ctx), ctx)
+            artifacts = paginated(
+                artifact2(
+                    ctx,
+                    entity=body["variables"]["entity"],
+                    project=body["variables"]["project"],
+                ),
+                ctx,
+            )
             artifacts["totalCount"] = ctx["page_times"]
             return {"data": {"project": {"run": {"inputArtifacts": artifacts}}}}
         if "query RunOutputArtifacts(" in body["query"]:
-            artifacts = paginated(artifact2(ctx), ctx)
+            artifacts = paginated(
+                artifact2(
+                    ctx,
+                    entity=body["variables"]["entity"],
+                    project=body["variables"]["project"],
+                ),
+                ctx,
+            )
             artifacts["totalCount"] = ctx["page_times"]
             return {"data": {"project": {"run": {"outputArtifacts": artifacts}}}}
         if "query Artifacts(" in body["query"]:
             version = "v%i" % ctx["page_count"]
-            artifacts = paginated(artifact2(ctx), ctx, {"version": version})
+            artifacts = paginated(
+                artifact2(
+                    ctx,
+                    entity=body["variables"]["entity"],
+                    project=body["variables"]["project"],
+                ),
+                ctx,
+                {"version": version},
+            )
             artifacts["totalCount"] = ctx["page_times"]
             return {
                 "data": {

--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ setenv=
     ; Setting low network buffer so that we exercise flow control logic
     WANDB__NETWORK_BUFFER=1000
     COVERAGE_FILE={envdir}/.coverage
-    YEA_WANDB_VERSION=0.9.13
+    YEA_WANDB_VERSION=0.9.14
 passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -125,7 +125,13 @@ class Artifact:
           description
           metadata
           aliases {
-              artifactCollectionName
+              artifactCollection {
+                  project {
+                      entityName
+                      name
+                  }
+                  name
+              }
               alias
           }
           state
@@ -296,11 +302,15 @@ class Artifact:
         artifact._entity = entity
         artifact._project = project
         artifact._name = name
-        version_aliases = [
+        aliases = [
             alias["alias"]
-            for alias in attrs.get("aliases", [])
-            if alias["artifactCollectionName"] == name.split(":")[0]
-            and util.alias_is_version_index(alias["alias"])
+            for alias in attrs["aliases"]
+            if alias["artifactCollection"]["project"]["entityName"] == entity
+            and alias["artifactCollection"]["project"]["name"] == project
+            and alias["artifactCollection"]["name"] == name.split(":")[0]
+        ]
+        version_aliases = [
+            alias for alias in aliases if util.alias_is_version_index(alias)
         ]
         assert len(version_aliases) == 1
         artifact._version = version_aliases[0]
@@ -316,10 +326,7 @@ class Artifact:
             json.loads(attrs["metadata"] or "{}")
         )
         artifact._aliases = [
-            alias["alias"]
-            for alias in attrs.get("aliases", [])
-            if alias["artifactCollectionName"] == name.split(":")[0]
-            and not util.alias_is_version_index(alias["alias"])
+            alias for alias in aliases if not util.alias_is_version_index(alias)
         ]
         artifact._saved_aliases = copy(artifact._aliases)
         artifact._state = ArtifactState(attrs["state"])
@@ -724,7 +731,13 @@ class Artifact:
                     }
                     versionIndex
                     aliases {
-                        artifactCollectionName
+                        artifactCollection {
+                            project {
+                                entityName
+                                name
+                            }
+                            name
+                        }
                         alias
                     }
                     state
@@ -762,8 +775,10 @@ class Artifact:
         self._source_version = self._version
         self._aliases = [
             alias["alias"]
-            for alias in attrs.get("aliases", [])
-            if alias["artifactCollectionName"] == self._name.split(":")[0]
+            for alias in attrs["aliases"]
+            if alias["artifactCollection"]["project"]["entityName"] == self._entity
+            and alias["artifactCollection"]["project"]["name"] == self._project
+            and alias["artifactCollection"]["name"] == self._name.split(":")[0]
             and not util.alias_is_version_index(alias["alias"])
         ]
         self._state = ArtifactState(attrs["state"])


### PR DESCRIPTION
Fixes WB-14295

# Description

Each artifact has a different set of aliases in each collection it's a member of. We fetch aliases as (collection name, alias) pairs and filter to those where the collection name is the same as the one used to fetch the artifact. However, comparing by name is not enough, since there can be collections with the same name in different projects. We have to compare collections by their (entity, project, name).

Corresponding yea-wandb PR: https://github.com/wandb/yea-wandb/pull/116

# Test plan

In 0.15.4:
<img width="1154" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/5d8fc467-524b-44b5-b94d-65dc335d290c">

After an assert that there is exactly one vN alias was added in https://github.com/wandb/wandb/pull/5454:
<img width="1156" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/2d6240dc-79c2-44a2-a6a1-f0faaec2f938">

After this PR:
<img width="1155" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/879be84e-ae1e-44fc-8124-ca8f465e4fe6">