### PR TITLE
chore(sdk): Constrain tensorflow version in tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,7 +22,7 @@ nbclient
 
 scikit-learn
 tensorflow<2.14; sys_platform != 'darwin' and python_version < '3.12'
-tensorflow>=1.15.2; sys_platform == 'darwin' and platform.machine != 'arm64'
+tensorflow~=1.15.2; sys_platform == 'darwin' and platform.machine != 'arm64'
 tensorflow-macos; python_version > '3.7' and python_version < '3.11' and sys_platform == 'darwin' and platform.machine == 'arm64'
 tensorboard
 torch; python_version < '3.12'


### PR DESCRIPTION
Description
-----------
Tests are broken with the new major version of TensorFlow, possibly indicating that the SDK is broken as well. However, that's expected with a major version change.

We should add a version constraint somewhere, but I don't know where.

To fix CI, I updated the test requirements file to limit the TensorFlow version. `~=` means [Compatible Release](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release), which means the same major version. We should use this by default instead of `>=` in general.
