### PR TITLE
feat(sdk): Respect rate-limiting headers

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -35,7 +35,7 @@ type Backend struct {
 // Multiple Clients can be created for one Backend when different retry
 // policies are needed.
 //
-// TODO: The client is responsible for setting auth headers, retrying
+// The client is responsible for setting auth headers, retrying
 // gracefully, and respecting rate-limit response headers.
 type Client interface {
 	// Sends an HTTP request to the W&B backend.

--- a/core/internal/api/ratelimit.go
+++ b/core/internal/api/ratelimit.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Blocks until we don't need to rate-limit requests.
+func (backend *Backend) waitIfRateLimited() {
+	backend.isRateLimitedCond.L.Lock()
+	defer backend.isRateLimitedCond.L.Unlock()
+
+	for backend.isRateLimited {
+		backend.isRateLimitedCond.Wait()
+	}
+}
+
+// Processes rate-limiting headers from the server response.
+func (backend *Backend) processRateLimitHeaders(response *http.Response) {
+	remainingStr := response.Header.Get("RateLimit-Remaining")
+	resetStr := response.Header.Get("RateLimit-Reset")
+
+	if len(remainingStr) == 0 || len(resetStr) == 0 {
+		return // Missing relevant headers.
+	}
+
+	remaining, err := strconv.ParseInt(remainingStr, 10, 64)
+	if err != nil || remaining > 0 {
+		// Bad string, or we're not out of quota yet.
+		return
+	}
+
+	resetSeconds, err := strconv.ParseInt(resetStr, 10, 64)
+	if err != nil {
+		return
+	}
+
+	backend.markRateLimitedFor(time.Duration(resetSeconds) * time.Second)
+}
+
+// Marks us as rate-limited for the given duration.
+//
+// At the end of the duration, wakes all goroutines blocked on
+// [waitIfRateLimited].
+func (backend *Backend) markRateLimitedFor(duration time.Duration) {
+	backend.isRateLimitedCond.L.Lock()
+	defer backend.isRateLimitedCond.L.Unlock()
+
+	if !backend.isRateLimited {
+		backend.isRateLimited = true
+
+		go func() {
+			time.Sleep(duration)
+
+			backend.isRateLimitedCond.L.Lock()
+			backend.isRateLimited = false
+			backend.isRateLimitedCond.L.Unlock()
+
+			backend.isRateLimitedCond.Broadcast()
+		}()
+	}
+
+}

--- a/core/internal/api/ratelimit.go
+++ b/core/internal/api/ratelimit.go
@@ -74,18 +74,19 @@ func (ratelimit *rateLimiter) markRateLimitedFor(duration time.Duration) {
 	ratelimit.isRateLimitedCond.L.Lock()
 	defer ratelimit.isRateLimitedCond.L.Unlock()
 
-	if !ratelimit.isRateLimited {
-		ratelimit.isRateLimited = true
-
-		go func() {
-			time.Sleep(duration)
-
-			ratelimit.isRateLimitedCond.L.Lock()
-			ratelimit.isRateLimited = false
-			ratelimit.isRateLimitedCond.L.Unlock()
-
-			ratelimit.isRateLimitedCond.Broadcast()
-		}()
+	if ratelimit.isRateLimited {
+		return
 	}
 
+	ratelimit.isRateLimited = true
+
+	go func() {
+		time.Sleep(duration)
+
+		ratelimit.isRateLimitedCond.L.Lock()
+		ratelimit.isRateLimited = false
+		ratelimit.isRateLimitedCond.L.Unlock()
+
+		ratelimit.isRateLimitedCond.Broadcast()
+	}()
 }

--- a/core/internal/api/ratelimit.go
+++ b/core/internal/api/ratelimit.go
@@ -36,7 +36,15 @@ func (backend *Backend) processRateLimitHeaders(response *http.Response) {
 		return
 	}
 
-	backend.markRateLimitedFor(time.Duration(resetSeconds) * time.Second)
+	// If the server sends rate-limits using the wrong units, don't hang
+	// the whole program.
+	const maxDuration = time.Duration(30) * time.Second
+	resetDuration := time.Duration(resetSeconds) * time.Second
+	if resetDuration > maxDuration {
+		resetDuration = maxDuration
+	}
+
+	backend.markRateLimitedFor(resetDuration)
 }
 
 // Marks us as rate-limited for the given duration.

--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -46,7 +46,16 @@ func (client *clientImpl) sendToWandbBackend(
 ) (*http.Response, error) {
 	client.addClientHeaders(req)
 	client.addAuthHeaders(req)
-	return client.sendArbitrary(req)
+
+	client.backend.waitIfRateLimited()
+
+	response, err := client.sendArbitrary(req)
+
+	if response != nil {
+		client.backend.processRateLimitHeaders(response)
+	}
+
+	return response, err
 }
 
 func (client *clientImpl) sendArbitrary(

--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -54,15 +54,7 @@ func (client *clientImpl) sendToWandbBackend(
 ) (*http.Response, error) {
 	client.setClientHeaders(req)
 	client.setAuthHeaders(req)
-
-	client.backend.waitIfRateLimited()
-
 	response, err := client.send(req)
-
-	if response != nil {
-		client.backend.processRateLimitHeaders(response)
-	}
-
 	return response, err
 }
 

--- a/core/internal/api/transport.go
+++ b/core/internal/api/transport.go
@@ -11,7 +11,7 @@ type backendTransport struct {
 	ratelimit rateLimiter
 }
 
-// Adds rate-limiting to an HTTP transport for the W&B backend.
+// Rate-limits an HTTP transport for the W&B backend.
 func (backend *Backend) rateLimitedTransport(
 	delegate http.RoundTripper,
 ) *backendTransport {

--- a/core/internal/api/transport.go
+++ b/core/internal/api/transport.go
@@ -1,0 +1,37 @@
+package api
+
+import "net/http"
+
+// A rate-limited HTTP transport for requests to the W&B backend.
+//
+// Implements [http.RoundTripper] for use as a transport for an HTTP client.
+type backendTransport struct {
+	backend   *Backend
+	delegate  http.RoundTripper
+	ratelimit rateLimiter
+}
+
+// Adds rate-limiting to an HTTP transport for the W&B backend.
+func (backend *Backend) rateLimitedTransport(
+	delegate http.RoundTripper,
+) *backendTransport {
+	return &backendTransport{
+		backend:   backend,
+		delegate:  delegate,
+		ratelimit: newRateLimiter(backend.logger),
+	}
+}
+
+func (transport *backendTransport) RoundTrip(
+	req *http.Request,
+) (*http.Response, error) {
+	transport.ratelimit.waitIfRateLimited()
+
+	response, err := transport.delegate.RoundTrip(req)
+
+	if response != nil {
+		transport.ratelimit.processRateLimitHeaders(response)
+	}
+
+	return response, err
+}


### PR DESCRIPTION
Description
-----------
Fixes WB-17344.

The crux of it is using a condvar in the classic way.

Note that if we're sending requests super fast, then after the first rate-limit header there may still be requests in flight which could fail. To minimize failed requests, the server should tell us to rate-limit ourselves sufficiently early.

Another thing to note is that we ignore rate-limit headers from requests that finish while a rate-limit is in effect. This shouldn't matter as long as the server's rate-limit responses are consistent.

Testing
-------
TODO