### PR TITLE
fix(sdk): fix graphql type mapping

### DIFF
--- a/nexus/api/graphql/genqlient.yaml
+++ b/nexus/api/graphql/genqlient.yaml
@@ -8,11 +8,11 @@ package: gql
 # optional: value
 optional: pointer
 bindings:
-  JSONString:
-    type: string
   DateTime:
     type: time.Time
   Duration:
     type: int64
   Int64:
-    type: int
+    type: int64
+  JSONString:
+    type: string

--- a/nexus/internal/gql/gql_gen.go
+++ b/nexus/internal/gql/gql_gen.go
@@ -542,12 +542,12 @@ type RunResumeStatusResponse struct {
 func (v *RunResumeStatusResponse) GetModel() *RunResumeStatusModelProject { return v.Model }
 
 type UploadPartsInput struct {
-	PartNumber int    `json:"partNumber"`
+	PartNumber int64  `json:"partNumber"`
 	HexMD5     string `json:"hexMD5"`
 }
 
 // GetPartNumber returns UploadPartsInput.PartNumber, and is useful for accessing the field via an interface.
-func (v *UploadPartsInput) GetPartNumber() int { return v.PartNumber }
+func (v *UploadPartsInput) GetPartNumber() int64 { return v.PartNumber }
 
 // GetHexMD5 returns UploadPartsInput.HexMD5, and is useful for accessing the field via an interface.
 func (v *UploadPartsInput) GetHexMD5() string { return v.HexMD5 }


### PR DESCRIPTION
Fixes WB-15188

# Description

Fixed GraphQL type mapping: `Int64` in GraphQL should be mapped to `int64` in Go.

# Test plan

Generated GraphQL code, made sure there are no build errors:
```
$ scripts/generate-graphql.sh
```