### PR TITLE
feat(launch): Allow overriding stopped run timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please add to relevant subsections here on every PR where this is applicable.
 
 * Added support for overriding kaniko builder settings in the agent config by @TimH98 in https://github.com/wandb/wandb/pull/7191
 * Added link to the project workspace of a run in the footer by @kptkin in https://github.com/wandb/wandb/pull/7276
+* Added support for overriding stopped run grace period in the agent config by @TimH98 in https://github.com/wandb/wandb/pull/7281
 
 ### Changed
 

--- a/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -594,7 +594,7 @@ async def test_thread_run_job_calls_finish_thread_id(mocker, exception, clean_ag
 @pytest.mark.asyncio
 async def test_inner_thread_run_job(mocker, clean_agent):
     _setup(mocker)
-    mocker.patch("wandb.sdk.launch.agent.agent.MAX_WAIT_RUN_STOPPED", new=0)
+    mocker.patch("wandb.sdk.launch.agent.agent.DEFAULT_STOPPED_RUN_TIMEOUT", new=0)
     mocker.patch("wandb.sdk.launch.agent.agent.AGENT_POLLING_INTERVAL", new=0)
     mock_config = {
         "entity": "test-entity",

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -45,7 +45,7 @@ MAX_RESUME_COUNT = 5
 
 RUN_INFO_GRACE_PERIOD = 60
 
-MAX_WAIT_RUN_STOPPED = 60
+DEFAULT_STOPPED_RUN_TIMEOUT = 60
 
 DEFAULT_PRINT_INTERVAL = 5 * 60
 VERBOSE_PRINT_INTERVAL = 20
@@ -191,7 +191,7 @@ class LaunchAgent:
         self._last_status_print_time = 0.0
         self.default_config: Dict[str, Any] = config
         self._stopped_run_timeout = config.get(
-            "stopped_run_timeout", MAX_WAIT_RUN_STOPPED
+            "stopped_run_timeout", DEFAULT_STOPPED_RUN_TIMEOUT
         )
 
         # Get agent version from env var if present, otherwise wandb version

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -190,6 +190,9 @@ class LaunchAgent:
         self._internal_logger = InternalAgentLogger(verbosity=self._verbosity)
         self._last_status_print_time = 0.0
         self.default_config: Dict[str, Any] = config
+        self._stopped_run_timeout = config.get(
+            "stopped_run_timeout", MAX_WAIT_RUN_STOPPED
+        )
 
         # Get agent version from env var if present, otherwise wandb version
         self.version: str = "wandb@" + wandb.__version__
@@ -740,7 +743,7 @@ class LaunchAgent:
                 if stopped_time is None:
                     stopped_time = time.time()
                 else:
-                    if time.time() - stopped_time > MAX_WAIT_RUN_STOPPED:
+                    if time.time() - stopped_time > self._stopped_run_timeout:
                         await run.cancel()
             await asyncio.sleep(AGENT_POLLING_INTERVAL)
 

--- a/wandb/sdk/launch/agent/config.py
+++ b/wandb/sdk/launch/agent/config.py
@@ -229,6 +229,10 @@ class AgentConfig(BaseModel):
         0,
         description="How verbose to print, 0 = default, 1 = verbose, 2 = very verbose",
     )
+    stopped_run_timeout: Optional[int] = Field(
+        60,
+        description="How many seconds to wait after receiving the stop command before forcibly cancelling a run.",
+    )
 
     class Config:
         extra = "forbid"


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes issue raised in [this Slack thread](https://weightsandbiases.slack.com/archives/C01KQ5KTDC3/p1712011361017579)

Adds the `stopped_run_timeout` parameter to the agent config.

When a run is stopped, it first tries to upload any necessary artifacts before exiting. By default, if that process takes more than 60 seconds, the agent cancels the run, force-removing any related processes (e.g. Kubernetes jobs). Sometimes users will have larger artifacts and want some extra time to allow them to upload, so now they can set the `stopped_run_timeout` parameter to increase the grace period.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Created an agent with the new parameter

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
