### PR TITLE
build(nexus): streamline nexus build pipeline

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -7,6 +7,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-11]
 

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -21,11 +21,11 @@ jobs:
            package-dir: "nexus"
            output-dir: "nexus/wheelhouse"
         env:
-          CIBW_ENVIRONMENT: PATH=/tmp/go/bin:/usr/local/go/bin:$PATH
+          CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
 #          CIBW_ENVIRONMENT_MACOS: GOROOT=/tmp/go
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
 #          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
-          CIBW_BEFORE_ALL_MACOS: brew update && brew upgrade go
+          CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -22,7 +22,8 @@ jobs:
           platforms: all
 
       - name: Remove specific Go version
-        run: rmdir /s /q "C:\hostedtoolcache\windows\go"
+        if: runner.os == 'Windows'
+        run: Remove-Item -Path "C:\hostedtoolcache\windows\go" -Recurse -Force
 
       - name: Install Go 1.21 on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
-          CIBW_BUILD: cp38-manylinux_x86_64,cp39-manylinux_x86_64
+          CIBW_BUILD: "{cp38-manylinux_x86_64,cp39-manylinux_x86_64}"
           CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -26,7 +26,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
 #          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           # update brew and install go 1.21 on MAC:
-          CIBW_BEFORE_ALL_MACOS: brew update && brew unlink go@1.20 && brew install go@1.21
+          CIBW_BEFORE_ALL_MACOS: brew update && brew uninstall --force go && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -22,9 +22,8 @@ jobs:
            output-dir: "nexus/wheelhouse"
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
-#          CIBW_ENVIRONMENT_MACOS: GOROOT=/tmp/go
+          CIWN_ENVIRONMENT_WINDOWS: GOROOT=C:\Program Files\Go
           CIBW_BEFORE_ALL_LINUX: python nexus/scripts/build/install_go.py
-#          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang && refreshenv
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -52,6 +52,13 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BUILD_VERBOSITY: 3
 
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build --sdist nexus
+
       - uses: actions/upload-artifact@v3
         with:
-          path: ./nexus/wheelhouse/*.whl
+          path: |
+            ./nexus/wheelhouse/*.whl
+            ./nexus/dist/*.tar.gz

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -66,10 +66,12 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: wandb-core-distributions
           path: ./nexus/wheelhouse/*.whl
 
   publish:
     name: Publish to PyPI
+    environment: release
     needs: build_wheels
     runs-on: ubuntu-latest
 
@@ -84,10 +86,10 @@ jobs:
       - name: Download all the wheels
         uses: actions/download-artifact@v3
         with:
-          name: python-package-distributions
-          path: nexus/wheelhouse/
+          name: wandb-core-distributions
+          path: dist/
       - name: Publish distribution to TestPyPI
-        run: ls -l nexus/wheelhouse
+        run: ls -l dist/
 
 #        uses: pypa/gh-action-pypi-publish@release/v1
 #        with:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -22,9 +22,11 @@ jobs:
            output-dir: "nexus/wheelhouse"
         env:
           CIBW_ENVIRONMENT: PATH=/tmp/go/bin:/usr/local/go/bin:$PATH
-          CIBW_ENVIRONMENT_MACOS: GOROOT=/tmp/go
+#          CIBW_ENVIRONMENT_MACOS: GOROOT=/tmp/go
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
-          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
+#          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
+          # update brew and install go 1.21 on MAC:
+          CIBW_BEFORE_ALL_MACOS: brew update && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -21,11 +21,13 @@ jobs:
         with:
           platforms: all
 
+      - name: Remove specific Go version
+        run: rmdir /s /q "C:\hostedtoolcache\windows\go"
+
       - name: Install Go 1.21 on Windows
         if: runner.os == 'Windows'
         run: |
           choco upgrade golang
-          refreshenv
           go version
 
       - name: Build wheels

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,8 +27,9 @@ jobs:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
-          CIBW_BUILD: cp38-manylinux_x86_64
+          CIBW_BUILD: cp38-manylinux_x86_64, cp39-manylinux_x86_64
+          CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheelhouse/*.whl
+          path: ./nexus/wheelhouse/*.whl

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -22,6 +22,7 @@ jobs:
            output-dir: "nexus/wheelhouse"
         env:
           CIBW_ENVIRONMENT: PATH=/tmp/go/bin:/usr/local/go/bin:$PATH
+          CIBW_ENVIRONMENT_MACOS: GOROOT=/tmp/go
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -29,6 +29,7 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,7 +27,8 @@ jobs:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
-          CIBW_BUILD: "{cp37-manylinux_x86_64,cp38-manylinux_x86_64,cp39-manylinux_x86_64}"
+          CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
+          CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
           CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         with:
@@ -25,10 +31,11 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang && refreshenv
-          CIBW_BEFORE_BUILD_WINDOWS: refreshenv && GOROOT=C:\Program Files\Go && PATH=%GOROOT%\bin;%PATH%
+          CIBW_BEFORE_BUILD_WINDOWS: refreshenv && set "GOROOT=C:\Program Files\Go" && set "PATH=%GOROOT%\bin;%PATH%"
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
-          CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -69,19 +69,15 @@ jobs:
           name: wandb-core-distributions
           path: ./nexus/wheelhouse/*.whl
 
-  publish:
-    name: Publish to PyPI
-    environment: release
+  test-pypi-publish:
+    name: Publish to TestPyPI
     needs: build_wheels
     runs-on: ubuntu-latest
-
-#    environment:
-#      name: testpypi
-#      url: https://test.pypi.org/p/wandb-core
-#
-#    permissions:
-#      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
+    environment:
+      name: release
+      url: https://test.pypi.org/p/wandb-core-alpha
+    permissions:
+      id-token: write  # trusted publishing
     steps:
       - name: Download all the wheels
         uses: actions/download-artifact@v3
@@ -90,7 +86,6 @@ jobs:
           path: dist/
       - name: Publish distribution to TestPyPI
         run: ls -l dist/
-
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          repository-url: https://test.pypi.org/legacy/
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
-          CIBW_BUILD: "{cp38-manylinux_x86_64,cp39-manylinux_x86_64}"
+          CIBW_BUILD: "{cp37-manylinux_x86_64,cp38-manylinux_x86_64,cp39-manylinux_x86_64}"
           CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -21,9 +21,10 @@ jobs:
            package-dir: "nexus"
            output-dir: "nexus/wheelhouse"
         env:
-          CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin:/tmp/go/bin
+          CIBW_ENVIRONMENT: PATH=/tmp/go/bin:/usr/local/go/bin:$PATH
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
+          CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
           CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           platforms: all
 
+      - name: Install Go 1.21 on Windows
+        if: runner.os == 'Windows'
+        run: |
+          choco upgrade golang
+          refreshenv
+          go version
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         with:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -6,6 +6,7 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -13,10 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-#      - uses: actions/setup-go@v4
-#        with:
-#          go-version: '==1.21.0'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
@@ -26,10 +23,10 @@ jobs:
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
-          CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
+          CIBW_BEFORE_ALL_MACOS: brew install wget && python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64
           CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -21,7 +21,7 @@ jobs:
            package-dir: "nexus"
            output-dir: "nexus/wheelhouse"
         env:
-          CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
+          CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin:/tmp/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -32,7 +32,9 @@ jobs:
           echo "C:\Program Files\Go\bin" >> $env:GITHUB_PATH
 
       - name: Verify Go Version
-        run: go version
+        run: |
+          go version
+          gcc --version
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
-          CIBW_BUILD: cp38-manylinux_x86_64, cp39-manylinux_x86_64
+          CIBW_BUILD: cp38-manylinux_x86_64,cp39-manylinux_x86_64
           CIBW_BUILD_VERBOSITY: 3
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
-          CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
+          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
           CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -29,7 +29,6 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco upgrade golang
-          go version
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -26,7 +26,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
 #          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           # update brew and install go 1.21 on MAC:
-          CIBW_BEFORE_ALL_MACOS: brew update && brew install go@1.21
+          CIBW_BEFORE_ALL_MACOS: brew update && brew unlink go@1.20 && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -22,7 +22,7 @@ jobs:
            output-dir: "nexus/wheelhouse"
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
-          CIWN_ENVIRONMENT_WINDOWS: GOROOT=C:\Program Files\Go
+          CIWN_ENVIRONMENT_WINDOWS: GOROOT=C:\Program Files\Go && PATH=%GOROOT%\bin;%PATH%
           CIBW_BEFORE_ALL_LINUX: python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang && refreshenv

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -22,12 +22,11 @@ jobs:
         with:
            package-dir: "nexus"
            output-dir: "nexus/wheelhouse"
-#           config-file: "nexus/pyproject.toml"
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
-          CIBW_BUILD: cp38-manylinux_x86_64
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
+      #          CIBW_BUILD: cp38-manylinux_x86_64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Remove specific Go version
         if: runner.os == 'Windows'
-        run: Remove-Item -Path "C:\hostedtoolcache\windows\go" -Recurse -Force
+        run: cmd /c "rmdir /s /q C:\hostedtoolcache\windows\go"
 
       - name: Install Go 1.21 on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -52,16 +52,17 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BUILD_VERBOSITY: 3
 
-      - name: Build sdist
-        if: runner.os == 'Linux'
-        run: |
-          python -m pip install --upgrade build
-          python -m build --sdist nexus
-
-      - uses: actions/upload-artifact@v3
-        if: runner.os == 'Linux'
-        with:
-          path: ./nexus/dist/*.tar.gz
+# todo: build sdist
+#      - name: Build sdist
+#        if: runner.os == 'Linux'
+#        run: |
+#          python -m pip install --upgrade build
+#          python -m build --sdist nexus
+#
+#      - uses: actions/upload-artifact@v3
+#        if: runner.os == 'Linux'
+#        with:
+#          path: ./nexus/dist/*.tar.gz
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -67,3 +67,28 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./nexus/wheelhouse/*.whl
+
+  publish:
+    name: Publish to PyPI
+    needs: build_wheels
+    runs-on: ubuntu-latest
+
+#    environment:
+#      name: testpypi
+#      url: https://test.pypi.org/p/wandb-core
+#
+#    permissions:
+#      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: nexus/wheelhouse/
+      - name: Publish distribution to TestPyPI
+        run: ls -l nexus/wheelhouse
+
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -22,10 +22,10 @@ jobs:
            output-dir: "nexus/wheelhouse"
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
-          CIWN_ENVIRONMENT_WINDOWS: GOROOT=C:\Program Files\Go && PATH=%GOROOT%\bin;%PATH%
           CIBW_BEFORE_ALL_LINUX: python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
           CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang && refreshenv
+          CIBW_BEFORE_BUILD_WINDOWS: refreshenv && GOROOT=C:\Program Files\Go && PATH=%GOROOT%\bin;%PATH%
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
           CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -23,10 +23,10 @@ jobs:
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
 #          CIBW_ENVIRONMENT_MACOS: GOROOT=/tmp/go
-          CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
+          CIBW_BEFORE_ALL_LINUX: python nexus/scripts/build/install_go.py
 #          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
-          CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py
+          CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
           CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
-          CIBW_BEFORE_ALL_MACOS: brew install wget && python nexus/scripts/build/install_go.py
+          CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
           CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -29,6 +29,10 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco upgrade golang
+          echo "C:\Program Files\Go\bin" >> $env:GITHUB_PATH
+
+      - name: Verify Go Version
+        run: go version
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
@@ -39,7 +43,6 @@ jobs:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
-          CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang && refreshenv
           CIBW_BEFORE_BUILD_WINDOWS: refreshenv && set "GOROOT=C:\Program Files\Go" && set "PATH=%GOROOT%\bin;%PATH%"
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -84,8 +84,9 @@ jobs:
         with:
           name: wandb-core-distributions
           path: dist/
+      - name: List wheels
+        run: ls dist/
       - name: Publish distribution to TestPyPI
-        run: ls -l dist/
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -27,7 +27,7 @@ jobs:
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/go/bin
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: python nexus/scripts/build/install_go.py
-      #          CIBW_BUILD: cp38-manylinux_x86_64
+          CIBW_BUILD: cp38-manylinux_x86_64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -26,7 +26,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: python nexus/scripts/build/install_go.py
 #          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
           CIBW_BEFORE_ALL_MACOS: brew update && rm -f /usr/local/bin/go* && brew install go@1.21
-          CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang
+          CIBW_BEFORE_ALL_WINDOWS: choco upgrade golang && refreshenv
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*
           CIBW_ARCHS_LINUX: "x86_64"  # todo: add aarch64

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -53,12 +53,16 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Build sdist
+        if: runner.os == 'Linux'
         run: |
           python -m pip install --upgrade build
           python -m build --sdist nexus
 
       - uses: actions/upload-artifact@v3
+        if: runner.os == 'Linux'
         with:
-          path: |
-            ./nexus/wheelhouse/*.whl
-            ./nexus/dist/*.tar.gz
+          path: ./nexus/dist/*.tar.gz
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./nexus/wheelhouse/*.whl

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -1,6 +1,7 @@
 name: Build W&B SDK Core
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   build_wheels:
@@ -90,3 +91,42 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  verify-test-pypi:
+    name: Verify TestPyPI upload
+    needs: test-pypi-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install wandb-core from TestPyPI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://test.pypi.org/simple/ --pre wandb-core
+      - name: Install wandb from source
+        run: |
+          python -m pip install .
+      - name: Smoke-test wandb-core TestPyPI install
+        env:
+          WANDB_REQUIRE_NEXUS: true
+        run: |
+          python -c "import wandb; run = wandb.init(settings={'mode': 'offline'}); run.finish()"
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: test-pypi-publish
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/wandb-core
+    permissions:
+      id-token: write  # trusted publishing
+    steps:
+      - name: Download all the wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wandb-core-distributions
+          path: dist/
+      - name: List wheels
+        run: ls dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -25,8 +25,7 @@ jobs:
 #          CIBW_ENVIRONMENT_MACOS: GOROOT=/tmp/go
           CIBW_BEFORE_ALL_LINUX: yum install -y wget && python nexus/scripts/build/install_go.py
 #          CIBW_BEFORE_ALL_MACOS: python3 nexus/scripts/build/install_go.py
-          # update brew and install go 1.21 on MAC:
-          CIBW_BEFORE_ALL_MACOS: brew update && brew uninstall --force go && brew install go@1.21
+          CIBW_BEFORE_ALL_MACOS: brew update && brew upgrade go
           CIBW_BEFORE_ALL_WINDOWS: python nexus/scripts/build/install_go.py
           CIBW_BUILD: "{*x86_64,*arm64,*aarch64,*amd64}"
           CIBW_SKIP: cp36-* cp312-* pp* *musllinux*

--- a/nexus/README.md
+++ b/nexus/README.md
@@ -19,17 +19,16 @@ but starting from a clean slate.
 To install Nexus, you will need to run the following commands:
 
 ```bash
-pip install wandb[nexus]
+pip install "wandb[nexus]==0.16.0b1"
 ```
 
 ### Supported Platforms
 
 Nexus is currently supported on the following platforms:
 
-- Linux (`x86_64`)
-- macOS (`x86_64`)
-- macOS (`arm64`)
-- Windows (`x86_64`)
+- Linux:`x86_64`, `aarch64`
+- macOS: `x86_64`, `arm64`
+- Windows `amd64`
 
 If you are using a different platform, you can build Nexus from source by following the
 instructions in the [contributing guide](docs/contributing.md#installing-nexus).
@@ -39,7 +38,7 @@ your platform, and we will prioritize adding support for it.
 
 ## Usage example
 
-While Nexus is still in development, you need to explicitly opt-in to use it.
+While Nexus is still in development, you need to explicitly opt in to use it.
 
 ```python
 import wandb
@@ -64,53 +63,52 @@ if you encounter an error and mention that you are using Nexus.
 ## Feature Parity Status
 
 The following table shows the status of feature parity
-between the current W&B SDK and Nexus for version `0.16.0beta1`.
+between the current W&B SDK and Nexus for version `0.16.0b1`.
 
 Status legend:
 - ✅: Available: The feature is relatively stable and ready for use.
 - 🚧: In Development: The feature is available, but may be unstable or incomplete.
 - ❌: Not Available: The feature is not yet available.
 
-| Category    | Feature           | Status         |
-|-------------|-------------------|----------------|
-| Experiments |                   |                |
+| Category    | Feature           | Status                |
+|-------------|-------------------|-----------------------|
+| Experiments |                   |                       |
 |             | `init`            | ✅[^E.1][^E.10][^E.11] |
-|             | `log`             | ✅[^E.2]        |
-|             | `log_artifact`    | ❌[^E.3]        |
-|             | `log_code`        | ❌[^E.4]        |
-|             | `config`          | ✅              |
-|             | `summary`         | ✅              |
-|             | `define_metric`   | 🚧[^E.5]       |
-|             | `tags`            | ✅              |
-|             | `notes`           | ✅              |
-|             | `name`            | ✅              |
-|             | `alert`           | ✅              |
-|             | `save`            | 🚧[^E.6]       |
-|             | `restore`         | ✅              |
-|             | `mark_preempting` | ✅              |
-|             | resume            | ✅              |
-|             | reinit            | ✅              |
-|             | Media             | 🚧[^E.7]       |
-|             | Grouping          | ✅              |
-|             | anonymous mode    | ✅              |
-|             | offline mode      | ✅              |
-|             | disabled mode     | ✅              |
-|             | multiprocessing   | ✅              |
-|             | TensorBoard sync  | ❌              |
-|             | console logging   | 🚧[^E.8]       |
-|             | system metrics    | 🚧[^E.9]       |
-|             | system info       | ✅              |
-|             | code saving       | 🚧[^E.11]      |
-|             | Settings          | 🚧[^E.12]      |
-| Login       |                   |                |
-|             | default entity    | ✅              |
-|             | team entity       | ✅              |
-|             | service account   | ✅              |
-| Public API  |                   | 🚧[^PA.1]      |
-| CLI         |                   | 🚧[^CLI.1]     |
-| Artifacts   |                   | ❌[^A.1]        |
-| Launch      |                   | ❌[^L.1]        |
-| Sweeps      |                   | 🚧[^S.1]       |
+|             | `log`             | ✅[^E.2]               |
+|             | `log_artifact`    | ❌[^E.3]               |
+|             | `log_code`        | ❌[^E.4]               |
+|             | `config`          | ✅                     |
+|             | `summary`         | ✅                     |
+|             | `define_metric`   | 🚧[^E.5]              |
+|             | `tags`            | ✅                     |
+|             | `notes`           | ✅                     |
+|             | `name`            | ✅                     |
+|             | `alert`           | ✅                     |
+|             | `save`            | 🚧[^E.6]              |
+|             | `restore`         | ✅                     |
+|             | `mark_preempting` | ✅                     |
+|             | resume            | ✅                     |
+|             | reinit            | ✅                     |
+|             | Media             | 🚧[^E.7]              |
+|             | Grouping          | ✅                     |
+|             | anonymous mode    | ✅                     |
+|             | offline mode      | ✅                     |
+|             | disabled mode     | ✅                     |
+|             | multiprocessing   | ✅                     |
+|             | TensorBoard sync  | ❌                     |
+|             | console logging   | 🚧[^E.8]              |
+|             | system metrics    | 🚧[^E.9]              |
+|             | system info       | ✅                     |
+|             | code saving       | 🚧[^E.11]             |
+|             | Settings          | 🚧[^E.12]             |
+| Login       |                   |                       |
+|             | default entity    | ✅                     |
+|             | team entity       | ✅                     |
+|             | service account   | ✅                     |
+| CLI         |                   | 🚧[^CLI.1]            |
+| Artifacts   |                   | ❌[^A.1]               |
+| Launch      |                   | ❌[^L.1]               |
+| Sweeps      |                   | 🚧[^S.1]              |
 
 [^E.1]: `sync_tensorboard` requires TensorBoard support.
 [^E.2]: `wandb.Table` is not supported. Requires Artifacts support.
@@ -125,8 +123,6 @@ Status legend:
 [^E.11]: Automatic code saving in Notebooks is not yet supported. Requires Artifacts support.
 [^E.12]: TODO: list unsupported settings.
     (`anonymous`, `_flow_control*`, `_stats_open_metrics_endpoints`, ...)
-[^PA.1]: The public API works, but uses the current Python backend under the hood.
-    Expect the public API to be rewritten to use the new backend.
 [^CLI.1]: The CLI works, but uses the current Python backend under the hood for some
     commands. Expect the CLI to be rewritten to use the new backend.
 [^A.1]: Artifacts support is not yet available. Expect Artifacts to be supported soon.

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -7,7 +7,13 @@ VERSION = "1.21.1"
 
 def go_get_go():
     system = platform.system().lower()
-    machine = platform.machine().lower().replace("x86_64", "amd64")
+    machine = platform.machine().lower()
+    if machine == "x86_64":
+        machine = "amd64"
+    elif machine == "aarch64":
+        machine = "arm64"
+    elif machine == "armv7l":
+        machine = "armv6l"
     extension = "tar.gz" if system != "windows" else "msi"
     out_path = "/usr/local" if system != "windows" else "C:\\Go"
 

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -13,13 +13,16 @@ def go_get_go():
 
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 
+    print(f"Downloading {file_name}")
     subprocess.check_call(["wget", f"https://golang.org/dl/{file_name}"])
 
     if system != "windows":
         if not os.path.exists(out_path):
             os.makedirs(out_path)
+        print(f"Extracting {file_name}")
         subprocess.check_call(["tar", "-C", out_path, "-xzf", file_name])
     else:
+        print(f"Installing {file_name}")
         subprocess.check_call(["msiexec", "/i", file_name, "/quiet"])
 
 

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import subprocess
 
@@ -15,6 +16,8 @@ def go_get_go():
     subprocess.check_call(["wget", f"https://golang.org/dl/{file_name}"])
 
     if system != "windows":
+        if not os.path.exists(out_path):
+            os.makedirs(out_path)
         subprocess.check_call(["tar", "-C", out_path, "-xzf", file_name])
     else:
         subprocess.check_call(["msiexec", "/i", file_name, "/quiet"])

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -1,16 +1,28 @@
+import platform
 import subprocess
 
 VERSION = "1.21.1"
 
 
 def go_get_go():
+    system = platform.system().lower()
+    machine = platform.machine().lower().replace("x86_64", "amd64")
+    extension = "tar.gz" if system != "windows" else "zip"
+
+    file_name = f"go{VERSION}.{system}-{machine}.{extension}"
+
     subprocess.check_call(
-        ["wget", f"https://golang.org/dl/go{VERSION}.linux-amd64.tar.gz"]
+        ["wget", f"https://golang.org/dl/{file_name}"]
     )
-    subprocess.check_call(
-        ["tar", "-C", "/usr/local", "-xzf", f"go{VERSION}.linux-amd64.tar.gz"]
-    )
-    subprocess.check_call(["rm", f"go{VERSION}.linux-amd64.tar.gz"])
+
+    if system != "windows":
+        subprocess.check_call(
+            ["tar", "-C", "/usr/local", "-xzf", file_name]
+        )
+    else:
+        subprocess.check_call(
+            ["unzip", file_name, "-d", "/usr/local"]
+        )
 
 
 if __name__ == "__main__":

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -14,7 +14,7 @@ def go_get_go():
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 
     print(f"Downloading {file_name}")
-    subprocess.check_call(["curl", "-L", f"https://golang.org/dl/{file_name}"])
+    subprocess.check_call(["curl", f"https://golang.org/dl/{file_name}"])
 
     if system != "windows":
         if not os.path.exists(out_path):

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -17,6 +17,7 @@ def go_get_go():
     subprocess.check_call(
         [
             "curl",
+            "-L",
             f"https://golang.org/dl/{file_name}",
             "-o",
             file_name,

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -11,18 +11,12 @@ def go_get_go():
 
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 
-    subprocess.check_call(
-        ["wget", f"https://golang.org/dl/{file_name}"]
-    )
+    subprocess.check_call(["wget", f"https://golang.org/dl/{file_name}"])
 
     if system != "windows":
-        subprocess.check_call(
-            ["tar", "-C", "/usr/local", "-xzf", file_name]
-        )
+        subprocess.check_call(["tar", "-C", "/usr/local", "-xzf", file_name])
     else:
-        subprocess.check_call(
-            ["unzip", file_name, "-d", "/usr/local"]
-        )
+        subprocess.check_call(["unzip", file_name, "-d", "/usr/local"])
 
 
 if __name__ == "__main__":

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -9,7 +9,7 @@ def go_get_go():
     system = platform.system().lower()
     machine = platform.machine().lower().replace("x86_64", "amd64")
     extension = "tar.gz" if system != "windows" else "msi"
-    out_path = "/usr/local" if system == "Linux" else "/tmp/go"
+    out_path = "/usr/local" if system == "linux" else "/tmp/go"
 
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -14,7 +14,7 @@ def go_get_go():
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 
     print(f"Downloading {file_name}")
-    subprocess.check_call(["wget", f"https://golang.org/dl/{file_name}"])
+    subprocess.check_call(["curl", "-L", f"https://golang.org/dl/{file_name}"])
 
     if system != "windows":
         if not os.path.exists(out_path):

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -9,7 +9,7 @@ def go_get_go():
     system = platform.system().lower()
     machine = platform.machine().lower().replace("x86_64", "amd64")
     extension = "tar.gz" if system != "windows" else "msi"
-    out_path = "/usr/local" if system == "linux" else "/tmp/go"
+    out_path = "/usr/local" if system != "windows" else "C:\\Go"
 
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 
@@ -24,9 +24,10 @@ def go_get_go():
         ]
     )
 
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
     if system != "windows":
-        if not os.path.exists(out_path):
-            os.makedirs(out_path)
         print(f"Extracting {file_name}")
         subprocess.check_call(["tar", "-C", out_path, "-xzf", file_name])
     else:

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -7,16 +7,17 @@ VERSION = "1.21.1"
 def go_get_go():
     system = platform.system().lower()
     machine = platform.machine().lower().replace("x86_64", "amd64")
-    extension = "tar.gz" if system != "windows" else "zip"
+    extension = "tar.gz" if system != "windows" else "msi"
+    out_path = "/usr/local" if system == "Linux" else "/tmp/go"
 
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 
     subprocess.check_call(["wget", f"https://golang.org/dl/{file_name}"])
 
     if system != "windows":
-        subprocess.check_call(["tar", "-C", "/usr/local", "-xzf", file_name])
+        subprocess.check_call(["tar", "-C", out_path, "-xzf", file_name])
     else:
-        subprocess.check_call(["unzip", file_name, "-d", "/usr/local"])
+        subprocess.check_call(["msiexec", "/i", file_name, "/quiet"])
 
 
 if __name__ == "__main__":

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -14,7 +14,13 @@ def go_get_go():
     file_name = f"go{VERSION}.{system}-{machine}.{extension}"
 
     print(f"Downloading {file_name}")
-    subprocess.check_call(["curl", f"https://golang.org/dl/{file_name}"])
+    subprocess.check_call(
+        [
+            "curl",
+            f"https://golang.org/dl/{file_name}",
+            "-o", file_name,
+        ]
+    )
 
     if system != "windows":
         if not os.path.exists(out_path):

--- a/nexus/scripts/build/install_go.py
+++ b/nexus/scripts/build/install_go.py
@@ -18,7 +18,8 @@ def go_get_go():
         [
             "curl",
             f"https://golang.org/dl/{file_name}",
-            "-o", file_name,
+            "-o",
+            file_name,
         ]
     )
 

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -64,7 +64,9 @@ class NexusBase:
             .strip()
         )
 
-        ldflags = f"-s -w -X main.commit={commit}"
+        ldflags = f'-s -w -X main.commit={commit}'
+        if f"{goos}-{goarch}" in PLATFORMS_TO_BUILD_WITH_CGO and goos == "linux":
+            ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
         cmd = (
             "go",
             "build",

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -107,7 +107,9 @@ if __name__ == "__main__":
     setup(
         name="wandb-core" if not _is_wandb_core_alpha else "wandb-core-alpha",
         version=NEXUS_VERSION,
-        description="Wandb core",
+        description="W&B Core Library",
+        long_description=open("README.md").read(),
+        long_description_content_type="text/markdown",
         packages=[PACKAGE],
         zip_safe=False,
         include_package_data=True,

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -18,7 +18,7 @@ _is_wandb_core_alpha = bool(os.environ.get(_WANDB_CORE_ALPHA_ENV))
 
 # Nexus version
 # -------------
-NEXUS_VERSION = "0.16.0beta1"
+NEXUS_VERSION = "0.16.0b1"
 
 
 PACKAGE: str = "wandb_core"

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -66,8 +66,8 @@ class NexusBase:
 
         ldflags = f"-s -w -X main.commit={commit}"
         if f"{goos}-{goarch}" == "linux-amd64":
-            # ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
-            ldflags += ' -extldflags "-fuse-ld=lld"'
+            # todo: try llvm's lld linker
+            ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
         cmd = (
             "go",
             "build",

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -64,7 +64,7 @@ class NexusBase:
             .strip()
         )
 
-        ldflags = f'-s -w -X main.commit={commit}'
+        ldflags = f"-s -w -X main.commit={commit}"
         if f"{goos}-{goarch}" in PLATFORMS_TO_BUILD_WITH_CGO and goos == "linux":
             ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
         cmd = (

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -66,7 +66,8 @@ class NexusBase:
 
         ldflags = f"-s -w -X main.commit={commit}"
         if f"{goos}-{goarch}" == "linux-amd64":
-            ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
+            # ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
+            ldflags += ' -extldflags "-fuse-ld=lld"'
         cmd = (
             "go",
             "build",

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -65,7 +65,7 @@ class NexusBase:
         )
 
         ldflags = f"-s -w -X main.commit={commit}"
-        if f"{goos}-{goarch}" in PLATFORMS_TO_BUILD_WITH_CGO and goos == "linux":
+        if f"{goos}-{goarch}" == "linux-amd64":
             ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
         cmd = (
             "go",

--- a/nexus/wandb_core/__init__.py
+++ b/nexus/wandb_core/__init__.py
@@ -1,6 +1,10 @@
-"""nexus."""
+"""W&B Nexus: Calcium-Rich Bones for the SDK."""
+__all__ = ("__version__", "get_nexus_path")
 
 from pathlib import Path
+
+
+__version__ = "0.16.0b1"
 
 
 def get_nexus_path() -> Path:

--- a/nexus/wandb_core/__init__.py
+++ b/nexus/wandb_core/__init__.py
@@ -3,7 +3,6 @@ __all__ = ("__version__", "get_nexus_path")
 
 from pathlib import Path
 
-
 __version__ = "0.16.0b1"
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,19 +7,7 @@ NEXUS_VERSION = "0.16.0b1"
 
 @nox.session(python=False, name="build-nexus")
 def build_nexus(session):
-    """Builds the nexus binary for the current platform.
-
-    Usage: nox -s build-nexus [target_system]
-
-    target_system: The target system to build for. Defaults to the current system.
-                   Use format: <system>-<arch> (e.g. linux-amd64, darwin-arm64)
-                   Use "all" to build for all known platforms.
-    """
-    # if session.posargs:
-    #     session.posargs[0]
-    # else:
-    #     platform.system().lower()
-    #     "amd64" if platform.machine() == "x86_64" else platform.machine()
+    """Builds the nexus binary for the current platform."""
     session.run(
         "python",
         "-m",
@@ -28,7 +16,6 @@ def build_nexus(session):
         "-n",  # disable building the project in an isolated virtual environment
         "-x",  # do not check that build dependencies are installed
         "./nexus",
-        # f"-C--build-option=bdist_wheel --nexus-build={target_system}",
         external=True,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,8 @@ def install_nexus(session):
     """Installs the nexus wheel into the current environment."""
     # get the wheel file in ./nexus/dist/:
     wheel_file = [
-        f for f in os.listdir("./nexus/dist/")
+        f
+        for f in os.listdir("./nexus/dist/")
         if f.startswith(f"wandb_core-{NEXUS_VERSION}") and f.endswith(".whl")
     ][0]
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-NEXUS_VERSION = "0.16.0beta1"
+NEXUS_VERSION = "0.16.0b1"
 
 
 @nox.session(python=False, name="build-nexus")
@@ -38,7 +38,7 @@ def install_nexus(session):
         "pip",
         "install",
         "--force-reinstall",
-        f"./nexus/dist/wandb_core-{NEXUS_VERSION}-py3-none-any.whl",
+        f"./nexus/dist/wandb_core-{NEXUS_VERSION}-py3-none-macosx_12_0_arm64.whl",
         external=True,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,12 +15,11 @@ def build_nexus(session):
                    Use format: <system>-<arch> (e.g. linux-amd64, darwin-arm64)
                    Use "all" to build for all known platforms.
     """
-    if session.posargs:
-        target_system = session.posargs[0]
-    else:
-        system = platform.system().lower()
-        arch = "amd64" if platform.machine() == "x86_64" else platform.machine()
-        target_system = f"{system}-{arch}"
+    # if session.posargs:
+    #     session.posargs[0]
+    # else:
+    #     platform.system().lower()
+    #     "amd64" if platform.machine() == "x86_64" else platform.machine()
     session.run(
         "python",
         "-m",

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,3 @@
-import platform
-
 import nox
 
 NEXUS_VERSION = "0.16.0beta1"

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ def build_nexus(session):
         "-n",  # disable building the project in an isolated virtual environment
         "-x",  # do not check that build dependencies are installed
         "./nexus",
-        f"-C--build-option=bdist_wheel --nexus-build={target_system}",
+        # f"-C--build-option=bdist_wheel --nexus-build={target_system}",
         external=True,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+import os
+
 import nox
 
 NEXUS_VERSION = "0.16.0b1"
@@ -34,11 +36,16 @@ def build_nexus(session):
 @nox.session(python=False, name="install-nexus")
 def install_nexus(session):
     """Installs the nexus wheel into the current environment."""
+    # get the wheel file in ./nexus/dist/:
+    wheel_file = [
+        f for f in os.listdir("./nexus/dist/")
+        if f.startswith(f"wandb_core-{NEXUS_VERSION}") and f.endswith(".whl")
+    ][0]
     session.run(
         "pip",
         "install",
         "--force-reinstall",
-        f"./nexus/dist/wandb_core-{NEXUS_VERSION}-py3-none-macosx_12_0_arm64.whl",
+        f"./nexus/dist/{wheel_file}",
         external=True,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,9 @@ launch = [
 models = ["cloudpickle"]
 async = ["httpx>=0.22.0"] # 0.23.0 dropped Python 3.6; we can upgrade once we drop it too
 perf = ["orjson"]
-nexus = ["wandb-core==0.16.0beta1"]  # todo: sync versions
+nexus = [
+    "wandb-core>=0.16.0b1"
+]
 
 [tool.setuptools]
 zip-safe = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.0b1
+current_version = 0.15.11.dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.16.0b1"
+__version__ = "0.15.11.dev1"
 _minimum_nexus_version = "0.16.0b1"
 
 # Used with pypi checks and other messages related to pip

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -12,6 +12,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
 __version__ = "0.16.0b1"
+_minimum_nexus_version = "0.16.0b1"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -193,7 +193,7 @@ def get_docker(
     return env.get(DOCKER, default)
 
 
-def get_http_timeout(default: int = 30, env: Optional[Env] = None) -> int:
+def get_http_timeout(default: int = 20, env: Optional[Env] = None) -> int:
     if env is None:
         env = os.environ
 

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -14,6 +14,7 @@ import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from wandb import _sentry
+from wandb.env import error_reporting_enabled
 from wandb.errors import Error
 from wandb.util import get_module
 
@@ -176,6 +177,8 @@ class _Service:
                     )
                     nexus_path = wandb_nexus.get_nexus_path()
                 service_args.extend([nexus_path])
+                if not error_reporting_enabled():
+                    service_args.append("--no-observability")
                 exec_cmd_list = []
             else:
                 service_args.extend(["wandb", "service"])

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from wandb import _sentry, _minimum_nexus_version
+from wandb import _minimum_nexus_version, _sentry
 from wandb.env import error_reporting_enabled
 from wandb.errors import Error
 from wandb.util import get_module
@@ -53,7 +53,6 @@ def _check_nexus_version_compatibility(nexus_version: str) -> None:
             f"Requires wandb-core version {_minimum_nexus_version} or later, "
             f"but you have {nexus_version}. Run `pip install --upgrade wandb[nexus]` to upgrade."
         )
-
 
 
 class _Service:

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from wandb import _sentry
+from wandb import _sentry, _minimum_nexus_version
 from wandb.env import error_reporting_enabled
 from wandb.errors import Error
 from wandb.util import get_module
@@ -42,6 +42,18 @@ class ServiceStartPortError(Error):
     """Raised when service start fails to find a port."""
 
     pass
+
+
+def _check_nexus_version_compatibility(nexus_version: str) -> None:
+    """Checks if the installed nexus version is compatible with the wandb version."""
+    from pkg_resources import parse_version
+
+    if parse_version(nexus_version) < parse_version(_minimum_nexus_version):
+        raise ImportError(
+            f"Requires wandb-core version {_minimum_nexus_version} or later, "
+            f"but you have {nexus_version}. Run `pip install --upgrade wandb[nexus]` to upgrade."
+        )
+
 
 
 class _Service:
@@ -175,6 +187,7 @@ class _Service:
                         "wandb_core",
                         required="The nexus experiment requires the wandb_core module.",
                     )
+                    _check_nexus_version_compatibility(wandb_nexus.__version__)
                     nexus_path = wandb_nexus.get_nexus_path()
                 service_args.extend([nexus_path])
                 if not error_reporting_enabled():


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Setting the stage for the first Nexus Beta release.

Accompanying wandb version bump for the beta release: https://github.com/wandb/wandb/pull/6298

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b99724</samp>

This pull request updates and simplifies the nexus package, which provides a binary interface for the wandb SDK. It aligns the nexus version with the SDK version, removes redundant or unused code, and adds a GitHub workflow to build the nexus wheel for different platforms using cibuildwheel. It also updates the documentation and the versioning tools to reflect the changes. The affected files are `nexus/README.md`, `nexus/setup.py`, `.github/workflows/build-core.yml`, `nexus/MANIFEST.in`, `nexus/pkg/server/sender.go`, `nexus/wandb_core/__init__.py`, `noxfile.py`, `pyproject.toml`, `setup.cfg`, and `wandb/__init__.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ed993d8</samp>

> _We build the nexus wheel of doom_
> _With `cibuildwheel` and `QEMU`_
> _We update the version and the code_
> _We unleash the power of the `wandb_core`_