### PR TITLE
chore(launch): special handling for resumed sweep runs

### DIFF
--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -637,6 +637,12 @@ class LaunchAgent:
                 wandb.termlog(
                     f"{LOG_PREFIX}Run {job_tracker.run_id} was preempted, requeueing..."
                 )
+
+                if "sweep_id" in config:
+                    # allow resumed runs from sweeps that have already completed by removing
+                    # the sweep id before pushing to queue
+                    del config["sweep_id"]
+
                 launch_add(
                     config=config,
                     project_queue=self._project,


### PR DESCRIPTION
delete the `sweep_id` from the launch_config, the run should already have it because we are resuming. Without the sweep_id the launch agent will let it run no matter what. 