### PR TITLE
chore(artifacts): edit check for termwarn to covers more artifact ttl older scenarios

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -969,7 +969,7 @@ class Artifact:
                 )
             )
         else:
-            if not self._ttl_is_inherited:
+            if self._ttl_changed:
                 termwarn(
                     "Server not compatible with setting Artifact TTLs, please upgrade the server to use Artifact TTL"
                 )

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3440,8 +3440,7 @@ class Api:
                 "Server not compatible with setting Artifact TTLs, please upgrade the server to use Artifact TTL"
             )
             # ttlDurationSeconds is only usable if ttlIsInherited is also present
-            fields.remove("ttlDurationSeconds")
-
+            ttl_duration_seconds = None
         query_template = self._get_create_artifact_mutation(
             fields, history_step, distributed_id
         )


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 648347f</samp>

Fixed a bug that caused a misleading warning about artifact TTLs. Changed the warning condition in `wandb/sdk/artifacts/artifact.py` to check if the user changed the TTL instead of if the TTL was inherited.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 648347f</samp>

> _`TTL` warning_
> _only when user changes it_
> _autumn bug is fixed_
