### PR TITLE
chore(artifacts): manually manage temp file deletion

### DIFF
--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -334,7 +334,7 @@ def test_cache_drops_lru_when_adding_not_enough_space(fs, artifacts_cache):
         cache_paths.append(path)
 
     # This next file won't fit; we should drop 1/2 the files in LRU order.
-    _, _, opener = artifacts_cache.check_md5_obj_path(md5_string("x"), 100)
+    _, _, opener = artifacts_cache.check_md5_obj_path(md5_string("x"), 1)
     with opener() as f:
         f.write("x")
 
@@ -371,7 +371,7 @@ def test_cache_add_cleans_up_tmp_when_write_fails(artifacts_cache, monkeypatch):
             path = f.name
             assert os.path.exists(path)
 
-            monkeypatch.setattr(os, "link", fail)
+            monkeypatch.setattr(os, "replace", fail)
 
     assert not os.path.exists(path)
 

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -306,13 +306,7 @@ class TestStoreFile:
         else:
             api.upload_method.assert_not_called()
 
-    @pytest.mark.parametrize(
-        "err",
-        [
-            None,
-            Exception("some error"),
-        ],
-    )
+    @pytest.mark.parametrize("err", [None, Exception("some error")])
     def test_caches_result_on_success(
         self,
         store_file: "StoreFileFixture",

--- a/wandb/sdk/artifacts/artifacts_cache.py
+++ b/wandb/sdk/artifacts/artifacts_cache.py
@@ -197,14 +197,15 @@ class ArtifactsCache:
                 raise ValueError("Appending to cache files is not supported")
 
             self._reserve_space(size)
-            with NamedTemporaryFile(dir=self._temp_dir, mode=mode) as f:
-                yield f
+            temp_file = NamedTemporaryFile(dir=self._temp_dir, mode=mode, delete=False)
+            try:
+                yield temp_file
+                temp_file.close()
                 path.parent.mkdir(parents=True, exist_ok=True)
-                try:
-                    os.link(f.name, path)
-                except FileExistsError:
-                    os.remove(path)
-                    os.link(f.name, path)
+                os.replace(temp_file.name, path)
+            except Exception:
+                os.remove(temp_file.name)
+                raise
 
         return helper
 


### PR DESCRIPTION
Description
-----------
Instead of using the context manager form of `NamedTemporaryFile`, manage deletion directly.

I'm honestly not exactly sure why this is necessary, but before this change the temp files it created weren't being deleted on Windows 🤷 

<!--
copilot:summary
-->


Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
