### PR TITLE
chore(sdk): Ignore ruff UP032

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ ignore = [
     "D1",    # Allow missing docstrings.
     "D417",  # Don't require descriptions for all arguments.
     "UP022",
+    "UP032", # Allow using format instead of f-string.
     "UP036",
 ]
 target-version = "py37"


### PR DESCRIPTION
This started failing recently. There are 64 instances and no auto-fix.