### PR TITLE
chore(core): Move wandb-core metadata to pyproject.toml

### DIFF
--- a/.bumpversion.core.cfg
+++ b/.bumpversion.core.cfg
@@ -32,9 +32,9 @@ values =
 	dev
 	_
 
-[bumpversion:file:core/setup.py]
-search = CORE_VERSION = "{current_version}"
-replace = CORE_VERSION = "{new_version}"
+[bumpversion:file:core/pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
 
 [bumpversion:file:core/README.md]
 search = `{current_version}`

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wandb-core"
+version = "0.17.0b10"
+description = "W&B Core Library"
+readme = { file = "README.md", content-type = "text/markdown" }
+requires-python = ">=3.7"
+license = { text = "MIT License" }
+
+[tool.setuptools]
+packages = ["wandb_core"]
+include-package-data = true

--- a/core/setup.py
+++ b/core/setup.py
@@ -8,16 +8,6 @@ from setuptools import setup
 from setuptools.command.build_py import build_py
 from wheel.bdist_wheel import bdist_wheel, get_platform
 
-# Package naming
-# --------------
-#   wandb-core:         Package containing architecture specific code
-
-# wandb-core versioning
-# ---------------------
-CORE_VERSION = "0.17.0b10"
-
-PACKAGE = "wandb_core"
-
 
 class CustomWheel(bdist_wheel):
     """Overrides the wheel tag with the proper information.
@@ -70,7 +60,7 @@ class CustomBuildPy(build_py):
     """Custom step to copy pre-built binary artifacts into the package."""
 
     def run(self):
-        pkgdir = pathlib.Path(__file__).parent / PACKAGE
+        pkgdir = pathlib.Path(__file__).parent / "wandb_core"
 
         # Figure out the normalized architecture name for our current arch.
         arch = platform.machine().lower()
@@ -120,16 +110,6 @@ if __name__ == "__main__":
     log.set_verbosity(log.INFO)
 
     setup(
-        name="wandb-core",
-        version=CORE_VERSION,
-        description="W&B Core Library",
-        long_description=open("README.md", encoding="utf-8").read(),
-        long_description_content_type="text/markdown",
-        packages=[PACKAGE],
-        zip_safe=False,
-        include_package_data=True,
-        license="MIT license",
-        python_requires=">=3.6",
         cmdclass={
             "bdist_wheel": CustomWheel,
             "build_py": CustomBuildPy,


### PR DESCRIPTION
# Description

pyproject.toml is the more modern way of specifying project information. I was adding the `build-system.requires` field because `cibuildwheel` doesn't include `wheel` by default in the newest version (1.17.0), and I figured I might as well make the full move.

# Tested

`./wini package wandb-core` still works and produces the correct output locally.