### PR TITLE
refactor(core): Move FileStream.SetPath/SetOffsets into Start()

### DIFF
--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -83,17 +83,6 @@ func (h apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("ERROR", err)
 	}
 
-	/*
-		tm := time.Now()
-		tmOld, ok := h.get("time").(time.Time)
-		diff := time.Duration(0)
-		if ok {
-			diff = tm.Sub(tmOld)
-		}
-		fmt.Printf("GOT %v %v %v\n", tm, diff, msg)
-		h.set("time", tm)
-	*/
-
 	f := msg.Files[filestream.HistoryFileName]
 	total := f.Offset
 	total += len(f.Content)
@@ -145,12 +134,16 @@ func NewFilestreamTest(
 ) *filestreamTest {
 	m := make(map[string]interface{})
 	capture := captureState{m: m}
-	fstreamPath := "/test/" + tName
+	fstreamPath := "/files/test-entity/test-project/" + tName + "/file_stream"
 	tServer.mux.Handle(fstreamPath, apiHandler{&capture})
 
 	fs := filestream.NewFileStream(params)
-	fs.SetPath(fstreamPath)
-	fs.Start()
+	fs.Start(
+		"test-entity",
+		"test-project",
+		tName,
+		make(filestream.FileStreamOffsetMap),
+	)
 
 	fsTest := filestreamTest{capture: &capture, path: fstreamPath, mux: tServer.mux, fs: fs, tserver: tServer}
 	defer fsTest.finish()

--- a/core/pkg/filestreamtest/filestreamtest.go
+++ b/core/pkg/filestreamtest/filestreamtest.go
@@ -45,10 +45,15 @@ func (fs *FakeFileStream) GetLastTransmitTime() time.Time {
 // Prove that we implement the interface.
 var _ filestream.FileStream = &FakeFileStream{}
 
-func (fs *FakeFileStream) Start()                                              {}
-func (fs *FakeFileStream) Close()                                              {}
-func (fs *FakeFileStream) SetPath(path string)                                 {}
-func (fs *FakeFileStream) SetOffsets(offsetMap filestream.FileStreamOffsetMap) {}
+func (fs *FakeFileStream) Start(
+	entity string,
+	project string,
+	runID string,
+	offsetMap filestream.FileStreamOffsetMap,
+) {
+}
+
+func (fs *FakeFileStream) Close() {}
 
 func (fs *FakeFileStream) StreamRecord(rec *service.Record) {
 	fs.Lock()

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -391,17 +391,13 @@ func (s *Sender) updateSettings() {
 func (s *Sender) sendRequestRunStart(_ *service.RunStartRequest) {
 	s.updateSettings()
 
-	fsPath := fmt.Sprintf(
-		"files/%s/%s/%s/file_stream",
-		s.RunRecord.Entity,
-		s.RunRecord.Project,
-		s.RunRecord.RunId,
-	)
-
 	if s.fileStream != nil {
-		s.fileStream.SetPath(fsPath)
-		s.fileStream.SetOffsets(s.resumeState.GetFileStreamOffset())
-		s.fileStream.Start()
+		s.fileStream.Start(
+			s.RunRecord.GetEntity(),
+			s.RunRecord.GetProject(),
+			s.RunRecord.GetRunId(),
+			s.resumeState.GetFileStreamOffset(),
+		)
 	}
 
 	if s.fileTransferManager != nil {


### PR DESCRIPTION
Description
---
Replaces the SetPath() and SetOffsets() methods by parameters to Start(). Also moves the responsibility for constructing the URL path from Sender to FileStream.
