### PR TITLE
chore(sdk): Cache .tox in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,7 +474,7 @@ jobs:
       - install_go
       - python_venv:
           py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor>>
+          machine: <<parameters.executor.name>>
 
       # For now, this step needs to be duplicated because there's no way
       # in YAML or CircleCI's config to change just the final argument to
@@ -550,7 +550,7 @@ jobs:
       - install_go
       - python_venv:
           py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor>>
+          machine: <<parameters.executor.name>>
 
       # TODO: replace tests with pytest markers and remove the conditional
       - when:
@@ -743,7 +743,7 @@ jobs:
       - install_go
       - python_venv:
           py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor>>
+          machine: <<parameters.executor.name>>
       - run:
           name: Run tests
           no_output_timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,35 +326,22 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
-  # Sets up a Python virtualenv with requirements_dev.txt installed.
-  #
-  # This modifies $BASH_ENV such that all shells in the job use the virtual
-  # environment afterward.
-  python_venv:
+  restore_cache_tox:
     steps:
       - restore_cache:
-          name: Restore .venv
+          name: Restore .tox cache
           keys:
             # Note that virtualenvs are not portable! We include the job name
             # in the key in the hopes that it encapsulates the Python version.
             # We include the architecture (OS + processor) as well to be safe.
-            - &python-venv-cache v1-venv-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "requirements_test.txt" }}
+            - &tox-cache v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "requirements_test.txt" }}
             - v1-venv-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
-      - run:
-          name: Set up and activate venv
-          # https://discuss.circleci.com/t/activate-python-virtualenv-for-whole-job/14434
-          command: |
-            python -m venv .venv
-            echo "source .venv/bin/activate" >> $BASH_ENV
-      - run:
-          name: pip install requirements
-          command:
-            pip install -U tox nox pip
-            pip install -r requirements_dev.txt
+  save_cache_tox:
+    steps:
       - save_cache:
-          name: Save .venv
-          key: *python-venv-cache
-          paths: [.venv]
+          name: Upload .tox cache
+          key: *tox-cache
+          paths: [.tox]
 
 
 jobs:
@@ -458,7 +445,12 @@ jobs:
       - checkout
       - <<parameters.install_deps>>
       - install_go
-      - python_venv
+      - run:
+          name: Install Python dependencies
+          command: pip install -U tox nox pip
+          no_output_timeout: 5m
+
+      - restore_cache_tox
 
       # For now, this step needs to be duplicated because there's no way
       # in YAML or CircleCI's config to change just the final argument to
@@ -503,6 +495,8 @@ jobs:
                     tests/pytest_tests/unit_tests/test_reports/ \
                     tests/pytest_tests/unit_tests/test_importers/
 
+      - save_cache_tox
+
       - codecov/upload: { flags: unit, validate: false }
 
       - save-test-results
@@ -532,7 +526,12 @@ jobs:
             apt-get update
             apt-get install -y libsndfile1 ffmpeg
       - install_go
-      - python_venv
+      - run:
+          name: Install Python dependencies
+          command: pip install -U tox nox pip
+          no_output_timeout: 5m
+
+      - restore_cache_tox
 
       # TODO: replace tests with pytest markers and remove the conditional
       - when:
@@ -588,6 +587,8 @@ jobs:
                     tests/pytest_tests/system_tests/test_launch \
                     tests/pytest_tests/system_tests/test_sweep \
                     tests/pytest_tests/system_tests/test_artifacts
+
+      - save_cache_tox
 
       - codecov/upload: { flags: system, validate: false }
 
@@ -667,13 +668,18 @@ jobs:
                 command: |
                   apt-get update && apt-get install -y libsndfile1 ffmpeg
             - install_go
-            - python_venv
+            - run:
+                name: Install Python dependencies
+                command: pip install -U tox nox pip
+                no_output_timeout: 5m
+            - restore_cache_tox
             - run:
                 name: Run tests
                 no_output_timeout: 15m
                 command: |
                   CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
                   tox run -v -e << parameters.toxenv >> -- << parameters.tox_args >>
+            - save_cache_tox
             - when:
                 condition:
                   not:
@@ -721,7 +727,11 @@ jobs:
             apt-get update
             apt-get install -y libsndfile1 ffmpeg
       - install_go
-      - python_venv
+      - run:
+          name: Install Python dependencies
+          command: pip install -U tox nox pip
+          no_output_timeout: 5m
+      - restore_cache_tox
       - run:
           name: Run tests
           no_output_timeout: 10m
@@ -731,6 +741,7 @@ jobs:
               -e importer-<<parameters.tests>>-py<<parameters.python_version_major>><<parameters.python_version_minor>>  \
               -- $(if [ "<<parameters.tests>>" = "wandb" ]; then echo "--wandb-second-server=true"; fi) \
               tests/pytest_tests/system_tests/test_importers/test_<<parameters.tests>>/
+      - save_cache_tox
       - codecov/upload: { flags: system, validate: false }
       - save-test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,50 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
+  # Sets up a Python virtualenv with requirements_dev.txt installed.
+  #
+  # This modifies $BASH_ENV such that all shells in the job use the virtual
+  # environment afterward.
+  python_venv:
+    parameters:
+      py:
+        description: |
+          A string without spaces describing the Python version.
+
+          Concatenating the major and minor version is a reasonable choice.
+          Virtualenvs are not portable across versions, so this is used to
+          create different cache keys.
+        type: string
+      machine:
+        description: |
+          A string without spaces describing the platform we're running on.
+
+          The executor name or the concatenation of the OS and architecture
+          works. Virtualenvs are not portable across machines, so this is
+          used to create different cache keys.
+    steps:
+      - restore_cache:
+          name: Restore .venv
+          keys:
+            - &python-venv-cache v1-venv-<<parameters.py>>-<<parameters.machine>>-{{ checksum requirements_dev.txt }}-{{ checksum requirements_test.txt }}
+            - v1-venv-<<parameters.py>>-<<parameters.machine>>-
+      - run:
+          name: Set up and activate venv
+          # https://discuss.circleci.com/t/activate-python-virtualenv-for-whole-job/14434
+          command: |
+            python -m venv .venv
+            echo "source .venv/bin/activate" >> $BASH_ENV
+      - run:
+          name: pip install requirements
+          command:
+            pip install -U tox nox pip
+            pip install -r requirements_dev.txt
+      - save_cache:
+          name: Save .venv
+          key: *python-venv-cache
+          paths: [.venv]
+
+
 jobs:
   regression:
     parameters:
@@ -427,11 +471,9 @@ jobs:
       - checkout
       - <<parameters.install_deps>>
       - install_go
-
-      - run:
-          name: Install Python dependencies
-          command: pip install -U tox nox pip
-          no_output_timeout: 5m
+      - python_venv:
+          py: <<parameters.python_version_major>><<parameters.python_version_minor>>
+          machine: <<parameters.executor>>
 
       # For now, this step needs to be duplicated because there's no way
       # in YAML or CircleCI's config to change just the final argument to
@@ -505,10 +547,9 @@ jobs:
             apt-get update
             apt-get install -y libsndfile1 ffmpeg
       - install_go
-      - run:
-          name: Install Python dependencies
-          command: pip install -U tox nox pip
-          no_output_timeout: 5m
+      - python_venv:
+          py: <<parameters.python_version_major>><<parameters.python_version_minor>>
+          machine: <<parameters.executor>>
 
       # TODO: replace tests with pytest markers and remove the conditional
       - when:
@@ -642,12 +683,10 @@ jobs:
                 name: Install system deps
                 command: |
                   apt-get update && apt-get install -y libsndfile1 ffmpeg
-            - run:
-                name: Install python dependencies
-                command: |
-                  pip install -U tox nox pip
-                no_output_timeout: 5m
             - install_go
+            - python_venv:
+                py: <<parameters.python_version_major>><<parameters.python_version_minor>>
+                machine: tox-base
             - run:
                 name: Run tests
                 no_output_timeout: 15m
@@ -701,10 +740,9 @@ jobs:
             apt-get update
             apt-get install -y libsndfile1 ffmpeg
       - install_go
-      - run:
-          name: Install Python dependencies
-          command: pip install -U tox nox pip
-          no_output_timeout: 5m
+      - python_venv:
+          py: <<parameters.python_version_major>><<parameters.python_version_minor>>
+          machine: <<parameters.executor>>
       - run:
           name: Run tests
           no_output_timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,29 +331,15 @@ commands:
   # This modifies $BASH_ENV such that all shells in the job use the virtual
   # environment afterward.
   python_venv:
-    parameters:
-      py:
-        description: |
-          A string without spaces describing the Python version.
-
-          Concatenating the major and minor version is a reasonable choice.
-          Virtualenvs are not portable across versions, so this is used to
-          create different cache keys.
-        type: string
-      machine:
-        description: |
-          A string without spaces describing the platform we're running on.
-
-          The executor name or the concatenation of the OS and architecture
-          works. Virtualenvs are not portable across machines, so this is
-          used to create different cache keys.
-        type: string
     steps:
       - restore_cache:
           name: Restore .venv
           keys:
-            - &python-venv-cache v1-venv-<<parameters.py>>-<<parameters.machine>>-{{ checksum "requirements_dev.txt" }}-{{ checksum "requirements_test.txt" }}
-            - v1-venv-<<parameters.py>>-<<parameters.machine>>-
+            # Note that virtualenvs are not portable! We include the job name
+            # in the key in the hopes that it encapsulates the Python version.
+            # We include the architecture (OS + processor) as well to be safe.
+            - &python-venv-cache v1-venv-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "requirements_test.txt" }}
+            - v1-venv-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
       - run:
           name: Set up and activate venv
           # https://discuss.circleci.com/t/activate-python-virtualenv-for-whole-job/14434
@@ -472,9 +458,7 @@ jobs:
       - checkout
       - <<parameters.install_deps>>
       - install_go
-      - python_venv:
-          py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor>>.name
+      - python_venv
 
       # For now, this step needs to be duplicated because there's no way
       # in YAML or CircleCI's config to change just the final argument to
@@ -548,9 +532,7 @@ jobs:
             apt-get update
             apt-get install -y libsndfile1 ffmpeg
       - install_go
-      - python_venv:
-          py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor>>.name
+      - python_venv
 
       # TODO: replace tests with pytest markers and remove the conditional
       - when:
@@ -685,9 +667,7 @@ jobs:
                 command: |
                   apt-get update && apt-get install -y libsndfile1 ffmpeg
             - install_go
-            - python_venv:
-                py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-                machine: tox-base
+            - python_venv
             - run:
                 name: Run tests
                 no_output_timeout: 15m
@@ -741,9 +721,7 @@ jobs:
             apt-get update
             apt-get install -y libsndfile1 ffmpeg
       - install_go
-      - python_venv:
-          py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor>>.name
+      - python_venv
       - run:
           name: Run tests
           no_output_timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,7 +474,7 @@ jobs:
       - install_go
       - python_venv:
           py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor.name>>
+          machine: <<parameters.executor>>.name
 
       # For now, this step needs to be duplicated because there's no way
       # in YAML or CircleCI's config to change just the final argument to
@@ -550,7 +550,7 @@ jobs:
       - install_go
       - python_venv:
           py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor.name>>
+          machine: <<parameters.executor>>.name
 
       # TODO: replace tests with pytest markers and remove the conditional
       - when:
@@ -743,7 +743,7 @@ jobs:
       - install_go
       - python_venv:
           py: <<parameters.python_version_major>><<parameters.python_version_minor>>
-          machine: <<parameters.executor.name>>
+          machine: <<parameters.executor>>.name
       - run:
           name: Run tests
           no_output_timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,7 @@ commands:
             # in the key in the hopes that it encapsulates the Python version.
             # We include the architecture (OS + processor) as well to be safe.
             - &tox-cache v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "requirements_test.txt" }}
-            - v1-venv-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
+            - v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
   save_cache_tox:
     steps:
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,6 +328,9 @@ commands:
 
   restore_cache_tox:
     steps:
+      - run:
+          name: Store current date
+          command: date "+%F" > tox-cache-date.txt
       - restore_cache:
           name: Restore .tox cache
           keys:
@@ -337,7 +340,8 @@ commands:
             - &tox-cache v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{
                 checksum "requirements_dev.txt" }}-{{
                 checksum "requirements_test.txt" }}-{{
-                checksum "tox.ini" }}
+                checksum "tox.ini" }}-{{
+                checksum "tox-cache-date.txt" }}
             - v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
   save_cache_tox:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ commands:
       - restore_cache:
           name: Restore .venv
           keys:
-            - &python-venv-cache v1-venv-<<parameters.py>>-<<parameters.machine>>-{{ checksum requirements_dev.txt }}-{{ checksum requirements_test.txt }}
+            - &python-venv-cache v1-venv-<<parameters.py>>-<<parameters.machine>>-{{ checksum "requirements_dev.txt" }}-{{ checksum "requirements_test.txt" }}
             - v1-venv-<<parameters.py>>-<<parameters.machine>>-
       - run:
           name: Set up and activate venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,6 +347,7 @@ commands:
           The executor name or the concatenation of the OS and architecture
           works. Virtualenvs are not portable across machines, so this is
           used to create different cache keys.
+        type: string
     steps:
       - restore_cache:
           name: Restore .venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,11 +338,12 @@ commands:
             # in the key in the hopes that it encapsulates the Python version.
             # We include the architecture (OS + processor) as well to be safe.
             - &tox-cache v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{
+                checksum "tox-cache-date.txt" }}-{{
                 checksum "requirements_dev.txt" }}-{{
                 checksum "requirements_test.txt" }}-{{
-                checksum "tox.ini" }}-{{
+                checksum "tox.ini" }}
+            - v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{
                 checksum "tox-cache-date.txt" }}
-            - v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
   save_cache_tox:
     steps:
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,10 @@ commands:
             # Note that virtualenvs are not portable! We include the job name
             # in the key in the hopes that it encapsulates the Python version.
             # We include the architecture (OS + processor) as well to be safe.
-            - &tox-cache v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "requirements_test.txt" }}
+            - &tox-cache v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{
+                checksum "requirements_dev.txt" }}-{{
+                checksum "requirements_test.txt" }}-{{
+                checksum "tox.ini" }}
             - v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
   save_cache_tox:
     steps:


### PR DESCRIPTION
Description
---
Adds commands to save and restore the `tox` cache. This cache includes the virtualenvs created by `tox`, so it significantly speeds up the Python dependency installation step. It seems this shaves off around 4 minutes from the workflow (from ~18m to ~14m).

Different executions of _the same job_ reuse the cache if the requirements files are unchanged. Different jobs don't share caches because .venvs are not portable. The cache is invalidated if `tox.ini` changes, since envs can specify dependencies.

As an alternative, I tried updating CI to use `uv`, but it did not reduce install times by a lot (from 180s to 160s in unit-tests-linux-sdk-3-8, for example) and caused various job failures (e.g. https://app.circleci.com/pipelines/github/wandb/wandb/33297/workflows/221ead99-b9d7-4777-b63f-49bb24e4257b/jobs/1130576/parallel-runs/0/steps/0-105). It can still be a good follow-up, and it'll work together with this change.