### PR TITLE
chore(sdk): Kill bad filesystem test

### DIFF
--- a/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
@@ -4,10 +4,8 @@ import os
 import platform
 import re
 import shutil
-import sys
 import tempfile
 import time
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -367,54 +365,6 @@ def test_safe_copy_str_path(tmp_path: Path):
 #         safe_copy(source_path, target_path)
 #
 #         assert target_path.read_text("utf-8") == source_content
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows locks active files")
-def test_safe_copy_target_file_changes_during_copy(tmp_path: Path, monkeypatch):
-    source_path = tmp_path / "source.txt"
-    target_path = tmp_path / "target.txt"
-    source_content = "Source content 📝" * 1000
-    changed_target_content = "Changed target content 🔀"
-
-    source_path.write_text(source_content, encoding="utf-8")
-
-    def repeatedly_write_content():
-        end_time = time.time() + 1.0
-        while time.time() < end_time:
-            try:
-                target_path.write_text(changed_target_content, encoding="utf-8")
-            except PermissionError:
-                pass
-
-    def delayed_copy_with_pause(src, dst, *args, **kwargs):
-        """Write a 4096 byte block at a time, pausing 0.1 seconds between writes."""
-        # Windows often doesn't allow opening a file for writing while there is an open
-        # file handle to it. To get around the PermissionError, we close the file
-        # between writes, but also retry failed writes.
-        pos = 0
-        with open(src, "rb") as infile:
-            for block in iter(lambda: infile.read(4096), b""):
-                success = False
-                while not success:
-                    time.sleep(0.1)
-                    try:
-                        with open(dst, "wb") as outfile:
-                            outfile.seek(pos)
-                            outfile.write(block)
-                        pos += len(block)
-                        success = True
-                    except PermissionError:
-                        pass
-
-    monkeypatch.setattr(shutil, "copy2", delayed_copy_with_pause)
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        future = executor.submit(repeatedly_write_content)
-        safe_copy(source_path, target_path)
-        future.result()
-
-    result_content = target_path.read_text("utf-8")
-    assert result_content == source_content or result_content == changed_target_content
 
 
 @pytest.mark.parametrize("src_link", [None, "symbolic", "hard"])

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -227,7 +227,17 @@ def safe_open(
 
 
 def safe_copy(source_path: StrPath, target_path: StrPath) -> StrPath:
-    """Copy a file, ensuring any changes only apply atomically once finished."""
+    """Copy a file atomically.
+
+    Copying is not usually atomic, and on operating systems that allow multiple
+    writers to the same file, the result can get corrupted. If two writers copy
+    to the same file, the contents can become interleaved.
+
+    We mitigate the issue somewhat by copying to a temporary file first and
+    then renaming. Renaming is atomic: if process 1 renames file A to X and
+    process 2 renames file B to X, then X will either contain the contents
+    of A or the contents of B, not some mixture of both.
+    """
     # TODO (hugh): check that there is enough free space.
     output_path = Path(target_path).resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Description
-----------
This test is flaky because it is wrong. Using `wb` in the `open()` mode in `delayed_copy_with_pause()` causes it to truncate the contents written so far, resulting in the null bytes you can see in [this run](https://app.circleci.com/pipelines/github/wandb/wandb/31659/workflows/f709e516-f2f4-4ae0-ad51-836af1b880b4/jobs/1052364/tests).

Could "fix" it by changing `wb` to `ab`, but the fact that this test was usually passing despite being wrong is proof that it's useless. Tests that rely on thread ordering and `time.sleep` make CI slow and flaky without adding value.

There is no way to test this aspect of the `safe_copy` function, but that's okay: it's short and straightforward. The key to being confident in this kind of code is not to write fake tests, but to make it obvious that it works. I updated the docstring to help with that.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable
