### PR TITLE
fix(artifacts): only skip file download if digest matches

### DIFF
--- a/core/pkg/utils/files.go
+++ b/core/pkg/utils/files.go
@@ -1,10 +1,22 @@
 package utils
 
 import (
+	"errors"
 	"os"
 
 	"github.com/segmentio/encoding/json"
 )
+
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
 
 func WriteJsonToFileWithDigest(marshallable interface{}) (filename string, digest string, rerr error) {
 	data, rerr := json.Marshal(marshallable)

--- a/core/pkg/utils/hash.go
+++ b/core/pkg/utils/hash.go
@@ -4,11 +4,27 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
+	"io"
+	"os"
 )
 
 func ComputeB64MD5(data []byte) (string, error) {
 	hasher := md5.New()
 	_, err := hasher.Write(data)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func ComputeFileB64MD5(path string) (string, error) {
+	hasher := md5.New()
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	_, err = io.Copy(hasher, f)
 	if err != nil {
 		return "", err
 	}

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -303,7 +303,6 @@ def test_artifact_upload_succeeds_with_async(
         assert (tmp_path / "downloaded" / "my-file.txt").read_text() == "my contents"
 
 
-@pytest.mark.wandb_core_failure(feature="artifacts")
 def test_check_existing_artifact_before_download(wandb_init, tmp_path, monkeypatch):
     """Don't re-download an artifact if it's already in the desired location."""
     cache_dir = tmp_path / "cache"
@@ -338,12 +337,8 @@ def test_check_existing_artifact_before_download(wandb_init, tmp_path, monkeypat
         assert file1.read_text() == "hello"
 
 
-@pytest.mark.wandb_core_failure(feature="artifacts")
-def test_check_changed_artifact_then_download(wandb_init, tmp_path, monkeypatch):
+def test_check_changed_artifact_then_download(wandb_init, tmp_path):
     """*Do* re-download an artifact if it's been modified in place."""
-    cache_dir = tmp_path / "cache"
-    monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
-
     original_file = tmp_path / "test.txt"
     original_file.write_text("hello")
     with wandb_init() as run:
@@ -357,9 +352,6 @@ def test_check_changed_artifact_then_download(wandb_init, tmp_path, monkeypatch)
         file1 = artifact_path / "test.txt"
         assert file1.is_file()
         assert file1.read_text() == "hello"
-
-    # Delete the cached file
-    shutil.rmtree(cache_dir)
 
     # Modify the artifact file to change its hash.
     file1.write_text("goodbye")


### PR DESCRIPTION
Fixes WB-15159

# Description

Modified artifact downloader in Nexus to only skip files if their digest matches.

# Test plan

```
$ nox -s build-core install-core
$ pytest tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py::test_check_changed_artifact_then_download
```