### PR TITLE
chore(launch): dont forbid waiting on container jobs

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2619,8 +2619,6 @@ class QueuedRun:
     def wait_until_running(self):
         if self._run is not None:
             return self._run
-        if self.container_job:
-            raise LaunchError("Container jobs cannot be waited on")
 
         while True:
             # sleep here to hide an ugly warning


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88569b2</samp>

This change enables the public API to wait for container jobs to start running. It removes a check that prevented `QueuedRun.wait_until_running` from working with container jobs, which are launched by `wandb launch`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 88569b2</samp>

> _`QueuedRun` changes_
> _Waiting for container jobs_
> _A new spring feature_
