### PR TITLE
ci(nexus): add basic ci testing for nexus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1395,7 +1395,8 @@ workflows:
               python_version_major: [ 3 ]
               python_version_minor: [ 7, 8, 9, 10, 11 ]
           name: "nexus-system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
+#          toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
+          toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_nexus"
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1397,6 +1397,7 @@ workflows:
           name: "nexus-system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          tox_args: "tests/pytest_tests/system_tests/test_nexus"
       #
       # Nexus unit tests
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,6 +427,7 @@ jobs:
           name: Run tests
           no_output_timeout: 10m
           command: |
+            PATH=/usr/local/go/bin:$PATH \
             CI_PYTEST_PARALLEL=<< parameters.xdist >> \
             tox run -v -e <<parameters.toxenv>>  \
               -- --wandb-server-tag << pipeline.parameters.wandb_server_tag >> << parameters.tox_args >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,19 @@ jobs:
                 # taken from slack-secrets context
                 channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
+  gotest:
+    docker:
+      - image: cimg/go:1.20
+    steps:
+      - checkout
+      - run:
+          name: Run Nexus' Go tests and collect coverage
+          command: |
+            cd nexus
+            go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+# todo: add codecov
+#      - codecov/upload
+
   protobuf-compatability:
     parameters:
       python_version_major:
@@ -1362,6 +1375,23 @@ workflows:
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_core"
+      #
+      # Nexus smoke tests with pytest on Linux, using real wandb server
+      #
+      - pytest:
+          requires:
+            - "system-tests"
+          matrix:
+            parameters:
+              python_version_major: [ 3 ]
+              python_version_minor: [ 7, 8, 9, 10, 11 ]
+          name: "nexus-system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
+          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+      #
+      # Nexus unit tests
+      #
+      - gotest
       #
       # Unit tests with pytest on Linux, using the old mock server
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,12 +409,20 @@ jobs:
           command: |
             apt-get update && apt-get install -y libsndfile1 ffmpeg
       - run:
-          name: Install python dependencies
+          name: Install Python dependencies
           command: |
             pip install tox==<< pipeline.parameters.tox_version >>
             pip install -U pip
             while ! curl http://localhost:8080/healthz; do sleep 1; done
           no_output_timeout: 5m
+      - run:
+          name: Install Go
+          command: |
+            wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
+            tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz
+            PATH=/usr/local/go/bin:$PATH
+            go version
+          no_output_timeout: 1m
       - run:
           name: Run tests
           no_output_timeout: 10m

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,14 +4,14 @@ codecov:
     # To calculate after_n_builds use
     # ./tools/coverage-tool.py jobs | wc -l
     # also change comment block after_n_builds just below
-    after_n_builds: 56
+    after_n_builds: 61
     wait_for_ci: no
 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: no
-  after_n_builds: 56
+  after_n_builds: 61
 
 ignore:
   - "wandb/vendor"

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -178,6 +178,8 @@ func (h *Handler) handleRequest(record *service.Record) {
 	case *service.Request_JobInfo:
 	case *service.Request_Attach:
 		h.handleAttach(record, response)
+	case *service.Request_Cancel:
+		h.handleCancel(record)
 	default:
 		err := fmt.Errorf("handleRequest: unknown request type %T", x)
 		h.logger.CaptureFatalAndPanic("error handling request", err)
@@ -255,6 +257,10 @@ func (h *Handler) handleAttach(_ *service.Record, response *service.Response) {
 			Run: h.runRecord,
 		},
 	}
+}
+
+func (h *Handler) handleCancel(record *service.Record) {
+	h.sendRecord(record)
 }
 
 func (h *Handler) handleMetadata(_ *service.Record, req *service.RunStartRequest) {

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -181,7 +181,7 @@ func (s *Sender) sendRunStart(_ *service.RunStartRequest) {
 			fs.WithSettings(s.settings),
 			fs.WithLogger(s.logger),
 			fs.WithHttpClient(NewRetryClient(s.settings.GetApiKey().GetValue(), s.logger)),
-			fs.WithOffsets(s.resumeState.FileStreamOffset),
+			// fs.WithOffsets(s.resumeState.FileStreamOffset), // todo: this will fail if resumeState is nil
 		)
 		s.fileStream.Start()
 		s.uploader = uploader.NewUploader(s.ctx, s.logger)

--- a/tox.ini
+++ b/tox.ini
@@ -152,10 +152,6 @@ passenv=
     PATH
 allowlist_externals=
     mkdir
-    echo
-    wget
-    tar
-    go
 commands=
     mkdir -p test-results
     # install nexus as wandb-core, requires go to be installed on the system

--- a/tox.ini
+++ b/tox.ini
@@ -145,11 +145,11 @@ deps=
 setenv=
     {[base]setenv}
     WINDIR=C:\\Windows
-    PATH={env:PATH}:/usr/local/go/bin
 passenv=
     {[base]passenv}
     CI_PYTEST_PARALLEL
     CI
+    PATH
 allowlist_externals=
     mkdir
     echo
@@ -158,11 +158,7 @@ allowlist_externals=
     go
 commands=
     mkdir -p test-results
-    # todo: install platform-specific go version
-    wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
-    tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz
-    go version
-    # install nexus as wandb-core
+    # install nexus as wandb-core, requires go to be installed on the system
     pip install ./nexus
     # run nexus-specific tests
     pytest -n=0 --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail --timeout 300 {posargs:tests/pytest_tests/system_tests/test_nexus}

--- a/tox.ini
+++ b/tox.ini
@@ -135,6 +135,38 @@ commands=
     !{notebooks}: pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:{env:WB_UNIT_PARALLEL:10}} --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail --timeout 300 {posargs:tests/pytest_tests/}
     notebooks: pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:{env:WB_UNIT_PARALLEL:10}} --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail --timeout 300 {posargs:tests/pytest_tests/system_tests/test_notebooks}
 
+;todo: this is a simple smoke test, it will be replaced by a more comprehensive suite
+[testenv:nexus-py{36,37,38,39,310,311}]
+install_command=
+; pytorch installations on non-darwin need the `-f`
+    pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
+deps=
+    -r{toxinidir}/requirements_test.txt
+setenv=
+    {[base]setenv}
+    WINDIR=C:\\Windows
+    PATH={env:PATH}:/usr/local/go/bin
+passenv=
+    {[base]passenv}
+    CI_PYTEST_PARALLEL
+    CI
+allowlist_externals=
+    mkdir
+    echo
+    wget
+    tar
+    go
+commands=
+    mkdir -p test-results
+    # todo: install platform-specific go version
+    wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz
+    go version
+    # install nexus as wandb-core
+    pip install ./nexus
+    # run nexus-specific tests
+    pytest -n=0 --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail --timeout 300 {posargs:tests/pytest_tests/system_tests/test_nexus}
+
 [testenv:launch-release]
 deps=
     pytest


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b4e1b9</samp>

This pull request adds cancel support to the `nexus` server and fixes a bug in file stream resume. It updates `handler.go` to handle cancel requests and `sender.go` to avoid a panic when the resume state is nil.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5b4e1b9</samp>

> _Sing, O Muse, of the valiant `nexus` server, the swift and skillful handler of requests_
> _That from the client came, with urgent needs, to cancel or resume the running tests_
> _But lo, a grievous bug the server faced, when nil the resume state it found_
> _And so, with prudent care, the line it silenced, that set the file stream offsets from the ground_
