### PR TITLE
feat(launch): Improve error message when building with noop builder

### DIFF
--- a/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
+++ b/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
@@ -1306,10 +1306,11 @@ def test_noop_builder(
             "project": "test",
             "synchronous": False,
         }
-        with pytest.raises(LaunchError) as e:
-            launch.run(**kwargs)
-
-        assert (
-            "Attempted build with noop builder. Specify a builder in your launch config at ~/.config/wandb/launch-config.yaml"
-            in str(e)
+        expected = (
+            "Attempted build with noop builder. Specify a builder in your launch config at ~/.config/wandb/launch-config.yaml.\n"
+            "Note: Jobs sourced from git repos and code artifacts require a builder, while jobs sourced from Docker images do not.\n"
+            "See https://docs.wandb.ai/guides/launch/create-job."
         )
+        expected = "Attempted build with noop builder. Specify a builder in your launch config at ~/.config/wandb/launch-config.yaml"
+        with pytest.raises(LaunchError, match=expected):
+            launch.run(**kwargs)

--- a/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
+++ b/tests/pytest_tests/unit_tests_old/tests_launch/test_launch.py
@@ -1311,6 +1311,5 @@ def test_noop_builder(
             "Note: Jobs sourced from git repos and code artifacts require a builder, while jobs sourced from Docker images do not.\n"
             "See https://docs.wandb.ai/guides/launch/create-job."
         )
-        expected = "Attempted build with noop builder. Specify a builder in your launch config at ~/.config/wandb/launch-config.yaml"
         with pytest.raises(LaunchError, match=expected):
             launch.run(**kwargs)

--- a/wandb/sdk/launch/builder/noop.py
+++ b/wandb/sdk/launch/builder/noop.py
@@ -51,5 +51,6 @@ class NoOpBuilder(AbstractBuilder):
         For this we raise a launch error since it can't build.
         """
         raise LaunchError(
-            "Attempted build with noop builder. Specify a builder in your launch config at ~/.config/wandb/launch-config.yaml"
+            "Attempted build with noop builder. Specify a builder in your launch config at ~/.config/wandb/launch-config.yaml.\n"
+            "Note: Jobs sourced from Docker images do not require a builder. See https://docs.wandb.ai/guides/launch/create-job."
         )

--- a/wandb/sdk/launch/builder/noop.py
+++ b/wandb/sdk/launch/builder/noop.py
@@ -52,5 +52,6 @@ class NoOpBuilder(AbstractBuilder):
         """
         raise LaunchError(
             "Attempted build with noop builder. Specify a builder in your launch config at ~/.config/wandb/launch-config.yaml.\n"
-            "Note: Jobs sourced from Docker images do not require a builder. See https://docs.wandb.ai/guides/launch/create-job."
+            "Note: Jobs sourced from git repos and code artifacts require a builder, while jobs sourced from Docker images do not.\n"
+            "See https://docs.wandb.ai/guides/launch/create-job."
         )


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-13852](https://wandb.atlassian.net/browse/WB-13852)

Description
-----------
Adds the following to the error message when attempting to build using a noop builder:
`Note: Jobs sourced from Docker images do not require a builder. See https://docs.wandb.ai/guides/launch/create-job.`

![image](https://github.com/wandb/wandb/assets/39655500/1be799b1-c55d-4316-a379-ab0568db9874)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e494931</samp>

Improved error message for noop builder in `wandb/sdk/launch/builder/noop.py`. The message now informs the user how to create a launch job from a Docker image and provides a link to the documentation.

Testing
-------
- `pip install -e {path to wandb repo}`
- start a launch agent with `builder: type: noop` in the config
- clone a [code-based job](https://wandb.ai/tim-hays/debugging/runs/alne37kw/overview?workspace=user-tim-hays) to the queue the agent is polling
- check the output for the desired error message

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e494931</samp>

> _`NoOpBuilder` fails_
> _Error message guides the user_
> _Autumn leaves fall down_


[WB-13852]: https://wandb.atlassian.net/browse/WB-13852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ