### PR TITLE
test(public-api): mark test_run_metadata as xfail

### DIFF
--- a/tests/pytest_tests/system_tests/test_core/test_public_api.py
+++ b/tests/pytest_tests/system_tests/test_core/test_public_api.py
@@ -238,6 +238,7 @@ def test_log_with_wrong_type_entity_project(wandb_init, logged_artifact):
             run.log_artifact(draft)
 
 
+@pytest.mark.xfail(reason="there is no guarantee that gorilla has processed the event")
 def test_run_metadata(wandb_init):
     project = "test_metadata"
     run = wandb_init(project=project)

--- a/tests/pytest_tests/system_tests/test_core/test_public_api.py
+++ b/tests/pytest_tests/system_tests/test_core/test_public_api.py
@@ -238,7 +238,9 @@ def test_log_with_wrong_type_entity_project(wandb_init, logged_artifact):
             run.log_artifact(draft)
 
 
-@pytest.mark.xfail(reason="there is no guarantee that the backend has processed the event")
+@pytest.mark.xfail(
+    reason="there is no guarantee that the backend has processed the event"
+)
 def test_run_metadata(wandb_init):
     project = "test_metadata"
     run = wandb_init(project=project)

--- a/tests/pytest_tests/system_tests/test_core/test_public_api.py
+++ b/tests/pytest_tests/system_tests/test_core/test_public_api.py
@@ -238,7 +238,7 @@ def test_log_with_wrong_type_entity_project(wandb_init, logged_artifact):
             run.log_artifact(draft)
 
 
-@pytest.mark.xfail(reason="there is no guarantee that gorilla has processed the event")
+@pytest.mark.xfail(reason="there is no guarantee that the backend has processed the event")
 def test_run_metadata(wandb_init):
     project = "test_metadata"
     run = wandb_init(project=project)


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2211345</samp>

Mark a system test case as `xfail` due to a race condition with the backend. This is part of a pull request to improve system test reliability.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2211345</samp>

> _`xfail` a test case_
> _Backend may lag behind events_
> _Winter of flakiness_
