### PR TITLE
fix(nexus): use UpsertBucketRetryPolicy in all gql.UpsertBucket calls

### DIFF
--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -602,9 +602,9 @@ func (s *Sender) sendConfig(_ *service.Record, configRecord *service.ConfigRecor
 	}
 
 	config := s.serializeConfig()
-
+	ctx := context.WithValue(s.ctx, CtxRetryPolicyKey, UpsertBucketRetryPolicy)
 	_, err := gql.UpsertBucket(
-		s.ctx,                            // ctx
+		ctx,                              // ctx
 		s.graphqlClient,                  // client
 		nil,                              // id
 		&s.RunRecord.RunId,               // name


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d750105</samp>

Add retry policy for `UpsertBucket` mutation in `sender.go`. This improves the reliability of file streaming to the backend.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d750105</samp>

> _`UpsertBucket` tries_
> _With context and retry policy_
> _Transient errors fade_
