### PR TITLE
Fixed single value problem in log_tensor_stats

### DIFF
--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -212,11 +212,15 @@ class TorchHistory:
             tmax = 0 if tmax < 0 else tmax
         # Anecdotally, this can somehow happen sometimes. Maybe a precision error
         # in min()/max() above. Swap here to prevent a runtime error.
-        if tmin > tmax:
-            tmin, tmax = tmax, tmin
-        tensor = flat.histc(bins=self._num_bins, min=tmin, max=tmax)
-        tensor = tensor.cpu().detach().clone()
-        bins = torch.linspace(tmin, tmax, steps=self._num_bins + 1)
+        # If all values are equal, just return a single bin.
+        if tmin == tmax:
+            tensor = torch.Tensor([flat.numel()])
+            tensor = tensor.cpu().clone().detach()
+            bins = torch.Tensor([tmin, tmax])
+        else:
+            tensor = flat.histc(bins=self._num_bins, min=tmin, max=tmax)
+            tensor = tensor.cpu().clone().detach()
+            bins = torch.linspace(tmin, tmax, steps=self._num_bins + 1)
 
         # Add back zeroes from a sparse tensor.
         if sparse_zeros:


### PR DESCRIPTION
Description
-----------
- Fixes WB-NA
- Fixes #NA

What does the PR do?

This PR fixes a minor bug when tmin == tmax in the log_tensor_stats function in which an error will sometimes will be thrown.

Testing
-------
How was this PR tested?

Tested with the model I was working on.
