### PR TITLE
chore(launch): remove gcp region check to avoid perm requirement

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_environment/test_gcp.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_environment/test_gcp.py
@@ -7,26 +7,6 @@ from wandb.sdk.launch.environment.gcp_environment import GcpEnvironment
 from wandb.sdk.launch.errors import LaunchError
 
 
-def test_environment_verify(mocker):
-    """Test that the environment is verified correctly."""
-    credentials = MagicMock()
-    credentials.refresh = MagicMock()
-    credentials.valid = True
-    mocker.patch(
-        "wandb.sdk.launch.environment.gcp_environment.google.auth.default",
-        return_value=(credentials, "project"),
-    )
-    mock_region_client = MagicMock()
-    mocker.patch(
-        "wandb.sdk.launch.environment.gcp_environment.google.cloud.compute_v1.RegionsClient",
-        mock_region_client,
-    )
-    GcpEnvironment("region")
-    mock_region_client.return_value.get.assert_called_once_with(
-        project="project", region="region"
-    )
-
-
 def test_environment_no_default_creds(mocker):
     """Test that the environment raises an error if there are no default credentials."""
     mocker.patch(
@@ -45,10 +25,6 @@ def test_environment_verify_invalid_creds(mocker):
     mocker.patch(
         "wandb.sdk.launch.environment.gcp_environment.google.auth.default",
         return_value=(credentials, "project"),
-    )
-    mocker.patch(
-        "wandb.sdk.launch.environment.gcp_environment.google.cloud.compute_v1.RegionsClient",
-        MagicMock(),
     )
     with pytest.raises(LaunchError):
         GcpEnvironment("region")

--- a/wandb/sdk/launch/environment/gcp_environment.py
+++ b/wandb/sdk/launch/environment/gcp_environment.py
@@ -175,15 +175,7 @@ class GcpEnvironment(AbstractEnvironment):
             None
         """
         _logger.debug("Verifying GCP environment")
-        creds = self.get_credentials()
-        try:
-            # Check if the region is available using the compute API.
-            compute_client = google.cloud.compute_v1.RegionsClient(credentials=creds)
-            compute_client.get(project=self.project, region=self.region)
-        except google.api_core.exceptions.NotFound as e:
-            raise LaunchError(
-                f"Region {self.region} is not available in project {self.project}."
-            ) from e
+        self.get_credentials()
 
     def verify_storage_uri(self, uri: str) -> None:
         """Verify that a storage URI is valid.


### PR DESCRIPTION
no longer require compute.regions.get permission

Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d33b88</samp>

### Summary
🗑️🛠️🚀

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, in this case the region verification code.
2.  🛠️ - This emoji represents the fixing or improvement of something, in this case the error handling and simplification of the `verify` method.
3.  🚀 - This emoji represents the launching or deployment of something, in this case the jobs on GCP.
-->
Simplify GCP region verification for launch jobs. Remove the compute API call from `gcp_environment.py` and rely on the region in the job configuration.

> _No region check now_
> _`verify` only credentials_
> _Simpler code for spring_

### Walkthrough
*  Simplify the verification of GCP environment by removing the region availability check ([link](https://github.com/wandb/wandb/pull/5835/files?diff=unified&w=0#diff-1ac507743c7f5aaa35e85fa08eed6b3032fb25a166fa7f270f1855fc5cad6af2L178-R178))



Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7d33b88</samp>

> _No region check now_
> _`verify` only credentials_
> _Simpler code for spring_
