### PR TITLE
perf(sdk): find perf bottlenecks in history-related code paths

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -630,10 +630,11 @@ class InterfaceBase:
         publish_step: bool = True,
         run: Optional["Run"] = None,
     ) -> None:
+        time.time_ns()
         run = run or self._run
 
-        data = history_dict_to_json(run, data, step=user_step, ignore_copy_err=True)
-        data.pop("_step", None)
+        # data = history_dict_to_json(run, data, step=user_step, ignore_copy_err=True)
+        # data.pop("_step", None)
 
         # add timestamp to the history request, if not already present
         # the timestamp might come from the tensorboard log logic
@@ -644,12 +645,15 @@ class InterfaceBase:
         for k, v in data.items():
             item = partial_history.item.add()
             item.key = k
-            item.value_json = json_dumps_safer_history(v)
+            # item.value_json = json_dumps_safer_history(v)
+            item.value_json = f"{v}"
 
         if publish_step and step is not None:
             partial_history.step.num = step
         if flush is not None:
             partial_history.action.flush = flush
+        time.time_ns()
+        # print(f"publish_partial_history took {(toc - tic) / 1e6} ms")
         self._publish_partial_history(partial_history)
 
     @abstractmethod

--- a/wandb/sdk/lib/sock_client.py
+++ b/wandb/sdk/lib/sock_client.py
@@ -97,6 +97,8 @@ class SockClient:
         self._bufsize = 4096
         self._buffer = SockBuffer()
 
+        # self._time_stamps = []
+
     def connect(self, port: int) -> None:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect(("localhost", port))
@@ -143,13 +145,22 @@ class SockClient:
                     time.sleep(self._retry_delay - delta_time)
 
     def _send_message(self, msg: Any) -> None:
+        # if len(self._time_stamps) % 100 == 0:
+        #     deltas = [x - y for x, y in zip(self._time_stamps[1:], self._time_stamps[:-1])]
+        #     print(deltas)
+        # self._time_stamps.append(time.time_ns())
         tracelog.log_message_send(msg, self._sockid)
+        time.perf_counter()
         raw_size = msg.ByteSize()
         data = msg.SerializeToString()
         assert len(data) == raw_size, "invalid serialization"
         header = struct.pack("<BI", ord("W"), raw_size)
+        # toc = time.perf_counter()
+        # print(f"pack time: {toc - tic:0.9f} seconds")
         with self._lock:
             self._sendall_with_error_handle(header + data)
+        # toc2 = time.perf_counter()
+        # print(f"send time: {toc2 - toc:0.9f} seconds")
 
     def send_server_request(self, msg: Any) -> None:
         self._send_message(msg)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1393,7 +1393,6 @@ class Run:
 
         if self._backend and self._backend.interface:
             not_using_tensorboard = len(wandb.patched["tensorboard"]) == 0
-
             self._backend.interface.publish_partial_history(
                 row,
                 user_step=self._step,

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -49,6 +49,7 @@ from typing import (
 import requests
 import yaml
 
+import orjson
 import wandb
 import wandb.env
 from wandb.errors import AuthenticationError, CommError, UsageError, term


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e979e00</samp>

This pull request adds some code for performance testing of the `publish_partial_history` function and the `SockClient` class, but does not enable it by default. It also imports `orjson` for faster JSON processing and removes an empty line from `wandb_run.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e979e00</samp>

> _We're on a quest for speed and power_
> _We import `orjson` and measure every hour_
> _We comment out the code that slows us down_
> _We pack and send with `SockClient` and make them frown_
