### PR TITLE
feat(artifacts): allow any os.PathLike as the download root

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1616,7 +1616,7 @@ class Artifact:
 
     def download(
         self,
-        root: Optional[str] = None,
+        root: Optional[StrPath] = None,
         allow_missing_references: bool = False,
         skip_cache: Optional[bool] = None,
         path_prefix: Optional[StrPath] = None,
@@ -1642,7 +1642,7 @@ class Artifact:
         """
         self._ensure_logged("download")
 
-        root = root or self._default_root()
+        root = FilePathStr(str(root or self._default_root()))
         self._add_download_root(root)
 
         if is_require_core():


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18383](https://wandb.atlassian.net/browse/WB-18383)

Support `pathlib.Path` and other `os.PathLike` objects as the download root, e.g. `Artifact.download(root=Path("test/path"))`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable

Testing
-------
Added small unit test.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18383]: https://wandb.atlassian.net/browse/WB-18383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ