### PR TITLE
security(launch): Pass wandb API key as a kubernetes secret to nodes

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
@@ -12,6 +12,8 @@ from wandb.sdk.launch.utils import make_name_dns_safe
 async def _mock_maybe_create_imagepull_secret(*args, **kwargs):
     pass
 
+async def _mock_create_api_key_secret(*args, **kwargs):
+    pass
 
 @pytest.mark.asyncio
 async def test_kubernetes_run_clean_generate_name(
@@ -141,6 +143,11 @@ async def test_kubernetes_run_with_annotations(relay_server, monkeypatch, assets
             kubernetes_runner,
             "maybe_create_imagepull_secret",
             _mock_maybe_create_imagepull_secret,
+        )
+        monkeypatch.setattr(
+            kubernetes_runner,
+            "create_api_key_secret",
+            _mock_create_api_key_secret,
         )
         project.launch_spec = {"_resume_count": 0}
         run = await runner.run(image_uri="hello-world", launch_project=project)

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
@@ -12,8 +12,10 @@ from wandb.sdk.launch.utils import make_name_dns_safe
 async def _mock_maybe_create_imagepull_secret(*args, **kwargs):
     pass
 
+
 async def _mock_create_api_key_secret(*args, **kwargs):
     pass
+
 
 @pytest.mark.asyncio
 async def test_kubernetes_run_clean_generate_name(

--- a/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -24,6 +24,7 @@ from wandb.sdk.launch.runner.kubernetes_runner import (
     add_entrypoint_args_overrides,
     add_label_to_pods,
     add_wandb_env,
+    create_api_key_secret,
     maybe_create_imagepull_secret,
 )
 
@@ -695,6 +696,16 @@ async def test_maybe_create_imagepull_secret_given_creds():
             }
         ).encode("utf-8")
     ).decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_create_api_key_secret():
+    api = MockCoreV1Api()
+    await create_api_key_secret(api, "wandb", "testsecret")
+    namespace, secret = api.secrets[0]
+    assert namespace == "wandb"
+    assert secret.metadata.name == "wandb-api-key"
+    assert secret.data["password"] == base64.b64encode("testsecret").decode()
 
 
 # Test monitor class.

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -391,7 +391,7 @@ class KubernetesRunner(AbstractRunner):
             # Add our env vars to user supplied env vars
             env = cont.get("env") or []
             for key, value in env_vars.items():
-                if key == "WANDB_API_KEY":
+                if key == "WANDB_API_KEY" and value:
                     # Override API key with secret. TODO: Do the same for other runners
                     await create_api_key_secret(core_api, namespace, value)
                     env.append(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-16588](https://wandb.atlassian.net/browse/WB-16588)

For the Kubernetes runner, use a secret instead of passing the API key as plaintext.

copilot:summary

Testing
-------
Agent was able to successfully launch & complete a job with this change. Inspecting the pod shows that the API key is using a secret, and inspecting the secret gives the expected value.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

copilot:poem
