### PR TITLE
feat(core): Don't reupload files that have already been uploaded

### DIFF
--- a/core/internal/runfiles/debounced_transfer.go
+++ b/core/internal/runfiles/debounced_transfer.go
@@ -1,0 +1,63 @@
+package runfiles
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/wandb/wandb/core/internal/filetransfer"
+	"github.com/wandb/wandb/core/pkg/observability"
+)
+
+// debouncedTransfer wraps a FileTransferManager to avoid reuploading
+// unmodified files.
+type debouncedTransfer struct {
+	sync.Mutex
+
+	ftm filetransfer.FileTransferManager
+
+	logger *observability.CoreLogger
+
+	// The modification time of each file at its last upload.
+	lastUploadedModTime map[string]time.Time
+}
+
+func newDebouncedTransfer(
+	ftm filetransfer.FileTransferManager,
+	logger *observability.CoreLogger,
+) *debouncedTransfer {
+	return &debouncedTransfer{
+		ftm:                 ftm,
+		logger:              logger,
+		lastUploadedModTime: make(map[string]time.Time),
+	}
+}
+
+// AddTask queues a file upload task unless it's unnecessary.
+func (t *debouncedTransfer) AddTask(task *filetransfer.Task) {
+	t.Lock()
+	defer t.Unlock()
+
+	info, err := os.Stat(task.Path)
+	if err != nil {
+		t.logger.Error(
+			"runfiles: failed to stat file; not uploading",
+			"file", task.Path,
+		)
+		task.CompletionCallback(task)
+		return
+	}
+
+	if !info.ModTime().After(t.lastUploadedModTime[task.Path]) {
+		t.logger.Debug(
+			"runfiles: skipping upload because file is up to date",
+			"file", task.Path,
+		)
+		task.CompletionCallback(task)
+		return
+	}
+
+	t.lastUploadedModTime[task.Path] = info.ModTime()
+
+	t.ftm.AddTask(task)
+}

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -210,6 +210,20 @@ func TestUploader(t *testing.T) {
 			assert.Len(t, fakeFileTransfer.Tasks(), 0)
 		})
 
+	runTest("upload does not reupload same file if unchanged",
+		func() {},
+		func(t *testing.T) {
+			writeEmptyFile(t, filepath.Join(filesDir, "test.txt"))
+
+			stubCreateRunFilesOneFile(mockGQLClient, "test.txt")
+			uploader.UploadNow("test.txt")
+			stubCreateRunFilesOneFile(mockGQLClient, "test.txt")
+			uploader.UploadNow("test.txt")
+			uploader.Finish()
+
+			assert.Len(t, fakeFileTransfer.Tasks(), 1)
+		})
+
 	runTest("upload is no-op if GraphQL returns wrong number of files",
 		func() {},
 		func(t *testing.T) {


### PR DESCRIPTION
# Description

Resolves WB-18103.

This affects only run.save() and some internal files which use that codepath, not artifacts behavior. The main purpose is to not reupload files at the end (in UploadRemaining()) if they were previously uploaded with the "now" policy and unchanged since.
