### PR TITLE
fix(sdk): fix docstring in wandb_init 

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1124,10 +1124,10 @@ def init(
             for saving hyperparameters to compare across runs. The ID cannot
             contain the following special characters: `/\#?%:`.
             See [our guide to resuming runs](https://docs.wandb.com/guides/runs/resuming).
-        fork_from: (str, optional) A string with the format <run_id>?_step=<step> describing
+        fork_from: (str, optional) A string with the format {run_id}?_step={step} describing
             a moment in a previous run to fork a new run from. Creates a new run that picks up
             logging history from the specified run at the specified moment. The target run must
-            be in the current project.
+            be in the current project. Example: `fork_from="my-run-id?_step=1234"`.
 
     Examples:
     ### Set where the run is logged


### PR DESCRIPTION
Description
-----------
Removes `<` and `>` from `wandb.init()` doc strings, as they break doc builds. 

-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
