### PR TITLE
feat(artifacts): Add partial file downloads, via directory prefix

### DIFF
--- a/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -105,6 +105,73 @@ def test_capped_cache():
     assert len(artifact_instance_cache) == 100
 
 
+def test_artifact_path_fn():
+    assert Artifact.path_contains_dir_prefix("/a/b/c", "/a/b")
+    assert Artifact.path_contains_dir_prefix("a/b/c", "a/b")
+
+    # Case 2: dir_path is identical to path
+    assert Artifact.path_contains_dir_prefix("/a/b/c", "/a/b/c")
+    assert Artifact.path_contains_dir_prefix("a/b/c", "a/b/c")
+
+    # Case 3: dir_path is not a prefix of path
+    assert not Artifact.path_contains_dir_prefix("/a/b/c", "/d/e")
+    assert not Artifact.path_contains_dir_prefix("a/b/c", "d/e")
+
+    # Case 4: Testing with trailing slashes
+    assert Artifact.path_contains_dir_prefix("/a/b/c/", "/a/b")
+    assert Artifact.path_contains_dir_prefix("a/b/c/", "a/b")
+
+    # Case 5: Empty strings
+    assert not Artifact.path_contains_dir_prefix("", "/a/b")
+    assert Artifact.path_contains_dir_prefix("", "")
+
+    # Case 6: Nested directories
+    assert Artifact.path_contains_dir_prefix("/a/b/c/d", "/a/b")
+    assert Artifact.path_contains_dir_prefix("a/b/c/d", "a/b")
+
+    # Case 7: dir_path is a prefix but not a directory prefix
+    assert not Artifact.path_contains_dir_prefix("/a/b/cd", "/a/b/c")
+    assert not Artifact.path_contains_dir_prefix("a/b/cd", "a/b/c")
+
+    assert not Artifact.path_contains_dir_prefix("/a/b/c", "a/b")
+    assert not Artifact.path_contains_dir_prefix("a/b/c", "/a/b")
+
+
+class InternalArtifactManifestEntry:
+    def __init__(self, path: str):
+        self.path = path
+
+
+def test_should_download_entry_fn():
+    def make_entry(path: str) -> InternalArtifactManifestEntry:
+        return InternalArtifactManifestEntry(path)
+
+    # Case 1: prefix is None
+    assert Artifact.should_download_entry(make_entry("/a/b/c"), None)
+    assert Artifact.should_download_entry(make_entry("a/b/c"), None)
+
+    # Case 2: prefix is a valid prefix of entry.path
+    assert Artifact.should_download_entry(make_entry("/a/b/c"), "/a/b")
+    assert Artifact.should_download_entry(make_entry("a/b/c"), "a/b")
+
+    # Case 3: prefix is not a prefix of entry.path
+    assert not Artifact.should_download_entry(make_entry("/a/b/c"), "/d/e")
+    assert not Artifact.should_download_entry(make_entry("a/b/c"), "d/e")
+
+    # Case 4: prefix and entry.path are identical
+    assert Artifact.should_download_entry(make_entry("/a/b/c"), "/a/b/c")
+    assert Artifact.should_download_entry(make_entry("a/b/c"), "a/b/c")
+
+    # Case 5: Testing with empty strings
+    assert Artifact.should_download_entry(make_entry(""), "")
+    assert Artifact.should_download_entry(make_entry("/a/b/c"), "")
+    assert not Artifact.should_download_entry(make_entry(""), "/a/b")
+
+    # Case 6: Testing with trailing slashes
+    assert Artifact.should_download_entry(make_entry("/a/b/c/"), "/a/b")
+    assert Artifact.should_download_entry(make_entry("a/b/c/"), "a/b")
+
+
 class TestStoreFile:
     @staticmethod
     def _fixture_kwargs_to_kwargs(

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1680,6 +1680,7 @@ class Artifact:
         root: Optional[str] = None,
         allow_missing_references: bool = False,
         skip_cache: Optional[bool] = None,
+        path_prefix: Optional[StrPath] = None,
     ) -> FilePathStr:
         """Download the contents of the artifact to the specified root directory.
 
@@ -1689,6 +1690,10 @@ class Artifact:
 
         Arguments:
             root: The directory in which to download this artifact's files.
+            skip_cache: If true, then the artifact cache will be skipped when downloading
+            and we will download each file into the default root or specified download directory.
+            dir_path_prefix: If specified, then only files with paths that start with the
+            specified prefix StrPath will be downloaded.
 
         Returns:
             The path to the downloaded contents.
@@ -1710,7 +1715,25 @@ class Artifact:
             root=root,
             allow_missing_references=allow_missing_references,
             skip_cache=skip_cache,
+            path_prefix=path_prefix,
         )
+
+    @classmethod
+    def path_contains_dir_prefix(cls, path: StrPath, dir_path: StrPath) -> bool:
+        """Returns true if `path` contains `dir_path` as a prefix."""
+        if not dir_path:
+            return True
+        path_parts = PurePosixPath(path).parts
+        dir_parts = PurePosixPath(dir_path).parts
+        return path_parts[: len(dir_parts)] == dir_parts
+
+    @classmethod
+    def should_download_entry(
+        cls, entry: ArtifactManifestEntry, prefix: Optional[StrPath]
+    ) -> bool:
+        if prefix is None:
+            return True
+        return cls.path_contains_dir_prefix(entry.path, prefix)
 
     def _download_using_core(
         self,
@@ -1783,6 +1806,7 @@ class Artifact:
         root: str,
         allow_missing_references: bool = False,
         skip_cache: Optional[bool] = None,
+        path_prefix: Optional[StrPath] = None,
     ) -> FilePathStr:
         # todo: remove once artifact reference downloads are supported in core
         require_core = get_core_path() != ""
@@ -1841,7 +1865,8 @@ class Artifact:
                         # Handled by core
                         continue
                     entry._download_url = edge["node"]["directUrl"]
-                    active_futures.add(executor.submit(download_entry, entry))
+                    if self.should_download_entry(entry, prefix=path_prefix):
+                        active_futures.add(executor.submit(download_entry, entry))
                 # Wait for download threads to catch up.
                 max_backlog = fetch_url_batch_size
                 if len(active_futures) > max_backlog:


### PR DESCRIPTION
Description
-----------
- Fixes WB-13672

What does the PR do?
Read: https://wandb.atlassian.net/browse/WB-13672

* We allow users to optionally only download files that match the prefix of an input path prefix.
* If nothing is specified, the behavior is as before, we download all paths in the artifact. This prefix match only applies to OUR W&B path structure, NOT references or download file path structures.
* See the below for examples:

Testing
-------
Download prefix case:
<img width="648" alt="Screenshot 2024-01-27 at 10 24 10 AM" src="https://github.com/wandb/wandb/assets/155467726/ff4f6b80-13d7-47aa-9ad5-bacd33717004">
<img width="236" alt="Screenshot 2024-01-27 at 10 24 25 AM" src="https://github.com/wandb/wandb/assets/155467726/0f2ebab4-feb8-4730-82d3-8dd41c34e012">
<img width="620" alt="Screenshot 2024-01-27 at 10 24 32 AM" src="https://github.com/wandb/wandb/assets/155467726/0313afdb-4a97-4ba3-b3c1-9ae9f11b0096">

Result:
<img width="784" alt="Screenshot 2024-01-27 at 10 24 51 AM" src="https://github.com/wandb/wandb/assets/155467726/5298b111-a9f0-4db2-aa3f-ea052990b683">

Basecase (no arg given and we download everything):
![Uploading Screenshot 2024-01-27 at 10.25.22 AM.png…]()

<img width="461" alt="Screenshot 2024-01-27 at 10 25 09 AM" src="https://github.com/wandb/wandb/assets/155467726/83bce2c5-863d-4a8f-97e2-271cafd6cef0">

**Final comments**: this method is easier to code but a little off from the 'optimal' way of doing things. Ideally within the graphQL query itself we specific a prefix and in the backend we do the filtering. however for now we will just filter after querying filenames (but importantly BEFORE we actually download the files).

There should be ample communication to clients that this argument is prefix / directory filtering for W&B FILEPATHS, not REFERENCE PATHS! they are not the same

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
