### PR TITLE
chore(sdk): Delete ./core/dist/ directory when rebuilding in wini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ logs/
 # Conventional location for Python virtual environments.
 .venv/*
 
+# Private directory for wini (scripts & tools for the repo).
+.wini/*
+
 # Swift compiler's cache when building Apple stats monitoring library.
 core/pkg/monitor/apple/.build/*
 

--- a/tools/wini/subprocess.py
+++ b/tools/wini/subprocess.py
@@ -7,7 +7,7 @@ from . import print
 
 
 def check_call(
-    cmd: List[str],
+    cmd: List[object],
     *,
     cwd: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
@@ -24,7 +24,7 @@ def check_call(
     else:
         print.info("Running")
 
-    print.command(cmd)
+    print.command([str(part) for part in cmd])
 
     subprocess.check_call(
         cmd,
@@ -33,12 +33,12 @@ def check_call(
     )
 
 
-def run(cmd: List[str]) -> None:
+def run(cmd: List[object]) -> None:
     """Invokes `subprocess.run`.
 
     Args:
         cmd: The command to run.
     """
     print.info("Running")
-    print.command(cmd)
+    print.command([str(part) for part in cmd])
     subprocess.run(cmd)

--- a/tools/wini/wini.py
+++ b/tools/wini/wini.py
@@ -8,7 +8,7 @@ from core.pkg.monitor.apple import winibuild as build_applestats
 
 from . import print, subprocess, workspace
 
-_CORE_WHEEL_DIR = pathlib.Path("./core/dist/")
+_CORE_WHEEL_DIR = pathlib.Path("./.wini/core/")
 """The output directory for the wandb-core wheel."""
 
 
@@ -92,6 +92,7 @@ def package_wandb_core(should_install, with_coverage):
             ]
         )
 
+    _CORE_WHEEL_DIR.mkdir(parents=True)
     subprocess.run(
         [
             "python",
@@ -100,6 +101,8 @@ def package_wandb_core(should_install, with_coverage):
             "-w",  # Only build the wheel.
             "-n",  # Disable building the project in an isolated venv.
             "-x",  # Do not check that build deps are installed.
+            "--outdir",
+            _CORE_WHEEL_DIR,
             "./core",
         ]
     )

--- a/tools/wini/wini.py
+++ b/tools/wini/wini.py
@@ -6,7 +6,13 @@ import click
 from core import winibuild as build_core
 from core.pkg.monitor.apple import winibuild as build_applestats
 
-from . import print, subprocess, workspace
+from . import print
+from . import subprocess
+from . import workspace
+
+
+_CORE_WHEEL_DIR = pathlib.Path("./core/dist/")
+"""The output directory for the wandb-core wheel."""
 
 
 @click.group()
@@ -80,6 +86,15 @@ def package_wandb_core(should_install, with_coverage):
     """Creates the wandb-core wheel, optionally installing it."""
     _build_wandb_core_artifacts(with_coverage=with_coverage)
 
+    if _CORE_WHEEL_DIR.exists():
+        subprocess.run(
+            [
+                "rm",
+                "-rf",
+                _CORE_WHEEL_DIR,
+            ]
+        )
+
     subprocess.run(
         [
             "python",
@@ -110,12 +125,12 @@ def _do_install():
     try:
         wheel_files = [
             f
-            for f in os.listdir("./core/dist/")
+            for f in os.listdir(_CORE_WHEEL_DIR)
             if f.startswith("wandb_core-") and f.endswith(".whl")
         ]
     except FileNotFoundError:
         print.error(
-            "No ./core/dist/ directory. Did you forget to run"
+            f"No {_CORE_WHEEL_DIR} directory. Did you forget to run"
             " `./wini package wandb-core`?"
         )
         sys.exit(1)
@@ -138,7 +153,7 @@ def _do_install():
             "pip",
             "install",
             "--force-reinstall",
-            f"./core/dist/{wheel_files[0]}",
+            _CORE_WHEEL_DIR / wheel_files[0],
         ]
     )
 

--- a/tools/wini/wini.py
+++ b/tools/wini/wini.py
@@ -6,10 +6,7 @@ import click
 from core import winibuild as build_core
 from core.pkg.monitor.apple import winibuild as build_applestats
 
-from . import print
-from . import subprocess
-from . import workspace
-
+from . import print, subprocess, workspace
 
 _CORE_WHEEL_DIR = pathlib.Path("./core/dist/")
 """The output directory for the wandb-core wheel."""


### PR DESCRIPTION
Description
-----------
The `rm -rf` is a little scary, but I don't have another way that's still simple. Alternatively, I considered adding a selection prompt to the install command if there are multiple wheels, but I think it might be more annoying than useful.

Testing
-------
```sh
# Run this, then rename the generated wheel:
./wini package wandb-core

# This would fail before, but succeeds now:
./wini package wandb-core --install
```
