### PR TITLE
test(artifacts): fix standalone_tests/artifact_tests.py::test_artifact_creation_with_diff_type

### DIFF
--- a/tests/standalone_tests/artifact_tests.py
+++ b/tests/standalone_tests/artifact_tests.py
@@ -107,7 +107,7 @@ def test_artifact_creation_with_diff_type():
             assert (
                 str(err)
                 == f"Artifact {artifact_name} already exists with type 'artifact_type_1';"
-                   " cannot create another with type 'artifact_type_2'"
+                " cannot create another with type 'artifact_type_2'"
             )
         assert did_err
 

--- a/tests/standalone_tests/artifact_tests.py
+++ b/tests/standalone_tests/artifact_tests.py
@@ -106,7 +106,8 @@ def test_artifact_creation_with_diff_type():
             did_err = True
             assert (
                 str(err)
-                == f"Artifact {artifact_name} already exists with type artifact_type_1; cannot create another with type artifact_type_2"
+                == f"Artifact {artifact_name} already exists with type 'artifact_type_1';"
+                   " cannot create another with type 'artifact_type_2'"
             )
         assert did_err
 

--- a/tests/standalone_tests/artifact_tests.yea
+++ b/tests/standalone_tests/artifact_tests.yea
@@ -4,6 +4,7 @@ tag:
     - linux
     - mac
     - win
+  skip: true  # todo: unskip once the test is fixed
 plugin:
   - wandb
 depend:

--- a/tests/standalone_tests/artifact_tests.yea
+++ b/tests/standalone_tests/artifact_tests.yea
@@ -4,7 +4,6 @@ tag:
     - linux
     - mac
     - win
-  skip: true  # todo: unskip once the test is fixed
 plugin:
   - wandb
 depend:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3025,7 +3025,7 @@ class Run:
         if expected_type is not None and artifact.type != expected_type:
             raise ValueError(
                 f"Artifact {artifact.name} already exists with type '{expected_type}'; "
-                f"cannot create another with type {artifact.type}"
+                f"cannot create another with type '{artifact.type}'"
             )
         if entity and artifact._source_entity and entity != artifact._source_entity:
             raise ValueError(


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

Fixing the test whose failure we have been contemplating in nightly for a while, like here:
https://app.circleci.com/pipelines/github/wandb/wandb/27026/workflows/6681b890-33c4-424d-8fb9-57b0d9114060/jobs/797145

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99b0b9f</samp>

This pull request improves the error messages for invalid artifact types by adding single quotes around the expected types. The changes affect both the `artifact_tests.py` file in the tests directory and the `wandb_run.py` file in the sdk directory.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 99b0b9f</samp>

> _`Run` logs artifacts_
> _With quotes around their types_
> _Clearer in winter_
