### PR TITLE
chore(sdk): Write 'wandb beta' error to stderr

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -433,11 +433,14 @@ def beta():
     from wandb.util import get_core_path
 
     if not get_core_path():
-        msg = (
-            "wandb beta commands require wandb-core, please install with"
-            " `pip install wandb-core`"
+        click.secho(
+            (
+                "wandb beta commands require wandb-core, please install with"
+                " `pip install wandb-core`"
+            ),
+            fg="red",
+            err=True,
         )
-        click.echo(click.style(msg, fg="red"))
 
 
 @beta.command(


### PR DESCRIPTION
Description
-----------
Follow-up to try to fix docugen. Write the error to stderr so that (hopefully) docugen doesn't pick it up as part of the `--help` string.

Also updated to use `click.secho` to combine `click.echo` and `click.style`.
