### PR TITLE
feat(nexus): add sampled history

### DIFF
--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -103,6 +103,10 @@ type Handler struct {
 	// current active history record for the stream
 	historyRecord *service.HistoryRecord
 
+	// sampledHistory is the sampled history for the stream
+	// TODO fix this to be generic type
+	sampledHistory map[string]*ReservoirSampling[float32]
+
 	// mh is the metric handler for the stream
 	mh *MetricHandler
 
@@ -235,6 +239,7 @@ func (h *Handler) handleRecord(record *service.Record) {
 	case *service.Record_Footer:
 	case *service.Record_Header:
 	case *service.Record_History:
+		h.handleHistory(x.History)
 	case *service.Record_LinkArtifact:
 		h.handleLinkArtifact(record)
 	case *service.Record_Metric:
@@ -289,6 +294,7 @@ func (h *Handler) handleRequest(record *service.Record) {
 	case *service.Request_RunStart:
 		h.handleRunStart(record, x.RunStart)
 	case *service.Request_SampledHistory:
+		h.handleSampledHistory(record, response)
 	case *service.Request_ServerInfo:
 		h.handleServerInfo(record)
 	case *service.Request_Shutdown:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3626270</samp>

This pull request adds a sampled history feature to the nexus service, which allows clients to query a random subset of history records for a given key. It implements a reservoir sampling algorithm in the `ReservoirSampling` type and the `sampleHistory` method, and exposes a new endpoint in the `handleSampledHistory` method in the `handler.go` file.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3626270</samp>

> _To query the nexus service faster_
> _We added a new field and method_
> _The `ReservoirSampling` type_
> _Uses a clever algorithmic hype_
> _To store and return a sampled history master_
