### PR TITLE
fix(launch): Fix override entrypoint when using sweeps on launch without a scheduler job

### DIFF
--- a/wandb/sdk/launch/runner/local_process.py
+++ b/wandb/sdk/launch/runner/local_process.py
@@ -46,7 +46,10 @@ class LocalProcessRunner(AbstractRunner):
             _logger.warning(_msg)
 
         synchronous: bool = self.backend_config[PROJECT_SYNCHRONOUS]
-        entry_point = launch_project.get_single_entry_point()
+        entry_point = (
+            launch_project.override_entrypoint
+            or launch_project.get_single_entry_point()
+        )
 
         cmd: List[Any] = []
 


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fdbb67</samp>

Allow overriding entry point for launch projects. Modify `entry_point` variable in `LocalProcessRunner.run` to use `launch_project.override_entrypoint` if available.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7fdbb67</samp>

> _Launch project with_
> _`override_entrypoint`_
> _A new path in spring_
