### PR TITLE
chore(sdk): fix generate-docodile-documentation.yml

### DIFF
--- a/.github/workflows/generate-docodile-documentation.yml
+++ b/.github/workflows/generate-docodile-documentation.yml
@@ -20,6 +20,9 @@ jobs: # update the docs.
       - name: Prepare wandb-branch value
         run: |
           REF_VALUE="${{ github.event.inputs.ref }}"
+          if [[ -z "$REF_VALUE" ]]; then
+            REF_VALUE="${{ github.event.release.tag_name }}"
+          fi
           if [[ "$REF_VALUE" == refs/tags/* ]]; then
           echo "WANDB_BRANCH=${REF_VALUE/refs\/tags\//}" >> "$GITHUB_ENV"
           else


### PR DESCRIPTION
Fixes
-----
- Fixes WB-NNNNN
- Fixes #NNNN

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8df0577</samp>

This change improves the docodile documentation generation workflow by using the release tag name as the reference value for the wandb library version if no other value is provided. This affects the file `.github/workflows/generate-docodile-documentation.yml`.

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8df0577</samp>

> _`REF_VALUE` empty?_
> _Assign release tag name then_
> _Docodile in fall_
