### PR TITLE
test(core): replace logger with a no-op logger for testing

### DIFF
--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/wandb/wandb/core/pkg/observability"
 
 	"github.com/wandb/wandb/core/pkg/filestream"
-	"github.com/wandb/wandb/core/pkg/server"
 
 	"net/http"
 	"net/http/httptest"
@@ -117,7 +116,7 @@ type testServer struct {
 
 func NewTestServer() *testServer {
 	settings := service.Settings{}
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 
 	mux := http.NewServeMux()
 	hserver := httptest.NewServer(mux)

--- a/core/pkg/filestream/loop_transmit_test.go
+++ b/core/pkg/filestream/loop_transmit_test.go
@@ -2,7 +2,6 @@ package filestream
 
 import (
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
@@ -41,8 +40,7 @@ type testObj struct {
 func newFsTest(t *testing.T) *testObj {
 	ctrl := gomock.NewController(t)
 
-	slogger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	logger := observability.NewCoreLogger(slogger, nil)
+	logger := observability.NewNoOpLogger()
 	m := clienttest.NewMockRoundTripper(ctrl)
 	client := clienttest.NewMockRetryClient(m)
 	client.Logger = logger

--- a/core/pkg/observability/logging.go
+++ b/core/pkg/observability/logging.go
@@ -38,13 +38,11 @@ func WithTags(tags Tags) CoreLoggerOption {
 func NewCoreLogger(logger *slog.Logger, opts ...CoreLoggerOption) *CoreLogger {
 
 	cl := &CoreLogger{}
-
 	for _, opt := range opts {
 		opt(cl)
 	}
 
 	var args []interface{}
-
 	for tag := range cl.tags {
 		args = append(args, slog.String(tag, cl.tags[tag]))
 	}
@@ -88,10 +86,10 @@ func (cl *CoreLogger) SetTags(tags Tags) {
 func (cl *CoreLogger) CaptureError(msg string, err error, args ...any) {
 	cl.Logger.Error(msg, args...)
 	if err != nil {
-		// convert args to tags to pass to sentry:
-		tags := cl.tagsFromArgs(args...)
 		// send error to sentry:
 		if cl.captureException != nil {
+			// convert args to tags to pass to sentry:
+			tags := cl.tagsFromArgs(args...)
 			cl.captureException(err, tags)
 		}
 	}
@@ -113,14 +111,13 @@ func (cl *CoreLogger) FatalAndPanic(msg string, err error, args ...any) {
 
 // CaptureFatal logs an error at the fatal level and sends it to sentry.
 func (cl *CoreLogger) CaptureFatal(msg string, err error, args ...any) {
-	// todo: make sure this level is printed nicely
+	// TODO: make sure this level is printed nicely
 	cl.Logger.Log(context.TODO(), LevelFatal, msg, args...)
-
 	if err != nil {
-		// convert args to tags to pass to sentry:
-		tags := cl.tagsFromArgs(args...)
 		// send error to sentry:
 		if cl.captureException != nil {
+			// convert args to tags to pass to sentry:
+			tags := cl.tagsFromArgs(args...)
 			cl.captureException(err, tags)
 		}
 	}
@@ -138,10 +135,9 @@ func (cl *CoreLogger) CaptureFatalAndPanic(msg string, err error, args ...any) {
 // CaptureWarn logs a warning and sends it to sentry.
 func (cl *CoreLogger) CaptureWarn(msg string, args ...any) {
 	cl.Logger.Warn(msg, args...)
-
-	tags := cl.tagsFromArgs(args...)
 	// send message to sentry:
 	if cl.captureMessage != nil {
+		tags := cl.tagsFromArgs(args...)
 		cl.captureMessage(msg, tags)
 	}
 }
@@ -149,10 +145,9 @@ func (cl *CoreLogger) CaptureWarn(msg string, args ...any) {
 // CaptureInfo logs an info message and sends it to sentry.
 func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 	cl.Logger.Info(msg, args...)
-
-	tags := cl.tagsFromArgs(args...)
 	// send message to sentry:
 	if cl.captureMessage != nil {
+		tags := cl.tagsFromArgs(args...)
 		cl.captureMessage(msg, tags)
 	}
 }

--- a/core/pkg/observability/logging.go
+++ b/core/pkg/observability/logging.go
@@ -8,16 +8,20 @@ import (
 
 type Tags map[string]string
 
+// NewTags creates a new Tags from a mix of slog.Attr and any other types.
+// It ignores final if they are strings without a corresponding value.
 func NewTags(args ...any) Tags {
+	var done bool
 	tags := Tags{}
 	// add tags from args:
-	for len(args) > 0 {
+	for len(args) > 0 && !done {
 		switch x := args[0].(type) {
 		case slog.Attr:
 			tags[x.Key] = x.Value.String()
 			args = args[1:]
 		case string:
 			if len(args) < 2 {
+				done = true
 				break
 			}
 			attr := slog.Any(x, args[1])

--- a/core/pkg/observability/logging.go
+++ b/core/pkg/observability/logging.go
@@ -112,7 +112,7 @@ func (cl *CoreLogger) FatalAndPanic(msg string, err error, args ...any) {
 }
 
 // CaptureFatal logs an error at the fatal level and sends it to sentry.
-func (cl *CoreLogger) CaptureFatal(msg string, err error, args ...interface{}) {
+func (cl *CoreLogger) CaptureFatal(msg string, err error, args ...any) {
 	// todo: make sure this level is printed nicely
 	cl.Logger.Log(context.TODO(), LevelFatal, msg, args...)
 
@@ -128,7 +128,7 @@ func (cl *CoreLogger) CaptureFatal(msg string, err error, args ...interface{}) {
 
 // CaptureFatalAndPanic logs an error at the fatal level and sends it to sentry.
 // It then panics.
-func (cl *CoreLogger) CaptureFatalAndPanic(msg string, err error, args ...interface{}) {
+func (cl *CoreLogger) CaptureFatalAndPanic(msg string, err error, args ...any) {
 	cl.CaptureFatal(msg, err, args...)
 	if err != nil {
 		panic(err)

--- a/core/pkg/observability/logging.go
+++ b/core/pkg/observability/logging.go
@@ -8,8 +8,8 @@ import (
 
 type Tags map[string]string
 
-// NewTags creates a new Tags from a mix of slog.Attr and any other types.
-// It ignores final if they are strings without a corresponding value.
+// NewTags creates a new Tags from a mix of slog.Attr and a string and its corresponding value.
+// It ignores incomplete pairs and other types.
 func NewTags(args ...any) Tags {
 	var done bool
 	tags := Tags{}
@@ -168,6 +168,26 @@ func (cl *CoreLogger) Reraise(args ...any) {
 	if err := recover(); err != nil {
 		Reraise(err, cl.tagsWithArgs(args...))
 	}
+}
+
+// GetTags returns the tags associated with the logger.
+func (cl *CoreLogger) GetTags() Tags {
+	return cl.tags
+}
+
+// GetLogger returns the underlying slog.Logger.
+func (cl *CoreLogger) GetLogger() *slog.Logger {
+	return cl.Logger
+}
+
+// GetCaptureException returns the function used to capture exceptions.
+func (cl *CoreLogger) GetCaptureException() func(err error, tags Tags) {
+	return cl.captureException
+}
+
+// GetCaptureMessage returns the function used to capture messages.
+func (cl *CoreLogger) GetCaptureMessage() func(msg string, tags Tags) {
+	return cl.captureMessage
 }
 
 func NewNoOpLogger() *CoreLogger {

--- a/core/pkg/observability/logging_test.go
+++ b/core/pkg/observability/logging_test.go
@@ -20,17 +20,22 @@ func TestNewTags(t *testing.T) {
 			expect: observability.Tags{"key1": "123"},
 		},
 		{
-			name:   "Tags from string and slog.Any",
+			name:   "Tags from string and int",
 			input:  []interface{}{"key2", 456},
 			expect: observability.Tags{"key2": "456"},
 		},
 		{
-			name:   "Tags from a mix of slog.Attr, string, and slog.Any",
+			name:   "Tags from a mix of slog.Attr, string, and int",
 			input:  []interface{}{slog.Attr{Key: "key3", Value: slog.StringValue("value3")}, "key4", 789, slog.Any("key5", "value5")},
 			expect: observability.Tags{"key3": "value3", "key4": "789", "key5": "value5"},
 		},
 		{
-			name:   "Empty Tags",
+			name:   "Tags from slog.Attr and string",
+			input:  []interface{}{slog.Attr{Key: "key6", Value: slog.Int64Value(123)}, "key7"},
+			expect: observability.Tags{"key6": "123"},
+		},
+		{
+			name:   "Tags from empty input",
 			input:  []interface{}{},
 			expect: observability.Tags{},
 		},

--- a/core/pkg/observability/logging_test.go
+++ b/core/pkg/observability/logging_test.go
@@ -70,16 +70,17 @@ func TestNewNoOpLogger(t *testing.T) {
 func TestNewCoreLoggerWithTags(t *testing.T) {
 	// Mock logger for testing
 	var buf bytes.Buffer
-	mockLogger := slog.New(slog.NewTextHandler(&buf,
-		&slog.HandlerOptions{
-			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-				if a.Key == slog.TimeKey && len(groups) == 0 {
-					return slog.Attr{}
-				}
-				return a
+	mockLogger := slog.New(
+		slog.NewTextHandler(&buf,
+			&slog.HandlerOptions{
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.TimeKey && len(groups) == 0 {
+						return slog.Attr{}
+					}
+					return a
+				},
 			},
-		},
-	),
+		),
 	)
 	// Create tags for testing
 	tags := observability.Tags{"key1": "value1", "key2": "value2"}
@@ -87,14 +88,14 @@ func TestNewCoreLoggerWithTags(t *testing.T) {
 	// Create a CoreLogger with tags
 	logger := observability.NewCoreLogger(mockLogger, observability.WithTags(tags))
 
-	// Verify that the tags are correctly applied to the logger
+	// Assert that the logger has the expected configuration
 	assert.NotNil(t, logger)
 	assert.NotNil(t, logger.Logger)
 
-	// Check if the logger received the expected tags
+	// Assert that the logger has the expected tags
 	assert.Equal(t, tags, logger.GetTags(), "Unexpected tags in the logger")
 
-	// Check if the logger received the expected tags
+	// Assert that the slog logger has the expected tags
 	logger.Info("Test message")
 	assert.Equal(t, "level=INFO msg=\"Test message\" key1=value1 key2=value2\n", buf.String(), "Unexpected log message")
 }

--- a/core/pkg/observability/logging_test.go
+++ b/core/pkg/observability/logging_test.go
@@ -1,0 +1,45 @@
+package observability_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/pkg/observability"
+)
+
+func TestNewTags(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  []interface{}
+		expect observability.Tags
+	}{
+		{
+			name:   "Tags from slog.Attr",
+			input:  []interface{}{slog.Attr{Key: "key1", Value: slog.Int64Value(123)}},
+			expect: observability.Tags{"key1": "123"},
+		},
+		{
+			name:   "Tags from string and slog.Any",
+			input:  []interface{}{"key2", 456},
+			expect: observability.Tags{"key2": "456"},
+		},
+		{
+			name:   "Tags from a mix of slog.Attr, string, and slog.Any",
+			input:  []interface{}{slog.Attr{Key: "key3", Value: slog.StringValue("value3")}, "key4", 789, slog.Any("key5", "value5")},
+			expect: observability.Tags{"key3": "value3", "key4": "789", "key5": "value5"},
+		},
+		{
+			name:   "Empty Tags",
+			input:  []interface{}{},
+			expect: observability.Tags{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tags := observability.NewTags(tc.input...)
+			assert.Equal(t, tc.expect, tags, "Unexpected result for test case: %s", tc.name)
+		})
+	}
+}

--- a/core/pkg/observability/sentry.go
+++ b/core/pkg/observability/sentry.go
@@ -14,6 +14,8 @@ import (
 
 const sentryDsn = "https://0d0c6674e003452db392f158c42117fb@o151352.ingest.sentry.io/4505513612214272"
 
+type Tags map[string]string
+
 type SentryClient struct {
 	Dsn    string
 	Commit string
@@ -74,7 +76,7 @@ func InitSentry(disabled bool, commit string) {
 	}
 }
 
-func CaptureException(err error, tags map[string]string) {
+func CaptureException(err error, tags Tags) {
 	localHub := sentry.CurrentHub().Clone()
 	localHub.ConfigureScope(func(scope *sentry.Scope) {
 		for k, v := range tags {
@@ -86,7 +88,7 @@ func CaptureException(err error, tags map[string]string) {
 	localHub.CaptureException(err)
 }
 
-func CaptureMessage(msg string, tags map[string]string) {
+func CaptureMessage(msg string, tags Tags) {
 	localHub := sentry.CurrentHub().Clone()
 	localHub.ConfigureScope(func(scope *sentry.Scope) {
 		for k, v := range tags {
@@ -98,7 +100,7 @@ func CaptureMessage(msg string, tags map[string]string) {
 
 // Reraise captures an error and re-raises it.
 // Used to capture unexpected panics.
-func Reraise(err any, tags map[string]string) {
+func Reraise(err any, tags Tags) {
 	if err != nil {
 		var e error
 		if errors.As(e, &err) {

--- a/core/pkg/observability/sentry.go
+++ b/core/pkg/observability/sentry.go
@@ -14,8 +14,6 @@ import (
 
 const sentryDsn = "https://0d0c6674e003452db392f158c42117fb@o151352.ingest.sentry.io/4505513612214272"
 
-type Tags map[string]string
-
 type SentryClient struct {
 	Dsn    string
 	Commit string

--- a/core/pkg/server/handler_test.go
+++ b/core/pkg/server/handler_test.go
@@ -25,7 +25,7 @@ func makeHandler(
 	outChan chan *service.Result,
 	debounce bool,
 ) *server.Handler {
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	h := server.NewHandler(context.Background(), &service.Settings{}, logger)
 
 	h.SetInboundChannels(inChan, loopbackChan)

--- a/core/pkg/server/logging.go
+++ b/core/pkg/server/logging.go
@@ -67,7 +67,12 @@ func SetupStreamLogger(settings *service.Settings) *observability.CoreLogger {
 
 	writer := io.MultiWriter(writers...)
 
-	logger := observability.NewCoreLogger(setupLogger(nil, writer), nil)
+	logger := observability.NewCoreLogger(
+		setupLogger(nil, writer),
+		observability.WithTags(observability.Tags{}),
+		observability.WithCaptureMessage(observability.CaptureMessage),
+		observability.WithCaptureException(observability.CaptureException),
+	)
 	logger.Info("using version", "core version", version.Version)
 	logger.Info("created symlink", "path", targetPath)
 	tags := observability.Tags{

--- a/core/pkg/server/sender_test.go
+++ b/core/pkg/server/sender_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func makeSender(client graphql.Client, resultChan chan *service.Result) *server.Sender {
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	sender := server.NewSender(
 		context.Background(),
 		&service.Settings{

--- a/core/pkg/server/store_test.go
+++ b/core/pkg/server/store_test.go
@@ -38,7 +38,7 @@ func TestOpenCreateStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
@@ -53,7 +53,7 @@ func TestOpenReadStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
@@ -75,7 +75,7 @@ func TestReadWriteRecord(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	defer store.Close()
 
@@ -111,7 +111,7 @@ func TestCorruptFile(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	defer store.Close()
 
@@ -147,7 +147,7 @@ func TestInvalidHeader(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 
 	// Intentionally writing bad header data
@@ -160,7 +160,7 @@ func TestInvalidHeader(t *testing.T) {
 
 // TestStoreHeader_Write_Error is intended to test the error scenario when writing the header
 func TestStoreHeader_Write_Error(t *testing.T) {
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), "non_existent_dir/file", logger)
 	err := store.Open(os.O_WRONLY)
 	assert.Error(t, err)
@@ -173,7 +173,7 @@ func TestInvalidFlag(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(9999) // 9999 is an invalid flag
 	assert.Errorf(t, err, "invalid flag %d", 9999)
@@ -186,7 +186,7 @@ func TestWriteToClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
@@ -206,7 +206,7 @@ func TestReadFromClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewCoreLogger(server.SetupDefaultLogger(), nil)
+	logger := observability.NewNoOpLogger()
 	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)

--- a/tox.ini
+++ b/tox.ini
@@ -128,6 +128,7 @@ setenv=
     {[base]setenv}
     WINDIR=C:\\Windows
     GOCOVERDIR={tox_root}/.coverage
+    core: WANDB_ERROR_REPORTING=false
 passenv=
     {[base]passenv}
     CI_PYTEST_PARALLEL

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,6 @@ setenv=
     {[base]setenv}
     WINDIR=C:\\Windows
     GOCOVERDIR={tox_root}/.coverage
-    core: WANDB_ERROR_REPORTING=false
 passenv=
     {[base]passenv}
     CI_PYTEST_PARALLEL


### PR DESCRIPTION
Description
-----------

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 422fc3c</samp>

This pull request refactors the core tests by replacing the core logger with a no-op logger and disabling error reporting. These changes reduce noise, complexity, and external dependencies in the test code. The affected files are `filestream_test.go`, `loop_transmit_test.go`, `store_test.go`, `handler_test.go`, `sender_test.go`, and `tox.ini`.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 422fc3c</samp>

> _Sing, O Muse, of the valiant code reviewers_
> _Who scrutinized the changes of the core_
> _And praised the ones who silenced the loud loggers_
> _With no-op substitutes in every store._
