### PR TITLE
chore(artifacts): Reduce the network calls when parsing artifact paths

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -727,7 +727,6 @@ class Api:
 
     def _parse_artifact_path(self, path):
         """Return project, entity and artifact name for project specified by path."""
-
         # Adding this short circuit skips the potential access of
         # self.default_entity which incurs a network call. However, if the path
         # is fully qualified, then this `entity` is thrown away.

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -727,11 +727,18 @@ class Api:
 
     def _parse_artifact_path(self, path):
         """Return project, entity and artifact name for project specified by path."""
+
+        # Adding this short circuit skips the potential access of
+        # self.default_entity which incurs a network call. However, if the path
+        # is fully qualified, then this `entity` is thrown away.
+        parts = [] if path is None else path.split("/")
+        if len(parts) == 3:
+            return parts
+
         project = self.settings["project"] or "uncategorized"
         entity = self.settings["entity"] or self.default_entity
         if path is None:
             return entity, project
-        parts = path.split("/")
         if len(parts) > 3:
             raise ValueError("Invalid artifact path: %s" % path)
         elif len(parts) == 1:


### PR DESCRIPTION
Description
-----------
In Weave, we hit this code path and it is causing an extra network call for every artifact construction. Here we short circuit if the path is fully qualified.

```
# Adding this short circuit skips the potential access of
# self.default_entity which incurs a network call. However, if the path
# is fully qualified, then this `entity` is thrown away.
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8868ee3</samp>

Improved the efficiency of parsing artifact paths in `wandb/apis/public.py` by skipping a network call when possible. This reduces the latency and bandwidth usage of working with artifacts.

Testing
-------
Manually

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8868ee3</samp>

> _`_parse_artifact_path`_
> _Faster with fewer network calls_
> _Winter of code_
