### PR TITLE
test(artifacts): fix video fixture

### DIFF
--- a/tests/standalone_tests/artifact_object_reference_test.py
+++ b/tests/standalone_tests/artifact_object_reference_test.py
@@ -176,9 +176,10 @@ def _make_html():
 
 
 def _make_video():
+    # time, channel, height, width
     return wandb.Video(
-        np.random.randint(0, high=255, size=(4, 1, 10, 10), dtype=np.uint8)
-    )  # 1 second video of 10x10 pixels
+        np.random.randint(0, high=255, size=(4, 3, 10, 10), dtype=np.uint8)
+    )
 
 
 vid1 = _make_video()


### PR DESCRIPTION
Fixes WB-14400

# Description

Since `imageio==2.28` ([changes](https://github.com/imageio/imageio/compare/v2.27.0...v2.28.0)), this code:
```
import numpy as np
import wandb

wandb.Video(np.random.randint(0, high=255, size=(4, 1, 10, 10), dtype=np.uint8))
```

started giving an error:
```
Traceback (most recent call last):
File "/Users/szymon/wandb/wandb/sdk/data_types/video.py", line 128, in __init__
    self.encode()
File "/Users/szymon/wandb/wandb/sdk/data_types/video.py", line 149, in encode
    write_gif_with_image_io(clip, filename)
File "/Users/szymon/wandb/wandb/sdk/data_types/video.py", line 45, in write_gif_with_image_io
    writer.append_data(frame)
File "/Users/szymon/.pyenv/versions/venv_dev/lib/python3.9/site-packages/imageio/v2.py", line 226, in append_data
    return self.instance.write(im, **self.write_args)
File "/Users/szymon/.pyenv/versions/venv_dev/lib/python3.9/site-packages/imageio/plugins/pillow.py", line 405, in write
    raise ValueError("Can't write images with one color channel.")
ValueError: Can't write images with one color channel.
```

# Test plan

```
$ cd empty_dir
$ python ~/wandb/tests/standalone_tests/artifact_object_reference_test.py
```