### PR TITLE
fix(sdk): merge-update config with sweep/launch config

### DIFF
--- a/tests/pytest_tests/system_tests/test_core/test_sync_tb.py
+++ b/tests/pytest_tests/system_tests/test_core/test_sync_tb.py
@@ -15,7 +15,7 @@ def create_model():
     )
 
 
-@pytest.mark.xfail(reason="flaky test, depends on an external service")
+@pytest.mark.skip(reason="flaky test, depends on an external service")
 def test_sync_tensorboard(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init(sync_tensorboard=True)

--- a/tests/pytest_tests/unit_tests/test_library_public.py
+++ b/tests/pytest_tests/unit_tests/test_library_public.py
@@ -259,6 +259,7 @@ SYMBOLS_CONFIG_OTHER = {
     "as_dict",
     "update_locked",
     "persist",
+    "merge_locked",
 }
 
 

--- a/tests/pytest_tests/unit_tests/test_wandb_config.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_config.py
@@ -123,3 +123,12 @@ def test_config_getattr_default(config):
 
     with pytest.raises(AttributeError, match="object has no attribute 'a'"):
         _ = config.a
+
+
+def test_nested_config_overwrite(consolidated, config):
+    config.update({"path": {"to": {"override": "baz", "keep": "baf"}}})
+    config.merge_locked(
+        {"path": {"to": {"override": "bar"}}}, "sweep", _allow_val_change=True
+    )
+    assert dict(config) == {"path": {"to": {"override": "bar", "keep": "baf"}}}
+    assert consolidated == dict(config)

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -123,9 +123,7 @@ def dict_from_config_file(
 
 
 def merge_dicts(dest: dict, src: dict) -> dict:
-    """
-    Recursively merge two dictionaries. Similar to Lodash's _.merge().
-    """
+    """Recursively merge two dictionaries. Similar to Lodash's _.merge()."""
     for key, value in src.items():
         if isinstance(value, dict) and key in dest and isinstance(dest[key], dict):
             merge_dicts(dest[key], value)

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -120,3 +120,15 @@ def dict_from_config_file(
     for k, v in loaded.items():
         data[k] = v["value"]
     return data
+
+
+def merge_dicts(dest: dict, src: dict) -> dict:
+    """
+    Recursively merge two dictionaries. Similar to Lodash's _.merge().
+    """
+    for key, value in src.items():
+        if isinstance(value, dict) and key in dest and isinstance(dest[key], dict):
+            merge_dicts(dest[key], value)
+        else:
+            dest[key] = value
+    return dest

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -210,7 +210,6 @@ class Config:
 
         return self._users[user]
 
-
     def update_locked(self, d, user=None, _allow_val_change=None):
         num = self._get_user_id(user)
 
@@ -221,7 +220,6 @@ class Config:
 
         if self._callback:
             self._callback(data=d)
-
 
     def merge_locked(self, d, user=None, _allow_val_change=None):
         num = self._get_user_id(user)
@@ -235,12 +233,11 @@ class Config:
                 self._items[k] = config_util.merge_dicts(self._items[k], v)
             else:
                 self._items[k] = v
-                
+
             callback_d[k] = self._items[k]
-        
+
         if self._callback:
             self._callback(data=callback_d)
-
 
     def _load_defaults(self):
         conf_dict = config_util.dict_from_config_file("config-defaults.yaml")

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -223,9 +223,7 @@ class Config:
             self._callback(data=d)
 
     def merge_locked(self, d, user=None, _allow_val_change=None):
-        """Recursively merge-update config with `d` and lock config updates
-        on d's keys.
-        """
+        """Recursively merge-update config with `d` and lock config updates on d's keys."""
         num = self._get_user_id(user)
         callback_d = {}
 

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -229,7 +229,11 @@ class Config:
             k, v = self._sanitize(k, v, allow_val_change=_allow_val_change)
             self._locked[k] = num
 
-            if k in self._items and isinstance(self._items[k], dict) and isinstance(v, dict):
+            if (
+                k in self._items
+                and isinstance(self._items[k], dict)
+                and isinstance(v, dict)
+            ):
                 self._items[k] = config_util.merge_dicts(self._items[k], v)
             else:
                 self._items[k] = v

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -202,13 +202,17 @@ class Config:
         if self._callback:
             self._callback(data=d)
 
-    def update_locked(self, d, user=None, _allow_val_change=None):
+    def _get_user_id(self, user) -> int:
         if user not in self._users:
             self._users[user] = self._users_cnt
             self._users_inv[self._users_cnt] = user
             object.__setattr__(self, "_users_cnt", self._users_cnt + 1)
 
-        num = self._users[user]
+        return self._users[user]
+
+
+    def update_locked(self, d, user=None, _allow_val_change=None):
+        num = self._get_user_id(user)
 
         for k, v in d.items():
             k, v = self._sanitize(k, v, allow_val_change=_allow_val_change)
@@ -217,6 +221,26 @@ class Config:
 
         if self._callback:
             self._callback(data=d)
+
+
+    def merge_locked(self, d, user=None, _allow_val_change=None):
+        num = self._get_user_id(user)
+        callback_d = {}
+
+        for k, v in d.items():
+            k, v = self._sanitize(k, v, allow_val_change=_allow_val_change)
+            self._locked[k] = num
+
+            if k in self._items:
+                self._items[k] = config_util.merge_dicts(self._items[k], v)
+            else:
+                self._items[k] = v
+                
+            callback_d[k] = self._items[k]
+        
+        if self._callback:
+            self._callback(data=callback_d)
+
 
     def _load_defaults(self):
         conf_dict = config_util.dict_from_config_file("config-defaults.yaml")

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -229,7 +229,7 @@ class Config:
             k, v = self._sanitize(k, v, allow_val_change=_allow_val_change)
             self._locked[k] = num
 
-            if k in self._items:
+            if k in self._items and isinstance(self._items[k], dict) and isinstance(v, dict):
                 self._items[k] = config_util.merge_dicts(self._items[k], v)
             else:
                 self._items[k] = v

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -211,6 +211,7 @@ class Config:
         return self._users[user]
 
     def update_locked(self, d, user=None, _allow_val_change=None):
+        """Shallow-update config with `d` and lock config updates on d's keys."""
         num = self._get_user_id(user)
 
         for k, v in d.items():
@@ -222,6 +223,9 @@ class Config:
             self._callback(data=d)
 
     def merge_locked(self, d, user=None, _allow_val_change=None):
+        """Recursively merge-update config with `d` and lock config updates
+        on d's keys.
+        """
         num = self._get_user_id(user)
         callback_d = {}
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -688,15 +688,15 @@ class Run:
         # if run is from a launch queue, add queue id to _wandb config
         launch_queue_name = wandb.env.get_launch_queue_name()
         if launch_queue_name:
-            config[wandb_key]["launch_queue_name"] = launch_queue_name
+            self._config[wandb_key]["launch_queue_name"] = launch_queue_name
 
         launch_queue_entity = wandb.env.get_launch_queue_entity()
         if launch_queue_entity:
-            config[wandb_key]["launch_queue_entity"] = launch_queue_entity
+            self._config[wandb_key]["launch_queue_entity"] = launch_queue_entity
 
         launch_trace_id = wandb.env.get_launch_trace_id()
         if launch_trace_id:
-            config[wandb_key]["launch_trace_id"] = launch_trace_id
+            self._config[wandb_key]["launch_trace_id"] = launch_trace_id
 
         # interface pid and port configured when backend is configured (See _hack_set_run)
         # TODO: using pid isn't the best for windows as pid reuse can happen more often than unix

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -672,13 +672,16 @@ class Run:
             config[wandb_key]["code_path"] = LogicalPath(
                 os.path.join("code", self._settings.program_relpath)
             )
+
+        self._config._update(config, ignore_locked=True)
+
         if sweep_config:
-            self._config.update_locked(
+            self._config.merge_locked(
                 sweep_config, user="sweep", _allow_val_change=True
             )
 
         if launch_config:
-            self._config.update_locked(
+            self._config.merge_locked(
                 launch_config, user="launch", _allow_val_change=True
             )
 
@@ -694,8 +697,6 @@ class Run:
         launch_trace_id = wandb.env.get_launch_trace_id()
         if launch_trace_id:
             config[wandb_key]["launch_trace_id"] = launch_trace_id
-
-        self._config._update(config, ignore_locked=True)
 
         # interface pid and port configured when backend is configured (See _hack_set_run)
         # TODO: using pid isn't the best for windows as pid reuse can happen more often than unix


### PR DESCRIPTION
Description
-----------
- Fixes WB-16967

What does the PR do?

This PR ensures that wandb run configs generated by sweeps and launch runs are merge-updated into user provided configs, instead of updated at the top level only. This ensures that nested parameters are properly handled in sweep configs and fixes the following situation: 

--- 

Right now, if you init a run with config: 

```python
wandb.init(config={'path': {'to': {'overwrite': 'foo', 'keep': 'bar'}}})
```

Then if the config generated by your current iteration of a sweep looks like this: 

```
{'path': {'to': {'overwrite': 'baz'}}}
```

Then your final config will look like this: 

```
{'path': {'to': {'overwrite': 'baz'}}}
```

When instead it should look like this:
```
{'path': {'to': {'overwrite': 'baz', 'keep': 'bar'}}}
```

This PR fixes this issue. 

Testing
-------
Unit test
