### PR TITLE
chore(launch): Add job CLI ref docs

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1536,7 +1536,7 @@ def job() -> None:
     pass
 
 
-@job.command("list")
+@job.command(help="List jobs in a project")
 @click.option(
     "--project",
     "-p",
@@ -1578,7 +1578,7 @@ def _list(project, entity):
         wandb.termlog(f"{name} -- versions ({len(aliases)}): {aliases_str}")
 
 
-@job.command()
+@job.command(help="Describe a job")
 @click.argument("job")
 def describe(job):
     public_api = PublicApi()

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1536,7 +1536,7 @@ def job() -> None:
     pass
 
 
-@job.command(help="List jobs in a project")
+@job.command("list", help="List jobs in a project")
 @click.option(
     "--project",
     "-p",

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1213,7 +1213,6 @@ def launch_sweep(
 )
 @click.option(
     "--async",
-    "run_async",
     is_flag=True,
     help="Flag to run the job asynchronously. Defaults to false, i.e. unless --async is set, wandb launch will wait for "
     "the job to finish. This option is incompatible with --queue; asynchronous options when running with an agent should be "
@@ -1531,7 +1530,7 @@ def scheduler(
         raise e
 
 
-@cli.group("job")
+@cli.group("job", help="Commands for creating and viewing W&B Jobs")
 def job() -> None:
     pass
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1214,6 +1214,7 @@ def launch_sweep(
 @click.option(
     "--async",
     is_flag=True,
+    default=False,
     help="Flag to run the job asynchronously. Defaults to false, i.e. unless --async is set, wandb launch will wait for "
     "the job to finish. This option is incompatible with --queue; asynchronous options when running with an agent should be "
     "set on wandb launch-agent.",

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1531,7 +1531,7 @@ def scheduler(
         raise e
 
 
-@cli.group("job")
+@cli.group(help="Commands for managing and viewing W&B")
 def job() -> None:
     pass
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1578,7 +1578,7 @@ def _list(project, entity):
         wandb.termlog(f"{name} -- versions ({len(aliases)}): {aliases_str}")
 
 
-@job.command(help="Describe a job")
+@job.command("describe", help="Describe a job")
 @click.argument("job", help="The W&B Job to be described")
 def describe(job):
     public_api = PublicApi()
@@ -1595,6 +1595,7 @@ def describe(job):
 
 
 @job.command(
+    "create",
     no_args_is_help=True,
     help="Create a job"
 )

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1215,9 +1215,9 @@ def launch_sweep(
     "--async",
     "run_async",
     is_flag=True,
-    help="""Flag to run the job asynchronously. Defaults to false, i.e. unless --async is set, wandb launch will wait for
-    the job to finish. This option is incompatible with --queue; asynchronous options when running with an agent should be
-    set on wandb launch-agent.""",
+    help="Flag to run the job asynchronously. Defaults to false, i.e. unless --async is set, wandb launch will wait for "
+    "the job to finish. This option is incompatible with --queue; asynchronous options when running with an agent should be "
+    "set on wandb launch-agent.",
 )
 @click.option(
     "--resource-args",

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1531,7 +1531,7 @@ def scheduler(
         raise e
 
 
-@cli.group(help="Commands for managing and viewing W&B")
+@cli.group(help="Commands for managing and viewing W&B jobs")
 def job() -> None:
     pass
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1213,11 +1213,11 @@ def launch_sweep(
 )
 @click.option(
     "--async",
+    "run_async",
     is_flag=True,
-    default=False,
-    help="Flag to run the job asynchronously. Defaults to false, i.e. unless --async is set, wandb launch will wait for "
-    "the job to finish. This option is incompatible with --queue; asynchronous options when running with an agent should be "
-    "set on wandb launch-agent.",
+    help="""Flag to run the job asynchronously. Defaults to false, i.e. unless --async is set, wandb launch will wait for
+    the job to finish. This option is incompatible with --queue; asynchronous options when running with an agent should be
+    set on wandb launch-agent.""",
 )
 @click.option(
     "--resource-args",
@@ -1531,12 +1531,12 @@ def scheduler(
         raise e
 
 
-@cli.group("job", help="Commands for creating and viewing W&B Jobs")
+@cli.group("job")
 def job() -> None:
     pass
 
 
-@job.command("list", help="List existing jobs")
+@job.command("list")
 @click.option(
     "--project",
     "-p",
@@ -1578,8 +1578,8 @@ def _list(project, entity):
         wandb.termlog(f"{name} -- versions ({len(aliases)}): {aliases_str}")
 
 
-@job.command("describe", help="Describe a job")
-@click.argument("job", help="The W&B Job to be described")
+@job.command()
+@click.argument("job")
 def describe(job):
     public_api = PublicApi()
     try:
@@ -1595,9 +1595,7 @@ def describe(job):
 
 
 @job.command(
-    "create",
     no_args_is_help=True,
-    help="Create a job"
 )
 @click.option(
     "--project",

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1536,7 +1536,7 @@ def job() -> None:
     pass
 
 
-@job.command("list")
+@job.command("list", help="List existing jobs")
 @click.option(
     "--project",
     "-p",
@@ -1578,8 +1578,8 @@ def _list(project, entity):
         wandb.termlog(f"{name} -- versions ({len(aliases)}): {aliases_str}")
 
 
-@job.command()
-@click.argument("job")
+@job.command(help="Describe a job")
+@click.argument("job", help="The W&B Job to be described")
 def describe(job):
     public_api = PublicApi()
     try:
@@ -1596,6 +1596,7 @@ def describe(job):
 
 @job.command(
     no_args_is_help=True,
+    help="Create a job"
 )
 @click.option(
     "--project",


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Adds required help strings to include jobs in CLI ref docs

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5621a9b</samp>

Added help messages for the `job` group of commands in `wandb/cli/cli.py` to enhance the W&B jobs feature.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5621a9b</samp>

> _`Job` is the command of doom_
> _It unleashes the power of the wand_
> _But we need some help to face the gloom_
> _So we added some messages to respond_
