### PR TITLE
fix(launch): Add prioritization mode to RunQueue create

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2882,14 +2882,19 @@ class RunQueue:
         cls,
         name: str,
         resource: "RunQueueResourceType",
-        access: "RunQueueAccessType",
         entity: Optional[str] = None,
+        prioritization_mode: Optional["RunQueuePrioritizationMode"] = None,
         config: Optional[dict] = None,
         template_variables: Optional[dict] = None,
     ) -> "RunQueue":
         public_api = Api()
         return public_api.create_run_queue(
-            name, resource, access, entity, config, template_variables
+            name,
+            resource,
+            entity,
+            prioritization_mode,
+            config,
+            template_variables
         )
 
 

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2889,12 +2889,7 @@ class RunQueue:
     ) -> "RunQueue":
         public_api = Api()
         return public_api.create_run_queue(
-            name,
-            resource,
-            entity,
-            prioritization_mode,
-            config,
-            template_variables
+            name, resource, entity, prioritization_mode, config, template_variables
         )
 
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- [Previous PR](https://github.com/wandb/wandb/pull/6599)

When adding prioritization_mode to RunQueue, I missed adding it to the `RunQueue.create()` method.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4540420</samp>

This change adds a new feature to the `wandb` API for creating and managing run queues with different priorities. It updates the `RunQueue` class in `wandb/apis/public.py` to accept a `mode` argument that determines the ordering of runs in the queue.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4540420</samp>

> _Choose your mode of doom, `RunQueue` awaits_
> _Order and execute, the runs that seal your fate_
> _No mercy for the weak, no fairness for the strong_
> _Only the prioritized, will survive the onslaught_
