### PR TITLE
fix(launch): Use resume=allow when auto requeuing

### DIFF
--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -250,7 +250,7 @@ def get_env_vars_dict(launch_project: LaunchProject, api: Api) -> Dict[str, str]
     if launch_project.sweep_id:
         env_vars["WANDB_SWEEP_ID"] = launch_project.sweep_id
     if launch_project.launch_spec.get("_resume_count", 0) > 0:
-        env_vars["WANDB_RESUME"] = "must"
+        env_vars["WANDB_RESUME"] = "allow"
 
     # TODO: handle env vars > 32760 characters
     env_vars["WANDB_CONFIG"] = json.dumps(launch_project.override_config)


### PR DESCRIPTION
Fixes
-----
- Fixes [this Sentry issue](https://weights-biases.sentry.io/issues/4065168938/?project=4504800232407040&query=entity%3Ahumane&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=1)

Description
-----------
If a run is auto-requeued before the RQI is converted to a full run, there is no run ID to resume from, so `resume=must` is an invalid param. Use `resume=allow` instead.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21db4b7</samp>

Change `WANDB_RESUME` behavior to allow resuming runs from various sources. Update `build.py` to handle different resume scenarios.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 21db4b7</samp>

> _`WANDB_RESUME` changed_
> _More ways to resume runs now_
> _Autumn of progress_
