### PR TITLE
chore(launch): try/catch local docker image pull

### DIFF
--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -10,13 +10,13 @@ from typing import Any, Dict, List, Optional
 import wandb
 from wandb.sdk.launch.environment.abstract import AbstractEnvironment
 from wandb.sdk.launch.registry.abstract import AbstractRegistry
-from wandb.sdk.launch.utils import LaunchError
 
 from .._project_spec import LaunchProject
 from ..builder.build import get_env_vars_dict
 from ..utils import (
     LOG_PREFIX,
     PROJECT_SYNCHRONOUS,
+    LaunchError,
     _is_wandb_dev_uri,
     _is_wandb_local_uri,
     docker_image_exists,

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -13,10 +13,10 @@ from wandb.sdk.launch.registry.abstract import AbstractRegistry
 
 from .._project_spec import LaunchProject
 from ..builder.build import get_env_vars_dict
+from ..errors import LaunchError
 from ..utils import (
     LOG_PREFIX,
     PROJECT_SYNCHRONOUS,
-    LaunchError,
     _is_wandb_dev_uri,
     _is_wandb_local_uri,
     docker_image_exists,

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 import wandb
 from wandb.sdk.launch.environment.abstract import AbstractEnvironment
 from wandb.sdk.launch.registry.abstract import AbstractRegistry
+from wandb.sdk.launch.utils import LaunchError
 
 from .._project_spec import LaunchProject
 from ..builder.build import get_env_vars_dict
@@ -139,9 +140,13 @@ class LocalContainerRunner(AbstractRunner):
 
         if launch_project.docker_image:
             if image_uri.endswith(":latest") or not docker_image_exists(image_uri):
-                pull_docker_image(image_uri)
+                try:
+                    pull_docker_image(image_uri)
+                except Exception as e:
+                    raise LaunchError(
+                        f"Failed to pull docker image {image_uri}: {e}"
+                    ) from e
             assert launch_project.docker_image == image_uri
-            pull_docker_image(image_uri)
 
         additional_args = (
             launch_project.override_args if launch_project.docker_image else None

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -143,9 +143,12 @@ class LocalContainerRunner(AbstractRunner):
                 try:
                     pull_docker_image(image_uri)
                 except Exception as e:
-                    raise LaunchError(
-                        f"Failed to pull docker image {image_uri}: {e}"
-                    ) from e
+                    wandb.termwarn(f"Error attempting to pull docker image {image_uri}")
+                    if not docker_image_exists(image_uri):
+                        raise LaunchError(
+                            f"Failed to pull docker image {image_uri} with error: {e}"
+                        )
+
             assert launch_project.docker_image == image_uri
 
         additional_args = (


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f917d77</samp>

### Summary
🐳🛠️❗

<!--
1.  🐳 - This emoji represents docker, the technology used for creating and running containers. It is relevant to the changes because they involve docker image pulling and running containers locally.
2.  🛠️ - This emoji represents a wrench or a tool, which can symbolize improvement, fixing, or maintenance. It is relevant to the changes because they involve improving the error handling for docker operations and adding exception handling to the `run` method.
3.  ❗ - This emoji represents an exclamation mark, which can symbolize urgency, importance, or alert. It is relevant to the changes because they involve raising and handling `LaunchError` exceptions, which indicate that something went wrong with launching the container.
-->
Improved error handling for launching docker containers in `LocalContainerRunner`. Added `LaunchError` exceptions to catch failures in pulling docker images from `wandb/sdk/launch/runner/local_container.py`.

> _When you run a container locally_
> _You might face some errors, you see_
> _So `LocalContainerRunner`_
> _Now has a `LaunchError` gunner_
> _To handle docker image pulling gracefully_

### Walkthrough
* Import `LaunchError` class to handle docker image pull failures ([link](https://github.com/wandb/wandb/pull/5978/files?diff=unified&w=0#diff-03853de6b6ac99be1dc94a98df47da16d8d172f5870a0fbbe5aa39e59e89df83R13))
* Modify `run` method of `LocalContainerRunner` class to catch and raise `LaunchError` with descriptive message if `pull_docker_image` fails ([link](https://github.com/wandb/wandb/pull/5978/files?diff=unified&w=0#diff-03853de6b6ac99be1dc94a98df47da16d8d172f5870a0fbbe5aa39e59e89df83L142-R149))



Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f917d77</samp>

Improved error handling for launching docker containers in `LocalContainerRunner`. Added `LaunchError` exceptions to catch failures in pulling docker images from `wandb/sdk/launch/runner/local_container.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f917d77</samp>

> _When you run a container locally_
> _You might face some errors, you see_
> _So `LocalContainerRunner`_
> _Now has a `LaunchError` gunner_
> _To handle docker image pulling gracefully_
