### PR TITLE
chore(sdk): bump sdk dev version 0.15.7.dev1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.15.6 (July 24, 2023)
+
+### :magic_wand: Enhancements
+* feat(launch): add job link to wandb footer by @bcsherma in https://github.com/wandb/wandb/pull/5767
+* feat(launch): re-implement job requeueing, fixed cancel behavior by @TimH98 in https://github.com/wandb/wandb/pull/5822
+* feat(launch): manually create jobs from cli by @gtarpenning in https://github.com/wandb/wandb/pull/5661
+* feat(launch): allow users to specify job name via the `job_name` setting by @bcsherma in https://github.com/wandb/wandb/pull/5791
+* feat(sdk): Add an simplified trace API to log prompt traces by @parambharat in https://github.com/wandb/wandb/pull/5794
+* feat(integrations): support `.keras` model format with `WandbModelCheckpoint` and TF 2.13.0 compatible by @soumik12345 in https://github.com/wandb/wandb/pull/5720
+* feat(sdk): Initial support for migrating W&B runs and reports between instances by @andrewtruong in https://github.com/wandb/wandb/pull/5777
+### :hammer: Fixes
+* fix(integrations): make LightGBM callback compatible with 4.0.0 by @ayulockin in https://github.com/wandb/wandb/pull/5906
+* fix(sdk): use default settings for project retrieval if available by @KyleGoyette in https://github.com/wandb/wandb/pull/5917
+### :books: Docs
+* docs(sdk): Add introspection section to CONTRIBUTING.md by @nickpenaranda in https://github.com/wandb/wandb/pull/5887
+### :nail_care: Cleanup
+* revert(launch): revert job re-queuing implementation on pod disconnect by @KyleGoyette in https://github.com/wandb/wandb/pull/5811
+
+**Full Changelog**: https://github.com/wandb/wandb/compare/v0.15.5...v0.15.6
+
 ## 0.15.5 (July 5, 2023)
 
 ### :magic_wand: Enhancements
@@ -39,7 +59,6 @@
 **Full Changelog**: https://github.com/wandb/wandb/compare/v0.15.4...v0.15.5
 
 ## 0.15.4 (June 6, 2023)
-
 ### :magic_wand: Enhancements
 * feat(sdk): set job source in settings by @TimH98 in https://github.com/wandb/wandb/pull/5442
 * feat(sweeps): launch sweeps controlled by wandb run by @gtarpenning in https://github.com/wandb/wandb/pull/5456

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.15.6.dev1
+current_version = 0.15.7.dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prekind}{pre}.{devkind}{dev}
 	{major}.{minor}.{patch}.{devkind}{dev}
 	{major}.{minor}.{patch}{prekind}{pre}
@@ -14,7 +14,7 @@ first_value = 1
 
 [bumpversion:part:prekind]
 optional_value = _
-values =
+values = 
 	_
 	rc
 	_
@@ -24,7 +24,7 @@ first_value = 1
 
 [bumpversion:part:devkind]
 optional_value = _
-values =
+values = 
 	_
 	dev
 	_
@@ -38,7 +38,7 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [tool:pytest]
-norecursedirs =
+norecursedirs = 
 	vendor
 	wandb/vendor
 open_files_ignore = "*.ttf"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ perf_requirements = ["orjson"]
 
 setup(
     name="wandb",
-    version="0.15.6.dev1",
+    version="0.15.7.dev1",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.6.dev1"
+__version__ = "0.15.7.dev1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"


### PR DESCRIPTION
Description
-----------
Bumping sdk dev version and adding release notes for 0.15.6

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 11aef36</samp>

> _Sing, O Muse, of the wandb library, the wondrous tool of data science_
> _That tracks and logs the experiments of the eager and the wise_
> _How after releasing the splendid version, the one with six and five_
> _They updated the setup and the changelog, and the version to seven point dev one_
