### PR TITLE
chore(artifacts): add helper functions for verifying data/files

### DIFF
--- a/core/pkg/artifacts/builder.go
+++ b/core/pkg/artifacts/builder.go
@@ -76,10 +76,7 @@ func (b *ArtifactBuilder) AddFile(path string, name string) error {
 	if err != nil {
 		return err
 	}
-	digest, err := utils.ComputeB64MD5(data)
-	if err != nil {
-		return err
-	}
+	digest := utils.ComputeB64MD5(data)
 	b.artifactRecord.Manifest.Contents = append(b.artifactRecord.Manifest.Contents,
 		&service.ArtifactManifestEntry{
 			Path:      name,

--- a/core/pkg/artifacts/builder.go
+++ b/core/pkg/artifacts/builder.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -130,5 +131,5 @@ func computeManifestDigest(manifest *Manifest) string {
 		hasher.Write([]byte(fmt.Sprintf("%s:%s\n", entry.name, entry.digest)))
 	}
 
-	return utils.EncodeBytesAsHex(hasher.Sum(nil))
+	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/core/pkg/utils/files.go
+++ b/core/pkg/utils/files.go
@@ -73,6 +73,6 @@ func WriteJsonToFileWithDigest(marshallable interface{}) (filename string, diges
 		size = stat.Size()
 	}
 
-	digest, rerr = ComputeB64MD5(data)
+	digest = ComputeB64MD5(data)
 	return
 }

--- a/core/pkg/utils/hash.go
+++ b/core/pkg/utils/hash.go
@@ -17,6 +17,14 @@ func ComputeB64MD5(data []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
 }
 
+func VerifyDataHash(data []byte, b64md5 string) bool {
+	actual, err := ComputeB64MD5(data)
+	if err != nil {
+		return false
+	}
+	return actual == b64md5
+}
+
 func ComputeFileB64MD5(path string) (string, error) {
 	hasher := md5.New()
 	f, err := os.Open(path)
@@ -29,6 +37,14 @@ func ComputeFileB64MD5(path string) (string, error) {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func VerifyFileHash(path string, b64md5 string) bool {
+	actual, err := ComputeFileB64MD5(path)
+	if err != nil {
+		return false
+	}
+	return actual == b64md5
 }
 
 func B64ToHex(data string) (string, error) {

--- a/core/pkg/utils/hash.go
+++ b/core/pkg/utils/hash.go
@@ -47,10 +47,8 @@ func B64ToHex(data string) (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
-func EncodeBytesAsHex(contents []byte) string {
-	return hex.EncodeToString(contents)
-}
-
+// HexToB64 converts a hexadecimal string to a base64 encoded string.
+// It returns an error if the string provided is not valid hexadecimal.
 func HexToB64(data string) (string, error) {
 	buf, err := hex.DecodeString(data)
 	if err != nil {

--- a/core/pkg/utils/hash.go
+++ b/core/pkg/utils/hash.go
@@ -8,21 +8,13 @@ import (
 	"os"
 )
 
-func ComputeB64MD5(data []byte) (string, error) {
+// ComputeB64MD5 computes the MD5 hash of the given data and returns the result as a
+// base64 encoded string.
+func ComputeB64MD5(data []byte) string {
 	hasher := md5.New()
-	_, err := hasher.Write(data)
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
-}
-
-func VerifyDataHash(data []byte, b64md5 string) bool {
-	actual, err := ComputeB64MD5(data)
-	if err != nil {
-		return false
-	}
-	return actual == b64md5
+	// hasher.Write can't fail; the returned values are just to implement io.Writer
+	_, _ = hasher.Write(data)
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 }
 
 func ComputeFileB64MD5(path string) (string, error) {

--- a/core/pkg/utils/hash.go
+++ b/core/pkg/utils/hash.go
@@ -17,13 +17,16 @@ func ComputeB64MD5(data []byte) string {
 	return base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 }
 
+// ComputeFileB64MD5 computes the MD5 hash of the file at the given path and returns the
+// result as a base64 encoded string.
+// It returns an error if the file cannot be opened or read.
 func ComputeFileB64MD5(path string) (string, error) {
-	hasher := md5.New()
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
 	defer f.Close()
+	hasher := md5.New()
 	_, err = io.Copy(hasher, f)
 	if err != nil {
 		return "", err
@@ -31,6 +34,9 @@ func ComputeFileB64MD5(path string) (string, error) {
 	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
 }
 
+// VerifyFileHash checks if file at the given path matches the MD5 hash provided as a
+// base64 encoded string. It returns true if the file is present and matches the hash,
+// false otherwise -- including if the file is missing, a directory, or can't be read.
 func VerifyFileHash(path string, b64md5 string) bool {
 	actual, err := ComputeFileB64MD5(path)
 	if err != nil {
@@ -39,6 +45,8 @@ func VerifyFileHash(path string, b64md5 string) bool {
 	return actual == b64md5
 }
 
+// B64ToHex converts a base64 encoded string to a hexadecimal string.
+// It returns an error if the string provided is not a valid base64 string.
 func B64ToHex(data string) (string, error) {
 	buf, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {

--- a/core/pkg/utils/hash_test.go
+++ b/core/pkg/utils/hash_test.go
@@ -13,8 +13,7 @@ func TestEncode(t *testing.T) {
 }
 
 func TestHexB64RoundTrip(t *testing.T) {
-	b64hash, err := ComputeB64MD5([]byte(`some data`))
-	assert.NoError(t, err)
+	b64hash := ComputeB64MD5([]byte(`some data`))
 
 	hexHash, err := B64ToHex(b64hash)
 	assert.NoError(t, err)
@@ -25,25 +24,13 @@ func TestHexB64RoundTrip(t *testing.T) {
 }
 
 func TestHashValidity(t *testing.T) {
-	b64hash, err := ComputeB64MD5([]byte(`test`))
-	assert.NoError(t, err)
+	b64hash := ComputeB64MD5([]byte(`test`))
 
 	hexHash, err := B64ToHex(b64hash)
 	assert.NoError(t, err)
 
 	// Hash according to Python's hashlib.md5(b"test").hexdigest()
 	assert.Equal(t, "098f6bcd4621d373cade4e832627b4f6", hexHash)
-}
-
-func TestVerifyDataHash(t *testing.T) {
-	b64md5, err := ComputeB64MD5([]byte(`foobar`))
-	assert.NoError(t, err)
-
-	assert.True(t, VerifyDataHash([]byte(`foobar`), b64md5))
-
-	otherB64md5, err := ComputeB64MD5([]byte(`foobar\0`))
-	assert.NoError(t, err)
-	assert.False(t, VerifyDataHash([]byte(`foobar`), otherB64md5))
 }
 
 func TestVerifyFileHash(t *testing.T) {
@@ -53,8 +40,6 @@ func TestVerifyFileHash(t *testing.T) {
 	_, err = testFile.Write([]byte(`foobar`))
 	assert.NoError(t, err)
 
-	b64md5, err := ComputeB64MD5([]byte(`foobar`))
-	assert.NoError(t, err)
-
+	b64md5 := ComputeB64MD5([]byte(`foobar`))
 	assert.True(t, VerifyFileHash(testFile.Name(), b64md5))
 }

--- a/core/pkg/utils/hash_test.go
+++ b/core/pkg/utils/hash_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,4 +10,51 @@ import (
 func TestEncode(t *testing.T) {
 	encoded := EncodeBytesAsHex([]byte(`junk`))
 	assert.Equal(t, "6a756e6b", encoded)
+}
+
+func TestHexB64RoundTrip(t *testing.T) {
+	b64hash, err := ComputeB64MD5([]byte(`some data`))
+	assert.NoError(t, err)
+
+	hexHash, err := B64ToHex(b64hash)
+	assert.NoError(t, err)
+	alsoB64, err := HexToB64(hexHash)
+	assert.NoError(t, err)
+	assert.Equal(t, b64hash, alsoB64)
+	assert.NotEqual(t, b64hash, hexHash)
+}
+
+func TestHashValidity(t *testing.T) {
+	b64hash, err := ComputeB64MD5([]byte(`test`))
+	assert.NoError(t, err)
+
+	hexHash, err := B64ToHex(b64hash)
+	assert.NoError(t, err)
+
+	// Hash according to Python's hashlib.md5(b"test").hexdigest()
+	assert.Equal(t, "098f6bcd4621d373cade4e832627b4f6", hexHash)
+}
+
+func TestVerifyDataHash(t *testing.T) {
+	b64md5, err := ComputeB64MD5([]byte(`foobar`))
+	assert.NoError(t, err)
+
+	assert.True(t, VerifyDataHash([]byte(`foobar`), b64md5))
+
+	otherB64md5, err := ComputeB64MD5([]byte(`foobar\0`))
+	assert.NoError(t, err)
+	assert.False(t, VerifyDataHash([]byte(`foobar`), otherB64md5))
+}
+
+func TestVerifyFileHash(t *testing.T) {
+	testFile, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	defer testFile.Close()
+	_, err = testFile.Write([]byte(`foobar`))
+	assert.NoError(t, err)
+
+	b64md5, err := ComputeB64MD5([]byte(`foobar`))
+	assert.NoError(t, err)
+
+	assert.True(t, VerifyFileHash(testFile.Name(), b64md5))
 }

--- a/core/pkg/utils/hash_test.go
+++ b/core/pkg/utils/hash_test.go
@@ -7,11 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEncode(t *testing.T) {
-	encoded := EncodeBytesAsHex([]byte(`junk`))
-	assert.Equal(t, "6a756e6b", encoded)
-}
-
 func TestHexB64RoundTrip(t *testing.T) {
 	b64hash := ComputeB64MD5([]byte(`some data`))
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This could be split up, but it's pretty small. This PR:
* Adds a convenience function `VerifyFileHash` that returns true/false rather than both an error and a digest to check
* Adds documentation strings for the other functions in `hash.go`
* Removes `EncodeBytesAsHex`, since it just forwards to `hex.EncodeToString`

It also removes the `err` returned by `ComputeB64MD5`, since it turns out that function can't actually fail.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Added some unit tests, both for previously existing hashing code and for the new helpers.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
