### PR TITLE
fix(core): symlink to resolved path rather than relative path

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -111,7 +111,7 @@ class CustomBuildPy(build_py):
             except FileNotFoundError:
                 pass
 
-            os.symlink(file, dest)
+            os.symlink(file.resolve(), dest)
 
         super().run()
 


### PR DESCRIPTION
At first I didn't understand why it wasn't working. Now I don't understand how it ever worked.
