### PR TITLE
chore(artifacts): small improvements for server side not incompatible situations for Artifact TTL

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -949,7 +949,7 @@ class Artifact:
                 ) {
                     artifact {
                         id
-                        _TTL_DURATION_SECONDS_FIELD_
+                        _TTL_DURATION_SECONDS_FIELDS_
                     }
                 }
             }
@@ -964,7 +964,9 @@ class Artifact:
                     "_TTL_DURATION_SECONDS_VALUE_",
                     "ttlDurationSeconds: $ttlDurationSeconds,",
                 )
-                .replace("_TTL_DURATION_SECONDS_FIELD_", "ttlDurationSeconds")
+                .replace(
+                    "_TTL_DURATION_SECONDS_FIELDS_", "ttlDurationSeconds ttlIsInherited"
+                )
             )
         else:
             if not self._ttl_is_inherited:
@@ -998,6 +1000,9 @@ class Artifact:
         # Update ttl_duration_seconds based on updateArtifact
         self._ttl_duration_seconds = self._ttl_duration_seconds_from_gql(
             attrs.get("ttlDurationSeconds")
+        )
+        self._ttl_is_inherited = (
+            True if attrs.get("ttlIsInherited") is None else attrs["ttlIsInherited"]
         )
         self._ttl_changed = False  # Reset after updating artifact
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -979,7 +979,7 @@ class Artifact:
                     "_TTL_DURATION_SECONDS_VALUE_",
                     "",
                 )
-                .replace("_TTL_DURATION_SECONDS_FIELD_", "")
+                .replace("_TTL_DURATION_SECONDS_FIELDS_", "")
             )
         mutation = gql(mutation_template)
         assert self._client is not None

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3436,7 +3436,7 @@ class Api:
         fields = self.server_create_artifact_introspection()
         artifact_fields = self.server_artifact_introspection()
         if "ttlIsInherited" not in artifact_fields and ttl_duration_seconds:
-            logger.warning(
+            wandb.termwarn(
                 "Server not compatible with setting Artifact TTLs, please upgrade the server to use Artifact TTL"
             )
             # ttlDurationSeconds is only usable if ttlIsInherited is also present


### PR DESCRIPTION
Fixes
-----
- Make server side incompatibile warning a termwarn instead of logger.warning so easier for user to see
- Add self._ttl_is_inherited from the GraphQL response in updates for where server is old and no op

Description
-----------

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b36198</samp>

Use `wandb.termwarn` for terminal warnings in `internal_api.py`. This improves the visibility and consistency of warning messages for the user.

Testing
-------
Locally, and making sure existing tests didn't break

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2b36198</samp>

> _`logger.warning` gone_
> _`wandb.termwarn` shows colors_
> _Autumn leaves falling_
