### PR TITLE
test(nexus): skip test_run_log_artifact test

### DIFF
--- a/tests/pytest_tests/system_tests/test_core/test_public_api.py
+++ b/tests/pytest_tests/system_tests/test_core/test_public_api.py
@@ -273,6 +273,7 @@ def test_run_queue(user):
         queue.delete()
 
 
+@pytest.mark.nexus_failure(feature="artifacts")
 def test_run_log_artifact(relay_server, wandb_init):
     with relay_server():
         # Prepare data.


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ee006b</samp>

Marked a test function as expected to fail due to a Nexus issue. This helps to track and filter the tests that are affected by the external service.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0ee006b</samp>

> _`test_artifact_run`_
> _Marked as nexus failure_
> _Autumn of features_
