### PR TITLE
chore(artifacts): add updateArtifact mutation to wandb-core code gen

### DIFF
--- a/core/api/graphql/mutation_update_artifact.graphql
+++ b/core/api/graphql/mutation_update_artifact.graphql
@@ -1,0 +1,7 @@
+mutation UpdateArtifact($artifactID: ID!, $metadata: JSONString) {
+  updateArtifact(input: { artifactID: $artifactID, metadata: $metadata }) {
+    artifact {
+      id
+    }
+  }
+}

--- a/core/internal/gql/gql_gen.go
+++ b/core/internal/gql/gql_gen.go
@@ -673,6 +673,34 @@ func (v *ServerInfoServerInfoLatestLocalVersionInfo) GetVersionOnThisInstanceStr
 	return v.VersionOnThisInstanceString
 }
 
+// UpdateArtifactResponse is returned by UpdateArtifact on success.
+type UpdateArtifactResponse struct {
+	UpdateArtifact *UpdateArtifactUpdateArtifactUpdateArtifactPayload `json:"updateArtifact"`
+}
+
+// GetUpdateArtifact returns UpdateArtifactResponse.UpdateArtifact, and is useful for accessing the field via an interface.
+func (v *UpdateArtifactResponse) GetUpdateArtifact() *UpdateArtifactUpdateArtifactUpdateArtifactPayload {
+	return v.UpdateArtifact
+}
+
+// UpdateArtifactUpdateArtifactUpdateArtifactPayload includes the requested fields of the GraphQL type UpdateArtifactPayload.
+type UpdateArtifactUpdateArtifactUpdateArtifactPayload struct {
+	Artifact UpdateArtifactUpdateArtifactUpdateArtifactPayloadArtifact `json:"artifact"`
+}
+
+// GetArtifact returns UpdateArtifactUpdateArtifactUpdateArtifactPayload.Artifact, and is useful for accessing the field via an interface.
+func (v *UpdateArtifactUpdateArtifactUpdateArtifactPayload) GetArtifact() UpdateArtifactUpdateArtifactUpdateArtifactPayloadArtifact {
+	return v.Artifact
+}
+
+// UpdateArtifactUpdateArtifactUpdateArtifactPayloadArtifact includes the requested fields of the GraphQL type Artifact.
+type UpdateArtifactUpdateArtifactUpdateArtifactPayloadArtifact struct {
+	Id string `json:"id"`
+}
+
+// GetId returns UpdateArtifactUpdateArtifactUpdateArtifactPayloadArtifact.Id, and is useful for accessing the field via an interface.
+func (v *UpdateArtifactUpdateArtifactUpdateArtifactPayloadArtifact) GetId() string { return v.Id }
+
 type UploadPartsInput struct {
 	PartNumber int64  `json:"partNumber"`
 	HexMD5     string `json:"hexMD5"`
@@ -1133,6 +1161,18 @@ func (v *__RunStoppedStatusInput) GetProjectName() *string { return v.ProjectNam
 
 // GetRunId returns __RunStoppedStatusInput.RunId, and is useful for accessing the field via an interface.
 func (v *__RunStoppedStatusInput) GetRunId() string { return v.RunId }
+
+// __UpdateArtifactInput is used internally by genqlient
+type __UpdateArtifactInput struct {
+	ArtifactID string  `json:"artifactID"`
+	Metadata   *string `json:"metadata"`
+}
+
+// GetArtifactID returns __UpdateArtifactInput.ArtifactID, and is useful for accessing the field via an interface.
+func (v *__UpdateArtifactInput) GetArtifactID() string { return v.ArtifactID }
+
+// GetMetadata returns __UpdateArtifactInput.Metadata, and is useful for accessing the field via an interface.
+func (v *__UpdateArtifactInput) GetMetadata() *string { return v.Metadata }
 
 // __UpsertBucketInput is used internally by genqlient
 type __UpsertBucketInput struct {
@@ -1831,6 +1871,45 @@ func ServerInfo(
 	var err_ error
 
 	var data_ ServerInfoResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by UpdateArtifact.
+const UpdateArtifact_Operation = `
+mutation UpdateArtifact ($artifactID: ID!, $metadata: JSONString) {
+	updateArtifact(input: {artifactID:$artifactID,metadata:$metadata}) {
+		artifact {
+			id
+		}
+	}
+}
+`
+
+func UpdateArtifact(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	artifactID string,
+	metadata *string,
+) (*UpdateArtifactResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "UpdateArtifact",
+		Query:  UpdateArtifact_Operation,
+		Variables: &__UpdateArtifactInput{
+			ArtifactID: artifactID,
+			Metadata:   metadata,
+		},
+	}
+	var err_ error
+
+	var data_ UpdateArtifactResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This PR adds the `UpdateArtifact` mutation for use in core. This is to enable enable the job builder in core to update partial job metadata.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
