### PR TITLE
test(artifacts): fix broken tests

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -785,11 +785,7 @@ class Artifact:
             and not util.alias_is_version_index(alias["alias"])
         ]
         self._state = ArtifactState(attrs["state"])
-        with requests.get(attrs["currentManifest"]["file"]["directUrl"]) as request:
-            request.raise_for_status()
-            self._manifest = ArtifactManifest.from_manifest_json(
-                json.loads(util.ensure_text(request.content))
-            )
+        self._load_manifest(attrs["currentManifest"]["file"]["directUrl"])
         self._commit_hash = attrs["commitHash"]
         self._file_count = attrs["fileCount"]
         self._created_at = attrs["createdAt"]
@@ -1817,7 +1813,7 @@ class Artifact:
         return ArtifactFiles(self._client, self, names, per_page)
 
     def _default_root(self, include_version: bool = True) -> str:
-        name = self.name if include_version else self.name.split(":")[0]
+        name = self.source_name if include_version else self.source_name.split(":")[0]
         root = os.path.join(env.get_artifact_dir(), name)
         if platform.system() == "Windows":
             head, tail = os.path.splitdrive(root)


### PR DESCRIPTION
Fixes WB-14400

# Description

In https://github.com/wandb/wandb/pull/5533 we changed the behavior or `artifact.name` to return the name of the secondary (portfolio) collection instead of the name of the primary (sequence) collection. This changed the default download location as well. In this PR, I modified the default download location to use `artifact.source_name` to go back to the previous behavior.

# Test plan

- Modified `S3Handler.versioning_enabled` to `return False`; otherwise I was getting a permission error.
- Ran the tests:
```
$ cd empty_dir
$ python ~/wandb/tests/standalone_tests/artifact_object_reference_test.py
1/19 Complete
2/19 Complete
3/19 Complete
4/19 Complete
5/19 Complete
6/19 Complete
7/19 Complete
8/19 Complete
9/19 Complete
10/19 Complete
11/19 Complete
12/19 Complete
13/19 Complete
14/19 Complete
15/19 Complete
16/19 Complete
17/19 Complete
18/19 Complete
19/19 Complete
```