### PR TITLE
chore(nexus): remove system metric extra channel

### DIFF
--- a/nexus/pkg/monitor/monitor.go
+++ b/nexus/pkg/monitor/monitor.go
@@ -116,6 +116,9 @@ func NewSystemMonitor(
 }
 
 func (sm *SystemMonitor) Do() {
+	if sm == nil {
+		return
+	}
 	// reset context:
 	sm.ctx, sm.cancel = context.WithCancel(context.Background())
 

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -123,7 +123,7 @@ func NewHandler(
 		loopbackChan:        loopbackChan,
 	}
 	if !settings.GetXDisableStats().GetValue() {
-		h.systemMonitor = monitor.NewSystemMonitor(settings, logger)
+		h.systemMonitor = monitor.NewSystemMonitor(settings, logger, loopbackChan)
 	}
 	return h
 }
@@ -329,15 +329,6 @@ func (h *Handler) startSystemMonitor() {
 	if h.systemMonitor == nil {
 		return
 	}
-	go func() {
-		// this goroutine reads from the system monitor channel and writes
-		// to the handler's record channel. it will exit when the system
-		// monitor channel is closed
-		for msg := range h.systemMonitor.OutChan {
-			h.fwdChan <- msg
-		}
-		h.logger.Debug("system monitor channel closed")
-	}()
 	h.systemMonitor.Do()
 }
 

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -324,14 +324,6 @@ func (h *Handler) handleLogArtifact(record *service.Record, _ *service.LogArtifa
 	h.sendRecord(record)
 }
 
-// startSystemMonitor starts the system monitor
-func (h *Handler) startSystemMonitor() {
-	if h.systemMonitor == nil {
-		return
-	}
-	h.systemMonitor.Do()
-}
-
 func (h *Handler) handlePollExit(record *service.Record) {
 	h.sendRecordWithControl(record,
 		func(control *service.Control) {
@@ -381,7 +373,7 @@ func (h *Handler) handleRunStart(record *service.Record, request *service.RunSta
 	h.handleMetadata(record, request)
 
 	// start the system monitor
-	h.startSystemMonitor()
+	h.systemMonitor.Do()
 }
 
 func (h *Handler) handleAttach(_ *service.Record, response *service.Response) {
@@ -404,7 +396,7 @@ func (h *Handler) handlePause() {
 
 func (h *Handler) handleResume() {
 	h.timer.Resume()
-	h.startSystemMonitor()
+	h.systemMonitor.Do()
 }
 
 func (h *Handler) handleMetadata(_ *service.Record, req *service.RunStartRequest) {


### PR DESCRIPTION
Description
-----------
Directly use the loopback channel as output of system metrics logger.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57c1e90</samp>

Refactored the monitor and handler code in `nexus` to use a single loopback channel for sending and receiving service records. This improves the performance and readability of the code.

Testing
-------
Manually tested

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 57c1e90</samp>

> _`SystemMonitor` changed_
> _Loopback channel from caller_
> _Encapsulates well_
