### PR TITLE
chore(nexus): fix broken benchmark tool

### DIFF
--- a/nexus/pkg/gowandb/run.go
+++ b/nexus/pkg/gowandb/run.go
@@ -71,6 +71,9 @@ func (r *Run) init() {
 	}
 
 	config := &service.ConfigRecord{}
+	if r.config == nil {
+		r.config = &runconfig.Config{}
+	}
 	for key, value := range *r.config {
 		data, err := json.Marshal(value)
 		if err != nil {


### PR DESCRIPTION
Description
-----------

benchmark tool was broken... this makes sure that we dont crash when we create a run without a config

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61ea166</samp>

Fix a nil pointer bug in `gowandb` package. Ensure `r.config` is always initialized in `run.go`.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61ea166</samp>

> _`r.config` was nil_
> _A bug in the winter code_
> _Now it has a struct_
