### PR TITLE
fix(core): Raise the default rate limit

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -13,10 +13,10 @@ import (
 
 const (
 	// Don't go slower than 1 request per 10 seconds.
-	minRateLimit = 0.1
+	minRequestsPerSecond = 0.1
 
-	// Don't go faster than 20 requests per second.
-	maxRequestsPerSecond = 20
+	// Don't go faster than 200 requests per second.
+	maxRequestsPerSecond = 200
 
 	// Don't send more than 10 requests at a time.
 	maxBurst = 10

--- a/core/internal/api/transport.go
+++ b/core/internal/api/transport.go
@@ -28,7 +28,7 @@ func NewRateLimitedTransport(
 		delegate:    delegate,
 		rateLimiter: rate.NewLimiter(maxRequestsPerSecond, maxBurst),
 		rlTracker: NewRateLimitTracker(RateLimitTrackerParams{
-			MinPerSecond: minRateLimit,
+			MinPerSecond: minRequestsPerSecond,
 			MaxPerSecond: maxRequestsPerSecond,
 
 			// TODO: Allow changing these through settings.


### PR DESCRIPTION
Improves WB-18172.

It turns out that 20QPS is very easy to hit in a Python script that calls `run.save()` on a large number of files.
