### PR TITLE
refactor(artifacts): add `md5_bytes` to hashutil.py to directly hash bytes objects

### DIFF
--- a/wandb/sdk/lib/hashutil.py
+++ b/wandb/sdk/lib/hashutil.py
@@ -21,8 +21,12 @@ def _md5(data: bytes = b"") -> "hashlib._Hash":
         return hashlib.md5(data)
 
 
+def md5_bytes(data: bytes) -> B64MD5:
+    return _b64_from_hasher(_md5(data))
+
+
 def md5_string(string: str) -> B64MD5:
-    return _b64_from_hasher(_md5(string.encode("utf-8")))
+    return md5_bytes(string.encode("utf-8"))
 
 
 def _b64_from_hasher(hasher: "hashlib._Hash") -> B64MD5:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Useful in a child PR, fairly trivial change.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Since the new function is used by `md5_string`, it's implicitly tested by all our unit tests.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
