### PR TITLE
chore(sdk): Use a single unit test job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,22 @@ parameters:
     type: string
     default: "master"
 
+executors:
+  macos:
+    # TODO: Ignored
+    parameters:
+      python_version_major: {type: integer}
+      python_version_minor: {type: integer}
+    macos:
+      xcode: 15.1.0
+
+  linux-python:
+    parameters:
+      python_version_major: {type: integer}
+      python_version_minor: {type: integer}
+    docker:
+      - image: python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>
+
 commands:
   save-test-results:
     description: "Save test results"
@@ -345,6 +361,8 @@ jobs:
 
   unit-tests-new:
     parameters:
+      executor: {type: string}
+      install_deps: {type: steps}
       python_version_major: {type: integer}
       python_version_minor: {type: integer}
       with_core: {type: boolean}
@@ -352,8 +370,10 @@ jobs:
         type: enum
         enum: [sdk, other]
 
-    docker:
-      - image: python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>
+    executor:
+      name: <<parameters.executor>>
+      python_version_major: <<parameters.python_version_major>>
+      python_version_minor: <<parameters.python_version_minor>>
 
     # We're testing some heavy "units". Ideally we would use the default,
     # but for that we must pare down the unit tests.
@@ -365,13 +385,8 @@ jobs:
 
     steps:
       - checkout
+      - <<parameters.install_deps>>
       - install_go
-
-      - run:
-          name: Install system deps
-          command: |
-            apt-get update
-            apt-get install -y libsndfile1 ffmpeg
 
       - run:
           name: Install Python dependencies
@@ -1593,12 +1608,59 @@ workflows:
       - unit-tests-new:
           requires:
             - unit-tests
+          name: "\
+            unit-tests-linux-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.tests>>-\
+            <<matrix.python_version_major>>-\
+            <<matrix.python_version_minor>>"
+
           matrix:
             parameters:
               python_version_major: [3]
               python_version_minor: [7, 12]
               with_core: [true, false]
               tests: [sdk, other]
+
+          executor: linux-python
+          install_deps:
+            - run:
+                name: Install system deps
+                command: |
+                  apt-get update
+                  apt-get install -y libsndfile1 ffmpeg
+
+      #
+      # Unit tests with pytest on macOS
+      #
+      - unit-tests-new:
+          requires:
+            - unit-tests
+          name: "\
+            unit-tests-macos-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.tests>>-\
+            <<matrix.python_version_major>>-\
+            <<matrix.python_version_minor>>"
+          matrix:
+            parameters:
+              python_version_major: [3]
+              python_version_minor: [7, 12]
+              with_core: [true, false]
+              tests: [sdk, other]
+
+          executor: macos
+          install_deps:
+            - run:
+                name: Install system deps
+                command: |
+                  brew install ffmpeg \
+                    python@<<matrix.python_version_major>>.<<matrix.python_version_minor>>
+            - run:
+                name: Add unversioned 'python' to PATH
+                command: |
+                  echo "export PATH=$(brew --prefix python)/libexec/bin:\$PATH"
+
 
       #
       # Unit tests with pytest on Windows and MacOS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,15 +266,6 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
-executors:
-  macos:
-    macos: {xcode: 15.0.1}
-    resource_class: macos.m1.medium.gen1
-
-  docker-python310:
-    docker: [image: "python:3.10"]
-    resource_class: xlarge
-
 jobs:
   regression:
     parameters:
@@ -352,13 +343,26 @@ jobs:
                       # taken from slack-secrets context
                       channel: << parameters.notify_on_failure_channel >>
 
-  unit-tests-sdk:
+  unit-tests-new:
     parameters:
       python_version_major: {type: integer}
       python_version_minor: {type: integer}
       with_core: {type: boolean}
+      tests:
+        type: enum
+        enum: [sdk, other]
+
     docker:
       - image: python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>
+
+    # We're testing some heavy "units". Ideally we would use the default,
+    # but for that we must pare down the unit tests.
+    resource_class: xlarge
+
+    # Shards the job, setting $CIRCLE_NODE_TOTAL and $CIRCLE_NODE_INDEX.
+    # https://circleci.com/docs/parallelism-faster-jobs/
+    parallelism: 2
+
     steps:
       - checkout
       - install_go
@@ -374,20 +378,44 @@ jobs:
           command: pip install -U tox nox pip
           no_output_timeout: 5m
 
-      - run:
-          name: Run tests
-          no_output_timeout: 10m
-          command: |
-            CI_PYTEST_SPLIT_ARGS=" \
-              --splits $CIRCLE_NODE_TOTAL \
-              --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
-            tox run -v \
-              -e <<#parameters.with_core>>core-<</parameters.with_core
-                >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
-              -- \
-              tests/pytest_tests/unit_tests/ \
-              --ignore tests/pytest_tests/unit_tests/test_launch/ \
-              --ignore tests/pytest_tests/unit_tests/test_reports/
+      # For now, this step needs to be duplicated because there's no way
+      # in YAML or CircleCI's config to change just the final argument to
+      # tox run. Ideally, we would just pass "sdk" or "other" directly to
+      # the test command, and have it decide on the paths to run.
+      - when:
+          condition: { equal: [tests, "sdk"] }
+          steps:
+            - run:
+                name: Run tests owned by SDK
+                no_output_timeout: 10m
+                command: |
+                  CI_PYTEST_SPLIT_ARGS=" \
+                    --splits $CIRCLE_NODE_TOTAL \
+                    --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
+                  tox run -v \
+                    -e <<#parameters.with_core>>core-<</parameters.with_core
+                      >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
+                    -- \
+                    tests/pytest_tests/unit_tests/ \
+                    --ignore tests/pytest_tests/unit_tests/test_launch/ \
+                    --ignore tests/pytest_tests/unit_tests/test_reports/
+
+      - when:
+          condition: { equal: [tests, "other"] }
+          steps:
+            - run:
+                name: Run tests not owned by SDK
+                no_output_timeout: 10m
+                command: |
+                  CI_PYTEST_SPLIT_ARGS=" \
+                    --splits $CIRCLE_NODE_TOTAL \
+                    --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
+                  tox run -v \
+                    -e <<#parameters.with_core>>core-<</parameters.with_core
+                      >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
+                    -- \
+                    tests/pytest_tests/unit_tests/test_launch/ \
+                    tests/pytest_tests/unit_tests/test_reports/
 
       - run:
           name: Upload code coverage results
@@ -1562,7 +1590,7 @@ workflows:
       #
       # Unit tests with pytest on Linux
       #
-      - unit-tests-sdk:
+      - unit-tests-new:
           requires:
             - unit-tests
           matrix:
@@ -1570,6 +1598,7 @@ workflows:
               python_version_major: [3]
               python_version_minor: [7, 12]
               with_core: [true, false]
+              tests: [sdk, other]
 
       #
       # Unit tests with pytest on Windows and MacOS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ executors:
   macos:
     macos:
       xcode: 15.1.0
+    resource_class: macos.m1.medium.gen1
 
   linux-python:
     parameters:
@@ -94,6 +95,7 @@ executors:
       python_version_minor: {type: integer}
     docker:
       - image: python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>
+    resource_class: xlarge
 
 commands:
   save-test-results:
@@ -367,10 +369,6 @@ jobs:
         enum: [sdk, other]
 
     executor: <<parameters.executor>>
-
-    # We're testing some heavy "units". Ideally we would use the default,
-    # but for that we must pare down the unit tests.
-    resource_class: xlarge
 
     # Shards the job, setting $CIRCLE_NODE_TOTAL and $CIRCLE_NODE_INDEX.
     # https://circleci.com/docs/parallelism-faster-jobs/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1631,6 +1631,7 @@ workflows:
       # This differs from the Linux tests above only in:
       #   - executor
       #   - install_deps
+      #   - Python versions tested (Homebrew doesn't have 3.7)
       #
       # Unfortunately, CircleCI does not seem to provide a way to define
       # the common part separately and reuse it.
@@ -1648,7 +1649,7 @@ workflows:
           matrix:
             parameters:
               python_version_major: [3]
-              python_version_minor: [7, 12]
+              python_version_minor: [9, 12]
               with_core: [true, false]
               tests: [sdk, other]
 
@@ -1660,10 +1661,6 @@ workflows:
                 command: |
                   brew install ffmpeg \
                     python@<<matrix.python_version_major>>.<<matrix.python_version_minor>>
-            - run:
-                name: Add unversioned 'python' to PATH
-                command: |
-                  echo "export PATH=$(brew --prefix python)/libexec/bin:\$PATH"
 
 
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,16 +377,16 @@ jobs:
       - run:
           name: Run tests
           no_output_timeout: 10m
-          command: >
-            CI_PYTEST_SPLIT_ARGS="
-              --splits $CIRCLE_NODE_TOTAL
-              --group $(( $CIRCLE_NODE_INDEX + 1 ))"
-            tox run -v
+          command: |
+            CI_PYTEST_SPLIT_ARGS="\
+              --splits $CIRCLE_NODE_TOTAL\
+              --group $(( $CIRCLE_NODE_INDEX + 1 ))"\
+            tox run -v \
               -e <<#parameters.with_core>>core-<</parameters.with_core
-                >>py<<parameters.python_version_major>><<parameters.python_version_minor>>
-              --
-              tests/pytest_tests/unit_tests/
-              --ignore tests/pytest_tests/unit_tests/test_launch/
+                >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
+              -- \
+              tests/pytest_tests/unit_tests/ \
+              --ignore tests/pytest_tests/unit_tests/test_launch/ \
               --ignore tests/pytest_tests/unit_tests/test_reports/
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1860,19 +1860,6 @@ workflows:
           parallelism: 6
           xdist: 1
 
-      # report api tests
-      - tox-base:
-          requires:
-            - "unit-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [8]
-          name: "unit-linux-reports-api-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "reports-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/unit_tests/test_reports"
-          codecov_args: "-F unit"
-
       #
       # wandb launch tests
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,8 +380,8 @@ jobs:
       - run:
           name: Install Python version <<parameters.python_version_major>>.<<parameters.python_version_minor>>
           command: |
-            pyenv install <parameters.python_version_major>>.<<parameters.python_version_minor>>
-            pyenv global <parameters.python_version_major>>.<<parameters.python_version_minor>>
+            pyenv install <<parameters.python_version_major>>.<<parameters.python_version_minor>>
+            pyenv global <<parameters.python_version_major>>.<<parameters.python_version_minor>>
 
       - run:
           name: Install Python dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1609,7 +1609,7 @@ workflows:
           matrix:
             parameters:
               python_version_major: [3]
-              python_version_minor: [7, 12]
+              python_version_minor: [8, 12]
               with_core: [true, false]
               tests: [sdk, other]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,15 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
+executors:
+  macos:
+    macos: {xcode: 15.0.1}
+    resource_class: macos.m1.medium.gen1
+
+  docker-python310:
+    docker: [image: "python:3.10"]
+    resource_class: xlarge
+
 jobs:
   regression:
     parameters:
@@ -342,6 +351,63 @@ jobs:
                       mentions: "@channel"
                       # taken from slack-secrets context
                       channel: << parameters.notify_on_failure_channel >>
+
+  unit-tests-sdk:
+    parameters:
+      executor: {type: executor}
+      python_version_major: {type: integer}
+      python_version_minor: {type: integer}
+      with_core: {type: boolean}
+    executor: <<parameters.executor>>
+    steps:
+      - checkout
+      - install_go
+
+      - when:
+          condition: { equal: [<<parameters.executor>>, "docker-python310"]}
+          steps:
+            run:
+              name: Install system deps
+              command: apt-get update && apt-get install -y libsndfile1 ffmpeg
+
+      - when:
+          condition: { equal: [<<parameters.executor>>, "macos"]}
+          steps:
+            run:
+              name: Install system deps
+              command: brew install libsndfile ffmpeg
+
+      - run:
+          name: Install Python version <<parameters.python_version_major>>.<<parameters.python_version_minor>>
+          command: |
+            pyenv install <parameters.python_version_major>>.<<parameters.python_version_minor>>
+            pyenv global <parameters.python_version_major>>.<<parameters.python_version_minor>>
+
+      - run:
+          name: Install Python dependencies
+          command: pip install -U tox nox pip pyenv
+          no_output_timeout: 5m
+
+      - run:
+          name: Run tests
+          no_output_timeout: 10m
+          command: >
+            CI_PYTEST_SPLIT_ARGS="
+              --splits $CIRCLE_NODE_TOTAL
+              --group $(( $CIRCLE_NODE_INDEX + 1 ))"
+            tox run -v
+              -e <<#parameters.with_core>>core-<</parameters.with_core
+                >>py<<parameters.python_version_major>><<parameters.python_version_minor>>
+              --
+              tests/pytest_tests/unit_tests/
+              --ignore tests/pytest_tests/unit_tests/test_launch/
+              --ignore tests/pytest_tests/unit_tests/test_reports/
+
+      - run:
+          name: Upload code coverage results
+          command: nox -s codecov -- -F unit
+
+      - save-test-results
 
   code-check:
     docker:
@@ -1510,55 +1576,18 @@ workflows:
       #
       # Unit tests with pytest on Linux
       #
-      - tox-base:
+      - unit-tests-sdk:
           requires:
-            - "unit-tests"
+            - unit-tests
           matrix:
             parameters:
+              executor: [docker-python310, macos]
               python_version_major: [3]
-              python_version_minor: [7, 8, 9, 10, 11, 12]
-          name: "unit-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
-          codecov_args: "-F unit"
-      #
-      # Unit tests with pytest on Linux
-      #
-      - tox-base:
-          requires:
-            - "unit-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [10]
-          name: "unit(service)-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
-          codecov_args: "-F unit"
-
-      - tox-base:
-          requires:
-            - "unit-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [10]
-          name: "unit(service)-launch-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/unit_tests/test_launch"
-          codecov_args: "-F unit"
-
-      - tox-base:
-          requires:
-            - "unit-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [10]
-          name: "unit-launch-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/unit_tests/test_launch"
-          codecov_args: "-F unit"
+              python_version_minor: [7, 12]
+              with_core: [true, false]
+          name: "unit-tests-new-linux\
+            <<#matrix.with_core>>-core<</matrix.with_core>>\
+            -py<<matrix.python_version_major>><<matrix.python_version_minor>>"
 
       #
       # Unit tests with pytest on Windows and MacOS
@@ -1659,29 +1688,6 @@ workflows:
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
           codecov_args: "-F unit"
 
-      - mac:
-          requires:
-            - "unit-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
-          name: "unit-macos-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
-          codecov_args: "-F unit"
-
-      - mac:
-          requires:
-            - "unit-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
-          name: "unit(service)-macos-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
-          codecov_args: "-F unit"
       #
       # Functional tests with yea on Linux (base only)
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,10 @@ jobs:
           steps:
             run:
               name: Install system deps
-              command: apt-get update && apt-get install -y libsndfile1 ffmpeg
+              command: |
+                apt-get update
+                apt-get install -y libsndfile1 ffmpeg
+                curl https://pyenv.run | bash
 
       - when:
           condition: { equal: [<<parameters.executor>>, "macos"]}
@@ -385,7 +388,7 @@ jobs:
 
       - run:
           name: Install Python dependencies
-          command: pip install -U tox nox pip pyenv
+          command: pip install -U tox nox pip
           no_output_timeout: 5m
 
       - run:
@@ -1585,9 +1588,6 @@ workflows:
               python_version_major: [3]
               python_version_minor: [7, 12]
               with_core: [true, false]
-          name: "unit-tests-new-linux\
-            <<#matrix.with_core>>-core<</matrix.with_core>>\
-            -py<<matrix.python_version_major>><<matrix.python_version_minor>>"
 
       #
       # Unit tests with pytest on Windows and MacOS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
       # tox run. Ideally, we would just pass "sdk" or "other" directly to
       # the test command, and have it decide on the paths to run.
       - when:
-          condition: { equal: [tests, "sdk"] }
+          condition: { equal: [<<parameters.tests>>, sdk] }
           steps:
             - run:
                 name: Run tests owned by SDK
@@ -401,7 +401,7 @@ jobs:
                     --ignore tests/pytest_tests/unit_tests/test_reports/
 
       - when:
-          condition: { equal: [tests, "other"] }
+          condition: { equal: [<<parameters.tests>>, other] }
           steps:
             - run:
                 name: Run tests not owned by SDK

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,37 +354,20 @@ jobs:
 
   unit-tests-sdk:
     parameters:
-      executor: {type: string}
       python_version_major: {type: integer}
       python_version_minor: {type: integer}
       with_core: {type: boolean}
-    executor: <<parameters.executor>>
+    docker:
+      - image: python<<parameters.python_version_major>>.<<parameters.python_version_minor>>
     steps:
       - checkout
       - install_go
 
-      - when:
-          condition: { equal: [<<parameters.executor>>, docker-python310]}
-          steps:
-            run:
-              name: Install system deps
-              command: |
-                apt-get update
-                apt-get install -y libsndfile1 ffmpeg
-                curl https://pyenv.run | bash
-
-      - when:
-          condition: { equal: [<<parameters.executor>>, macos]}
-          steps:
-            run:
-              name: Install system deps
-              command: brew install libsndfile ffmpeg
-
       - run:
-          name: Install Python version <<parameters.python_version_major>>.<<parameters.python_version_minor>>
+          name: Install system deps
           command: |
-            pyenv install <<parameters.python_version_major>>.<<parameters.python_version_minor>>
-            pyenv global <<parameters.python_version_major>>.<<parameters.python_version_minor>>
+            apt-get update
+            apt-get install -y libsndfile1 ffmpeg
 
       - run:
           name: Install Python dependencies
@@ -1584,7 +1567,6 @@ workflows:
             - unit-tests
           matrix:
             parameters:
-              executor: [docker-python310, macos]
               python_version_major: [3]
               python_version_minor: [7, 12]
               with_core: [true, false]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,6 @@ parameters:
 
 executors:
   macos:
-    # TODO: Ignored
-    parameters:
-      python_version_major: {type: integer}
-      python_version_minor: {type: integer}
     macos:
       xcode: 15.1.0
 
@@ -361,7 +357,7 @@ jobs:
 
   unit-tests-new:
     parameters:
-      executor: {type: string}
+      executor: {type: executor}
       install_deps: {type: steps}
       python_version_major: {type: integer}
       python_version_minor: {type: integer}
@@ -370,10 +366,7 @@ jobs:
         type: enum
         enum: [sdk, other]
 
-    executor:
-      name: <<parameters.executor>>
-      python_version_major: <<parameters.python_version_major>>
-      python_version_minor: <<parameters.python_version_minor>>
+    executor: <<parameters.executor>>
 
     # We're testing some heavy "units". Ideally we would use the default,
     # but for that we must pare down the unit tests.
@@ -1622,7 +1615,11 @@ workflows:
               with_core: [true, false]
               tests: [sdk, other]
 
-          executor: linux-python
+          executor:
+            name: linux-python
+            python_version_major: <<matrix.python_version_major>>
+            python_version_minor: <<matrix.python_version_minor>>
+
           install_deps:
             - run:
                 name: Install system deps
@@ -1650,6 +1647,7 @@ workflows:
               tests: [sdk, other]
 
           executor: macos
+
           install_deps:
             - run:
                 name: Install system deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ jobs:
                       # taken from slack-secrets context
                       channel: << parameters.notify_on_failure_channel >>
 
-  unit-tests-new:
+  unit-tests:
     parameters:
       executor: {type: executor}
       install_deps: {type: steps}
@@ -1503,8 +1503,6 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
       - prep:
-          name: "unit-tests"
-      - prep:
           name: "unit-tests-legacy"
       - prep:
           name: "functional-tests"
@@ -1561,9 +1559,7 @@ workflows:
       #
       # core unit tests
       #
-      - gotest:
-          requires:
-            - "unit-tests"
+      - gotest
 
       #
       # Unit tests with pytest on Linux, using the old mock server
@@ -1596,9 +1592,7 @@ workflows:
       #
       # Unit tests with pytest on Linux
       #
-      - unit-tests-new:
-          requires:
-            - unit-tests
+      - unit-tests:
           name: "\
             unit-tests-linux-\
             <<#matrix.with_core>>core-<</matrix.with_core>>\
@@ -1636,9 +1630,7 @@ workflows:
       # Unfortunately, CircleCI does not seem to provide a way to define
       # the common part separately and reuse it.
       #
-      - unit-tests-new:
-          requires:
-            - unit-tests
+      - unit-tests:
           name: "\
             unit-tests-macos-\
             <<#matrix.with_core>>core-<</matrix.with_core>>\
@@ -1721,8 +1713,6 @@ workflows:
       #     tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
 
       - win:
-          requires:
-            - "unit-tests"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,9 +378,9 @@ jobs:
           name: Run tests
           no_output_timeout: 10m
           command: |
-            CI_PYTEST_SPLIT_ARGS="\
-              --splits $CIRCLE_NODE_TOTAL\
-              --group $(( $CIRCLE_NODE_INDEX + 1 ))"\
+            CI_PYTEST_SPLIT_ARGS=" \
+              --splits $CIRCLE_NODE_TOTAL \
+              --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
             tox run -v \
               -e <<#parameters.with_core>>core-<</parameters.with_core
                 >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ jobs:
       python_version_minor: {type: integer}
       with_core: {type: boolean}
     docker:
-      - image: python<<parameters.python_version_major>>.<<parameters.python_version_minor>>
+      - image: python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>
     steps:
       - checkout
       - install_go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,7 +354,7 @@ jobs:
 
   unit-tests-sdk:
     parameters:
-      executor: {type: executor}
+      executor: {type: string}
       python_version_major: {type: integer}
       python_version_minor: {type: integer}
       with_core: {type: boolean}
@@ -364,7 +364,7 @@ jobs:
       - install_go
 
       - when:
-          condition: { equal: [<<parameters.executor>>, "docker-python310"]}
+          condition: { equal: [<<parameters.executor>>, docker-python310]}
           steps:
             run:
               name: Install system deps
@@ -374,7 +374,7 @@ jobs:
                 curl https://pyenv.run | bash
 
       - when:
-          condition: { equal: [<<parameters.executor>>, "macos"]}
+          condition: { equal: [<<parameters.executor>>, macos]}
           steps:
             run:
               name: Install system deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1630,6 +1630,13 @@ workflows:
       #
       # Unit tests with pytest on macOS
       #
+      # This differs from the Linux tests above only in:
+      #   - executor
+      #   - install_deps
+      #
+      # Unfortunately, CircleCI does not seem to provide a way to define
+      # the common part separately and reuse it.
+      #
       - unit-tests-new:
           requires:
             - unit-tests
@@ -1639,6 +1646,7 @@ workflows:
             <<matrix.tests>>-\
             <<matrix.python_version_major>>-\
             <<matrix.python_version_minor>>"
+
           matrix:
             parameters:
               python_version_major: [3]

--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,7 @@ passenv=
     USERNAME
     CI_PYTEST_SPLIT_ARGS
 
-[testenv:{,core-}{,notebooks-}py{37,38,39,310,311,312}]
+[testenv:{,core-}{,notebooks-}py{38,39,310,311,312}]
 install_command=
     ; pytorch installations on non-darwin need the `-f`
     pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -106,6 +106,8 @@ install_command=
     pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     {[base]deps}
+    .[reports]
+    polyfactory
     wheel
     build
     nox
@@ -159,29 +161,6 @@ commands_pre=
 commands=
     yea {env:CI_PYTEST_SPLIT_ARGS:} --strict --shard {env:SHARD:default} run {posargs:--all}
 
-[testenv:reports-py{38,39,310,311,312}]
-deps=
-    -r{toxinidir}/requirements_test.txt
-    .[reports]
-    polyfactory
-    wheel
-    build
-    nox
-setenv=
-    {[base]setenv}
-    WINDIR=C:\\Windows
-    WANDB_ERROR_REPORTING=false
-passenv=
-    {[base]passenv}
-    CI_PYTEST_PARALLEL
-    CI
-allowlist_externals=
-    mkdir
-    nox
-commands_pre=
-    mkdir -p test-results .coverage
-commands=
-    pytest {env:CI_PYTEST_SPLIT_ARGS:} -n=8 --durations=20 --reruns 2 --reruns-delay 1 --junitxml=test-results/junit.xml --cov --cov-report=xml --no-cov-on-fail --timeout 300 {posargs}
 
 [testenv:func-{mitm,docs}-py{37,38,39,310,311,312}]
 install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Use a single job called "unit-tests-new" to run both SDK and non-SDK unit tests on Linux (non-"legacy" tests).

I didn't add an option to run unit tests on Mac, assuming that there is not much value in running unit tests on different systems and machines, but I can add it if we think it's still useful.

Testing
-------
Running on CircleCI.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
