### PR TITLE
fix(artifacts): fix wandb.Api().run(run_name).log_artifact(artifact)

### DIFF
--- a/tests/pytest_tests/system_tests/test_core/test_public_api.py
+++ b/tests/pytest_tests/system_tests/test_core/test_public_api.py
@@ -271,3 +271,23 @@ def test_run_queue(user):
         assert queue.type == "local-container"
     finally:
         queue.delete()
+
+
+def test_run_log_artifact(relay_server, wandb_init):
+    with relay_server():
+        # Prepare data.
+        with wandb_init() as run:
+            pass
+        run = wandb.Api().run(run.path)
+
+        artifact = wandb.Artifact("my_artifact", type="test")
+        artifact.save()
+        artifact.wait()
+
+        # Run.
+        run.log_artifact(artifact)
+
+        # Assert.
+        actual_artifacts = list(run.logged_artifacts())
+        assert len(actual_artifacts) == 1
+        assert actual_artifacts[0].qualified_name == artifact.qualified_name

--- a/tests/pytest_tests/unit_tests_old/test_public_api.py
+++ b/tests/pytest_tests/unit_tests_old/test_public_api.py
@@ -421,13 +421,6 @@ def test_artifact_bracket_accessor(runner, live_mock_server, api):
         art["s"] = wandb.Table(data=[], columns=[])
 
 
-def test_artifact_manual_log(runner, mock_server, api):
-    run = api.run("test/test/test")
-    art = api.artifact("entity/project/mnist:v0", type="dataset")
-    run.log_artifact(art)
-    assert True
-
-
 def test_artifact_manual_link(runner, mock_server, api):
     run = api.run("test/test/test")
     art = api.artifact("entity/project/mnist:v0", type="dataset")

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2361,7 +2361,12 @@ class Run(Attrs):
         api.set_current_run_id(self.id)
 
         if isinstance(artifact, wandb.Artifact) and not artifact.is_draft():
-            artifact_collection_name = artifact.name.split(":")[0]
+            if (
+                self.entity != artifact.source_entity
+                or self.project != artifact.source_project
+            ):
+                raise ValueError("A run can't log an artifact to a different project.")
+            artifact_collection_name = artifact.source_name.split(":")[0]
             api.create_artifact(
                 artifact.type,
                 artifact_collection_name,

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3357,11 +3357,11 @@ class Api:
             values += "distributedID: $distributedID,"
 
         if "clientID" in fields:
-            types += "$clientID: ID!,"
+            types += "$clientID: ID,"
             values += "clientID: $clientID,"
 
         if "sequenceClientID" in fields:
-            types += "$sequenceClientID: ID!,"
+            types += "$sequenceClientID: ID,"
             values += "sequenceClientID: $sequenceClientID,"
 
         if "enableDigestDeduplication" in fields:


### PR DESCRIPTION
Fixes WB-15686

# Description

`wandb.Api().run(run_name).log_artifact(artifact)` has been broken since July 2021 ([blame](https://github.com/wandb/wandb/pull/2325/files#r1334892771)). I fixed it by making `clientID` optional in the GraphQL query.

Also:
- raise an error if the run and artifact are in different projects, instead of silent no-op
- use `.source_name` instead of `.name`

# Test plan

Before:
<img width="1221" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/ca9c0ec9-08da-49dc-9af7-f4f9c0dccce5">

After:
<img width="1224" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/a3370659-d7cc-4b8f-b2c0-a7916fdf4c4e">

Tried to log an artifact from a different project, made sure I get an error:
<img width="1227" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/549f8f8f-7397-4b23-9c5b-d5617d7e4345">