### PR TITLE
refactor(sdk): Factor out config manipulation logic in sender.py

### DIFF
--- a/tests/pytest_tests/unit_tests/test_lib/test_apikey.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_apikey.py
@@ -9,4 +9,3 @@ def test_write_netrc():
         assert f.read() == (
             "machine localhost\n" "  login vanpelt\n" "  password %s\n" % api_key
         )
-

--- a/tests/pytest_tests/unit_tests/test_sender_config.py
+++ b/tests/pytest_tests/unit_tests/test_sender_config.py
@@ -1,0 +1,80 @@
+from wandb.proto import wandb_internal_pb2
+from wandb.sdk.internal import sender_config
+from wandb.sdk.lib import telemetry
+
+
+def test_config_record_update():
+    config = sender_config.ConfigState({"b": {"x": 9, "c": "old"}})
+
+    config.update_from_proto(
+        wandb_internal_pb2.ConfigRecord(
+            update=[
+                wandb_internal_pb2.ConfigItem(
+                    key="a",
+                    value_json="123",
+                ),
+                wandb_internal_pb2.ConfigItem(
+                    nested_key=["b", "c"],
+                    value_json='"new"',
+                ),
+            ]
+        )
+    )
+
+    assert config.non_internal_config() == {
+        "a": 123,
+        "b": {"x": 9, "c": "new"},
+    }
+
+
+def test_config_record_remove():
+    config = sender_config.ConfigState(
+        {
+            "x": 1,
+            "a": {"b": 2, "y": 3},
+        }
+    )
+
+    config.update_from_proto(
+        wandb_internal_pb2.ConfigRecord(
+            remove=[
+                wandb_internal_pb2.ConfigItem(key="x"),
+                wandb_internal_pb2.ConfigItem(nested_key=["a", "y"]),
+            ]
+        )
+    )
+
+    assert config.non_internal_config() == {"a": {"b": 2}}
+
+
+def test_to_backend_dict():
+    config = sender_config.ConfigState(
+        {
+            "x": 1,
+            "y": {"z": 2},
+            "_wandb": {"test": 3},
+        }
+    )
+
+    backend_dict = config.to_backend_dict(
+        telemetry_record=telemetry.TelemetryRecord(),
+        framework="some-framework",
+        start_time_millis=123454321,
+        metric_pbdicts=[],
+    )
+
+    assert backend_dict == {
+        "x": {"desc": None, "value": 1},
+        "y": {"desc": None, "value": {"z": 2}},
+        "_wandb": {
+            "desc": None,
+            "value": {
+                "test": 3,
+                "framework": "some-framework",
+                "is_jupyter_run": False,
+                "is_kaggle_kernel": False,
+                "start_time": 123454321,
+                "t": {},
+            },
+        },
+    }

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1604,10 +1604,7 @@ class SendManager:
     def _flush_job(self) -> None:
         if self._job_builder.disable or self._settings._offline:
             return
-        self._job_builder.set_config(
-            # TODO: Can the key ever be "_wandb"?
-            {k: v for k, v in self._consolidated_config.items() if k != "_wandb"}
-        )
+        self._job_builder.set_config(self._consolidated_config.non_internal_config())
         summary_dict = self._cached_summary.copy()
         summary_dict.pop("_wandb", None)
         self._job_builder.set_summary(summary_dict)

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -1,0 +1,156 @@
+import json
+from typing import Any, Dict, ItemsView, NewType, Optional, Sequence
+
+from wandb.proto import wandb_internal_pb2
+from wandb.sdk.lib import proto_util, telemetry
+
+
+BackendConfigDict = NewType("BackendConfigDict", Dict[str, Any])
+
+
+class ConfigState:
+    """The configuration of a run."""
+
+    def __init__(self):
+        self._tree: Dict[str, Any] = {}
+        """A tree with string-valued nodes and JSON leaves.
+
+        Leaves are Python objects that are valid JSON values:
+
+        * Primitives like strings and numbers
+        * Dictionaries from strings to JSON objects
+        * Lists of JSON objects
+        """
+
+    def items(self) -> ItemsView[str, Any]:
+        """Returns the items of the underlying dictionary representation.
+
+        Note, this is not the same dictionary as returned by `to_backend_dict`.
+        """
+        return self._tree.items()
+
+    def update_from_proto(
+        self,
+        config_record: wandb_internal_pb2.ConfigRecord,
+    ) -> None:
+        """Applies update and remove commands."""
+        for config_item in config_record.update:
+            self._update_at_path(
+                _key_path(config_item),
+                json.loads(config_item.value_json),
+            )
+
+        for config_item in config_record.remove:
+            self._delete_at_path(_key_path(config_item))
+
+    def add_unset_keys(self, other_config_tree: Dict[str, Any]) -> None:
+        """Uses the given dict for any keys that aren't already set."""
+        for k, v in other_config_tree:
+            if k not in self._tree:
+                self._tree[k] = v
+
+    def to_backend_dict(
+        self,
+        telemetry_record: telemetry.TelemetryRecord,
+        framework: Optional[str],
+        start_time_millis: int,
+        metric_pbdicts: Sequence[Dict[int, Any]],
+    ) -> BackendConfigDict:
+        """Returns a dictionary representation expected by the backend.
+
+        The backend expects the configuration in a specific format, and the
+        config is also used to store additional metadata about the run.
+
+        Args:
+            telemetry_record: Telemetry information to insert.
+            framework: The detected framework used in the run (e.g. TensorFlow).
+            start_time_millis: The run's start time in Unix milliseconds.
+            metric_pbdicts: List of dict representations of metric protobuffers.
+        """
+        backend_dict = self._tree.copy()
+        wandb_internal = backend_dict.setdefault("_wandb", {})
+
+        ###################################################
+        # Telemetry information
+        ###################################################
+        if py_version := telemetry_record.python_version:
+            wandb_internal["python_version"] = py_version
+
+        if cli_version := telemetry_record.cli_version:
+            wandb_internal["cli_version"] = cli_version
+
+        if framework:
+            wandb_internal["framework"] = framework
+
+        if huggingface_version := telemetry_record.huggingface_version:
+            wandb_internal["huggingface_version"] = huggingface_version
+
+        wandb_internal["is_jupyter_run"] = telemetry_record.env.jupyter
+        wandb_internal["is_kaggle_kernel"] = telemetry_record.env.kaggle
+
+        # TODO: ?
+        wandb_internal["start_time"] = start_time_millis
+
+        # The full telemetry record. Admittedly this is redundant with some of
+        # the above, but we do it because.. uh...
+        wandb_internal["t"] = proto_util.proto_encode_to_dict(telemetry_record)
+
+        ###################################################
+        # Metrics
+        ###################################################
+        if metric_pbdicts:
+            wandb_internal["m"] = metric_pbdicts
+
+        return BackendConfigDict(
+            {
+                key: {
+                    # Configurations can be stored in a hand-written YAML file,
+                    # and users can add descriptions to their hyperparameters
+                    # there. However, we don't support a way to set descriptions
+                    # via code, so this is always None.
+                    "desc": None,
+                    "value": value,
+                }
+                for key, value in self._tree
+            }
+        )
+
+    def _update_at_path(
+        self,
+        key_path: Sequence[str],
+        value: Any,
+    ) -> None:
+        """Sets the value at the path in the config tree."""
+        update_in = self._tree
+        for key in key_path[:-1]:
+            update_in = update_in.setdefault(key, {})
+        update_in[key_path[-1]] = value
+
+    def _delete_at_path(
+        self,
+        key_path: Sequence[str],
+    ) -> None:
+        """Removes the subtree at the path in the config tree."""
+        remove_from = self._tree
+
+        for key in key_path[:-1]:
+            if key not in remove_from:
+                return
+            remove_from = remove_from[key]
+
+        del remove_from[key_path[-1]]
+
+
+def _key_path(
+    self,
+    config_item: wandb_internal_pb2.ConfigItem,
+) -> Sequence[str]:
+    """Returns the key path referenced by the config item."""
+    if config_item.nested_key:
+        return config_item.nested_key
+    elif config_item.key:
+        return [config_item.key]
+    else:
+        raise AssertionError(
+            "Invalid ConfigItem: either key or nested_key must be set",
+        )

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -140,10 +140,7 @@ class ConfigState:
         del remove_from[key_path[-1]]
 
 
-def _key_path(
-    self,
-    config_item: wandb_internal_pb2.ConfigItem,
-) -> Sequence[str]:
+def _key_path(config_item: wandb_internal_pb2.ConfigItem) -> Sequence[str]:
     """Returns the key path referenced by the config item."""
     if config_item.nested_key:
         return config_item.nested_key

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -46,7 +46,7 @@ class ConfigState:
     def add_unset_keys(self, other_config_tree: Dict[str, Any]) -> None:
         """Uses the given dict for any keys that aren't already set."""
         for k, v in other_config_tree:
-            if k not in self._tree:
+            if k not in self._tree.items():
                 self._tree[k] = v
 
     def to_backend_dict(

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -5,6 +5,7 @@ from wandb.proto import wandb_internal_pb2
 from wandb.sdk.lib import proto_util, telemetry
 
 BackendConfigDict = NewType("BackendConfigDict", Dict[str, Any])
+"""Run config dictionary in the format used by the backend."""
 
 
 class ConfigState:

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -11,7 +11,7 @@ BackendConfigDict = NewType("BackendConfigDict", Dict[str, Any])
 class ConfigState:
     """The configuration of a run."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._tree: Dict[str, Any] = {}
         """A tree with string-valued nodes and JSON leaves.
 
@@ -45,7 +45,7 @@ class ConfigState:
 
     def add_unset_keys(self, other_config_tree: Dict[str, Any]) -> None:
         """Uses the given dict for any keys that aren't already set."""
-        for k, v in other_config_tree:
+        for k, v in other_config_tree.items():
             if k not in self._tree.items():
                 self._tree[k] = v
 

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -91,8 +91,7 @@ class ConfigState:
         wandb_internal["is_kaggle_kernel"] = telemetry_record.env.kaggle
         wandb_internal["start_time"] = start_time_millis
 
-        # The full telemetry record. Admittedly this is redundant with some of
-        # the above, but we do it because.. uh...
+        # The full telemetry record.
         wandb_internal["t"] = proto_util.proto_encode_to_dict(telemetry_record)
 
         ###################################################

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -111,7 +111,7 @@ class ConfigState:
                     "desc": None,
                     "value": value,
                 }
-                for key, value in self._tree
+                for key, value in self._tree.items()
             }
         )
 

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -13,8 +13,8 @@ _WANDB_INTERNAL_KEY = "_wandb"
 class ConfigState:
     """The configuration of a run."""
 
-    def __init__(self) -> None:
-        self._tree: Dict[str, Any] = {}
+    def __init__(self, tree: Optional[Dict[str, Any]] = None) -> None:
+        self._tree: Dict[str, Any] = tree or {}
         """A tree with string-valued nodes and JSON leaves.
 
         Leaves are Python objects that are valid JSON values:

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, ItemsView, NewType, Optional, Sequence
 from wandb.proto import wandb_internal_pb2
 from wandb.sdk.lib import proto_util, telemetry
 
-
 BackendConfigDict = NewType("BackendConfigDict", Dict[str, Any])
 
 

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -73,16 +73,19 @@ class ConfigState:
         ###################################################
         # Telemetry information
         ###################################################
-        if py_version := telemetry_record.python_version:
+        py_version = telemetry_record.python_version
+        if py_version:
             wandb_internal["python_version"] = py_version
 
-        if cli_version := telemetry_record.cli_version:
+        cli_version = telemetry_record.cli_version
+        if cli_version:
             wandb_internal["cli_version"] = cli_version
 
         if framework:
             wandb_internal["framework"] = framework
 
-        if huggingface_version := telemetry_record.huggingface_version:
+        huggingface_version = telemetry_record.huggingface_version
+        if huggingface_version:
             wandb_internal["huggingface_version"] = huggingface_version
 
         wandb_internal["is_jupyter_run"] = telemetry_record.env.jupyter

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -25,37 +25,6 @@ def dict_from_proto_list(obj_list):
     return d
 
 
-def update_from_proto(config_dict, config_proto):
-    for item in config_proto.update:
-        key_list = item.nested_key or (item.key,)
-        assert key_list, "key or nested key must be set"
-        target = config_dict
-        # recurse down the dictionary structure:
-        for prop in key_list[:-1]:
-            if not target.get(prop):
-                target[prop] = {}
-            target = target[prop]
-        # use the last element of the key to write the leaf:
-        target[key_list[-1]] = json.loads(item.value_json)
-    for item in config_proto.remove:
-        key_list = item.nested_key or (item.key,)
-        assert key_list, "key or nested key must be set"
-        target = config_dict
-        # recurse down the dictionary structure:
-        for prop in key_list[:-1]:
-            target = target[prop]
-        # use the last element of the key to write the leaf:
-        del target[key_list[-1]]
-        # TODO(jhr): should we delete empty parents?
-
-
-def dict_add_value_dict(config_dict):
-    d = dict()
-    for k, v in config_dict.items():
-        d[k] = dict(desc=None, value=v)
-    return d
-
-
 def dict_strip_value_dict(config_dict):
     d = dict()
     for k, v in config_dict.items():


### PR DESCRIPTION
Description
-----------
Refactors a portion of `sender.py` (huge file!) to make WB-16244 a little easier to reason about.

Testing
-------
* Codecov shows that existing tests cover the new codepaths, including 100% of the changed lines in sender.py
* Unit tests for sender_config.py