### PR TITLE
fix(nexus): fix resume reference when nil

### DIFF
--- a/nexus/pkg/server/resume.go
+++ b/nexus/pkg/server/resume.go
@@ -1,0 +1,233 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/wandb/wandb/nexus/internal/gql"
+	fs "github.com/wandb/wandb/nexus/pkg/filestream"
+	"github.com/wandb/wandb/nexus/pkg/service"
+)
+
+type ResumeState struct {
+	FileStreamOffset fs.FileStreamOffsetMap
+}
+
+func (r *ResumeState) GetFileStreamOffset() fs.FileStreamOffsetMap {
+	if r == nil {
+		return nil
+	}
+	return r.FileStreamOffset
+}
+
+func (r *ResumeState) AddOffset(key fs.ChunkFile, offset int) {
+	if r.FileStreamOffset == nil {
+		r.FileStreamOffset = make(fs.FileStreamOffsetMap)
+	}
+	r.FileStreamOffset[key] = offset
+}
+
+func NewResumeState() *ResumeState {
+	return &ResumeState{}
+}
+
+type Bucket = gql.RunResumeStatusModelProjectBucketRun
+
+func (s *Sender) sendRunResult(record *service.Record, runResult *service.RunUpdateResult) {
+	result := &service.Result{
+		ResultType: &service.Result_RunResult{
+			RunResult: runResult,
+		},
+		Control: record.Control,
+		Uuid:    record.Uuid,
+	}
+	s.resultChan <- result
+
+}
+
+func (s *Sender) checkAndUpdateResumeState(record *service.Record, run *service.RunRecord) error {
+	if s.graphqlClient == nil {
+		return nil
+	}
+	// There was no resume status set, so we don't need to do anything
+	if s.settings.GetResume().GetValue() == "" {
+		return nil
+	}
+
+	s.resumeState = NewResumeState()
+	// If we couldn't get the resume status, we should fail if resume is set
+	data, err := gql.RunResumeStatus(s.ctx, s.graphqlClient, &run.Project, emptyAsNil(&run.Entity), run.RunId)
+	if err != nil {
+		err = fmt.Errorf("failed to get run resume status: %s", err)
+		s.logger.Error("sender:", "error", err)
+		result := &service.RunUpdateResult{
+			Error: &service.ErrorInfo{
+				Message: err.Error(),
+				Code:    service.ErrorInfo_COMMUNICATION,
+			}}
+		s.sendRunResult(record, result)
+		return err
+	}
+
+	// If we get that the run is not a resume run, we should fail if resume is set to must
+	// for any other case of resume status, it is fine to ignore it
+	// If we get that the run is a resume run, we should fail if resume is set to never
+	// for any other case of resume status, we should continue to process the resume response
+	if data.GetModel() == nil || data.GetModel().GetBucket() == nil {
+		if s.settings.GetResume().GetValue() == "must" {
+			err = fmt.Errorf("You provided an invalid value for the `resume` argument. "+
+				"The value 'must' is not a valid option for resuming a run (%s/%s) that does not exist. "+
+				"Please check your inputs and try again with a valid run ID. "+
+				"If you are trying to start a new run, please omit the `resume` argument or use `resume='allow'`.\n", run.Project, run.RunId)
+			s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
+			result := &service.RunUpdateResult{
+				Error: &service.ErrorInfo{
+					Message: err.Error(),
+					Code:    service.ErrorInfo_USAGE,
+				}}
+			s.sendRunResult(record, result)
+			return err
+		}
+		return nil
+	} else if s.settings.GetResume().GetValue() == "never" {
+		err = fmt.Errorf("You provided an invalid value for the `resume` argument. "+
+			"The value 'never' is not a valid option for resuming a run (%s/%s) that already exists. "+
+			"Please check your inputs and try again with a valid value for the `resume` argument.\n", run.Project, run.RunId)
+		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
+		result := &service.RunUpdateResult{
+			Error: &service.ErrorInfo{
+				Message: err.Error(),
+				Code:    service.ErrorInfo_USAGE,
+			}}
+		s.sendRunResult(record, result)
+		return err
+	}
+
+	bucket := data.GetModel().GetBucket()
+	run.Resumed = true
+
+	if err = s.handleResumeHistory(record, run, bucket); err != nil {
+		return err
+	}
+
+	if err = s.handleSummaryResume(record, run, bucket); err != nil {
+		return err
+	}
+
+	if err = s.handleConfigResume(record, run, bucket); err != nil {
+		return err
+	}
+
+	s.resumeState.AddOffset(fs.HistoryChunk, *bucket.GetHistoryLineCount())
+	s.resumeState.AddOffset(fs.EventsChunk, *bucket.GetEventsLineCount())
+	s.resumeState.AddOffset(fs.OutputChunk, *bucket.GetLogLineCount())
+
+	return nil
+}
+
+func (s *Sender) handleResumeHistory(record *service.Record, run *service.RunRecord, bucket *Bucket) error {
+	var historyTail []string
+	var historyTailMap map[string]interface{}
+
+	if err := json.Unmarshal([]byte(*bucket.GetHistoryTail()), &historyTail); err != nil {
+		err = fmt.Errorf("failed to unmarshal history tail: %s", err)
+		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
+		if s.settings.GetResume().GetValue() == "must" {
+			result := &service.RunUpdateResult{
+				Error: &service.ErrorInfo{
+					Message: err.Error(),
+					Code:    service.ErrorInfo_UNKNOWN,
+				},
+			}
+			s.sendRunResult(record, result)
+			return err
+		}
+	}
+
+	if err := json.Unmarshal([]byte(historyTail[0]), &historyTailMap); err != nil {
+		err = fmt.Errorf("failed to unmarshal history tail map: %s", err)
+		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
+		if s.settings.GetResume().GetValue() == "must" {
+			result := &service.RunUpdateResult{
+				Error: &service.ErrorInfo{
+					Message: err.Error(),
+					Code:    service.ErrorInfo_UNKNOWN,
+				},
+			}
+			s.sendRunResult(record, result)
+			return err
+		}
+	}
+
+	if step, ok := historyTailMap["_step"].(float64); ok {
+		// if we are resuming, we need to update the starting step
+		// to be the next step after the last step we ran
+		if step > 0 {
+			run.StartingStep = int64(step) + 1
+		}
+	}
+
+	if runtime, ok := historyTailMap["_runtime"].(float64); ok {
+		run.Runtime = int32(runtime)
+	}
+	return nil
+}
+
+func (s *Sender) handleSummaryResume(record *service.Record, run *service.RunRecord, bucket *Bucket) error {
+	// If we are unable to parse the config, we should fail if resume is set to must
+	// for any other case of resume status, it is fine to ignore it
+	var summary map[string]interface{}
+	if err := json.Unmarshal([]byte(*bucket.GetSummaryMetrics()), &summary); err != nil {
+		err = fmt.Errorf("failed to unmarshal summary metrics: %s", err)
+		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
+		if s.settings.GetResume().GetValue() == "must" {
+			result := &service.RunUpdateResult{
+				Error: &service.ErrorInfo{
+					Message: err.Error(),
+					Code:    service.ErrorInfo_UNKNOWN,
+				},
+			}
+			s.sendRunResult(record, result)
+			return err
+		}
+	}
+
+	summaryRecord := service.SummaryRecord{}
+	for key, value := range summary {
+		jsonValue, _ := json.Marshal(value)
+		summaryRecord.Update = append(summaryRecord.Update, &service.SummaryItem{
+			Key:       key,
+			ValueJson: string(jsonValue),
+		})
+	}
+	run.Summary = &summaryRecord
+
+	return nil
+}
+
+func (s *Sender) handleConfigResume(record *service.Record, _ *service.RunRecord, bucket *Bucket) error {
+	var config map[string]interface{}
+	if err := json.Unmarshal([]byte(*bucket.GetConfig()), &config); err != nil {
+		err = fmt.Errorf("sender: checkAndUpdateResumeState: failed to unmarshal config: %s", err)
+		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
+		if s.settings.GetResume().GetValue() == "must" {
+			result := &service.RunUpdateResult{
+				Error: &service.ErrorInfo{
+					Message: err.Error(),
+					Code:    service.ErrorInfo_UNKNOWN,
+				},
+			}
+			s.sendRunResult(record, result)
+			return err
+		}
+	}
+
+	for key, value := range config {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			s.configMap[key] = v["value"]
+		default:
+			s.logger.Error("sender: checkAndUpdateResumeState: config value is not a map[string]interface{}")
+		}
+	}
+	return nil
+}

--- a/nexus/pkg/server/resume.go
+++ b/nexus/pkg/server/resume.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/wandb/wandb/nexus/internal/gql"
 	fs "github.com/wandb/wandb/nexus/pkg/filestream"
 	"github.com/wandb/wandb/nexus/pkg/service"

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -26,11 +26,6 @@ const (
 	NexusVersion = "0.0.1a3"
 )
 
-type ResumeState struct {
-	FileStreamOffset fs.FileStreamOffsetMap
-	Error            service.ErrorInfo
-}
-
 // Sender is the sender for a stream it handles the incoming messages and sends to the server
 // or/and to the dispatcher/handler
 type Sender struct {
@@ -181,7 +176,7 @@ func (s *Sender) sendRunStart(_ *service.RunStartRequest) {
 			fs.WithSettings(s.settings),
 			fs.WithLogger(s.logger),
 			fs.WithHttpClient(NewRetryClient(s.settings.GetApiKey().GetValue(), s.logger)),
-			fs.WithOffsets(s.resumeState.FileStreamOffset),
+			fs.WithOffsets(s.resumeState.GetFileStreamOffset()),
 		)
 		s.fileStream.Start()
 		s.uploader = uploader.NewUploader(s.ctx, s.logger)
@@ -283,139 +278,6 @@ func (s *Sender) sendTelemetry(record *service.Record, telemetry *service.Teleme
 	s.sendConfig(nil, nil)
 }
 
-func (s *Sender) checkAndUpdateResumeState(run *service.RunRecord) error {
-	if s.graphqlClient == nil {
-		return nil
-	}
-	// There was no resume status set, so we don't need to do anything
-	if s.settings.GetResume().GetValue() == "" {
-		return nil
-	}
-
-	s.resumeState = &ResumeState{}
-	// If we couldn't get the resume status, we should fail if resume is set
-	data, err := gql.RunResumeStatus(s.ctx, s.graphqlClient, &run.Project, emptyAsNil(&run.Entity), run.RunId)
-	if err != nil {
-		err = fmt.Errorf("failed to get run resume status: %s", err)
-		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-		s.resumeState.Error = service.ErrorInfo{
-			Message: err.Error(),
-			Code:    service.ErrorInfo_COMMUNICATION,
-		}
-		return err
-	}
-
-	// If we get that the run is not a resume run, we should fail if resume is set to must
-	// for any other case of resume status, it is fine to ignore it
-	// If we get that the run is a resume run, we should fail if resume is set to never
-	// for any other case of resume status, we should continue to process the resume response
-	if data.GetModel() == nil || data.GetModel().GetBucket() == nil {
-		if s.settings.GetResume().GetValue() == "must" {
-			err = fmt.Errorf("You provided an invalid value for the `resume` argument. "+
-				"The value 'must' is not a valid option for resuming a run (%s/%s) that does not exist. "+
-				"Please check your inputs and try again with a valid run ID. "+
-				"If you are trying to start a new run, please omit the `resume` argument or use `resume='allow'`.\n", run.Project, run.RunId)
-			s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-			s.resumeState.Error = service.ErrorInfo{
-				Message: err.Error(),
-				Code:    service.ErrorInfo_USAGE,
-			}
-			return err
-		}
-		return nil
-	} else if s.settings.GetResume().GetValue() == "never" {
-		err = fmt.Errorf("You provided an invalid value for the `resume` argument. "+
-			"The value 'never' is not a valid option for resuming a run (%s/%s) that already exists. "+
-			"Please check your inputs and try again with a valid value for the `resume` argument.\n", run.Project, run.RunId)
-		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-		s.resumeState.Error = service.ErrorInfo{
-			Message: err.Error(),
-			Code:    service.ErrorInfo_USAGE,
-		}
-		return err
-	}
-
-	var rerr error
-	bucket := data.GetModel().GetBucket()
-	run.Resumed = true
-
-	var historyTail []string
-	var historyTailMap map[string]interface{}
-	if err = json.Unmarshal([]byte(*bucket.GetHistoryTail()), &historyTail); err != nil {
-		err = fmt.Errorf("failed to unmarshal history tail: %s", err)
-		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-		rerr = err
-		// TODO: verify the list is not empty and has one element
-	} else if err = json.Unmarshal([]byte(historyTail[0]), &historyTailMap); err != nil {
-		err = fmt.Errorf("failed to unmarshal history tail map: %s", err)
-		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-		rerr = err
-	} else {
-		if step, ok := historyTailMap["_step"].(float64); ok {
-			// if we are resuming, we need to update the starting step
-			// to be the next step after the last step we ran
-			if step > 0 {
-				run.StartingStep = int64(step) + 1
-			}
-		}
-		if runtime, ok := historyTailMap["_runtime"].(float64); ok {
-			run.Runtime = int32(runtime)
-		}
-	}
-
-	if s.resumeState.FileStreamOffset == nil {
-		s.resumeState.FileStreamOffset = make(fs.FileStreamOffsetMap)
-	}
-	s.resumeState.FileStreamOffset[fs.HistoryChunk] = *bucket.GetHistoryLineCount()
-	s.resumeState.FileStreamOffset[fs.EventsChunk] = *bucket.GetEventsLineCount()
-	s.resumeState.FileStreamOffset[fs.OutputChunk] = *bucket.GetLogLineCount()
-
-	// If we are unable to parse the config, we should fail if resume is set to must
-	// for any other case of resume status, it is fine to ignore it
-	var summary map[string]interface{}
-	if err = json.Unmarshal([]byte(*bucket.GetSummaryMetrics()), &summary); err != nil {
-		err = fmt.Errorf("failed to unmarshal summary metrics: %s", err)
-		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-		rerr = err
-	} else {
-		summaryRecord := service.SummaryRecord{}
-		for key, value := range summary {
-			jsonValue, _ := json.Marshal(value)
-			summaryRecord.Update = append(summaryRecord.Update, &service.SummaryItem{
-				Key:       key,
-				ValueJson: string(jsonValue),
-			})
-		}
-		run.Summary = &summaryRecord
-	}
-
-	var config map[string]interface{}
-	if err = json.Unmarshal([]byte(*bucket.GetConfig()), &config); err != nil {
-		err = fmt.Errorf("sender: checkAndUpdateResumeState: failed to unmarshal config: %s", err)
-		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-		rerr = err
-	} else {
-		for key, value := range config {
-			switch v := value.(type) {
-			case map[string]interface{}:
-				s.configMap[key] = v["value"]
-			default:
-				s.logger.Error("sender: checkAndUpdateResumeState: config value is not a map[string]interface{}")
-			}
-		}
-	}
-	if rerr != nil && s.settings.GetResume().GetValue() == "must" {
-		err = fmt.Errorf("failed to parse resume state but resume is set to must")
-		s.logger.Error("sender: checkAndUpdateResumeState:", "error", err)
-		s.resumeState.Error = service.ErrorInfo{
-			Message: err.Error(),
-			Code:    service.ErrorInfo_COMMUNICATION,
-		}
-		return err
-	}
-	return nil
-}
-
 // updateConfig updates the config map with the config record
 func (s *Sender) updateConfig(configRecord *service.ConfigRecord) {
 	// TODO: handle nested key updates and deletes
@@ -484,18 +346,8 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			s.logger.CaptureFatalAndPanic("sender: sendRun: ", err)
 		}
 
-		if err := s.checkAndUpdateResumeState(s.RunRecord); err != nil {
+		if err := s.checkAndUpdateResumeState(record, s.RunRecord); err != nil {
 			s.logger.Error("sender: sendRun: failed to checkAndUpdateResumeState", "error", err)
-			result := &service.Result{
-				ResultType: &service.Result_RunResult{
-					RunResult: &service.RunUpdateResult{
-						Error: &s.resumeState.Error,
-					},
-				},
-				Control: record.Control,
-				Uuid:    record.Uuid,
-			}
-			s.resultChan <- result
 			return
 		}
 	}


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4ddf5f</samp>

This pull request refactors the run resumption logic from `sender.go` to a new file `resume.go` in the `server` package. It also introduces a new `ResumeState` struct and several methods to handle the file stream offsets and the GraphQL queries for resuming a run. The aim is to improve the modularity, readability, and robustness of the resume code.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c4ddf5f</samp>

> _Sing, O Muse, of the skillful coder who refactored_
> _The logic of resume, from `sender.go` to `resume.go`,_
> _And made the code more modular and robust, pleasing the reviewers._
> _He defined a `ResumeState` struct, a `Bucket` type, and many methods_
