### PR TITLE
refactor(artifacts): rename cache modules

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -12,7 +12,7 @@ import requests
 import responses
 import wandb
 import wandb.data_types as data_types
-import wandb.sdk.artifacts.artifacts_cache as artifacts_cache
+import wandb.sdk.artifacts.artifact_file_cache as artifact_file_cache
 from wandb import util
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
@@ -1425,7 +1425,7 @@ def test_s3_storage_handler_load_path_uses_cache(tmp_path):
     uri = "s3://some-bucket/path/to/file.json"
     etag = "some etag"
 
-    cache = artifacts_cache.ArtifactsCache(tmp_path)
+    cache = artifact_file_cache.ArtifactFileCache(tmp_path)
     path, _, opener = cache.check_etag_obj_path(uri, etag, 123)
     with opener() as f:
         f.write(123 * "a")
@@ -1491,9 +1491,9 @@ def test_manifest_json_invalid_version(version):
 @pytest.mark.flaky
 @pytest.mark.xfail(reason="flaky")
 def test_cache_cleanup_allows_upload(wandb_init, tmp_path, monkeypatch):
-    cache = artifacts_cache.ArtifactsCache(tmp_path)
-    monkeypatch.setattr(artifacts_cache, "_artifacts_cache", cache)
-    assert cache == artifacts_cache.get_artifacts_cache()
+    cache = artifact_file_cache.ArtifactFileCache(tmp_path)
+    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
+    assert cache == artifact_file_cache.get_artifact_file_cache()
     cache.cleanup(0)
 
     artifact = wandb.Artifact(type="dataset", name="survive-cleanup")

--- a/tests/pytest_tests/unit_tests/test_artifacts/conftest.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/conftest.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import pytest
-from wandb.sdk.artifacts.artifacts_cache import ArtifactsCache
+from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
 
 
 @pytest.fixture
-def artifacts_cache(tmp_path: Path) -> ArtifactsCache:
-    return ArtifactsCache(tmp_path / "artifacts-cache")
+def artifact_file_cache(tmp_path: Path) -> ArtifactFileCache:
+    return ArtifactFileCache(tmp_path / "artifacts-cache")

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -23,8 +23,8 @@ from wandb.sdk.lib.hashutil import md5_string
 example_digest = md5_string("example")
 
 
-def test_opener_rejects_append_mode(artifacts_cache):
-    _, _, opener = artifacts_cache.check_md5_obj_path(example_digest, 7)
+def test_opener_rejects_append_mode(artifact_file_cache):
+    _, _, opener = artifact_file_cache.check_md5_obj_path(example_digest, 7)
 
     with pytest.raises(ValueError):
         with opener("a"):
@@ -35,11 +35,15 @@ def test_opener_rejects_append_mode(artifacts_cache):
         f.write("example")
 
 
-def test_check_md5_obj_path(artifacts_cache):
+def test_check_md5_obj_path(artifact_file_cache):
     md5 = md5_string("hi")
-    path, exists, opener = artifacts_cache.check_md5_obj_path(md5, 2)
+    path, exists, opener = artifact_file_cache.check_md5_obj_path(md5, 2)
     expected_path = os.path.join(
-        artifacts_cache._cache_dir, "obj", "md5", "49", "f68a5c8493ec2c0bf489821c21fc3b"
+        artifact_file_cache._cache_dir,
+        "obj",
+        "md5",
+        "49",
+        "f68a5c8493ec2c0bf489821c21fc3b",
     )
     assert path == expected_path
 
@@ -52,8 +56,10 @@ def test_check_md5_obj_path(artifacts_cache):
     assert contents == "hi"
 
 
-def test_check_etag_obj_path_points_to_opener_dst(artifacts_cache):
-    path, _, opener = artifacts_cache.check_etag_obj_path("http://my/url", "abc", 10)
+def test_check_etag_obj_path_points_to_opener_dst(artifact_file_cache):
+    path, _, opener = artifact_file_cache.check_etag_obj_path(
+        "http://my/url", "abc", 10
+    )
 
     with opener() as f:
         f.write("hi")
@@ -63,9 +69,9 @@ def test_check_etag_obj_path_points_to_opener_dst(artifacts_cache):
     assert contents == "hi"
 
 
-def test_check_etag_obj_path_returns_exists_if_exists(artifacts_cache):
+def test_check_etag_obj_path_returns_exists_if_exists(artifact_file_cache):
     size = 123
-    _, exists, opener = artifacts_cache.check_etag_obj_path(
+    _, exists, opener = artifact_file_cache.check_etag_obj_path(
         "http://my/url", "abc", size
     )
     assert not exists
@@ -73,13 +79,13 @@ def test_check_etag_obj_path_returns_exists_if_exists(artifacts_cache):
     with opener() as f:
         f.write(size * "a")
 
-    _, exists, _ = artifacts_cache.check_etag_obj_path("http://my/url", "abc", size)
+    _, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", size)
     assert exists
 
 
-def test_check_etag_obj_path_returns_not_exists_if_incomplete(artifacts_cache):
+def test_check_etag_obj_path_returns_not_exists_if_incomplete(artifact_file_cache):
     size = 123
-    _, exists, opener = artifacts_cache.check_etag_obj_path(
+    _, exists, opener = artifact_file_cache.check_etag_obj_path(
         "http://my/url", "abc", size
     )
     assert not exists
@@ -87,18 +93,18 @@ def test_check_etag_obj_path_returns_not_exists_if_incomplete(artifacts_cache):
     with opener() as f:
         f.write((size - 1) * "a")
 
-    _, exists, _ = artifacts_cache.check_etag_obj_path("http://my/url", "abc", size)
+    _, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", size)
     assert not exists
 
     with opener() as f:
         f.write(size * "a")
 
-    _, exists, _ = artifacts_cache.check_etag_obj_path("http://my/url", "abc", size)
+    _, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", size)
     assert exists
 
 
-def test_check_etag_obj_path_does_not_include_etag(artifacts_cache):
-    path, _, _ = artifacts_cache.check_etag_obj_path("http://url/1", "abcdef", 10)
+def test_check_etag_obj_path_does_not_include_etag(artifact_file_cache):
+    path, _, _ = artifact_file_cache.check_etag_obj_path("http://url/1", "abcdef", 10)
     assert "abcdef" not in path
 
 
@@ -111,10 +117,10 @@ def test_check_etag_obj_path_does_not_include_etag(artifacts_cache):
     ],
 )
 def test_check_etag_obj_path_hashes_url_and_etag(
-    url1, url2, etag1, etag2, path_equal, artifacts_cache
+    url1, url2, etag1, etag2, path_equal, artifact_file_cache
 ):
-    path_1, _, _ = artifacts_cache.check_etag_obj_path(url1, etag1, 10)
-    path_2, _, _ = artifacts_cache.check_etag_obj_path(url2, etag2, 10)
+    path_1, _, _ = artifact_file_cache.check_etag_obj_path(url1, etag1, 10)
+    path_2, _, _ = artifact_file_cache.check_etag_obj_path(url2, etag2, 10)
 
     if path_equal:
         assert path_1 == path_2
@@ -124,40 +130,42 @@ def test_check_etag_obj_path_hashes_url_and_etag(
 
 # This function should only be used in `test_check_write_parallel`,
 # but it needs to be a global function for multiprocessing.
-def _cache_writer(artifacts_cache):
+def _cache_writer(artifact_file_cache):
     etag = "abcdef"
-    _, _, opener = artifacts_cache.check_etag_obj_path("http://wandb.ex/foo", etag, 10)
+    _, _, opener = artifact_file_cache.check_etag_obj_path(
+        "http://wandb.ex/foo", etag, 10
+    )
     with opener() as f:
         f.write("".join(random.choice("0123456") for _ in range(10)))
 
 
 @pytest.mark.flaky
 @pytest.mark.xfail(reason="flaky")
-def test_check_write_parallel(artifacts_cache):
+def test_check_write_parallel(artifact_file_cache):
     num_parallel = 5
 
     p = Pool(num_parallel)
-    p.map(_cache_writer, [artifacts_cache for _ in range(num_parallel)])
-    _cache_writer(artifacts_cache)  # run in this process too for code coverage
+    p.map(_cache_writer, [artifact_file_cache for _ in range(num_parallel)])
+    _cache_writer(artifact_file_cache)  # run in this process too for code coverage
     p.close()
     p.join()
 
     # Regardless of the ordering, we should be left with one file at the end.
     files = [
         f
-        for f in (artifacts_cache._cache_dir / "obj" / "etag").rglob("*")
+        for f in (artifact_file_cache._cache_dir / "obj" / "etag").rglob("*")
         if f.is_file()
     ]
     assert len(files) == 1
 
 
-def test_artifacts_cache_cleanup_empty(artifacts_cache):
-    reclaimed_bytes = artifacts_cache.cleanup(100000)
+def test_artifact_file_cache_cleanup_empty(artifact_file_cache):
+    reclaimed_bytes = artifact_file_cache.cleanup(100000)
     assert reclaimed_bytes == 0
 
 
-def test_artifacts_cache_cleanup(artifacts_cache):
-    cache_root = os.path.join(artifacts_cache._cache_dir, "obj", "md5")
+def test_artifact_file_cache_cleanup(artifact_file_cache):
+    cache_root = os.path.join(artifact_file_cache._cache_dir, "obj", "md5")
 
     path_1 = os.path.join(cache_root, "aa")
     os.makedirs(path_1)
@@ -180,29 +188,31 @@ def test_artifacts_cache_cleanup(artifacts_cache):
         f.flush()
         os.fsync(f)
 
-    reclaimed_bytes = artifacts_cache.cleanup(5000)
+    reclaimed_bytes = artifact_file_cache.cleanup(5000)
 
     # We should get rid of "aardvark" in this case
     assert reclaimed_bytes == 5000
 
 
-def test_artifacts_cache_cleanup_tmp_files_when_asked(artifacts_cache):
-    with open(artifacts_cache._temp_dir / "foo", "w") as f:
+def test_artifact_file_cache_cleanup_tmp_files_when_asked(artifact_file_cache):
+    with open(artifact_file_cache._temp_dir / "foo", "w") as f:
         f.truncate(1000)
 
     # Even if we are above our target size, the cleanup
     # should reclaim tmp files.
-    reclaimed_bytes = artifacts_cache.cleanup(10000, remove_temp=True)
+    reclaimed_bytes = artifact_file_cache.cleanup(10000, remove_temp=True)
 
     assert reclaimed_bytes == 1000
 
 
-def test_artifacts_cache_cleanup_leaves_tmp_files_by_default(artifacts_cache, capsys):
-    with open(artifacts_cache._temp_dir / "foo", "w") as f:
+def test_artifact_file_cache_cleanup_leaves_tmp_files_by_default(
+    artifact_file_cache, capsys
+):
+    with open(artifact_file_cache._temp_dir / "foo", "w") as f:
         f.truncate(1000)
 
     # The cleanup should leave temp files alone, even if we haven't reached our target.
-    reclaimed_bytes = artifacts_cache.cleanup(0)
+    reclaimed_bytes = artifact_file_cache.cleanup(0)
     assert reclaimed_bytes == 0
 
     # However, it should issue a warning.
@@ -210,18 +220,18 @@ def test_artifacts_cache_cleanup_leaves_tmp_files_by_default(artifacts_cache, ca
     assert "Cache contains 1000.0B of temporary files" in stderr
 
 
-def test_local_file_handler_load_path_uses_cache(artifacts_cache, tmp_path):
+def test_local_file_handler_load_path_uses_cache(artifact_file_cache, tmp_path):
     file = tmp_path / "file.txt"
     file.write_text("hello")
     uri = file.as_uri()
     digest = "XUFAKrxLKna5cZ2REBfFkg=="
 
-    path, _, opener = artifacts_cache.check_md5_obj_path(b64_md5=digest, size=5)
+    path, _, opener = artifact_file_cache.check_md5_obj_path(b64_md5=digest, size=5)
     with opener() as f:
         f.write("hello")
 
     handler = LocalFileHandler()
-    handler._cache = artifacts_cache
+    handler._cache = artifact_file_cache
 
     local_path = handler.load_path(
         ArtifactManifestEntry(
@@ -235,16 +245,16 @@ def test_local_file_handler_load_path_uses_cache(artifacts_cache, tmp_path):
     assert local_path == path
 
 
-def test_s3_storage_handler_load_path_uses_cache(artifacts_cache):
+def test_s3_storage_handler_load_path_uses_cache(artifact_file_cache):
     uri = "s3://some-bucket/path/to/file.json"
     etag = "some etag"
 
-    path, _, opener = artifacts_cache.check_etag_obj_path(uri, etag, 123)
+    path, _, opener = artifact_file_cache.check_etag_obj_path(uri, etag, 123)
     with opener() as f:
         f.write(123 * "a")
 
     handler = S3Handler()
-    handler._cache = artifacts_cache
+    handler._cache = artifact_file_cache
 
     local_path = handler.load_path(
         ArtifactManifestEntry(
@@ -275,16 +285,16 @@ def test_gcs_storage_handler_load_path_nonlocal():
     assert local_path == uri
 
 
-def test_gcs_storage_handler_load_path_uses_cache(artifacts_cache):
+def test_gcs_storage_handler_load_path_uses_cache(artifact_file_cache):
     uri = "gs://some-bucket/path/to/file.json"
     digest = md5_string("a" * 123)
 
-    path, _, opener = artifacts_cache.check_md5_obj_path(digest, 123)
+    path, _, opener = artifact_file_cache.check_md5_obj_path(digest, 123)
     with opener() as f:
         f.write(123 * "a")
 
     handler = GCSHandler()
-    handler._cache = artifacts_cache
+    handler._cache = artifact_file_cache
 
     local_path = handler.load_path(
         ArtifactManifestEntry(
@@ -298,12 +308,14 @@ def test_gcs_storage_handler_load_path_uses_cache(artifacts_cache):
     assert local_path == path
 
 
-def test_cache_add_gives_useful_error_when_out_of_space(artifacts_cache, monkeypatch):
+def test_cache_add_gives_useful_error_when_out_of_space(
+    artifact_file_cache, monkeypatch
+):
     term_log = MagicMock()
     monkeypatch.setattr(term, "_log", term_log)
 
     # Ask to create a 1 quettabyte file to ensure the cache won't find room.
-    _, _, opener = artifacts_cache.check_md5_obj_path(example_digest, size=10**30)
+    _, _, opener = artifact_file_cache.check_md5_obj_path(example_digest, size=10**30)
 
     with pytest.raises(OSError, match="Insufficient free space"):
         with opener():
@@ -320,7 +332,7 @@ def test_cache_add_gives_useful_error_when_out_of_space(artifacts_cache, monkeyp
 
 
 # todo: fix this test
-# def test_cache_drops_lru_when_adding_not_enough_space(fs, artifacts_cache):
+# def test_cache_drops_lru_when_adding_not_enough_space(fs, artifact_file_cache):
 #     # Simulate a 1KB drive.
 #     fs.set_disk_usage(1000)
 #
@@ -328,13 +340,13 @@ def test_cache_add_gives_useful_error_when_out_of_space(artifacts_cache, monkeyp
 #     cache_paths = []
 #     for i in range(10):
 #         content = f"{i}" * 100
-#         path, _, opener = artifacts_cache.check_md5_obj_path(md5_string(content), 100)
+#         path, _, opener = artifact_file_cache.check_md5_obj_path(md5_string(content), 100)
 #         with opener() as f:
 #             f.write(content)
 #         cache_paths.append(path)
 #
 #     # This next file won't fit; we should drop 1/2 the files in LRU order.
-#     _, _, opener = artifacts_cache.check_md5_obj_path(md5_string("x"), 1)
+#     _, _, opener = artifact_file_cache.check_md5_obj_path(md5_string("x"), 1)
 #     with opener() as f:
 #         f.write("x")
 #
@@ -346,7 +358,7 @@ def test_cache_add_gives_useful_error_when_out_of_space(artifacts_cache, monkeyp
 #     assert fs.get_disk_usage()[1] == 501
 #
 #     # Add something big enough that removing half the items isn't enough.
-#     _, _, opener = artifacts_cache.check_md5_obj_path(md5_string("y" * 800), 800)
+#     _, _, opener = artifact_file_cache.check_md5_obj_path(md5_string("y" * 800), 800)
 #     with opener() as f:
 #         f.write("y" * 800)
 #
@@ -356,11 +368,13 @@ def test_cache_add_gives_useful_error_when_out_of_space(artifacts_cache, monkeyp
 #     assert fs.get_disk_usage()[1] == 800
 
 
-def test_cache_add_cleans_up_tmp_when_write_fails(artifacts_cache, monkeypatch):
+def test_cache_add_cleans_up_tmp_when_write_fails(artifact_file_cache, monkeypatch):
     def fail(*args, **kwargs):
         raise OSError
 
-    _, _, opener = artifacts_cache.check_md5_obj_path(b64_md5=example_digest, size=7)
+    _, _, opener = artifact_file_cache.check_md5_obj_path(
+        b64_md5=example_digest, size=7
+    )
 
     with pytest.raises(OSError):
         with opener() as f:

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -11,9 +11,9 @@ import pytest
 import requests
 from wandb.filesync.step_prepare import ResponsePrepare, StepPrepare
 from wandb.sdk.artifacts.artifact import Artifact
-from wandb.sdk.artifacts.artifact_cache import artifact_cache
+from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
+from wandb.sdk.artifacts.artifact_instance_cache import artifact_instance_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifacts_cache import ArtifactsCache
 from wandb.sdk.artifacts.exceptions import ArtifactNotLoggedError
 from wandb.sdk.artifacts.storage_policies.wandb_storage_policy import WandbStoragePolicy
 
@@ -51,7 +51,7 @@ def asyncify(f):
     return async_f
 
 
-def is_cache_hit(cache: ArtifactsCache, digest: str, size: int) -> bool:
+def is_cache_hit(cache: ArtifactFileCache, digest: str, size: int) -> bool:
     _, hit, _ = cache.check_md5_obj_path(digest, size)
     return hit
 
@@ -101,8 +101,8 @@ def test_capped_cache():
         art = Artifact(f"foo-{i}", type="test")
         art._id = f"foo-{i}"
         art._state = "COMMITTED"
-        artifact_cache[art.id] = art
-    assert len(artifact_cache) == 100
+        artifact_instance_cache[art.id] = art
+    assert len(artifact_instance_cache) == 100
 
 
 class TestStoreFile:
@@ -313,26 +313,26 @@ class TestStoreFile:
         store_file: "StoreFileFixture",
         api,
         example_file: Path,
-        artifacts_cache: ArtifactsCache,
+        artifact_file_cache: ArtifactFileCache,
         err: Optional[Exception],
     ):
         size = example_file.stat().st_size
 
         api.upload_file_retry = Mock(side_effect=err)
         api.upload_file_retry_async = asyncify(Mock(side_effect=err))
-        policy = WandbStoragePolicy(api=api, cache=artifacts_cache)
+        policy = WandbStoragePolicy(api=api, cache=artifact_file_cache)
 
-        assert not is_cache_hit(artifacts_cache, "my-digest", size)
+        assert not is_cache_hit(artifact_file_cache, "my-digest", size)
 
         store = functools.partial(store_file, policy, entry_local_path=example_file)
 
         if err is None:
             store()
-            assert is_cache_hit(artifacts_cache, "my-digest", size)
+            assert is_cache_hit(artifact_file_cache, "my-digest", size)
         else:
             with pytest.raises(Exception, match=err.args[0]):
                 store()
-            assert not is_cache_hit(artifacts_cache, "my-digest", size)
+            assert not is_cache_hit(artifact_file_cache, "my-digest", size)
 
     @pytest.mark.parametrize(
         [

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -35,7 +35,7 @@ from wandb import Config, Error, env, util, wandb_agent, wandb_sdk
 from wandb.apis import InternalApi, PublicApi
 from wandb.apis.public import RunQueue
 from wandb.integration.magic import magic_install
-from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
+from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.launch import utils as launch_utils
 from wandb.sdk.launch._launch_add import _launch_add
 from wandb.sdk.launch.errors import ExecutionError, LaunchError
@@ -2406,7 +2406,7 @@ def cache():
 @display_error
 def cleanup(target_size, remove_temp):
     target_size = util.from_human_size(target_size)
-    cache = get_artifacts_cache()
+    cache = get_artifact_file_cache()
     reclaimed_bytes = cache.cleanup(target_size, remove_temp)
     print(f"Reclaimed {util.to_human_size(reclaimed_bytes)} of space")
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -37,8 +37,8 @@ from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public import ArtifactCollection, ArtifactFiles, RetryingClient, Run
 from wandb.data_types import WBValue
 from wandb.errors.term import termerror, termlog, termwarn
-from wandb.sdk.artifacts.artifact_cache import artifact_cache
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
+from wandb.sdk.artifacts.artifact_instance_cache import artifact_instance_cache
 from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.artifact_manifests.artifact_manifest_v1 import (
@@ -185,14 +185,14 @@ class Artifact:
         self._final: bool = False
 
         # Cache.
-        artifact_cache[self._client_id] = self
+        artifact_instance_cache[self._client_id] = self
 
     def __repr__(self) -> str:
         return f"<Artifact {self.id or self.name}>"
 
     @classmethod
     def _from_id(cls, artifact_id: str, client: RetryingClient) -> Optional["Artifact"]:
-        artifact = artifact_cache.get(artifact_id)
+        artifact = artifact_instance_cache.get(artifact_id)
         if artifact is not None:
             return artifact
 
@@ -320,7 +320,7 @@ class Artifact:
         # Cache.
 
         assert artifact.id is not None
-        artifact_cache[artifact.id] = artifact
+        artifact_instance_cache[artifact.id] = artifact
         return artifact
 
     def new_draft(self) -> "Artifact":

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
             pass
 
 
-class ArtifactsCache:
+class ArtifactFileCache:
     def __init__(self, cache_dir: StrPath) -> None:
         self._cache_dir = Path(cache_dir)
         self._obj_dir = self._cache_dir / "obj"
@@ -197,11 +197,11 @@ class ArtifactsCache:
         return helper
 
 
-_artifacts_cache = None
+_artifact_file_cache = None
 
 
-def get_artifacts_cache() -> ArtifactsCache:
-    global _artifacts_cache
-    if _artifacts_cache is None:
-        _artifacts_cache = ArtifactsCache(env.get_cache_dir() / "artifacts")
-    return _artifacts_cache
+def get_artifact_file_cache() -> ArtifactFileCache:
+    global _artifact_file_cache
+    if _artifact_file_cache is None:
+        _artifact_file_cache = ArtifactFileCache(env.get_cache_dir() / "artifacts")
+    return _artifact_file_cache

--- a/wandb/sdk/artifacts/artifact_instance_cache.py
+++ b/wandb/sdk/artifacts/artifact_instance_cache.py
@@ -11,4 +11,4 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
 
 # There is nothing special about the artifact cache, it's just a global capped dict.
-artifact_cache: Dict[str, "Artifact"] = CappedDict(100)
+artifact_instance_cache: Dict[str, "Artifact"] = CappedDict(100)

--- a/wandb/sdk/artifacts/storage_handlers/azure_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/azure_handler.py
@@ -6,8 +6,8 @@ from urllib.parse import ParseResult, parse_qsl, urlparse
 
 import wandb
 from wandb import util
+from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
 from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHandler
 from wandb.sdk.lib.hashutil import ETag
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
@@ -34,7 +34,7 @@ class AzureHandler(StorageHandler):
         if not local:
             return manifest_entry.ref
 
-        path, hit, cache_open = get_artifacts_cache().check_etag_obj_path(
+        path, hit, cache_open = get_artifact_file_cache().check_etag_obj_path(
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),
             manifest_entry.size or 0,

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -6,8 +6,8 @@ from urllib.parse import ParseResult, urlparse
 
 from wandb import util
 from wandb.errors.term import termlog
+from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
 from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHandler
 from wandb.sdk.lib.hashutil import B64MD5
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
@@ -24,7 +24,7 @@ class GCSHandler(StorageHandler):
     def __init__(self, scheme: Optional[str] = None) -> None:
         self._scheme = scheme or "gs"
         self._client = None
-        self._cache = get_artifacts_cache()
+        self._cache = get_artifact_file_cache()
 
     def can_handle(self, parsed_url: "ParseResult") -> bool:
         return parsed_url.scheme == self._scheme

--- a/wandb/sdk/artifacts/storage_handlers/http_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/http_handler.py
@@ -3,8 +3,8 @@ import os
 from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple, Union
 from urllib.parse import ParseResult
 
+from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
 from wandb.sdk.artifacts.storage_handler import StorageHandler
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.lib.hashutil import ETag
@@ -21,7 +21,7 @@ class HTTPHandler(StorageHandler):
         self, session: "requests.Session", scheme: Optional[str] = None
     ) -> None:
         self._scheme = scheme or "http"
-        self._cache = get_artifacts_cache()
+        self._cache = get_artifact_file_cache()
         self._session = session
 
     def can_handle(self, parsed_url: "ParseResult") -> bool:

--- a/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
@@ -7,8 +7,8 @@ from urllib.parse import ParseResult
 
 from wandb import util
 from wandb.errors.term import termlog
+from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
 from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHandler
 from wandb.sdk.lib import filesystem
 from wandb.sdk.lib.hashutil import B64MD5, md5_file_b64, md5_string
@@ -27,7 +27,7 @@ class LocalFileHandler(StorageHandler):
         Expand directories to create an entry for each file contained.
         """
         self._scheme = scheme or "file"
-        self._cache = get_artifacts_cache()
+        self._cache = get_artifact_file_cache()
 
     def can_handle(self, parsed_url: "ParseResult") -> bool:
         return parsed_url.scheme == self._scheme

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -8,8 +8,8 @@ from urllib.parse import parse_qsl, urlparse
 from wandb import util
 from wandb.errors import CommError
 from wandb.errors.term import termlog
+from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
 from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHandler
 from wandb.sdk.lib.hashutil import ETag
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
@@ -36,7 +36,7 @@ class S3Handler(StorageHandler):
     def __init__(self, scheme: Optional[str] = None) -> None:
         self._scheme = scheme or "s3"
         self._s3 = None
-        self._cache = get_artifacts_cache()
+        self._cache = get_artifact_file_cache()
 
     def can_handle(self, parsed_url: "ParseResult") -> bool:
         return parsed_url.scheme == self._scheme

--- a/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
@@ -6,8 +6,8 @@ from urllib.parse import urlparse
 import wandb
 from wandb import util
 from wandb.apis import PublicApi
+from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifacts_cache import get_artifacts_cache
 from wandb.sdk.artifacts.storage_handler import StorageHandler
 from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, hex_to_b64_id
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
@@ -25,7 +25,7 @@ class WBArtifactHandler(StorageHandler):
 
     def __init__(self) -> None:
         self._scheme = "wandb-artifact"
-        self._cache = get_artifacts_cache()
+        self._cache = get_artifact_file_cache()
         self._client = None
 
     def can_handle(self, parsed_url: "ParseResult") -> bool:

--- a/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 import wandb
 from wandb import util
-from wandb.sdk.artifacts.artifact_cache import artifact_cache
+from wandb.sdk.artifacts.artifact_instance_cache import artifact_instance_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.storage_handler import StorageHandler
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
@@ -53,7 +53,7 @@ class WBLocalArtifactHandler(StorageHandler):
         """
         client_id = util.host_from_path(path)
         target_path = util.uri_from_path(path)
-        target_artifact = artifact_cache.get(client_id)
+        target_artifact = artifact_instance_cache.get(client_id)
         if not isinstance(target_artifact, wandb.Artifact):
             raise RuntimeError("Local Artifact not found - invalid reference")
         target_entry = target_artifact._manifest.entries[target_path]  # type: ignore

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -10,7 +10,10 @@ import urllib3
 
 from wandb.apis import InternalApi
 from wandb.errors.term import termwarn
-from wandb.sdk.artifacts.artifacts_cache import ArtifactsCache, get_artifacts_cache
+from wandb.sdk.artifacts.artifact_file_cache import (
+    ArtifactFileCache,
+    get_artifact_file_cache,
+)
 from wandb.sdk.artifacts.storage_handlers.azure_handler import AzureHandler
 from wandb.sdk.artifacts.storage_handlers.gcs_handler import GCSHandler
 from wandb.sdk.artifacts.storage_handlers.http_handler import HTTPHandler
@@ -63,10 +66,10 @@ class WandbStoragePolicy(StoragePolicy):
     def __init__(
         self,
         config: Optional[Dict] = None,
-        cache: Optional[ArtifactsCache] = None,
+        cache: Optional[ArtifactFileCache] = None,
         api: Optional[InternalApi] = None,
     ) -> None:
-        self._cache = cache or get_artifacts_cache()
+        self._cache = cache or get_artifact_file_cache()
         self._config = config or {}
         self._session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(


### PR DESCRIPTION
Fixes WB-13717

# Description

In https://github.com/wandb/wandb/pull/6171 we split artifacts cache into two modules: one for caching `Artifact` instances and one for caching artifact files. Here, I'm renaming the modules to make this more clear:
- "artifact cache" -> "artifact instance cache": caches `Artifact` instances
- "artifacts cache" -> "artifact file cache": caches artifact files

# Test plan

CI