### PR TITLE
chore(nexus): use segmentio's json package instead of stdlib's

### DIFF
--- a/nexus/go.mod
+++ b/nexus/go.mod
@@ -26,6 +26,8 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.3.6 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect

--- a/nexus/go.mod
+++ b/nexus/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/radovskyb/watcher v1.0.7
+	github.com/segmentio/encoding v0.3.6
 	github.com/shirou/gopsutil/v3 v3.23.6
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/time v0.3.0
@@ -27,7 +28,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
-	github.com/segmentio/encoding v0.3.6 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect

--- a/nexus/go.sum
+++ b/nexus/go.sum
@@ -63,6 +63,10 @@ github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8t
 github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.3.6 h1:E6lVLyDPseWEulBmCmAKPanDd3jiyGDo5gMcugCRwZQ=
+github.com/segmentio/encoding v0.3.6/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil/v3 v3.23.6 h1:5y46WPI9QBKBbK7EEccUPNXpJpNrvPuTD0O2zHEHT08=
@@ -108,6 +112,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=

--- a/nexus/internal/nexuslib/summarylib.go
+++ b/nexus/internal/nexuslib/summarylib.go
@@ -1,8 +1,9 @@
 package nexuslib
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/nexus/pkg/service"
 )

--- a/nexus/internal/nexustest/nexustest.go
+++ b/nexus/internal/nexustest/nexustest.go
@@ -2,8 +2,9 @@ package nexustest
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/golang/mock/gomock"

--- a/nexus/pkg/artifacts/manifest.go
+++ b/nexus/pkg/artifacts/manifest.go
@@ -1,11 +1,12 @@
 package artifacts
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/nexus/pkg/service"
 	"github.com/wandb/wandb/nexus/pkg/utils"

--- a/nexus/pkg/filestream/filestream_test.go
+++ b/nexus/pkg/filestream/filestream_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/wandb/wandb/nexus/pkg/filestream"
 	"github.com/wandb/wandb/nexus/pkg/server"
 
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/segmentio/encoding/json"
 
 	"sync"
 

--- a/nexus/pkg/filestream/loop_process.go
+++ b/nexus/pkg/filestream/loop_process.go
@@ -1,8 +1,9 @@
 package filestream
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/nexus/internal/nexuslib"
 	"github.com/wandb/wandb/nexus/pkg/service"

--- a/nexus/pkg/filestream/loop_transmit.go
+++ b/nexus/pkg/filestream/loop_transmit.go
@@ -2,9 +2,10 @@ package filestream
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"net/http"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/hashicorp/go-retryablehttp"
 )

--- a/nexus/pkg/filestream/loop_transmit_test.go
+++ b/nexus/pkg/filestream/loop_transmit_test.go
@@ -1,12 +1,13 @@
 package filestream
 
 import (
-	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/nexus/pkg/gowandb/run.go
+++ b/nexus/pkg/gowandb/run.go
@@ -2,10 +2,11 @@ package gowandb
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
 	"os"
 	"sync"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/nexus/internal/shared"
 	"github.com/wandb/wandb/nexus/pkg/gowandb/opts/runopts"

--- a/nexus/pkg/monitor/monitor.go
+++ b/nexus/pkg/monitor/monitor.go
@@ -2,10 +2,11 @@ package monitor
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/segmentio/encoding/json"
 
 	"google.golang.org/protobuf/proto"
 

--- a/nexus/pkg/server/history.go
+++ b/nexus/pkg/server/history.go
@@ -2,13 +2,14 @@ package server
 
 import (
 	"container/heap"
-	"encoding/json"
 	"fmt"
 	"math"
 	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/nexus/internal/nexuslib"
 	"github.com/wandb/wandb/nexus/pkg/service"

--- a/nexus/pkg/server/resume.go
+++ b/nexus/pkg/server/resume.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/nexus/internal/gql"
 	fs "github.com/wandb/wandb/nexus/pkg/filestream"

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -2,13 +2,14 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/segmentio/encoding/json"
 
 	"github.com/Khan/genqlient/graphql"
 	"google.golang.org/protobuf/encoding/protojson"


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

---
It's much faster! See https://github.com/go-json-experiment/jsonbench

In the near future, will likely replace again with the v2 of the encoding/json package in stdlib: https://github.com/go-json-experiment/json.

Notes:
- https://github.com/bytedance/sonic is even faster, but the binary is huge
- consider https://github.com/sugawarayuuta/sonnet?
- consider https://github.com/tidwall/gjson?
---

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3a9220a</samp>

This pull request replaces the standard `encoding/json` package with the `github.com/segmentio/encoding/json` package in several files across the nexus package and its subpackages. The purpose of this change is to use a faster and more efficient JSON encoder and decoder library, which improves the performance and memory usage of the nexus service and its client and test code.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3a9220a</samp>

> _We're sailing on the nexus ship, with JSON in our code_
> _We need a faster library, to lighten up our load_
> _So `segmentio/encoding/json` is what we're gonna use_
> _Heave away, me hearties, heave away on two!_
