### PR TITLE
feat(launch): add wandb.ai/run-id label to jobs

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_monitor.py
+++ b/wandb/sdk/launch/runner/kubernetes_monitor.py
@@ -23,6 +23,7 @@ from wandb.sdk.launch.runner.abstract import State, Status
 from wandb.sdk.launch.utils import get_kube_context_and_api_client
 
 WANDB_K8S_LABEL_NAMESPACE = "wandb.ai"
+WANDB_K8S_RUN_ID = f"{WANDB_K8S_LABEL_NAMESPACE}/run-id"
 WANDB_K8S_LABEL_AGENT = f"{WANDB_K8S_LABEL_NAMESPACE}/agent"
 WANDB_K8S_LABEL_MONITOR = f"{WANDB_K8S_LABEL_NAMESPACE}/monitor"
 

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -19,6 +19,7 @@ from wandb.sdk.launch.runner.abstract import Status
 from wandb.sdk.launch.runner.kubernetes_monitor import (
     WANDB_K8S_LABEL_AGENT,
     WANDB_K8S_LABEL_MONITOR,
+    WANDB_K8S_RUN_ID,
     CustomResource,
     LaunchKubernetesMonitor,
 )
@@ -333,6 +334,7 @@ class KubernetesRunner(AbstractRunner):
 
         # Add labels to job metadata
         job_metadata.setdefault("labels", {})
+        job_metadata["labels"][WANDB_K8S_RUN_ID] = launch_project.run_id
         job_metadata["labels"][WANDB_K8S_LABEL_MONITOR] = "true"
         if LaunchAgent.initialized():
             job_metadata["labels"][WANDB_K8S_LABEL_AGENT] = LaunchAgent.name()

--- a/wandb/sdk/launch/runner/sagemaker_runner.py
+++ b/wandb/sdk/launch/runner/sagemaker_runner.py
@@ -363,6 +363,11 @@ def build_sagemaker_args(
     total_env = {**calced_env, **given_env}
     sagemaker_args["Environment"] = total_env
 
+    # Add wandb tag
+    tags = sagemaker_args.get("Tags", [])
+    tags.append({"Key": "WandbRunId", "Value": launch_project.run_id})
+    sagemaker_args["Tags"] = tags
+
     # remove args that were passed in for launch but not passed to sagemaker
     sagemaker_args.pop("EcrRepoName", None)
     sagemaker_args.pop("region", None)

--- a/wandb/sdk/launch/runner/vertex_runner.py
+++ b/wandb/sdk/launch/runner/vertex_runner.py
@@ -23,6 +23,7 @@ _logger = logging.getLogger(__name__)
 
 WANDB_RUN_ID_KEY = "wandb-run-id"
 
+
 class VertexSubmittedRun(AbstractRun):
     def __init__(self, job: Any) -> None:
         self._job = job
@@ -193,7 +194,7 @@ async def launch_vertex_job(
             worker_pool_specs=spec_args.get("worker_pool_specs"),
             base_output_dir=spec_args.get("base_output_dir"),
             encryption_spec_key_name=spec_args.get("encryption_spec_key_name"),
-            labels=labels
+            labels=labels,
         )
         execution_kwargs = dict(
             timeout=run_args.get("timeout"),

--- a/wandb/sdk/launch/runner/vertex_runner.py
+++ b/wandb/sdk/launch/runner/vertex_runner.py
@@ -21,6 +21,8 @@ GCP_CONSOLE_URI = "https://console.cloud.google.com"
 _logger = logging.getLogger(__name__)
 
 
+WANDB_RUN_ID_KEY = "wandb-run-id"
+
 class VertexSubmittedRun(AbstractRun):
     def __init__(self, job: Any) -> None:
         self._job = job
@@ -184,12 +186,14 @@ async def launch_vertex_job(
             staging_bucket=spec_args.get("staging_bucket"),
             credentials=await environment.get_credentials(),
         )
+        labels = spec_args.get("labels", {})
+        labels[WANDB_RUN_ID_KEY] = launch_project.run_id
         job = aiplatform.CustomJob(
             display_name=launch_project.name,
             worker_pool_specs=spec_args.get("worker_pool_specs"),
             base_output_dir=spec_args.get("base_output_dir"),
             encryption_spec_key_name=spec_args.get("encryption_spec_key_name"),
-            labels=spec_args.get("labels", {}),
+            labels=labels
         )
         execution_kwargs = dict(
             timeout=run_args.get("timeout"),


### PR DESCRIPTION
Description
-----------
- Fixes WB-15081

This PR makes the agent add a label/tag on sagemaker, vertex, and k8s jobs indicating the wandb run id. We add:

- `wandb.ai/run-id: fdsafdsa` to K8s jobs

- `WandbRunId: fdsafdsa` to sagemaker jobs

- `wandb-run-id: fdsafdsa` to vertex jobs

in accord with the style preference and limitations of each system.

Copilot
-------------
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8d60ce7</samp>

### Summary
🏷️🚀📊

<!--
1.  🏷️ - This emoji represents the addition of labels or tags to the different job types (Kubernetes, Sagemaker, Vertex AI) that can be launched by wandb launch. Labels or tags are a common way to identify and group resources in cloud platforms and orchestration systems.
2.  🚀 - This emoji represents the launch feature of wandb, which allows users to run their code on various cloud platforms and orchestration systems with minimal configuration. The rocket emoji conveys the idea of launching something into the cloud or space.
3.  📊 - This emoji represents the monitoring and logging feature of wandb, which allows users to track and visualize the performance and outputs of their jobs on various cloud platforms and orchestration systems. The chart emoji conveys the idea of displaying data and metrics in a graphical way.
-->
This pull request adds labels or tags with the wandb run id to various cloud runners (`kubernetes_runner.py`, `vertex_runner.py`, `sagemaker_runner.py`) to enable monitoring and logging of cloud jobs launched by wandb launch. It also defines a constant for the Kubernetes label key in `kubernetes_monitor.py`.

> _To monitor jobs on the cloud_
> _We add labels that make us proud_
> _We use `WANDB_K8S_RUN_ID`_
> _And `WandbRunId` for sagemaker bid_
> _And Vertex AI gets the same crowd_

### Walkthrough
*  Add label keys for wandb run id in Kubernetes, Sagemaker, and Vertex AI ([link](https://github.com/wandb/wandb/pull/6543/files?diff=unified&w=0#diff-43022b57aa5144e1d98d107a9abee1b45dc7396e6a70efa4ef2fe60b7302c2b9R26), [link](https://github.com/wandb/wandb/pull/6543/files?diff=unified&w=0#diff-971309ad05d166697209cdb39e7af4378445d88f459aadd134a5509f7fd70a62R24-R26))
*  Inject wandb run id labels to job metadata in KubernetesRunner ([link](https://github.com/wandb/wandb/pull/6543/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86R22), [link](https://github.com/wandb/wandb/pull/6543/files?diff=unified&w=0#diff-8ea6631c99cbc07d88e28024cec144305c704436041cc90266e8ff10c2017f86R337))
*  Add wandb run id tag to sagemaker_args in `sagemaker_runner.py` ([link](https://github.com/wandb/wandb/pull/6543/files?diff=unified&w=0#diff-66f6587e310db906417a8cc4b6f996469d58ab461405436c713217d850726ca7R366-R370))
*  Update labels argument in CustomJob constructor in `vertex_runner.py` ([link](https://github.com/wandb/wandb/pull/6543/files?diff=unified&w=0#diff-971309ad05d166697209cdb39e7af4378445d88f459aadd134a5509f7fd70a62R190-R191), [link](https://github.com/wandb/wandb/pull/6543/files?diff=unified&w=0#diff-971309ad05d166697209cdb39e7af4378445d88f459aadd134a5509f7fd70a62L192-R197))

