### PR TITLE
fix(artifacts): Revert "make upload request async to support progress reporting (#6497)"

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_artifact_saver.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_artifact_saver.py
@@ -66,14 +66,13 @@ def test_calls_commit_on_success():
         file_pusher=pusher,
     )
 
-    _, fut = saver.save(
+    saver.save(
         type="my-type",
         name="my-name",
         client_id="my-client-id",
         sequence_client_id="my-sequence-client-id",
     )
 
-    fut.result()
     api.commit_artifact.assert_called_once()
 
 
@@ -90,15 +89,13 @@ class TestReraisesErr:
             file_pusher=pusher,
         )
 
-        _, fut = saver.save(
+        saver.save(
             type="my-type",
             name="my-name",
             client_id="my-client-id",
             sequence_client_id="my-sequence-client-id",
             use_after_commit=True,
         )
-
-        fut.result()
 
     def test_use_artifact_err_reraised(self):
         exc = Exception("test-exc")

--- a/tests/pytest_tests/system_tests/test_artifacts/test_misc2.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_misc2.py
@@ -192,7 +192,7 @@ def test_reference_download(user):
             assert entry.ref_target()
 
 
-def test_deliver_artifact(user, relay_server, publish_util, mock_run):
+def test_communicate_artifact(user, relay_server, publish_util, mock_run):
     with relay_server() as relay:
         run = mock_run()
         artifact = wandb.Artifact("comms_test_PENDING", "dataset")

--- a/tests/pytest_tests/system_tests/test_artifacts/test_model_workflows.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_model_workflows.py
@@ -7,9 +7,6 @@ from wandb.sdk.wandb_run import Run
 
 
 class FakeArtifact:
-    def wait(self):
-        pass
-
     def is_draft(self):
         return False
 

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -435,7 +435,7 @@ def test_new_draft(wandb_init):
     # We would use public properties, but they're only available on non-draft artifacts.
     assert draft._entity == parent.entity
     assert draft._project == parent.project
-    assert draft._source_name == art.name.split(":")[0]
+    assert draft._source_name == art.name
     assert draft._source_entity == parent.entity
     assert draft._source_project == parent.project
 

--- a/tests/pytest_tests/system_tests/test_core/test_cli_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_cli_full.py
@@ -168,7 +168,7 @@ def test_sync_wandb_run(runner, relay_server, user, copy_asset):
     # (as we used to use a mock backend)
     # todo: create a new test asset that will contain an artifact
     with relay_server() as relay, runner.isolated_filesystem(), mock.patch(
-        "wandb.sdk.artifacts.artifact_saver.ArtifactSaver.save", return_value=({}, None)
+        "wandb.sdk.artifacts.artifact_saver.ArtifactSaver.save", return_value=None
     ):
         copy_asset("wandb")
 
@@ -189,7 +189,7 @@ def test_sync_wandb_run(runner, relay_server, user, copy_asset):
 @pytest.mark.wandb_core_failure(feature="offline_sync")
 def test_sync_wandb_run_and_tensorboard(runner, relay_server, user, copy_asset):
     with relay_server() as relay, runner.isolated_filesystem(), mock.patch(
-        "wandb.sdk.artifacts.artifact_saver.ArtifactSaver.save", return_value=({}, None)
+        "wandb.sdk.artifacts.artifact_saver.ArtifactSaver.save", return_value=None
     ):
         run_dir = os.path.join("wandb", "offline-run-20210216_154407-g9dvvkua")
         copy_asset("wandb")

--- a/wandb/sdk/artifacts/artifact_saver.py
+++ b/wandb/sdk/artifacts/artifact_saver.py
@@ -4,7 +4,7 @@ import json
 import os
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Awaitable, Dict, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Awaitable, Dict, Optional, Sequence
 
 import wandb
 import wandb.filesync.step_prepare
@@ -75,11 +75,9 @@ class ArtifactSaver:
         incremental: bool = False,
         history_step: Optional[int] = None,
         base_id: Optional[str] = None,
-    ) -> Tuple[Dict, Optional[concurrent.futures.Future]]:
-        server_artifact = None
-        commit_fut = None
+    ) -> Optional[Dict]:
         try:
-            server_artifact, commit_fut = self._save_internal(
+            return self._save_internal(
                 type,
                 name,
                 client_id,
@@ -95,12 +93,8 @@ class ArtifactSaver:
                 history_step,
                 base_id,
             )
-            return server_artifact, commit_fut
         finally:
-            if commit_fut is not None:
-                commit_fut.add_done_callback(lambda _: self._cleanup_staged_entries())
-            else:
-                self._cleanup_staged_entries()
+            self._cleanup_staged_entries()
 
     def _save_internal(
         self,
@@ -118,7 +112,7 @@ class ArtifactSaver:
         incremental: bool = False,
         history_step: Optional[int] = None,
         base_id: Optional[str] = None,
-    ) -> Tuple[Dict, Optional[concurrent.futures.Future]]:
+    ) -> Optional[Dict]:
         alias_specs = []
         for alias in aliases or []:
             alias_specs.append({"artifactCollectionName": name, "alias": alias})
@@ -146,7 +140,7 @@ class ArtifactSaver:
         if self._server_artifact["state"] == "COMMITTED":
             if use_after_commit:
                 self._api.use_artifact(artifact_id)
-            return self._server_artifact, None
+            return self._server_artifact
         if (
             self._server_artifact["state"] != "PENDING"
             # For old servers, see https://github.com/wandb/wandb/pull/6190
@@ -248,25 +242,17 @@ class ArtifactSaver:
             result_future=commit_result,
         )
 
-        saver_future: concurrent.futures.Future[None] = concurrent.futures.Future()
+        # Block until all artifact files are uploaded and the
+        # artifact is committed.
+        try:
+            commit_result.result()
+        finally:
+            step_prepare.shutdown()
 
-        # do not wait for the commit to finish. Instead, once the commit is finished, set the result in the
-        # a future returned by this function. This allows the caller to decide if they should
-        # synchronously wait for the result of the saver or let it run async in the background
-        def on_commit_result(fut: concurrent.futures.Future) -> None:
-            try:
-                res = fut.result()
-                if finalize and use_after_commit:
-                    self._api.use_artifact(artifact_id)
-                saver_future.set_result(res)
-            except Exception as e:
-                saver_future.set_exception(e)
-            finally:
-                step_prepare.shutdown()
+        if finalize and use_after_commit:
+            self._api.use_artifact(artifact_id)
 
-        commit_result.add_done_callback(on_commit_result)
-
-        return self._server_artifact, saver_future
+        return self._server_artifact
 
     def _resolve_client_id_manifest_references(self) -> None:
         for entry_path in self._manifest.entries:

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -389,17 +389,17 @@ class InterfaceShared(InterfaceBase):
         rec = self._make_record(files=files)
         self._publish(rec)
 
-    def _publish_link_artifact(self, link_artifact: pb.LinkArtifactRecord) -> None:
+    def _publish_link_artifact(self, link_artifact: pb.LinkArtifactRecord) -> Any:
         rec = self._make_record(link_artifact=link_artifact)
         self._publish(rec)
 
-    def _publish_use_artifact(self, use_artifact: pb.UseArtifactRecord) -> None:
+    def _publish_use_artifact(self, use_artifact: pb.UseArtifactRecord) -> Any:
         rec = self._make_record(use_artifact=use_artifact)
         self._publish(rec)
 
-    def _deliver_artifact(self, log_artifact: pb.LogArtifactRequest) -> MailboxHandle:
+    def _communicate_artifact(self, log_artifact: pb.LogArtifactRequest) -> Any:
         rec = self._make_request(log_artifact=log_artifact)
-        return self._deliver_record(rec)
+        return self._communicate_async(rec)
 
     def _deliver_download_artifact(
         self, download_artifact: pb.DownloadArtifactRequest

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -121,7 +121,9 @@ class JobBuilder:
     def disable(self, val: bool) -> None:
         self._disable = val
 
-    def _handle_server_artifact(self, res: Dict, artifact: "ArtifactRecord") -> None:
+    def _handle_server_artifact(
+        self, res: Optional[Dict], artifact: "ArtifactRecord"
+    ) -> None:
         if artifact.type == "job" and res is not None:
             try:
                 if res["artifactSequence"]["latestArtifact"] is None:
@@ -135,7 +137,7 @@ class JobBuilder:
                 self._job_seq_id = res["artifactSequence"]["id"]
             except KeyError as e:
                 _logger.info(f"Malformed response from ArtifactSaver.save {e}")
-        if artifact.type == "code" and "id" in res:
+        if artifact.type == "code" and res is not None:
             self._logged_code_artifact = ArtifactInfoForJob(
                 {
                     "id": res["id"],

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -248,7 +248,7 @@ class StreamMux:
     def _on_probe_exit(self, probe_handle: MailboxProbe, stream: StreamRecord) -> None:
         handle = probe_handle.get_mailbox_handle()
         if handle:
-            result = handle.wait(timeout=0, release=False)
+            result = handle.wait(timeout=0)
             if not result:
                 return
             probe_handle.set_probe_result(result)


### PR DESCRIPTION
…s reporting (#6497)"

This reverts commit cb57e43018daff0909147f09f76f675dc59968b2.

Description
-----------
We discovered a significant performance regression with polling for file pusher stats in order to report progress. This lead to artifact uploads to take 3-4 times longer for very large artifacts.

Testing
-------
Tested uploading 1 million files with around 300GB of data and confirmed performance is back to around 0.16.1 levels.
