### PR TITLE
fix(core): Avoid concurrent map read and write

### DIFF
--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -408,6 +408,9 @@ func (u *uploader) scheduleUploadTask(
 	uploadURL string,
 	headers []string,
 ) {
+	u.stateMu.Lock()
+	defer u.stateMu.Unlock()
+
 	localPath := filepath.Join(u.settings.GetFilesDir(), relativePath)
 	task := &filetransfer.Task{
 		FileKind: u.category[relativePath],


### PR DESCRIPTION
The read of u.category in scheduleUploadTask() was not protected by a mutex, causing a panic in CI: https://app.circleci.com/pipelines/github/wandb/wandb/32680/workflows/db4e43c2-e481-49df-9f5e-1dde424987b1/jobs/1101049
