### PR TITLE
refactor(core): Move (nil, nil) retryablehttp output handling

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -52,6 +52,8 @@ type Backend struct {
 // gracefully, and respecting rate-limit response headers.
 type Client interface {
 	// Sends an HTTP request to the W&B backend.
+	//
+	// It is guaranteed that the response is non-nil unless there is an error.
 	Send(*Request) (*http.Response, error)
 
 	// Sends an arbitrary HTTP request.
@@ -60,6 +62,8 @@ type Client interface {
 	// then use to make requests to the backend, like GraphQL. If the request
 	// URL matches the backend's base URL, there's special handling as in
 	// Send().
+	//
+	// It is guaranteed that the response is non-nil unless there is an error.
 	Do(*http.Request) (*http.Response, error)
 }
 

--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -65,7 +65,15 @@ func (client *clientImpl) sendToWandbBackend(
 ) (*http.Response, error) {
 	client.setClientHeaders(req)
 	client.setAuthHeaders(req)
-	return client.send(req)
+
+	resp, err := client.send(req)
+
+	// This is a bug that happens with retryablehttp sometimes.
+	if err == nil && resp == nil {
+		return nil, fmt.Errorf("api: nil error and nil response")
+	}
+
+	return resp, err
 }
 
 // Sends any HTTP request.

--- a/core/internal/filetransfer/file_transfer_default.go
+++ b/core/internal/filetransfer/file_transfer_default.go
@@ -109,10 +109,6 @@ func (ft *DefaultFileTransfer) Upload(task *Task) error {
 	if err != nil {
 		return err
 	}
-	// TODO: why would we get an empty response?
-	if resp == nil {
-		return fmt.Errorf("file transfer: upload: response is nil")
-	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return fmt.Errorf("file transfer: upload: failed to upload: %s", resp.Status)
 	}


### PR DESCRIPTION
Description
---
Moves the err==nil && resp==nil check into `api` to avoid duplicating it. We had this check in `filetransfer` but we also need it to apply in `filestream`.

As I recall, this is some bug in the retryablehttp client, but I don't remember if we have a tracking bug or a way to reproduce it.
