### PR TITLE
fix(core): Increment file offsets in filestream

### DIFF
--- a/core/pkg/filestream/filestream.go
+++ b/core/pkg/filestream/filestream.go
@@ -208,7 +208,10 @@ func (fs *fileStream) Start(
 		project,
 		runID,
 	)
-	fs.offsetMap = maps.Clone(offsetMap)
+
+	if offsetMap != nil {
+		fs.offsetMap = maps.Clone(offsetMap)
+	}
 
 	fs.processWait.Add(1)
 	go func() {

--- a/core/pkg/filestream/filestream_test.go
+++ b/core/pkg/filestream/filestream_test.go
@@ -31,6 +31,12 @@ func NewHistoryRecord() filestream.Update {
 	}
 }
 
+func jsonCompact(t *testing.T, s string) []byte {
+	var result bytes.Buffer
+	assert.NoError(t, json.Compact(&result, []byte(s)))
+	return result.Bytes()
+}
+
 func TestFileStream(t *testing.T) {
 	var fakeClient *apitest.FakeClient
 	var printer *observability.Printer
@@ -71,18 +77,52 @@ func TestFileStream(t *testing.T) {
 		assert.Equal(t, "POST", req.Method)
 		assert.Equal(t, "test-url/files/entity/project/run/file_stream", req.URL)
 		assert.Equal(t, http.Header{}, req.Header)
-		var expected bytes.Buffer
-		assert.NoError(t, json.Compact(&expected,
-			[]byte(`{
-				"files": {
-					"wandb-history.jsonl": {
-						"offset": 0,
-						"content": ["{\"test_key\":0}"]
-					}
-				},
-				"uploaded": ["file.txt"]
-			}`)))
-		assert.Equal(t, expected.String(), string(req.Body))
+		assert.Equal(t,
+			jsonCompact(t,
+				`{
+					"files": {
+						"wandb-history.jsonl": {
+							"offset": 0,
+							"content": ["{\"test_key\":0}"]
+						}
+					},
+					"uploaded": ["file.txt"]
+				}`),
+			req.Body,
+		)
+	})
+
+	t.Run("increments file offsets", func(t *testing.T) {
+		fakeBatchDelay := waitingtest.NewFakeDelay()
+		fs := setup(func() {
+			processDelay = fakeBatchDelay
+		})
+
+		fs.Start("entity", "project", "run", filestream.FileStreamOffsetMap{})
+		fakeClient.SetResponse(&apitest.TestResponse{StatusCode: 200}, nil)
+		fs.StreamUpdate(NewHistoryRecord())
+		fakeBatchDelay.WaitAndTick(true, time.Second)
+		fs.StreamUpdate(NewHistoryRecord())
+		fakeBatchDelay.WaitAndTick(true, time.Second)
+		fs.Close()
+
+		requests := fakeClient.GetRequests()
+		assert.Len(t, requests, 3) // 2 history, 1 final transmission
+
+		assert.Equal(t,
+			jsonCompact(t,
+				`{
+					"files": {"wandb-history.jsonl":
+						{"offset": 0, "content": ["{\"test_key\":0}"]}}
+				}`),
+			requests[0].Body)
+		assert.Equal(t,
+			jsonCompact(t,
+				`{
+					"files": {"wandb-history.jsonl":
+						{"offset": 1, "content": ["{\"test_key\":0}"]}}
+				}`),
+			requests[1].Body)
 	})
 
 	t.Run("sends heartbeat", func(t *testing.T) {

--- a/core/pkg/filestream/transmitchunk.go
+++ b/core/pkg/filestream/transmitchunk.go
@@ -52,6 +52,7 @@ func (c *TransmitChunk) Write(
 				Offset:  offsets[chunkType],
 				Content: lines,
 			}
+			offsets[chunkType] += len(lines)
 		}
 	}
 	addLines(HistoryChunk, c.HistoryLines)


### PR DESCRIPTION
Description
---
Accidentally missed this in https://github.com/wandb/wandb/pull/7553, so `filestream` was always writing to offset 0 in Nexus.

It's a little surprising that no tests caught this! It would seem it's because of request batching, but a test only needs to log just over 20 milliseconds apart to send more than a single batch.

Testing
---
I originally wrote a test, but it was flaky because there's no way to wait until `collector.go` reads exactly one update from the input stream. I have a different PR in which I delete `collector.go` completely, and other PRs where I improve the tests.
