### PR TITLE
feat(artifacts): Add 'id' option to artifact put method in cli

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2058,8 +2058,9 @@ def artifact():
     multiple=True,
     help="An alias to apply to this artifact",
 )
+@click.option("--id", "run_id", help="The run you want to upload to.")
 @display_error
-def put(path, name, description, type, alias):
+def put(path, name, description, type, alias, run_id):
     if name is None:
         name = os.path.basename(path)
     public_api = PublicApi()
@@ -2086,8 +2087,14 @@ def put(path, name, description, type, alias):
     else:
         raise ClickException("Path argument must be a file or directory")
 
+    resume_run = False if run_id == None else True
     run = wandb.init(
-        entity=entity, project=project, config={"path": path}, job_type="cli_put"
+        entity=entity,
+        project=project,
+        config={"path": path},
+        job_type="cli_put",
+        id=run_id,
+        resume=resume_run,
     )
     # We create the artifact manually to get the current version
     res, _ = api.create_artifact(


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-15005](https://wandb.atlassian.net/browse/WB-15005)
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63d616b</samp>

Add `--id` option to `wandb put` command to upload artifacts to existing runs. Resume the run in `wandb.init` if `--id` is given.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 63d616b</samp>

> _`wandb put` your artifact in the run_
> _Resume the quest with the given ID_
> _No matter how hard the challenge is_
> _You'll never give up, you'll never flee_


[WB-15005]: https://wandb.atlassian.net/browse/WB-15005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ