### PR TITLE
feat(public-api): Added option to control number of grouped sampled runs in reports

### DIFF
--- a/wandb/apis/reports/_panels.py
+++ b/wandb/apis/reports/_panels.py
@@ -89,6 +89,7 @@ class LinePlot(Panel):
     # Attr( json_path="spec.config.useMetricRegex")
     # Attr( json_path="spec.config.yAxisAutoRange")
     # Attr( json_path="spec.config.groupRunsLimit")
+    group_runs_limit: Optional[int] = Attr(json_path="spec.config.groupRunsLimit")
     xaxis_expression: Optional[str] = Attr(json_path="spec.config.xExpression")
     # Attr( json_path="spec.config.colorEachMetricDifferently")
     # Attr( json_path="spec.config.showLegend")
@@ -148,6 +149,7 @@ class LinePlot(Panel):
         legend_template: Optional[str] = None,
         aggregate: Optional[bool] = None,
         xaxis_expression: Optional[str] = None,
+        group_runs_limit: Optional[int] = None,
         # line_titles: Optional[dict] = None,
         # line_marks: Optional[dict] = None,
         # line_colors: Optional[dict] = None,
@@ -180,6 +182,7 @@ class LinePlot(Panel):
         self.legend_template = legend_template
         self.aggregate = aggregate
         self.xaxis_expression = xaxis_expression
+        self.group_runs_limit = group_runs_limit
         # self.line_titles = line_titles
         # self.line_marks = line_marks
         # self.line_colors = line_colors


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-16963
- Fixes #NNNN

What does the PR do?

Added the `group_runs_limit` argument to specify the number of sampled runs when they are grouped using programmatic reports. This argument now controls the `Sampled Runs` parameter in the UI's `Grouping` tab within Line plots.

<img width="538" alt="Screenshot 2024-01-15 at 17 59 58" src="https://github.com/wandb/wandb/assets/108423944/862610e9-2a5c-455a-a971-3005a16d8ef8">

Usage:
```
panel_grids = wr.PanelGrid(
    panels=[
        wr.LinePlot(
            title="line title",
            x="x",
            y="y",
            groupby="hyperparameter",
            groupby_aggfunc="mean",
            groupby_rangefunc="minmax",
            max_runs_to_show=100,
            group_runs_limit=1000,
        )
    ],
    runsets=[wr.Runset(project=PROJECT, entity=ENTITY, groupby=["hyperparameter"])],
)
```

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
