### PR TITLE
chore(artifacts): reduce ttl link warning

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2678,10 +2678,7 @@ class Run:
                     entity,
                     project,
                 )
-                if (
-                    artifact._ttl_duration_seconds is not None
-                    or artifact._ttl_is_inherited
-                ):
+                if artifact._ttl_duration_seconds is not None:
                     wandb.termwarn(
                         "Artifact TTL will be disabled for source artifacts that are linked to portfolios."
                     )


### PR DESCRIPTION
Fixes
-----
https://wandb.atlassian.net/browse/WB-15585

Description
-----------
reduce ttl warning only when there is a ttl set, as opposed to warning pretty much everytime a model is being linked. This takes away potential warning if the TTL is inherited but we prioritize reducing logging clutter

Testing
-------
locally tested
