### PR TITLE
fix(sweeps): ValueError with None value in sweep

### DIFF
--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -227,9 +227,11 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
     # (5) flags without equals (e.g. --foo bar)
     args_no_equals: List[str] = []
     for param, config in command["args"].items():
-        _value: Any = config.get("value", None)
-        if _value is None:
+        try:
+            _value: Any = config["value"]
+        except KeyError:
             raise ValueError('No "value" found for command["args"]["%s"]' % param)
+
         _flag: str = f"{param}={_value}"
         flags.append("--" + _flag)
         flags_no_hyphens.append(_flag)


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-10919](https://wandb.atlassian.net/browse/WB-10919)
- Fixes #6249

Description
-----------
What does the PR do?

Fixes https://github.com/wandb/wandb/issues/6249

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71cbb3d</samp>

Refactored `wandb/sdk/launch/sweeps/utils.py` to use try-except for config access. This improves the error handling and logging of the launch sweeps feature.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 71cbb3d</samp>

> _Launch sweeps feature_
> _`config` gets try-except_
> _Fall leaves catch errors_


[WB-10919]: https://wandb.atlassian.net/browse/WB-10919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ