### PR TITLE
fix(sdk): add more accuracy to the log dir name to avoid collision

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -138,7 +138,7 @@ def _str_as_tuple(val: Union[str, Sequence[str]]) -> Tuple[str, ...]:
 def _datetime_as_str(val: Union[datetime, str]) -> str:
     """Parse a datetime object as a string."""
     if isinstance(val, datetime):
-        return datetime.strftime(val, "%Y%m%d_%H%M%S")
+        return datetime.strftime(val, "%Y%m%d_%H%M%S_%f")
     return val
 
 


### PR DESCRIPTION
Fixes
-----
- Fixes WB-14098

Description
-----------
What does the PR do?

add more accuracy to the log dir name to avoid collision

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85a0311</samp>

Added microseconds to run timestamps in `wandb_settings.py` to prevent duplicate names. Fixed issue #2629.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 85a0311</samp>

> _`_datetime_as_str`_
> _adds microseconds to avoid_
> _clashes in spring runs_
