### PR TITLE
chore(sdk): migrate from appdirs (deprecated) to platformdirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "protobuf>=3.19.0,!=4.21.0,<5; sys_platform != 'linux'",
     "PyYAML",
     "setproctitle",
-    "appdirs>=1.4.3",
+    "platformdirs",
     "typing_extensions; python_version < '3.10'",
 ]
 classifiers = [

--- a/tests/standalone_tests/executor_tests/requirements.txt
+++ b/tests/standalone_tests/executor_tests/requirements.txt
@@ -12,6 +12,5 @@ PyYAML
 setproctitle
 setuptools
 platformdirs
-dataclasses; python_version < '3.7'
 typing_extensions; python_version < '3.10'
 

--- a/tests/standalone_tests/executor_tests/requirements.txt
+++ b/tests/standalone_tests/executor_tests/requirements.txt
@@ -11,6 +11,7 @@ protobuf>=3.19.0,!=4.21.0,<5; sys_platform != 'linux'
 PyYAML
 setproctitle
 setuptools
-appdirs>=1.4.3
+platformdirs
 dataclasses; python_version < '3.7'
 typing_extensions; python_version < '3.10'
+

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 from typing import List, MutableMapping, Optional, Union
 
-import appdirs  # type: ignore
+import platformdirs  # type: ignore
 
 Env = Optional[MutableMapping]
 
@@ -385,7 +385,7 @@ def get_magic(
 
 
 def get_data_dir(env: Optional[Env] = None) -> str:
-    default_dir = appdirs.user_data_dir("wandb")
+    default_dir = platformdirs.user_data_dir("wandb")
     if env is None:
         env = os.environ
     val = env.get(DATA_DIR, default_dir)
@@ -410,7 +410,7 @@ def get_artifact_fetch_file_url_batch_size(env: Optional[Env] = None) -> int:
 
 def get_cache_dir(env: Optional[Env] = None) -> Path:
     env = env or os.environ
-    return Path(env.get(CACHE_DIR, appdirs.user_cache_dir("wandb")))
+    return Path(env.get(CACHE_DIR, platformdirs.user_cache_dir("wandb")))
 
 
 def get_use_v1_artifacts(env: Optional[Env] = None) -> bool:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes #7409 

`appdirs` is no longer maintained; this moves to `platformdirs`, an actively maintained fork.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
