### PR TITLE
chore(nexus): prep for wandb-core roll-out

### DIFF
--- a/.bumpversion.core.cfg
+++ b/.bumpversion.core.cfg
@@ -56,5 +56,5 @@ search = "wandb-core>={current_version}"
 replace = "wandb-core>={new_version}"
 
 [bumpversion:file:wandb/__init__.py]
-search = _minimum_nexus_version = "{current_version}"
-replace = _minimum_nexus_version = "{new_version}"
+search = _minimum_core_version = "{current_version}"
+replace = _minimum_core_version = "{new_version}"

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -117,8 +117,6 @@ jobs:
         run: |
           python -m pip install .
       - name: Smoke-test wandb-core TestPyPI install
-        env:
-          WANDB_REQUIRE_NEXUS: true
         run: |
           python -c "import wandb; run = wandb.init(settings={'mode': 'offline'}); run.finish()"
 

--- a/nexus/README.md
+++ b/nexus/README.md
@@ -1,54 +1,43 @@
-# W&B Nexus: A New Backend for the W&B SDK
+# Project Nexus: A New Backend for the W&B SDK
 
 [![PyPI version](https://badge.fury.io/py/wandb-core.svg)](https://badge.fury.io/py/wandb-core)
 [![PyPI - License](https://img.shields.io/pypi/l/wandb-core)]()
 
-## What is Nexus?
+## What is it all about?
 
-Greetings, developers!
+Good News, Everyone!
 
-*What is Project Nexus?* At the highest level, Nexus is a new backend for the W&B SDK.
+We have built a new backend for the W&B SDK that is more robust, performant, and versatile!
 
-*Why would anyone care and want to use it?* There are multiple reasons, but here are just two:
-- It's faster. A lot faster. We're talking orders of magnitude faster for some operations.
-- It enables clean multi-language support.
+## How do I use it?
 
-`nexus` is a Golang reimplementation of the W&B SDK internal process, `wandb service`,
-based on the lessons learned from the original implementation(s),
-but starting from a clean slate.
-
-## Installation
-
-To install Nexus, you will need to run the following commands:
+All you need is to have the `wandb-core` package installed into your environment. `wandb` will
+pick it up and use it automatically:
 
 ```bash
-pip install "wandb[nexus]" --pre
+pip install -U wandb wandb-core
 ```
 
-### Supported Platforms
+Note: you will need `wandb>=0.16.0`.
 
-Nexus is currently supported on the following platforms:
+### Supported Platforms
 
 - Linux:`x86_64`, `aarch64`
 - macOS: `x86_64`, `arm64`
 - Windows `amd64`
 
-If you are using a different platform, you can build Nexus from the source by following the
+If you are using a different platform, you can build `wandb-core` from sources by following the
 instructions in the [contributing guide](docs/contributing.md#installing-nexus).
 Please also open a [GitHub issue](https://github.com/wandb/wandb/issues/new/choose)
-to let us know that you are interested in using Nexus on
+to let us know that you are interested in using it on
 your platform, and we will prioritize adding support for it.
 
-## Usage example
+### How do I fall back to the previous version of the SDK backend?
 
-While Nexus is still in development, you need to explicitly opt-in to use it.
+Just uninstall `wandb-core` from your environment.
 
-```python
-import wandb
-
-wandb.require("nexus")
-
-# Your code here using the W&B SDK
+```bash
+pip uninstall wandb-core
 ```
 
 ## Contributing
@@ -59,14 +48,13 @@ your development environment and how to contribute to the codebase.
 ## Feedback
 Please give Nexus a try and let us know what you think, we believe it is worth it!
 
-We are very much looking forward to your feedback, especially bug reports.
+We are very much looking forward to your feedback, especially bug reports!
 Please open a [GitHub issue](https://github.com/wandb/wandb/issues/new/choose)
-if you encounter an error, mention that you are using Nexus.
+if you encounter an error, and mention that you are using `wandb-core`.
 
-## Feature Parity Status
+## Feature Support Status
 
-The following table shows the status of the feature parity
-between the current W&B SDK and Nexus for version `0.17.0b2`.
+The following table shows the status of the feature support as of `wandb-core` version `0.17.0b2`.
 
 Status legend:
 - ✅: Available: The feature is relatively stable and ready for use.

--- a/nexus/docs/contributing.md
+++ b/nexus/docs/contributing.md
@@ -48,5 +48,5 @@ nox -s list-failing-tests-nexus
 To run the tests excluding the failing ones locally, you will need to run the following
 commands in your active Python environment (assuming you are in the root of the repository):
 ```bash
-WANDB_REQUIRE_NEXUS=true pytest -m "not nexus_failure" tests/pytest_tests/system_tests/test_core
+pytest -m "not nexus_failure" tests/pytest_tests/system_tests/test_core
 ```

--- a/nexus/wandb_core/__init__.py
+++ b/nexus/wandb_core/__init__.py
@@ -1,10 +1,10 @@
 """W&B Core: This is the backend for the W&B client library."""
-__all__ = ("__version__", "get_core_path")
+__all__ = ("__version__", "get_nexus_path")
 
 from pathlib import Path
 
 __version__ = "0.17.0b2"
 
 
-def get_core_path() -> Path:
+def get_nexus_path() -> Path:
     return (Path(__file__).parent / "wandb-nexus").resolve()

--- a/nexus/wandb_core/__init__.py
+++ b/nexus/wandb_core/__init__.py
@@ -1,10 +1,10 @@
-"""W&B Nexus: Calcium-Rich Bones for the SDK."""
-__all__ = ("__version__", "get_nexus_path")
+"""W&B Core: This is the backend for the W&B client library."""
+__all__ = ("__version__", "get_core_path")
 
 from pathlib import Path
 
 __version__ = "0.17.0b2"
 
 
-def get_nexus_path() -> Path:
+def get_core_path() -> Path:
     return (Path(__file__).parent / "wandb-nexus").resolve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ launch = [
 models = ["cloudpickle"]
 async = ["httpx>=0.23.0"]
 perf = ["orjson"]
-nexus = ["wandb-core>=0.17.0b2"]
+core = ["wandb-core>=0.17.0b2"]
 
 [tool.setuptools]
 zip-safe = false

--- a/tests/pytest_tests/system_tests/test_nexus/conftest.py
+++ b/tests/pytest_tests/system_tests/test_nexus/conftest.py
@@ -1,7 +1,0 @@
-import pytest
-import wandb
-
-
-@pytest.fixture(scope="session", autouse=True)
-def wandb_require_nexus():
-    wandb.require(experiment="nexus")

--- a/tox.ini
+++ b/tox.ini
@@ -149,7 +149,6 @@ deps=
 setenv=
     {[base]setenv}
     WINDIR=C:\\Windows
-    WANDB_REQUIRE_NEXUS=true
     GOCOVERDIR={tox_root}/.coverage
 passenv=
     {[base]passenv}

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -12,7 +12,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
 __version__ = "0.16.1.dev1"
-_minimum_nexus_version = "0.17.0b2"
+_minimum_core_version = "0.17.0b2"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -181,13 +181,14 @@ class _Service:
             wandb_core = get_module("wandb_core")
             if not core_path and wandb_core:
                 _check_wandb_core_version_compatibility(wandb_core.__version__)
-                core_path = wandb_core.get_core_path()
-
+                core_path = wandb_core.get_nexus_path()
             if core_path:
                 service_args.extend([core_path])
                 if not error_reporting_enabled():
                     service_args.append("--no-observability")
                 exec_cmd_list = []
+                # TODO: this is temporary until artifacts fixes their logic
+                os.environ["WANDB_REQUIRE_NEXUS"] = "True"
             else:
                 service_args.extend(["wandb", "service"])
 

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -170,6 +170,7 @@ class _Service:
             if os.environ.get("YEA_RUN_COVERAGE") and os.environ.get("COVERAGE_RCFILE"):
                 exec_cmd_list += ["coverage", "run", "-m"]
 
+            # TODO: add proper logic here:
             service_args = []
             if self._settings._require_nexus:
                 # NOTE: The wandb_core module will be distributed at first as an alpha

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -170,7 +170,6 @@ class _Service:
             if os.environ.get("YEA_RUN_COVERAGE") and os.environ.get("COVERAGE_RCFILE"):
                 exec_cmd_list += ["coverage", "run", "-m"]
 
-            # TODO: add proper logic here:
             service_args = []
             # NOTE: "wandb-core" is the name of the package that will be distributed
             #       as the stable version of the wandb core library.
@@ -187,7 +186,7 @@ class _Service:
                 if not error_reporting_enabled():
                     service_args.append("--no-observability")
                 exec_cmd_list = []
-                # TODO: this is temporary until artifacts fixes their logic
+                # TODO(artifacts): this is temporary until artifacts fixes their logic
                 os.environ["WANDB_REQUIRE_NEXUS"] = "True"
             else:
                 service_args.extend(["wandb", "service"])

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -186,7 +186,7 @@ class _Service:
                 if not error_reporting_enabled():
                     service_args.append("--no-observability")
                 exec_cmd_list = []
-                # TODO(artifacts): this is temporary until artifacts fixes their logic
+                # TODO(artifacts): this is temporary until the artifact logic is fixed
                 os.environ["WANDB_REQUIRE_NEXUS"] = "True"
             else:
                 service_args.extend(["wandb", "service"])

--- a/wandb/sdk/wandb_require.py
+++ b/wandb/sdk/wandb_require.py
@@ -9,7 +9,6 @@ Example:
     wandb.require("incremental-artifacts@beta")
 """
 
-import os
 from typing import Optional, Sequence, Union
 
 import wandb
@@ -38,12 +37,6 @@ class _Requires:
 
     def require_service(self) -> None:
         self._require_service()
-
-    def _require_nexus(self) -> None:
-        os.environ["WANDB_REQUIRE_NEXUS"] = "True"
-
-    def require_nexus(self) -> None:
-        self._require_nexus()
 
     def apply(self) -> None:
         """Call require_* method for supported features."""


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7794ffb</samp>

This pull request updates the documentation and configuration files to reflect the renaming of the `wandb-core` project, which is a new backend for the `wandb` package. It also adds a placeholder line of code to the service module to prepare for future enhancements of the `wandb-core` process management.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7794ffb</samp>

> _We are the core, we run the show_
> _We launch the server, we make it glow_
> _But we are not done, we have to grow_
> _We face the TODOs, we crush the foe_
