### PR TITLE
fix(artifacts): Add environment variable to configure batch size for download urls

### DIFF
--- a/wandb/env.py
+++ b/wandb/env.py
@@ -123,6 +123,7 @@ def immutable_keys() -> List[str]:
         HOST,
         DATA_DIR,
         ARTIFACT_DIR,
+        ARTIFACT_FETCH_FILE_URL_BATCH_SIZE,
         CACHE_DIR,
         USE_V1_ARTIFACTS,
         DISABLE_SSL,

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -381,11 +381,11 @@ def get_artifact_dir(env: Optional[Env] = None) -> str:
     return val
 
 
-def get_artifact_fetch_file_url_batch_size(env: Optional[Env] = None) -> str:
+def get_artifact_fetch_file_url_batch_size(env: Optional[Env] = None) -> int:
     default_batch_size = 5000
     if env is None:
         env = os.environ
-    val = env.get(ARTIFACT_FETCH_FILE_URL_BATCH_SIZE, default_batch_size)
+    val = int(env.get(ARTIFACT_FETCH_FILE_URL_BATCH_SIZE, default_batch_size))
     return val
 
 

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -74,6 +74,7 @@ JUPYTER = "WANDB_JUPYTER"
 CONFIG_DIR = "WANDB_CONFIG_DIR"
 DATA_DIR = "WANDB_DATA_DIR"
 ARTIFACT_DIR = "WANDB_ARTIFACT_DIR"
+ARTIFACT_FETCH_FILE_URL_BATCH_SIZE = "WANDB_ARTIFACT_FETCH_FILE_URL_BATCH_SIZE"
 CACHE_DIR = "WANDB_CACHE_DIR"
 DISABLE_SSL = "WANDB_INSECURE_DISABLE_SSL"
 SERVICE = "WANDB_SERVICE"
@@ -377,6 +378,14 @@ def get_artifact_dir(env: Optional[Env] = None) -> str:
     if env is None:
         env = os.environ
     val = env.get(ARTIFACT_DIR, default_dir)
+    return val
+
+
+def get_artifact_fetch_file_url_batch_size(env: Optional[Env] = None) -> str:
+    default_batch_size = 5000
+    if env is None:
+        env = os.environ
+    val = env.get(ARTIFACT_FETCH_FILE_URL_BATCH_SIZE, default_batch_size)
     return val
 
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1730,7 +1730,7 @@ class Artifact:
             has_next_page = True
             cursor = None
             while has_next_page:
-                fetch_url_batch_size = int(env.get_artifact_fetch_file_url_batch_size())
+                fetch_url_batch_size = env.get_artifact_fetch_file_url_batch_size()
                 attrs = self._fetch_file_urls(cursor, fetch_url_batch_size)
                 has_next_page = attrs["pageInfo"]["hasNextPage"]
                 cursor = attrs["pageInfo"]["endCursor"]

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1730,7 +1730,8 @@ class Artifact:
             has_next_page = True
             cursor = None
             while has_next_page:
-                attrs = self._fetch_file_urls(cursor)
+                fetch_url_batch_size = int(env.get_artifact_fetch_file_url_batch_size())
+                attrs = self._fetch_file_urls(cursor, fetch_url_batch_size)
                 has_next_page = attrs["pageInfo"]["hasNextPage"]
                 cursor = attrs["pageInfo"]["endCursor"]
                 for edge in attrs["edges"]:
@@ -1738,7 +1739,7 @@ class Artifact:
                     entry._download_url = edge["node"]["directUrl"]
                     active_futures.add(executor.submit(download_entry, entry))
                 # Wait for download threads to catch up.
-                max_backlog = 5000
+                max_backlog = fetch_url_batch_size
                 if len(active_futures) > max_backlog:
                     for future in concurrent.futures.as_completed(active_futures):
                         future.result()  # check for errors
@@ -1769,12 +1770,14 @@ class Artifact:
         retry_timedelta=timedelta(minutes=3),
         retryable_exceptions=(requests.RequestException),
     )
-    def _fetch_file_urls(self, cursor: Optional[str]) -> Any:
+    def _fetch_file_urls(
+        self, cursor: Optional[str], per_page: Optional[int] = 5000
+    ) -> Any:
         query = gql(
             """
-            query ArtifactFileURLs($id: ID!, $cursor: String) {
+            query ArtifactFileURLs($id: ID!, $cursor: String, $perPage: Int) {
                 artifact(id: $id) {
-                    files(after: $cursor, first: 5000) {
+                    files(after: $cursor, first: $perPage) {
                         pageInfo {
                             hasNextPage
                             endCursor
@@ -1793,7 +1796,7 @@ class Artifact:
         assert self._client is not None
         response = self._client.execute(
             query,
-            variable_values={"id": self.id, "cursor": cursor},
+            variable_values={"id": self.id, "cursor": cursor, "perPage": per_page},
             timeout=60,
         )
         return response["artifact"]["files"]


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-15437](https://wandb.atlassian.net/browse/WB-15437)
- Fixes #NNNN

Description
-----------
Add option to configure batch size while fetching file urls for artifact downloads. The default remains 5000. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0c42f5</samp>

Added a new option to configure the batch size of file URL requests for artifact downloads. This helps to download large artifacts faster and more reliably from `wandb/sdk/artifacts/artifact.py`.

Testing
-------
https://stdai-sbx.wandb.ml/
https://stdai-sbx.wandb.ml/emea-team/log_large_artifacts/artifacts/dataset/my_large_artifact/v0/usage

`use_artifact() -> download()` for the above artifact fails with the default batch size of 5000. Succeeded when changed to 1000 or 500. 

Set the env variable as follows:
`os.environ["WANDB_ARTIFACT_FETCH_FILE_URL_BATCH_SIZE"] = "1000"`

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d0c42f5</samp>

> _`download` the artifact, unleash the power_
> _Customize the batch size, don't let it cower_
> _`file URL` requests, blazing like a fire_
> _`Artifact` class, the master of the pyre_


[WB-15437]: https://wandb.atlassian.net/browse/WB-15437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ