### PR TITLE
feat(launch): add helper to load wandb.Config from env vars

### DIFF
--- a/wandb/sdk/launch/__init__.py
+++ b/wandb/sdk/launch/__init__.py
@@ -1,5 +1,6 @@
 from ._launch import launch
 from ._launch_add import launch_add
 from .agent.agent import LaunchAgent
+from .utils import load_wandb_config
 
-__all__ = ["LaunchAgent", "launch", "launch_add"]
+__all__ = ["LaunchAgent", "launch", "launch_add", "load_wandb_config"]

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -1,5 +1,6 @@
 # heavily inspired by https://github.com/mlflow/mlflow/blob/master/mlflow/projects/utils.py
 import asyncio
+import json
 import logging
 import os
 import platform
@@ -19,6 +20,7 @@ from wandb.errors import CommError
 from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.git_reference import GitReference
 from wandb.sdk.launch.wandb_reference import WandbReference
+from wandb.sdk.wandb_config import Config
 
 from .builder.templates._wandb_bootstrap import (
     FAILED_PACKAGES_POSTFIX,
@@ -64,6 +66,42 @@ LOG_PREFIX = f"{click.style('launch:', fg='magenta')} "
 
 MAX_ENV_LENGTHS: Dict[str, int] = defaultdict(lambda: 32670)
 MAX_ENV_LENGTHS["SageMakerRunner"] = 512
+
+
+def load_wandb_config() -> Config:
+    """Load wandb config from WANDB_CONFIG environment variable(s).
+
+    The WANDB_CONFIG environment variable is a json string that can contain
+    multiple config keys. The WANDB_CONFIG_[0-9]+ environment variables are
+    used for environments where there is a limit on the length of environment
+    variables. In that case, we shard the contents of WANDB_CONFIG into
+    multiple environment variables numbered from 0.
+
+    Returns:
+        A dictionary of wandb config values.
+    """
+    config_str = os.environ.get("WANDB_CONFIG")
+    if config_str is None:
+        config_str = ""
+        idx = 0
+        while True:
+            chunk = os.environ.get(f"WANDB_CONFIG_{idx}")
+            if chunk is None:
+                break
+            config_str += chunk
+            idx += 1
+        if idx < 1:
+            raise LaunchError(
+                "No WANDB_CONFIG or WANDB_CONFIG_[0-9]+ environment variables found"
+            )
+    wandb_config = Config()
+    try:
+        env_config = json.loads(config_str)
+    except json.JSONDecodeError as e:
+        raise LaunchError(f"Failed to parse WANDB_CONFIG: {e}") from e
+
+    wandb_config.update(env_config)
+    return wandb_config
 
 
 def event_loop_thread_exec(func: Any) -> Any:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-16003
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4de534f</samp>

Added a new function `load_wandb_config` to the `launch` package that can load the wandb config from environment variables. This function enables macro substitution and other features for wandb launch. Added a unit test for the new function and updated the package imports.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4de534f</samp>

> _Sing, O Muse, of the skillful launchers of wandb runs,_
> _Who from the environs of various platforms and services_
> _Could load the wandb config with `load_wandb_config`,_
> _A cunning function devised by the wise `utils.py`._
