### PR TITLE
test(core): check wandb-core compatibility with latest wandb from pypi

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -118,14 +118,14 @@ jobs:
       - name: Install wandb from source
         run: |
           python -m pip install .
-      - name: Smoke-test wandb-core TestPyPI install WRT wandb@main
+      - name: Smoke-test wandb-core TestPyPI install against wandb@main
         run: |
           python -c "import wandb; run = wandb.init(settings={'mode': 'offline'}); run.finish()"
       - name: Install latest wandb from PyPI
         run: |
           python -m pip uninstall wandb -y
           python -m pip install --upgrade wandb
-      - name: Smoke-test wandb-core TestPyPI install WRT latest wandb from PyPI
+      - name: Smoke-test wandb-core TestPyPI install against latest wandb from PyPI
         run: |
           python -c "import wandb; run = wandb.init(settings={'mode': 'offline'}); run.finish()"
 

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -118,7 +118,14 @@ jobs:
       - name: Install wandb from source
         run: |
           python -m pip install .
-      - name: Smoke-test wandb-core TestPyPI install
+      - name: Smoke-test wandb-core TestPyPI install WRT wandb@main
+        run: |
+          python -c "import wandb; run = wandb.init(settings={'mode': 'offline'}); run.finish()"
+      - name: Install latest wandb from PyPI
+        run: |
+          python -m pip uninstall wandb -y
+          python -m pip install --upgrade wandb
+      - name: Smoke-test wandb-core TestPyPI install WRT latest wandb from PyPI
         run: |
           python -c "import wandb; run = wandb.init(settings={'mode': 'offline'}); run.finish()"
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9431df1</samp>

Add compatibility tests for `wandb-core` package. The workflow `.github/workflows/release-core.yml` now installs and runs `wandb-core` with both the latest `wandb` and the main branch.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9431df1</samp>

> _`wandb-core` tests_
> _add more steps for PyPI_
> _autumn of features_
