### PR TITLE
fix(artifacts): wrap call to get S3 bucket version to guard against permission errors

### DIFF
--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -75,8 +75,11 @@ class S3Handler(StorageHandler):
         assert self._s3 is not None  # mypy: unwraps optionality
         if self._versioning_enabled is not None:
             return self._versioning_enabled
-        res = self._s3.BucketVersioning(bucket)
-        self._versioning_enabled = res.status == "Enabled"
+        try:
+            res = self._s3.BucketVersioning(bucket)
+            self._versioning_enabled = res.status == "Enabled"
+        except self._botocore.exceptions.ClientError:
+            self._versioning_enabled = False
         return self._versioning_enabled
 
     def load_path(


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-14629](https://wandb.atlassian.net/browse/WB-14629)

Description
-----------
Don't check whether bucket versioning is enabled when using S3 references.

Currently we do an early check for whether bucket versioning in enabled if the user specifies a version when adding a reference, or if we're loading a reference where we stored the version (because it was explicitly specified when initially added). This isn't necessary at all; if they specify an invalid version (any version is invalid if bucket versioning is not enabled), that's already an error and will 404 appropriately. So we might as well just proceed assuming we can instead of failing early.

The reason it's necessary to actually remove it is that IAM roles might not have the permissions that would allow them to check the status of bucket versioning, but they can still use versionIDs to load objects; so in that case we currently fail unnecessarily.

<!--
copilot:summary
-->


Testing
-------
Before patch:
<img width="1110" alt="Screenshot 2023-07-20 at 4 00 55 PM" src="https://github.com/wandb/wandb/assets/1124196/e586677c-66ae-4e4d-92f4-3fd321cbbebd">

After patch:
<img width="1597" alt="Screenshot 2023-07-20 at 4 21 12 PM" src="https://github.com/wandb/wandb/assets/1124196/67ea6346-c713-4e9f-9b19-50770a6bce22">


Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->

[WB-14629]: https://wandb.atlassian.net/browse/WB-14629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ