### PR TITLE
saving mlp figure to buffer and reading with PIL should specify format

### DIFF
--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -277,8 +277,8 @@ class Image(BatchableMedia):
         )
         if util.is_matplotlib_typename(util.get_full_typename(data)):
             buf = BytesIO()
-            util.ensure_matplotlib_figure(data).savefig(buf)
-            self._image = pil_image.open(buf)
+            util.ensure_matplotlib_figure(data).savefig(buf, format='png')
+            self._image = pil_image.open(buf, formats=["PNG"])
         elif isinstance(data, pil_image.Image):
             self._image = data
         elif util.is_pytorch_tensor_typename(util.get_full_typename(data)):


### PR DESCRIPTION
, otherwise using matplotlibs`s pgf backend yields an error when reading with PIL.

Testing
-------
How was this PR tested?
In my project, yes; otherwise no.
