### PR TITLE
refactor(artifacts): split file

### DIFF
--- a/nexus/pkg/artifacts/linker.go
+++ b/nexus/pkg/artifacts/linker.go
@@ -1,0 +1,72 @@
+package artifacts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Khan/genqlient/graphql"
+
+	"github.com/wandb/wandb/nexus/internal/gql"
+	"github.com/wandb/wandb/nexus/pkg/observability"
+	"github.com/wandb/wandb/nexus/pkg/service"
+)
+
+type ArtifactLinker struct {
+	Ctx           context.Context
+	Logger        *observability.NexusLogger
+	LinkArtifact  *service.LinkArtifactRecord
+	GraphqlClient graphql.Client
+}
+
+func (al *ArtifactLinker) Link() error {
+	client_id := al.LinkArtifact.ClientId
+	server_id := al.LinkArtifact.ServerId
+	portfolio_name := al.LinkArtifact.PortfolioName
+	portfolio_entity := al.LinkArtifact.PortfolioEntity
+	portfolio_project := al.LinkArtifact.PortfolioProject
+	portfolio_aliases := []gql.ArtifactAliasInput{}
+
+	for _, alias := range al.LinkArtifact.PortfolioAliases {
+		portfolio_aliases = append(portfolio_aliases,
+			gql.ArtifactAliasInput{
+				ArtifactCollectionName: portfolio_name,
+				Alias:                  alias,
+			},
+		)
+	}
+	var err error
+	var response *gql.LinkArtifactResponse
+	switch {
+	case server_id != "":
+		response, err = gql.LinkArtifact(
+			al.Ctx,
+			al.GraphqlClient,
+			portfolio_name,
+			portfolio_entity,
+			portfolio_project,
+			portfolio_aliases,
+			nil,
+			&server_id,
+		)
+	case client_id != "":
+		response, err = gql.LinkArtifact(
+			al.Ctx,
+			al.GraphqlClient,
+			portfolio_name,
+			portfolio_entity,
+			portfolio_project,
+			portfolio_aliases,
+			&client_id,
+			nil,
+		)
+	default:
+		err = fmt.Errorf("LinkArtifact: %s, error: artifact must have either server id or client id", portfolio_name)
+		al.Logger.CaptureFatalAndPanic("linkArtifact", err)
+	}
+	if err != nil {
+		err = fmt.Errorf("LinkArtifact: %s, error: %+v response: %+v", portfolio_name, err, response)
+		al.Logger.CaptureFatalAndPanic("linkArtifact", err)
+		return err
+	}
+	return nil
+}

--- a/nexus/pkg/artifacts/saver.go
+++ b/nexus/pkg/artifacts/saver.go
@@ -46,13 +46,6 @@ type ManifestV1 struct {
 	Contents            map[string]ManifestEntry    `json:"contents"`
 }
 
-type ArtifactLinker struct {
-	Ctx           context.Context
-	Logger        *observability.NexusLogger
-	LinkArtifact  *service.LinkArtifactRecord
-	GraphqlClient graphql.Client
-}
-
 func computeB64MD5(manifestFile string) (string, error) {
 	file, err := os.ReadFile(manifestFile)
 	if err != nil {
@@ -256,57 +249,4 @@ func (as *ArtifactSaver) Save() (ArtifactSaverResult, error) {
 	as.commitArtifact(artifactId)
 
 	return ArtifactSaverResult{ArtifactId: artifactId}, nil
-}
-
-func (al *ArtifactLinker) Link() error {
-	client_id := al.LinkArtifact.ClientId
-	server_id := al.LinkArtifact.ServerId
-	portfolio_name := al.LinkArtifact.PortfolioName
-	portfolio_entity := al.LinkArtifact.PortfolioEntity
-	portfolio_project := al.LinkArtifact.PortfolioProject
-	portfolio_aliases := []gql.ArtifactAliasInput{}
-
-	for _, alias := range al.LinkArtifact.PortfolioAliases {
-		portfolio_aliases = append(portfolio_aliases,
-			gql.ArtifactAliasInput{
-				ArtifactCollectionName: portfolio_name,
-				Alias:                  alias,
-			},
-		)
-	}
-	var err error
-	var response *gql.LinkArtifactResponse
-	switch {
-	case server_id != "":
-		response, err = gql.LinkArtifact(
-			al.Ctx,
-			al.GraphqlClient,
-			portfolio_name,
-			portfolio_entity,
-			portfolio_project,
-			portfolio_aliases,
-			nil,
-			&server_id,
-		)
-	case client_id != "":
-		response, err = gql.LinkArtifact(
-			al.Ctx,
-			al.GraphqlClient,
-			portfolio_name,
-			portfolio_entity,
-			portfolio_project,
-			portfolio_aliases,
-			&client_id,
-			nil,
-		)
-	default:
-		err = fmt.Errorf("LinkArtifact: %s, error: artifact must have either server id or client id", portfolio_name)
-		al.Logger.CaptureFatalAndPanic("linkArtifact", err)
-	}
-	if err != nil {
-		err = fmt.Errorf("LinkArtifact: %s, error: %+v response: %+v", portfolio_name, err, response)
-		al.Logger.CaptureFatalAndPanic("linkArtifact", err)
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
Fixes WB-13717

# Description

Moved `ArtifactSaver` and `ArtifactLinker` into separate files.

# Test plan

Created an artifact, observed the artifact saver was correctly called (but failed as before, since it's not fully implemented):
<img width="1226" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/58784f6f-eed5-420a-8593-db17b4f010cf">