### PR TITLE
fix(sdk): hook_handle being set to list instead of dict on unhook

### DIFF
--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -270,7 +270,7 @@ class TorchHistory:
     def unhook_all(self):
         for handle in self._hook_handles.values():
             handle.remove()
-        self._hook_handles = []
+        self._hook_handles = {}
 
     def unhook(self, name):
         handle = self._hook_handles.pop(name)


### PR DESCRIPTION
Description
-----------

- The PR fixes issues with using `wandb.unwatch()` and then running `wandb.watch()` afterward. For some reason, `.unwatch` was changing `_hook_handles` to a list instead of dict. This PR fixes this bug.
- This issue was also raised in https://github.com/wandb/wandb/issues/1164.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aed441d</samp>

Refactored the `wandb_torch.py` module to use a dictionary for storing hook handles of PyTorch tensors. This improves the efficiency and flexibility of logging gradients and activations.

Testing
-------
How was this PR tested?

Ran a training with the modified wandb library using `wandb.watch` and `wandb.unwatch` in succession.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aed441d</samp>

> _`_hook_handles` now_
> _a dictionary of names_
> _cutting hooks in spring_
