### PR TITLE
fix(nexus): clean up issues with file sending

### DIFF
--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -577,7 +577,11 @@ func (h *Handler) handleMetadata() {
 			},
 		},
 	}
-	h.sendRecord(&record)
+	h.sendRecordWithControl(&record,
+		func(control *service.Control) {
+			control.AlwaysSend = true
+		},
+	)
 }
 
 func (h *Handler) handleSystemMetrics(record *service.Record) {

--- a/nexus/pkg/server/responder.go
+++ b/nexus/pkg/server/responder.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/wandb/wandb/nexus/pkg/observability"
 	"github.com/wandb/wandb/nexus/pkg/service"
 )
@@ -68,7 +70,12 @@ func (d *Dispatcher) handleRespond(result *service.Result) {
 			ResultCommunicate: result,
 		},
 	}
-	d.responders[responderId].Respond(response)
+	if responder, ok := d.responders[responderId]; ok {
+		responder.Respond(response)
+	} else {
+		err := fmt.Errorf("dispatch: no responder found: %s", responderId)
+		d.logger.CaptureFatalAndPanic("dispatch: no responder found", err)
+	}
 }
 
 func NewDispatcher(logger *observability.NexusLogger) *Dispatcher {

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -278,6 +278,7 @@ func (s *Sender) sendRunStart(_ *service.RunStartRequest) {
 
 	// Update run start time in the settings if it is not set
 	if s.settings.XStartTime == nil {
+		// TODO: rewrite in a more robust way
 		startTime := float64(s.RunRecord.StartTime.Seconds) + float64(s.RunRecord.StartTime.Nanos)/1e9
 		s.settings.XStartTime = &wrapperspb.DoubleValue{Value: startTime}
 	}

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -296,7 +296,6 @@ func (s *Sender) sendMetadata(request *service.MetadataRequest) {
 	}
 	jsonBytes, _ := mo.Marshal(request)
 	_ = os.WriteFile(filepath.Join(s.settings.GetFilesDir().GetValue(), MetaFilename), jsonBytes, 0644)
-	// s.sendFile(MetaFilename, filetransfer.WandbFile)
 	s.loopbackChan <- &service.Record{
 		RecordType: &service.Record_Files{
 			Files: &service.FilesRecord{

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/wandb/wandb/nexus/internal/clients"
 	"github.com/wandb/wandb/nexus/internal/debounce"
@@ -229,6 +230,7 @@ func (s *Sender) sendRecord(record *service.Record) {
 	case *service.Record_LinkArtifact:
 		s.sendLinkArtifact(record)
 	case *service.Record_UseArtifact:
+	case *service.Record_Artifact:
 	case nil:
 		err := fmt.Errorf("sender: sendRecord: nil RecordType")
 		s.logger.CaptureFatalAndPanic("sender: sendRecord: nil RecordType", err)
@@ -257,8 +259,12 @@ func (s *Sender) sendRequest(record *service.Record, request *service.Request) {
 		s.sendServerInfo(record, x.ServerInfo)
 	case *service.Request_DownloadArtifact:
 		s.sendDownloadArtifact(record, x.DownloadArtifact)
+	case nil:
+		err := fmt.Errorf("sender: sendRequest: nil RequestType")
+		s.logger.CaptureFatalAndPanic("sender: sendRequest: nil RequestType", err)
 	default:
-		// TODO: handle errors
+		err := fmt.Errorf("sender: sendRequest: unexpected type %T", x)
+		s.logger.CaptureFatalAndPanic("sender: sendRequest: unexpected type", err)
 	}
 }
 
@@ -269,6 +275,12 @@ func (s *Sender) sendRunStart(_ *service.RunStartRequest) {
 
 	fs.WithPath(fsPath)(s.fileStream)
 	fs.WithOffsets(s.resumeState.GetFileStreamOffset())(s.fileStream)
+
+	// Update run start time in the settings if it is not set
+	if s.settings.XStartTime == nil {
+		startTime := float64(s.RunRecord.StartTime.Seconds) + float64(s.RunRecord.StartTime.Nanos)/1e9
+		s.settings.XStartTime = &wrapperspb.DoubleValue{Value: startTime}
+	}
 
 	s.fileStream.Start()
 	s.fileTransferManager.Start()
@@ -284,7 +296,16 @@ func (s *Sender) sendMetadata(request *service.MetadataRequest) {
 	}
 	jsonBytes, _ := mo.Marshal(request)
 	_ = os.WriteFile(filepath.Join(s.settings.GetFilesDir().GetValue(), MetaFilename), jsonBytes, 0644)
-	s.sendFile(MetaFilename, filetransfer.WandbFile)
+	// s.sendFile(MetaFilename, filetransfer.WandbFile)
+	s.loopbackChan <- &service.Record{
+		RecordType: &service.Record_Files{
+			Files: &service.FilesRecord{
+				Files: []*service.FilesItem{
+					{Path: MetaFilename},
+				},
+			},
+		},
+	}
 }
 
 func (s *Sender) sendDefer(request *service.DeferRequest) {
@@ -722,6 +743,10 @@ func (s *Sender) sendExit(record *service.Record, _ *service.RunExitRecord) {
 	request := &service.Request{RequestType: &service.Request_Defer{
 		Defer: &service.DeferRequest{State: service.DeferRequest_BEGIN}},
 	}
+	if record.Control == nil {
+		record.Control = &service.Control{AlwaysSend: true}
+	}
+
 	rec := &service.Record{
 		RecordType: &service.Record_Request{Request: request},
 		Control:    record.Control,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e113199</samp>

This pull request improves the server-side logic for handling run data and artifacts. It adds error handling for missing responder IDs, supports new record types and run settings, and ensures the metadata record is always sent to the backend. It affects the files `responder.go`, `sender.go`, and `handler.go` in `nexus/pkg/server`.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e113199</samp>

> _We're sending records with control, me hearties, yo ho ho_
> _We're handling errors and new types, me hearties, yo ho ho_
> _We're updating run settings and metadata, me hearties, yo ho ho_
> _And we'll heave away on the count of three, me hearties, yo ho ho_
