### PR TITLE
chore(sdk): Don't exit in 'wandb beta' if wandb-core not found

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -433,10 +433,11 @@ def beta():
     from wandb.util import get_core_path
 
     if not get_core_path():
-        click.echo(
-            "wandb beta commands require wandb-core, please install with `pip install wandb-core`"
+        msg = (
+            "wandb beta commands require wandb-core, please install with"
+            " `pip install wandb-core`"
         )
-        sys.exit(1)
+        click.echo(click.style(msg, fg="red"))
 
 
 @beta.command(


### PR DESCRIPTION
Description
-----------
When running `wandb beta` commands, if `wandb-core` is not found, print a warning but don't exit. This was breaking the doc generation GitHub workflow.

Testing
-------
```
pip install -e .
wandb beta sync --help
```