### PR TITLE
refactor(artifacts): rename get_path() to get_entry()

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_misc2.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_misc2.py
@@ -94,7 +94,7 @@ def test_lazy_artifact_passthrough(user):
         testable_methods_valid = ["finalize", "is_draft"]
         # These methods should be valid only after logging
         testable_methods_invalid = [
-            "get_path",
+            "get_entry",
             "get",
             "download",
             "checkout",
@@ -104,7 +104,7 @@ def test_lazy_artifact_passthrough(user):
             "logged_by",
             "json_encode",
         ]
-        params = {"get_path": ["t1.table.json"], "get": ["t1"], "delete": [True]}
+        params = {"get_entry": ["t1.table.json"], "get": ["t1"], "delete": [True]}
 
         for valid_getter in testable_getters_valid:
             _ = getattr(art, valid_getter)
@@ -179,14 +179,14 @@ def test_reference_download(user):
 
     with wandb.init() as run:
         artifact = run.use_artifact("test_reference_download:latest")
-        entry = artifact.get_path("StarWars3.wav")
+        entry = artifact.get_entry("StarWars3.wav")
         entry.download()
         assert (
             entry.ref_target()
             == "https://wandb-artifacts-refs-public-test.s3-us-west-2.amazonaws.com/StarWars3.wav"
         )
 
-        entry = artifact.get_path("file1.txt")
+        entry = artifact.get_entry("file1.txt")
         entry.download()
         with pytest.raises(ValueError):
             assert entry.ref_target()

--- a/tests/pytest_tests/system_tests/test_artifacts/test_object_references.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_object_references.py
@@ -360,7 +360,7 @@ def test_artifact_add_reference_via_url(user, cleanup):
             assert file.read() == file_text
 
 
-# # Artifact1.add_reference(artifact2.get_path(file_name))
+# # Artifact1.add_reference(artifact2.get_entry(file_name))
 def test_add_reference_via_artifact_entry(user, cleanup):
     """Test adding a reference to an artifact via an ArtifactEntry.
 
@@ -401,7 +401,7 @@ def test_add_reference_via_artifact_entry(user, cleanup):
         artifact = wandb.Artifact(middle_artifact_name, "database")
         upstream_artifact = run.use_artifact(upstream_artifact_name + ":latest")
         artifact.add_reference(
-            upstream_artifact.get_path(upstream_artifact_file_path),
+            upstream_artifact.get_entry(upstream_artifact_file_path),
             middle_artifact_file_path,
         )
         run.log_artifact(artifact)
@@ -411,7 +411,7 @@ def test_add_reference_via_artifact_entry(user, cleanup):
         artifact = wandb.Artifact(downstream_artifact_name, "database")
         middle_artifact = run.use_artifact(middle_artifact_name + ":latest")
         artifact.add_reference(
-            middle_artifact.get_path(middle_artifact_file_path),
+            middle_artifact.get_entry(middle_artifact_file_path),
             downstream_artifact_file_path,
         )
         run.log_artifact(artifact)
@@ -637,7 +637,7 @@ def assert_media_obj_referential_equality(obj):
     assert obj2 == obj
     # name = "obj2." + type(obj)._log_type + ".json"
     # start_path = os.path.join(mid_dir, name)
-    # mid_artifact_ref.get_path(name).download()
+    # mid_artifact_ref.get_entry(name).download()
     # assert os.path.islink(start_path)
     # assert os.path.abspath(os.readlink(start_path)) == os.path.abspath(target_path)
 
@@ -661,7 +661,7 @@ def assert_media_obj_referential_equality(obj):
     assert not os.path.isdir(os.path.join(mid_dir))
     # name = "obj3." + type(obj)._log_type + ".json"
     # start_path = os.path.join(down_dir, name)
-    # down_artifact_ref.get_path(name).download()
+    # down_artifact_ref.get_entry(name).download()
     # assert os.path.islink(start_path)
     # assert os.path.abspath(os.readlink(start_path)) == os.path.abspath(target_path)
 
@@ -768,7 +768,7 @@ def test_joined_table_add_by_path(user, cleanup):
 
         # Able to add by reference
         jt = wandb.JoinedTable(
-            upstream.get_path("src_table_1"), upstream.get_path("src_table_2"), "id"
+            upstream.get_entry("src_table_1"), upstream.get_entry("src_table_2"), "id"
         )
         tables_2.add(jt, "jt")
         run.log_artifact(tables_2)

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -396,7 +396,7 @@ def test_wbartifact_handler_load_path_nonlocal(monkeypatch):
     handler = WBArtifactHandler()
     handler._client = FakePublicApi()
     monkeypatch.setattr(Artifact, "_from_id", lambda _1, _2: artifact)
-    artifact.get_path = lambda _: artifact
+    artifact.get_entry = lambda _: artifact
     artifact.ref_target = lambda: uri
 
     local_path = handler.load_path(manifest_entry)
@@ -417,7 +417,7 @@ def test_wbartifact_handler_load_path_local(monkeypatch):
     handler = WBArtifactHandler()
     handler._client = FakePublicApi()
     monkeypatch.setattr(Artifact, "_from_id", lambda _1, _2: artifact)
-    artifact.get_path = lambda _: artifact
+    artifact.get_entry = lambda _: artifact
     artifact.download = lambda: path
 
     local_path = handler.load_path(manifest_entry, local=True)

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -502,8 +502,8 @@ def test_unlogged_artifact_basic_method_errors(method):
 
 def test_unlogged_artifact_other_method_errors():
     art = Artifact("foo", type="any")
-    with pytest.raises(ArtifactNotLoggedError, match="Artifact.get_path"):
-        art.get_path("pathname")
+    with pytest.raises(ArtifactNotLoggedError, match="Artifact.get_entry"):
+        art.get_entry("pathname")
 
     with pytest.raises(ArtifactNotLoggedError, match="Artifact.get"):
         art["obj_name"]

--- a/tests/pytest_tests/unit_tests_old/test_artifacts/test_artifact_public_api.py
+++ b/tests/pytest_tests/unit_tests_old/test_artifacts/test_artifact_public_api.py
@@ -40,7 +40,7 @@ def test_artifact_get_path(runner, mock_server, api):
     assert art.type == "dataset"
     assert art.name == "mnist:v0"
     with runner.isolated_filesystem():
-        path = art.get_path("digits.h5")
+        path = art.get_entry("digits.h5")
         res = path.download()
         part = art.name
         if platform.system() == "Windows":
@@ -52,7 +52,7 @@ def test_artifact_get_path(runner, mock_server, api):
 def test_artifact_get_path_download(runner, mock_server, api):
     with runner.isolated_filesystem():
         art = api.artifact("entity/project/mnist:v0", type="dataset")
-        path = art.get_path("digits.h5").download(os.getcwd())
+        path = art.get_entry("digits.h5").download(os.getcwd())
         assert os.path.exists("./digits.h5")
         assert path == os.path.join(os.getcwd(), "digits.h5")
 

--- a/tests/standalone_tests/dsviz_demo.py
+++ b/tests/standalone_tests/dsviz_demo.py
@@ -442,7 +442,7 @@ def main():
 
             # Download the saved model file.
             model_artifact = run.use_artifact("trained_model:latest")
-            path = model_artifact.get_path("model.pkl").download()
+            path = model_artifact.get_entry("model.pkl").download()
 
             # Load the model from the file and score it
             model = ExampleSegmentationModel.load(path)

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -584,7 +584,7 @@ class Table(Media):
                         required="Deserializing numpy columns requires numpy to be installed",
                     )
                     deserialized = np.load(
-                        source_artifact.get_path(serialization_path["path"]).download()
+                        source_artifact.get_entry(serialization_path["path"]).download()
                     )
                     np_deserialized_columns[
                         json_obj["columns"].index(col_name)
@@ -1100,7 +1100,7 @@ class Audio(BatchableMedia):
     @classmethod
     def from_json(cls, json_obj, source_artifact):
         return cls(
-            source_artifact.get_path(json_obj["path"]).download(),
+            source_artifact.get_entry(json_obj["path"]).download(),
             caption=json_obj["caption"],
         )
 
@@ -1383,7 +1383,7 @@ class Bokeh(Media):
 
     @classmethod
     def from_json(cls, json_obj, source_artifact):
-        return cls(source_artifact.get_path(json_obj["path"]).download())
+        return cls(source_artifact.get_entry(json_obj["path"]).download())
 
 
 def _nest(thing):

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1281,7 +1281,7 @@ class Artifact:
 
         Arguments:
             uri: The URI path of the reference to add. Can be an object returned from
-                Artifact.get_path to store a reference to another artifact's entry.
+                Artifact.get_entry to store a reference to another artifact's entry.
             name: The path within the artifact to place the contents of this reference
             checksum: Whether or not to checksum the resource(s) located at the
                 reference URI. Checksumming is strongly recommended as it enables
@@ -1512,6 +1512,13 @@ class Artifact:
             self.manifest.remove_entry(entry)
 
     def get_path(self, name: StrPath) -> ArtifactManifestEntry:
+        """Deprecated, use get_entry(name) instead."""
+        termwarn(
+            "Artifact.get_path(name) is deprecated, use Artifact.get_entry(name) instead."
+        )
+        return self.get_entry(name)
+
+    def get_entry(self, name: StrPath) -> ArtifactManifestEntry:
         """Get the entry with the given name.
 
         Arguments:
@@ -1533,13 +1540,13 @@ class Artifact:
             # Run using the artifact
             with wandb.init() as r:
                 artifact = r.use_artifact("my_dataset:latest")
-                path = artifact.get_path("file.txt")
+                entry = artifact.get_entry("file.txt")
 
                 # Can now download 'file.txt' directly:
-                path.download()
+                entry.download()
             ```
         """
-        self._ensure_logged("get_path")
+        self._ensure_logged("get_entry")
 
         name = LogicalPath(name)
         entry = self.manifest.entries.get(name) or self._get_obj_entry(name)[0]
@@ -1599,7 +1606,7 @@ class Artifact:
             self.download()
 
         # Get the ArtifactManifestEntry
-        item = self.get_path(entry.path)
+        item = self.get_entry(entry.path)
         item_path = item.download()
 
         # Load the object from the JSON blob
@@ -1796,7 +1803,7 @@ class Artifact:
                 has_next_page = attrs["pageInfo"]["hasNextPage"]
                 cursor = attrs["pageInfo"]["endCursor"]
                 for edge in attrs["edges"]:
-                    entry = self.get_path(edge["node"]["name"])
+                    entry = self.get_entry(edge["node"]["name"])
                     if require_nexus and entry.ref is None:
                         # Handled by nexus
                         continue
@@ -1885,7 +1892,7 @@ class Artifact:
                 full_path = os.path.join(dirpath, file)
                 artifact_path = os.path.relpath(full_path, start=root)
                 try:
-                    self.get_path(artifact_path)
+                    self.get_entry(artifact_path)
                 except KeyError:
                     # File is not part of the artifact, remove it.
                     os.remove(full_path)
@@ -1917,7 +1924,7 @@ class Artifact:
                 full_path = os.path.join(dirpath, file)
                 artifact_path = os.path.relpath(full_path, start=root)
                 try:
-                    self.get_path(artifact_path)
+                    self.get_entry(artifact_path)
                 except KeyError:
                     raise ValueError(
                         "Found file {} which is not a member of artifact {}".format(
@@ -1957,10 +1964,10 @@ class Artifact:
         if len(self.manifest.entries) > 1:
             raise ValueError(
                 "This artifact contains more than one file, call `.download()` to get "
-                'all files or call .get_path("filename").download()'
+                'all files or call .get_entry("filename").download()'
             )
 
-        return self.get_path(list(self.manifest.entries)[0]).download(root)
+        return self.get_entry(list(self.manifest.entries)[0]).download(root)
 
     def files(
         self, names: Optional[List[str]] = None, per_page: int = 50

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -164,7 +164,7 @@ class ArtifactManifestEntry:
         Examples:
             Basic usage
             ```
-            ref_url = source_artifact.get_path('file.txt').ref_url()
+            ref_url = source_artifact.get_entry('file.txt').ref_url()
             derived_artifact.add_reference(ref_url)
             ```
         """

--- a/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
@@ -68,9 +68,9 @@ class WBArtifactHandler(StorageHandler):
         assert dep_artifact is not None
         link_target_path: Union[URIStr, FilePathStr]
         if local:
-            link_target_path = dep_artifact.get_path(artifact_file_path).download()
+            link_target_path = dep_artifact.get_entry(artifact_file_path).download()
         else:
-            link_target_path = dep_artifact.get_path(artifact_file_path).ref_target()
+            link_target_path = dep_artifact.get_entry(artifact_file_path).ref_target()
 
         return link_target_path
 

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -232,7 +232,7 @@ class Media(WBValue):
                             name = name.lstrip(os.sep)
 
                         # Add this image as a reference
-                        path = self._artifact_source.artifact.get_path(name)
+                        path = self._artifact_source.artifact.get_entry(name)
                         artifact.add_reference(path.ref_url(), name=name)
                     elif (
                         isinstance(self, Audio) or isinstance(self, Image)
@@ -254,7 +254,7 @@ class Media(WBValue):
         cls: Type["Media"], json_obj: dict, source_artifact: "Artifact"
     ) -> "Media":
         """Likely will need to override for any more complicated media objects."""
-        return cls(source_artifact.get_path(json_obj["path"]).download())
+        return cls(source_artifact.get_entry(json_obj["path"]).download())
 
     def __eq__(self, other: object) -> bool:
         """Likely will need to override for any more complicated media objects."""

--- a/wandb/sdk/data_types/base_types/wb_value.py
+++ b/wandb/sdk/data_types/base_types/wb_value.py
@@ -207,7 +207,7 @@ class WBValue:
     def _get_artifact_entry_ref_url(self) -> Optional[str]:
         # If the object is coming from another artifact
         if self._artifact_source and self._artifact_source.name:
-            ref_entry = self._artifact_source.artifact.get_path(
+            ref_entry = self._artifact_source.artifact.get_entry(
                 type(self).with_suffix(self._artifact_source.name)
             )
             return str(ref_entry.ref_url())
@@ -236,7 +236,7 @@ class WBValue:
             and not _server_accepts_client_ids()
         ):
             self._artifact_target.artifact.wait()
-            ref_entry = self._artifact_target.artifact.get_path(
+            ref_entry = self._artifact_target.artifact.get_entry(
                 type(self).with_suffix(self._artifact_target.name)
             )
             return str(ref_entry.ref_url())
@@ -267,7 +267,7 @@ class WBValue:
             and not _server_accepts_client_ids()
         ):
             self._artifact_target.artifact.wait()
-            ref_entry = self._artifact_target.artifact.get_path(
+            ref_entry = self._artifact_target.artifact.get_entry(
                 type(self).with_suffix(self._artifact_target.name)
             )
             return str(ref_entry.ref_url())

--- a/wandb/sdk/data_types/helper_types/image_mask.py
+++ b/wandb/sdk/data_types/helper_types/image_mask.py
@@ -186,7 +186,7 @@ class ImageMask(Media):
         cls: Type["ImageMask"], json_obj: dict, source_artifact: "Artifact"
     ) -> "ImageMask":
         return cls(
-            {"path": source_artifact.get_path(json_obj["path"]).download()},
+            {"path": source_artifact.get_entry(json_obj["path"]).download()},
             key="",
         )
 

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -86,7 +86,7 @@ class Html(BatchableMedia):
     def from_json(
         cls: Type["Html"], json_obj: dict, source_artifact: "Artifact"
     ) -> "Html":
-        return cls(source_artifact.get_path(json_obj["path"]).download(), inject=False)
+        return cls(source_artifact.get_entry(json_obj["path"]).download(), inject=False)
 
     @classmethod
     def seq_to_json(

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -336,7 +336,7 @@ class Image(BatchableMedia):
                 _boxes[key]._key = key
 
         return cls(
-            source_artifact.get_path(json_obj["path"]).download(),
+            source_artifact.get_entry(json_obj["path"]).download(),
             caption=json_obj.get("caption"),
             grouping=json_obj.get("grouping"),
             classes=classes,

--- a/wandb/sdk/data_types/saved_model.py
+++ b/wandb/sdk/data_types/saved_model.py
@@ -57,7 +57,7 @@ def _load_dir_from_artifact(source_artifact: "Artifact", path: str) -> str:
     # Construct the directory path by inspecting the target download location.
     for p, _ in source_artifact.manifest.entries.items():
         if p.startswith(path):
-            example_path = source_artifact.get_path(p).download()
+            example_path = source_artifact.get_entry(p).download()
             if dl_path is None:
                 root = example_path[: -len(p)]
                 dl_path = os.path.join(root, path)
@@ -132,7 +132,7 @@ class _SavedModel(WBValue, Generic[SavedModelObjType]):
         # First, if the entry is a file, the download it.
         entry = source_artifact.manifest.entries.get(path)
         if entry is not None:
-            dl_path = str(source_artifact.get_path(path).download())
+            dl_path = str(source_artifact.get_entry(path).download())
         else:
             # If not, assume it is directory.
             # FUTURE: Add this functionality to the artifact loader

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -421,7 +421,7 @@ class InterfaceBase:
             # Download source info from logged partial job artifact
             job_info = {}
             try:
-                path = artifact.get_path("wandb-job.json").download()
+                path = artifact.get_entry("wandb-job.json").download()
                 with open(path) as f:
                     job_info = json.load(f)
             except Exception as e:


### PR DESCRIPTION
Fixes WB-16027

# Description

`Artifact.get_path(name)` returns an `ArtifactManifestEntry`, it should be called `get_entry(name)`.

# Test plan

![Untitled](https://github.com/wandb/wandb/assets/127154459/6235876c-d5be-4760-818f-91b878b8849a)