### PR TITLE
chore(sdk): Fix Artifacts test that's broken on Windows

### DIFF
--- a/tests/pytest_tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
@@ -1,7 +1,7 @@
 import base64
 import os
 from logging import getLogger
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
@@ -64,5 +64,5 @@ def test_manifest_download(monkeypatch):
     )
 
     short_entry.path = default_cache
-    fpath = short_entry.download(root=abspath_to_cur_dir, skip_cache=True)
-    assert fpath.endswith("unit_tests/test_artifacts/default_cache")
+    fpath = PurePath(short_entry.download(root=abspath_to_cur_dir, skip_cache=True))
+    assert fpath.parts[-3:] == ["unit_tests", "test_artifacts", "default_cache"]

--- a/tests/pytest_tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
@@ -65,4 +65,4 @@ def test_manifest_download(monkeypatch):
 
     short_entry.path = default_cache
     fpath = PurePath(short_entry.download(root=abspath_to_cur_dir, skip_cache=True))
-    assert fpath.parts[-3:] == ["unit_tests", "test_artifacts", "default_cache"]
+    assert fpath.parts[-3:] == ("unit_tests", "test_artifacts", "default_cache")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Failure: https://app.circleci.com/pipelines/github/wandb/wandb/31659/workflows/f709e516-f2f4-4ae0-ad51-836af1b880b4/jobs/1052367/tests

It's broken on Windows because it uses `/` rather than `\` as the separator.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable

