### PR TITLE
fix(sdk): fall back to /tmp/username/.config/wandb in old settings

### DIFF
--- a/wandb/old/settings.py
+++ b/wandb/old/settings.py
@@ -1,4 +1,5 @@
 import configparser
+import getpass
 import os
 import tempfile
 from typing import Any, Optional
@@ -124,6 +125,10 @@ class Settings:
         # if not writable, fall back to a temp directory
         if not os.access(default_config_dir, os.W_OK):
             default_config_dir = os.path.join(tempfile.gettempdir(), ".config", "wandb")
+        # if not writable (if tempdir is shared, for example), try creating a subdir
+        if not os.access(default_config_dir, os.W_OK):
+            username = getpass.getuser()
+            default_config_dir = os.path.join(tempfile.gettempdir(), username, ".config", "wandb")
 
         config_dir = os.environ.get(env.CONFIG_DIR, default_config_dir)
         os.makedirs(config_dir, exist_ok=True)

--- a/wandb/old/settings.py
+++ b/wandb/old/settings.py
@@ -128,7 +128,9 @@ class Settings:
         # if not writable (if tempdir is shared, for example), try creating a subdir
         if not os.access(default_config_dir, os.W_OK):
             username = getpass.getuser()
-            default_config_dir = os.path.join(tempfile.gettempdir(), username, ".config", "wandb")
+            default_config_dir = os.path.join(
+                tempfile.gettempdir(), username, ".config", "wandb"
+            )
 
         config_dir = os.environ.get(env.CONFIG_DIR, default_config_dir)
         os.makedirs(config_dir, exist_ok=True)


### PR DESCRIPTION
Fixes
-----
- Fixes WB-14974
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ec3193</samp>

Improve user and config handling in `wandb/old/settings.py`. Use `getpass` to get the user's name and fallback to a temp directory if the default config directory is not writable.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5ec3193</samp>

> _To avoid any permission woes_
> _And get the user's name, I suppose_
> _You imported `getpass`_
> _And improved the config path_
> _In the file called `settings.py` - nice code!_
