### PR TITLE
chore(sweeps): allow all launch overrides on execution job

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -650,7 +650,11 @@ class Scheduler(ABC):
             pidx = entry_point.index("${program}")
             entry_point[pidx] = self._sweep_config["program"]
 
-        launch_config = {"overrides": {"run_config": args["args_dict"]}}
+        launch_config = self._wandb_run.config.get("launch")
+        if "overrides" not in launch_config:
+            launch_config["overrides"] = {"run_config": {}}
+        launch_config["overrides"]["run_config"].update(args["args_dict"])
+
         if macro_args:  # pipe in hyperparam args as params to launch
             launch_config["overrides"]["args"] = macro_args
 


### PR DESCRIPTION
Fixes
-----


Description
-----------
enables all launch args to be passed through to launch-sweep execution points (job or image_uri). This includes manually specifying params in the run_config. Unique keys will always be respected, but keys that overlap with sweep config variables will be overwritten by the sweep hyperparameters. 

<img width="786" alt="Screen Shot 2023-08-14 at 11 08 41 AM" src="https://github.com/wandb/wandb/assets/19414170/6e5c1bd7-a4e8-46fa-8929-9838bd716247">

<img width="620" alt="Screen Shot 2023-08-14 at 11 08 56 AM" src="https://github.com/wandb/wandb/assets/19414170/2d465e8b-a994-4ca5-9692-8f06fa9f63c4">
