### PR TITLE
chore(sdk): Create FakeFileTransferManager for tests

### DIFF
--- a/core/internal/filetransfer/file_transfer_manager.go
+++ b/core/internal/filetransfer/file_transfer_manager.go
@@ -158,9 +158,6 @@ func (fm *fileTransferManager) FileStreamCallback(task *Task) {
 }
 
 func (fm *fileTransferManager) Close() {
-	if fm == nil {
-		return
-	}
 	if !fm.active {
 		return
 	}

--- a/core/internal/filetransfer/file_transfer_manager.go
+++ b/core/internal/filetransfer/file_transfer_manager.go
@@ -22,8 +22,23 @@ type FileTransfer interface {
 	Download(task *Task) error
 }
 
+// A manager of asynchronous file upload tasks.
+type FileTransferManager interface {
+	// Asynchronously begins the main loop of the file transfer manager.
+	Start()
+
+	// Waits for all asynchronous work to finish.
+	Close()
+
+	// Schedules a file upload operation.
+	AddTask(task *Task)
+
+	// Generates a FilesUploaded record.
+	FileStreamCallback(task *Task)
+}
+
 // FileTransferManager handles the upload/download of files
-type FileTransferManager struct {
+type fileTransferManager struct {
 	// inChan is the channel for incoming messages
 	inChan chan *Task
 
@@ -50,35 +65,35 @@ type FileTransferManager struct {
 	active bool
 }
 
-type FileTransferManagerOption func(fm *FileTransferManager)
+type FileTransferManagerOption func(fm *fileTransferManager)
 
 func WithLogger(logger *observability.CoreLogger) FileTransferManagerOption {
-	return func(fm *FileTransferManager) {
+	return func(fm *fileTransferManager) {
 		fm.logger = logger
 	}
 }
 
 func WithSettings(settings *service.Settings) FileTransferManagerOption {
-	return func(fm *FileTransferManager) {
+	return func(fm *fileTransferManager) {
 		fm.settings = settings
 	}
 }
 
 func WithFileTransfer(fileTransfer FileTransfer) FileTransferManagerOption {
-	return func(fm *FileTransferManager) {
+	return func(fm *fileTransferManager) {
 		fm.fileTransfer = fileTransfer
 	}
 }
 
 func WithFSCChan(fsChan chan protoreflect.ProtoMessage) FileTransferManagerOption {
-	return func(fm *FileTransferManager) {
+	return func(fm *fileTransferManager) {
 		fm.fsChan = fsChan
 	}
 }
 
-func NewFileTransferManager(opts ...FileTransferManagerOption) *FileTransferManager {
+func NewFileTransferManager(opts ...FileTransferManagerOption) FileTransferManager {
 
-	fm := FileTransferManager{
+	fm := fileTransferManager{
 		inChan:    make(chan *Task, bufferSize),
 		wg:        &sync.WaitGroup{},
 		semaphore: make(chan struct{}, defaultConcurrencyLimit),
@@ -91,8 +106,7 @@ func NewFileTransferManager(opts ...FileTransferManagerOption) *FileTransferMana
 	return &fm
 }
 
-// Start is the main loop for the fileTransfer
-func (fm *FileTransferManager) Start() {
+func (fm *fileTransferManager) Start() {
 	if fm.active {
 		return
 	}
@@ -127,14 +141,12 @@ func (fm *FileTransferManager) Start() {
 	}()
 }
 
-// AddTask adds a task to the fileTransfer
-func (fm *FileTransferManager) AddTask(task *Task) {
+func (fm *fileTransferManager) AddTask(task *Task) {
 	fm.logger.Debug("fileTransfer: adding upload task", "path", task.Path, "url", task.Url)
 	fm.inChan <- task
 }
 
-// FileStreamCallback returns a callback for filestream updates
-func (fm *FileTransferManager) FileStreamCallback(task *Task) {
+func (fm *fileTransferManager) FileStreamCallback(task *Task) {
 	fm.logger.Debug("uploader: filestream callback", "task", task)
 	if task.Err != nil {
 		return
@@ -145,8 +157,7 @@ func (fm *FileTransferManager) FileStreamCallback(task *Task) {
 	fm.fsChan <- record
 }
 
-// Close closes the fileTransfer
-func (fm *FileTransferManager) Close() {
+func (fm *fileTransferManager) Close() {
 	if fm == nil {
 		return
 	}
@@ -163,8 +174,8 @@ func (fm *FileTransferManager) Close() {
 	fm.active = false
 }
 
-// transfer uploads/downloads a file to/from the server
-func (fm *FileTransferManager) transfer(task *Task) error {
+// Uploads or downloads a file.
+func (fm *fileTransferManager) transfer(task *Task) error {
 	var err error
 	switch task.Type {
 	case UploadTask:

--- a/core/internal/filetransfertest/filetransfertest.go
+++ b/core/internal/filetransfertest/filetransfertest.go
@@ -1,0 +1,44 @@
+// Testability for the filetransfer package.
+package filetransfertest
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/wandb/wandb/core/internal/filetransfer"
+)
+
+type FakeFileTransferManager struct {
+	tasks   []*filetransfer.Task
+	tasksMu *sync.Mutex
+}
+
+func NewFakeFileTransferManager() *FakeFileTransferManager {
+	return &FakeFileTransferManager{
+		tasksMu: &sync.Mutex{},
+	}
+}
+
+// All the tasks added via `AddTask`.
+func (m *FakeFileTransferManager) Tasks() []*filetransfer.Task {
+	m.tasksMu.Lock()
+	defer m.tasksMu.Unlock()
+	return slices.Clone(m.tasks)
+}
+
+//
+// FileTransferManager interface implementation
+//
+
+func (m *FakeFileTransferManager) Start() {}
+
+func (m *FakeFileTransferManager) Close() {}
+
+func (m *FakeFileTransferManager) AddTask(t *filetransfer.Task) {
+	m.tasksMu.Lock()
+	defer m.tasksMu.Unlock()
+
+	m.tasks = append(m.tasks, t)
+}
+
+func (m *FakeFileTransferManager) FileStreamCallback(t *filetransfer.Task) {}

--- a/core/pkg/artifacts/downloader.go
+++ b/core/pkg/artifacts/downloader.go
@@ -19,7 +19,7 @@ type ArtifactDownloader struct {
 	// Resources
 	Ctx             context.Context
 	GraphqlClient   graphql.Client
-	DownloadManager *filetransfer.FileTransferManager
+	DownloadManager filetransfer.FileTransferManager
 	// Input
 	ArtifactID             string
 	DownloadRoot           string
@@ -29,7 +29,7 @@ type ArtifactDownloader struct {
 func NewArtifactDownloader(
 	ctx context.Context,
 	graphQLClient graphql.Client,
-	downloadManager *filetransfer.FileTransferManager,
+	downloadManager filetransfer.FileTransferManager,
 	artifactID string,
 	downloadRoot string,
 	allowMissingReferences *bool,

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -20,7 +20,7 @@ type ArtifactSaver struct {
 	// Resources.
 	Ctx                 context.Context
 	GraphqlClient       graphql.Client
-	FileTransferManager *filetransfer.FileTransferManager
+	FileTransferManager filetransfer.FileTransferManager
 	// Input.
 	Artifact    *service.ArtifactRecord
 	HistoryStep int64
@@ -30,7 +30,7 @@ type ArtifactSaver struct {
 func NewArtifactSaver(
 	ctx context.Context,
 	graphQLClient graphql.Client,
-	uploadManager *filetransfer.FileTransferManager,
+	uploadManager filetransfer.FileTransferManager,
 	artifact *service.ArtifactRecord,
 	historyStep int64,
 	stagingDir string,

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -84,7 +84,7 @@ type Sender struct {
 	fileStream *fs.FileStream
 
 	// filetransfer is the file uploader/downloader
-	fileTransferManager *filetransfer.FileTransferManager
+	fileTransferManager filetransfer.FileTransferManager
 
 	// RunRecord is the run record
 	// TODO: remove this and use properly updated settings

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -459,7 +459,9 @@ func (s *Sender) sendDefer(request *service.DeferRequest) {
 		s.sendRequestDefer(request)
 	case service.DeferRequest_FLUSH_FP:
 		s.wgFileTransfer.Wait()
-		s.fileTransferManager.Close()
+		if s.fileTransferManager != nil {
+			s.fileTransferManager.Close()
+		}
 		request.State++
 		s.sendRequestDefer(request)
 	case service.DeferRequest_JOIN_FP:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
I needed this while trying to write better file upload tests. This makes `FileTransferManager` an interface and creates a fake implementation in the `filetransfertest` package.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable
