### PR TITLE
feat(sdk): drop support of python 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "package_readme.md"
 license = { file = "LICENSE"}
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
     "Click>=7.1,!=8.0.0",  # click 8.0.0 is broken
     "GitPython>=1.0.0,!=3.1.29",  # CVE-2022-24439
@@ -37,7 +37,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -101,7 +100,7 @@ launch = [
     "PyYAML>=6.0.0",
 ]
 models = ["cloudpickle"]
-async = ["httpx>=0.22.0"] # 0.23.0 dropped Python 3.6; we can upgrade once we drop it too
+async = ["httpx>=0.23.0"]
 perf = ["orjson"]
 nexus = [
     "wandb-core>=0.16.0b1"

--- a/tests/pytest_tests/conftest.py
+++ b/tests/pytest_tests/conftest.py
@@ -52,8 +52,7 @@ def copy_asset(assets_path) -> Generator[Callable, None, None]:
 
 @pytest.fixture(scope="function", autouse=True)
 def filesystem_isolate(tmp_path):
-    # Click>=8 implements temp_dir argument which depends on python>=3.7
-    kwargs = dict(temp_dir=tmp_path) if sys.version_info >= (3, 7) else {}
+    kwargs = dict(temp_dir=tmp_path)
     with CliRunner().isolated_filesystem(**kwargs):
         yield
 

--- a/tests/pytest_tests/conftest.py
+++ b/tests/pytest_tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 import unittest.mock
 from pathlib import Path
 from queue import Queue

--- a/tests/pytest_tests/unit_tests/test_wandb_settings.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_settings.py
@@ -16,12 +16,8 @@ from wandb.sdk.lib._settings_toposort_generate import _get_modification_order
 
 if sys.version_info >= (3, 8):
     from typing import get_type_hints
-elif sys.version_info >= (3, 7):
-    from typing_extensions import get_type_hints
 else:
-
-    def get_type_hints(obj):
-        return obj.__annotations__
+    from typing_extensions import get_type_hints
 
 
 Property = wandb_settings.Property

--- a/tests/pytest_tests/unit_tests_old/conftest.py
+++ b/tests/pytest_tests/unit_tests_old/conftest.py
@@ -62,7 +62,7 @@ servers = ServerMap()
 
 def get_temp_dir_kwargs(tmp_path):
     # Click>=8 implements temp_dir argument which depends on python>=3.7
-    return dict(temp_dir=tmp_path) if sys.version_info >= (3, 7) else {}
+    return dict(temp_dir=tmp_path)
 
 
 def test_cleanup(*args, **kwargs):

--- a/tests/pytest_tests/unit_tests_old/conftest.py
+++ b/tests/pytest_tests/unit_tests_old/conftest.py
@@ -3,7 +3,6 @@ import logging
 import os
 import platform
 import queue
-import random
 import shutil
 import subprocess
 import sys
@@ -20,7 +19,6 @@ from unittest.mock import MagicMock
 
 import click
 import git
-import nbformat
 import psutil
 import pytest
 import requests

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS
 
-[testenv:{,notebooks-}py{36,37,38,39,310,311}]
+[testenv:{,notebooks-}py{37,38,39,310,311}]
 install_command=
     ; pytorch installations on non-darwin need the `-f`
     pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
@@ -139,7 +139,7 @@ commands=
     notebooks: pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:{env:WB_UNIT_PARALLEL:10}} --durations=20 --reruns 3 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail --timeout 300 {posargs:tests/pytest_tests/system_tests/test_notebooks}
 
 ;todo: this is a simple smoke test, it will be replaced by a more comprehensive suite
-[testenv:nexus-py{36,37,38,39,310,311}]
+[testenv:nexus-py{37,38,39,310,311}]
 install_command=
     pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
@@ -185,7 +185,7 @@ deps=
     scikit-learn
     xgboost>=1.3.0
 
-[testenv:func-{,docs-,noml-,}py{36,37,38,39,310,311}]
+[testenv:func-{,docs-,noml-,}py{37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps =
     yea-wandb=={env:YEA_WANDB_VERSION}
@@ -204,7 +204,7 @@ commands=
     !{docs}: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard {env:SHARD:default} run {posargs:--all}
     docs: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --yeadoc --shard docs run {posargs:--all}
 
-[testenv:func-mitm-py{36,37,38,39,310,311}]
+[testenv:func-mitm-py{37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps =
     yea-wandb=={env:YEA_WANDB_VERSION}
@@ -221,7 +221,7 @@ commands_pre=
 commands=
     yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard mitm --mitm run {posargs:--all}
 
-[testenv:func-{llm,kfp}-py{36,37,38,39,310,311}]
+[testenv:func-{llm,kfp}-py{37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     yea-wandb=={env:YEA_WANDB_VERSION}
@@ -266,7 +266,7 @@ commands=
     !{local}: yea --debug --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-{env:SHARD:cpu} run {posargs:--all}
     local: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}
 
-[testenv:regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-other,s3,sagemaker}-py{36,37,38,39,310,311}]
+[testenv:regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-other,s3,sagemaker}-py{37,38,39,310,311}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     pyyaml

--- a/wandb/sdk/lib/_settings_toposort_generate.py
+++ b/wandb/sdk/lib/_settings_toposort_generate.py
@@ -1,18 +1,14 @@
 import inspect
 import sys
-from typing import Any, Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 from wandb.errors import UsageError
 from wandb.sdk.wandb_settings import Settings
 
 if sys.version_info >= (3, 8):
     from typing import get_type_hints
-elif sys.version_info >= (3, 7):
-    from typing_extensions import get_type_hints
 else:
-
-    def get_type_hints(obj: Any) -> Dict[str, Any]:
-        return dict(obj.__annotations__) if hasattr(obj, "__annotations__") else dict()
+    from typing_extensions import get_type_hints
 
 
 template = """

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -54,18 +54,8 @@ from .lib.runid import generate_id
 
 if sys.version_info >= (3, 8):
     from typing import get_args, get_origin, get_type_hints
-elif sys.version_info >= (3, 7):
-    from typing_extensions import get_args, get_origin, get_type_hints
 else:
-
-    def get_args(obj: Any) -> Optional[Any]:
-        return obj.__args__ if hasattr(obj, "__args__") else None
-
-    def get_origin(obj: Any) -> Optional[Any]:
-        return obj.__origin__ if hasattr(obj, "__origin__") else None
-
-    def get_type_hints(obj: Any) -> Dict[str, Any]:
-        return dict(obj.__annotations__) if hasattr(obj, "__annotations__") else dict()
+    from typing_extensions import get_args, get_origin, get_type_hints
 
 
 class SettingsPreprocessingError(UsageError):


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14859ef</samp>

This pull request removes Python 3.6 support and compatibility code from the wandb library and its tests. It also updates the `pyproject.toml` and `tox.ini` files to reflect the supported Python versions and dependencies. It simplifies some conditional imports and type annotations using the `typing` and `typing_extensions` modules.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 14859ef</samp>

> _We're dropping Python 3.6, me hearties, yo ho ho_
> _We're simplifying imports and `typing`, don't you know_
> _We're upgrading `httpx` and cleaning up the code_
> _We're sailing with the wandb library on the latest mode_
