### PR TITLE
chore(launch): only save run config inputs to metdata if manage_wandb_config is called

### DIFF
--- a/core/pkg/launch/job_builder.go
+++ b/core/pkg/launch/job_builder.go
@@ -198,13 +198,12 @@ func MakeArtifactNameSafe(name string) string {
 
 func NewJobBuilder(settings *service.Settings, logger *observability.CoreLogger, verbose bool) *JobBuilder {
 	jobBuilder := JobBuilder{
-		settings:              settings,
-		isNotebookRun:         settings.GetXJupyter().GetValue(),
-		logger:                logger,
-		Disable:               settings.GetDisableJobCreation().GetValue(),
-		wandbConfigParameters: newWandbConfigParameters(),
-		saveShapeToMetadata:   false,
-		verbose:               verbose,
+		settings:            settings,
+		isNotebookRun:       settings.GetXJupyter().GetValue(),
+		logger:              logger,
+		Disable:             settings.GetDisableJobCreation().GetValue(),
+		saveShapeToMetadata: false,
+		verbose:             verbose,
 	}
 	return &jobBuilder
 }
@@ -762,7 +761,7 @@ func (j *JobBuilder) makeJobMetadata(output *data_types.TypeRepresentation) (str
 		}
 		input_types["files"] = files
 	}
-	if j.runConfig != nil {
+	if j.runConfig != nil && j.wandbConfigParameters != nil {
 		runConfigTypes, err := j.inferRunConfigTypes()
 		if err == nil {
 			input_types[WandbConfigKey] = runConfigTypes
@@ -828,6 +827,9 @@ func (j *JobBuilder) HandleJobInputRequest(request *service.JobInputRequest) {
 		}
 		j.configFiles = append(j.configFiles, newInput)
 	case *service.JobInputSource_RunConfig:
+		if j.wandbConfigParameters == nil {
+			j.wandbConfigParameters = newWandbConfigParameters()
+		}
 		j.wandbConfigParameters.appendIncludePaths(request.GetIncludePaths())
 		j.wandbConfigParameters.appendExcludePaths(request.GetExcludePaths())
 	}

--- a/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
+++ b/tests/pytest_tests/system_tests/test_launch/test_launch_manage.py
@@ -116,7 +116,6 @@ def test_manage_config_file(
                         "wb_type": "typedDict",
                     }
                 },
-                "@wandb.config": {"params": {"type_map": {}}, "wb_type": "typedDict"},
             },
             "output_types": {"wb_type": "unknown"},
         }


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18772

This PR modifies the core job builder to save `wandb.config` inputs iff `launch.manage_wandb_config` was called. A system test has been updated to check this.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
