### PR TITLE
fix(reports): fix b64 padding for low id reports

### DIFF
--- a/wandb/apis/reports/report.py
+++ b/wandb/apis/reports/report.py
@@ -1,3 +1,4 @@
+import base64
 import inspect
 import json
 import re
@@ -72,6 +73,10 @@ class Report(Base):
             # If the report title ends in trailing space
             report = report.replace("---", "--")
             *_, report_id = report.split("--")
+            # server does not generate IDs with correct padding, decode with "validate=False" which
+            # will work when there is padding or when there is no padding. Then re-encode it with correct
+            # padding
+            report_id = base64.b64encode(base64.b64decode(report_id + "==", validate=False)).decode('utf-8')
         except ValueError as e:
             raise ValueError("Path must be `entity/project/reports/report_id`") from e
         else:


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d54af99</samp>

Improved handling of base64 report IDs in `wandb/apis/reports/report.py`. Fixed a decoding bug and added support for IDs with varying padding.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d54af99</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A way to handle base64 report IDs with grace_
> _And fixed the faulty function that often failed to parse_
> _The hidden meaning of the padded characters in place._
