### PR TITLE
ci(sdk): store local-testcontainer's of local server releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install system deps
+          name: Install system deps for docker install
           command: |
             apt-get update && apt-get install -y jq
       - docker/install-docker-tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,6 +576,10 @@ jobs:
     working_directory: /mnt/ramdisk
     steps:
       - checkout
+      - run:
+          name: Install system deps
+          command: |
+            apt-get update && apt-get install -y jq
       - docker/install-docker-tools
       - gcloud/install
       - setup_gcloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1381,7 +1381,6 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
-      - local-testcontainer
       #
       # Linting
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   slack: circleci/slack@4.12.5
   go: circleci/go@1.9.0
   gcloud: circleci/gcp-cli@3.1.1
-  docker: circleci/docker@2.5.0
 
 parameters:
   manual:
@@ -580,13 +579,13 @@ jobs:
           name: Install system deps for docker install
           command: |
             apt-get update && apt-get install -y jq
-      - docker/install-docker-tools
+      - install_go
       - gcloud/install
       - setup_gcloud
       - run:
           name:
           command: |
-            systemctl start docker
+            go install github.com/google/go-containerregistry/cmd/gcrane@latest
             pip install -U pip nox requests
             nox -s local-testcontainer-registry
           no_output_timeout: 5m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,9 @@ parameters:
   nightly_execute_regression:
     type: boolean
     default: true
+  gcp_project:
+    type: string
+    default: wandb-production  # wandb-production or wandb-client-cicd
   wandb_server_tag:
     type: string
     default: "master"
@@ -459,7 +462,7 @@ jobs:
         default: ""
     docker:
       - image: "python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>"
-      - image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:<< pipeline.parameters.wandb_server_tag >>
+      - image: us-central1-docker.pkg.dev/<< pipeline.parameters.gcp_project >>/images/local-testcontainer:<< pipeline.parameters.wandb_server_tag >>
         auth:
           username: _json_key
           password: $GCP_SERVICE_ACCOUNT_JSON_DECODED
@@ -576,6 +579,7 @@ jobs:
       #     name: Install system deps
       #     command: |
       #       apt-get update && apt-get install -y libsndfile1 ffmpeg
+      - gcloud/install
       - setup_gcloud
       - run:
           name:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,32 @@ jobs:
           no_output_timeout: 5m
       - save-test-results
 
+  local-testcontainer:
+    parameters:
+      python_version_major:
+        type: integer
+        default: 3
+      python_version_minor:
+        type: integer
+        default: 10
+    docker:
+      - image: "python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>"
+    resource_class: small
+    working_directory: /mnt/ramdisk
+    steps:
+      - checkout
+      # - run:
+      #     name: Install system deps
+      #     command: |
+      #       apt-get update && apt-get install -y libsndfile1 ffmpeg
+      - setup_gcloud
+      - run:
+          name:
+          command: |
+            pip install -U pip nox
+            nox -s local-testcontainer-registry
+          no_output_timeout: 5m
+
   win:
     parameters:
       python_version_major:
@@ -1343,6 +1369,10 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
+      # TODO: move to nightly workflow
+      # Keep local-testcontainer registry up to date
+      #
+      - local-testcontainer
       #
       # Linting
       #
@@ -1353,7 +1383,7 @@ workflows:
       #
       # Prep jobs
       #
-      # todo: pre-create toxenvs for all python versions,
+      # TODO: pre-create toxenvs for all python versions,
       #       currently these are just placeholders
       - prep:
           name: "system-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1227,6 +1227,12 @@ workflows:
           message: ":runner: *Nightly run started!*"
           execute: << pipeline.parameters.nightly_slack_notify >>
       #
+      # Keep local-testcontainer registry up to date
+      #
+      - local-testcontainer:
+          requires:
+              - "slack-notify-on-start"
+      #
       # Regression tests
       #
       - regression:
@@ -1375,10 +1381,6 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
-      # TODO: move to nightly workflow
-      # Keep local-testcontainer registry up to date
-      #
-      - local-testcontainer
       #
       # Linting
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -584,7 +584,7 @@ jobs:
       - run:
           name:
           command: |
-            pip install -U pip nox
+            pip install -U pip nox requests
             nox -s local-testcontainer-registry
           no_output_timeout: 5m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,7 +568,7 @@ jobs:
         default: 3
       python_version_minor:
         type: integer
-        default: 10
+        default: 11
     docker:
       - image: "python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>"
     resource_class: small
@@ -576,9 +576,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install system deps for docker install
+          name: Install system deps
           command: |
-            apt-get update && apt-get install -y jq
+            apt-get update
       - install_go
       - gcloud/install
       - setup_gcloud
@@ -1381,6 +1381,7 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
+      - local-testcontainer:
       #
       # Linting
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
   slack: circleci/slack@4.12.5
   go: circleci/go@1.9.0
   gcloud: circleci/gcp-cli@3.1.1
+  docker: circleci/docker@2.5.0
 
 parameters:
   manual:
@@ -575,10 +576,7 @@ jobs:
     working_directory: /mnt/ramdisk
     steps:
       - checkout
-      # - run:
-      #     name: Install system deps
-      #     command: |
-      #       apt-get update && apt-get install -y libsndfile1 ffmpeg
+      - docker/install-docker-tools
       - gcloud/install
       - setup_gcloud
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1381,7 +1381,7 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
-      - local-testcontainer:
+      - local-testcontainer
       #
       # Linting
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,6 +586,7 @@ jobs:
       - run:
           name:
           command: |
+            systemctl start docker
             pip install -U pip nox requests
             nox -s local-testcontainer-registry
           no_output_timeout: 5m

--- a/core/internal/data_types/data_types_test.go
+++ b/core/internal/data_types/data_types_test.go
@@ -187,8 +187,9 @@ func TestGenerateTypeRepresentation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := data_types.ResolveTypes(tc.input)
 			if !reflect.DeepEqual(result, tc.expected) {
+				jsonExpected, _ := json.MarshalIndent(tc.expected, "", "  ")
 				jsonResult, _ := json.MarshalIndent(result, "", "  ")
-				t.Errorf("\nExpected: %v\nActual:   %v", tc.expected, string(jsonResult))
+				t.Errorf("\nExpected: %v\nActual:   %v", string(jsonExpected), string(jsonResult))
 			}
 		})
 	}

--- a/noxfile.py
+++ b/noxfile.py
@@ -291,8 +291,8 @@ def local_testcontainer_registry(session: nox.Session) -> None:
     local_release_tag, commit_hash = get_release_tag_and_commit_hash(tags)
 
     release_tag = local_release_tag.removeprefix("local/v")
-    print(f"Latest release tag: {release_tag}")
-    print(f"Latest commit hash: {commit_hash}")
+    print(f"Release tag: {release_tag}")
+    print(f"Commit hash: {commit_hash}")
 
     if not release_tag or not commit_hash:
         print("Failed to get release tag or commit hash.")

--- a/noxfile.py
+++ b/noxfile.py
@@ -323,13 +323,10 @@ def local_testcontainer_registry(session: nox.Session) -> None:
         print(f"Image with tag {release_tag} already exists.")
         return
 
-    # Pull image from the source registry
     source_image = f"us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:{commit_hash}"
-    subprocess.check_call(["docker", "pull", "--platform", "linux/amd64", source_image])
-
-    # Tag and push the image to the target registry
     target_image = f"us-central1-docker.pkg.dev/wandb-client-cicd/images/local-testcontainer:{release_tag}"
-    subprocess.check_call(["docker", "tag", source_image, target_image])
-    subprocess.check_call(["docker", "push", target_image])
 
-    print(f"Successfully pushed image {target_image}")
+    # install gcrane: `go install github.com/google/go-containerregistry/cmd/gcrane@latest`
+    subprocess.check_call(["gcrane", "cp", source_image, target_image])
+
+    print(f"Successfully copied image {target_image}")

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -160,10 +160,6 @@ class LocalContainerRunner(AbstractRunner):
 
             assert launch_project.docker_image == image_uri
 
-        additional_args = (
-            launch_project.override_args if launch_project.docker_image else None
-        )
-
         entry_cmd = (
             launch_project.override_entrypoint.command
             if launch_project.override_entrypoint is not None
@@ -176,7 +172,7 @@ class LocalContainerRunner(AbstractRunner):
                 env_vars,
                 docker_args=docker_args,
                 entry_cmd=entry_cmd,
-                additional_args=additional_args,
+                additional_args=launch_project.override_args,
             )
         ).strip()
         sanitized_cmd_str = sanitize_wandb_api_key(command_str)


### PR DESCRIPTION
What does the PR do? Solves the following problem:

Problem: local-testcontainers are not published on docker hub and therefore recycled after a month due to our storage policy. But we still want to test the SDK against older versions.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
