### PR TITLE
chore(launch): Reduce print frequency of launch agent

### DIFF
--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -475,12 +475,11 @@ class LaunchAgent:
 
                 for thread_id in self.thread_ids:
                     self._update_finished(thread_id)
-                if self._ticks % 2 == 0:
+                if self._ticks % 8 == 0:
                     if len(self.thread_ids) == 0:
                         self.update_status(AGENT_POLLING)
                     else:
                         self.update_status(AGENT_RUNNING)
-                    self.print_status()
 
                 if (
                     self.num_running_jobs == self._max_jobs


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
1/4s the status print frequency of the launch agent since we now have a 100k log line limit. This is a temporary work around to make logs last longer, but we'll need a way to fix it better

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfb8203</samp>

Reduced the logging frequency of the launch agent to make the output less noisy. This was part of a pull request to enhance the launch agent feature in `wandb/sdk/launch/agent/agent.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfb8203</samp>

> _`print_status` less_
> _Agent logs are quieter_
> _Autumn leaves whisper_
