### PR TITLE
chore(artifacts): use a retrying client to download manifests

### DIFF
--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/core/pkg/service"
@@ -77,8 +78,8 @@ func (m *Manifest) GetManifestEntryFromArtifactFilePath(path string) (ManifestEn
 }
 
 func loadManifestFromURL(url string) (Manifest, error) {
-	// TODO: this should use a retryable HTTP client from internal/clients
-	resp, err := http.Get(url)
+	resp, err := retryablehttp.NewClient().Get(url)
+
 	if err != nil {
 		return Manifest{}, err
 	}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18010](https://wandb.atlassian.net/browse/WB-18010)

As per the `TODO` comment, move to using a retryable http client. Presumably comment was written before we started using `retryablehttp`?

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Just CI

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18010]: https://wandb.atlassian.net/browse/WB-18010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ