### PR TITLE
chore(launch): scrub launch_metadata.json from codebase

### DIFF
--- a/tests/pytest_tests/unit_tests_old/test_launch/test_launch.py
+++ b/tests/pytest_tests/unit_tests_old/test_launch/test_launch.py
@@ -463,35 +463,6 @@ async def test_launch_code_artifact(
     check_mock_run_info(mock_with_run_info, EMPTY_BACKEND_CONFIG, kwargs)
 
 
-def test_run_in_launch_context_with_artifact_name_string_used_as_config(
-    runner, live_mock_server, test_settings, monkeypatch
-):
-    live_mock_server.set_ctx({"swappable_artifacts": True})
-    arti = {
-        "name": "test:v0",
-        "project": "test",
-        "entity": "test",
-        "_version": "v0",
-        "_type": "artifactVersion",
-        "id": "QXJ0aWZhY3Q6NTI1MDk4",
-    }
-    overrides = {
-        "overrides": {"run_config": {"epochs": 10}, "artifacts": {"dataset": arti}},
-    }
-    with runner.isolated_filesystem():
-        monkeypatch.setenv("WANDB_CONFIG", json.dumps(overrides))
-        test_settings.update(launch=True, source=wandb.sdk.wandb_settings.Source.INIT)
-        run = wandb.init(settings=test_settings, config={"epochs": 2, "lr": 0.004})
-        arti_inst = run.use_artifact("old_name:latest", use_as="dataset")
-        run.config.dataset = arti_inst
-        assert run.config.epochs == 10
-        assert run.config.lr == 0.004
-        run.finish()
-        assert arti_inst.name == "test:v0"
-        arti_info = live_mock_server.get_ctx()["used_artifact_info"]
-        assert arti_info["used_name"] == "dataset"
-
-
 # this test includes building a docker container which can take some time,
 # hence the timeout. caching should usually keep this under 30 seconds
 @pytest.mark.flaky

--- a/tests/pytest_tests/unit_tests_old/test_launch/test_launch.py
+++ b/tests/pytest_tests/unit_tests_old/test_launch/test_launch.py
@@ -338,20 +338,6 @@ async def test_launch_base_case(
         default_settings=test_settings, load_settings=False
     )
 
-    def mock_create_metadata_file(*args, **kwargs):
-        dockerfile_contents = args[4]
-        assert "ENV WANDB_BASE_URL=https://api.wandb.ai" in dockerfile_contents
-        assert f"ENV WANDB_API_KEY={api.api_key}" in dockerfile_contents
-        assert "ENV WANDB_PROJECT=test" in dockerfile_contents
-        assert "ENV WANDB_ENTITY=mock_server_entity" in dockerfile_contents
-
-        _project_spec.create_metadata_file(*args, **kwargs)
-
-    monkeypatch.setattr(
-        wandb.sdk.launch._project_spec,
-        "create_metadata_file",
-        mock_create_metadata_file,
-    )
     uri = "https://wandb.ai/mock_server_entity/test/runs/1"
     kwargs = {
         "uri": uri,

--- a/tests/pytest_tests/unit_tests_old/test_launch/test_launch_aws.py
+++ b/tests/pytest_tests/unit_tests_old/test_launch/test_launch_aws.py
@@ -79,17 +79,6 @@ async def test_launch_aws_sagemaker_no_instance(
     monkeypatch,
     capsys,
 ):
-    def mock_create_metadata_file(*args, **kwargs):
-        dockerfile_contents = args[4]
-        expected_entrypoint = 'ENTRYPOINT ["sh", "train"]'
-        assert expected_entrypoint in dockerfile_contents, dockerfile_contents
-        _project_spec.create_metadata_file(*args, **kwargs)
-
-    monkeypatch.setattr(
-        wandb.sdk.launch._project_spec,
-        "create_metadata_file",
-        mock_create_metadata_file,
-    )
     monkeypatch.setattr(wandb.docker, "tag", lambda x, y: "")
     monkeypatch.setattr(
         wandb.docker, "push", lambda x, y: f"The push refers to repository [{x}]"
@@ -134,12 +123,6 @@ async def test_launch_aws_sagemaker_no_instance(
 async def test_launch_aws_sagemaker(
     live_mock_server, test_settings, mocked_fetchable_git_repo, monkeypatch, capsys
 ):
-    def mock_create_metadata_file(*args, **kwargs):
-        dockerfile_contents = args[4]
-        expected_entrypoint = 'ENTRYPOINT ["sh", "train"]'
-        assert expected_entrypoint in dockerfile_contents, dockerfile_contents
-        _project_spec.create_metadata_file(*args, **kwargs)
-
     mock_env = MagicMock(spec=AwsEnvironment)
     session = MagicMock()
     session.client.return_value = mock_sagemaker_client()
@@ -158,11 +141,6 @@ async def test_launch_aws_sagemaker(
         wandb.sdk.launch.loader,
         "registry_from_config",
         lambda *args: None,
-    )
-    monkeypatch.setattr(
-        wandb.sdk.launch._project_spec,
-        "create_metadata_file",
-        mock_create_metadata_file,
     )
     monkeypatch.setattr(wandb.docker, "tag", lambda x, y: "")
     monkeypatch.setattr(

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -3,7 +3,6 @@
 Arguments can come from a launch spec or call to wandb launch.
 """
 import enum
-import json
 import logging
 import os
 import tempfile
@@ -25,7 +24,6 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-DEFAULT_LAUNCH_METADATA_PATH = "launch_metadata.json"
 
 # need to make user root for sagemaker, so users have access to /opt/ml directories
 # that let users create artifacts and access input data
@@ -159,8 +157,6 @@ class LaunchProject:
                 )
             self.source = LaunchSource.LOCAL
             self.project_dir = self.uri
-
-        self.aux_dir = tempfile.mkdtemp()
 
     @property
     def base_image(self) -> str:
@@ -555,25 +551,3 @@ def fetch_and_validate_project(
         launch_project.deps_type = "conda"
 
     return launch_project
-
-
-def create_metadata_file(
-    launch_project: LaunchProject,
-    image_uri: str,
-    sanitized_entrypoint_str: str,
-    sanitized_dockerfile_contents: str,
-) -> None:
-    assert launch_project.project_dir is not None
-    with open(
-        os.path.join(launch_project.project_dir, DEFAULT_LAUNCH_METADATA_PATH),
-        "w",
-    ) as f:
-        json.dump(
-            {
-                **launch_project.launch_spec,
-                "image_uri": image_uri,
-                "command": sanitized_entrypoint_str,
-                "dockerfile_contents": sanitized_dockerfile_contents,
-            },
-            f,
-        )

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -315,7 +315,6 @@ def get_env_vars_dict(
     _inject_wandb_config_env_vars(
         launch_project.override_config, env_vars, max_env_length
     )
-    # env_vars["WANDB_CONFIG"] = json.dumps(launch_project.override_config)
     artifacts = {}
     # if we're spinning up a launch process from a job
     # we should tell the run to use that artifact

--- a/wandb/sdk/launch/builder/docker_builder.py
+++ b/wandb/sdk/launch/builder/docker_builder.py
@@ -11,18 +11,12 @@ from wandb.sdk.launch.builder.build import registry_from_uri
 from wandb.sdk.launch.environment.abstract import AbstractEnvironment
 from wandb.sdk.launch.registry.abstract import AbstractRegistry
 
-from .._project_spec import (
-    EntryPoint,
-    LaunchProject,
-    create_metadata_file,
-    get_entry_point_command,
-)
+from .._project_spec import EntryPoint, LaunchProject
 from ..errors import LaunchDockerError, LaunchError
 from ..registry.local_registry import LocalRegistry
 from ..utils import (
     LOG_PREFIX,
     event_loop_thread_exec,
-    sanitize_wandb_api_key,
     warn_failed_packages_from_build_logs,
 )
 from .build import (
@@ -155,14 +149,6 @@ class DockerBuilder(AbstractBuilder):
             f"image {image_uri} does not already exist in repository, building."
         )
 
-        entry_cmd = get_entry_point_command(entrypoint, launch_project.override_args)
-
-        create_metadata_file(
-            launch_project,
-            image_uri,
-            sanitize_wandb_api_key(" ".join(entry_cmd)),
-            dockerfile_str,
-        )
         build_ctx_path = _create_docker_build_ctx(launch_project, dockerfile_str)
         dockerfile = os.path.join(build_ctx_path, _WANDB_DOCKERFILE_NAME)
         try:

--- a/wandb/sdk/launch/builder/kaniko_builder.py
+++ b/wandb/sdk/launch/builder/kaniko_builder.py
@@ -23,17 +23,11 @@ from wandb.sdk.launch.registry.elastic_container_registry import (
 from wandb.sdk.launch.registry.google_artifact_registry import GoogleArtifactRegistry
 from wandb.util import get_module
 
-from .._project_spec import (
-    EntryPoint,
-    LaunchProject,
-    create_metadata_file,
-    get_entry_point_command,
-)
+from .._project_spec import EntryPoint, LaunchProject
 from ..errors import LaunchError
 from ..utils import (
     LOG_PREFIX,
     get_kube_context_and_api_client,
-    sanitize_wandb_api_key,
     warn_failed_packages_from_build_logs,
 )
 from .build import (
@@ -271,16 +265,6 @@ class KanikoBuilder(AbstractBuilder):
 
         _logger.info(f"Building image {image_uri}...")
 
-        entry_cmd = " ".join(
-            get_entry_point_command(entrypoint, launch_project.override_args)
-        )
-
-        create_metadata_file(
-            launch_project,
-            image_uri,
-            sanitize_wandb_api_key(entry_cmd),
-            sanitize_wandb_api_key(dockerfile_str),
-        )
         context_path = _create_docker_build_ctx(launch_project, dockerfile_str)
         run_id = launch_project.run_id
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Launch used to use a file in the build context called `launch_metadata.json` to pass in overrides. This has been deprecated for some time but there is still code being used to construct this file in the docker and kaniko builders. But it's never read. This PR removes all of that old stuff.

What does the PR do?

Include a concise description of the PR contents

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
