### PR TITLE
chore(sweeps): sane limit on local sweep controller run history req

### DIFF
--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -431,7 +431,7 @@ class _WandbController:
         if self._sweep_metric:
             k = ["_step"]
             k.append(self._sweep_metric)
-            specs_json = {"keys": k, "samples": 100000}
+            specs_json = {"keys": k, "samples": 1000}
         specs = json.dumps(specs_json)
         # TODO(jhr): catch exceptions?
         sweep_obj = self._api.sweep(self._sweep_id, specs)

--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -431,7 +431,7 @@ class _WandbController:
         if self._sweep_metric:
             k = ["_step"]
             k.append(self._sweep_metric)
-            specs_json = {"keys": k, "samples": 1000}
+            specs_json = {"keys": k, "samples": 10_000}
         specs = json.dumps(specs_json)
         # TODO(jhr): catch exceptions?
         sweep_obj = self._api.sweep(self._sweep_id, specs)


### PR DESCRIPTION
`100_000` sampled metrics seems like, a lot of metrics to be fetching by default. If a sweep absolutely needs high sample counts, it can always be specified manually...