### PR TITLE
chore(artifacts): allow updates to WANDB_CACHE_DIR during execution

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_artifact_cli.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_artifact_cli.py
@@ -42,14 +42,8 @@ def test_artifact_put_with_cache_enabled(runner, user, monkeypatch, tmp_path, ap
     monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))
     staging_dir = Path(get_staging_dir())
 
-    # Setup cache dir
-    cache_dir = Path(tmp_path / "test_artifact_put_with_cache_enabled/cache")
-    cache
-    monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
-    cache = artifact_file_cache.ArtifactFileCache(str(cache_dir / "artifacts"))
-    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
-    assert cache._cache_dir == artifact_file_cache.get_artifact_file_cache()._cache_dir
-    cache.cleanup(0)
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path))
+    cache = artifact_file_cache.get_artifact_file_cache()
 
     data_dir_path = Path(tmp_path / "data")
     data_path = Path(data_dir_path / "random.txt")
@@ -77,16 +71,11 @@ def test_artifact_put_with_cache_enabled(runner, user, monkeypatch, tmp_path, ap
 
 def test_artifact_put_with_cache_disabled(runner, user, monkeypatch, tmp_path, api):
     # Use a separate staging directory for the duration of this test.
-    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "staging"))
     staging_dir = Path(get_staging_dir())
 
-    # Setup cache dir
-    cache_dir = Path(tmp_path / "test_artifact_put_with_cache_enabled/cache")
-    monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
-    cache = artifact_file_cache.ArtifactFileCache(str(cache_dir / "artifacts"))
-    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
-    assert cache._cache_dir == artifact_file_cache.get_artifact_file_cache()._cache_dir
-    cache.cleanup(0)
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path / "cache"))
+    cache = artifact_file_cache.get_artifact_file_cache()
 
     data_dir_path = Path(tmp_path / "data")
     data_path = Path(data_dir_path / "random.txt")

--- a/tests/pytest_tests/system_tests/test_artifacts/test_artifact_cli.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_artifact_cli.py
@@ -44,6 +44,7 @@ def test_artifact_put_with_cache_enabled(runner, user, monkeypatch, tmp_path, ap
 
     # Setup cache dir
     cache_dir = Path(tmp_path / "test_artifact_put_with_cache_enabled/cache")
+    cache
     monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
     cache = artifact_file_cache.ArtifactFileCache(str(cache_dir / "artifacts"))
     monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -1533,10 +1533,8 @@ def test_manifest_json_invalid_version(version):
 @pytest.mark.flaky
 @pytest.mark.xfail(reason="flaky")
 def test_cache_cleanup_allows_upload(wandb_init, tmp_path, monkeypatch):
-    cache = artifact_file_cache.ArtifactFileCache(tmp_path)
-    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
-    assert cache == artifact_file_cache.get_artifact_file_cache()
-    cache.cleanup(0)
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path))
+    cache = artifact_file_cache.get_artifact_file_cache()
 
     artifact = wandb.Artifact(type="dataset", name="survive-cleanup")
     with open("test-file", "wb") as f:

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -240,16 +240,11 @@ def test_uploaded_artifacts_are_unstaged(wandb_init, tmp_path, monkeypatch):
 @pytest.mark.wandb_core_failure(feature="artifacts_cache")
 def test_mutable_uploads_with_cache_enabled(wandb_init, tmp_path, monkeypatch, api):
     # Use a separate staging directory for the duration of this test.
-    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "staging"))
     staging_dir = Path(get_staging_dir())
 
-    # Setup cache dir
-    cache_dir = Path(tmp_path / "test_artifact_put_with_cache_enabled/cache")
-    monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
-    cache = artifact_file_cache.ArtifactFileCache(str(cache_dir / "artifacts"))
-    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
-    assert cache._cache_dir == artifact_file_cache.get_artifact_file_cache()._cache_dir
-    cache.cleanup(0)
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path / "cache"))
+    cache = artifact_file_cache.get_artifact_file_cache()
 
     data_path = Path(tmp_path / "random.txt")
     artifact = wandb.Artifact(name="stage-test", type="dataset")
@@ -276,16 +271,11 @@ def test_mutable_uploads_with_cache_enabled(wandb_init, tmp_path, monkeypatch, a
 
 def test_mutable_uploads_with_cache_disabled(wandb_init, tmp_path, monkeypatch):
     # Use a separate staging directory for the duration of this test.
-    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "staging"))
     staging_dir = Path(get_staging_dir())
 
-    # Setup cache dir
-    cache_dir = Path(tmp_path / "test_artifact_put_with_cache_enabled/cache")
-    monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
-    cache = artifact_file_cache.ArtifactFileCache(str(cache_dir / "artifacts"))
-    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
-    assert cache._cache_dir == artifact_file_cache.get_artifact_file_cache()._cache_dir
-    cache.cleanup(0)
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path / "cache"))
+    cache = artifact_file_cache.get_artifact_file_cache()
 
     data_path = Path(tmp_path / "random.txt")
     artifact = wandb.Artifact(name="stage-test", type="dataset")
@@ -313,16 +303,11 @@ def test_mutable_uploads_with_cache_disabled(wandb_init, tmp_path, monkeypatch):
 @pytest.mark.wandb_core_failure(feature="artifacts_cache")
 def test_immutable_uploads_with_cache_enabled(wandb_init, tmp_path, monkeypatch):
     # Use a separate staging directory for the duration of this test.
-    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "staging"))
     staging_dir = Path(get_staging_dir())
 
-    # Setup cache dir
-    cache_dir = Path(tmp_path / "test_artifact_put_with_cache_enabled/cache")
-    monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
-    cache = artifact_file_cache.ArtifactFileCache(str(cache_dir / "artifacts"))
-    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
-    assert cache._cache_dir == artifact_file_cache.get_artifact_file_cache()._cache_dir
-    cache.cleanup(0)
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path / "cache"))
+    cache = artifact_file_cache.get_artifact_file_cache()
 
     data_path = Path(tmp_path / "random.txt")
     artifact = wandb.Artifact(name="stage-test", type="dataset")
@@ -344,16 +329,11 @@ def test_immutable_uploads_with_cache_enabled(wandb_init, tmp_path, monkeypatch)
 
 def test_immutable_uploads_with_cache_disabled(wandb_init, tmp_path, monkeypatch):
     # Use a separate staging directory for the duration of this test.
-    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "staging"))
     staging_dir = Path(get_staging_dir())
 
-    # Setup cache dir
-    cache_dir = Path(tmp_path / "test_artifact_put_with_cache_enabled/cache")
-    monkeypatch.setenv("WANDB_CACHE_DIR", str(cache_dir))
-    cache = artifact_file_cache.ArtifactFileCache(str(cache_dir / "artifacts"))
-    monkeypatch.setattr(artifact_file_cache, "_artifact_file_cache", cache)
-    assert cache._cache_dir == artifact_file_cache.get_artifact_file_cache()._cache_dir
-    cache.cleanup(0)
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path / "cache"))
+    cache = artifact_file_cache.get_artifact_file_cache()
 
     data_path = Path(tmp_path / "random.txt")
     artifact = wandb.Artifact(name="stage-test", type="dataset")

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -218,11 +218,12 @@ class ArtifactFileCache:
             ) from e
 
 
-_artifact_file_cache = None
+_artifact_file_cache: Optional[ArtifactFileCache] = None
 
 
 def get_artifact_file_cache() -> ArtifactFileCache:
     global _artifact_file_cache
-    if _artifact_file_cache is None:
-        _artifact_file_cache = ArtifactFileCache(env.get_cache_dir() / "artifacts")
+    cache_dir = env.get_cache_dir() / "artifacts"
+    if _artifact_file_cache is None or _artifact_file_cache._cache_dir != cache_dir:
+        _artifact_file_cache = ArtifactFileCache(cache_dir)
     return _artifact_file_cache

--- a/wandb/sdk/internal/datastore.py
+++ b/wandb/sdk/internal/datastore.py
@@ -52,7 +52,7 @@ try:
     bytes("", "ascii")
 
     def strtobytes(x):
-        """strtobytes."""
+        """Strtobytes."""
         return bytes(x, "iso8859-1")
 
     # def bytestostr(x):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This is mostly to simplify tests and remove some counter-intuitive behavior that happens when the cache is mocked out. Test changes are included.

Technically this helps with the issue brought up by [WB-18090](https://wandb.atlassian.net/browse/WB-18090) but this shouldn't be considered a supported feature--changing the cache directory mid-run isn't something that we want to encourage.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Implicitly, by the existing tests.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18090]: https://wandb.atlassian.net/browse/WB-18090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ