### PR TITLE
feat(artifacts): cache files when uploading with wandb-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
   * The binary can be activated using `wandb.require("core")` at the start of a script
   * Eventually it will be opt-out, and at some point required as we deprecate and remove old Python code
   * Please report any issues with `pip install wandb`!
-* `wandb-core` now supports Artifact file caching by @moredatarequired in https://github.com/wandb/wandb/pull/7364
+* `wandb-core` now supports Artifact file caching by @moredatarequired in https://github.com/wandb/wandb/pull/7364 and https://github.com/wandb/wandb/pull/7366
 
 ### Fixed
 

--- a/core/pkg/artifacts/downloader.go
+++ b/core/pkg/artifacts/downloader.go
@@ -182,8 +182,9 @@ func (ad *ArtifactDownloader) downloadFiles(artifactID string, manifest Manifest
 					continue
 				}
 				numDone++
+				digest := manifest.Contents[result.Name].Digest
 				go func() {
-					err := ad.FileCache.AddFileAndCheckDigest(result.Task.Path, manifest.Contents[result.Name].Digest)
+					err := ad.FileCache.AddFileAndCheckDigest(result.Task.Path, digest)
 					if err != nil {
 						slog.Error("Error adding file to cache", "err", err)
 					}

--- a/core/pkg/artifacts/file_cache.go
+++ b/core/pkg/artifacts/file_cache.go
@@ -46,8 +46,8 @@ func UserCacheDir() string {
 	if !found {
 		userCacheDir, err := os.UserCacheDir()
 		if err != nil {
-			slog.Error("Unable to find cache directory, using .wandb-cache", "err", err)
-			return "./.wandb-cache/wandb"
+			slog.Error("Unable to find cache directory, using .wandb_cache", "err", err)
+			return ".wandb_cache/wandb"
 		}
 		dir = filepath.Join(userCacheDir, "wandb")
 	}

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -24,13 +24,16 @@ type StoragePolicyConfig struct {
 }
 
 type ManifestEntry struct {
+	// Fields from the service.ArtifactManifestEntry proto.
 	Digest          string                 `json:"digest"`
-	BirthArtifactID *string                `json:"birthArtifactID"`
 	Ref             *string                `json:"ref,omitempty"`
 	Size            int64                  `json:"size"`
-	Extra           map[string]interface{} `json:"extra,omitempty"`
 	LocalPath       *string                `json:"-"`
-	DownloadURL     *string                `json:"-"`
+	BirthArtifactID *string                `json:"birthArtifactID"`
+	SkipCache       bool                   `json:"-"`
+	Extra           map[string]interface{} `json:"extra,omitempty"`
+	// Added and used during download.
+	DownloadURL *string `json:"-"`
 }
 
 func NewManifestFromProto(proto *service.ArtifactManifest) (Manifest, error) {
@@ -54,11 +57,12 @@ func NewManifestFromProto(proto *service.ArtifactManifest) (Manifest, error) {
 		}
 		manifest.Contents[entry.Path] = ManifestEntry{
 			Digest:          entry.Digest,
-			BirthArtifactID: utils.NilIfZero(entry.BirthArtifactId),
 			Ref:             utils.NilIfZero(entry.Ref),
 			Size:            entry.Size,
-			Extra:           extra,
 			LocalPath:       utils.NilIfZero(entry.LocalPath),
+			BirthArtifactID: utils.NilIfZero(entry.BirthArtifactId),
+			SkipCache:       entry.SkipCache,
+			Extra:           extra,
 		}
 	}
 	return manifest, nil

--- a/tests/pytest_tests/system_tests/test_artifacts/test_artifact_cli.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_artifact_cli.py
@@ -2,7 +2,6 @@ import os
 import platform
 from pathlib import Path
 
-import pytest
 from wandb.cli import cli
 from wandb.sdk.artifacts import artifact_file_cache
 from wandb.sdk.artifacts.staging import get_staging_dir
@@ -36,7 +35,6 @@ def test_artifact(runner, user):
     assert os.path.exists(path)
 
 
-@pytest.mark.wandb_core_failure(feature="artifacts_cache")
 def test_artifact_put_with_cache_enabled(runner, user, monkeypatch, tmp_path, api):
     # Use a separate staging directory for the duration of this test.
     monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path))

--- a/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -266,7 +266,6 @@ def test_uploaded_artifacts_are_unstaged(wandb_init, tmp_path, monkeypatch):
     assert dir_size() == 0
 
 
-@pytest.mark.wandb_core_failure(feature="artifacts_cache")
 def test_mutable_uploads_with_cache_enabled(wandb_init, tmp_path, monkeypatch, api):
     # Use a separate staging directory for the duration of this test.
     monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "staging"))
@@ -329,7 +328,6 @@ def test_mutable_uploads_with_cache_disabled(wandb_init, tmp_path, monkeypatch):
     assert len(staging_files) == 0
 
 
-@pytest.mark.wandb_core_failure(feature="artifacts_cache")
 def test_immutable_uploads_with_cache_enabled(wandb_init, tmp_path, monkeypatch):
     # Use a separate staging directory for the duration of this test.
     monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "staging"))


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18295](https://wandb.atlassian.net/browse/WB-18295)

Cache files when uploading with `wandb-core`, unless `SkipCache` is set to true for that entry

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Removed the `wandb_core_failure` mark from tests that previously failed because they relied on the upload caching behavior of the Python core.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18295]: https://wandb.atlassian.net/browse/WB-18295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ