### PR TITLE
refactor(sdk): move copyFile helper function to pkg/utils/files.go

### DIFF
--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/segmentio/encoding/json"
 	"github.com/wandb/wandb/core/pkg/monitor"
+	"github.com/wandb/wandb/core/pkg/utils"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -714,7 +715,7 @@ func (h *Handler) handleCodeSave() {
 	}
 	savedProgram := filepath.Join(codeDir, programRelative)
 	if _, err := os.Stat(savedProgram); err != nil {
-		if err = copyFile(programAbsolute, savedProgram); err != nil {
+		if err = utils.CopyFile(programAbsolute, savedProgram); err != nil {
 			return
 		}
 	}

--- a/core/pkg/server/util.go
+++ b/core/pkg/server/util.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 )
@@ -41,25 +40,4 @@ func writePortFile(portFile string, port int) {
 		LogError(slog.Default(), "fail rename", err)
 	}
 	// slog.Info("wrote port file", "file", portFile, "port", port)
-}
-
-// Helper function to copy a file
-func copyFile(src, dst string) error {
-	source, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer source.Close()
-
-	destination, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer destination.Close()
-
-	_, err = io.Copy(destination, source)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/core/pkg/utils/files.go
+++ b/core/pkg/utils/files.go
@@ -2,7 +2,10 @@ package utils
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/segmentio/encoding/json"
 )
@@ -16,6 +19,37 @@ func FileExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// CopyFile copies the contents of `src` into `dst`.
+//
+// If the source doesn't exist this is a no-op and an error is returned.
+//
+// If the destination exists, it will be overwritten.
+//
+// This operation is not atomic: if either the source or destination files are modified
+// during the copy, the destination file's contents may be corrupted.
+func CopyFile(src, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %v", err)
+	}
+	defer source.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("failed to create destination folder: %v", err)
+	}
+	destination, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %v", err)
+	}
+	defer destination.Close()
+
+	_, err = io.Copy(destination, source)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func WriteJsonToFileWithDigest(marshallable interface{}) (filename string, digest string, size int64, rerr error) {


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Refactor, make `CopyFile` an exported function of utils.

I'm using this in another PR, and thought it would be better to reuse this one rather than writing another helper.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
