### PR TITLE
fix(launch): add + to torch cpu regex + tests

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_bootstrap.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_bootstrap.py
@@ -1,0 +1,32 @@
+import re
+
+import pytest
+from wandb.sdk.launch.builder.templates._wandb_bootstrap import TORCH_DEP_REGEX
+
+
+@pytest.mark.parametrize(
+    "dep,expected",
+    [
+        ("torch", None),
+        ("torch==1.7.0", (None, None)),
+        ("torch==1.7.0+cu110", (None, "+cu110")),
+        (
+            "torch==1.7.0+cu110 -f https://download.pytorch.org/whl/torch_stable.html",
+            (None, "+cu110"),
+        ),
+        (
+            "torchvision==1.7.0+cu110 -f https://download.pytorch.org/whl/torch_stable.html",
+            ("vision", "+cu110"),
+        ),
+        ("torch==2.0.1+cpu", (None, "+cpu")),
+        ("torchvision==2.0.1+cpu", ("vision", "+cpu")),
+        ("torchaudio==2.0.1+cpu", ("audio", "+cpu")),
+    ],
+)
+def test_torch_dep_regex(dep, expected):
+    match = re.match(TORCH_DEP_REGEX, dep)
+    if expected is None:
+        assert match is None
+        return
+    assert match is not None
+    assert match.groups() == expected

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -20,6 +20,8 @@ if len(ONLY_INCLUDE) == 0:
 else:
     OPTS.append("--force")
 
+TORCH_DEP_REGEX = r"torch(vision|audio)?==\d+\.\d+\.\d+(\+(?:cu[\d]{2,3})|(?:\+cpu))?"
+
 
 def install_deps(
     deps: List[str],
@@ -100,7 +102,7 @@ def main() -> None:
                     if req.startswith("wandb==") and "dev1" in req:
                         req = "wandb"
                     match = re.match(
-                        r"torch(vision|audio)?==\d+\.\d+\.\d+(\+(?:cu[\d]{2,3})|(?:\+cpu))?",
+                        TORCH_DEP_REGEX,
                         req,
                     )
                     if match:

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -100,7 +100,7 @@ def main() -> None:
                     if req.startswith("wandb==") and "dev1" in req:
                         req = "wandb"
                     match = re.match(
-                        r"torch(vision|audio)?==\d+\.\d+\.\d+(\+(?:cu[\d]{2,3})|(?:cpu))?",
+                        r"torch(vision|audio)?==\d+\.\d+\.\d+(\+(?:cu[\d]{2,3})|(?:\+cpu))?",
                         req,
                     )
                     if match:


### PR DESCRIPTION
adding parameterized tests for regex for posterity

Fixes
-----
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1dac0b6</samp>

### Summary
🧪🔄🔥

<!--
1.  🧪 This emoji represents testing, which is the main purpose of the new test file and function.
2.  🔄 This emoji represents refactoring, which is the main action performed on the regular expression in the `_wandb_bootstrap.py` module.
3.  🔥 This emoji represents torch, which is the specific dependency that the regular expression is designed to match.
-->
Refactor and test torch dependency regex in `_wandb_bootstrap.py`. This change defines a constant for the regex and adds a new unit test file `test_bootstrap.py` to verify its correctness.

> _We face the doom of dependency hell_
> _We need a regex to break the spell_
> _We test the cases with parametrize_
> _We refactor code to optimize_

### Walkthrough
* Extract torch dependency matching regex to a global constant `TORCH_DEP_REGEX` in `_wandb_bootstrap.py` ([link](https://github.com/wandb/wandb/pull/5833/files?diff=unified&w=0#diff-1ac65703763dcbe78487cbcf4a871ed6b1066e08329da6e078e01cd08931c5ecL23-R25), [link](https://github.com/wandb/wandb/pull/5833/files?diff=unified&w=0#diff-1ac65703763dcbe78487cbcf4a871ed6b1066e08329da6e078e01cd08931c5ecL103-R105))
* Add unit test function `test_torch_dep_regex` in `test_bootstrap.py` to test various cases of torch dependency strings and their expected matches with `TORCH_DEP_REGEX` ([link](https://github.com/wandb/wandb/pull/5833/files?diff=unified&w=0#diff-5e47b9f450baf07e2402c2dc7571ec8a8ce85f6a20f6b12fb8b5c1701c840112R1-R32))



Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1dac0b6</samp>

Refactor and test torch dependency regex in `_wandb_bootstrap.py`. This change defines a constant for the regex and adds a new unit test file `test_bootstrap.py` to verify its correctness.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1dac0b6</samp>

> _We face the doom of dependency hell_
> _We need a regex to break the spell_
> _We test the cases with parametrize_
> _We refactor code to optimize_
