### PR TITLE
chore(artifacts): remove dead code

### DIFF
--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -1,5 +1,4 @@
 """GCS storage handler."""
-import base64
 import time
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple, Union
@@ -213,12 +212,3 @@ class GCSHandler(StorageHandler):
             "etag": obj.etag,
             "versionID": obj.generation,
         }
-
-    @staticmethod
-    def _content_addressed_path(md5: str) -> FilePathStr:
-        # TODO: is this the structure we want? not at all human
-        # readable, but that's probably OK. don't want people
-        # poking around in the bucket
-        return FilePathStr(
-            "wandb/%s" % base64.b64encode(md5.encode("ascii")).decode("ascii")
-        )

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -1,5 +1,4 @@
 """S3 storage handler."""
-import base64
 import os
 import time
 from pathlib import PurePosixPath
@@ -292,12 +291,3 @@ class S3Handler(StorageHandler):
         if hasattr(obj, "version_id") and obj.version_id and obj.version_id != "null":
             extra["versionID"] = obj.version_id
         return extra
-
-    @staticmethod
-    def _content_addressed_path(md5: str) -> FilePathStr:
-        # TODO: is this the structure we want? not at all human
-        # readable, but that's probably OK. don't want people
-        # poking around in the bucket
-        return FilePathStr(
-            "wandb/%s" % base64.b64encode(md5.encode("ascii")).decode("ascii")
-        )


### PR DESCRIPTION
Fixes WB-13717

# Description

Removing a function that was added in the [original artifacts PR](https://github.com/wandb/client-ng/pull/30) and never used.

# Test plan

Grepped for `_content_addressed_path`.