### PR TITLE
chore(sdk): gitignore the .wandb run directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ mypy-results/
 cover-results/
 wandb/proto_check/
 *.log
+.wandb/
 wandb/latest-run
 wandb/run-202*
 .idea/


### PR DESCRIPTION
Description
-----------
Running code that invokes `wandb` in the repo directory currently creates and clobbers the source directory `wandb`, unless there already exists a `.wandb`, in which case it goes there. If we (git)ignore that directory, my IDE will stop freaking out about thousands of new changes to index 😛 

copilot:summary

Testing
-------
-

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

copilot:poem
