### PR TITLE
fix(core): Handle relative paths in file watcher

### DIFF
--- a/core/internal/watcher/registry.go
+++ b/core/internal/watcher/registry.go
@@ -22,9 +22,3 @@ func (r *registry) get(name string) (func(Event) error, bool) {
 	fn, ok := r.events[name]
 	return fn, ok
 }
-
-func (r *registry) clear() {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	clear(r.events)
-}

--- a/core/internal/watcher/watcher_test.go
+++ b/core/internal/watcher/watcher_test.go
@@ -36,10 +36,9 @@ func TestNew(t *testing.T) {
 
 	logger := observability.NewNoOpLogger()
 
-	options := []watcher.WatcherOption{
-		watcher.WithLogger(logger),
-	}
-	w := watcher.New(options...)
+	w := watcher.New(watcher.Params{
+		Logger: logger,
+	})
 
 	require.NotNil(t, w, "Watcher should not be nil")
 }

--- a/core/pkg/observability/logging.go
+++ b/core/pkg/observability/logging.go
@@ -95,6 +95,7 @@ func (cl *CoreLogger) SetTags(tags Tags) {
 
 // CaptureError logs an error and sends it to sentry.
 func (cl *CoreLogger) CaptureError(msg string, err error, args ...any) {
+	args = append(args, "error", err)
 	cl.Logger.Error(msg, args...)
 	if err != nil {
 		// send error to sentry:

--- a/core/pkg/server/files.go
+++ b/core/pkg/server/files.go
@@ -10,6 +10,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Creates a files Record with the given set of files.
+//
+// Sets the policy for each file to "now" (maybe it shouldn't!)
+//
+// Returns nil if there are no files.
 func makeRecord(fileSet map[string]*service.FilesItem) *service.Record {
 	if len(fileSet) == 0 {
 		return nil
@@ -38,9 +43,20 @@ func WithFilesHandlerHandleFn(fn func(*service.Record)) FilesHandlerOption {
 }
 
 type FilesHandler struct {
-	watcher  *watcher.Watcher
+	// Function to forward records down the chain.
+	//
+	// Passing a file record here causes it to be persisted if necessary and
+	// causes the file to get uploaded.
 	handleFn func(*service.Record)
-	endSet   map[string]*service.FilesItem
+
+	// File watcher for "live"-mode files.
+	watcher *watcher.Watcher
+
+	// Files to upload at the end of the run.
+	//
+	// Map from the file path to the file.
+	endSet map[string]*service.FilesItem
+
 	settings *service.Settings
 	logger   *observability.CoreLogger
 }

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -134,7 +134,10 @@ func NewStream(ctx context.Context, settings *settings.Settings, streamId string
 		outChan:      make(chan *service.ServerResponse, BufferSize),
 	}
 
-	watcher := watcher.New(watcher.WithLogger(s.logger))
+	watcher := watcher.New(watcher.Params{
+		Logger:   s.logger,
+		FilesDir: s.settings.Proto.GetFilesDir().GetValue(),
+	})
 	s.handler = NewHandler(s.ctx, s.logger,
 		WithHandlerSettings(s.settings.Proto),
 		WithHandlerFwdChannel(make(chan *service.Record, BufferSize)),


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Fix: `watcher.go` was interpreting relative paths relative to the current working directory. This fixes it to use the Settings `files_dir` instead, and refactors it a bit.

This fixes the first part of the directory saving issue: it wasn't even finding the directory. The second part is that it can't upload directories.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Existing tests + unit tests.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
