### PR TITLE
feat(artifacts): Add ability to change artifact collection types

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -1392,6 +1392,20 @@ def test_s3_storage_handler_load_path_missing_reference(monkeypatch, wandb_init)
             artifact.download()
 
 
+def test_change_artifact_collection_type(monkeypatch, wandb_init):
+    with wandb_init() as run:
+        artifact = wandb.Artifact("image_data", "data")
+        run.log_artifact(artifact)
+
+    with wandb_init() as run:
+        artifact = run.use_artifact("image_data:latest")
+        artifact.collection.change_type("lucas_type")
+
+    with wandb_init() as run:
+        artifact = run.use_artifact("image_data:latest")
+        assert artifact.type == "lucas_type"
+
+
 def test_s3_storage_handler_load_path_missing_reference_allowed(
     monkeypatch, wandb_init, capsys
 ):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-16910
- Fixes #16910

What does the PR do?
Allow users in the SDK, given an artifact object, change the artifact's entire collection type

If the typename is invalid, throw an error.
We termlog the before and after.

Testing
-------
How was this PR tested?

Running the command
<img width="934" alt="Screenshot 2024-02-07 at 10 16 33 PM" src="https://github.com/wandb/wandb/assets/155467726/d3106d35-3136-4cd7-a40a-47fbd0522bcf">

The result in WandB UI
<img width="427" alt="Screenshot 2024-02-07 at 10 17 22 PM" src="https://github.com/wandb/wandb/assets/155467726/b099f185-4713-4179-b67e-3a832ea35eea">


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
