### PR TITLE
feat(sdk, integrations): Autolog Integration for openai major version with detail logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ run.finish()
 <summary>🧠 OpenAI python sdk</summary>
 
 Just use autolog for logging and tracing openai python sdk.
+**autolog supports openai major version(>=1.0.0)**
 
 ```python
 import openai
@@ -595,11 +596,6 @@ chat_completion = client.chat.completions.create(
     ],
 )
 ```
-
-- Run an example [Google Colab Notebook](http://wandb.me/pytorch-colab).
-- Read the [Developer Guide](https://docs.wandb.com/guides/integrations/pytorch?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=integrations) for technical details on how to integrate PyTorch with W&B.
-- Explore [W&B Reports](https://app.wandb.ai/wandb/getting-started/reports/Pytorch--VmlldzoyMTEwNzM?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=integrations).
-
 </details>
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -573,6 +573,34 @@ run.finish()
 - Read the [Developer Guide](https://docs.wandb.ai/guides/integrations/scikit?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=integrations) for technical details on how to integrate Scikit-Learn with W&B.
 </details>
 
+<details>
+<summary>🧠 OpenAI python sdk</summary>
+
+Just use autolog for logging and tracing openai python sdk.
+
+```python
+import openai
+from wandb.integration.openai import autolog
+
+# 1. Start autolog. This method automatically calls wandb.init().
+autolog({"project": "test-project"})
+
+# 2. Just use openai sdk!
+client = openai.OpenAI()
+chat_completion = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What's your name?'"},
+    ],
+)
+```
+
+- Run an example [Google Colab Notebook](http://wandb.me/pytorch-colab).
+- Read the [Developer Guide](https://docs.wandb.com/guides/integrations/pytorch?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=integrations) for technical details on how to integrate PyTorch with W&B.
+- Explore [W&B Reports](https://app.wandb.ai/wandb/getting-started/reports/Pytorch--VmlldzoyMTEwNzM?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=integrations).
+
+</details>
 &nbsp;
 
 # W&B Hosting Options

--- a/wandb/integration/openai/openai.py
+++ b/wandb/integration/openai/openai.py
@@ -1,22 +1,30 @@
 import logging
 
 from wandb.sdk.integration_utils.auto_logging import AutologAPI
+from wandb.util import check_openai_version_is_major_version
 
 from .resolver import OpenAIRequestResponseResolver
 
 logger = logging.getLogger(__name__)
 
-
-autolog = AutologAPI(
-    name="OpenAI",
-    symbols=(
-        "Edit.create",
-        "Completion.create",
-        "ChatCompletion.create",
-        "Edit.acreate",
-        "Completion.acreate",
-        "ChatCompletion.acreate",
-    ),
-    resolver=OpenAIRequestResponseResolver(),
-    telemetry_feature="openai_autolog",
-)
+if check_openai_version_is_major_version():
+    autolog = AutologAPI(
+        name="OpenAI",
+        symbols=(),
+        resolver=OpenAIRequestResponseResolver(is_major_version=True),
+        telemetry_feature="openai_autolog",
+    )
+else:
+    autolog = AutologAPI(
+        name="OpenAI",
+        symbols=(
+            "Edit.create",
+            "Completion.create",
+            "ChatCompletion.create",
+            "Edit.acreate",
+            "Completion.acreate",
+            "ChatCompletion.acreate",
+        ),
+        resolver=OpenAIRequestResponseResolver(),
+        telemetry_feature="openai_autolog",
+    )

--- a/wandb/integration/openai/resolver.py
+++ b/wandb/integration/openai/resolver.py
@@ -1,12 +1,12 @@
 import datetime
-import io
 import logging
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Sequence
 
 import wandb
 from wandb.sdk.data_types import trace_tree
-from wandb.sdk.integration_utils.auto_logging import Response
+from wandb.sdk.integration_utils.auto_logging import OpenAIResponse, Response
+from wandb.util import check_openai_version_is_major_version
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +29,41 @@ class Metrics:
 usage_metric_keys = {f"usage/{k}" for k in asdict(UsageMetrics())}
 
 
+def get_openai_object(
+    response: Response, key: str, is_major_version: bool, default=None
+) -> Any:
+    if is_major_version:
+        try:
+            return getattr(response, key)
+        except Exception:
+            logger.warning("Failed to get object from response: {e}")
+            return default
+    else:
+        try:
+            return response.get(key, default)
+        except Exception as e:
+            logger.warning("Failed to get object from response: {e}")
+            raise ValueError(f"Failed to get object from response: {e}")
+
+
+def serialize(obj):
+    """Serialize the complex object recursively into dict, list, and basic types."""
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    elif isinstance(obj, dict):
+        return {key: serialize(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [serialize(item) for item in obj]
+    elif hasattr(obj, "__dict__"):
+        return {key: serialize(value) for key, value in obj.__dict__.items()}
+    else:
+        return str(obj)
+
+
 class OpenAIRequestResponseResolver:
-    def __init__(self):
+    def __init__(self, is_major_version: bool = False):
         self.define_metrics_called = False
+        self.is_major_version: bool = is_major_version
 
     def __call__(
         self,
@@ -50,17 +82,18 @@ class OpenAIRequestResponseResolver:
             self.define_metrics_called = True
 
         try:
-            if response.get("object") == "edit":
+            response_object = get_openai_object(
+                response, "object", self.is_major_version
+            )
+            if response_object == "edit":
                 return self._resolve_edit(request, response, time_elapsed)
-            elif response.get("object") == "text_completion":
+            elif response_object == "text_completion":
                 return self._resolve_completion(request, response, time_elapsed)
-            elif response.get("object") == "chat.completion":
+            elif response_object == "chat.completion":
                 return self._resolve_chat_completion(request, response, time_elapsed)
             else:
                 # todo: properly treat failed requests
-                logger.info(
-                    f"Unsupported OpenAI response object: {response.get('object')}"
-                )
+                logger.info(f"Unsupported OpenAI response object: {response_object}")
         except Exception as e:
             logger.warning(f"Failed to resolve request/response: {e}")
         return None
@@ -68,7 +101,7 @@ class OpenAIRequestResponseResolver:
     @staticmethod
     def results_to_trace_tree(
         request: Dict[str, Any],
-        response: Response,
+        response: Response | OpenAIResponse,
         results: List[trace_tree.Result],
         time_elapsed: float,
     ) -> trace_tree.WBTraceTree:
@@ -82,17 +115,36 @@ class OpenAIRequestResponseResolver:
         returns:
             A wandb trace tree object.
         """
-        start_time_ms = int(round(response["created"] * 1000))
+        is_major_version = check_openai_version_is_major_version()
+        created = get_openai_object(response, "created", is_major_version)
+        start_time_ms = int(round(created * 1000))
         end_time_ms = start_time_ms + int(round(time_elapsed * 1000))
+        openai_model = get_openai_object(
+            response,
+            "model",
+            is_major_version,
+            "openai",
+        )
+        openai_object = get_openai_object(response, "object", is_major_version)
+
+        if is_major_version:
+            serialized_response = serialize(response)
+        else:
+            serialized_response = dict(response)
+
         span = trace_tree.Span(
-            name=f"{response.get('model', 'openai')}_{response['object']}_{response.get('created')}",
-            attributes=dict(response),  # type: ignore
+            name=f"{openai_model}_{openai_object}_{created}",
+            attributes=serialized_response,  # type: ignore
             start_time_ms=start_time_ms,
             end_time_ms=end_time_ms,
             span_kind=trace_tree.SpanKind.LLM,
             results=results,
         )
-        model_obj = {"request": request, "response": response, "_kind": "openai"}
+        model_obj = {
+            "request": request,
+            "response": serialized_response,
+            "_kind": "openai",
+        }
         return trace_tree.WBTraceTree(root_span=span, model_dict=model_obj)
 
     def _resolve_edit(
@@ -101,7 +153,10 @@ class OpenAIRequestResponseResolver:
         response: Response,
         time_elapsed: float,
     ) -> Dict[str, Any]:
-        """Resolves the request and response objects for `openai.Edit`."""
+        """Resolves the request and response objects for `openai.Edit`.
+
+        Deprecated in openai major version, 2024-01-04.
+        """
         request_str = (
             f"\n\n**Instruction**: {request['instruction']}\n\n"
             f"**Input**: {request['input']}\n"
@@ -121,14 +176,20 @@ class OpenAIRequestResponseResolver:
     def _resolve_completion(
         self,
         request: Dict[str, Any],
-        response: Response,
+        response: Response | OpenAIResponse,
         time_elapsed: float,
     ) -> Dict[str, Any]:
-        """Resolves the request and response objects for `openai.Completion`."""
+        """Resolves the request and response objects for `openai.Completion` and `openai.resources.completions."""
         request_str = f"\n\n**Prompt**: {request['prompt']}\n"
-        choices = [
-            f"\n\n**Completion**: {choice['text']}\n" for choice in response["choices"]
-        ]
+        if self.is_major_version:
+            choices = [
+                f"\n\n**Completion**: {choice.text}\n" for choice in response.choices
+            ]
+        else:
+            choices = [
+                f"\n\n**Completion**: {choice['text']}\n"
+                for choice in response["choices"]
+            ]
 
         return self._resolve_metrics(
             request=request,
@@ -141,19 +202,22 @@ class OpenAIRequestResponseResolver:
     def _resolve_chat_completion(
         self,
         request: Dict[str, Any],
-        response: Response,
+        response: Response | OpenAIResponse,
         time_elapsed: float,
     ) -> Dict[str, Any]:
-        """Resolves the request and response objects for `openai.Completion`."""
-        prompt = io.StringIO()
-        for message in request["messages"]:
-            prompt.write(f"\n\n**{message['role']}**: {message['content']}\n")
-        request_str = prompt.getvalue()
+        """Resolves the request and response objects for `openai.Completion` and `openai.resources.chat.completions."""
+        request_str = request["messages"]
 
-        choices = [
-            f"\n\n**{choice['message']['role']}**: {choice['message']['content']}\n"
-            for choice in response["choices"]
-        ]
+        if self.is_major_version:
+            choices = [
+                f"\n\n{choice.message.role}: {choice.message.content}\n"
+                for choice in response.choices
+            ]
+        else:
+            choices = [
+                f"\n\n{choice['message']['role']}: {choice['message']['content']}\n"
+                for choice in response["choices"]
+            ]
 
         return self._resolve_metrics(
             request=request,
@@ -166,12 +230,14 @@ class OpenAIRequestResponseResolver:
     def _resolve_metrics(
         self,
         request: Dict[str, Any],
-        response: Response,
+        response: Response | OpenAIResponse,
         request_str: str,
         choices: List[str],
         time_elapsed: float,
     ) -> Dict[str, Any]:
-        """Resolves the request and response objects for `openai.Completion`."""
+        """Resolves the request and response objects for `openai.Completion` and `openai.resources.completions."""
+        if self.is_major_version:
+            choices = [serialize(choice) for choice in response.choices]
         results = [
             trace_tree.Result(
                 inputs={"request": request_str},
@@ -185,8 +251,18 @@ class OpenAIRequestResponseResolver:
     @staticmethod
     def _get_usage_metrics(response: Response, time_elapsed: float) -> UsageMetrics:
         """Gets the usage stats from the response object."""
-        if response.get("usage"):
-            usage_stats = UsageMetrics(**response["usage"])
+        is_major_version = check_openai_version_is_major_version()
+        usage = get_openai_object(response, "usage", is_major_version)
+        if usage:
+            if is_major_version:
+                # The major version of openai doesn't return usage as a dictionary.
+                usage_stats = UsageMetrics(
+                    prompt_tokens=usage.prompt_tokens,
+                    completion_tokens=usage.completion_tokens,
+                    total_tokens=usage.total_tokens,
+                )
+            else:
+                usage_stats = UsageMetrics(**usage)
         else:
             usage_stats = UsageMetrics()
         usage_stats.elapsed_time = time_elapsed
@@ -199,21 +275,24 @@ class OpenAIRequestResponseResolver:
         results: List[Any],
         time_elapsed: float,
     ) -> Metrics:
-        model = response.get("model") or request.get("model")
+        model = get_openai_object(
+            response, "model", self.is_major_version
+        ) or request.get("model")
         usage_metrics = self._get_usage_metrics(response, time_elapsed)
+        created = get_openai_object(response, "created", self.is_major_version)
 
         usage = []
         for result in results:
             row = {
-                "request": result.inputs["request"],
+                "request": request,
                 "response": result.outputs["response"],
                 "model": model,
-                "start_time": datetime.datetime.fromtimestamp(response["created"]),
-                "end_time": datetime.datetime.fromtimestamp(
-                    response["created"] + time_elapsed
+                "start_time": datetime.datetime.fromtimestamp(created),
+                "end_time": datetime.datetime.fromtimestamp(created + time_elapsed),
+                "request_id": get_openai_object(response, "id", self.is_major_version),
+                "api_type": get_openai_object(
+                    response, "api_type", self.is_major_version, "openai"
                 ),
-                "request_id": response.get("id", None),
-                "api_type": response.get("api_type", "openai"),
                 "session_id": wandb.run.id,
             }
             row.update(asdict(usage_metrics))

--- a/wandb/integration/openai/wandb_openai.py
+++ b/wandb/integration/openai/wandb_openai.py
@@ -75,7 +75,6 @@ class WandbOpenAIBase:
                 request_start_time,
                 request_end_time - request_start_time,
             )
-            print(f"LOGGABLE DICT: {loggable_dict}")
             if loggable_dict is not None:
                 WandbOpenAIBase.wandb_run.log(loggable_dict)
         except Exception as e:

--- a/wandb/integration/openai/wandb_openai.py
+++ b/wandb/integration/openai/wandb_openai.py
@@ -1,0 +1,83 @@
+import datetime
+import inspect
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class WandbOpenAIBase:
+    """WandbOpenAIClient is a wrapper around the openai module.
+
+    Inspired by https://github.com/MagnivOrg/prompt-layer-library/blob/master/promptlayer/promptlayer.py based on Apache-2.0 license.
+    """
+
+    __slots__ = ["_obj", "__weakref__", "_function_name", "_provider_type"]
+    wandb_run = None
+    wandb_openai_resolver = None
+
+    def __init__(
+        self,
+        obj,
+        function_name="",
+        provider_type="openai",
+        wandb_run=None,
+        wandb_openai_resolver=None,
+    ):
+        object.__setattr__(self, "_obj", obj)
+        object.__setattr__(self, "_function_name", function_name)
+        object.__setattr__(self, "_provider_type", provider_type)
+        if wandb_run is not None:
+            WandbOpenAIBase.wandb_run = wandb_run
+        if wandb_openai_resolver is not None:
+            WandbOpenAIBase.wandb_openai_resolver = wandb_openai_resolver
+
+    def __getattr__(self, name):
+        attr = getattr(object.__getattribute__(self, "_obj"), name)
+        if not re.match(
+            r"<class 'openai\..*Error'>", str(attr)
+        ) and (  # fix for openai errors
+            inspect.isclass(attr)
+            or inspect.isfunction(attr)
+            or inspect.ismethod(attr)
+            or re.match(r"<class 'openai\.resources.*'>", str(type(attr)))
+        ):
+            return WandbOpenAIBase(
+                attr,
+                function_name=f'{object.__getattribute__(self, "_function_name")}.{name}',
+                provider_type=object.__getattribute__(self, "_provider_type"),
+            )
+        return attr
+
+    def __delattr__(self, name):
+        delattr(object.__getattribute__(self, "_obj"), name)
+
+    def __setattr__(self, name, value):
+        setattr(object.__getattribute__(self, "_obj"), name, value)
+
+    def __call__(self, *args, **kwargs):
+        request_start_time = datetime.datetime.now().timestamp()
+        function_object = object.__getattribute__(self, "_obj")
+        if inspect.isclass(function_object):
+            return WandbOpenAIBase(
+                function_object(*args, **kwargs),
+                function_name=object.__getattribute__(self, "_function_name"),
+                provider_type=object.__getattribute__(self, "_provider_type"),
+            )
+        function_response = function_object(*args, **kwargs)
+        request_end_time = datetime.datetime.now().timestamp()
+
+        try:
+            loggable_dict = WandbOpenAIBase.wandb_openai_resolver(
+                args,
+                kwargs,
+                function_response,
+                request_start_time,
+                request_end_time - request_start_time,
+            )
+            print(f"LOGGABLE DICT: {loggable_dict}")
+            if loggable_dict is not None:
+                WandbOpenAIBase.wandb_run.log(loggable_dict)
+        except Exception as e:
+            logger.warning(e)
+        return function_response


### PR DESCRIPTION
Update integration for openai major version in autolog and utils

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes #7129 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
I found lots of issues in this PR.. 
- Can't wrap the openai major version client constructor using exist PatchAPI class. So PatchAPI can't wrap the openai api for callling run.log.
- OpenAI Trace Table doesn't include the whole information and the structure of data has limited utility, like logging the chat history.
- OpenAIRequestResponseResolver can't handle openai major version(>=1.0.0). All the parsing logic is based on dictionary type, not other property. (e.g., chat_completion.choices[0].message)


So, I resolve the problems.
- [X] Add functions in utils to check the version of openai client
- [X] Add functions in utils to make the simple factory pattern for openai synchronous client
- [X] Update sdk.integration.auto_logging for major version of openai client.
- [x] Update integrations.openai.resolver to handle the response of major version openai client.
- [x] Add integrations.openai.wandb_openai.WandbOpenAIBase which can be used as recursive proxy. It just wrap the class and function. I inspired by [promptlayer's code](https://github.com/MagnivOrg/prompt-layer-library/blob/master/promptlayer/promptlayer.py.) and fix it. I express my gratitude to [promptlayer-library contributors](https://github.com/MagnivOrg).
- [x] Add integrations.openai.resolver.OpenAIRequestResponseResolver for openai major version. It contain improved logging like chat history, openai parameters. 
- [x] Update README.md

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
- I integrate wandb autolog in [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) and it works. 
- In tests/pytest_test/unit_test, I found the unit test for autolog and patch api. I will add the new unit test for openai major client version.