### PR TITLE
refactor(sdk): allow uploader to communicate errors back to the caller

### DIFF
--- a/nexus/internal/uploader/upload_task.go
+++ b/nexus/internal/uploader/upload_task.go
@@ -1,10 +1,7 @@
 package uploader
 
-import "sync"
-
 // UploadTask is a task to upload a file
 type UploadTask struct {
-
 	// Path is the path to the file
 	Path string
 
@@ -14,20 +11,9 @@ type UploadTask struct {
 	// Headers to send on the upload
 	Headers []string
 
-	// allow tasks to wait for completion (failed or success)
-	WgOutstanding *sync.WaitGroup
-}
+	// Error, if any.
+	Err error
 
-func (t *UploadTask) outstandingAdd() {
-	if t.WgOutstanding == nil {
-		return
-	}
-	t.WgOutstanding.Add(1)
-}
-
-func (t *UploadTask) outstandingDone() {
-	if t.WgOutstanding == nil {
-		return
-	}
-	t.WgOutstanding.Done()
+	// Callback to execute after completion (success or failure).
+	CompletionCallback func(*UploadTask)
 }

--- a/nexus/internal/uploader/uploader_default.go
+++ b/nexus/internal/uploader/uploader_default.go
@@ -33,7 +33,6 @@ func (u *DefaultUploader) Upload(task *UploadTask) error {
 	// open the file for reading and defer closing it
 	file, err := os.Open(task.Path)
 	if err != nil {
-		task.outstandingDone()
 		return err
 	}
 	defer func(file *os.File) {
@@ -55,15 +54,12 @@ func (u *DefaultUploader) Upload(task *UploadTask) error {
 	}
 
 	if err != nil {
-		task.outstandingDone()
 		return err
 	}
 
 	if _, err = u.client.Do(req); err != nil {
-		task.outstandingDone()
 		return err
 	}
 
-	task.outstandingDone()
 	return nil
 }

--- a/nexus/pkg/artifacts/saver.go
+++ b/nexus/pkg/artifacts/saver.go
@@ -164,10 +164,11 @@ func (as *ArtifactSaver) sendManifestFiles(artifactID string, manifestID string)
 	}
 	for n, edge := range response.GetCreateArtifactFiles().GetFiles().Edges {
 		task := uploader.UploadTask{
-			Url:           *edge.Node.GetUploadUrl(),
-			Path:          man.Contents[n].LocalPath,
-			WgOutstanding: &as.WgOutstanding,
+			Url:                *edge.Node.GetUploadUrl(),
+			Path:               man.Contents[n].LocalPath,
+			CompletionCallback: func(*uploader.UploadTask) { as.WgOutstanding.Done() },
 		}
+		as.WgOutstanding.Add(1)
 		as.UploadManager.AddTask(&task)
 	}
 }
@@ -209,11 +210,12 @@ func (as *ArtifactSaver) writeManifest() (string, error) {
 
 func (as *ArtifactSaver) sendManifest(manifestFile string, uploadUrl *string, uploadHeaders []string) {
 	task := uploader.UploadTask{
-		Url:           *uploadUrl,
-		Path:          manifestFile,
-		Headers:       uploadHeaders,
-		WgOutstanding: &as.WgOutstanding,
+		Url:                *uploadUrl,
+		Path:               manifestFile,
+		Headers:            uploadHeaders,
+		CompletionCallback: func(*uploader.UploadTask) { as.WgOutstanding.Done() },
 	}
+	as.WgOutstanding.Add(1)
 	as.UploadManager.AddTask(&task)
 }
 


### PR DESCRIPTION
Fixes WB-15188

# Description

There was no way to know whether an upload task succeeded or not. I made each task store the `error` (if any), and allow passing in a callback to execute when the task is finished (either succeeded or failed).

# Test plan

Tested in https://github.com/wandb/wandb/pull/6296