### PR TITLE
fix(nexus): update error message and remove extra

### DIFF
--- a/.bumpversion.core.cfg
+++ b/.bumpversion.core.cfg
@@ -51,10 +51,6 @@ replace = __version__ = "{new_version}"
 search = NEXUS_VERSION = "{current_version}"
 replace = NEXUS_VERSION = "{new_version}"
 
-[bumpversion:file:pyproject.toml]
-search = "wandb-core>={current_version}"
-replace = "wandb-core>={new_version}"
-
 [bumpversion:file:wandb/__init__.py]
 search = _minimum_core_version = "{current_version}"
 replace = _minimum_core_version = "{new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ launch = [
 models = ["cloudpickle"]
 async = ["httpx>=0.23.0"]
 perf = ["orjson"]
-core = ["wandb-core>=0.17.0b2"]
 
 [tool.setuptools]
 zip-safe = false

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1855,5 +1855,5 @@ def _check_wandb_core_version_compatibility(core_version: str) -> None:
     if parse_version(core_version) < parse_version(wandb._minimum_core_version):
         raise ImportError(
             f"Requires wandb-core version {wandb._minimum_core_version} or later, "
-            f"but you have {core_version}. Run `pip install --upgrade wandb[core]` to upgrade."
+            f"but you have {core_version}. Run `pip install wandb-core>={wandb._minimum_core_version}` to upgrade."
         )

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1855,5 +1855,5 @@ def _check_wandb_core_version_compatibility(core_version: str) -> None:
     if parse_version(core_version) < parse_version(wandb._minimum_core_version):
         raise ImportError(
             f"Requires wandb-core version {wandb._minimum_core_version} or later, "
-            f"but you have {core_version}. Run `pip install wandb-core>={wandb._minimum_core_version}` to upgrade."
+            f"but you have {core_version}. Run `pip install --upgrade wandb-core` to upgrade."
         )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac22147</samp>

This pull request refactors the dependency management and installation process for wandb, removing the core extra from `pyproject.toml` and the bumpversion configuration for it. It also updates the error message for incompatible wandb-core versions to use a minimum version constraint.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac22147</samp>

> _`wandb-core` changes_
> _simplify dependencies_
> _autumn leaves fall fast_
