### PR TITLE
perf(artifacts): pipeline the artifact file uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Changed
 
 - Require `unsafe=True` in `use_model` calls that could potentially load and deserialize unsafe pickle files by @anandwandb https://github.com/wandb/wandb/pull/7663
+- Eliminate signed URL timeout errors during artifact file uploads in core by @moredatarequired in https://github.com/wandb/wandb/pull/7586
 
 ### Deprecated
 

--- a/core/internal/filetransfer/file_transfer_manager.go
+++ b/core/internal/filetransfer/file_transfer_manager.go
@@ -13,7 +13,7 @@ type Storage int
 
 const (
 	bufferSize              = 32
-	defaultConcurrencyLimit = 128
+	DefaultConcurrencyLimit = 128
 )
 
 type FileTransfer interface {
@@ -92,7 +92,7 @@ func NewFileTransferManager(opts ...FileTransferManagerOption) FileTransferManag
 	fm := fileTransferManager{
 		inChan:    make(chan *Task, bufferSize),
 		wg:        &sync.WaitGroup{},
-		semaphore: make(chan struct{}, defaultConcurrencyLimit),
+		semaphore: make(chan struct{}, DefaultConcurrencyLimit),
 	}
 
 	for _, opt := range opts {

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -455,7 +455,7 @@ func (s *Sender) sendJobFlush() {
 		return
 	}
 	saver := artifacts.NewArtifactSaver(
-		s.ctx, s.graphqlClient, s.fileTransferManager, artifact, 0, "",
+		s.ctx, s.logger, s.graphqlClient, s.fileTransferManager, artifact, 0, "",
 	)
 	if _, err = saver.Save(s.fwdChan); err != nil {
 		s.logger.Error("sender: sendDefer: failed to save job artifact", "error", err)
@@ -1109,7 +1109,7 @@ func (s *Sender) sendFiles(_ *service.Record, filesRecord *service.FilesRecord) 
 
 func (s *Sender) sendArtifact(_ *service.Record, msg *service.ArtifactRecord) {
 	saver := artifacts.NewArtifactSaver(
-		s.ctx, s.graphqlClient, s.fileTransferManager, msg, 0, "",
+		s.ctx, s.logger, s.graphqlClient, s.fileTransferManager, msg, 0, "",
 	)
 	artifactID, err := saver.Save(s.fwdChan)
 	if err != nil {
@@ -1122,7 +1122,7 @@ func (s *Sender) sendArtifact(_ *service.Record, msg *service.ArtifactRecord) {
 func (s *Sender) sendRequestLogArtifact(record *service.Record, msg *service.LogArtifactRequest) {
 	var response service.LogArtifactResponse
 	saver := artifacts.NewArtifactSaver(
-		s.ctx, s.graphqlClient, s.fileTransferManager, msg.Artifact, msg.HistoryStep, msg.StagingDir,
+		s.ctx, s.logger, s.graphqlClient, s.fileTransferManager, msg.Artifact, msg.HistoryStep, msg.StagingDir,
 	)
 	artifactID, err := saver.Save(s.fwdChan)
 	if err != nil {


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-17571](https://wandb.atlassian.net/browse/WB-17571)

Rewrite of `ArtifactSaver.uploadFiles` to use buffered channels and switch between available pending tasks

This is an alternative to https://github.com/wandb/wandb/pull/7274, and should be considered to supersede it. It's dramatically simpler, has similar (though slightly lower) performance, and handles retries better.

**Key differences**:
1. We don't impose an arbitrary minimum time (previously 1 hour) before retrying failed uploads
2. We bound the number of outstanding goroutines to limit maximum memory consumption
3. Overall this version is 20-25% faster for artifacts with many small files

Minor differences:
Differences:
1. I hope that this version is simplified and a little easier to follow, though YMMV
2. We use a smaller batch size (1000); this decreases stuttering and improves performance especially for 2k-10k file artifacts
2. We don't pause after requesting a batch of URLs, and can immediately start scheduling uploads made available from a previous batch
4. We process upload responses as they come in, rather than a tick-tock pattern where we alternate between scheduling them and processing them in ~10k batches
5. By selecting among all available tasks we are able to terminate earlier in case of fatal errors; this will also allow us to more easily integrate progress reporting with a `time.Ticker` channel in the future

Data flow:
Assemble batches
While not done:
1. If there are 1000 or fewer outstanding uploads, request upload URLs for a batch (in the background)
2. Select first available
    - Error to handle
    - File to schedule for upload
    - Upload result to check

If files fail to upload, collect them to retry. Retry all failed uploads by rerunning the above as long as each time we succeed for at least half the files.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Very extensively tested for performance (on extremely large artifacts).

Relies somewhat heavily on existing integration tests in CI for correctness.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-17571]: https://wandb.atlassian.net/browse/WB-17571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ