### PR TITLE
refactor(core): Move server/config.go into its own package

### DIFF
--- a/core/internal/runconfig/runconfig.go
+++ b/core/internal/runconfig/runconfig.go
@@ -1,4 +1,4 @@
-package server
+package runconfig
 
 import (
 	"fmt"
@@ -41,11 +41,11 @@ const (
 	FormatJson
 )
 
-func NewRunConfig() *RunConfig {
+func New() *RunConfig {
 	return &RunConfig{make(RunConfigDict)}
 }
 
-func NewRunConfigFrom(tree RunConfigDict) *RunConfig {
+func NewFrom(tree RunConfigDict) *RunConfig {
 	return &RunConfig{tree}
 }
 

--- a/core/internal/runconfig/runconfig_test.go
+++ b/core/internal/runconfig/runconfig_test.go
@@ -1,17 +1,17 @@
-package server_test
+package runconfig_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/corelib"
-	"github.com/wandb/wandb/core/pkg/server"
+	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
 func TestConfigUpdate(t *testing.T) {
-	runConfig := server.NewRunConfigFrom(server.RunConfigDict{
-		"b": server.RunConfigDict{
+	runConfig := runconfig.NewFrom(runconfig.RunConfigDict{
+		"b": runconfig.RunConfigDict{
 			"c": 321.0,
 			"d": 123.0,
 		},
@@ -33,9 +33,9 @@ func TestConfigUpdate(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		server.RunConfigDict{
+		runconfig.RunConfigDict{
 			"a": 1.0,
-			"b": server.RunConfigDict{
+			"b": runconfig.RunConfigDict{
 				"c": "text",
 				"d": 123.0,
 			},
@@ -45,9 +45,9 @@ func TestConfigUpdate(t *testing.T) {
 }
 
 func TestConfigRemove(t *testing.T) {
-	runConfig := server.NewRunConfigFrom(server.RunConfigDict{
+	runConfig := runconfig.NewFrom(runconfig.RunConfigDict{
 		"a": 9,
-		"b": server.RunConfigDict{
+		"b": runconfig.RunConfigDict{
 			"c": 321.0,
 			"d": 123.0,
 		},
@@ -63,21 +63,21 @@ func TestConfigRemove(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		server.RunConfigDict{"b": server.RunConfigDict{"d": 123.0}},
+		runconfig.RunConfigDict{"b": runconfig.RunConfigDict{"d": 123.0}},
 		runConfig.Tree(),
 	)
 }
 
 func TestConfigSerialize(t *testing.T) {
-	runConfig := server.NewRunConfigFrom(server.RunConfigDict{
+	runConfig := runconfig.NewFrom(runconfig.RunConfigDict{
 		"number": 9,
-		"nested": server.RunConfigDict{
+		"nested": runconfig.RunConfigDict{
 			"list": []string{"a", "b", "c"},
 			"text": "xyz",
 		},
 	})
 
-	yaml, _ := runConfig.Serialize(server.FormatYaml)
+	yaml, _ := runConfig.Serialize(runconfig.FormatYaml)
 
 	assert.Equal(t,
 		""+
@@ -95,7 +95,7 @@ func TestConfigSerialize(t *testing.T) {
 }
 
 func TestAddTelemetryAndMetrics(t *testing.T) {
-	runConfig := server.NewRunConfig()
+	runConfig := runconfig.New()
 	telemetry := &service.TelemetryRecord{}
 
 	runConfig.AddTelemetryAndMetrics(
@@ -104,8 +104,8 @@ func TestAddTelemetryAndMetrics(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		server.RunConfigDict{
-			"_wandb": server.RunConfigDict{
+		runconfig.RunConfigDict{
+			"_wandb": runconfig.RunConfigDict{
 				"t": corelib.ProtoEncodeToDict(telemetry),
 				"m": []map[int]interface{}{},
 			},

--- a/core/pkg/server/resume.go
+++ b/core/pkg/server/resume.go
@@ -6,6 +6,7 @@ import (
 	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/core/internal/gql"
+	"github.com/wandb/wandb/core/internal/runconfig"
 	fs "github.com/wandb/wandb/core/pkg/filestream"
 	"github.com/wandb/wandb/core/pkg/observability"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -40,7 +41,7 @@ type Bucket = gql.RunResumeStatusModelProjectBucketRun
 func (r *ResumeState) Update(
 	data *gql.RunResumeStatusResponse,
 	run *service.RunRecord,
-	config *RunConfig,
+	config *runconfig.RunConfig,
 ) (*service.RunUpdateResult, error) {
 	// If we get that the run is not a resume run, we should fail if resume is set to must
 	// for any other case of resume status, it is fine to ignore it
@@ -178,7 +179,7 @@ func (r *ResumeState) updateSummary(run *service.RunRecord, bucket *Bucket) (*se
 // Merges the original run's config into the current config.
 func (r *ResumeState) updateConfig(
 	bucket *Bucket,
-	config *RunConfig,
+	config *runconfig.RunConfig,
 ) (*service.RunUpdateResult, error) {
 	var cfg map[string]interface{}
 	if err := json.Unmarshal([]byte(*bucket.GetConfig()), &cfg); err != nil {
@@ -194,7 +195,7 @@ func (r *ResumeState) updateConfig(
 		}
 	}
 
-	deserializedConfig := make(RunConfigDict)
+	deserializedConfig := make(runconfig.RunConfigDict)
 	for key, value := range cfg {
 		valueDict, ok := value.(map[string]interface{})
 

--- a/core/pkg/server/resume_test.go
+++ b/core/pkg/server/resume_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/gql"
+	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/pkg/observability"
 	server "github.com/wandb/wandb/core/pkg/server"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -229,7 +230,7 @@ func TestUpdate(t *testing.T) {
 				},
 			}
 
-			configCopy := server.NewRunConfig()
+			configCopy := runconfig.New()
 			_, err := rs.Update(fakeResp, tc.run, configCopy)
 
 			if tc.expectError {

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wandb/wandb/core/internal/debounce"
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/gql"
+	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/internal/shared"
 	"github.com/wandb/wandb/core/internal/version"
 	"github.com/wandb/wandb/core/pkg/artifacts"
@@ -103,7 +104,7 @@ type Sender struct {
 	summaryMap map[string]*service.SummaryItem
 
 	// Keep track of config which is being updated incrementally
-	runConfig *RunConfig
+	runConfig *runconfig.RunConfig
 
 	// Info about the (local) server we are talking to
 	serverInfo *gql.ServerInfoServerInfo
@@ -135,7 +136,7 @@ func NewSender(
 		settings:       settings,
 		logger:         logger,
 		summaryMap:     make(map[string]*service.SummaryItem),
-		runConfig:      NewRunConfig(),
+		runConfig:      runconfig.New(),
 		telemetry:      &service.TelemetryRecord{CoreVersion: version.Version},
 		wgFileTransfer: sync.WaitGroup{},
 	}
@@ -547,7 +548,7 @@ func (s *Sender) updateConfigPrivate() {
 }
 
 // Serializes the run configuration to send to the backend.
-func (s *Sender) serializeConfig(format ConfigFormat) string {
+func (s *Sender) serializeConfig(format runconfig.ConfigFormat) string {
 	serializedConfig, err := s.runConfig.Serialize(format)
 
 	if err != nil {
@@ -635,7 +636,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			}
 		}
 
-		config := s.serializeConfig(FormatJson)
+		config := s.serializeConfig(runconfig.FormatJson)
 
 		var tags []string
 		tags = append(tags, run.Tags...)
@@ -765,7 +766,7 @@ func (s *Sender) upsertConfig() {
 	if s.graphqlClient == nil {
 		return
 	}
-	config := s.serializeConfig(FormatJson)
+	config := s.serializeConfig(runconfig.FormatJson)
 
 	ctx := context.WithValue(s.ctx, clients.CtxRetryPolicyKey, clients.UpsertBucketRetryPolicy)
 	_, err := gql.UpsertBucket(
@@ -802,7 +803,7 @@ func (s *Sender) writeAndSendConfigFile() {
 		return
 	}
 
-	config := s.serializeConfig(FormatYaml)
+	config := s.serializeConfig(runconfig.FormatYaml)
 	configFile := filepath.Join(s.settings.GetFilesDir().GetValue(), ConfigFileName)
 	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
 		s.logger.Error("sender: writeAndSendConfigFile: failed to write config file", "error", err)


### PR DESCRIPTION
Description
-----------
It was due to get factored out.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable

