### PR TITLE
fix(sweeps): dont swallow exceptions in pyagent

### DIFF
--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -12,6 +12,7 @@ import queue
 import socket
 import threading
 import time
+import traceback
 
 import wandb
 from wandb import wandb_sdk
@@ -223,8 +224,11 @@ class Agent:
                         self._run_status[run_id] = RunStatus.DONE
                     elif self._run_status[run_id] == RunStatus.ERRORED:
                         exc = self._exceptions[run_id]
-                        logger.error(f"Run {run_id} errored: {repr(exc)}")
-                        wandb.termerror(f"Run {run_id} errored: {repr(exc)}")
+                        exc_type, exc_value, exc_traceback = exc.__class__, exc, exc.__traceback__
+                        exc_traceback_formatted = traceback.format_exception(exc_type, exc_value, exc_traceback)
+                        exc_repr = ''.join(exc_traceback_formatted)
+                        logger.error(f"Run {run_id} errored:\n{exc_repr}")
+                        wandb.termerror(f"Run {run_id} errored:\n{exc_repr}")
                         if os.getenv(wandb.env.AGENT_DISABLE_FLAPPING) == "true":
                             self._exit_flag = True
                             return

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -224,9 +224,15 @@ class Agent:
                         self._run_status[run_id] = RunStatus.DONE
                     elif self._run_status[run_id] == RunStatus.ERRORED:
                         exc = self._exceptions[run_id]
-                        exc_type, exc_value, exc_traceback = exc.__class__, exc, exc.__traceback__
-                        exc_traceback_formatted = traceback.format_exception(exc_type, exc_value, exc_traceback)
-                        exc_repr = ''.join(exc_traceback_formatted)
+                        exc_type, exc_value, exc_traceback = (
+                            exc.__class__,
+                            exc,
+                            exc.__traceback__,
+                        )
+                        exc_traceback_formatted = traceback.format_exception(
+                            exc_type, exc_value, exc_traceback
+                        )
+                        exc_repr = "".join(exc_traceback_formatted)
                         logger.error(f"Run {run_id} errored:\n{exc_repr}")
                         wandb.termerror(f"Run {run_id} errored:\n{exc_repr}")
                         if os.getenv(wandb.env.AGENT_DISABLE_FLAPPING) == "true":


### PR DESCRIPTION
Description
-----------
- Fixes [WB-16926](https://wandb.atlassian.net/browse/WB-16926)


What does the PR do?

`pyagent` currently only shows a top level error message and not a full traceback when a called sweep function raises an exception. For example, if I had a `my_train.py` that looked like this:

my_train.py:

```python
def exc_fn():
    raise Exception('bad')

def sweep_fn():
    exc_fn()
```

and a sweep config that looked like this:

config.yaml:
```
method: grid
metric:
  goal: minimize
  name: val_loss
parameters:
  a:
    values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
program: train.py
```

Then if I ran this code before this PR I would see log entires that look like this: 

```
wandb.agent('dannygoldstein/uncategorized/brqlf3cs', my_train.sweep_fn)
wandb: Agent Starting Run: fgbwdyfk with config:
wandb:  a: 1
Run fgbwdyfk errored: Exception('bad')
```

(the exception is swallowed)

Now with this PR I see:

```
wandb.agent('dannygoldstein/uncategorized/brqlf3cs', my_train.sweep_fn)
wandb: Agent Starting Run: xwd3nq6z with config:
wandb:  a: 8
Run xwd3nq6z errored:
Traceback (most recent call last):
  File "/Users/danielgoldstein/.pyenv/versions/wandb/lib/python3.10/site-packages/wandb/agents/pyagent.py", line 302, in _run_job
    self._function()
  File "/Users/danielgoldstein/my_train.py", line 5, in sweep_fn
    exc_fn()
  File "/Users/danielgoldstein/my_train.py", line 2, in exc_fn
    raise Exception('bad')
Exception: bad
```

which is more useful

Testing
-------
Ran the above sweep 

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-16926]: https://wandb.atlassian.net/browse/WB-16926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ