### PR TITLE
feat(artifacts): use the cache when uploading files

### DIFF
--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -30,6 +30,7 @@ type ManifestEntry struct {
 	Extra           map[string]interface{} `json:"extra,omitempty"`
 	LocalPath       *string                `json:"-"`
 	DownloadURL     *string                `json:"-"`
+	SkipCache       bool                   `json:"-"`
 }
 
 func NewManifestFromProto(proto *service.ArtifactManifest) (Manifest, error) {
@@ -58,6 +59,7 @@ func NewManifestFromProto(proto *service.ArtifactManifest) (Manifest, error) {
 			Size:            entry.Size,
 			Extra:           extra,
 			LocalPath:       utils.NilIfZero(entry.LocalPath),
+			SkipCache:       entry.SkipCache,
 		}
 	}
 	return manifest, nil

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -237,7 +237,6 @@ def test_uploaded_artifacts_are_unstaged(wandb_init, tmp_path, monkeypatch):
     assert dir_size() == 0
 
 
-@pytest.mark.wandb_core_failure(feature="artifacts_cache")
 def test_mutable_uploads_with_cache_enabled(wandb_init, tmp_path, monkeypatch, api):
     # Use a separate staging directory for the duration of this test.
     monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18295](https://wandb.atlassian.net/browse/WB-18295)

Add caching to the artifact file uploader--also requires passing the `skip_cache` directive through to the core.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18295]: https://wandb.atlassian.net/browse/WB-18295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ