### PR TITLE
fix(launch): recognize deleted k8s jobs as failed

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_kubernetes.py
@@ -291,4 +291,4 @@ def setup_mock_kubernetes_client(monkeypatch, jobs, pods, mock_job_base):
             }
         )
         jobs_dict[name] = mock_job
-        return [[mock_job]]
+        return [mock_job]

--- a/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -368,7 +368,7 @@ def mock_maybe_create_image_pullsecret(monkeypatch):
 def mock_create_from_dict(monkeypatch):
     """Patches the kubernetes create_from_dict with a mock and returns it."""
     function_mock = MagicMock()
-    function_mock.return_value = [[MockDict({"metadata": {"name": "test-job"}})]]
+    function_mock.return_value = [MockDict({"metadata": {"name": "test-job"}})]
 
     async def _mock_create_from_yaml(*args, **kwargs):
         return function_mock(*args, **kwargs)

--- a/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -697,14 +697,15 @@ async def test_maybe_create_imagepull_secret_given_creds():
 # Test monitor class.
 
 
-def job_factory(name, statuses):
+def job_factory(name, statuses, type="MODIFIED"):
     """Factory for creating job events."""
     return MockDict(
         {
+            "type": f"{type}",
             "object": {
                 "status": {f"{status}": 1 for status in statuses},
                 "metadata": {"name": name},
-            }
+            },
         }
     )
 
@@ -831,6 +832,26 @@ async def test_monitor_running(
     )
     await asyncio.sleep(0.1)
     assert LaunchKubernetesMonitor.get_status("job-name").state == "running"
+
+
+@pytest.mark.asyncio
+async def test_monitor_job_deleted(
+    mock_event_streams,
+    mock_kube_context_and_api_client,
+    mock_batch_api,
+    mock_core_api,
+    clean_monitor,
+):
+    """Test if the monitor thread detects a job being deleted."""
+    await LaunchKubernetesMonitor.ensure_initialized()
+    LaunchKubernetesMonitor.monitor_namespace("wandb")
+    job_event_stream, pod_event_stream = mock_event_streams
+    await asyncio.sleep(0.1)
+    await pod_event_stream.add(pod_factory("ADDED", "job-name", [], []))
+    await asyncio.sleep(0.1)
+    await job_event_stream.add(job_factory("job-name", ["active"], type="DELETED"))
+    await asyncio.sleep(0.1)
+    assert LaunchKubernetesMonitor.get_status("job-name").state == "failed"
 
 
 # Test util functions

--- a/wandb/sdk/launch/runner/kubernetes_monitor.py
+++ b/wandb/sdk/launch/runner/kubernetes_monitor.py
@@ -314,6 +314,8 @@ class LaunchKubernetesMonitor:
             job_name = obj.metadata.labels.get("job-name")
             if job_name is None or not hasattr(obj, "status"):
                 continue
+            if self.__get_status(job_name) in ["finished", "failed"]:
+                continue
             if obj.status.phase == "Running" or _is_container_creating(obj.status):
                 self._set_status(job_name, Status("running"))
             elif _is_preempted(obj.status):
@@ -329,10 +331,17 @@ class LaunchKubernetesMonitor:
         ):
             obj = event.get("object")
             job_name = obj.metadata.name
+
             if obj.status.succeeded == 1:
                 self._set_status(job_name, Status("finished"))
             elif obj.status.failed is not None and obj.status.failed >= 1:
                 self._set_status(job_name, Status("failed"))
+
+            # If the job is deleted and we haven't seen a terminal state
+            # then we will consider the job failed.
+            if event.get("type") == "DELETED":
+                if self._job_states.get(job_name) != Status("finished"):
+                    self._set_status(job_name, Status("failed"))
 
     async def _monitor_crd(
         self, namespace: str, custom_resource: CustomResource

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -562,7 +562,7 @@ class KubernetesRunner(AbstractRunner):
             raise LaunchError(
                 f"Unexpected exception when creating Kubernetes job: {str(e)}\n"
             )
-        job_response = response[0][0]
+        job_response = response[0]
         job_name = job_response.metadata.name
         LaunchKubernetesMonitor.monitor_namespace(namespace)
         submitted_job = KubernetesSubmittedRun(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-16596
- Fixes #NNNN

This PR adds logic in the launch kubernetes monitor so that any job deleted while in a non terminal state will be recognized as failed. There is also a bad regression fixed in here and caused by https://github.com/wandb/wandb/pull/6730



Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
