### PR TITLE
fix(artifacts): fix the argument order for new argument target_fraction

### DIFF
--- a/wandb/sdk/artifacts/artifacts_cache.py
+++ b/wandb/sdk/artifacts/artifacts_cache.py
@@ -67,8 +67,8 @@ class ArtifactsCache:
     def cleanup(
         self,
         target_size: Optional[int] = None,
-        target_fraction: Optional[float] = None,
         remove_temp: bool = False,
+        target_fraction: Optional[float] = None,
     ) -> int:
         """Clean up the cache, removing the least recently used files first.
 
@@ -76,14 +76,14 @@ class ArtifactsCache:
             target_size: The target size of the cache in bytes. If the cache is larger
                 than this, we will remove the least recently used files until the cache
                 is smaller than this size.
-            target_fraction: The target fraction of the cache to reclaim. If the cache
-                is larger than this, we will remove the least recently used files until
-                the cache is smaller than this fraction of its current size. It is an
-                error to specify both target_size and target_fraction.
             remove_temp: Whether to remove temporary files. Temporary files are files
                 that are currently being written to the cache. If remove_temp is True,
                 all temp files will be removed, regardless of the target_size or
                 target_fraction.
+            target_fraction: The target fraction of the cache to reclaim. If the cache
+                is larger than this, we will remove the least recently used files until
+                the cache is smaller than this fraction of its current size. It is an
+                error to specify both target_size and target_fraction.
 
         Returns:
             The number of bytes reclaimed.


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
The new argument `target_fraction` should have been added at the end of the argument list, rather than after `target_size`.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6865bb</samp>

Refactored the `cleanup` function of the `ArtifactsCache` class in `wandb/sdk/artifacts/artifacts_cache.py` to make the code more clear and consistent.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f6865bb</samp>

> _To make the code more consistent_
> _The `cleanup` function was insistent_
> _On changing the order_
> _Of args and doc border_
> _And now it looks much more persistent_
