### PR TITLE
feat(integrations): fix `wandb.Error` in ultralytics integration

### DIFF
--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -50,7 +50,7 @@ try:
         plot_pose_validation_results,
     )
 except ImportError as e:
-    wandb.error(e)
+    wandb.Error(e)
 
 
 TRAINER_TYPE = Union[

--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -31,7 +31,7 @@ try:
         SegmentationValidator,
     )
     from ultralytics.utils.torch_utils import de_parallel
-    from ultralytics.yolo.utils import RANK, __version__
+    from ultralytics.utils import RANK, __version__
 
     from wandb.integration.ultralytics.bbox_utils import (
         plot_predictions,


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
Fix `wandb.Error` in ultralytics integration

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba07f0e</samp>

Replaced `wandb.error` with `wandb.Error` in `wandb/integration/ultralytics/callback.py` to standardize exception handling. This affects the `setup_wandb_logger` function that imports the `wandb` module.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba07f0e</samp>

> _`wandb.error` gone_
> _`wandb.Error` class instead_
> _cutting through the code_
