### PR TITLE
chore(sweeps): catch set state error and remove cling api

### DIFF
--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_scheduler.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_scheduler.py
@@ -86,7 +86,8 @@ def test_sweep_scheduler_start_failed(user, monkeypatch):
 
     scheduler.state = SchedulerState.CANCELLED
     scheduler.start()
-    assert scheduler.state == SchedulerState.FAILED
+    # should not be able to start a cancelled scheduler
+    assert scheduler.state == SchedulerState.CANCELLED
 
 
 def test_sweep_scheduler_runcap(user, monkeypatch):

--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_scheduler.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_scheduler.py
@@ -452,7 +452,7 @@ def test_sweep_scheduler_base_add_to_launch_queue(user, sweep_config, monkeypatc
     assert _scheduler.is_alive is False
     assert len(_scheduler._runs) == 1
     assert isinstance(_scheduler._runs["foo_run"].queued_run, public.QueuedRun)
-    assert not _scheduler._runs["foo_run"].state.is_alive
+    _scheduler._runs["foo_run"].queued_run.state = RunState.FINISHED
     assert _scheduler._runs["foo_run"].queued_run.args()[-2] == _project
 
     sweep_id2 = wandb.sweep(sweep_config, entity=user, project=_project)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1497,11 +1497,11 @@ def scheduler(
     ctx,
     sweep_id,
 ):
-    api = _get_cling_api()
+    api = InternalApi()
     if api.api_key is None:
         wandb.termlog("Login to W&B to use the sweep scheduler feature")
         ctx.invoke(login, no_offline=True)
-        api = _get_cling_api(reset=True)
+        api = InternalApi(reset=True)
 
     wandb._sentry.configure_scope(process_context="sweep_scheduler")
     wandb.termlog("Starting a Launch Scheduler 🚀")

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -655,12 +655,17 @@ class LaunchAgent:
                     wandb.termlog(f"{LOG_PREFIX}Scheduler finished with ID: {run.id}")
                     if status == "failed":
                         # on fail, update sweep state. scheduler run_id should == sweep_id
-                        self._api.set_sweep_state(
-                            sweep=job_tracker.run_id,
-                            entity=job_tracker.entity,
-                            project=job_tracker.project,
-                            state="CANCELED",
-                        )
+                        try:
+                            self._api.set_sweep_state(
+                                sweep=job_tracker.run_id,
+                                entity=job_tracker.entity,
+                                project=job_tracker.project,
+                                state="CANCELED",
+                            )
+                        except CommError as e:
+                            wandb.termerror(
+                                f"{LOG_PREFIX}Failed to update sweep state: {e}"
+                            )
                 else:
                     wandb.termlog(f"{LOG_PREFIX}Job finished with ID: {run.id}")
                 with self._jobs_lock:

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -540,7 +540,7 @@ class LaunchAgent:
                 _logger.debug(f"Fetch sweep state error: {e}")
                 state = None
 
-            if state and state != "RUNNING" and state != "PAUSED":
+            if state != "RUNNING" and state != "PAUSED":
                 raise LaunchError(
                     f"Launch agent picked up sweep job, but sweep ({launch_spec['sweep_id']}) was in a terminal state ({state})"
                 )
@@ -663,9 +663,7 @@ class LaunchAgent:
                                 state="CANCELED",
                             )
                         except CommError as e:
-                            wandb.termerror(
-                                f"{LOG_PREFIX}Failed to update sweep state: {e}"
-                            )
+                            raise LaunchError(f"Failed to update sweep state: {e}")
                 else:
                     wandb.termlog(f"{LOG_PREFIX}Job finished with ID: {run.id}")
                 with self._jobs_lock:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -362,13 +362,13 @@ class Scheduler(ABC):
         status = ""
         if self.state == SchedulerState.FLUSH_RUNS:
             self._set_sweep_state("PAUSED")
-            status = "completed successfully"
+            status = "paused"
         elif self.state == SchedulerState.COMPLETED:
             self._set_sweep_state("FINISHED")
-            status = "paused successfully"
+            status = "completed"
         elif self.state in [SchedulerState.CANCELLED, SchedulerState.STOPPED]:
             self._set_sweep_state("CANCELED")  # one L
-            status = "cancelled successfully"
+            status = "cancelled"
         else:
             self.state = SchedulerState.FAILED
             self._set_sweep_state("CRASHED")

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -358,8 +358,6 @@ class Scheduler(ABC):
                 f"{LOG_PREFIX}Failed to save state: {traceback.format_exc()}"
             )
 
-        self._stop_runs()
-
         status = ""
         if self.state == SchedulerState.FLUSH_RUNS:
             self._set_sweep_state("PAUSED")
@@ -373,9 +371,10 @@ class Scheduler(ABC):
         else:
             self.state = SchedulerState.FAILED
             self._set_sweep_state("CRASHED")
-            raise Exception("Scheduler run in crashed state, excepting.")
+            status = "crashed"
 
         wandb.termlog(f"{LOG_PREFIX}Scheduler {status}")
+        self._stop_runs()
         self._wandb_run.finish()
 
     def _get_num_runs_launched(self, runs: List[Dict[str, Any]]) -> int:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -359,7 +359,6 @@ class Scheduler(ABC):
             )
 
         self._stop_runs()
-        self._wandb_run.finish()
 
         status = ""
         if self.state == SchedulerState.FLUSH_RUNS:
@@ -375,7 +374,9 @@ class Scheduler(ABC):
             self.state = SchedulerState.FAILED
             self._set_sweep_state("CRASHED")
             raise Exception("Scheduler run in crashed state, excepting.")
+
         wandb.termlog(f"{LOG_PREFIX}Scheduler {status}")
+        self._wandb_run.finish()
 
     def _get_num_runs_launched(self, runs: List[Dict[str, Any]]) -> int:
         """Returns the number of valid runs in the sweep."""

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -358,6 +358,7 @@ class Scheduler(ABC):
                 f"{LOG_PREFIX}Failed to save state: {traceback.format_exc()}"
             )
 
+        # self._stop_runs()
         status = ""
         if self.state == SchedulerState.FLUSH_RUNS:
             self._set_sweep_state("PAUSED")
@@ -371,7 +372,7 @@ class Scheduler(ABC):
         else:
             self.state = SchedulerState.FAILED
             self._set_sweep_state("CRASHED")
-            status = "marked as failed"
+            raise Exception("Scheduler run in crashed state, excepting.")
 
         self._stop_runs()
         self._wandb_run.finish()

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -358,7 +358,9 @@ class Scheduler(ABC):
                 f"{LOG_PREFIX}Failed to save state: {traceback.format_exc()}"
             )
 
-        # self._stop_runs()
+        self._stop_runs()
+        self._wandb_run.finish()
+
         status = ""
         if self.state == SchedulerState.FLUSH_RUNS:
             self._set_sweep_state("PAUSED")
@@ -373,9 +375,6 @@ class Scheduler(ABC):
             self.state = SchedulerState.FAILED
             self._set_sweep_state("CRASHED")
             raise Exception("Scheduler run in crashed state, excepting.")
-
-        self._stop_runs()
-        self._wandb_run.finish()
         wandb.termlog(f"{LOG_PREFIX}Scheduler {status}")
 
     def _get_num_runs_launched(self, runs: List[Dict[str, Any]]) -> int:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -368,13 +368,14 @@ class Scheduler(ABC):
         elif self.state in [SchedulerState.CANCELLED, SchedulerState.STOPPED]:
             self._set_sweep_state("CANCELED")  # one L
             status = "cancelled"
+            self._stop_runs()
         else:
             self.state = SchedulerState.FAILED
             self._set_sweep_state("CRASHED")
             status = "crashed"
+            self._stop_runs()
 
         wandb.termlog(f"{LOG_PREFIX}Scheduler {status}")
-        self._stop_runs()
         self._wandb_run.finish()
 
     def _get_num_runs_launched(self, runs: List[Dict[str, Any]]) -> int:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -346,7 +346,7 @@ class Scheduler(ABC):
             self.exit()
             raise e
         else:
-            wandb.termlog(f"{LOG_PREFIX}Scheduler completed successfully")
+            wandb.termlog(f"{LOG_PREFIX}Scheduler completed")
             # don't overwrite special states (e.g. STOPPED, FAILED)
             if self.state in [SchedulerState.RUNNING, SchedulerState.FLUSH_RUNS]:
                 self.state = SchedulerState.COMPLETED
@@ -506,7 +506,7 @@ class Scheduler(ABC):
                 self._sweep_id, self._entity, self._project
             )
         except Exception as e:
-            _logger.debug(f"sweep state error: {sweep_state} e: {e}")
+            _logger.debug(f"sweep state error: {e}")
             return
 
         if sweep_state in ["FINISHED", "CANCELLED"]:


### PR DESCRIPTION
Fixes
-----
https://weightsandbiases.slack.com/archives/C044BQJCB46/p1691003760557389?thread_ts=1690933174.850759&cid=C044BQJCB46

Description
-----------
Catch comm errors so that we return from the thread process on error, rather than entering infinite loop. Happens when set_sweep_state errors, commonly when the sweep is not found....

Also remove the cling api instantiation, replacing with `InternalApi`. The cling api pre-populates the singleton value, which results in replacing the `WANDB_RUN_ID` that the scheduler relies on when in the local process. 
