### PR TITLE
refactor(sdk): Use parameters directly rather than via `locals()`

### DIFF
--- a/tests/pytest_tests/unit_tests/test_wandb_settings.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_settings.py
@@ -11,7 +11,7 @@ import pytest
 import wandb
 from click.testing import CliRunner
 from wandb.errors import UsageError
-from wandb.sdk import wandb_login, wandb_settings
+from wandb.sdk import wandb_settings
 from wandb.sdk.lib._settings_toposort_generate import _get_modification_order
 
 if sys.version_info >= (3, 8):
@@ -1010,21 +1010,6 @@ def test_code_saving_disable_code(mock_run, test_settings):
         settings._infer_settings_from_environment()
         run = mock_run(settings=settings)
         assert run.settings.save_code is False
-
-
-def test_override_login_settings(test_settings):
-    wlogin = wandb_login._WandbLogin()
-    login_settings = test_settings().copy()
-    login_settings.update(show_emoji=True)
-    wlogin.setup({"_settings": login_settings})
-    assert wlogin._settings.show_emoji is True
-
-
-def test_override_login_settings_with_dict():
-    wlogin = wandb_login._WandbLogin()
-    login_settings = dict(show_emoji=True)
-    wlogin.setup({"_settings": login_settings})
-    assert wlogin._settings.show_emoji is True
 
 
 def test_setup_offline(test_settings):

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -138,12 +138,14 @@ class _WandbLogin:
         logger = wandb.setup()._get_logger()
 
         login_settings._apply_login(
-            anonymous=anonymous,
-            key=key,
-            host=host,
-            force=force,
-            timeout=timeout,
-            logger=logger,
+            {
+                "anonymous": anonymous,
+                "key": key,
+                "host": host,
+                "force": force,
+                "timeout": timeout,
+            },
+            _logger=logger,
         )
 
         # make sure they are applied globally

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -22,7 +22,7 @@ from wandb.old.settings import Settings as OldSettings
 from ..apis import InternalApi
 from .internal.internal_api import Api
 from .lib import apikey
-from .wandb_settings import Settings, Source
+from .wandb_settings import Settings
 
 
 def _handle_host_wandb_setting(host: Optional[str], cloud: bool = False) -> None:

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -80,11 +80,17 @@ def login(
     _handle_host_wandb_setting(host)
     if wandb.setup()._settings._noop:
         return True
-    kwargs = dict(locals())
-    _verify = kwargs.pop("verify", False)
-    configured = _login(**kwargs)
 
-    if _verify:
+    configured = _login(
+        anonymous=anonymous,
+        key=key,
+        relogin=relogin,
+        host=host,
+        force=force,
+        timeout=timeout,
+    )
+
+    if verify:
         from . import wandb_setup
 
         singleton = wandb_setup._WandbSetup._instance
@@ -115,22 +121,30 @@ class _WandbLogin:
         self._key = None
         self._relogin = None
 
-    def setup(self, kwargs):
-        self.kwargs = kwargs
+    def setup(
+        self,
+        *,
+        anonymous: Optional[Literal["must", "allow", "never"]] = None,
+        key: Optional[str] = None,
+        relogin: Optional[bool] = None,
+        host: Optional[str] = None,
+        force: Optional[bool] = None,
+        timeout: Optional[int] = None,
+    ):
+        self._relogin = relogin
 
         # built up login settings
         login_settings: Settings = wandb.Settings()
-        settings_param = kwargs.pop("_settings", None)
-        # note that this case does not come up anywhere except for the tests
-        if settings_param is not None:
-            if isinstance(settings_param, Settings):
-                login_settings._apply_settings(settings_param)
-            elif isinstance(settings_param, dict):
-                login_settings.update(settings_param, source=Source.LOGIN)
-        _logger = wandb.setup()._get_logger()
-        # Do not save relogin into settings as we just want to relogin once
-        self._relogin = kwargs.pop("relogin", None)
-        login_settings._apply_login(kwargs, _logger=_logger)
+        logger = wandb.setup()._get_logger()
+
+        login_settings._apply_login(
+            anonymous=anonymous,
+            key=key,
+            host=host,
+            force=force,
+            timeout=timeout,
+            _logger=logger,
+        )
 
         # make sure they are applied globally
         self._wl = wandb.setup(settings=login_settings)
@@ -259,6 +273,7 @@ class _WandbLogin:
 
 
 def _login(
+    *,
     anonymous: Optional[Literal["must", "allow", "never"]] = None,
     key: Optional[str] = None,
     relogin: Optional[bool] = None,
@@ -270,9 +285,6 @@ def _login(
     _disable_warning: Optional[bool] = None,
     _entity: Optional[str] = None,
 ):
-    kwargs = dict(locals())
-    _disable_warning = kwargs.pop("_disable_warning", None)
-
     if wandb.run is not None:
         if not _disable_warning:
             wandb.termwarn("Calling wandb.login() after wandb.init() has no effect.")
@@ -280,20 +292,24 @@ def _login(
 
     wlogin = _WandbLogin()
 
-    _backend = kwargs.pop("_backend", None)
     if _backend:
         wlogin.set_backend(_backend)
 
-    _silent = kwargs.pop("_silent", None)
     if _silent:
         wlogin.set_silent(_silent)
 
-    _entity = kwargs.pop("_entity", None)
     if _entity:
         wlogin.set_entity(_entity)
 
     # configure login object
-    wlogin.setup(kwargs)
+    wlogin.setup(
+        anonymous=anonymous,
+        key=key,
+        relogin=relogin,
+        host=host,
+        force=force,
+        timeout=timeout,
+    )
 
     if wlogin._settings._offline:
         return False
@@ -306,7 +322,6 @@ def _login(
     # perform a login
     logged_in = wlogin.login()
 
-    key = kwargs.get("key")
     if key:
         wlogin.configure_api_key(key)
 

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -143,7 +143,7 @@ class _WandbLogin:
             host=host,
             force=force,
             timeout=timeout,
-            _logger=logger,
+            logger=logger,
         )
 
         # make sure they are applied globally

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1915,7 +1915,7 @@ class Settings(SettingsData):
         if force is not None:
             login_settings["force"] = force
         if timeout is not None:
-            login_settings["timeout"] = timeout
+            login_settings["login_timeout"] = timeout
 
         if logger:
             logger.info(f"Applying login settings: {_redact_dict(login_settings)}")

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -24,6 +24,7 @@ from typing import (
     FrozenSet,
     ItemsView,
     Iterable,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -297,8 +298,8 @@ class SettingsData:
     _cuda: str
     _disable_meta: bool  # Do not collect system metadata
     _disable_service: (
-        bool
-    )  # Disable wandb-service, spin up internal process the old way
+        bool  # Disable wandb-service, spin up internal process the old way
+    )
     _disable_setproctitle: bool  # Do not use setproctitle on internal process
     _disable_stats: bool  # Do not collect system metrics
     _disable_viewer: bool  # Prevent early viewer query
@@ -355,20 +356,18 @@ class SettingsData:
     _stats_sample_rate_seconds: float
     _stats_samples_to_average: int
     _stats_join_assets: (
-        bool
-    )  # join metrics from different assets before sending to backend
+        bool  # join metrics from different assets before sending to backend
+    )
     _stats_neuron_monitor_config_path: (
-        str
-    )  # path to place config file for neuron-monitor (AWS Trainium)
+        str  # path to place config file for neuron-monitor (AWS Trainium)
+    )
     _stats_open_metrics_endpoints: Mapping[str, str]  # open metrics endpoint names/urls
     # open metrics filters in one of the two formats:
     # - {"metric regex pattern, including endpoint name as prefix": {"label": "label value regex pattern"}}
     # - ("metric regex pattern 1", "metric regex pattern 2", ...)
     _stats_open_metrics_filters: Union[Sequence[str], Mapping[str, Mapping[str, str]]]
     _stats_disk_paths: Sequence[str]  # paths to monitor disk usage
-    _stats_buffer_size: (
-        int
-    )  # number of consolidated samples to buffer before flushing, available in run obj
+    _stats_buffer_size: int  # number of consolidated samples to buffer before flushing, available in run obj
     _tmp_code_dir: str
     _tracelog: str
     _unsaved_keys: Sequence[str]
@@ -1897,16 +1896,34 @@ class Settings(SettingsData):
                 f.write(json.dumps({"run_id": self.run_id}))
 
     def _apply_login(
-        self, login_settings: Dict[str, Any], _logger: Optional[_EarlyLogger] = None
+        self,
+        *,
+        anonymous: Optional[Literal["must", "allow", "never"]] = None,
+        key: Optional[str] = None,
+        host: Optional[str] = None,
+        force: Optional[bool] = None,
+        timeout: Optional[int] = None,
+        logger: Optional[_EarlyLogger] = None,
     ) -> None:
-        param_map = dict(key="api_key", host="base_url", timeout="login_timeout")
-        login_settings = {
-            param_map.get(k, k): v for k, v in login_settings.items() if v is not None
-        }
-        if login_settings:
-            if _logger:
-                _logger.info(f"Applying login settings: {_redact_dict(login_settings)}")
-            self.update(login_settings, source=Source.LOGIN)
+        login_settings: Dict[str, Any] = {}
+        if anonymous is not None:
+            login_settings["anonymous"] = anonymous
+        if key is not None:
+            login_settings["api_key"] = key
+        if host is not None:
+            login_settings["base_url"] = host
+        if force is not None:
+            login_settings["force"] = force
+        if timeout is not None:
+            login_settings["timeout"] = timeout
+
+        if logger:
+            logger.info(f"Applying login settings: {_redact_dict(login_settings)}")
+
+        self.update(
+            login_settings,
+            source=Source.LOGIN,
+        )
 
     def _apply_run_start(self, run_start_settings: Dict[str, Any]) -> None:
         # This dictionary maps from the "run message dict" to relevant fields in settings

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1897,28 +1897,27 @@ class Settings(SettingsData):
 
     def _apply_login(
         self,
-        *,
-        anonymous: Optional[Literal["must", "allow", "never"]] = None,
-        key: Optional[str] = None,
-        host: Optional[str] = None,
-        force: Optional[bool] = None,
-        timeout: Optional[int] = None,
-        logger: Optional[_EarlyLogger] = None,
+        login_settings: Dict[str, Any],
+        _logger: Optional[_EarlyLogger] = None,
     ) -> None:
-        login_settings: Dict[str, Any] = {}
-        if anonymous is not None:
-            login_settings["anonymous"] = anonymous
-        if key is not None:
-            login_settings["api_key"] = key
-        if host is not None:
-            login_settings["base_url"] = host
-        if force is not None:
-            login_settings["force"] = force
-        if timeout is not None:
-            login_settings["login_timeout"] = timeout
+        key_map = {
+            "key": "api_key",
+            "host": "base_url",
+            "timeout": "login_timeout",
+        }
 
-        if logger:
-            logger.info(f"Applying login settings: {_redact_dict(login_settings)}")
+        # Rename keys and keep only the non-None values.
+        #
+        # The input keys are parameters to wandb.login(), but we use different
+        # names for some of them in Settings.
+        login_settings = {
+            key_map.get(key, key): value
+            for key, value in login_settings.items()
+            if value is not None
+        }
+
+        if _logger:
+            _logger.info(f"Applying login settings: {_redact_dict(login_settings)}")
 
         self.update(
             login_settings,

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -24,7 +24,6 @@ from typing import (
     FrozenSet,
     ItemsView,
     Iterable,
-    Literal,
     Mapping,
     Optional,
     Sequence,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Make the code easier to read. We definitely shouldn't be using `locals()` as much as we are!

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Wait for CI.

The functions are private, so we should be able to freely change signatures. There are no additional code references I could find. It could break things if we do weird dynamic stuff somewhere instead of calling functions directly---but then it's the calling code that's at fault and should be fixed.
