### PR TITLE
chore(artifacts): get length from ArtifactManifest

### DIFF
--- a/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_artifacts.py
@@ -493,3 +493,16 @@ def test_cache_write_failure_is_ignored(monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert "Failed to cache" in captured.err
+
+
+def test_artifact_manifest_length():
+    artifact = Artifact("test-artifact", "test-type")
+    assert len(artifact.manifest) == 0
+    with artifact.new_file("test.txt") as f:
+        f.write("test")
+    assert len(artifact.manifest) == 1
+
+    testpath = Path("test.txt")
+    testpath.write_text("also a test")
+    artifact.add_reference(testpath.resolve().as_uri(), "test2.txt")
+    assert len(artifact.manifest) == 2

--- a/wandb/sdk/artifacts/artifact_manifest.py
+++ b/wandb/sdk/artifacts/artifact_manifest.py
@@ -35,6 +35,9 @@ class ArtifactManifest:
         self.storage_policy = storage_policy
         self.entries = dict(entries) if entries else {}
 
+    def __len__(self) -> int:
+        return len(self.entries)
+
     def to_manifest_json(self) -> Dict:
         raise NotImplementedError
 


### PR DESCRIPTION
Description
-----------
Add `__len__` to the ArtifactManifest; just a convenience to allow `len(art.manifest)` rather than `len(art.manifest.entries)`, but that provides a better abstraction without requiring users to access the underlying dict.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 728f88d</samp>

This pull request adds a `__len__` method to the `ArtifactManifest` class and a unit test for it. The method returns the number of entries in the artifact manifest and enables the use of the `len` function on manifest objects.

Testing
-------
Adds a test... why are there basically no actual unit tests for artifacts? They don't _all_ need to be systems tests.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 728f88d</samp>

> _`ArtifactManifest`_
> _Has a length now, thanks to_
> _`__len__` method_
