### PR TITLE
build(nexus): fix config flag for the nexus build

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def build_nexus(session):
         "-w",
         "-n",
         "./nexus",
-        f"-Cbuild-option=--nexus-build={system}-{arch}",
+        f"-C--build-option=bdist_wheel --nexus-build={system}-{arch}",
         external=True,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def build_nexus(session):
         "-w",
         "-n",
         "./nexus",
-        f"--config-setting=--build-option=--nexus-build={system}-{arch}",
+        f"-Cbuild-option=--nexus-build={system}-{arch}",
         external=True,
     )
 


### PR DESCRIPTION
Description
-----------
What does the PR do?

`build` released [1.0 version](https://pypi.org/project/build/1.0.0/) today and it seems that the old config flag doesn't work anymore (properly). 
Looking at the [release notes](https://pypa-build.readthedocs.io/en/latest/changelog.html#id1) i found this: 
note the config-settings point

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3d593d</samp>

Updated `build_nexus` function in `noxfile.py` to use new poetry config syntax. This fixed a bug and improved nexus installation.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f3d593d</samp>

> _`build_nexus` changed_
> _New syntax for poetry_
> _Winter bug is gone_
