### PR TITLE
feat(sdk): enable set types in wandb.Config

### DIFF
--- a/tests/pytest_tests/unit_tests/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_run.py
@@ -212,7 +212,16 @@ def test_run_basic():
         ),
     )
     run = wandb_sdk.wandb_run.Run(settings=s, config=c)
-    assert dict(run.config) == c
+    assert dict(run.config) == dict(
+        param1=2,
+        param2=4,
+        param3=list(range(10)),
+        param4=list(range(10, 20)),
+        param5=list(range(20, 30)),
+        dict_param=dict(
+            a=list(range(10)), b=list(range(10, 20)), c=list(range(20, 30))
+        ),
+    )
 
 
 def test_run_sweep():

--- a/tests/pytest_tests/unit_tests/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_run.py
@@ -201,25 +201,18 @@ def test_use_artifact_offline(mock_run):
 
 def test_run_basic():
     s = wandb.Settings()
-    c = dict(param1=2, 
-             param2=4, 
-             param3=set(range(10)),
-             param4=list(range(10,20)),
-             param5=tuple(range(20,30)),
-             dict_param=dict(
-                 a=list(range(10)), 
-                 b=tuple(range(10,20)), 
-                 c=set(range(20,30))))
+    c = dict(
+        param1=2,
+        param2=4,
+        param3=set(range(10)),
+        param4=list(range(10, 20)),
+        param5=tuple(range(20, 30)),
+        dict_param=dict(
+            a=list(range(10)), b=tuple(range(10, 20)), c=set(range(20, 30))
+        ),
+    )
     run = wandb_sdk.wandb_run.Run(settings=s, config=c)
-    assert dict(run.config) == dict(param1=2, 
-                                    param2=4, 
-                                    param3=list(range(10)),
-                                    param4=list(range(10,20)),
-                                    param5=list(range(20,30)),
-                                    dict_param=dict(
-                                        a=list(range(10)), 
-                                        b=list(range(10,20)), 
-                                        c=list(range(20,30))))
+    assert dict(run.config) == c
 
 
 def test_run_sweep():

--- a/tests/pytest_tests/unit_tests/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_run.py
@@ -201,9 +201,25 @@ def test_use_artifact_offline(mock_run):
 
 def test_run_basic():
     s = wandb.Settings()
-    c = dict(param1=2, param2=4)
+    c = dict(param1=2, 
+             param2=4, 
+             param3=set(range(10)),
+             param4=list(range(10,20)),
+             param5=tuple(range(20,30)),
+             dict_param=dict(
+                 a=list(range(10)), 
+                 b=tuple(range(10,20)), 
+                 c=set(range(20,30))))
     run = wandb_sdk.wandb_run.Run(settings=s, config=c)
-    assert dict(run.config) == dict(param1=2, param2=4)
+    assert dict(run.config) == dict(param1=2, 
+                                    param2=4, 
+                                    param3=list(range(10)),
+                                    param4=list(range(10,20)),
+                                    param5=list(range(20,30)),
+                                    dict_param=dict(
+                                        a=list(range(10)), 
+                                        b=list(range(10,20)), 
+                                        c=list(range(20,30))))
 
 
 def test_run_sweep():

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -635,6 +635,8 @@ def json_friendly(  # noqa: C901
     elif isinstance(obj, dict) and np:
         obj, converted = _sanitize_numpy_keys(obj)
     elif isinstance(obj,set):
+        print('I am a set and i am being turned into a tuple')
+        print(f' object {obj}')
         obj = tuple(obj)
     else:
         converted = False

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -635,7 +635,7 @@ def json_friendly(  # noqa: C901
     elif isinstance(obj, dict) and np:
         obj, converted = _sanitize_numpy_keys(obj)
     elif isinstance(obj,set):
-        'convert set to tuple to make it json serializable'
+        "set is not json serializable so we convert it to tuple"
         obj = tuple(obj)
     else:
         converted = False

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -634,8 +634,8 @@ def json_friendly(  # noqa: C901
         obj = None
     elif isinstance(obj, dict) and np:
         obj, converted = _sanitize_numpy_keys(obj)
-    elif isinstance(obj,set):
-        "set is not json serializable so we convert it to tuple"
+    elif isinstance(obj, set):
+        # set is not json serializable, so we convert it to tuple
         obj = tuple(obj)
     else:
         converted = False

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -635,8 +635,6 @@ def json_friendly(  # noqa: C901
     elif isinstance(obj, dict) and np:
         obj, converted = _sanitize_numpy_keys(obj)
     elif isinstance(obj,set):
-        print('I am a set and i am being turned into a tuple')
-        print(f' object {obj}')
         obj = tuple(obj)
     else:
         converted = False

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -634,6 +634,8 @@ def json_friendly(  # noqa: C901
         obj = None
     elif isinstance(obj, dict) and np:
         obj, converted = _sanitize_numpy_keys(obj)
+    elif isinstance(obj,set):
+        obj = tuple(obj)
     else:
         converted = False
     if getsizeof(obj) > VALUE_BYTES_LIMIT:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -635,6 +635,7 @@ def json_friendly(  # noqa: C901
     elif isinstance(obj, dict) and np:
         obj, converted = _sanitize_numpy_keys(obj)
     elif isinstance(obj,set):
+        'convert set to tuple to make it json serializable'
         obj = tuple(obj)
     else:
         converted = False


### PR DESCRIPTION
Fixes
-----
- Fixes [WB 13517](https://wandb.atlassian.net/browse/WB-13517) 

Description
-----------
What does the PR do?
Passing a set into wandb.config will cause the run to crash as this cannot be serialized as json, this pr converts sets to tuples when passed in the config dict and updates the functional unit test that corresponds to this'


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5df4ff4</samp>

The pull request enhances the `json_friendly` function to support sets and adds more tests for complex config types. This improves the robustness and consistency of the `Run` class and its config handling.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5df4ff4</samp>

> _`json_friendly` changed_
> _to handle sets and lists alike_
> _autumn of testing_
