### PR TITLE
ci(sdk): increase sleep time before installing from TestPyPI

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -222,7 +222,7 @@ jobs:
           python-version: "3.10"
       - name: Install wandb from TestPyPI
         run: |
-          sleep 30
+          sleep 60
           python -m pip install --upgrade pip
           python -m pip install --extra-index-url https://test.pypi.org/simple/ wandb==${{ github.event.inputs.version }}
       - name: Smoke-test wandb TestPyPI install


### PR DESCRIPTION
Description
-----------

What does the PR do? Include a concise description of the PR contents.

Increase sleep time in the release action for TestPyPI to make sure the package is uploaded, we saw that 30 sec wasn't enough. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
