### PR TITLE
chore(sdk): add ability to launch nexus from dev dir

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -785,11 +785,7 @@ class Artifact:
             and not util.alias_is_version_index(alias["alias"])
         ]
         self._state = ArtifactState(attrs["state"])
-        with requests.get(attrs["currentManifest"]["file"]["directUrl"]) as request:
-            request.raise_for_status()
-            self._manifest = ArtifactManifest.from_manifest_json(
-                json.loads(util.ensure_text(request.content))
-            )
+        self._load_manifest(attrs["currentManifest"]["file"]["directUrl"])
         self._commit_hash = attrs["commitHash"]
         self._file_count = attrs["fileCount"]
         self._created_at = attrs["createdAt"]
@@ -1817,7 +1813,7 @@ class Artifact:
         return ArtifactFiles(self._client, self, names, per_page)
 
     def _default_root(self, include_version: bool = True) -> str:
-        name = self.name if include_version else self.name.split(":")[0]
+        name = self.source_name if include_version else self.source_name.split(":")[0]
         root = os.path.join(env.get_artifact_dir(), name)
         if platform.system() == "Windows":
             head, tail = os.path.splitdrive(root)

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -180,7 +180,7 @@ class _Service:
                 #
                 #       Environment variable _WANDB_NEXUS_PATH is a temporary development feature
                 #       to assist in running the nexus service from a live development directory.
-                nexus_path = os.environ.get("_WANDB_NEXUS_PATH")
+                nexus_path: str = os.environ.get("_WANDB_NEXUS_PATH") or ""
                 if not nexus_path:
                     wandb_nexus = get_module(
                         "wandb_core",

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -172,15 +172,21 @@ class _Service:
 
             service_args = []
             if self._settings._require_nexus:
-                # NOTE: the wandb_core module will be distributed at first as an alpha
+                # NOTE: The wandb_core module will be distributed at first as an alpha
                 #       package as "wandb-core-alpha" to avoid polluting the pypi namespace.
+                #
                 #       When the package reaches compatibility milestones, it will be released
                 #       as "wandb-core".
-                wandb_nexus = get_module(
-                    "wandb_core",
-                    required="The nexus experiment requires the wandb_core module.",
-                )
-                nexus_path = wandb_nexus.get_nexus_path()
+                #
+                #       Environment variable _WANDB_NEXUS_PATH is a temporary development feature
+                #       to assist in running the nexus service from a live development directory.
+                nexus_path = os.environ.get("_WANDB_NEXUS_PATH")
+                if not nexus_path:
+                    wandb_nexus = get_module(
+                        "wandb_core",
+                        required="The nexus experiment requires the wandb_core module.",
+                    )
+                    nexus_path = wandb_nexus.get_nexus_path()
                 service_args.extend([nexus_path])
                 exec_cmd_list = []
             else:


### PR DESCRIPTION
Description
-----------
Development feature to allow running nexus service without installing the pip package.

Usage:
```
$ cat train.py
import wandb
wandb.require("nexus")
wandb.init()
$ _WANDB_NEXUS_PATH=${NEXUS_DEV}/scripts/run-nexus.sh python train.py
```

Alternative 1:
```
${NEXUS_DEV}/scripts/setup-nexus-path.sh python train.py
```

Alternative 2:
```
source ${NEXUS_DEV}/scripts/setup-nexus-path.sh
python train.py
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7c1dac</samp>

Added support for custom nexus path via `_WANDB_NEXUS_PATH` environment variable. Updated `wandb/sdk/service/service.py` to import `wandb_core` module conditionally and document its usage.

Testing
-------
Tested manually with the above script

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d7c1dac</samp>

> _`_WANDB_NEXUS_PATH`_
> _Customize the import logic_
> _Winter of testing_
