### PR TITLE
Fix entity override bug where ENVVAR is prioritized over kwargs

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2807,6 +2807,7 @@ class Run:
                 self._used_artifact_slots[use_as] = artifact.id
             api.use_artifact(
                 artifact.id,
+                entity_name=r.entity,
                 use_as=use_as or artifact_or_name,
             )
         else:


### PR DESCRIPTION
Description
-----------
[<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->](https://wandb.atlassian.net/browse/WB-16564)
- Fixes WB-16564

What does the PR do?
There are two ways to fix this bug, one is to properly inject the `run` entity like i did
the other is the use the `default_settings` entity as the fallback instead of the ENVVAR overridden `self.settings(..)` like we do.

Testing
-------
tox
lint

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
