### PR TITLE
fix(launch): correct entrypoint path from disabled git repo subir

### DIFF
--- a/tests/functional_tests/t0_main/jobs/job_repo_creation.py
+++ b/tests/functional_tests/t0_main/jobs/job_repo_creation.py
@@ -5,7 +5,7 @@ import wandb
 parser = argparse.ArgumentParser()
 parser.add_argument("--log-test", action="store_true")
 args = parser.parse_args()
-run = wandb.init(project="test-job", config={"foo": "bar", "lr": 0.1, "epochs": 5})
+run = wandb.init(project="test-job", config={"foo": "bar", "lr": 0.1, "epochs": 5}, job_source="repo")
 for i in range(1, run.config["epochs"]):
     wandb.log({"loss": i})
 if args.log_test:

--- a/tests/functional_tests/t0_main/jobs/job_repo_creation.py
+++ b/tests/functional_tests/t0_main/jobs/job_repo_creation.py
@@ -5,7 +5,10 @@ import wandb
 parser = argparse.ArgumentParser()
 parser.add_argument("--log-test", action="store_true")
 args = parser.parse_args()
-run = wandb.init(project="test-job", config={"foo": "bar", "lr": 0.1, "epochs": 5}, job_source="repo")
+s = wandb.Settings(job_source="repo")
+run = wandb.init(
+    project="test-job", config={"foo": "bar", "lr": 0.1, "epochs": 5}, settings=s
+)
 for i in range(1, run.config["epochs"]):
     wandb.log({"loss": i})
 if args.log_test:

--- a/tests/functional_tests/t0_main/jobs/job_repo_end_to_end.py
+++ b/tests/functional_tests/t0_main/jobs/job_repo_end_to_end.py
@@ -24,7 +24,7 @@ assert (
     job.name
     == f"{api.settings['entity']}/{api.settings['project']}/job-git_github.com_wandb_wandb.git_tests_functional_tests_t0_main_jobs_job_repo_creation.py:v0"
 )
-assert job._job_info["source_type"] == "repo"
+# assert job._job_info["source_type"] == "repo"
 assert job._input_types == TypeRegistry.type_of({"foo": "bar", "lr": 0.1, "epochs": 5})
 
 with pytest.raises(TypeError):

--- a/tests/functional_tests/t0_main/jobs/job_repo_end_to_end.py
+++ b/tests/functional_tests/t0_main/jobs/job_repo_end_to_end.py
@@ -24,7 +24,7 @@ assert (
     job.name
     == f"{api.settings['entity']}/{api.settings['project']}/job-git_github.com_wandb_wandb.git_tests_functional_tests_t0_main_jobs_job_repo_creation.py:v0"
 )
-# assert job._job_info["source_type"] == "repo"
+assert job._job_info["source_type"] == "repo"
 assert job._input_types == TypeRegistry.type_of({"foo": "bar", "lr": 0.1, "epochs": 5})
 
 with pytest.raises(TypeError):

--- a/tests/pytest_tests/system_tests/test_core/test_system_info.py
+++ b/tests/pytest_tests/system_tests/test_core/test_system_info.py
@@ -139,7 +139,7 @@ def test_jupyter_name(meta, test_settings, mocked_ipython):
 
 def test_jupyter_path(meta, test_settings, mocked_ipython, git_repo):
     # not actually how jupyter setup works but just to test the meta paths
-    meta = meta(test_settings(dict(_jupyter_path="dummy/path")))
+    meta = meta(test_settings(dict(_jupyter_path="dummy/path", job_source="repo")))
     data = meta.probe()
     assert data["program"] == "dummy/path"
     assert data.get("root") is not None

--- a/tests/pytest_tests/unit_tests_old/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests_old/test_wandb_run.py
@@ -391,7 +391,9 @@ def test_wandb_artifact_config_update(
 
 def test_repo_job_creation(live_mock_server, test_settings, git_repo_fn):
     _ = git_repo_fn(commit_msg="initial commit")
-    test_settings.update({"program_relpath": "./blah/test_program.py"})
+    test_settings.update(
+        {"program_relpath": "./blah/test_program.py", "job_source": "repo"}
+    )
     with wandb.init(settings=test_settings) as run:
         run.log({"test": 1})
     ctx = live_mock_server.get_ctx()
@@ -401,13 +403,14 @@ def test_repo_job_creation(live_mock_server, test_settings, git_repo_fn):
     )
 
 
-def test_artifact_job_creation(live_mock_server, test_settings, runner):
+@pytest.mark.parametrize("disable_git", [True, False])
+def test_artifact_job_creation(live_mock_server, test_settings, runner, disable_git):
     with runner.isolated_filesystem():
         with open("test.py", "w") as f:
             f.write('print("test")')
         test_settings.update(
             {
-                "disable_git": True,
+                "disable_git": disable_git,
                 "program": "test.py",
                 "program_relpath": "./blah/test_program.py",
             }

--- a/tests/pytest_tests/unit_tests_old/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests_old/test_wandb_run.py
@@ -408,6 +408,7 @@ def test_artifact_job_creation(live_mock_server, test_settings, runner):
         test_settings.update(
             {
                 "disable_git": True,
+                "program": "test.py",
                 "program_relpath": "./blah/test_program.py",
             }
         )

--- a/wandb/sdk/internal/system/system_info.py
+++ b/wandb/sdk/internal/system/system_info.py
@@ -19,6 +19,7 @@ from wandb.sdk.lib.filenames import (
     REQUIREMENTS_FNAME,
 )
 from wandb.sdk.lib.gitlib import GitRepo
+from wandb.sdk.wandb_settings import _get_program_relpath_from_gitrepo
 
 from .assets.interfaces import Interface
 
@@ -170,6 +171,11 @@ class SystemInfo:
 
     def _probe_git(self, data: Dict[str, Any]) -> Dict[str, Any]:
         if self.settings.disable_git:
+            # can't trust relpapth, possibly set before git_disabled
+            data["codePath"] = _get_program_relpath_from_gitrepo(
+                self.settings.program,
+                True,
+            )
             return data
 
         # in case of manually passing the git repo info, `enabled` would be False,

--- a/wandb/sdk/internal/system/system_info.py
+++ b/wandb/sdk/internal/system/system_info.py
@@ -170,6 +170,7 @@ class SystemInfo:
         logger.debug("Saving git patches done")
 
     def _probe_git(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Add git information to data dict."""
         # in case of manually passing the git repo info, `enabled` would be False,
         # but we still want to save the git repo info
         if not self.git.enabled and self.git.auto:
@@ -225,11 +226,15 @@ class SystemInfo:
                         data["program"] = self.settings._jupyter_path
                         data["root"] = self.settings._jupyter_root
 
-            if self.settings.job_source != "repo" or self.settings.disable_git:
-                # can't trust relpapth, possibly set before git_disabled when in a git repo
-                data["codePath"] = _get_program_relpath(self.settings.program)
-            else:  # get the git repo info
+            is_git_job = (
+                self.settings.job_source == "repo" and not self.settings.disable_git
+            )
+            if is_git_job:
                 data = self._probe_git(data)
+            else:
+                # remake relpapth, possibly set before git_disabled loaded in settings.
+                # if in a git repo, codePath will be incorrectly set to repo root
+                data["codePath"] = _get_program_relpath(self.settings.program)
 
         if self.settings.anonymous != "true":
             data["host"] = self.settings.host

--- a/wandb/sdk/internal/system/system_info.py
+++ b/wandb/sdk/internal/system/system_info.py
@@ -225,7 +225,7 @@ class SystemInfo:
                         data["program"] = self.settings._jupyter_path
                         data["root"] = self.settings._jupyter_root
 
-            if self.settings.disable_git:
+            if self.settings.job_source != "repo" or self.settings.disable_git:
                 # can't trust relpapth, possibly set before git_disabled when in a git repo
                 data["codePath"] = _get_program_relpath(self.settings.program)
             else:  # get the git repo info

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -181,6 +181,9 @@ def _get_program_relpath_from_gitrepo(
 def _get_program_relpath(
     program: str, root: Optional[str] = None, _logger: Optional[_EarlyLogger] = None
 ) -> Optional[str]:
+    if not program:
+        return None
+
     root = root or os.getcwd()
     if not root:
         return None

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -181,8 +181,10 @@ def _get_program_relpath_from_gitrepo(
 def _get_program_relpath(
     program: str, root: Optional[str] = None, _logger: Optional[_EarlyLogger] = None
 ) -> Optional[str]:
+    root = root or os.getcwd()
     if not root:
-        root = os.getcwd()
+        return None
+
     full_path_to_program = os.path.join(
         root, os.path.relpath(os.getcwd(), root), program
     )

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -182,6 +182,8 @@ def _get_program_relpath(
     program: str, root: Optional[str] = None, _logger: Optional[_EarlyLogger] = None
 ) -> Optional[str]:
     if not program:
+        if _logger is not None:
+            _logger.warning("Empty program passed to get_program_relpath")
         return None
 
     root = root or os.getcwd()

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -171,11 +171,11 @@ def _get_program() -> Optional[str]:
 
 
 def _get_program_relpath_from_gitrepo(
-    program: str, _logger: Optional[_EarlyLogger] = None
+    program: str, disable_git: Optional[bool], _logger: Optional[_EarlyLogger] = None
 ) -> Optional[str]:
     repo = GitRepo()
     root = repo.root
-    if not root:
+    if not root or disable_git:
         root = os.getcwd()
     full_path_to_program = os.path.join(
         root, os.path.relpath(os.getcwd(), root), program
@@ -1666,7 +1666,9 @@ class Settings(SettingsData):
         program = self.program or _get_program()
         if program is not None:
             program_relpath = self.program_relpath or _get_program_relpath_from_gitrepo(
-                program, _logger=_logger
+                program,
+                self.disable_git,
+                _logger=_logger,
             )
             settings["program_relpath"] = program_relpath
         else:


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-13821](https://wandb.atlassian.net/browse/WB-13821)

Description
-----------
Recreates the rel-path (to cwd()) when git_disabled instead of root.

Example repo structure, where `train.py` inits a run with `wandb.Settings(disable_git=True)` and calls `log_code`: 

```
git_repo
   ├── src
   |   ├── engine
   │   │   ├── train.py
``` 

Prod: 
`cd src && python engine/train.py` --> results in job with entrypoint: `src/engine/train.py` 

This branch: 
`cd src && python engine/train.py` --> results in job with entrypoint: `engine/train.py` 


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4137065</samp>

This pull request improves the consistency and accuracy of the `codePath` and `program_relpath` settings in the system information and the wandb settings, by using a helper function that respects the `disable_git` setting and the git repository root. This affects the files `system_info.py` and `wandb_settings.py`.

Testing
-------
How was this PR tested?

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4137065</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The system's data, and the `codePath` value aligned_
> _With the `disable_git` setting, using a helper function wise_
> _As Hephaestus, who forged the thunderbolts for Zeus in the skies_


[WB-13821]: https://wandb.atlassian.net/browse/WB-13821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ