### PR TITLE
chore(launch): Add priority field for pushing to run queue

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_launch_add.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_add.py
@@ -632,7 +632,9 @@ def test_display_updated_runspec(
     settings = test_settings({"project": proj})
     api = InternalApi()
 
-    def push_with_drc(api, queue_name, launch_spec, template_variables, project_queue, priority):
+    def push_with_drc(
+        api, queue_name, launch_spec, template_variables, project_queue, priority
+    ):
         # mock having a DRC
         res = api.push_to_run_queue(
             queue_name, launch_spec, template_variables, project_queue, priority

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_add.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_add.py
@@ -558,7 +558,7 @@ def test_launch_add_template_variables_not_supported(user, monkeypatch):
 
     def patched_push_to_run_queue_introspection(*args, **kwargs):
         args[0].server_supports_template_varaibles = False
-        return False
+        return (False, False)
 
     monkeypatch.setattr(
         wandb.sdk.internal.internal_api.Api,
@@ -592,7 +592,7 @@ def test_launch_add_template_variables_not_supported_legacy_push(
 
     def patched_push_to_run_queue_introspection(*args, **kwargs):
         args[0].server_supports_template_varaibles = False
-        return False
+        return (False, False)
 
     monkeypatch.setattr(
         wandb.sdk.internal.internal_api.Api,
@@ -632,10 +632,10 @@ def test_display_updated_runspec(
     settings = test_settings({"project": proj})
     api = InternalApi()
 
-    def push_with_drc(api, queue_name, launch_spec, template_variables, project_queue):
+    def push_with_drc(api, queue_name, launch_spec, template_variables, project_queue, priority):
         # mock having a DRC
         res = api.push_to_run_queue(
-            queue_name, launch_spec, template_variables, project_queue
+            queue_name, launch_spec, template_variables, project_queue, priority
         )
         res["runSpec"] = launch_spec
         res["runSpec"]["resource_args"] = {"kubernetes": {"volume": "x/awda/xxx"}}

--- a/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock
+import json
+from unittest.mock import ANY, MagicMock
 
 import pytest
 import wandb
@@ -63,3 +64,36 @@ def test_create_run_queue(monkeypatch):
             "defaultResourceConfigID": "test-config-id",
         },
     )
+
+
+def test_push_to_run_queue_by_name(monkeypatch):
+    _api = internal.Api()
+    mock_run_spec = {"test-key": "test-value"}
+    mock_gql_response = {"pushToRunQueueByName": {"runSpec": json.dumps(mock_run_spec)}}
+    _api.api.gql = MagicMock(return_value=mock_gql_response)
+    _api.api.push_to_run_queue_introspection = MagicMock()
+    monkeypatch.setattr(wandb.sdk.internal.internal_api, "gql", lambda x: x)
+
+    _api.api.server_push_to_run_queue_supports_priority = True
+    push_kwargs = {
+        "entity": "test-entity",
+        "project": "test-project",
+        "queue_name": "test-queue",
+        "run_spec": "{}",
+        "template_variables": None,
+        "priority": 2,
+    }
+
+    resp = _api.api.push_to_run_queue_by_name(**push_kwargs)
+
+    assert resp == {"runSpec": mock_run_spec}
+    call_args = _api.api.gql.call_args[0]
+    assert "$priority: Int" in call_args[0]
+    assert "priority: $priority" in call_args[0]
+    assert call_args[1] == {
+        "entityName": "test-entity",
+        "projectName": "test-project",
+        "queueName": "test-queue",
+        "runSpec": "{}",
+        "priority": 2,
+    }

--- a/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import wandb

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -983,6 +983,7 @@ class Api:
         queue_name,
         run_queue_item_id,
         project_queue=None,
+        priority=None,
     ):
         """Return a single queued run based on the path.
 
@@ -995,6 +996,7 @@ class Api:
             queue_name,
             run_queue_item_id,
             project_queue=project_queue,
+            priority=priority,
         )
 
     def run_queue(
@@ -2492,6 +2494,7 @@ class QueuedRun:
         queue_name,
         run_queue_item_id,
         project_queue=LAUNCH_DEFAULT_PROJECT,
+        priority=None,
     ):
         self.client = client
         self._entity = entity
@@ -2501,6 +2504,7 @@ class QueuedRun:
         self.sweep = None
         self._run = None
         self.project_queue = project_queue
+        self.priority = priority
 
     @property
     def queue_name(self):
@@ -4904,6 +4908,7 @@ class Job:
         resource_args=None,
         template_variables=None,
         project_queue=None,
+        priority=None,
     ):
         from wandb.sdk.launch import _launch_add
 
@@ -4935,5 +4940,6 @@ class Job:
             resource=resource,
             project_queue=project_queue,
             resource_args=resource_args,
+            priority=priority,
         )
         return queued_run

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -682,7 +682,10 @@ class Api:
             }
         """
 
-        if self.server_supports_template_variables is None or self.server_push_to_run_queue_supports_priority is None:
+        if (
+            self.server_supports_template_variables is None
+            or self.server_push_to_run_queue_supports_priority is None
+        ):
             query = gql(query_string)
             res = self.gql(query)
             self.server_supports_template_variables = "templateVariableValues" in [
@@ -698,7 +701,10 @@ class Api:
                 )
             ]
 
-        return self.server_supports_template_variables, self.server_push_to_run_queue_supports_priority
+        return (
+            self.server_supports_template_variables,
+            self.server_push_to_run_queue_supports_priority,
+        )
 
     @normalize_exceptions
     def create_default_resource_config_introspection(self) -> bool:
@@ -1406,7 +1412,7 @@ class Api:
     ) -> Optional[Dict[str, Any]]:
         if not self.create_default_resource_config_introspection():
             raise Exception()
-        supports_template_vars = self.push_to_run_queue_introspection()
+        supports_template_vars, _ = self.push_to_run_queue_introspection()
 
         mutation_params = """
             $entityName: String!,
@@ -1592,7 +1598,7 @@ class Api:
             runSpec: $runSpec
         """
 
-        variables = {
+        variables: Dict[str, Any] = {
             "entityName": entity,
             "projectName": project,
             "queueName": queue_name,

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1702,13 +1702,14 @@ class Api:
         launch_spec: Dict[str, str],
         template_variables: Optional[dict],
         project_queue: str,
+        priority: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
         self.push_to_run_queue_introspection()
         entity = launch_spec.get("queue_entity") or launch_spec["entity"]
         run_spec = json.dumps(launch_spec)
 
         push_result = self.push_to_run_queue_by_name(
-            entity, project_queue, queue_name, run_spec, template_variables
+            entity, project_queue, queue_name, run_spec, template_variables, priority
         )
 
         if push_result:

--- a/wandb/sdk/launch/_launch_add.py
+++ b/wandb/sdk/launch/_launch_add.py
@@ -64,6 +64,7 @@ def launch_add(
         project: Target project to send launched run to
         entity: Target entity to send launched run to
         queue: the name of the queue to enqueue the run to
+        priority: the priority level of the job, where 1 is the highest priority
         resource: Execution backend for the run: W&B provides built-in support for "local-container" backend
         entry_point: Entry point to run within the project. Defaults to using the entry point used
             in the original run for wandb URIs, or main.py for git repository URIs.

--- a/wandb/sdk/launch/_launch_add.py
+++ b/wandb/sdk/launch/_launch_add.py
@@ -219,7 +219,9 @@ async def _launch_add(
             }
 
     validate_launch_spec_source(launch_spec)
-    res = push_to_queue(api, queue_name, launch_spec, template_variables, project_queue, priority)
+    res = push_to_queue(
+        api, queue_name, launch_spec, template_variables, project_queue, priority
+    )
 
     if res is None or "runQueueItemId" not in res:
         raise LaunchError("Error adding run to queue")
@@ -250,5 +252,6 @@ async def _launch_add(
         queue_name,
         res["runQueueItemId"],
         project_queue,
+        priority,
     )
     return queued_run  # type: ignore

--- a/wandb/sdk/launch/_launch_add.py
+++ b/wandb/sdk/launch/_launch_add.py
@@ -23,9 +23,10 @@ def push_to_queue(
     launch_spec: Dict[str, Any],
     template_variables: Optional[dict],
     project_queue: str,
+    priority: Optional[int] = None,
 ) -> Any:
     return api.push_to_run_queue(
-        queue_name, launch_spec, template_variables, project_queue
+        queue_name, launch_spec, template_variables, project_queue, priority
     )
 
 
@@ -49,6 +50,7 @@ def launch_add(
     repository: Optional[str] = None,
     sweep_id: Optional[str] = None,
     author: Optional[str] = None,
+    priority: Optional[int] = None,
 ) -> "public.QueuedRun":
     """Enqueue a W&B launch experiment. With either a source uri, job or docker_image.
 
@@ -125,6 +127,7 @@ def launch_add(
             repository=repository,
             sweep_id=sweep_id,
             author=author,
+            priority=priority,
         )
     )
 
@@ -150,6 +153,7 @@ async def _launch_add(
     repository: Optional[str] = None,
     sweep_id: Optional[str] = None,
     author: Optional[str] = None,
+    priority: Optional[int] = None,
 ) -> "public.QueuedRun":
     launch_spec = construct_launch_spec(
         uri,
@@ -215,7 +219,7 @@ async def _launch_add(
             }
 
     validate_launch_spec_source(launch_spec)
-    res = push_to_queue(api, queue_name, launch_spec, template_variables, project_queue)
+    res = push_to_queue(api, queue_name, launch_spec, template_variables, project_queue, priority)
 
     if res is None or "runQueueItemId" not in res:
         raise LaunchError("Error adding run to queue")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-15884](https://wandb.atlassian.net/browse/WB-15884)

Added the field `priority` to the public API, in `Job.call()` and `launch_add()`.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e5fa101</samp>

This pull request adds priority support for the run queue in the wandb launch module and the public and internal APIs. It also updates the system and unit tests to reflect the new behavior and parameters. It modifies the files `wandb/sdk/launch/_launch_add.py`, `wandb/apis/public.py`, `wandb/sdk/internal/internal_api.py`, `tests/pytest_tests/system_tests/test_launch/test_launch_add.py`, and `tests/pytest_tests/unit_tests/test_launch/test_internal_api.py`.

Testing
-------
Tested locally against the [core E2E implementation](https://github.com/wandb/core/pull/17874/). A unit test was also added for `push_to_run_queue_by_name`.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e5fa101</samp>

> _Sing, O Muse, of the valiant code warriors who strove_
> _To enhance the `launch` module with a `priority` parameter_
> _That they might control the order of their runs and jobs_
> _On the server, swift and powerful, like Zeus hurling thunder_


[WB-15884]: https://wandb.atlassian.net/browse/WB-15884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ