### PR TITLE
chore(nexus): clean up stream close path

### DIFF
--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -128,7 +128,7 @@ func (h *Handler) do(in, lb <-chan *service.Record) {
 	defer observability.Reraise()
 
 	h.logger.Info("handler: started", "stream_id", h.settings.RunId)
-	loop:
+loop:
 	for in != nil || lb != nil {
 		select {
 		case record, ok := <-in:

--- a/nexus/pkg/server/stream.go
+++ b/nexus/pkg/server/stream.go
@@ -117,20 +117,9 @@ func (s *Stream) GetRun() *service.RunRecord {
 	return s.handler.GetRun()
 }
 
-// Close closes the stream's handler, writer, sender, and dispatcher.
-// This can be triggered by the client (force=False) or by the server (force=True).
-// We need the ExitRecord to initiate the shutdown procedure (which we
-// either get from the client, or generate ourselves if the server is shutting us down).
-// This will trigger the defer state machines (SM) in the stream's components:
-//   - when the sender's SM gets to the final state, it will Close the handler
-//   - this will trigger the handler to Close the writer
-//   - this will trigger the writer to Close the sender
-//
-// This will finish the Stream's wait group, which will allow the stream to be
-// garbage collected.
+// Gracefully wait for handler, writer, sender, dispatcher to shutdown cleanly
+// assumes an exit record has already been sent
 func (s *Stream) Close() {
-	// Close and wait for input channel to shutdown
-	close(s.inChan)
 	s.wg.Wait()
 }
 


### PR DESCRIPTION
Description
-----------
Fix an issue where a channel write would often occur after it was closed down.

This is caused by the connection writing to the stream channel, but the stream channel has shutdown already.

A fix is to not close the stream channel and rely on the loopback channel to dictate when the handler should exit.

This should be safer (shouldnt crash as often, but the connection code could use some cleanups also)

copilot:summary

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

copilot:poem
