### PR TITLE
chore(sdk): close temp file before saving image

### DIFF
--- a/tests/pytest_tests/unit_tests/test_data_types.py
+++ b/tests/pytest_tests/unit_tests/test_data_types.py
@@ -2,7 +2,6 @@ import glob
 import io
 import os
 import platform
-import tempfile
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -1530,7 +1529,7 @@ def test_numpy_arrays_to_list():
 
 
 def test_log_uint8_image():
-    with tempfile.NamedTemporaryFile(suffix=".png") as temp:
+    with open("temp.png", "wb") as temp:
         # Create and save image
         imarray = np.random.rand(100, 100, 3) * 255
         im = Image.fromarray(imarray.astype("uint8")).convert("RGBA")


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Replaces #6183 in order to add Windows CI

Fixes conflict on Windows with tempfile that can't be re-written to by another writer. `pytest` uses a temporary directory and cleans up after itself, so it's fine to not use `tempfile` here.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8e03b8</samp>

Fixed a unit test bug for logging `uint8` images on Windows and cleaned up the test code.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d8e03b8</samp>

> _Oh we're the coders of the sea, we write the tests that make it run_
> _We log the images with care, no matter if they're `uint8` or `float`_
> _But sometimes bugs will slip us by, and make our Windows tests go wrong_
> _So we fix them with a static file, and sing this merry coding song_
