### PR TITLE
DNM: Revert to 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,8 +419,8 @@ jobs:
       - run:
           name: Install Go
           command: |
-            wget https://go.dev/dl/go1.21.0.linux-amd64.tar.gz
-            tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz
+            wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
+            tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz
             PATH=/usr/local/go/bin:$PATH
             go version
           no_output_timeout: 1m
@@ -446,7 +446,7 @@ jobs:
 
   gotest:
     docker:
-      - image: cimg/go:1.21
+      - image: cimg/go:1.20
     steps:
       - checkout
       - run:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
-      with:
-        go-version: '1.21'
     - uses: actions/setup-python@v3
     - name: setup env
       run: |

--- a/nexus/cmd/nexus/main.go
+++ b/nexus/cmd/nexus/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"log/slog"
 	_ "net/http/pprof"
 	"os"
 	"runtime"
@@ -12,6 +11,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/wandb/wandb/nexus/pkg/observability"
 	"github.com/wandb/wandb/nexus/pkg/server"
+	"golang.org/x/exp/slog"
 )
 
 // this is set by the build script and used by the observability package

--- a/nexus/go.mod
+++ b/nexus/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/shirou/gopsutil/v3 v3.23.6
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/sys v0.9.0
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	golang.org/x/sys v0.9.0
 	google.golang.org/protobuf v1.31.0
 )
 

--- a/nexus/go.mod
+++ b/nexus/go.mod
@@ -1,6 +1,6 @@
 module github.com/wandb/wandb/nexus
 
-go 1.21
+go 1.20
 
 require (
 	github.com/Khan/genqlient v0.6.0
@@ -11,6 +11,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.6
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.9.0
+	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	google.golang.org/protobuf v1.31.0
 )
 

--- a/nexus/go.sum
+++ b/nexus/go.sum
@@ -14,7 +14,6 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
-github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -23,7 +22,6 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8
 github.com/getsentry/sentry-go v0.22.0 h1:XNX9zKbv7baSEI65l+H1GEJgSeIC1c7EN5kluWaP6dM=
 github.com/getsentry/sentry-go v0.22.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
-github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
@@ -47,9 +45,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
-github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
@@ -82,6 +78,8 @@ github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFi
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df h1:UA2aFVmmsIlefxMk29Dp2juaUSth8Pyn3Tq5Y5mJGME=
+golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
 golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/nexus/pkg/filestream/loop_transmit_test.go
+++ b/nexus/pkg/filestream/loop_transmit_test.go
@@ -3,13 +3,13 @@ package filestream
 import (
 	"encoding/json"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/slog"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/wandb/nexus/internal/clienttest"

--- a/nexus/pkg/observability/logging.go
+++ b/nexus/pkg/observability/logging.go
@@ -3,7 +3,7 @@ package observability
 import (
 	"context"
 
-	"log/slog"
+	"golang.org/x/exp/slog"
 )
 
 type Tags map[string]string

--- a/nexus/pkg/observability/sentry.go
+++ b/nexus/pkg/observability/sentry.go
@@ -1,10 +1,10 @@
 package observability
 
 import (
-	"log/slog"
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"golang.org/x/exp/slog"
 )
 
 const sentryDsn = "https://0d0c6674e003452db392f158c42117fb@o151352.ingest.sentry.io/4505513612214272"

--- a/nexus/pkg/server/clients.go
+++ b/nexus/pkg/server/clients.go
@@ -2,8 +2,9 @@ package server
 
 import (
 	"encoding/base64"
-	"log/slog"
 	"net/http"
+
+	"golang.org/x/exp/slog"
 
 	"github.com/wandb/wandb/nexus/pkg/observability"
 

--- a/nexus/pkg/server/connection.go
+++ b/nexus/pkg/server/connection.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/url"
 	"sync"
 
 	"github.com/wandb/wandb/nexus/pkg/auth"
 	"github.com/wandb/wandb/nexus/pkg/service"
+	"golang.org/x/exp/slog"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )

--- a/nexus/pkg/server/logging.go
+++ b/nexus/pkg/server/logging.go
@@ -3,11 +3,11 @@ package server
 import (
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 
 	"github.com/wandb/wandb/nexus/pkg/observability"
 	"github.com/wandb/wandb/nexus/pkg/service"
+	"golang.org/x/exp/slog"
 )
 
 func setupLogger(opts *slog.HandlerOptions, writers ...io.Writer) *slog.Logger {

--- a/nexus/pkg/server/server.go
+++ b/nexus/pkg/server/server.go
@@ -2,9 +2,10 @@ package server
 
 import (
 	"context"
-	"log/slog"
 	"net"
 	"sync"
+
+	"golang.org/x/exp/slog"
 )
 
 const BufferSize = 32

--- a/nexus/pkg/server/stream_mux.go
+++ b/nexus/pkg/server/stream_mux.go
@@ -2,8 +2,9 @@ package server
 
 import (
 	"fmt"
-	"log/slog"
 	"sync"
+
+	"golang.org/x/exp/slog"
 )
 
 // StreamMux is a multiplexer for streams.

--- a/nexus/pkg/server/tokenizer.go
+++ b/nexus/pkg/server/tokenizer.go
@@ -3,7 +3,8 @@ package server
 import (
 	"bytes"
 	"encoding/binary"
-	"log/slog"
+
+	"golang.org/x/exp/slog"
 )
 
 type Header struct {

--- a/nexus/pkg/server/util.go
+++ b/nexus/pkg/server/util.go
@@ -3,8 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
+
+	"golang.org/x/exp/slog"
+
+	"github.com/wandb/wandb/nexus/pkg/service"
 )
 
 func LogError(log *slog.Logger, msg string, err error) {

--- a/nexus/pkg/server/util.go
+++ b/nexus/pkg/server/util.go
@@ -6,8 +6,6 @@ import (
 	"os"
 
 	"golang.org/x/exp/slog"
-
-	"github.com/wandb/wandb/nexus/pkg/service"
 )
 
 func LogError(log *slog.Logger, msg string, err error) {

--- a/nexus/scripts/update-dev-env.txt
+++ b/nexus/scripts/update-dev-env.txt
@@ -3,4 +3,4 @@ google.golang.org/protobuf/cmd/protoc-gen-go v1.30.0
 golang.org/x/tools/cmd/goimports v0.11.0
 github.com/go-critic/go-critic/cmd/gocritic v0.8.1
 github.com/fzipp/gocyclo/cmd/gocyclo v0.6.0
-github.com/golangci/golangci-lint/cmd/golangci-lint v1.54.1 scripts/install-golangci-lint.sh
+github.com/golangci/golangci-lint/cmd/golangci-lint v1.53.3 scripts/install-golangci-lint.sh


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bb5734</samp>

This pull request replaces the `log/slog` package with the `golang.org/x/exp/slog` package for structured logging in the Go code of the nexus package and its subpackages. It also downgrades the Go version to 1.20.5 in the CircleCI config, the Docker image, and the go.mod file to ensure consistency and avoid compatibility issues. Additionally, it downgrades the golangci-lint tool version to 1.53.3 in the scripts/update-dev-env.txt file to match the version used in the CI and pre-commit checks.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0bb5734</samp>

> _We're breaking free from the old log/slog_
> _We're embracing the new `golang.org/x/exp/slog`_
> _We're syncing our versions across the board_
> _We're building a better `nexus` with Go_
