### PR TITLE
feat(artifacts): use the cache when downloading through wandb-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
   * The binary can be activated using `wandb.require("core")` at the start of a script
   * Eventually it will be opt-out, and at some point required as we deprecate and remove old Python code
   * Please report any issues with `pip install wandb`!
+* `wandb-core` now supports Artifact file caching by @moredatarequired in https://github.com/wandb/wandb/pull/7364
 
 ### Fixed
 

--- a/core/pkg/artifacts/downloader.go
+++ b/core/pkg/artifacts/downloader.go
@@ -3,13 +3,13 @@ package artifacts
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/gql"
-	"github.com/wandb/wandb/core/pkg/utils"
 )
 
 const BATCH_SIZE int = 10000
@@ -20,6 +20,7 @@ type ArtifactDownloader struct {
 	Ctx             context.Context
 	GraphqlClient   graphql.Client
 	DownloadManager filetransfer.FileTransferManager
+	FileCache       Cache
 	// Input
 	ArtifactID             string
 	DownloadRoot           string
@@ -38,6 +39,10 @@ func NewArtifactDownloader(
 	skipCache bool,
 	pathPrefix string,
 ) *ArtifactDownloader {
+	fileCache := NewHashOnlyCache()
+	if !skipCache {
+		fileCache = NewFileCache(UserCacheDir())
+	}
 	return &ArtifactDownloader{
 		Ctx:                    ctx,
 		GraphqlClient:          graphQLClient,
@@ -47,6 +52,7 @@ func NewArtifactDownloader(
 		AllowMissingReferences: allowMissingReferences,
 		SkipCache:              skipCache,
 		PathPrefix:             pathPrefix,
+		FileCache:              fileCache,
 	}
 }
 
@@ -141,20 +147,11 @@ func (ad *ArtifactDownloader) downloadFiles(artifactID string, manifest Manifest
 				for _, entry := range manifestEntriesBatch {
 					// Add function that returns download path?
 					downloadLocalPath := filepath.Join(ad.DownloadRoot, *entry.LocalPath)
-					// Skip downloading the file if it already exists and has the same digest.
-					exists, err := utils.FileExists(downloadLocalPath)
-					if err != nil {
-						return err
-					}
-					if exists {
-						existingDigest, err := utils.ComputeFileB64MD5(downloadLocalPath)
-						if err != nil {
-							return err
-						}
-						if existingDigest == entry.Digest {
-							numDone++
-							continue
-						}
+					// If we're skipping the cache, the HashOnlyCache still checks the destination
+					// and returns true if the file is there and has the correct hash.
+					if success := ad.FileCache.RestoreTo(entry, downloadLocalPath); success {
+						numDone++
+						continue
 					}
 					task := &filetransfer.Task{
 						FileKind: filetransfer.RunFileKindArtifact,
@@ -185,6 +182,12 @@ func (ad *ArtifactDownloader) downloadFiles(artifactID string, manifest Manifest
 					continue
 				}
 				numDone++
+				go func() {
+					err := ad.FileCache.AddFileAndCheckDigest(result.Task.Path, manifest.Contents[result.Name].Digest)
+					if err != nil {
+						slog.Error("Error adding file to cache", "err", err)
+					}
+				}()
 			}
 		}
 	}

--- a/core/pkg/artifacts/file_cache.go
+++ b/core/pkg/artifacts/file_cache.go
@@ -1,0 +1,178 @@
+package artifacts
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/wandb/wandb/core/pkg/utils"
+)
+
+const defaultDirPermissions = 0700 // read/write/execute for owner only.
+
+type Cache interface {
+	AddFile(path string) (string, error)
+	AddFileAndCheckDigest(path string, digest string) error
+	RestoreTo(entry ManifestEntry, dst string) bool
+	Write(src io.Reader) (string, error)
+}
+
+type FileCache struct {
+	root string
+}
+
+// HashOnlyCache never writes data but still computes and compares hashes.
+type HashOnlyCache struct{}
+
+func NewFileCache(cacheDir string) Cache {
+	return &FileCache{root: filepath.Join(cacheDir, "artifacts")}
+}
+
+func NewHashOnlyCache() Cache {
+	return &HashOnlyCache{}
+}
+
+// UserCacheDir returns the cache directory for the current user.
+// In order, the following are checked:
+// 1. WANDB_CACHE_DIR environment variable
+// 2. Platform-specific default home directory
+// 3. ./.wandb-cache/wandb
+func UserCacheDir() string {
+	dir, found := os.LookupEnv("WANDB_CACHE_DIR")
+	if !found {
+		userCacheDir, err := os.UserCacheDir()
+		if err != nil {
+			slog.Error("Unable to find cache directory, using .wandb-cache", "err", err)
+			return "./.wandb-cache/wandb"
+		}
+		dir = filepath.Join(userCacheDir, "wandb")
+	}
+	return dir
+}
+
+// AddFile copies a file into the cache and returns the B64MD5 cache key.
+func (c *FileCache) AddFile(path string) (string, error) {
+	return addFile(c, path)
+}
+
+// AddFile computes the base-64 MD5 hash of the file and returns it. It doesn't write.
+func (c *HashOnlyCache) AddFile(path string) (string, error) {
+	return addFile(c, path)
+}
+
+func addFile(c Cache, path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return c.Write(f)
+}
+
+// AddFileAndCheckDigest copies a file into the cache. If a digest is provided, it also
+// verifies that the file's MD5 hash matches the digest.
+func (c *FileCache) AddFileAndCheckDigest(path string, digest string) error {
+	return addFileAndCheckDigest(c, path, digest)
+}
+
+func (c *HashOnlyCache) AddFileAndCheckDigest(path string, digest string) error {
+	return addFileAndCheckDigest(c, path, digest)
+}
+
+func addFileAndCheckDigest(c Cache, path string, digest string) error {
+	b64md5, err := c.AddFile(path)
+	if err != nil {
+		return err
+	}
+	if digest != "" && digest != b64md5 {
+		return fmt.Errorf("file hash mismatch: expected %s, actual %s", digest, b64md5)
+	}
+	return nil
+}
+
+// RestoreTo tries to restore the file referenced in a manifest entry to the given destination.
+//
+// If the file exists, it will be hashed and overwritten if the hash is different; if
+// the hash is correct, RestoreTo leaves it alone and returns true.
+func (c *FileCache) RestoreTo(entry ManifestEntry, dst string) bool {
+	b64md5, err := utils.ComputeFileB64MD5(dst)
+	if err == nil && b64md5 == entry.Digest {
+		return true
+	}
+	cachePath, err := c.md5Path(entry.Digest)
+	if err != nil {
+		return false
+	}
+	// TODO (hugh): should we set the LocalPath in the entry to the dst?
+	return utils.CopyFile(cachePath, dst) == nil
+}
+
+// RestoreTo is the same as the FileCache version, but it doesn't copy the file, so it
+// always returns false if the file is missing.
+func (c *HashOnlyCache) RestoreTo(entry ManifestEntry, dst string) bool {
+	b64md5, err := utils.ComputeFileB64MD5(dst)
+	return err == nil && b64md5 == entry.Digest
+}
+
+func (c *FileCache) md5Path(b64md5 string) (string, error) {
+	hexHash, err := utils.B64ToHex(b64md5)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(c.root, "obj", "md5", hexHash[:2], hexHash[2:]), nil
+}
+
+// Write copies the contents of the reader to the cache and returns the B64MD5 cache key.
+func (c *FileCache) Write(src io.Reader) (string, error) {
+	tmpDir := filepath.Join(c.root, "tmp")
+	if err := os.MkdirAll(tmpDir, defaultDirPermissions); err != nil {
+		return "", err
+	}
+	tmpFile, err := os.CreateTemp(tmpDir, "")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	b64md5, err := copyWithHash(src, tmpFile)
+	if err != nil {
+		return "", err
+	}
+	dstPath, err := c.md5Path(b64md5)
+	if err != nil {
+		return "", err
+	}
+	if exists, _ := utils.FileExists(dstPath); exists {
+		return b64md5, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dstPath), defaultDirPermissions); err != nil {
+		return "", err
+	}
+	tmpFile.Close()
+	if err := os.Rename(tmpFile.Name(), dstPath); err != nil {
+		return "", err
+	}
+	return b64md5, nil
+}
+
+// Write computes and returns the B64MD5 cache key. It doesn't write any data.
+func (c *HashOnlyCache) Write(src io.Reader) (string, error) {
+	return copyWithHash(src, io.Discard)
+}
+
+func copyWithHash(src io.Reader, dst io.Writer) (string, error) {
+	hasher := md5.New()
+	w := io.MultiWriter(dst, hasher)
+	_, err := io.Copy(w, src)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/core/pkg/artifacts/file_cache_test.go
+++ b/core/pkg/artifacts/file_cache_test.go
@@ -1,0 +1,178 @@
+package artifacts
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/pkg/utils"
+)
+
+func setupTestEnvironment(t *testing.T) (*FileCache, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "wandb_test")
+	require.NoError(t, err)
+	os.Setenv("WANDB_CACHE_DIR", dir)
+
+	cleanup := func() {
+		os.RemoveAll(dir)
+		os.Unsetenv("WANDB_CACHE_DIR")
+	}
+
+	fc := NewFileCache(UserCacheDir())
+	require.Equal(t, fc.(*FileCache).root, filepath.Join(dir, "artifacts"))
+
+	return fc.(*FileCache), cleanup
+}
+
+func TestNewFileCache(t *testing.T) {
+	_, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+}
+
+func TestFileCache_Write(t *testing.T) {
+	cache, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Assuming Write works correctly for setup
+	data := []byte("test data")
+	expectedMd5, err := cache.Write(bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.Equal(t, utils.ComputeB64MD5(data), expectedMd5)
+
+	path, err := cache.md5Path(expectedMd5)
+	require.NoError(t, err)
+	require.NotNil(t, path)
+	exists, err := utils.FileExists(path)
+	require.NoError(t, err)
+	require.True(t, exists)
+	readData, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, data, readData)
+}
+
+func TestHashOnlyCache_Write(t *testing.T) {
+	cache := NewHashOnlyCache()
+	data := []byte("test data")
+	expectedMd5, err := cache.Write(bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.Equal(t, utils.ComputeB64MD5(data), expectedMd5)
+}
+
+func TestFileCache_AddFile(t *testing.T) {
+	cache, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	srcFile, err := os.CreateTemp("", "source")
+	require.NoError(t, err)
+	defer os.Remove(srcFile.Name())
+
+	data := []byte("test data")
+	_, err = srcFile.Write(data)
+	require.NoError(t, err)
+	srcFile.Close()
+
+	md5Hash, err := cache.AddFile(srcFile.Name())
+	require.NoError(t, err)
+	calculatedHash, err := utils.ComputeFileB64MD5(srcFile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, md5Hash, calculatedHash)
+}
+
+func TestHashOnlyCache_AddFile(t *testing.T) {
+	cache := NewHashOnlyCache()
+	_, err := cache.AddFile("test")
+	require.ErrorContains(t, err, "no such file")
+}
+
+func TestFileCache_AddFileAndCheckDigest(t *testing.T) {
+	cache, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	srcFile, err := os.CreateTemp("", "source")
+	require.NoError(t, err)
+	defer os.Remove(srcFile.Name())
+
+	data := []byte("some data")
+	calculatedHash := utils.ComputeB64MD5(data)
+	_, err = srcFile.Write(data)
+	require.NoError(t, err)
+	srcFile.Close()
+
+	err = cache.AddFileAndCheckDigest(srcFile.Name(), calculatedHash)
+	require.NoError(t, err)
+}
+
+func TestHashOnlyCache_AddFileAndCheckDigest(t *testing.T) {
+	cache := NewHashOnlyCache()
+
+	err := cache.AddFileAndCheckDigest("test", "")
+	require.ErrorContains(t, err, "no such file")
+
+	srcFile, err := os.CreateTemp("", "source")
+	require.NoError(t, err)
+	defer os.Remove(srcFile.Name())
+
+	data := []byte("some data")
+	calculatedHash := utils.ComputeB64MD5(data)
+	_, err = srcFile.Write(data)
+	require.NoError(t, err)
+	srcFile.Close()
+
+	err = cache.AddFileAndCheckDigest(srcFile.Name(), "invalid")
+	require.ErrorContains(t, err, "file hash mismatch")
+
+	err = cache.AddFileAndCheckDigest(srcFile.Name(), calculatedHash)
+	require.NoError(t, err)
+}
+
+func TestFileCache_RestoreTo(t *testing.T) {
+	cache, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Write some data to the cache
+	data := []byte("restore data")
+	cacheKey, err := cache.Write(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	rootDir := filepath.Join(os.TempDir(), "restore_root")
+	defer os.Remove(rootDir)
+	localPath := filepath.Join(rootDir, "test", "dir", "restore_target.test")
+	manifestEntry := ManifestEntry{
+		Digest: cacheKey,
+		Size:   12,
+	}
+
+	// Restore the cache file to the target path
+	assert.True(t, cache.RestoreTo(manifestEntry, localPath))
+
+	// Verify the file exists at the target path and content matches
+	restoredData, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	assert.Equal(t, data, restoredData)
+
+	// Delete the file from the cache
+	internalPath, err := cache.md5Path(cacheKey)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(internalPath))
+
+	// Restore again, and verify that it's fine despite not being in the cache.
+	assert.True(t, cache.RestoreTo(manifestEntry, localPath))
+
+	// Our HashOnlyCache should also return true, this is important.
+	noOpCache := NewHashOnlyCache()
+	assert.True(t, noOpCache.RestoreTo(manifestEntry, localPath))
+
+	// Delete the restored file
+	require.NoError(t, os.Remove(localPath))
+
+	// Now when we attempt to restore we should fail.
+	assert.False(t, cache.RestoreTo(manifestEntry, localPath))
+
+	// And if we give it an invalid manifest entry, it should fail.
+	assert.False(t, cache.RestoreTo(ManifestEntry{Digest: "invalid"}, localPath))
+}

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -215,6 +215,34 @@ def test_remove_after_log(wandb_init):
             retrieved.remove("file1.txt")
 
 
+def test_download_uses_cache(wandb_init, tmp_path, monkeypatch):
+    # Setup cache dir
+    monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path))
+    cache = artifact_file_cache.get_artifact_file_cache()
+
+    artifact = wandb.Artifact(name="cache-test", type="dataset")
+    file_path = Path(tmp_path / "text.txt")
+    with open(file_path, "w") as f:
+        f.write("test123")
+    entry = artifact.add_file(file_path, policy="immutable", skip_cache=True)
+
+    with wandb_init() as run:
+        run.log_artifact(artifact)
+    artifact.wait()
+
+    # Ensure the uploaded file is in the cache.
+    cache_path, hit, _ = cache.check_md5_obj_path(entry.digest, entry.size)
+    assert not hit
+
+    # Manually write a file into the cache path to ensure that it's the one that is used.
+    # This is kind of evil and might break if we later force cache validity.
+    Path(cache_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(cache_path, "w") as f:
+        f.write("corrupt")
+    download_root = Path(artifact.download(tmp_path / "download_root"))
+    assert (download_root / "text.txt").read_text() == "corrupt"
+
+
 def test_uploaded_artifacts_are_unstaged(wandb_init, tmp_path, monkeypatch):
     # Use a separate staging directory for the duration of this test.
     monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18294](https://wandb.atlassian.net/browse/WB-18294)

Add a file cache manager and integrated it into the wandb-core artifact downloader.

`FileCache` is a lightweight struct (it only contains a reference to the cache directory) used to centralize access.

New exported Methods (all on `FileCache`):
* `AddFile(path)`: Copies file at `path` into the cache and returns the B64MD5 digest that's used as the cache key.
* `AddFileAndCheckDigest(path, digest)`: Convenience function, same, but checks that the digest matches what's expected. Used for background adds, since it logs errors but doesn't return them.
* `RestoreTo(entry, path)`: uses the entry digest/etag to attempt to restore a cached file to given path. Succeeds without copying anything if the file is already there, overwrites it if it's missing or has the wrong content. Returns false if it can't restore for whatever reason. 
* `Write(src io.Reader)`: mostly for internal use, but makes up the bulk of the `AddFile` logic, and can be used for any reader.

Note that the API for this differs from the Python API. The Python `ArtifactFileCache` gives callers the responsibility of using the cache correctly, and exposes the internal cache paths for reading and writing; it also conflates check and add operations into a single call. The Go `FileCache` never provides direct access to internally cached items--the cache itself is responsible for reading and writing data. blobs are hashed as they are written to temp files, and then atomically renamed to match their hash, and copies are done by the user providing a destination rather than the cache providing the source.

New module: `github.com/natefinch/atomic` for cross-platform atomic renames to prevent write corruption. The code here is not terribly complicated so we could vendor it and maintain it ourselves if we wanted to minimize dependencies; the module does not appear to be actively maintained.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Adds `test_download_uses_cache` to check that files are added to the cache and that cached files are used instead of re-downloading them.

There are some disabled tests that check upload caching that also cover download; those will be re-enabled and also test this code once #7366 is merged.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18294]: https://wandb.atlassian.net/browse/WB-18294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ