### PR TITLE
chore(sdk): Fix bad test that reads from stdin

### DIFF
--- a/tests/pytest_tests/unit_tests/test_public_api.py
+++ b/tests/pytest_tests/unit_tests/test_public_api.py
@@ -7,7 +7,8 @@ from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 
 
-def test_api_auto_login_no_tty():
+def test_api_auto_login_no_tty(monkeypatch):
+    monkeypatch.setattr("sys.stdin", None)
     with pytest.raises(wandb.UsageError):
         Api()
 

--- a/tests/pytest_tests/unit_tests/test_public_api.py
+++ b/tests/pytest_tests/unit_tests/test_public_api.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import mock
 
 import pytest
@@ -7,10 +8,10 @@ from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 
 
-def test_api_auto_login_no_tty(monkeypatch):
-    monkeypatch.setattr("sys.stdin", None)
-    with pytest.raises(wandb.UsageError):
-        Api()
+def test_api_auto_login_no_tty():
+    with mock.patch.object(sys, "stdin", None):
+        with pytest.raises(wandb.UsageError):
+            Api()
 
 
 def test_thread_local_cookies():


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Explicitly replace `stdin` by `None` as a way to simulate there not being a TTY available. `pytest` is supposed to replace `stdin`, but there's no guarantee that it replaces it with something that doesn't _look_ like a TTY. In fact, when I try to run this test locally, it prompts me for input!

See the second failure here: https://app.circleci.com/pipelines/github/wandb/wandb/31659/workflows/f709e516-f2f4-4ae0-ad51-836af1b880b4/jobs/1052367/tests. The `login()` routine tries to prompt using `input()` which raises an EOF error. I think the code might not be testing for a TTY correctly, but it's hard to follow.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable

