### PR TITLE
chore(sdk): disable flake8 in Visual Studio Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   ],
 
   "python.linting.enabled": true,
-  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Enabled": false,
   "python.linting.mypyEnabled": false,
 
   "python.testing.unittestEnabled": false,


### PR DESCRIPTION
Fixes WB-14418

# Description

flake8 config was removed in https://github.com/wandb/wandb/pull/5812. In this PR I've disabled it in Visual Studio Code.

# Test plan

Opened a Python file, made sure there are no more errors like

> line too long (85 > 79 characters) flake8(E501)