### PR TITLE
fix(launch): unnest launch sweep params

### DIFF
--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 import yaml
-
 from wandb.sdk.launch.sweeps import utils
 
 

--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import json
 
 import pytest
@@ -125,3 +126,18 @@ def test_sweep_construct_scheduler_args():
             return_job=False,
         )
     )
+
+
+@mock.patch.parametrize(
+    [
+        ({"nonesting": {"value": 1}}, {"nonesting": {"value": 1}}),
+        ({"no.nesting": {"value": 1}}, {"no": {"nesting": {"value": 1}}}),
+        ({"no.nesting.okay.but": 1}, {"no": {"nesting": {"okay": {"but": 1}}}}),
+        (
+            {"no.nesting": {"okay.but": 1}, "no.ugh": {"value": 1}},
+            {"no": {"nesting": {"okay": {"but": 1}}}, "ugh": {"value": 1}},
+        ),
+    ]
+)
+def test_agent_renest_concatted_args(config, gold):
+    assert utils.renest_concatted_args(config) == gold

--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
@@ -1,5 +1,4 @@
 import json
-from unittest import mock
 
 import pytest
 import yaml
@@ -128,7 +127,7 @@ def test_sweep_construct_scheduler_args():
     )
 
 
-@mock.patch.parametrize(
+@pytest.mark.parametrize(
     [
         ({"nonesting": {"value": 1}}, {"nonesting": {"value": 1}}),
         ({"no.nesting": {"value": 1}}, {"no": {"nesting": {"value": 1}}}),

--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_utils.py
@@ -1,8 +1,9 @@
-from unittest import mock
 import json
+from unittest import mock
 
 import pytest
 import yaml
+
 from wandb.sdk.launch.sweeps import utils
 
 

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -23,6 +23,7 @@ from wandb.sdk.launch.sweeps import SchedulerError
 from wandb.sdk.launch.sweeps.utils import (
     create_sweep_command_args,
     make_launch_sweep_entrypoint,
+    renest_concatted_args,
 )
 from wandb.sdk.launch.utils import event_loop_thread_exec
 from wandb.sdk.lib.runid import generate_id
@@ -661,7 +662,9 @@ class Scheduler(ABC):
         launch_config = self._wandb_run.config.get("launch", {})
         if "overrides" not in launch_config:
             launch_config["overrides"] = {"run_config": {}}
-        launch_config["overrides"]["run_config"].update(args["args_dict"])
+        
+        renested_args = renest_concatted_args(args["args_dict"])
+        launch_config["overrides"]["run_config"].update(renested_args)
 
         if macro_args:  # pipe in hyperparam args as params to launch
             launch_config["overrides"]["args"] = macro_args

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -662,7 +662,7 @@ class Scheduler(ABC):
         launch_config = self._wandb_run.config.get("launch", {})
         if "overrides" not in launch_config:
             launch_config["overrides"] = {"run_config": {}}
-        
+
         renested_args = renest_concatted_args(args["args_dict"])
         launch_config["overrides"]["run_config"].update(renested_args)
 

--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -250,16 +250,19 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
         "args_dict": flags_dict,
     }
 
+
 def renest_concatted_args(args: Dict[str, Any]) -> Dict[str, Any]:
-    """renest args.
+    """Renest args with '.' delimiters.
+
+    Unsafe (!) for args with '.' in the name.
 
     {'components.base_model': 'roberta'} -> {'components': {'base_model': 'roberta'}}
 
     Args:
-        args (dict): nested args dict
+        args (dict): unnested args dict
 
     Returns:
-        dict: unnested args dict
+        dict: renested args dict
     """
     unnested_args = {}
     for arg in args:

--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -250,6 +250,28 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
         "args_dict": flags_dict,
     }
 
+def renest_concatted_args(args: Dict[str, Any]) -> Dict[str, Any]:
+    """renest args.
+
+    {'components.base_model': 'roberta'} -> {'components': {'base_model': 'roberta'}}
+
+    Args:
+        args (dict): nested args dict
+
+    Returns:
+        dict: unnested args dict
+    """
+    unnested_args = {}
+    for arg in args:
+        if "." in arg:
+            parts = arg.split(".")
+            if parts[0] not in unnested_args:
+                unnested_args[parts[0]] = {}
+            unnested_args[parts[0]][parts[1]] = args[arg]
+        else:
+            unnested_args[arg] = args[arg]
+    return unnested_args
+
 
 def make_launch_sweep_entrypoint(
     args: Dict[str, Any], command: Optional[List[str]]


### PR DESCRIPTION
vanilla sweeps automatically turns `{'components.base_model': 'roberta'}` into `{'components': {'base_model': 'roberta'}}` in gorilla, setting the run args as the output from anaconda. Launch blasts away the config with its own config, so for launch sweeps we have to do this again...