### PR TITLE
refactor(artifacts): move staging logic to separate file

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -10,8 +10,8 @@ import numpy as np
 import pytest
 import wandb
 from wandb.sdk.artifacts.artifact import Artifact
-from wandb.sdk.artifacts.artifact_saver import get_staging_dir
 from wandb.sdk.artifacts.exceptions import ArtifactFinalizedError, WaitTimeoutError
+from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.wandb_run import Run
 
 sm = wandb.wandb_sdk.internal.sender.SendManager

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -9,7 +9,7 @@ import pytest
 import wandb
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifact_saver import get_staging_dir
+from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.artifacts.storage_handler import StorageHandler
 from wandb.sdk.artifacts.storage_handlers.gcs_handler import GCSHandler
 from wandb.sdk.artifacts.storage_handlers.local_file_handler import LocalFileHandler

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -44,7 +44,6 @@ from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.artifact_manifests.artifact_manifest_v1 import (
     ArtifactManifestV1,
 )
-from wandb.sdk.artifacts.artifact_saver import get_staging_dir
 from wandb.sdk.artifacts.artifact_state import ArtifactState
 from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
 from wandb.sdk.artifacts.exceptions import (
@@ -52,6 +51,7 @@ from wandb.sdk.artifacts.exceptions import (
     ArtifactNotLoggedError,
     WaitTimeoutError,
 )
+from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.artifacts.storage_layout import StorageLayout
 from wandb.sdk.artifacts.storage_policies.wandb_storage_policy import WandbStoragePolicy
 from wandb.sdk.data_types._dtypes import Type as WBType

--- a/wandb/sdk/artifacts/artifact_saver.py
+++ b/wandb/sdk/artifacts/artifact_saver.py
@@ -8,11 +8,11 @@ from typing import TYPE_CHECKING, Awaitable, Dict, List, Optional, Sequence
 
 import wandb
 import wandb.filesync.step_prepare
-from wandb import env, util
+from wandb import util
 from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
-from wandb.sdk.lib.filesystem import mkdir_exists_ok
+from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
-from wandb.sdk.lib.paths import FilePathStr, URIStr
+from wandb.sdk.lib.paths import URIStr
 
 if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
@@ -306,16 +306,3 @@ class ArtifactSaver:
                     os.remove(entry.local_path)
                 except OSError:
                     pass
-
-
-def get_staging_dir() -> FilePathStr:
-    path = os.path.join(env.get_data_dir(), "artifacts", "staging")
-    try:
-        mkdir_exists_ok(path)
-    except OSError as e:
-        raise PermissionError(
-            f"Unable to write staging files to {path}. To fix this problem, please set "
-            f"{env.DATA_DIR} to a directory where you have the necessary write access."
-        ) from e
-
-    return FilePathStr(os.path.abspath(os.path.expanduser(path)))

--- a/wandb/sdk/artifacts/staging.py
+++ b/wandb/sdk/artifacts/staging.py
@@ -1,3 +1,10 @@
+"""Manages artifact file staging.
+
+Artifact files are copied to the staging area as soon as they are added to an artifact
+in order to avoid file changes corrupting the artifact. Once the upload is complete, the
+file should be moved to the artifact cache.
+"""
+
 import os
 
 from wandb import env

--- a/wandb/sdk/artifacts/staging.py
+++ b/wandb/sdk/artifacts/staging.py
@@ -1,0 +1,18 @@
+import os
+
+from wandb import env
+from wandb.sdk.lib.filesystem import mkdir_exists_ok
+from wandb.sdk.lib.paths import FilePathStr
+
+
+def get_staging_dir() -> FilePathStr:
+    path = os.path.join(env.get_data_dir(), "artifacts", "staging")
+    try:
+        mkdir_exists_ok(path)
+    except OSError as e:
+        raise PermissionError(
+            f"Unable to write staging files to {path}. To fix this problem, please set "
+            f"{env.DATA_DIR} to a directory where you have the necessary write access."
+        ) from e
+
+    return FilePathStr(os.path.abspath(os.path.expanduser(path)))


### PR DESCRIPTION
Fixes
-----
- Supports [WB-13413](https://wandb.atlassian.net/browse/WB-13413)

Description
-----------
Broken out of #5384 , the portion that's just a straightforward refactor.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d42787b</samp>

Refactored the artifact staging logic into a new module `wandb/sdk/artifacts/staging.py` and updated the imports and tests accordingly. This improves the modularity and readability of the artifact saving code and fixes some potential test issues.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d42787b</samp>

> _Sing, O Muse, of the skillful refactorers who_
> _Split the staging logic from the saving code_
> _And placed it in a new module, `staging.py`,_
> _To make the artifact handling more robust and clear._


[WB-13413]: https://wandb.atlassian.net/browse/WB-13413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ