### PR TITLE
ci(launch): disable 2 launch unit tests on windows

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_docker.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_docker.py
@@ -1,3 +1,4 @@
+import platform
 from unittest.mock import MagicMock
 
 import pytest
@@ -86,6 +87,10 @@ def mock_docker_build(mocker):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Windows handles the path differently and isn't supported",
+)
 async def test_docker_builder_build(
     mock_launch_project,
     mock_build_context_manager,

--- a/tests/pytest_tests/unit_tests/test_launch/test_create_job.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_create_job.py
@@ -1,9 +1,11 @@
 import json
 import os
+import platform
 import sys
 import tempfile
 from unittest.mock import MagicMock
 
+import pytest
 from wandb.sdk.internal.job_builder import JobBuilder
 from wandb.sdk.launch.create_job import (
     _configure_job_builder_for_partial,
@@ -93,6 +95,10 @@ def test_dump_metadata_and_requirements():
     assert metadata == m
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="python exec name is different on windows",
+)
 def test_get_entrypoint():
     dir = tempfile.TemporaryDirectory().name
     job_source = "artifact"


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This PR disables two launch unit tests on Windows because to make them pass we would need to make the assertions more complex and windows is not even a supported environment for launch.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
