### PR TITLE
chore(nexus): Don't change dir to nexus to run nexus core in dev mode

### DIFF
--- a/nexus/scripts/run-nexus.sh
+++ b/nexus/scripts/run-nexus.sh
@@ -14,5 +14,4 @@
 
 set -e
 BASE=$(dirname $(dirname $(readlink -f $0)))
-cd $BASE
-go run cmd/nexus/main.go $*
+go run $BASE/cmd/nexus/main.go $*


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Re. [Slack thread](https://weightsandbiases.slack.com/archives/C02DTSCHND8/p1698868061704199)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eb1949</samp>

Removed `cd $BASE` from `run-nexus.sh` to enable running the script from any directory. This improves the script's usability and compatibility with other projects.

Testing
-------
Executed the following script outside the wandb/nexus dir and logged the `cwd` from within the core (in the `sender.go`) to the console. Without the change, the result was `/Users/ibindlish/Documents/Projects/wandb/nexus` whereas after the change, the core `wd` was where I ran the script from.

```
wandb.require("nexus")
with wandb.init() as run:
    artifact = run.use_artifact('test-paige/uncategorized/b2:v0', type='tmp')
    path = artifact.download(recursive=True)
    print(f"\n\n Path: {path}")
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3eb1949</samp>

> _`cd $BASE` gone_
> _Script runs from anywhere_
> _Autumn leaves falling_
