### PR TITLE
chore(sdk): Add "wandb_core_only" pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ markers = [
     "wandb_args",
     "flaky",
     "wandb_core_failure(feature): test failures with wandb-core, grouped by feature",
+    "wandb_core_only: tests for features only available with wandb-core",
 ]
 timeout = 60
 log_format = "%(asctime)s %(levelname)s %(message)s"

--- a/tests/pytest_tests/conftest.py
+++ b/tests/pytest_tests/conftest.py
@@ -51,16 +51,27 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if toggle_wandb_core.__name__ in metafunc.fixturenames:
         # Allow tests to opt-out of wandb-core until we have feature parity.
         skip_wandb_core = False
+        wandb_core_only = False
         for mark in metafunc.definition.iter_markers():
             if mark.name == "wandb_core_failure":
                 skip_wandb_core = True
-                break
+            elif mark.name == "wandb_core_only":
+                wandb_core_only = True
 
-        values = [False]
-        ids = ["no_wandb_core"]
-        if not skip_wandb_core:
-            values.append(True)
-            ids.append("wandb_core")
+        if wandb_core_only:
+            # Don't merge tests like this. Implement the feature first.
+            assert (
+                not skip_wandb_core
+            ), "Cannot mark test both wandb_core_failure and wandb_core_only"
+
+            values = [True]
+            ids = ["wandb_core"]
+        elif skip_wandb_core:
+            values = [False]
+            ids = ["no_wandb_core"]
+        else:
+            values = [False, True]
+            ids = ["no_wandb_core", "wandb_core"]
 
         metafunc.parametrize(
             toggle_wandb_core.__name__,

--- a/tests/pytest_tests/system_tests/test_core/test_wandb_run.py
+++ b/tests/pytest_tests/system_tests/test_core/test_wandb_run.py
@@ -316,10 +316,7 @@ def test_summary_from_history(relay_server, wandb_init):
     assert summary == {"a": 2}
 
 
-@pytest.mark.skipif(
-    not wandb.env.is_require_core(),
-    reason="This is broken in the python code",
-)
+@pytest.mark.wandb_core_only
 def test_summary_remove(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
@@ -331,10 +328,7 @@ def test_summary_remove(relay_server, wandb_init):
     assert summary == {}
 
 
-@pytest.mark.skipif(
-    not wandb.env.is_require_core(),
-    reason="This is broken in the python code",
-)
+@pytest.mark.wandb_core_only
 def test_summary_remove_nested(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init(allow_val_change=True)

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
@@ -31,6 +31,7 @@ def test_config():
     }
 
 
+@pytest.mark.wandb_core_only
 def test_manage_config_file(
     test_settings,
     wandb_init,
@@ -45,11 +46,6 @@ def test_manage_config_file(
     have the config file saved in its files and the job should have the config
     file schema.
     """
-    # This is a short term hack to avoid running this test without wandb core
-    # enabled. Long term this should controlled with a pytest marker.
-    core = os.environ.get("WANDB__REQUIRE_CORE", "false")
-    if core.lower() != "true":
-        return
     monkeypatch.chdir(tmp_path)
     config_str = yaml.dump(test_config)
 
@@ -127,6 +123,7 @@ def test_manage_config_file(
         }
 
 
+@pytest.mark.wandb_core_only
 def test_manage_wandb_config(
     test_settings,
     wandb_init,
@@ -137,9 +134,6 @@ def test_manage_wandb_config(
     If `manage_wandb_config` is called and a job is created then the job should
     have the wandb config schema saved in its metadata.
     """
-    core = os.environ.get("WANDB__REQUIRE_CORE", "false")
-    if core.lower() != "true":
-        return
     settings = test_settings()
     settings.update(
         {

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
@@ -4,7 +4,6 @@ These tests execute the real user flow exposed by the
 `wandb.sdk.launch.inputs.manage` module.
 """
 
-import os
 import time
 
 import pytest


### PR DESCRIPTION
Description
---
Creates a "wandb_core_only" pytest marker intended for tests for features in wandb-core that are not available in the Python service implementation.
