### PR TITLE
fix(artifacts): handle None description correctly

### DIFF
--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1492,7 +1492,7 @@ class SendManager:
             client_id=artifact.client_id,
             sequence_client_id=artifact.sequence_client_id,
             metadata=metadata,
-            description=artifact.description,
+            description=artifact.description or None,
             aliases=artifact.aliases,
             use_after_commit=artifact.use_after_commit,
             distributed_id=artifact.distributed_id,


### PR DESCRIPTION
Fixes WB-14508

# Description

Protocol buffers don't support nulls. When we serialize an artifact to protocol buffer [here](https://github.com/wandb/wandb/blob/3d5b63e7e4b89e76d149b9bd2740a437dff1b29e/wandb/sdk/interface/interface.py#L376), `None` description becomes `""`.

When creating an artifact, we check if there is an existing artifact with the same digest. If there is, we don't create a new artifact and return the existing one instead. We also set the artifact properties (description, metadata, aliases) if they're specified. Because we were sending a `""` description when someone didn't set it, we were incorrectly removing the description of the existing artifact.

After this PR, we turn `""` back to `None` before sending the description to the server.

# Test plan

- Created an artifact with description, metadata and aliases; then created an identical artifact without setting description, metadata and aliases:
<img width="1158" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/08fd051d-7b1b-4e0d-bd4a-ae855e070ba6">

- Before this PR, the description was reset. After this PR, the description is preserved.