### PR TITLE
chore(launch): Better check for empty cli template vars

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1493,7 +1493,7 @@ def launch(
             config["overrides"] = {"dockerfile": dockerfile}
 
     template_variables = None
-    if cli_template_vars is not None:
+    if cli_template_vars:
         if queue is None:
             raise LaunchError("'--set-var' flag requires queue to be set")
         public_api = PublicApi()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

When a variadic param isn't supplied, Click sets its value to an empty tuple `()` instead of None.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aec548c</samp>

Refactored the `launch` function in `wandb/cli/cli.py` to simplify a condition and improve readability. This function launches a wandb project from a URI or a local directory, optionally using template variables and a queue name.

Testing
-------
Ran the test suite

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aec548c</samp>

> _Launch a project_
> _With `cli_template_vars`_
> _Or use the `queue`_
