### PR TITLE
refactor(core): Remove unused FileStreamCallback in FileTransferManager

### DIFF
--- a/core/internal/filetransfertest/filetransfertest.go
+++ b/core/internal/filetransfertest/filetransfertest.go
@@ -64,5 +64,3 @@ func (m *FakeFileTransferManager) AddTask(t *filetransfer.Task) {
 		m.unfinishedTasks[t] = struct{}{}
 	}
 }
-
-func (m *FakeFileTransferManager) FileStreamCallback(t *filetransfer.Task) {}

--- a/core/pkg/filestream/filestream.go
+++ b/core/pkg/filestream/filestream.go
@@ -217,10 +217,6 @@ func (fs *FileStream) StreamRecord(rec *service.Record) {
 	fs.addProcess(rec)
 }
 
-func (fs *FileStream) GetInputChan() chan protoreflect.ProtoMessage {
-	return fs.processChan
-}
-
 // Close gracefully shuts down the goroutines created by Start
 func (fs *FileStream) Close() {
 	if fs == nil {

--- a/core/pkg/server/sender_test.go
+++ b/core/pkg/server/sender_test.go
@@ -51,7 +51,6 @@ func makeSender(client graphql.Client, resultChan chan *service.Result) *server.
 	backend := server.NewBackend(logger, settings)
 	fileStream := server.NewFileStream(backend, logger, settings, nil)
 	fileTransferManager := server.NewFileTransferManager(
-		fileStream,
 		filetransfer.NewFileTransferStats(),
 		logger,
 		settings,

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -156,7 +156,6 @@ func NewStream(ctx context.Context, settings *settings.Settings, streamId string
 		graphqlClientOrNil = NewGraphQLClient(backendOrNil, settings, peeker)
 		fileStreamOrNil = NewFileStream(backendOrNil, s.logger, settings, peeker)
 		fileTransferManagerOrNil = NewFileTransferManager(
-			fileStreamOrNil,
 			fileTransferStats,
 			s.logger,
 			settings,

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -93,7 +93,6 @@ func NewFileStream(
 }
 
 func NewFileTransferManager(
-	fileStream *filestream.FileStream,
 	fileTransferStats filetransfer.FileTransferStats,
 	logger *observability.CoreLogger,
 	settings *settings.Settings,
@@ -117,7 +116,6 @@ func NewFileTransferManager(
 		filetransfer.WithSettings(settings.Proto),
 		filetransfer.WithFileTransfer(defaultFileTransfer),
 		filetransfer.WithFileTransferStats(fileTransferStats),
-		filetransfer.WithFSCChan(fileStream.GetInputChan()),
 	)
 }
 


### PR DESCRIPTION
I'll add a replacement in `runfiles` in a separate PR.
