### PR TITLE
test(sdk): handle case `HTTPError.response` is `None` for mypy

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1474,9 +1474,7 @@ class Graph(Media):
             node = Node(**node_kwargs)
         elif node_kwargs:
             raise ValueError(
-                "Only pass one of either node ({node}) or other keyword arguments ({node_kwargs})".format(
-                    node=node, node_kwargs=node_kwargs
-                )
+                f"Only pass one of either node ({node}) or other keyword arguments ({node_kwargs})"
             )
         self.nodes.append(node)
         self.nodes_by_id[node.id] = node

--- a/wandb/integration/sacred/__init__.py
+++ b/wandb/integration/sacred/__init__.py
@@ -86,9 +86,7 @@ class WandbObserver(RunObserver):
                     wandb.log({f"result_{i}": wandb.Image(r)})
                 else:
                     warnings.warn(
-                        "logging results does not support type '{}' results. Ignoring this result".format(
-                            type(r),
-                        ),
+                        f"logging results does not support type '{type(r)}' results. Ignoring this result",
                         stacklevel=2,
                     )
 

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -441,9 +441,7 @@ class ConstType(Type):
     def __init__(self, val: t.Optional[t.Any] = None, is_set: t.Optional[bool] = False):
         if val.__class__ not in [str, int, float, bool, set, list, None.__class__]:
             TypeError(
-                "ConstType only supports str, int, float, bool, set, list, and None types. Found {}".format(
-                    val
-                )
+                f"ConstType only supports str, int, float, bool, set, list, and None types. Found {val}"
             )
         if is_set or isinstance(val, set):
             is_set = True

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -366,6 +366,7 @@ class Api:
             return self.client.execute(*args, **kwargs)  # type: ignore
         except requests.exceptions.HTTPError as err:
             response = err.response
+            assert response is not None
             logger.error(f"{response.status_code} response executing GraphQL.")
             logger.error(response.text)
             for error in parse_backend_error_messages(response):

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -444,7 +444,11 @@ def check_large_post() -> bool:
             timeout=60,
         )
     except Exception as e:
-        if isinstance(e, requests.HTTPError) and e.response.status_code == 413:
+        if (
+            isinstance(e, requests.HTTPError)
+            and e.response is not None
+            and e.response.status_code == 413
+        ):
             failed_test_strings.append(
                 'Failed to send a large payload. Check nginx.ingress.kubernetes.io/proxy-body-size is "0".'
             )

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -226,9 +226,7 @@ class SyncThread(threading.Thread):
         except AssertionError as e:
             if ds.in_last_block():
                 wandb.termwarn(
-                    ".wandb file is incomplete ({}), be sure to sync this run again once it's finished".format(
-                        e
-                    )
+                    f".wandb file is incomplete ({e}), be sure to sync this run again once it's finished"
                 )
                 return None
             else:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -871,6 +871,7 @@ def make_safe_for_json(obj: Any) -> Any:
 def no_retry_4xx(e: Exception) -> bool:
     if not isinstance(e, requests.HTTPError):
         return True
+    assert e.response is not None
     if not (400 <= e.response.status_code < 500) or e.response.status_code == 429:
         return True
     body = json.loads(e.response.content)
@@ -883,7 +884,7 @@ def no_retry_auth(e: Any) -> bool:
     if not isinstance(e, requests.HTTPError):
         return True
     if e.response is None:
-        return True  # type: ignore
+        return True
     # Don't retry bad request errors; raise immediately
     if e.response.status_code in (400, 409):
         return False


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5eed89</samp>

This pull request fixes a bug in the retry logic for requests to the server and refactors some functions related to checking the response size. It adds assertions and conditions to prevent AttributeError exceptions when the response object is None. It affects the files `wandb/util.py`, `wandb/sdk/internal/internal_api.py`, and `wandb/sdk/verify/verify.py`.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e5eed89</samp>

> _To avoid errors that are quite rare_
> _We assert that response is not `None` everywhere_
> _We also refactor some code_
> _And rename a function node_
> _And fix the retry logic with care_
