### PR TITLE
test(sdk): fix a couple tests broken on win

### DIFF
--- a/tests/functional_tests/t0_main/mp/17-service-crash.yea
+++ b/tests/functional_tests/t0_main/mp/17-service-crash.yea
@@ -1,4 +1,8 @@
 id: 0.mp.17-service-crash
+tag:
+  skips:
+    - platform: win
+
 plugin:
   - wandb
 assert:

--- a/tests/pytest_tests/unit_tests/test_wandb_settings_old.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_settings_old.py
@@ -18,7 +18,11 @@ def test__global_path_default_does_not_exist_and_is_not_writable():
         "getpass.getuser", return_value="testuser"
     ):
         mock_makedirs.side_effect = [OSError, True]
-        assert Settings._global_path() == "/tmp/.config/wandb/settings"
+        assert Settings._global_path() == os.path.join(
+            "/tmp", ".config", "wandb", "settings"
+        )
 
         mock_makedirs.side_effect = OSError
-        assert Settings._global_path() == "/tmp/testuser/.config/wandb/settings"
+        assert Settings._global_path() == os.path.join(
+            "/tmp", "testuser", ".config", "wandb", "settings"
+        )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ddd81c2</samp>

This pull request improves the portability and robustness of some tests related to the global settings path for wandb. It skips a test that is not applicable on Windows and uses `os.path.join` to handle different path separators.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ddd81c2</samp>

> _`yea` test skipped on_
> _Windows platform, paths differ_
> _Fall is for changes_
