### PR TITLE
chore(launch): Exclude wandb and .git folders from code artifact when creating a job from the CLI

### DIFF
--- a/tests/pytest_tests/system_tests/test_launch/test_job.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_job.py
@@ -61,6 +61,10 @@ def test_create_job_artifact(runner, user, wandb_init, test_settings):
     with open(f"{source_dir}/requirements.txt", "w") as f:
         f.write("wandb")
 
+    os.makedirs(f"{source_dir}/wandb")
+    with open(f"{source_dir}/wandb/debug.log", "w") as f:
+        f.write("log text")
+
     artifact, action, aliases = _create_job(
         api=internal_api,
         path=source_dir,
@@ -74,6 +78,7 @@ def test_create_job_artifact(runner, user, wandb_init, test_settings):
     )
 
     assert isinstance(artifact, Artifact)
+    assert artifact.file_count == 2
     assert artifact.name == "test-job-9999:v0"
     assert action == "Created"
     assert aliases == ["latest"]

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -440,11 +440,11 @@ def _make_code_artifact(
         return None
 
     # Remove paths we don't want to include, if present
-    try:
-        for item in CODE_ARTIFACT_EXCLUDE_PATHS:
+    for item in CODE_ARTIFACT_EXCLUDE_PATHS:
+        try:
             code_artifact.remove(item)
-    except FileNotFoundError:
-        pass
+        except FileNotFoundError:
+            pass
 
     res, _ = api.create_artifact(
         artifact_type_name="code",

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -19,6 +19,9 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 _logger = logging.getLogger("wandb")
 
 
+CODE_ARTIFACT_EXCLUDE_PATHS = ["wandb", ".git"]
+
+
 def create_job(
     path: str,
     job_type: str,
@@ -435,6 +438,13 @@ def _make_code_artifact(
             )
         wandb.termerror(f"Error adding to code artifact: {e}")
         return None
+
+    # Remove paths we don't want to include, if present
+    try:
+        for item in CODE_ARTIFACT_EXCLUDE_PATHS:
+            code_artifact.remove(item)
+    except FileNotFoundError:
+        pass
 
     res, _ = api.create_artifact(
         artifact_type_name="code",


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18110](https://wandb.atlassian.net/browse/WB-18110)

Code artifacts were being made much larger than needed because they contain the generated `wandb` directory. This removes it from the artifact before logging it, along with the `.git` directory that users probably don't want to include either.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
A system test was modified to ensure a `wandb` subdirectory isn't added. Also, manual testing:

- Create a directory with a simple python job file and a `wandb` subdirectory
- Run `wandb job create`
- Confirm that the [generated code artifact](https://wandb.ai/tim-hays/debugging/artifacts/code/code-testjob2/v0/files) doesn't contain a `wandb` directory.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18110]: https://wandb.atlassian.net/browse/WB-18110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ