### PR TITLE
chore(artifacts): copy data directly into file handle rather than getting the file name

### DIFF
--- a/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -518,7 +518,7 @@ def test_cache_write_failure_is_ignored(monkeypatch, capsys):
     def bad_write(*args, **kwargs):
         raise FileNotFoundError("unable to copy from source file")
 
-    monkeypatch.setattr(shutil, "copyfile", bad_write)
+    monkeypatch.setattr(shutil, "copyfileobj", bad_write)
     policy = WandbStoragePolicy()
     path = Path("foo.txt")
     path.write_text("hello")

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -381,7 +381,7 @@ class WandbStoragePolicy(StoragePolicy):
         )
         if not hit:
             try:
-                with cache_open() as f:
-                    shutil.copyfile(entry.local_path, f.name)
+                with cache_open("wb") as f, open(entry.local_path, "rb") as src:
+                    shutil.copyfileobj(src, f)
             except OSError as e:
                 termwarn(f"Failed to cache {entry.local_path}, ignoring {e}")


### PR DESCRIPTION
Description
-----------
When using the `cache_opener`, instead of accessing the name of the temp file for a high-level copy, write directly into the file handle.

This is actually less efficient in some cases, but it circumvents a multiple-writer conflict and Windows file locking.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58719c0</samp>

Fixed file corruption bug in `WandbStoragePolicy` by using binary mode and `shutil.copyfileobj` in `_write_cache`. This affects how artifacts are cached locally on Windows systems.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 58719c0</samp>

> _`_write_cache` changed_
> _To avoid corrupted files_
> _Binary mode, winter cold_
