### PR TITLE
perf(artifacts): Reduce artifact download latency via optional cache copy + threads

### DIFF
--- a/tests/pytest_tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
@@ -1,4 +1,12 @@
+import base64
+import os
+from logging import getLogger
+from pathlib import Path
+
+from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
+
+logger = getLogger(__name__)
 
 
 def test_repr():
@@ -23,6 +31,38 @@ def test_repr():
     assert entry != blank_entry
     assert entry != repr(entry)
 
-    short_entry = ArtifactManifestEntry(path="foo", digest="bar")
-    assert repr(short_entry) == "ArtifactManifestEntry(path='foo', digest='bar')"
+    short_entry = ArtifactManifestEntry(path="foo", digest="barr")
+    assert repr(short_entry) == "ArtifactManifestEntry(path='foo', digest='barr')"
     assert entry != short_entry
+
+
+def base64_decode(data):
+    padding_needed = 4 - (len(data) % 4)
+    if padding_needed:
+        data += "=" * padding_needed
+    return base64.b64decode(data)
+
+
+def test_manifest_download(monkeypatch):
+    artifact = Artifact("mnist", type="dataset")
+    short_entry = ArtifactManifestEntry(path="foo", digest="barr")
+    assert repr(short_entry) == "ArtifactManifestEntry(path='foo', digest='barr')"
+    short_entry._parent_artifact = artifact
+
+    abspath_to_cur_dir = os.path.dirname(os.path.abspath(__file__))
+    default_cache = Path("default_cache")
+
+    monkeypatch.setattr(
+        short_entry._parent_artifact.manifest.storage_policy,
+        "load_reference",
+        lambda x, y, **kwargs: default_cache,
+    )
+    monkeypatch.setattr(
+        short_entry._parent_artifact.manifest.storage_policy,
+        "load_file",
+        lambda x, y, **kwargs: default_cache,
+    )
+
+    short_entry.path = default_cache
+    fpath = short_entry.download(root=abspath_to_cur_dir, skip_cache=True)
+    assert fpath.endswith("unit_tests/test_artifacts/default_cache")

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_storage.py
@@ -56,6 +56,15 @@ def test_check_md5_obj_path(artifact_file_cache):
     assert contents == "hi"
 
 
+def test_check_md5_obj_path_override(artifact_file_cache):
+    md5 = md5_string("hi")
+    override_path = os.path.join(artifact_file_cache._cache_dir, "override.cache")
+    artifact_file_cache._override_cache_path = override_path
+    path, exists, _ = artifact_file_cache.check_md5_obj_path(md5, 2)
+    assert path == override_path
+    assert exists is False
+
+
 def test_check_etag_obj_path_points_to_opener_dst(artifact_file_cache):
     path, _, opener = artifact_file_cache.check_etag_obj_path(
         "http://my/url", "abc", 10
@@ -67,6 +76,14 @@ def test_check_etag_obj_path_points_to_opener_dst(artifact_file_cache):
         contents = f.read()
 
     assert contents == "hi"
+
+
+def test_check_etag_obj_path_override(artifact_file_cache):
+    override_path = os.path.join(artifact_file_cache._cache_dir, "override.cache")
+    artifact_file_cache._override_cache_path = override_path
+    path, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", 2)
+    assert path == override_path
+    assert exists is False
 
 
 def test_check_etag_obj_path_returns_exists_if_exists(artifact_file_cache):

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1677,6 +1677,7 @@ class Artifact:
         self,
         root: Optional[str] = None,
         allow_missing_references: bool = False,
+        skip_cache: Optional[bool] = None,
     ) -> FilePathStr:
         """Download the contents of the artifact to the specified root directory.
 
@@ -1706,6 +1707,7 @@ class Artifact:
         return self._download(
             root=root,
             allow_missing_references=allow_missing_references,
+            skip_cache=skip_cache,
         )
 
     def _download_using_core(
@@ -1778,6 +1780,7 @@ class Artifact:
         self,
         root: str,
         allow_missing_references: bool = False,
+        skip_cache: Optional[bool] = None,
     ) -> FilePathStr:
         # todo: remove once artifact reference downloads are supported in core
         require_core = get_core_path() != ""
@@ -1806,7 +1809,7 @@ class Artifact:
             _thread_local_api_settings.headers = headers
 
             try:
-                entry.download(root)
+                entry.download(root, skip_cache=skip_cache)
             except FileNotFoundError as e:
                 if allow_missing_references:
                     wandb.termwarn(str(e))

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -41,7 +41,7 @@ class ArtifactFileCache:
         umask = int(subprocess.check_output(umask_cmd))
         self._sys_umask = umask
 
-        self._override_cache_path: Optional[str] = None
+        self._override_cache_path: Optional[StrPath] = None
 
     def check_md5_obj_path(
         self, b64_md5: B64MD5, size: int

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -41,11 +41,16 @@ class ArtifactFileCache:
         umask = int(subprocess.check_output(umask_cmd))
         self._sys_umask = umask
 
+        self._override_cache_path: Optional[str] = None
+
     def check_md5_obj_path(
         self, b64_md5: B64MD5, size: int
     ) -> Tuple[FilePathStr, bool, "Opener"]:
-        hex_md5 = b64_to_hex_id(b64_md5)
-        path = self._obj_dir / "md5" / hex_md5[:2] / hex_md5[2:]
+        if self._override_cache_path is not None:
+            path = Path(self._override_cache_path)
+        else:
+            hex_md5 = b64_to_hex_id(b64_md5)
+            path = self._obj_dir / "md5" / hex_md5[:2] / hex_md5[2:]
         return self._check_or_create(path, size)
 
     # TODO(spencerpearson): this method at least needs its signature changed.
@@ -56,11 +61,14 @@ class ArtifactFileCache:
         etag: ETag,
         size: int,
     ) -> Tuple[FilePathStr, bool, "Opener"]:
-        hexhash = hashlib.sha256(
-            hashlib.sha256(url.encode("utf-8")).digest()
-            + hashlib.sha256(etag.encode("utf-8")).digest()
-        ).hexdigest()
-        path = self._obj_dir / "etag" / hexhash[:2] / hexhash[2:]
+        if self._override_cache_path is not None:
+            path = Path(self._override_cache_path)
+        else:
+            hexhash = hashlib.sha256(
+                hashlib.sha256(url.encode("utf-8")).digest()
+                + hashlib.sha256(etag.encode("utf-8")).digest()
+            ).hexdigest()
+            path = self._obj_dir / "etag" / hexhash[:2] / hexhash[2:]
         return self._check_or_create(path, size)
 
     def _check_or_create(

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -102,7 +102,9 @@ class ArtifactManifestEntry:
             raise NotImplementedError
         return self._parent_artifact
 
-    def download(self, root: Optional[str] = None) -> FilePathStr:
+    def download(
+        self, root: Optional[str] = None, skip_cache: Optional[bool] = None
+    ) -> FilePathStr:
         """Download this artifact entry to the specified root path.
 
         Arguments:
@@ -119,6 +121,11 @@ class ArtifactManifestEntry:
         self._parent_artifact._add_download_root(root)
         dest_path = os.path.join(root, self.path)
 
+        if skip_cache:
+            override_cache_path = dest_path
+        else:
+            override_cache_path = None
+
         # Skip checking the cache (and possibly downloading) if the file already exists
         # and has the digest we're expecting.
         if os.path.exists(dest_path) and self.digest == md5_file_b64(dest_path):
@@ -126,15 +133,19 @@ class ArtifactManifestEntry:
 
         if self.ref is not None:
             cache_path = self._parent_artifact.manifest.storage_policy.load_reference(
-                self, local=True
+                self, local=True, dest_path=override_cache_path
             )
         else:
             cache_path = self._parent_artifact.manifest.storage_policy.load_file(
-                self._parent_artifact, self
+                self._parent_artifact, self, dest_path=override_cache_path
             )
-        return FilePathStr(
-            str(filesystem.copy_or_overwrite_changed(cache_path, dest_path))
-        )
+
+        if skip_cache:
+            return FilePathStr(dest_path)
+        else:
+            return FilePathStr(
+                str(filesystem.copy_or_overwrite_changed(cache_path, dest_path))
+            )
 
     def ref_target(self) -> Union[FilePathStr, URIStr]:
         """Get the reference URL that is targeted by this artifact entry.

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -111,7 +111,9 @@ class WandbStoragePolicy(StoragePolicy):
         self,
         artifact: "Artifact",
         manifest_entry: "ArtifactManifestEntry",
+        dest_path: Optional[str] = None,
     ) -> FilePathStr:
+        self._cache._override_cache_path = dest_path
         path, hit, cache_open = self._cache.check_md5_obj_path(
             B64MD5(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
             manifest_entry.size if manifest_entry.size is not None else 0,
@@ -160,7 +162,12 @@ class WandbStoragePolicy(StoragePolicy):
         self,
         manifest_entry: "ArtifactManifestEntry",
         local: bool = False,
+        dest_path: Optional[str] = None,
     ) -> Union[FilePathStr, URIStr]:
+        assert manifest_entry.ref is not None
+        used_handler = self._handler._get_handler(manifest_entry.ref)
+        if hasattr(used_handler, "_cache"):
+            used_handler._cache._override_cache_path = dest_path
         return self._handler.load_path(manifest_entry, local)
 
     def _file_url(

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -32,7 +32,10 @@ class StoragePolicy:
         raise NotImplementedError
 
     def load_file(
-        self, artifact: "Artifact", manifest_entry: "ArtifactManifestEntry"
+        self,
+        artifact: "Artifact",
+        manifest_entry: "ArtifactManifestEntry",
+        dest_path: Optional[str] = None,
     ) -> FilePathStr:
         raise NotImplementedError
 
@@ -71,5 +74,6 @@ class StoragePolicy:
         self,
         manifest_entry: "ArtifactManifestEntry",
         local: bool = False,
+        dest_path: Optional[str] = None,
     ) -> Union[FilePathStr, URIStr]:
         raise NotImplementedError


### PR DESCRIPTION
Description
-----------
This resolves the issue here: https://weightsandbiases.slack.com/archives/C01KQ5KTDC3/p1705601806215009
Fixes: https://wandb.atlassian.net/browse/WB-17009?filter=10470
- Fixes WB-17009

What does the PR do?

Optimizes artifact downloads via two dimensions: (1) make the cache copy optional (it takes 6-10 seconds) and (2) scale the number of boto threads we use to the size of the big artifact

Include a concise description of the PR contents

Testing
-------
How was this PR tested?
Proved a reduction in latency of llama-13b download from 6.3-7.1 minutes to 5.88 minutes (though the variance of download speeds is large)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
