### PR TITLE
test(artifacts): fix directory fallback on Windows

### DIFF
--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -43,11 +43,12 @@ def path_fallbacks(path: StrPath) -> Generator[str, None, None]:
     create-ability. Essentially, keep replacing "suspect" characters until we run out.
     """
     path = str(path)
-    yield path
+    root, tail = os.path.splitdrive(path)
+    yield os.path.join(root, tail)
     for char in PROBLEMATIC_PATH_CHARS:
-        if char in path:
-            path = path.replace(char, "-")
-            yield path
+        if char in tail:
+            tail = tail.replace(char, "-")
+            yield os.path.join(root, tail)
 
 
 def mkdir_allow_fallback(dir_name: StrPath) -> StrPath:

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -62,7 +62,7 @@ def mkdir_allow_fallback(dir_name: StrPath) -> StrPath:
             if Path(new_name) != Path(dir_name):
                 logger.warning(f"Creating '{new_name}' instead of '{dir_name}'")
             return Path(new_name) if isinstance(dir_name, Path) else new_name
-        except ValueError:
+        except (ValueError, NotADirectoryError):
             pass
         except OSError as e:
             if e.errno != 22:


### PR DESCRIPTION
Fixes
-----
Windows fix for https://github.com/wandb/wandb/pull/6094

Description
-----------
- catch `NotADirectoryError` as a sign for retrying directory creation with fewer suspect characters
- separate the root (drive) from the path to prevent `C:\` from being turned into `C-\`

Should address the failure https://app.circleci.com/pipelines/github/wandb/wandb/25559/workflows/1ac1f844-427e-43bb-b6c7-bf936a657a0c/jobs/720592/tests

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce6fbf4</samp>

Handle `NotADirectoryError` in `mkdir_allow_fallback` to avoid crashing `wandb sync` when given a file name. This fixes a user-reported bug in `wandb/sdk/lib/filesystem.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ce6fbf4</samp>

> _`mkdir` can fail_
> _when name is a file, not dir_
> _autumn bug is fixed_
