### PR TITLE
chore(nexus): use context to trigger stream finish

### DIFF
--- a/nexus/pkg/server/connection.go
+++ b/nexus/pkg/server/connection.go
@@ -344,7 +344,8 @@ func (nc *Connection) handleInformFinish(msg *service.ServerInformFinishRequest)
 	if stream, err := streamMux.RemoveStream(streamId); err != nil {
 		slog.Error("handleInformFinish:", "err", err, "streamId", streamId, "id", nc.id)
 	} else {
-		stream.Close()
+		// tell the Stream to start shutting down
+		stream.cancel()
 	}
 }
 

--- a/nexus/pkg/server/handler_test.go
+++ b/nexus/pkg/server/handler_test.go
@@ -26,7 +26,8 @@ func makeHandler(
 	debounce bool,
 ) *server.Handler {
 	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
-	h := server.NewHandler(context.Background(), &service.Settings{}, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	h := server.NewHandler(ctx, cancel, &service.Settings{}, logger)
 
 	h.SetInboundChannels(inChan, loopbackChan)
 	h.SetOutboundChannels(fwdChan, outChan)
@@ -35,7 +36,7 @@ func makeHandler(
 		h.DisableSummaryDebouncer()
 	}
 
-	go h.Handle()
+	go h.Run()
 
 	return h
 }

--- a/nexus/pkg/server/responder.go
+++ b/nexus/pkg/server/responder.go
@@ -19,8 +19,8 @@ type Dispatcher struct {
 	logger     *observability.NexusLogger
 }
 
-// do is the main loop of the dispatcher to process incoming messages
-func (d *Dispatcher) do(hChan, sChan <-chan *service.Result) {
+// Run is the main loop of the dispatcher to process incoming messages
+func (d *Dispatcher) Run(hChan, sChan <-chan *service.Result) {
 	defer d.logger.Reraise()
 	for hChan != nil || sChan != nil {
 		select {

--- a/nexus/pkg/server/writer.go
+++ b/nexus/pkg/server/writer.go
@@ -16,6 +16,9 @@ type Writer struct {
 	// ctx is the context for the writer
 	ctx context.Context
 
+	// cancel is the cancel function for the writer
+	cancel context.CancelFunc
+
 	// settings is the settings for the writer
 	settings *service.Settings
 
@@ -39,10 +42,16 @@ type Writer struct {
 }
 
 // NewWriter returns a new Writer
-func NewWriter(ctx context.Context, settings *service.Settings, logger *observability.NexusLogger) *Writer {
+func NewWriter(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	settings *service.Settings,
+	logger *observability.NexusLogger,
+) *Writer {
 
 	w := &Writer{
 		ctx:      ctx,
+		cancel:   cancel,
 		settings: settings,
 		logger:   logger,
 		fwdChan:  make(chan *service.Record, BufferSize),
@@ -50,8 +59,8 @@ func NewWriter(ctx context.Context, settings *service.Settings, logger *observab
 	return w
 }
 
-// do is the main loop of the writer to process incoming messages
-func (w *Writer) do(inChan <-chan *service.Record) {
+// Run is the main loop of the writer to process incoming messages
+func (w *Writer) Run(inChan <-chan *service.Record) {
 	defer w.logger.Reraise()
 	w.logger.Info("writer: started", "stream_id", w.settings.RunId)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1c4f388</samp>

This pull request refactors and improves the lifecycle management of the server components in `nexus/pkg/server`. It introduces a `cancel` function for each component's context to handle shutdown more gracefully, and renames the main methods of the components to `Run` for consistency and readability. It also updates the test code in `handler_test.go` to reflect the changes.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1c4f388</samp>

> _We're refactoring the code, me hearties, yo ho ho_
> _We're using `Run` and `cancel` to make it run so_
> _On the count of three, we'll pull the rope and see_
> _If the stream will close gracefully, me hearties, yo ho ho_
