### PR TITLE
fix(integrations): Handle ultralytics utils import refactor

### DIFF
--- a/wandb/integration/ultralytics/bbox_utils.py
+++ b/wandb/integration/ultralytics/bbox_utils.py
@@ -3,7 +3,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 from ultralytics.engine.results import Results
 from ultralytics.models.yolo.detect import DetectionPredictor
-from ultralytics.yolo.utils import ops
+try:
+    from ultralytics.yolo.utils import ops
+except ModuleNotFoundError:
+    from ultralytics.utils import ops
 
 import wandb
 

--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -42,7 +42,10 @@ try:
         SegmentationValidator,
     )
     from ultralytics.utils.torch_utils import de_parallel
-    from ultralytics.yolo.utils import RANK, __version__
+    try:
+        from ultralytics.yolo.utils import RANK, __version__
+    except ModuleNotFoundError:
+        from ultralytics.utils import RANK, __version__
 
     from wandb.integration.ultralytics.bbox_utils import (
         plot_predictions,

--- a/wandb/integration/yolov8/yolov8.py
+++ b/wandb/integration/yolov8/yolov8.py
@@ -2,8 +2,13 @@ from typing import Any, Callable, Dict, List, Optional
 
 from ultralytics.yolo.engine.model import YOLO
 from ultralytics.yolo.engine.trainer import BaseTrainer
-from ultralytics.yolo.utils import RANK
-from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+
+try:
+    from ultralytics.yolo.utils import RANK
+    from ultralytics.yolo.utils.torch_utils import get_flops, get_num_params
+except ModuleNotFoundError:
+    from ultralytics.utils import RANK
+    from ultralytics.utils.torch_utils import get_flops, get_num_params
 from ultralytics.yolo.v8.classify.train import ClassificationTrainer
 
 import wandb


### PR DESCRIPTION
On ModuleNotFound exception from ultralytics.yolo.utils try from ultralytics.utils instead.

Description
-----------
- Fixes #6740
- Fixes #6566

A recent version of ultralytics refactored the module `ultralytics.yolo.utils` to `ultralytics.utils`. This PR imports from the latter if the former raises a ModuleNotFoundError.

Testing
-------
This function is already covered in https://github.com/wandb/wandb/blob/main/tests/functional_tests/t0_main/ultralytics/test_ultralytics_detection.py .

This PR should improve compatibility with ultralytics > 8.0.186
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
