### PR TITLE
fix(artifacts): fix typo in s3 handler

### DIFF
--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -193,7 +193,7 @@ class S3Handler(StorageHandler):
                 newline=False,
             )
             if key != "":
-                objs = objs = (
+                objs = (
                     self._s3.Bucket(bucket)
                     .objects.filter(Prefix=key)
                     .limit(max_objects)


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Fixes typo https://github.com/wandb/wandb/pull/6346/files#r1337547614

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3500e03</samp>

Fix a typo in `s3_handler.py` that assigned a variable to itself. Improve code readability and clarity.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3500e03</samp>

> _`objs` assigned twice_
> _A typo or a mistake_
> _Code is now clearer_
