### PR TITLE
fix(sdk): increase max message size, handle errors

### DIFF
--- a/nexus/pkg/server/connection.go
+++ b/nexus/pkg/server/connection.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -20,8 +21,8 @@ import (
 )
 
 const (
-	messageSize    = 1024 * 1024      // 1MB message size
-	maxMessageSize = 64 * 1024 * 1024 // 64MB max message size
+	messageSize    = 1024 * 1024            // 1MB message size
+	maxMessageSize = 2 * 1024 * 1024 * 1024 // 2GB max message size
 )
 
 // Connection is the connection for a stream.
@@ -157,6 +158,9 @@ func (nc *Connection) readConnection() {
 		} else {
 			nc.inChan <- msg
 		}
+	}
+	if scanner.Err() != nil && !errors.Is(scanner.Err(), net.ErrClosed) {
+		panic(scanner.Err())
 	}
 	close(nc.inChan)
 }


### PR DESCRIPTION
Fixes WB-15188

# Description

- increased max message size passed to the background process from 64 MB to 2 GB
- added error handling (before we got stuck on errors)

# Test plan

- Created an artifact with ~120 MB manifest, made sure it got saved instead of getting stuck.
- Changed the max message size back to 64 MB and made sure we `panic`ed with an informative error message.