### PR TITLE
chore(sdk): Disable pytest reruns, as they don't work with xdist

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,6 @@ pytest-mock
 pytest-timeout
 pytest-openfiles
 pytest-flakefinder
-pytest-rerunfailures
 parameterized
 
 flask>2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ commands_pre=
     mkdir -p test-results .coverage
     core: ./wini package wandb-core --coverage --install
 commands=
-    pytest {env:CI_PYTEST_SPLIT_ARGS:} -n=8 --durations=20 --reruns 2 --reruns-delay 1 --junitxml=test-results/junit.xml --cov --cov-report=xml --no-cov-on-fail --timeout 300 {posargs}
+    pytest {env:CI_PYTEST_SPLIT_ARGS:} -n=8 --durations=20 --junitxml=test-results/junit.xml --cov --cov-report=xml --no-cov-on-fail --timeout 300 {posargs}
 commands_post=
     core: go tool covdata textfmt -i=.coverage -o coverage.txt
 


### PR DESCRIPTION
Description
-----------
Example failing test: https://app.circleci.com/pipelines/github/wandb/wandb/31608/workflows/76f5f3d3-be59-4bdf-8fa4-3a8c697b2cd7/jobs/1049934/tests

```
  File "/root/project/.tox/py312/lib/python3.12/site-packages/pytest_rerunfailures.py", line 351, in pytest_handlecrashitem
    sched.mark_test_pending(crashitem)
  File "/root/project/.tox/py312/lib/python3.12/site-packages/xdist/scheduler/loadscope.py", line 245, in mark_test_pending
    raise NotImplementedError()
NotImplementedError
```

This appears to be a bad interaction between pytest-rerunfailures and pytest-xdist. As a result, the actual test failure is hard to find.