### PR TITLE
chore(core): use more standard cache dir for logs

### DIFF
--- a/core/pkg/observability/util.go
+++ b/core/pkg/observability/util.go
@@ -62,7 +62,7 @@ func GetLoggerPathFS(fs FileSystem) (fs.File, error) {
 	}
 
 	timestamp := time.Now().Format("20060102_150405")
-	path := filepath.Join(dir, "wandb", fmt.Sprintf("core-debug-%s.log", timestamp))
+	path := filepath.Join(dir, "wandb", "logs", fmt.Sprintf("core-debug-%s.log", timestamp))
 
 	if err := fs.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return nil, fmt.Errorf("error creating log directory: %s", err)

--- a/core/pkg/observability/util.go
+++ b/core/pkg/observability/util.go
@@ -62,7 +62,7 @@ func GetLoggerPathFS(fs FileSystem) (fs.File, error) {
 	}
 
 	timestamp := time.Now().Format("20060102_150405")
-	path := filepath.Join(dir, ".wandb", fmt.Sprintf("core-debug-%s.log", timestamp))
+	path := filepath.Join(dir, "wandb", fmt.Sprintf("core-debug-%s.log", timestamp))
 
 	if err := fs.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return nil, fmt.Errorf("error creating log directory: %s", err)


### PR DESCRIPTION
Description
-----------
Currently the nexus core creates a cache dir at:
```
~/.cache/.wandb
```
And stores a bunch of files there related to nexus startup logs.
This is somewhat hard to find, i don't think we do a great job of advertising that this file exists.

But the more trivial problem, is that it probably could be more better named.   We already create a cache dir at:
```
~/.cache/wandb
```
which stores:
```
~/.cache/wandb/artifacts/
```

The .wandb is possibly an over-reaction to the troubles we have felt with the "wandb" dir in the users working directory.   In the cache dir, it is more common to be less hidden -- and we should be consistent.

I propose:
```
~/.cache/wandb/logs/
```

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
