### PR TITLE
style(sdk): fix to new ruff rule E721 additions

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -300,13 +300,13 @@ class Table(Media):
     @staticmethod
     def _assert_valid_columns(columns):
         valid_col_types = [str, int]
-        assert type(columns) is list, "columns argument expects a `list` object"
+        assert isinstance(columns, list), "columns argument expects a `list` object"
         assert len(columns) == 0 or all(
             [type(col) in valid_col_types for col in columns]
         ), "columns argument expects list of strings or ints"
 
     def _init_from_list(self, data, columns, optional=True, dtype=None):
-        assert type(data) is list, "data argument expects a `list` object"
+        assert isinstance(data, list), "data argument expects a `list` object"
         self.data = []
         self._assert_valid_columns(columns)
         self.columns = columns
@@ -656,7 +656,7 @@ class Table(Media):
                 is_1d_array = (
                     ndarray_type is not None
                     and "shape" in ndarray_type._params
-                    and type(ndarray_type._params["shape"]) == list
+                    and isinstance(ndarray_type._params["shape"], list)
                     and len(ndarray_type._params["shape"]) == 1
                     and ndarray_type._params["shape"][0]
                     <= self._MAX_EMBEDDING_DIMENSIONS

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -414,9 +414,9 @@ class SendManager:
         self._result_q.put(result)
 
     def _flatten(self, dictionary: Dict) -> None:
-        if type(dictionary) == dict:
+        if isinstance(dictionary, dict):
             for k, v in list(dictionary.items()):
-                if type(v) == dict:
+                if isinstance(v, dict):
                     self._flatten(v)
                     dictionary.pop(k)
                     for k2, v2 in v.items():


### PR DESCRIPTION
Description
-----------
What does the PR do?

This [change](https://github.com/astral-sh/ruff/pull/6469) from this [ruff release](https://github.com/astral-sh/ruff/releases/tag/v0.0.285) started breaking our lint check.  Update a few spots to use `isinstance` instead of `type(...) == ...`

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb4f458</samp>

Refactored type checking and validation in `Table` and `SendManager` classes to use `isinstance` instead of `type`. This improves the robustness and readability of the code in `wandb/data_types.py` and `wandb/sdk/internal/sender.py`.

Testing
-------
How was this PR tested? `code-check` CI job should pass.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb4f458</samp>

> _Oh we're the coders of the `wandb` ship_
> _And we work hard to make it fit_
> _We flatten dicts and check the types_
> _With `isinstance` we avoid the gripes_
