### PR TITLE
fix(launch): Fix race condition in agent thread clean up

### DIFF
--- a/.github/workflows/generate-docodile-documentation.yml
+++ b/.github/workflows/generate-docodile-documentation.yml
@@ -17,10 +17,19 @@ jobs: # update the docs.
   update-docs:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare wandb-branch value
+        run: |
+          REF_VALUE="${{ github.event.inputs.ref }}"
+          if [[ "$REF_VALUE" == refs/tags/* ]]; then
+          echo "WANDB_BRANCH=${REF_VALUE/refs\/tags\//}" >> "$GITHUB_ENV"
+          else
+          echo "WANDB_BRANCH=${REF_VALUE}" >> "$GITHUB_ENV"
+          fi
+
       - uses: wandb/docugen@v0.4.1
         with:
           docodile-branch: main
-          wandb-branch: ${{ replace(github.event.inputs.ref, 'refs/tags/', '') || github.ref }}
+          wandb-branch: $WANDB_BRANCH
           generate-sdk-docs: true
           generate-weave-docs: false
           access-token: ${{ secrets.DOCUGEN_ACCESS_TOKEN }}

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -543,7 +543,8 @@ class LaunchAgent:
             wandb.termerror(f"{LOG_PREFIX}Error running job: {traceback.format_exc()}")
             exception = e
             wandb._sentry.exception(e)
-        self.finish_thread_id(thread_id, exception)
+        finally:
+            self.finish_thread_id(thread_id, exception)
 
     def _thread_run_job(
         self,

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -206,7 +206,7 @@ class LaunchAgent:
     def thread_ids(self) -> List[int]:
         """Returns a list of keys running thread ids for the agent."""
         with self._jobs_lock:
-            yield list(self._jobs.keys())
+            return list(self._jobs.keys())
 
     @property
     def num_running_schedulers(self) -> int:

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -282,7 +282,8 @@ class LaunchAgent:
         exception: Optional[Union[Exception, LaunchDockerError]] = None,
     ) -> None:
         """Removes the job from our list for now."""
-        job_and_run_status = self._jobs[thread_id]
+        with self._jobs_lock:
+            job_and_run_status = self._jobs[thread_id]
         if (
             job_and_run_status.entity is not None
             and job_and_run_status.entity != self._entity


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
There was a race condition between the main agent loops `update_finished` function and the within thread, thread clean up. The agent could try to access a thread that was deleted in `update_finished` but this would lead to a KeyError and crash the whole agent.

The solution is to move all thread clean up out of the main agent loop, threads all clean up after themselves now.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e337a1</samp>

Improved the launch agent logic and fixed a `TypeError` bug. The file `wandb/sdk/launch/agent/agent.py` was refactored to use a generator for thread ids and to simplify the job status checking and thread finishing.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e337a1</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who tamed the agent logic with his code_
> _And made a generator for thread ids_
> _To spawn and join the workers as they strode._
