### PR TITLE
fix(launch): Local container runner doesn't ignore override args

### DIFF
--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -160,10 +160,6 @@ class LocalContainerRunner(AbstractRunner):
 
             assert launch_project.docker_image == image_uri
 
-        additional_args = (
-            launch_project.override_args if launch_project.docker_image else None
-        )
-
         entry_cmd = (
             launch_project.override_entrypoint.command
             if launch_project.override_entrypoint is not None
@@ -176,7 +172,7 @@ class LocalContainerRunner(AbstractRunner):
                 env_vars,
                 docker_args=docker_args,
                 entry_cmd=entry_cmd,
-                additional_args=additional_args,
+                additional_args=launch_project.override_args,
             )
         ).strip()
         sanitized_cmd_str = sanitize_wandb_api_key(command_str)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-16970](https://wandb.atlassian.net/browse/WB-16970)

For non-image jobs using the local container runner, we ignore anything passed in through the `args` override since we assume the args have been built into the image's entrypoint in the build step. This is not the case, so the args should be included in the run step.

Testing
-------
- Start an agent polling a Docker queue with `builder: docker`
- Submit [this job](https://wandb.ai/tim-hays/debugging/jobs/QXJ0aWZhY3RDb2xsZWN0aW9uOjEzMDg2NzIyMQ==/runs/latest) to the queue, which prints the passed in command line args. Include overrides for args and entrypoint
- Confirm that the args are present

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-16970]: https://wandb.atlassian.net/browse/WB-16970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ