### PR TITLE
Sweeps/cross entity schedulers deprecate

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_job.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_job.py
@@ -28,7 +28,7 @@ def test_job_call(relay_server, user, wandb_init, test_settings):
             entity=user, project=proj, queue_name=queue, access="PROJECT"
         )
 
-        queued_run = job.call(config={}, project=proj, queue=queue, project_queue=proj)
+        queued_run = job.call(config={}, project=proj, queue=queue, queue_project=proj)
 
         assert queued_run.state == "pending"
         assert queued_run.entity == user

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_add.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_add.py
@@ -506,9 +506,9 @@ def test_display_updated_runspec(
     settings = test_settings({"project": proj})
     api = InternalApi()
 
-    def push_with_drc(api, queue_name, launch_spec, project_queue):
+    def push_with_drc(api, queue_name, launch_spec, queue_project, queue_entity):
         # mock having a DRC
-        res = api.push_to_run_queue(queue_name, launch_spec, project_queue)
+        res = api.push_to_run_queue(queue_name, launch_spec, queue_project)
         res["runSpec"] = launch_spec
         res["runSpec"]["resource_args"] = {"kubernetes": {"volume": "x/awda/xxx"}}
         return res

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -952,7 +952,7 @@ class Api:
         queue_name,
         run_queue_item_id,
         container_job=False,
-        project_queue=None,
+        queue_project=None,
     ):
         """Return a single queued run based on the path.
 
@@ -965,7 +965,7 @@ class Api:
             queue_name,
             run_queue_item_id,
             container_job=container_job,
-            project_queue=project_queue,
+            queue_project=queue_project,
         )
 
     def run_queue(
@@ -2451,7 +2451,8 @@ class QueuedRun:
         queue_name,
         run_queue_item_id,
         container_job=False,
-        project_queue=LAUNCH_DEFAULT_PROJECT,
+        project_queue=LAUNCH_DEFAULT_PROJECT,  # deprecated
+        queue_project=LAUNCH_DEFAULT_PROJECT,
     ):
         self.client = client
         self._entity = entity
@@ -2461,7 +2462,8 @@ class QueuedRun:
         self.sweep = None
         self._run = None
         self.container_job = container_job
-        self.project_queue = project_queue
+        self.queue_project = queue_project
+        self.project_queue = project_queue  # deprecated
 
     @property
     def queue_name(self):
@@ -2511,7 +2513,7 @@ class QueuedRun:
             """
         )
         variable_values = {
-            "projectName": self.project_queue,
+            "projectName": self.queue_project or self.project_queue,
             "entityName": self._entity,
             "runQueue": self.queue_name,
         }
@@ -2539,7 +2541,7 @@ class QueuedRun:
         """
         )
         variable_values = {
-            "projectName": self.project_queue,
+            "projectName": self.queue_project or self.project_queue,
             "entityName": self._entity,
             "runQueue": self.queue_name,
             "itemId": self.id,
@@ -2583,7 +2585,7 @@ class QueuedRun:
             query,
             variable_values={
                 "entityName": self.entity,
-                "projectName": self.project_queue,
+                "projectName": self.queue_project or self.project_queue,
                 "runQueueName": self.queue_name,
             },
         )
@@ -4768,7 +4770,8 @@ class Job:
         queue=None,
         resource="local-container",
         resource_args=None,
-        project_queue=None,
+        queue_project=None,
+        project_queue=None,  # deprecated
     ):
         from wandb.sdk.launch import launch_add
 
@@ -4797,7 +4800,8 @@ class Job:
             entity=entity or self._entity,
             queue_name=queue,
             resource=resource,
-            project_queue=project_queue,
+            queue_project=queue_project,  
+            project_queue=project_queue,  # deprecated
             resource_args=resource_args,
         )
         return queued_run

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1515,21 +1515,21 @@ class Api:
         self,
         queue_name: str,
         launch_spec: Dict[str, str],
-        project_queue: str,
+        queue_project: str,
         queue_entity: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         entity = queue_entity or launch_spec["entity"]
         run_spec = json.dumps(launch_spec)
 
         push_result = self.push_to_run_queue_by_name(
-            entity, project_queue, queue_name, run_spec
+            entity, queue_project, queue_name, run_spec
         )
 
         if push_result:
             return push_result
 
         """ Legacy Method """
-        queues_found = self.get_project_run_queues(entity, project_queue)
+        queues_found = self.get_project_run_queues(entity, queue_project)
         matching_queues = [
             q
             for q in queues_found
@@ -1545,27 +1545,27 @@ class Api:
             # in the case of a missing default queue. create it
             if queue_name == "default":
                 wandb.termlog(
-                    f"No default queue existing for entity: {entity} in project: {project_queue}, creating one."
+                    f"No default queue existing for entity: {entity} in project: {queue_project}, creating one."
                 )
                 res = self.create_run_queue(
                     launch_spec["entity"],
-                    project_queue,
+                    queue_project,
                     queue_name,
                     access="PROJECT",
                 )
 
                 if res is None or res.get("queueID") is None:
                     wandb.termerror(
-                        f"Unable to create default queue for entity: {entity} on project: {project_queue}. Run could not be added to a queue"
+                        f"Unable to create default queue for entity: {entity} on project: {queue_project}. Run could not be added to a queue"
                     )
                     return None
                 queue_id = res["queueID"]
 
             else:
-                if project_queue == "model-registry":
+                if queue_project == "model-registry":
                     _msg = f"Unable to push to run queue {queue_name}. Queue not found."
                 else:
-                    _msg = f"Unable to push to run queue {project_queue}/{queue_name}. Queue not found."
+                    _msg = f"Unable to push to run queue {queue_project}/{queue_name}. Queue not found."
                 wandb.termwarn(_msg)
                 return None
         elif len(matching_queues) > 1:

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1516,8 +1516,9 @@ class Api:
         queue_name: str,
         launch_spec: Dict[str, str],
         project_queue: str,
+        queue_entity: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        entity = launch_spec["entity"]
+        entity = queue_entity or launch_spec["entity"]
         run_spec = json.dumps(launch_spec)
 
         push_result = self.push_to_run_queue_by_name(

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -668,7 +668,7 @@ class LaunchAgent:
 
                 launch_add(
                     config=config,
-                    project_queue=self._project,
+                    queue_project=self._project,
                     queue_name=job_tracker.queue,
                 )
                 return True

--- a/wandb/sdk/launch/launch_add.py
+++ b/wandb/sdk/launch/launch_add.py
@@ -16,10 +16,16 @@ from wandb.sdk.launch.utils import (
 
 
 def push_to_queue(
-    api: Api, queue_name: str, launch_spec: Dict[str, Any], project_queue: str
+    api: Api,
+    queue_name: str,
+    launch_spec: Dict[str, Any],
+    project_queue: str,
+    queue_entity: Optional[str] = None,
 ) -> Any:
     try:
-        res = api.push_to_run_queue(queue_name, launch_spec, project_queue)
+        res = api.push_to_run_queue(
+            queue_name, launch_spec, project_queue, queue_entity
+        )
     except Exception as e:
         wandb.termwarn(f"{LOG_PREFIX}Exception when pushing to queue {e}")
         return None
@@ -189,8 +195,10 @@ def _launch_add(
     if project_queue is None:
         project_queue = LAUNCH_DEFAULT_PROJECT
 
+    queue_entity = launch_spec.get("queue_entity")
+
     validate_launch_spec_source(launch_spec)
-    res = push_to_queue(api, queue_name, launch_spec, project_queue)
+    res = push_to_queue(api, queue_name, launch_spec, project_queue, queue_entity)
 
     if res is None or "runQueueItemId" not in res:
         raise LaunchError("Error adding run to queue")

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -104,7 +104,8 @@ class Scheduler(ABC):
         sweep_id: Optional[str] = None,
         entity: Optional[str] = None,
         project: Optional[str] = None,
-        project_queue: Optional[str] = None,
+        project_queue: Optional[str] = None,  # deprecated
+        queue_project: Optional[str] = None,
         num_workers: Optional[Union[int, str]] = None,
         **kwargs: Optional[Any],
     ):
@@ -148,7 +149,8 @@ class Scheduler(ABC):
         # Threading lock to ensure thread-safe access to the runs dictionary
         self._threading_lock: threading.Lock = threading.Lock()
         self._polling_sleep = polling_sleep or DEFAULT_POLLING_SLEEP
-        self._project_queue = project_queue
+        self._project_queue = project_queue  # deprecated
+        self._queue_project = queue_project or project_queue
         # Optionally run multiple workers in (pseudo-)parallel. Workers do not
         # actually run training workloads, they simply send heartbeat messages
         # (emulating a real agent) and add new runs to the launch queue. The
@@ -698,7 +700,7 @@ class Scheduler(ABC):
             project=self._project,
             entity=self._entity,
             queue_name=self._kwargs.get("queue"),
-            project_queue=self._project_queue,
+            queue_project=self._queue_project,
             resource=_job_launch_config.get("resource"),
             resource_args=_job_launch_config.get("resource_args"),
             author=self._kwargs.get("author"),


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
<img width="883" alt="Screen Shot 2023-08-21 at 1 30 14 PM" src="https://github.com/wandb/wandb/assets/19414170/b2d9282b-f201-4b86-b598-125cb39e5f27">

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12e4087</samp>

This pull request refactors the code related to run queues and launch sweeps to use a consistent argument name `queue_project` for the project name of a queue. It also adds support for specifying the entity name for the queue in various functions and methods. It updates the tests and the launch agent accordingly. It deprecates the old argument name `project_queue` for backward compatibility.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 12e4087</samp>

> _`queue_project` now_
> _replaces `project_queue` -_
> _autumn of old code_
