### PR TITLE
test(sdk): update jax to use python > 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1567,13 +1567,27 @@ workflows:
           matrix:
             parameters:
               python_version_major: [3]
-              python_version_minor: [8]
+              python_version_minor: [7]
               shard:
                 - "tf115"
                 - "tf21"
-                - "tf24"
                 - "tf25"
                 - "tf26"
+                - "xgboost"
+          name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
+          coverage_dir: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          tox_args: "tests/functional_tests"
+
+      - tox-base:
+          requires:
+            - "functional-tests"
+          matrix:
+            parameters:
+              python_version_major: [3]
+              python_version_minor: [8]
+              shard:
+                - "tf24"
                 - "ray112"
                 - "ray2"
                 - "sklearn"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1567,7 +1567,7 @@ workflows:
           matrix:
             parameters:
               python_version_major: [3]
-              python_version_minor: [7]
+              python_version_minor: [8]
               shard:
                 - "tf115"
                 - "tf21"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,14 +4,14 @@ codecov:
     # To calculate after_n_builds use
     # ./tools/coverage-tool.py jobs
     # also change comment block after_n_builds just below
-    after_n_builds: 50
+    after_n_builds: 51
     wait_for_ci: no
 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: no
-  after_n_builds: 50
+  after_n_builds: 51
 
 ignore:
   - "wandb/vendor"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,22 +1,23 @@
 [paths]
 canonicalsrc =
     wandb/
-    .tox/func-s_artifacts-py37/lib/python3.7/site-packages/wandb/
+    .tox/func-s_artifacts-py38/lib/python3.8/site-packages/wandb/
     .tox/func-s_default-py39/lib/python3.9/site-packages/wandb/
     .tox/func-s_docs-py39/lib/python3.9/site-packages/wandb/
     .tox/func-s_llm-py39/lib/python3.9/site-packages/wandb/
-    .tox/func-s_metaflow-py37/lib/python3.7/site-packages/wandb/
+    .tox/func-s_metaflow-py38/lib/python3.8/site-packages/wandb/
     .tox/func-s_mitm-py39/lib/python3.9/site-packages/wandb/
     .tox/func-s_noml-py39/lib/python3.9/site-packages/wandb/
-    .tox/func-s_ray112-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_ray2-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_service-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_sklearn-py37/lib/python3.7/site-packages/wandb/
+    .tox/func-s_ray112-py38/lib/python3.8/site-packages/wandb/
+    .tox/func-s_ray2-py38/lib/python3.8/site-packages/wandb/
+    .tox/func-s_service-py38/lib/python3.8/site-packages/wandb/
+    .tox/func-s_sklearn-py38/lib/python3.8/site-packages/wandb/
     .tox/func-s_tf115-py37/lib/python3.7/site-packages/wandb/
     .tox/func-s_tf21-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_tf24-py37/lib/python3.7/site-packages/wandb/
+    .tox/func-s_tf24-py38/lib/python3.8/site-packages/wandb/
     .tox/func-s_tf25-py37/lib/python3.7/site-packages/wandb/
     .tox/func-s_tf26-py37/lib/python3.7/site-packages/wandb/
+    .tox/func-s_xgboost-py37/lib/python3.7/site-packages/wandb/
 
 [run]
 # TODO(jhr): enable this in the future

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@ tensorflow-macos; python_version > '3.7' and python_version < '3.11' and sys_pla
 tensorboard
 torch; python_version < '3.12'
 torchvision; python_version < '3.12'
-jax[cpu]; sys_platform == 'darwin' or sys_platform == 'linux'
+jax[cpu]; python_version > '3.7' and (sys_platform == 'darwin' or sys_platform == 'linux')
 
 fastcore
 pyarrow; python_version < '3.12'  # TODO: 3.12 support will be added in 14.0.0

--- a/tests/functional_tests/t0_main/xgboost/xgboost_clf.yea
+++ b/tests/functional_tests/t0_main/xgboost/xgboost_clf.yea
@@ -8,6 +8,7 @@ depend:
         - xgboost>=1.3.0
         - scikit-learn
 tag:
+  shard: xgboost
   skips:
     - platform: win
 assert:

--- a/tests/functional_tests/t0_main/xgboost/xgboost_clf_old.yea
+++ b/tests/functional_tests/t0_main/xgboost/xgboost_clf_old.yea
@@ -1,6 +1,6 @@
 id: 0.xgboost.01-old-xgboost
 tag:
-  shard: service
+  shard: xgboost
   skips:
     - platform: win
 plugin:

--- a/tests/functional_tests/t0_main/xgboost/xgboost_reg.yea
+++ b/tests/functional_tests/t0_main/xgboost/xgboost_reg.yea
@@ -1,6 +1,6 @@
 id: 0.xgboost.01-regression
 tag:
-  shard: service
+    shard: xgboost
 plugin:
   - wandb
 command:

--- a/tests/pytest_tests/unit_tests/test_util.py
+++ b/tests/pytest_tests/unit_tests/test_util.py
@@ -136,7 +136,7 @@ def test_tensorflow_json_nd(array_shape):
     ],
 )
 def test_jax_json(array_shape):
-    from jax import numpy as jnp
+    jnp = pytest.importorskip("jax.numpy")
 
     orig_data = nested_list(*array_shape)
     jax_array = jnp.asarray(orig_data)
@@ -148,7 +148,7 @@ def test_jax_json(array_shape):
     platform.system() == "Windows", reason="test suite does not build jaxlib on windows"
 )
 def test_bfloat16_to_float():
-    import jax.numpy as jnp
+    jnp = pytest.importorskip("jax.numpy")
 
     array = jnp.array(1.0, dtype=jnp.bfloat16)
     # array to scalar bfloat16


### PR DESCRIPTION
Description
-----------
What does the PR do?

Fixes broken tests that require jax

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf74788</samp>

This pull request improves the compatibility and testing of `wandb` with different Python versions and frameworks. It modifies the JAX-related unit tests in `test_util.py`, updates the Python version for the TensorFlow 1.15 workflow in `.circleci/config.yml`, and adds a condition to the `jax[cpu]` dependency in `requirements_dev.txt`.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cf74788</samp>

> _Sing, O Muse, of the valiant deeds of the Python coders,_
> _Who strive to update their frameworks with the latest versions,_
> _And face the challenges of compatibility and dependencies,_
> _With skillful logic and ingenious tests, like cunning Odysseus._
