### PR TITLE
refactor(sdk): Fix order-dependent tests that check wandb.term*()

### DIFF
--- a/tests/pytest_tests/conftest.py
+++ b/tests/pytest_tests/conftest.py
@@ -3,7 +3,7 @@ import shutil
 import unittest.mock
 from pathlib import Path
 from queue import Queue
-from typing import Any, Callable, Generator, Optional, Union
+from typing import Any, Callable, Generator, Iterable, Optional, Union
 
 os.environ["WANDB_ERROR_REPORTING"] = "false"
 
@@ -47,6 +47,74 @@ def copy_asset(assets_path) -> Generator[Callable, None, None]:
 # --------------------------------
 # Misc Fixtures
 # --------------------------------
+
+
+class MockWandbTerm:
+    """Helper to test wandb.term*() calls.
+
+    See the `mock_wandb_log` fixture.
+    """
+
+    def __init__(
+        self,
+        termlog: unittest.mock.MagicMock,
+        termwarn: unittest.mock.MagicMock,
+        termerror: unittest.mock.MagicMock,
+    ):
+        self._termlog = termlog
+        self._termwarn = termwarn
+        self._termerror = termerror
+
+    def logged(self, msg: str) -> bool:
+        """Returns whether the message was included in a termlog()."""
+        return self._logged(self._termlog, msg)
+
+    def warned(self, msg: str) -> bool:
+        """Returns whether the message was included in a termwarn()."""
+        return self._logged(self._termwarn, msg)
+
+    def errored(self, msg: str) -> bool:
+        """Returns whether the message was included in a termerror()."""
+        return self._logged(self._termerror, msg)
+
+    def _logged(self, termfunc: unittest.mock.MagicMock, msg: str) -> bool:
+        return any(msg in logged for logged in self._logs(termfunc))
+
+    def _logs(self, termfunc: unittest.mock.MagicMock) -> Iterable[str]:
+        # All the term*() functions have a similar API: the message is the
+        # first argument, which may also be passed as a keyword argument called
+        # "string".
+        for call in termfunc.call_args_list:
+            if "string" in call.kwargs:
+                yield call.kwargs["string"]
+            else:
+                yield call.args[0]
+
+
+@pytest.fixture()
+def mock_wandb_log() -> Generator[MockWandbTerm, None, None]:
+    """Mocks the wandb.term*() methods for a test.
+
+    This patches the termlog() / termwarn() / termerror() methods and returns
+    a `MockWandbTerm` object that can be used to assert on their usage.
+
+    The logging functions mutate global state (for repeat=False), making
+    them unsuitable for tests. Use this fixture to assert that a message
+    was logged.
+    """
+    # NOTE: This only stubs out calls like "wandb.termlog()", NOT
+    # "from wandb.errors.term import termlog; termlog()".
+    with unittest.mock.patch.multiple(
+        "wandb",
+        termlog=unittest.mock.DEFAULT,
+        termwarn=unittest.mock.DEFAULT,
+        termerror=unittest.mock.DEFAULT,
+    ) as patched:
+        yield MockWandbTerm(
+            patched["termlog"],
+            patched["termwarn"],
+            patched["termerror"],
+        )
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/pytest_tests/system_tests/test_core/test_data_types_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_data_types_full.py
@@ -111,29 +111,39 @@ def test_log_with_back_slash_windows(wandb_init):
     run.finish()
 
 
-def test_image_array_old_wandb(relay_server, wandb_init, monkeypatch, capsys):
+def test_image_array_old_wandb(
+    relay_server,
+    wandb_init,
+    monkeypatch,
+    mock_wandb_log,
+):
     with relay_server() as relay:
         monkeypatch.setattr(wandb.util, "_get_max_cli_version", lambda: "0.10.33")
+
         run = wandb_init()
         wb_image = [wandb.Image(np.zeros((28, 28))) for i in range(5)]
         run.log({"logged_images": wb_image})
         run.finish()
-        outerr = capsys.readouterr()
 
-        assert "Unable to log image array filenames." in outerr.err
+        assert mock_wandb_log.warned("Unable to log image array filenames.")
 
         assert "filenames" not in relay.context.summary["logged_images"][0]
 
 
-def test_image_array_old_wandb_mp_warning(wandb_init, capsys, monkeypatch):
+def test_image_array_old_wandb_mp_warning(
+    wandb_init,
+    monkeypatch,
+    mock_wandb_log,
+):
     monkeypatch.setattr(wandb.util, "_get_max_cli_version", lambda: "0.10.33")
+
     run = wandb_init()
     wb_image = [wandb.Image(np.zeros((28, 28))) for _ in range(5)]
     run._init_pid += 1
     run.log({"logged_images": wb_image})
     run.finish()
-    outerr = capsys.readouterr()
-    assert (
-        "Attempting to log a sequence of Image objects from multiple processes might result in data loss. Please upgrade your wandb server"
-        in outerr.err
+
+    assert mock_wandb_log.warned(
+        "Attempting to log a sequence of Image objects from multiple processes"
+        " might result in data loss. Please upgrade your wandb server"
     )

--- a/tests/pytest_tests/unit_tests/test_torch.py
+++ b/tests/pytest_tests/unit_tests/test_torch.py
@@ -74,13 +74,12 @@ def test_double_log(mock_run):
 
 
 @pytest.mark.parametrize("log_type", ["parameters", "all"])
-def test_watch_parameters_torch_jit(mock_run, capsys, log_type):
+def test_watch_parameters_torch_jit(mock_run, log_type, mock_wandb_log):
     run = mock_run(use_magic_mock=True)
     net = torch.jit.script(nn.Linear(10, 2))
     run.watch(net, log=log_type)
 
-    outerr = capsys.readouterr()
-    assert "skipping parameter tracking" in outerr.err
+    assert mock_wandb_log.warned("skipping parameter tracking")
 
 
 def test_watch_graph_torch_jit(mock_run, capsys):

--- a/tests/pytest_tests/unit_tests/test_wandb_run.py
+++ b/tests/pytest_tests/unit_tests/test_wandb_run.py
@@ -167,28 +167,30 @@ def test_run_pub_history(mock_run, record_q, parse_records):
     assert history[1]["that"] == "2"
 
 
-def test_deprecated_run_log_sync(mock_run, capsys):
+def test_deprecated_run_log_sync(mock_run, mock_wandb_log):
     run = mock_run()
+
     run.log(dict(this=1), sync=True)
-    _, stderr = capsys.readouterr()
-    assert (
-        "`sync` argument is deprecated and does not affect the behaviour of `wandb.log`"
-        in stderr
+
+    assert mock_wandb_log.warned(
+        "`sync` argument is deprecated"
+        " and does not affect the behaviour of `wandb.log`"
     )
 
 
-def test_run_log_mp_warn(mock_run, test_settings, capsys):
+def test_run_log_mp_warn(mock_run, test_settings, monkeypatch, mock_wandb_log):
+    monkeypatch.setenv("WANDB_DISABLE_SERVICE", "true")
     test_settings = test_settings()
-    with mock.patch.dict("os.environ", {"WANDB_DISABLE_SERVICE": "true"}):
-        test_settings._apply_env_vars(os.environ)
-        run = mock_run(settings=test_settings)
-        run._init_pid = os.getpid()
-        run._init_pid += 1
-        run.log(dict(this=1))
-    _, stderr = capsys.readouterr()
-    assert (
+    test_settings._apply_env_vars(os.environ)
+
+    run = mock_run(settings=test_settings)
+    run._init_pid = os.getpid()
+    run._init_pid += 1
+    run.log(dict(this=1))
+
+    assert mock_wandb_log.warned(
         f"`log` ignored (called from pid={os.getpid()}, "
-        f"`init` called from pid={run._init_pid})" in stderr
+        f"`init` called from pid={run._init_pid})"
     )
 
 

--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -27,7 +27,10 @@ def termsetup(settings, logger) -> None:
 
 
 def termlog(
-    string: str = "", newline: bool = True, repeat: bool = True, prefix: bool = True
+    string: str = "",
+    newline: bool = True,
+    repeat: bool = True,
+    prefix: bool = True,
 ) -> None:
     """Log to standard error with formatting.
 
@@ -68,7 +71,12 @@ def termerror(string: str, **kwargs: Any) -> None:
 
 
 def _log(
-    string="", newline=True, repeat=True, prefix=True, silent=False, level=logging.INFO
+    string="",
+    newline=True,
+    repeat=True,
+    prefix=True,
+    silent=False,
+    level=logging.INFO,
 ):
     global _logger
     silent = silent or _silent


### PR DESCRIPTION
Description
---
These tests are order-dependent because of logging with `repeat=False`, which mutates module-level state. This state is not reset between tests, causing order-dependence.
