### PR TITLE
chore(launch): Disable service in local process runner

### DIFF
--- a/wandb/sdk/launch/runner/local_process.py
+++ b/wandb/sdk/launch/runner/local_process.py
@@ -87,7 +87,7 @@ class LocalProcessRunner(AbstractRunner):
         command_str = " ".join(cmd).strip()
         _msg = f"{LOG_PREFIX}Launching run as a local-process with command {sanitize_wandb_api_key(command_str)}"
         wandb.termlog(_msg)
-        run = _run_entry_point(command_str, launch_project.project_dir)
+        run = _run_entry_point(command_str, launch_project.project_dir, True)
         if synchronous:
             run.wait()
         return run


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------

Disables service when using the local process runner. This prevents the internal api from being clobbered by new project and run ids because it is assumed shared

copilot:summary

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

copilot:poem
