### PR TITLE
fix(sdk): handle tags when resuming a run

### DIFF
--- a/nexus/api/graphql/query_run_resume_status.graphql
+++ b/nexus/api/graphql/query_run_resume_status.graphql
@@ -18,6 +18,7 @@ query RunResumeStatus($project: String, $entity: String, $name: String!) {
             historyTail
             eventsTail
             config
+            tags
         }
     }
 }

--- a/nexus/internal/gql/gql_gen.go
+++ b/nexus/internal/gql/gql_gen.go
@@ -541,16 +541,17 @@ func (v *RunResumeStatusModelProject) GetBucket() *RunResumeStatusModelProjectBu
 
 // RunResumeStatusModelProjectBucketRun includes the requested fields of the GraphQL type Run.
 type RunResumeStatusModelProjectBucketRun struct {
-	Id               string  `json:"id"`
-	Name             string  `json:"name"`
-	SummaryMetrics   *string `json:"summaryMetrics"`
-	DisplayName      *string `json:"displayName"`
-	LogLineCount     *int    `json:"logLineCount"`
-	HistoryLineCount *int    `json:"historyLineCount"`
-	EventsLineCount  *int    `json:"eventsLineCount"`
-	HistoryTail      *string `json:"historyTail"`
-	EventsTail       *string `json:"eventsTail"`
-	Config           *string `json:"config"`
+	Id               string   `json:"id"`
+	Name             string   `json:"name"`
+	SummaryMetrics   *string  `json:"summaryMetrics"`
+	DisplayName      *string  `json:"displayName"`
+	LogLineCount     *int     `json:"logLineCount"`
+	HistoryLineCount *int     `json:"historyLineCount"`
+	EventsLineCount  *int     `json:"eventsLineCount"`
+	HistoryTail      *string  `json:"historyTail"`
+	EventsTail       *string  `json:"eventsTail"`
+	Config           *string  `json:"config"`
+	Tags             []string `json:"tags"`
 }
 
 // GetId returns RunResumeStatusModelProjectBucketRun.Id, and is useful for accessing the field via an interface.
@@ -582,6 +583,9 @@ func (v *RunResumeStatusModelProjectBucketRun) GetEventsTail() *string { return 
 
 // GetConfig returns RunResumeStatusModelProjectBucketRun.Config, and is useful for accessing the field via an interface.
 func (v *RunResumeStatusModelProjectBucketRun) GetConfig() *string { return v.Config }
+
+// GetTags returns RunResumeStatusModelProjectBucketRun.Tags, and is useful for accessing the field via an interface.
+func (v *RunResumeStatusModelProjectBucketRun) GetTags() []string { return v.Tags }
 
 // RunResumeStatusModelProjectEntity includes the requested fields of the GraphQL type Entity.
 type RunResumeStatusModelProjectEntity struct {
@@ -1685,6 +1689,7 @@ query RunResumeStatus ($project: String, $entity: String, $name: String!) {
 			historyTail
 			eventsTail
 			config
+			tags
 		}
 	}
 }

--- a/nexus/pkg/server/resume.go
+++ b/nexus/pkg/server/resume.go
@@ -120,6 +120,15 @@ func (s *Sender) checkAndUpdateResumeState(record *service.Record, run *service.
 		return err
 	}
 
+	// handle tags
+	// - when resuming a run, its tags will be overwritten by the tags
+	//   passed to `wandb.init()`.
+	// - to add tags to a resumed run without overwriting its existing tags
+	//   use `run.tags += ["new_tag"]` after `wandb.init()`.
+	if run.Tags == nil {
+		run.Tags = append(run.Tags, bucket.GetTags()...)
+	}
+
 	s.resumeState.AddOffset(fs.HistoryChunk, *bucket.GetHistoryLineCount())
 	s.resumeState.AddOffset(fs.EventsChunk, *bucket.GetEventsLineCount())
 	s.resumeState.AddOffset(fs.OutputChunk, *bucket.GetLogLineCount())

--- a/tests/pytest_tests/system_tests/conftest.py
+++ b/tests/pytest_tests/system_tests/conftest.py
@@ -431,9 +431,9 @@ class WandbServerSettings:
     fixture_service_port: str
     wandb_server_pull: str
     wandb_server_tag: str
-    internal_local_base_port: str = "8080"
-    internal_local_services_api_port: str = "8083"
-    internal_fixture_service_port: str = "9015"
+    internal_local_base_port: str = LOCAL_BASE_PORT
+    internal_local_services_api_port: str = SERVICES_API_PORT
+    internal_fixture_service_port: str = FIXTURE_SERVICE_PORT
     url: str = "http://localhost"
 
     base_url: Optional[str] = None
@@ -686,9 +686,9 @@ def wandb_server(wandb_server_factory):
     settings = WandbServerSettings(
         name="wandb-dst-server",
         volume="wandb-dst-server-vol",
-        local_base_port="8080",
-        services_api_port="8083",
-        fixture_service_port="9015",
+        local_base_port=LOCAL_BASE_PORT,
+        services_api_port=SERVICES_API_PORT,
+        fixture_service_port=FIXTURE_SERVICE_PORT,
         wandb_server_pull="missing",
         wandb_server_tag="master",
     )

--- a/tests/pytest_tests/system_tests/test_core/test_resume.py
+++ b/tests/pytest_tests/system_tests/test_core/test_resume.py
@@ -1,0 +1,59 @@
+import wandb
+
+
+def test_resume_tags_overwrite(user, test_settings):
+    run = wandb.init(project="tags", tags=["tag1", "tag2"], settings=test_settings())
+    run.tags += ("tag3",)
+    run_id = run.id
+    run.finish()
+
+    run = wandb.init(
+        id=run_id,
+        resume="must",
+        project="tags",
+        tags=["tag4", "tag5"],
+        settings=test_settings(),
+    )
+    run.tags += ("tag7",)
+    assert run.tags == ("tag4", "tag5", "tag7")
+    run.finish()
+
+
+def test_resume_tags_preserve(user, test_settings):
+    run = wandb.init(project="tags", tags=["tag1", "tag2"], settings=test_settings())
+    run.tags += ("tag3",)
+    run_id = run.id
+    run.finish()
+
+    run = wandb.init(id=run_id, resume="must", project="tags", settings=test_settings())
+    run.tags += ("tag7",)
+    assert run.tags == ("tag1", "tag2", "tag3", "tag7")
+    run.finish()
+
+
+def test_resume_tags_add_after_resume(user, test_settings):
+    run = wandb.init(project="tags", settings=test_settings())
+    run_id = run.id
+    run.finish()
+
+    run = wandb.init(id=run_id, resume="must", project="tags", settings=test_settings())
+    run.tags += ("tag7",)
+    assert run.tags == ("tag7",)
+    run.finish()
+
+
+def test_resume_tags_add_at_resume(user, test_settings):
+    run = wandb.init(project="tags", settings=test_settings())
+    run_id = run.id
+    run.finish()
+
+    run = wandb.init(
+        id=run_id,
+        resume="must",
+        project="tags",
+        tags=["tag4", "tag5"],
+        settings=test_settings(),
+    )
+    run.tags += ("tag7",)
+    assert run.tags == ("tag4", "tag5", "tag7")
+    run.finish()

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1231,6 +1231,7 @@ class Api:
                     historyTail
                     eventsTail
                     config
+                    tags
                 }
             }
         }

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -149,6 +149,7 @@ class ResumeState:
     wandb_runtime: Optional[int]
     summary: Optional[Dict[str, Any]]
     config: Optional[Dict[str, Any]]
+    tags: Optional[List[str]]
 
     def __init__(self) -> None:
         self.resumed = False
@@ -161,6 +162,7 @@ class ResumeState:
         self.wandb_runtime = None
         self.summary = None
         self.config = None
+        self.tags = None
 
     def __str__(self) -> str:
         obj = ",".join(map(lambda it: f"{it[0]}={it[1]}", vars(self).items()))
@@ -542,7 +544,9 @@ class SendManager:
         # TODO(jhr): check result of upsert_run?
         if self._run:
             self._api.upsert_run(
-                name=self._run.run_id, config=config_value_dict, **self._api_settings  # type: ignore
+                name=self._run.run_id,
+                config=config_value_dict,
+                **self._api_settings,  # type: ignore
             )
         self._config_save(config_value_dict)
         self._config_needs_debounce = False
@@ -760,7 +764,9 @@ class SendManager:
             "checking resume status for %s/%s/%s", entity, run.project, run.run_id
         )
         resume_status = self._api.run_resume_status(
-            entity=entity, project_name=run.project, name=run.run_id  # type: ignore
+            entity=entity,
+            project_name=run.project,
+            name=run.run_id,  # type: ignore
         )
 
         if not resume_status:
@@ -809,6 +815,7 @@ class SendManager:
             new_runtime = summary.get("_wandb", {}).get("runtime", None)
             if new_runtime is not None:
                 self._resume_state.wandb_runtime = new_runtime
+            tags = resume_status.get("tags") or []
 
         except (IndexError, ValueError) as e:
             logger.error("unable to load resume tails", exc_info=e)
@@ -829,6 +836,7 @@ class SendManager:
         self._resume_state.output = resume_status["logLineCount"]
         self._resume_state.config = config
         self._resume_state.summary = summary
+        self._resume_state.tags = tags
         self._resume_state.resumed = True
         logger.info("configured resuming with: %s" % self._resume_state)
         return None
@@ -1012,6 +1020,10 @@ class SendManager:
         ) - self._resume_state.runtime
         # TODO: we don't check inserted currently, ultimately we should make
         # the upsert know the resume state and fail transactionally
+
+        if self._resume_state and self._resume_state.tags and not run.tags:
+            run.tags.extend(self._resume_state.tags)
+
         server_run, inserted, server_messages = self._api.upsert_run(
             name=run.run_id,
             entity=run.entity or None,

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -764,9 +764,9 @@ class SendManager:
             "checking resume status for %s/%s/%s", entity, run.project, run.run_id
         )
         resume_status = self._api.run_resume_status(
-            entity=entity,
+            entity=entity,  # type: ignore
             project_name=run.project,
-            name=run.run_id,  # type: ignore
+            name=run.run_id,
         )
 
         if not resume_status:

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1039,6 +1039,10 @@ def init(
             together, or applying temporary labels like "baseline" or
             "production". It's easy to add and remove tags in the UI, or filter
             down to just runs with a specific tag.
+            If you are resuming a run, its tags will be overwritten by the tags
+            you pass to `wandb.init()`. If you want to add tags to a resumed run
+            without overwriting its existing tags, use `run.tags += ["new_tag"]`
+            after `wandb.init()`.
         name: (str, optional) A short display name for this run, which is how
             you'll identify this run in the UI. By default, we generate a random
             two-word name that lets you easily cross-reference runs from the


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-15572

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cf4b79a</samp>

Added support for resuming runs with tags in the wandb Python SDK. The sender and the internal API were modified to query and store the tags of the resumed run. The `wandb.init()` docstring was updated to explain how to add tags to a resumed run.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cf4b79a</samp>

> _Sing, O Muse, of the clever wandb team, who added tags to resume_
> _And made their code more clear and consistent, pleasing the gods of review_
> _They queried the server with `run_resume_status`, fetching the tags of old_
> _And warned the users with docstrings, lest they overwrite them with bold_
