### PR TITLE
refactor(nexus): unify history/summary to use basic structs

### DIFF
--- a/nexus/internal/nexuslib/summarylib.go
+++ b/nexus/internal/nexuslib/summarylib.go
@@ -8,12 +8,12 @@ import (
 )
 
 // Generic item which works with summary and history
-type genericItem interface {
+type GenericItem interface {
 	GetKey() string
 	GetValueJson() string
 }
 
-func JsonifyItems[V genericItem](items []V) (string, error) {
+func JsonifyItems[V GenericItem](items []V) (string, error) {
 	jsonMap := make(map[string]interface{})
 
 	for _, item := range items {
@@ -32,12 +32,12 @@ func JsonifyItems[V genericItem](items []V) (string, error) {
 	return string(jsonBytes), nil
 }
 
-func ConsolidateSummaryItems[V genericItem](consolidatedSummary map[string]string, items []V) *service.Record {
+func ConsolidateSummaryItems[V GenericItem](consolidatedSummary map[string]string, items []V) *service.Record {
 	var summaryItems []*service.SummaryItem
 
-	for i := 0; i < len(items); i++ {
-		key := items[i].GetKey()
-		value := items[i].GetValueJson()
+	for _, item := range items {
+		key := item.GetKey()
+		value := item.GetValueJson()
 		consolidatedSummary[key] = value
 		summaryItems = append(summaryItems,
 			&service.SummaryItem{

--- a/nexus/pkg/server/history.go
+++ b/nexus/pkg/server/history.go
@@ -1,230 +1,37 @@
 package server
 
 import (
-	"container/heap"
 	"encoding/json"
 	"fmt"
-	"math"
-	"math/rand"
-	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/wandb/wandb/nexus/internal/nexuslib"
+	"github.com/wandb/wandb/nexus/pkg/server/history"
 	"github.com/wandb/wandb/nexus/pkg/service"
+	"google.golang.org/protobuf/proto"
 )
 
-type Item[T comparable] struct {
-	value     T
-	priority  float64
-	timestamp int
-}
-
-func (item Item[T]) String() string {
-	return fmt.Sprintf("%v", item.value)
-}
-
-type PriorityQueue[T comparable] []*Item[T]
-
-func (pq PriorityQueue[T]) Len() int           { return len(pq) }
-func (pq PriorityQueue[T]) Less(i, j int) bool { return pq[i].priority < pq[j].priority }
-func (pq PriorityQueue[T]) Swap(i, j int)      { pq[i], pq[j] = pq[j], pq[i] }
-
-func (pq *PriorityQueue[T]) Push(x interface{}) {
-	item := x.(*Item[T])
-	*pq = append(*pq, item)
-}
-
-func (pq *PriorityQueue[T]) Pop() interface{} {
-	old := *pq
-	n := len(old)
-	item := old[n-1]
-	*pq = old[0 : n-1]
-	return item
-}
-
-type ReservoirSampling[T comparable] struct {
-	waitingList PriorityQueue[T]
-	k           int
-	delta       float64
-	j           int
-}
-
-func (r *ReservoirSampling[T]) computeQ(j int) float64 {
-	gamma := -math.Log(r.delta) / float64(j)
-	ratio := float64(r.k) / float64(j)
-	return math.Min(1, ratio+gamma+math.Sqrt(math.Pow(gamma, 2)+2*gamma*ratio))
-}
-
-func (r *ReservoirSampling[T]) Add(value T) {
-	x := rand.Float64()
-	if x < r.computeQ(r.j+1) {
-		item := &Item[T]{value: value, priority: x, timestamp: r.j}
-		heap.Push(&r.waitingList, item)
-	}
-	r.j += 1
-}
-
-func (r *ReservoirSampling[T]) GetSample() []T {
-	k := min(r.k, r.waitingList.Len())
-	result := make([]*Item[T], k)
-
-	for i := 0; i < k; i++ {
-		item := heap.Pop(&r.waitingList).(*Item[T])
-		result[i] = item
-	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].timestamp < result[j].timestamp
-	})
-
-	values := make([]T, k)
-	for i := 0; i < k; i++ {
-		values[i] = result[i].value
-	}
-
-	return values
-}
-
-func (h *Handler) sampleHistory(history *service.HistoryRecord) {
-	var value float32
-	if h.sampledHistory == nil {
-		h.sampledHistory = make(map[string]*ReservoirSampling[float32])
-	}
-	for _, item := range history.GetItem() {
-		err := json.Unmarshal([]byte(item.ValueJson), &value)
-		if err != nil {
-			continue
-		}
-		if _, ok := h.sampledHistory[item.Key]; !ok {
-			h.sampledHistory[item.Key] = &ReservoirSampling[float32]{
-				k:     48,
-				delta: 0.0005,
-			}
-		}
-		h.sampledHistory[item.Key].Add(value)
-	}
-}
-
-// handleHistory handles a history record. This is the main entry point for history records.
-// It is responsible for handling the history record internally, processing it,
-// and forwarding it to the Writer.
-func (h *Handler) handleHistory(history *service.HistoryRecord) {
-	if history.GetItem() == nil {
+func (h *Handler) handleSampledHistory(record *service.Record, response *service.Response) {
+	samples := h.sm.Samples()
+	if samples == nil {
 		return
 	}
 
-	// TODO replace history encoding with a map, this will make it easier to handle history
-	historyMap := make(map[string]string)
-	for _, item := range history.GetItem() {
-		historyMap[item.GetKey()] = item.GetValueJson()
-	}
+	var items []*service.SampledHistoryItem
 
-	h.handleHistoryInternal(history, &historyMap)
-	h.handleAllHistoryMetric(history, &historyMap)
-
-	h.sampleHistory(history)
-
-	record := &service.Record{
-		RecordType: &service.Record_History{History: history},
-	}
-	h.sendRecord(record)
-
-	// TODO unify with handleSummary
-	// TODO add an option to disable summary (this could be quite expensive)
-	summaryRecord := nexuslib.ConsolidateSummaryItems(h.consolidatedSummary, history.Item)
-	// h.sendRecord(summaryRecord)
-	h.updateSummaryDelta(summaryRecord)
-}
-
-// handleHistoryInternal adds internal history items to the history record
-// these items are used for internal bookkeeping and are not sent by the user
-func (h *Handler) handleHistoryInternal(history *service.HistoryRecord, historyMap *map[string]string) {
-
-	// TODO: add a timestamp field to the history record
-	var runTime float64 = 0
-	if value, ok := (*historyMap)["_timestamp"]; ok {
-		val, err := strconv.ParseFloat(value, 64)
-		if err != nil {
-			h.logger.CaptureError("error parsing timestamp", err)
-		} else {
-			runTime = val - h.timer.GetStartTimeMicro()
+	for key, values := range samples {
+		item := &service.SampledHistoryItem{
+			Key:         key,
+			ValuesFloat: values,
 		}
-	}
-	history.Item = append(history.Item,
-		&service.HistoryItem{Key: "_runtime", ValueJson: fmt.Sprintf("%f", runTime)},
-		&service.HistoryItem{Key: "_step", ValueJson: fmt.Sprintf("%d", history.GetStep().GetNum())},
-	)
-}
-
-// handleAllHistoryMetric handles all history items. It is responsible for matching current history
-// items with defined metrics, and creating new metrics if needed. It also handles step metric in case
-// it needs to be synced, but not part of the history record.
-func (h *Handler) handleAllHistoryMetric(history *service.HistoryRecord, historyMap *map[string]string) {
-	// This means that there are no metrics defined, and we don't need to do anything
-	if h.mh == nil {
-		return
+		items = append(items, item)
 	}
 
-	for _, item := range history.GetItem() {
-		h.imputeStepMetric(item, history, historyMap)
+	response.ResponseType = &service.Response_SampledHistoryResponse{
+		SampledHistoryResponse: &service.SampledHistoryResponse{
+			Item: items,
+		},
 	}
-}
-
-// imputeStepMetric imputes a step metric if it needs to be synced, but not part of the history record.
-func (h *Handler) imputeStepMetric(item *service.HistoryItem, history *service.HistoryRecord, historyMap *map[string]string) {
-
-	// check if history item matches a defined metric or a glob metric
-	metric := h.matchHistoryItemMetric(item)
-
-	key := metric.GetStepMetric()
-	// check if step metric is defined and if it needs to be synced
-	if !(metric.GetOptions().GetStepSync() && key != "") {
-		return
-	}
-
-	// check if step metric is already in history
-	if _, ok := (*historyMap)[key]; ok {
-		return
-	}
-
-	// we use the summary value of the metric as the algorithm for imputing the step metric
-	if value, ok := h.consolidatedSummary[key]; ok {
-		(*historyMap)[key] = value
-		hi := &service.HistoryItem{
-			Key:       key,
-			ValueJson: value,
-		}
-		history.Item = append(history.Item, hi)
-	}
-}
-
-// matchHistoryItemMetric matches a history item with a defined metric or creates a new metric if needed.
-func (h *Handler) matchHistoryItemMetric(item *service.HistoryItem) *service.MetricRecord {
-
-	// ignore internal history items
-	if strings.HasPrefix(item.Key, "_") {
-		return nil
-	}
-
-	// check if history item matches a defined metric exactly, if it does return the metric
-	if metric, ok := h.mh.definedMetrics[item.Key]; ok {
-		return metric
-	}
-
-	// if a new metric was created, we need to handle it
-	metric := h.mh.createMatchingGlobMetric(item.Key)
-	if metric != nil {
-		record := &service.Record{
-			RecordType: &service.Record_Metric{
-				Metric: metric,
-			},
-			Control: &service.Control{
-				Local: true,
-			},
-		}
-		h.handleMetric(record, metric)
-	}
-	return metric
 }
 
 // handlePartialHistory handles a partial history request. Collects the history items until a full
@@ -235,13 +42,20 @@ func (h *Handler) handlePartialHistory(_ *service.Record, request *service.Parti
 	// for this step, so we need to initialize the history record
 	// and step. If the user provided a step in the request,
 	// use that, otherwise use 0.
-	if h.historyRecord == nil {
-		h.historyRecord = &service.HistoryRecord{}
+	if h.has == nil {
+		step := h.runRecord.StartingStep
 		if request.Step != nil {
-			h.historyRecord.Step = request.Step
-		} else {
-			h.historyRecord.Step = &service.HistoryStep{Num: h.runRecord.StartingStep}
+			step = request.Step.Num
 		}
+		h.has = history.NewActiveSet(step, func(step int64, items map[string]*service.HistoryItem) {
+			history := &service.HistoryRecord{
+				Step: &service.HistoryStep{Num: step},
+			}
+			for _, item := range items {
+				history.Item = append(history.Item, item)
+			}
+			h.handleHistory(history)
+		})
 	}
 
 	// The HistoryRecord struct is responsible for tracking data related to
@@ -273,51 +87,152 @@ func (h *Handler) handlePartialHistory(_ *service.Record, request *service.Parti
 	//	equivalent to step being equal to the current step number and a flush flag
 	//	being set to true.
 	if request.Step != nil {
-		if request.Step.Num > h.historyRecord.Step.Num {
-			h.handleHistory(h.historyRecord)
-			h.historyRecord = &service.HistoryRecord{
-				Step: &service.HistoryStep{Num: request.Step.Num},
-			}
-		} else if request.Step.Num < h.historyRecord.Step.Num {
+		step := h.has.GetIdx()
+		if request.Step.Num > step {
+			h.has.FlushWithIdx(request.Step.Num)
+		} else if request.Step.Num < step {
 			h.logger.CaptureWarn("received history record for a step that has already been received",
-				"received", request.Step, "current", h.historyRecord.Step)
+				"received", request.Step, "current", step)
 			return
 		}
 	}
 
 	// Append the history items from the request to the current history record.
-	h.historyRecord.Item = append(h.historyRecord.Item, request.Item...)
+	h.has.Updates(request.Item...)
 
 	// Flush the history record and start to collect a new one with
 	// the next step number.
 	if (request.Step == nil && request.Action == nil) || (request.Action != nil && request.Action.Flush) {
-		h.handleHistory(h.historyRecord)
-		h.historyRecord = &service.HistoryRecord{
-			Step: &service.HistoryStep{
-				Num: h.historyRecord.Step.Num + 1,
-			},
-		}
+		h.has.Flush()
 	}
 }
 
-func (h *Handler) handleSampledHistory(record *service.Record, response *service.Response) {
-	if h.sampledHistory == nil {
+// handleHistory handles a history record. This is the main entry point for history records.
+// It is responsible for handling the history record internally, processing it,
+// and forwarding it to the Writer.
+func (h *Handler) handleHistory(record *service.HistoryRecord) {
+	if record.GetItem() == nil {
 		return
 	}
-	var items []*service.SampledHistoryItem
 
-	for key, sampler := range h.sampledHistory {
-		values := sampler.GetSample()
-		item := &service.SampledHistoryItem{
-			Key:         key,
-			ValuesFloat: values,
-		}
-		items = append(items, item)
+	// TODO replace history encoding with a map, this will make it easier to handle history
+	if h.has == nil {
+		h.has = history.NewActiveSet[*service.HistoryItem](record.GetStep().GetNum(), nil)
+		h.has.Updates(record.GetItem()...)
 	}
 
-	response.ResponseType = &service.Response_SampledHistoryResponse{
-		SampledHistoryResponse: &service.SampledHistoryResponse{
-			Item: items,
+	// TODO: add a timestamp field to the history record
+	var runTime float64 = 0
+	if value, ok := h.has.GetValue("_timestamp"); ok {
+		if val, err := strconv.ParseFloat(value, 64); err != nil {
+			h.logger.CaptureError("error parsing timestamp", err)
+		} else {
+			runTime = val - h.timer.GetStartTimeMicro()
+		}
+	}
+	h.has.Updates(
+		&service.HistoryItem{Key: "_runtime", ValueJson: fmt.Sprintf("%f", runTime)},
+		&service.HistoryItem{Key: "_step", ValueJson: fmt.Sprintf("%d", record.GetStep().GetNum())},
+	)
+
+	if h.mm != nil {
+		for _, item := range record.GetItem() {
+			key := h.imputeStepMetric(item.GetKey())
+			if key == "" {
+				continue
+			}
+			// check if step metric is already in history
+			if _, ok := h.has.Get(key); ok {
+				continue
+			}
+			// we use the summary value of the metric as the algorithm for imputing the step metric
+			if value, ok := h.csas.Get(key); ok {
+				h.has.Updates(
+					&service.HistoryItem{
+						Key:       value.GetKey(),
+						NestedKey: item.GetNestedKey(),
+						ValueJson: value.GetValueJson(),
+					},
+				)
+			}
+		}
+	}
+
+	flush_record := &service.Record{
+		RecordType: &service.Record_History{
+			History: &service.HistoryRecord{
+				Item: h.has.Gets(),
+				Step: record.GetStep(),
+			},
 		},
 	}
+	h.sendRecord(flush_record)
+
+	// sample history
+	if h.sm == nil {
+		h.sm = history.NewSampleManager[float32](48, 0.0005)
+	}
+	var value float32
+	for _, item := range record.GetItem() {
+		err := json.Unmarshal([]byte(item.ValueJson), &value)
+		if err != nil {
+			continue
+		}
+		h.sm.Add(item.GetKey(), value)
+	}
+
+	// TODO unify with handleSummary
+	// TODO add an option to disable summary (this could be quite expensive)
+	var items []*service.SummaryItem
+	for _, item := range record.GetItem() {
+		items = append(items, &service.SummaryItem{
+			Key:       item.GetKey(),
+			NestedKey: item.GetNestedKey(),
+			ValueJson: item.GetValueJson(),
+		})
+		summary := &service.SummaryRecord{
+			Update: items,
+		}
+
+		h.updateSummaryDelta(summary)
+	}
+}
+
+// imputeStepMetric imputes a step metric if it needs to be synced, but not part of the history record.
+func (h *Handler) imputeStepMetric(key string) string {
+
+	// ignore internal history items
+	if strings.HasPrefix(key, "_") {
+		return ""
+	}
+
+	// check if history item matches a defined metric or a glob metric
+	var metric *service.MetricRecord
+	// check if history item matches a defined metric exactly, if it does we can use it
+	if value, ok := h.mm.GetDefinedMetricKeySet().Get(key); ok {
+		metric = value
+	} else if value, ok := h.mm.GetGlobMetricKeySet().Match(key); ok {
+		// if a new metric was created, we need to handle it
+		metric = proto.Clone(value).(*service.MetricRecord)
+		metric.Name = key
+		metric.Options.Defined = false
+		metric.GlobName = ""
+		record := &service.Record{
+			RecordType: &service.Record_Metric{
+				Metric: metric,
+			},
+			Control: &service.Control{
+				Local: true,
+			},
+		}
+		h.handleMetric(record, metric)
+	} else {
+		return ""
+	}
+
+	// check if step metric is defined and if it needs to be synced
+	if !metric.GetOptions().GetStepSync() {
+		return ""
+	}
+	return metric.GetStepMetric()
 }

--- a/nexus/pkg/server/history/active_set.go
+++ b/nexus/pkg/server/history/active_set.go
@@ -1,0 +1,70 @@
+package history
+
+type Value interface {
+	GetKey() string
+	GetNestedKey() []string
+	GetValueJson() string
+}
+
+type ActiveSet[T Value] struct {
+	values map[string]T
+	idx    int64
+	f      func(idx int64, values map[string]T)
+}
+
+func NewActiveSet[T Value](idx int64, f func(idx int64, values map[string]T)) *ActiveSet[T] {
+	return &ActiveSet[T]{
+		values: make(map[string]T),
+		idx:    idx,
+		f:      f,
+	}
+}
+
+func (as *ActiveSet[T]) GetIdx() int64 {
+	return as.idx
+}
+
+func (as *ActiveSet[T]) Update(key string, value T) {
+	as.values[key] = value
+}
+
+func (as *ActiveSet[T]) Updates(values ...T) {
+	for _, value := range values {
+		as.values[value.GetKey()] = value
+	}
+}
+
+func (as *ActiveSet[T]) Get(key string) (T, bool) {
+	if value, ok := as.values[key]; ok {
+		return value, ok
+	}
+	var value T
+	return value, false
+}
+
+func (as *ActiveSet[T]) Gets() []T {
+	var values []T
+	for _, value := range as.values {
+		values = append(values, value)
+	}
+	return values
+}
+
+func (as *ActiveSet[T]) GetValue(key string) (string, bool) {
+	if value, ok := as.values[key]; ok {
+		return value.GetValueJson(), ok
+	}
+	return "", false
+}
+
+func (as *ActiveSet[T]) Flush() {
+	as.FlushWithIdx(as.idx + 1)
+}
+
+func (as *ActiveSet[T]) FlushWithIdx(idx int64) {
+	if as.f != nil {
+		as.f(as.idx, as.values)
+	}
+	as.idx = idx
+	clear(as.values)
+}

--- a/nexus/pkg/server/history/key_set.go
+++ b/nexus/pkg/server/history/key_set.go
@@ -1,0 +1,72 @@
+package history
+
+type KeySetOption[T any] func(*KeySet[T])
+
+type KeySet[T any] struct {
+	values map[string]*T
+	merge  func(value, newValue *T)
+	match  func(pattern, key string) (bool, error)
+}
+
+func NewKeySet[T any](opts ...KeySetOption[T]) *KeySet[T] {
+	ks := &KeySet[T]{
+		values: make(map[string]*T),
+	}
+	for _, opt := range opts {
+		opt(ks)
+	}
+	return ks
+}
+
+func WithMatch[T any](match func(pattern, key string) (bool, error)) KeySetOption[T] {
+	return func(ks *KeySet[T]) {
+		ks.match = match
+	}
+}
+
+func WithMerge[T any](merge func(value, newValue *T)) KeySetOption[T] {
+	return func(ks *KeySet[T]) {
+		ks.merge = merge
+	}
+}
+
+func (ks *KeySet[T]) Replace(key string, value *T) {
+	ks.values[key] = value
+}
+
+func (ks *KeySet[T]) Merge(key string, value *T) {
+	if dst, ok := ks.Get(key); ok {
+		ks.merge(dst, value)
+	} else {
+		ks.Replace(key, value)
+	}
+}
+
+func (ks *KeySet[T]) Get(key string) (*T, bool) {
+	if ks.values == nil || key == "" {
+		return nil, false
+	}
+	if value, ok := ks.values[key]; ok {
+		return value, ok
+	}
+	return nil, false
+}
+
+func (ks *KeySet[T]) Match(key string) (*T, bool) {
+	if ks.values == nil || key == "" {
+		return nil, false
+	}
+	for pattern, value := range ks.values {
+		if match, err := ks.match(pattern, key); err != nil {
+			// h.logger.CaptureError("error matching metric", err)
+			continue
+		} else if match {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func (ks *KeySet[T]) GetValues() map[string]*T {
+	return ks.values
+}

--- a/nexus/pkg/server/history/manger.go
+++ b/nexus/pkg/server/history/manger.go
@@ -1,0 +1,36 @@
+package history
+
+type DefineKeys[N any] struct {
+	dm *KeySet[N]
+	gm *KeySet[N]
+}
+
+func NewDefineKeys[N any](opts ...DefineKeysOptions[N]) *DefineKeys[N] {
+	m := &DefineKeys[N]{}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+type DefineKeysOptions[N any] func(*DefineKeys[N])
+
+func WithDefinedMetricKeySet[N any](dm *KeySet[N]) DefineKeysOptions[N] {
+	return func(m *DefineKeys[N]) {
+		m.dm = dm
+	}
+}
+
+func WithGlobMetricKeySet[N any](gm *KeySet[N]) DefineKeysOptions[N] {
+	return func(m *DefineKeys[N]) {
+		m.gm = gm
+	}
+}
+
+func (m *DefineKeys[N]) GetDefinedMetricKeySet() *KeySet[N] {
+	return m.dm
+}
+
+func (m *DefineKeys[N]) GetGlobMetricKeySet() *KeySet[N] {
+	return m.gm
+}

--- a/nexus/pkg/server/history/sampler.go
+++ b/nexus/pkg/server/history/sampler.go
@@ -1,0 +1,127 @@
+package history
+
+import (
+	"container/heap"
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+)
+
+type Item[T comparable] struct {
+	value     T
+	priority  float64
+	timestamp int
+}
+
+func (item Item[T]) String() string {
+	return fmt.Sprintf("%v", item.value)
+}
+
+// PriorityQueue implements heap.Interface and holds Items.
+type PriorityQueue[T comparable] []*Item[T]
+
+func (pq PriorityQueue[T]) Len() int           { return len(pq) }
+func (pq PriorityQueue[T]) Less(i, j int) bool { return pq[i].priority < pq[j].priority }
+func (pq PriorityQueue[T]) Swap(i, j int)      { pq[i], pq[j] = pq[j], pq[i] }
+
+func (pq *PriorityQueue[T]) Push(x interface{}) {
+	item := x.(*Item[T])
+	*pq = append(*pq, item)
+}
+
+func (pq *PriorityQueue[T]) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[0 : n-1]
+	return item
+}
+
+// ReservoirSampling implements reservoir sampling algorithm.
+type ReservoirSampling[T comparable] struct {
+	waitingList PriorityQueue[T]
+	k           int
+	delta       float64
+	j           int
+}
+
+func (r *ReservoirSampling[T]) computeQ(j int) float64 {
+	gamma := -math.Log(r.delta) / float64(j)
+	ratio := float64(r.k) / float64(j)
+	return math.Min(1, ratio+gamma+math.Sqrt(math.Pow(gamma, 2)+2*gamma*ratio))
+}
+
+// Add adds a new value to the reservoir.
+func (r *ReservoirSampling[T]) Add(value T) {
+	x := rand.Float64()
+	if x < r.computeQ(r.j+1) {
+		item := &Item[T]{value: value, priority: x, timestamp: r.j}
+		heap.Push(&r.waitingList, item)
+	}
+	r.j += 1
+}
+
+// GetSample returns a sample of the reservoir.
+func (r *ReservoirSampling[T]) GetSample() []T {
+	k := min(r.k, r.waitingList.Len())
+	result := make([]*Item[T], k)
+
+	for i := 0; i < k; i++ {
+		item := heap.Pop(&r.waitingList).(*Item[T])
+		result[i] = item
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].timestamp < result[j].timestamp
+	})
+
+	values := make([]T, k)
+	for i := 0; i < k; i++ {
+		values[i] = result[i].value
+	}
+
+	return values
+}
+
+// SampleManager manages multiple reservoir samplers.
+type SampleManager[T comparable] struct {
+	samplers map[string]*ReservoirSampling[T]
+	k        int
+	delta    float64
+}
+
+// NewSampleManager creates a new SampleManager.
+func NewSampleManager[T comparable](k int, delta float64) *SampleManager[T] {
+	return &SampleManager[T]{
+		k:     k,
+		delta: delta,
+	}
+}
+
+// Add adds a new value to the reservoir.
+func (sm *SampleManager[T]) Add(key string, value T) {
+	if sm.samplers == nil {
+		sm.samplers = make(map[string]*ReservoirSampling[T])
+	}
+
+	if _, ok := sm.samplers[key]; !ok {
+		sm.samplers[key] = &ReservoirSampling[T]{
+			k:     sm.k,
+			delta: sm.delta,
+		}
+	}
+	sm.samplers[key].Add(value)
+}
+
+// Samples returns a map of samples.
+func (sm *SampleManager[T]) Samples() map[string][]T {
+	if sm.samplers == nil {
+		return nil
+	}
+	samples := make(map[string][]T)
+	for key, sampler := range sm.samplers {
+		values := sampler.GetSample()
+		samples[key] = values
+	}
+	return samples
+}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5c40fb</samp>

The pull request refactors the server and summary library code to improve the performance, modularity, and extensibility of the history and metric features. It introduces a new `history` package that contains generic types for managing summary and history records, defined and glob metrics, and reservoir sampling. It also exports the `GenericItem` interface and generalizes the `ConsolidateSummaryItems` function in the `summarylib.go` file.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d5c40fb</samp>

> _We are the history makers, we rewrite the code_
> _We use the `ActiveSet` and the `KeySet` to lighten the load_
> _We refactor and export, we merge and match_
> _We sample and consolidate, we are the history batch_
