### PR TITLE
chore(sdk): Use better Go style in config.go

### DIFF
--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -37,8 +37,8 @@ type RunConfig struct {
 type ConfigFormat int
 
 const (
-	FORMAT_YAML ConfigFormat = iota
-	FORMAT_JSON
+	FormatYaml ConfigFormat = iota
+	FormatJson
 )
 
 func NewRunConfig() *RunConfig {
@@ -75,7 +75,7 @@ func (runConfig *RunConfig) ApplyChangeRecord(
 		); err != nil {
 			onError(
 				fmt.Errorf(
-					"Failed to unmarshall JSON for config key %v: %w",
+					"config: failed to unmarshall JSON for config key %v: %w",
 					path,
 					err,
 				),
@@ -156,13 +156,13 @@ func (runConfig *RunConfig) Serialize(format ConfigFormat) ([]byte, error) {
 	}
 
 	switch format {
-	case FORMAT_YAML:
+	case FormatYaml:
 		return yaml.Marshal(valueConfig)
-	case FORMAT_JSON:
+	case FormatJson:
 		return json.Marshal(valueConfig)
 	}
 
-	return nil, fmt.Errorf("Unknown format: %v", format)
+	return nil, fmt.Errorf("config: unknown format: %v", format)
 }
 
 // Uses the given subtree for keys that aren't already set.
@@ -280,7 +280,7 @@ func getOrMakeSubtree(
 		subtree, ok := node.(RunConfigDict)
 		if !ok {
 			return nil, fmt.Errorf(
-				"Config value at path %v is type %T, not a map",
+				"config: value at path %v is type %T, not a map",
 				path,
 				node,
 			)

--- a/core/pkg/server/config.go
+++ b/core/pkg/server/config.go
@@ -75,7 +75,7 @@ func (runConfig *RunConfig) ApplyChangeRecord(
 		); err != nil {
 			onError(
 				fmt.Errorf(
-					"config: failed to unmarshall JSON for config key %v: %w",
+					"config: failed to unmarshall JSON for config key %v: %v",
 					path,
 					err,
 				),

--- a/core/pkg/server/config_test.go
+++ b/core/pkg/server/config_test.go
@@ -77,7 +77,7 @@ func TestConfigSerialize(t *testing.T) {
 		},
 	})
 
-	yaml, _ := runConfig.Serialize(server.FORMAT_YAML)
+	yaml, _ := runConfig.Serialize(server.FormatYaml)
 
 	assert.Equal(t,
 		""+

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -626,7 +626,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			}
 		}
 
-		config := s.serializeConfig(FORMAT_JSON)
+		config := s.serializeConfig(FormatJson)
 
 		var tags []string
 		tags = append(tags, run.Tags...)
@@ -750,7 +750,7 @@ func (s *Sender) upsertConfig() {
 	if s.graphqlClient == nil {
 		return
 	}
-	config := s.serializeConfig(FORMAT_JSON)
+	config := s.serializeConfig(FormatJson)
 
 	ctx := context.WithValue(s.ctx, clients.CtxRetryPolicyKey, clients.UpsertBucketRetryPolicy)
 	_, err := gql.UpsertBucket(
@@ -787,7 +787,7 @@ func (s *Sender) writeAndSendConfigFile() {
 		return
 	}
 
-	config := s.serializeConfig(FORMAT_YAML)
+	config := s.serializeConfig(FormatYaml)
 	configFile := filepath.Join(s.settings.GetFilesDir().GetValue(), ConfigFileName)
 	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
 		s.logger.Error("sender: writeAndSendConfigFile: failed to write config file", "error", err)


### PR DESCRIPTION
Description
-----------
* Use MixedCase for enums
* Format errors in the conventional way: lowercase first letter with a prefix mentioning the source
