### PR TITLE
chore(sdk): fix UP032 linting errors

### DIFF
--- a/tests/pytest_tests/system_tests/test_core/test_wandb_integration.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb_integration.py
@@ -91,9 +91,7 @@ def test_dir_on_import():
     # Test for the base case
     _remove_dir_if_exists(default_path)
     reload_fn(wandb)
-    assert not os.path.isdir(default_path), "Unexpected directory at {}".format(
-        default_path
-    )
+    assert not os.path.isdir(default_path), f"Unexpected directory at {default_path}"
 
     # test for the case that the env variable is set
     with mock.patch.dict(os.environ, {"WANDB_DIR": custom_env_path}):
@@ -120,9 +118,7 @@ def test_dir_on_init(wandb_init):
         _remove_dir_if_exists(default_path)
         run = wandb_init()
         run.finish()
-        assert os.path.isdir(default_path), "Expected directory at {}".format(
-            default_path
-        )
+        assert os.path.isdir(default_path), f"Expected directory at {default_path}"
 
 
 def test_dir_on_init_env(wandb_init):
@@ -169,22 +165,14 @@ def test_dir_on_init_dir(wandb_init):
         os.makedirs(custom_dir_path)
     run = wandb_init(dir="./" + dir_name)
     run.finish()
-    assert not os.path.isdir(default_path), "Unexpected directory at {}".format(
-        default_path
-    )
-    assert os.path.isdir(custom_dir_path), "Expected directory at {}".format(
-        custom_dir_path
-    )
+    assert not os.path.isdir(default_path), f"Unexpected directory at {default_path}"
+    assert os.path.isdir(custom_dir_path), f"Expected directory at {custom_dir_path}"
     # And for the duplicate-run case
     _remove_dir_if_exists(default_path)
     run = wandb_init(dir="./" + dir_name)
     run.finish()
-    assert not os.path.isdir(default_path), "Unexpected directory at {}".format(
-        default_path
-    )
-    assert os.path.isdir(custom_dir_path), "Expected directory at {}".format(
-        custom_dir_path
-    )
+    assert not os.path.isdir(default_path), f"Unexpected directory at {default_path}"
+    assert os.path.isdir(custom_dir_path), f"Expected directory at {custom_dir_path}"
 
 
 @pytest.mark.parametrize(

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -251,11 +251,7 @@ def grab(args, vhash, bnum):
         os.mkdir(cachedir)
     if os.path.exists(cfname):
         return
-    url = (
-        "https://circleci.com/api/v1.1/project/github/wandb/wandb/{}/artifacts".format(
-            bnum
-        )
-    )
+    url = f"https://circleci.com/api/v1.1/project/github/wandb/wandb/{bnum}/artifacts"
     r = requests.get(url, auth=(args.api_token, ""))
     assert r.status_code == 200, f"Error making api request: {r}"
     lst = r.json()

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2071,28 +2071,16 @@ def put(path, name, description, type, alias):
     api.set_setting("entity", entity)
     api.set_setting("project", project)
     artifact = wandb.Artifact(name=artifact_name, type=type, description=description)
-    artifact_path = "{entity}/{project}/{name}:{alias}".format(
-        entity=entity, project=project, name=artifact_name, alias=alias[0]
-    )
+    artifact_path = f"{entity}/{project}/{artifact_name}:{alias[0]}"
     if os.path.isdir(path):
-        wandb.termlog(
-            'Uploading directory {path} to: "{artifact_path}" ({type})'.format(
-                path=path, type=type, artifact_path=artifact_path
-            )
-        )
+        wandb.termlog(f'Uploading directory {path} to: "{artifact_path}" ({type})')
         artifact.add_dir(path)
     elif os.path.isfile(path):
-        wandb.termlog(
-            'Uploading file {path} to: "{artifact_path}" ({type})'.format(
-                path=path, type=type, artifact_path=artifact_path
-            )
-        )
+        wandb.termlog(f'Uploading file {path} to: "{artifact_path}" ({type})')
         artifact.add_file(path)
     elif "://" in path:
         wandb.termlog(
-            'Logging reference artifact from {path} to: "{artifact_path}" ({type})'.format(
-                path=path, type=type, artifact_path=artifact_path
-            )
+            f'Logging reference artifact from {path} to: "{artifact_path}" ({type})'
         )
         artifact.add_reference(path)
     else:
@@ -2124,9 +2112,7 @@ def put(path, name, description, type, alias):
     )
 
     wandb.termlog(
-        '    artifact = run.use_artifact("{path}")\n'.format(
-            path=artifact_path,
-        ),
+        f'    artifact = run.use_artifact("{artifact_path}")\n',
         prefix=False,
     )
 
@@ -2149,9 +2135,7 @@ def get(path, root, type):
             artifact_name = artifact_parts[0]
         else:
             version = "latest"
-        full_path = "{entity}/{project}/{artifact}:{version}".format(
-            entity=entity, project=project, artifact=artifact_name, version=version
-        )
+        full_path = f"{entity}/{project}/{artifact_name}:{version}"
         wandb.termlog(
             "Downloading {type} artifact {full_path}".format(
                 type=type or "dataset", full_path=full_path
@@ -2233,11 +2217,7 @@ def pull(run, project, entity):
     urls = api.download_urls(project, run=run, entity=entity)
     if len(urls) == 0:
         raise ClickException("Run has no files")
-    click.echo(
-        "Downloading: {project}/{run}".format(
-            project=click.style(project, bold=True), run=run
-        )
-    )
+    click.echo(f"Downloading: {click.style(project, bold=True)}/{run}")
 
     for name in urls:
         if api.file_current(name, urls[name]["md5"]):

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -220,9 +220,7 @@ def auth_token(registry: str, repo: str) -> Dict[str, str]:
             info = {}
     else:
         log.error(
-            "Received {} when attempting to authenticate with {}".format(
-                response, registry
-            )
+            f"Received {response} when attempting to authenticate with {registry}"
         )
         info = {}
     if info.get("bearer"):

--- a/wandb/docker/auth.py
+++ b/wandb/docker/auth.py
@@ -190,9 +190,7 @@ class AuthConfig(dict):
 
             username, password = decode_auth(entry["auth"])
             log.debug(
-                "Found entry (registry={}, username={})".format(
-                    repr(registry), repr(username)
-                )
+                f"Found entry (registry={repr(registry)}, username={repr(username)})"
             )
 
             conf[registry] = {

--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -78,9 +78,7 @@ class UploadJob:
                 if hasattr(e, "response"):
                     message = e.response.content
                 wandb.termerror(
-                    'Error uploading "{}": {}, {}'.format(
-                        self.save_path, type(e).__name__, message
-                    )
+                    f'Error uploading "{self.save_path}": {type(e).__name__}, {message}'
                 )
                 raise
 
@@ -137,9 +135,7 @@ class UploadJob:
                 wandb._sentry.exception(e)
                 if not self.silent:
                     wandb.termerror(
-                        'Error uploading "{}": {}, {}'.format(
-                            self.save_name, type(e).__name__, e
-                        )
+                        f'Error uploading "{self.save_name}": {type(e).__name__}, {e}'
                     )
                 raise
 

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -279,9 +279,7 @@ class Type:
         if depth > 0:
             return f"{gap}{wbtype} not assignable to {self}"
         else:
-            return "{}{} of type {} is not assignable to {}".format(
-                gap, other, wbtype, self
-            )
+            return f"{gap}{other} of type {wbtype} is not assignable to {self}"
 
     def __repr__(self):
         rep = self.name.capitalize()

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -60,9 +60,7 @@ class Media(WBValue):
         self._extension = extension
         assert extension is None or path.endswith(
             extension
-        ), 'Media file extension "{}" must occur at the end of path "{}".'.format(
-            extension, path
-        )
+        ), f'Media file extension "{extension}" must occur at the end of path "{path}".'
 
         with open(self._path, "rb") as f:
             self._sha256 = hashlib.sha256(f.read()).hexdigest()

--- a/wandb/sdk/internal/datastore.py
+++ b/wandb/sdk/internal/datastore.py
@@ -172,9 +172,7 @@ class DataStore:
                 break
             assert (
                 dtype == LEVELDBLOG_MIDDLE
-            ), "expected record to be type {} but found {}".format(
-                LEVELDBLOG_MIDDLE, dtype
-            )
+            ), f"expected record to be type {LEVELDBLOG_MIDDLE} but found {dtype}"
             data += new_data
         return data
 
@@ -187,9 +185,7 @@ class DataStore:
         )
         assert (
             len(data) == LEVELDBLOG_HEADER_LEN
-        ), "header size is {} bytes, expected {}".format(
-            len(data), LEVELDBLOG_HEADER_LEN
-        )
+        ), f"header size is {len(data)} bytes, expected {LEVELDBLOG_HEADER_LEN}"
         self._fp.write(data)
         self._index += len(data)
 

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1421,9 +1421,7 @@ class SendManager:
             logger.info(f"logged artifact {artifact.name} - {res}")
         except Exception as e:
             result.response.log_artifact_response.error_message = (
-                'error logging artifact "{}/{}": {}'.format(
-                    artifact.type, artifact.name, e
-                )
+                f'error logging artifact "{artifact.type}/{artifact.name}": {e}'
             )
 
         self._respond_result(result)

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -363,9 +363,9 @@ def generate_dockerfile(
 
     # ----- stage 1: build -----
     if launch_project.deps_type == "pip" or launch_project.deps_type is None:
-        python_build_image = "python:{}".format(
-            py_version
-        )  # use full python image for package installation
+        python_build_image = (
+            f"python:{py_version}"  # use full python image for package installation
+        )
     elif launch_project.deps_type == "conda":
         # neither of these images are receiving regular updates, latest should be pretty stable
         python_build_image = (

--- a/wandb/sdk/launch/runner/vertex_runner.py
+++ b/wandb/sdk/launch/runner/vertex_runner.py
@@ -120,10 +120,9 @@ class VertexRunner(AbstractRunner):
         )
         gcp_accelerator_count = int(resource_args.get("accelerator_count") or 0)
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-        gcp_training_job_name = resource_args.get(
-            "job_name"
-        ) or "{project}_{time}".format(
-            project=launch_project.target_project, time=timestamp
+        gcp_training_job_name = (
+            resource_args.get("job_name")
+            or f"{launch_project.target_project}_{timestamp}"
         )
         service_account = resource_args.get("service_account")
         tensorboard = resource_args.get("tensorboard")

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1186,9 +1186,7 @@ class Run:
         for k, v in (("code", code), ("repo", repo), ("code_version", code_version)):
             if v and not RE_LABEL.match(v):
                 wandb.termwarn(
-                    "Label added for '{}' with invalid identifier '{}' (ignored).".format(
-                        k, v
-                    ),
+                    f"Label added for '{k}' with invalid identifier '{v}' (ignored).",
                     repeat=False,
                 )
         for v in kwargs:
@@ -2495,16 +2493,12 @@ class Run:
             if arg_val is not None and not isinstance(arg_val, exp_type):
                 arg_type = type(arg_val).__name__
                 raise wandb.Error(
-                    "Unhandled define_metric() arg: {} type: {}".format(
-                        arg_name, arg_type
-                    )
+                    f"Unhandled define_metric() arg: {arg_name} type: {arg_type}"
                 )
         stripped = name[:-1] if name.endswith("*") else name
         if "*" in stripped:
             raise wandb.Error(
-                "Unhandled define_metric() arg: name (glob suffixes only): {}".format(
-                    name
-                )
+                f"Unhandled define_metric() arg: name (glob suffixes only): {name}"
             )
         summary_ops: Optional[Sequence[str]] = None
         if summary:

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -265,9 +265,7 @@ class TorchHistory:
         if not isinstance(var, torch.autograd.Variable):
             cls = type(var)
             raise TypeError(
-                "Expected torch.Variable, not {}.{}".format(
-                    cls.__module__, cls.__name__
-                )
+                f"Expected torch.Variable, not {cls.__module__}.{cls.__name__}"
             )
 
         handle = self._hook_handles.get(name)


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ef350a</samp>

This pull request refactors various functions and tests across the wandb codebase to use f-strings instead of the old string formatting method. This improves the readability and consistency of the code and the output. The files affected include `test_wandb_integration.py`, `cli.py`, `upload_job.py`, `datastore.py`, `wandb_run.py`, `circleci-tool.py`, `__init__.py`, `auth.py`, `_dtypes.py`, `media.py`, `sender.py`, `build.py`, `vertex_runner.py`, and `wandb_torch.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5ef350a</samp>

> _We are the masters of the f-string_
> _We make the code more clear and clean_
> _We don't need the old and rusty syntax_
> _We unleash the power of the format_
