### PR TITLE
fix(sdk): sweep crashes when wandb folder is symlink

### DIFF
--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 WRITE_PERMISSIONS = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH | stat.S_IWRITE
 
 
-def mkdir_exists_ok(dir_name: str) -> None:
+def mkdir_exists_ok(dir_name: StrPath) -> None:
     """Create `dir_name` and any parent directories if they don't exist.
 
     Raises:

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -17,19 +17,20 @@ logger = logging.getLogger(__name__)
 WRITE_PERMISSIONS = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH | stat.S_IWRITE
 
 
-def mkdir_exists_ok(dir_name: StrPath) -> None:
+def mkdir_exists_ok(dir_name: str) -> None:
     """Create `dir_name` and any parent directories if they don't exist.
 
     Raises:
         FileExistsError: if `dir_name` exists and is not a directory.
         PermissionError: if `dir_name` is not writable.
     """
-    try:
-        os.makedirs(dir_name, exist_ok=True)
-    except FileExistsError as e:
-        raise FileExistsError(f"{dir_name!s} exists and is not a directory") from e
-    except PermissionError as e:
-        raise PermissionError(f"{dir_name!s} is not writable") from e
+    if not os.path.islink(dir_name):
+        try:
+            os.makedirs(dir_name, exist_ok=True)
+        except FileExistsError as e:
+            raise FileExistsError(f"{dir_name!s} exists and is not a directory") from e
+        except PermissionError as e:
+            raise PermissionError(f"{dir_name!s} is not writable") from e
 
 
 class WriteSerializingFile:


### PR DESCRIPTION
Description
-----------
Creating a sweep (using `wand sweep my_sweep.yaml`) crashes when my `wandb` folder is a symlink. (I do this because lots of runs can take considerable space so I save them on a different drive). The problem is caused by the `mkdir_exists_ok` folder, which raises a `FileExistsError` for symlinks (as symlinks are just files). I added a check for symlinks which resolved the issue.

