### PR TITLE
feat(nexus): add support of wandb.Jog

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -48,6 +48,9 @@ AlertLevel = wandb_sdk.AlertLevel
 Settings = wandb_sdk.Settings
 Config = wandb_sdk.Config
 
+Nexus = wandb_sdk.Nexus
+Jog = wandb_sdk.Jog
+
 from wandb.apis import InternalApi, PublicApi
 from wandb.errors import CommError, UsageError
 
@@ -223,4 +226,6 @@ __all__ = (
     "Object3D",
     "Molecule",
     "Histogram",
+    "Nexus",
+    "Jog",
 )

--- a/wandb/sdk/__init__.py
+++ b/wandb/sdk/__init__.py
@@ -1,16 +1,39 @@
-"""module sdk."""
+__all__ = (
+    "helper",
+    "Artifact",
+    "AlertLevel",
+    "Config",
+    "init",
+    "login",
+    "require",
+    "finish",
+    "save",
+    "Settings",
+    "Summary",
+    "controller",
+    "sweep",
+    "unwatch",
+    "watch",
+    "setup",
+    "teardown",
+    "_attach",
+    "Nexus",
+    "Jog",  # lol. rename to stream or something
+)
 
-from . import wandb_helper as helper  # noqa: F401
-from .artifacts.artifact import Artifact  # noqa: F401
-from .wandb_alerts import AlertLevel  # noqa: F401
-from .wandb_config import Config  # noqa: F401
-from .wandb_init import _attach, init  # noqa: F401
-from .wandb_login import login  # noqa: F401
-from .wandb_require import require  # noqa: F401
-from .wandb_run import finish  # noqa: F401
-from .wandb_save import save  # noqa: F401
-from .wandb_settings import Settings  # noqa: F401
-from .wandb_setup import setup, teardown  # noqa: F401
-from .wandb_summary import Summary  # noqa: F401
-from .wandb_sweep import controller, sweep  # noqa: F401
-from .wandb_watch import unwatch, watch  # noqa: F401
+from . import wandb_helper as helper
+from .artifacts.artifact import Artifact
+from .wandb_alerts import AlertLevel
+from .wandb_config import Config
+from .wandb_init import _attach, init
+from .wandb_jog import Jog
+from .wandb_login import login
+from .wandb_nexus import Nexus
+from .wandb_require import require
+from .wandb_run import finish
+from .wandb_save import save
+from .wandb_settings import Settings
+from .wandb_setup import setup, teardown
+from .wandb_summary import Summary
+from .wandb_sweep import controller, sweep
+from .wandb_watch import unwatch, watch

--- a/wandb/sdk/wandb_jog.py
+++ b/wandb/sdk/wandb_jog.py
@@ -1,6 +1,86 @@
+import os
+from copy import copy
+from typing import TYPE_CHECKING
+
+from ..proto.wandb_internal_pb2 import (
+    ConfigRecord,
+    Record,
+    Request,
+    RunRecord,
+    RunStartRequest,
+)
+from .interface.interface_sock import InterfaceSock
+from .lib import filesystem, runid
+from .lib.mailbox import Mailbox
+from .lib.sock_client import SockClient
+
+if TYPE_CHECKING:
+    import wandb_settings
+
+
 class Jog:
-    def __init__(self, stream_name: str):
-        self.stream_name = stream_name
+    settings: "wandb_settings.Settings"
+    interface: InterfaceSock
+
+    def setup_jog_dirs(self) -> None:
+        settings = self.settings
+        filesystem.mkdir_exists_ok(os.path.dirname(settings.log_user))
+        filesystem.mkdir_exists_ok(os.path.dirname(settings.log_internal))
+        filesystem.mkdir_exists_ok(os.path.dirname(settings.sync_file))
+        filesystem.mkdir_exists_ok(settings.files_dir)
+        filesystem.mkdir_exists_ok(settings._tmp_code_dir)
+
+    def __init__(
+        self,
+        settings: "wandb_settings.Settings",
+        socket_client: SockClient,
+    ) -> None:
+        self.settings = copy(settings)
+        self.interface = InterfaceSock(socket_client, Mailbox())  # noqa
+
+        jog_id = runid.generate_id()
+        self.settings.update(run_id=jog_id)
+        self.settings._set_run_start_time()
+
+        self.interface._stream_id = jog_id
+
+        self.setup_jog_dirs()
+
+    def start(self):
+        jog_id = self.settings.run_id
+        config_pb = ConfigRecord()
+        update = config_pb.update.add()
+        update.key = "_wandb"
+        update.value_json = '{"cli_version": "1.0.0"}'
+
+        jog_pb = RunRecord(
+            run_id=jog_id,
+            config=config_pb,
+        )
+        record = Record(run=jog_pb)
+
+        # print("jog_pb", jog_pb)
+        handle = self.interface._deliver_record(record)
+        result = handle.wait(timeout=self.settings.init_timeout)
+        print("result", result)
+
+        run_start_settings = {
+            "entity": result.run_result.run.entity,
+            "project": result.run_result.run.project,
+            "display_name": result.run_result.run.display_name,
+        }
+        self.settings._apply_run_start(run_start_settings)
+
+        print(self.settings)
+
+        run_start_request = RunStartRequest(run=result.run_result.run)
+        request = Request(run_start=run_start_request)
+        record = Record(request=request)
+        # All requests do not get persisted
+        record.control.local = True
+        handle = self.interface._deliver_record(record)
+        result = handle.wait(timeout=self.settings.init_timeout)
+        print("result", result)
 
     def log(self, data):
         pass

--- a/wandb/sdk/wandb_jog.py
+++ b/wandb/sdk/wandb_jog.py
@@ -1,0 +1,9 @@
+class Jog:
+    def __init__(self, stream_name: str):
+        self.stream_name = stream_name
+
+    def log(self, data):
+        pass
+
+    def finish(self):
+        pass

--- a/wandb/sdk/wandb_nexus.py
+++ b/wandb/sdk/wandb_nexus.py
@@ -28,10 +28,10 @@ class Nexus:
     command_interface: "ServiceSockInterface"
     jogs: Dict[str, "Jog"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.jogs = {}
 
-    def up(self):
+    def up(self) -> None:
         self.settings = init_settings()
         self.manager = wandb_manager._Manager(settings=self.settings)
         # print("manager", self.manager.__dict__)
@@ -39,7 +39,7 @@ class Nexus:
         self.command_interface = self.manager._service._service_interface
         # print("command_interface", self.command_interface.__dict__)
 
-    def init(self):
+    def init(self) -> Jog:
         # return Jog("sprint")
         jog = Jog(self.settings, self.command_interface._sock_client)
 
@@ -50,5 +50,7 @@ class Nexus:
 
         jog.start()
 
-    def down(self):
+        return jog
+
+    def down(self) -> None:
         pass

--- a/wandb/sdk/wandb_nexus.py
+++ b/wandb/sdk/wandb_nexus.py
@@ -1,0 +1,69 @@
+import os
+from copy import copy
+from typing import TYPE_CHECKING, Dict
+
+from ..proto.wandb_internal_pb2 import RunRecord
+from . import wandb_manager, wandb_settings
+from .lib import filesystem, runid
+
+if TYPE_CHECKING:
+    from interface.interface_sock import InterfaceSock
+
+
+def init_settings():
+    pid = os.getpid()
+    s = wandb_settings.Settings()
+    s._apply_base(pid=pid)
+    s._apply_config_files()
+    s._apply_env_vars(os.environ)
+
+    s._infer_settings_from_environment()
+    s._infer_run_settings_from_environment()
+
+    return s
+
+
+class Nexus:
+    address: str
+    settings: "wandb_settings.Settings"
+    manager: "wandb_manager._Manager"
+    interface: "InterfaceSock"
+    jog_settings: Dict[str, "wandb_settings.Settings"]
+
+    def __init__(self):
+        self.jog_settings = {}
+
+    def up(self):
+        self.settings = init_settings()
+        self.manager = wandb_manager._Manager(settings=self.settings)
+        # print("manager", self.manager.__dict__)
+
+        self.interface = self.manager._service._service_interface
+        # print("interface", self.interface.__dict__)
+
+    @staticmethod
+    def setup_jog_dirs(settings: "wandb_settings.Settings"):
+        filesystem.mkdir_exists_ok(os.path.dirname(settings.log_user))
+        filesystem.mkdir_exists_ok(os.path.dirname(settings.log_internal))
+        filesystem.mkdir_exists_ok(os.path.dirname(settings.sync_file))
+        filesystem.mkdir_exists_ok(settings.files_dir)
+        filesystem.mkdir_exists_ok(settings._tmp_code_dir)
+
+    def init(self):
+        # return Jog("sprint")
+        jog_id = runid.generate_id()
+        jog_settings = copy(self.settings)
+        jog_settings.update(run_id=jog_id)
+        jog_settings._set_run_start_time()
+
+        self.setup_jog_dirs(jog_settings)
+
+        self.manager._inform_init(settings=jog_settings, run_id=jog_id)
+        self.jog_settings[jog_id] = jog_settings
+
+        jog_pb = RunRecord(run_id=jog_id)
+
+        print("jog_pb", jog_pb)
+
+    def down(self):
+        pass

--- a/wandb/sdk/wandb_nexus.py
+++ b/wandb/sdk/wandb_nexus.py
@@ -1,13 +1,11 @@
 import os
-from copy import copy
 from typing import TYPE_CHECKING, Dict
 
-from ..proto.wandb_internal_pb2 import RunRecord
 from . import wandb_manager, wandb_settings
-from .lib import filesystem, runid
+from .wandb_jog import Jog
 
 if TYPE_CHECKING:
-    from interface.interface_sock import InterfaceSock
+    from .service.service_sock import ServiceSockInterface
 
 
 def init_settings():
@@ -27,43 +25,30 @@ class Nexus:
     address: str
     settings: "wandb_settings.Settings"
     manager: "wandb_manager._Manager"
-    interface: "InterfaceSock"
-    jog_settings: Dict[str, "wandb_settings.Settings"]
+    command_interface: "ServiceSockInterface"
+    jogs: Dict[str, "Jog"]
 
     def __init__(self):
-        self.jog_settings = {}
+        self.jogs = {}
 
     def up(self):
         self.settings = init_settings()
         self.manager = wandb_manager._Manager(settings=self.settings)
         # print("manager", self.manager.__dict__)
 
-        self.interface = self.manager._service._service_interface
-        # print("interface", self.interface.__dict__)
-
-    @staticmethod
-    def setup_jog_dirs(settings: "wandb_settings.Settings"):
-        filesystem.mkdir_exists_ok(os.path.dirname(settings.log_user))
-        filesystem.mkdir_exists_ok(os.path.dirname(settings.log_internal))
-        filesystem.mkdir_exists_ok(os.path.dirname(settings.sync_file))
-        filesystem.mkdir_exists_ok(settings.files_dir)
-        filesystem.mkdir_exists_ok(settings._tmp_code_dir)
+        self.command_interface = self.manager._service._service_interface
+        # print("command_interface", self.command_interface.__dict__)
 
     def init(self):
         # return Jog("sprint")
-        jog_id = runid.generate_id()
-        jog_settings = copy(self.settings)
-        jog_settings.update(run_id=jog_id)
-        jog_settings._set_run_start_time()
+        jog = Jog(self.settings, self.command_interface._sock_client)
 
-        self.setup_jog_dirs(jog_settings)
+        jog_id = jog.settings.run_id
+        # send command to nexus to init stream for our jog
+        self.manager._inform_init(settings=jog.settings, run_id=jog_id)
+        self.jogs[jog_id] = jog
 
-        self.manager._inform_init(settings=jog_settings, run_id=jog_id)
-        self.jog_settings[jog_id] = jog_settings
-
-        jog_pb = RunRecord(run_id=jog_id)
-
-        print("jog_pb", jog_pb)
+        jog.start()
 
     def down(self):
         pass


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Use this script to test:

```python
import wandb


if __name__ == "__main__":
    wandb.require(experiment="nexus")

    nexus = wandb.Nexus()
    nexus.up()

    jog = nexus.init()

    for i in range(10):
        jog.log({"x": i})
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a25e7d</samp>

This pull request adds two new experimental features, `Jog` and `Nexus`, to the `wandb` module. `Jog` allows creating and logging to multiple runs in a single process without calling `wandb.init`. `Nexus` manages the communication and coordination between multiple `Jog` objects and the wandb service. These features are intended to simplify and enhance the user experience of creating and managing multiple runs in a single process.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a25e7d</samp>

> _`Nexus` and `Jog`_
> _New ways to run experiments_
> _Winter of research_
