### PR TITLE
fix(sdk): correctly identify colab as a jupyter-like env in settings

### DIFF
--- a/wandb/sdk/lib/ipython.py
+++ b/wandb/sdk/lib/ipython.py
@@ -42,13 +42,11 @@ def _get_python_type() -> PythonType:
 
     # jupyter-based environments (e.g. jupyter itself, colab, kaggle, etc) have a connection file
     ip_kernel_app_connection_file = (
-        (
-            get_ipython().config.get(
-                "IPKernelApp",
-                get_ipython().config.get("ColabKernelApp", {}),
-            )
-            or {}
-        )
+        (get_ipython().config.get("IPKernelApp", {}) or {})
+        .get("connection_file", "")
+        .lower()
+    ) or (
+        (get_ipython().config.get("ColabKernelApp", {}) or {})
         .get("connection_file", "")
         .lower()
     )

--- a/wandb/sdk/lib/ipython.py
+++ b/wandb/sdk/lib/ipython.py
@@ -40,9 +40,14 @@ def _get_python_type() -> PythonType:
     except ImportError:
         return "python"
 
-    # jupyter-based environments (e.g. jupyter itself, colab, kaggle, etc) have a connection file
+    # jupyter-based environments (e.g. jupyter itself, kaggle, etc) have a connection file
     ip_kernel_app_connection_file = (
-        (get_ipython().config.get("IPKernelApp", {}) or {})
+        (
+            get_ipython().config.get(
+                "IPKernelApp",
+                get_ipython().config.get("ColabKernelApp", {}),
+            ) or {}
+        )
         .get("connection_file", "")
         .lower()
     )

--- a/wandb/sdk/lib/ipython.py
+++ b/wandb/sdk/lib/ipython.py
@@ -40,7 +40,7 @@ def _get_python_type() -> PythonType:
     except ImportError:
         return "python"
 
-    # jupyter-based environments (e.g. jupyter itself, kaggle, etc) have a connection file
+    # jupyter-based environments (e.g. jupyter itself, colab, kaggle, etc) have a connection file
     ip_kernel_app_connection_file = (
         (
             get_ipython().config.get(

--- a/wandb/sdk/lib/ipython.py
+++ b/wandb/sdk/lib/ipython.py
@@ -46,7 +46,8 @@ def _get_python_type() -> PythonType:
             get_ipython().config.get(
                 "IPKernelApp",
                 get_ipython().config.get("ColabKernelApp", {}),
-            ) or {}
+            )
+            or {}
         )
         .get("connection_file", "")
         .lower()


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Colab moved the connection file key from thestandard `IPython.get_ipython.config` key `IPKernelApp` to `ColabKernelApp`, which made our settings think that Colab is not a jupyter-like env, but rather only an ipython-like one.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 24b2105</samp>

Improved Colab detection in `wandb/sdk/lib/ipython.py` by checking the IPython config for the kernel type. This enables wandb to handle Colab-specific features and behaviors.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 24b2105</samp>

> _`_get_python_type`_
> _Detects Colab or Jupyter_
> _Kernel is the key_
