### PR TITLE
fix(nexus): rm unused import

### DIFF
--- a/nexus/internal/uploader/rlimit.go
+++ b/nexus/internal/uploader/rlimit.go
@@ -3,8 +3,6 @@
 package uploader
 
 import (
-	"fmt"
-
 	"golang.org/x/sys/unix"
 )
 


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53cee22</samp>

Removed unused `fmt` package from `uploader` package. This simplifies the code and avoids importing unused dependencies.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 53cee22</samp>

> _`fmt` package gone_
> _uploader is more readable_
> _a crisp autumn code_
