### PR TITLE
fix(launch): get logs from failed k8s pods

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -59,7 +59,6 @@ class KubernetesSubmittedRun(AbstractRun):
         batch_api: "BatchV1Api",
         core_api: "CoreV1Api",
         name: str,
-        pod_names: List[str],
         namespace: Optional[str] = "default",
         secret: Optional["V1Secret"] = None,
     ) -> None:
@@ -77,7 +76,6 @@ class KubernetesSubmittedRun(AbstractRun):
             batch_api: Kubernetes BatchV1Api object.
             core_api: Kubernetes CoreV1Api object.
             name: Name of the job.
-            pod_names: List of pod names.
             namespace: Kubernetes namespace.
             secret: Kubernetes secret.
 
@@ -90,7 +88,6 @@ class KubernetesSubmittedRun(AbstractRun):
         self.name = name
         self.namespace = namespace
         self._fail_count = 0
-        self.pod_names = pod_names
         self.secret = secret
 
     @property
@@ -100,15 +97,20 @@ class KubernetesSubmittedRun(AbstractRun):
 
     def get_logs(self) -> Optional[str]:
         try:
+            pods = self.core_api.list_namespaced_pod(
+                label_selector=f"job-name={self.name}", namespace=self.namespace
+            )
+            pod_names = [pi.metadata.name for pi in pods.items]
+            if not pod_names:
+                wandb.termwarn(f"Found no pods for kubernetes job: {self.name}")
+                return None
             logs = self.core_api.read_namespaced_pod_log(
-                name=self.pod_names[0], namespace=self.namespace
+                name=pod_names[0], namespace=self.namespace
             )
             if logs:
                 return str(logs)
             else:
-                wandb.termwarn(
-                    f"Retrieved no logs for kubernetes pod(s): {self.pod_names}"
-                )
+                wandb.termwarn(f"Retrieved no logs for kubernetes pod(s): {pod_names}")
             return None
         except Exception as e:
             wandb.termerror(f"{LOG_PREFIX}Failed to get pod logs: {e}")
@@ -521,7 +523,6 @@ class KubernetesRunner(AbstractRunner):
             0
         ]  # create_from_yaml returns a nested list of k8s objects
         job_name = job_response.metadata.name
-
         # Event stream monitor to ensure pod creation and job completion.
         monitor = KubernetesRunMonitor(
             job_field_selector=f"metadata.name={job_name}",
@@ -532,7 +533,7 @@ class KubernetesRunner(AbstractRunner):
         )
         monitor.start()
         submitted_job = KubernetesSubmittedRun(
-            monitor, batch_api, core_api, job_name, [], namespace, secret
+            monitor, batch_api, core_api, job_name, namespace, secret
         )
         if self.backend_config[PROJECT_SYNCHRONOUS]:
             submitted_job.wait()

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -110,7 +110,7 @@ class KubernetesSubmittedRun(AbstractRun):
             if logs:
                 return str(logs)
             else:
-                wandb.termwarn(f"Retrieved no logs for kubernetes pod(s): {pod_names}")
+                wandb.termwarn(f"No logs for kubernetes pod(s): {pod_names}")
             return None
         except Exception as e:
             wandb.termerror(f"{LOG_PREFIX}Failed to get pod logs: {e}")


### PR DESCRIPTION
Fixes
-----
- Fixes WB-15582

Description
-----------
What does the PR do?

This PR fixes the mechanism for retrieving pod logs in the case that a launched job fails and a W&B run was not created. This was broken by extensive refactors to the kubernetes monitoring code and was not caught by automated or manual testing. Previously a list of pod names was passed in when the `KubernetesSubmittedRun` is created, but no longer. We now do a `list_namespaced_pod` filtered to the job we are interested in right before attempting to get the logs.

In the case where no run exists we also give a 60 second grace period for the run to appear in the W&B backend. This PR modifies the logic in that retry/backoff loop so that we get the logs immediately after the first attempt to get run info fails. If we wait until the end of the 60 second grace period when we are sure we need the logs to get them, the pods may already have been cleaned up by k8s.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 90f93ab</samp>

### Summary
🐛🗑️🚀

<!--
1.  🐛 for fixing a potential error and optimizing the log fetching logic.
2.  🗑️ for removing the unused parameter and attribute.
3.  🚀 for using the kubernetes API to get the pod names dynamically and improving the style.
-->
This pull request improves the launch agent and the kubernetes runner modules in the `wandb/sdk/launch` package. It fixes some potential errors, removes unused code, and optimizes the log fetching logic for launched runs.

> _Sing, O Muse, of the skillful coder who refined the logic_
> _Of fetching logs from kubernetes, the cloud-born platform_
> _He stripped away the needless pod names, source of much confusion_
> _And made the LaunchAgent more robust, like wise Odysseus_

### Walkthrough
*  Remove `pod_names` parameter and attribute from `KubernetesSubmittedRun` class and use kubernetes API to get pod logs ([link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86L62), [link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86L80), [link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86L93), [link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86L103-R113), [link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86L535-R536))
*  Initialize `logs` variable to `None` and fetch logs from run object only once in `finish_thread_id` method of `LaunchAgent` class ([link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-75b70c365dac28700af3ff8747334d736d608078fc88317bf6c726d2231978b2R317), [link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-75b70c365dac28700af3ff8747334d736d608078fc88317bf6c726d2231978b2R335-R339), [link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-75b70c365dac28700af3ff8747334d736d608078fc88317bf6c726d2231978b2L343))
*  Remove empty line from end of file `wandb/sdk/launch/runner/kubernetes_runner.py` ([link](https://github.com/wandb/wandb/pull/6339/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86L524))



Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 90f93ab</samp>

> _Sing, O Muse, of the skillful coder who refined the logic_
> _Of fetching logs from kubernetes, the cloud-born platform_
> _He stripped away the needless pod names, source of much confusion_
> _And made the LaunchAgent more robust, like wise Odysseus_
