### PR TITLE
fix(artifacts): Allow adding s3 bucket as reference artifact

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -544,21 +544,6 @@ def test_add_s3_reference_object():
     }
 
 
-def test_add_s3_reference_object_dir():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
-    mock_boto(artifact, content_type="application/x-directory; charset=UTF-8")
-    artifact.add_reference("s3://my-bucket/my_dir")
-
-    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
-    manifest = artifact.manifest.to_manifest_json()
-    assert manifest["contents"]["my_object.pb"] == {
-        "digest": "1234567890abcde",
-        "ref": "s3://my-bucket/my_dir",
-        "extra": {"etag": "1234567890abcde", "versionID": "1"},
-        "size": 10,
-    }
-
-
 def test_add_s3_reference_object_no_version():
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, version_id=None)
@@ -626,13 +611,13 @@ def test_add_s3_reference_path_with_content_type(runner, capsys):
     with runner.isolated_filesystem():
         artifact = wandb.Artifact(type="dataset", name="my-arty")
         mock_boto(artifact, path=False, content_type="application/x-directory")
-        artifact.add_reference("s3://my-bucket/")
+        artifact.add_reference("s3://my-bucket/my_dir")
 
         assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
         manifest = artifact.manifest.to_manifest_json()
         assert manifest["contents"]["my_object.pb"] == {
             "digest": "1234567890abcde",
-            "ref": "s3://my-bucket/my_object.pb",
+            "ref": "s3://my-bucket/my_dir",
             "extra": {"etag": "1234567890abcde", "versionID": "1"},
             "size": 10,
         }
@@ -644,7 +629,7 @@ def test_add_s3_max_objects():
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, path=True)
     with pytest.raises(ValueError):
-        artifact.add_reference("s3://my-bucket", max_objects=1)
+        artifact.add_reference("s3://my-bucket/", max_objects=1)
 
 
 def test_add_reference_s3_no_checksum():

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -67,6 +67,9 @@ def mock_boto(artifact, path=False, content_type=None, version_id="1"):
         def filter(self, **kwargs):
             return Filtered()
 
+        def limit(self, *args, **kwargs):
+            return [S3ObjectSummary(), S3ObjectSummary(name="my_other_object.pb")]
+
     class S3Bucket:
         def __init__(self, *args, **kwargs):
             self.objects = S3Objects()

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -59,11 +59,6 @@ def mock_boto(artifact, path=False, content_type=None, version_id="1"):
             self.key = name or "my_object.pb"
             self.size = size
 
-        @property
-        def is_directory(self):
-            # Check if the object summary is a directory based on the key
-            return self.key.endswith("/")
-
     class Filtered:
         def limit(self, *args, **kwargs):
             return [S3ObjectSummary(), S3ObjectSummary(name="my_other_object.pb")]

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -647,7 +647,9 @@ def test_add_s3_reference_path_with_content_type(runner, capsys):
 
 def test_add_s3_max_objects():
     artifact = wandb.Artifact(type="dataset", name="my-arty")
-    mock_boto(artifact, path=True)
+    mock_boto(
+        artifact, path=True, content_type="application/x-directory; charset=UTF-8"
+    )
     with pytest.raises(ValueError):
         artifact.add_reference("s3://my-bucket/my-dir/", max_objects=1)
 

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -544,6 +544,22 @@ def test_add_s3_reference_object():
     }
 
 
+def test_add_s3_reference_object_directory():
+    artifact = wandb.Artifact(type="dataset", name="my-arty")
+    mock_boto(artifact, path=True)
+    artifact.add_reference("s3://my-bucket/my_dir/")
+
+    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
+    manifest = artifact.manifest.to_manifest_json()
+    print(manifest)
+    assert manifest["contents"]["my_object.pb"] == {
+        "digest": "1234567890abcde",
+        "ref": "s3://my-bucket/my_dir",
+        "extra": {"etag": "1234567890abcde", "versionID": "1"},
+        "size": 10,
+    }
+
+
 def test_add_s3_reference_object_no_version():
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, version_id=None)

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -544,6 +544,21 @@ def test_add_s3_reference_object():
     }
 
 
+def test_add_s3_reference_object_dir():
+    artifact = wandb.Artifact(type="dataset", name="my-arty")
+    mock_boto(artifact, content_type="application/x-directory; charset=UTF-8")
+    artifact.add_reference("s3://my-bucket/my_dir")
+
+    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
+    manifest = artifact.manifest.to_manifest_json()
+    assert manifest["contents"]["my_object.pb"] == {
+        "digest": "1234567890abcde",
+        "ref": "s3://my-bucket/my_dir",
+        "extra": {"etag": "1234567890abcde", "versionID": "1"},
+        "size": 10,
+    }
+
+
 def test_add_s3_reference_object_no_version():
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, version_id=None)

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -549,21 +549,6 @@ def test_add_s3_reference_object():
     }
 
 
-def test_add_s3_reference_object_dir():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
-    mock_boto(artifact)
-    artifact.add_reference("s3://my-bucket/my_object.pb")
-
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
-    manifest = artifact.manifest.to_manifest_json()
-    assert manifest["contents"]["my_object.pb"] == {
-        "digest": "1234567890abcde",
-        "ref": "s3://my-bucket/my_object.pb",
-        "extra": {"etag": "1234567890abcde", "versionID": "1"},
-        "size": 10,
-    }
-
-
 def test_add_s3_reference_object_no_version():
     artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, version_id=None)
@@ -647,11 +632,9 @@ def test_add_s3_reference_path_with_content_type(runner, capsys):
 
 def test_add_s3_max_objects():
     artifact = wandb.Artifact(type="dataset", name="my-arty")
-    mock_boto(
-        artifact, path=True, content_type="application/x-directory; charset=UTF-8"
-    )
+    mock_boto(artifact, path=True)
     with pytest.raises(ValueError):
-        artifact.add_reference("s3://my-bucket/my-dir/", max_objects=1)
+        artifact.add_reference("s3://my-bucket", max_objects=1)
 
 
 def test_add_reference_s3_no_checksum():

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -192,10 +192,14 @@ class S3Handler(StorageHandler):
                 % (max_objects, bucket, key),
                 newline=False,
             )
-            objs = self._s3.Bucket(bucket).objects.limit(max_objects)
             if key != "":
-                objs = objs.filter(Prefix=key)
-
+                objs = objs = (
+                    self._s3.Bucket(bucket)
+                    .objects.filter(Prefix=key)
+                    .limit(max_objects)
+                )
+            else:
+                objs = self._s3.Bucket(bucket).objects.limit(max_objects)
         # Weird iterator scoping makes us assign this to a local function
         size = self._size_from_obj
         entries = [

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -164,15 +164,7 @@ class S3Handler(StorageHandler):
         )
         start_time = None
         multi = False
-        if key == "":
-            start_time = time.time()
-            termlog(
-                'Generating checksum for up to %i objects in the bucket "%s"... '
-                % (max_objects, bucket),
-                newline=False,
-            )
-            objs = self._s3.Bucket(bucket).objects.limit(max_objects)
-        else:
+        if key != "":
             try:
                 objs[0].load()
                 # S3 doesn't have real folders, however there are cases where the folder key has a valid file which will not
@@ -197,6 +189,17 @@ class S3Handler(StorageHandler):
                 newline=False,
             )
             objs = self._s3.Bucket(bucket).objects.filter(Prefix=key).limit(max_objects)
+
+        if key == "":
+            multi = True
+            start_time = time.time()
+            termlog(
+                'Generating checksum for up to %i objects in the bucket "%s"... '
+                % (max_objects, bucket),
+                newline=False,
+            )
+            objs = self._s3.Bucket(bucket).objects.limit(max_objects)
+
         # Weird iterator scoping makes us assign this to a local function
         size = self._size_from_obj
         entries = [

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -172,7 +172,6 @@ class S3Handler(StorageHandler):
                 newline=False,
             )
             objs = self._s3.Bucket(bucket).objects.limit(max_objects)
-            print(objs)
         else:
             try:
                 objs[0].load()

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -96,8 +96,6 @@ class S3Handler(StorageHandler):
         if version:
             obj = self._s3.ObjectVersion(bucket, key, version).Object()
             extra_args["VersionId"] = version
-        elif key == "":
-            obj = self._s3.Bucket(bucket)
         else:
             obj = self._s3.Object(bucket, key)
 
@@ -174,6 +172,7 @@ class S3Handler(StorageHandler):
                 newline=False,
             )
             objs = self._s3.Bucket(bucket).objects.limit(max_objects)
+            print(objs)
         else:
             try:
                 objs[0].load()


### PR DESCRIPTION
Fixes
-----
- Fixes [WB-2758](https://wandb.atlassian.net/browse/WB-2758)
- Fixes #NNNN

Description
-----------
Allows

```
artifact.add_reference("s3://<bucket_name>")
```
If the bucket is empty then an empty artifact sequence (i.e., no versions) is created.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ba269f</samp>

This pull request enhances the `S3Handler` class to support empty keys as bucket artifacts and optimize the bucket operations. It modifies the `load_path` and `store_path` functions in `s3_handler.py` to implement these changes.

Testing
-------

Upload
```
ENTITY = "ibindlish"
PROJECT = "test-s3"
ARTIFACT = "ref-artifact"

with wandb.init(entity=ENTITY, project=PROJECT) as run:
    artifact = wandb.Artifact(ARTIFACT, type="data")
    artifact.add_reference("s3://dev-test-ibindlish")
    run.log_artifact(artifact)
```
`https://wandb.ai/ibindlish/test-s3/artifacts/data/ref-artifact/v2/overview`

Download
```
with wandb.init() as run:
    artifact = run.use_artifact(f"{ENTITY}/{PROJECT}/{ARTIFACT}:v2", type="data")
    artifact_dir = artifact.download()
    print(artifact_dir)
```

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2ba269f</samp>

> _The `S3Handler` class had a flaw_
> _When dealing with buckets so raw_
> _It could not handle keys_
> _That were empty with ease_
> _But this pull request fixes that draw_


[WB-2758]: https://wandb.atlassian.net/browse/WB-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ