### PR TITLE
fix(launch): load environment config when `wandb launch` is called

### DIFF
--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -19,7 +19,7 @@ from wandb.sdk.lib import runid
 
 from .. import loader
 from .._project_spec import create_project_from_spec, fetch_and_validate_project
-from ..builder.build import construct_builder_args
+from ..builder.build import construct_agent_configs
 from ..errors import LaunchDockerError, LaunchError
 from ..utils import LAUNCH_DEFAULT_PROJECT, LOG_PREFIX, PROJECT_SYNCHRONOUS
 from .job_status_tracker import JobAndRunStatusTracker
@@ -557,7 +557,7 @@ class LaunchAgent:
         _logger.info("Loading backend")
         override_build_config = launch_spec.get("builder")
 
-        build_config, registry_config = construct_builder_args(
+        build_config, registry_config = construct_agent_configs(
             default_config, override_build_config
         )
         image_uri = project.docker_image

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -436,10 +436,11 @@ def join(split_command: List[str]) -> str:
     return " ".join(shlex.quote(arg.replace("'", "")) for arg in split_command)
 
 
-def construct_builder_args(
+def construct_agent_configs(
     launch_config: Optional[Dict] = None,
     build_config: Optional[Dict] = None,
-) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+    environment_config = None
     registry_config = None
     if launch_config is not None:
         build_config = launch_config.get("builder")
@@ -449,12 +450,13 @@ def construct_builder_args(
     if os.path.exists(os.path.expanduser(LAUNCH_CONFIG_FILE)):
         with open(os.path.expanduser(LAUNCH_CONFIG_FILE)) as f:
             default_launch_config = yaml.safe_load(f)
+        environment_config = default_launch_config.get("environment")
 
     build_config, registry_config = resolve_build_and_registry_config(
         default_launch_config, build_config, registry_config
     )
 
-    return build_config, registry_config
+    return environment_config or {}, build_config, registry_config
 
 
 def build_image_with_builder(

--- a/wandb/sdk/launch/launch.py
+++ b/wandb/sdk/launch/launch.py
@@ -10,7 +10,7 @@ from wandb.apis.internal import Api
 from . import loader
 from ._project_spec import create_project_from_spec, fetch_and_validate_project
 from .agent import LaunchAgent
-from .builder.build import construct_builder_args
+from .builder.build import construct_agent_configs
 from .errors import ExecutionError, LaunchError
 from .runner.abstract import AbstractRun
 from .utils import (
@@ -170,9 +170,9 @@ def _run(
     runner_config[PROJECT_SYNCHRONOUS] = synchronous
 
     config = launch_config or {}
-    build_config, registry_config = construct_builder_args(config)
+    environment_config, build_config, registry_config = construct_agent_configs(config)
 
-    environment = loader.environment_from_config(config.get("environment", {}))
+    environment = loader.environment_from_config(environment_config)
     registry = loader.registry_from_config(registry_config, environment)
     builder = loader.builder_from_config(build_config, environment, registry)
     if not launch_project.docker_image:


### PR DESCRIPTION
from cli

Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ddc928</samp>

Refactored the wandb launch feature to use a consistent and descriptive function name for constructing the configuration arguments for launching jobs. Renamed `construct_builder_args` to `construct_agent_configs` and updated its usage in `agent.py`, `build.py`, and `launch.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6ddc928</samp>

> _Sing, O Muse, of the wandb launch feature, the skillful work of code_
> _That lets the users run their jobs with ease, on any platform or mode_
> _How the agent module was refactored well, by the wise and prudent coder_
> _Who renamed the function `construct_agent_configs`, like a cunning builder_
