### PR TITLE
fix(sweeps):  ValueError with None value in sweep

### DIFF
--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -228,7 +228,7 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
     args_no_equals: List[str] = []
     for param, config in command["args"].items():
         _value: Any = config.get("value", None)
-        if _value is None:
+        if _value is None and "value" not in config:
             raise ValueError('No "value" found for command["args"]["%s"]' % param)
         _flag: str = f"{param}={_value}"
         flags.append("--" + _flag)

--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -227,9 +227,11 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
     # (5) flags without equals (e.g. --foo bar)
     args_no_equals: List[str] = []
     for param, config in command["args"].items():
-        _value: Any = config.get("value", None)
-        if _value is None and "value" not in config:
-            raise ValueError('No "value" found for command["args"]["%s"]' % param)
+        try:
+            _value: Any = config["value"]
+        except KeyError:
+            raise ValueError(f'No "value" found for command["args"]["{param}"]')
+
         _flag: str = f"{param}={_value}"
         flags.append("--" + _flag)
         flags_no_hyphens.append(_flag)


### PR DESCRIPTION
Fixes
-----
https://wandb.atlassian.net/browse/WB-10919

Description
-----------
TEMP

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c967c2c</samp>

Fix a bug in `create_sweep_command_args` that prevented using `None` as a sweep parameter value. Update `wandb/sdk/launch/sweeps/utils.py` to handle `None` values correctly.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c967c2c</samp>

> _`None` can be value_
> _Fixing bug in sweep command_
> _Autumn leaves falling_
