### PR TITLE
chore(sdk): Don't discriminate between unit_tests subdirectories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,32 @@ commands:
           environment:
             GKE_CLUSTER_NAME: << parameters.cluster >>
 
+  restore_cache_tox:
+    steps:
+      - run:
+          name: Store current date
+          command: date "+%F" > tox-cache-date.txt
+      - restore_cache:
+          name: Restore .tox cache
+          keys:
+            # Note that virtualenvs are not portable! We include the job name
+            # in the key in the hopes that it encapsulates the Python version.
+            # We include the architecture (OS + processor) as well to be safe.
+            - &tox-cache v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{
+                checksum "tox-cache-date.txt" }}-{{
+                checksum "requirements_dev.txt" }}-{{
+                checksum "requirements_test.txt" }}-{{
+                checksum "tox.ini" }}
+            - v1-tox-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{
+                checksum "tox-cache-date.txt" }}
+  save_cache_tox:
+    steps:
+      - save_cache:
+          name: Upload .tox cache
+          key: *tox-cache
+          paths: [.tox]
+
+
 jobs:
   regression:
     parameters:
@@ -427,11 +453,12 @@ jobs:
       - checkout
       - <<parameters.install_deps>>
       - install_go
-
       - run:
           name: Install Python dependencies
           command: pip install -U tox nox pip
           no_output_timeout: 5m
+
+      - restore_cache_tox
 
       # For now, this step needs to be duplicated because there's no way
       # in YAML or CircleCI's config to change just the final argument to
@@ -476,6 +503,8 @@ jobs:
                     tests/pytest_tests/unit_tests/test_reports/ \
                     tests/pytest_tests/unit_tests/test_importers/
 
+      - save_cache_tox
+
       - codecov/upload: { flags: unit, validate: false }
 
       - save-test-results
@@ -509,6 +538,8 @@ jobs:
           name: Install Python dependencies
           command: pip install -U tox nox pip
           no_output_timeout: 5m
+
+      - restore_cache_tox
 
       # TODO: replace tests with pytest markers and remove the conditional
       - when:
@@ -564,6 +595,8 @@ jobs:
                     tests/pytest_tests/system_tests/test_launch \
                     tests/pytest_tests/system_tests/test_sweep \
                     tests/pytest_tests/system_tests/test_artifacts
+
+      - save_cache_tox
 
       - codecov/upload: { flags: system, validate: false }
 
@@ -642,18 +675,19 @@ jobs:
                 name: Install system deps
                 command: |
                   apt-get update && apt-get install -y libsndfile1 ffmpeg
-            - run:
-                name: Install python dependencies
-                command: |
-                  pip install -U tox nox pip
-                no_output_timeout: 5m
             - install_go
+            - run:
+                name: Install Python dependencies
+                command: pip install -U tox nox pip
+                no_output_timeout: 5m
+            - restore_cache_tox
             - run:
                 name: Run tests
                 no_output_timeout: 15m
                 command: |
                   CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" \
                   tox run -v -e << parameters.toxenv >> -- << parameters.tox_args >>
+            - save_cache_tox
             - when:
                 condition:
                   not:
@@ -705,6 +739,7 @@ jobs:
           name: Install Python dependencies
           command: pip install -U tox nox pip
           no_output_timeout: 5m
+      - restore_cache_tox
       - run:
           name: Run tests
           no_output_timeout: 10m
@@ -714,6 +749,7 @@ jobs:
               -e importer-<<parameters.tests>>-py<<parameters.python_version_major>><<parameters.python_version_minor>>  \
               -- $(if [ "<<parameters.tests>>" = "wandb" ]; then echo "--wandb-second-server=true"; fi) \
               tests/pytest_tests/system_tests/test_importers/test_<<parameters.tests>>/
+      - save_cache_tox
       - codecov/upload: { flags: system, validate: false }
       - save-test-results
 

--- a/core/hatch.py
+++ b/core/hatch.py
@@ -33,12 +33,12 @@ def build_wandb_core(
     # paths relative to ./core
     subprocess.check_call(
         [
-            go_binary,
+            str(go_binary),
             "build",
             *coverage_flags,
             *ld_flags,
             *output_flags,
-            pathlib.Path("cmd", "wandb-core", "main.go"),
+            str(pathlib.Path("cmd", "wandb-core", "main.go")),
         ],
         cwd="./core",
         env=_go_env(),

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,6 @@ deps=
     {[base]deps}
 setenv=
     {[base]setenv}
-    .[reports]   ; for test-reports
     polyfactory  ; for test-reports
     core: WANDB__REQUIRE_CORE=true
     core: GOCOVERDIR={tox_root}/.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -77,9 +77,10 @@ passenv=
 [testenv:unit-tests-{,core-}py{37,38,39,310,311,312}]
 deps=
     {[base]deps}
+    .[reports]  # for test-reports
+    polyfactory # for test-reports
 setenv=
     {[base]setenv}
-    polyfactory  ; for test-reports
     core: WANDB__REQUIRE_CORE=true
     core: GOCOVERDIR={tox_root}/.coverage
 passenv=


### PR DESCRIPTION
Description
---

Instead of selecting test directories through positional arguments to `tox`, start creating separate `tox` environments for different directories. This will allow us to better manage test dependencies by grouping tests with similar requirements in different directories.

This starts by adding the `unit-tests-...` environment. The `unit-tests-{macos,linux}-{sdk,other}-<py>` jobs are now `unit-tests-{macos,linux}-<py>`. As a nice side effect, the CircleCI config is a little shorter!

All tests generally succeed now, so we no longer need to separate them into different jobs. If any tests are flaky or slow, we should fix them or move them to other folders.