### PR TITLE
chore(sweeps): scheduler handles empty launch_config gracefully

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -650,7 +650,7 @@ class Scheduler(ABC):
             pidx = entry_point.index("${program}")
             entry_point[pidx] = self._sweep_config["program"]
 
-        launch_config = self._wandb_run.config.get("launch")
+        launch_config = self._wandb_run.config.get("launch", {})
         if "overrides" not in launch_config:
             launch_config["overrides"] = {"run_config": {}}
         launch_config["overrides"]["run_config"].update(args["args_dict"])


### PR DESCRIPTION
Default for launch config should be dict (`{}`) not Nonetype. Older server versions don't necessarily set this. 