### PR TITLE
fix(launch): allow trailing zero floats (ex. 1.0) in run config

### DIFF
--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -101,6 +101,8 @@ class LaunchProject:
         self.docker_user_id: int = docker_config.get("user_id", uid)
         self.git_version: Optional[str] = git_info.get("version")
         self.git_repo: Optional[str] = git_info.get("repo")
+        if isinstance(overrides, str):
+            overrides = json.loads(overrides)
         self.override_args: List[str] = overrides.get("args", [])
         self.override_config: Dict[str, Any] = overrides.get("run_config", {})
         self.override_artifacts: Dict[str, Any] = overrides.get("artifacts", {})


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-13827](https://wandb.atlassian.net/browse/WB-13827)

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86d03d2</samp>

Support JSON strings for launch overrides. The `overrides` argument of the `LaunchProject` class in `wandb/sdk/launch/_project_spec.py` can now handle JSON strings as well as dictionaries.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 86d03d2</samp>

> _`overrides` can be_
> _JSON string or dict now_
> _cutting with `json.loads`_


[WB-13827]: https://wandb.atlassian.net/browse/WB-13827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ