### PR TITLE
refactor(artifacts): simplify artifact saver

### DIFF
--- a/tests/pytest_tests/unit_tests_old/test_cli.py
+++ b/tests/pytest_tests/unit_tests_old/test_cli.py
@@ -54,24 +54,16 @@ def test_artifact_download(runner, git_repo, mock_server):
     assert os.path.exists(path)
 
 
-def test_artifact_upload(runner, git_repo, mock_server, mocker, mocked_run):
+def test_artifact_upload(runner, git_repo, mock_server, mocked_run):
     with open("artifact.txt", "w") as f:
         f.write("My Artifact")
-    mocker.patch("wandb.init", lambda *args, **kwargs: mocked_run)
-    mocker.patch(
-        "wandb.Artifact.wait",
-        lambda *args, **kwargs: wandb_internal_pb2.LogArtifactResponse(
-            artifact_id="some-artifact-id",
-        ),
-    )
     result = runner.invoke(cli.artifact, ["put", "artifact.txt", "-n", "test/simple"])
     print(result.output)
     print(result.exception)
     print(traceback.print_tb(result.exc_info[2]))
     assert result.exit_code == 0
     assert "Uploading file artifact.txt to:" in result.output
-    #  TODO: one of the tests above is setting entity to y
-    assert "test/simple:v0" in result.output
+    assert "FAKE_ENTITY/FAKE_PROJECT/mnist:v0" in result.output
 
 
 def test_artifact_ls(runner, git_repo, mock_server):

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2109,30 +2109,14 @@ def put(path, name, description, type, alias, run_id, resume):
         id=run_id,
         resume=resume,
     )
-    # We create the artifact manually to get the current version
-    res, _ = api.create_artifact(
-        type,
-        artifact_name,
-        artifact.digest,
-        client_id=artifact._client_id,
-        sequence_client_id=artifact._sequence_client_id,
-        entity_name=entity,
-        project_name=project,
-        run_name=run.id,
-        description=description,
-        aliases=[{"artifactCollectionName": artifact_name, "alias": a} for a in alias],
-    )
-    artifact_path = artifact_path.split(":")[0] + ":" + res.get("version", "latest")
-    # Re-create the artifact and actually upload any files needed
     run.log_artifact(artifact, aliases=alias)
     artifact.wait()
 
     wandb.termlog(
         "Artifact uploaded, use this artifact in a run by adding:\n", prefix=False
     )
-
     wandb.termlog(
-        f'    artifact = run.use_artifact("{artifact_path}")\n',
+        f'    artifact = run.use_artifact("{artifact.source_qualified_name}")\n',
         prefix=False,
     )
 

--- a/wandb/sdk/artifacts/artifact_saver.py
+++ b/wandb/sdk/artifacts/artifact_saver.py
@@ -130,24 +130,17 @@ class ArtifactSaver:
             history_step=history_step,
         )
 
-        # TODO(artifacts):
-        #   if it's committed, all is good. If it's committing, just moving ahead isn't necessarily
-        #   correct. It may be better to poll until it's committed or failed, and then decided what to
-        #   do
         assert self._server_artifact is not None  # mypy optionality unwrapper
         artifact_id = self._server_artifact["id"]
         if base_id is None and latest:
             base_id = latest["id"]
-        if (
-            self._server_artifact["state"] == "COMMITTED"
-            or self._server_artifact["state"] == "COMMITTING"
-        ):
-            # TODO: update aliases, description etc?
+        if self._server_artifact["state"] == "COMMITTED":
             if use_after_commit:
                 self._api.use_artifact(artifact_id)
             return self._server_artifact
-        elif (
+        if (
             self._server_artifact["state"] != "PENDING"
+            # For old servers, see https://github.com/wandb/wandb/pull/6190
             and self._server_artifact["state"] != "DELETED"
         ):
             raise Exception(

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3391,12 +3391,7 @@ class Api:
                 }) {
                     artifact {
                         id
-                        digest
                         state
-                        aliases {
-                            artifactCollectionName
-                            alias
-                        }
                         artifactSequence {
                             id
                             latestArtifact {
@@ -3473,13 +3468,6 @@ class Api:
             },
         )
         av = response["createArtifact"]["artifact"]
-        # TODO: make this a part of the graph
-        av["version"] = "latest"
-        for alias in av["aliases"]:
-            if alias["artifactCollectionName"] == artifact_collection_name and re.match(
-                r"^v\d+$", alias["alias"]
-            ):
-                av["version"] = alias["alias"]
         latest = response["createArtifact"]["artifact"]["artifactSequence"].get(
             "latestArtifact"
         )


### PR DESCRIPTION
Fixes WB-13717

# Description

- removed unused fields from the `createArtifact()` mutation
- removed handling of `COMMITTING` state. This state was never used, I checked there are no artifacts in this state in the db. It was removed in June 2020 ([server PR](https://github.com/wandb/core/pull/5321)).
- why do we allow `DELETED` -> `COMMITTED` state:
  - It was introduced in June 2020 (before Artifacts V2): [server PR](https://github.com/wandb/core/pull/5321), [client PR](https://github.com/wandb/wandb/pull/1119). Creating an artifact with identical digest reused an existing artifact even if it was `DELETED` ([code](https://github.com/wandb/core/blob/07f22c77c7e27766fcd8d3d8a68307855d85e3bd/services/gorilla/resolver/mutation.go#L6539)).
  - It was changed in August 2020 (Artifacts V2): [server PR](https://github.com/wandb/core/pull/5514). We only considered the latest artifact ([code](https://github.com/wandb/core/blob/c42b152b71e71c29c928568252dbf17c4d62ecc6/services/gorilla/resolver/mutation.go#L7016)).
  - It was changed in October 2020: [server PR](https://github.com/wandb/core/pull/5940). We only considered the latest `COMMITTED` artifact ([code](https://github.com/wandb/core/blob/a02e4d3965e63b2e4ce3af923e5b6648b710b4f1/services/gorilla/mysql/metadata_artifacts.go#L1303)).

  This means with the current server, `createArtifact()` will never return an artifact in a `DELETED` state. However, an old server might, and we should keep the old behavior. I'll revert this change.

# Test plan

```
$ wandb artifact put --name my_artifact --type tmp benchmark/f0.txt
wandb: Uploading file benchmark/f0.txt to: "szymon-piechowicz-wandb/uncategorized/my_artifact:latest" (tmp)
wandb: Currently logged in as: szymon-piechowicz-wandb. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.15.10.dev1
wandb: Run data is saved locally in /Users/szymon/tmp/.wandb/run-20230831_135029-uwiyighj
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run splendid-dust-159
wandb: ⭐️ View project at https://wandb.ai/szymon-piechowicz-wandb/uncategorized
wandb: 🚀 View run at https://wandb.ai/szymon-piechowicz-wandb/uncategorized/runs/uwiyighj
Artifact uploaded, use this artifact in a run by adding:

    artifact = run.use_artifact("szymon-piechowicz-wandb/uncategorized/my_artifact:v0")

wandb: Waiting for W&B process to finish... (success).
wandb: 🚀 View run splendid-dust-159 at: https://wandb.ai/szymon-piechowicz-wandb/uncategorized/runs/uwiyighj
wandb: Synced 5 W&B file(s), 0 media file(s), 1 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./.wandb/run-20230831_135029-uwiyighj/logs
```