### PR TITLE
docs(integrations): fix doc-string typo in a keras callback

### DIFF
--- a/wandb/integration/keras/callbacks/model_checkpoint.py
+++ b/wandb/integration/keras/callbacks/model_checkpoint.py
@@ -27,7 +27,7 @@ patch_tf_keras()
 class WandbModelCheckpoint(callbacks.ModelCheckpoint):
     """A checkpoint that periodically saves a Keras model or model weights.
 
-    Saves weights are uploaded to W&B as a `wandb.Artifact`.
+    Saved weights are uploaded to W&B as a `wandb.Artifact`.
 
     Since this callback is subclassed from `tf.keras.callbacks.ModelCheckpoint`, the
     checkpointing logic is taken care of by the parent callback. You can learn more


### PR DESCRIPTION
Description
-----------

- Fixes a typo

What does the PR do?

Fixes a grammatical typo in the docs

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a3a217</samp>

Fix a typo in the docstring of `WandbModelCheckpoint` in `wandb/integration/keras/callbacks/model_checkpoint.py`. This improves the documentation of the class that allows saving Keras models to wandb.

Testing
-------
How was this PR tested?

None

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a3a217</samp>

> _`WandbModelCheckpoint`_
> _Docstring typo fixed - saved_
> _Winter of errors_
