### PR TITLE
fix(sdk): fix import issue to support python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1357,7 +1357,7 @@ workflows:
           matrix:
             parameters:
               python_version_major: [3]
-              python_version_minor: [7, 8, 9, 10, 11]
+              python_version_minor: [6, 7, 8, 9, 10, 11]
           name: "system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
@@ -1371,7 +1371,7 @@ workflows:
           matrix:
             parameters:
               python_version_major: [3]
-              python_version_minor: [7, 8, 9, 10, 11]
+              python_version_minor: [6, 7, 8, 9, 10, 11]
           name: "unit-linux-mock_server-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
@@ -1385,7 +1385,7 @@ workflows:
           matrix:
             parameters:
               python_version_major: [3]
-              python_version_minor: [7, 8, 9, 10, 11]
+              python_version_minor: [6, 7, 8, 9, 10, 11]
           name: "unit-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -16,7 +16,7 @@ import time
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Iterable, NewType, Optional, Tuple, Union
 
-import wandb.sdk.lib.json_util as json
+from wandb.sdk.lib.json_util import dumps, load
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_telemetry_pb2 as tpb
 from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
@@ -254,7 +254,7 @@ class InterfaceBase:
         for k, v in summary_dict.items():
             update = summary.update.add()
             update.key = k
-            update.value_json = json.dumps(v)
+            update.value_json = dumps(v)
         return summary
 
     def _summary_encode(self, value: Any, path_from_root: str) -> dict:
@@ -310,7 +310,7 @@ class InterfaceBase:
             json_value = self._summary_encode(item.value, path_from_root)
             json_value, _ = json_friendly(json_value)  # type: ignore
 
-            pb_summary_item.value_json = json.dumps(
+            pb_summary_item.value_json = dumps(
                 json_value,
                 cls=WandBJSONEncoderOld,
             )
@@ -385,7 +385,7 @@ class InterfaceBase:
         if artifact.description:
             proto_artifact.description = artifact.description
         if artifact.metadata:
-            proto_artifact.metadata = json.dumps(json_friendly_val(artifact.metadata))
+            proto_artifact.metadata = dumps(json_friendly_val(artifact.metadata))
         if artifact._base_id:
             proto_artifact.base_id = artifact._base_id
         proto_artifact.incremental_beta1 = artifact.incremental
@@ -404,7 +404,7 @@ class InterfaceBase:
         for k, v in artifact_manifest.storage_policy.config().items() or {}.items():
             cfg = proto_manifest.storage_policy_config.add()
             cfg.key = k
-            cfg.value_json = json.dumps(v)
+            cfg.value_json = dumps(v)
 
         for entry in sorted(artifact_manifest.entries.values(), key=lambda k: k.path):
             proto_entry = proto_manifest.contents.add()
@@ -421,7 +421,7 @@ class InterfaceBase:
             for k, v in entry.extra.items():
                 proto_extra = proto_entry.extra.add()
                 proto_extra.key = k
-                proto_extra.value_json = json.dumps(v)
+                proto_extra.value_json = dumps(v)
         return proto_manifest
 
     def publish_link_artifact(
@@ -513,7 +513,7 @@ class InterfaceBase:
             try:
                 path = artifact.get_path("wandb-job.json").download()
                 with open(path) as f:
-                    job_info = json.load(f)
+                    job_info = load(f)
             except Exception as e:
                 logger.warning(
                     f"Failed to download partial job info from artifact {artifact}, : {e}"

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -16,7 +16,7 @@ import time
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Iterable, NewType, Optional, Tuple, Union
 
-from wandb.sdk.lib.json_util import dumps, load
+from wandb.sdk.lib import json_util as json
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_telemetry_pb2 as tpb
 from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
@@ -254,7 +254,7 @@ class InterfaceBase:
         for k, v in summary_dict.items():
             update = summary.update.add()
             update.key = k
-            update.value_json = dumps(v)
+            update.value_json = json.dumps(v)
         return summary
 
     def _summary_encode(self, value: Any, path_from_root: str) -> dict:
@@ -310,7 +310,7 @@ class InterfaceBase:
             json_value = self._summary_encode(item.value, path_from_root)
             json_value, _ = json_friendly(json_value)  # type: ignore
 
-            pb_summary_item.value_json = dumps(
+            pb_summary_item.value_json = json.dumps(
                 json_value,
                 cls=WandBJSONEncoderOld,
             )
@@ -385,7 +385,7 @@ class InterfaceBase:
         if artifact.description:
             proto_artifact.description = artifact.description
         if artifact.metadata:
-            proto_artifact.metadata = dumps(json_friendly_val(artifact.metadata))
+            proto_artifact.metadata = json.dumps(json_friendly_val(artifact.metadata))
         if artifact._base_id:
             proto_artifact.base_id = artifact._base_id
         proto_artifact.incremental_beta1 = artifact.incremental
@@ -404,7 +404,7 @@ class InterfaceBase:
         for k, v in artifact_manifest.storage_policy.config().items() or {}.items():
             cfg = proto_manifest.storage_policy_config.add()
             cfg.key = k
-            cfg.value_json = dumps(v)
+            cfg.value_json = json.dumps(v)
 
         for entry in sorted(artifact_manifest.entries.values(), key=lambda k: k.path):
             proto_entry = proto_manifest.contents.add()
@@ -421,7 +421,7 @@ class InterfaceBase:
             for k, v in entry.extra.items():
                 proto_extra = proto_entry.extra.add()
                 proto_extra.key = k
-                proto_extra.value_json = dumps(v)
+                proto_extra.value_json = json.dumps(v)
         return proto_manifest
 
     def publish_link_artifact(
@@ -513,7 +513,7 @@ class InterfaceBase:
             try:
                 path = artifact.get_path("wandb-job.json").download()
                 with open(path) as f:
-                    job_info = load(f)
+                    job_info = json.load(f)
             except Exception as e:
                 logger.warning(
                     f"Failed to download partial job info from artifact {artifact}, : {e}"

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -16,10 +16,10 @@ import time
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Iterable, NewType, Optional, Tuple, Union
 
-from wandb.sdk.lib import json_util as json
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_telemetry_pb2 as tpb
 from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
+from wandb.sdk.lib import json_util as json
 from wandb.util import (
     WandBJSONEncoderOld,
     get_h5_typename,


### PR DESCRIPTION
Description
-----------
What does the PR do?

In python 3.7 if the attribute lookup fails, the import falls back to a `sys.modules` lookup to find the import. This fallback does not exist on 3.6, causing the discrepancy. Replacing `import` with `from` will lookup directly in `sys.modules` and will work!  See this issue for more details: https://bugs.python.org/issue30024


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f08eb06</samp>

This pull request adds Python 3.6 tests on Linux and improves JSON handling in `interface.py`. It aims to ensure compatibility and robustness of the wandb library.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f08eb06</samp>

> _To test Python 3.6 on Linux_
> _This pull request adds some new tricks_
> _It uses `toxenv`_
> _For unit test heaven_
> _And refactors the JSON `dumps` and `load` mix_
