### PR TITLE
chore(sdk): fix typos 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,7 +342,7 @@ here on every PR where this is applicable.
 ### :hammer: Fixes
 * fix(sdk): Fix logger when logging filestream exception by @KyleGoyette in https://github.com/wandb/wandb/pull/6246
 * fix(launch): use watch api to monitor launched CRDs by @bcsherma in https://github.com/wandb/wandb/pull/6226
-* fix(launch): forbid enqueing docker images without target project by @bcsherma in https://github.com/wandb/wandb/pull/6248
+* fix(launch): forbid enqueuing docker images without target project by @bcsherma in https://github.com/wandb/wandb/pull/6248
 * fix(sdk): add missing Twitter import for API users by @fdsig in https://github.com/wandb/wandb/pull/6261
 * fix(artifacts): get S3 versionIDs from directory references by @moredatarequired in https://github.com/wandb/wandb/pull/6255
 * fix(launch): make watch streams recover from connection reset by @bcsherma in https://github.com/wandb/wandb/pull/6272
@@ -414,7 +414,7 @@ here on every PR where this is applicable.
 * fix(sdk): further speed up import time by @hauntsaninja in https://github.com/wandb/wandb/pull/6032
 * fix(launch): Fix sample kubernetes agent manifest secret mount by @KyleGoyette in https://github.com/wandb/wandb/pull/6057
 * fix(nexus): rm unused import by @dmitryduev in https://github.com/wandb/wandb/pull/6085
-* fix(launch): watch to get kuberntes run statuses by @bcsherma in https://github.com/wandb/wandb/pull/6022
+* fix(launch): watch to get kubernetes run statuses by @bcsherma in https://github.com/wandb/wandb/pull/6022
 * fix(artifacts): prohibit saving artifacts to a different project than their base artifact by @moredatarequired in https://github.com/wandb/wandb/pull/6042
 * fix(artifacts): require existing artifacts to save to their source entity/project by @moredatarequired in https://github.com/wandb/wandb/pull/6034
 * fix(nexus): adjust system monitor start and stop functionality by @dmitryduev in https://github.com/wandb/wandb/pull/6087
@@ -436,7 +436,7 @@ here on every PR where this is applicable.
 ### :books: Docs
 * docs(nexus): add package level docstrings for filestream by @raubitsj in https://github.com/wandb/wandb/pull/6061
 * docs(nexus): add basic developer guide by @kptkin in https://github.com/wandb/wandb/pull/6119
-* docs(cli): Added more context for lauch job describe description. by @ngrayluna in https://github.com/wandb/wandb/pull/6193
+* docs(cli): Added more context for launch job describe description. by @ngrayluna in https://github.com/wandb/wandb/pull/6193
 ### :nail_care: Cleanup
 * style(sdk): fix to new ruff rule E721 additions by @nickpenaranda in https://github.com/wandb/wandb/pull/6102
 
@@ -980,7 +980,7 @@ here on every PR where this is applicable.
 * refactor(artifacts): use a pytest fixture for the artifact cache by @moredatarequired in https://github.com/wandb/wandb/pull/4648
 * refactor(artifacts): use ArtifactEntry directly instead of subclassing by @moredatarequired in https://github.com/wandb/wandb/pull/4649
 * refactor(artifacts): consolidate hash utilities into lib.hashutil by @moredatarequired in https://github.com/wandb/wandb/pull/4525
-* style(public-api): format public file with proper formating by @kptkin in https://github.com/wandb/wandb/pull/4697
+* style(public-api): format public file with proper formatting by @kptkin in https://github.com/wandb/wandb/pull/4697
 * chore(sdk): install tox into proper env in dev env setup tool by @dmitryduev in https://github.com/wandb/wandb/pull/4318
 * refactor(sdk): clean up the init and run logic by @kptkin in https://github.com/wandb/wandb/pull/4730
 
@@ -1847,7 +1847,7 @@ here on every PR where this is applicable.
 - Found and fixed the remaining issues causing runs to be marked crashed during outages
 - Improved performance for users of `define_metric`, pytorch-lightning, and aggressive config saving
 - Fix issue when trying to log a cuda tensor to config or summary
-- Remove dependancy on torch `backward_hooks` to compute graph
+- Remove dependency on torch `backward_hooks` to compute graph
 - Fix an issue preventing the ability to resume runs on sagemaker
 - Fix issues preventing pdb from working reliably with wandb
 - Fix deprecation warning in vendored library (user submission)
@@ -1901,7 +1901,7 @@ here on every PR where this is applicable.
 - Fix network handling issue where syncing stopped (use wandb sync to recover)
 - Fix auth problem when using sagemaker and hugginface integrations together
 - Fix handling of NaN values in tables with non floats
-- Lazy load API object to prevent unnessary file access on module load
+- Lazy load API object to prevent unnecessary file access on module load
 
 #### :nail_care: Enhancement
 
@@ -2253,7 +2253,7 @@ here on every PR where this is applicable.
 #### :bug: Bug Fix
 
 -  Fix codesaving to respect the server settings
--  Fix issue runing wandb.init() on restricted networks
+-  Fix issue running wandb.init() on restricted networks
 -  Fix issue where we were ignoring settings changes
 -  Fix artifact download issues
 
@@ -2502,7 +2502,7 @@ wandb.Api().Artifact().file()
 
 #### :bug: Bug Fix
 
--   Fix situations where uncommited data from wandb.log() is not persisted
+-   Fix situations where uncommitted data from wandb.log() is not persisted
 
 ## 0.8.27 (Feb 11, 2020)
 
@@ -2534,7 +2534,7 @@ wandb.Api().Artifact().file()
 
 #### :bug: Bug Fix
 
--   Relax version dependancy for PyYAML for users with old environments
+-   Relax version dependency for PyYAML for users with old environments
 
 ## 0.8.23 (Feb 3, 2020)
 
@@ -2585,7 +2585,7 @@ wandb.Api().Artifact().file()
 
 #### :bug: Bug Fix
 
--   Prevent sweep agent from failing continously when misconfigured
+-   Prevent sweep agent from failing continuously when misconfigured
 
 ## 0.8.19 (Dec 18, 2019)
 
@@ -2692,7 +2692,7 @@ wandb.Api().Artifact().file()
 -   wandb.config object now has a setdefaults method enabling improved sweep support
 -   Improved terminal and jupyter message incorporating :rocket: emojii!
 -   Allow wandb.watch to be called multiple times on different models
--   Improved support for watching multple tfevent files
+-   Improved support for watching multiple tfevent files
 -   Windows no longer requires `wandb run` simply run `python script_name.py`
 -   `wandb agent` now works on windows.
 -   Nice error message when wandb.log is called without a dict
@@ -2741,7 +2741,7 @@ wandb.Api().Artifact().file()
 -   New global config file in ~/.config/wandb for global settings
 -   Added tests for fastai, thanks @borisdayma
 -   Public api performance enhancements
--   Deprecated username in favor of enitity in the public api for consistency
+-   Deprecated username in favor of entity in the public api for consistency
 -   Anonymous login support enabled by default
 -   New wandb.login method to be used in jupyter enabling anonymous logins
 -   Better dependency error messages for data frames
@@ -2847,7 +2847,7 @@ wandb.Api().Artifact().file()
 
 -   WANDB_IGNORE_GLOBS is respected on the final scan of files
 -   Unified run.id, run.name, and run.notes across all apis
--   Handle funky terminal sizes when setting up our psuedo tty
+-   Handle funky terminal sizes when setting up our pseudo tty
 -   Fixed Jupyter notebook introspection logic
 -   run.summary.update() persists changes to the server
 -   tensorboard syncing is robust to invalid histograms and truncated files
@@ -2912,7 +2912,7 @@ wandb.Api().Artifact().file()
 -   wandb.Api().runs returns an iterator that's reusable
 -   WANDB_DIR within a hidden directory doesn't prevent syncing
 -   run.files() iterates over all files
--   pytorch recurssion too deep error
+-   pytorch recursion too deep error
 
 #### :nail_care: Enhancement
 
@@ -2925,7 +2925,7 @@ wandb.Api().Artifact().file()
 
 -   Better error messages on access denied
 -   Better error messages when optional packages aren't installed
--   Urls printed to the termial are url-escaped
+-   Urls printed to the terminal are url-escaped
 -   Namespaced tensorboard events work with histograms
 -   Public API now retries on failures and re-uses connection pool
 -   Catch git errors when remotes aren't pushed to origin

--- a/core/pkg/launch/job_builder.go
+++ b/core/pkg/launch/job_builder.go
@@ -732,7 +732,7 @@ func (j *JobBuilder) HandleUseArtifactRecord(record *service.Record) {
 	}
 }
 
-// Makes job input schema into a json string to be stored as artifact metdata.
+// Makes job input schema into a json string to be stored as artifact metadata.
 func (j *JobBuilder) makeJobMetadata(output *data_types.TypeRepresentation) (string, error) {
 	metadata := make(map[string]interface{})
 	input_types := make(map[string]interface{})

--- a/core/pkg/launch/job_builder_test.go
+++ b/core/pkg/launch/job_builder_test.go
@@ -601,7 +601,7 @@ func TestJobBuilderHandleUseArtifactRecord(t *testing.T) {
 		assert.Equal(t, "3.11.2", *jobBuilder.PartialJobSource.JobSourceInfo.Runtime)
 	})
 
-	t.Run("HandleUseArtifactRecord disabeld when use non partial artifact job", func(t *testing.T) {
+	t.Run("HandleUseArtifactRecord disabled when use non partial artifact job", func(t *testing.T) {
 		settings := &service.Settings{}
 		artifactRecord := &service.Record{
 			RecordType: &service.Record_UseArtifact{
@@ -722,7 +722,7 @@ func TestJobBuilderHandleUseArtifactRecord(t *testing.T) {
 func TestJobBuilderGetSourceType(t *testing.T) {
 	t.Run("GetSourceType job type specified repo", func(t *testing.T) {
 		sourceType := RepoSourceType
-		noRepoIngrediantsError := "no repo job ingredients found, but source type set to repo"
+		noRepoIngredientsError := "no repo job ingredients found, but source type set to repo"
 		commit := "1234567890"
 		remote := "example.com"
 		settings := &service.Settings{
@@ -749,7 +749,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 			{
 				metadata:           RunMetadata{},
 				expectedSourceType: nil,
-				expectedError:      &noRepoIngrediantsError,
+				expectedError:      &noRepoIngredientsError,
 			},
 		}
 		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
@@ -771,7 +771,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 
 	t.Run("GetSourceType job type specified artifact", func(t *testing.T) {
 		sourceType := ArtifactSourceType
-		noArtifactIngrediantsError := "no artifact job ingredients found, but source type set to artifact"
+		noArtifactIngredientsError := "no artifact job ingredients found, but source type set to artifact"
 		settings := &service.Settings{
 			JobSource: &wrapperspb.StringValue{
 				Value: string(sourceType),
@@ -791,7 +791,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 			{
 				metadata:           RunMetadata{},
 				expectedSourceType: nil,
-				expectedError:      &noArtifactIngrediantsError,
+				expectedError:      &noArtifactIngredientsError,
 			},
 		}
 
@@ -821,7 +821,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 	t.Run("getSourceType job type specified image", func(t *testing.T) {
 		sourceType := ImageSourceType
 		imageName := "testImage"
-		noImageIngrediantsError := "no image job ingredients found, but source type set to image"
+		noImageIngredientsError := "no image job ingredients found, but source type set to image"
 		settings := &service.Settings{
 			JobSource: &wrapperspb.StringValue{
 				Value: string(sourceType),
@@ -843,7 +843,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 			{
 				metadata:           RunMetadata{},
 				expectedSourceType: nil,
-				expectedError:      &noImageIngrediantsError,
+				expectedError:      &noImageIngredientsError,
 			},
 		}
 		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)

--- a/core/pkg/leveldb/record_internal_test.go
+++ b/core/pkg/leveldb/record_internal_test.go
@@ -558,7 +558,7 @@ func TestRecoverMultipleBlocks(t *testing.T) {
 	// Reading deeper should yield a checksum mismatch.
 	_, err = io.ReadAll(r0)
 	if err == nil {
-		t.Fatal("Exptected a checksum mismatch error, got nil")
+		t.Fatal("Expected a checksum mismatch error, got nil")
 	}
 	if !strings.Contains(err.Error(), "checksum mismatch") {
 		t.Fatalf("Unexpected error returned: %v", err)

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -1097,7 +1097,7 @@ func (h *Handler) handleRequestNetworkStatus(record *service.Record) {
 // The main entry point for partial history records.
 //
 // This collects partial history records until a full history record is
-// received. A full history record is recieved when the condition for flushing
+// received. A full history record is received when the condition for flushing
 // the history record is met. The condition for flushing the history record is
 // determined by the action in the partial history request and the step number.
 // Once a full history record is received, it is forwarded to the writer.
@@ -1291,7 +1291,7 @@ func (h *Handler) imputeStepMetric(item *service.HistoryItem) *service.HistoryIt
 // samples history items and updates the history record with the sampled values
 //
 // This function samples history items and updates the history record with the
-// sampled values. It is used to diplay a subset of the history items in the
+// sampled values. It is used to display a subset of the history items in the
 // terminal. The sampling is done using a reservoir sampling algorithm.
 func (h *Handler) handleRequestSampledHistory(record *service.Record) {
 	response := &service.Response{}

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -1073,7 +1073,7 @@ func (s *Sender) sendRequestLogArtifact(record *service.Record, msg *service.Log
 }
 
 func (s *Sender) sendRequestDownloadArtifact(record *service.Record, msg *service.DownloadArtifactRequest) {
-	// TODO: this should be handled by a separate service starup mechanism
+	// TODO: this should be handled by a separate service startup mechanism
 	s.fileTransferManager.Start()
 
 	var response service.DownloadArtifactResponse

--- a/tests/functional_tests/t0_main/cohere/t5_cohere_summarization.py
+++ b/tests/functional_tests/t0_main/cohere/t5_cohere_summarization.py
@@ -24,7 +24,7 @@ def main():
         "relative quantities of the main ingredients, notably the amount of cream. "
         "Products that do not meet the criteria to be called ice cream are sometimes labelled "
         '"frozen dairy dessert" instead. In other countries, such as Italy and Argentina, '
-        "one word is used fo\r all variants. Analogues made from dairy alternatives, "
+        "one word is used for all variants. Analogues made from dairy alternatives, "
         "such as goat's or sheep's milk, or milk substitutes "
         "(e.g., soy, cashew, coconut, almond milk or tofu), are available for those who are "
         "lactose intolerant, allergic to dairy protein or vegan."

--- a/tests/functional_tests/t0_main/keras/keras_subclassed_test_tf_2_6.yea
+++ b/tests/functional_tests/t0_main/keras/keras_subclassed_test_tf_2_6.yea
@@ -13,7 +13,7 @@ assert:
     - :wandb:runs_len: 1
     - :wandb:artifacts[model-lovely-dawn-32][type]: model
     # Test doesnt always save 2 models since it might not improve
-    # on second epoch.  When test is made more determinstic, this
+    # on second epoch.  When test is made more deterministic, this
     # should be changed back to a stricter check
     - :op:>=:
       - :wandb:artifacts[model-lovely-dawn-32][num]

--- a/tests/functional_tests/t0_main/sklearn/plot_classifier-basic.py
+++ b/tests/functional_tests/t0_main/sklearn/plot_classifier-basic.py
@@ -2,7 +2,7 @@
 """Demonstrate basic API of plot_classifier.
 
 ---
-id: 0.sklearn.plot_classifer-basic
+id: 0.sklearn.plot_classifier-basic
 tag:
   shard: sklearn
 plugin:

--- a/tests/pytest_tests/system_tests/test_core/test_system_info.py
+++ b/tests/pytest_tests/system_tests/test_core/test_system_info.py
@@ -151,7 +151,7 @@ def test_jupyter_path(meta, test_settings, mocked_ipython, git_repo):
     platform.system() == "Windows",
     reason="backend sometimes crashes on Windows in CI",
 )
-def test_commmit_hash_sent_correctly(wandb_init, git_repo):
+def test_commit_hash_sent_correctly(wandb_init, git_repo):
     # disable_git is False is by default
     # so run object should have git info
     run = wandb_init()

--- a/tests/pytest_tests/system_tests/test_core/test_wandb.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb.py
@@ -365,7 +365,7 @@ def test_log_multiple_cases_example(relay_server, wandb_init):
     assert relay.context.history["_step"].tolist() == [0, 1, 100, 101, 102]
 
 
-def test_log_step_uncommited(relay_server, wandb_init):
+def test_log_step_uncommitted(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
         run.log(dict(cool=2), step=2, commit=False)

--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_scheduler.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_scheduler.py
@@ -247,12 +247,12 @@ def test_sweep_scheduler_base_scheduler_states(
         assert _scheduler.state == SchedulerState.COMPLETED
         assert _scheduler.is_alive is False
 
-        def mock_run_raise_keyboard_interupt(*args, **kwargs):
+        def mock_run_raise_keyboard_interrupt(*args, **kwargs):
             raise KeyboardInterrupt
 
         monkeypatch.setattr(
             "wandb.sdk.launch.sweeps.scheduler.Scheduler._update_run_states",
-            mock_run_raise_keyboard_interupt,
+            mock_run_raise_keyboard_interrupt,
         )
 
         sweep_id = wandb.sweep(sweep_config, entity=_entity, project=_project)
@@ -457,7 +457,7 @@ def test_sweep_scheduler_base_add_to_launch_queue(user, sweep_config, monkeypatc
 
 @pytest.mark.parametrize("sweep_config", VALID_SWEEP_CONFIGS_MINIMAL)
 @pytest.mark.parametrize("num_workers", [1, 8])
-def test_sweep_scheduler_sweeps_stop_agent_hearbeat(
+def test_sweep_scheduler_sweeps_stop_agent_heartbeat(
     user, sweep_config, num_workers, monkeypatch
 ):
     _patch_wandb_run(monkeypatch)

--- a/tests/pytest_tests/unit_tests/test_artifacts/saved_model_constructors.py
+++ b/tests/pytest_tests/unit_tests/test_artifacts/saved_model_constructors.py
@@ -1,4 +1,4 @@
-# This file is seperated from the main test file in
+# This file is separated from the main test file in
 # order to simulate models defined in external modules.
 import pytest
 

--- a/tests/pytest_tests/unit_tests/test_import_wandb.py
+++ b/tests/pytest_tests/unit_tests/test_import_wandb.py
@@ -3,7 +3,7 @@ import sys
 
 def test_path_is_unchanged():
     # Ideally we would compare directly to the user's starting path,
-    # but that seems to be mutiliated with tox. So, we check for known
+    # but that seems to be mutilated with tox. So, we check for known
     # leaks.
     import wandb  # noqa: F401
 

--- a/tests/pytest_tests/unit_tests/test_launch/test_registry/test_ecr.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_registry/test_ecr.py
@@ -50,7 +50,7 @@ from wandb.sdk.launch.registry.elastic_container_registry import (
 def test_ecr_init(uri, account_id, region, repo_name, expected_uri):
     """This tests how we initialize the ElasticContainerRegistry.
 
-    It basically just checks that we alway set the arguments correctly.
+    It basically just checks that we always set the arguments correctly.
     """
     if expected_uri is None:
         with pytest.raises(LaunchError):

--- a/tests/pytest_tests/unit_tests/test_launch/test_registry/test_gcp_artifact_registry.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_registry/test_gcp_artifact_registry.py
@@ -52,7 +52,7 @@ def mock_gcp_artifact_registry_client(monkeypatch):
             "us-central1",
             "us-central1-docker.pkg.dev/wandb-ml/vertex-ai/wandb-ml",
         ),
-        # Fails becaues no region.
+        # Fails because no region.
         (
             None,
             "vertex-ai",

--- a/tests/pytest_tests/unit_tests/test_launch/test_runner/test_vertex.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_runner/test_vertex.py
@@ -205,7 +205,7 @@ async def test_vertex_runner_works(vertex_runner, mock_aiplatform):
     assert submitted_spec[0]["container_spec"]["image_uri"] == "test-image"
     assert submitted_spec[1]["machine_spec"]["machine_type"] == "n1-standard-8"
     assert submitted_spec[1]["replica_count"] == 1
-    # This assertion tests macro substituion of the image uri.
+    # This assertion tests macro substitution of the image uri.
     assert submitted_spec[1]["container_spec"]["image_uri"] == "test-image"
 
     submitted_run._job = MockCustomJob(["PENDING", "RUNNING", "SUCCEEDED"])

--- a/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_filesystem.py
@@ -108,7 +108,7 @@ def test_copy_or_overwrite_changed_no_copy(tmp_path):
         assert not copy2_mock.called
 
 
-def test_copy_or_overwrite_changed_overwite_different_mtime(tmp_path):
+def test_copy_or_overwrite_changed_overwrite_different_mtime(tmp_path):
     source_path = tmp_path / "new_file.txt"
     target1_path = tmp_path / "target1.txt"
     target2_path = tmp_path / "target2.txt"

--- a/tests/pytest_tests/unit_tests/test_sagemaker_config_parse.py
+++ b/tests/pytest_tests/unit_tests/test_sagemaker_config_parse.py
@@ -48,7 +48,7 @@ def test_parse_sm_config(mock_open, mock_json_load, mock_getenv, mock_path_exist
     }
     conf = parse_sm_config()
     # Setting the environment variable
-    sm_trainging_env = json.dumps(
+    sm_training_env = json.dumps(
         {
             "sagemaker_training_job_name": "2022-07-21",
             "param1": "2022-04-01",
@@ -106,7 +106,7 @@ def test_parse_sm_config(mock_open, mock_json_load, mock_getenv, mock_path_exist
     with mock.patch.dict(
         os.environ,
         {
-            "SM_TRAINING_ENV": sm_trainging_env,
+            "SM_TRAINING_ENV": sm_training_env,
         },
     ):
         # Mock  getenv to return the environment variable value

--- a/tests/pytest_tests/unit_tests_old/test_launch/test_launch_aws.py
+++ b/tests/pytest_tests/unit_tests_old/test_launch/test_launch_aws.py
@@ -393,7 +393,7 @@ async def test_no_sagemaker_resource_args(
 
 
 @pytest.mark.asyncio
-async def test_no_OuputDataConfig(
+async def test_no_OutputDataConfig(
     runner, live_mock_server, test_settings, mocked_fetchable_git_repo, monkeypatch
 ):
     mock_env = MagicMock(spec=AwsEnvironment)
@@ -416,7 +416,7 @@ async def test_no_OuputDataConfig(
         lambda *args: None,
     )
     monkeypatch.setattr(
-        "wandb.sdk.launch._launch.LAUNCH_CONFIG_FILE", "./random-nonexistant-file.yaml"
+        "wandb.sdk.launch._launch.LAUNCH_CONFIG_FILE", "./random-nonexistent-file.yaml"
     )
     monkeypatch.setattr(
         wandb.docker, "push", lambda x, y: f"The push refers to repository [{x}]"

--- a/tests/standalone_tests/point_cloud.py
+++ b/tests/standalone_tests/point_cloud.py
@@ -19,7 +19,7 @@ point_cloud_1 = np.array([[0, 0, 0, 1], [0, 0, 1, 13], [0, 1, 0, 2], [0, 1, 0, 4
 
 point_cloud_2 = np.array([[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 0]])
 
-# Generate a symetric pattern
+# Generate a symmetric pattern
 POINT_COUNT = 20000
 
 # Choose a random sample

--- a/tools/build_launch_agent.py
+++ b/tools/build_launch_agent.py
@@ -1,4 +1,4 @@
-"""Build and optinally push the launch agent image."""
+"""Build and optionally push the launch agent image."""
 
 import argparse
 import os

--- a/wandb/apis/reports/v1/_blocks.py
+++ b/wandb/apis/reports/v1/_blocks.py
@@ -1060,7 +1060,7 @@ class WeaveBlockArtifact(Block):
 
 
 class WeaveBlockArtifactVersionedFile(Block):
-    """This is a hacky solution to support the most common way of getting Weave artifact verions for now..."""
+    """This is a hacky solution to support the most common way of getting Weave artifact versions for now..."""
 
     entity: str = Attr()
     project: str = Attr()

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -191,7 +191,7 @@ class Table(Media):
     ):
         """Initializes a Table object.
 
-        The rows is availble for legacy reasons and should not be used.
+        The rows is available for legacy reasons and should not be used.
         The Table class uses data to mimic the Pandas API.
         """
         super().__init__()
@@ -280,7 +280,10 @@ class Table(Media):
             self.cast(col_name, dt, opt)
 
     def cast(self, col_name, dtype, optional=False):
-        """Casts a column to a specific data type. This can be one of the normal python classes, an internal W&B type, or an example objec, like an instance of wandb.Image or wandb.Classes.
+        """Casts a column to a specific data type.
+
+        This can be one of the normal python classes, an internal W&B type, or an
+        example object, like an instance of wandb.Image or wandb.Classes.
 
         Arguments:
             col_name: (str) - The name of the column to cast.
@@ -763,7 +766,7 @@ class Table(Media):
 
         Arguments:
             name: (str) - the unique name of the column
-            data: (list | np.array) - a column of homogenous data
+            data: (list | np.array) - a column of homogeneous data
             optional: (bool) - if null-like values are permitted
         """
         assert isinstance(name, str) and name not in self.columns

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -289,7 +289,7 @@ def image_id_from_registry(image_name: str) -> Optional[str]:
 
 
 def image_id(image_name: str) -> Optional[str]:
-    """Retreve the image id from the local docker daemon or remote registry."""
+    """Retrieve the image id from the local docker daemon or remote registry."""
     if "@sha256:" in image_name:
         return image_name
     else:

--- a/wandb/integration/huggingface/resolver.py
+++ b/wandb/integration/huggingface/resolver.py
@@ -91,8 +91,8 @@ class HuggingFacePipelineRequestResponseResolver:
 
     # TODO: This should have a dependency on PreTrainedModel. i.e. isinstance(PreTrainedModel)
     # from transformers.modeling_utils import PreTrainedModel
-    # We do not want this dependency explicity in our codebase so we make a very general assumption about
-    # the structure of the pipeline which may have unintended consequences
+    # We do not want this dependency explicitly in our codebase so we make a very general
+    # assumption about the structure of the pipeline which may have unintended consequences
     def _get_model(self, pipe) -> Optional[Any]:
         """Extracts model from the pipeline.
 

--- a/wandb/integration/keras/callbacks/metrics_logger.py
+++ b/wandb/integration/keras/callbacks/metrics_logger.py
@@ -43,7 +43,7 @@ class WandbMetricsLogger(callbacks.Callback):
             at the end of each epoch. If "batch", logs metrics at the end
             of each batch. If an integer, logs metrics at the end of that
             many batches. Defaults to "epoch".
-        initial_global_step: (int) Use this argument to correcly log the
+        initial_global_step: (int) Use this argument to correctly log the
             learning rate when you resume training from some `initial_epoch`,
             and a learning rate scheduler is used. This can be computed as
             `step_size * initial_step`. Defaults to 0.

--- a/wandb/integration/keras/keras.py
+++ b/wandb/integration/keras/keras.py
@@ -576,7 +576,7 @@ class WandbCallback(tf.keras.callbacks.Callback):
                     )
                     self._model_trained_since_last_eval = False
             except Exception as e:
-                wandb.termwarn("Error durring prediction logging for epoch: " + str(e))
+                wandb.termwarn("Error during prediction logging for epoch: " + str(e))
 
     def on_epoch_end(self, epoch, logs=None):
         if logs is None:

--- a/wandb/old/summary.py
+++ b/wandb/old/summary.py
@@ -61,7 +61,7 @@ class SummarySubDict:
         This should only be implemented by the "_root" child class.
 
         We pass the child_dict so the item can be set on it or not as
-        appropriate. Returning None for a nonexistant path wouldn't be
+        appropriate. Returning None for a nonexistent path wouldn't be
         distinguishable from that path being set to the value None.
         """
         raise NotImplementedError

--- a/wandb/plot/confusion_matrix.py
+++ b/wandb/plot/confusion_matrix.py
@@ -48,7 +48,7 @@ def confusion_matrix(
 
     assert (probs is None or preds is None) and not (
         probs is None and preds is None
-    ), "Must provide probabilties or predictions but not both to confusion matrix"
+    ), "Must provide probabilities or predictions but not both to confusion matrix"
 
     if probs is not None:
         preds = np.argmax(probs, axis=1).tolist()

--- a/wandb/plots/precision_recall.py
+++ b/wandb/plots/precision_recall.py
@@ -25,7 +25,7 @@ def precision_recall(
     Arguments:
     y_true (arr): Test set labels.
     y_probas (arr): Test set predicted probabilities.
-    labels (list): Named labels for target varible (y). Makes plots easier to
+    labels (list): Named labels for target variable (y). Makes plots easier to
       read by replacing target values with corresponding index.
       For example labels= ['dog', 'cat', 'owl'] all 0s are
       replaced by 'dog', 1s by 'cat'.

--- a/wandb/plots/roc.py
+++ b/wandb/plots/roc.py
@@ -25,7 +25,7 @@ def roc(
     Arguments:
      y_true (arr): Test set labels.
      y_probas (arr): Test set predicted probabilities.
-     labels (list): Named labels for target varible (y). Makes plots easier to
+     labels (list): Named labels for target variable (y). Makes plots easier to
                      read by replacing target values with corresponding index.
                      For example labels= ['dog', 'cat', 'owl'] all 0s are
                      replaced by 'dog', 1s by 'cat'.

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -14,7 +14,7 @@ np = get_module("numpy")  # intentionally not required
 if t.TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
 
-ConvertableToType = t.Union["Type", t.Type["Type"], type, t.Any]
+ConvertibleToType = t.Union["Type", t.Type["Type"], type, t.Any]
 
 
 class TypeRegistry:
@@ -84,7 +84,7 @@ class TypeRegistry:
         return _type.from_json(json_dict, artifact)
 
     @staticmethod
-    def type_from_dtype(dtype: ConvertableToType) -> "Type":
+    def type_from_dtype(dtype: ConvertibleToType) -> "Type":
         # The dtype is already an instance of Type
         if isinstance(dtype, Type):
             wbtype: Type = dtype
@@ -528,7 +528,7 @@ class UnionType(Type):
 
     def __init__(
         self,
-        allowed_types: t.Optional[t.Sequence[ConvertableToType]] = None,
+        allowed_types: t.Optional[t.Sequence[ConvertibleToType]] = None,
     ):
         assert allowed_types is None or (allowed_types.__class__ == list)
         if allowed_types is None:
@@ -576,7 +576,7 @@ class UnionType(Type):
         return "{}".format(" or ".join([str(t) for t in self.params["allowed_types"]]))
 
 
-def OptionalType(dtype: ConvertableToType) -> UnionType:  # noqa: N802
+def OptionalType(dtype: ConvertibleToType) -> UnionType:  # noqa: N802
     """Function that mimics the Type class API for constructing an "Optional Type".
 
     This is just a Union[wb_type, NoneType].
@@ -591,14 +591,14 @@ def OptionalType(dtype: ConvertableToType) -> UnionType:  # noqa: N802
 
 
 class ListType(Type):
-    """A list of homogenous types."""
+    """A list of homogeneous types."""
 
     name = "list"
     types: t.ClassVar[t.List[type]] = [list, tuple, set, frozenset]
 
     def __init__(
         self,
-        element_type: t.Optional[ConvertableToType] = None,
+        element_type: t.Optional[ConvertibleToType] = None,
         length: t.Optional[int] = None,
     ):
         if element_type is None:
@@ -691,7 +691,7 @@ class ListType(Type):
 
 
 class NDArrayType(Type):
-    """Represents a list of homogenous types."""
+    """Represents a list of homogeneous types."""
 
     name = "ndarray"
     types: t.ClassVar[t.List[type]] = []  # will manually add type if np is available
@@ -786,7 +786,7 @@ class TypedDictType(Type):
 
     def __init__(
         self,
-        type_map: t.Optional[t.Dict[str, ConvertableToType]] = None,
+        type_map: t.Optional[t.Dict[str, ConvertibleToType]] = None,
     ):
         if type_map is None:
             type_map = {}

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -167,7 +167,7 @@ class Image(BatchableMedia):
         self._file_type = None
 
         # Allows the user to pass an Image object as the first parameter and have a perfect copy,
-        # only overriding additional metdata passed in. If this pattern is compelling, we can generalize.
+        # only overriding additional metadata passed in. If this pattern is compelling, we can generalize.
         if isinstance(data_or_path, Image):
             self._initialize_from_wbimage(data_or_path)
         elif isinstance(data_or_path, str):

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # https://github.com/wandb/wandb/issues/3472
 #
 # Essentially, the issue is that moviepy's write_gif function fails to close
-# the open write / file descripter returned from `imageio.save`. The following
+# the open write / file descriptor returned from `imageio.save`. The following
 # function is a simplified copy of the function in the moviepy source code.
 # See https://github.com/Zulko/moviepy/blob/7e3e8bb1b739eb6d1c0784b0cb2594b587b93b39/moviepy/video/io/gif_writers.py#L428
 #

--- a/wandb/sdk/integration_utils/data_logging.py
+++ b/wandb/sdk/integration_utils/data_logging.py
@@ -78,7 +78,7 @@ class ValidationDataLogger:
                 Defaults to `"wb_validation_data"`.
             artifact_type: The artifact type to use for the validation data.
                 Defaults to `"validation_dataset"`.
-            class_labels: Optional list of lables to use in the inferred
+            class_labels: Optional list of labels to use in the inferred
                 processors. If the model's `target` or `output` is inferred to be a class,
                 we will attempt to map the class to these labels. Defaults to `None`.
             infer_missing_processors: Determines if processors are inferred if
@@ -262,7 +262,7 @@ def _infer_single_example_keyed_processor(
     ):
         np = wandb.util.get_module(
             "numpy",
-            required="Infering processors require numpy",
+            required="Inferring processors require numpy",
         )
         # Assume these are logits
         class_names = class_labels_table.get_column("label")
@@ -301,7 +301,7 @@ def _infer_single_example_keyed_processor(
     elif len(shape) == 1:
         np = wandb.util.get_module(
             "numpy",
-            required="Infering processors require numpy",
+            required="Inferring processors require numpy",
         )
         # This could be anything
         if shape[0] <= 10:
@@ -354,7 +354,7 @@ def _infer_validation_row_processor(
     input_col_name: str = "input",
     target_col_name: str = "target",
 ) -> Callable:
-    """Infers the composit processor for the validation data."""
+    """Infers the composite processor for the validation data."""
     single_processors = {}
     if isinstance(example_input, dict):
         for key in example_input:
@@ -431,7 +431,7 @@ def _infer_prediction_row_processor(
     input_col_name: str = "input",
     output_col_name: str = "output",
 ) -> Callable:
-    """Infers the composit processor for the prediction output data."""
+    """Infers the composite processor for the prediction output data."""
     single_processors = {}
 
     if isinstance(example_prediction, dict):

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -387,7 +387,7 @@ class InterfaceBase:
     def _make_partial_source_str(
         source: Any, job_info: Dict[str, Any], metadata: Dict[str, Any]
     ) -> str:
-        """Construct use_artifact.partial.source_info.sourc as str."""
+        """Construct use_artifact.partial.source_info.source as str."""
         source_type = job_info.get("source_type", "").strip()
         if source_type == "artifact":
             info_source = job_info.get("source", {})

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -276,7 +276,7 @@ class JobBuilder:
         return source, name
 
     def _make_job_name(self, input_str: str) -> str:
-        """Use job name from settings if provided, else use programatic name."""
+        """Use job name from settings if provided, else use programmatic name."""
         if self._settings.job_name:
             return self._settings.job_name
 

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -404,7 +404,7 @@ class LaunchProject:
             _logger.debug("")
             return self.docker_image
         else:
-            raise LaunchError("Unknown source type when determing image source string")
+            raise LaunchError("Unknown source type when determining image source string")
 
     def _ensure_not_docker_image_and_local_process(self) -> None:
         """Ensure that docker image is not specified with local-process resource runner.

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -404,7 +404,9 @@ class LaunchProject:
             _logger.debug("")
             return self.docker_image
         else:
-            raise LaunchError("Unknown source type when determining image source string")
+            raise LaunchError(
+                "Unknown source type when determining image source string"
+            )
 
     def _ensure_not_docker_image_and_local_process(self) -> None:
         """Ensure that docker image is not specified with local-process resource runner.

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -241,7 +241,7 @@ class LaunchAgent:
         """Determine whether a job/runSpec is a sweep scheduler."""
         if not run_spec:
             self._internal_logger.debug(
-                "Recieved runSpec in _is_scheduler_job that was empty"
+                "Received runSpec in _is_scheduler_job that was empty"
             )
 
         if run_spec.get("uri") != Scheduler.PLACEHOLDER_URI:

--- a/wandb/sdk/launch/builder/abstract.py
+++ b/wandb/sdk/launch/builder/abstract.py
@@ -35,7 +35,7 @@ class AbstractBuilder(ABC):
             verify: Whether to verify the functionality of the builder.
 
         Raises:
-            LaunchError: If the builder cannot be intialized or verified.
+            LaunchError: If the builder cannot be initialized or verified.
         """
         raise NotImplementedError
 

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -65,7 +65,7 @@ def registry_from_uri(uri: str) -> AbstractRegistry:
     it as an AWS Elastic Container Registry. If the uri contains
     `-docker.pkg.dev`, we classify it as a Google Artifact Registry.
 
-    This function will attempt to load the approriate cloud helpers for the
+    This function will attempt to load the appropriate cloud helpers for the
 
     `https://` prefix is optional for all of the above.
 

--- a/wandb/sdk/launch/builder/kaniko_builder.py
+++ b/wandb/sdk/launch/builder/kaniko_builder.py
@@ -286,7 +286,7 @@ class KanikoBuilder(AbstractBuilder):
         _, api_client = await get_kube_context_and_api_client(
             kubernetes, launch_project.resource_args
         )
-        # TODO: use same client as kuberentes_runner.py
+        # TODO: use same client as kubernetes_runner.py
         batch_v1 = client.BatchV1Api(api_client)
         core_v1 = client.CoreV1Api(api_client)
 
@@ -522,7 +522,7 @@ class KanikoBuilder(AbstractBuilder):
             volume_mounts.append(
                 {"name": "docker-config", "mountPath": "/kaniko/.docker/"}
             )
-        # Kaniko doesn't want https:// at the begining of the image tag.
+        # Kaniko doesn't want https:// at the beginning of the image tag.
         destination = image_tag
         if destination.startswith("https://"):
             destination = destination.replace("https://", "")

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -408,7 +408,7 @@ class Scheduler(ABC):
         return count
 
     def _try_load_executable(self) -> bool:
-        """Check existance of valid executable for a run.
+        """Check existence of valid executable for a run.
 
         logs and returns False when job is unreachable
         """
@@ -423,7 +423,7 @@ class Scheduler(ABC):
                 return False
             return True
         elif self._kwargs.get("image_uri"):
-            # TODO(gst): check docker existance? Use registry in launch config?
+            # TODO(gst): check docker existence? Use registry in launch config?
             return True
         else:
             return False
@@ -611,7 +611,7 @@ class Scheduler(ABC):
                     f"Failed to get runstate for run ({run_id}). Error: {traceback.format_exc()}"
                 )
                 run_state = RunState.FAILED
-            else:  # first time we get unknwon state
+            else:  # first time we get unknown state
                 run_state = RunState.UNKNOWN
         except (AttributeError, ValueError):
             wandb.termwarn(

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -59,7 +59,7 @@ class SweepScheduler(Scheduler):
         return None
 
     def _get_sweep_commands(self, worker_id: int) -> List[Dict[str, Any]]:
-        """Helper to recieve sweep command from backend."""
+        """Helper to receive sweep command from backend."""
         # AgentHeartbeat wants a Dict of runs which are running or queued
         _run_states: Dict[str, bool] = {}
         for run_id, run in self._yield_runs():

--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -217,7 +217,7 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
     flags: List[str] = []
     # (2) flags without hyphens (e.g. foo=bar)
     flags_no_hyphens: List[str] = []
-    # (3) flags with false booleans ommited  (e.g. --foo)
+    # (3) flags with false booleans omitted  (e.g. --foo)
     flags_no_booleans: List[str] = []
     # (4) flags as a dictionary (used for constructing a json)
     flags_dict: Dict[str, Any] = {}
@@ -257,7 +257,7 @@ def make_launch_sweep_entrypoint(
     """Use args dict from create_sweep_command_args to construct entrypoint.
 
     If replace is True, remove macros from entrypoint, fill them in with args
-    and then return the args in seperate return value.
+    and then return the args in separate return value.
     """
     if not command:
         return None, None

--- a/wandb/sdk/lib/import_hooks.py
+++ b/wandb/sdk/lib/import_hooks.py
@@ -143,7 +143,7 @@ class _ImportHookChainedLoader:
         # None, so handle None as well. The module may not support attribute
         # assignment, in which case we simply skip it. Note that we also deal
         # with __loader__ not existing at all. This is to future proof things
-        # due to proposal to remove the attribue as described in the GitHub
+        # due to proposal to remove the attribute as described in the GitHub
         # issue at https://github.com/python/cpython/issues/77458. Also prior
         # to Python 3.3, the __loader__ attribute was only set if a custom
         # module loader was used. It isn't clear whether the attribute still

--- a/wandb/sdk/lib/redirect.py
+++ b/wandb/sdk/lib/redirect.py
@@ -224,7 +224,7 @@ class TerminalEmulator:
     def carriage_return(self):
         self.cursor.x = 0
 
-    def cursor_postion(self, line, column):
+    def cursor_position(self, line, column):
         self.cursor.x = min(column, 1) - 1
         self.cursor.y = min(line, 1) - 1
 
@@ -393,25 +393,30 @@ class TerminalEmulator:
                         p = (int(p[0]), 1)
                     else:
                         p = (1, 1)
-                    self.cursor_postion(*p)
+                    self.cursor_position(*p)
         except Exception:
             pass
 
     def _get_line(self, n):
         line = self.buffer[n]
         line_len = self._get_line_len(n)
-        # We have to loop through each character in the line and check if foreground, background and
-        # other attributes (italics, bold, underline, etc) of the ith character are different from those of the
-        # (i-1)th character. If different, the appropriate ascii character for switching the color/attribute
-        # should be appended to the output string before appending the actual character. This loop and subsequent
-        # checks can be expensive, especially because 99% of terminal output use default colors and formatting. Even
-        # in outputs that do contain colors and styles, its unlikely that they will change on a per character basis.
+        # We have to loop through each character in the line and check if foreground,
+        # background and other attributes (italics, bold, underline, etc) of the ith
+        # character are different from those of the (i-1)th character. If different, the
+        # appropriate ascii character for switching the color/attribute should be
+        # appended to the output string before appending the actual character. This loop
+        # and subsequent checks can be expensive, especially because 99% of terminal
+        # output use default colors and formatting. Even in outputs that do contain
+        # colors and styles, its unlikely that they will change on a per character
+        # basis.
 
-        # So instead we create a character list without any ascii codes (`out`), and a list of all the foregrounds
-        # in the line (`fgs`) on which we call np.diff() and np.where() to find the indices where the foreground change,
-        # and insert the ascii characters in the output list (`out`) on those indices. All of this is the done ony if
-        # there are more than 1 foreground color in the line in the first place (`if len(set(fgs)) > 1 else None`).
-        # Same logic is repeated for background colors and other attributes.
+        # So instead we create a character list without any ascii codes (`out`), and a
+        # list of all the foregrounds in the line (`fgs`) on which we call np.diff() and
+        # np.where() to find the indices where the foreground change, and insert the
+        # ascii characters in the output list (`out`) on those indices. All of this is
+        # the done only if there are more than 1 foreground color in the line in the
+        # first place (`if len(set(fgs)) > 1 else None`). Same logic is repeated for
+        # background colors and other attributes.
 
         out = [line[i].data for i in range(line_len)]
 

--- a/wandb/sdk/lib/tracelog.py
+++ b/wandb/sdk/lib/tracelog.py
@@ -6,7 +6,7 @@ Functions:
     log_message_send    - message sent to socket
     log_message_recv    - message received from socket
     log_message_process - message processed by thread
-    log_message_link    - message linked to another mesage
+    log_message_link    - message linked to another message
     log_message_assert  - message encountered problem
 
 """

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1853,7 +1853,7 @@ class Run:
         picked up automatically.
 
         A `base_path` may be provided to control the directory structure of
-        uploaded files. It should be a prefix of `glob_str`, and the direcotry
+        uploaded files. It should be a prefix of `glob_str`, and the directory
         structure beneath it is preserved. It's best understood through
         examples:
 
@@ -3658,7 +3658,7 @@ class Run:
     # FOOTER
     # ------------------------------------------------------------------------------
     # Note: All the footer methods are static methods since we want to share the printing logic
-    # with the service execution path that doesn't have acess to the run instance
+    # with the service execution path that doesn't have access to the run instance
     @staticmethod
     def _footer(
         sampled_history: Optional["SampledHistoryResponse"] = None,

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -1,7 +1,7 @@
 #
 """Setup wandb session.
 
-This module configures a wandb session which can extend to mutiple wandb runs.
+This module configures a wandb session which can extend to multiple wandb runs.
 
 Functions:
     setup(): Configure wandb session.

--- a/wandb/sklearn/plot/classifier.py
+++ b/wandb/sklearn/plot/classifier.py
@@ -33,9 +33,9 @@ def classifier(
 
     The following plots are generated:
         feature importances, confusion matrix, summary metrics,
-        class propotions, calibration curve, roc curve, precision-recall curve.
+        class proportions, calibration curve, roc curve, precision-recall curve.
 
-    Should only be called with a fitted classifer (otherwise an error is thrown).
+    Should only be called with a fitted classifier (otherwise an error is thrown).
 
     Arguments:
         model: (classifier) Takes in a fitted classifier.
@@ -45,7 +45,7 @@ def classifier(
         y_test: (arr) Test set labels.
         y_pred: (arr) Test set predictions by the model passed.
         y_probas: (arr) Test set predicted probabilities by the model passed.
-        labels: (list) Named labels for target varible (y). Makes plots easier to
+        labels: (list) Named labels for target variable (y). Makes plots easier to
                         read by replacing target values with corresponding index.
                         For example if `labels=['dog', 'cat', 'owl']` all 0s are
                         replaced by dog, 1s by cat.
@@ -225,7 +225,7 @@ def feature_importances(
 ):
     """Log a plot depicting the relative importance of each feature for a classifier's decisions.
 
-    Should only be called with a fitted classifer (otherwise an error is thrown).
+    Should only be called with a fitted classifier (otherwise an error is thrown).
     Only works with classifiers that have a feature_importances_ attribute, like trees.
 
     Arguments:
@@ -252,7 +252,7 @@ def feature_importances(
 
 
 def class_proportions(y_train=None, y_test=None, labels=None):
-    """Plot the distribution of target classses in training and test sets.
+    """Plot the distribution of target classes in training and test sets.
 
     Useful for detecting imbalanced classes.
 
@@ -296,7 +296,7 @@ def calibration_curve(clf=None, X=None, y=None, clf_name="Classifier"):
     if so which calibration (sigmoid or isotonic) might help fix this.
     For more details, see https://scikit-learn.org/stable/auto_examples/calibration/plot_calibration_curve.html.
 
-    Should only be called with a fitted classifer (otherwise an error is thrown).
+    Should only be called with a fitted classifier (otherwise an error is thrown).
 
     Please note this function fits variations of the model on the training set when called.
 

--- a/wandb/sklearn/plot/clusterer.py
+++ b/wandb/sklearn/plot/clusterer.py
@@ -25,7 +25,7 @@ def clusterer(model, X_train, cluster_labels, labels=None, model_name="Clusterer
         X_train: (arr) Training set features.
         cluster_labels: (list) Names for cluster labels. Makes plots easier to read
                             by replacing cluster indexes with corresponding names.
-        labels: (list) Named labels for target varible (y). Makes plots easier to
+        labels: (list) Named labels for target variable (y). Makes plots easier to
                         read by replacing target values with corresponding index.
                         For example if `labels=['dog', 'cat', 'owl']` all 0s are
                         replaced by dog, 1s by cat.

--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -20,7 +20,7 @@ Example:
     tuner = wandb.controller()
     tuner.configure(sweep_config)
     tuner.create()
-    # (3) create by constructing progamatic sweep configuration
+    # (3) create by constructing programmatic sweep configuration
     tuner = wandb.controller()
     tuner.configure_search('random')
     tuner.configure_program('train-dummy.py')
@@ -127,7 +127,7 @@ class _WandbController:
     """
 
     def __init__(self, sweep_id_or_config=None, entity=None, project=None):
-        # sweep id configured in constuctor
+        # sweep id configured in constructor
         self._sweep_id: Optional[str] = None
 
         # configured parameters


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

I was playing with [typos](https://github.com/crate-ci/typos), and I would have liked to be able to just add it to our pre-commit but it still has too many false positives, and this was more manual work than I'd like it to be.

None of these changes should affect our API or user-facing surface, or cause any backward incompatibility in tests. I intentionally avoided fixing typos that were used as dict keys or values in places where another tool might read them, or they might need to match with some golden master. The large majority of fixes are in comments or docstrings; some are in error messages, and only a very few are function or variable names, and only where the use of the variable/function was quite restricted.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
CI only

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
