### PR TITLE
chore(sdk): Replace install_command in tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,9 @@ envlist=greet
 [testenv]
 package=wheel
 wheel_build_env=.pkg
+setenv=
+    PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
+    PIP_TIMEOUT=600
 
 [testenv:.pkg]
 setenv=
@@ -71,9 +74,6 @@ passenv=
     CI_PYTEST_SPLIT_ARGS
 
 [testenv:{,core-}{,notebooks-,importer-wandb-,importer-mlflow-}py{37,38,39,310,311,312}]
-install_command=
-    ; pytorch installations on non-darwin need the `-f`
-    pip install --timeout 600 --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     {[base]deps}
     !py37-!mlflow: .[reports]
@@ -120,7 +120,6 @@ commands=
     pytest tests/release_tests/test_launch/ {posargs}
 
 [testenv:func-{,core-}{base-,mitm-,docs-}py{37,38,39,310,311,312}]
-install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps =
     yea-wandb=={env:YEA_WANDB_VERSION}
     core: wheel
@@ -154,7 +153,6 @@ commands_post=
 
 
 [testenv:func-{llm,kfp}-py{37,38,39,310,311,312}]
-install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     yea-wandb=={env:YEA_WANDB_VERSION}
 setenv=
@@ -179,7 +177,6 @@ commands=
     kfp: yea {env:CI_PYTEST_SPLIT_ARGS:} --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard kfp run {posargs:--all}
 
 [testenv:standalone-{local,cpu,gpu,tpu}-py{37,38,39,310,311,312}]
-install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 setenv=
     {[base]setenv}
     YEACOV_SOURCE={envsitepackagesdir}/wandb/
@@ -209,7 +206,6 @@ commands=
     local: yea --debug --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}
 
 [testenv:regression-{yolov5,huggingface,keras,tensorflow,pytorch,wandb-sdk-standalone,wandb-sdk-examples,wandb-sdk-other,s3,sagemaker}-py{37,38,39,310,311,312}]
-install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 deps=
     pyyaml
     six
@@ -241,7 +237,6 @@ commands=
     s3: env bash -c "./wandb-testing/regression/do-s3-regression.sh tests/s3-beta/ {posargs}"
 
 [testenv:executor-{pex,uwsgi,gunicorn}]
-install_command=pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 basepython=python3.9
 deps=
     {uwsgi,gunicorn}: flask


### PR DESCRIPTION
Description
---
Replaces the `install_command` setting by environment variables that pip knows. This makes it easier to use our `tox` with `uv`.

https://pip.pypa.io/en/stable/topics/configuration/#environment-variables
