### PR TITLE
fix(sdk): Don't resolve() globs on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1701,12 +1701,13 @@ workflows:
                     python@<<matrix.python_version_major>>.<<matrix.python_version_minor>>
 
       - win:
-          filters:
-            branches:
-              only:
-                # - main
-                - /^release-.*/
-                - /^.*-ci-win$/
+          # DO NOT MERGE!!! Uncomment before merging.
+          # filters:
+          #   branches:
+          #     only:
+          #       # - main
+          #       - /^release-.*/
+          #       - /^.*-ci-win$/
           matrix:
             parameters:
               python_version_major: [3]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1701,13 +1701,12 @@ workflows:
                     python@<<matrix.python_version_major>>.<<matrix.python_version_minor>>
 
       - win:
-          # DO NOT MERGE!!! Uncomment before merging.
-          # filters:
-          #   branches:
-          #     only:
-          #       # - main
-          #       - /^release-.*/
-          #       - /^.*-ci-win$/
+          filters:
+            branches:
+              only:
+                # - main
+                - /^release-.*/
+                - /^.*-ci-win$/
           matrix:
             parameters:
               python_version_major: [3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ here on every PR where this is applicable.
 
 * Correctly report file upload errors when using wandb-core by @moredatarequired in https://github.com/wandb/wandb/pull/7196
 * Implemented a stricter check for AMD GPU availability by @dmitryduev in https://github.com/wandb/wandb/pull/7322
+* Fixed `run.save()` on Windows by @timoffex in https://github.com/wandb/wandb/pull/7412
 
 ### Changed
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1911,6 +1911,9 @@ class Run:
             # Provide a better error message for a common misuse.
             wandb.termlog(f"{glob_str} is a cloud storage url, can't save file to W&B.")
             return []
+        # NOTE: We use PurePath instead of Path because WindowsPath doesn't
+        # like asterisks and errors out in resolve(). It also makes logical
+        # sense: globs aren't real paths, they're just path-like strings.
         glob_path = pathlib.PurePath(glob_str)
         resolved_glob_path = pathlib.PurePath(os.path.abspath(glob_path))
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1911,7 +1911,8 @@ class Run:
             # Provide a better error message for a common misuse.
             wandb.termlog(f"{glob_str} is a cloud storage url, can't save file to W&B.")
             return []
-        glob_path = pathlib.Path(glob_str)
+        glob_path = pathlib.PurePath(glob_str)
+        resolved_glob_path = pathlib.PurePath(os.path.abspath(glob_path))
 
         if base_path is not None:
             base_path = pathlib.Path(base_path)
@@ -1925,15 +1926,14 @@ class Run:
                 'wandb.save("/mnt/folder/file.h5", base_path="/mnt")',
                 repeat=False,
             )
-            base_path = glob_path.resolve().parent.parent
+            base_path = resolved_glob_path.parent.parent
 
         if policy not in ("live", "end", "now"):
             raise ValueError(
                 'Only "live", "end" and "now" policies are currently supported.'
             )
 
-        resolved_glob_path = glob_path.resolve()
-        resolved_base_path = base_path.resolve()
+        resolved_base_path = pathlib.PurePath(os.path.abspath(base_path))
 
         return self._save(
             resolved_glob_path,
@@ -1943,8 +1943,8 @@ class Run:
 
     def _save(
         self,
-        glob_path: pathlib.Path,
-        base_path: pathlib.Path,
+        glob_path: pathlib.PurePath,
+        base_path: pathlib.PurePath,
         policy: "PolicyName",
     ) -> List[str]:
         # Can't use is_relative_to() because that's added in Python 3.9,


### PR DESCRIPTION
Description
---

Fixes WB-18412. Tested by temporarily enabling Windows unit tests to run for this PR: https://app.circleci.com/pipelines/github/wandb/wandb/33397/workflows/60292dc6-9104-4439-852a-cfe3fdd96c86/jobs/1135123/steps

The resolve() implementation of the WindowsPath subclass of Path doesn't like asterisks.
