### PR TITLE
chore(artifacts): fix swapped local_path vs save_name

### DIFF
--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -30,15 +30,15 @@ logger = logging.getLogger(__name__)
 class FileEventHandler(abc.ABC):
     def __init__(
         self,
-        file_path: Path,
-        save_name: LogicalPath,
+        file_path: StrPath,
+        save_name: StrPath,
         file_pusher: "FilePusher",
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        self.file_path = file_path
+        self.file_path = Path(file_path)
         # Convert windows paths to unix paths
-        self.save_name = save_name
+        self.save_name = LogicalPath(save_name)
         self._file_pusher = file_pusher
         self._last_sync: Optional[float] = None
 
@@ -55,9 +55,9 @@ class FileEventHandler(abc.ABC):
     def finish(self) -> None:
         raise NotImplementedError
 
-    def on_renamed(self, new_path: Path, new_name: LogicalPath) -> None:
-        self.file_path = new_path
-        self.save_name = new_name
+    def on_renamed(self, new_path: StrPath, new_name: StrPath) -> None:
+        self.file_path = Path(new_path)
+        self.save_name = LogicalPath(new_name)
         self.on_modified()
 
 
@@ -204,7 +204,7 @@ class DirWatcher:
         self._file_event_handlers: MutableMapping[LogicalPath, FileEventHandler] = {}
         self._file_observer = wd_polling.PollingObserver()
         self._file_observer.schedule(
-            self._per_file_event_handler(), self._dir, recursive=True
+            self._per_file_event_handler(), str(self._dir), recursive=True
         )
         self._file_observer.start()
         logger.info("watching files in: %s", settings.files_dir)

--- a/wandb/filesync/stats.py
+++ b/wandb/filesync/stats.py
@@ -2,6 +2,7 @@ import threading
 from typing import MutableMapping, NamedTuple
 
 import wandb
+from wandb.sdk.lib.paths import LogicalPath
 
 
 class FileStats(NamedTuple):
@@ -27,11 +28,11 @@ class FileCountsByCategory(NamedTuple):
 
 class Stats:
     def __init__(self) -> None:
-        self._stats: MutableMapping[str, FileStats] = {}
+        self._stats: MutableMapping[LogicalPath, FileStats] = {}
         self._lock = threading.Lock()
 
     def init_file(
-        self, save_name: str, size: int, is_artifact_file: bool = False
+        self, save_name: LogicalPath, size: int, is_artifact_file: bool = False
     ) -> None:
         with self._lock:
             self._stats[save_name] = FileStats(
@@ -42,7 +43,7 @@ class Stats:
                 artifact_file=is_artifact_file,
             )
 
-    def set_file_deduped(self, save_name: str) -> None:
+    def set_file_deduped(self, save_name: LogicalPath) -> None:
         with self._lock:
             orig = self._stats[save_name]
             self._stats[save_name] = orig._replace(
@@ -50,13 +51,13 @@ class Stats:
                 uploaded=orig.total,
             )
 
-    def update_uploaded_file(self, save_name: str, total_uploaded: int) -> None:
+    def update_uploaded_file(self, save_name: LogicalPath, total_uploaded: int) -> None:
         with self._lock:
             self._stats[save_name] = self._stats[save_name]._replace(
                 uploaded=total_uploaded,
             )
 
-    def update_failed_file(self, save_name: str) -> None:
+    def update_failed_file(self, save_name: LogicalPath) -> None:
         with self._lock:
             self._stats[save_name] = self._stats[save_name]._replace(
                 uploaded=0,

--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -6,6 +6,7 @@ import logging
 import queue
 import sys
 import threading
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Awaitable,
@@ -49,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 
 class RequestUpload(NamedTuple):
-    path: str
+    path: Path
     save_name: LogicalPath
     artifact_id: Optional[str]
     md5: Optional[str]

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -5,6 +5,7 @@ import queue
 import tempfile
 import threading
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import wandb
@@ -129,7 +130,7 @@ class FilePusher:
     def file_counts_by_category(self) -> stats.FileCountsByCategory:
         return self._stats.file_counts_by_category()
 
-    def file_changed(self, save_name: LogicalPath, path: str, copy: bool = True):
+    def file_changed(self, save_name: LogicalPath, path: Path, copy: bool = True):
         """Tell the file pusher that a file's changed and should be uploaded.
 
         Arguments:
@@ -138,9 +139,7 @@ class FilePusher:
             path: actual string path of the file to upload on the filesystem.
         """
         # Tests in linux were failing because wandb-events.jsonl didn't exist
-        if not os.path.exists(path) or not os.path.isfile(path):
-            return
-        if os.path.getsize(path) == 0:
+        if not path.is_file() or path.stat().st_size == 0:
             return
 
         event = step_checksum.RequestUpload(path, save_name, copy)

--- a/wandb/vendor/watchdog_0_9_0/wandb_watchdog/events.py
+++ b/wandb/vendor/watchdog_0_9_0/wandb_watchdog/events.py
@@ -115,6 +115,8 @@ class FileSystemEvent(object):
     """True if event was emitted for a directory; False otherwise."""
 
     def __init__(self, src_path):
+        if not isinstance(src_path, str):
+            raise ValueError("src_path must be a string.")
         self._src_path = src_path
 
     @property


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
* Use `pathlib.Path` and `paths.LogicalPath` to improve the type checking in the files in the upload process
* Fix inversions where a local path is passed as `save_name` or vice versa

Initially I was just trying to get rid of the fairly pointless `PathStr = str`, but in the process I discovered that there is a consistent inversion of which path is local vs which one is referred to as local. I think the inversion was _so_ consistent there wasn't actually a bug, but the fact that everything was named backwards seems worth fixing.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 612645a</samp>

This pull request refactors several modules in the wandb SDK to use `pathlib` and `LogicalPath` for file path handling. This simplifies the code, improves cross-platform compatibility, and standardizes the file names and paths used for file syncing and uploading. The affected modules are `wandb.filesync`, `wandb.sdk.internal.file_pusher`, and `tests/pytest_tests/unit_tests/test_dir_watcher.py`.

Testing
-------
Passing existing tests only

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 612645a</samp>

> _`pathlib` and `LogicalPath`_
> _simplify file syncing code_
> _autumn of refactoring_
