### PR TITLE
chore(launch): Launch runner fails when env is null

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -389,7 +389,7 @@ class KubernetesRunner(AbstractRunner):
         )
         for cont in containers:
             # Add our env vars to user supplied env vars
-            env = cont.get("env", [])
+            env = cont.get("env") or []
             env.extend(
                 [{"name": key, "value": value} for key, value in env_vars.items()]
             )


### PR DESCRIPTION
Description
-----------

I removed all env variables from the launch-queue config, and that resulted in the following spec:

```
spec:
  template:
    spec:
      containers:
        - env: null
           resources:
            requests:
              cpu: 40000m
              memory: 40Gi
```

Then, when I ran a job, I saw the following error:

```
123983 05:23:09pm wandb: ERROR launch: Error running job: Traceback (most recent call last):
123984 05:23:09pm wandb: ERROR   File "/usr/local/lib/python3.9/site-packages/wandb/sdk/launch/agent/agent.py", line 534, in thread_run_job
123985 05:23:09pm wandb: ERROR     self._thread_run_job(
123986 05:23:09pm wandb: ERROR   File "/usr/local/lib/python3.9/site-packages/wandb/sdk/launch/agent/agent.py", line 616, in _thread_run_job
123987 05:23:09pm wandb: ERROR     run = backend.run(project, image_uri)
123988 05:23:09pm wandb: ERROR   File "/usr/local/lib/python3.9/site-packages/wandb/sdk/launch/runner/kubernetes_runner.py", line 513, in run
123989 05:23:09pm wandb: ERROR     job, secret = self._inject_defaults(
123990 05:23:09pm wandb: ERROR   File "/usr/local/lib/python3.9/site-packages/wandb/sdk/launch/runner/kubernetes_runner.py", line 397, in _inject_defaults
123991 05:23:09pm wandb: ERROR     env.extend(
123992 05:23:09pm wandb: ERROR AttributeError: 'NoneType' object has no attribute 'extend'
123993 05:23:09pm wandb: ERROR
```

What does the PR do?
Add default empty string _after_ the value is get from the config. This will cause null to also parse correctly.
