### PR TITLE
feat(launch): Runless git jobs can use requirements.txt in parent directories

### DIFF
--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -346,8 +346,8 @@ def _create_repo_metadata(
     if not os.path.exists(os.path.join(req_dir, "requirements.txt")):
         wandb.termerror(
             "Could not find requirements.txt file in git repo at "
-            f"{os.path.join(local_dir, 'requirements.txt')} "
-            "or parent directories"
+            f"{os.path.join(os.path.dirname(path), 'requirements.txt')} "
+            "or parent directories."
         )
         return None
 

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -335,10 +335,15 @@ def _create_repo_metadata(
         entrypoint = rel_entrypoint
 
     # check if requirements.txt exists
+    # Note: local_dir will be a subdirectory of the git repo
+    # requirements_entrypoint = os.path.join(local_dir, "requirements.txt")
+    # while not os.path.exists(requirements_entrypoint) and requirements_entrypoint :
+    wandb.termlog(f"{local_dir=}")
+    wandb.termlog(f"{entrypoint=}")
+
     if not os.path.exists(os.path.join(local_dir, "requirements.txt")):
-        repo_formd = path.replace(entrypoint, "")
         wandb.termerror(
-            f"Could not find requirements.txt file in git repo at: {repo_formd}/requirements.txt"
+            f"Could not find requirements.txt file in git repo at: {os.path.join(local_dir, "requirements.txt")}"
         )
         return None
 

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -335,15 +335,19 @@ def _create_repo_metadata(
         entrypoint = rel_entrypoint
 
     # check if requirements.txt exists
-    # Note: local_dir will be a subdirectory of the git repo
-    # requirements_entrypoint = os.path.join(local_dir, "requirements.txt")
-    # while not os.path.exists(requirements_entrypoint) and requirements_entrypoint :
-    wandb.termlog(f"{local_dir=}")
-    wandb.termlog(f"{entrypoint=}")
+    # start at the location of the python file and recurse up to the git root
+    req_dir = local_dir
+    while (
+        not os.path.exists(os.path.join(req_dir, "requirements.txt"))
+        and req_dir != tempdir
+    ):
+        req_dir = os.path.dirname(req_dir)
 
-    if not os.path.exists(os.path.join(local_dir, "requirements.txt")):
+    if not os.path.exists(os.path.join(req_dir, "requirements.txt")):
         wandb.termerror(
-            f"Could not find requirements.txt file in git repo at: {os.path.join(local_dir, "requirements.txt")}"
+            "Could not find requirements.txt file in git repo at "
+            f"{os.path.join(local_dir, 'requirements.txt')} "
+            "or parent directories"
         )
         return None
 


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-14081](https://wandb.atlassian.net/browse/WB-14081)

Description
-----------
Previously, when creating a git job using `wandb job create`, we require that `requirements.txt` is present in the same subdirectory that the user passed in. For example, if using `https://github.com/TimH98/wandb-debugging/blob/main/subdir/train_2.py`, there would need to be a `requirements.txt` in `/subdir/`.

Now, we will search recursively for a `requirements.txt`, starting with the subdirectory and ending at the git root.

copilot:summary

Testing
-------
- Create a git repo, `https://github.com/TimH98/wandb-debugging`, with a script `train_2.py` in a subdirectory that depends on some dependency (in my case, I chose `requests`.
- Add a `requirements.txt` in the root of the repo
- Call `wandb job create -e tim-hays -p debugging -n test-job git https://github.com/TimH98/wandb-debugging/blob/main/subdir/train_2.py`
- Launch the newly created job, confirm it pulls the requirements correctly
- Remove the `requirements.txt` from the repo
- Again call `wandb job create -e tim-hays -p debugging -n test-job-7 git https://github.com/TimH98/wandb-debugging/blob/main/subdir/train_2.py`
- Get an error message indicating `requirements.txt` could not be found.

copilot:poem
