### PR TITLE
fix(integrations): tmin vs tmax in wandb/wandb_torch.py::log_tensor_stats

### DIFF
--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -213,13 +213,15 @@ class TorchHistory:
         # Anecdotally, this can somehow happen sometimes. Maybe a precision error
         # in min()/max() above. Swap here to prevent a runtime error.
         # If all values are equal, just return a single bin.
+        if tmin > tmax:
+            tmin, tmax = tmax, tmin
         if tmin == tmax:
             tensor = torch.Tensor([flat.numel()])
             tensor = tensor.cpu().clone().detach()
             bins = torch.Tensor([tmin, tmax])
         else:
             tensor = flat.histc(bins=self._num_bins, min=tmin, max=tmax)
-            tensor = tensor.cpu().clone().detach()
+            tensor = tensor.cpu().detach().clone()
             bins = torch.linspace(tmin, tmax, steps=self._num_bins + 1)
 
         # Add back zeroes from a sparse tensor.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

Follow up on #6640

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 895c8f0</samp>

> _`wandb_torch` fixed_
> _histograms and tensors cloned_
> _autumn leaves the graph_
