### PR TITLE
refactor(sdk): Settings fields => methods

### DIFF
--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -55,35 +55,35 @@ func (s *Settings) EnsureAPIKey() error {
 //
 // This can be empty if we're in offline mode.
 func (s *Settings) GetAPIKey() string {
-	return s.Proto.GetApiKey().GetValue()
+	return s.Proto.ApiKey.GetValue()
 }
 
 // The ID of the run.
 func (s *Settings) GetRunID() string {
-	return s.Proto.GetRunId().GetValue()
+	return s.Proto.RunId.GetValue()
 }
 
 // The W&B URL where the run can be viewed.
 func (s *Settings) GetRunURL() string {
-	return s.Proto.GetRunUrl().GetValue()
+	return s.Proto.RunUrl.GetValue()
 }
 
 // The W&B project ID.
 func (s *Settings) GetProject() string {
-	return s.Proto.GetProject().GetValue()
+	return s.Proto.Project.GetValue()
 }
 
 // The W&B entity, like a user or a team.
 func (s *Settings) GetEntity() string {
-	return s.Proto.GetEntity().GetValue()
+	return s.Proto.Entity.GetValue()
 }
 
 // The directory for storing log files.
 func (s *Settings) GetLogDir() string {
-	return s.Proto.GetLogDir().GetValue()
+	return s.Proto.LogDir.GetValue()
 }
 
 // Filename to use for internal logs.
 func (s *Settings) GetInternalLogFile() string {
-	return s.Proto.GetLogInternal().GetValue()
+	return s.Proto.LogInternal.GetValue()
 }

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -14,28 +14,6 @@ import (
 //
 // This is derived from the Settings proto and adapted for use in Go.
 type Settings struct {
-	// The W&B API key.
-	//
-	// This can be empty if we're in offline mode.
-	APIKey string
-
-	// The ID of the run.
-	RunID string
-
-	// The W&B URL where the run can be viewed.
-	RunURL string
-
-	// The W&B project ID.
-	Project string
-
-	// The W&B entity, like a user or a team.
-	Entity string
-
-	// The directory for storing log files.
-	LogDir string
-
-	// Filename to use for internal logs.
-	InternalLogFile string
 
 	// The source proto.
 	//
@@ -45,16 +23,7 @@ type Settings struct {
 
 // Parses the Settings proto into a Settings object.
 func Parse(proto *service.Settings) *Settings {
-	return &Settings{
-		APIKey:          proto.GetApiKey().GetValue(),
-		RunID:           proto.GetRunId().GetValue(),
-		RunURL:          proto.GetRunUrl().GetValue(),
-		Project:         proto.GetProject().GetValue(),
-		Entity:          proto.GetEntity().GetValue(),
-		LogDir:          proto.GetLogDir().GetValue(),
-		InternalLogFile: proto.GetLogInternal().GetValue(),
-		Proto:           proto,
-	}
+	return &Settings{Proto: proto}
 }
 
 // Ensures the APIKey is set if it needs to be.
@@ -80,4 +49,41 @@ func (s *Settings) EnsureAPIKey() error {
 	s.Proto.ApiKey = &wrapperspb.StringValue{Value: password}
 
 	return nil
+}
+
+// The W&B API key.
+//
+// This can be empty if we're in offline mode.
+func (s *Settings) APIKey() string {
+	return s.Proto.ApiKey.Value
+}
+
+// The ID of the run.
+func (s *Settings) RunID() string {
+	return s.Proto.RunId.Value
+}
+
+// The W&B URL where the run can be viewed.
+func (s *Settings) RunURL() string {
+	return s.Proto.RunUrl.Value
+}
+
+// The W&B project ID.
+func (s *Settings) Project() string {
+	return s.Proto.Project.Value
+}
+
+// The W&B entity, like a user or a team.
+func (s *Settings) Entity() string {
+	return s.Proto.Entity.Value
+}
+
+// The directory for storing log files.
+func (s *Settings) LogDir() string {
+	return s.Proto.LogDir.Value
+}
+
+// Filename to use for internal logs.
+func (s *Settings) InternalLogFile() string {
+	return s.Proto.LogInternal.Value
 }

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -22,7 +22,7 @@ type Settings struct {
 }
 
 // Parses the Settings proto into a Settings object.
-func Parse(proto *service.Settings) *Settings {
+func From(proto *service.Settings) *Settings {
 	return &Settings{Proto: proto}
 }
 

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -55,35 +55,35 @@ func (s *Settings) EnsureAPIKey() error {
 //
 // This can be empty if we're in offline mode.
 func (s *Settings) GetAPIKey() string {
-	return s.Proto.ApiKey.Value
+	return s.Proto.GetApiKey().GetValue()
 }
 
 // The ID of the run.
 func (s *Settings) GetRunID() string {
-	return s.Proto.RunId.Value
+	return s.Proto.GetRunId().GetValue()
 }
 
 // The W&B URL where the run can be viewed.
 func (s *Settings) GetRunURL() string {
-	return s.Proto.RunUrl.Value
+	return s.Proto.GetRunUrl().GetValue()
 }
 
 // The W&B project ID.
 func (s *Settings) GetProject() string {
-	return s.Proto.Project.Value
+	return s.Proto.GetProject().GetValue()
 }
 
 // The W&B entity, like a user or a team.
 func (s *Settings) GetEntity() string {
-	return s.Proto.Entity.Value
+	return s.Proto.GetEntity().GetValue()
 }
 
 // The directory for storing log files.
 func (s *Settings) GetLogDir() string {
-	return s.Proto.LogDir.Value
+	return s.Proto.GetLogDir().GetValue()
 }
 
 // Filename to use for internal logs.
 func (s *Settings) GetInternalLogFile() string {
-	return s.Proto.LogInternal.Value
+	return s.Proto.GetLogInternal().GetValue()
 }

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -54,36 +54,36 @@ func (s *Settings) EnsureAPIKey() error {
 // The W&B API key.
 //
 // This can be empty if we're in offline mode.
-func (s *Settings) APIKey() string {
+func (s *Settings) GetAPIKey() string {
 	return s.Proto.ApiKey.Value
 }
 
 // The ID of the run.
-func (s *Settings) RunID() string {
+func (s *Settings) GetRunID() string {
 	return s.Proto.RunId.Value
 }
 
 // The W&B URL where the run can be viewed.
-func (s *Settings) RunURL() string {
+func (s *Settings) GetRunURL() string {
 	return s.Proto.RunUrl.Value
 }
 
 // The W&B project ID.
-func (s *Settings) Project() string {
+func (s *Settings) GetProject() string {
 	return s.Proto.Project.Value
 }
 
 // The W&B entity, like a user or a team.
-func (s *Settings) Entity() string {
+func (s *Settings) GetEntity() string {
 	return s.Proto.Entity.Value
 }
 
 // The directory for storing log files.
-func (s *Settings) LogDir() string {
+func (s *Settings) GetLogDir() string {
 	return s.Proto.LogDir.Value
 }
 
 // Filename to use for internal logs.
-func (s *Settings) InternalLogFile() string {
+func (s *Settings) GetInternalLogFile() string {
 	return s.Proto.LogInternal.Value
 }

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -267,8 +267,8 @@ func (nc *Connection) handleInformStart(msg *service.ServerInformStartRequest) {
 	// update sentry tags
 	// add attrs from settings:
 	nc.stream.logger.SetTags(observability.Tags{
-		"run_url": nc.stream.settings.RunURL(),
-		"entity":  nc.stream.settings.Entity(),
+		"run_url": nc.stream.settings.GetRunURL(),
+		"entity":  nc.stream.settings.GetEntity(),
 	})
 	// TODO: remove this once we have a better observability setup
 	nc.stream.logger.CaptureInfo("core", nil)

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -267,8 +267,8 @@ func (nc *Connection) handleInformStart(msg *service.ServerInformStartRequest) {
 	// update sentry tags
 	// add attrs from settings:
 	nc.stream.logger.SetTags(observability.Tags{
-		"run_url": nc.stream.settings.RunURL,
-		"entity":  nc.stream.settings.Entity,
+		"run_url": nc.stream.settings.RunURL(),
+		"entity":  nc.stream.settings.Entity(),
 	})
 	// TODO: remove this once we have a better observability setup
 	nc.stream.logger.CaptureInfo("core", nil)

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -229,7 +229,7 @@ func (nc *Connection) handleServerRequest() {
 // handleInformInit is called when the client sends an InformInit message
 // to the server, to start a new stream
 func (nc *Connection) handleInformInit(msg *service.ServerInformInitRequest) {
-	settings := settings.Parse(msg.GetSettings())
+	settings := settings.From(msg.GetSettings())
 
 	err := settings.EnsureAPIKey()
 	if err != nil {
@@ -262,7 +262,7 @@ func (nc *Connection) handleInformInit(msg *service.ServerInformInitRequest) {
 func (nc *Connection) handleInformStart(msg *service.ServerInformStartRequest) {
 	// todo: if we keep this and end up updating the settings here
 	//       we should update the stream logger to use the new settings as well
-	nc.stream.settings = settings.Parse(msg.GetSettings())
+	nc.stream.settings = settings.From(msg.GetSettings())
 
 	// update sentry tags
 	// add attrs from settings:

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -68,7 +68,7 @@ type Stream struct {
 
 func streamLogger(settings *settings.Settings) *observability.CoreLogger {
 	// TODO: when we add session concept re-do this to use user provided path
-	targetPath := filepath.Join(settings.LogDir, "debug-core.log")
+	targetPath := filepath.Join(settings.LogDir(), "debug-core.log")
 	if path := defaultLoggerPath.Load(); path != nil {
 		path := path.(string)
 		// check path exists
@@ -81,7 +81,7 @@ func streamLogger(settings *settings.Settings) *observability.CoreLogger {
 	}
 
 	var writers []io.Writer
-	name := settings.InternalLogFile
+	name := settings.InternalLogFile()
 	file, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		slog.Error(fmt.Sprintf("error opening log file: %s", err))
@@ -110,10 +110,10 @@ func streamLogger(settings *settings.Settings) *observability.CoreLogger {
 	logger.Info("using version", "core version", version.Version)
 	logger.Info("created symlink", "path", targetPath)
 	tags := observability.Tags{
-		"run_id":  settings.RunID,
-		"run_url": settings.RunURL,
-		"project": settings.Project,
-		"entity":  settings.Entity,
+		"run_id":  settings.RunID(),
+		"run_url": settings.RunURL(),
+		"project": settings.Project(),
+		"entity":  settings.Entity(),
 	}
 	logger.SetTags(tags)
 
@@ -160,7 +160,7 @@ func NewStream(ctx context.Context, settings *settings.Settings, streamId string
 
 	s.dispatcher = NewDispatcher(s.logger)
 
-	s.logger.Info("created new stream", "id", s.settings.Proto.RunId)
+	s.logger.Info("created new stream", "id", s.settings.RunID)
 	return s
 }
 
@@ -231,7 +231,7 @@ func (s *Stream) Start() {
 		close(s.outChan)
 		s.wg.Done()
 	}()
-	s.logger.Debug("starting stream", "id", s.settings.Proto.RunId)
+	s.logger.Debug("starting stream", "id", s.settings.RunID)
 }
 
 // HandleRecord handles the given record by sending it to the stream's handler.
@@ -280,7 +280,7 @@ func (s *Stream) FinishAndClose(exitCode int32) {
 	s.Close()
 
 	s.PrintFooter()
-	s.logger.Info("closed stream", "id", s.settings.Proto.RunId)
+	s.logger.Info("closed stream", "id", s.settings.RunID)
 }
 
 func (s *Stream) PrintFooter() {

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -68,7 +68,7 @@ type Stream struct {
 
 func streamLogger(settings *settings.Settings) *observability.CoreLogger {
 	// TODO: when we add session concept re-do this to use user provided path
-	targetPath := filepath.Join(settings.LogDir(), "debug-core.log")
+	targetPath := filepath.Join(settings.GetLogDir(), "debug-core.log")
 	if path := defaultLoggerPath.Load(); path != nil {
 		path := path.(string)
 		// check path exists
@@ -81,7 +81,7 @@ func streamLogger(settings *settings.Settings) *observability.CoreLogger {
 	}
 
 	var writers []io.Writer
-	name := settings.InternalLogFile()
+	name := settings.GetInternalLogFile()
 	file, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		slog.Error(fmt.Sprintf("error opening log file: %s", err))
@@ -110,10 +110,10 @@ func streamLogger(settings *settings.Settings) *observability.CoreLogger {
 	logger.Info("using version", "core version", version.Version)
 	logger.Info("created symlink", "path", targetPath)
 	tags := observability.Tags{
-		"run_id":  settings.RunID(),
-		"run_url": settings.RunURL(),
-		"project": settings.Project(),
-		"entity":  settings.Entity(),
+		"run_id":  settings.GetRunID(),
+		"run_url": settings.GetRunURL(),
+		"project": settings.GetProject(),
+		"entity":  settings.GetEntity(),
 	}
 	logger.SetTags(tags)
 
@@ -160,7 +160,7 @@ func NewStream(ctx context.Context, settings *settings.Settings, streamId string
 
 	s.dispatcher = NewDispatcher(s.logger)
 
-	s.logger.Info("created new stream", "id", s.settings.RunID())
+	s.logger.Info("created new stream", "id", s.settings.GetRunID())
 	return s
 }
 
@@ -231,7 +231,7 @@ func (s *Stream) Start() {
 		close(s.outChan)
 		s.wg.Done()
 	}()
-	s.logger.Debug("starting stream", "id", s.settings.RunID())
+	s.logger.Debug("starting stream", "id", s.settings.GetRunID())
 }
 
 // HandleRecord handles the given record by sending it to the stream's handler.
@@ -280,7 +280,7 @@ func (s *Stream) FinishAndClose(exitCode int32) {
 	s.Close()
 
 	s.PrintFooter()
-	s.logger.Info("closed stream", "id", s.settings.RunID())
+	s.logger.Info("closed stream", "id", s.settings.GetRunID())
 }
 
 func (s *Stream) PrintFooter() {

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -160,7 +160,7 @@ func NewStream(ctx context.Context, settings *settings.Settings, streamId string
 
 	s.dispatcher = NewDispatcher(s.logger)
 
-	s.logger.Info("created new stream", "id", s.settings.RunID)
+	s.logger.Info("created new stream", "id", s.settings.RunID())
 	return s
 }
 
@@ -231,7 +231,7 @@ func (s *Stream) Start() {
 		close(s.outChan)
 		s.wg.Done()
 	}()
-	s.logger.Debug("starting stream", "id", s.settings.RunID)
+	s.logger.Debug("starting stream", "id", s.settings.RunID())
 }
 
 // HandleRecord handles the given record by sending it to the stream's handler.
@@ -280,7 +280,7 @@ func (s *Stream) FinishAndClose(exitCode int32) {
 	s.Close()
 
 	s.PrintFooter()
-	s.logger.Info("closed stream", "id", s.settings.RunID)
+	s.logger.Info("closed stream", "id", s.settings.RunID())
 }
 
 func (s *Stream) PrintFooter() {


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Use methods instead of fields on Settings because we have to keep the underlying proto.

My original plan was for `settings.Parse()` to create a Settings struct and discard the proto, but since we pass the proto back to the user process, we'll want to keep its original value. This is because it may include fields not used by Nexus, so if `Settings` only contains accessors for fields that are used by Nexus, we won't be able to reconstruct the proto.

I prefix the methods with "Get" to make bugs like this obvious:

```go
// Without Get... see the problem?
s.logger.Info("created new stream", "id", s.settings.RunID)

// With Get, it's easier to spot!
s.logger.Info("created new stream", "id", s.settings.GetRunID)
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable
