### PR TITLE
fix(core): replace usage of standard library's json with `segmentio`'s

### DIFF
--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/segmentio/encoding/json"
 	"github.com/wandb/wandb/core/pkg/monitor"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"


### PR DESCRIPTION
Description
-----------

Replace the standard library's encoding/json with sementio's. See here for more details: https://github.com/segmentio/encoding?tab=readme-ov-file#encodingjson-
