### PR TITLE
chore(nexus): fix dev script which doesnt work with bash

### DIFF
--- a/nexus/scripts/setup-nexus-path.sh
+++ b/nexus/scripts/setup-nexus-path.sh
@@ -8,8 +8,9 @@
 #   source scripts/setup-nexus-path.sh
 #   source scripts/setup-nexus-path.sh --unset
 
+PROG="${BASH_SOURCE[0]:-$0}"
 ARG=$1
-BASE=$(dirname $(dirname $(readlink -f $0)))
+BASE=$(dirname $(dirname $(readlink -f $PROG)))
 
 if [ "x$ARG" = "x--unset" ]; then
     echo "[INFO]: Clearing nexus dev dir."


### PR DESCRIPTION
Description
-----------
bash is funky and doesnt like telling you about $0 when you source a script... this works around it

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fecfba7</samp>

Improved the portability of the `setup-nexus-path.sh` script by using a more reliable way to get the script name and path. This was part of a pull request to enhance the wandb CLI tool.

Testing
-------
Tested with bash and linux

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fecfba7</samp>

> _`PROG` holds script name_
> _More robust and portable_
> _Autumn of `readlink`_
