### PR TITLE
feat(launch): Add kaniko-settings key in build config

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_kaniko.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_kaniko.py
@@ -242,7 +242,7 @@ async def test_create_kaniko_job_static(
             f"--destination={image_tag}",
             "--cache=true",
             f"--cache-repo={repo_url}",
-            "--snapshotMode=redo",
+            "--snapshot-mode=redo",
             "--compressed-caching=false",
         ]
 
@@ -315,7 +315,7 @@ async def test_create_kaniko_job_instance(
             f"--destination={image_tag}",
             "--cache=true",
             f"--cache-repo={repo_url}",
-            "--snapshotMode=redo",
+            "--snapshot-mode=redo",
             "--compressed-caching=false",
         ]
 
@@ -365,7 +365,7 @@ async def test_create_kaniko_job_pvc_dockerconfig(
             f"--destination={image_tag}",
             "--cache=true",
             f"--cache-repo={repo_url}",
-            "--snapshotMode=redo",
+            "--snapshot-mode=redo",
             "--compressed-caching=false",
         ]
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-17742](https://wandb.atlassian.net/browse/WB-17742)

Adds a new key under an agent's `builder` config. Under `builder.kaniko-config`, users can provide the pod spec for their kaniko build process. For example:
```
builder:
  type: kaniko
  [...other builder keys...]
  kaniko-config:
    containers:
    - args:
      - "--cache=false"  # Note that all args must be in the format `key=value`
      volumeMounts:
      - name: my-volume
        mountPath: /my/mount/path/
    volumes:
    - name: my-volume
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
- Start a launch agent with the following config:
```
entity: tim-hays
queues:
- kube-queue
builder:
  type: kaniko
  build-context-store: s3://timh-launch-test/build-contexts/
  build-job-name: wandb-image-build
  destination: 305054156030.dkr.ecr.us-east-2.amazonaws.com/tim_launch_repo
  secret-name: aws-secret
  secret-key: credentials
  kaniko-config:
    containers:
    - args:
      - "--cache=false"
      volumeMounts:
      - name: timh-volume
        mountPath: /kaniko/timhtest/
    volumes:
    - name: timh-volume
environment:
  type: aws
  region: us-east-2
registry:
  type: ecr
  uri: 305054156030.dkr.ecr.us-east-2.amazonaws.com/tim_launch_repo
```
- Log into the AWS LaunchSandbox account
- Add a code or git job to the queue, have the agent pick it up
- While the agent is building, use `kubectl -n wandb get pod` to find the pod with the name `wandb-image-build-...`
- Run `kubectl -n wandb describe pod wandb-image-build-...` and verify that the arg, volumeMount, and volume from the `kaniko-config` are present
- Verify that the job runs successfully

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
