### PR TITLE
chore(sdk): Add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ wandb/proto_check/
 .yea-requirements.txt
 .yeadoc/
 logs/
+
+# Conventional location for Python virtual environments.
+.venv/*


### PR DESCRIPTION
Description
-----------
Add the conventional ".venv" directory to .gitignore to make it easy to develop in a virtual environment.

