### PR TITLE
chore(artifacts): better check of when to warn user of ttl disabling after linking

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2000,11 +2000,6 @@ class Artifact:
         Raises:
             ArtifactNotLoggedError: if the artifact has not been logged
         """
-        if self._ttl_duration_seconds is not None:
-            termwarn(
-                "Artifact TTL will be disabled for source artifacts that are linked to portfolios."
-            )
-
         if wandb.run is None:
             with wandb.init(
                 entity=self._source_entity,

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2000,9 +2000,9 @@ class Artifact:
         Raises:
             ArtifactNotLoggedError: if the artifact has not been logged
         """
-        if not self._ttl_is_inherited:
+        if self._ttl_duration_seconds is not None:
             termwarn(
-                "Artifact TTL will be removed for source artifacts that are linked to portfolios."
+                "Artifact TTL will be disabled for source artifacts that are linked to portfolios."
             )
 
         if wandb.run is None:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2634,7 +2634,10 @@ class Run:
                     entity,
                     project,
                 )
-                if artifact._ttl_duration_seconds is not None:
+                if (
+                    artifact._ttl_duration_seconds is not None
+                    or artifact._ttl_is_inherited
+                ):
                     wandb.termwarn(
                         "Artifact TTL will be disabled for source artifacts that are linked to portfolios."
                     )

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2634,9 +2634,9 @@ class Run:
                     entity,
                     project,
                 )
-                if not artifact._ttl_is_inherited:
+                if artifact._ttl_duration_seconds is not None:
                     wandb.termwarn(
-                        "Artifact TTL will be removed for source artifacts that are linked to portfolios."
+                        "Artifact TTL will be disabled for source artifacts that are linked to portfolios."
                     )
             else:
                 # TODO: implement offline mode + sync


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15226

Testing
-------
Ran locally and made sure the warning were showing up accordingly
```
artifact.ttl = None
artifact.link(...) # no warning since the artifact.ttl is disabled anyways

artifact2.ttl = timedelta(days=123)
artifact2.link(...) # warning

artifact3.ttl = wandb.ArtifactTTL.INHERIT
artifact3.link(...) # warning

artifact4.link(...) # warning
```
