### PR TITLE
refactor(core): Move some output preprocessing into filestream

### DIFF
--- a/core/pkg/filestream/logsupdate.go
+++ b/core/pkg/filestream/logsupdate.go
@@ -1,6 +1,15 @@
 package filestream
 
-import "github.com/wandb/wandb/core/pkg/service"
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wandb/wandb/core/pkg/service"
+)
+
+// rfc3339Micro Modified from time.RFC3339Nano
+const rfc3339Micro = "2006-01-02T15:04:05.000000Z07:00"
 
 // LogsUpdate is new lines in a run's console output.
 type LogsUpdate struct {
@@ -8,8 +17,38 @@ type LogsUpdate struct {
 }
 
 func (u *LogsUpdate) Chunk(fs *fileStream) error {
-	fs.addTransmit(&TransmitChunk{
-		ConsoleLogLines: []string{u.Record.Line},
+	// generate compatible timestamp to python iso-format (microseconds without Z)
+	t := strings.TrimSuffix(time.Now().UTC().Format(rfc3339Micro), "Z")
+
+	var line string
+	switch u.Record.OutputType {
+	case service.OutputRawRecord_STDOUT:
+		line = fmt.Sprintf("%s %s", t, u.Record.Line)
+	case service.OutputRawRecord_STDERR:
+		line = fmt.Sprintf("ERROR %s %s", t, u.Record.Line)
+	default:
+		fs.logger.CaptureError(
+			fmt.Sprintf(
+				"filestream: unexpected logs output type %v",
+				u.Record.OutputType,
+			),
+			nil,
+		)
+
+		return nil
+	}
+
+	fs.addTransmit(&collectorLogsUpdate{
+		line: line,
 	})
+
 	return nil
+}
+
+type collectorLogsUpdate struct {
+	line string
+}
+
+func (u *collectorLogsUpdate) Apply(state *CollectorState) {
+	state.Buffer.ConsoleLogLines = append(state.Buffer.ConsoleLogLines, u.line)
 }

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"google.golang.org/protobuf/proto"
@@ -34,8 +33,6 @@ import (
 )
 
 const (
-	// RFC3339Micro Modified from time.RFC3339Nano
-	RFC3339Micro              = "2006-01-02T15:04:05.000000Z07:00"
 	configDebouncerRateLimit  = 1 / 30.0 // todo: audit rate limit
 	configDebouncerBurstSize  = 1        // todo: audit burst size
 	summaryDebouncerRateLimit = 1 / 30.0 // todo: audit rate limit
@@ -982,27 +979,9 @@ func (s *Sender) sendOutputRaw(record *service.Record, outputRaw *service.Output
 		s.logger.Error("sender: sendOutput: failed to write to output file", "error", err)
 	}
 
-	if s.fileStream == nil {
-		return
+	if s.fileStream != nil {
+		s.fileStream.StreamUpdate(&fs.LogsUpdate{Record: outputRaw})
 	}
-
-	// generate compatible timestamp to python iso-format (microseconds without Z)
-	t := strings.TrimSuffix(time.Now().UTC().Format(RFC3339Micro), "Z")
-	var line string
-	switch outputRaw.OutputType {
-	case service.OutputRawRecord_STDOUT:
-		line = fmt.Sprintf("%s %s", t, outputRaw.Line)
-	case service.OutputRawRecord_STDERR:
-		line = fmt.Sprintf("ERROR %s %s", t, outputRaw.Line)
-	default:
-		err := fmt.Errorf("sender: sendOutputRaw: unexpected output type %v", outputRaw.OutputType)
-		s.logger.CaptureError("sender received error", err)
-		return
-	}
-
-	s.fileStream.StreamUpdate(&fs.LogsUpdate{
-		Record: &service.OutputRawRecord{Line: line},
-	})
 }
 
 func (s *Sender) sendAlert(_ *service.Record, alert *service.AlertRecord) {


### PR DESCRIPTION
Description
---
Moves some console logs related code from `sender.go` into `filestream` as a pre-cursor to adding carriage-return handling.
