### PR TITLE
refactor(artifacts): simplify artifact saver

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3207,7 +3207,6 @@ class Api:
                     description
                     state
                     createdAt
-                    labels
                     metadata
                 }
             }
@@ -3358,8 +3357,7 @@ class Api:
             values += "sequenceClientID: $sequenceClientID,"
 
         if "enableDigestDeduplication" in fields:
-            types += "$enableDigestDeduplication: Boolean,"
-            values += "enableDigestDeduplication: $enableDigestDeduplication,"
+            values += "enableDigestDeduplication: true,"
 
         if "ttlDurationSeconds" in fields:
             types += "$ttlDurationSeconds: Int64,"
@@ -3374,7 +3372,6 @@ class Api:
                 $runName: String,
                 $description: String,
                 $digest: String!,
-                $labels: JSONString,
                 $aliases: [ArtifactAliasInput!],
                 $metadata: JSONString,
                 _CREATE_ARTIFACT_ADDITIONAL_TYPE_
@@ -3388,7 +3385,6 @@ class Api:
                     description: $description,
                     digest: $digest,
                     digestAlgorithm: MANIFEST_MD5,
-                    labels: $labels,
                     aliases: $aliases,
                     metadata: $metadata,
                     _CREATE_ARTIFACT_ADDITIONAL_VALUE_
@@ -3428,13 +3424,11 @@ class Api:
         project_name: Optional[str] = None,
         run_name: Optional[str] = None,
         description: Optional[str] = None,
-        labels: Optional[List[str]] = None,
         metadata: Optional[Dict] = None,
         ttl_duration_seconds: Optional[int] = None,
         aliases: Optional[List[Dict[str, str]]] = None,
         distributed_id: Optional[str] = None,
         is_user_created: Optional[bool] = False,
-        enable_digest_deduplication: Optional[bool] = False,
         history_step: Optional[int] = None,
     ) -> Tuple[Dict, Dict]:
         fields = self.server_create_artifact_introspection()
@@ -3470,15 +3464,11 @@ class Api:
                 "digest": digest,
                 "description": description,
                 "aliases": [alias for alias in aliases],
-                "labels": json.dumps(util.make_safe_for_json(labels))
-                if labels
-                else None,
                 "metadata": json.dumps(util.make_safe_for_json(metadata))
                 if metadata
                 else None,
                 "ttlDurationSeconds": ttl_duration_seconds,
                 "distributedID": distributed_id,
-                "enableDigestDeduplication": enable_digest_deduplication,
                 "historyStep": history_step,
             },
         )

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -180,7 +180,6 @@ def _create_job(
         run_name=run.id,  # run will be deleted after creation
         description=description,
         metadata=metadata,
-        labels=["manually-created"],
         is_user_created=True,
         aliases=[{"artifactCollectionName": name, "alias": a} for a in aliases],
     )


### PR DESCRIPTION
Fixes WB-15188

# Description

Removing some legacy code from artifact saver:
- labels: the implementation was never finished. I don't think we need labels in addition to aliases, metadata and tags. There are 1146 artifacts with labels with various formats:
  - `null`
  - `["manually-created"]`
  - `{"env":["staging"]}`
- aliases with `collection:alias`: they are no longer allowed
<img width="1158" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/7444f7ee-9e8e-42b9-bc8d-29edc9e8676e">

- enable_digest_deduplication: always set to true

# Test plan

Created 3 artifacts. Made sure aliases were correctly set, and the third artifact reused the first artifact.
<img width="1156" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/c5393f91-1a75-4dee-8b9d-0d7d08690844">