### PR TITLE
refactor(sdk): Factor out RunConfig in Go code

### DIFF
--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -132,6 +132,7 @@ func (runConfig *RunConfig) Serialize(format ConfigFormat) ([]byte, error) {
 	return nil, fmt.Errorf("Unknown format: %v", format)
 }
 
+// Returns the "_wandb" subtree of the config.
 func (runConfig *RunConfig) internalSubtree() RunConfigDict {
 	node, found := runConfig.tree["_wandb"]
 

--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -1,9 +1,9 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/segmentio/encoding/json"
 	"github.com/wandb/wandb/core/internal/corelib"
 	"github.com/wandb/wandb/core/pkg/service"
 )

--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -29,6 +29,10 @@ func NewRunConfig() *RunConfig {
 	return &RunConfig{make(RunConfigDict)}
 }
 
+func NewRunConfigFrom(tree RunConfigDict) *RunConfig {
+	return &RunConfig{tree}
+}
+
 // Returns the underlying config tree.
 //
 // Provided temporarily as part of a refactor. Avoid using this, especially

--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -8,7 +8,11 @@ import (
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
-type RunConfigDict map[string]interface{}
+// A RunConfig representation.
+//
+// This is a type alias for refactoring purposes; it should be new type
+// otherwise.
+type RunConfigDict = map[string]interface{}
 
 // The configuration of a run.
 //

--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -19,7 +19,8 @@ type RunConfigDict = map[string]interface{}
 //
 // This is usually used for hyperparameters and some run metadata like the
 // start time and the ML framework used. In a somewhat hacky way, it is also
-// used to store programmatic custom charts for the run.
+// used to store programmatic custom charts for the run and various other
+// things.
 //
 // The server process builds this up incrementally throughout a run's lifetime.
 type RunConfig struct {

--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -186,10 +186,10 @@ func getOrMakeSubtree(
 	path []string,
 ) (RunConfigDict, error) {
 	for _, key := range path {
-		node, ok := tree[key]
-		if !ok {
-			tree[key] = make(RunConfigDict)
-			continue
+		node, exists := tree[key]
+		if !exists {
+			node = make(RunConfigDict)
+			tree[key] = node
 		}
 
 		subtree, ok := node.(RunConfigDict)

--- a/core/pkg/server/config_test.go
+++ b/core/pkg/server/config_test.go
@@ -1,15 +1,16 @@
-package server
+package server_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/pkg/server"
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
 func TestConfigUpdate(t *testing.T) {
-	runConfig := NewRunConfigFrom(RunConfigDict{
-		"b": RunConfigDict{
+	runConfig := server.NewRunConfigFrom(server.RunConfigDict{
+		"b": server.RunConfigDict{
 			"c": 321.0,
 			"d": 123.0,
 		},
@@ -31,9 +32,9 @@ func TestConfigUpdate(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		RunConfigDict{
+		server.RunConfigDict{
 			"a": 1.0,
-			"b": RunConfigDict{
+			"b": server.RunConfigDict{
 				"c": "text",
 				"d": 123.0,
 			},
@@ -43,9 +44,9 @@ func TestConfigUpdate(t *testing.T) {
 }
 
 func TestConfigRemove(t *testing.T) {
-	runConfig := NewRunConfigFrom(RunConfigDict{
+	runConfig := server.NewRunConfigFrom(server.RunConfigDict{
 		"a": 9,
-		"b": RunConfigDict{
+		"b": server.RunConfigDict{
 			"c": 321.0,
 			"d": 123.0,
 		},
@@ -61,7 +62,7 @@ func TestConfigRemove(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		RunConfigDict{"b": RunConfigDict{"d": 123.0}},
+		server.RunConfigDict{"b": server.RunConfigDict{"d": 123.0}},
 		runConfig.Tree(),
 	)
 }

--- a/core/pkg/server/config_test.go
+++ b/core/pkg/server/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/internal/corelib"
 	"github.com/wandb/wandb/core/pkg/server"
 	"github.com/wandb/wandb/core/pkg/service"
 )
@@ -79,7 +80,6 @@ func TestConfigSerialize(t *testing.T) {
 	yaml, _ := runConfig.Serialize(server.FORMAT_YAML)
 
 	assert.Equal(t,
-		string(yaml),
 		""+
 			"nested:\n"+
 			"    value:\n"+
@@ -90,6 +90,27 @@ func TestConfigSerialize(t *testing.T) {
 			"        text: xyz\n"+
 			"number:\n"+
 			"    value: 9\n",
+		string(yaml),
+	)
+}
+
+func TestAddTelemetryAndMetrics(t *testing.T) {
+	runConfig := server.NewRunConfig()
+	telemetry := &service.TelemetryRecord{}
+
+	runConfig.AddTelemetryAndMetrics(
+		telemetry,
+		[]map[int]interface{}{},
+	)
+
+	assert.Equal(t,
+		server.RunConfigDict{
+			"_wandb": server.RunConfigDict{
+				"t": corelib.ProtoEncodeToDict(telemetry),
+				"m": []map[int]interface{}{},
+			},
+		},
+		runConfig.Tree(),
 	)
 }
 

--- a/core/pkg/server/config_test.go
+++ b/core/pkg/server/config_test.go
@@ -67,4 +67,30 @@ func TestConfigRemove(t *testing.T) {
 	)
 }
 
+func TestConfigSerialize(t *testing.T) {
+	runConfig := server.NewRunConfigFrom(server.RunConfigDict{
+		"number": 9,
+		"nested": server.RunConfigDict{
+			"list": []string{"a", "b", "c"},
+			"text": "xyz",
+		},
+	})
+
+	yaml, _ := runConfig.Serialize(server.FORMAT_YAML)
+
+	assert.Equal(t,
+		string(yaml),
+		""+
+			"nested:\n"+
+			"    value:\n"+
+			"        list:\n"+
+			"            - a\n"+
+			"            - b\n"+
+			"            - c\n"+
+			"        text: xyz\n"+
+			"number:\n"+
+			"    value: 9\n",
+	)
+}
+
 func ignoreError(_err error) {}

--- a/core/pkg/server/config_test.go
+++ b/core/pkg/server/config_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/pkg/service"
+)
+
+func TestConfigUpdate(t *testing.T) {
+	runConfig := NewRunConfigFrom(RunConfigDict{
+		"b": RunConfigDict{
+			"c": 321.0,
+			"d": 123.0,
+		},
+	})
+
+	runConfig.ApplyChangeRecord(
+		&service.ConfigRecord{
+			Update: []*service.ConfigItem{
+				{
+					Key:       "a",
+					ValueJson: "1",
+				},
+				{
+					NestedKey: []string{"b", "c"},
+					ValueJson: "\"text\"",
+				},
+			},
+		}, ignoreError,
+	)
+
+	assert.Equal(t,
+		RunConfigDict{
+			"a": 1.0,
+			"b": RunConfigDict{
+				"c": "text",
+				"d": 123.0,
+			},
+		},
+		runConfig.Tree(),
+	)
+}
+
+func TestConfigRemove(t *testing.T) {
+	runConfig := NewRunConfigFrom(RunConfigDict{
+		"a": 9,
+		"b": RunConfigDict{
+			"c": 321.0,
+			"d": 123.0,
+		},
+	})
+
+	runConfig.ApplyChangeRecord(
+		&service.ConfigRecord{
+			Remove: []*service.ConfigItem{
+				{Key: "a"},
+				{NestedKey: []string{"b", "c"}},
+			},
+		}, ignoreError,
+	)
+
+	assert.Equal(t,
+		RunConfigDict{"b": RunConfigDict{"d": 123.0}},
+		runConfig.Tree(),
+	)
+}
+
+func ignoreError(_err error) {}

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/wandb/wandb/core/internal/clients"
-	"github.com/wandb/wandb/core/internal/corelib"
 	"github.com/wandb/wandb/core/internal/debounce"
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/gql"
@@ -102,7 +101,7 @@ type Sender struct {
 	summaryMap map[string]*service.SummaryItem
 
 	// Keep track of config which is being updated incrementally
-	configMap map[string]interface{}
+	configMap *RunConfig
 
 	// Info about the (local) server we are talking to
 	serverInfo *gql.ServerInfoServerInfo
@@ -134,7 +133,7 @@ func NewSender(
 		settings:       settings,
 		logger:         logger,
 		summaryMap:     make(map[string]*service.SummaryItem),
-		configMap:      make(map[string]interface{}),
+		configMap:      NewRunConfig(),
 		telemetry:      &service.TelemetryRecord{CoreVersion: version.Version},
 		wgFileTransfer: sync.WaitGroup{},
 	}
@@ -379,7 +378,7 @@ func (s *Sender) sendJobFlush() {
 	if s.jobBuilder == nil {
 		return
 	}
-	input := s.configMap
+	input := s.configMap.Tree()
 	output := make(map[string]interface{})
 
 	var out interface{}
@@ -484,7 +483,7 @@ func (s *Sender) sendRequestDefer(request *service.DeferRequest) {
 
 func (s *Sender) sendTelemetry(_ *service.Record, telemetry *service.TelemetryRecord) {
 	proto.Merge(s.telemetry, telemetry)
-	s.updateConfigPrivate(s.telemetry)
+	s.updateConfigPrivate()
 	// TODO(perf): improve when debounce config is added, for now this sends all the time
 	s.sendConfig(nil, nil /*configRecord*/)
 }
@@ -520,65 +519,30 @@ func (s *Sender) sendUseArtifact(record *service.Record) {
 	s.jobBuilder.HandleUseArtifactRecord(record)
 }
 
-// updateConfig updates the config map with the config record
+// Applies the change record to the run configuration.
 func (s *Sender) updateConfig(configRecord *service.ConfigRecord) {
-	// TODO: handle nested key updates and deletes
-	for _, d := range configRecord.GetUpdate() {
-		var value interface{}
-		if err := json.Unmarshal([]byte(d.GetValueJson()), &value); err != nil {
-			s.logger.CaptureError("unmarshal problem", err)
-			continue
-		}
-		keyList := d.GetNestedKey()
-		if keyList == nil {
-			keyList = []string{d.GetKey()}
-		}
-		target := s.configMap
-		for _, k := range keyList[:len(keyList)-1] {
-			val, ok := target[k].(map[string]interface{})
-			if !ok {
-				val = make(map[string]interface{})
-				target[k] = val
-			}
-			target = val
-		}
-		target[keyList[len(keyList)-1]] = value
-	}
-	for _, d := range configRecord.GetRemove() {
-		delete(s.configMap, d.GetKey())
-	}
+	s.configMap.ApplyChangeRecord(configRecord, func(err error) {
+		s.logger.CaptureError("Error updating run config", err)
+	})
 }
 
-// updateConfigPrivate updates the private part of the config map
-func (s *Sender) updateConfigPrivate(telemetry *service.TelemetryRecord) {
-	if _, ok := s.configMap["_wandb"]; !ok {
-		s.configMap["_wandb"] = make(map[string]interface{})
+// Inserts W&B-internal information into the run configuration.
+//
+// Uses the given telemetry
+func (s *Sender) updateConfigPrivate() {
+	metrics := []map[int]interface{}(nil)
+	if s.metricSender != nil {
+		metrics = s.metricSender.configMetrics
 	}
 
-	switch v := s.configMap["_wandb"].(type) {
-	case map[string]interface{}:
-		if telemetry.GetCliVersion() != "" {
-			v["cli_version"] = telemetry.CliVersion
-		}
-		if telemetry.GetPythonVersion() != "" {
-			v["python_version"] = telemetry.PythonVersion
-		}
-		v["t"] = corelib.ProtoEncodeToDict(s.telemetry)
-		if s.metricSender != nil {
-			v["m"] = s.metricSender.configMetrics
-		}
-		// todo: add the rest of the telemetry from telemetry
-	default:
-		err := fmt.Errorf("can not parse config _wandb, saw: %v", v)
-		s.logger.CaptureFatalAndPanic("sender received error", err)
-	}
+	s.configMap.AddTelemetryAndMetrics(s.telemetry, metrics)
 }
 
 // serializeConfig serializes the config map to a json string
 // that can be sent to the server
 func (s *Sender) serializeConfig(format string) string {
 	valueConfig := make(map[string]map[string]interface{})
-	for key, elem := range s.configMap {
+	for key, elem := range s.configMap.Tree() {
 		valueConfig[key] = make(map[string]interface{})
 		valueConfig[key]["value"] = elem
 	}
@@ -636,7 +600,11 @@ func (s *Sender) checkAndUpdateResumeState(record *service.Record) error {
 		return err
 	}
 
-	if result, err := s.resumeState.Update(data, s.RunRecord, s.configMap); err != nil {
+	if result, err := s.resumeState.Update(
+		data,
+		s.RunRecord,
+		s.configMap.Tree(),
+	); err != nil {
 		s.sendRunResult(record, result)
 		return err
 	}
@@ -664,7 +632,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 
 		s.updateConfig(run.Config)
 		proto.Merge(s.telemetry, run.Telemetry)
-		s.updateConfigPrivate(run.Telemetry)
+		s.updateConfigPrivate()
 		config := s.serializeConfig("json")
 
 		var tags []string
@@ -984,7 +952,7 @@ func (s *Sender) sendMetric(record *service.Record, metric *service.MetricRecord
 	}
 
 	s.encodeMetricHints(record, metric)
-	s.updateConfigPrivate(nil /*telemetry*/)
+	s.updateConfigPrivate()
 	s.sendConfig(nil, nil /*configRecord*/)
 }
 


### PR DESCRIPTION
Description
-----------
Factors out a RunConfig type to consolidate config manipulation logic and simplify `sender.go`.

I tried to mostly preserve semantics. The `updateConfigPrivate()` method had some odd usage: it accepted a `telemetry` parameter but also used the `Sender::telemetry` field. It seems in all cases the given telemetry was merged into `Sender::telemetry` anyway, so I removed that parameter. The only case semantics are different is where the method was called with a `nil`, where it wouldn't have added "cli_version" and "python_version" previously but does now.

This isn't a complete refactor---I didn't want to touch too many files in a single PR.

Testing
-------
Unit tests.