### PR TITLE
feat(core): send heartbeat to server

### DIFF
--- a/core/pkg/filestream/filestream.go
+++ b/core/pkg/filestream/filestream.go
@@ -84,6 +84,9 @@ type FileStream interface {
 
 	// SetOffsets sets the per-chunk offsets to stream to.
 	SetOffsets(offsetMap FileStreamOffsetMap)
+
+	// GetLastTransmitTime returns the last time we sent data to the server.
+	GetLastTransmitTime() time.Time
 }
 
 // fileStream is a stream of data to the server
@@ -190,6 +193,10 @@ func (fs *fileStream) SetOffsets(offsetMap FileStreamOffsetMap) {
 	for k, v := range offsetMap {
 		fs.offsetMap[k] = v
 	}
+}
+
+func (fs *fileStream) GetLastTransmitTime() time.Time {
+	return fs.lastTransmitTime
 }
 
 func (fs *fileStream) Start() {

--- a/core/pkg/filestream/filestream.go
+++ b/core/pkg/filestream/filestream.go
@@ -49,7 +49,7 @@ const (
 	defaultMaxItemsPerPush   = 5_000
 	defaultDelayProcess      = 20 * time.Millisecond
 	defaultPollInterval      = 2 * time.Second
-	defaultHeartbeatInterval = 3 * time.Second // TODO: make me 30s
+	defaultHeartbeatInterval = 30 * time.Second
 )
 
 type ChunkTypeEnum int8

--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -204,15 +204,33 @@ func TestSendHistory(t *testing.T) {
 	assert.Equal(t, num, tst.capture.m["total"].(int))
 }
 
-// func TestHeartbeat(t *testing.T) {
-// 	// num := 10
-// 	// delay := 5 * time.Millisecond
-// 	tst := NewFilestreamTest(t.Name(),
-// 		func(fs filestream.FileStream) {
-// 			fs.SetHeartbeatInterval(10 * time.Millisecond)
-// 		})
-// 	// assert.Equal(t, num, tst.capture.m["total"].(int))
-// }
+func TestHeartbeat(t *testing.T) {
+	// num := 10
+	lastTransmitTime := time.Now()
+	heartbeatInterval := 1 * time.Millisecond
+
+	tServer := NewTestServer()
+	fsParams := filestream.FileStreamParams{
+		Settings: tServer.settings,
+		Logger:   tServer.logger,
+		ApiClient: apitest.TestingClient(
+			tServer.hserver.URL,
+			api.ClientOptions{},
+		),
+		LastTransmitTime:  lastTransmitTime,
+		HeartbeatInterval: heartbeatInterval,
+	}
+
+	tst := NewFilestreamTest(
+		t.Name(),
+		tServer,
+		fsParams,
+		func(fs filestream.FileStream) {
+			time.Sleep(10 * time.Millisecond)
+		},
+	)
+	assert.NotEqual(t, lastTransmitTime, tst.fs.GetLastTransmitTime())
+}
 
 func BenchmarkHistory(b *testing.B) {
 	num := 10_000

--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -137,23 +137,22 @@ type filestreamTest struct {
 	tserver *testServer
 }
 
-func NewFilestreamTest(tName string, fn func(fs filestream.FileStream)) *filestreamTest {
-	tserver := NewTestServer()
+func NewFilestreamTest(
+	tName string,
+	tServer *testServer,
+	params filestream.FileStreamParams,
+	fn func(fs filestream.FileStream),
+) *filestreamTest {
 	m := make(map[string]interface{})
 	capture := captureState{m: m}
 	fstreamPath := "/test/" + tName
-	tserver.mux.Handle(fstreamPath, apiHandler{&capture})
-	fs := filestream.NewFileStream(
-		filestream.WithSettings(tserver.settings),
-		filestream.WithLogger(tserver.logger),
-		filestream.WithAPIClient(apitest.TestingClient(
-			tserver.hserver.URL,
-			api.ClientOptions{},
-		)),
-	)
+	tServer.mux.Handle(fstreamPath, apiHandler{&capture})
+
+	fs := filestream.NewFileStream(params)
 	fs.SetPath(fstreamPath)
 	fs.Start()
-	fsTest := filestreamTest{capture: &capture, path: fstreamPath, mux: tserver.mux, fs: fs, tserver: tserver}
+
+	fsTest := filestreamTest{capture: &capture, path: fstreamPath, mux: tServer.mux, fs: fs, tserver: tServer}
 	defer fsTest.finish()
 	fn(fsTest.fs)
 	return &fsTest
@@ -179,20 +178,59 @@ func NewHistoryRecord() *service.Record {
 func TestSendHistory(t *testing.T) {
 	num := 10
 	delay := 5 * time.Millisecond
-	tst := NewFilestreamTest(t.Name(),
+
+	tServer := NewTestServer()
+	fsParams := filestream.FileStreamParams{
+		Settings: tServer.settings,
+		Logger:   tServer.logger,
+		ApiClient: apitest.TestingClient(
+			tServer.hserver.URL,
+			api.ClientOptions{},
+		),
+	}
+
+	tst := NewFilestreamTest(
+		t.Name(),
+		tServer,
+		fsParams,
 		func(fs filestream.FileStream) {
 			msg := NewHistoryRecord()
 			for i := 0; i < num; i++ {
 				time.Sleep(delay)
 				fs.StreamRecord(msg)
 			}
-		})
+		},
+	)
 	assert.Equal(t, num, tst.capture.m["total"].(int))
 }
 
+// func TestHeartbeat(t *testing.T) {
+// 	// num := 10
+// 	// delay := 5 * time.Millisecond
+// 	tst := NewFilestreamTest(t.Name(),
+// 		func(fs filestream.FileStream) {
+// 			fs.SetHeartbeatInterval(10 * time.Millisecond)
+// 		})
+// 	// assert.Equal(t, num, tst.capture.m["total"].(int))
+// }
+
 func BenchmarkHistory(b *testing.B) {
 	num := 10_000
-	tst := NewFilestreamTest(b.Name(),
+
+	tServer := NewTestServer()
+	fsParams := filestream.FileStreamParams{
+		Settings: tServer.settings,
+		Logger:   tServer.logger,
+		ApiClient: apitest.TestingClient(
+			tServer.hserver.URL,
+			api.ClientOptions{},
+		),
+	}
+
+	tst := NewFilestreamTest(
+		b.Name(),
+		tServer,
+		fsParams,
 		func(fs filestream.FileStream) {
 			msg := NewHistoryRecord()
 			b.ResetTimer()

--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -205,7 +205,6 @@ func TestSendHistory(t *testing.T) {
 }
 
 func TestHeartbeat(t *testing.T) {
-	// num := 10
 	lastTransmitTime := time.Now()
 	heartbeatInterval := 1 * time.Millisecond
 

--- a/core/pkg/filestream/loop_transmit.go
+++ b/core/pkg/filestream/loop_transmit.go
@@ -1,7 +1,6 @@
 package filestream
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -43,13 +42,10 @@ func (fs *fileStream) loopTransmit(inChan <-chan processedChunk) {
 		}
 		data := collector.dump(fs.offsetMap)
 		timeNow := time.Now()
-		fmt.Println(timeNow, data)
-
 		if data != nil {
 			fs.send(data)
 			fs.lastTransmitTime = time.Now()
 		} else if timeNow.Sub(fs.lastTransmitTime) > fs.heartbeatInterval {
-			fmt.Println("+++++Sending heartbeat")
 			fs.send(&FsTransmitData{})
 			fs.lastTransmitTime = timeNow
 		}

--- a/core/pkg/filestream/loop_transmit_test.go
+++ b/core/pkg/filestream/loop_transmit_test.go
@@ -61,10 +61,12 @@ func testSendAndReceive(t *testing.T, chunks []processedChunk, fsd FsTransmitDat
 		DoAndReturn(requestMatch(t, fsd)).
 		AnyTimes()
 
-	fs := NewFileStream(
-		WithLogger(fsTest.logger),
-		WithAPIClient(apitest.ForwardingClient(fsTest.client)),
-	).(*fileStream)
+	params := FileStreamParams{
+		Logger:    fsTest.logger,
+		ApiClient: apitest.ForwardingClient(fsTest.client),
+	}
+
+	fs := NewFileStream(params).(*fileStream)
 	for _, d := range chunks {
 		fs.transmitChan <- d
 	}

--- a/core/pkg/filestreamtest/filestreamtest.go
+++ b/core/pkg/filestreamtest/filestreamtest.go
@@ -3,6 +3,7 @@ package filestreamtest
 import (
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/wandb/wandb/core/pkg/filestream"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -35,6 +36,10 @@ func (fs *FakeFileStream) GetFilesUploaded() []string {
 	fs.Lock()
 	defer fs.Unlock()
 	return slices.Clone(fs.filesUploaded)
+}
+
+func (fs *FakeFileStream) GetLastTransmitTime() time.Time {
+	return time.Now()
 }
 
 // Prove that we implement the interface.

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -86,12 +86,14 @@ func NewFileStream(
 		NetworkPeeker:   peeker,
 	})
 
-	return filestream.NewFileStream(
-		filestream.WithSettings(settings.Proto),
-		filestream.WithLogger(logger),
-		filestream.WithAPIClient(fileStreamRetryClient),
-		filestream.WithClientId(shared.ShortID(32)),
-	)
+	params := filestream.FileStreamParams{
+		Settings:  settings.Proto,
+		Logger:    logger,
+		ApiClient: fileStreamRetryClient,
+		ClientId:  shared.ShortID(32),
+	}
+
+	return filestream.NewFileStream(params)
 }
 
 func NewFileTransferManager(

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2394,7 +2394,7 @@ class Run:
             self._run_status_checker = RunStatusChecker(
                 interface=self._backend.interface,
             )
-            self._run_status_checker.start()
+            # self._run_status_checker.start()
 
         self._console_start()
         self._on_ready()

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2394,7 +2394,7 @@ class Run:
             self._run_status_checker = RunStatusChecker(
                 interface=self._backend.interface,
             )
-            # self._run_status_checker.start()
+            self._run_status_checker.start()
 
         self._console_start()
         self._on_ready()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18360

Send heartbeats to the server to ensure the latter never erroneously marks the run as crashed if we don't send any data for a long period of time.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
