### PR TITLE
test(sdk): unpin anyio as it was fixed by prefect

### DIFF
--- a/tests/functional_tests/t0_main/prefect_ray/t1_prefect_ray_workflow.yea
+++ b/tests/functional_tests/t0_main/prefect_ray/t1_prefect_ray_workflow.yea
@@ -10,7 +10,6 @@ depend:
     - "numpy"
     - "prefect"
     - "prefect-ray"
-    - anyio<4.0.0 # TODO: remove when prefect updates to anyio 4
 assert:
     - :wandb:runs_len: 11
     - :wandb:runs[0][exitcode]: 0


### PR DESCRIPTION
Description
-----------
What does the PR do?

unpin the pin from #6199 PR as the issue was resolved

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec4e713</samp>

Remove anyio workaround from `t1_prefect_ray_workflow.yea` test. This test checks the integration of wandb, prefect, and ray, and the workaround was causing errors with the latest versions of the libraries.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ec4e713</samp>

> _`anyio` conflict_
> _resolved by `prefect` update_
> _no workaround now_
