### PR TITLE
Adds contexual information about runs.

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -959,6 +959,11 @@ def init(
 ) -> Union[Run, RunDisabled, None]:
     r"""Start a new run to track and log to W&B.
 
+    `wandb.init` creates a [run](https://docs.wandb.ai/ref/python/run), a single unit of computation
+    that W&B can log. If you find yourself making major changes
+    like editing a hyperparameter, using a different model,
+    or creating an artifact, you should initialize a new run.
+
     In an ML training pipeline, you could add `wandb.init()`
     to the beginning of your training script as well as your evaluation
     script, and each piece would be tracked as a run in W&B.
@@ -966,7 +971,7 @@ def init(
     `wandb.init()` spawns a new background process to log data to a run, and it
     also syncs data to wandb.ai by default, so you can see live visualizations.
 
-    Call `wandb.init()` to start a run before logging data with `wandb.log()`:
+    You must call `wandb.init()` to start a run before logging data with `wandb.log()`:
     <!--yeadoc-test:init-method-log-->
     ```python
     import wandb
@@ -986,6 +991,8 @@ def init(
 
     assert run is wandb.run
     ```
+
+    There is only ever at most one active run object in any process.
 
     At the end of your script, we will automatically call `wandb.finish` to
     finalize and cleanup the run. However, if you call `wandb.init` from a


### PR DESCRIPTION
Updates the context of the doc strings for the [sdk reference](https://docs.wandb.ai/ref/python/init) docs.

Context: according to a [preliminary audit](https://www.notion.so/wandbai/Katherine-s-Audit-of-Docs-Metrics-bc2c2f1532da4860b1a40950c799b95f?pvs=4), some of the SDK reference documentation is confusing to readers. These fixes are intended to provide a quick boost to this by improving format and readability. This is one of a series of PRs that will touch our reference documentation.

Changes:
- Fixed some spelling and grammatical errors.
- Added additional content on runs and logging.
- Added some parity between CLI and SDK doc strings, where applicable.

Next Steps:
- Continue to expand and/or clarify conceptual content on other SDK reference pages (login, run)
- A larger effort focused on revamping CLI doc strings.

Fixes
-----
- Linked to [DOCS-777](https://wandb.atlassian.net/browse/DOCS-777)
- Linked to #6420 (and a cleaner re-upload of #6421)

Description
-----------
What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 560b1c0</samp>

This pull request enhances the documentation of the `wandb.init()` function, which creates a run object to track and manage experiments. It clarifies the definition, parameters, and behavior of the function and the run object in the file `wandb/sdk/wandb_init.py`.

Testing
-------
How was this PR tested?

Checklist
-------
- [x] Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [x] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 560b1c0</samp>

> _`wandb.init()` is the key to the gate_
> _The gate of knowledge and power_
> _But beware of the run object's fate_
> _It may vanish in the final hour_


[DOCS-777]: https://wandb.atlassian.net/browse/DOCS-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ