### PR TITLE
docs(sdk): Bump docugen version

### DIFF
--- a/.github/workflows/generate-docodile-documentation.yml
+++ b/.github/workflows/generate-docodile-documentation.yml
@@ -10,14 +10,14 @@ on: # Whenever a release is published,
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Reference (tag or commit sha) to generate docs from'
+        description: "Reference (tag or commit sha) to generate docs from"
         required: false
 
 jobs: # update the docs.
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: wandb/docugen@v0.3.0
+      - uses: wandb/docugen@v0.4.0
         with:
           docodile-branch: main
           wandb-branch: ${{ github.event.inputs.ref || github.ref }}

--- a/.github/workflows/generate-docodile-documentation.yml
+++ b/.github/workflows/generate-docodile-documentation.yml
@@ -10,7 +10,7 @@ on: # Whenever a release is published,
   workflow_dispatch:
     inputs:
       ref:
-        description: "Reference (tag or commit sha) to generate docs from"
+        description: 'Reference (tag or commit sha) to generate docs from'
         required: false
 
 jobs: # update the docs.


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Bumps docugen tag to this release:
https://github.com/wandb/docugen/releases

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9524f3e</samp>

Updated the documentation workflow to use the latest version of the `wandb/docugen` action and improved readability. This enhances the quality and consistency of the wandb library documentation.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9524f3e</samp>

> _Oh we're the wandb crew and we document what we do_
> _We use the `docugen` action to make it easy and true_
> _We pull the latest version and we format it so nice_
> _We heave away and hoist the docs with every pull request_
