### PR TITLE
chore(sdk): Remove functions from clients.go

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -153,13 +153,12 @@ type ClientOptions struct {
 
 // Creates a new [Client] for making requests to the [Backend].
 func (backend *Backend) NewClient(opts ClientOptions) Client {
-	retryableHTTP := clients.NewRetryClient(
-		clients.WithRetryClientBackoff(clients.ExponentialBackoffWithJitter),
-		clients.WithRetryClientRetryMax(opts.RetryMax),
-		clients.WithRetryClientRetryWaitMin(opts.RetryWaitMin),
-		clients.WithRetryClientRetryWaitMax(opts.RetryWaitMax),
-		clients.WithRetryClientHttpTimeout(opts.NonRetryTimeout),
-	)
+	retryableHTTP := retryablehttp.NewClient()
+	retryableHTTP.Backoff = clients.ExponentialBackoffWithJitter
+	retryableHTTP.RetryMax = opts.RetryMax
+	retryableHTTP.RetryWaitMin = opts.RetryWaitMin
+	retryableHTTP.RetryWaitMax = opts.RetryWaitMax
+	retryableHTTP.HTTPClient.Timeout = opts.NonRetryTimeout
 
 	// Set the retry policy with debug logging if possible.
 	retryPolicy := opts.RetryPolicy

--- a/core/internal/clients/clients.go
+++ b/core/internal/clients/clients.go
@@ -1,12 +1,8 @@
+// Deprecated package providing utilities for defining HTTP clients.
 package clients
 
 import (
-	"log/slog"
 	"time"
-
-	"github.com/wandb/wandb/core/pkg/observability"
-
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 func SecondsToDuration(seconds float64) time.Duration {
@@ -15,57 +11,4 @@ func SecondsToDuration(seconds float64) time.Duration {
 
 func DurationToSeconds(duration time.Duration) float64 {
 	return float64(duration) / float64(time.Second)
-}
-
-func NewRetryClient(opts ...RetryClientOption) *retryablehttp.Client {
-	retryClient := retryablehttp.NewClient()
-
-	for _, opt := range opts {
-		opt(retryClient)
-	}
-	return retryClient
-}
-
-type RetryClientOption func(rc *retryablehttp.Client)
-
-func WithRetryClientLogger(logger *observability.CoreLogger) RetryClientOption {
-	return func(rc *retryablehttp.Client) {
-		rc.Logger = slog.NewLogLogger(logger.Logger.Handler(), slog.LevelDebug)
-	}
-}
-
-func WithRetryClientRetryMax(retryMax int) RetryClientOption {
-	return func(rc *retryablehttp.Client) {
-		rc.RetryMax = retryMax
-	}
-}
-
-func WithRetryClientRetryWaitMin(retryWaitMin time.Duration) RetryClientOption {
-	return func(rc *retryablehttp.Client) {
-		rc.RetryWaitMin = retryWaitMin
-	}
-}
-
-func WithRetryClientRetryWaitMax(retryWaitMax time.Duration) RetryClientOption {
-	return func(rc *retryablehttp.Client) {
-		rc.RetryWaitMax = retryWaitMax
-	}
-}
-
-func WithRetryClientHttpTimeout(timeout time.Duration) RetryClientOption {
-	return func(rc *retryablehttp.Client) {
-		rc.HTTPClient.Timeout = timeout
-	}
-}
-
-func WithRetryClientRetryPolicy(retryPolicy retryablehttp.CheckRetry) RetryClientOption {
-	return func(rc *retryablehttp.Client) {
-		rc.CheckRetry = retryPolicy
-	}
-}
-
-func WithRetryClientBackoff(backoff retryablehttp.Backoff) RetryClientOption {
-	return func(rc *retryablehttp.Client) {
-		rc.Backoff = backoff
-	}
 }

--- a/core/internal/filetransfer/file_transfer_default_test.go
+++ b/core/internal/filetransfer/file_transfer_default_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
-	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/pkg/observability"
 )
@@ -31,7 +31,7 @@ func TestDefaultFileTransfer_Download(t *testing.T) {
 	defer mockServer.Close()
 
 	// Creating a file transfer
-	ft := filetransfer.NewDefaultFileTransfer(observability.NewNoOpLogger(), clients.NewRetryClient())
+	ft := filetransfer.NewDefaultFileTransfer(observability.NewNoOpLogger(), retryablehttp.NewClient())
 
 	// Mocking task
 	task := &filetransfer.Task{
@@ -86,7 +86,7 @@ func TestDefaultFileTransfer_Upload(t *testing.T) {
 	defer mockServer.Close()
 
 	// Creating a file transfer
-	ft := filetransfer.NewDefaultFileTransfer(observability.NewNoOpLogger(), clients.NewRetryClient())
+	ft := filetransfer.NewDefaultFileTransfer(observability.NewNoOpLogger(), retryablehttp.NewClient())
 
 	// Creating a file to be uploaded
 	filename := "test-upload-file.txt"


### PR DESCRIPTION
Description
-----------
Clean up a little by removing most functions from `clients.go` and setting retryablehttp client fields directly at callsites.
