### PR TITLE
test(nexus): generate coverage reports for system tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,7 @@ jobs:
                 name: Install python dependencies
                 command: |
                   pip install tox==<< pipeline.parameters.tox_version >>
+                  pip install nox
                   pip install -U pip
                 no_output_timeout: 5m
             - run:
@@ -416,6 +417,7 @@ jobs:
           name: Install Python dependencies
           command: |
             pip install tox==<< pipeline.parameters.tox_version >>
+            pip install nox
             pip install -U pip
             while ! curl http://localhost:8080/healthz; do sleep 1; done
           no_output_timeout: 5m
@@ -463,7 +465,11 @@ jobs:
             cd nexus
             go test -race -coverprofile=coverage.txt -covermode=atomic ./...
             # Added to force a coverage count by coverage-tools.py: cover-gotest-circle
-      - codecov/upload
+      - run:
+          name: Install nox and upload coverage to codecov
+          command: |
+            pip install nox
+            nox -s codecov
 
   protobuf-compatability:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,9 +439,8 @@ jobs:
       - when:
           condition: << parameters.upload_go_cov >>
           steps:
-            - codecov/upload
-                - flags:
-                    - system
+            - codecov/upload:
+                flags: system
       # conditionally post a notification to slack if the job failed
       - when:
           condition: << parameters.notify_on_failure >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1546,12 +1546,12 @@ workflows:
       - win:
           requires:
             - "unit-tests"
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
-          #       - /^release-.*/
-          #       - /^.*-ci-win$/
+          filters:
+            branches:
+              only:
+                - main
+                - /^release-.*/
+                - /^.*-ci-win$/
           matrix:
             parameters:
               python_version_major: [3]
@@ -1707,7 +1707,6 @@ workflows:
       #
       # wandb launch tests
       #
-      # todo: fix base docker image for cuda and uncomment this
       - launch:
           requires:
             - "unit-tests-mock-server"
@@ -1718,6 +1717,7 @@ workflows:
           name: "unit-launch-mock-server-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_args: "-F unit"
           tox_args: "tests/pytest_tests/unit_tests_old/test_launch/"
 
       - pytest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   win: circleci/windows@5.0.0
   slack: circleci/slack@4.12.5
-  go: circleci/go@1.7.3
+  go: circleci/go@1.9.0
   gcloud: circleci/gcp-cli@3.1.0
   gke: circleci/gcp-gke@2.1.0
   codecov: codecov/codecov@3
@@ -380,6 +380,9 @@ jobs:
       coverage_dir:
         type: string
         default: ""
+      upload_go_cov:
+        type: boolean
+        default: false
       notify_on_failure:
         type: boolean
         default: false
@@ -433,6 +436,10 @@ jobs:
             tox run -v -e <<parameters.toxenv>>  \
               -- --wandb-server-tag << pipeline.parameters.wandb_server_tag >> << parameters.tox_args >>
       - save-test-results
+      - when:
+          condition: << parameters.upload_go_cov >>
+          steps:
+            - codecov/upload
       # conditionally post a notification to slack if the job failed
       - when:
           condition: << parameters.notify_on_failure >>
@@ -1397,6 +1404,7 @@ workflows:
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_core"
+          upload_go_cov: true
       #
       # Nexus smoke tests with pytest on Linux, using real wandb server
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,6 +440,8 @@ jobs:
           condition: << parameters.upload_go_cov >>
           steps:
             - codecov/upload
+                - flags:
+                    - system
       # conditionally post a notification to slack if the job failed
       - when:
           condition: << parameters.notify_on_failure >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,6 @@ jobs:
                 no_output_timeout: 10m
                 command: |
                   CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox run -v -e << parameters.toxenv >> -- << parameters.tox_args >>
-            - save-test-results
             - when:
                 condition:
                   not:
@@ -358,6 +357,7 @@ jobs:
                       name: Upload coverage to codecov
                       command: |
                         nox -s codecov -- << parameters.codecov_args >>
+            - save-test-results
             # conditionally post a notification to slack if the job failed
             - when:
                 condition: << parameters.notify_on_failure >>
@@ -449,7 +449,6 @@ jobs:
             CI_PYTEST_PARALLEL=<< parameters.xdist >> \
             tox run -v -e <<parameters.toxenv>>  \
               -- --wandb-server-tag << pipeline.parameters.wandb_server_tag >> << parameters.tox_args >>
-      - save-test-results
       - when:
           condition:
             not:
@@ -459,6 +458,7 @@ jobs:
                 name: Upload coverage to codecov
                 command: |
                   nox -s codecov -- << parameters.codecov_args >>
+      - save-test-results
       # conditionally post a notification to slack if the job failed
       - when:
           condition: << parameters.notify_on_failure >>
@@ -659,6 +659,9 @@ jobs:
       python_version_minor:
         type: integer
         default: 7
+      codecov_args:
+        type: string
+        default: ""
     machine:
       image: ubuntu-2004:202104-01
       docker_layer_caching: true
@@ -673,6 +676,7 @@ jobs:
           name: Install python dependencies, build r2d
           command: |
             pip3 install tox==<< pipeline.parameters.tox_version >>
+            pip3 install nox
             pip3 install chardet
             pip3 install iso8601
       - run:
@@ -684,6 +688,15 @@ jobs:
           command: |
             python3 -m tox run -v -e << parameters.toxenv >> -- << parameters.tox_args >>
           no_output_timeout: 10m
+      - when:
+          condition:
+            not:
+              equal: ["", << parameters.codecov_args >>]
+          steps:
+            - run:
+                name: Upload coverage to codecov
+                command: |
+                  python3 -m nox -s codecov -- << parameters.codecov_args >>
       - save-test-results
 
   kfp:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1351,8 +1351,8 @@ workflows:
       - tox-base:
           name: "code-check"
           python_version_minor: 9
-          toxenv: "proto-3-check,proto-4-check,black-check,ruff-check,mypy,mypy-report,codecov-check,auto-codegen-check"
-
+          # toxenv: "proto-3-check,proto-4-check,black-check,ruff-check,mypy,mypy-report,codecov-check,auto-codegen-check"
+          toxenv: "proto-3-check,proto-4-check,black-check,ruff-check,mypy,mypy-report,auto-codegen-check"
       #
       # Prep jobs
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ jobs:
       - run:
           name: Upload coverage to codecov
           command: |
-            nox -s codecov -- -F core -F unit
+            nox -s codecov -- -F unit
 
   protobuf-compatability:
     parameters:
@@ -609,6 +609,9 @@ jobs:
       tox_args:
         type: string
         default: ""
+      codecov_args:
+        type: string
+        default: ""
     macos:
       xcode: 14.3.1
     resource_class: macos.m1.medium.gen1
@@ -621,6 +624,7 @@ jobs:
           name: Install python dependencies
           command: |
             pip3 install tox==<< pipeline.parameters.tox_version >>
+            pip3 install nox
             brew install ffmpeg
       - run:
           name: Run tests
@@ -629,6 +633,15 @@ jobs:
             ulimit -n 4096
             CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" python3 -m tox run -v -e << parameters.toxenv >> -- << parameters.tox_args >>
           no_output_timeout: 10m
+      - when:
+          condition:
+            not:
+              equal: ["", << parameters.codecov_args >>]
+          steps:
+            - run:
+                name: Upload coverage to codecov
+                command: |
+                  python3 -m nox -s codecov -- << parameters.codecov_args >>
       - save-test-results
 
   launch:
@@ -1531,7 +1544,8 @@ workflows:
           name: "unit-macos-mock_server-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-mac-circle"
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
-          # codecov_args: "-F client -F unit"
+          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_args: "-F unit"
 
       - mac:
           requires:
@@ -1542,9 +1556,9 @@ workflows:
               python_version_minor: [9]
           name: "unit-macos-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-mac-circle"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/unit_tests"
-
+          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_args: "-F unit"
       #
       # Functional tests with yea on Linux (base only)
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,8 +466,9 @@ jobs:
             go test -race -coverprofile=coverage.txt -covermode=atomic ./...
             # Added to force a coverage count by coverage-tools.py: cover-gotest-circle
       - run:
-          name: Install nox and upload coverage to codecov
+          name: Install python, nox and upload coverage to codecov
           command: |
+            apt-get update && apt-get install -y python3-pip
             pip install nox
             nox -s codecov
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,6 +530,9 @@ jobs:
       coverage_dir:
         type: string
         default: ""
+      codecov_args:
+        type: string
+        default: ""
       parallelism:
         type: integer
         default: 4
@@ -564,6 +567,7 @@ jobs:
                 shell: bash.exe
                 command: |
                   pip install tox==<< pipeline.parameters.tox_version >>
+                  pip install nox
             - when:
                 condition:
                   equal: ["server-2019-cuda", << parameters.machine_executor >>]
@@ -585,6 +589,15 @@ jobs:
                   yes | gcloud auth configure-docker
                   DATE=$(date -u +%Y%m%d) CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox run -v -e << parameters.toxenv >> -- << parameters.tox_args >>
                 no_output_timeout: 10m
+            - when:
+                condition:
+                  not:
+                    equal: ["", << parameters.codecov_args >>]
+                steps:
+                  - run:
+                      name: Upload coverage to codecov
+                      command: |
+                        nox -s codecov -- << parameters.codecov_args >>
             - save-test-results
 
   mac:
@@ -1527,17 +1540,18 @@ workflows:
           name: "unit-win-mock_server-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-win-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_args: "-F unit"
           tox_args: "tests/pytest_tests/unit_tests_old --timeout 300 --ignore=tests/pytest_tests/unit_tests_old/test_launch"
 
       - win:
           requires:
             - "unit-tests"
-          filters:
-            branches:
-              only:
-                - main
-                - /^release-.*/
-                - /^.*-ci-win$/
+          # filters:
+          #   branches:
+          #     only:
+          #       - main
+          #       - /^release-.*/
+          #       - /^.*-ci-win$/
           matrix:
             parameters:
               python_version_major: [3]
@@ -1545,6 +1559,7 @@ workflows:
           name: "unit-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-win-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_args: "-F unit"
           tox_args: "tests/pytest_tests/unit_tests --timeout 300"
 
       - mac:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1415,7 +1415,6 @@ workflows:
       - tox-base:
           name: "code-check"
           python_version_minor: 9
-          # toxenv: "proto-3-check,proto-4-check,black-check,ruff-check,mypy,mypy-report,codecov-check,auto-codegen-check"
           toxenv: "proto-3-check,proto-4-check,black-check,ruff-check,mypy,mypy-report,auto-codegen-check"
       #
       # Prep jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1414,8 +1414,8 @@ workflows:
               python_version_minor: [7, 8, 9, 10, 11, 12]
           name: "system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_core"
+          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F system"
       #
       # System tests with pytest on Linux, using real wandb server, with Nexus
@@ -1464,6 +1464,7 @@ workflows:
           name: "unit-linux-mock_server-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F unit"
       #
       # Unit tests with pytest on Linux
@@ -1478,6 +1479,7 @@ workflows:
           name: "unit-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           tox_args: "tests/pytest_tests/unit_tests"
+          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F unit"
 
       #
@@ -1559,6 +1561,7 @@ workflows:
           toxenv: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
           parallelism: 4
+          coverage_dir: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F func"
 
       - tox-base:
@@ -1573,6 +1576,7 @@ workflows:
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/standalone_tests"
+          coverage_dir: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F func"
 
       - tox-base:
@@ -1590,6 +1594,7 @@ workflows:
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
+          coverage_dir: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F func"
 
       #
@@ -1611,6 +1616,7 @@ workflows:
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
+          coverage_dir: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F func"
 
       - tox-base:
@@ -1631,6 +1637,7 @@ workflows:
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
+          coverage_dir: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F func"
 
       #
@@ -1685,6 +1692,7 @@ workflows:
           name: "system-<<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           tox_args: "tests/pytest_tests/system_tests/test_<<matrix.shard>>"
+          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F system"
 
       #
@@ -1700,6 +1708,7 @@ workflows:
           name: "system-notebooks-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-notebooks-linux-circle"
           tox_args: "tests/pytest_tests/system_tests/test_notebooks"
+          coverage_dir: "notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_args: "-F system"
 
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,16 +460,19 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install python, pip, and nox
+          command: |
+            apt-get update && apt-get install -y python3-pip
+            python3 -m pip3 install nox
+      - run:
           name: Run Nexus' Go tests and collect coverage
           command: |
             cd nexus
             go test -race -coverprofile=coverage.txt -covermode=atomic ./...
             # Added to force a coverage count by coverage-tools.py: cover-gotest-circle
       - run:
-          name: Install python, nox and upload coverage to codecov
+          name: Upload coverage to codecov
           command: |
-            apt-get update && apt-get install -y python3-pip
-            python3 -m pip install nox
             nox -s codecov
 
   protobuf-compatability:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,7 +469,7 @@ jobs:
           name: Install python, nox and upload coverage to codecov
           command: |
             apt-get update && apt-get install -y python3-pip
-            pip install nox
+            python3 -m pip install nox
             nox -s codecov
 
   protobuf-compatability:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,8 +462,8 @@ jobs:
       - run:
           name: Install python, pip, and nox
           command: |
-            apt-get update && apt-get install -y python3-pip
-            python3 -m pip3 install nox
+            sudo apt-get update && sudo apt-get install -y python3-pip
+            pip install nox
       - run:
           name: Run Nexus' Go tests and collect coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,9 +381,9 @@ jobs:
       coverage_dir:
         type: string
         default: ""
-      upload_go_cov:
-        type: boolean
-        default: false
+      codecov_args:
+        type: string
+        default: ""
       notify_on_failure:
         type: boolean
         default: false
@@ -439,10 +439,14 @@ jobs:
               -- --wandb-server-tag << pipeline.parameters.wandb_server_tag >> << parameters.tox_args >>
       - save-test-results
       - when:
-          condition: << parameters.upload_go_cov >>
+          condition:
+            not:
+              equal: ["", << parameters.codecov_args >>]
           steps:
-            - codecov/upload:
-                flags: system
+            - run:
+                name: Upload coverage to codecov
+                command: |
+                  nox -s codecov -- << parameters.codecov_args >>
       # conditionally post a notification to slack if the job failed
       - when:
           condition: << parameters.notify_on_failure >>
@@ -469,11 +473,10 @@ jobs:
           command: |
             cd nexus
             go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-            # Added to force a coverage count by coverage-tools.py: cover-gotest-circle
       - run:
           name: Upload coverage to codecov
           command: |
-            nox -s codecov
+            nox -s codecov -- -F core -F unit
 
   protobuf-compatability:
     parameters:
@@ -1413,9 +1416,8 @@ workflows:
               python_version_minor: [ 7, 8, 9, 10, 11, 12 ]
           name: "nexus-system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_core"
-          upload_go_cov: true
+          codecov_args: "-F core -F system"
       #
       # Nexus smoke tests with pytest on Linux, using real wandb server
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,9 @@ jobs:
       coverage_dir:
         type: string
         default: ""
+      codecov_args:
+        type: string
+        default: ""
       shard:
         type: string
         default: "default"
@@ -346,6 +349,15 @@ jobs:
                 command: |
                   CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox run -v -e << parameters.toxenv >> -- << parameters.tox_args >>
             - save-test-results
+            - when:
+                condition:
+                  not:
+                    equal: ["", << parameters.codecov_args >>]
+                steps:
+                  - run:
+                      name: Upload coverage to codecov
+                      command: |
+                        nox -s codecov -- << parameters.codecov_args >>
             # conditionally post a notification to slack if the job failed
             - when:
                 condition: << parameters.notify_on_failure >>
@@ -1404,6 +1416,7 @@ workflows:
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
           coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_core"
+          codecov_args: "-F system"
       #
       # System tests with pytest on Linux, using real wandb server, with Nexus
       #
@@ -1417,7 +1430,7 @@ workflows:
           name: "nexus-system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_core"
-          codecov_args: "-F core -F system"
+          codecov_args: "-F system"
       #
       # Nexus smoke tests with pytest on Linux, using real wandb server
       #
@@ -1430,8 +1443,8 @@ workflows:
               python_version_minor: [ 7, 8, 9, 10, 11, 12 ]
           name: "nexus-smoke-system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_nexus"
+          codecov_args: "-F system"
       #
       # Nexus unit tests
       #
@@ -1450,8 +1463,8 @@ workflows:
               python_version_minor: [7, 8, 9, 10, 11]
           name: "unit-linux-mock_server-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+          codecov_args: "-F unit"
       #
       # Unit tests with pytest on Linux
       #
@@ -1464,8 +1477,8 @@ workflows:
               python_version_minor: [7, 8, 9, 10, 11, 12]
           name: "unit-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/unit_tests"
+          codecov_args: "-F unit"
 
       #
       # Unit tests with pytest on Windows and MacOS
@@ -1515,8 +1528,8 @@ workflows:
               python_version_minor: [9]
           name: "unit-macos-mock_server-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-mac-circle"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+          # codecov_args: "-F client -F unit"
 
       - mac:
           requires:
@@ -1544,9 +1557,9 @@ workflows:
                 - "default"
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
-          coverage_dir: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/functional_tests"
           parallelism: 4
+          codecov_args: "-F func"
 
       - tox-base:
           requires:
@@ -1559,8 +1572,8 @@ workflows:
                 - "mitm"
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
-          coverage_dir: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/standalone_tests"
+          codecov_args: "-F func"
 
       - tox-base:
           requires:
@@ -1576,8 +1589,8 @@ workflows:
                 - "noml"
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
-          coverage_dir: "func-<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/functional_tests"
+          codecov_args: "-F func"
 
       #
       # Functional tests with yea on Linux
@@ -1597,8 +1610,8 @@ workflows:
                 - "xgboost"
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
-          coverage_dir: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/functional_tests"
+          codecov_args: "-F func"
 
       - tox-base:
           requires:
@@ -1617,8 +1630,8 @@ workflows:
                 - "artifacts"
           name: "func-linux-s_<<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
-          coverage_dir: "func-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/functional_tests"
+          codecov_args: "-F func"
 
       #
       # Functional tests with yea on Windows
@@ -1671,8 +1684,8 @@ workflows:
                 - "artifacts"
           name: "system-<<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-linux-circle"
-          coverage_dir: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_<<matrix.shard>>"
+          codecov_args: "-F system"
 
       #
       # notebook tests
@@ -1686,26 +1699,9 @@ workflows:
               python_version_minor: [9]
           name: "system-notebooks-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-notebooks-linux-circle"
-          coverage_dir: "notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           tox_args: "tests/pytest_tests/system_tests/test_notebooks"
-#      - win:
-#          matrix:
-#            parameters:
-#              python_version_major: [3]
-#              python_version_minor: [9]
-#          name: "system-notebooks-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-#          toxenv: "notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-#          parallelism: 1
-#          xdist: 1
-#      - mac:
-#          matrix:
-#            parameters:
-#              python_version_major: [3]
-#              python_version_minor: [9]
-#          name: "system-notebooks-macos-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-#          toxenv: "notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-#          parallelism: 1
-#          xdist: 1
+          codecov_args: "-F system"
+
       #
       # functional tests with different executors
       #
@@ -1721,32 +1717,3 @@ workflows:
                 - "executor-gunicorn"
                 - "executor-pex"
           name: "<<matrix.toxenv>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-
-  # todo: needs love
-  #  manual_test:
-  #    when: << pipeline.parameters.manual_test >>
-  #    jobs:
-  #      - test:
-  #          name: << pipeline.parameters.manual_test_name >>
-  #          image: << pipeline.parameters.manual_test_image >>
-  #          toxenv: << pipeline.parameters.manual_test_toxenv >>
-  #          parallelism: << pipeline.parameters.manual_parallelism >>
-  #          xdist: << pipeline.parameters.manual_xdist >>
-  #
-  #  manual_win:
-  #    when: << pipeline.parameters.manual_win >>
-  #    jobs:
-  #      - win:
-  #          name: << pipeline.parameters.manual_win_name >>
-  #          toxenv: << pipeline.parameters.manual_win_toxenv >>
-  #          parallelism: << pipeline.parameters.manual_parallelism >>
-  #          xdist: << pipeline.parameters.manual_xdist >>
-  #
-  #  manual_mac:
-  #    when: << pipeline.parameters.manual_mac >>
-  #    jobs:
-  #      - mac:
-  #          name: << pipeline.parameters.manual_mac_name >>
-  #          toxenv: << pipeline.parameters.manual_mac_toxenv >>
-  #          parallelism: << pipeline.parameters.manual_parallelism >>
-  #          xdist: << pipeline.parameters.manual_xdist >>

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,6 +16,8 @@ comment:
 ignore:
   - "wandb/vendor"
   - "wandb/proto"
+  - "nexus/pkg/service"
+  - "nexus/internal/gql"
 
 coverage:
   precision: 2

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,17 +1,12 @@
 codecov:
   require_ci_to_pass: no
   notify:
-    # To calculate after_n_builds use
-    # ./tools/coverage-tool.py jobs
-    # also change comment block after_n_builds just below
-    after_n_builds: 56
-    wait_for_ci: no
+    wait_for_ci: yes
 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: no
-  after_n_builds: 56
 
 ignore:
   - "wandb/vendor"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,14 +4,14 @@ codecov:
     # To calculate after_n_builds use
     # ./tools/coverage-tool.py jobs
     # also change comment block after_n_builds just below
-    after_n_builds: 50
+    after_n_builds: 56
     wait_for_ci: no
 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: no
-  after_n_builds: 50
+  after_n_builds: 56
 
 ignore:
   - "wandb/vendor"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,22 +1,7 @@
 [paths]
 canonicalsrc =
     wandb/
-    .tox/func-s_artifacts-py38/lib/python3.8/site-packages/wandb/
-    .tox/func-s_default-py39/lib/python3.9/site-packages/wandb/
-    .tox/func-s_docs-py39/lib/python3.9/site-packages/wandb/
-    .tox/func-s_metaflow-py38/lib/python3.8/site-packages/wandb/
-    .tox/func-s_mitm-py39/lib/python3.9/site-packages/wandb/
-    .tox/func-s_noml-py39/lib/python3.9/site-packages/wandb/
-    .tox/func-s_ray112-py38/lib/python3.8/site-packages/wandb/
-    .tox/func-s_ray2-py38/lib/python3.8/site-packages/wandb/
-    .tox/func-s_service-py38/lib/python3.8/site-packages/wandb/
-    .tox/func-s_sklearn-py38/lib/python3.8/site-packages/wandb/
-    .tox/func-s_tf115-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_tf21-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_tf24-py38/lib/python3.8/site-packages/wandb/
-    .tox/func-s_tf25-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_tf26-py37/lib/python3.7/site-packages/wandb/
-    .tox/func-s_xgboost-py37/lib/python3.7/site-packages/wandb/
+    .tox/func-*/lib/python*/site-packages/wandb/
 
 [run]
 # TODO(jhr): enable this in the future

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -50,6 +50,9 @@ class NexusBase:
         elif goarch == "armv7l":
             goarch = "armv6l"
 
+        # build a binary for coverage profiling if the GOCOVERDIR env var is set
+        gocover = True if os.environ.get("GOCOVERDIR") else False
+
         # cgo is needed on:
         #  - arm macs to build the gopsutil dependency,
         #    otherwise several system metrics will be unavailable.
@@ -68,14 +71,16 @@ class NexusBase:
         if f"{goos}-{goarch}" == "linux-amd64":
             # todo: try llvm's lld linker
             ldflags += ' -extldflags "-fuse-ld=gold -Wl,--weak-unresolved-symbols"'
-        cmd = (
+        cmd = [
             "go",
             "build",
             f"-ldflags={ldflags}",
             "-o",
             str(nexus_path / "wandb-nexus"),
             "cmd/nexus/main.go",
-        )
+        ]
+        if gocover:
+            cmd.insert(2, "-cover")
         log.info("Building for current platform")
         log.info(f"Running command: {' '.join(cmd)}")
         subprocess.check_call(cmd, cwd=src_dir, env=env)

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,7 +97,7 @@ def download_codecov(session):
 
     session.run(
         "curl",
-        "-o" if system != "windows" else "-Os",
+        "-o",
         local_file,
         url,
         external=True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -127,7 +127,7 @@ def run_codecov(session):
 
     command.extend(args)
 
-    session.run(command, external=True)
+    session.run(*command, external=True)
 
 
 @nox.session(python=False, name="codecov")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import subprocess
 
 import nox
 
@@ -80,3 +82,61 @@ def list_failing_tests_nexus(session):
         ],
         plugins=[my_plugin],
     )
+
+
+@nox.session(python=False, name="download-codecov")
+def download_codecov(session):
+    system = platform.system().lower()
+    if system == "darwin":
+        system = "macos"
+    url = f"https://uploader.codecov.io/latest/{system}/codecov"
+    if system == "windows":
+        url += ".exe"
+        local_file = "codecov.exe"
+    else:
+        local_file = "codecov"
+
+    session.run(
+        "curl",
+        "-o" if system != "windows" else "-Os",
+        local_file,
+        url,
+        external=True,
+    )
+
+    session.run("chmod", "+x", local_file, external=True)
+
+
+@nox.session(python=False, name="run-codecov")
+def run_codecov(session):
+    args = session.posargs or []
+
+    system = platform.system().lower()
+    if system == "linux":
+        command = ["./codecov"]
+    elif system == "darwin":
+        arch = platform.machine().lower()
+        if arch != "x86_64":
+            session.run("softwareupdate", "--install-rosetta", "--agree-to-license")
+            command = ["arch", "-x86_64", "./codecov"]
+        else:
+            command = ["./codecov"]
+    elif system == "windows":
+        command = ["codecov.exe"]
+    else:
+        raise OSError("Unsupported operating system")
+
+    command.extend(args)
+
+    session.run(command, external=True)
+
+
+@nox.session(python=False, name="codecov")
+def codecov(session):
+    session.notify("download-codecov")
+    session.notify("run-codecov", posargs=session.posargs)
+
+
+if __name__ == "__main__":
+    download_codecov()
+    run_codecov()

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import subprocess
 
 import nox
 

--- a/tox.ini
+++ b/tox.ini
@@ -150,7 +150,7 @@ setenv=
     {[base]setenv}
     WINDIR=C:\\Windows
     WANDB_REQUIRE_NEXUS=true
-    GOCOVERDIR={work_dir}/.coverage
+    GOCOVERDIR={tox_root}/.coverage
 passenv=
     {[base]passenv}
     CI_PYTEST_PARALLEL

--- a/tox.ini
+++ b/tox.ini
@@ -159,6 +159,7 @@ passenv=
 allowlist_externals=
     mkdir
     nox
+    go
 commands=
     mkdir -p test-results .coverage
     # install nexus as wandb-core, requires go to be installed on the system

--- a/tox.ini
+++ b/tox.ini
@@ -150,6 +150,7 @@ setenv=
     {[base]setenv}
     WINDIR=C:\\Windows
     WANDB_REQUIRE_NEXUS=true
+    GOCOVERDIR={work_dir}/.coverage
 passenv=
     {[base]passenv}
     CI_PYTEST_PARALLEL
@@ -159,11 +160,12 @@ allowlist_externals=
     mkdir
     nox
 commands=
-    mkdir -p test-results
+    mkdir -p test-results .coverage
     # install nexus as wandb-core, requires go to be installed on the system
     nox -s build-nexus install-nexus
     # run nexus-specific tests, skipping the nexus_failure marker todo
     pytest -m "not nexus_failure" -n=auto --durations=20 --reruns 0 --reruns-delay 1 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail --timeout 30 {posargs:tests/pytest_tests/system_tests}
+    go tool covdata textfmt -i=.coverage -o coverage.txt
 
 [testenv:launch-release]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -330,7 +330,6 @@ passenv=
     circle: CIRCLECI
     circle: CIRCLE_*
     circle: CODECOV_*
-    circle: TOXENV
     COVERAGE_DIR
 allowlist_externals=
     mkdir
@@ -352,18 +351,6 @@ commands=
     cp .coverage coverage.xml cover-results/
     !{win}: coverage report --rcfile=.coveragerc
     win: {envpython} -m coverage report --rcfile=.coveragerc
-commands_post=
-    linux-circle: curl -Os https://uploader.codecov.io/latest/linux/codecov
-    mac-circle: curl -Os https://uploader.codecov.io/latest/macos/codecov
-    win-circle: curl -o codecov.exe https://uploader.codecov.io/latest/windows/codecov.exe
-
-    !{win}-circle: chmod +x codecov
-    win-circle: chmod +x codecov.exe
-    linux-circle: ./codecov -e TOXENV -F unittest
-    # todo: remove this when codecov releases a native macos arm64 binary
-    mac-circle: softwareupdate --install-rosetta --agree-to-license
-    mac-circle: arch -x86_64 ./codecov -e TOXENV -F unittest
-    win-circle: codecov.exe -e TOXENV -F unittest
 
 [testenv:pod-store]
 allowlist_externals=


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b79c59f</samp>

This pull request improves the coverage reporting for the wandb Python and Nexus Go modules by using codecov and nox. It updates the `.circleci/config.yml`, `.codecov.yml`, `nexus/setup.py`, `noxfile.py`, `tox.ini`, and `.coveragerc` files to enable and configure the coverage profiling and uploading. It also removes some redundant or outdated code from the CI configuration.

Testing
-------
How was this PR tested?

A lot :)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b79c59f</samp>

> _Sing, O Muse, of the valiant deeds of wandb,_
> _The mighty tool for tracking machine learning experiments,_
> _How they refined their code coverage with skill and care,_
> _And pleased the gods of codecov with their offerings._
