### PR TITLE
fix(core): avoid setting the debouncer if there were no changes made

### DIFF
--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -475,7 +475,6 @@ func (s *Sender) sendRequestDefer(request *service.DeferRequest) {
 		request.State++
 		s.fwdRequestDefer(request)
 	case service.DeferRequest_FLUSH_SUM:
-		s.summaryDebouncer.SetNeedsDebounce()
 		s.summaryDebouncer.Flush(s.streamSummary)
 		s.uploadSummaryFile()
 		request.State++


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Every time we send an update message to the sender, we set the debounce logic, hence there is no need to do it when we are flushing the summary, as if we already debounce it, we won't need to do anything.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
