### PR TITLE
Improve error handling for gitlib for FileNotFoundErrors

### DIFF
--- a/wandb/sdk/lib/gitlib.py
+++ b/wandb/sdk/lib/gitlib.py
@@ -50,7 +50,7 @@ class GitRepo:
         try:
             return Repo(self._root or os.getcwd(), search_parent_directories=True)
         except FileNotFoundError:
-            wandb.termwarn(f"current working directory has been invalidated")
+            wandb.termwarn("current working directory has been invalidated")
             logger.warn("current working directory has been invalidated")
         except InvalidGitRepositoryError:
             logger.debug("git repository is invalid")

--- a/wandb/sdk/lib/gitlib.py
+++ b/wandb/sdk/lib/gitlib.py
@@ -49,6 +49,9 @@ class GitRepo:
             return None
         try:
             return Repo(self._root or os.getcwd(), search_parent_directories=True)
+        except FileNotFoundError:
+            wandb.termwarn(f"current working directory has been invalidated")
+            logger.warn("current working directory has been invalidated")
         except InvalidGitRepositoryError:
             logger.debug("git repository is invalid")
         except NoSuchPathError:


### PR DESCRIPTION
Description
-----------

Spent a good while trying to figure out why clearing my `tmp_path` with `pytest tests/loggers/test_wandb_logger.py -x -s -o tmp_path_retention_policy=failed` errors out in the mosaicml [composer tests](https://github.com/mosaicml/composer/blob/9977bd60ea8f5e745b9b8f02eba0a3360900dd9c/tests/loggers/test_wandb_logger.py#L45-L46) whereas `pytest tests/loggers/test_wandb_logger.py -x -s -o tmp_path_retention_policy=all` passes. 

Here is the error log:

```
Thread HandlerThread:
Traceback (most recent call last):
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/internal_util.py", line 49, in run
    self._run()
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/internal_util.py", line 100, in _run
    self._process(record)
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/internal.py", line 278, in _process
    self._hm.handle(record)
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/handler.py", line 136, in handle
    handler(record)
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/handler.py", line 146, in handle_request
    handler(record)
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/handler.py", line 706, in handle_request_run_start
    self._system_monitor.probe(publish=True)
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/system/system_monitor.py", line 207, in probe
    software_info: dict = self.system_info.probe()
                          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/system/system_info.py", line 230, in probe
    data = self._probe_git(data)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/internal/system/system_info.py", line 177, in _probe_git
    if not self.git.enabled and self.git.auto:
           ^^^^^^^^^^^^^^^^
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/lib/gitlib.py", line 79, in enabled
    return bool(self.repo)
                ^^^^^^^^^
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/lib/gitlib.py", line 62, in repo
    self._repo = self._init_repo()
                 ^^^^^^^^^^^^^^^^^
  File "/Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/lib/gitlib.py", line 51, in _init_repo
    return Repo(self._root or os.getcwd(), search_parent_directories=True)
                              ^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
wandb: ERROR Internal wandb error: file data was not synced
Problem at: /Users/chuck.tang/miniconda3/lib/python3.11/site-packages/wandb/sdk/wandb_init.py 829 getcaller
```

The reason is because `tmp_path` is cleared at the end of a pytest in the main wandb process which results in the background thread spawned in wandb_init having an invalid `os.getcwd().` This error is currently **uncaught** in the existing codebase ❌ .

The correct behavior here should be that a FileNotFoundError exception is caught and no git repo logic is logged  ✅ . This PR implements that so that users don't have to set the WANDB_DISABLE_GIT flag if they decide to clear their pytest tmp_paths with the flag `-o tmp_path_retention_policy=failed`


Testing
-------
How was this PR tested? Tested in mosaicml/composer tests e.g:
```
git clone https://github.com/mosaicml/composer.git
git checkout dev
pip install -e .[all]
```
Before: `pytest tests/loggers/test_wandb_logger.py -x -s -o tmp_path_retention_policy=failed` fails with error log above ❌ 
After: `pytest tests/loggers/test_wandb_logger.py -x -s -o tmp_path_retention_policy=failed` works if we add this commit ✅ 
