### PR TITLE
fix(launch): verify gcp credentials before creating vertex job

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_launch_vertex.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_vertex.py
@@ -13,6 +13,10 @@ def mock_vertex_environment():
     """Mock an instance of the GcpEnvironment class."""
     environment = MagicMock()
     environment.region.return_value = "europe-west-4"
+    async def _mock_verify():
+        return True
+    environment.verify = _mock_verify
+
 
 
 @pytest.mark.asyncio
@@ -114,9 +118,10 @@ async def test_vertex_resolved_submitted_job(relay_server, monkeypatch):
             == "NVIDIA_TESLA_T4"
         )
         env = req["worker_pool_specs"][0]["container_spec"]["env"]
-        env.pop(0)
+        # Pop api key and base url - these are hard to control because our 
+        # sdk will autopopulate them from a million places.
+        env = env[2:]
         assert env == [
-            {"name": "WANDB_API_KEY", "value": None},
             {"name": "WANDB_PROJECT", "value": "test_project"},
             {"name": "WANDB_ENTITY", "value": "test_entity"},
             {"name": "WANDB_LAUNCH", "value": "True"},

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_vertex.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_vertex.py
@@ -118,7 +118,7 @@ async def test_vertex_resolved_submitted_job(relay_server, monkeypatch):
             == "NVIDIA_TESLA_T4"
         )
         env = req["worker_pool_specs"][0]["container_spec"]["env"]
-        # Pop api key and base url - these are hard to control because our 
+        # Pop api key and base url - these are hard to control because our
         # sdk will autopopulate them from a million places.
         env = env[2:]
         assert env == [

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_vertex.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_vertex.py
@@ -13,10 +13,11 @@ def mock_vertex_environment():
     """Mock an instance of the GcpEnvironment class."""
     environment = MagicMock()
     environment.region.return_value = "europe-west-4"
+
     async def _mock_verify():
         return True
-    environment.verify = _mock_verify
 
+    environment.verify = _mock_verify
 
 
 @pytest.mark.asyncio

--- a/tests/pytest_tests/unit_tests/test_launch/test_runner/test_vertex.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_runner/test_vertex.py
@@ -88,7 +88,11 @@ def vertex_runner(test_settings):
     async def _mock_get_credentials(*args, **kwargs):
         return MagicMock()
 
+    async def _mock_verify(*args, **kwargs):
+        return MagicMock()
+
     environment.get_credentials = _mock_get_credentials
+    environment.verify = _mock_verify
     api = Api(default_settings=test_settings(), load_settings=False)
     runner = VertexRunner(api, {"SYNCHRONOUS": False}, environment, registry)
     return runner

--- a/wandb/sdk/launch/runner/vertex_runner.py
+++ b/wandb/sdk/launch/runner/vertex_runner.py
@@ -172,6 +172,7 @@ async def launch_vertex_job(
     synchronous: bool = False,
 ) -> VertexSubmittedRun:
     try:
+        await environment.verify()
         aiplatform = get_module(  # noqa: F811
             "google.cloud.aiplatform",
             "VertexRunner requires google.cloud.aiplatform to be installed",


### PR DESCRIPTION
Description
-----------
What does the PR do?

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 096886e</samp>

### Summary
🧪🚀✅

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of a mock function for testing purposes.
2.  🚀 - This emoji represents launching, deploying, or sending something, and can be used to indicate the invocation of the `launch_vertex_job` function, which launches a Vertex job.
3.  ✅ - This emoji represents checking, verifying, or confirming something, and can be used to indicate the verification of the environment settings before launching a job.
-->
This pull request adds a verification step for the Vertex environment settings before launching a Vertex job using the `VertexRunner` class. It also adds a mock function for testing this verification step without making actual API calls.

> _`verify` env settings_
> _before launching Vertex job_
> _a wise precaution_

### Walkthrough
* Verify the Vertex environment settings before launching a job ([link](https://github.com/wandb/wandb/pull/6537/files?diff=unified&w=0#diff-971309ad05d166697209cdb39e7af4378445d88f459aadd134a5509f7fd70a62R175))
* Mock the `environment.verify` method for unit testing ([link](https://github.com/wandb/wandb/pull/6537/files?diff=unified&w=0#diff-885ef25b2101e382a587cfe5ef2a058712f32af5eb11791b2a853c735864be8fL91-R95))



Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 096886e</samp>

> _`verify` env settings_
> _before launching Vertex job_
> _a wise precaution_
