### PR TITLE
chore(sdk): bump next dev version 0.15.9.dev1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# 0.15.8 (Aug 01, 2023)
+
+### :magic_wand: Enhancements
+* perf(sdk): use mutation createRunFiles to get uploadUrls by @harukatab in https://github.com/wandb/wandb/pull/5731
+* feat(launch): add create_run_queue to public API by @nickpenaranda in https://github.com/wandb/wandb/pull/5874
+* perf(sdk): add hidden option to use orjson instead of json by @dmitryduev in https://github.com/wandb/wandb/pull/5911
+* feat(launch): Improve error message when building with noop builder by @TimH98 in https://github.com/wandb/wandb/pull/5925
+* feat(launch): create launch agent includes agent config if present by @TimH98 in https://github.com/wandb/wandb/pull/5893
+* feat(launch): Check if job ingredients exist before making job by @TimH98 in https://github.com/wandb/wandb/pull/5942
+* feat(launch): Gracefully handle Kubernetes 404 error by @TimH98 in https://github.com/wandb/wandb/pull/5945
+### :hammer: Fixes
+* fix(sdk): only creating new project if it doesn't already exist by @mbarrramsey in https://github.com/wandb/wandb/pull/5814
+* fix(launch): Support namespace in metadata key of resource args by @KyleGoyette in https://github.com/wandb/wandb/pull/5639
+* fix(launch): use "" instead of None for project kwarg when no project given by @bcsherma in https://github.com/wandb/wandb/pull/5839
+* fix(launch): add + to torch cpu regex + tests by @bcsherma in https://github.com/wandb/wandb/pull/5833
+* fix(sdk): implement timeout for file_stream and add debug logs by @kptkin in https://github.com/wandb/wandb/pull/5812
+* fix(artifacts): fix collection filtering when getting aliases by @szymon-piechowicz-wandb in https://github.com/wandb/wandb/pull/5810
+* fix(sdk): replace `dir_watcher` settings with SettingsStatic by @kptkin in https://github.com/wandb/wandb/pull/5863
+* fix(artifacts): set correct base for incremental artifacts by @szymon-piechowicz-wandb in https://github.com/wandb/wandb/pull/5870
+* fix(launch): drop https from azure registries to ensure compatibility with ${image_uri} macro by @bcsherma in https://github.com/wandb/wandb/pull/5880
+* fix(artifacts): handle None description correctly by @szymon-piechowicz-wandb in https://github.com/wandb/wandb/pull/5910
+* fix(launch): Don't create k8s secret if it already exists by @TimH98 in https://github.com/wandb/wandb/pull/5900
+* fix(artifacts): drop S3 bucket versioning check by @moredatarequired in https://github.com/wandb/wandb/pull/5927
+* fix(sdk): speed up import time and fix `pkg_resources` DeprecationWarning by @hauntsaninja in https://github.com/wandb/wandb/pull/5899
+### :books: Docs
+* docs(sdk): Add introspection section to CONTRIBUTING.md by @nickpenaranda in https://github.com/wandb/wandb/pull/5887
+* docs(sdk): update GH action to generate reference docs and clean up docstrings by @dmitryduev in https://github.com/wandb/wandb/pull/5947
+* docs(sdk): update `README.md` to unify the spelling of `Hugging Face` by @eltociear in https://github.com/wandb/wandb/pull/5891
+### :nail_care: Cleanup
+* revert(launch): revert job re-queuing implementation on pod disconnect by @KyleGoyette in https://github.com/wandb/wandb/pull/5811
+
+## New Contributors
+* @mbarrramsey made their first contribution in https://github.com/wandb/wandb/pull/5814
+* @hauntsaninja made their first contribution in https://github.com/wandb/wandb/pull/5899
+* @eltociear made their first contribution in https://github.com/wandb/wandb/pull/5891
+
+**Full Changelog**: https://github.com/wandb/wandb/compare/v0.15.7...v0.15.8
+
 # 0.15.7 (July 25, 2023)
 
 ### :hammer: Fixes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.8
+current_version = 0.15.9
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.9
+current_version = 0.15.9.dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.8.dev1
+current_version = 0.15.8
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?
@@ -32,4 +32,3 @@ values =
 [bumpversion:file:wandb/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
-

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.9"
+__version__ = "0.15.9.dev1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.8.dev1"
+__version__ = "0.15.8"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.15.8"
+__version__ = "0.15.9"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"


### PR DESCRIPTION
Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a082818</samp>

This pull request updates the wandb Python SDK to version `0.15.9.dev1` and adds a changelog section for the previous release `0.15.8`. These changes prepare the SDK for the next release and document the recent improvements and fixes.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a082818</samp>

> _Oh we are the wandb crew and we code with skill and pride_
> _We update the `__version__` and the `CHANGELOG.md`_
> _We heave away on the pull request with the count of three_
> _We're ready for the next release of the wandb SDK_
