### PR TITLE
chore(artifacts): artifact ttl older server check for ttldurationseconds

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3440,8 +3440,7 @@ class Api:
                 "Server not compatible with setting Artifact TTLs, please upgrade the server to use Artifact TTL"
             )
             # ttlDurationSeconds is only usable if ttlIsInherited is also present
-            fields.remove("ttlDurationSeconds")
-
+            ttl_duration_seconds = None
         query_template = self._get_create_artifact_mutation(
             fields, history_step, distributed_id
         )


### PR DESCRIPTION
Fixes
-----
If server is too old just set ttlDurationSeconds = None during artifact creation.

Description
-----------
Didn't catch this earlier since was testing with lastest server without new changes instead of even older server.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fc4503</samp>

Fix a bug in artifact creation mutation and add support for artifact TTL settings. The change in `wandb/sdk/internal/internal_api.py` ensures that the `ttlDurationSeconds` field is always included in the mutation, even if it is null.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0fc4503</samp>

> _`ttlDuration`_
> _A bug in mutation fixed_
> _Null instead of gone_
