### PR TITLE
fix(artifacts): revert #6759 and read object version etag in place 

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -1372,7 +1372,7 @@ def test_http_storage_handler_uses_etag_for_digest(
 def test_s3_storage_handler_load_path_missing_reference(monkeypatch, wandb_init):
     # Create an artifact that references a non-existent S3 object.
     artifact = wandb.Artifact(type="dataset", name="my-arty")
-    mock_boto(artifact)
+    mock_boto(artifact, version_id="")
     artifact.add_reference("s3://my-bucket/my_object.pb")
 
     with wandb_init(project="test") as run:
@@ -1398,7 +1398,7 @@ def test_s3_storage_handler_load_path_missing_reference_allowed(
 ):
     # Create an artifact that references a non-existent S3 object.
     artifact = wandb.Artifact(type="dataset", name="my-arty")
-    mock_boto(artifact)
+    mock_boto(artifact, version_id="")
     artifact.add_reference("s3://my-bucket/my_object.pb")
 
     with wandb_init(project="test") as run:

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -285,9 +285,9 @@ class S3Handler(StorageHandler):
         ]
     ) -> ETag:
         etag: ETag
-        if hasattr(obj, "e_tag"):
+        try:
             etag = obj.e_tag[1:-1]  # escape leading and trailing quote
-        else:
+        except:
             etag = obj.get()["ETag"][1:-1]  # escape leading and trailing quote
         return etag
 

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -285,10 +285,11 @@ class S3Handler(StorageHandler):
         ]
     ) -> ETag:
         etag: ETag
+        boto = util.get_module("boto3")
         try:
             etag = obj.e_tag[1:-1]  # escape leading and trailing quote
-        except:
-            etag = obj.get()["ETag"][1:-1]  # escape leading and trailing quote
+        except boto.exceptions.ResourceLoadException:
+            etag = obj.get()["ETag"][1:-1]  # escape leading and trailing
         return etag
 
     def _extra_from_obj(

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -285,11 +285,11 @@ class S3Handler(StorageHandler):
         ]
     ) -> ETag:
         etag: ETag
-        boto = util.get_module("boto3")
-        try:
-            etag = obj.e_tag[1:-1]  # escape leading and trailing quote
-        except boto.exceptions.ResourceLoadException:
+        if hasattr(obj, "meta") and obj.meta.data is None:
+            # obj.meta.data is None for ObjectVersion while using s3.ObjectVersion()
             etag = obj.get()["ETag"][1:-1]  # escape leading and trailing
+        else:
+            etag = obj.e_tag[1:-1]  # escape leading and trailing quote
         return etag
 
     def _extra_from_obj(

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -101,7 +101,7 @@ class S3Handler(StorageHandler):
 
         try:
             etag = (
-                self._etag_from_obj(obj_version)
+                obj_version.head()["ETag"][1:-1]  # escape leading and trailing
                 if version
                 else self._etag_from_obj(obj)
             )
@@ -279,17 +279,9 @@ class S3Handler(StorageHandler):
         )
 
     @staticmethod
-    def _etag_from_obj(
-        obj: Union[
-            "boto3.s3.Object", "boto3.s3.ObjectVersion", "boto3.s3.ObjectSummary"
-        ]
-    ) -> ETag:
+    def _etag_from_obj(obj: Union["boto3.s3.Object", "boto3.s3.ObjectSummary"]) -> ETag:
         etag: ETag
-        if hasattr(obj, "meta") and obj.meta.data is None:
-            # obj.meta.data is None for ObjectVersion while using s3.ObjectVersion()
-            etag = obj.get()["ETag"][1:-1]  # escape leading and trailing
-        else:
-            etag = obj.e_tag[1:-1]  # escape leading and trailing quote
+        etag = obj.e_tag[1:-1]  # escape leading and trailing quote
         return etag
 
     def _extra_from_obj(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-16491](https://wandb.atlassian.net/browse/WB-16491)
- Fixes https://github.com/wandb/wandb/pull/6759

What does the PR do?

Linked PR introduced a bug where `hasAttr(obj, 'e_tag')` throws an exception instead of returning the assumed boolean for s3's `ObjectVersion`. This PR removes the additional if-else block from `_etag_from_obj()`, and gets the etag for the ObjectVersion in place. 

Testing
-------
Same as https://github.com/wandb/wandb/pull/6759

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-16491]: https://wandb.atlassian.net/browse/WB-16491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ