### PR TITLE
fix(sdk): only creating new project if it doesn't already exist

### DIFF
--- a/wandb/apis/reports/report.py
+++ b/wandb/apis/reports/report.py
@@ -183,7 +183,15 @@ class Report(Base):
             termwarn("Report has not been modified")
 
         # create project if not exists
-        PublicApi().create_project(self.project, self.entity)
+        projects = PublicApi().projects(self.entity)
+        is_new_project = True
+        for p in projects:
+            if p.name == self.project:
+                is_new_project = False
+                break
+
+        if is_new_project:
+            PublicApi().create_project(self.project, self.entity)
 
         # All panel grids must have at least one runset
         for pg in self.panel_grids:


### PR DESCRIPTION
Fixes
-----

WB-11954


Description
-----------
What does the PR do?

Issue where if a project already exists we require admin permissions to change (makes sense, don’t want non-admins changing a private project to public for example). 

If the project didn’t exist, we created it successfully and saved the report. 

We should instead check if the project exists first, and if it doesn’t, create it, otherwise just save the report. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1bcc58e</samp>

Fix report saving bug with new projects. Add a check for existing project in `report.py` before creating one.

Testing
-------


Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1bcc58e</samp>

> _Before `create_project`_
> _Check if it already exists_
> _A wise autumn leaf_
