### PR TITLE
chore(launch): Handle multibyte characters better in local container output

### DIFF
--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -234,7 +234,13 @@ def _thread_process_runner(
         if not chunk:
             break
         index = chunk.find(b"\r")
-        decoded_chunk = chunk.decode()
+        decoded_chunk = None
+        while not decoded_chunk:
+            try:
+                decoded_chunk = chunk.decode()
+            except UnicodeDecodeError:
+                # Multi-byte character cut off, try to get the rest of it
+                chunk += os.read(process.stdout.fileno(), 1)  # type: ignore
         if index != -1:
             run._stdout += decoded_chunk
             print(chunk.decode(), end="")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- [Slack thread](https://weightsandbiases.slack.com/archives/C01UUUHP153/p1708006498698569)

In the local container runner, we process the std output in chunks of 4096 bytes. This can cause a problem when a multi-byte character (like å) appears on the chunk threshold, leaving the first byte unprocessable. This change has us add one byte at a time to a chunk until it's successfully processed.

Testing
-------
How was this PR tested?

Created a [job](https://wandb.ai/tim-hays/debugging/jobs/QXJ0aWZhY3RDb2xsZWN0aW9uOjEzOTk2ODQzNQ==/runs/latest) that prints out the character å several times at an odd output. Running this job on a local-container queue fails on main but passes in this branch.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
