### PR TITLE
feat(public-api): add function to check if artifact exists

### DIFF
--- a/tests/pytest_tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/pytest_tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -111,6 +111,12 @@ def test_artifact_download(user, api, sample_data):
     assert path == os.path.abspath(os.path.join(".", "artifacts", part))
     assert os.listdir(path) == ["digits.h5"]
 
+def test_artifact_exists(user, api, sample_data):
+    assert api.exists("mnist:v0") == True
+    assert api.exists("mnist:v2") == False
+    assert api.exists("mnist-fake:v0") == False
+    assert api.exists("mnist", type="dataset") == True
+    assert api.exists("mnist-fake", type="dataset") == False
 
 def test_artifact_delete(user, api, sample_data):
     art = api.artifact("mnist:v0", type="dataset")

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1048,3 +1048,23 @@ class Api:
             return [x["node"]["artifacts"] for x in artifacts]
         except requests.exceptions.HTTPError:
             return False
+
+    @normalize_exceptions
+    def exists(self, name, type=None):
+        _, _, artifact_name = self._parse_artifact_path(name)
+        if ":" in artifact_name:
+            try:
+                self.artifact(name, type)
+                return True
+            except: 
+                return False
+        else:
+            if type is None:
+                raise ValueError('You must specify type= to check if there are any artifacts in this collection')
+            try:
+                artifacts = self.artifacts(type, name, 1)
+                len(artifacts)
+                return True
+            except:
+                return False
+


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-15063](https://wandb.atlassian.net/browse/WB-15063)

This PR addresses the ticket above for artifact existence specifically by adding a function to the public api to check if an artifact exists, or if there are any artifacts in the specified collection. Eventually we might want to extend this to other types of existence checks.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Added an integration test for various cases

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
