### PR TITLE
test(artifacts): use real MD5 hashes for ArtifactsCache tests

### DIFF
--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -37,7 +37,7 @@ def test_opener_rejects_append_mode(artifacts_cache):
 
 def test_check_md5_obj_path(artifacts_cache):
     md5 = md5_string("hi")
-    path, exists, opener = artifacts_cache.check_md5_obj_path(md5, 6)
+    path, exists, opener = artifacts_cache.check_md5_obj_path(md5, 2)
     expected_path = os.path.join(
         artifacts_cache._cache_dir, "obj", "md5", "49", "f68a5c8493ec2c0bf489821c21fc3b"
     )


### PR DESCRIPTION
Description
-----------
Instead of using `deadbeef` style hashes in unit tests, use the actual MD5 of whatever content is being tested.

This PR prepares the unit tests so that they won't all break when in a future PR we start enforcing cache correctness (not allowing files with the wrong hash to be written into the cache)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 958b43b</samp>

Refactored and improved some artifact storage tests in `test_storage.py`. Used a helper function for md5 digests and varied the file contents for different cases. Enhanced the test readability, consistency, and accuracy.

Testing
-------
-

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 958b43b</samp>

> _`test_storage.py`_
> _Refactored tests with helper_
> _Snowflakes of md5_
