### PR TITLE
chore(sdk): Don't use "rm" in wini

### DIFF
--- a/tools/wini/wini.py
+++ b/tools/wini/wini.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import pathlib
 import sys

--- a/tools/wini/wini.py
+++ b/tools/wini/wini.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import pathlib
 import sys
@@ -84,15 +85,11 @@ def package_wandb_core(should_install, with_coverage):
     _build_wandb_core_artifacts(with_coverage=with_coverage)
 
     if _CORE_WHEEL_DIR.exists():
-        subprocess.run(
-            [
-                "rm",
-                "-rf",
-                _CORE_WHEEL_DIR,
-            ]
-        )
+        # Remove old wheel files to prevent ambiguity issues when installing.
+        for file in _CORE_WHEEL_DIR.glob("*"):
+            file.unlink()
 
-    _CORE_WHEEL_DIR.mkdir(parents=True)
+    _CORE_WHEEL_DIR.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         [
             "python",


### PR DESCRIPTION
Description
-----------
Instead of using "rm", use Python APIs for cross-platform compatibility. I'm not sure if "rm" would consistently work on Windows.

Also, this avoids using "-rf" which always makes me nervous.

Testing
-------
Running `./wini package wandb-core --install` several times, manually creating files in `.wini/core/` and making sure they got deleted.