### PR TITLE
docs(sdk): update comment on unresolved symbols when building with cgo

### DIFF
--- a/core/hatch.py
+++ b/core/hatch.py
@@ -64,9 +64,9 @@ def _go_linker_flags(wandb_commit_sha: Optional[str]) -> str:
                 # Use https://en.wikipedia.org/wiki/Gold_(linker)
                 "-fuse-ld=gold",
                 # Set the --weak-unresolved-symbols option in gold, converting
-                # unresolved symbols to weak references.
-                #
-                # TODO: why?
+                # unresolved symbols to weak references. This is necessary to
+                # build a Go binary with cgo on Linux, where the NVML libraries
+                # needed for Nvidia GPU monitoring may not be available at build time.
                 "-Wl,--weak-unresolved-symbols",
             ]
         )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

We pass the `--weak-unresolved-symbols` flag to the gold linker on Linux when building core. It is necessary to
because the NVML libraries that are needed for Nvidia GPU monitoring may not be available at build time. (The Go buildings for nvml assume that those libs are available at build time, see https://github.com/NVIDIA/go-nvml)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
