### PR TITLE
fix(artifacts): don't assume run and its i/o artifacts are in the same project

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -4293,8 +4293,8 @@ class RunArtifacts(Paginator):
     def convert_objects(self):
         return [
             wandb.Artifact._from_attrs(
-                self.run.entity,
-                self.run.project,
+                r["node"]["artifactSequence"]["project"]["entityName"],
+                r["node"]["artifactSequence"]["project"]["name"],
                 "{}:v{}".format(
                     r["node"]["artifactSequence"]["name"], r["node"]["versionIndex"]
                 ),


### PR DESCRIPTION
Fixes WB-15686

# Description

Runs can be moved to a different project ([docs](https://docs.wandb.ai/guides/app/features/runs-table#move-runs-between-projects)). When fetching input / output artifacts of a run, we should use the entity & project of the artifact, not the run.

# Test plan

- Created an artifact
- Moved its creator run to a different project
- Fetched the output artifacts of the run

Before:
<img width="1226" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/040d74a3-9dfd-4e74-a1c2-5a4b7c05fb7e">

After:
<img width="1225" alt="Untitled" src="https://github.com/wandb/wandb/assets/127154459/7a185988-ef31-4bdc-81c1-1a7957eb4a8e">