### PR TITLE
docs(public-api): Fix suggested command for uploading artifacts

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2338,7 +2338,7 @@ class Run(Attrs):
         elif isinstance(artifact, wandb.Artifact) and artifact.is_draft():
             raise ValueError(
                 "Only existing artifacts are accepted by this api. "
-                "Manually create one with `wandb artifacts put`"
+                "Manually create one with `wandb artifact put`"
             )
         else:
             raise ValueError("You must pass a wandb.Api().artifact() to use_artifact")
@@ -2377,7 +2377,7 @@ class Run(Attrs):
         elif isinstance(artifact, wandb.Artifact) and artifact.is_draft():
             raise ValueError(
                 "Only existing artifacts are accepted by this api. "
-                "Manually create one with `wandb artifacts put`"
+                "Manually create one with `wandb artifact put`"
             )
         else:
             raise ValueError("You must pass a wandb.Api().artifact() to use_artifact")


### PR DESCRIPTION
Description
-----------
What does the PR do?

Fix an error message suggesting to use the `wandb artifact put` command.  Was saying `artifacts`
Testing

-------
How was this PR tested?

Error message fix, no impact on functionality.