### PR TITLE
chore(sdk): add SDK as codeowners of the CI configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,7 @@
 /tests/pytest_tests/unit_tests/test_library_public.py @wandb/sdk-team
 # Adding or removing dependencies needs extra scrutiny
 /pyproject.toml @wandb/sdk-team
-/setup.cfg @wandb/sdk-team
 /setup.py @wandb/sdk-team
-/requirements.txt @wandb/sdk-team
 # core changes need extra scrutiny during the initial rollout
 /core/ @wandb/sdk-team
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,10 @@
 /setup.py @wandb/sdk-team
 # core changes need extra scrutiny during the initial rollout
 /core/ @wandb/sdk-team
+# CircleCI configuration changes need extra scrutiny
+/.circleci @wandb/sdk-team
+# GitHub configuration changes need extra scrutiny
+/.github @wandb/sdk-team
 
 # ML Workflows team
 /core/pkg/artifacts/ @wandb/mlw-team


### PR DESCRIPTION
Description
-----------

Add SDK team as codeowner of all the CI and GitHub repo config files