### PR TITLE
feat(nexus): add standalone system monitor service

### DIFF
--- a/nexus/cmd/symon/main.go
+++ b/nexus/cmd/symon/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/wandb/wandb/nexus/pkg/monitor"
+
+func main() {
+	smm := monitor.NewSystemMonitorService()
+
+	smm.Start()
+}

--- a/nexus/pkg/monitor/service.go
+++ b/nexus/pkg/monitor/service.go
@@ -1,0 +1,73 @@
+package monitor
+
+import (
+	"fmt"
+	"github.com/wandb/wandb/nexus/pkg/observability"
+	"github.com/wandb/wandb/nexus/pkg/service"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type SystemMonitorService struct {
+	SystemMonitor *SystemMonitor
+	LatestSample  *service.Record
+}
+
+func NewSystemMonitorService() *SystemMonitorService {
+	settings := &service.Settings{
+		XDisableStats:           &wrapperspb.BoolValue{Value: false},
+		XStatsSampleRateSeconds: &wrapperspb.DoubleValue{Value: 1},
+		XStatsSamplesToAverage:  &wrapperspb.Int32Value{Value: 1},
+	}
+
+	logger := observability.NewNexusLogger(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		nil,
+	)
+
+	return &SystemMonitorService{
+		SystemMonitor: NewSystemMonitor(settings, logger),
+		LatestSample:  &service.Record{},
+	}
+}
+
+func (smm *SystemMonitorService) Start() {
+	// Start the system monitor
+	smm.SystemMonitor.Do()
+
+	go func() {
+		for sample := range smm.SystemMonitor.OutChan {
+			fmt.Println(sample)
+			smm.LatestSample = sample
+		}
+	}()
+
+	// Register a function for the root path
+	http.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		// Set the response header content type to be plain text
+		w.Header().Set("Content-Type", "text/plain")
+
+		// Write the response body
+		fmt.Fprint(w, smm.LatestSample)
+	})
+
+	server := &http.Server{
+		Addr:           ":1337",
+		Handler:        nil, // Use default ServeMux
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20, // 1 MB
+	}
+
+	// Listen to the address and port using the custom configuration
+	err := server.ListenAndServe()
+
+	// If there is an error, log it and exit the application
+	if err != nil {
+		fmt.Println("Error starting server:", err)
+		return
+	}
+}

--- a/nexus/pkg/monitor/service.go
+++ b/nexus/pkg/monitor/service.go
@@ -2,13 +2,14 @@ package monitor
 
 import (
 	"fmt"
-	"github.com/wandb/wandb/nexus/pkg/observability"
-	"github.com/wandb/wandb/nexus/pkg/service"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"io"
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/wandb/wandb/nexus/pkg/observability"
+	"github.com/wandb/wandb/nexus/pkg/service"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 type SystemMonitorService struct {

--- a/nexus/pkg/monitor/service.go
+++ b/nexus/pkg/monitor/service.go
@@ -15,6 +15,7 @@ import (
 type SystemMonitorService struct {
 	SystemMonitor *SystemMonitor
 	LatestSample  *service.Record
+	// todo: consolidate the samples into a map and update it on each sample
 }
 
 func NewSystemMonitorService() *SystemMonitorService {


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5dcdeac</samp>

This pull request adds a new package `monitor` that implements a system monitor service that collects and exposes system metrics. It also adds a new command-line tool `symon` that uses the `monitor` package to run the service.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5dcdeac</samp>

> _`symon` tool born_
> _monitoring system metrics_
> _autumn leaves fall fast_
