### PR TITLE
fix(sdk): Fix logger when logging filestream exception

### DIFF
--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -500,7 +500,7 @@ class FileStreamApi:
             wandb.termerror(
                 "Dropped streaming file chunk (see wandb/debug-internal.log)"
             )
-            logging.exception("dropped chunk %s" % response)
+            logger.exception("dropped chunk %s" % response)
             self._dropped_chunks += 1
         else:
             parsed: Optional[dict] = None


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 066e48c</samp>

Refactored logging in `file_stream.py` to use the `logger` object instead of the `logging` module. This improves logging consistency and configurability across the wandb SDK.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 066e48c</samp>

> _`logging` module gone_
> _`logger` object takes its place_
> _autumn of refactor_
