### PR TITLE
fix(launch): manually created image jobs can rerun correctly

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -469,7 +469,7 @@ class InterfaceBase:
             source.git.entrypoint.extend(metadata.get("entrypoint", []))
             source.git.notebook = metadata.get("notebook", False)
         elif source_type == "image":
-            source.image.image = metadata.get("image", "")
+            source.image.image = metadata.get("docker", "")
         else:
             raise ValueError("Invalid source type")
 


### PR DESCRIPTION
Bug where we call an incorrect metadata key, resulting in image jobs manually created NOT rerunning correctly. They run correcty the first time, but then upgrade from "partial" to a full job with **no** image key, resulting in failed job runs after v0. 

Current:
<img width="1728" alt="Screen Shot 2023-08-23 at 1 17 46 PM" src="https://github.com/wandb/wandb/assets/19414170/eb9cf0bb-69ab-49d7-a37f-6043c6cc4b5e">