### PR TITLE
test(sdk): use asyncio.run instead of homemade solutions, now that we require py37

### DIFF
--- a/tests/pytest_tests/unit_tests/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_internal_api.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import (
-    Awaitable,
     Callable,
     Mapping,
     Optional,

--- a/tests/pytest_tests/unit_tests/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_internal_api.py
@@ -38,11 +38,6 @@ from .test_retry import MockTime, mock_time  # noqa: F401
 _T = TypeVar("_T")
 
 
-def asyncio_run(coro: Awaitable[_T]) -> _T:
-    """Approximately the same as `asyncio.run`, which isn't available in Python 3.6."""
-    return asyncio.get_event_loop().run_until_complete(coro)
-
-
 @pytest.fixture
 def mock_responses():
     with responses.RequestsMock() as rsps:
@@ -162,7 +157,7 @@ class TestUploadFile:
         ):
             route = mock_respx.put("http://example.com/upload-dst")
             route.mock(return_value=httpx.Response(200))
-            asyncio_run(
+            asyncio.run(
                 internal.InternalApi().upload_file_async(
                     "http://example.com/upload-dst",
                     example_file.open("rb"),
@@ -229,7 +224,7 @@ class TestUploadFile:
                 return_value=httpx.Response(errcode)
             )
             with pytest.raises(httpx.HTTPStatusError):
-                asyncio_run(
+                asyncio.run(
                     internal.InternalApi().upload_file_async(
                         "http://example.com/upload-dst", example_file.open("rb")
                     )
@@ -251,7 +246,7 @@ class TestUploadFile:
         ):
             mock_respx.put("http://example.com/upload-dst").mock(side_effect=err)
             with pytest.raises(type(err)):
-                asyncio_run(
+                asyncio.run(
                     internal.InternalApi().upload_file_async(
                         "http://example.com/upload-dst", example_file.open("rb")
                     )
@@ -296,7 +291,7 @@ class TestUploadFile:
             )
 
             progress_callback = Mock()
-            asyncio_run(
+            asyncio.run(
                 internal.InternalApi().upload_file_async(
                     "http://example.com/upload-dst",
                     example_file.open("rb"),
@@ -359,7 +354,7 @@ class TestUploadFile:
             )
 
             progress_callback = Mock()
-            asyncio_run(
+            asyncio.run(
                 internal.InternalApi().upload_file_async(
                     "http://example.com/upload-dst",
                     example_file.open("rb"),
@@ -438,7 +433,7 @@ class TestUploadFile:
 
             progress_callback = Mock()
             with pytest.raises(httpx.HTTPError):
-                asyncio_run(
+                asyncio.run(
                     internal.InternalApi().upload_file_async(
                         "http://example.com/upload-dst",
                         example_file.open("rb"),
@@ -707,7 +702,7 @@ class TestUploadFileRetry:
         route = mock_respx.put("http://example.com/upload-dst")
         route.side_effect = [httpx.Response(status) for status in schedule]
 
-        asyncio_run(
+        asyncio.run(
             internal.InternalApi().upload_file_retry_async(
                 "http://example.com/upload-dst",
                 example_file.open("rb"),
@@ -740,7 +735,7 @@ class TestUploadFileRetry:
         route.side_effect = [httpx.Response(400)]
 
         with pytest.raises(httpx.HTTPStatusError):
-            asyncio_run(
+            asyncio.run(
                 internal.InternalApi().upload_file_retry_async(
                     "http://example.com/upload-dst",
                     example_file.open("rb"),
@@ -776,7 +771,7 @@ class TestUploadFileRetry:
         route.side_effect = httpx.Response(500)
 
         with pytest.raises(httpx.HTTPStatusError):
-            asyncio_run(
+            asyncio.run(
                 internal.InternalApi().upload_file_retry_async(
                     "http://example.com/upload-dst",
                     example_file.open("rb"),
@@ -822,7 +817,7 @@ class TestUploadFileRetry:
         route = mock_respx.put("http://example.com/upload-dst")
         route.mock(side_effect=[response, httpx.Response(200)])
         try:
-            asyncio_run(
+            asyncio.run(
                 internal.InternalApi().upload_file_retry_async(
                     "http://example.com/upload-dst",
                     example_file.open("rb"),

--- a/tests/pytest_tests/unit_tests/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_internal_api.py
@@ -7,16 +7,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
-from typing import (
-    Callable,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Callable, Mapping, Optional, Sequence, Tuple, Type, TypeVar, Union
 from unittest.mock import Mock, call, patch
 
 import httpx

--- a/tests/pytest_tests/unit_tests/test_retry.py
+++ b/tests/pytest_tests/unit_tests/test_retry.py
@@ -3,7 +3,6 @@
 import asyncio
 import dataclasses
 import datetime
-import sys
 from typing import Iterator
 from unittest import mock
 

--- a/tests/pytest_tests/unit_tests/test_retry.py
+++ b/tests/pytest_tests/unit_tests/test_retry.py
@@ -10,13 +10,6 @@ from unittest import mock
 import pytest
 from wandb.sdk.lib import retry
 
-if sys.version_info >= (3, 10):
-    asyncio_run = asyncio.run
-else:
-
-    def asyncio_run(coro):
-        return asyncio.new_event_loop().run_until_complete(coro)
-
 
 @dataclasses.dataclass
 class MockTime:
@@ -223,7 +216,7 @@ class TestRetryAsync:
     def test_follows_backoff_schedule(self, mock_time: MockTime):
         fn = mock.Mock(side_effect=MyError("oh no"))
         with pytest.raises(MyError):
-            asyncio_run(
+            asyncio.run(
                 retry.retry_async(
                     mock.Mock(
                         spec=retry.Backoff,
@@ -277,7 +270,7 @@ class TestRetryAsync:
             return fn_sync()
 
         on_exc = mock.Mock()
-        asyncio_run(retry.retry_async(backoff, fn, on_exc=on_exc))
+        asyncio.run(retry.retry_async(backoff, fn, on_exc=on_exc))
 
         on_exc.assert_has_calls(
             [


### PR DESCRIPTION
Description
-----------

When I added some asyncio stuff ~1yr ago, we supported Python 3.6, which doesn't have `asyncio.run`, which would have made some of our tests easier to write. So I implemented a kinda-hacky, not-equivalent helper.

But now, [our pyproject.toml](https://github.com/wandb/wandb/blob/8f78e41ec3ff5bf2595b7a8a4ea26f779592246f/pyproject.toml#L12) makes it look like we _do_ require 3.7, so we can use the real `asyncio.run`!

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8f78e41</samp>

This pull request refactors some unit tests to use the built-in `asyncio.run` function for running asynchronous code. This affects the tests for the `InternalApi` and `retry` modules in the files `test_internal_api.py` and `test_retry.py`. This change improves the simplicity and consistency of the test code.

Testing
-------
None; if this isn't right, probably the relevant tests will just fail catastrophically. And they don't on my laptop.
