### PR TITLE
chore(core): Inject backend into sender

### DIFF
--- a/core/pkg/server/sender_test.go
+++ b/core/pkg/server/sender_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/coretest"
 	"github.com/wandb/wandb/core/internal/gql"
+	wbsettings "github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/pkg/observability"
 	"github.com/wandb/wandb/core/pkg/server"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -18,13 +19,16 @@ import (
 func makeSender(client graphql.Client, resultChan chan *service.Result) *server.Sender {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger := observability.NewNoOpLogger()
+	settings := wbsettings.From(&service.Settings{
+		RunId: &wrapperspb.StringValue{Value: "run1"},
+	})
+	backend := server.NewBackend(settings, logger)
 	sender := server.NewSender(
 		ctx,
 		cancel,
+		backend,
 		logger,
-		&service.Settings{
-			RunId: &wrapperspb.StringValue{Value: "run1"},
-		},
+		settings.Proto,
 		server.WithSenderFwdChannel(make(chan *service.Record, 1)),
 		server.WithSenderOutChannel(resultChan),
 	)

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -156,7 +156,9 @@ func NewStream(ctx context.Context, settings *settings.Settings, streamId string
 		WithWriterFwdChannel(make(chan *service.Record, BufferSize)),
 	)
 
-	s.sender = NewSender(s.ctx, s.cancel, s.logger, s.settings.Proto,
+	backend := NewBackend(settings, s.logger)
+
+	s.sender = NewSender(s.ctx, s.cancel, backend, s.logger, s.settings.Proto,
 		WithSenderFwdChannel(s.loopBackChan),
 		WithSenderOutChannel(make(chan *service.Result, BufferSize)),
 	)

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -1,0 +1,31 @@
+package server
+
+// This file contains functions to construct the objects used by a Stream.
+
+import (
+	"net/url"
+
+	"github.com/wandb/wandb/core/internal/api"
+	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/pkg/observability"
+)
+
+// NewBackend returns a Backend or nil if we're offline.
+func NewBackend(
+	settings *settings.Settings,
+	logger *observability.CoreLogger,
+) *api.Backend {
+	if settings.IsOffline() {
+		return nil
+	}
+
+	baseURL, err := url.Parse(settings.Proto.GetBaseUrl().GetValue())
+	if err != nil {
+		logger.CaptureFatalAndPanic("sender: failed to parse base URL", err)
+	}
+	return api.New(api.BackendOptions{
+		BaseURL: baseURL,
+		Logger:  logger.Logger,
+		APIKey:  settings.GetAPIKey(),
+	})
+}


### PR DESCRIPTION
Description
-----------
I was trying to clean up file stats upload code but ran into issues while trying to rewire FilesInfoHandler and FileTransferManager because Sender creates them directly. Then while trying to inject them into Sender, I ended up having to move a lot of other code.

I'm going to rewrite Sender and possibly Handler to inject objects rather than create them directly. This will improve testability and unlock some nice refactors.

In this PR, I inject the Backend object.