### PR TITLE
build(nexus): fix reading readme on windows

### DIFF
--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         name="wandb-core" if not _is_wandb_core_alpha else "wandb-core-alpha",
         version=NEXUS_VERSION,
         description="W&B Core Library",
-        long_description=open("README.md").read(),
+        long_description=open("README.md", encoding="utf-8").read(),
         long_description_content_type="text/markdown",
         packages=[PACKAGE],
         zip_safe=False,


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6dc2d05</samp>

Fixed a possible encoding issue when reading `README.md` in `nexus/setup.py`. Enhanced the cross-platform reliability of the installation script.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6dc2d05</samp>

> _`open` with utf-8_
> _avoids errors in setup_
> _autumn of coding_
