### PR TITLE
refactor(core): create common PathTree struct and use  in RunConfig

### DIFF
--- a/core/internal/paththree/pathtree.go
+++ b/core/internal/paththree/pathtree.go
@@ -1,0 +1,281 @@
+package pathtree
+
+import (
+	"fmt"
+
+	"github.com/segmentio/encoding/json"
+	"gopkg.in/yaml.v3"
+)
+
+// Generic item which works with config, summary, and history
+type item interface {
+	GetKey() string
+	GetNestedKey() []string
+	GetValueJson() string
+}
+
+// TreeData is an internal representation for a nested key-value pair.
+type TreeData = map[string]interface{}
+
+// A key path determining a node in the tree.
+type TreePath []string
+
+// PathTree is used to represent a nested key-value pair object,
+// such as Run config or summary.
+type PathTree[I item] struct {
+	// The underlying configuration tree.
+	//
+	// Nodes are strings and leaves are types supported by JSON,
+	// such as primitives and lists.
+	tree TreeData
+}
+
+type Format int
+
+const (
+	FormatYaml Format = iota
+	FormatJson
+)
+
+func New[I item]() *PathTree[I] {
+	return &PathTree[I]{make(TreeData)}
+}
+
+func NewFrom[I item](tree TreeData) *PathTree[I] {
+	return &PathTree[I]{tree}
+}
+
+// Returns the underlying config tree.
+//
+// Provided temporarily as part of a refactor. Avoid using this, especially
+// mutating it.
+func (pathTree *PathTree[I]) Tree() TreeData {
+	return pathTree.tree
+}
+
+// Makes and returns a deep copy of the underlying tree.
+func (pathTree *PathTree[I]) CloneTree() (TreeData, error) {
+	clone, err := DeepCopy(pathTree.tree)
+	if err != nil {
+		return nil, err
+	}
+	return clone, nil
+}
+
+// Updates and/or removes values from the tree.
+//
+// Does a best-effort job to apply all changes. Errors are passed to `onError`
+// and skipped.
+func (pathTree *PathTree[I]) ApplyUpdate(
+	update []I,
+	onError func(error),
+) {
+	for _, val := range update {
+		path := keyPath(val)
+
+		var value interface{}
+		if err := json.Unmarshal(
+			[]byte(val.GetValueJson()),
+			&value,
+		); err != nil {
+			onError(
+				fmt.Errorf(
+					"config: failed to unmarshal JSON for config key %v: %v",
+					path,
+					err,
+				),
+			)
+			continue
+		}
+
+		if err := updateAtPath(pathTree.tree, path, value); err != nil {
+			onError(err)
+			continue
+		}
+	}
+}
+
+func (pathTree *PathTree[I]) ApplyRemove(
+	remove []I,
+	onError func(error),
+) {
+	for _, val := range remove {
+		pathTree.removeAtPath(keyPath(val))
+	}
+}
+
+// Serializes the object to send to the backend.
+func (pathTree *PathTree[I]) Serialize(format Format, postProcessFunc func(any) any) ([]byte, error) {
+	// A configuration dict in the format expected by the backend.
+	serialized := make(map[string]any)
+	for treeKey, treeValue := range pathTree.tree {
+		serialized[treeKey] = postProcessFunc(treeValue)
+	}
+
+	switch format {
+	case FormatYaml:
+		return yaml.Marshal(serialized)
+	case FormatJson:
+		return json.Marshal(serialized)
+	}
+
+	return nil, fmt.Errorf("config: unknown format: %v", format)
+}
+
+type Leaf struct {
+	Key   []string
+	Value any
+}
+
+func Flatten(tree TreeData, leaves []Leaf, path []string) []Leaf {
+	// Iterate over each key-value pair in the map
+	for treeKey, treeValue := range tree {
+		// Make a copy of the path slice and append the current key to the new slice
+		newPath := make([]string, len(path))
+		copy(newPath, path)
+		newPath = append(newPath, treeKey)
+
+		// Check if the value is another TreeData (map). If so, call Flatten recursively
+		if subTree, ok := treeValue.(TreeData); ok {
+			leaves = Flatten(subTree, leaves, newPath) // Use the copied and updated newPath
+		} else {
+			// If value is not a TreeData, add it to the leaves slice with the current path
+			leaves = append(leaves, Leaf{
+				Key:   newPath, // Use the copied and updated newPath
+				Value: treeValue,
+			})
+		}
+	}
+
+	return leaves
+}
+
+// Uses the given subtree for keys that aren't already set.
+func (runConfig *PathTree[I]) AddUnsetKeysFromSubtree(
+	tree TreeData,
+	path TreePath,
+) error {
+	oldSubtree := getSubtree(tree, path)
+	if oldSubtree == nil {
+		return nil
+	}
+
+	newSubtree, err := getOrMakeSubtree(runConfig.tree, path)
+	if err != nil {
+		return err
+	}
+
+	for key, value := range oldSubtree {
+		if _, exists := newSubtree[key]; !exists {
+			newSubtree[key] = value
+		}
+	}
+
+	return nil
+}
+
+// Sets the value at the path in the config tree.
+func updateAtPath(
+	tree TreeData,
+	path []string,
+	value interface{},
+) error {
+	pathPrefix := path[:len(path)-1]
+	key := path[len(path)-1]
+
+	subtree, err := getOrMakeSubtree(tree, pathPrefix)
+
+	if err != nil {
+		return err
+	}
+
+	subtree[key] = value
+	return nil
+}
+
+// Removes the value at the path in the config tree.
+func (pathTree *PathTree[I]) removeAtPath(path TreePath) {
+	pathPrefix := path[:len(path)-1]
+	key := path[len(path)-1]
+
+	subtree := getSubtree(pathTree.tree, pathPrefix)
+	if subtree != nil {
+		delete(subtree, key)
+	}
+}
+
+// Returns the key path referenced by the item.
+func keyPath(item item) TreePath {
+	return TreePath(append([]string{item.GetKey()}, item.GetNestedKey()...))
+}
+
+// Returns the subtree at the path, or nil if it does not exist.
+func getSubtree(
+	tree TreeData,
+	path TreePath,
+) TreeData {
+	for _, key := range path {
+		node, ok := tree[key]
+		if !ok {
+			return nil
+		}
+
+		subtree, ok := node.(TreeData)
+		if !ok {
+			return nil
+		}
+
+		tree = subtree
+	}
+
+	return tree
+}
+
+// Returns the subtree at the path, creating it if necessary.
+//
+// Returns an error if there exists a non-map value at the path.
+func getOrMakeSubtree(
+	tree TreeData,
+	path TreePath,
+) (TreeData, error) {
+	for _, key := range path {
+		node, exists := tree[key]
+		if !exists {
+			node = make(TreeData)
+			tree[key] = node
+		}
+
+		subtree, ok := node.(TreeData)
+		if !ok {
+			return nil, fmt.Errorf(
+				"config: value at path %v is type %T, not a map",
+				path,
+				node,
+			)
+		}
+
+		tree = subtree
+	}
+
+	return tree, nil
+}
+
+// Returns a deep copy of the given tree.
+//
+// Slice values are copied by reference, which is fine for our use case.
+func DeepCopy(tree TreeData) (TreeData, error) {
+	clone := make(TreeData)
+	for key, value := range tree {
+		switch value := value.(type) {
+		case TreeData:
+			innerClone, err := DeepCopy(value)
+			if err != nil {
+				return nil, err
+			}
+			clone[key] = innerClone
+		default:
+			clone[key] = value
+		}
+	}
+	return clone, nil
+}

--- a/core/internal/pathtree/pathtree.go
+++ b/core/internal/pathtree/pathtree.go
@@ -55,7 +55,7 @@ func (pathTree *PathTree[I]) Tree() TreeData {
 
 // Makes and returns a deep copy of the underlying tree.
 func (pathTree *PathTree[I]) CloneTree() (TreeData, error) {
-	clone, err := DeepCopy(pathTree.tree)
+	clone, err := deepCopy(pathTree.tree)
 	if err != nil {
 		return nil, err
 	}
@@ -125,29 +125,6 @@ func (pathTree *PathTree[I]) Serialize(format Format, postProcessFunc func(any) 
 type Leaf struct {
 	Key   []string
 	Value any
-}
-
-func Flatten(tree TreeData, leaves []Leaf, path []string) []Leaf {
-	// Iterate over each key-value pair in the map
-	for treeKey, treeValue := range tree {
-		// Make a copy of the path slice and append the current key to the new slice
-		newPath := make([]string, len(path))
-		copy(newPath, path)
-		newPath = append(newPath, treeKey)
-
-		// Check if the value is another TreeData (map). If so, call Flatten recursively
-		if subTree, ok := treeValue.(TreeData); ok {
-			leaves = Flatten(subTree, leaves, newPath) // Use the copied and updated newPath
-		} else {
-			// If value is not a TreeData, add it to the leaves slice with the current path
-			leaves = append(leaves, Leaf{
-				Key:   newPath, // Use the copied and updated newPath
-				Value: treeValue,
-			})
-		}
-	}
-
-	return leaves
 }
 
 // Uses the given subtree for keys that aren't already set.
@@ -263,12 +240,12 @@ func getOrMakeSubtree(
 // Returns a deep copy of the given tree.
 //
 // Slice values are copied by reference, which is fine for our use case.
-func DeepCopy(tree TreeData) (TreeData, error) {
+func deepCopy(tree TreeData) (TreeData, error) {
 	clone := make(TreeData)
 	for key, value := range tree {
 		switch value := value.(type) {
 		case TreeData:
-			innerClone, err := DeepCopy(value)
+			innerClone, err := deepCopy(value)
 			if err != nil {
 				return nil, err
 			}

--- a/core/internal/runconfig/runconfig.go
+++ b/core/internal/runconfig/runconfig.go
@@ -1,22 +1,16 @@
 package runconfig
 
 import (
-	"fmt"
-
-	"github.com/segmentio/encoding/json"
 	"github.com/wandb/wandb/core/internal/corelib"
+	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/pkg/service"
-	"gopkg.in/yaml.v3"
 )
 
 // A RunConfig representation.
 //
 // This is a type alias for refactoring purposes; it should be new type
 // otherwise.
-type RunConfigDict = map[string]interface{}
-
-// A key path determining a node in the run config tree.
-type RunConfigPath []string
+type RunConfigDict = pathtree.TreeData
 
 // The configuration of a run.
 //
@@ -27,43 +21,21 @@ type RunConfigPath []string
 //
 // The server process builds this up incrementally throughout a run's lifetime.
 type RunConfig struct {
-	// The underlying configuration tree.
-	//
-	// Nodes are strings and leaves are types supported by JSON,
-	// such as primitives and lists.
-	tree RunConfigDict
+	*pathtree.PathTree[*service.ConfigItem]
 }
 
-type ConfigFormat int
-
-const (
-	FormatYaml ConfigFormat = iota
-	FormatJson
-)
-
 func New() *RunConfig {
-	return &RunConfig{make(RunConfigDict)}
+	return &RunConfig{PathTree: pathtree.New[*service.ConfigItem]()}
 }
 
 func NewFrom(tree RunConfigDict) *RunConfig {
-	return &RunConfig{tree}
+	return &RunConfig{PathTree: pathtree.NewFrom[*service.ConfigItem](tree)}
 }
 
-// Returns the underlying config tree.
-//
-// Provided temporarily as part of a refactor. Avoid using this, especially
-// mutating it.
-func (runConfig *RunConfig) Tree() RunConfigDict {
-	return runConfig.tree
-}
-
-// Makes and returns a deep copy of the underlying tree.
-func (runConfig *RunConfig) CloneTree() (RunConfigDict, error) {
-	clone, err := deepCopy(runConfig.tree)
-	if err != nil {
-		return nil, err
-	}
-	return clone, nil
+func (runConfig *RunConfig) Serialize(format pathtree.Format) ([]byte, error) {
+	return runConfig.PathTree.Serialize(format, func(value any) any {
+		return map[string]any{"value": value}
+	})
 }
 
 // Updates and/or removes values from the configuration tree.
@@ -74,33 +46,11 @@ func (runConfig *RunConfig) ApplyChangeRecord(
 	configRecord *service.ConfigRecord,
 	onError func(error),
 ) {
-	for _, configItem := range configRecord.Update {
-		path := keyPath(configItem)
+	update := configRecord.GetUpdate()
+	runConfig.ApplyUpdate(update, onError)
 
-		var value interface{}
-		if err := json.Unmarshal(
-			[]byte(configItem.GetValueJson()),
-			&value,
-		); err != nil {
-			onError(
-				fmt.Errorf(
-					"config: failed to unmarshal JSON for config key %v: %v",
-					path,
-					err,
-				),
-			)
-			continue
-		}
-
-		if err := updateAtPath(runConfig.tree, path, value); err != nil {
-			onError(err)
-			continue
-		}
-	}
-
-	for _, configItem := range configRecord.Remove {
-		runConfig.removeAtPath(keyPath(configItem))
-	}
+	remove := configRecord.GetRemove()
+	runConfig.ApplyRemove(remove, onError)
 }
 
 // Inserts W&B-internal values into the run's configuration.
@@ -127,9 +77,9 @@ func (runConfig *RunConfig) AddTelemetryAndMetrics(
 // Incorporates the config from a run that's being resumed.
 func (runConfig *RunConfig) MergeResumedConfig(oldConfig RunConfigDict) error {
 	// Add any top-level keys that aren't already set.
-	if err := runConfig.addUnsetKeysFromSubtree(
+	if err := runConfig.AddUnsetKeysFromSubtree(
 		oldConfig,
-		RunConfigPath{},
+		pathtree.TreePath{},
 	); err != nil {
 		return err
 	}
@@ -137,62 +87,18 @@ func (runConfig *RunConfig) MergeResumedConfig(oldConfig RunConfigDict) error {
 	// When a user logs visualizations, we unfortunately store them in the
 	// run's config. When resuming a run, we want to avoid erasing previously
 	// logged visualizations, hence this special handling.
-	if err := runConfig.addUnsetKeysFromSubtree(
+	if err := runConfig.AddUnsetKeysFromSubtree(
 		oldConfig,
-		RunConfigPath{"_wandb", "visualize"},
+		pathtree.TreePath{"_wandb", "visualize"},
 	); err != nil {
 		return err
 	}
 
-	if err := runConfig.addUnsetKeysFromSubtree(
+	if err := runConfig.AddUnsetKeysFromSubtree(
 		oldConfig,
-		RunConfigPath{"_wandb", "viz"},
+		pathtree.TreePath{"_wandb", "viz"},
 	); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-// Serializes the run configuration to send to the backend.
-func (runConfig *RunConfig) Serialize(format ConfigFormat) ([]byte, error) {
-	// A configuration dict in the format expected by the backend.
-	valueConfig := make(map[string]map[string]interface{})
-	for treeKey, treeValue := range runConfig.tree {
-		valueConfig[treeKey] = map[string]interface{}{
-			"value": treeValue,
-		}
-	}
-
-	switch format {
-	case FormatYaml:
-		return yaml.Marshal(valueConfig)
-	case FormatJson:
-		return json.Marshal(valueConfig)
-	}
-
-	return nil, fmt.Errorf("config: unknown format: %v", format)
-}
-
-// Uses the given subtree for keys that aren't already set.
-func (runConfig *RunConfig) addUnsetKeysFromSubtree(
-	tree RunConfigDict,
-	path RunConfigPath,
-) error {
-	oldSubtree := getSubtree(tree, path)
-	if oldSubtree == nil {
-		return nil
-	}
-
-	newSubtree, err := getOrMakeSubtree(runConfig.tree, path)
-	if err != nil {
-		return err
-	}
-
-	for key, value := range oldSubtree {
-		if _, exists := newSubtree[key]; !exists {
-			newSubtree[key] = value
-		}
 	}
 
 	return nil
@@ -200,124 +106,14 @@ func (runConfig *RunConfig) addUnsetKeysFromSubtree(
 
 // Returns the "_wandb" subtree of the config.
 func (runConfig *RunConfig) internalSubtree() RunConfigDict {
-	node, found := runConfig.tree["_wandb"]
+	node, found := runConfig.Tree()["_wandb"]
 
 	if !found {
 		wandbInternal := make(RunConfigDict)
-		runConfig.tree["_wandb"] = wandbInternal
+		runConfig.Tree()["_wandb"] = wandbInternal
 		return wandbInternal
 	}
 
 	// Panic if the type is wrong, which should never happen.
 	return node.(RunConfigDict)
-}
-
-// Sets the value at the path in the config tree.
-func updateAtPath(
-	tree RunConfigDict,
-	path []string,
-	value interface{},
-) error {
-	pathPrefix := path[:len(path)-1]
-	key := path[len(path)-1]
-
-	subtree, err := getOrMakeSubtree(tree, pathPrefix)
-
-	if err != nil {
-		return err
-	}
-
-	subtree[key] = value
-	return nil
-}
-
-// Removes the value at the path in the config tree.
-func (runConfig *RunConfig) removeAtPath(path RunConfigPath) {
-	pathPrefix := path[:len(path)-1]
-	key := path[len(path)-1]
-
-	subtree := getSubtree(runConfig.tree, pathPrefix)
-	if subtree != nil {
-		delete(subtree, key)
-	}
-}
-
-// Returns the key path referenced by the config item.
-func keyPath(configItem *service.ConfigItem) RunConfigPath {
-	if len(configItem.GetNestedKey()) > 0 {
-		return RunConfigPath(configItem.NestedKey)
-	} else {
-		return RunConfigPath{configItem.Key}
-	}
-}
-
-// Returns the subtree at the path, or nil if it does not exist.
-func getSubtree(
-	tree RunConfigDict,
-	path RunConfigPath,
-) RunConfigDict {
-	for _, key := range path {
-		node, ok := tree[key]
-		if !ok {
-			return nil
-		}
-
-		subtree, ok := node.(RunConfigDict)
-		if !ok {
-			return nil
-		}
-
-		tree = subtree
-	}
-
-	return tree
-}
-
-// Returns the subtree at the path, creating it if necessary.
-//
-// Returns an error if there exists a non-map value at the path.
-func getOrMakeSubtree(
-	tree RunConfigDict,
-	path RunConfigPath,
-) (RunConfigDict, error) {
-	for _, key := range path {
-		node, exists := tree[key]
-		if !exists {
-			node = make(RunConfigDict)
-			tree[key] = node
-		}
-
-		subtree, ok := node.(RunConfigDict)
-		if !ok {
-			return nil, fmt.Errorf(
-				"config: value at path %v is type %T, not a map",
-				path,
-				node,
-			)
-		}
-
-		tree = subtree
-	}
-
-	return tree, nil
-}
-
-// Returns a deep copy of the given tree.
-//
-// Slice values are copied by reference, which is fine for our use case.
-func deepCopy(tree RunConfigDict) (RunConfigDict, error) {
-	clone := make(RunConfigDict)
-	for key, value := range tree {
-		switch value := value.(type) {
-		case RunConfigDict:
-			innerClone, err := deepCopy(value)
-			if err != nil {
-				return nil, err
-			}
-			clone[key] = innerClone
-		default:
-			clone[key] = value
-		}
-	}
-	return clone, nil
 }

--- a/core/internal/runconfig/runconfig_test.go
+++ b/core/internal/runconfig/runconfig_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/corelib"
+	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/pkg/service"
 )
@@ -25,7 +26,8 @@ func TestConfigUpdate(t *testing.T) {
 					ValueJson: "1",
 				},
 				{
-					NestedKey: []string{"b", "c"},
+					Key:       "b",
+					NestedKey: []string{"c"},
 					ValueJson: "\"text\"",
 				},
 			},
@@ -57,7 +59,7 @@ func TestConfigRemove(t *testing.T) {
 		&service.ConfigRecord{
 			Remove: []*service.ConfigItem{
 				{Key: "a"},
-				{NestedKey: []string{"b", "c"}},
+				{Key: "b", NestedKey: []string{"c"}},
 			},
 		}, ignoreError,
 	)
@@ -77,7 +79,7 @@ func TestConfigSerialize(t *testing.T) {
 		},
 	})
 
-	yaml, _ := runConfig.Serialize(runconfig.FormatYaml)
+	yaml, _ := runConfig.Serialize(pathtree.FormatYaml)
 
 	assert.Equal(t,
 		""+

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -22,6 +22,7 @@ import (
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/gql"
 	"github.com/wandb/wandb/core/internal/mailbox"
+	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/internal/runfiles"
 	"github.com/wandb/wandb/core/internal/runresume"
@@ -102,7 +103,7 @@ type Sender struct {
 	// metricSender is a service for managing metrics
 	metricSender *MetricSender
 
-	// debouncer for config updates
+	// configDebouncer is the debouncer for config updates
 	configDebouncer *debounce.Debouncer
 
 	// Keep track of summary which is being updated incrementally
@@ -479,8 +480,9 @@ func (s *Sender) sendRequestDefer(request *service.DeferRequest) {
 		request.State++
 		s.fwdRequestDefer(request)
 	case service.DeferRequest_FLUSH_DEBOUNCER:
+		s.configDebouncer.SetNeedsDebounce()
 		s.configDebouncer.Flush(s.upsertConfig)
-		s.writeAndSendConfigFile()
+		s.uploadConfigFile()
 		request.State++
 		s.fwdRequestDefer(request)
 	case service.DeferRequest_FLUSH_OUTPUT:
@@ -543,7 +545,7 @@ func (s *Sender) sendTelemetry(_ *service.Record, telemetry *service.TelemetryRe
 	proto.Merge(s.telemetry, telemetry)
 	s.updateConfigPrivate()
 	// TODO(perf): improve when debounce config is added, for now this sends all the time
-	s.sendConfig(nil, nil /*configRecord*/)
+	s.configDebouncer.SetNeedsDebounce()
 }
 
 func (s *Sender) sendPreempting(record *service.Record) {
@@ -598,15 +600,16 @@ func (s *Sender) updateConfigPrivate() {
 }
 
 // Serializes the run configuration to send to the backend.
-func (s *Sender) serializeConfig(format runconfig.ConfigFormat) string {
+func (s *Sender) serializeConfig(format pathtree.Format) (string, error) {
 	serializedConfig, err := s.runConfig.Serialize(format)
 
 	if err != nil {
 		err = fmt.Errorf("failed to marshal config: %s", err)
-		s.logger.CaptureFatalAndPanic("sender: sendRun: ", err)
+		s.logger.Error("sender: serializeConfig", "error", err)
+		return "", err
 	}
 
-	return string(serializedConfig)
+	return string(serializedConfig), nil
 }
 
 func (s *Sender) checkAndUpdateResumeState(record *service.Record) error {
@@ -676,7 +679,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			}
 		}
 
-		config := s.serializeConfig(runconfig.FormatJson)
+		config, _ := s.serializeConfig(pathtree.FormatJson)
 
 		var tags []string
 		tags = append(tags, run.Tags...)
@@ -816,10 +819,22 @@ func (s *Sender) upsertConfig() {
 	if s.graphqlClient == nil {
 		return
 	}
-	config := s.serializeConfig(runconfig.FormatJson)
+	if s.RunRecord == nil {
+		s.logger.Error("sender: upsertConfig: RunRecord is nil")
+		return
+	}
+
+	config, err := s.serializeConfig(pathtree.FormatJson)
+	if err != nil {
+		s.logger.Error("sender: upsertConfig: failed to serialize config", "error", err)
+		return
+	}
+	if config == "" {
+		return
+	}
 
 	ctx := context.WithValue(s.ctx, clients.CtxRetryPolicyKey, clients.UpsertBucketRetryPolicy)
-	_, err := gql.UpsertBucket(
+	_, err = gql.UpsertBucket(
 		ctx,                                  // ctx
 		s.graphqlClient,                      // client
 		nil,                                  // id
@@ -847,16 +862,21 @@ func (s *Sender) upsertConfig() {
 	}
 }
 
-func (s *Sender) writeAndSendConfigFile() {
+func (s *Sender) uploadConfigFile() {
 	if s.settings.GetXSync().GetValue() {
 		// if sync is enabled, we don't need to do all this
 		return
 	}
 
-	config := s.serializeConfig(runconfig.FormatYaml)
+	config, err := s.serializeConfig(pathtree.FormatYaml)
+	if err != nil {
+		s.logger.Error("sender: writeAndSendConfigFile: failed to serialize config", "error", err)
+		return
+	}
 	configFile := filepath.Join(s.settings.GetFilesDir().GetValue(), ConfigFileName)
 	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
 		s.logger.Error("sender: writeAndSendConfigFile: failed to write config file", "error", err)
+		return
 	}
 
 	record := &service.Record{
@@ -1030,7 +1050,7 @@ func (s *Sender) sendMetric(record *service.Record, metric *service.MetricRecord
 
 	s.encodeMetricHints(record, metric)
 	s.updateConfigPrivate()
-	s.sendConfig(nil, nil /*configRecord*/)
+	s.configDebouncer.SetNeedsDebounce()
 }
 
 // sendFiles uploads files according to a FilesRecord


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

This PR creates a common PathTree object that will be used with many objects in the stream, in this PR we just use it for RunConfig

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
