### PR TITLE
fix(launch): capture errors from the creation of k8s job from yaml

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
@@ -234,8 +234,8 @@ def setup_mock_kubernetes_client(monkeypatch, jobs, pods, mock_job_base):
     )
     monkeypatch.setattr(
         kubernetes_asyncio.utils,
-        "create_from_yaml",
-        lambda _, yaml_objects, namespace: mock_create_from_yaml(
+        "create_from_dict",
+        lambda _, yaml_objects, namespace: mock_create_from_dict(
             yaml_objects, jobs, mock_job_base
         ),
     )
@@ -254,7 +254,7 @@ def setup_mock_kubernetes_client(monkeypatch, jobs, pods, mock_job_base):
         _mock_get_context_and_client,
     )
 
-    async def mock_create_from_yaml(path, jobs_dict, mock_status):
+    async def mock_create_from_dict(path, jobs_dict, mock_status):
         with open(path) as path:
             jobd = yaml.safe_load(path)
         name = jobd["metadata"].get("name")

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
@@ -254,9 +254,7 @@ def setup_mock_kubernetes_client(monkeypatch, jobs, pods, mock_job_base):
         _mock_get_context_and_client,
     )
 
-    async def mock_create_from_dict(path, jobs_dict, mock_status):
-        with open(path) as path:
-            jobd = yaml.safe_load(path)
+    async def mock_create_from_dict(jobd, jobs_dict, mock_status):
         name = jobd["metadata"].get("name")
         if not name:
             name = jobd["metadata"]["generateName"] + "testname"

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 
 import kubernetes_asyncio
 import pytest
-import yaml
 from wandb.apis.internal import Api
 from wandb.sdk.launch import loader
 from wandb.sdk.launch.runner import kubernetes_monitor, kubernetes_runner

--- a/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 
 import pytest
 import wandb
-import yaml
 from kubernetes_asyncio.client import ApiException
 from wandb.sdk.launch._project_spec import LaunchProject
 from wandb.sdk.launch.errors import LaunchError

--- a/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -366,8 +366,8 @@ def mock_maybe_create_image_pullsecret(monkeypatch):
 
 
 @pytest.fixture
-def mock_create_from_yaml(monkeypatch):
-    """Patches the kubernetes create_from_yaml with a mock and returns it."""
+def mock_create_from_dict(monkeypatch):
+    """Patches the kubernetes create_from_dict with a mock and returns it."""
     function_mock = MagicMock()
     function_mock.return_value = [[MockDict({"metadata": {"name": "test-job"}})]]
 
@@ -375,7 +375,7 @@ def mock_create_from_yaml(monkeypatch):
         return function_mock(*args, **kwargs)
 
     monkeypatch.setattr(
-        "kubernetes_asyncio.utils.create_from_yaml",
+        "kubernetes_asyncio.utils.create_from_dict",
         lambda *args, **kwargs: _mock_create_from_yaml(*args, **kwargs),
     )
     return function_mock
@@ -388,7 +388,7 @@ async def test_launch_kube_works(
     mock_batch_api,
     mock_kube_context_and_api_client,
     mock_maybe_create_image_pullsecret,
-    mock_create_from_yaml,
+    mock_create_from_dict,
     test_api,
     manifest,
     clean_monitor,
@@ -481,10 +481,8 @@ async def test_launch_kube_works(
     )
     await asyncio.sleep(0.1)
     assert str(await submitted_run.get_status()) == "finished"
-    assert mock_create_from_yaml.call_count == 1
-    submitted_manifest = mock_create_from_yaml.call_args_list[0][0][1]
-    with open(submitted_manifest) as f:
-        submitted_manifest = yaml.safe_load(f)
+    assert mock_create_from_dict.call_count == 1
+    submitted_manifest = mock_create_from_dict.call_args_list[0][0][1]
     assert submitted_manifest["spec"]["template"]["spec"]["containers"][0]["args"] == [
         "--test_arg",
         "test_value",
@@ -515,7 +513,7 @@ async def test_launch_crd_works(
     mock_batch_api,
     mock_custom_api,
     mock_kube_context_and_api_client,
-    mock_create_from_yaml,
+    mock_create_from_dict,
     test_api,
     volcano_spec,
     clean_monitor,
@@ -617,7 +615,7 @@ async def test_launch_kube_failed(
     monkeypatch,
     mock_batch_api,
     mock_kube_context_and_api_client,
-    mock_create_from_yaml,
+    mock_create_from_dict,
     mock_maybe_create_image_pullsecret,
     mock_event_streams,
     test_api,

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -552,9 +552,11 @@ class KubernetesRunner(AbstractRunner):
             )
         except kubernetes_asyncio.utils.FailToCreateError as e:
             for exc in e.api_exceptions:
+                resp = json.loads(exc.body)
+                msg = resp.get("message")
+                code = resp.get("code")
                 raise LaunchError(
-                    f"Failed to create Kubernetes job for run {launch_project.run_id} ({exc.reason}) response:\n\n"
-                    f"{yaml.dump(json.loads(exc.body), indent=2)}\n"
+                    f"Failed to create Kubernetes job for run {launch_project.run_id} ({code} {exc.reason}): {msg}"
                 )
         except Exception as e:
             raise LaunchError(

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -3,7 +3,6 @@ import asyncio
 import base64
 import json
 import logging
-import tempfile
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import yaml
@@ -547,15 +546,21 @@ class KubernetesRunner(AbstractRunner):
         if "name" in resource_args:
             msg += f": {resource_args['name']}"
         _logger.info(msg)
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-            f.write(yaml.dump(job))
-            job_yaml_path = f.name
-
-        job_response = (
-            await kubernetes_asyncio.utils.create_from_yaml(
-                api_client, job_yaml_path, namespace=namespace
+        try:
+            response = await kubernetes_asyncio.utils.create_from_dict(
+                api_client, job, namespace=namespace
             )
-        )[0][0]
+        except kubernetes_asyncio.utils.FailToCreateError as e:
+            for exc in e.api_exceptions:
+                raise LaunchError(
+                    f"Failed to create Kubernetes job for run {launch_project.run_id} ({exc.reason}) response:\n\n"
+                    f"{yaml.dump(json.loads(exc.body), indent=2)}\n"
+                )
+        except Exception as e:
+            raise LaunchError(
+                f"Unexpected exception when creating Kubernetes job: {str(e)}\n"
+            )
+        job_response = response[0][0]
         job_name = job_response.metadata.name
         LaunchKubernetesMonitor.monitor_namespace(namespace)
         submitted_job = KubernetesSubmittedRun(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-15786
- Fixes #NNNN

Since adopting `kubernbetes_asyncio` as our k8s client we have had a regression where errors during the creation of a k8s job in the kubernetes cluster are handled improperly. This is actually due to bugs in the `create_from_yaml` util of the `kubernetes_asyncio` library. They have a nearly equivalent function `create_from_dict` that works are returns errors from the server normally. So where you used to have errors like in the image below:

![image](https://github.com/wandb/wandb/assets/11450487/9d9db050-5496-41e3-9457-7e010cdd2c4b)

You will now get something much better, like:

<img width="615" alt="Screenshot 2023-12-15 at 10 44 09 AM" src="https://github.com/wandb/wandb/assets/11450487/cf3f52d5-641e-44d5-a377-fa4c3a17bb32">


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

copilot:poem
