### PR TITLE
chore(nexus): rename nexus to core

### DIFF
--- a/.bumpversion.core.cfg
+++ b/.bumpversion.core.cfg
@@ -32,8 +32,8 @@ values =
 	_
 
 [bumpversion:file:nexus/setup.py]
-search = NEXUS_VERSION = "{current_version}"
-replace = NEXUS_VERSION = "{new_version}"
+search = CORE_VERSION = "{current_version}"
+replace = CORE_VERSION = "{new_version}"
 
 [bumpversion:file:nexus/README.md]
 search = `{current_version}`
@@ -48,8 +48,8 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [bumpversion:file:noxfile.py]
-search = NEXUS_VERSION = "{current_version}"
-replace = NEXUS_VERSION = "{new_version}"
+search = CORE_VERSION = "{current_version}"
+replace = CORE_VERSION = "{new_version}"
 
 [bumpversion:file:wandb/__init__.py]
 search = _minimum_core_version = "{current_version}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,7 +522,7 @@ jobs:
             sudo apt-get update && sudo apt-get install -y python3-pip
             pip install nox
       - run:
-          name: Run Nexus' Go tests and collect coverage
+          name: Run wandb core's Go tests and collect coverage
           command: |
             cd nexus
             go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1386,7 +1386,7 @@ workflows:
               python_version_minor: [7, 8, 9, 10, 11, 12]
           name: "system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not nexus_failure' tests/pytest_tests/system_tests/test_core"
+          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/system_tests/test_core"
           codecov_args: "-F system"
       #
       # System tests with Service
@@ -1421,7 +1421,7 @@ workflows:
               python_version_minor: [10]
           name: "unit-legacy-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not nexus_failure' tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
           codecov_args: "-F unit"
       #
       # Unit tests with pytest on Linux, using the old mock server
@@ -1562,7 +1562,7 @@ workflows:
               python_version_minor: [9]
           name: "unit-legacy-macos-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not nexus_failure' tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
           codecov_args: "-F unit"
 
       - mac:
@@ -1724,7 +1724,7 @@ workflows:
                 - "artifacts"
           name: "system-<<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not nexus_failure' tests/pytest_tests/system_tests/test_<<matrix.shard>>"
+          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/system_tests/test_<<matrix.shard>>"
           codecov_args: "-F system"
 
       - pytest:
@@ -1755,7 +1755,7 @@ workflows:
               python_version_minor: [9]
           name: "system-notebooks-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           toxenv: "nexus-notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not nexus_failure' tests/pytest_tests/system_tests/test_notebooks"
+          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/system_tests/test_notebooks"
           codecov_args: "-F system"
 
       - pytest:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -33,6 +33,7 @@ jobs:
           # Product based scopes
           scopes: |
             nexus
+            core
             sdk
             cli
             public-api

--- a/nexus/.gitignore
+++ b/nexus/.gitignore
@@ -1,5 +1,5 @@
 __pycache__/
-wandb_nexus.egg-info/
-wandb_nexus/bin-*/
+wandb_core.egg-info/
+wandb_core/bin-*/
 # Lets not save the schema in the repo right now
 api/graphql/schema.graphql

--- a/nexus/README.md
+++ b/nexus/README.md
@@ -27,7 +27,7 @@ Note: you will need `wandb>=0.16.0`.
 - Windows `amd64`
 
 If you are using a different platform, you can build `wandb-core` from sources by following the
-instructions in the [contributing guide](docs/contributing.md#installing-nexus).
+instructions in the [contributing guide](docs/contributing.md#installing-wandb-core).
 Please also open a [GitHub issue](https://github.com/wandb/wandb/issues/new/choose)
 to let us know that you are interested in using it on
 your platform, and we will prioritize adding support for it.
@@ -46,7 +46,7 @@ Please read our [contributing guide](docs/contributing.md) to learn to set up
 your development environment and how to contribute to the codebase.
 
 ## Feedback
-Please give Nexus a try and let us know what you think, we believe it is worth it!
+Please give our new core a try and let us know what you think, we believe it is worth it!
 
 We are very much looking forward to your feedback, especially bug reports!
 Please open a [GitHub issue](https://github.com/wandb/wandb/issues/new/choose)

--- a/nexus/cmd/nexus/main.go
+++ b/nexus/cmd/nexus/main.go
@@ -88,7 +88,7 @@ func main() {
 		}
 		defer trace.Stop()
 	}
-	nexus := server.NewServer(ctx, "127.0.0.1:0", *portFilename)
-	nexus.SetDefaultLoggerPath(loggerPath)
-	nexus.Close()
+	serve := server.NewServer(ctx, "127.0.0.1:0", *portFilename)
+	serve.SetDefaultLoggerPath(loggerPath)
+	serve.Close()
 }

--- a/nexus/docs/contributing.md
+++ b/nexus/docs/contributing.md
@@ -11,26 +11,26 @@ Now when you run `git push` the hooks will run automatically.
 
 This step is not required, but it is highly recommended.
 
-## Installing Nexus
-To install Nexus, you will need to run the following commands (assuming you are in the
+## Installing WandB Core
+To install wandb-core, you will need to run the following commands (assuming you are in the
 root of the repository):
 ```shell
 pip install -r requirements_build.txt  # Install build dependencies, if needed
 nox -s build-core install-core
 ```
-This will build Nexus for your current platform and install it into your current Python environment.
+This will build wandb-core for your current platform and install it into your current Python environment.
 Note that every time you make a change to the code, you will need to re-run this command to install
 the changes. If you want to make changes to the code and have them immediately available,
-you can install Nexus in development mode.
+you can install wandb-core in development mode.
 
-## Installing Nexus in Development Mode
-To install Nexus in development mode, you will need to run the following commands
+## Installing WandB Core in Development Mode
+To install wandb-core in development mode, you will need to run the following commands
 (assuming you are in the root of the repository):
 ```shell
 ./nexus/scripts/setup-nexus-path.sh
 ```
-This script will also allow you to unset the Nexus path if you no longer want to use
-the development version of Nexus. Follow the instructions in the script to do that.
+This script will also allow you to unset the wandb-core path if you no longer want to use
+the development version of wandb-core. Follow the instructions in the script to do that.
 
 ## Running System Tests Locally
 Install the test requirements into the current Python environment:

--- a/nexus/docs/contributing.md
+++ b/nexus/docs/contributing.md
@@ -39,16 +39,16 @@ pip install -r requirements_test.txt  # Install test dependencies, if needed
 ```
 
 A number of tests are not currently passing due to feature incompleteness.
-These tests are marked with the `@pytest.mark.nexus_failure` decorator.
+These tests are marked with the `@pytest.mark.wandb_core_failure` decorator.
 To list all tests that are currently failing, run the following command:
 ```shell
-nox -s list-failing-tests-nexus
+nox -s list-failing-tests-wandb-core
 ```
 
 To run the tests excluding the failing ones locally, you will need to run the following
 commands in your active Python environment (assuming you are in the root of the repository):
 ```shell
-pytest -m "not nexus_failure" tests/pytest_tests/system_tests/test_core
+pytest -m "not wandb_core_failure" tests/pytest_tests/system_tests/test_core
 ```
 
 ## Modifying GraphQL Schema

--- a/nexus/docs/contributing.md
+++ b/nexus/docs/contributing.md
@@ -16,7 +16,7 @@ To install Nexus, you will need to run the following commands (assuming you are 
 root of the repository):
 ```shell
 pip install -r requirements_build.txt  # Install build dependencies, if needed
-nox -s build-nexus install-nexus
+nox -s build-core install-core
 ```
 This will build Nexus for your current platform and install it into your current Python environment.
 Note that every time you make a change to the code, you will need to re-run this command to install

--- a/nexus/internal/clients/clients.go
+++ b/nexus/internal/clients/clients.go
@@ -66,7 +66,7 @@ func NewRetryClient(opts ...RetryClientOption) *retryablehttp.Client {
 
 type RetryClientOption func(rc *retryablehttp.Client)
 
-func WithRetryClientLogger(logger *observability.NexusLogger) RetryClientOption {
+func WithRetryClientLogger(logger *observability.CoreLogger) RetryClientOption {
 	return func(rc *retryablehttp.Client) {
 		rc.Logger = slog.NewLogLogger(logger.Logger.Handler(), slog.LevelDebug)
 	}

--- a/nexus/internal/debounce/debounce.go
+++ b/nexus/internal/debounce/debounce.go
@@ -11,14 +11,14 @@ import (
 type Debouncer struct {
 	limiter       *rate.Limiter
 	needsDebounce bool
-	logger        *observability.NexusLogger
+	logger        *observability.CoreLogger
 }
 
 // NewDebouncer creates a new debouncer
 func NewDebouncer(
 	eventRate rate.Limit,
 	burstSize int,
-	logger *observability.NexusLogger,
+	logger *observability.CoreLogger,
 ) *Debouncer {
 	return &Debouncer{
 		limiter: rate.NewLimiter(eventRate, burstSize),

--- a/nexus/internal/filetransfer/file_transfer_default.go
+++ b/nexus/internal/filetransfer/file_transfer_default.go
@@ -19,11 +19,11 @@ type DefaultFileTransfer struct {
 	client *retryablehttp.Client
 
 	// logger is the logger for the file transfer
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 }
 
 // NewDefaultFileTransfer creates a new fileTransfer
-func NewDefaultFileTransfer(logger *observability.NexusLogger, client *retryablehttp.Client) *DefaultFileTransfer {
+func NewDefaultFileTransfer(logger *observability.CoreLogger, client *retryablehttp.Client) *DefaultFileTransfer {
 	fileTransfer := &DefaultFileTransfer{
 		logger: logger,
 		client: client,

--- a/nexus/internal/filetransfer/file_transfer_default_test.go
+++ b/nexus/internal/filetransfer/file_transfer_default_test.go
@@ -1,6 +1,7 @@
 package filetransfer
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -61,4 +62,6 @@ func TestDefaultFileTransfer_Download(t *testing.T) {
 			}
 		})
 	}
+	// clean up test file
+	_ = os.Remove("./test-download-file.txt")
 }

--- a/nexus/internal/filetransfer/file_transfer_default_test.go
+++ b/nexus/internal/filetransfer/file_transfer_default_test.go
@@ -13,7 +13,7 @@ import (
 func TestDefaultFileTransfer_Download(t *testing.T) {
 	type fields struct {
 		client *retryablehttp.Client
-		logger *observability.NexusLogger
+		logger *observability.CoreLogger
 	}
 	type args struct {
 		task *Task

--- a/nexus/internal/filetransfer/file_transfer_manager.go
+++ b/nexus/internal/filetransfer/file_transfer_manager.go
@@ -40,7 +40,7 @@ type FileTransferManager struct {
 	settings *service.Settings
 
 	// logger is the logger for the file transfer
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 
 	// wg is the wait group
 	wg *sync.WaitGroup
@@ -48,7 +48,7 @@ type FileTransferManager struct {
 
 type FileTransferManagerOption func(fm *FileTransferManager)
 
-func WithLogger(logger *observability.NexusLogger) FileTransferManagerOption {
+func WithLogger(logger *observability.CoreLogger) FileTransferManagerOption {
 	return func(fm *FileTransferManager) {
 		fm.logger = logger
 	}

--- a/nexus/internal/watcher/watcher.go
+++ b/nexus/internal/watcher/watcher.go
@@ -20,10 +20,10 @@ type Watcher struct {
 	pathMap map[string]string
 	outChan chan *service.Record
 	wg      *sync.WaitGroup
-	logger  *observability.NexusLogger
+	logger  *observability.CoreLogger
 }
 
-func NewWatcher(logger *observability.NexusLogger, outChan chan *service.Record) *Watcher {
+func NewWatcher(logger *observability.CoreLogger, outChan chan *service.Record) *Watcher {
 	return &Watcher{
 		watcher: fw.New(),
 		pathMap: make(map[string]string),

--- a/nexus/pkg/artifacts/linker.go
+++ b/nexus/pkg/artifacts/linker.go
@@ -13,7 +13,7 @@ import (
 
 type ArtifactLinker struct {
 	Ctx           context.Context
-	Logger        *observability.NexusLogger
+	Logger        *observability.CoreLogger
 	LinkArtifact  *service.LinkArtifactRecord
 	GraphqlClient graphql.Client
 }

--- a/nexus/pkg/filestream/filestream.go
+++ b/nexus/pkg/filestream/filestream.go
@@ -83,7 +83,7 @@ type FileStream struct {
 	settings *service.Settings
 
 	// logger is the logger for the filestream
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 
 	// httpClient is the http client
 	httpClient *retryablehttp.Client
@@ -101,7 +101,7 @@ func WithSettings(settings *service.Settings) FileStreamOption {
 	}
 }
 
-func WithLogger(logger *observability.NexusLogger) FileStreamOption {
+func WithLogger(logger *observability.CoreLogger) FileStreamOption {
 	return func(fs *FileStream) {
 		fs.logger = logger
 	}

--- a/nexus/pkg/filestream/filestream_test.go
+++ b/nexus/pkg/filestream/filestream_test.go
@@ -111,13 +111,13 @@ func (h apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type testServer struct {
 	hserver  *httptest.Server
 	settings *service.Settings
-	logger   *observability.NexusLogger
+	logger   *observability.CoreLogger
 	mux      *http.ServeMux
 }
 
 func NewTestServer() *testServer {
 	settings := service.Settings{}
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 
 	mux := http.NewServeMux()
 	hserver := httptest.NewServer(mux)

--- a/nexus/pkg/filestream/loop_transmit_test.go
+++ b/nexus/pkg/filestream/loop_transmit_test.go
@@ -33,7 +33,7 @@ func requestMatch(t *testing.T, fsd FsTransmitData) func(*http.Request) (*http.R
 }
 
 type testObj struct {
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 	client *retryablehttp.Client
 	m      *clienttest.MockRoundTripper
 }
@@ -42,7 +42,7 @@ func newFsTest(t *testing.T) *testObj {
 	ctrl := gomock.NewController(t)
 
 	slogger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	logger := observability.NewNexusLogger(slogger, nil)
+	logger := observability.NewCoreLogger(slogger, nil)
 	m := clienttest.NewMockRoundTripper(ctrl)
 	client := clienttest.NewMockRetryClient(m)
 	client.Logger = logger

--- a/nexus/pkg/monitor/monitor.go
+++ b/nexus/pkg/monitor/monitor.go
@@ -137,13 +137,13 @@ type SystemMonitor struct {
 	settings *service.Settings
 
 	// logger is the logger for the system monitor
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 }
 
 // NewSystemMonitor creates a new SystemMonitor with the given settings
 func NewSystemMonitor(
 	settings *service.Settings,
-	logger *observability.NexusLogger,
+	logger *observability.CoreLogger,
 	outChan chan *service.Record,
 ) *SystemMonitor {
 	sbs := settings.XStatsBufferSize.GetValue()

--- a/nexus/pkg/server/files.go
+++ b/nexus/pkg/server/files.go
@@ -16,10 +16,10 @@ type FileHandler struct {
 	savedFiles map[string]interface{}
 	final      *service.Record
 	watcher    *watcher.Watcher
-	logger     *observability.NexusLogger
+	logger     *observability.CoreLogger
 }
 
-func NewFileHandler(logger *observability.NexusLogger, watcherOutChan chan *service.Record) *FileHandler {
+func NewFileHandler(logger *observability.CoreLogger, watcherOutChan chan *service.Record) *FileHandler {
 	return &FileHandler{
 		savedFiles: make(map[string]interface{}),
 		watcher:    watcher.NewWatcher(logger, watcherOutChan),

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -39,7 +39,7 @@ type Handler struct {
 	settings *service.Settings
 
 	// logger is the logger for the handler
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 
 	// fwdChan is the channel for forwarding messages to the writer
 	fwdChan chan *service.Record
@@ -98,7 +98,7 @@ type Handler struct {
 func NewHandler(
 	ctx context.Context,
 	settings *service.Settings,
-	logger *observability.NexusLogger,
+	logger *observability.CoreLogger,
 ) *Handler {
 	// init the system monitor if stats are enabled
 	h := &Handler{

--- a/nexus/pkg/server/handler_test.go
+++ b/nexus/pkg/server/handler_test.go
@@ -25,7 +25,7 @@ func makeHandler(
 	outChan chan *service.Result,
 	debounce bool,
 ) *server.Handler {
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	h := server.NewHandler(context.Background(), &service.Settings{}, logger)
 
 	h.SetInboundChannels(inChan, loopbackChan)

--- a/nexus/pkg/server/logging.go
+++ b/nexus/pkg/server/logging.go
@@ -38,7 +38,7 @@ func SetupDefaultLogger(writers ...io.Writer) *slog.Logger {
 
 // TODO: add a noop logger
 
-func SetupStreamLogger(settings *service.Settings) *observability.NexusLogger {
+func SetupStreamLogger(settings *service.Settings) *observability.CoreLogger {
 	// TODO: when we add session concept re-do this to use user provided path
 	targetPath := filepath.Join(settings.GetLogDir().GetValue(), "core-debug.log")
 	if path := defaultLoggerPath.Load(); path != nil {
@@ -67,7 +67,7 @@ func SetupStreamLogger(settings *service.Settings) *observability.NexusLogger {
 
 	writer := io.MultiWriter(writers...)
 
-	logger := observability.NewNexusLogger(setupLogger(nil, writer), nil)
+	logger := observability.NewCoreLogger(setupLogger(nil, writer), nil)
 	logger.Info("using version", "core version", version.Version)
 	logger.Info("created symlink", "path", targetPath)
 	tags := observability.Tags{

--- a/nexus/pkg/server/responder.go
+++ b/nexus/pkg/server/responder.go
@@ -18,7 +18,7 @@ type ResponderEntry struct {
 
 type Dispatcher struct {
 	responders map[string]Responder
-	logger     *observability.NexusLogger
+	logger     *observability.CoreLogger
 }
 
 // do is the main loop of the dispatcher to process incoming messages
@@ -78,7 +78,7 @@ func (d *Dispatcher) handleRespond(result *service.Result) {
 	}
 }
 
-func NewDispatcher(logger *observability.NexusLogger) *Dispatcher {
+func NewDispatcher(logger *observability.CoreLogger) *Dispatcher {
 	return &Dispatcher{
 		logger:     logger,
 		responders: make(map[string]Responder),

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -44,7 +44,7 @@ type Sender struct {
 	ctx context.Context
 
 	// logger is the logger for the sender
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 
 	// settings is the settings for the sender
 	settings *service.Settings
@@ -90,7 +90,7 @@ type Sender struct {
 }
 
 // NewSender creates a new Sender with the given settings
-func NewSender(ctx context.Context, settings *service.Settings, logger *observability.NexusLogger, loopbackChan chan *service.Record) *Sender {
+func NewSender(ctx context.Context, settings *service.Settings, logger *observability.CoreLogger, loopbackChan chan *service.Record) *Sender {
 
 	sender := &Sender{
 		ctx:          ctx,

--- a/nexus/pkg/server/sender_test.go
+++ b/nexus/pkg/server/sender_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func makeSender(client graphql.Client, resultChan chan *service.Result) *server.Sender {
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	sender := server.NewSender(
 		context.Background(),
 		&service.Settings{

--- a/nexus/pkg/server/store.go
+++ b/nexus/pkg/server/store.go
@@ -96,11 +96,11 @@ type Store struct {
 	db *os.File
 
 	// logger is the logger for the store
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 }
 
 // NewStore creates a new store
-func NewStore(ctx context.Context, fileName string, logger *observability.NexusLogger) *Store {
+func NewStore(ctx context.Context, fileName string, logger *observability.CoreLogger) *Store {
 	sr := &Store{ctx: ctx,
 		name:   fileName,
 		logger: logger,

--- a/nexus/pkg/server/store_test.go
+++ b/nexus/pkg/server/store_test.go
@@ -38,7 +38,7 @@ func TestOpenCreateStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
@@ -53,7 +53,7 @@ func TestOpenReadStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
@@ -75,7 +75,7 @@ func TestReadWriteRecord(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	defer store.Close()
 
@@ -111,7 +111,7 @@ func TestCorruptFile(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	defer store.Close()
 
@@ -147,7 +147,7 @@ func TestInvalidHeader(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 
 	// Intentionally writing bad header data
@@ -160,7 +160,7 @@ func TestInvalidHeader(t *testing.T) {
 
 // TestStoreHeader_Write_Error is intended to test the error scenario when writing the header
 func TestStoreHeader_Write_Error(t *testing.T) {
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), "non_existent_dir/file", logger)
 	err := store.Open(os.O_WRONLY)
 	assert.Error(t, err)
@@ -173,7 +173,7 @@ func TestInvalidFlag(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(9999) // 9999 is an invalid flag
 	assert.Errorf(t, err, "invalid flag %d", 9999)
@@ -186,7 +186,7 @@ func TestWriteToClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
@@ -206,7 +206,7 @@ func TestReadFromClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNexusLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)

--- a/nexus/pkg/server/stream.go
+++ b/nexus/pkg/server/stream.go
@@ -42,7 +42,7 @@ type Stream struct {
 	settings *service.Settings
 
 	// logger is the logger for the stream
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 
 	// inChan is the channel for incoming messages
 	inChan chan *service.Record

--- a/nexus/pkg/server/writer.go
+++ b/nexus/pkg/server/writer.go
@@ -21,7 +21,7 @@ type Writer struct {
 	settings *service.Settings
 
 	// logger is the logger for the writer
-	logger *observability.NexusLogger
+	logger *observability.CoreLogger
 
 	// fwdChan is the channel for forwarding messages to the sender
 	fwdChan chan *service.Record
@@ -40,7 +40,7 @@ type Writer struct {
 }
 
 // NewWriter returns a new Writer
-func NewWriter(ctx context.Context, settings *service.Settings, logger *observability.NexusLogger) *Writer {
+func NewWriter(ctx context.Context, settings *service.Settings, logger *observability.CoreLogger) *Writer {
 
 	w := &Writer{
 		ctx:      ctx,

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -74,7 +74,7 @@ class NexusBase:
             "build",
             f"-ldflags={ldflags}",
             "-o",
-            str(core_path / "wandb-nexus"),
+            str(core_path / "wandb-core"),
             "cmd/nexus/main.go",
         ]
         if gocover:

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -11,10 +11,9 @@ from wheel.bdist_wheel import bdist_wheel, get_platform
 # Package naming
 # --------------
 #   wandb-core:         Package containing architecture specific code
-#   wandb-core-nightly: Package created every night based on main branch
 
-# Nexus version
-# -------------
+# wandb-core versioning
+# ---------------------
 CORE_VERSION = "0.17.0b2"
 
 
@@ -25,7 +24,7 @@ PLATFORMS_TO_BUILD_WITH_CGO = (
 )
 
 
-class NexusBase:
+class WBCoreBase:
     @staticmethod
     def _get_package_path():
         base = Path(__file__).parent / PACKAGE
@@ -93,13 +92,13 @@ class NexusBase:
                 subprocess.check_call(["cp", str(monitor_path), str(core_path)])
 
 
-class WrapDevelop(develop, NexusBase):
+class WrapDevelop(develop, WBCoreBase):
     def run(self):
         develop.run(self)
         self._build_core()
 
 
-class WrapBdistWheel(bdist_wheel, NexusBase):
+class WrapBdistWheel(bdist_wheel, WBCoreBase):
     def get_tag(self):
         # Use the default implementation to get python and abi tags
         python, abi = bdist_wheel.get_tag(self)[:2]

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -32,8 +32,8 @@ class NexusBase:
         print(f"Package path: {base}")
         return base
 
-    def _build_nexus(self):
-        nexus_path = self._get_package_path()
+    def _build_core(self):
+        core_path = self._get_package_path()
 
         src_dir = Path(__file__).parent
 
@@ -58,7 +58,7 @@ class NexusBase:
         if f"{goos}-{goarch}" in PLATFORMS_TO_BUILD_WITH_CGO:
             env["CGO_ENABLED"] = "1"
 
-        os.makedirs(nexus_path, exist_ok=True)
+        os.makedirs(core_path, exist_ok=True)
         commit = (
             subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=src_dir)
             .decode("utf-8")
@@ -74,7 +74,7 @@ class NexusBase:
             "build",
             f"-ldflags={ldflags}",
             "-o",
-            str(nexus_path / "wandb-nexus"),
+            str(core_path / "wandb-nexus"),
             "cmd/nexus/main.go",
         ]
         if gocover:
@@ -90,13 +90,13 @@ class NexusBase:
             monitor_path = src_dir / "pkg/monitor/apple/AppleStats"
             if monitor_path.exists():
                 log.info("Copying AppleStats binary")
-                subprocess.check_call(["cp", str(monitor_path), str(nexus_path)])
+                subprocess.check_call(["cp", str(monitor_path), str(core_path)])
 
 
 class WrapDevelop(develop, NexusBase):
     def run(self):
         develop.run(self)
-        self._build_nexus()
+        self._build_core()
 
 
 class WrapBdistWheel(bdist_wheel, NexusBase):
@@ -109,7 +109,7 @@ class WrapBdistWheel(bdist_wheel, NexusBase):
         return python, abi, plat_name
 
     def run(self):
-        self._build_nexus()
+        self._build_core()
         bdist_wheel.run(self)
 
 

--- a/nexus/setup.py
+++ b/nexus/setup.py
@@ -15,7 +15,7 @@ from wheel.bdist_wheel import bdist_wheel, get_platform
 
 # Nexus version
 # -------------
-NEXUS_VERSION = "0.17.0b2"
+CORE_VERSION = "0.17.0b2"
 
 
 PACKAGE: str = "wandb_core"
@@ -118,7 +118,7 @@ if __name__ == "__main__":
 
     setup(
         name="wandb-core",
-        version=NEXUS_VERSION,
+        version=CORE_VERSION,
         description="W&B Core Library",
         long_description=open("README.md", encoding="utf-8").read(),
         long_description_content_type="text/markdown",

--- a/nexus/wandb_core/__init__.py
+++ b/nexus/wandb_core/__init__.py
@@ -1,10 +1,10 @@
 """W&B Core: This is the backend for the W&B client library."""
-__all__ = ("__version__", "get_nexus_path")
+__all__ = ("__version__", "get_core_path")
 
 from pathlib import Path
 
 __version__ = "0.17.0b2"
 
 
-def get_nexus_path() -> Path:
-    return (Path(__file__).parent / "wandb-nexus").resolve()
+def get_core_path() -> Path:
+    return (Path(__file__).parent / "wandb-core").resolve()

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,12 +3,12 @@ import platform
 
 import nox
 
-NEXUS_VERSION = "0.17.0b2"
+CORE_VERSION = "0.17.0b2"
 
 
-@nox.session(python=False, name="build-nexus")
-def build_nexus(session: nox.Session) -> None:
-    """Builds the nexus binary for the current platform."""
+@nox.session(python=False, name="build-core")
+def build_core(session: nox.Session) -> None:
+    """Builds the wandb-core binary for the current platform."""
     session.run(
         "python3",
         "-m",
@@ -21,14 +21,14 @@ def build_nexus(session: nox.Session) -> None:
     )
 
 
-@nox.session(python=False, name="install-nexus")
-def install_nexus(session: nox.Session) -> None:
-    """Installs the nexus wheel into the current environment."""
+@nox.session(python=False, name="install-core")
+def install_core(session: nox.Session) -> None:
+    """Installs the wandb-core wheel into the current environment."""
     # get the wheel file in ./nexus/dist/:
     wheel_file = [
         f
         for f in os.listdir("./nexus/dist/")
-        if f.startswith(f"wandb_core-{NEXUS_VERSION}") and f.endswith(".whl")
+        if f.startswith(f"wandb_core-{CORE_VERSION}") and f.endswith(".whl")
     ][0]
     session.run(
         "pip",

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,8 +39,8 @@ def install_core(session: nox.Session) -> None:
     )
 
 
-@nox.session(python=False, name="list-failing-tests-nexus")
-def list_failing_tests_nexus(session: nox.Session) -> None:
+@nox.session(python=False, name="list-failing-tests-wandb-core")
+def list_failing_tests_wandb_core(session: nox.Session) -> None:
     """Lists the nexus failing tests grouped by feature."""
     import pandas as pd
     import pytest
@@ -54,7 +54,7 @@ def list_failing_tests_nexus(session: nox.Session) -> None:
             for item in items:
                 marks = item.own_markers
                 for mark in marks:
-                    if mark.name == "nexus_failure":
+                    if mark.name == "wandb_core_failure":
                         self.collected.append(item.nodeid)
                         self.features.append(
                             {
@@ -75,7 +75,7 @@ def list_failing_tests_nexus(session: nox.Session) -> None:
     pytest.main(
         [
             "-m",
-            "nexus_failure",
+            "wandb_core_failure",
             "tests/pytest_tests/system_tests/test_core",
             "--collect-only",
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ markers = [
     "multiclass",
     "wandb_args",
     "flaky",
-    "nexus_failure(feature): test failures on nexus, grouped by feature",
+    "wandb_core_failure(feature): test failures with wandb-core, grouped by feature",
 ]
 timeout = 60
 log_format = "%(asctime)s %(levelname)s %(message)s"

--- a/tests/pytest_tests/system_tests/test_artifacts/test_public_api.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_public_api.py
@@ -5,7 +5,7 @@ import wandb
 from wandb import Api
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_fetching_artifact_files(user, wandb_init):
     project = "test"
 
@@ -37,7 +37,7 @@ def test_fetching_artifact_files(user, wandb_init):
     assert open(file_path).read() == "testing"
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_save_aliases_after_logging_artifact(user, wandb_init):
     project = "test"
     run = wandb_init(entity=user, project=project)
@@ -59,7 +59,7 @@ def test_save_aliases_after_logging_artifact(user, wandb_init):
     assert "hello" in aliases
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_update_aliases_on_artifact(user, wandb_init):
     project = "test"
     run = wandb_init(entity=user, project=project)
@@ -99,7 +99,7 @@ def test_update_aliases_on_artifact(user, wandb_init):
     assert "sequence" not in aliases
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_artifact_version(wandb_init):
     def create_test_artifact(content: str):
         art = wandb.Artifact("test-artifact", "test-type")
@@ -131,7 +131,7 @@ def test_artifact_version(wandb_init):
     assert artifact.source_version == "v1"
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_delete_collection(wandb_init):
     with wandb_init(project="test") as run:
         art = wandb.Artifact("test-artifact", "test-type")
@@ -167,7 +167,7 @@ def test_delete_collection(wandb_init):
         )
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_log_with_wrong_type_entity_project(wandb_init, logged_artifact):
     # todo: logged_artifact does not work with nexus
     entity, project = logged_artifact.entity, logged_artifact.project
@@ -191,7 +191,7 @@ def test_log_with_wrong_type_entity_project(wandb_init, logged_artifact):
             run.log_artifact(draft)
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_run_log_artifact(wandb_init):
     # Prepare data.
     with wandb_init() as run:

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -303,7 +303,7 @@ def test_artifact_upload_succeeds_with_async(
         assert (tmp_path / "downloaded" / "my-file.txt").read_text() == "my contents"
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_check_existing_artifact_before_download(wandb_init, tmp_path, monkeypatch):
     """Don't re-download an artifact if it's already in the desired location."""
     cache_dir = tmp_path / "cache"
@@ -338,7 +338,7 @@ def test_check_existing_artifact_before_download(wandb_init, tmp_path, monkeypat
         assert file1.read_text() == "hello"
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_check_changed_artifact_then_download(wandb_init, tmp_path, monkeypatch):
     """*Do* re-download an artifact if it's been modified in place."""
     cache_dir = tmp_path / "cache"

--- a/tests/pytest_tests/system_tests/test_core/test_cli_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_cli_full.py
@@ -128,7 +128,7 @@ def test_pull(runner, wandb_init):
         ),
     ],
 )
-@pytest.mark.nexus_failure(feature="offline_sync")
+@pytest.mark.wandb_core_failure(feature="offline_sync")
 def test_sync_tensorboard(
     runner,
     relay_server,
@@ -159,7 +159,7 @@ def test_sync_tensorboard(
         assert tb_file_name in os.listdir(".")
 
 
-@pytest.mark.nexus_failure(feature="offline_sync")
+@pytest.mark.wandb_core_failure(feature="offline_sync")
 def test_sync_wandb_run(runner, relay_server, user, copy_asset):
     # note: we have to mock out ArtifactSaver.save
     # because the artifact does not actually exist
@@ -186,7 +186,7 @@ def test_sync_wandb_run(runner, relay_server, user, copy_asset):
         assert "wandb: ERROR Nothing to sync." in result.output
 
 
-@pytest.mark.nexus_failure(feature="offline_sync")
+@pytest.mark.wandb_core_failure(feature="offline_sync")
 def test_sync_wandb_run_and_tensorboard(runner, relay_server, user, copy_asset):
     with relay_server() as relay, runner.isolated_filesystem(), mock.patch(
         "wandb.sdk.artifacts.artifact_saver.ArtifactSaver.save", return_value=None

--- a/tests/pytest_tests/system_tests/test_core/test_file_stream_internal.py
+++ b/tests/pytest_tests/system_tests/test_core/test_file_stream_internal.py
@@ -120,7 +120,7 @@ def test_fstream_status_429(
     assert_history(relay_server, run, publish_util, inject=[injected_response])
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     "file_stream", reason="need to implement dropped in file_stream"
 )
 @pytest.mark.skip(reason="need to verify that history is correct and fix dropped count")

--- a/tests/pytest_tests/system_tests/test_core/test_file_upload.py
+++ b/tests/pytest_tests/system_tests/test_core/test_file_upload.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 
-@pytest.mark.nexus_failure(feature="file_uploader")
+@pytest.mark.wandb_core_failure(feature="file_uploader")
 def test_file_upload_good(mock_run, publish_util, relay_server, user):
     run = mock_run(use_magic_mock=True)
 

--- a/tests/pytest_tests/system_tests/test_core/test_footer.py
+++ b/tests/pytest_tests/system_tests/test_core/test_footer.py
@@ -69,7 +69,7 @@ def test_footer_private(wandb_init, check_output_fn):
 
 
 # todo(nexus): implement sparklines / run history
-@pytest.mark.nexus_failure(feature="terminal_ui")
+@pytest.mark.wandb_core_failure(feature="terminal_ui")
 def test_footer_normal(wandb_init, check_output_fn):
     run = wandb_init()
     run.log(dict(d=2))
@@ -112,7 +112,7 @@ def test_footer_summary_image(wandb_init, check_output_fn):
 
 
 # todo(nexus): implement sparklines / run history
-@pytest.mark.nexus_failure(feature="terminal_ui")
+@pytest.mark.wandb_core_failure(feature="terminal_ui")
 def test_footer_history(wandb_init, check_output_fn):
     run = wandb_init()
     run.define_metric("*", summary="none")
@@ -125,7 +125,7 @@ def test_footer_history(wandb_init, check_output_fn):
 
 
 # todo(nexus): implement job info
-@pytest.mark.nexus_failure(feature="terminal_ui")
+@pytest.mark.wandb_core_failure(feature="terminal_ui")
 def test_footer_job_output(wandb_init, capsys, monkeypatch):
     """Test that footer includes job info when a job is created."""
     monkeypatch.setenv("WANDB_DOCKER", "hello-world")  # Needed to trigger job creation.

--- a/tests/pytest_tests/system_tests/test_core/test_keras_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_keras_full.py
@@ -334,7 +334,7 @@ def test_keras_save_model(dummy_model, dummy_data, wandb_init):
     assert len(glob.glob(os.path.join(run.dir, "model-best.h5"))) == 1
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_keras_dsviz(dummy_model, dummy_data, wandb_init):
     run = wandb_init()
     dummy_model.fit(

--- a/tests/pytest_tests/system_tests/test_core/test_metric_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_metric_full.py
@@ -21,7 +21,7 @@ def test_metric_default(relay_server, wandb_init):
     assert len(summary) == 3
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_copy(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -42,7 +42,7 @@ def test_metric_copy(relay_server, wandb_init):
     assert len(summary) == 3
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_glob_none(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -94,7 +94,7 @@ def test_metric_nosummary(relay_server, wandb_init):
     assert len(summary) == 1
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_none(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -131,7 +131,7 @@ def test_metric_sum_none(relay_server, wandb_init):
     assert len(summary) == 3
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_max(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -150,7 +150,7 @@ def test_metric_max(relay_server, wandb_init):
     assert len(summary) == 2
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_min(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -169,7 +169,7 @@ def test_metric_min(relay_server, wandb_init):
     assert len(summary) == 2
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_last(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -197,7 +197,7 @@ def _gen_metric_sync_step(run):
     # run.finish()
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_no_sync_step(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -224,7 +224,7 @@ def test_metric_no_sync_step(relay_server, wandb_init):
     assert metrics and len(metrics) == 2
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_sync_step(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -284,7 +284,7 @@ def test_metric_goal(relay_server, wandb_init):
     assert metrics and len(metrics) == 3
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_nan_mean(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -300,7 +300,7 @@ def test_metric_nan_mean(relay_server, wandb_init):
     assert summary["val"] == {"mean": 3}
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_nan_min_norm(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -314,7 +314,7 @@ def test_metric_nan_min_norm(relay_server, wandb_init):
     assert "val" not in summary
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_nan_min_more(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -343,7 +343,7 @@ def test_metric_nested_default(relay_server, wandb_init):
     assert summary["this"] == {"that": 4}
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_nested_copy(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -359,7 +359,7 @@ def test_metric_nested_copy(relay_server, wandb_init):
     assert summary["this"] == {"that": 4}
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_nested_min(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -375,7 +375,7 @@ def test_metric_nested_min(relay_server, wandb_init):
     assert summary["this"] == {"that": {"min": 2}}
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_nested_mult(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -394,7 +394,7 @@ def test_metric_nested_mult(relay_server, wandb_init):
     assert metrics[0] == {"1": "this.that", "7": [1, 2], "6": [3]}
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_dotted(relay_server, wandb_init):
     """Escape dots in metric definitions."""
     with relay_server() as relay:
@@ -414,7 +414,7 @@ def test_metric_dotted(relay_server, wandb_init):
     assert metrics[0] == {"1": "this\\.that", "7": [1], "6": [3]}
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_nested_glob(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -433,7 +433,7 @@ def test_metric_nested_glob(relay_server, wandb_init):
     assert metrics[0] == {"1": "this.that", "7": [1, 2]}
 
 
-@pytest.mark.nexus_failure(feature="define_metric")
+@pytest.mark.wandb_core_failure(feature="define_metric")
 def test_metric_debouncing(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()

--- a/tests/pytest_tests/system_tests/test_core/test_model_workflow.py
+++ b/tests/pytest_tests/system_tests/test_core/test_model_workflow.py
@@ -18,7 +18,7 @@ def test_offline_link_artifact(wandb_init):
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="models")
+@pytest.mark.wandb_core_failure(feature="models")
 def test_log_model(
     wandb_init: Callable[..., Run],
     tmp_path: pathlib.Path,
@@ -36,7 +36,7 @@ def test_log_model(
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="models")
+@pytest.mark.wandb_core_failure(feature="models")
 def test_use_model(
     wandb_init: Callable[..., Run],
     tmp_path: pathlib.Path,
@@ -53,7 +53,7 @@ def test_use_model(
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="models")
+@pytest.mark.wandb_core_failure(feature="models")
 def test_use_model_error_artifact_type(
     wandb_init: Callable[..., Run],
     tmp_path: pathlib.Path,
@@ -69,7 +69,7 @@ def test_use_model_error_artifact_type(
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="models")
+@pytest.mark.wandb_core_failure(feature="models")
 def test_link_model(
     wandb_init: Callable[..., Run],
     tmp_path: pathlib.Path,

--- a/tests/pytest_tests/system_tests/test_core/test_redir_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_redir_full.py
@@ -35,7 +35,7 @@ def test_run_with_console_redirect(wandb_init, capfd, console):
 
 
 @pytest.mark.parametrize("console", console_modes)
-@pytest.mark.nexus_failure(feature="console")
+@pytest.mark.wandb_core_failure(feature="console")
 def test_offline_compression(wandb_init, capfd, console):
     # map to old style wrap implementation until test is refactored
     if console == "wrap":
@@ -84,7 +84,7 @@ def test_offline_compression(wandb_init, capfd, console):
 @pytest.mark.parametrize("console", console_modes)
 @pytest.mark.parametrize("numpy", [True, False])
 @pytest.mark.timeout(300)
-@pytest.mark.nexus_failure(feature="console")
+@pytest.mark.wandb_core_failure(feature="console")
 def test_very_long_output(wandb_init, capfd, console, numpy):
     # https://wandb.atlassian.net/browse/WB-5437
     with capfd.disabled():

--- a/tests/pytest_tests/system_tests/test_core/test_sender.py
+++ b/tests/pytest_tests/system_tests/test_core/test_sender.py
@@ -13,7 +13,7 @@ from wandb.sdk.interface.interface import InterfaceBase
 from wandb.sdk.lib import filesystem
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -32,7 +32,7 @@ def test_save_live_existing_file(relay_server, user, mock_run, backend_interface
     assert uploaded_files.count(file_name) == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -49,7 +49,7 @@ def test_save_live_write_after_policy(relay_server, user, mock_run, backend_inte
     assert uploaded_files.count(file_name) == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -61,7 +61,7 @@ def test_preempting_sent_to_server(relay_server, user, mock_run, backend_interfa
     assert relay.context.entries[run.id].get("preempting") is not None
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -86,7 +86,7 @@ def test_save_live_multi_write(relay_server, user, mock_run, backend_interface):
 
 
 @pytest.mark.xfail(reason="TODO: fix this test")
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -129,7 +129,7 @@ def test_save_live_glob_multi_write(
     assert uploaded_files.count("checkpoints/test_2.txt") == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -150,7 +150,7 @@ def test_save_rename_file(relay_server, user, mock_run, backend_interface):
     assert uploaded_files.count("test-copy.txt") == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -165,7 +165,7 @@ def test_save_end_write_after_policy(relay_server, user, mock_run, backend_inter
     assert uploaded_files.count("test.txt") == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -180,7 +180,7 @@ def test_save_end_existing_file(relay_server, user, mock_run, backend_interface)
     assert uploaded_files.count("test.txt") == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -201,7 +201,7 @@ def test_save_end_multi_write(relay_server, user, mock_run, backend_interface):
 
 
 @pytest.mark.xfail(reason="This test is flakey")
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -217,7 +217,7 @@ def test_save_now_write_after_policy(relay_server, user, mock_run, backend_inter
     assert uploaded_files.count("test.txt") == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -233,7 +233,7 @@ def test_save_now_existing_file(relay_server, user, mock_run, backend_interface)
 
 
 @pytest.mark.xfail(reason="This test is flakey")
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -253,7 +253,7 @@ def test_save_now_multi_write(relay_server, user, mock_run, backend_interface):
     assert uploaded_files.count("test.txt") == 1
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -281,7 +281,7 @@ def test_save_glob_multi_write(relay_server, user, mock_run, backend_interface):
 
 
 @pytest.mark.xfail(reason="This test is flakey")
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -300,7 +300,7 @@ def test_save_now_relative_path(relay_server, user, mock_run, backend_interface)
 
 
 @pytest.mark.xfail(reason="TODO: This test is flakey")
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -323,7 +323,7 @@ def test_save_now_twice(relay_server, user, mock_run, backend_interface):
     assert uploaded_files.count("foo/test.txt") == 2
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -361,7 +361,7 @@ def test_upgrade_upgraded(
         assert run_result.HasField("error") is False
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -402,7 +402,7 @@ def test_upgrade_yanked(
         assert run_result.HasField("error") is False
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )
@@ -443,7 +443,7 @@ def test_upgrade_yanked_message(
         assert run_result.HasField("error") is False
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="test relies on internal python implementation",
 )

--- a/tests/pytest_tests/system_tests/test_core/test_system_info.py
+++ b/tests/pytest_tests/system_tests/test_core/test_system_info.py
@@ -60,7 +60,7 @@ def send_manager(
     yield send_manager_helper
 
 
-@pytest.mark.nexus_failure(feature="file_uploader")
+@pytest.mark.wandb_core_failure(feature="file_uploader")
 def test_meta_probe(
     relay_server, meta, mock_run, send_manager, record_q, user, monkeypatch
 ):

--- a/tests/pytest_tests/system_tests/test_core/test_validation_data_logger.py
+++ b/tests/pytest_tests/system_tests/test_core/test_validation_data_logger.py
@@ -8,7 +8,7 @@ from wandb.sdk.integration_utils.data_logging import (
 )
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_data_logger_val_data_lists(wandb_init):
     run = wandb_init()
     print(run.settings)
@@ -38,7 +38,7 @@ def test_data_logger_val_data_lists(wandb_init):
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_data_logger_val_data_dicts(wandb_init):
     run = wandb_init()
     vd = ValidationDataLogger(
@@ -113,7 +113,7 @@ def test_data_logger_val_invalid(wandb_init):
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_data_logger_val_user_proc(wandb_init):
     run = wandb_init()
     vd = ValidationDataLogger(
@@ -316,7 +316,7 @@ def test_data_logger_val_inferred_proc_no_class(wandb_init):
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_data_logger_pred(wandb_init):
     run = wandb_init()
     vd = ValidationDataLogger(
@@ -338,7 +338,7 @@ def test_data_logger_pred(wandb_init):
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_data_logger_pred_user_proc(wandb_init):
     run = wandb_init()
     vd = ValidationDataLogger(

--- a/tests/pytest_tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb_init.py
@@ -44,7 +44,7 @@ def test_upsert_bucket_410(
 
 
 @pytest.mark.skip(reason="we should handle such cases gracefully")
-@pytest.mark.nexus_failure(feature="error_handling")  # now we just panic
+@pytest.mark.wandb_core_failure(feature="error_handling")  # now we just panic
 def test_gql_409(
     wandb_init,
     relay_server,

--- a/tests/pytest_tests/system_tests/test_core/test_wandb_integration.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb_integration.py
@@ -68,7 +68,7 @@ def test_include_exclude_config_keys(wandb_init):
         )
 
 
-@pytest.mark.nexus_failure(feature="file_uploader")
+@pytest.mark.wandb_core_failure(feature="file_uploader")
 def test_ignore_globs_wandb_files(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init(settings=dict(ignore_globs=["requirements.txt"]))
@@ -184,7 +184,7 @@ def test_dir_on_init_dir(wandb_init):
         ("0.9.0", "ERROR wandb version 0.9.0 has been retired"),
     ],
 )  # TODO should we mock pypi?
-@pytest.mark.nexus_failure(feature="terminal_ui")
+@pytest.mark.wandb_core_failure(feature="terminal_ui")
 def test_versions_messages(wandb_init, capsys, version, message):
     with mock.patch("wandb.__version__", version):
         run = wandb_init(settings=dict(console="off"))
@@ -193,7 +193,7 @@ def test_versions_messages(wandb_init, capsys, version, message):
 
 
 # todo(nexus): debug how the record is sent in the file stream
-@pytest.mark.nexus_failure(feature="mark_preempting")
+@pytest.mark.wandb_core_failure(feature="mark_preempting")
 def test_end_to_end_preempting(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init(settings=dict(console="off"))
@@ -210,7 +210,7 @@ def test_end_to_end_preempting(relay_server, wandb_init):
         run.finish()
 
 
-@pytest.mark.nexus_failure(feature="mark_preempting")
+@pytest.mark.wandb_core_failure(feature="mark_preempting")
 def test_end_to_end_preempting_via_module_func(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init(settings=dict(console="off"))

--- a/tests/pytest_tests/system_tests/test_core/test_wandb_run.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb_run.py
@@ -208,7 +208,7 @@ def test_offline_resume(wandb_init, test_settings, capsys, resume, found):
         ({}, True),
     ],
 )
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="version_check",
     reason="need to implement versioning in wandb core",
 )
@@ -246,7 +246,7 @@ def test_local_warning(
         assert msg not in captured
 
 
-@pytest.mark.nexus_failure(
+@pytest.mark.wandb_core_failure(
     feature="file_uploader",
     reason="need to implement upload of wandb files",
 )

--- a/tests/pytest_tests/system_tests/test_core/test_wandb_tensorflow.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb_tensorflow.py
@@ -48,7 +48,7 @@ PR_CURVE_PANEL_CONFIG = {
     platform.system() == "Windows",
     reason="TODO: Windows is legitimately busted",
 )
-@pytest.mark.nexus_failure(feature="tensorboard")
+@pytest.mark.wandb_core_failure(feature="tensorboard")
 def test_compat_tensorboard(relay_server, wandb_init):
     # TODO(jhr): does not work with --flake-finder
     # TODO: we currently don't unpatch tensorflow so this is the only test that can do it...
@@ -95,7 +95,7 @@ def test_compat_tensorboard(relay_server, wandb_init):
     platform.system() == "Windows",
     reason="TODO: Windows is legitimately busted",
 )
-@pytest.mark.nexus_failure(feature="tensorboard")
+@pytest.mark.wandb_core_failure(feature="tensorboard")
 def test_tensorboard_log_with_wandb_log(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init(sync_tensorboard=True)
@@ -151,7 +151,7 @@ def test_tensorboard_log_with_wandb_log(relay_server, wandb_init):
     platform.system() == "Windows",
     reason="TODO: Windows is legitimately busted",
 )
-@pytest.mark.nexus_failure(feature="tensorboard")
+@pytest.mark.wandb_core_failure(feature="tensorboard")
 def test_add_pr_curve(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init(sync_tensorboard=True)
@@ -188,7 +188,7 @@ def test_add_pr_curve(relay_server, wandb_init):
     platform.system() == "Windows",
     reason="TODO: Windows is legitimately busted",
 )
-@pytest.mark.nexus_failure(feature="tensorboard")
+@pytest.mark.wandb_core_failure(feature="tensorboard")
 def test_add_pr_curve_plugin(relay_server, wandb_init):
     tf.compat.v1.disable_v2_behavior()
     with relay_server() as relay:

--- a/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
@@ -270,7 +270,7 @@ def test_code_saving(notebook):
         assert "WANDB_NOTEBOOK_NAME should be a path" in nb.all_output_text()
 
 
-@pytest.mark.nexus_failure(feature="launch")
+@pytest.mark.wandb_core_failure(feature="launch")
 def test_notebook_creates_artifact_job(notebook):
     with notebook("one_cell_disable_git.ipynb") as nb:
         nb.execute_all()
@@ -280,7 +280,7 @@ def test_notebook_creates_artifact_job(notebook):
         assert "5 artifact file(s)" in output
 
 
-@pytest.mark.nexus_failure(feature="launch")
+@pytest.mark.wandb_core_failure(feature="launch")
 def test_notebook_creates_repo_job(notebook):
     with notebook("one_cell_set_git.ipynb") as nb:
         nb.execute_all()

--- a/tests/pytest_tests/unit_tests_old/test_artifacts/test_artifact_cli.py
+++ b/tests/pytest_tests/unit_tests_old/test_artifacts/test_artifact_cli.py
@@ -6,7 +6,7 @@ import pytest
 from wandb.cli import cli
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 @pytest.mark.skipif(platform.system() == "Windows", reason="TODO: fix on windows")
 def test_artifact_download(runner, git_repo, mock_server, mocked_run):
     result = runner.invoke(cli.artifact, ["get", "test/mnist:v0"])
@@ -23,7 +23,7 @@ def test_artifact_download(runner, git_repo, mock_server, mocked_run):
     assert os.path.exists(path)
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_artifact_upload(runner, git_repo, mock_server, mocked_run):
     with open("artifact.txt", "w") as f:
         f.write("My Artifact")

--- a/tests/pytest_tests/unit_tests_old/test_artifacts/test_artifact_public_api.py
+++ b/tests/pytest_tests/unit_tests_old/test_artifacts/test_artifact_public_api.py
@@ -83,7 +83,7 @@ def test_artifact_files(runner, mock_server, api):
         assert "storagePath" not in file._attrs.keys()
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 @pytest.mark.skipif(platform.system() == "Windows", reason="TODO: fix on windows")
 def test_artifact_download(runner, mock_server, api, mocked_run):
     wandb.run = mocked_run
@@ -110,7 +110,7 @@ def test_artifact_delete(runner, mock_server, api):
         art.delete(delete_aliases=True)
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_artifact_checkout(runner, mock_server, api, mocked_run):
     wandb.run = mocked_run
     with runner.isolated_filesystem():
@@ -155,7 +155,7 @@ def test_artifact_manual_use(runner, mock_server, api):
     assert True
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_artifact_bracket_accessor(runner, live_mock_server, api):
     art = api.artifact("entity/project/dummy:v0", type="dataset")
     assert art["t"].__class__ == wandb.Table
@@ -188,7 +188,7 @@ def test_artifact_manual_error(runner, mock_server, api):
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Verify is broken on Windows"
 )
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_artifact_verify(runner, mock_server, api, mocked_run):
     wandb.run = mocked_run
     art = api.artifact("entity/project/mnist:v0", type="dataset")

--- a/tests/pytest_tests/unit_tests_old/test_artifacts/test_data_types.py
+++ b/tests/pytest_tests/unit_tests_old/test_artifacts/test_data_types.py
@@ -46,7 +46,7 @@ def test_wb_value(live_mock_server, test_settings):
     run.finish()
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_log_dataframe(live_mock_server, test_settings):
     import pandas as pd
 
@@ -59,7 +59,7 @@ def test_log_dataframe(live_mock_server, test_settings):
 
 
 @pytest.mark.parametrize("max_cli_version", ["0.10.33", "0.11.0"])
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_reference_table_logging(
     mocked_run, live_mock_server, test_settings, reinit_internal_api, max_cli_version
 ):

--- a/tests/pytest_tests/unit_tests_old/test_artifacts/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests_old/test_artifacts/test_wandb_run.py
@@ -4,7 +4,7 @@ import pytest
 import wandb
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_artifacts_in_config(live_mock_server, test_settings, parse_ctx):
     run = wandb.init(settings=test_settings)
 
@@ -169,7 +169,7 @@ def test_artifact_string_run_config_update(
     }
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_wandb_artifact_config_update(
     runner, live_mock_server, test_settings, parse_ctx
 ):
@@ -201,7 +201,7 @@ def test_wandb_artifact_config_update(
             assert run.config.test_reference_download.id == artifact.id
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_wandb_artifact_config_set_item(
     runner, live_mock_server, test_settings, parse_ctx
 ):
@@ -227,7 +227,7 @@ def test_wandb_artifact_config_set_item(
         }
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_use_artifact(live_mock_server, test_settings):
     run = wandb.init(settings=test_settings)
     artifact = wandb.Artifact("arti", type="dataset")
@@ -295,7 +295,7 @@ def test_public_artifact_run_config_update(
     }
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_wandb_artifact_init_config(runner, live_mock_server, test_settings, parse_ctx):
     with runner.isolated_filesystem():
         open("file1.txt", "w").write("hello")
@@ -319,7 +319,7 @@ def test_wandb_artifact_init_config(runner, live_mock_server, test_settings, par
         }
 
 
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_log_code_settings(live_mock_server, test_settings):
     with open("test.py", "w") as f:
         f.write('print("test")')
@@ -336,7 +336,7 @@ def test_log_code_settings(live_mock_server, test_settings):
 
 
 @pytest.mark.parametrize("save_code", [True, False])
-@pytest.mark.nexus_failure(feature="artifacts")
+@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_log_code_env(live_mock_server, test_settings, save_code):
     # test for WB-7468
     with mock.patch.dict("os.environ", WANDB_SAVE_CODE=str(save_code).lower()):

--- a/tests/pytest_tests/unit_tests_old/test_core/test_wandb.py
+++ b/tests/pytest_tests/unit_tests_old/test_core/test_wandb.py
@@ -43,7 +43,7 @@ reloadFn = importlib.reload
     platform.system() == "Windows",
     reason="File syncing is somewhat busted in windows",
 )
-@pytest.mark.nexus_failure(feature="files")
+@pytest.mark.wandb_core_failure(feature="files")
 def test_parallel_runs(runner, live_mock_server, test_settings, test_name):
     with runner.isolation():
         with open("train.py", "w") as f:
@@ -85,7 +85,7 @@ def test_parallel_runs(runner, live_mock_server, test_settings, test_name):
         assert num_runs == 2
 
 
-@pytest.mark.nexus_failure(feature="files")
+@pytest.mark.wandb_core_failure(feature="files")
 def test_network_fault_files(live_mock_server, test_settings):
     live_mock_server.set_ctx({"fail_storage_times": 5})
     run = wandb.init(settings=test_settings)
@@ -108,7 +108,7 @@ def test_network_fault_files(live_mock_server, test_settings):
 
 @pytest.mark.flaky
 @pytest.mark.xfail(platform.system() == "Windows", reason="flaky test")
-@pytest.mark.nexus_failure(feature="files")
+@pytest.mark.wandb_core_failure(feature="files")
 def test_live_policy_file_upload(live_mock_server, test_settings):
     test_settings.update(
         {

--- a/tox.ini
+++ b/tox.ini
@@ -139,7 +139,7 @@ allowlist_externals=
 commands_pre=
     notebooks: ipython kernel install --user --name=wandb_python
     mkdir -p test-results .coverage
-    nexus: nox -s build-nexus install-nexus
+    nexus: nox -s build-core install-core
 commands=
     pytest {env:CI_PYTEST_SPLIT_ARGS:} -n=auto --durations=20 --reruns 2 --reruns-delay 1 --junitxml=test-results/junit.xml --cov --cov-report=xml --no-cov-on-fail --timeout 300 {posargs}
 commands_post=

--- a/wandb/sdk/internal/system/system_monitor.py
+++ b/wandb/sdk/internal/system/system_monitor.py
@@ -137,8 +137,8 @@ class SystemMonitor:
 
         if aggregated_metrics:
             # update buffer:
-            # todo: get t from publish_stats instead?
-            #  either is not too accurate, just use nexus!
+            # todo: get it from publish_stats instead?
+            #  either is not too accurate, just use wandb-core!
             t = datetime.datetime.now().timestamp()
             for k, v in aggregated_metrics.items():
                 self.buffer[k].append((t, v))

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1844,7 +1844,7 @@ def get_core_path() -> str:
     wandb_core = get_module("wandb_core")
     if not core_path and wandb_core:
         _check_wandb_core_version_compatibility(wandb_core.__version__)
-        core_path = wandb_core.get_nexus_path()
+        core_path = wandb_core.get_core_path()
     return core_path
 
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at deee698</samp>

Renamed the `wandb-nexus` package to `wandb-core` and updated the configuration files, documentation, and scripts to use the new name. This is to avoid confusion with the Nexus product name and to align with the wandb-core branding.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at deee698</samp>

> _We're changing the name of our package today_
> _From `wandb-nexus` to `wandb-core` we say_
> _So pull on the line and update your files_
> _And sing out loud for the `wandb-core` style_
