### PR TITLE
feat(integrations): fix channel swapping on ultrlytics classification task

### DIFF
--- a/wandb/integration/ultralytics/classification_utils.py
+++ b/wandb/integration/ultralytics/classification_utils.py
@@ -17,7 +17,7 @@ def plot_classification_predictions(
     class_id_to_label = {int(k): str(v) for k, v in result.names.items()}
     table_row = [
         model_name,
-        wandb.Image(result.orig_img[:, :, ::-1]),
+        wandb.Image(result.orig_img),
         class_id_to_label[int(probabilities.top1)],
         probabilities.top1conf,
         [class_id_to_label[int(class_idx)] for class_idx in list(probabilities.top5)],


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
This PR fixes the channel-swapping issue for Ultralytics classification task as mentioned in this issue https://github.com/wandb/wandb/issues/6333

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 584fbaa</samp>

Fixed a bug in the `wandb.Image` constructor for the ultralytics integration for image classification. Removed the color channel reversal in `wandb/integration/ultralytics/classification_utils.py` to simplify the code and display the image correctly.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 584fbaa</samp>

> _`wandb.Image` fixed_
> _No more color reversal_
> _Winter bug is gone_
