### PR TITLE
test(artifacts): move tests from unit_tests_old to system_tests

### DIFF
--- a/tests/pytest_tests/system_tests/conftest.py
+++ b/tests/pytest_tests/system_tests/conftest.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 import os
 import platform
 import secrets
@@ -877,20 +878,26 @@ def inject_graphql_response(base_url, user):
     def helper(
         body: Union[str, Exception] = "{}",
         status: int = 200,
-        custom_match_fn=None,
+        query_match_fn=None,
         application_pattern: str = "1",
     ) -> InjectedResponse:
+        def match(self, request):
+            body = json.loads(request.body)
+            return query_match_fn(body["query"], body["variables"])
+
         if status > 299:
             message = body if isinstance(body, str) else "::".join(body.args)
             body = DeliberateHTTPError(status_code=status, message=message)
 
         return InjectedResponse(
+            # request
             method="POST",
             url=urllib.parse.urljoin(base_url, "/graphql"),
+            custom_match_fn=match if query_match_fn else None,
+            application_pattern=TokenizedCircularPattern(application_pattern),
+            # response
             body=body,
             status=status,
-            custom_match_fn=custom_match_fn,
-            application_pattern=TokenizedCircularPattern(application_pattern),
         )
 
     yield helper

--- a/tests/pytest_tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb_init.py
@@ -8,15 +8,10 @@ def test_upsert_bucket_409(
     inject_graphql_response,
 ):
     """Test that we retry upsert bucket mutations on 409s."""
-
-    def custom_match_fn(self, other):  # noqa
-        request_body = other.__dict__.get("body") or b"{}"
-        return b"mutation UpsertBucket" in request_body
-
     inject_response = inject_graphql_response(
         body="GOT ME A 409",
         status=409,
-        custom_match_fn=custom_match_fn,
+        query_match_fn=lambda query, variables: "mutation UpsertBucket" in query,
         application_pattern="12",  # apply once and stop
     )
     # we'll retry once and succeed
@@ -32,15 +27,10 @@ def test_upsert_bucket_410(
     inject_graphql_response,
 ):
     """Test that we do not retry upsert bucket mutations on 410s."""
-
-    def custom_match_fn(self, other):  # noqa
-        request_body = other.__dict__.get("body") or b"{}"
-        return b"mutation UpsertBucket" in request_body
-
     inject_response = inject_graphql_response(
         body="GOT ME A 410",
         status=410,
-        custom_match_fn=custom_match_fn,
+        query_match_fn=lambda query, variables: "mutation UpsertBucket" in query,
         application_pattern="12",  # apply once and stop
     )
     # we do not retry 410s on upsert bucket mutations, so this should fail
@@ -57,15 +47,10 @@ def test_gql_409(
     inject_graphql_response,
 ):
     """Test that we retry upsert bucket mutations on 409s."""
-
-    def custom_match_fn(self, other):  # noqa
-        request_body = other.__dict__.get("body") or b"{}"
-        return b"mutation CreateRunFiles" in request_body
-
     inject_response = inject_graphql_response(
         body="GOT ME A 409",
         status=409,
-        custom_match_fn=custom_match_fn,
+        query_match_fn=lambda query, variables: "mutation CreateRunFiles" in query,
         application_pattern="12",  # apply once and stop
     )
     # we do not retry 409s on queries, so this should fail
@@ -81,15 +66,10 @@ def test_gql_410(
     inject_graphql_response,
 ):
     """Test that we do not retry upsert bucket mutations on 410s."""
-
-    def custom_match_fn(self, other):  # noqa
-        request_body = other.__dict__.get("body") or b"{}"
-        return b"mutation CreateRunFiles" in request_body
-
     inject_response = inject_graphql_response(
         body="GOT ME A 410",
         status=410,
-        custom_match_fn=custom_match_fn,
+        query_match_fn=lambda query, variables: "mutation CreateRunFiles" in query,
         application_pattern="1112",  # apply thrice and stop
     )
     # we'll retry once and succeed

--- a/wandb/testing/relay.py
+++ b/wandb/testing/relay.py
@@ -284,9 +284,10 @@ class QueryResolver:
                 "name": "upsert_sweep",
                 "resolver": self.resolve_upsert_sweep,
             },
-            # { "name": "create_artifact",
-            #     "resolver": self.resolve_create_artifact,
-            # },
+            {
+                "name": "create_artifact",
+                "resolver": self.resolve_create_artifact,
+            },
         ]
 
     @staticmethod
@@ -525,8 +526,8 @@ class InjectedResponse:
         # always check the method and url
         ret = self.method == other.method and self.url == other.url
         # use custom_match_fn to check, e.g. the request body content
-        if self.custom_match_fn is not None:
-            ret = ret and self.custom_match_fn(self, other)
+        if ret and self.custom_match_fn is not None:
+            ret = self.custom_match_fn(self, other)
         return ret
 
     def to_dict(self):


### PR DESCRIPTION
Fixes WB-13808

# Description

Artifacts tests in the `wandb` repo are a mess. As a result, we don't write tests and spend a lot of time keeping the existing ones up to date. I'm on a mission to clean this up in WB-13808.

First, I want to consolidate our tests into the [system_tests directory](https://github.com/wandb/wandb/tree/main/tests/pytest_tests/system_tests/test_artifacts) and move each test to a file corresponding to the code under test. This will solve a number of problems:
- when you look at a file, it will be clear where to look for its tests, and vice versa
- we will no longer use the mock server, which was a pain
- all tests will be run the same way
Note that terminology like "unit" vs "integration" vs "system" vs "functional" etc. is arbitrary, see [here](https://testing.googleblog.com/2010/12/test-sizes.html).

In this PR, I moved tests from `unit_tests_old` to `system_tests` and made some necessary changes:
- improved server response injection:
  - only execute custom request matching function if the request method & url match, so that the function doesn't have to check it again
  - modified util for injecting GraphQL responses to handle request body parsing, so that the request matching function doesn't have to do it
- removed filesystem isolation, this is done automatically for all pytest tests [here](https://github.com/wandb/wandb/blob/0a11b2e456178d1e5b25912fb9ee20caab4bfb46/tests/pytest_tests/conftest.py#L54)
- added `user` fixture to each test for isolation
- replaced `with.init()` + `wandb.finish()` with `with wandb.init():` so that the run is finished before the user is deleted in case there's an exception in the middle of the test
- changed the way transient server errors are injected
- changed the way captured requests are accessed
- removed unnecessary timeout increses
- `artifact.verify()` now works correctly, so I removed the special case for it

# Test plan

```
$ pytest tests/pytest_tests/system_tests/test_artifacts/test_misc2.py
```