### PR TITLE
chore(launch): always pull latest tag

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_launch_cli.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_cli.py
@@ -407,6 +407,10 @@ def test_launch_supplied_docker_image(
         lambda docker_image: None,
     )
     monkeypatch.setattr(
+        "wandb.sdk.launch.runner.local_container.docker_image_exists",
+        lambda docker_image: None,
+    )
+    monkeypatch.setattr(
         "wandb.sdk.launch.runner.local_container._run_entry_point",
         patched_run_run_entry,
     )

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_local_container.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_local_container.py
@@ -16,6 +16,10 @@ def test_local_container_entrypoint(relay_server, monkeypatch):
     )
 
     monkeypatch.setattr(
+        "wandb.sdk.launch.runner.local_container.docker_image_exists",
+        lambda x: None,
+    )
+    monkeypatch.setattr(
         "wandb.sdk.launch.runner.local_container.pull_docker_image",
         lambda x: None,
     )

--- a/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
+++ b/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
@@ -933,7 +933,9 @@ def test_launch_project_spec_docker_image(
 
 def test_launch_local_docker_image(live_mock_server, test_settings, monkeypatch):
     monkeypatch.setattr("wandb.sdk.launch.utils.docker_image_exists", lambda x: True)
-    monkeypatch.setattr("wandb.sdk.launch.utils.pull_docker_image", lambda x: True)
+    monkeypatch.setattr(
+        "wandb.sdk.launch.runner.local_container.pull_docker_image", lambda x: True
+    )
     monkeypatch.setattr(
         "wandb.sdk.launch.runner.local_container._run_entry_point",
         lambda cmd, project_dir: (cmd, project_dir),

--- a/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
+++ b/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
@@ -933,6 +933,7 @@ def test_launch_project_spec_docker_image(
 
 def test_launch_local_docker_image(live_mock_server, test_settings, monkeypatch):
     monkeypatch.setattr("wandb.sdk.launch.utils.docker_image_exists", lambda x: True)
+    monkeypatch.setattr("wandb.sdk.launch.utils.pull_docker_image", lambda x: True)
     monkeypatch.setattr(
         "wandb.sdk.launch.runner.local_container._run_entry_point",
         lambda cmd, project_dir: (cmd, project_dir),

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -19,6 +19,7 @@ from ..utils import (
     PROJECT_SYNCHRONOUS,
     _is_wandb_dev_uri,
     _is_wandb_local_uri,
+    docker_image_exists,
     pull_docker_image,
     sanitize_wandb_api_key,
 )
@@ -139,7 +140,8 @@ class LocalContainerRunner(AbstractRunner):
         if launch_project.docker_image:
             # user has provided their own docker image
             image_uri = launch_project.image_name
-            pull_docker_image(image_uri)
+            if image_uri.endswith(":latest") or not docker_image_exists(image_uri):
+                pull_docker_image(image_uri)
             entry_cmd = []
             if entry_point is not None:
                 entry_cmd = entry_point.command

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -657,9 +657,6 @@ def docker_image_exists(docker_image: str, should_raise: bool = False) -> bool:
 
 def pull_docker_image(docker_image: str) -> None:
     """Pull the requested docker image."""
-    if docker_image_exists(docker_image):
-        # don't pull images if they exist already, eg if they are local images
-        return
     try:
         docker.run(["docker", "pull", docker_image])
     except docker.DockerError as e:


### PR DESCRIPTION
Description
-----------
What does the PR do?

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a5c8939</samp>

### Summary
🧹🐳🚀

<!--
1.  🧹 for simplifying and cleaning up the code
2.  🐳 for improving docker image handling
3.  🚀 for enhancing the local container runner performance
-->
Improved docker image handling for local container runner. Removed redundant check for docker image existence in `pull_docker_image` function.

> _To run a container with `wandb`_
> _You need a docker image at hand_
> _But don't pull it twice_
> _That's not very nice_
> _Just check if it's local or bland_

### Walkthrough
*  Import and use `docker_image_exists` function to conditionally pull docker images for wandb projects ([link](https://github.com/wandb/wandb/pull/5850/files?diff=unified&w=0#diff-03853de6b6ac99be1dc94a98df47da16d8d172f5870a0fbbe5aa39e59e89df83R22), [link](https://github.com/wandb/wandb/pull/5850/files?diff=unified&w=0#diff-03853de6b6ac99be1dc94a98df47da16d8d172f5870a0fbbe5aa39e59e89df83L142-R144))
* Simplify `pull_docker_image` function by removing redundant check for docker image existence ([link](https://github.com/wandb/wandb/pull/5850/files?diff=unified&w=0#diff-cbbb677decdd1d0e95eb6d34e11c2ac3878d178ff6793291e2dd36dc9788fabcL660-L662))



Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a5c8939</samp>

> _To run a container with `wandb`_
> _You need a docker image at hand_
> _But don't pull it twice_
> _That's not very nice_
> _Just check if it's local or bland_
