### PR TITLE
chore(launch): allow seeding _wandb config from gorilla

### DIFF
--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -959,6 +959,12 @@ class SendManager:
             config_override = self._consolidated_config
             config_dict = self._resume_state.config
             config_dict = config_util.dict_strip_value_dict(config_dict)
+
+            # override everything EXCEPT _wandb key
+            _wandb = config_override.pop("_wandb", {})
+            if config_dict.get("_wandb"):
+                config_dict["_wandb"].update(_wandb)
+
             config_dict.update(config_override)
             self._consolidated_config.update(config_dict)
             config_value_dict = self._config_format(self._consolidated_config)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1821,6 +1821,7 @@ class Settings(SettingsData):
                         f"Ignored wandb.init() arg {key} when running a sweep."
                     )
         if self.launch:
+            init_settings["resume"] = "allow"  # launch runs must be resumable
             if self.project is not None and init_settings.pop("project", None):
                 wandb.termwarn(
                     "Project is ignored when running from wandb launch context. "


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d711c8f</samp>

This pull request enables config overriding and resuming for runs launched with `wandb launch`. It modifies `wandb/sdk/internal/sender.py` to merge the user-provided config with the internal `_wandb` config, and `wandb/sdk/wandb_settings.py` to set the resume option to "allow" for launched runs.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d711c8f</samp>

> _Launch runs with `wandb`_
> _Override config settings_
> _Except for `_wandb`_
