### PR TITLE
test(sdk): add storage to relay server and filepusher test

### DIFF
--- a/tests/standalone_tests/mitm_tests/fp_inject.py
+++ b/tests/standalone_tests/mitm_tests/fp_inject.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import time
+
+import wandb
+import yea
+
+
+def main():
+    run = wandb.init()
+    history = 200
+    for i in range(history):
+        print(i)
+        run.log(dict(num=i))
+        time.sleep(0.1)
+    print("done")
+    run.finish()
+
+
+if __name__ == "__main__":
+    yea.setup()
+    main()

--- a/tests/standalone_tests/mitm_tests/t3_fp_inject.yea
+++ b/tests/standalone_tests/mitm_tests/t3_fp_inject.yea
@@ -1,0 +1,21 @@
+plugin:
+  - wandb
+tag:
+  shards:
+    - standalone-mitm
+option:
+  - :wandb:mitm
+command:
+  program: fp_inject.py
+assert:
+  - :wandb:runs_len: 1
+trigger:
+  - storage:
+      command: pause
+      service: storage
+      count: 1
+      time: 60
+      skip: 3
+      one_shot: 1
+      # on the 3rd storage request, inject a one_shot delay of 60 seconds
+      # this will cause a retry (with the new filestream logic that is being added)

--- a/wandb/testing/relay.py
+++ b/wandb/testing/relay.py
@@ -320,6 +320,11 @@ class QueryResolver:
                 .get("files", {})
                 .get("edges", [])
             )
+            print("FILES#############", files)
+            print("RESP#############", response_data)
+            # {'data': {'model': {'bucket': {'id': 'UnVuOnYxOjBncnVydnZsOndhbmRiLXRlc3RzX3N0YW5kYWxvbmVfdGVzdHNfbWl0bV90ZXN0czpqZWZmcg==', 'files': {'uploadHeaders': [], 'edges': [{'node': {'name': 'wandb-summary.json', 'url': 'https://storage.googleapis.com/wandb-production.appspot.com/jeffr/wandb-tests_standalone_tests_mitm_tests/0grurvvl/wandb-summary.json?Expires=1688170259&GoogleAccessId=wandb-production%40appspot.gserviceaccount.com&Signature=b4ggpmIe%2F21r%2FWkdT%2F0NFblxiTVy9zXws%2BzEjq0v5ymIVYyVf7TOjfMaDLUNSxY2V5ZjYkru8qjv6Wjghcog5IPXHoOeQYrGZbbnAeTPQnAGZA59QB43QcrMNdmc%2F%2Bbw1kIRs5W%2B%2BbeLLBxaG2lVQ1JPnyuewLbA10ShqxLZWgT8kaUsH2weX1ieYIJpYc%2Br%2BQxAxC6YPM6XZ7gKikjxfm%2FmLd4VyqBCse6z1pYIRwyUDPYDbbhsKIu3%2FVDNm3GgBzyZyDOPGOhnJR19B6tXVeMmWygXuU%2F0KMPTP6bVveoT94nP7d9VyFaJsOc6kuq%2BELSXR71lyiVZNOlOy73LqQ%3D%3D', 'updatedAt': None}}]}}}}}
+            # TODO: replace storage urls with relay storage urls so we can snoop on it
+
             # note: we count all attempts to upload files
             post_processed_data = {
                 "name": name,

--- a/wandb/testing/relay.py
+++ b/wandb/testing/relay.py
@@ -323,7 +323,10 @@ class QueryResolver:
             print("FILES#############", files)
             print("RESP#############", response_data)
             # {'data': {'model': {'bucket': {'id': 'UnVuOnYxOjBncnVydnZsOndhbmRiLXRlc3RzX3N0YW5kYWxvbmVfdGVzdHNfbWl0bV90ZXN0czpqZWZmcg==', 'files': {'uploadHeaders': [], 'edges': [{'node': {'name': 'wandb-summary.json', 'url': 'https://storage.googleapis.com/wandb-production.appspot.com/jeffr/wandb-tests_standalone_tests_mitm_tests/0grurvvl/wandb-summary.json?Expires=1688170259&GoogleAccessId=wandb-production%40appspot.gserviceaccount.com&Signature=b4ggpmIe%2F21r%2FWkdT%2F0NFblxiTVy9zXws%2BzEjq0v5ymIVYyVf7TOjfMaDLUNSxY2V5ZjYkru8qjv6Wjghcog5IPXHoOeQYrGZbbnAeTPQnAGZA59QB43QcrMNdmc%2F%2Bbw1kIRs5W%2B%2BbeLLBxaG2lVQ1JPnyuewLbA10ShqxLZWgT8kaUsH2weX1ieYIJpYc%2Br%2BQxAxC6YPM6XZ7gKikjxfm%2FmLd4VyqBCse6z1pYIRwyUDPYDbbhsKIu3%2FVDNm3GgBzyZyDOPGOhnJR19B6tXVeMmWygXuU%2F0KMPTP6bVveoT94nP7d9VyFaJsOc6kuq%2BELSXR71lyiVZNOlOy73LqQ%3D%3D', 'updatedAt': None}}]}}}}}
+            # FILES############# [{'node': {'name': 'wandb-summary.json', 'url': 'https://storage.googleapis.com/wandb-production.appspot.com/jeffr/wandb-tests_standalone_tests_mitm_tests/uy9r3u0k/wandb-summary.json?Expires=1688172951&GoogleAccessId=wandb-production%40appspot.gserviceaccount.com&Signature=A7611BJ1Y71%2FSsKU8%2Fb%2BLXM0kb3xRDODF2lkt5sTmjghAaHT6PlljtGIRPukz%2F8ymaty0lgf7%2Fj6XjlpcmQ2Aa4901%2Fx9YiRd1oM6lzzAfnipc0SZsjSvv77VyOIdfX4ZgVFa0AuTtUGmeQ%2BqKbZxi69gMrYu5Rvyf1vl%2Fv3Hx0j8m%2Bg6H0d7npBl70%2FwzKYzxibQ730uNIyIPDe1MWDUiqtmezUO1lB3oX7b2BWebB0oQWM1tyQFEHvdf96n32pNMAE%2B%2BKf%2Brk3%2BXLvK5yJUiwGGQ7zOeTRf4X5DGJ8HTbcLD%2B7Jqs8NEfMJd1vFgCLqy2ynyLVhN2Sn1P0a0LsYg%3D%3D', 'updatedAt': None}}]
+
             # TODO: replace storage urls with relay storage urls so we can snoop on it
+            # FIXME: walk into files list.. changing the url values
 
             # note: we count all attempts to upload files
             post_processed_data = {


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e8179c</samp>

This pull request adds a new feature to customize the timeout for the file stream requests in wandb, which are used to upload files and data to the wandb server. It modifies the `FileStreamApi`, `SendManager`, `Settings`, and `SettingsStatic` classes to support the new `_file_stream_timeout_seconds` attribute. It also adds some tests and debugging code to verify the file stream logic and the retry mechanism. It fixes a typo and updates the `tox.ini` file.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1e8179c</samp>

> _Sing, O Muse, of the file stream logic and its testing_
> _How the skilled developers of wandb devised a script_
> _`fs_inject.py`, the swift and cunning data logger_
> _And how they checked its workings with a yea test and a trigger_
