### PR TITLE
fix(sdk): guard against undefined filestream timeout

### DIFF
--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -335,6 +335,7 @@ class FileStreamApi:
         self._run_id = run_id
         self._start_time = start_time
         self._client = requests.Session()
+        timeout = timeout or 0
         if timeout > 0:
             self._client.post = functools.partial(self._client.post, timeout=timeout)  # type: ignore[method-assign]
         self._client.auth = api.client.transport.session.auth


### PR DESCRIPTION
Fixes
-----
Fixes https://weights-biases.sentry.io/issues/4364420668/?project=4504800232407040&query=release%3A0.15.8&referrer=release-issue-stream

Description
-----------
This shouldn't happen, but it did. Didn't look too closely into why that happened, just treating the symptom.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 468818b</samp>

Refactor file streaming to handle timeouts and errors better. Set default `timeout` to 0 in `file_stream.py` to avoid passing `None` to `requests`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 468818b</samp>

> _`timeout` is zero_
> _if not given by caller_
> _autumn leaves falling_
