### PR TITLE
chore(nexus): reorganize filestream into a package

### DIFF
--- a/nexus/pkg/filestream/filestream.go
+++ b/nexus/pkg/filestream/filestream.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	BufferSize      = 32
-	EventsFileName  = "wandb-events.jsonl"
-	HistoryFileName = "wandb-history.jsonl"
-	SummaryFileName = "wandb-summary.json"
-	OutputFileName  = "output.log"
+	BufferSize             = 32
+	EventsFileName         = "wandb-events.jsonl"
+	HistoryFileName        = "wandb-history.jsonl"
+	SummaryFileName        = "wandb-summary.json"
+	OutputFileName         = "output.log"
 	defaultMaxItemsPerPush = 5_000
 	defaultDelayProcess    = 20 * time.Millisecond
 	defaultHeartbeatTime   = 2 * time.Second
@@ -96,7 +96,7 @@ type FileStream struct {
 	// keep track of the exit chunk for when we shut down filestream
 	stageExitChunk *chunkData
 
-	maxItemsPerPush  int
+	maxItemsPerPush int
 	delayProcess    time.Duration
 	heartbeatTime   time.Duration
 }
@@ -148,16 +148,16 @@ func WithHeartbeatTime(heartbeatTime time.Duration) FileStreamOption {
 // NewFileStream creates a new filestream
 func NewFileStream(opts ...FileStreamOption) *FileStream {
 	fs := &FileStream{
-		recordWait: &sync.WaitGroup{},
-		chunkWait:  &sync.WaitGroup{},
-		replyWait:  &sync.WaitGroup{},
-		recordChan: make(chan *service.Record, BufferSize),
-		chunkChan:  make(chan chunkData, BufferSize),
-		replyChan:  make(chan map[string]interface{}, BufferSize),
-		offset:     make(map[ChunkFile]int),
+		recordWait:      &sync.WaitGroup{},
+		chunkWait:       &sync.WaitGroup{},
+		replyWait:       &sync.WaitGroup{},
+		recordChan:      make(chan *service.Record, BufferSize),
+		chunkChan:       make(chan chunkData, BufferSize),
+		replyChan:       make(chan map[string]interface{}, BufferSize),
+		offset:          make(map[ChunkFile]int),
 		maxItemsPerPush: defaultMaxItemsPerPush,
-		delayProcess: defaultDelayProcess,
-	    heartbeatTime: defaultHeartbeatTime,
+		delayProcess:    defaultDelayProcess,
+		heartbeatTime:   defaultHeartbeatTime,
 	}
 	for _, opt := range opts {
 		opt(fs)

--- a/nexus/pkg/filestream/filestream.go
+++ b/nexus/pkg/filestream/filestream.go
@@ -1,17 +1,11 @@
 package filestream
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/wandb/wandb/nexus/internal/nexuslib"
 	"github.com/wandb/wandb/nexus/pkg/observability"
 	"github.com/wandb/wandb/nexus/pkg/service"
 )
@@ -27,8 +21,6 @@ const (
 	defaultHeartbeatTime   = 2 * time.Second
 )
 
-var completeTrue bool = true
-
 type ChunkFile int8
 type FileStreamOffsetMap map[ChunkFile]int
 
@@ -39,48 +31,18 @@ const (
 	SummaryChunk
 )
 
-type chunkData struct {
-	fileName string
-	fileData *chunkLine
-	Exitcode *int32
-	Complete *bool
-}
-
-type chunkLine struct {
-	chunkType ChunkFile
-	line      string
-}
-
-// FsChunkData is the data for a chunk of a file
-type FsChunkData struct {
-	Offset  int      `json:"offset"`
-	Content []string `json:"content"`
-}
-
-type FsData struct {
-	Files    map[string]FsChunkData `json:"files,omitempty"`
-	Complete *bool                  `json:"complete,omitempty"`
-	Exitcode *int32                 `json:"exitcode,omitempty"`
-}
-
 // FileStream is a stream of data to the server
 type FileStream struct {
 
-	// recordChan is the channel for incoming messages
-	recordChan chan *service.Record
-
-	// chunkChan is the channel for chunk data
-	chunkChan chan chunkData
-
-	// replyChan is the channel for replies
-	replyChan chan map[string]interface{}
-
-	// wg is the wait group
-	recordWait *sync.WaitGroup
-	chunkWait  *sync.WaitGroup
-	replyWait  *sync.WaitGroup
-
 	path string
+
+	processChan chan *service.Record
+	transmitChan chan chunkData
+	feedbackChan chan map[string]interface{}
+
+	processWait  *sync.WaitGroup
+	transmitWait *sync.WaitGroup
+	feedbackWait *sync.WaitGroup
 
 	// keep track of where we are streaming each file chunk
 	offsetMap FileStreamOffsetMap
@@ -154,15 +116,14 @@ func WithOffsets(offsetMap FileStreamOffsetMap) FileStreamOption {
 	}
 }
 
-// NewFileStream creates a new filestream
 func NewFileStream(opts ...FileStreamOption) *FileStream {
 	fs := &FileStream{
-		recordWait:      &sync.WaitGroup{},
-		chunkWait:       &sync.WaitGroup{},
-		replyWait:       &sync.WaitGroup{},
-		recordChan:      make(chan *service.Record, BufferSize),
-		chunkChan:       make(chan chunkData, BufferSize),
-		replyChan:       make(chan map[string]interface{}, BufferSize),
+		processWait:      &sync.WaitGroup{},
+		transmitWait:       &sync.WaitGroup{},
+		feedbackWait:       &sync.WaitGroup{},
+		processChan:      make(chan *service.Record, BufferSize),
+		transmitChan:       make(chan chunkData, BufferSize),
+		feedbackChan:       make(chan map[string]interface{}, BufferSize),
 		offsetMap:       make(FileStreamOffsetMap),
 		maxItemsPerPush: defaultMaxItemsPerPush,
 		delayProcess:    defaultDelayProcess,
@@ -177,283 +138,36 @@ func NewFileStream(opts ...FileStreamOption) *FileStream {
 func (fs *FileStream) Start() {
 	fs.logger.Debug("filestream: start", "path", fs.path)
 
-	fs.recordWait.Add(1)
+	fs.processWait.Add(1)
 	go func() {
-		fs.doRecordProcess(fs.recordChan)
-		fs.recordWait.Done()
+		fs.loopProcess(fs.processChan)
+		fs.processWait.Done()
 	}()
 
-	fs.chunkWait.Add(1)
+	fs.transmitWait.Add(1)
 	go func() {
-		// todo: treat different file types separately
-		fs.doChunkProcess(fs.chunkChan)
-		fs.chunkWait.Done()
+		fs.loopTransmit(fs.transmitChan)
+		fs.transmitWait.Done()
 	}()
 
-	fs.replyWait.Add(1)
+	fs.feedbackWait.Add(1)
 	go func() {
-		fs.doReplyProcess(fs.replyChan)
-		fs.replyWait.Done()
+		fs.loopFeedback(fs.feedbackChan)
+		fs.feedbackWait.Done()
 	}()
-}
-
-func (fs *FileStream) pushRecord(rec *service.Record) {
-	fs.recordChan <- rec
-}
-
-func (fs *FileStream) pushChunk(chunk chunkData) {
-	fs.chunkChan <- chunk
-}
-
-func (fs *FileStream) pushReply(reply map[string]interface{}) {
-	fs.replyChan <- reply
-}
-
-func (fs *FileStream) doRecordProcess(inChan <-chan *service.Record) {
-	fs.logger.Debug("filestream: open", "path", fs.path)
-
-	for record := range inChan {
-		fs.logger.Debug("filestream: record", "record", record)
-		switch x := record.RecordType.(type) {
-		case *service.Record_History:
-			fs.streamHistory(x.History)
-		case *service.Record_Summary:
-			fs.streamSummary(x.Summary)
-		case *service.Record_Stats:
-			fs.streamSystemMetrics(x.Stats)
-		case *service.Record_OutputRaw:
-			fs.streamOutputRaw(x.OutputRaw)
-		case *service.Record_Exit:
-			fs.streamFinish(x.Exit)
-		case nil:
-			err := fmt.Errorf("filestream: field not set")
-			fs.logger.CaptureFatalAndPanic("filestream error:", err)
-		default:
-			err := fmt.Errorf("filestream: Unknown type %T", x)
-			fs.logger.CaptureFatalAndPanic("filestream error:", err)
-		}
-	}
-}
-
-func (fs *FileStream) doChunkProcess(inChan <-chan chunkData) {
-
-	overflow := false
-
-	for active := true; active; {
-		var chunkMaps = make(map[string][]chunkData)
-		select {
-		case chunk, ok := <-inChan:
-			if !ok {
-				active = false
-				break
-			}
-
-			chunkMaps[chunk.fileName] = append(chunkMaps[chunk.fileName], chunk)
-
-			delayTime := fs.delayProcess
-			if overflow {
-				delayTime = 0
-			}
-			delayChan := time.After(delayTime)
-			overflow = false
-
-			for ready := true; ready; {
-				select {
-				case chunk, ok = <-inChan:
-					if !ok {
-						ready = false
-						active = false
-						break
-					}
-					chunkMaps[chunk.fileName] = append(chunkMaps[chunk.fileName], chunk)
-					if len(chunkMaps[chunk.fileName]) >= fs.maxItemsPerPush {
-						ready = false
-						overflow = true
-					}
-				case <-delayChan:
-					ready = false
-				}
-			}
-			for _, chunkList := range chunkMaps {
-				fs.sendChunkList(chunkList)
-			}
-		case <-time.After(fs.heartbeatTime):
-			for _, chunkList := range chunkMaps {
-				if len(chunkList) > 0 {
-					fs.sendChunkList(chunkList)
-				}
-			}
-		}
-		if fs.stageExitChunk != nil {
-			fs.sendChunkList([]chunkData{*fs.stageExitChunk})
-		}
-	}
-}
-
-func (fs *FileStream) doReplyProcess(inChan <-chan map[string]interface{}) {
-	for range inChan {
-	}
-}
-
-func (fs *FileStream) streamHistory(msg *service.HistoryRecord) {
-	line, err := nexuslib.JsonifyItems(msg.Item)
-	if err != nil {
-		fs.logger.CaptureFatalAndPanic("json unmarshal error", err)
-	}
-	chunk := chunkData{
-		fileName: HistoryFileName,
-		fileData: &chunkLine{
-			chunkType: HistoryChunk,
-			line:      line,
-		},
-	}
-	fs.pushChunk(chunk)
-}
-
-func (fs *FileStream) streamSummary(msg *service.SummaryRecord) {
-	line, err := nexuslib.JsonifyItems(msg.Update)
-	if err != nil {
-		fs.logger.CaptureFatalAndPanic("json unmarshal error", err)
-	}
-	chunk := chunkData{
-		fileName: SummaryFileName,
-		fileData: &chunkLine{
-			chunkType: SummaryChunk,
-			line:      line,
-		},
-	}
-	fs.pushChunk(chunk)
-}
-
-func (fs *FileStream) streamOutputRaw(msg *service.OutputRawRecord) {
-	chunk := chunkData{
-		fileName: OutputFileName,
-		fileData: &chunkLine{
-			chunkType: OutputChunk,
-			line:      msg.Line,
-		},
-	}
-	fs.pushChunk(chunk)
-}
-
-func (fs *FileStream) streamSystemMetrics(msg *service.StatsRecord) {
-	// todo: there is a lot of unnecessary overhead here,
-	//  we should prepare all the data in the system monitor
-	//  and then send it in one record
-	row := make(map[string]interface{})
-	row["_wandb"] = true
-	timestamp := float64(msg.GetTimestamp().Seconds) + float64(msg.GetTimestamp().Nanos)/1e9
-	row["_timestamp"] = timestamp
-	row["_runtime"] = timestamp - fs.settings.XStartTime.GetValue()
-
-	for _, item := range msg.Item {
-		var val interface{}
-		if err := json.Unmarshal([]byte(item.ValueJson), &val); err != nil {
-			e := fmt.Errorf("json unmarshal error: %v, items: %v", err, item)
-			errMsg := fmt.Sprintf("sender: sendSystemMetrics: failed to marshal value: %s for key: %s", item.ValueJson, item.Key)
-			fs.logger.CaptureError(errMsg, e)
-			continue
-		}
-
-		row["system."+item.Key] = val
-	}
-
-	// marshal the row
-	line, err := json.Marshal(row)
-	if err != nil {
-		fs.logger.CaptureError("sender: sendSystemMetrics: failed to marshal system metrics", err)
-		return
-	}
-
-	chunk := chunkData{
-		fileName: EventsFileName,
-		fileData: &chunkLine{chunkType: EventsChunk, line: string(line)},
-	}
-	fs.pushChunk(chunk)
-}
-
-func (fs *FileStream) streamFinish(exitRecord *service.RunExitRecord) {
-	// exitChunk is sent last, so instead of pushing to the chunk channel we
-	// stage it to be sent after processing all other chunks
-	fs.stageExitChunk = &chunkData{Complete: &completeTrue, Exitcode: &exitRecord.ExitCode}
 }
 
 func (fs *FileStream) StreamRecord(rec *service.Record) {
 	fs.logger.Debug("filestream: stream record", "record", rec)
-	fs.pushRecord(rec)
-}
-
-func (fs *FileStream) sendChunkList(chunks []chunkData) {
-	var lines []string
-	var complete *bool
-	var exitcode *int32
-
-	for i := range chunks {
-		if chunks[i].fileData != nil {
-			lines = append(lines, chunks[i].fileData.line)
-		}
-		if chunks[i].Complete != nil {
-			complete = chunks[i].Complete
-		}
-		if chunks[i].Exitcode != nil {
-			exitcode = chunks[i].Exitcode
-		}
-	}
-	var files map[string]FsChunkData
-	if len(lines) > 0 {
-		// all chunks in the list should have the same file name
-		chunkType := chunks[0].fileData.chunkType
-		chunkFileName := chunks[0].fileName
-		fsChunk := FsChunkData{
-			Offset:  fs.offsetMap[chunkType],
-			Content: lines}
-		fs.offsetMap[chunkType] += len(lines)
-		files = map[string]FsChunkData{
-			chunkFileName: fsChunk,
-		}
-	}
-	data := FsData{Files: files, Complete: complete, Exitcode: exitcode}
-	fs.send(data)
-}
-
-func (fs *FileStream) send(data interface{}) {
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		fs.logger.CaptureFatalAndPanic("json marshal error", err)
-	}
-	fs.logger.Debug("filestream: post request", "request", string(jsonData))
-
-	buffer := bytes.NewBuffer(jsonData)
-	req, err := retryablehttp.NewRequest(http.MethodPost, fs.path, buffer)
-	if err != nil {
-		fs.logger.CaptureFatalAndPanic("filestream: error creating HTTP request", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := fs.httpClient.Do(req)
-	if err != nil {
-		fs.logger.CaptureFatalAndPanic("filestream: error making HTTP request", err)
-	}
-	defer func(Body io.ReadCloser) {
-		if err = Body.Close(); err != nil {
-			fs.logger.CaptureError("filestream: error closing response body", err)
-		}
-	}(resp.Body)
-
-	var res map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&res)
-	if err != nil {
-		fs.logger.CaptureError("json decode error", err)
-	}
-	fs.pushReply(res)
-	fs.logger.Debug("filestream: post response", "response", res)
+	fs.addProcess(rec)
 }
 
 func (fs *FileStream) Close() {
-	close(fs.recordChan)
-	fs.recordWait.Wait()
-	close(fs.chunkChan)
-	fs.chunkWait.Wait()
-	close(fs.replyChan)
-	fs.replyWait.Wait()
+	close(fs.processChan)
+	fs.processWait.Wait()
+	close(fs.transmitChan)
+	fs.transmitWait.Wait()
+	close(fs.feedbackChan)
+	fs.feedbackWait.Wait()
 	fs.logger.Debug("filestream: closed")
 }

--- a/nexus/pkg/filestream/filestream.go
+++ b/nexus/pkg/filestream/filestream.go
@@ -1,3 +1,10 @@
+// package filesteam implements routines necessary for communicating with
+// the W&B backend filestream service.
+//
+// Internally there are three goroutines spun up:
+//   process:  process records into an appopriate format to transmit
+//   transmit: transmit messages to the filestream service
+//   feedback: process feedback from the filestream service
 package filestream
 
 import (

--- a/nexus/pkg/filestream/filestream.go
+++ b/nexus/pkg/filestream/filestream.go
@@ -33,10 +33,9 @@ const (
 
 // FileStream is a stream of data to the server
 type FileStream struct {
-
 	path string
 
-	processChan chan *service.Record
+	processChan  chan *service.Record
 	transmitChan chan chunkData
 	feedbackChan chan map[string]interface{}
 
@@ -118,12 +117,12 @@ func WithOffsets(offsetMap FileStreamOffsetMap) FileStreamOption {
 
 func NewFileStream(opts ...FileStreamOption) *FileStream {
 	fs := &FileStream{
-		processWait:      &sync.WaitGroup{},
-		transmitWait:       &sync.WaitGroup{},
-		feedbackWait:       &sync.WaitGroup{},
-		processChan:      make(chan *service.Record, BufferSize),
-		transmitChan:       make(chan chunkData, BufferSize),
-		feedbackChan:       make(chan map[string]interface{}, BufferSize),
+		processWait:     &sync.WaitGroup{},
+		transmitWait:    &sync.WaitGroup{},
+		feedbackWait:    &sync.WaitGroup{},
+		processChan:     make(chan *service.Record, BufferSize),
+		transmitChan:    make(chan chunkData, BufferSize),
+		feedbackChan:    make(chan map[string]interface{}, BufferSize),
 		offsetMap:       make(FileStreamOffsetMap),
 		maxItemsPerPush: defaultMaxItemsPerPush,
 		delayProcess:    defaultDelayProcess,

--- a/nexus/pkg/filestream/filestream.go
+++ b/nexus/pkg/filestream/filestream.go
@@ -2,9 +2,10 @@
 // the W&B backend filestream service.
 //
 // Internally there are three goroutines spun up:
-//   process:  process records into an appopriate format to transmit
-//   transmit: transmit messages to the filestream service
-//   feedback: process feedback from the filestream service
+//
+//	process:  process records into an appopriate format to transmit
+//	transmit: transmit messages to the filestream service
+//	feedback: process feedback from the filestream service
 package filestream
 
 import (

--- a/nexus/pkg/filestream/filestream_test.go
+++ b/nexus/pkg/filestream/filestream_test.go
@@ -1,4 +1,4 @@
-package server_test
+package filestream_test
 
 import (
 	"fmt"

--- a/nexus/pkg/filestream/filestream_test.go
+++ b/nexus/pkg/filestream/filestream_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/wandb/wandb/nexus/pkg/observability"
 
+	"github.com/wandb/wandb/nexus/pkg/filestream"
 	"github.com/wandb/wandb/nexus/pkg/server"
 
 	"encoding/json"
@@ -73,7 +74,7 @@ func (h apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 	dec := json.NewDecoder(r.Body)
-	var msg server.FsData
+	var msg filestream.FsData
 	err := dec.Decode(&msg)
 	if err != nil {
 		fmt.Println("ERROR", err)
@@ -90,7 +91,7 @@ func (h apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.set("time", tm)
 	*/
 
-	f := msg.Files[server.HistoryFileName]
+	f := msg.Files[filestream.HistoryFileName]
 	total := f.Offset
 	total += len(f.Content)
 	h.set("total", total)
@@ -126,24 +127,24 @@ func (ts *testServer) close() {
 }
 
 type filestreamTest struct {
-	fs      *server.FileStream
+	fs      *filestream.FileStream
 	capture *captureState
 	path    string
 	mux     *http.ServeMux
 	tserver *testServer
 }
 
-func NewFilestreamTest(tName string, fn func(fs *server.FileStream)) *filestreamTest {
+func NewFilestreamTest(tName string, fn func(fs *filestream.FileStream)) *filestreamTest {
 	tserver := NewTestServer()
 	m := make(map[string]interface{})
 	capture := captureState{m: m}
 	fstreamPath := "/test/" + tName
 	tserver.mux.Handle(fstreamPath, apiHandler{&capture})
-	fs := server.NewFileStream(
-		server.WithPath(tserver.hserver.URL+fstreamPath),
-		server.WithSettings(tserver.settings),
-		server.WithLogger(tserver.logger),
-		server.WithHttpClient(server.NewRetryClient(
+	fs := filestream.NewFileStream(
+		filestream.WithPath(tserver.hserver.URL+fstreamPath),
+		filestream.WithSettings(tserver.settings),
+		filestream.WithLogger(tserver.logger),
+		filestream.WithHttpClient(server.NewRetryClient(
 			tserver.settings.GetApiKey().GetValue(),
 			tserver.logger)))
 	fs.Start()
@@ -174,7 +175,7 @@ func TestSendHistory(t *testing.T) {
 	num := 10
 	delay := 5 * time.Millisecond
 	tst := NewFilestreamTest(t.Name(),
-		func(fs *server.FileStream) {
+		func(fs *filestream.FileStream) {
 			msg := NewHistoryRecord()
 			for i := 0; i < num; i++ {
 				time.Sleep(delay)
@@ -187,7 +188,7 @@ func TestSendHistory(t *testing.T) {
 func BenchmarkHistory(b *testing.B) {
 	num := 10_000
 	tst := NewFilestreamTest(b.Name(),
-		func(fs *server.FileStream) {
+		func(fs *filestream.FileStream) {
 			msg := NewHistoryRecord()
 			b.ResetTimer()
 			for i := 0; i < num; i++ {

--- a/nexus/pkg/filestream/loop_feedback.go
+++ b/nexus/pkg/filestream/loop_feedback.go
@@ -1,0 +1,10 @@
+package filestream
+
+func (fs *FileStream) addFeedback(reply map[string]interface{}) {
+	fs.feedbackChan <- reply
+}
+
+func (fs *FileStream) loopFeedback(inChan <-chan map[string]interface{}) {
+	for range inChan {
+	}
+}

--- a/nexus/pkg/filestream/loop_process.go
+++ b/nexus/pkg/filestream/loop_process.go
@@ -1,0 +1,122 @@
+package filestream
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/wandb/wandb/nexus/internal/nexuslib"
+	"github.com/wandb/wandb/nexus/pkg/service"
+)
+
+func (fs *FileStream) addProcess(rec *service.Record) {
+	fs.processChan <- rec
+}
+
+func (fs *FileStream) loopProcess(inChan <-chan *service.Record) {
+	fs.logger.Debug("filestream: open", "path", fs.path)
+
+	for record := range inChan {
+		fs.logger.Debug("filestream: record", "record", record)
+		switch x := record.RecordType.(type) {
+		case *service.Record_History:
+			fs.streamHistory(x.History)
+		case *service.Record_Summary:
+			fs.streamSummary(x.Summary)
+		case *service.Record_Stats:
+			fs.streamSystemMetrics(x.Stats)
+		case *service.Record_OutputRaw:
+			fs.streamOutputRaw(x.OutputRaw)
+		case *service.Record_Exit:
+			fs.streamFinish(x.Exit)
+		case nil:
+			err := fmt.Errorf("filestream: field not set")
+			fs.logger.CaptureFatalAndPanic("filestream error:", err)
+		default:
+			err := fmt.Errorf("filestream: Unknown type %T", x)
+			fs.logger.CaptureFatalAndPanic("filestream error:", err)
+		}
+	}
+}
+
+func (fs *FileStream) streamHistory(msg *service.HistoryRecord) {
+	line, err := nexuslib.JsonifyItems(msg.Item)
+	if err != nil {
+		fs.logger.CaptureFatalAndPanic("json unmarshal error", err)
+	}
+	chunk := chunkData{
+		fileName: HistoryFileName,
+		fileData: &chunkLine{
+			chunkType: HistoryChunk,
+			line:      line,
+		},
+	}
+	fs.addTransmit(chunk)
+}
+
+func (fs *FileStream) streamSummary(msg *service.SummaryRecord) {
+	line, err := nexuslib.JsonifyItems(msg.Update)
+	if err != nil {
+		fs.logger.CaptureFatalAndPanic("json unmarshal error", err)
+	}
+	chunk := chunkData{
+		fileName: SummaryFileName,
+		fileData: &chunkLine{
+			chunkType: SummaryChunk,
+			line:      line,
+		},
+	}
+	fs.addTransmit(chunk)
+}
+
+func (fs *FileStream) streamOutputRaw(msg *service.OutputRawRecord) {
+	chunk := chunkData{
+		fileName: OutputFileName,
+		fileData: &chunkLine{
+			chunkType: OutputChunk,
+			line:      msg.Line,
+		},
+	}
+	fs.addTransmit(chunk)
+}
+
+func (fs *FileStream) streamSystemMetrics(msg *service.StatsRecord) {
+	// todo: there is a lot of unnecessary overhead here,
+	//  we should prepare all the data in the system monitor
+	//  and then send it in one record
+	row := make(map[string]interface{})
+	row["_wandb"] = true
+	timestamp := float64(msg.GetTimestamp().Seconds) + float64(msg.GetTimestamp().Nanos)/1e9
+	row["_timestamp"] = timestamp
+	row["_runtime"] = timestamp - fs.settings.XStartTime.GetValue()
+
+	for _, item := range msg.Item {
+		var val interface{}
+		if err := json.Unmarshal([]byte(item.ValueJson), &val); err != nil {
+			e := fmt.Errorf("json unmarshal error: %v, items: %v", err, item)
+			errMsg := fmt.Sprintf("sender: sendSystemMetrics: failed to marshal value: %s for key: %s", item.ValueJson, item.Key)
+			fs.logger.CaptureError(errMsg, e)
+			continue
+		}
+
+		row["system."+item.Key] = val
+	}
+
+	// marshal the row
+	line, err := json.Marshal(row)
+	if err != nil {
+		fs.logger.CaptureError("sender: sendSystemMetrics: failed to marshal system metrics", err)
+		return
+	}
+
+	chunk := chunkData{
+		fileName: EventsFileName,
+		fileData: &chunkLine{chunkType: EventsChunk, line: string(line)},
+	}
+	fs.addTransmit(chunk)
+}
+
+func (fs *FileStream) streamFinish(exitRecord *service.RunExitRecord) {
+	// exitChunk is sent last, so instead of pushing to the chunk channel we
+	// stage it to be sent after processing all other chunks
+	fs.stageExitChunk = &chunkData{Complete: &completeTrue, Exitcode: &exitRecord.ExitCode}
+}

--- a/nexus/pkg/filestream/loop_transmit.go
+++ b/nexus/pkg/filestream/loop_transmit.go
@@ -1,0 +1,161 @@
+package filestream
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+var completeTrue bool = true
+
+type chunkData struct {
+	fileName string
+	fileData *chunkLine
+	Exitcode *int32
+	Complete *bool
+}
+
+type chunkLine struct {
+	chunkType ChunkFile
+	line      string
+}
+
+// FsChunkData is the data for a chunk of a file
+type FsChunkData struct {
+	Offset  int      `json:"offset"`
+	Content []string `json:"content"`
+}
+
+type FsData struct {
+	Files    map[string]FsChunkData `json:"files,omitempty"`
+	Complete *bool                  `json:"complete,omitempty"`
+	Exitcode *int32                 `json:"exitcode,omitempty"`
+}
+
+func (fs *FileStream) addTransmit(chunk chunkData) {
+	fs.transmitChan <- chunk
+}
+
+func (fs *FileStream) loopTransmit(inChan <-chan chunkData) {
+
+	overflow := false
+
+	for active := true; active; {
+		var chunkMaps = make(map[string][]chunkData)
+		select {
+		case chunk, ok := <-inChan:
+			if !ok {
+				active = false
+				break
+			}
+
+			chunkMaps[chunk.fileName] = append(chunkMaps[chunk.fileName], chunk)
+
+			delayTime := fs.delayProcess
+			if overflow {
+				delayTime = 0
+			}
+			delayChan := time.After(delayTime)
+			overflow = false
+
+			for ready := true; ready; {
+				select {
+				case chunk, ok = <-inChan:
+					if !ok {
+						ready = false
+						active = false
+						break
+					}
+					chunkMaps[chunk.fileName] = append(chunkMaps[chunk.fileName], chunk)
+					if len(chunkMaps[chunk.fileName]) >= fs.maxItemsPerPush {
+						ready = false
+						overflow = true
+					}
+				case <-delayChan:
+					ready = false
+				}
+			}
+			for _, chunkList := range chunkMaps {
+				fs.sendChunkList(chunkList)
+			}
+		case <-time.After(fs.heartbeatTime):
+			for _, chunkList := range chunkMaps {
+				if len(chunkList) > 0 {
+					fs.sendChunkList(chunkList)
+				}
+			}
+		}
+		if fs.stageExitChunk != nil {
+			fs.sendChunkList([]chunkData{*fs.stageExitChunk})
+		}
+	}
+}
+
+func (fs *FileStream) sendChunkList(chunks []chunkData) {
+	var lines []string
+	var complete *bool
+	var exitcode *int32
+
+	for i := range chunks {
+		if chunks[i].fileData != nil {
+			lines = append(lines, chunks[i].fileData.line)
+		}
+		if chunks[i].Complete != nil {
+			complete = chunks[i].Complete
+		}
+		if chunks[i].Exitcode != nil {
+			exitcode = chunks[i].Exitcode
+		}
+	}
+	var files map[string]FsChunkData
+	if len(lines) > 0 {
+		// all chunks in the list should have the same file name
+		chunkType := chunks[0].fileData.chunkType
+		chunkFileName := chunks[0].fileName
+		fsChunk := FsChunkData{
+			Offset:  fs.offsetMap[chunkType],
+			Content: lines}
+		fs.offsetMap[chunkType] += len(lines)
+		files = map[string]FsChunkData{
+			chunkFileName: fsChunk,
+		}
+	}
+	data := FsData{Files: files, Complete: complete, Exitcode: exitcode}
+	fs.send(data)
+}
+
+func (fs *FileStream) send(data interface{}) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		fs.logger.CaptureFatalAndPanic("json marshal error", err)
+	}
+	fs.logger.Debug("filestream: post request", "request", string(jsonData))
+
+	buffer := bytes.NewBuffer(jsonData)
+	req, err := retryablehttp.NewRequest(http.MethodPost, fs.path, buffer)
+	if err != nil {
+		fs.logger.CaptureFatalAndPanic("filestream: error creating HTTP request", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := fs.httpClient.Do(req)
+	if err != nil {
+		fs.logger.CaptureFatalAndPanic("filestream: error making HTTP request", err)
+	}
+	defer func(Body io.ReadCloser) {
+		if err = Body.Close(); err != nil {
+			fs.logger.CaptureError("filestream: error closing response body", err)
+		}
+	}(resp.Body)
+
+	var res map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	if err != nil {
+		fs.logger.CaptureError("json decode error", err)
+	}
+	fs.addFeedback(res)
+	fs.logger.Debug("filestream: post response", "response", res)
+}

--- a/nexus/pkg/server/clients.go
+++ b/nexus/pkg/server/clients.go
@@ -28,8 +28,8 @@ func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.wrapped.RoundTrip(req)
 }
 
-// newRetryClient creates a new http client
-func newRetryClient(apiKey string, logger *observability.NexusLogger) *retryablehttp.Client {
+// NewRetryClient creates a new http client
+func NewRetryClient(apiKey string, logger *observability.NexusLogger) *retryablehttp.Client {
 	tr := &authedTransport{
 		key:     apiKey,
 		wrapped: http.DefaultTransport,
@@ -42,7 +42,7 @@ func newRetryClient(apiKey string, logger *observability.NexusLogger) *retryable
 
 // newGraphqlClient creates a new graphql client
 func newGraphqlClient(url, apiKey string, logger *observability.NexusLogger) graphql.Client {
-	retryClient := newRetryClient(apiKey, logger)
+	retryClient := NewRetryClient(apiKey, logger)
 	httpClient := retryClient.StandardClient()
 	return graphql.NewClient(url, httpClient)
 }

--- a/nexus/pkg/server/filestream_test.go
+++ b/nexus/pkg/server/filestream_test.go
@@ -139,7 +139,13 @@ func NewFilestreamTest(tName string, fn func(fs *server.FileStream)) *filestream
 	capture := captureState{m: m}
 	fstreamPath := "/test/" + tName
 	tserver.mux.Handle(fstreamPath, apiHandler{&capture})
-	fs := server.NewFileStream(tserver.hserver.URL+fstreamPath, tserver.settings, tserver.logger)
+	fs := server.NewFileStream(
+		server.WithPath(tserver.hserver.URL+fstreamPath),
+		server.WithSettings(tserver.settings),
+		server.WithLogger(tserver.logger),
+		server.WithHttpClient(server.NewRetryClient(
+			tserver.settings.GetApiKey().GetValue(),
+			tserver.logger)))
 	fs.Start()
 	fsTest := filestreamTest{capture: &capture, path: fstreamPath, mux: tserver.mux, fs: fs, tserver: tserver}
 	defer fsTest.finish()

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -27,7 +27,7 @@ const (
 )
 
 type ResumeState struct {
-	FileStreamOffset map[fs.ChunkFile]int
+	FileStreamOffset fs.FileStreamOffsetMap
 	Error            service.ErrorInfo
 }
 
@@ -180,12 +180,9 @@ func (s *Sender) sendRunStart(_ *service.RunStartRequest) {
 			fs.WithPath(fsPath),
 			fs.WithSettings(s.settings),
 			fs.WithLogger(s.logger),
-			fs.WithHttpClient(NewRetryClient(s.settings.GetApiKey().GetValue(), s.logger)))
-		if s.resumeState != nil {
-			for k, v := range s.resumeState.FileStreamOffset {
-				s.fileStream.SetOffset(k, v)
-			}
-		}
+			fs.WithHttpClient(NewRetryClient(s.settings.GetApiKey().GetValue(), s.logger)),
+			fs.WithOffsets(s.resumeState.FileStreamOffset),
+		)
 		s.fileStream.Start()
 		s.uploader = uploader.NewUploader(s.ctx, s.logger)
 		s.uploader.Start()

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -12,8 +12,8 @@ import (
 	"github.com/wandb/wandb/nexus/internal/nexuslib"
 	"github.com/wandb/wandb/nexus/internal/uploader"
 	"github.com/wandb/wandb/nexus/pkg/artifacts"
-	"github.com/wandb/wandb/nexus/pkg/observability"
 	fs "github.com/wandb/wandb/nexus/pkg/filestream"
+	"github.com/wandb/wandb/nexus/pkg/observability"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/wandb/wandb/nexus/pkg/service"

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -364,7 +364,7 @@ func (s *Sender) checkAndUpdateResumeState(run *service.RunRecord) error {
 	}
 
 	if s.resumeState.FileStreamOffset == nil {
-		s.resumeState.FileStreamOffset = make(map[fs.ChunkFile]int)
+		s.resumeState.FileStreamOffset = make(fs.FileStreamOffsetMap)
 	}
 	s.resumeState.FileStreamOffset[fs.HistoryChunk] = *bucket.GetHistoryLineCount()
 	s.resumeState.FileStreamOffset[fs.EventsChunk] = *bucket.GetEventsLineCount()

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -175,7 +175,11 @@ func (s *Sender) sendRunStart(_ *service.RunStartRequest) {
 	if !s.settings.GetXOffline().GetValue() {
 		fsPath := fmt.Sprintf("%s/files/%s/%s/%s/file_stream",
 			s.settings.GetBaseUrl().GetValue(), s.RunRecord.Entity, s.RunRecord.Project, s.RunRecord.RunId)
-		s.fileStream = NewFileStream(fsPath, s.settings, s.logger)
+		s.fileStream = NewFileStream(
+			WithPath(fsPath),
+			WithSettings(s.settings),
+			WithLogger(s.logger),
+			WithHttpClient(NewRetryClient(s.settings.GetApiKey().GetValue(), s.logger)))
 		if s.resumeState != nil {
 			for k, v := range s.resumeState.FileStreamOffset {
 				s.fileStream.SetOffset(k, v)


### PR DESCRIPTION
Description
-----------
Objective of this PR: Reorganize and rename methods but do not impact functionality in this PR

Follow on PRs:
- more testing
- better handling of updates with multiple data types
- more cleanup of naming of internal structures

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de5d195</samp>

This pull request introduces a new `filestream` package that handles streaming data to the W&B backend filestream service. It refactors the existing `server` package to use the `filestream` package for sending data, and updates the tests and imports accordingly. It also adds functional options to the `filestream` package to customize its behavior.

Testing
-------
golang tests