### PR TITLE
chore(nexus): set nexus codeowners to sdk-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 /setup.cfg @wandb/sdk-team
 /setup.py @wandb/sdk-team
 /requirements.txt @wandb/sdk-team
+# Nexus changes need extra scrutiny during the initial rollout
+/nexus/ @wandb/sdk-team
 
 /tests/pytest_tests/unit_tests/test_launch/ @wandb/mlw-team
 /tests/pytest_tests/unit_tests_old/tests_launch/ @wandb/mlw-team


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6d2320</samp>

Assign wandb/sdk-team as reviewers for Nexus feature. This change updates the `.github/CODEOWNERS` file to ensure that the new `/nexus/` directory, which contains the code for the Nexus integration, gets proper feedback and oversight.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e6d2320</samp>

> _`CODEOWNERS` change_
> _Nexus needs more reviewers_
> _Winter of testing_
