### PR TITLE
fix(sdk): remove job link and link run to workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ subsections here on every PR where this is applicable.
 
 * In case of transient server issues when creating the wandb API key kubernetes secret, we'll retry up to 5 times by @TimH98 in https://github.com/wandb/wandb/pull/7108
 
+### Changed
+
+* When printing the run link point to the workspace explicitly by @kptkin in https://github.com/wandb/wandb/pull/7132
+
+### Removed
+
+* When printing run's information in the terminal remove links to jobs by @kptkin in https://github.com/wandb/wandb/pull/7132
 
 ## [0.16.4] - 2024-03-05
 

--- a/tests/pytest_tests/system_tests/test_core/test_footer.py
+++ b/tests/pytest_tests/system_tests/test_core/test_footer.py
@@ -1,7 +1,5 @@
 """footer tests."""
 
-import re
-
 import numpy as np
 import pytest
 import wandb
@@ -121,23 +119,3 @@ def test_footer_history(wandb_init, check_output_fn):
     run.log(dict(a=3))
     run.finish()
     check_output_fn(exp_summary=[], exp_history=["a", "d", "🚀"])
-
-
-# todo(core): implement job info
-@pytest.mark.wandb_core_failure(feature="launch")
-def test_footer_job_output(wandb_init, capsys, monkeypatch):
-    """Test that footer includes job info when a job is created."""
-    monkeypatch.setenv("WANDB_DOCKER", "hello-world")  # Needed to trigger job creation.
-    run = wandb_init()
-    run.log({"a": 1})
-    run.finish()
-    captured = capsys.readouterr()
-    lines = captured.err.splitlines()
-    for line in lines:
-        if re.search(
-            r"View job at http://localhost:8080/user-\w+-\w+/uncategorized/jobs/[\w=]+/version_details/v0",
-            line,
-        ):
-            break
-    else:
-        raise AssertionError(f"Job URL not found in footer: {captured.err}")

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_run.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_run.py
@@ -1,8 +1,6 @@
 import json
-import re
 from unittest import mock
 
-import pytest
 from wandb.sdk.internal import job_builder
 
 
@@ -32,22 +30,3 @@ def test_run_use_job_env_var(runner, relay_server, test_settings, user, wandb_in
                 if "mutation UseArtifact(" in data.get("request", {}).get("query", ""):
                     use_count += 1
         assert use_count == 1
-
-
-@pytest.mark.wandb_core_failure(feature="launch")
-def test_footer_job_output(wandb_init, capsys, monkeypatch):
-    """Test that footer includes job info when a job is created."""
-    monkeypatch.setenv("WANDB_DOCKER", "hello-world")  # Needed to trigger job creation.
-    run = wandb_init()
-    run.log({"a": 1})
-    run.finish()
-    captured = capsys.readouterr()
-    lines = captured.err.splitlines()
-    for line in lines:
-        if re.search(
-            r"View job at http://localhost:8080/user-\w+-\w+/uncategorized/jobs/[\w=]+/version_details/v0",
-            line,
-        ):
-            break
-    else:
-        raise AssertionError(f"Job URL not found in footer: {captured.err}")

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_run.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_run.py
@@ -1,6 +1,8 @@
 import json
+import re
 from unittest import mock
 
+import pytest
 from wandb.sdk.internal import job_builder
 
 
@@ -30,3 +32,22 @@ def test_run_use_job_env_var(runner, relay_server, test_settings, user, wandb_in
                 if "mutation UseArtifact(" in data.get("request", {}).get("query", ""):
                     use_count += 1
         assert use_count == 1
+
+
+@pytest.mark.wandb_core_failure(feature="launch")
+def test_footer_job_output(wandb_init, capsys, monkeypatch):
+    """Test that footer includes job info when a job is created."""
+    monkeypatch.setenv("WANDB_DOCKER", "hello-world")  # Needed to trigger job creation.
+    run = wandb_init()
+    run.log({"a": 1})
+    run.finish()
+    captured = capsys.readouterr()
+    lines = captured.err.splitlines()
+    for line in lines:
+        if re.search(
+            r"View job at http://localhost:8080/user-\w+-\w+/uncategorized/jobs/[\w=]+/version_details/v0",
+            line,
+        ):
+            break
+    else:
+        raise AssertionError(f"Job URL not found in footer: {captured.err}")

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -871,11 +871,3 @@ class InterfaceBase:
         self, run_status: pb.RunStatusRequest
     ) -> MailboxHandle:
         raise NotImplementedError
-
-    def deliver_request_job_info(self) -> MailboxHandle:
-        job_info = pb.JobInfoRequest()
-        return self._deliver_request_job_info(job_info)
-
-    @abstractmethod
-    def _deliver_request_job_info(self, job_info: pb.JobInfoRequest) -> MailboxHandle:
-        raise NotImplementedError

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -145,7 +145,6 @@ class InterfaceShared(InterfaceBase):
         cancel: Optional[pb.CancelRequest] = None,
         summary_record: Optional[pb.SummaryRecordRequest] = None,
         telemetry_record: Optional[pb.TelemetryRecordRequest] = None,
-        job_info: Optional[pb.JobInfoRequest] = None,
         get_system_metrics: Optional[pb.GetSystemMetricsRequest] = None,
         python_packages: Optional[pb.PythonPackagesRequest] = None,
     ) -> pb.Record:
@@ -202,8 +201,6 @@ class InterfaceShared(InterfaceBase):
             request.summary_record.CopyFrom(summary_record)
         elif telemetry_record:
             request.telemetry_record.CopyFrom(telemetry_record)
-        elif job_info:
-            request.job_info.CopyFrom(job_info)
         elif get_system_metrics:
             request.get_system_metrics.CopyFrom(get_system_metrics)
         elif sync:
@@ -521,10 +518,6 @@ class InterfaceShared(InterfaceBase):
         self, run_status: pb.RunStatusRequest
     ) -> MailboxHandle:
         record = self._make_request(run_status=run_status)
-        return self._deliver_record(record)
-
-    def _deliver_request_job_info(self, job_info: pb.JobInfoRequest) -> MailboxHandle:
-        record = self._make_request(job_info=job_info)
         return self._deliver_record(record)
 
     def _transport_keepalive_failed(self, keepalive_interval: int = 5) -> bool:

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -862,9 +862,6 @@ class HandleManager:
         self._respond_result(result)
         self._stopped.set()
 
-    def handle_request_job_info(self, record: Record) -> None:
-        self._dispatch_record(record, always_send=True)
-
     def finish(self) -> None:
         logger.info("shutting down handler")
         if self._system_monitor is not None:

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -733,17 +733,6 @@ class SendManager:
             )
         self._respond_result(result)
 
-    def send_request_job_info(self, record: "Record") -> None:
-        """Respond to a request for a job link."""
-        result = proto_util._result_from_record(record)
-        result.response.job_info_response.sequenceId = (
-            self._job_builder._job_seq_id or ""
-        )
-        result.response.job_info_response.version = (
-            self._job_builder._job_version_alias or ""
-        )
-        self._respond_result(result)
-
     def _maybe_setup_resume(
         self, run: "RunRecord"
     ) -> Optional["wandb_internal_pb2.ErrorInfo"]:

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -328,7 +328,6 @@ class StreamMux:
             result = internal_messages_handle.wait(timeout=-1)
             assert result
             internal_messages_response = result.response.internal_messages_response
-            # job_info_handle = stream.interface.deliver_request_job_info()
 
             # wait for them, it's ok to do this serially but this can be improved
             result = poll_exit_handle.wait(timeout=-1)
@@ -346,10 +345,6 @@ class StreamMux:
             result = final_summary_handle.wait(timeout=-1)
             assert result
             final_summary = result.response.get_summary_response
-
-            # result = job_info_handle.wait(timeout=-1)
-            # assert result
-            # job_info = result.response.job_info_response
 
             Run._footer(
                 sampled_history=sampled_history,

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -352,7 +352,6 @@ class StreamMux:
                 poll_exit_response=poll_exit_response,
                 server_info_response=server_info_response,
                 internal_messages_response=internal_messages_response,
-                # job_info=job_info,
                 settings=stream._settings,  # type: ignore
                 printer=printer,
             )

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -5,6 +5,7 @@ StreamRecord: All the external state for the internal thread (queues, etc)
 StreamAction: Lightweight record for stream ops for thread safety
 StreamMux: Container for dictionary of stream threads per runid
 """
+
 import functools
 import multiprocessing
 import queue
@@ -327,7 +328,7 @@ class StreamMux:
             result = internal_messages_handle.wait(timeout=-1)
             assert result
             internal_messages_response = result.response.internal_messages_response
-            job_info_handle = stream.interface.deliver_request_job_info()
+            # job_info_handle = stream.interface.deliver_request_job_info()
 
             # wait for them, it's ok to do this serially but this can be improved
             result = poll_exit_handle.wait(timeout=-1)
@@ -346,9 +347,9 @@ class StreamMux:
             assert result
             final_summary = result.response.get_summary_response
 
-            result = job_info_handle.wait(timeout=-1)
-            assert result
-            job_info = result.response.job_info_response
+            # result = job_info_handle.wait(timeout=-1)
+            # assert result
+            # job_info = result.response.job_info_response
 
             Run._footer(
                 sampled_history=sampled_history,
@@ -356,7 +357,7 @@ class StreamMux:
                 poll_exit_response=poll_exit_response,
                 server_info_response=server_info_response,
                 internal_messages_response=internal_messages_response,
-                job_info=job_info,
+                # job_info=job_info,
                 settings=stream._settings,  # type: ignore
                 printer=printer,
             )

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3500,7 +3500,6 @@ class Run:
         if settings._offline or settings.silent:
             return
 
-        # run_url = settings.run_url
         workspace_url = f"{settings.run_url}/workspace"
         project_url = settings.project_url
         sweep_url = settings.sweep_url

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -42,7 +42,6 @@ from wandb.apis import internal, public
 from wandb.apis.internal import Api
 from wandb.apis.public import Api as PublicApi
 from wandb.proto.wandb_internal_pb2 import (
-    JobInfoResponse,
     MetricRecord,
     PollExitResponse,
     Result,
@@ -531,7 +530,6 @@ class Run:
     _check_version: Optional["CheckVersionResponse"]
     _sampled_history: Optional["SampledHistoryResponse"]
     _final_summary: Optional["GetSummaryResponse"]
-    _job_info: Optional["JobInfoResponse"]
     _poll_exit_handle: Optional[MailboxHandle]
     _poll_exit_response: Optional[PollExitResponse]
     _server_info_response: Optional[ServerInfoResponse]
@@ -642,7 +640,6 @@ class Run:
         self._server_info_response = None
         self._internal_messages_response = None
         self._poll_exit_handle = None
-        # self._job_info = None
 
         # Initialize telemetry object
         self._telemetry_obj = telemetry.TelemetryRecord()
@@ -2485,7 +2482,6 @@ class Run:
         sampled_history_handle = (
             self._backend.interface.deliver_request_sampled_history()
         )
-        # job_info_handle = self._backend.interface.deliver_request_job_info()
 
         result = server_info_handle.wait(timeout=-1)
         assert result
@@ -2498,10 +2494,6 @@ class Run:
         result = final_summary_handle.wait(timeout=-1)
         assert result
         self._final_summary = result.response.get_summary_response
-
-        # result = job_info_handle.wait(timeout=-1)
-        # assert result
-        # self._job_info = result.response.job_info_response
 
         if self._backend:
             self._backend.cleanup()
@@ -2525,7 +2517,6 @@ class Run:
             server_info_response=self._server_info_response,
             check_version_response=self._check_version,
             internal_messages_response=self._internal_messages_response,
-            # job_info=self._job_info,
             reporter=self._reporter,
             quiet=self._quiet,
             settings=self._settings,
@@ -3577,7 +3568,6 @@ class Run:
         server_info_response: Optional[ServerInfoResponse] = None,
         check_version_response: Optional["CheckVersionResponse"] = None,
         internal_messages_response: Optional["InternalMessagesResponse"] = None,
-        # job_info: Optional["JobInfoResponse"] = None,
         reporter: Optional[Reporter] = None,
         quiet: Optional[bool] = None,
         *,
@@ -3594,7 +3584,6 @@ class Run:
 
         Run._footer_sync_info(
             poll_exit_response=poll_exit_response,
-            # job_info=job_info,
             quiet=quiet,
             settings=settings,
             printer=printer,
@@ -3779,7 +3768,6 @@ class Run:
     @staticmethod
     def _footer_sync_info(
         poll_exit_response: Optional[PollExitResponse] = None,
-        # job_info: Optional["JobInfoResponse"] = None,
         quiet: Optional[bool] = None,
         *,
         settings: "Settings",
@@ -3803,11 +3791,6 @@ class Run:
                 info = [
                     f"{printer.emoji('rocket')} View run {printer.name(settings.run_name)} at: {printer.link(run_workspace)}"
                 ]
-            # if job_info and job_info.version and job_info.sequenceId:
-            #     link = f"{settings.project_url}/jobs/{job_info.sequenceId}/version_details/{job_info.version}"
-            #     info.append(
-            #         f"{printer.emoji('lightning')} View job at {printer.link(link)}",
-            #     )
             if poll_exit_response and poll_exit_response.file_counts:
                 logger.info("logging synced files")
                 file_counts = poll_exit_response.file_counts

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -642,7 +642,7 @@ class Run:
         self._server_info_response = None
         self._internal_messages_response = None
         self._poll_exit_handle = None
-        self._job_info = None
+        # self._job_info = None
 
         # Initialize telemetry object
         self._telemetry_obj = telemetry.TelemetryRecord()
@@ -2485,7 +2485,7 @@ class Run:
         sampled_history_handle = (
             self._backend.interface.deliver_request_sampled_history()
         )
-        job_info_handle = self._backend.interface.deliver_request_job_info()
+        # job_info_handle = self._backend.interface.deliver_request_job_info()
 
         result = server_info_handle.wait(timeout=-1)
         assert result
@@ -2499,9 +2499,9 @@ class Run:
         assert result
         self._final_summary = result.response.get_summary_response
 
-        result = job_info_handle.wait(timeout=-1)
-        assert result
-        self._job_info = result.response.job_info_response
+        # result = job_info_handle.wait(timeout=-1)
+        # assert result
+        # self._job_info = result.response.job_info_response
 
         if self._backend:
             self._backend.cleanup()
@@ -2525,7 +2525,7 @@ class Run:
             server_info_response=self._server_info_response,
             check_version_response=self._check_version,
             internal_messages_response=self._internal_messages_response,
-            job_info=self._job_info,
+            # job_info=self._job_info,
             reporter=self._reporter,
             quiet=self._quiet,
             settings=self._settings,
@@ -3509,7 +3509,8 @@ class Run:
         if settings._offline or settings.silent:
             return
 
-        run_url = settings.run_url
+        # run_url = settings.run_url
+        workspace_url = f"{settings.run_url}/workspace"
         project_url = settings.project_url
         sweep_url = settings.sweep_url
 
@@ -3520,7 +3521,7 @@ class Run:
 
         if printer._html:
             if not wandb.jupyter.maybe_display():
-                run_line = f"<strong>{printer.link(run_url, run_name)}</strong>"
+                run_line = f"<strong>{printer.link(workspace_url, run_name)}</strong>"
                 project_line, sweep_line = "", ""
 
                 # TODO(settings): make settings the source of truth
@@ -3552,7 +3553,7 @@ class Run:
                     f'{printer.emoji("broom")} View sweep at {printer.link(sweep_url)}'
                 )
         printer.display(
-            f'{printer.emoji("rocket")} View run at {printer.link(run_url)}',
+            f'{printer.emoji("rocket")} View run at {printer.link(workspace_url)}',
         )
 
         # TODO(settings) use `wandb_settings` (if self.settings.anonymous == "true":)
@@ -3576,7 +3577,7 @@ class Run:
         server_info_response: Optional[ServerInfoResponse] = None,
         check_version_response: Optional["CheckVersionResponse"] = None,
         internal_messages_response: Optional["InternalMessagesResponse"] = None,
-        job_info: Optional["JobInfoResponse"] = None,
+        # job_info: Optional["JobInfoResponse"] = None,
         reporter: Optional[Reporter] = None,
         quiet: Optional[bool] = None,
         *,
@@ -3593,7 +3594,7 @@ class Run:
 
         Run._footer_sync_info(
             poll_exit_response=poll_exit_response,
-            job_info=job_info,
+            # job_info=job_info,
             quiet=quiet,
             settings=settings,
             printer=printer,
@@ -3778,7 +3779,7 @@ class Run:
     @staticmethod
     def _footer_sync_info(
         poll_exit_response: Optional[PollExitResponse] = None,
-        job_info: Optional["JobInfoResponse"] = None,
+        # job_info: Optional["JobInfoResponse"] = None,
         quiet: Optional[bool] = None,
         *,
         settings: "Settings",
@@ -3798,14 +3799,15 @@ class Run:
         else:
             info = []
             if settings.run_name and settings.run_url:
+                run_workspace = f"{settings.run_url}/workspace"
                 info = [
-                    f"{printer.emoji('rocket')} View run {printer.name(settings.run_name)} at: {printer.link(settings.run_url)}"
+                    f"{printer.emoji('rocket')} View run {printer.name(settings.run_name)} at: {printer.link(run_workspace)}"
                 ]
-            if job_info and job_info.version and job_info.sequenceId:
-                link = f"{settings.project_url}/jobs/{job_info.sequenceId}/version_details/{job_info.version}"
-                info.append(
-                    f"{printer.emoji('lightning')} View job at {printer.link(link)}",
-                )
+            # if job_info and job_info.version and job_info.sequenceId:
+            #     link = f"{settings.project_url}/jobs/{job_info.sequenceId}/version_details/{job_info.version}"
+            #     info.append(
+            #         f"{printer.emoji('lightning')} View job at {printer.link(link)}",
+            #     )
             if poll_exit_response and poll_exit_response.file_counts:
                 logger.info("logging synced files")
                 file_counts = poll_exit_response.file_counts


### PR DESCRIPTION
Description
-----------

What does the PR do? Include a concise description of the PR contents.

This PR removes the job links from the information displayed in the terminal, as well as explicitly point the run's link to the workspace, even though it is the same link now, in the future it is potentially could change.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
