### PR TITLE
fix(launch): fetch all commits to enable checking out by sha

### DIFF
--- a/wandb/sdk/launch/git_reference.py
+++ b/wandb/sdk/launch/git_reference.py
@@ -65,7 +65,7 @@ class GitReference:
 
         try:
             # We fetch the origin so that we have branch and tag references
-            origin.fetch(depth=1)
+            origin.fetch()
         except git.exc.GitCommandError as e:
             raise LaunchError(
                 f"Unable to fetch from git remote repository {self.url}:\n{e}"


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

When the launch agent clones a git repository referenced in a job, it needs to do a full fetch. Prior to this PR we were doing a shallow fetch `depth=1` which only fetches the last commit.

What does the PR do?

Include a concise description of the PR contents

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
