### PR TITLE
chore(artifacts): add docstrings for artifact collection method on public api

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -912,6 +912,15 @@ class Api:
 
     @normalize_exceptions
     def artifact_collection(self, type_name: str, name: str):
+        """Return a single artifact collection by type and parsing path in the form `entity/project/name`.
+
+        Arguments:
+            name: (str) An artifact collection name. May be prefixed with entity/project.
+            type: (str) The type of artifact collection to fetch.
+
+        Returns:
+            An `ArtifactCollection` object.
+        """
         entity, project, collection_name = self._parse_artifact_path(name)
         return public.ArtifactCollection(
             self.client, entity, project, collection_name, type_name


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
[WB-17072](https://wandb.atlassian.net/browse/WB-17072)
Artifacts docs: https://github.com/wandb/docodile/pull/566 that need to use this method.

What does the PR do?

Adds docstrings to `api.artifact_collection()` to update Artifacts docs.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-17072]: https://wandb.atlassian.net/browse/WB-17072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ