### PR TITLE
chore(launch): add helpers for config file job inputs

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_inputs/test_files_helpers.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_inputs/test_files_helpers.py
@@ -1,0 +1,201 @@
+import json
+
+import pytest
+from wandb.sdk.launch.errors import LaunchError
+from wandb.sdk.launch.inputs.files import (
+    FileOverrides,
+    config_path_is_valid,
+    override_file,
+)
+
+
+@pytest.fixture
+def fresh_config_singleton():
+    """Fixture to reset the config singleton."""
+    FileOverrides._instance = None
+
+
+def test_override_file_basic(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test override_file function."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.json"
+    path.write_text('{"key": "value"}')
+    monkeypatch.setenv(
+        "WANDB_LAUNCH_FILE_OVERRIDES",
+        json.dumps({"config.json": {"key": "new_value"}}),
+    )
+
+    override_file("config.json")
+
+    assert path.read_text() == json.dumps({"key": "new_value"}, indent=2)
+
+
+def test_override_file_nested(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test override_file function with nested dictionary."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.json"
+    path.write_text('{"key": {"nested_key": "value"}}')
+    monkeypatch.setenv(
+        "WANDB_LAUNCH_FILE_OVERRIDES",
+        json.dumps({"config.json": {"key": {"nested_key": "new_value"}}}),
+    )
+
+    override_file("config.json")
+
+    assert path.read_text() == json.dumps(
+        {"key": {"nested_key": "new_value"}}, indent=2
+    )
+
+
+def test_override_file_split_env_var(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test override_file function with split env var."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.json"
+    path.write_text('{"key": "value"}')
+    override_dict = json.dumps({"config.json": {"key": "new_value"}})
+    monkeypatch.setenv(
+        "WANDB_LAUNCH_FILE_OVERRIDES_0",
+        override_dict[: len(override_dict) // 2],
+    )
+    monkeypatch.setenv(
+        "WANDB_LAUNCH_FILE_OVERRIDES_1",
+        override_dict[len(override_dict) // 2 :],
+    )
+
+    override_file("config.json")
+
+    assert path.read_text() == json.dumps({"key": "new_value"}, indent=2)
+
+
+def test_override_file_yaml(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test override_file function with YAML."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.yaml"
+    path.write_text("key: value")
+    monkeypatch.setenv(
+        "WANDB_LAUNCH_FILE_OVERRIDES",
+        json.dumps({"config.yaml": {"key": "new_value"}}),
+    )
+
+    override_file("config.yaml")
+
+    assert path.read_text() == "key: new_value\n"
+
+
+def test_override_file_unknown_extension(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test override_file function with unknown extension."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.unknown"
+    path.write_text('{"key": "value"}')
+    monkeypatch.setenv(
+        "WANDB_LAUNCH_FILE_OVERRIDES",
+        json.dumps({"config.unknown": {"key": "new_value"}}),
+    )
+
+    with pytest.raises(LaunchError):
+        override_file("config.unknown")
+
+
+def test_file_overrides_invalid_json(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test FileOverrides with invalid JSON."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.json"
+    path.write_text('{"key": "value"}')
+    monkeypatch.setenv(
+        "WANDB_LAUNCH_FILE_OVERRIDES", '{"config.json": {"key": "new_value"}'
+    )
+
+    with pytest.raises(LaunchError):
+        override_file("config.json")
+
+
+def test_file_overrides_non_dict(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test FileOverrides with non-dictionary value."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.json"
+    path.write_text('{"key": "value"}')
+    monkeypatch.setenv("WANDB_LAUNCH_FILE_OVERRIDES", '["config.json"]')
+
+    with pytest.raises(LaunchError):
+        override_file("config.json")
+
+
+def test_config_path_is_valid(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test config_path_is_valid function."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.json"
+    path.write_text('{"key": "value"}')
+
+    config_path_is_valid("config.json")
+
+
+def test_config_path_is_valid_invalid(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test config_path_is_valid function with invalid path."""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(LaunchError):
+        config_path_is_valid("config.json")
+
+
+def test_config_path_is_valid_not_file(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test config_path_is_valid function with non-file path."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config"
+    path.mkdir()
+
+    with pytest.raises(LaunchError):
+        config_path_is_valid("config")
+
+
+def test_config_path_is_valid_absolute(
+    monkeypatch,
+    tmp_path,
+    fresh_config_singleton,
+):
+    """Test config_path_is_valid function with absolute path."""
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "config.json"
+    path.write_text('{"key": "value"}')
+
+    with pytest.raises(LaunchError):
+        config_path_is_valid(str(path))

--- a/wandb/sdk/launch/inputs/files.py
+++ b/wandb/sdk/launch/inputs/files.py
@@ -1,0 +1,148 @@
+import json
+import os
+from typing import Any, Dict
+
+import yaml
+
+from ..errors import LaunchError
+
+FILE_OVERRIDE_ENV_VAR = "WANDB_LAUNCH_FILE_OVERRIDES"
+
+
+class FileOverrides:
+    """Singleton that read file overrides json from environment variables."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = object.__new__(cls)
+            cls._instance.overrides = {}
+            cls._instance.load()
+        return cls._instance
+
+    def load(self) -> None:
+        """Load overrides from an environment variable."""
+        overrides = os.environ.get(FILE_OVERRIDE_ENV_VAR)
+        if overrides is None:
+            if f"{FILE_OVERRIDE_ENV_VAR}_0" in os.environ:
+                overrides = ""
+                idx = 0
+                while f"{FILE_OVERRIDE_ENV_VAR}_{idx}" in os.environ:
+                    overrides += os.environ[f"{FILE_OVERRIDE_ENV_VAR}_{idx}"]
+                    idx += 1
+        if overrides:
+            try:
+                contents = json.loads(overrides)
+                if not isinstance(contents, dict):
+                    raise LaunchError(f"Invalid JSON in {FILE_OVERRIDE_ENV_VAR}")
+                self.overrides = contents
+            except json.JSONDecodeError:
+                raise LaunchError(f"Invalid JSON in {FILE_OVERRIDE_ENV_VAR}")
+
+
+def config_path_is_valid(path: str) -> None:
+    """Validate a config file path.
+
+    This function checks if a given config file path is valid. A valid path
+    should meet the following criteria:
+
+    - The path must be expressed as a relative path without any upwards path
+      traversal, e.g. `../config.json`.
+    - The file specified by the path must exist.
+    - The file must have a supported extension (`.json`, `.yaml`, or `.yml`).
+
+    Args:
+        path (str): The path to validate.
+
+    Raises:
+        LaunchError: If the path is not valid.
+    """
+    if os.path.isabs(path):
+        raise LaunchError(
+            f"Invalid config path: {path}. Please provide a relative path."
+        )
+    if ".." in path:
+        raise LaunchError(
+            f"Invalid config path: {path}. Please provide a relative path "
+            "without any upward path traversal, e.g. `../config.json`."
+        )
+    path = os.path.normpath(path)
+    if not os.path.exists(path):
+        raise LaunchError(f"Invalid config path: {path}. File does not exist.")
+    if not any(path.endswith(ext) for ext in [".json", ".yaml", ".yml"]):
+        raise LaunchError(
+            f"Invalid config path: {path}. Only JSON and YAML files are supported."
+        )
+
+
+def override_file(path: str) -> None:
+    """Check for file overrides in the environment and apply them if found."""
+    file_overrides = FileOverrides()
+    if path in file_overrides.overrides:
+        overrides = file_overrides.overrides.get(path)
+        if overrides is not None:
+            config = _read_config_file(path)
+            _update_dict(config, overrides)
+            _write_config_file(path, config)
+
+
+def _write_config_file(path: str, config: Any) -> None:
+    """Write a config file to disk.
+
+    Args:
+        path (str): The path to the config file.
+        config (Any): The contents of the config file as a Python object.
+
+    Raises:
+        LaunchError: If the file extension is not supported.
+    """
+    _, ext = os.path.splitext(path)
+    if ext == ".json":
+        with open(path, "w") as f:
+            json.dump(config, f, indent=2)
+    elif ext in [".yaml", ".yml"]:
+        with open(path, "w") as f:
+            yaml.safe_dump(config, f)
+    else:
+        raise LaunchError(f"Unsupported file extension: {ext}")
+
+
+def _read_config_file(path: str) -> Any:
+    """Read a config file from disk.
+
+    Args:
+        path (str): The path to the config file.
+
+    Returns:
+        Any: The contents of the config file as a Python object.
+    """
+    _, ext = os.path.splitext(path)
+    if ext == ".json":
+        with open(
+            path,
+        ) as f:
+            return json.load(f)
+    elif ext in [".yaml", ".yml"]:
+        with open(
+            path,
+        ) as f:
+            return yaml.safe_load(f)
+    else:
+        raise LaunchError(f"Unsupported file extension: {ext}")
+
+
+def _update_dict(target: Dict, source: Dict) -> None:
+    """Update a dictionary with the contents of another dictionary.
+
+    Args:
+        target (Dict): The dictionary to update.
+        source (Dict): The dictionary to update from.
+    """
+    for key, value in source.items():
+        if isinstance(value, dict):
+            if key not in target:
+                target[key] = {}
+            _update_dict(target[key], value)
+        else:
+            target[key] = value


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This PR adds an internal library to the launch SDK for reading and writing user config files that are being managed as part of job inputs. The PR also includes a test suite.

- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
