### PR TITLE
feat(integrations): add max batch sample size for predictions in wand…

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -40,6 +40,7 @@ mlflow
 kfp<2.0.0
 urllib3<2
 docker
+webdataset
 
 responses
 respx

--- a/wandb/integration/ultralytics/bbox_utils.py
+++ b/wandb/integration/ultralytics/bbox_utils.py
@@ -140,11 +140,15 @@ def plot_validation_results(
     predictor: DetectionPredictor,
     table: wandb.Table,
     max_validation_batches: int,
+    max_batch_samples: Optional[int] = None,
     epoch: Optional[int] = None,
 ) -> wandb.Table:
     data_idx = 0
     for batch_idx, batch in enumerate(dataloader):
-        for img_idx, image_path in enumerate(batch["im_file"]):
+        samples = batch["im_file"]
+        if max_batch_samples is not None and max_batch_samples > 0:
+            samples = samples[:min(len(samples), max_batch_samples)]
+        for img_idx, image_path in enumerate(samples):
             prediction_result = predictor(image_path)[0]
             _, prediction_box_data, mean_confidence_map = plot_predictions(
                 prediction_result, model_name
@@ -179,6 +183,6 @@ def plot_validation_results(
                 data_idx += 1
             except TypeError:
                 pass
-        if batch_idx + 1 == max_validation_batches:
+        if batch_idx + 1 >= max_validation_batches:
             break
     return table

--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -262,6 +262,7 @@ class WandBUltralyticsCallback:
                         predictor=self.predictor,
                         table=self.train_validation_table,
                         max_validation_batches=self.max_validation_batches,
+                        max_batch_samples=self.max_batch_samples,
                         epoch=trainer.epoch,
                     )
                 elif self.task == "detect":
@@ -272,6 +273,7 @@ class WandBUltralyticsCallback:
                         predictor=self.predictor,
                         table=self.train_validation_table,
                         max_validation_batches=self.max_validation_batches,
+                        max_batch_samples=self.max_batch_samples,
                         epoch=trainer.epoch,
                     )
                 elif self.task == "classify":
@@ -282,6 +284,7 @@ class WandBUltralyticsCallback:
                             predictor=self.predictor,
                             table=self.train_validation_table,
                             max_validation_batches=self.max_validation_batches,
+                            max_batch_samples=self.max_batch_samples,
                             epoch=trainer.epoch,
                         )
                     )
@@ -321,6 +324,7 @@ class WandBUltralyticsCallback:
                         predictor=self.predictor,
                         table=self.validation_table,
                         max_validation_batches=self.max_validation_batches,
+                        max_batch_samples=self.max_batch_samples,
                     )
                 elif self.task == "detect":
                     self.validation_table = plot_validation_results(
@@ -330,6 +334,7 @@ class WandBUltralyticsCallback:
                         predictor=self.predictor,
                         table=self.validation_table,
                         max_validation_batches=self.max_validation_batches,
+                        max_batch_samples=self.max_batch_samples,
                     )
                 elif self.task == "classify":
                     self.validation_table = plot_classification_validation_results(
@@ -338,6 +343,7 @@ class WandBUltralyticsCallback:
                         predictor=self.predictor,
                         table=self.validation_table,
                         max_validation_batches=self.max_validation_batches,
+                        max_batch_samples=self.max_batch_samples,
                     )
             wandb.log({"Validation-Table": self.validation_table})
 

--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -111,10 +111,12 @@ class WandBUltralyticsCallback:
         max_validation_batches: int = 1,
         enable_model_checkpointing: bool = False,
         visualize_skeleton: bool = False,
+        max_batch_samples: Optional[int] = None
     ) -> None:
         self.max_validation_batches = max_validation_batches
         self.enable_model_checkpointing = enable_model_checkpointing
         self.visualize_skeleton = visualize_skeleton
+        self.max_batch_samples = max_batch_samples
         self.task = model.task
         self.task_map = model.task_map
         self.model_name = model.overrides["model"].split(".")[0]
@@ -249,6 +251,7 @@ class WandBUltralyticsCallback:
                         visualize_skeleton=self.visualize_skeleton,
                         table=self.train_validation_table,
                         max_validation_batches=self.max_validation_batches,
+                        max_batch_samples=self.max_batch_samples,
                         epoch=trainer.epoch,
                     )
                 elif self.task == "segment":
@@ -308,6 +311,7 @@ class WandBUltralyticsCallback:
                         visualize_skeleton=self.visualize_skeleton,
                         table=self.validation_table,
                         max_validation_batches=self.max_validation_batches,
+                        max_batch_samples=self.max_batch_samples
                     )
                 elif self.task == "segment":
                     self.validation_table = plot_mask_validation_results(
@@ -382,6 +386,7 @@ def add_wandb_callback(
     enable_validation_logging: bool = True,
     enable_prediction_logging: bool = True,
     max_validation_batches: Optional[int] = 1,
+    max_batch_samples: Optional[int] = None,
     visualize_skeleton: Optional[bool] = True,
 ):
     """Function to add the `WandBUltralyticsCallback` callback to the `YOLO` model.
@@ -439,6 +444,7 @@ def add_wandb_callback(
             max_validation_batches,
             enable_model_checkpointing,
             visualize_skeleton,
+            max_batch_samples,
         )
         if not enable_train_validation_logging:
             _ = wandb_callback.callbacks.pop("on_fit_epoch_end")

--- a/wandb/integration/ultralytics/classification_utils.py
+++ b/wandb/integration/ultralytics/classification_utils.py
@@ -39,6 +39,7 @@ def plot_classification_validation_results(
     predictor: ClassificationPredictor,
     table: wandb.Table,
     max_validation_batches: int,
+    max_batch_samples: Optional[int] = None,
     epoch: Optional[int] = None,
 ):
     data_idx = 0
@@ -47,7 +48,7 @@ def plot_classification_validation_results(
     for batch_idx, batch in enumerate(dataloader):
         image_batch = batch["img"].numpy()
         ground_truth = batch["cls"].numpy().tolist()
-        for img_idx in range(image_batch.shape[0]):
+        for img_idx in range(min(image_batch.shape[0], max_batch_samples)):
             image = np.transpose(image_batch[img_idx], (1, 2, 0))
             # print(image)
             prediction_result = predictor(image, show=False)[0]
@@ -60,6 +61,6 @@ def plot_classification_validation_results(
             table_row = [model_name] + table_row
             table.add_data(*table_row)
             data_idx += 1
-        if batch_idx + 1 == max_validation_batches:
+        if batch_idx + 1 >= max_validation_batches:
             break
     return table

--- a/wandb/integration/ultralytics/mask_utils.py
+++ b/wandb/integration/ultralytics/mask_utils.py
@@ -96,11 +96,15 @@ def plot_mask_validation_results(
     predictor: SegmentationPredictor,
     table: wandb.Table,
     max_validation_batches: int,
+    max_batch_samples: Optional[int] = None,
     epoch: Optional[int] = None,
 ):
     data_idx = 0
     for batch_idx, batch in enumerate(dataloader):
-        for img_idx, image_path in enumerate(batch["im_file"]):
+        samples = batch["im_file"]
+        if max_batch_samples is not None and max_batch_samples > 0:
+            samples = samples[:min(len(samples), max_batch_samples)]
+        for img_idx, image_path in enumerate(samples):
             prediction_result = predictor(image_path)[0]
             (
                 _,
@@ -136,6 +140,6 @@ def plot_mask_validation_results(
                 data_idx += 1
             except TypeError:
                 pass
-        if batch_idx + 1 == max_validation_batches:
+        if batch_idx + 1 >= max_validation_batches:
             break
     return table

--- a/wandb/integration/ultralytics/pose_utils.py
+++ b/wandb/integration/ultralytics/pose_utils.py
@@ -58,11 +58,15 @@ def plot_pose_validation_results(
     visualize_skeleton: bool,
     table: wandb.Table,
     max_validation_batches: int,
+    max_batch_samples: Optional[int] = None,
     epoch: Optional[int] = None,
 ) -> wandb.Table:
     data_idx = 0
     for batch_idx, batch in enumerate(dataloader):
-        for img_idx, image_path in enumerate(batch["im_file"]):
+        samples = batch["im_file"]
+        if max_batch_samples is not None and max_batch_samples > 0:
+            samples = samples[:min(len(samples), max_batch_samples)]
+        for img_idx, image_path in enumerate(samples):
             prediction_result = predictor(image_path)[0].to("cpu")
             table_row = plot_pose_predictions(
                 prediction_result, model_name, visualize_skeleton
@@ -85,6 +89,6 @@ def plot_pose_validation_results(
             table_row = [model_name] + table_row
             table.add_data(*table_row)
             data_idx += 1
-        if batch_idx + 1 == max_validation_batches:
+        if batch_idx + 1 >= max_validation_batches:
             break
     return table


### PR DESCRIPTION
Fixes
-----
- Fixes #6145

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cbb19d1</samp>

Added a new feature and fixed a bug in the wandb integration for ultralytics. The feature allows users to control the number of pose samples logged and plotted per batch with the `max_batch_samples` parameter in the `wandb` callback. The bug fix corrects the logic for limiting the maximum validation batches in the `plot_pose_validation_results` function.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cbb19d1</samp>

> _Sing, O Muse, of the valiant ultralytics team_
> _Who trained their models with wandb's aid divine_
> _And added a new parameter, `max_batch_samples`, to their scheme_
> _To control the pose samples that on their plots would shine_
