### PR TITLE
chore(sweeps): more verbose scheduler logging

### DIFF
--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -1,10 +1,9 @@
 """Scheduler for classic wandb Sweeps."""
 import logging
-from pprint import pformat as pf
 from typing import Any, Dict, List, Optional
 
 import wandb
-from wandb.sdk.launch.sweeps.scheduler import LOG_PREFIX, RunState, Scheduler, SweepRun
+from wandb.sdk.launch.sweeps.scheduler import RunState, Scheduler, SweepRun
 
 _logger = logging.getLogger(__name__)
 
@@ -45,7 +44,7 @@ class SweepScheduler(Scheduler):
                 return None
 
             if _run_id in self._runs:
-                wandb.termlog(f"{LOG_PREFIX}Skipping duplicate run: {_run_id}")
+                wandb.termlog(f"{self._log_pre}Skipping duplicate run: {_run_id}")
                 continue
 
             return SweepRun(
@@ -66,14 +65,11 @@ class SweepScheduler(Scheduler):
             if run.worker_id == worker_id and run.state.is_alive:
                 _run_states[run_id] = True
 
-        _logger.debug(f"Sending states: \n{pf(_run_states)}\n")
         commands: List[Dict[str, Any]] = self._api.agent_heartbeat(
             agent_id=self._workers[worker_id].agent_id,
             metrics={},
             run_states=_run_states,
         )
-        _logger.debug(f"AgentHeartbeat commands: \n{pf(commands)}\n")
-
         return commands
 
     def _exit(self) -> None:


### PR DESCRIPTION
Fixes
-----

Description
-----------
Improves logging, specifically identifies the sweep id in each log line, and adds worker IDs for launched runs. 


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0010614</samp>

This pull request refactors the sweep scheduler code in the `wandb/sdk/launch/sweeps` module, by simplifying the class structure, the logging, the naming, and the imports. It also fixes a minor typo. These changes aim to improve the readability and maintainability of the code.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0010614</samp>

> _We are the sweepers of the code_
> _We merge, we rename, we refactor_
> _We log with colors and with ID_
> _We catch the errors and we soar_
