### PR TITLE
docs(sdk): fixes a broken link in Image docs.

### DIFF
--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -69,7 +69,7 @@ class Image(BatchableMedia):
             image data, or a PIL image. The class attempts to infer
             the data format and converts it.
         mode: (string) The PIL mode for an image. Most common are "L", "RGB",
-            "RGBA". Full explanation at https://pillow.readthedocs.io/en/4.2.x/handbook/concepts.html#concept-modes.
+            "RGBA". Full explanation at https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes.
         caption: (string) Label for display of image.
 
     Note : When logging a `torch.Tensor` as a `wandb.Image`, images are normalized. If you do not want to normalize your images, please convert your tensors to a PIL Image.


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-421](https://wandb.atlassian.net/browse/DOCS-421)

Description
-----------
Fixes a broken link to the Pillow documentation in the API Reference docs.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3591e1</samp>

Updated the URL for the PIL modes documentation in `wandb/sdk/data_types/image.py` to avoid referencing an outdated version. This improves the accuracy and clarity of the image data type documentation.

Testing
-------
How was this PR tested?
Ran the tests listed [here](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#testing).

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b3591e1</samp>

> _`PIL modes` doc link_
> _Updated to stable version_
> _Fresh as spring blossom_
