### PR TITLE
chore(core): Build universal no-op wandb-core wheel

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -132,7 +132,7 @@ jobs:
         run: pip install -r requirements_tools.txt
 
       - name: Install requirements for build
-        run: pip install -U build setuptools
+        run: pip install -r requirements_build.txt
 
       - name: Build no-op wheel
         run: bash wini package wandb-core --noop

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -10,7 +10,7 @@ on:
         default: false
 
 jobs:
-  build-wheels:
+  build-platform-wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -117,10 +117,23 @@ jobs:
           name: wandb-core-distributions
           path: ./core/wheelhouse/*.whl
 
+  build-noop-wheel:
+    name: Build universal no-op wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: pip install build setuptools
+      - name: Build no-op wheel
+        run: WANDB_CORE_BUILD_NOOP=1 python -m build -wnx --outdir wheelhouse core
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wandb-core-distributions
+          path: wheelhouse
 
   test-pypi-publish:
     name: Publish to TestPyPI
-    needs: build-wheels
+    needs: [build-platform-wheels, build-noop-wheel]
     continue-on-error: true
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -122,10 +122,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: pip install build setuptools
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install requirements for wini
+        run: pip install -r requirements_tools.txt
+
+      - name: Install requirements for build
+        run: pip install -U build setuptools
+
       - name: Build no-op wheel
-        run: WANDB_CORE_BUILD_NOOP=1 python -m build -wnx --outdir wheelhouse core
+        run: bash wini package wandb-core --noop
+
+      - name: Copy wheel to temporary directory
+        run: |
+          mkdir wheelhouse
+          cp $(bash wini info wandb-core-wheel) wheelhouse/
+
       - uses: actions/upload-artifact@v3
         with:
           name: wandb-core-distributions

--- a/core/setup.py
+++ b/core/setup.py
@@ -8,6 +8,12 @@ from setuptools import setup
 from setuptools.command.build_py import build_py
 from wheel.bdist_wheel import bdist_wheel, get_platform
 
+PKGDIR = pathlib.Path(__file__).parent / "wandb_core"
+
+
+def _should_build_noop():
+    return bool(os.getenv("WANDB_CORE_BUILD_NOOP", ""))
+
 
 class CustomWheel(bdist_wheel):
     """Overrides the wheel tag with the proper information.
@@ -28,6 +34,10 @@ class CustomWheel(bdist_wheel):
     # Setting self.plat_name in initialize_options() would be the proper way to
     # do this, but see the macOS issue described below.
     def get_tag(self):
+        if _should_build_noop():
+            # The default tag will be universal.
+            return super().get_tag()
+
         python, abi = super().get_tag()[:2]
 
         # We always build wheels for the platform we're running on.
@@ -60,8 +70,17 @@ class CustomBuildPy(build_py):
     """Custom step to copy pre-built binary artifacts into the package."""
 
     def run(self):
-        pkgdir = pathlib.Path(__file__).parent / "wandb_core"
+        # Delete all files except __init__.py.
+        for file in PKGDIR.iterdir():
+            if file.name != "__init__.py":
+                file.unlink()
 
+        if not _should_build_noop():
+            self._symlink_binaries()
+
+        super().run()
+
+    def _symlink_binaries(self):
         # Figure out the normalized architecture name for our current arch.
         arch = platform.machine().lower()
         if arch == "arm64":
@@ -91,19 +110,10 @@ class CustomBuildPy(build_py):
 
         # Symlink the artifacts into bin/. The build system will copy the
         # actual files into the wheel.
-        archdir = pkgdir.parent / "wandb_core_artifacts" / arch
+        archdir = PKGDIR.parent / "wandb_core_artifacts" / arch
         for file in archdir.iterdir():
-            dest = pkgdir / file.name
-
-            try:
-                # missing_ok=True doesn't exist in Python 3.7
-                dest.unlink()
-            except FileNotFoundError:
-                pass
-
+            dest = PKGDIR / file.name
             os.symlink(file.resolve(), dest)
-
-        super().run()
 
 
 if __name__ == "__main__":

--- a/core/wandb_core/__init__.py
+++ b/core/wandb_core/__init__.py
@@ -7,7 +7,6 @@ __all__ = (
 )
 
 from pathlib import Path
-from typing import Optional
 
 __version__ = "0.17.0b10"
 

--- a/core/wandb_core/__init__.py
+++ b/core/wandb_core/__init__.py
@@ -1,4 +1,5 @@
 """W&B Core: This is the backend for the W&B client library."""
+
 __all__ = (
     "__version__",
     "get_core_path",
@@ -6,14 +7,29 @@ __all__ = (
 )
 
 from pathlib import Path
+from typing import Optional
 
 __version__ = "0.17.0b10"
 
 
-def get_core_path() -> Path:
-    return (Path(__file__).parent / "wandb-core").resolve()
+_cached_core_path = None
+
+
+def get_core_path() -> str:
+    global _cached_core_path
+
+    if _cached_core_path is None:
+        path = (Path(__file__).parent / "wandb-core").resolve()
+
+        # If the binary doesn't exist, we return an empty string.
+        if path.exists():
+            _cached_core_path = str(path)
+        else:
+            _cached_core_path = ""
+
+    return _cached_core_path
 
 
 # for backwards compatibility
-def get_nexus_path() -> Path:
+def get_nexus_path() -> str:
     return get_core_path()

--- a/tools/wini/print.py
+++ b/tools/wini/print.py
@@ -1,5 +1,6 @@
 """Terminal output functions for wini."""
 
+import sys
 from typing import Dict, List, Optional
 
 import rich
@@ -12,19 +13,19 @@ def info(msg: str) -> None:
     """Prints an informational message to tell the user what's happening."""
     text = Text(msg)
     text.stylize("bold white")
-    rich.print(text)
+    rich.print(text, file=sys.stderr)
 
 
 def command(parts: List[str], env: Optional[Dict[str, str]] = None) -> None:
     """Prints out a terminal command."""
-    rich.print(Padding(Pretty(parts), (0, 2)))
+    rich.print(Padding(Pretty(parts), (0, 2)), file=sys.stderr)
     if env:
-        rich.print(Padding("with environment variables:", (0, 2)))
-        rich.print(Padding(Pretty(env), (0, 2)))
+        rich.print(Padding("with environment variables:", (0, 2)), file=sys.stderr)
+        rich.print(Padding(Pretty(env), (0, 2)), file=sys.stderr)
 
 
 def error(msg: str) -> None:
     """Prints an error message to tell the user something is wrong."""
     text = Text(msg)
     text.stylize("red")
-    rich.print(text)
+    rich.print(text, file=sys.stderr)

--- a/tools/wini/subprocess.py
+++ b/tools/wini/subprocess.py
@@ -19,7 +19,7 @@ def check_call(
     Args:
         cmd: The command to run.
         cwd: The directory in which to run the command.
-        env: Environment variables to use for the command.
+        extra_env: Environment variables to use for the command.
     """
     if cwd:
         print.info(f"In directory '{cwd}', running")
@@ -41,12 +41,23 @@ def check_call(
     )
 
 
-def run(cmd: Sequence[Union[str, pathlib.PurePath]]) -> None:
+def run(
+    cmd: Sequence[Union[str, pathlib.PurePath]],
+    extra_env: Optional[Dict[str, str]],
+) -> None:
     """Invokes `subprocess.run`.
 
     Args:
         cmd: The command to run.
+        extra_env: Environment variables to use for the command.
     """
     print.info("Running")
     print.command([str(part) for part in cmd])
-    subprocess.run(cmd)
+
+    if extra_env:
+        env = os.environ.copy()
+        env.update(extra_env)
+    else:
+        env = None
+
+    subprocess.run(cmd, env=env)

--- a/tools/wini/wini.py
+++ b/tools/wini/wini.py
@@ -26,6 +26,27 @@ def wini():
 
 
 @wini.group()
+def info():
+    """Commands that help with automation by printing info to stdout."""
+
+
+@info.command(name="wandb-core-wheel")
+def info_wandb_core_wheel():
+    """Prints out the path to the built wandb-core wheel."""
+    try:
+        for file in _CORE_WHEEL_DIR.iterdir():
+            if file.name.endswith(".whl"):
+                sys.stdout.write(str(file))
+                return
+    except FileNotFoundError:
+        # Fall through to below.
+        pass
+
+    print.error("No wandb-core wheel found.")
+    sys.exit(1)
+
+
+@wini.group()
 def build():
     """Commands to build parts of the application."""
 
@@ -94,9 +115,16 @@ def package():
     is_flag=True,
     default=False,
 )
-def package_wandb_core(should_install, with_coverage):
+@click.option(
+    "--noop",
+    help="Builds a wandb-core package that does nothing.",
+    is_flag=True,
+    default=False,
+)
+def package_wandb_core(should_install, with_coverage, noop):
     """Creates the wandb-core wheel, optionally installing it."""
-    _build_wandb_core_artifacts(with_coverage=with_coverage)
+    if not noop:
+        _build_wandb_core_artifacts(with_coverage=with_coverage)
 
     if _CORE_WHEEL_DIR.exists():
         # Remove old wheel files to prevent ambiguity issues when installing.
@@ -115,7 +143,8 @@ def package_wandb_core(should_install, with_coverage):
             "--outdir",
             _CORE_WHEEL_DIR,
             "./core",
-        ]
+        ],
+        extra_env={"WANDB_CORE_BUILD_NOOP": "1"} if noop else {},
     )
 
     if should_install:


### PR DESCRIPTION
Description
---
Fixes WB-18030, unblocking us from making wandb-core a required dependency of wandb. This is a stopgap; eventually we will create source distributions and build Go from source.

Testing
---
Run `./wini package wandb-core --noop`. This creates a wheel named `wandb_core-0.17.0b10-py3-none-any.whl`. Unzipping the wheel shows that it does not contain any binary files.

Install the wheel with `pip install --force-reinstall $(./wini info wandb-core-wheel)`. Then `pip show wandb-core` shows that `wandb-core` is installed, but running `wandb.init()` doesn't print a message saying that wandb-core is being used.

Finally, you can see a successful workflow run and view the `wandb-core-distributions` artifact, which includes a universal wheel: https://github.com/wandb/wandb/actions/runs/8559610507