### PR TITLE
feat(integrations): fix bug in ultralytics import and version pinning

### DIFF
--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -61,7 +61,7 @@ try:
         plot_pose_validation_results,
     )
 except ImportError as e:
-    wandb.error(e)
+    wandb.Error(e)
 
 
 TRAINER_TYPE = Union[


### PR DESCRIPTION
Description
-----------
Fix a bug in the version pinning and imports for the ultralytics integration.

Fixes: WB-16357

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3eedae0</samp>

Replaced `wandb.error` with `wandb.Error` in `wandb/integration/ultralytics/callback.py` to standardize exception handling. This affects the `setup_wandb_logger` function that imports the `wandb` module.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3eedae0</samp>

> _`wandb.error` gone_
> _`wandb.Error` class for all_
> _cutting edge in spring_
