### PR TITLE
revert(sdk): reverts dropping the support for python 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "package_readme.md"
 license = { file = "LICENSE"}
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 dependencies = [
     "Click>=7.1,!=8.0.0",  # click 8.0.0 is broken
     "GitPython>=1.0.0,!=3.1.29",  # CVE-2022-24439
@@ -37,6 +37,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -100,7 +101,7 @@ launch = [
     "typing_extensions",
 ]
 models = ["cloudpickle"]
-async = ["httpx>=0.23.0"]
+async = ["httpx>=0.22.0"] # 0.23.0 dropped Python 3.6; we can upgrade once we drop it too
 perf = ["orjson"]
 
 [tool.setuptools]

--- a/tests/pytest_tests/conftest.py
+++ b/tests/pytest_tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import unittest.mock
 from pathlib import Path
 from queue import Queue
@@ -51,7 +52,8 @@ def copy_asset(assets_path) -> Generator[Callable, None, None]:
 
 @pytest.fixture(scope="function", autouse=True)
 def filesystem_isolate(tmp_path):
-    kwargs = dict(temp_dir=tmp_path)
+    # Click>=8 implements temp_dir argument which depends on python>=3.7
+    kwargs = dict(temp_dir=tmp_path) if sys.version_info >= (3, 7) else {}
     with CliRunner().isolated_filesystem(**kwargs):
         yield
 

--- a/tests/pytest_tests/unit_tests/test_wandb_settings.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_settings.py
@@ -16,8 +16,12 @@ from wandb.sdk.lib._settings_toposort_generate import _get_modification_order
 
 if sys.version_info >= (3, 8):
     from typing import get_type_hints
-else:
+elif sys.version_info >= (3, 7):
     from typing_extensions import get_type_hints
+else:
+
+    def get_type_hints(obj):
+        return obj.__annotations__
 
 
 Property = wandb_settings.Property

--- a/tests/pytest_tests/unit_tests_old/conftest.py
+++ b/tests/pytest_tests/unit_tests_old/conftest.py
@@ -61,7 +61,8 @@ servers = ServerMap()
 
 
 def get_temp_dir_kwargs(tmp_path):
-    return dict(temp_dir=tmp_path)
+    # Click>=8 implements temp_dir argument which depends on python>=3.7
+    return dict(temp_dir=tmp_path) if sys.version_info >= (3, 7) else {}
 
 
 def test_cleanup(*args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS
 
-[testenv:{,notebooks-}py{37,38,39,310,311}]
+[testenv:{,notebooks-}py{36,37,38,39,310,311}]
 install_command=
     ; pytorch installations on non-darwin need the `-f`
     pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
@@ -155,7 +155,7 @@ deps=
     scikit-learn
     xgboost>=1.3.0
 
-[testenv:func-{,grpc-,docs-,noml-,}py{37,38,39,310,311}]
+[testenv:func-{,grpc-,docs-,noml-,}py{36,37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps =
     yea-wandb=={env:YEA_WANDB_VERSION}
@@ -176,7 +176,7 @@ commands=
     !{docs}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard {env:SHARD:default} run {posargs:--all}
     docs: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --yeadoc --shard docs run {posargs:--all}
 
-[testenv:func-mitm-py{37,38,39,310}]
+[testenv:func-mitm-py{36,37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps =
     yea-wandb=={env:YEA_WANDB_VERSION}
@@ -193,7 +193,7 @@ commands_pre=
 commands=
     yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard mitm --mitm run {posargs:--all}
 
-[testenv:func-{llm,kfp}-py{37,38,39,310,311}]
+[testenv:func-{llm,kfp}-py{36,37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     yea-wandb=={env:YEA_WANDB_VERSION}
@@ -238,7 +238,7 @@ commands=
     !{local}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-{env:SHARD:cpu} run {posargs:--all}
     local: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}
 
-[testenv:regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-other,s3,sagemaker}-py{37,38,39,310,311}]
+[testenv:regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-other,s3,sagemaker}-py{36,37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     pyyaml

--- a/wandb/sdk/lib/_settings_toposort_generate.py
+++ b/wandb/sdk/lib/_settings_toposort_generate.py
@@ -1,6 +1,6 @@
 import inspect
 import sys
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from wandb.errors import UsageError
 from wandb.sdk.wandb_settings import Settings
@@ -10,8 +10,10 @@ if sys.version_info >= (3, 8):
 elif sys.version_info >= (3, 7):
     from typing_extensions import get_type_hints
 else:
+
     def get_type_hints(obj: Any) -> Dict[str, Any]:
         return dict(obj.__annotations__) if hasattr(obj, "__annotations__") else dict()
+
 
 template = """
 __all__ = ("SETTINGS_TOPOLOGICALLY_SORTED", "_Setting")

--- a/wandb/sdk/lib/_settings_toposort_generate.py
+++ b/wandb/sdk/lib/_settings_toposort_generate.py
@@ -1,15 +1,17 @@
 import inspect
 import sys
-from typing import Dict, List, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from wandb.errors import UsageError
 from wandb.sdk.wandb_settings import Settings
 
 if sys.version_info >= (3, 8):
     from typing import get_type_hints
-else:
+elif sys.version_info >= (3, 7):
     from typing_extensions import get_type_hints
-
+else:
+    def get_type_hints(obj: Any) -> Dict[str, Any]:
+        return dict(obj.__annotations__) if hasattr(obj, "__annotations__") else dict()
 
 template = """
 __all__ = ("SETTINGS_TOPOLOGICALLY_SORTED", "_Setting")

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -54,8 +54,17 @@ from .lib.runid import generate_id
 
 if sys.version_info >= (3, 8):
     from typing import get_args, get_origin, get_type_hints
-else:
+elif sys.version_info >= (3, 7):
     from typing_extensions import get_args, get_origin, get_type_hints
+else:
+    def get_args(obj: Any) -> Optional[Any]:
+        return obj.__args__ if hasattr(obj, "__args__") else None
+
+    def get_origin(obj: Any) -> Optional[Any]:
+        return obj.__origin__ if hasattr(obj, "__origin__") else None
+
+    def get_type_hints(obj: Any) -> Dict[str, Any]:
+        return dict(obj.__annotations__) if hasattr(obj, "__annotations__") else dict()
 
 
 class SettingsPreprocessingError(UsageError):

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -57,6 +57,7 @@ if sys.version_info >= (3, 8):
 elif sys.version_info >= (3, 7):
     from typing_extensions import get_args, get_origin, get_type_hints
 else:
+
     def get_args(obj: Any) -> Optional[Any]:
         return obj.__args__ if hasattr(obj, "__args__") else None
 


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

relating to this PR:
https://github.com/wandb/wandb/pull/4386

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a59e227</samp>

The pull request adds support for Python 3.6 to the wandb package and fixes type checking errors in some modules. It modifies `pyproject.toml` and two files that use the `get_type_hints` function from the `typing` module.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a59e227</samp>

> _We are the wandb, we defy the Python doom_
> _We make our code compatible, we make our types assume_
> _We use the `get_type_hints`, we sort our settings well_
> _We are the wandb, we cast our magic spell_
