### PR TITLE
chore(launch): save config files to `_wandb_configs/` instead of `configs/`

### DIFF
--- a/core/pkg/launch/config_files.go
+++ b/core/pkg/launch/config_files.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
+const LAUNCH_MANAGED_CONFIGS_DIR = "_wandb_configs"
+
 // Represents a config file parameter for a job.
 //
 // The relpath is the path to the config file relative to the files directory.
@@ -49,7 +51,7 @@ func newFileInputFromProto(
 func (j *JobBuilder) generateConfigFileSchema(
 	configFile *configFileParameter,
 ) data_types.TypeRepresentation {
-	path := filepath.Join(j.settings.FilesDir.GetValue(), "configs", configFile.relpath)
+	path := filepath.Join(j.settings.FilesDir.GetValue(), LAUNCH_MANAGED_CONFIGS_DIR, configFile.relpath)
 	config, err := deserializeConfig(path)
 	if err != nil {
 		j.logger.Error("jobBuilder: error creating runconfig from config file", err)

--- a/core/pkg/launch/job_builder_test.go
+++ b/core/pkg/launch/job_builder_test.go
@@ -1068,7 +1068,7 @@ func TestConfigFileParameters(t *testing.T) {
 	writeRequirements(t, fdir)
 	writeDiffFile(t, fdir)
 	writeWandbMetadata(t, fdir, metadata)
-	configDir := filepath.Join(fdir, "configs")
+	configDir := filepath.Join(fdir, LAUNCH_MANAGED_CONFIGS_DIR)
 	err = os.Mkdir(configDir, 0777)
 	assert.Nil(t, err)
 	yamlContents := "key1: value1\nkey2: value2\nkey3:\n  key4:\n    key6: value6\n    key7: value7\n  key5: value5\n"

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
@@ -70,7 +70,7 @@ def test_manage_config_file(
         run_api_object = api.run(run.path)
         poll = 1
         while poll < 8:
-            file = run_api_object.file("configs/config.yaml")
+            file = run_api_object.file("_wandb_configs/config.yaml")
             if file.size == len(config_str):
                 break
             time.sleep(poll)

--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -22,6 +22,7 @@ from .files import config_path_is_valid, override_file
 
 PERIOD = "."
 BACKSLASH = "\\"
+LAUNCH_MANAGED_CONFIGS_DIR = "_wandb_configs"
 
 
 class ConfigTmpDir:
@@ -42,7 +43,7 @@ class ConfigTmpDir:
     def __init__(self):
         if not hasattr(self, "_tmp_dir"):
             self._tmp_dir = tempfile.mkdtemp()
-            self._configs_dir = os.path.join(self._tmp_dir, "configs")
+            self._configs_dir = os.path.join(self._tmp_dir, LAUNCH_MANAGED_CONFIGS_DIR)
             os.mkdir(self._configs_dir)
 
     @property


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-18773

This PR changes the value of an important constant: the path within run files where we save config files managed by launch. The features this is used for has not been officially released so this is a chore.

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
