### PR TITLE
build(nexus): add nexus proto gen to tox and make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1340,7 +1340,7 @@ workflows:
       - tox-base:
           name: "code-check"
           python_version_minor: 9
-          toxenv: "proto3-check,proto4-check,black-check,ruff-check,mypy,mypy-report,codecov-check,auto-codegen-check"
+          toxenv: "proto-3-check,proto-4-check,black-check,ruff-check,mypy,mypy-report,codecov-check,auto-codegen-check"
 
       #
       # Prep jobs

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,9 @@ format:
 	tox -e black
 
 proto:
-	tox -e proto3
-	tox -e proto4
+	tox -e proto-3
+	tox -e proto-4
+	tox -e proto-go
 
 isort:
 	isort -o wandb -o gql --force-sort-within-sections $(args)

--- a/tox.ini
+++ b/tox.ini
@@ -62,30 +62,32 @@ commands=
     check: python tools{/}coverage-tool.py check
     !{check}: python tools{/}coverage-tool.py {posargs:}
 
-[testenv:proto{3,4}{,-check}]
+[testenv:proto{-3,-4,-go}{,-check}]
 basepython=python3.9
 allowlist_externals=
     check: cp
     check: rm
     check: diff
+    go: bash
 deps=
-    proto3: mypy-protobuf==3.3.0
-    proto3: grpcio==1.46.3
-    proto3: grpcio-tools==1.46.3
-    proto4: mypy-protobuf==3.4.0
-    proto4: grpcio==1.50.0
-    proto4: grpcio-tools==1.50.0
-    packaging
+    proto-3: mypy-protobuf==3.3.0
+    proto-3: grpcio==1.46.3
+    proto-3: grpcio-tools==1.46.3
+    proto-4: mypy-protobuf==3.4.0
+    proto-4: grpcio==1.50.0
+    proto-4: grpcio-tools==1.50.0
+    !{go}: packaging
 changedir={toxinidir}/wandb/proto
 commands_pre=
     check: rm -rf {toxinidir}/wandb/proto_check
-    proto3-check: cp -r {toxinidir}/wandb/proto/v3 {toxinidir}/wandb/proto_check
-    proto4-check: cp -r {toxinidir}/wandb/proto/v4 {toxinidir}/wandb/proto_check
+    proto-3-check: cp -r {toxinidir}/wandb/proto/v3 {toxinidir}/wandb/proto_check
+    proto-4-check: cp -r {toxinidir}/wandb/proto/v4 {toxinidir}/wandb/proto_check
 commands=
-    python wandb_internal_codegen.py
+    !{go}: python wandb_internal_codegen.py
+    go: bash ../../nexus/scripts/generate-proto.sh
 commands_post=
-    proto3-check: diff {toxinidir}/wandb/proto/v3 {toxinidir}/wandb/proto_check/
-    proto4-check: diff {toxinidir}/wandb/proto/v4 {toxinidir}/wandb/proto_check/
+    proto-3-check: diff {toxinidir}/wandb/proto/v3 {toxinidir}/wandb/proto_check/
+    proto-4-check: diff {toxinidir}/wandb/proto/v4 {toxinidir}/wandb/proto_check/
 
 [testenv:auto-codegen{,-check}]
 basepython=python3


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10fd80d</samp>

This pull request adds support for generating protobuf files in Go and Python using tox. It also updates the `tox.ini`, `.circleci/config.yml`, and `Makefile` files to use consistent and readable toxenv names.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 10fd80d</samp>

> _Toxenvs of doom, unleash the proto power_
> _Generate the code, for Go and Python_
> _Hyphens of despair, make the names readable_
> _CircleCI, run the workflow of fire_
