### PR TITLE
refactor(core): Add comments in `collector.go`

### DIFF
--- a/core/pkg/filestream/collector.go
+++ b/core/pkg/filestream/collector.go
@@ -26,9 +26,9 @@ type chunkCollector struct {
 	// Maximum number of chunks to include in a push.
 	maxItemsPerPush int
 
-	//**************************************************
+	// **************************************************
 	// Internal state
-	//**************************************************
+	// **************************************************
 
 	// The next batch of updates to send.
 	transmitData *FsTransmitData

--- a/core/pkg/filestream/collector.go
+++ b/core/pkg/filestream/collector.go
@@ -14,24 +14,71 @@ var chunkFilename = map[ChunkTypeEnum]string{
 }
 
 type chunkCollector struct {
-	input             <-chan processedChunk
-	isDone            bool
-	heartbeatDelay    waiting.Delay
-	processDelay      waiting.Delay
-	fileChunks        chunkMap
-	maxItemsPerPush   int
-	itemsCollected    int
-	isOverflow        bool
-	isTransmitReady   bool
-	isDirty           bool
-	transmitData      *FsTransmitData
+	// A stream of updates which get batched together.
+	input <-chan processedChunk
+
+	// Maximum time to wait for an input.
+	heartbeatDelay waiting.Delay
+
+	// Maximum time to wait before finalizing a batch.
+	processDelay waiting.Delay
+
+	// Maximum number of chunks to include in a push.
+	maxItemsPerPush int
+
+	//**************************************************
+	// Internal state
+	//**************************************************
+
+	// The next batch of updates to send.
+	transmitData *FsTransmitData
+	fileChunks   chunkMap
+
+	// Whether we have something for the next batch.
+	isTransmitReady bool
+
+	// Whether we gathered at least one chunk.
+	isDirty bool
+
+	// Number of chunks collected for the next batch.
+	itemsCollected int
+
+	// Whether itemsCollected >= maxItemsPerPush in the last batch.
+	//
+	// When this is true, we skip waiting in the next batch.
+	isOverflow bool
+
+	// Whether we finished reading the entire input stream.
+	isDone bool
+
+	// The Complete and ExitCode status for the final transmission.
 	finalTransmitData *FsTransmitData
 }
 
+// CollectAndDump returns the next batch of updates to send to the backend.
+//
+// Returns nil and false if there are no updates. Otherwise, returns
+// the updates and true.
+func (cr *chunkCollector) CollectAndDump(
+	offsetMap FileStreamOffsetMap,
+) (*FsTransmitData, bool) {
+	shouldReadMore := cr.read()
+	if shouldReadMore {
+		cr.readMore()
+	}
+	data := cr.dump(offsetMap)
+
+	if data == nil {
+		return nil, false
+	} else {
+		return data, true
+	}
+}
+
 func (cr *chunkCollector) reset() {
+	cr.transmitData = &FsTransmitData{}
 	cr.fileChunks = make(chunkMap)
 	cr.itemsCollected = 0
-	cr.transmitData = &FsTransmitData{}
 	cr.isTransmitReady = false
 	cr.isDirty = false
 }

--- a/core/pkg/filestream/loop_transmit.go
+++ b/core/pkg/filestream/loop_transmit.go
@@ -36,11 +36,9 @@ func (fs *fileStream) loopTransmit(inChan <-chan processedChunk) {
 		maxItemsPerPush: fs.maxItemsPerPush,
 	}
 	for !collector.isDone {
-		if readMore := collector.read(); readMore {
-			collector.readMore()
-		}
-		data := collector.dump(fs.offsetMap)
-		if data != nil {
+		data, ok := collector.CollectAndDump(fs.offsetMap)
+
+		if ok {
 			fs.send(data)
 			fs.heartbeatStopwatch.Reset()
 		} else if fs.heartbeatStopwatch.IsDone() {


### PR DESCRIPTION
Description
---
Every time I looked at this file I kept forgetting the differences between "isTransmitReady" and "isDirty", how "isDone" is set, and the fact that "finalTransmitData" is just used to store two booleans. Added docs so that I don't have to reread the whole thing every time :)

Also updated its interface to just a "CollectAndDump" method instead of calling read(), readMore() and dump() from loop_transmit.go. This lets loop_transmit.go focus on its job and clarifies the contract for collector.go.
