### PR TITLE
chore(launch): add internal library for handling inputs and applying overrides

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_inputs/test_internal.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_inputs/test_internal.py
@@ -1,0 +1,109 @@
+"""Test internal methods of the job input management sdk."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from wandb.sdk.launch.errors import LaunchError
+from wandb.sdk.launch.inputs.internal import (
+    ConfigTmpDir,
+    JobInputArguments,
+    _publish_job_input,
+    _split_on_unesc_dot,
+    handle_config_file_input,
+    handle_run_config_input,
+)
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        (r"path", ["path"]),
+        (r"path.with.dot", ["path", "with", "dot"]),
+        (r"path\.with\.esc.dot", ["path.with.esc", "dot"]),
+        (r"path\.with.esc\.dot", ["path.with", "esc.dot"]),
+        (r"path.with\.esc.dot", ["path", "with.esc", "dot"]),
+    ],
+)
+def test_split_on_unesc_dot(path, expected):
+    """Test _split_on_unesc_dot function."""
+    assert _split_on_unesc_dot(path) == expected
+
+
+def test_split_on_unesc_dot_trailing_backslash():
+    """Test _split_on_unesc_dot function with trailing backslash."""
+    with pytest.raises(LaunchError):
+        _split_on_unesc_dot("path\\")
+
+
+def test_config_tmp_dir():
+    """Test ConfigTmpDir class."""
+    config_dir = ConfigTmpDir()
+    assert config_dir.tmp_dir.is_dir()
+    assert config_dir.configs_dir.is_dir()
+    assert config_dir.tmp_dir != config_dir.configs_dir
+
+
+def test_job_input_arguments():
+    """Test JobInputArguments class."""
+    arguments = JobInputArguments(
+        include=["include"], exclude=["exclude"], file_path="path", run_config=True
+    )
+    assert arguments.include == ["include"]
+    assert arguments.exclude == ["exclude"]
+    assert arguments.file_path == "path"
+    assert arguments.run_config is True
+
+
+def test_publish_job_input(mocker):
+    """Test _publish_job_input function."""
+    run = mocker.MagicMock()
+    run._backend.interface = mocker.MagicMock()
+    arguments = JobInputArguments(
+        include=["include"], exclude=["exclude"], file_path="path", run_config=True
+    )
+    _publish_job_input(arguments, run)
+    run._backend.interface.publish_job_input.assert_called_once_with(
+        include_paths=[["include"]],
+        exclude_paths=[["exclude"]],
+        run_config=True,
+        file_path="path",
+    )
+
+
+def test_handle_config_file_input(mocker):
+    """Test handle_config_file_input function."""
+    mocker.patch("wandb.sdk.launch.inputs.internal.override_file")
+    mocker.patch("wandb.sdk.launch.inputs.internal.config_path_is_valid")
+    mocker.patch("wandb.sdk.launch.inputs.internal.ConfigTmpDir")
+    mocker.patch("wandb.sdk.launch.inputs.internal.shutil.copy")
+    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", None)
+    with pytest.raises(NotImplementedError):
+        handle_config_file_input("path", include=["include"], exclude=["exclude"])
+
+    wandb_run = MagicMock()
+    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", wandb_run)
+    handle_config_file_input("path", include=["include"], exclude=["exclude"])
+    wandb_run._backend.interface.publish_job_input.assert_called_once_with(
+        include_paths=[["include"]],
+        exclude_paths=[["exclude"]],
+        run_config=False,
+        file_path="path",
+    )
+
+
+def test_handle_run_config_input(mocker):
+    """Test handle_run_config_input function."""
+    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", None)
+    with pytest.raises(NotImplementedError):
+        handle_run_config_input(include=["include"], exclude=["exclude"])
+
+    wandb_run = mocker.MagicMock()
+    wandb_run._backend.interface = mocker.MagicMock()
+    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", wandb_run)
+    handle_run_config_input(include=["include"], exclude=["exclude"])
+    wandb_run._backend.interface.publish_job_input.assert_called_once_with(
+        include_paths=[["include"]],
+        exclude_paths=[["exclude"]],
+        run_config=True,
+        file_path="",
+    )

--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -1,0 +1,189 @@
+"""The layer between launch sdk user code and the wandb internal process.
+
+If there is an active run this communication is done through the wandb run's
+backend interface.
+
+If there is no active run, the messages are staged on the StagedLaunchInputs
+singleton and sent when a run is created.
+"""
+
+import os
+import pathlib
+import shutil
+import tempfile
+from typing import List, Optional
+
+import wandb
+import wandb.data_types
+from wandb.sdk.launch.errors import LaunchError
+from wandb.sdk.wandb_run import Run
+
+from .files import config_path_is_valid, override_file
+
+PERIOD = "."
+BACKSLASH = "\\"
+
+
+class ConfigTmpDir:
+    """Singleton for managing temporary directories for configuration files.
+
+    Any configuration files designated as inputs to a launch job are copied to
+    a temporary directory. This singleton manages the temporary directory and
+    provides paths to the configuration files.
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = object.__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if not hasattr(self, "_tmp_dir"):
+            self._tmp_dir = tempfile.mkdtemp()
+            self._configs_dir = os.path.join(self._tmp_dir, "configs")
+            os.mkdir(self._configs_dir)
+
+    @property
+    def tmp_dir(self):
+        return pathlib.Path(self._tmp_dir)
+
+    @property
+    def configs_dir(self):
+        return pathlib.Path(self._configs_dir)
+
+
+class JobInputArguments:
+    """Arguments for the publish_job_input of Interface."""
+
+    def __init__(
+        self,
+        include: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        file_path: Optional[str] = None,
+        run_config: Optional[bool] = None,
+    ):
+        self.include = include
+        self.exclude = exclude
+        self.file_path = file_path
+        self.run_config = run_config
+
+
+def _publish_job_input(
+    input: JobInputArguments,
+    run: Run,
+) -> None:
+    """Publish a job input to the backend interface of the given run.
+
+    Arguments:
+        input (JobInputArguments): The arguments for the job input.
+        run (Run): The run to publish the job input to.
+    """
+    assert run._backend is not None
+    assert run._backend.interface is not None
+    assert input.run_config is not None
+
+    interface = run._backend.interface
+    if input.file_path:
+        config_dir = ConfigTmpDir()
+        dest = os.path.join(config_dir.configs_dir, input.file_path)
+        run.save(dest, base_path=config_dir.tmp_dir)
+    interface.publish_job_input(
+        include_paths=[_split_on_unesc_dot(path) for path in input.include]
+        if input.include
+        else [],
+        exclude_paths=[_split_on_unesc_dot(path) for path in input.exclude]
+        if input.exclude
+        else [],
+        run_config=input.run_config,
+        file_path=input.file_path or "",
+    )
+
+
+def handle_config_file_input(
+    path: str,
+    include: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
+):
+    """Declare an overridable configuration file for a launch job.
+
+    The configuration file is copied to a temporary directory and the path to
+    the copy is sent to the backend interface of the active run and used to
+    configure the job builder.
+
+    If there is no active run, a NotImplementedError is raised.
+    """
+    config_path_is_valid(path)
+    override_file(path)
+    tmp_dir = ConfigTmpDir()
+    dest = os.path.join(tmp_dir.configs_dir, path)
+    shutil.copy(path, dest)
+    arguments = JobInputArguments(
+        include=include,
+        exclude=exclude,
+        file_path=path,
+        run_config=False,
+    )
+    if wandb.run is not None:
+        _publish_job_input(arguments, wandb.run)
+    else:
+        raise NotImplementedError("Staging config file inputs is not yet implemented.")
+
+
+def handle_run_config_input(
+    include: Optional[List[str]] = None, exclude: Optional[List[str]] = None
+):
+    """Declare wandb.config as an overridable configuration for a launch job.
+
+    The include and exclude paths are sent to the backend interface of the
+    active run and used to configure the job builder.
+
+    If there is no active run, a NotImplementedError is raised.
+    """
+    arguments = JobInputArguments(
+        include=include,
+        exclude=exclude,
+        run_config=True,
+        file_path=None,
+    )
+    if wandb.run is not None:
+        _publish_job_input(arguments, wandb.run)
+    else:
+        raise NotImplementedError("Staging run config inputs is not yet implemented.")
+
+
+def _split_on_unesc_dot(path: str) -> List[str]:
+    r"""Split a string on unescaped dots.
+
+    Arguments:
+        path (str): The string to split.
+
+    Raises:
+        ValueError: If the path has a trailing escape character.
+
+    Returns:
+        List[str]: The split string.
+    """
+    parts = []
+    part = ""
+    i = 0
+    while i < len(path):
+        if path[i] == BACKSLASH:
+            if i == len(path) - 1:
+                raise LaunchError(
+                    f"Invalid config path {path}: trailing {BACKSLASH}.",
+                )
+            if path[i + 1] == PERIOD:
+                part += PERIOD
+                i += 2
+        elif path[i] == PERIOD:
+            parts.append(part)
+            part = ""
+            i += 1
+        else:
+            part += path[i]
+            i += 1
+    if part:
+        parts.append(part)
+    return parts


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This PR adds the internal library for handling user specified launch job inputs. The library serves as a layer between the user SDK functions (not yet added) and the wandb internal process. The library has two `handle` functions, `handle_config_file_input` and `handle_run_config_input`

These methods process user requests to add config file and run config inputs to their job, respectively. This mostly consists of passing these arguments to the internal process to configure the job builder with the correct inputs.

`handle_config_file_inputs` is also responsible for patching the config file.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
