### PR TITLE
fix(sdk): Support for floating-like types in `json_friendly()` 

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -632,6 +632,9 @@ def json_friendly(  # noqa: C901
         )
     elif isinstance(obj, float) and math.isnan(obj):
         obj = None
+    # For types that are float-like, but not techincally the builtin float
+    elif isinstance(obj, float):
+        obj = float(obj)
     elif isinstance(obj, dict) and np:
         obj, converted = _sanitize_numpy_keys(obj)
     elif isinstance(obj, set):


### PR DESCRIPTION
Types that are not technically `builtin.float` but for which `isinstance(obj, float)` is true are not handled in this function and thus are co-erced to strings. This adds support and explicitly performs a cast, towards he end, after other more specific conversions have been performed.

Description
-----------
What does the PR do?
In my specific case, I am loading in data from YAML, and passing this as the config argument to `wandb.init`. Floating-point values are deserialised not as the builtin type, but instead as a YAMLwrapper type (see [this issue](https://github.com/gschizas/ruamel-yaml/issues/2) for more). 

This therefore results in all floating values from the config being co-erced into strings in the wandb config, and then externally I had to walk over the config and convert them back to floats again.

I presume there are many other libraries that have their own float-like types that wrap around the default functionality, or otherwise support large or high-precision numbers. In poarticular I have seen behaviour like this in various languages and packages when reading in from serialised data, and it makes sense that various wandb users might be loading their configs in from somewhere external.

For this type (and I presume others, although I'm not a massive python fan so don't know the full semantics of `isinstance`), `isinstance(someFloatingLikeObject,float)` is true, even though `type(someFloatingLikeObject)` is not `float`.

This PR adds support for testing if the object is an instance of a floating-like object when sanitising a dictionary to be JSON-compatible, and thenexplicitly converting it if so. The exact location of this test might want changed; I have placed it towards the bottom of the "switch" statement so that other cases with more specific conversions are handled first - e.g. testing if the object is a numpy scalar or a TF tensor.



Testing
-------
How was this PR tested?
Not tested yet. Others may want to discuss the appropriateness of the location of this or modify the implementation. I assume this utility may be used in multiple locations and am not sure how the development team would want to stress-test it.


