### PR TITLE
feat(sdk): Rate-limit GraphQL and filestream separately

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/wandb/core/internal/clients"
-	"golang.org/x/time/rate"
 )
 
 const (
@@ -25,8 +24,8 @@ const (
 
 // The W&B backend server.
 //
-// This models the server, in particular to handle rate limiting. There is
-// generally exactly one Backend and a small number of Clients in a process.
+// There is generally exactly one Backend and a small number of Clients in a
+// process.
 type Backend struct {
 	// The URL prefix for all requests to the W&B API.
 	baseURL *url.URL
@@ -39,18 +38,13 @@ type Backend struct {
 
 	// API key for backend requests.
 	apiKey string
-
-	// Rate limit for all outgoing requests.
-	rateLimiter *rate.Limiter
-
-	// Dynamic adjustments to the rate-limit based on server backpressure.
-	rlTracker *RateLimitTracker
 }
 
 // An HTTP client for interacting with the W&B backend.
 //
-// Multiple Clients can be created for one Backend when different retry
-// policies are needed.
+// There is one Client per API provided by the backend, where "API" is a
+// collection of related HTTP endpoints. It's expected that different APIs
+// have different properties such as rate-limits and ideal retry behaviors.
 //
 // The client is responsible for setting auth headers, retrying
 // gracefully, and respecting rate-limit response headers.
@@ -120,18 +114,9 @@ type BackendOptions struct {
 // including a final slash. Example "http://localhost:8080".
 func New(opts BackendOptions) *Backend {
 	return &Backend{
-		baseURL:     opts.BaseURL,
-		logger:      opts.Logger,
-		apiKey:      opts.APIKey,
-		rateLimiter: rate.NewLimiter(maxRequestsPerSecond, maxBurst),
-		rlTracker: NewRateLimitTracker(RateLimitTrackerParams{
-			MinPerSecond: minRateLimit,
-			MaxPerSecond: maxRequestsPerSecond,
-
-			// TODO: Allow changing these through settings.
-			Smoothing:              0.2,
-			MinRequestsForEstimate: 5,
-		}),
+		baseURL: opts.BaseURL,
+		logger:  opts.Logger,
+		apiKey:  opts.APIKey,
 	}
 }
 
@@ -194,9 +179,13 @@ func (backend *Backend) NewClient(opts ClientOptions) Client {
 		)
 	}
 
-	retryableHTTP.HTTPClient.Transport = backend.rateLimitedTransport(
+	retryableHTTP.HTTPClient.Transport = NewRateLimitedTransport(
 		retryableHTTP.HTTPClient.Transport,
 	)
 
-	return &clientImpl{backend, retryableHTTP, opts.ExtraHeaders}
+	return &clientImpl{
+		backend:       backend,
+		retryableHTTP: retryableHTTP,
+		extraHeaders:  opts.ExtraHeaders,
+	}
 }


### PR DESCRIPTION
Description
-----------
Fixes WB-17769.

I capitalized `rateLimitedTransport` because it's used outside of `transport.go`, even though it shouldn't be used outside of `api/`. It just feels wrong to use lowercase names defined in other files, even if they're in the same package.

Testing
-------
Unit tests.
