### PR TITLE
add server info

### DIFF
--- a/nexus/api/graphql/genqlient.yaml
+++ b/nexus/api/graphql/genqlient.yaml
@@ -16,3 +16,5 @@ bindings:
     type: int64
   JSONString:
     type: string
+  JSON:
+    type: interface{}

--- a/nexus/api/graphql/query_server_info.graphql
+++ b/nexus/api/graphql/query_server_info.graphql
@@ -1,0 +1,10 @@
+# @genqlient(omitempty: true)
+query ServerInfo{
+    serverInfo {
+        cliVersionInfo
+        latestLocalVersionInfo {
+            outOfDate
+            latestVersionString
+        }
+    }
+}

--- a/nexus/internal/gql/gql_gen.go
+++ b/nexus/internal/gql/gql_gen.go
@@ -1289,6 +1289,42 @@ type RunResumeStatusResponse struct {
 // GetModel returns RunResumeStatusResponse.Model, and is useful for accessing the field via an interface.
 func (v *RunResumeStatusResponse) GetModel() *RunResumeStatusModelProject { return v.Model }
 
+// ServerInfoResponse is returned by ServerInfo on success.
+type ServerInfoResponse struct {
+	ServerInfo *ServerInfoServerInfo `json:"serverInfo"`
+}
+
+// GetServerInfo returns ServerInfoResponse.ServerInfo, and is useful for accessing the field via an interface.
+func (v *ServerInfoResponse) GetServerInfo() *ServerInfoServerInfo { return v.ServerInfo }
+
+// ServerInfoServerInfo includes the requested fields of the GraphQL type ServerInfo.
+type ServerInfoServerInfo struct {
+	CliVersionInfo         interface{}                                 `json:"cliVersionInfo"`
+	LatestLocalVersionInfo *ServerInfoServerInfoLatestLocalVersionInfo `json:"latestLocalVersionInfo"`
+}
+
+// GetCliVersionInfo returns ServerInfoServerInfo.CliVersionInfo, and is useful for accessing the field via an interface.
+func (v *ServerInfoServerInfo) GetCliVersionInfo() interface{} { return v.CliVersionInfo }
+
+// GetLatestLocalVersionInfo returns ServerInfoServerInfo.LatestLocalVersionInfo, and is useful for accessing the field via an interface.
+func (v *ServerInfoServerInfo) GetLatestLocalVersionInfo() *ServerInfoServerInfoLatestLocalVersionInfo {
+	return v.LatestLocalVersionInfo
+}
+
+// ServerInfoServerInfoLatestLocalVersionInfo includes the requested fields of the GraphQL type LocalVersionInfo.
+type ServerInfoServerInfoLatestLocalVersionInfo struct {
+	OutOfDate           bool   `json:"outOfDate"`
+	LatestVersionString string `json:"latestVersionString"`
+}
+
+// GetOutOfDate returns ServerInfoServerInfoLatestLocalVersionInfo.OutOfDate, and is useful for accessing the field via an interface.
+func (v *ServerInfoServerInfoLatestLocalVersionInfo) GetOutOfDate() bool { return v.OutOfDate }
+
+// GetLatestVersionString returns ServerInfoServerInfoLatestLocalVersionInfo.LatestVersionString, and is useful for accessing the field via an interface.
+func (v *ServerInfoServerInfoLatestLocalVersionInfo) GetLatestVersionString() string {
+	return v.LatestVersionString
+}
+
 type UploadPartsInput struct {
 	PartNumber int64  `json:"partNumber"`
 	HexMD5     string `json:"hexMD5"`
@@ -2530,6 +2566,41 @@ func RunResumeStatus(
 	var err error
 
 	var data RunResumeStatusResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by ServerInfo.
+const ServerInfo_Operation = `
+query ServerInfo {
+	serverInfo {
+		cliVersionInfo
+		latestLocalVersionInfo {
+			outOfDate
+			latestVersionString
+		}
+	}
+}
+`
+
+func ServerInfo(
+	ctx context.Context,
+	client graphql.Client,
+) (*ServerInfoResponse, error) {
+	req := &graphql.Request{
+		OpName: "ServerInfo",
+		Query:  ServerInfo_Operation,
+	}
+	var err error
+
+	var data ServerInfoResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02522cb</samp>

This pull request adds the functionality to query the server information from the GraphQL API and handle the response in the nexus package. It generates the Go code for the query using genqlient, and updates the server handler and sender methods to support the new request type. It also adds a custom scalar type JSON to handle arbitrary JSON values in the query response.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 02522cb</samp>

> _`ServerInfo` query_
> _JSON scalar for any value_
> _Autumn of GraphQL_
