### PR TITLE
fix(public-api): use json.loads(..., strict=False) to ignore invalid utf-8 and control characters in api.Run.load

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1992,11 +1992,18 @@ class Run(Attrs):
                     withRuns=False,
                 )
 
-        self._attrs["summaryMetrics"] = (
-            json.loads(self._attrs["summaryMetrics"])
-            if self._attrs.get("summaryMetrics")
-            else {}
-        )
+        try:
+            self._attrs["summaryMetrics"] = (
+                json.loads(self._attrs["summaryMetrics"])
+                if self._attrs.get("summaryMetrics")
+                else {}
+            )
+        except json.decoder.JSONDecodeError:
+            # ignore invalid utf-8 or control characters
+            self._attrs["summaryMetrics"] = json.loads(
+                self._attrs["summaryMetrics"],
+                strict=False,
+            )
         self._attrs["systemMetrics"] = (
             json.loads(self._attrs["systemMetrics"])
             if self._attrs.get("systemMetrics")

--- a/wandb/sdk/lib/json_util.py
+++ b/wandb/sdk/lib/json_util.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import re
 from typing import Any, Union
 
 logger = logging.getLogger(__name__)
@@ -79,10 +78,3 @@ try:
 
 except ImportError:
     from json import dump, dumps, load, loads  # type: ignore[assignment] # noqa: F401
-
-
-def clean_invalid_utf8_and_control_chars(data: str) -> str:
-    # Replace invalid UTF-8 characters
-    cleaned_data = data.encode('utf-8', 'replace').decode('utf-8')
-    # Remove control characters
-    return re.sub(r'[\x00-\x1F]+', '<WANDB:REPLACED_CONTROL_CHARS>', cleaned_data)

--- a/wandb/sdk/lib/json_util.py
+++ b/wandb/sdk/lib/json_util.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from typing import Any, Union
 
 logger = logging.getLogger(__name__)
@@ -78,3 +79,10 @@ try:
 
 except ImportError:
     from json import dump, dumps, load, loads  # type: ignore[assignment] # noqa: F401
+
+
+def clean_invalid_utf8_and_control_chars(data: str) -> str:
+    # Replace invalid UTF-8 characters
+    cleaned_data = data.encode('utf-8', 'replace').decode('utf-8')
+    # Remove control characters
+    return re.sub(r'[\x00-\x1F]+', '<WANDB:REPLACED_CONTROL_CHARS>', cleaned_data)


### PR DESCRIPTION
Fixes
-----
- Fixes WB-15459

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd2a358</samp>

Fix a bug where some runs fail to load due to invalid JSON data in `summaryMetrics`. Use `json.loads` with `strict=False` to handle invalid characters in `wandb/apis/public.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fd2a358</samp>

> _`summaryMetrics`_
> _Invalid JSON data_
> _Fall leaves the run broken_
