### PR TITLE
test(integrations): skip test_tb_watcher_logdir_not_exists on circle'…

### DIFF
--- a/tests/pytest_tests/unit_tests_old/test_tb_watcher.py
+++ b/tests/pytest_tests/unit_tests_old/test_tb_watcher.py
@@ -39,7 +39,7 @@ def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
 
 
 # skip on macos
-@pytest.skipif(
+@pytest.mark.skipif(
     platform.system() == "Darwin",
     reason="todo: fix gpu monitoring on CircleCI's M1 Macs",
 )

--- a/tests/pytest_tests/unit_tests_old/test_tb_watcher.py
+++ b/tests/pytest_tests/unit_tests_old/test_tb_watcher.py
@@ -38,6 +38,11 @@ def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
     ]
 
 
+# skip on macos
+@pytest.skipif(
+    platform.system() == "Darwin",
+    reason="todo: fix gpu monitoring on CircleCI's M1 Macs",
+)
 def test_tb_watcher_logdir_not_exists(mocked_run, tbwatcher_util, capsys):
     # TODO: check caplog for right error text
     pytest.importorskip("tensorboard.summary.v1")


### PR DESCRIPTION
…s m1 mac runners

Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44af306</samp>

Skip `test_tb_watcher` on macos to avoid gpu monitoring issue on CircleCI's M1 Macs. This is a temporary fix for `tests/pytest_tests/unit_tests_old/test_tb_watcher.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 44af306</samp>

> _`test_tb_watcher`_
> _skipped on macos for now_
> _gpu issue - fall_
