### PR TITLE
feat(nexus): add support for `policy=end` in `wandb.save`

### DIFF
--- a/nexus/pkg/server/files.go
+++ b/nexus/pkg/server/files.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"github.com/wandb/wandb/nexus/pkg/service"
+	"google.golang.org/protobuf/proto"
+)
+
+type FileHandler struct {
+	savedFiles map[string]interface{}
+	final      *service.Record
+}
+
+func (fh *FileHandler) Handle(record *service.Record) *service.Record {
+	if fh.final == nil {
+		fh.final = &service.Record{
+			RecordType: &service.Record_Files{
+				Files: &service.FilesRecord{
+					Files: []*service.FilesItem{},
+				},
+			},
+		}
+	}
+
+	var files []*service.FilesItem
+	for _, item := range record.GetFiles().GetFiles() {
+		// TODO: support live policy?
+		if item.Policy == service.FilesItem_END || item.Policy == service.FilesItem_LIVE {
+			if _, ok := fh.savedFiles[item.Path]; !ok {
+				fh.savedFiles[item.Path] = nil
+				fh.final.GetFiles().Files = append(fh.final.GetFiles().Files, item)
+			}
+		} else {
+			files = append(files, item)
+		}
+	}
+
+	if files == nil {
+		return nil
+	}
+
+	// TODO: should we replace clone with something else?
+	rec := proto.Clone(record).(*service.Record)
+	rec.GetFiles().Files = files
+	return rec
+}
+
+func (fh *FileHandler) Final() *service.Record {
+	if fh == nil {
+		return nil
+	}
+	return fh.final
+}
+
+func NewFileHandler() *FileHandler {
+	return &FileHandler{
+		savedFiles: make(map[string]interface{}),
+	}
+}

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -564,6 +564,7 @@ func (h *Handler) handleFiles(record *service.Record) {
 			files = append(files, item)
 		}
 	}
+	// TODO: should we replace clone with somethign lighter?
 	rec := proto.Clone(record).(*service.Record)
 	rec.GetFiles().Files = files
 	h.sendRecord(rec)

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -555,9 +555,6 @@ func (h *Handler) handleFiles(record *service.Record) {
 	var files []*service.FilesItem
 	for _, item := range record.GetFiles().GetFiles() {
 		// TODO: support live policy?
-		if item.Policy == service.FilesItem_LIVE {
-			fmt.Printf("live policy is not supported yet, the file %s will be saved as end policy\n", item.Path)
-		}
 		if item.Policy == service.FilesItem_END || item.Policy == service.FilesItem_LIVE {
 			if _, ok := h.savedFiles[item.Path]; !ok {
 				h.savedFiles[item.Path] = nil
@@ -568,7 +565,7 @@ func (h *Handler) handleFiles(record *service.Record) {
 			files = append(files, item)
 		}
 	}
-	// TODO: should we replace clone with somethign lighter?
+	// TODO: should we replace clone with something lighter?
 	rec := proto.Clone(record).(*service.Record)
 	rec.GetFiles().Files = files
 	h.sendRecord(rec)

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -538,7 +538,6 @@ func (h *Handler) handleExit(record *service.Record, exit *service.RunExitRecord
 }
 
 func (h *Handler) handleFiles(record *service.Record) {
-	fmt.Printf("handleFiles: %v\n", record)
 	if record.GetFiles() == nil {
 		return
 	}

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -176,6 +176,10 @@ func (h *Handler) close() {
 }
 
 func (h *Handler) sendRecordWithControl(record *service.Record, controlOptions ...func(*service.Control)) {
+	if record == nil {
+		return
+	}
+
 	if record.GetControl() == nil {
 		record.Control = &service.Control{}
 	}
@@ -188,6 +192,9 @@ func (h *Handler) sendRecordWithControl(record *service.Record, controlOptions .
 }
 
 func (h *Handler) sendRecord(record *service.Record) {
+	if record == nil {
+		return
+	}
 	h.fwdChan <- record
 }
 

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -554,6 +554,10 @@ func (h *Handler) handleFiles(record *service.Record) {
 
 	var files []*service.FilesItem
 	for _, item := range record.GetFiles().GetFiles() {
+		// TODO: support live policy?
+		if item.Policy == service.FilesItem_LIVE {
+			fmt.Printf("live policy is not supported yet, the file %s will be saved as end policy\n", item.Path)
+		}
 		if item.Policy == service.FilesItem_END || item.Policy == service.FilesItem_LIVE {
 			if _, ok := h.savedFiles[item.Path]; !ok {
 				h.savedFiles[item.Path] = nil


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 094b530</samp>

Add caching for files with `END` or `LIVE` policy in `handler.go`. This improves the efficiency and consistency of file handling on the server.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f35fe91</samp>

> _Sing, O Muse, of the cunning Handler, who tracked the files_
> _That he sent to the cloud with swift and varied policies,_
> _And when his task was done, he sent a final message clear_
> _To tell the mighty backend all the deeds that he had wrought._
