### PR TITLE
chore(artifacts): fix artifacts test regression by sorting lists before comparing

### DIFF
--- a/tests/standalone_tests/artifact_tests.py
+++ b/tests/standalone_tests/artifact_tests.py
@@ -33,7 +33,10 @@ def _run_eq(run_a, run_b):
     )
 
 
-def _runs_eq(runs_a, runs_b):
+def _runs_eq(runs_a, runs_b, sort=True):
+    if sort:
+        runs_a = sorted(runs_a, key=lambda run: run.id)
+        runs_b = sorted(runs_b, key=lambda run: run.id)
     return all([_run_eq(run_a, run_b) for run_a, run_b in zip(runs_a, runs_b)])
 
 


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-14321](https://wandb.atlassian.net/browse/WB-14321)

Description
-----------
Artifacts regression test is failing due to comparing two unsorted lists with random orders. This just sorts them in the test. (if `Artifact.used_by()` should return a consistent order that would be a different PR)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c93a125</samp>

Fixed a flaky artifact test by adding a `sort` argument to the `_runs_eq` helper function in `tests/standalone_tests/artifact_tests.py`. Updated the test cases to use the new argument.

Testing
-------
Standalone test affected run a few times, seems to work consistently instead of half the time.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c93a125</samp>

> _`_runs_eq` changed_
> _Optional `sort` argument_
> _Fixes flaky test_


[WB-14321]: https://wandb.atlassian.net/browse/WB-14321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ