### PR TITLE
DNM: chore(sdk): add nexus dependency for testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ setuptools
 appdirs>=1.4.3
 dataclasses; python_version < '3.7'
 typing_extensions; python_version < '3.10'
-wandb-core @ git+https://github.com/wandb/nexus@main#subdirectory=nexus
+wandb-core@git+https://github.com/wandb/nexus@main#subdirectory=nexus

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ setuptools
 appdirs>=1.4.3
 dataclasses; python_version < '3.7'
 typing_extensions; python_version < '3.10'
+wandb-core @ git+https://github.com/wandb/nexus@main#subdirectory=nexus

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ setuptools
 appdirs>=1.4.3
 dataclasses; python_version < '3.7'
 typing_extensions; python_version < '3.10'
-wandb-core@git+https://github.com/wandb/nexus@main#subdirectory=nexus
+wandb-core-alpha

--- a/tox.ini
+++ b/tox.ini
@@ -102,6 +102,7 @@ deps=
 setenv=
     ; Setting low network buffer so that we exercise flow control logic
     WANDB__NETWORK_BUFFER=1000
+    WANDB_REQUIRE_NEXUS=true
     COVERAGE_FILE={envdir}/.coverage
     YEA_WANDB_VERSION=0.9.15
 passenv=

--- a/tox.ini
+++ b/tox.ini
@@ -155,7 +155,8 @@ deps=
 [testenv:func-{,grpc-,docs-,noml-,}py{37,38,39,310}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps =
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb@git+https://github.com/wandb/yea-wandb@nexus-hack-1
+    # yea-wandb=={env:YEA_WANDB_VERSION}
     ; {[func-win32-hack]deps}
 setenv=
     {[base]setenv}
@@ -176,7 +177,8 @@ commands=
 [testenv:func-mitm-py{37,38,39,310}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps =
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb@git+https://github.com/wandb/yea-wandb@nexus-hack-1
+    # yea-wandb=={env:YEA_WANDB_VERSION}
 setenv=
     {[base]setenv}
     YEACOV_SOURCE={envsitepackagesdir}/wandb/
@@ -193,7 +195,8 @@ commands=
 [testenv:func-{llm,kfp}-py{37,38,39,310}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb@git+https://github.com/wandb/yea-wandb@nexus-hack-1
+    # yea-wandb=={env:YEA_WANDB_VERSION}
 setenv=
     {[base]setenv}
     YEACOV_SOURCE={envsitepackagesdir}/wandb/
@@ -225,7 +228,8 @@ passenv=
     WANDB_API_KEY
     SHARD
 deps=
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb@git+https://github.com/wandb/yea-wandb@nexus-hack-1
+    # yea-wandb=={env:YEA_WANDB_VERSION}
 allowlist_externals=
     mkdir
 commands_pre=


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at daa19eb</samp>

Enable Nexus artifact repository for `tox` tests. This change modifies `tox.ini` to set `WANDB_REQUIRE_NEXUS=true` for all test environments.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at daa19eb</samp>

> _`WANDB_REQUIRE_NEXUS`_
> _A switch for artifact store_
> _Winter of Nexus_
