### PR TITLE
fix(launch): slice memory bug in core process job input filtering

### DIFF
--- a/core/pkg/launch/config.go
+++ b/core/pkg/launch/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/segmentio/encoding/json"
 	"gopkg.in/yaml.v3"
@@ -137,12 +138,13 @@ func dictToPathMap(dict ConfigDict) PathMap {
 // Recursively constructs a flattened map of paths to values from a nested dict.
 func flattenMap(input ConfigDict, path ConfigPath, output PathMap) {
 	for k, v := range input {
-		path := append(path, k)
+		new_path := slices.Clone(path)
+		new_path = append(new_path, k)
 		switch v := v.(type) {
 		case ConfigDict:
-			flattenMap(v, path, output)
+			flattenMap(v, new_path, output)
 		default:
-			output[&path] = v
+			output[&new_path] = v
 		}
 	}
 }

--- a/core/pkg/launch/config_test.go
+++ b/core/pkg/launch/config_test.go
@@ -112,3 +112,41 @@ func TestFilterTree_IncludeAndExclude(t *testing.T) {
 		include_exclude_tree,
 	)
 }
+
+func TestFilterTree_DeeplyNested(t *testing.T) {
+	config := NewConfigFrom(ConfigDict{
+		"key1": "value1",
+		"key2": ConfigDict{
+			"key3": "value3",
+			"key4": ConfigDict{
+				"key5": "value5",
+				"key6": ConfigDict{
+					"key7": "value7",
+					"key8": "value8",
+				},
+			},
+		},
+	})
+	include_paths := []ConfigPath{{"key2"}}
+	exclude_paths := []ConfigPath{
+		{"key2", "key4", "key6", "key8"},
+		{"key2", "key3"},
+	}
+
+	include_exclude_tree := config.filterTree(include_paths, exclude_paths)
+
+	assert.Equal(t,
+		ConfigDict{
+			"key2": ConfigDict{
+				"key4": ConfigDict{
+					"key5": "value5",
+					"key6": ConfigDict{
+						"key7": "value7",
+					},
+				},
+			},
+		},
+		include_exclude_tree,
+	)
+
+}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

In the code for filtering configs down by prefix, we were using the same
slice address as a key for multiple paths. I modified the code that flattens
the user config into this map so that it creates distinct memory for each
path slice.

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
