### PR TITLE
chore(launch): Fix optionality of prioritization_mode parameter to create_run_queue

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2694,7 +2694,7 @@ RunQueueResourceType = Literal[
     "local-container", "local-process", "kubernetes", "sagemaker", "gcp-vertex"
 ]
 RunQueueAccessType = Literal["project", "user"]
-RunQueuePrioritizationMode = Literal["DISABLED","V0"]
+RunQueuePrioritizationMode = Literal["DISABLED", "V0"]
 
 
 class RunQueue:

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2694,7 +2694,7 @@ RunQueueResourceType = Literal[
     "local-container", "local-process", "kubernetes", "sagemaker", "gcp-vertex"
 ]
 RunQueueAccessType = Literal["project", "user"]
-RunQueuePrioritizationMode = Literal["V0"]
+RunQueuePrioritizationMode = Literal["DISABLED","V0"]
 
 
 class RunQueue:

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1476,7 +1476,7 @@ class Api:
         project: str,
         queue_name: str,
         access: str,
-        prioritization_mode: Optional[str] = None,
+        prioritization_mode: Optional[Literal["DISABLED","V0"]] = "DISABLED",
         config_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         (

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -20,7 +20,6 @@ from typing import (
     Dict,
     Iterable,
     List,
-    Literal,
     Mapping,
     MutableMapping,
     Optional,
@@ -1477,7 +1476,7 @@ class Api:
         project: str,
         queue_name: str,
         access: str,
-        prioritization_mode: Optional[Literal["DISABLED", "V0"]] = "DISABLED",
+        prioritization_mode: Optional[str] = "DISABLED",
         config_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         (

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -20,6 +20,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
     MutableMapping,
     Optional,

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1477,7 +1477,7 @@ class Api:
         project: str,
         queue_name: str,
         access: str,
-        prioritization_mode: Optional[Literal["DISABLED","V0"]] = "DISABLED",
+        prioritization_mode: Optional[Literal["DISABLED", "V0"]] = "DISABLED",
         config_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         (

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1476,7 +1476,7 @@ class Api:
         project: str,
         queue_name: str,
         access: str,
-        prioritization_mode: Optional[str] = "DISABLED",
+        prioritization_mode: Optional[str] = None,
         config_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         (
@@ -1508,7 +1508,7 @@ class Api:
                 $project: String!,
                 $queueName: String!,
                 $access: RunQueueAccessType!,
-                $prioritizationMode: RunQueuePrioritizationMode!,
+                $prioritizationMode: RunQueuePrioritizationMode,
                 $defaultResourceConfigID: ID,
             ) {
                 createRunQueue(


### PR DESCRIPTION
Description
-----------

- Fixes WB-16581

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9c2c9e7</samp>

Changed the type and default value of the `prioritization_mode` parameter in the `create_run_queue` function in `wandb/sdk/internal/internal_api.py`. This improves type safety and consistency for run queue prioritization.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9c2c9e7</samp>

> _`prioritization_mode`_
> _Literal type, clearer values_
> _Autumn of refactor_
