### PR TITLE
fix(core): Don't retry when trying to upload a directory

### DIFF
--- a/core/internal/filetransfer/file_transfer_retry_policy.go
+++ b/core/internal/filetransfer/file_transfer_retry_policy.go
@@ -1,0 +1,26 @@
+package filetransfer
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// FileTransferRetryPolicy is the retry policy to be used for file operations.
+func FileTransferRetryPolicy(
+	ctx context.Context,
+	resp *http.Response,
+	err error,
+) (bool, error) {
+	// Abort on any error from the HTTP transport.
+	//
+	// This happens if reading the file fails, for example if it is a directory
+	// or if it doesn't exist. retryablehttp's default policy for this situation
+	// is to retry, which we do not want.
+	if err != nil {
+		return false, err
+	}
+
+	return retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err)
+}

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -71,7 +71,7 @@ func NewFileTransferManager(
 ) filetransfer.FileTransferManager {
 	fileTransferRetryClient := retryablehttp.NewClient()
 	fileTransferRetryClient.Logger = logger
-	fileTransferRetryClient.CheckRetry = clients.CheckRetry
+	fileTransferRetryClient.CheckRetry = filetransfer.FileTransferRetryPolicy
 	fileTransferRetryClient.RetryMax = int(settings.Proto.GetXFileTransferRetryMax().GetValue())
 	fileTransferRetryClient.RetryWaitMin = clients.SecondsToDuration(settings.Proto.GetXFileTransferRetryWaitMinSeconds().GetValue())
 	fileTransferRetryClient.RetryWaitMax = clients.SecondsToDuration(settings.Proto.GetXFileTransferRetryWaitMaxSeconds().GetValue())


### PR DESCRIPTION
Fixes WB-17558: `run.save(directory)` will retry until it runs out of retries.

This happened because of retryablehttp retries Go errors from the HTTP transport (i.e. not HTTP response error statuses):

https://github.com/hashicorp/go-retryablehttp/blob/main/client.go#L506-L507

Our request body is a ReadSeeker, so retryablehttp doesn't try to read the entire file into memory when we create a Request. Instead, it passes the ReadSeeker to the underlying transport in Do(). When Go's http library calls Read(), it gets an error saying that the file is a directory; then retryablehttp treats it as a retryable error!
