### PR TITLE
docs(public-api): make `name` argument clearer in exists functions

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1055,7 +1055,8 @@ class Api:
 
         Arguments:
             name: (str) An artifact name. May be prefixed with entity/project.
-                If not specified, entity and project will be inferred from the default project settings.
+                If entity or project is not specified, it will be inferred from the override params if populated.
+                Otherwise, entity will be pulled from the user settings and project will default to "uncategorized".
                 Valid names can be in the following forms:
                     name:version
                     name:alias
@@ -1073,7 +1074,8 @@ class Api:
 
         Arguments:
             name: (str) An artifact collection name. May be prefixed with entity/project.
-                If not specified, entity and project will be inferred from the default project settings.
+                If entity or project is not specified, it will be inferred from the override params if populated.
+                Otherwise, entity will be pulled from the user settings and project will default to "uncategorized".
             type: (str) The type of artifact collection
         """
         try:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Follows up on [WB-15063](https://wandb.atlassian.net/browse/WB-15063)

This PR follows up on #7483 and #7519 to make the doc strings for the `name` argument in `artifact_exists` and `artifact_collection_exists` more accurate.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-15063]: https://wandb.atlassian.net/browse/WB-15063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ