### PR TITLE
chore(core): Correctly delete existing file in setup.py

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -105,9 +105,7 @@ class CustomBuildPy(build_py):
         for file in archdir.iterdir():
             dest = pkgdir / file.name
 
-            if dest.exists():
-                dest.unlink()
-
+            dest.unlink(missing_ok=True)
             os.symlink(file, dest)
 
         super().run()


### PR DESCRIPTION
`Path.exists()` can return `False` even if a file exists! Happens for broken symlinks.