### PR TITLE
fix(launch): wandb job create should not look for requirements.txt if Dockerfile.wandb is next to entrypoint

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_create_job.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_create_job.py
@@ -10,6 +10,7 @@ from wandb.sdk.launch.builder.build import get_current_python_version
 from wandb.sdk.launch.create_job import (
     _configure_job_builder_for_partial,
     _create_artifact_metadata,
+    _create_repo_metadata,
     _dump_metadata_and_requirements,
     _handle_artifact_entrypoint,
     _make_code_artifact_name,
@@ -138,3 +139,10 @@ def test__get_entrypoint():
     entrypoint = builder._get_entrypoint(program_relpath, metadata)
 
     assert entrypoint == [os.path.basename(sys.executable), "main.py"]
+
+
+def test_create_repo_metadata_entrypoint_traversal():
+    result = _create_repo_metadata(
+        "", "", entrypoint="../../../../../usr/bin/python3.9 main.py"
+    )
+    assert result is None

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -272,6 +272,10 @@ def _create_repo_metadata(
     git_hash: Optional[str] = None,
     runtime: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
+    # Make sure the entrypoint doesn't contain any backward path traversal
+    if entrypoint and ".." in entrypoint:
+        wandb.termerror("Entrypoint cannot contain backward path traversal")
+        return None
     if not _is_git_uri(path):
         wandb.termerror("Path must be a git URI")
         return None


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do?

Include a concise description of the PR contents

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
