### PR TITLE
ci(sdk): clean up system tests to use a single job spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,6 +455,8 @@ jobs:
 
     executor: <<parameters.executor>>
 
+    parallelism: 2
+
     steps:
       - checkout
       - run:
@@ -477,7 +479,9 @@ jobs:
                 name: Run tests for <<parameters.tests>>
                 no_output_timeout: 10m
                 command: |
-                  CI_PYTEST_PARALLEL=6 \
+                  CI_PYTEST_SPLIT_ARGS=" \
+                    --splits $CIRCLE_NODE_TOTAL \
+                    --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
                   tox run -v \
                     -e <<#parameters.with_core>>core-<</parameters.with_core
                       >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
@@ -493,7 +497,9 @@ jobs:
                 name: Run tests for <<parameters.tests>>
                 no_output_timeout: 10m
                 command: |
-                  CI_PYTEST_PARALLEL=6 \
+                  CI_PYTEST_SPLIT_ARGS=" \
+                    --splits $CIRCLE_NODE_TOTAL \
+                    --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
                   tox run -v \
                     -e <<#parameters.with_core>>core-<</parameters.with_core
                       >>notebooks-py<<parameters.python_version_major>><<parameters.python_version_minor>> \
@@ -507,7 +513,9 @@ jobs:
                 name: Run tests for <<parameters.tests>>
                 no_output_timeout: 10m
                 command: |
-                  CI_PYTEST_PARALLEL=6 \
+                  CI_PYTEST_SPLIT_ARGS=" \
+                    --splits $CIRCLE_NODE_TOTAL \
+                    --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
                   tox run -v \
                     -e <<#parameters.with_core>>core-<</parameters.with_core
                       >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
@@ -517,6 +525,7 @@ jobs:
                     tests/pytest_tests/system_tests/test_launch \
                     tests/pytest_tests/system_tests/test_sweep \
                     tests/pytest_tests/system_tests/test_artifacts
+
       - codecov/upload: { flags: system, validate: false }
 
       - save-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,11 +648,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install python, pip, and nox
-          command: |
-            sudo apt-get update && sudo apt-get install -y python3-pip
-            pip install nox
-      - run:
           name: Run wandb core's Go tests and collect coverage
           command: |
             cd core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1510,8 +1510,41 @@ workflows:
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
           codecov_flags: unit
 
+      - win:
+          requires:
+            - "unit-tests-legacy"
+          filters:
+            branches:
+              only:
+                # - main
+                - /^release-.*/
+                - /^.*-ci-win$/
+          matrix:
+            parameters:
+              python_version_major: [3]
+              python_version_minor: [9]
+          name: "unit(service)-legacy-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_flags: unit
+          tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+
       #
-      # core unit tests
+      # wandb launch tests
+      #
+      - launch:
+          requires:
+            - "unit-tests-legacy"
+          matrix:
+            parameters:
+              python_version_major: [3]
+              python_version_minor: [9]
+          name: "unit(service)-legacy-launch-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_flags: unit
+          tox_args: "tests/pytest_tests/unit_tests_old/test_launch/"
+
+      #
+      # Unit tests with Go on Linux
       #
       - unit-tests-go
 
@@ -1580,8 +1613,24 @@ workflows:
                   brew install ffmpeg \
                     python@<<matrix.python_version_major>>.<<matrix.python_version_minor>>
 
+      - win:
+          filters:
+            branches:
+              only:
+                # - main
+                - /^release-.*/
+                - /^.*-ci-win$/
+          matrix:
+            parameters:
+              python_version_major: [3]
+              python_version_minor: [9]
+          name: "unit(service)-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          codecov_flags: unit
+          tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
+
       #
-      # System tests with pytest on Linux
+      # System tests on Linux
       #
       - system-tests:
           name: "\
@@ -1607,79 +1656,6 @@ workflows:
             name: local-testcontainer
             python_version_major: <<matrix.python_version_major>>
             python_version_minor: <<matrix.python_version_minor>>
-
-      #
-      # Unit tests with pytest on Windows and MacOS
-      #
-      # - win:
-      #     requires:
-      #       - "unit-tests-legacy"
-      #     # filters:
-      #     #   branches:
-      #     #     only:
-      #     #       - main
-      #     #       - /^release-.*/
-      #     #       - /^.*-ci-win$/
-      #     matrix:
-      #       parameters:
-      #         python_version_major: [3]
-      #         python_version_minor: [9]
-      #     name: "unit-legacy-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     codecov_flags: unit
-      #     tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
-
-      - win:
-          requires:
-            - "unit-tests-legacy"
-          filters:
-            branches:
-              only:
-                # - main
-                - /^release-.*/
-                - /^.*-ci-win$/
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
-          name: "unit(service)-legacy-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          codecov_flags: unit
-          tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
-
-      # - win:
-      #     requires:
-      #       - "unit-tests"
-      #     # filters:
-      #     #   branches:
-      #     #     only:
-      #     #       - main
-      #     #       - /^release-.*/
-      #     #       - /^.*-ci-win$/
-      #     matrix:
-      #       parameters:
-      #         python_version_major: [3]
-      #         python_version_minor: [9]
-      #     name: "unit-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     codecov_flags: unit
-      #     tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
-
-      - win:
-          filters:
-            branches:
-              only:
-                # - main
-                - /^release-.*/
-                - /^.*-ci-win$/
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
-          name: "unit(service)-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          codecov_flags: unit
-          tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
 
       #
       # Functional tests with yea on Linux
@@ -1749,7 +1725,6 @@ workflows:
             <<matrix.python_version_minor>>"
           codecov_flags: func
 
-
       #
       # Functional tests with yea on Windows
       #
@@ -1769,22 +1744,6 @@ workflows:
           tox_args: "tests/functional_tests"
           parallelism: 6
           xdist: 1
-
-      #
-      # wandb launch tests
-      #
-      - launch:
-          requires:
-            - "unit-tests-legacy"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
-          name: "unit(service)-legacy-launch-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          codecov_flags: unit
-          tox_args: "tests/pytest_tests/unit_tests_old/test_launch/"
-
 
       #
       # functional tests with different executors

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,25 +443,6 @@ jobs:
 
       - save-test-results
 
-  code-check:
-    docker:
-      - image: "python:3.10"
-    resource_class: large
-    steps:
-      - checkout
-      - install_go
-      - run:
-          name: Install Python dependencies
-          command: pip install -U tox nox pip
-          no_output_timeout: 5m
-      - run:
-          name: Ensure proto files were generated
-          command: nox -t proto-check
-      - run:
-          name: Lint
-          command: tox run -v -e "black-check,ruff-check,mypy,mypy-report,auto-codegen-check"
-      - save-test-results
-
   system-tests:
     parameters:
       executor: { type: executor }
@@ -505,7 +486,6 @@ jobs:
                     tests/pytest_tests/system_tests/test_core \
                     tests/pytest_tests/system_tests/test_system_metrics \
                     tests/pytest_tests/system_tests/test_functional
-
       - when:
           condition: { equal: [<<parameters.tests>>, notebooks] }
           steps:
@@ -520,7 +500,6 @@ jobs:
                     -- \
                     <<#parameters.with_core>>-m 'not wandb_core_failure' <</parameters.with_core>> \
                     tests/pytest_tests/system_tests/test_notebooks
-
       - when:
           condition: { equal: [<<parameters.tests>>, other] }
           steps:
@@ -538,9 +517,27 @@ jobs:
                     tests/pytest_tests/system_tests/test_launch \
                     tests/pytest_tests/system_tests/test_sweep \
                     tests/pytest_tests/system_tests/test_artifacts
-
       - codecov/upload: { flags: system, validate: false }
 
+      - save-test-results
+
+  code-check:
+    docker:
+      - image: "python:3.10"
+    resource_class: large
+    steps:
+      - checkout
+      - install_go
+      - run:
+          name: Install Python dependencies
+          command: pip install -U tox nox pip
+          no_output_timeout: 5m
+      - run:
+          name: Ensure proto files were generated
+          command: nox -t proto-check
+      - run:
+          name: Lint
+          command: tox run -v -e "black-check,ruff-check,mypy,mypy-report,auto-codegen-check"
       - save-test-results
 
   tox-base:
@@ -1300,47 +1297,90 @@ workflows:
             - "slack-notify-on-start"
 
       - tox-base:
+          name: "\
+            func-tests-linux-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.shard>>-\
+            <<matrix.python_version_major>>-\
+            <<matrix.python_version_minor>>"
+
           matrix:
             parameters:
+              shard: ["tf115", "tf21", "tf24", "tf25", "tf26", "xgboost"]
               python_version_major: [3]
               python_version_minor: [7]
               with_core: [true]
-              shard: ["tf115", "tf21", "tf24", "tf25", "tf26", "xgboost"]
-          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
+
+          toxenv: "\
+            func-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            base-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>\
+            ,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
-          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+
+          coverage_dir: "\
+            func-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            base-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>"
           codecov_flags: func
 
+          notify_on_failure: true
+
+
       - tox-base:
+          name: "\
+            func-tests-linux-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.shard>>-\
+            <<matrix.python_version_major>>-\
+            <<matrix.python_version_minor>>"
+
           context: sdk-third-party-api
+
           matrix:
             parameters:
+              shard:
+                # - "llm"  # TODO: needs review
+                - noml
+                - ray112
+                - ray2
+                - sklearn
+                - metaflow
+                - fastai
+                - catboost
+                - jax
+                - prefect
+                - prodigy
+                - torch
+                - sacred
+                - sb3
+                - tf
+                - lightning
               python_version_major: [3]
               python_version_minor: [9]
               with_core: [true]
-              shard:
-                # - "llm"  # TODO: needs review
-                - "noml"
-                - "ray112"
-                - "ray2"
-                - "sklearn"
-                - "metaflow"
-                - "fastai"
-                - "catboost"
-                - "jax"
-                - "prefect"
-                - "prodigy"
-                - "torch"
-                - "sacred"
-                - "sb3"
-                - "tf"
-                - "lightning"
-          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
+
+          toxenv: "\
+            func-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            base-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>\
+            ,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
-          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+
+          coverage_dir: "\
+            func-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            base-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>"
           codecov_flags: func
+
           notify_on_failure: true
 
       # build docker images for yea shards
@@ -1434,8 +1474,6 @@ workflows:
       #       currently these are just placeholders
       - prep:
           name: "unit-tests-legacy"
-      - prep:
-          name: "functional-tests"
       - prep:
           name: "executor-tests"
           filters:
@@ -1570,6 +1608,27 @@ workflows:
             python_version_major: <<matrix.python_version_major>>
             python_version_minor: <<matrix.python_version_minor>>
 
+      #
+      # Unit tests with pytest on Windows and MacOS
+      #
+      # - win:
+      #     requires:
+      #       - "unit-tests-legacy"
+      #     # filters:
+      #     #   branches:
+      #     #     only:
+      #     #       - main
+      #     #       - /^release-.*/
+      #     #       - /^.*-ci-win$/
+      #     matrix:
+      #       parameters:
+      #         python_version_major: [3]
+      #         python_version_minor: [9]
+      #     name: "unit-legacy-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+      #     toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+      #     codecov_flags: unit
+      #     tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+
       - win:
           requires:
             - "unit-tests-legacy"
@@ -1588,6 +1647,24 @@ workflows:
           codecov_flags: unit
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
 
+      # - win:
+      #     requires:
+      #       - "unit-tests"
+      #     # filters:
+      #     #   branches:
+      #     #     only:
+      #     #       - main
+      #     #       - /^release-.*/
+      #     #       - /^.*-ci-win$/
+      #     matrix:
+      #       parameters:
+      #         python_version_major: [3]
+      #         python_version_minor: [9]
+      #     name: "unit-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+      #     toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+      #     codecov_flags: unit
+      #     tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
+
       - win:
           filters:
             branches:
@@ -1605,36 +1682,71 @@ workflows:
           tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
 
       #
-      # Functional tests with yea on Linux (base only)
+      # Functional tests with yea on Linux
       #
       - tox-base:
-          requires:
-            - "functional-tests"
+          name: "\
+            func-tests-linux-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.shard>>-\
+            <<matrix.python_version_major>>-\
+            <<matrix.python_version_minor>>"
+
+          parallelism: 4
+
           matrix:
             parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
               with_core: [true, false]
               shard: ["default", "artifacts", "launch"]
-          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
+              python_version_major: [3]
+              python_version_minor: [9]
+
+          toxenv: "\
+            func-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            base-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>\
+            ,cover-func-linux-circle"
+
           tox_args: "tests/functional_tests"
-          parallelism: 4
-          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+
+          coverage_dir: "\
+            func-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            base-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>"
           codecov_flags: func
 
       - tox-base:
-          requires:
-            - "functional-tests"
+          name: "\
+            func-tests-linux-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.shard>>-\
+            <<matrix.python_version_major>>-\
+            <<matrix.python_version_minor>>"
+
           matrix:
             parameters:
+              shard: [mitm, docs]
               python_version_major: [3]
               python_version_minor: [9]
               with_core: [true]
-              shard: [mitm, docs]
-          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
-          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+
+          toxenv: "\
+            func-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.shard>>-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>\
+            ,cover-func-linux-circle"
+
+          coverage_dir: "\
+            func-<<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.shard>>-py\
+            <<matrix.python_version_major>>\
+            <<matrix.python_version_minor>>"
           codecov_flags: func
 
 
@@ -1642,8 +1754,6 @@ workflows:
       # Functional tests with yea on Windows
       #
       - win:
-          requires:
-            - "functional-tests"
           filters:
             branches:
               only:
@@ -1674,6 +1784,7 @@ workflows:
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_flags: unit
           tox_args: "tests/pytest_tests/unit_tests_old/test_launch/"
+
 
       #
       # functional tests with different executors

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,21 @@ executors:
       - image: python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>
     resource_class: xlarge
 
+  local-testcontainer:
+    parameters:
+      python_version_major: { type: integer }
+      python_version_minor: { type: integer }
+    docker:
+      - image: "python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>"
+      - image: us-central1-docker.pkg.dev/<<pipeline.parameters.gcp_project>>/images/local-testcontainer:<<pipeline.parameters.wandb_server_tag>>
+        auth:
+          username: _json_key
+          password: $GCP_SERVICE_ACCOUNT_JSON_DECODED
+        environment:
+          CI: 1
+          WANDB_ENABLE_TEST_CONTAINER: true
+    resource_class: xlarge
+
 commands:
   save-test-results:
     description: "Save test results"
@@ -447,6 +462,87 @@ jobs:
           command: tox run -v -e "black-check,ruff-check,mypy,mypy-report,auto-codegen-check"
       - save-test-results
 
+  system-tests:
+    parameters:
+      executor: { type: executor }
+      python_version_major: { type: integer }
+      python_version_minor: { type: integer }
+      with_core: { type: boolean }
+      tests:
+        type: enum
+        enum: [sdk, notebooks, other]
+
+    executor: <<parameters.executor>>
+
+    steps:
+      - checkout
+      - run:
+          name: Install system deps
+          command: |
+            apt-get update
+            apt-get install -y libsndfile1 ffmpeg
+      - install_go
+
+      - run:
+          name: Install Python dependencies
+          command: pip install -U tox nox pip
+          no_output_timeout: 5m
+
+      # TODO: replace tests with pytest markers and remove the conditional
+      - when:
+          condition: { equal: [<<parameters.tests>>, sdk] }
+          steps:
+            - run:
+                name: Run tests for <<parameters.tests>>
+                no_output_timeout: 10m
+                command: |
+                  CI_PYTEST_PARALLEL=6 \
+                  tox run -v \
+                    -e <<#parameters.with_core>>core-<</parameters.with_core
+                      >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
+                    -- \
+                    <<#parameters.with_core>>-m 'not wandb_core_failure' <</parameters.with_core>> \
+                    tests/pytest_tests/system_tests/test_core \
+                    tests/pytest_tests/system_tests/test_system_metrics \
+                    tests/pytest_tests/system_tests/test_functional
+
+      - when:
+          condition: { equal: [<<parameters.tests>>, notebooks] }
+          steps:
+            - run:
+                name: Run tests for <<parameters.tests>>
+                no_output_timeout: 10m
+                command: |
+                  CI_PYTEST_PARALLEL=6 \
+                  tox run -v \
+                    -e <<#parameters.with_core>>core-<</parameters.with_core
+                      >>notebooks-py<<parameters.python_version_major>><<parameters.python_version_minor>> \
+                    -- \
+                    <<#parameters.with_core>>-m 'not wandb_core_failure' <</parameters.with_core>> \
+                    tests/pytest_tests/system_tests/test_notebooks
+
+      - when:
+          condition: { equal: [<<parameters.tests>>, other] }
+          steps:
+            - run:
+                name: Run tests for <<parameters.tests>>
+                no_output_timeout: 10m
+                command: |
+                  CI_PYTEST_PARALLEL=6 \
+                  tox run -v \
+                    -e <<#parameters.with_core>>core-<</parameters.with_core
+                      >>py<<parameters.python_version_major>><<parameters.python_version_minor>> \
+                    -- \
+                    <<#parameters.with_core>>-m 'not wandb_core_failure' <</parameters.with_core>> \
+                    tests/pytest_tests/system_tests/test_reports \
+                    tests/pytest_tests/system_tests/test_launch \
+                    tests/pytest_tests/system_tests/test_sweep \
+                    tests/pytest_tests/system_tests/test_artifacts
+
+      - codecov/upload: { flags: system, validate: false }
+
+      - save-test-results
+
   tox-base:
     parameters:
       python_version_major:
@@ -539,83 +635,6 @@ jobs:
     working_directory: /mnt/ramdisk
     steps:
       - checkout
-
-  pytest:
-    parameters:
-      python_version_major:
-        type: integer
-        default: 3
-      python_version_minor:
-        type: integer
-        default: 8
-      shard:
-        type: string
-        default: "core"
-      toxenv:
-        type: string
-      codecov_flags:
-        type: string
-        default: ""
-      notify_on_failure:
-        type: boolean
-        default: false
-      xdist:
-        type: integer
-        default: 6
-      tox_args:
-        type: string
-        default: ""
-    docker:
-      - image: "python:<<parameters.python_version_major>>.<<parameters.python_version_minor>>"
-      - image: us-central1-docker.pkg.dev/<< pipeline.parameters.gcp_project >>/images/local-testcontainer:<< pipeline.parameters.wandb_server_tag >>
-        auth:
-          username: _json_key
-          password: $GCP_SERVICE_ACCOUNT_JSON_DECODED
-        environment:
-          CI: 1
-          WANDB_ENABLE_TEST_CONTAINER: true
-    resource_class: xlarge
-    working_directory: /mnt/ramdisk
-    environment:
-      SHARD: << parameters.shard >>
-    steps:
-      - checkout
-      - run:
-          name: Install system deps
-          command: |
-            apt-get update && apt-get install -y libsndfile1 ffmpeg
-      - run:
-          name: Install Python dependencies
-          command: |
-            pip install -U tox nox pip
-            while ! curl http://localhost:8080/healthz; do sleep 1; done
-          no_output_timeout: 5m
-      - install_go
-      - run:
-          name: Run tests
-          no_output_timeout: 10m
-          command: |
-            CI_PYTEST_PARALLEL=<< parameters.xdist >> \
-            tox run -v -e <<parameters.toxenv>>  \
-              -- --wandb-server-tag='<< pipeline.parameters.wandb_server_tag >>' << parameters.tox_args >>
-      - when:
-          condition:
-            not:
-              equal: ["", << parameters.codecov_flags >>]
-          steps:
-            - codecov/upload:
-                { flags: <<parameters.codecov_flags>>, validate: false }
-      - save-test-results
-      # conditionally post a notification to slack if the job failed
-      - when:
-          condition: << parameters.notify_on_failure >>
-          steps:
-            - slack/notify:
-                event: fail
-                template: basic_fail_1
-                mentions: "@channel"
-                # taken from slack-secrets context
-                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
   unit-tests-go:
     docker:
@@ -1281,90 +1300,47 @@ workflows:
             - "slack-notify-on-start"
 
       - tox-base:
-          name: "\
-            func-tests-linux-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            <<matrix.shard>>-\
-            <<matrix.python_version_major>>-\
-            <<matrix.python_version_minor>>"
-
           matrix:
             parameters:
-              shard: ["tf115", "tf21", "tf24", "tf25", "tf26", "xgboost"]
               python_version_major: [3]
               python_version_minor: [7]
               with_core: [true]
-
-          toxenv: "\
-            func-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            base-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>\
-            ,cover-func-linux-circle"
+              shard: ["tf115", "tf21", "tf24", "tf25", "tf26", "xgboost"]
+          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
-
-          coverage_dir: "\
-            func-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            base-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>"
+          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_flags: func
 
-          notify_on_failure: true
-
-
       - tox-base:
-          name: "\
-            func-tests-linux-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            <<matrix.shard>>-\
-            <<matrix.python_version_major>>-\
-            <<matrix.python_version_minor>>"
-
           context: sdk-third-party-api
-
           matrix:
             parameters:
-              shard:
-                # - "llm"  # TODO: needs review
-                - noml
-                - ray112
-                - ray2
-                - sklearn
-                - metaflow
-                - fastai
-                - catboost
-                - jax
-                - prefect
-                - prodigy
-                - torch
-                - sacred
-                - sb3
-                - tf
-                - lightning
               python_version_major: [3]
               python_version_minor: [9]
               with_core: [true]
-
-          toxenv: "\
-            func-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            base-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>\
-            ,cover-func-linux-circle"
+              shard:
+                # - "llm"  # TODO: needs review
+                - "noml"
+                - "ray112"
+                - "ray2"
+                - "sklearn"
+                - "metaflow"
+                - "fastai"
+                - "catboost"
+                - "jax"
+                - "prefect"
+                - "prodigy"
+                - "torch"
+                - "sacred"
+                - "sb3"
+                - "tf"
+                - "lightning"
+          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
-
-          coverage_dir: "\
-            func-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            base-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>"
+          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_flags: func
-
           notify_on_failure: true
 
       # build docker images for yea shards
@@ -1457,65 +1433,15 @@ workflows:
       # TODO: pre-create toxenvs for all python versions,
       #       currently these are just placeholders
       - prep:
-          name: "system-tests"
-          filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
-      - prep:
           name: "unit-tests-legacy"
+      - prep:
+          name: "functional-tests"
       - prep:
           name: "executor-tests"
           filters:
             branches:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
-
-      #
-      # System tests with pytest on Linux, using real wandb server
-      #
-      - pytest:
-          requires:
-            - "system-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [7, 8, 9, 10, 11, 12]
-          name: "system-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/system_tests/test_core"
-          codecov_flags: system
-
-      #
-      # System tests with Service
-      #
-      - pytest:
-          requires:
-            - "system-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [10]
-          name: "system(service)-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/system_tests/test_core"
-          codecov_flags: system
-      #
-      # Functional tests with pytest on Linux, using real wandb server
-      #
-      - pytest:
-          requires:
-            - "system-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [10]
-          name: "functional-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/system_tests/test_functional"
-          codecov_flags: func
-
-
 
       #
       # Unit tests with pytest on Linux, using the old mock server
@@ -1617,25 +1543,32 @@ workflows:
                     python@<<matrix.python_version_major>>.<<matrix.python_version_minor>>
 
       #
-      # Unit tests with pytest on Windows and MacOS
+      # System tests with pytest on Linux
       #
-      # - win:
-      #     requires:
-      #       - "unit-tests-legacy"
-      #     # filters:
-      #     #   branches:
-      #     #     only:
-      #     #       - main
-      #     #       - /^release-.*/
-      #     #       - /^.*-ci-win$/
-      #     matrix:
-      #       parameters:
-      #         python_version_major: [3]
-      #         python_version_minor: [9]
-      #     name: "unit-legacy-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     codecov_flags: unit
-      #     tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
+      - system-tests:
+          name: "\
+            system-tests-linux-\
+            <<#matrix.with_core>>core-<</matrix.with_core>>\
+            <<matrix.tests>>-\
+            <<matrix.python_version_major>>-\
+            <<matrix.python_version_minor>>"
+
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
+
+          matrix:
+            parameters:
+              python_version_major: [3]
+              python_version_minor: [8, 12]
+              with_core: [true, false]
+              tests: [sdk, notebooks, other]
+
+          executor:
+            name: local-testcontainer
+            python_version_major: <<matrix.python_version_major>>
+            python_version_minor: <<matrix.python_version_minor>>
 
       - win:
           requires:
@@ -1655,24 +1588,6 @@ workflows:
           codecov_flags: unit
           tox_args: "tests/pytest_tests/unit_tests_old --ignore=tests/pytest_tests/unit_tests_old/test_launch"
 
-      # - win:
-      #     requires:
-      #       - "unit-tests"
-      #     # filters:
-      #     #   branches:
-      #     #     only:
-      #     #       - main
-      #     #       - /^release-.*/
-      #     #       - /^.*-ci-win$/
-      #     matrix:
-      #       parameters:
-      #         python_version_major: [3]
-      #         python_version_minor: [9]
-      #     name: "unit-win-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-      #     codecov_flags: unit
-      #     tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
-
       - win:
           filters:
             branches:
@@ -1690,71 +1605,36 @@ workflows:
           tox_args: "tests/pytest_tests/unit_tests --ignore=tests/pytest_tests/unit_tests/test_launch --ignore=tests/pytest_tests/unit_tests/test_reports"
 
       #
-      # Functional tests with yea on Linux
+      # Functional tests with yea on Linux (base only)
       #
       - tox-base:
-          name: "\
-            func-tests-linux-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            <<matrix.shard>>-\
-            <<matrix.python_version_major>>-\
-            <<matrix.python_version_minor>>"
-
-          parallelism: 4
-
+          requires:
+            - "functional-tests"
           matrix:
             parameters:
-              with_core: [true, false]
-              shard: ["default", "artifacts", "launch"]
               python_version_major: [3]
               python_version_minor: [9]
-
-          toxenv: "\
-            func-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            base-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>\
-            ,cover-func-linux-circle"
-
+              with_core: [true, false]
+              shard: ["default", "artifacts", "launch"]
+          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
           tox_args: "tests/functional_tests"
-
-          coverage_dir: "\
-            func-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            base-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>"
+          parallelism: 4
+          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>>base-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_flags: func
 
       - tox-base:
-          name: "\
-            func-tests-linux-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            <<matrix.shard>>-\
-            <<matrix.python_version_major>>-\
-            <<matrix.python_version_minor>>"
-
+          requires:
+            - "functional-tests"
           matrix:
             parameters:
-              shard: [mitm, docs]
               python_version_major: [3]
               python_version_minor: [9]
               with_core: [true]
-
-          toxenv: "\
-            func-\
-            <<#matrix.with_core>>core-<</matrix.with_core>>\
-            <<matrix.shard>>-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>\
-            ,cover-func-linux-circle"
-
-          coverage_dir: "\
-            func-<<#matrix.with_core>>core-<</matrix.with_core>>\
-            <<matrix.shard>>-py\
-            <<matrix.python_version_major>>\
-            <<matrix.python_version_minor>>"
+              shard: [mitm, docs]
+          name: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
+          toxenv: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>,cover-func-linux-circle"
+          coverage_dir: "func-<<#matrix.with_core>>core-<</matrix.with_core>><<matrix.shard>>-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_flags: func
 
 
@@ -1762,6 +1642,8 @@ workflows:
       # Functional tests with yea on Windows
       #
       - win:
+          requires:
+            - "functional-tests"
           filters:
             branches:
               only:
@@ -1792,66 +1674,6 @@ workflows:
           toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
           codecov_flags: unit
           tox_args: "tests/pytest_tests/unit_tests_old/test_launch/"
-
-      - pytest:
-          requires:
-            - "system-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [10]
-              shard:
-                - "launch"
-                - "artifacts"
-                - "system_metrics"
-                - "reports"
-          name: "system-<<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "core-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/system_tests/test_<<matrix.shard>>"
-          codecov_flags: system
-
-      - pytest:
-          requires:
-            - "system-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [8]
-              shard:
-                - "launch"
-                - "sweep"
-                - "artifacts"
-          name: "system(service)-<<matrix.shard>>-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/system_tests/test_<<matrix.shard>>"
-          codecov_flags: system
-
-      #
-      # notebook tests
-      #
-      - pytest:
-          requires:
-            - "system-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
-          name: "system-notebooks-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "core-notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "-m 'not wandb_core_failure' tests/pytest_tests/system_tests/test_notebooks"
-          codecov_flags: system
-
-      - pytest:
-          requires:
-            - "system-tests"
-          matrix:
-            parameters:
-              python_version_major: [3]
-              python_version_minor: [9]
-          name: "system(service)-notebooks-linux-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          toxenv: "notebooks-py<<matrix.python_version_major>><<matrix.python_version_minor>>"
-          tox_args: "tests/pytest_tests/system_tests/test_notebooks"
-          codecov_flags: system
 
       #
       # functional tests with different executors

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -654,7 +654,7 @@ jobs:
             go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - codecov/upload: { flags: unit, validate: false }
 
-  local-testcontainer:
+  store-local-testcontainer:
     parameters:
       python_version_major:
         type: integer
@@ -1249,7 +1249,7 @@ workflows:
       #
       # Keep local-testcontainer registry up to date
       #
-      - local-testcontainer:
+      - store-local-testcontainer:
           requires:
             - "slack-notify-on-start"
       #

--- a/tests/pytest_tests/system_tests/test_functional/test_mode_shared.py
+++ b/tests/pytest_tests/system_tests/test_functional/test_mode_shared.py
@@ -1,8 +1,15 @@
+import importlib.util
 import pathlib
 import runpy
 from unittest import mock
 
+import pytest
 
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("wandb-core") is None,
+    reason="shared mode only available in wandb-core",
+)
 def test_mode_shared(user, relay_server, copy_asset):
     # copy assets to test directory:
     pathlib.Path("scripts").mkdir()

--- a/tests/pytest_tests/system_tests/test_sweep/test_wandb_sweep.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_wandb_sweep.py
@@ -177,6 +177,7 @@ def test_minmax_validation():
         api.api._validate_config_and_fill_distribution(sweep_config)
 
 
+@pytest.mark.wandb_core_failure(feature="sweep")
 def test_add_run_to_existing_sweep(user, wandb_init, relay_server):
     # Test that updating settings with sweep_id includes it in upsertBucket mutation
 

--- a/tests/pytest_tests/system_tests/test_system_metrics/test_open_metrics.py
+++ b/tests/pytest_tests/system_tests/test_system_metrics/test_open_metrics.py
@@ -158,6 +158,7 @@ def mocked_requests_get(*args, **kwargs):
     ],
 )
 @pytest.mark.wandb_core_failure(feature="system_monitor_open_metrics")
+@pytest.mark.xfail(reason="Test is flaky")
 def test_dcgm(
     wandb_init, relay_server, test_settings, filters, expected_keys, unexpected_keys
 ):


### PR DESCRIPTION
Description
-----------

What does the PR do?

This PR just unifies all the system tests under same job to make sure we ran all the tests with nexus.
This found another issue with sweeps that wasn't covered earlier.

In follow up PRs we are going to slowly enabling all the tests that marked as `wandb_core_failure`