### PR TITLE
chore(sweeps): sweep scheduler waits for preempted runs to resume

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -536,9 +536,12 @@ class Scheduler(ABC):
                 # PREEMPTED_POLLING_TIMEOUT, if not restarted assume dead
                 if run.preempted_start:
                     if time.time() - run.preempted_start < PREEMPTED_POLLING_TIMEOUT:
+                        wandb.termlog(
+                            f"{LOG_PREFIX}Detected preempted run, elapsed wait time: {(time.time() - run.preempted_start):.2f}s"
+                        )
                         continue
                     wandb.termwarn(
-                        f"{LOG_PREFIX}Waited on preempted run: ({run.id}) for {time.time() - run.preempted_start}s but run never restarted."
+                        f"{LOG_PREFIX}Waited on preempted run: ({run.id}) for {(time.time() - run.preempted_start):.2f}s but run never restarted."
                     )
                 else:
                     run.preempted_start = time.time()

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -537,7 +537,7 @@ class Scheduler(ABC):
                 if run.preempted_start:
                     if time.time() - run.preempted_start < PREEMPTED_POLLING_TIMEOUT:
                         wandb.termlog(
-                            f"{LOG_PREFIX}Detected preempted run, elapsed wait time: {(time.time() - run.preempted_start):.2f}s"
+                            f"{LOG_PREFIX}Detected preempted run: ({run.id}), elapsed wait time: {(time.time() - run.preempted_start):.2f}s"
                         )
                         continue
                     wandb.termwarn(


### PR DESCRIPTION
Scheduler waits 10 minutes when a run is marked as preempted before launching more runs. 

Testing:

added basic preemption timeout: 
<img width="929" alt="Screen Shot 2023-07-21 at 9 03 42 AM" src="https://github.com/wandb/wandb/assets/19414170/d3c5354c-3059-4af3-907d-a65de87f6077">

k8's testing: TODO