### PR TITLE
test(sdk): bump wait time for local-testcontainer spin up

### DIFF
--- a/tests/pytest_tests/system_tests/conftest.py
+++ b/tests/pytest_tests/system_tests/conftest.py
@@ -567,7 +567,7 @@ def spin_wandb_server(settings: WandbServerSettings) -> bool:
         subprocess.Popen(command)
         # wait for the server to start
         server_is_up = check_server_health(
-            base_url=base_url, endpoint=app_health_endpoint, num_retries=30
+            base_url=base_url, endpoint=app_health_endpoint, num_retries=120
         )
         if not server_is_up:
             return False
@@ -579,7 +579,7 @@ def spin_wandb_server(settings: WandbServerSettings) -> bool:
         )
 
     return check_server_health(
-        base_url=fixture_url, endpoint=fixture_health_endpoint, num_retries=10
+        base_url=fixture_url, endpoint=fixture_health_endpoint, num_retries=20
     )
 
 


### PR DESCRIPTION
Description
-----------
Bump wait time for local-testcontainer spin up when running system tests. It can sometimes take a while to download and extract docker layers.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
