### PR TITLE
chore(launch): make job input handlers callable before `wandb.init`

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_inputs/test_internal.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_inputs/test_internal.py
@@ -7,11 +7,17 @@ from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.inputs.internal import (
     ConfigTmpDir,
     JobInputArguments,
+    StagedLaunchInputs,
     _publish_job_input,
     _split_on_unesc_dot,
     handle_config_file_input,
     handle_run_config_input,
 )
+
+
+@pytest.fixture
+def reset_staged_inputs():
+    StagedLaunchInputs._instance = None
 
 
 @pytest.mark.parametrize(
@@ -76,9 +82,6 @@ def test_handle_config_file_input(mocker):
     mocker.patch("wandb.sdk.launch.inputs.internal.config_path_is_valid")
     mocker.patch("wandb.sdk.launch.inputs.internal.ConfigTmpDir")
     mocker.patch("wandb.sdk.launch.inputs.internal.shutil.copy")
-    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", None)
-    with pytest.raises(NotImplementedError):
-        handle_config_file_input("path", include=["include"], exclude=["exclude"])
 
     wandb_run = MagicMock()
     mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", wandb_run)
@@ -93,10 +96,6 @@ def test_handle_config_file_input(mocker):
 
 def test_handle_run_config_input(mocker):
     """Test handle_run_config_input function."""
-    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", None)
-    with pytest.raises(NotImplementedError):
-        handle_run_config_input(include=["include"], exclude=["exclude"])
-
     wandb_run = mocker.MagicMock()
     wandb_run._backend.interface = mocker.MagicMock()
     mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", wandb_run)
@@ -107,3 +106,34 @@ def test_handle_run_config_input(mocker):
         run_config=True,
         file_path="",
     )
+
+
+def test_handle_config_file_input_staged(mocker, reset_staged_inputs):
+    """Test that config file input is staged when run is not available."""
+    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", None)
+    mocker.patch("wandb.sdk.launch.inputs.internal.override_file")
+    mocker.patch("wandb.sdk.launch.inputs.internal.config_path_is_valid")
+    mocker.patch("wandb.sdk.launch.inputs.internal.ConfigTmpDir")
+    mocker.patch("wandb.sdk.launch.inputs.internal.shutil.copy")
+
+    handle_config_file_input("path", include=["include"], exclude=["exclude"])
+    staged_inputs = StagedLaunchInputs()._staged_inputs
+    assert len(staged_inputs) == 1
+    config_file = staged_inputs[0]
+    assert config_file.include == ["include"]
+    assert config_file.exclude == ["exclude"]
+    assert config_file.file_path == "path"
+    assert config_file.run_config is False
+
+
+def test_handle_run_config_input_staged(mocker, reset_staged_inputs):
+    """Test that run config input is staged when run is not available."""
+    mocker.patch("wandb.sdk.launch.inputs.internal.wandb.run", None)
+    handle_run_config_input(include=["include"], exclude=["exclude"])
+    staged_inputs = StagedLaunchInputs()._staged_inputs
+    assert len(staged_inputs) == 1
+    run_config = staged_inputs[0]
+    assert run_config.include == ["include"]
+    assert run_config.exclude == ["exclude"]
+    assert run_config.file_path is None
+    assert run_config.run_config is True

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2477,12 +2477,20 @@ class Run:
         self._telemetry_obj_active = True
         self._telemetry_flush()
 
+        self._detect_and_apply_job_inputs()
+
         # object is about to be returned to the user, don't let them modify it
         self._freeze()
 
         if not self._settings.resume:
             if os.path.exists(self._settings.resume_fname):
                 os.remove(self._settings.resume_fname)
+
+    def _detect_and_apply_job_inputs(self) -> None:
+        """If the user has staged launch inputs, apply them to the run."""
+        from wandb.sdk.launch.inputs.internal import StagedLaunchInputs
+
+        StagedLaunchInputs().apply(self)
 
     def _make_job_source_reqs(self) -> Tuple[List[str], Dict[str, Any], Dict[str, Any]]:
         from wandb.util import working_set


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This PR modifies the internal handlers for launch job input customization. Instead of requiring an active run (`wandb.run`) to pass input customizations to the job builder, the functions can now stage user arguments on a singleton. When `wandb.init` is called, any staged arguments will be passed to the job builder in the `run._on_ready` hook.

- [x] I updated CHANGELOG.md, or it's not applicable

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
