### PR TITLE
fix(core): Fix a race condition caused by watcher in runfiles

### DIFF
--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -263,7 +263,7 @@ func (u *uploader) startWatcher() error {
 	// wouldn't have stopped the above goroutines.
 	watcherStarted := make(chan struct{})
 	go func() {
-		u.watcherWG.Wait()
+		u.watcherOrNil.Wait()
 		watcherStarted <- struct{}{}
 	}()
 	select {


### PR DESCRIPTION
This race condition should be super rare and maybe impossible to trigger in production. I discovered it because it got triggered in CI: https://app.circleci.com/pipelines/github/wandb/wandb/32643/workflows/8f3de1df-c8e8-4f39-8fb3-942a3ad099ff/jobs/1099232

Unfortunately, the `watcher` package we depend on has not been updated in 6 years and has a few design flaws, one being that to know whether Start() succeeded, we have to create a separate goroutine that blocks until Wait() returns. If Start() returns an error instead, then Wait() blocks forever and the goroutine is wasted. The API doesn't provide a channel that we could listen to in a `select` statement.
