### PR TITLE
refactor(sdk): Improve options for creating api.Client

### DIFF
--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -8,8 +8,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-// Sends an HTTP request to the W&B backend.
-func (client *Client) Send(req *Request) (*http.Response, error) {
+func (client *clientImpl) Send(req *Request) (*http.Response, error) {
 	retryableReq, err := retryablehttp.NewRequest(
 		req.Method,
 		client.backend.baseURL.JoinPath(req.Path).String(),
@@ -33,13 +32,13 @@ func (client *Client) Send(req *Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func (client *Client) addClientHeaders(req *retryablehttp.Request) {
+func (client *clientImpl) addClientHeaders(req *retryablehttp.Request) {
 	for headerKey, headerValue := range client.extraHeaders {
 		req.Header.Add(headerKey, headerValue)
 	}
 }
 
-func (client *Client) addAuthHeaders(req *retryablehttp.Request) {
+func (client *clientImpl) addAuthHeaders(req *retryablehttp.Request) {
 	req.Header.Add("User-Agent", "wandb-core")
 	req.Header.Add(
 		"Authorization",

--- a/core/internal/apitest/apitest.go
+++ b/core/internal/apitest/apitest.go
@@ -1,22 +1,48 @@
 package apitest
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/wandb/core/internal/api"
 )
 
-// Returns a fake [Client] for testing.
-func FakeClient(
-	baseURLString string,
-	retryableHTTP *retryablehttp.Client,
-) *api.Client {
+// Returns a real [api.Client] for testing.
+//
+// This is a simpler API that panics on error.
+func TestingClient(baseURLString string, opts api.ClientOptions) api.Client {
 	baseURL, err := url.Parse(baseURLString)
 	if err != nil {
 		panic(err)
 	}
 
-	backend := api.New(baseURL)
-	return backend.NewClient(retryableHTTP)
+	backend := api.New(api.BackendOptions{
+		BaseURL: baseURL,
+	})
+
+	return backend.NewClient(opts)
+}
+
+// Returns a fake [api.Client] that just forwards requests.
+func ForwardingClient(retryableHTTP *retryablehttp.Client) api.Client {
+	return &fakeClient{retryableHTTP}
+}
+
+type fakeClient struct {
+	client *retryablehttp.Client
+}
+
+func (c *fakeClient) Send(req *api.Request) (*http.Response, error) {
+	retryableReq, err := retryablehttp.NewRequest(
+		req.Method,
+		req.Path,
+		req.Body,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c.client.Do(retryableReq)
 }

--- a/core/pkg/filestream/filestream.go
+++ b/core/pkg/filestream/filestream.go
@@ -89,7 +89,7 @@ type FileStream struct {
 	logger *observability.CoreLogger
 
 	// The client for making API requests.
-	apiClient *api.Client
+	apiClient api.Client
 
 	maxItemsPerPush int
 	delayProcess    time.Duration
@@ -118,7 +118,7 @@ func WithPath(path string) FileStreamOption {
 	}
 }
 
-func WithAPIClient(client *api.Client) FileStreamOption {
+func WithAPIClient(client api.Client) FileStreamOption {
 	return func(fs *FileStream) {
 		fs.apiClient = client
 	}

--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/apitest"
-	"github.com/wandb/wandb/core/internal/clients"
 
 	"github.com/wandb/wandb/core/pkg/observability"
 
@@ -147,12 +147,13 @@ func NewFilestreamTest(tName string, fn func(fs *filestream.FileStream)) *filest
 		filestream.WithPath(fstreamPath),
 		filestream.WithSettings(tserver.settings),
 		filestream.WithLogger(tserver.logger),
-		filestream.WithAPIClient(apitest.FakeClient(
+		filestream.WithAPIClient(apitest.TestingClient(
 			tserver.hserver.URL,
-			clients.NewRetryClient(
-				clients.WithRetryClientHttpAuthTransport(tserver.settings.GetApiKey().GetValue()),
-				clients.WithRetryClientLogger(tserver.logger),
-			),
+			api.ClientOptions{},
+			// clients.NewRetryClient(
+			// 	clients.WithRetryClientHttpAuthTransport(tserver.settings.GetApiKey().GetValue()),
+			// 	clients.WithRetryClientLogger(tserver.logger),
+			// ),
 		)),
 	)
 	fs.Start()

--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -150,10 +150,6 @@ func NewFilestreamTest(tName string, fn func(fs *filestream.FileStream)) *filest
 		filestream.WithAPIClient(apitest.TestingClient(
 			tserver.hserver.URL,
 			api.ClientOptions{},
-			// clients.NewRetryClient(
-			// 	clients.WithRetryClientHttpAuthTransport(tserver.settings.GetApiKey().GetValue()),
-			// 	clients.WithRetryClientLogger(tserver.logger),
-			// ),
 		)),
 	)
 	fs.Start()
@@ -174,8 +170,8 @@ func NewHistoryRecord() *service.Record {
 			History: &service.HistoryRecord{
 				Step: &service.HistoryStep{Num: 0},
 				Item: []*service.HistoryItem{
-					&service.HistoryItem{Key: "_runtime", ValueJson: fmt.Sprintf("%f", 0.0)},
-					&service.HistoryItem{Key: "_step", ValueJson: fmt.Sprintf("%d", 0)},
+					{Key: "_runtime", ValueJson: fmt.Sprintf("%f", 0.0)},
+					{Key: "_step", ValueJson: fmt.Sprintf("%d", 0)},
 				}}}}
 	return msg
 }

--- a/core/pkg/filestream/loop_transmit_test.go
+++ b/core/pkg/filestream/loop_transmit_test.go
@@ -63,7 +63,7 @@ func testSendAndReceive(t *testing.T, chunks []processedChunk, fsd FsTransmitDat
 
 	fs := NewFileStream(
 		WithLogger(fsTest.logger),
-		WithAPIClient(apitest.FakeClient("", fsTest.client)),
+		WithAPIClient(apitest.ForwardingClient(fsTest.client)),
 	)
 	for _, d := range chunks {
 		fs.transmitChan <- d

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -143,7 +142,11 @@ func NewSender(
 		if err != nil {
 			logger.CaptureFatalAndPanic("sender: failed to parse base URL", err)
 		}
-		backend := api.New(baseURL)
+		backend := api.New(api.BackendOptions{
+			BaseURL: baseURL,
+			Logger:  logger.Logger,
+			APIKey:  settings.GetApiKey().GetValue(),
+		})
 
 		baseHeaders := map[string]string{
 			"X-WANDB-USERNAME":   settings.GetUsername().GetValue(),
@@ -166,24 +169,19 @@ func NewSender(
 		url := fmt.Sprintf("%s/graphql", settings.GetBaseUrl().GetValue())
 		sender.graphqlClient = graphql.NewClient(url, graphqlRetryClient.StandardClient())
 
-		headers := map[string]string{}
+		fileStreamHeaders := map[string]string{}
 		if settings.GetXShared().GetValue() {
-			headers["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
+			fileStreamHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
 		}
-		fileStreamRetryClient := backend.NewClient(clients.NewRetryClient(
-			clients.WithRetryClientLogger(logger),
-			clients.WithRetryClientResponseLogger(logger.Logger, func(resp *http.Response) bool {
-				return resp.StatusCode >= 400
-			}),
-			clients.WithRetryClientRetryMax(int(settings.GetXFileStreamRetryMax().GetValue())),
-			clients.WithRetryClientRetryWaitMin(clients.SecondsToDuration(settings.GetXFileStreamRetryWaitMinSeconds().GetValue())),
-			clients.WithRetryClientRetryWaitMax(clients.SecondsToDuration(settings.GetXFileStreamRetryWaitMaxSeconds().GetValue())),
-			clients.WithRetryClientHttpTimeout(clients.SecondsToDuration(settings.GetXFileStreamTimeoutSeconds().GetValue())),
-			clients.WithRetryClientHttpAuthTransport(sender.settings.GetApiKey().GetValue(), headers),
-			clients.WithRetryClientBackoff(clients.ExponentialBackoffWithJitter),
-			// TODO(core:beta): add custom retry function
-			// retryClient.CheckRetry = fs.GetCheckRetryFunc()
-		))
+
+		fileStreamRetryClient := backend.NewClient(api.ClientOptions{
+			RetryMax:        int(settings.GetXFileStreamRetryMax().GetValue()),
+			RetryWaitMin:    clients.SecondsToDuration(settings.GetXFileStreamRetryWaitMinSeconds().GetValue()),
+			RetryWaitMax:    clients.SecondsToDuration(settings.GetXFileStreamRetryWaitMaxSeconds().GetValue()),
+			NonRetryTimeout: clients.SecondsToDuration(settings.GetXFileStreamTimeoutSeconds().GetValue()),
+			ExtraHeaders:    fileStreamHeaders,
+		})
+
 		sender.fileStream = fs.NewFileStream(
 			fs.WithSettings(settings),
 			fs.WithLogger(logger),


### PR DESCRIPTION
Description
-----------
Further implements the "api" package, changing it to fully encapsulate its retryablehttp usage. There's a little duplication with the `clients` package (in particular when adding auth headers), which I'll be able to fix after updating the GraphQL code to use `api`.

Testing
-------
Unit tests, quick manual check that `run.log()` works.
