### PR TITLE
chore(sdk): Pin pydantic>=2.0.0,<=2.5.0 for reports api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ launch = [
 models = ["cloudpickle"]
 async = ["httpx>=0.23.0"]
 perf = ["orjson"]
-reports = ["pydantic>=2.0.0,<=2.5"]
+reports = ["pydantic>=2.0.0,<2.6"]
 
 [tool.setuptools]
 zip-safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ launch = [
 models = ["cloudpickle"]
 async = ["httpx>=0.23.0"]
 perf = ["orjson"]
-reports = ["pydantic>=2.0.0"]
+reports = ["pydantic>=2.0.0,<=2.5"]
 
 [tool.setuptools]
 zip-safe = false

--- a/tox.ini
+++ b/tox.ini
@@ -187,7 +187,7 @@ commands=
 [testenv:reports-py{38,39,310,311,312}]
 deps=
     -r{toxinidir}/requirements_test.txt
-    wandb[reports]
+    .[reports]
     polyfactory
     wheel
     build

--- a/tox.ini
+++ b/tox.ini
@@ -188,7 +188,7 @@ commands=
 deps=
     -r{toxinidir}/requirements_test.txt
     wandb[reports]
-    pydantic
+    pydantic>=2.0.0,<=2.5
     polyfactory
     wheel
     build

--- a/tox.ini
+++ b/tox.ini
@@ -188,7 +188,6 @@ commands=
 deps=
     -r{toxinidir}/requirements_test.txt
     wandb[reports]
-    pydantic>=2.0.0,<=2.5
     polyfactory
     wheel
     build


### PR DESCRIPTION
Description
-----------
Pydantic 2.6 introduces some changes that interact strangely with how we use dataclasses.  Pin to unblock main until we can investigate further.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
