### PR TITLE
fix(sdk): clean up temp folders

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -62,6 +62,7 @@ from wandb import wandb_torch
 
 # Move this (keras.__init__ expects it at top level)
 import atexit
+
 atexit.register(wandb.sdk.data_types._private.cleanup)
 from wandb.data_types import Graph
 from wandb.data_types import Image

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -62,6 +62,7 @@ from wandb import wandb_torch
 
 # Move this (keras.__init__ expects it at top level)
 from wandb.sdk.data_types._private import _cleanup_media_tmp_dir
+
 _cleanup_media_tmp_dir()
 
 from wandb.data_types import Graph

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -63,7 +63,7 @@ from wandb import wandb_torch
 # Move this (keras.__init__ expects it at top level)
 import atexit
 
-atexit.register(wandb.sdk.data_types._private.cleanup)
+atexit.register(wandb.sdk.data_types.MEDIA_TMP.cleanup)
 from wandb.data_types import Graph
 from wandb.data_types import Image
 from wandb.data_types import Plotly

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -61,9 +61,9 @@ wandb.sdk.wandb_require._import_module_hook()
 from wandb import wandb_torch
 
 # Move this (keras.__init__ expects it at top level)
-import atexit
+from wandb.sdk.data_types._private import _cleanup_media_tmp_dir
+_cleanup_media_tmp_dir()
 
-atexit.register(wandb.sdk.data_types._private.MEDIA_TMP.cleanup)
 from wandb.data_types import Graph
 from wandb.data_types import Image
 from wandb.data_types import Plotly

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -63,7 +63,7 @@ from wandb import wandb_torch
 # Move this (keras.__init__ expects it at top level)
 import atexit
 
-atexit.register(wandb.sdk.data_types.MEDIA_TMP.cleanup)
+atexit.register(wandb.sdk.data_types._private.MEDIA_TMP.cleanup)
 from wandb.data_types import Graph
 from wandb.data_types import Image
 from wandb.data_types import Plotly

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -61,6 +61,8 @@ wandb.sdk.wandb_require._import_module_hook()
 from wandb import wandb_torch
 
 # Move this (keras.__init__ expects it at top level)
+import atexit
+atexit.register(wandb.sdk.data_types._private.cleanup)
 from wandb.data_types import Graph
 from wandb.data_types import Image
 from wandb.data_types import Plotly

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -43,7 +43,7 @@ from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.launch.sweeps.scheduler import Scheduler
 from wandb.sdk.lib import filesystem
 from wandb.sdk.lib.wburls import wburls
-from wandb.sync import TMPDIR, SyncManager, get_run_from_path, get_runs
+from wandb.sync import SyncManager, get_run_from_path, get_runs
 
 # Send cli logs to wandb/debug-cli.<username>.log by default and fallback to a temp dir.
 _wandb_dir = wandb.old.core.wandb_dir(env.get_dir())
@@ -669,8 +669,6 @@ def sync(
     append=None,
     skip_console=None,
 ):
-    # TODO: rather unfortunate, needed to avoid creating a `wandb` directory
-    os.environ["WANDB_DIR"] = TMPDIR.name
     api = _get_cling_api()
     if api.api_key is None:
         wandb.termlog("Login to W&B to sync offline runs")

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -13,7 +13,6 @@ serialize to JSON, since that is what wandb uses to save the objects locally
 and upload them to the W&B server.
 """
 
-import atexit
 import base64
 import binascii
 import codecs
@@ -31,7 +30,7 @@ from wandb import util
 from wandb.sdk.lib import filesystem
 
 from .sdk.data_types import _dtypes
-from .sdk.data_types._private import _get_media_tmp_dir
+from .sdk.data_types._private import MEDIA_TMP
 from .sdk.data_types.base_types.media import (
     BatchableMedia,
     Media,
@@ -532,7 +531,7 @@ class Table(Media):
         # this code path will be ultimately removed. The 10k limit warning confuses
         # users given that we publicly say 200k is the limit.
         data = self._to_table_json(warn=False)
-        tmp_path = os.path.join(_get_media_tmp_dir().name, runid.generate_id() + ".table.json")
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".table.json")
         data = _numpy_arrays_to_lists(data)
         with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
             util.json_dump_safer(data, fp)
@@ -667,7 +666,7 @@ class Table(Media):
                         required="Serializing numpy requires numpy to be installed",
                     )
                     file_name = f"{str(col_name)}_{runid.generate_id()}.npz"
-                    npz_file_name = os.path.join(_get_media_tmp_dir().name, file_name)
+                    npz_file_name = os.path.join(MEDIA_TMP.name, file_name)
                     np.savez_compressed(
                         npz_file_name,
                         **{
@@ -1083,7 +1082,7 @@ class Audio(BatchableMedia):
                 required='Raw audio requires the soundfile package. To get it, run "pip install soundfile"',
             )
 
-            tmp_path = os.path.join(_get_media_tmp_dir().name, runid.generate_id() + ".wav")
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".wav")
             soundfile.write(tmp_path, data_or_path, sample_rate)
             self._duration = len(data_or_path) / float(sample_rate)
 
@@ -1357,7 +1356,7 @@ class Bokeh(Media):
             if "references" in b_json["roots"]:
                 b_json["roots"]["references"].sort(key=lambda x: x["id"])
 
-            tmp_path = os.path.join(_get_media_tmp_dir().name, runid.generate_id() + ".bokeh.json")
+            tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".bokeh.json")
             with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
                 util.json_dump_safer(b_json, fp)
             self._set_file(tmp_path, is_tmp=True, extension=".bokeh.json")
@@ -1438,7 +1437,7 @@ class Graph(Media):
 
     def bind_to_run(self, *args, **kwargs):
         data = self._to_graph_json()
-        tmp_path = os.path.join(_get_media_tmp_dir().name, runid.generate_id() + ".graph.json")
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".graph.json")
         data = _numpy_arrays_to_lists(data)
         with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
             util.json_dump_safer(data, fp)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1,4 +1,5 @@
 """Artifact class."""
+import atexit
 import concurrent.futures
 import contextlib
 import json
@@ -113,6 +114,7 @@ class Artifact:
     """
 
     _TMP_DIR = tempfile.TemporaryDirectory("wandb-artifacts")
+    atexit.register(_TMP_DIR.cleanup)
 
     def __init__(
         self,

--- a/wandb/sdk/data_types/_private.py
+++ b/wandb/sdk/data_types/_private.py
@@ -1,37 +1,12 @@
-import atexit
 import tempfile
-import threading
-from typing import Optional
-
-media_tmp_dir_lock = threading.Lock()
 
 # Staging directory, so we can encode raw data into files, then hash them before
 # we put them into the Run directory to be uploaded.
-MEDIA_TMP: Optional[tempfile.TemporaryDirectory] = None
+MEDIA_TMP = tempfile.TemporaryDirectory("wandb-media")
+print("Created new media tmpdir", MEDIA_TMP.name)
 
 
-def _get_media_tmp_dir() -> tempfile.TemporaryDirectory:
-    global MEDIA_TMP
-
-    if MEDIA_TMP:
-        print("Using existing media tmpdir", MEDIA_TMP.name)
-        return MEDIA_TMP
-
-    with media_tmp_dir_lock:
-        # check again in case another thread created it
-        if MEDIA_TMP:
-            print("Using existing media tmpdir", MEDIA_TMP.name)
-            return MEDIA_TMP
-
-        MEDIA_TMP = tempfile.TemporaryDirectory("wandb-media")
-        print("Created new media tmpdir", MEDIA_TMP.name)
-
-        # clear the tmpdir on exit
-        def cleanup() -> None:
-            if MEDIA_TMP:
-                print("Cleaning up media tmpdir", MEDIA_TMP.name)
-                MEDIA_TMP.cleanup()
-
-        atexit.register(cleanup)
-
-        return MEDIA_TMP
+# clear the tmpdir on exit
+def cleanup() -> None:
+    print("Cleaning up media tmpdir", MEDIA_TMP.name)
+    MEDIA_TMP.cleanup()

--- a/wandb/sdk/data_types/_private.py
+++ b/wandb/sdk/data_types/_private.py
@@ -3,10 +3,3 @@ import tempfile
 # Staging directory, so we can encode raw data into files, then hash them before
 # we put them into the Run directory to be uploaded.
 MEDIA_TMP = tempfile.TemporaryDirectory("wandb-media")
-print("Created new media tmpdir", MEDIA_TMP.name)
-
-
-# clear the tmpdir on exit
-def cleanup() -> None:
-    print("Cleaning up media tmpdir", MEDIA_TMP.name)
-    MEDIA_TMP.cleanup()

--- a/wandb/sdk/data_types/_private.py
+++ b/wandb/sdk/data_types/_private.py
@@ -1,3 +1,37 @@
+import atexit
 import tempfile
+import threading
+from typing import Optional
 
-MEDIA_TMP = tempfile.TemporaryDirectory("wandb-media")
+media_tmp_dir_lock = threading.Lock()
+
+# Staging directory, so we can encode raw data into files, then hash them before
+# we put them into the Run directory to be uploaded.
+MEDIA_TMP: Optional[tempfile.TemporaryDirectory] = None
+
+
+def _get_media_tmp_dir() -> tempfile.TemporaryDirectory:
+    global MEDIA_TMP
+
+    if MEDIA_TMP:
+        print("Using existing media tmpdir", MEDIA_TMP.name)
+        return MEDIA_TMP
+
+    with media_tmp_dir_lock:
+        # check again in case another thread created it
+        if MEDIA_TMP:
+            print("Using existing media tmpdir", MEDIA_TMP.name)
+            return MEDIA_TMP
+
+        MEDIA_TMP = tempfile.TemporaryDirectory("wandb-media")
+        print("Created new media tmpdir", MEDIA_TMP.name)
+
+        # clear the tmpdir on exit
+        def cleanup() -> None:
+            if MEDIA_TMP:
+                print("Cleaning up media tmpdir", MEDIA_TMP.name)
+                MEDIA_TMP.cleanup()
+
+        atexit.register(cleanup)
+
+        return MEDIA_TMP

--- a/wandb/sdk/data_types/_private.py
+++ b/wandb/sdk/data_types/_private.py
@@ -1,5 +1,11 @@
+import atexit
 import tempfile
+from typing import Optional
 
 # Staging directory, so we can encode raw data into files, then hash them before
 # we put them into the Run directory to be uploaded.
 MEDIA_TMP = tempfile.TemporaryDirectory("wandb-media")
+
+
+def _cleanup_media_tmp_dir() -> None:
+    atexit.register(MEDIA_TMP.cleanup)

--- a/wandb/sdk/data_types/_private.py
+++ b/wandb/sdk/data_types/_private.py
@@ -1,6 +1,5 @@
 import atexit
 import tempfile
-from typing import Optional
 
 # Staging directory, so we can encode raw data into files, then hash them before
 # we put them into the Run directory to be uploaded.

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -10,7 +10,7 @@ from wandb import util
 from wandb.sdk.lib import hashutil, runid
 from wandb.sdk.lib.paths import LogicalPath
 
-from ._private import MEDIA_TMP
+from ._private import _get_media_tmp_dir
 from .base_types.media import BatchableMedia, Media
 from .helper_types.bounding_boxes_2d import BoundingBoxes2D
 from .helper_types.classes import Classes
@@ -331,7 +331,7 @@ class Image(BatchableMedia):
         assert (
             self.format in accepted_formats
         ), f"file_type must be one of {accepted_formats}"
-        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + "." + self.format)
+        tmp_path = os.path.join(_get_media_tmp_dir().name, runid.generate_id() + "." + self.format)
         assert self._image is not None
         self._image.save(tmp_path, transparency=None)
         self._set_file(tmp_path, is_tmp=True)

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -10,7 +10,7 @@ from wandb import util
 from wandb.sdk.lib import hashutil, runid
 from wandb.sdk.lib.paths import LogicalPath
 
-from ._private import _get_media_tmp_dir
+from ._private import MEDIA_TMP
 from .base_types.media import BatchableMedia, Media
 from .helper_types.bounding_boxes_2d import BoundingBoxes2D
 from .helper_types.classes import Classes
@@ -331,7 +331,7 @@ class Image(BatchableMedia):
         assert (
             self.format in accepted_formats
         ), f"file_type must be one of {accepted_formats}"
-        tmp_path = os.path.join(_get_media_tmp_dir().name, runid.generate_id() + "." + self.format)
+        tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + "." + self.format)
         assert self._image is not None
         self._image.save(tmp_path, transparency=None)
         self._set_file(tmp_path, is_tmp=True)

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -19,12 +19,6 @@ if TYPE_CHECKING:
     from wandb.sdk.internal.settings_static import SettingsStatic
 
 
-# Temporary directory for copies we make of some file types to
-# reduce the probability that the file gets changed while we're
-# uploading it.
-TMP_DIR = tempfile.TemporaryDirectory("wandb")
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -47,6 +41,9 @@ class FilePusher:
     ) -> None:
         self._api = api
 
+        # Temporary directory for copies we make of some file types to
+        # reduce the probability that the file gets changed while we're
+        # uploading it.
         self._tempdir = tempfile.TemporaryDirectory("wandb")
 
         self._stats = stats.Stats()
@@ -181,6 +178,7 @@ class FilePusher:
         logger.info("waiting for file pusher")
         while self.is_alive():
             time.sleep(0.5)
+        self._tempdir.cleanup()
 
     def is_alive(self) -> bool:
         return self._step_checksum.is_alive() or self._step_upload.is_alive()

--- a/wandb/sync/__init__.py
+++ b/wandb/sync/__init__.py
@@ -1,3 +1,3 @@
 """module sync."""
 
-from .sync import TMPDIR, SyncManager, get_run_from_path, get_runs  # noqa: F401
+from .sync import SyncManager, get_run_from_path, get_runs  # noqa: F401

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -1,10 +1,12 @@
 """sync."""
 
+import atexit
 import datetime
 import fnmatch
 import os
 import queue
 import sys
+import tempfile
 import threading
 import time
 from typing import List, Optional
@@ -69,6 +71,9 @@ class SyncThread(threading.Thread):
         self._log_path = log_path
         self._append = append
         self._skip_console = skip_console
+
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        atexit.register(self._tmp_dir.cleanup)
 
     def _parse_pb(self, data, exit_pb=None):
         pb = wandb_internal_pb2.Record()

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -1,12 +1,10 @@
 """sync."""
 
-import atexit
 import datetime
 import fnmatch
 import os
 import queue
 import sys
-import tempfile
 import threading
 import time
 from typing import List, Optional
@@ -71,8 +69,6 @@ class SyncThread(threading.Thread):
         self._log_path = log_path
         self._append = append
         self._skip_console = skip_console
-        self._tmp_dir = tempfile.TemporaryDirectory()
-        atexit.register(self._tmp_dir.cleanup)
 
     def _parse_pb(self, data, exit_pb=None):
         pb = wandb_internal_pb2.Record()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-16987
- Fixes #5258

What does the PR do?

Clean up temp dirs that are created in different places in the code, mainly atexit.
Note that most of the relevant python code will soon be gone with the transition to Rust in the client.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
