### PR TITLE
chore(sdk): Set some envs in conftest instead of noxfile.py

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -50,9 +50,6 @@ def run_pytest(
 
     pytest_opts = []
     pytest_env = {
-        "WANDB__NETWORK_BUFFER": "1000",
-        "WANDB_ERROR_REPORTING": "false",
-        "WANDB_CORE_ERROR_REPORTING": "false",
         "USERNAME": session.env.get("USERNAME"),
         "PATH": session.env.get("PATH"),
         "USERPROFILE": session.env.get("USERPROFILE"),

--- a/tests/pytest_tests/conftest.py
+++ b/tests/pytest_tests/conftest.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from queue import Queue
 from typing import Any, Callable, Generator, Iterable, Optional, Union
 
-os.environ["WANDB_ERROR_REPORTING"] = "false"
-
 import git  # noqa: E402
 import pytest  # noqa: E402
 import wandb  # noqa: E402
@@ -26,9 +24,14 @@ from wandb.sdk.lib.paths import StrPath  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def disable_sentry_in_core(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Disables Sentry for all tests with core."""
+def disable_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configures wandb env variables to suitable defaults for tests."""
+    # Don't write to Sentry.
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
     monkeypatch.setenv("WANDB_CORE_ERROR_REPORTING", "false")
+
+    # Set the _network_buffer setting to 1000. Not sure why. It's undocumented.
+    monkeypatch.setenv("WANDB__NETWORK_BUFFER", "1000")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Description
---
People don't have to use `nox` to run tests, but `pytest` is required.

PR #7573 moved WANDB_CORE_ERROR_REPORTING to `conftest.py`. This moves some other ones as well.

TODO: I'm worried that we may be reading certain env variables when `wandb` is imported, but it's too hard to tell from the code. If we're really doing that, we should stop.
