### PR TITLE
chore(artifacts): add function to test whether paths reside on the same partition

### DIFF
--- a/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
@@ -14,9 +14,10 @@ from pyfakefs.fake_filesystem import OSType
 from wandb.sdk.lib.filesystem import (
     copy_or_overwrite_changed,
     mkdir_exists_ok,
+    on_same_partition,
+    resolve_to_existing_parent,
     safe_copy,
     safe_open,
-    resolve_to_existing_parent,
 )
 
 
@@ -95,6 +96,14 @@ def test_resolve_to_existing_parent(tmp_path):
     symlinked = tmp_path / "new_link.txt"
     symlinked.symlink_to(real_file)
     assert resolve_to_existing_parent(symlinked) == real_file
+
+
+def test_same_partition(tmp_path):
+    real_path = tmp_path / "foo" / "example.txt"
+    real_path.parent.mkdir()
+    real_path.touch()
+    other_path = tmp_path / "bar" / "missing.txt"
+    assert on_same_partition(real_path, other_path)
 
 
 def test_copy_or_overwrite_changed_windows_colon(tmp_path):

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -84,6 +84,20 @@ class CRDedupedFile(WriteSerializingFile):
         super().close()
 
 
+def resolve_to_existing_parent(path: StrPath) -> StrPath:
+    """Return the nearest ancestor path that actually exists.
+
+    The path will be resolved, eliminating `..` components and following symlinks. If
+    the path exists, that absolute path will be returned. Otherwise, path components
+    will be removed one by one until the resulting path points to a real directory.
+    """
+    real = Path(path).resolve(strict=False)
+    while not real.exists():
+        real = real.parent
+    # Return the same type as the input.
+    return type(path)(real)  # type: ignore
+
+
 def copy_or_overwrite_changed(source_path: StrPath, target_path: StrPath) -> StrPath:
     """Copy source_path to target_path, unless it already exists with the same mtime.
 


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-15138](https://wandb.atlassian.net/browse/WB-15138)

Description
-----------
Adds the ability to test two paths (each of which may or may not exist) to see if they (would) reside on the same filesystem partition; we'll use this before attempting to create a hardlink or a reflink

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71ab512</samp>

Added new functions and tests for working with disk partitions and parent directories. This helps `wandb` manage files more efficiently and robustly across different platforms and scenarios. The changes affect the `filesystem` module and its unit tests in `test_filesystem.py`.

Testing
-------
New tests for functionality.

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 71ab512</samp>

> _To improve file performance and handling_
> _We added some functions for scanning_
> _The `on_same_partition`_
> _And `resolve_to_existing_parent`_
> _Are now tested with unit code planning_


[WB-15138]: https://wandb.atlassian.net/browse/WB-15138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ