### PR TITLE
fix(launch): add source message to job input in publish method

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -775,6 +775,7 @@ class InterfaceBase:
             source.file.CopyFrom(
                 pb.JobInputSource.ConfigFileSource(path=file_path),
             )
+        request.input_source.CopyFrom(source)
 
         return self._publish_job_input(request)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

The `source` attribute of the `JobInputRequest` was not being set after being constructed in `publish_job_input`. This is a fix but since this is not directly exposed to users in any way I'm not updating the changelog.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
