### PR TITLE
refactor(core): Introduce 'waiting' package for testable code with Sleep()

### DIFF
--- a/core/internal/runfiles/runfiles.go
+++ b/core/internal/runfiles/runfiles.go
@@ -7,11 +7,11 @@ package runfiles
 
 import (
 	"context"
-	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/watcher2"
 	"github.com/wandb/wandb/core/pkg/filestream"
 	"github.com/wandb/wandb/core/pkg/observability"
@@ -70,8 +70,5 @@ type UploaderParams struct {
 	// This helps if multiple uploads are scheduled around the same time by
 	// grouping those that fall within this duration of each other and reducing
 	// the number of GraphQL invocations.
-	BatchWindow time.Duration
-
-	// Alternative to BatchWindow that specifies a waiting function.
-	BatchDelayFunc func() <-chan struct{}
+	BatchDelay waiting.Delay
 }

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -317,7 +317,7 @@ func TestUploader(t *testing.T) {
 			uploader.UploadNow("test1.txt")
 			uploader.UploadNow("test2.txt")
 			uploader.UploadNow("test2.txt")
-			batchDelay.Tick()
+			batchDelay.SetZero()
 			uploader.Finish()
 
 			assert.True(t, mockGQLClient.AllStubsUsed())

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/wandb/wandb/core/internal/runfiles"
 	"github.com/wandb/wandb/core/internal/runfilestest"
 	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/waitingtest"
 	"github.com/wandb/wandb/core/internal/watcher2test"
 	"github.com/wandb/wandb/core/pkg/filestreamtest"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -63,8 +64,8 @@ func TestUploader(t *testing.T) {
 	var fakeFileWatcher *watcher2test.FakeWatcher
 	var uploader Uploader
 
-	// Optional channel that's returned by the uploader's BatchDelayFunc.
-	var batchChan chan struct{}
+	// Optional batch delay to use in the uploader.
+	var batchDelay *waitingtest.FakeDelay
 
 	// The files_dir to set on Settings.
 	var filesDir string
@@ -85,7 +86,7 @@ func TestUploader(t *testing.T) {
 		test func(t *testing.T),
 	) {
 		// Set a default and allow tests to override it.
-		batchChan = nil
+		batchDelay = nil
 		filesDir = t.TempDir()
 		ignoreGlobs = []string{}
 		isOffline = false
@@ -101,20 +102,13 @@ func TestUploader(t *testing.T) {
 
 		fakeFileWatcher = watcher2test.NewFakeWatcher()
 
-		var batchDelayFunc func() <-chan struct{}
-		if batchChan != nil {
-			batchDelayFunc = func() <-chan struct{} {
-				return batchChan
-			}
-		}
-
 		uploader = NewUploader(runfilestest.WithTestDefaults(UploaderParams{
-			Ctx:            context.Background(),
-			GraphQL:        mockGQLClient,
-			FileStream:     fakeFileStream,
-			FileTransfer:   fakeFileTransfer,
-			FileWatcher:    fakeFileWatcher,
-			BatchDelayFunc: batchDelayFunc,
+			Ctx:          context.Background(),
+			GraphQL:      mockGQLClient,
+			FileStream:   fakeFileStream,
+			FileTransfer: fakeFileTransfer,
+			FileWatcher:  fakeFileWatcher,
+			BatchDelay:   batchDelay,
 			Settings: settings.From(&service.Settings{
 				FilesDir:    &wrapperspb.StringValue{Value: filesDir},
 				IgnoreGlobs: &service.ListStringValue{Value: ignoreGlobs},
@@ -291,7 +285,7 @@ func TestUploader(t *testing.T) {
 		})
 
 	runTest("upload batches and deduplicates CreateRunFiles calls",
-		func() { batchChan = make(chan struct{}) },
+		func() { batchDelay = waitingtest.NewFakeDelay() },
 		func(t *testing.T) {
 			writeEmptyFile(t, filepath.Join(filesDir, "test1.txt"))
 			writeEmptyFile(t, filepath.Join(filesDir, "test2.txt"))
@@ -323,7 +317,7 @@ func TestUploader(t *testing.T) {
 			uploader.UploadNow("test1.txt")
 			uploader.UploadNow("test2.txt")
 			uploader.UploadNow("test2.txt")
-			batchChan <- struct{}{}
+			batchDelay.Tick()
 			uploader.Finish()
 
 			assert.True(t, mockGQLClient.AllStubsUsed())

--- a/core/internal/runfiles/upload_batcher.go
+++ b/core/internal/runfiles/upload_batcher.go
@@ -45,8 +45,7 @@ func newUploadBatcher(
 
 // Add adds files to the next upload batch, scheduling one if necessary.
 func (b *uploadBatcher) Add(files []string) {
-	delay, ok := b.delay.Wait()
-	if !ok {
+	if b.delay.IsZero() {
 		b.upload(files)
 		return
 	}
@@ -63,7 +62,7 @@ func (b *uploadBatcher) Add(files []string) {
 		b.isQueued = true
 
 		go func() {
-			<-delay
+			<-b.delay.Wait()
 			b.uploadBatch()
 		}()
 	}

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/wandb/wandb/core/internal/filetransfer"
@@ -65,19 +64,8 @@ func newUploader(params UploaderParams) *uploader {
 		watcher: params.FileWatcher,
 	}
 
-	if params.BatchWindow != 0 {
-		params.BatchDelayFunc = func() <-chan struct{} {
-			ch := make(chan struct{})
-			go func() {
-				<-time.After(params.BatchWindow)
-				ch <- struct{}{}
-			}()
-			return ch
-		}
-	}
-
 	uploader.uploadBatcher = newUploadBatcher(
-		params.BatchDelayFunc,
+		params.BatchDelay,
 		uploader.upload,
 	)
 

--- a/core/internal/waiting/waiting.go
+++ b/core/internal/waiting/waiting.go
@@ -5,13 +5,13 @@ import "time"
 
 // Delay is a duration that some code waits for.
 type Delay interface {
+	// IsZero returns whether this is a zero-duration delay.
+	IsZero() bool
+
 	// Wait returns a channel that signals after the delay elapses.
 	//
-	// If the delay corresponds to a zero duration, this returns a nil channel
-	// and false. Otherwise, returns true.
-	//
 	// The channel is closed after signalling once.
-	Wait() (ch <-chan struct{}, ok bool)
+	Wait() <-chan struct{}
 }
 
 func NewDelay(duration time.Duration) Delay {
@@ -27,9 +27,13 @@ type realDelay struct {
 	duration time.Duration
 }
 
-func (d *realDelay) Wait() (<-chan struct{}, bool) {
-	if d.duration == 0 {
-		return nil, false
+func (d *realDelay) IsZero() bool {
+	return d.duration == 0
+}
+
+func (d *realDelay) Wait() <-chan struct{} {
+	if d.IsZero() {
+		return completedDelay()
 	}
 
 	ch := make(chan struct{}, 1)
@@ -38,5 +42,12 @@ func (d *realDelay) Wait() (<-chan struct{}, bool) {
 		ch <- struct{}{}
 		close(ch)
 	}()
-	return ch, true
+	return ch
+}
+
+func completedDelay() <-chan struct{} {
+	ch := make(chan struct{}, 1)
+	ch <- struct{}{}
+	close(ch)
+	return ch
 }

--- a/core/internal/waiting/waiting.go
+++ b/core/internal/waiting/waiting.go
@@ -1,0 +1,42 @@
+// Package waiting helps write testable code that sleeps.
+package waiting
+
+import "time"
+
+// Delay is a duration that some code waits for.
+type Delay interface {
+	// Wait returns a channel that signals after the delay elapses.
+	//
+	// If the delay corresponds to a zero duration, this returns a nil channel
+	// and false. Otherwise, returns true.
+	//
+	// The channel is closed after signalling once.
+	Wait() (ch <-chan struct{}, ok bool)
+}
+
+func NewDelay(duration time.Duration) Delay {
+	return &realDelay{duration}
+}
+
+// NoDelay returns a zero delay.
+func NoDelay() Delay {
+	return NewDelay(0)
+}
+
+type realDelay struct {
+	duration time.Duration
+}
+
+func (d *realDelay) Wait() (<-chan struct{}, bool) {
+	if d.duration == 0 {
+		return nil, false
+	}
+
+	ch := make(chan struct{}, 1)
+	go func() {
+		<-time.After(d.duration)
+		ch <- struct{}{}
+		close(ch)
+	}()
+	return ch, true
+}

--- a/core/internal/waitingtest/waitingtest.go
+++ b/core/internal/waitingtest/waitingtest.go
@@ -1,0 +1,55 @@
+// Package waitingtest defines fakes for package `waiting`.
+package waitingtest
+
+import (
+	"sync"
+
+	"github.com/wandb/wandb/core/internal/waiting"
+)
+
+// FakeDelay is a fake Delay that proceeds when Tick is called.
+//
+// This allows controlling time in a test without resorting to `time.Sleep()`
+// and hope.
+type FakeDelay struct {
+	cond *sync.Cond
+}
+
+func NewFakeDelay() *FakeDelay {
+	return &FakeDelay{
+		cond: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+// Tick unblocks any goroutine that called Wait.
+func (d *FakeDelay) Tick() {
+	// While we hold the lock, new goroutines are blocked from calling Wait().
+	d.cond.L.Lock()
+	defer d.cond.L.Unlock()
+
+	// Wakes all goroutines that called Wait() before this Tick().
+	d.cond.Broadcast()
+}
+
+// Prove we implement the Delay interface.
+var _ waiting.Delay = &FakeDelay{}
+
+func (d *FakeDelay) Wait() (<-chan struct{}, bool) {
+	if d == nil {
+		return nil, false
+	}
+
+	d.cond.L.Lock()
+
+	waitChan := make(chan struct{}, 1)
+
+	go func() {
+		defer d.cond.L.Unlock()
+		d.cond.Wait()
+
+		waitChan <- struct{}{}
+		close(waitChan)
+	}()
+
+	return waitChan, true
+}

--- a/core/internal/waitingtest/waitingtest.go
+++ b/core/internal/waitingtest/waitingtest.go
@@ -13,33 +13,68 @@ import (
 // and hope.
 type FakeDelay struct {
 	cond *sync.Cond
+
+	// If false, panic on the next Wait().
+	//
+	// Used to
+	allowsWait bool
+
+	// If true, this b
+	isZero bool
 }
 
 func NewFakeDelay() *FakeDelay {
 	return &FakeDelay{
-		cond: sync.NewCond(&sync.Mutex{}),
+		cond:       sync.NewCond(&sync.Mutex{}),
+		allowsWait: false,
+		isZero:     false,
 	}
 }
 
 // Tick unblocks any goroutine that called Wait.
-func (d *FakeDelay) Tick() {
+func (d *FakeDelay) Tick(allowMoreWait bool) {
 	// While we hold the lock, new goroutines are blocked from calling Wait().
 	d.cond.L.Lock()
 	defer d.cond.L.Unlock()
 
+	d.allowsWait = allowMoreWait
+
 	// Wakes all goroutines that called Wait() before this Tick().
+	d.cond.Broadcast()
+}
+
+// SetZero unblocks all current and future waiting goroutines.
+func (d *FakeDelay) SetZero() {
+	d.cond.L.Lock()
+	defer d.cond.L.Unlock()
+
+	d.isZero = true
 	d.cond.Broadcast()
 }
 
 // Prove we implement the Delay interface.
 var _ waiting.Delay = &FakeDelay{}
 
-func (d *FakeDelay) Wait() (<-chan struct{}, bool) {
+func (d *FakeDelay) IsZero() bool {
 	if d == nil {
-		return nil, false
+		return true
 	}
 
 	d.cond.L.Lock()
+	defer d.cond.L.Unlock()
+	return d.isZero
+}
+
+func (d *FakeDelay) Wait() <-chan struct{} {
+	if d.IsZero() {
+		return completedDelay()
+	}
+
+	d.cond.L.Lock()
+
+	if !d.allowsWait {
+		panic("tried to Wait() on a FakeDelay after the final Tick()")
+	}
 
 	waitChan := make(chan struct{}, 1)
 
@@ -51,5 +86,12 @@ func (d *FakeDelay) Wait() (<-chan struct{}, bool) {
 		close(waitChan)
 	}()
 
-	return waitChan, true
+	return waitChan
+}
+
+func completedDelay() <-chan struct{} {
+	ch := make(chan struct{}, 1)
+	ch <- struct{}{}
+	close(ch)
+	return ch
 }

--- a/core/internal/waitingtest/waitingtest.go
+++ b/core/internal/waitingtest/waitingtest.go
@@ -15,18 +15,16 @@ type FakeDelay struct {
 	cond *sync.Cond
 
 	// If false, panic on the next Wait().
-	//
-	// Used to
 	allowsWait bool
 
-	// If true, this b
+	// If true, this behaves like a zero delay.
 	isZero bool
 }
 
 func NewFakeDelay() *FakeDelay {
 	return &FakeDelay{
 		cond:       sync.NewCond(&sync.Mutex{}),
-		allowsWait: false,
+		allowsWait: true,
 		isZero:     false,
 	}
 }

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wandb/wandb/core/internal/runfiles"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/shared"
+	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/watcher2"
 	"github.com/wandb/wandb/core/pkg/filestream"
 	"github.com/wandb/wandb/core/pkg/observability"
@@ -140,6 +141,6 @@ func NewRunfilesUploader(
 		FileTransfer: fileTransfer,
 		GraphQL:      graphQL,
 		FileWatcher:  watcher2.New(watcher2.Params{Logger: logger}),
-		BatchWindow:  50 * time.Millisecond,
+		BatchDelay:   waiting.NewDelay(50 * time.Millisecond),
 	})
 }


### PR DESCRIPTION
Description
---
I was updating tests for `filestream` and found several untested bits of code relying on `time.After()`. This PR extracts the pattern I used in `runfiles` so that I can better test `filestream` later.
