### PR TITLE
feat(nexus): support user defined headers in the gql client transport

### DIFF
--- a/nexus/internal/clients/retry_policy.go
+++ b/nexus/internal/clients/retry_policy.go
@@ -1,0 +1,58 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+type ContextKey string
+
+const CtxRetryPolicyKey ContextKey = "retryFunc"
+
+func DefaultRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	statusCode := resp.StatusCode
+	switch {
+	case statusCode == http.StatusBadRequest, statusCode == http.StatusConflict: // don't retry on 400 bad request or 409 conflict
+		return false, fmt.Errorf("the server responded with an error. (Error %d: %s)", statusCode, http.StatusText(statusCode))
+	case statusCode == http.StatusUnauthorized: // don't retry on 401 unauthorized
+		return false, fmt.Errorf("the API key you provided is either invalid or missing. (Error %d: %s)", statusCode, http.StatusText(statusCode))
+	case statusCode == http.StatusForbidden: // don't retry on 403 forbidden
+		return false, fmt.Errorf("you don't have permission to access this resource. (Error %d: %s)", statusCode, http.StatusText(statusCode))
+	case statusCode == http.StatusNotFound: // don't retry on 404 not found
+		return false, fmt.Errorf("the resource you requested could not be found. (Error %d: %s)", statusCode, http.StatusText(statusCode))
+	case statusCode >= 400 && statusCode < 500: // retry on 4xx client error
+		return true, fmt.Errorf("the server responded with an error. (Error %d: %s)", statusCode, http.StatusText(statusCode))
+	default: // use default retry policy for all other status codes
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	}
+}
+
+func UpsertBucketRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	statusCode := resp.StatusCode
+	switch {
+	case statusCode == http.StatusGone: // don't retry on 410 Gone
+		return false, fmt.Errorf("the server responded with an error. (Error %d: %s)", statusCode, http.StatusText(statusCode))
+	case statusCode == http.StatusConflict: // retry on 409 Conflict
+		return true, fmt.Errorf("conflict, retrying. (Error %d: %s)", statusCode, http.StatusText(statusCode))
+	default: // use default retry policy for all other status codes
+		return DefaultRetryPolicy(ctx, resp, err)
+	}
+}
+
+func CheckRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if err != nil || ctx.Err() != nil {
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	}
+
+	// get retry policy from context
+	retryPolicy, ok := ctx.Value(CtxRetryPolicyKey).(func(context.Context, *http.Response, error) (bool, error))
+	switch {
+	case !ok, retryPolicy == nil:
+		return DefaultRetryPolicy(ctx, resp, err)
+	default:
+		return retryPolicy(ctx, resp, err)
+	}
+}

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -105,11 +105,10 @@ func NewSender(ctx context.Context, settings *service.Settings, logger *observab
 		baseHeaders := map[string]string{
 			"X-WANDB-USERNAME":   settings.GetUsername().GetValue(),
 			"X-WANDB-USER-EMAIL": settings.GetEmail().GetValue(),
-			"User-Agent":         "wandb-nexus",
 		}
 		graphqlRetryClient := clients.NewRetryClient(
 			clients.WithRetryClientLogger(logger),
-			clients.WithRetryClientHttpAuthTransportWithHeaders(
+			clients.WithRetryClientHttpAuthTransport(
 				settings.GetApiKey().GetValue(),
 				baseHeaders,
 				settings.GetXExtraHttpHeaders().GetValue(),

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -102,14 +102,16 @@ func NewSender(ctx context.Context, settings *service.Settings, logger *observab
 		telemetry:    &service.TelemetryRecord{CoreVersion: NexusVersion},
 	}
 	if !settings.GetXOffline().GetValue() {
-		// todo(nexus:beta): pass X-WANDB-USERNAME, X-WANDB-USER-EMAIL, and
-		//  user-defined headers from _graphql_extra_http_headers to the retry client
+		baseHeaders := map[string]string{
+			"X-WANDB-USERNAME":   settings.GetUsername().GetValue(),
+			"X-WANDB-USER-EMAIL": settings.GetEmail().GetValue(),
+			"User-Agent":         "wandb-nexus",
+		}
 		graphqlRetryClient := clients.NewRetryClient(
 			clients.WithRetryClientLogger(logger),
 			clients.WithRetryClientHttpAuthTransportWithHeaders(
 				settings.GetApiKey().GetValue(),
-				settings.GetUsername().GetValue(),
-				settings.GetEmail().GetValue(),
+				baseHeaders,
 				settings.GetXExtraHttpHeaders().GetValue(),
 			),
 			clients.WithRetryClientRetryPolicy(clients.CheckRetry),

--- a/nexus/pkg/server/stream.go
+++ b/nexus/pkg/server/stream.go
@@ -129,13 +129,13 @@ func (s *Stream) GetRun() *service.RunRecord {
 	return s.handler.GetRun()
 }
 
-// Gracefully wait for handler, writer, sender, dispatcher to shutdown cleanly
+// Close Gracefully wait for handler, writer, sender, dispatcher to shutdown cleanly
 // assumes an exit record has already been sent
 func (s *Stream) Close() {
 	s.wg.Wait()
 }
 
-// Handle internal responses like from the finish and close path
+// Respond Handle internal responses like from the finish and close path
 func (s *Stream) Respond(resp *service.ServerResponse) {
 	s.respChan <- resp
 }

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1166,7 +1166,7 @@ class Run:
     def entity(self) -> str:
         """The name of the W&B entity associated with the run.
 
-        Entity can be a user name or the name of a team or organization.
+        Entity can be a username or the name of a team or organization.
         """
         return self._entity or ""
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1584,6 +1584,7 @@ class Settings(SettingsData):
             "WANDB_JOB_TYPE": "run_job_type",
             "WANDB_HTTP_TIMEOUT": "_graphql_timeout_seconds",
             "WANDB_FILE_PUSHER_TIMEOUT": "_file_uploader_timeout_seconds",
+            "WANDB_USER_EMAIL": "email",
         }
         env = dict()
         for setting, value in environ.items():


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

ТODO:
 
- [ ] Rename extra_headers to graphql and filestream extra_headers?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d5bdb2</samp>

This pull request adds custom headers and retry policies to the nexus GraphQL client, and enables setting the email address for the wandb client using an environment variable. It also refactors and cleans up some of the existing code in `nexus/pkg/server/sender.go` and `wandb/sdk/wandb_settings.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5d5bdb2</samp>

> _We're sailing on the nexus of the code, me hearties_
> _We're adding and refactoring as we go_
> _We're setting up the retry policies and headers_
> _We're heaving on the `HTTP` on the count of three_
