### PR TITLE
fix(launch): drop https from azure registries to ensure compatibility with ${image_uri} macro

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_registry/test_acr.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_registry/test_acr.py
@@ -18,7 +18,8 @@ def test_acr_from_config(mocker):
         MagicMock(),
     )
     config = {"uri": "test"}
-    AzureContainerRegistry.from_config(config, AzureEnvironment.from_config({}))
+    acr = AzureContainerRegistry.from_config(config, AzureEnvironment.from_config({}))
+    assert acr.uri == "test"
 
 
 def test_acr_get_repo_uri(mocker):
@@ -80,6 +81,12 @@ def test_acr_registry_name(mocker):
         MagicMock(),
     )
     config = {"uri": "https://test.azurecr.io/repository"}
+    registry = AzureContainerRegistry.from_config(
+        config, AzureEnvironment.from_config({})
+    )
+    assert registry.registry_name == "test"
+    # Same thing but without https
+    config = {"uri": "test.azurecr.io/repository"}
     registry = AzureContainerRegistry.from_config(
         config, AzureEnvironment.from_config({})
     )

--- a/tests/pytest_tests/unit_tests/test_launch/test_registry/test_acr.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_registry/test_acr.py
@@ -56,13 +56,13 @@ def test_acr_check_image_exists(mocker):
     mock_client.get_manifest_properties.return_value = {"digest": "test"}
     mocker.patch(
         "wandb.sdk.launch.registry.azure_container_registry.ContainerRegistryClient",
-        MagicMock(),
+        MagicMock(return_value=mock_client),
     )
     config = {"uri": "test"}
     registry = AzureContainerRegistry.from_config(
         config, AzureEnvironment.from_config({})
     )
-    assert registry.check_image_exists("https://test.azurecr.io/launch-images:tag")
+    assert registry.check_image_exists("test.azurecr.io/launch-images:tag")
 
     # Make the mock client raise an error when get_manifest_properties is called and
     # check that the method returns False.

--- a/wandb/sdk/launch/registry/azure_container_registry.py
+++ b/wandb/sdk/launch/registry/azure_container_registry.py
@@ -37,6 +37,8 @@ class AzureContainerRegistry(AbstractRegistry):
         """Initialize an AzureContainerRegistry."""
         self.environment = environment
         self.uri = uri
+        if self.uri.startswith("https://"):
+            self.uri = self.uri[len("https://") :]
         if verify:
             self.verify()
 

--- a/wandb/sdk/launch/registry/azure_container_registry.py
+++ b/wandb/sdk/launch/registry/azure_container_registry.py
@@ -125,7 +125,7 @@ class AzureContainerRegistry(AbstractRegistry):
         Raises:
             LaunchError: If unable to parse URI.
         """
-        regex = r"(?:https://)([\w]+)\.azurecr\.io/([\w\-]+):?(.*)"
+        regex = r"(?:https://)?([\w]+)\.azurecr\.io/([\w\-]+):?(.*)"
         match = re.match(regex, uri)
         if match is None:
             raise LaunchError(f"Unable to parse Azure Container Registry URI: {uri}")


### PR DESCRIPTION
Fixes
-----
- Fixes WB-14477

Description
-----------

Removes the requirement that azure container registry uris be given with an https. And make it so that if an https is given it is dropped from the uri that the registry class saves. We don't support unsecure acr.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 94ad72f</samp>

### Summary
🧪🛠️🚀

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the improvement of the testing of the AzureContainerRegistry class.
2.  🛠️ - This emoji represents tools, fixing, or construction, and can be used to indicate the improvement of the handling of Azure Container Registry uris by the AzureContainerRegistry class.
3.  🚀 - This emoji represents speed, launch, or innovation, and can be used to indicate the enhancement of the AzureContainerRegistry class functionality and performance.
-->
This pull request enhances the support for Azure Container Registry by the `AzureContainerRegistry` class and its tests. It fixes the uri parsing and validation logic, and adds more robust testing for different uri formats and API responses.

> _We're testing the `AzureContainerRegistry` class_
> _With assertions and mocks to make it pass_
> _We'll strip the https from the uri_
> _And parse it well on the count of three_

### Walkthrough
*  Strip the https:// prefix from the uri attribute of the AzureContainerRegistry class to simplify the usage and parsing of the uri ([link](https://github.com/wandb/wandb/pull/5880/files?diff=unified&w=0#diff-e1eb7040b90080056523c0f47f68db0e8abd39bdb1a3dee8c6fda7f904e83e3bR40-R41))
*  Modify the regex pattern of the parse_azurecr_uri class method to make the https:// prefix optional and improve the flexibility and robustness of the method ([link](https://github.com/wandb/wandb/pull/5880/files?diff=unified&w=0#diff-e1eb7040b90080056523c0f47f68db0e8abd39bdb1a3dee8c6fda7f904e83e3bL128-R130))
*  Add an assertion to the test_acr_from_config function to check that the uri attribute of the AzureContainerRegistry object matches the expected value ([link](https://github.com/wandb/wandb/pull/5880/files?diff=unified&w=0#diff-9440eeaab02ac269f9be89635a862d840e5202900384b3ccfc375b6f86926f58L21-R22))
*  Modify the mocker.patch call in the test_check_image_exists function to pass a mock_client object as the return_value argument and simulate the response from the Azure Container Registry API ([link](https://github.com/wandb/wandb/pull/5880/files?diff=unified&w=0#diff-9440eeaab02ac269f9be89635a862d840e5202900384b3ccfc375b6f86926f58L58-R59))
*  Remove the https:// prefix from the uri argument passed to the check_image_exists method in the test_check_image_exists function to align the test with the updated logic of the class ([link](https://github.com/wandb/wandb/pull/5880/files?diff=unified&w=0#diff-9440eeaab02ac269f9be89635a862d840e5202900384b3ccfc375b6f86926f58L64-R65))
*  Add a new test case to the test_acr_registry_name function to check that the registry_name attribute of the AzureContainerRegistry object is correctly extracted from a uri without the https prefix ([link](https://github.com/wandb/wandb/pull/5880/files?diff=unified&w=0#diff-9440eeaab02ac269f9be89635a862d840e5202900384b3ccfc375b6f86926f58R88-R93))


