### PR TITLE
chore(launch): job source error now actionable

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -362,6 +362,8 @@ class InterfaceBase:
     def _make_partial_source_str(
         source: Any, job_info: Dict[str, Any], metadata: Dict[str, Any]
     ) -> str:
+        import wandb
+        wandb.termlog(f"{source=} {job_info=} {metadata=}")
         """Construct use_artifact.partial.source_info.sourc as str."""
         source_type = job_info.get("source_type", "").strip()
         if source_type == "artifact":
@@ -377,7 +379,9 @@ class InterfaceBase:
         elif source_type == "image":
             source.image.image = metadata.get("docker", "")
         else:
-            raise ValueError("Invalid source type")
+            raise ValueError(
+                f"Invalid source type: '{source_type}'. Valid source types are ['image', 'code', 'git']"
+            )
 
         source_str: str = source.SerializeToString()
         return source_str

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -362,8 +362,6 @@ class InterfaceBase:
     def _make_partial_source_str(
         source: Any, job_info: Dict[str, Any], metadata: Dict[str, Any]
     ) -> str:
-        import wandb
-        wandb.termlog(f"{source=} {job_info=} {metadata=}")
         """Construct use_artifact.partial.source_info.sourc as str."""
         source_type = job_info.get("source_type", "").strip()
         if source_type == "artifact":


### PR DESCRIPTION
not exactly sure that showing the possiblilties for job sources works in all cases, as depending on the creation path we call the sources different things (repo vs. git). 

also, this is happening when we are running the job for the first time, but **after** creation. We really should be catching this error on creation. I think this is only possible to hit if the user is intentionally playing games with job creation, or they used the broken job-creation path in last SDK version. 