### PR TITLE
chore(sdk): add space before ';' in requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -50,5 +50,5 @@ aiohttp==3.9.0b0; python_version >= '3.12'
 .[async]
 .[perf]
 .[launch]
-.[sweeps]; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
+.[sweeps] ; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 .[azure]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

`pip` doesn't care, but `uv pip` is more strict, and without this change attempting to install with `uv pip install -r requirements_dev.txt` results in:

```
error: Couldn't parse requirement in `requirements_dev.txt` at position 1265
  Caused by: Missing space before ';', the end of the URL is ambiguous
.[sweeps]; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
`uv pip install -r requirements_dev.txt` now works.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
