### PR TITLE
docs(public-api): make docstrings for public api exists functions clearer

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1051,11 +1051,12 @@ class Api:
 
     @normalize_exceptions
     def artifact_exists(self, name: str, type: Optional[str] = None):
-        """Return whether an artifact exists.
+        """Return whether an artifact version exists within a specified project and entity.
 
         Arguments:
-            name: (str) An artifact name. May be prefixed with entity/project. Valid names
-                can be in the following forms:
+            name: (str) An artifact name. May be prefixed with entity/project.
+                If not specified, entity and project will be inferred from the default project settings.
+                Valid names can be in the following forms:
                     name:version
                     name:alias
             type: (str, optional) The type of artifact
@@ -1068,10 +1069,11 @@ class Api:
 
     @normalize_exceptions
     def artifact_collection_exists(self, name: str, type: str):
-        """Return whether an artifact collection exists.
+        """Return whether an artifact collection exists within a specified project and entity.
 
         Arguments:
-            name: (str) An artifact collection name. May be prefixed with entity/project
+            name: (str) An artifact collection name. May be prefixed with entity/project.
+                If not specified, entity and project will be inferred from the default project settings.
             type: (str) The type of artifact collection
         """
         try:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Follows up on [WB-15063](https://wandb.atlassian.net/browse/WB-15063)

This PR follows up on #7483 and makes the docstrings for `artifact_exists` and `artifact_collection_exists` clearer

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Just a documentation change, no testing needed

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-15063]: https://wandb.atlassian.net/browse/WB-15063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ