### PR TITLE
chore(launch): Remove project from agent config

### DIFF
--- a/tests/pytest_tests/unit_tests_old/test_launch/test_launch.py
+++ b/tests/pytest_tests/unit_tests_old/test_launch/test_launch.py
@@ -943,7 +943,6 @@ def test_resolve_agent_config(monkeypatch, runner):
             )
         config, returned_api = _launch.resolve_agent_config(
             entity=None,
-            project=None,
             max_jobs=-1,
             queues=["diff-queue"],
             config=None,

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1642,13 +1642,6 @@ def launch(
     help="The name of a queue for the agent to watch. Multiple -q flags supported.",
 )
 @click.option(
-    "--project",
-    "-p",
-    default=None,
-    help="""Name of the project which the agent will watch.
-    If passed in, will override the project value passed in using a config file.""",
-)
-@click.option(
     "--entity",
     "-e",
     default=None,
@@ -1684,7 +1677,6 @@ def launch(
 @display_error
 def launch_agent(
     ctx,
-    project=None,
     entity=None,
     queues=None,
     max_jobs=None,
@@ -1709,7 +1701,7 @@ def launch_agent(
     api = _get_cling_api()
     wandb._sentry.configure_scope(process_context="launch_agent")
     agent_config, api = _launch.resolve_agent_config(
-        entity, project, max_jobs, queues, config, verbose
+        entity, max_jobs, queues, config, verbose
     )
 
     if len(agent_config.get("queues")) == 0:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18432](https://wandb.atlassian.net/browse/WB-18432)

The `project` input in the agent config has been deprecated for a long time. This change removes the warning message if a user tries to set `project`, which could happen if the user's `WANDB_PROJECT` environment variable is set (see [this Slack thread](https://weightsandbiases.slack.com/archives/C01UUUHP153/p1713538131804369)). Instead, the environment variable should be ignored completely when launching an agent.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Unit tests were updated

Manual testing:
- Checkout main
- `export WANDB_PROJECT=debugging`
- `wandb launch-agent`
- Get a warning about how specifying project is deprecated, and an error because the agent attempts to find a project-scoped queue that doesn't exist
- Checkout this branch
- `wandb launch-agent`
- No warning and the launch agent runs fine

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18432]: https://wandb.atlassian.net/browse/WB-18432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ