### PR TITLE
fix(launch): overwrite partial job metadata instead of building a new job version

### DIFF
--- a/core/pkg/launch/job_builder.go
+++ b/core/pkg/launch/job_builder.go
@@ -2,15 +2,18 @@
 package launch
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/segmentio/encoding/json"
 
 	"github.com/wandb/wandb/core/internal/data_types"
+	"github.com/wandb/wandb/core/internal/gql"
 	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/pkg/artifacts"
 	"github.com/wandb/wandb/core/pkg/observability"
@@ -31,6 +34,7 @@ const REQUIREMENTS_FNAME = "requirements.txt"
 const FROZEN_REQUIREMENTS_FNAME = "requirements.frozen.txt"
 const DIFF_FNAME = "diff.patch"
 const WANDB_METADATA_FNAME = "wandb-metadata.json"
+const BASE_JOB_VERSION = "v0"
 
 type LogLevel int
 
@@ -157,15 +161,10 @@ type ArtifactInfoForJob struct {
 	Name string `json:"name"`
 }
 
-type PartialJobSource struct {
-	JobName       string            `json:"job_name"`
-	JobSourceInfo JobSourceMetadata `json:"job_source_info"`
-}
-
 type JobBuilder struct {
 	logger *observability.CoreLogger
 
-	PartialJobSource *PartialJobSource
+	PartialJobID *string
 
 	verbose bool
 
@@ -509,6 +508,8 @@ func (j *JobBuilder) createImageJobSource(metadata RunMetadata) (*ImageSource, *
 }
 
 func (j *JobBuilder) Build(
+	ctx context.Context,
+	client graphql.Client,
 	output map[string]interface{},
 ) (artifact *service.ArtifactRecord, rerr error) {
 	j.logger.Debug("jobBuilder: building job artifact")
@@ -516,6 +517,23 @@ func (j *JobBuilder) Build(
 		j.logger.Debug("jobBuilder: disabled")
 		return nil, nil
 	}
+	if j.PartialJobID != nil {
+		// If we have a partial job source we just update the
+		// metadata and don't build the job.
+		typed_output := data_types.ResolveTypes(output)
+		metadata, err := j.MakeJobMetadata(&typed_output)
+		if err != nil {
+			return nil, err
+		}
+		_, err = gql.UpdateArtifact(
+			ctx, client, *j.PartialJobID, &metadata,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
 	fileDir := j.settings.FilesDir.GetValue()
 	_, err := os.Stat(filepath.Join(fileDir, REQUIREMENTS_FNAME))
 	if os.IsNotExist(err) {
@@ -542,43 +560,36 @@ func (j *JobBuilder) Build(
 	var sourceInfo JobSourceMetadata
 	var name *string
 	var sourceType *SourceType
-	// this flow is from using a partial job artifact that was created by the CLI to make a run
-	if j.PartialJobSource != nil {
-		name = &j.PartialJobSource.JobName
-		sourceInfo = j.PartialJobSource.JobSourceInfo
-		_sourceType := sourceInfo.Source.GetSourceType()
-		sourceType = &_sourceType
-	} else {
-		sourceType, err = j.GetSourceType(*metadata)
-		if err != nil {
-			return nil, err
-		}
-		if sourceType == nil {
-			j.logger.Debug("jobBuilder: unable to determine source type")
-			j.logIfVerbose("No source type found, not creating job artifact", Warn)
-			return nil, nil
-		}
-		programRelpath := j.getProgramRelpath(*metadata, *sourceType)
-		// all jobs except image jobs need to specify a program path
-		if *sourceType != ImageSourceType && programRelpath == nil {
-			j.logger.Debug("jobBuilder: no program path found")
-			j.logIfVerbose("No program path found, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job", Warn)
-			return nil, nil
-		}
 
-		var jobSource Source
-		jobSource, name, err = j.getSourceAndName(*sourceType, programRelpath, *metadata)
-		if err != nil {
-			return nil, err
-		} else if jobSource == nil || name == nil {
-			j.logger.Debug("jobBuilder: no job source or name found")
-			return nil, nil
-		}
-		sourceInfo.Source = jobSource
-		sourceInfo.SourceType = *sourceType
-
-		sourceInfo.Version = "v0"
+	sourceType, err = j.GetSourceType(*metadata)
+	if err != nil {
+		return nil, err
 	}
+	if sourceType == nil {
+		j.logger.Debug("jobBuilder: unable to determine source type")
+		j.logIfVerbose("No source type found, not creating job artifact", Warn)
+		return nil, nil
+	}
+	programRelpath := j.getProgramRelpath(*metadata, *sourceType)
+	// all jobs except image jobs need to specify a program path
+	if *sourceType != ImageSourceType && programRelpath == nil {
+		j.logger.Debug("jobBuilder: no program path found")
+		j.logIfVerbose("No program path found, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job", Warn)
+		return nil, nil
+	}
+
+	var jobSource Source
+	jobSource, name, err = j.getSourceAndName(*sourceType, programRelpath, *metadata)
+	if err != nil {
+		return nil, err
+	} else if jobSource == nil || name == nil {
+		j.logger.Debug("jobBuilder: no job source or name found")
+		return nil, nil
+	}
+	sourceInfo.Source = jobSource
+	sourceInfo.SourceType = *sourceType
+
+	sourceInfo.Version = BASE_JOB_VERSION
 
 	// inject partial field for create job CLI flow
 	if metadata.Partial != nil {
@@ -591,7 +602,7 @@ func (j *JobBuilder) Build(
 	}
 	var metadataString string
 	if j.saveShapeToMetadata {
-		metadataString, err = j.makeJobMetadata(&sourceInfo.OutputTypes)
+		metadataString, err = j.MakeJobMetadata(&sourceInfo.OutputTypes)
 		if err != nil {
 			return nil, err
 		}
@@ -684,74 +695,11 @@ func (j *JobBuilder) HandleUseArtifactRecord(record *service.Record) {
 		return
 	}
 
-	sourceInfo := useArtifact.Partial.SourceInfo
-	jobSourceMetadata := JobSourceMetadata{
-		Version:    sourceInfo.XVersion,
-		SourceType: SourceType(sourceInfo.SourceType),
-		Runtime:    &sourceInfo.Runtime,
-	}
-
-	switch sourceInfo.SourceType {
-	case "repo":
-		if sourceInfo.Source.Git == nil {
-			j.logger.Debug("jobBuilder: no git info found in repo type partial use artifact record, disabling job builder")
-			j.Disable = true
-			return
-		}
-		entrypoint := sourceInfo.Source.Git.Entrypoint
-		gitSource := GitSource{
-			Git: GitInfo{
-				Remote: &sourceInfo.Source.Git.GitInfo.Remote,
-				Commit: &sourceInfo.Source.Git.GitInfo.Commit,
-			},
-			Notebook:   sourceInfo.Source.Git.Notebook,
-			Entrypoint: entrypoint,
-		}
-		if sourceInfo.Source.Git.Dockerfile != "" {
-			gitSource.Dockerfile = &sourceInfo.Source.Git.Dockerfile
-		}
-		if sourceInfo.Source.Git.BuildContext != "" {
-			gitSource.BuildContext = &sourceInfo.Source.Git.BuildContext
-		}
-		jobSourceMetadata.Source = gitSource
-	case "artifact":
-		if sourceInfo.Source.Artifact == nil {
-			j.logger.Debug("jobBuilder: no artifact info found in artifact type partial use artifact record, disabling job builder")
-			j.Disable = true
-			return
-		}
-		entrypoint := sourceInfo.Source.Artifact.Entrypoint
-		artifactSource := ArtifactSource{
-			Artifact:   sourceInfo.Source.Artifact.Artifact,
-			Notebook:   sourceInfo.Source.Artifact.Notebook,
-			Entrypoint: entrypoint,
-		}
-		if sourceInfo.Source.Artifact.Dockerfile != "" {
-			artifactSource.Dockerfile = &sourceInfo.Source.Artifact.Dockerfile
-		}
-		if sourceInfo.Source.Artifact.BuildContext != "" {
-			artifactSource.BuildContext = &sourceInfo.Source.Artifact.BuildContext
-		}
-		jobSourceMetadata.Source = artifactSource
-	case "image":
-		if sourceInfo.Source.Image == nil {
-			j.logger.Debug("jobBuilder: no image info found in image type partial use artifact record, disabling job builder")
-			j.Disable = true
-			return
-		}
-		imageSource := ImageSource{
-			Image: sourceInfo.Source.Image.Image,
-		}
-		jobSourceMetadata.Source = imageSource
-	}
-	j.PartialJobSource = &PartialJobSource{
-		JobName:       strings.Split(useArtifact.Partial.JobName, ":")[0],
-		JobSourceInfo: jobSourceMetadata,
-	}
+	j.PartialJobID = &useArtifact.Id
 }
 
 // Makes job input schema into a json string to be stored as artifact metadata.
-func (j *JobBuilder) makeJobMetadata(output *data_types.TypeRepresentation) (string, error) {
+func (j *JobBuilder) MakeJobMetadata(output *data_types.TypeRepresentation) (string, error) {
 	metadata := make(map[string]interface{})
 	input_types := make(map[string]interface{})
 	if len(j.configFiles) > 0 {

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -450,13 +450,17 @@ func (s *Sender) sendJobFlush() {
 
 	output, err := s.runSummary.CloneTree()
 	if err != nil {
-		s.logger.Error("sender: sendJobFlush: failed to copy run summary", "error", err)
+		s.logger.Error(
+			"sender: sendJobFlush: failed to copy run summary", "error", err,
+		)
 		return
 	}
 
-	artifact, err := s.jobBuilder.Build(output)
+	artifact, err := s.jobBuilder.Build(s.ctx, s.graphqlClient, output)
 	if err != nil {
-		s.logger.Error("sender: sendDefer: failed to build job artifact", "error", err)
+		s.logger.Error(
+			"sender: sendDefer: failed to build job artifact", "error", err,
+		)
 		return
 	}
 	if artifact == nil {
@@ -467,7 +471,9 @@ func (s *Sender) sendJobFlush() {
 		s.ctx, s.logger, s.graphqlClient, s.fileTransferManager, artifact, 0, "",
 	)
 	if _, err = saver.Save(s.fwdChan); err != nil {
-		s.logger.Error("sender: sendDefer: failed to save job artifact", "error", err)
+		s.logger.Error(
+			"sender: sendDefer: failed to save job artifact", "error", err,
+		)
 	}
 }
 

--- a/tests/pytest_tests/unit_tests/test_job_builder.py
+++ b/tests/pytest_tests/unit_tests/test_job_builder.py
@@ -25,7 +25,7 @@ def make_proto_settings(**kwargs):
     return proto
 
 
-def test_build_repo_job(runner):
+def test_build_repo_job(runner, api):
     remote_name = str_of_length(129)
     metadata = {
         "git": {"remote": remote_name, "commit": "testtestcommit"},
@@ -46,7 +46,11 @@ def test_build_repo_job(runner):
             )
         )
         job_builder = JobBuilder(settings)
-        artifact = job_builder.build(dockerfile="Dockerfile", build_context="blah/")
+        artifact = job_builder.build(
+            api,
+            dockerfile="Dockerfile",
+            build_context="blah/",
+        )
         assert artifact is not None
         assert artifact.name == make_artifact_name_safe(
             f"job-{remote_name}_blah_test.py"
@@ -64,7 +68,7 @@ def test_build_repo_job(runner):
             assert source_json["build_context"] == "blah/"
 
 
-def test_build_repo_notebook_job(runner, tmp_path, mocker):
+def test_build_repo_notebook_job(runner, tmp_path, api, mocker):
     remote_name = str_of_length(129)
     metadata = {
         "git": {"remote": remote_name, "commit": "testtestcommit"},
@@ -99,7 +103,7 @@ def test_build_repo_notebook_job(runner, tmp_path, mocker):
             )
         )
         job_builder = JobBuilder(settings)
-        artifact = job_builder.build()
+        artifact = job_builder.build(api)
         assert artifact is not None
         assert artifact.name == make_artifact_name_safe(
             f"job-{remote_name}_blah_test.ipynb"
@@ -110,7 +114,7 @@ def test_build_repo_notebook_job(runner, tmp_path, mocker):
         assert job_builder._is_notebook_run is True
 
 
-def test_build_artifact_job(runner):
+def test_build_artifact_job(runner, api):
     metadata = {
         "codePath": "blah/test.py",
         "args": ["--test", "test"],
@@ -133,7 +137,7 @@ def test_build_artifact_job(runner):
             "id": "testtest",
             "name": artifact_name,
         }
-        artifact = job_builder.build()
+        artifact = job_builder.build(api)
         assert artifact is not None
         assert artifact.name == make_artifact_name_safe(f"job-{artifact_name}")
         assert artifact.type == "job"
@@ -141,7 +145,7 @@ def test_build_artifact_job(runner):
         assert artifact._manifest.entries["requirements.frozen.txt"]
 
 
-def test_build_artifact_notebook_job(runner, tmp_path, mocker):
+def test_build_artifact_notebook_job(runner, tmp_path, mocker, api):
     metadata = {
         "program": "blah/test.ipynb",
         "args": ["--test", "test"],
@@ -177,7 +181,7 @@ def test_build_artifact_notebook_job(runner, tmp_path, mocker):
             "id": "testtest",
             "name": artifact_name,
         }
-        artifact = job_builder.build()
+        artifact = job_builder.build(api)
         assert artifact is not None
         assert artifact.name == make_artifact_name_safe(f"job-{artifact_name}")
         assert artifact.type == "job"
@@ -187,7 +191,13 @@ def test_build_artifact_notebook_job(runner, tmp_path, mocker):
 
 
 @pytest.mark.parametrize("verbose", [True, False])
-def test_build_artifact_notebook_job_no_program(runner, tmp_path, capfd, verbose):
+def test_build_artifact_notebook_job_no_program(
+    runner,
+    tmp_path,
+    capfd,
+    verbose,
+    api,
+):
     metadata = {
         "program": "blah/test.ipynb",
         "args": ["--test", "test"],
@@ -216,7 +226,7 @@ def test_build_artifact_notebook_job_no_program(runner, tmp_path, capfd, verbose
             "id": "testtest",
             "name": artifact_name,
         }
-        artifact = job_builder.build()
+        artifact = job_builder.build(api)
 
         assert not artifact
         out = capfd.readouterr().err
@@ -228,7 +238,13 @@ def test_build_artifact_notebook_job_no_program(runner, tmp_path, capfd, verbose
 
 
 @pytest.mark.parametrize("verbose", [True, False])
-def test_build_artifact_notebook_job_no_metadata(runner, tmp_path, capfd, verbose):
+def test_build_artifact_notebook_job_no_metadata(
+    runner,
+    tmp_path,
+    capfd,
+    verbose,
+    api,
+):
     artifact_name = str_of_length(129)
     with runner.isolated_filesystem():
         with open("requirements.txt", "w") as f:
@@ -249,7 +265,7 @@ def test_build_artifact_notebook_job_no_metadata(runner, tmp_path, capfd, verbos
             "id": "testtest",
             "name": artifact_name,
         }
-        artifact = job_builder.build()
+        artifact = job_builder.build(api)
 
         assert not artifact
         out = capfd.readouterr().err
@@ -262,7 +278,11 @@ def test_build_artifact_notebook_job_no_metadata(runner, tmp_path, capfd, verbos
 
 @pytest.mark.parametrize("verbose", [True, False])
 def test_build_artifact_notebook_job_no_program_metadata(
-    runner, tmp_path, capfd, verbose
+    runner,
+    tmp_path,
+    capfd,
+    verbose,
+    api,
 ):
     metadata = {
         "args": ["--test", "test"],
@@ -290,7 +310,7 @@ def test_build_artifact_notebook_job_no_program_metadata(
             "id": "testtest",
             "name": artifact_name,
         }
-        artifact = job_builder.build()
+        artifact = job_builder.build(api)
 
         assert not artifact
         out = capfd.readouterr().err
@@ -301,7 +321,7 @@ def test_build_artifact_notebook_job_no_program_metadata(
             assert _msg not in out
 
 
-def test_build_image_job(runner):
+def test_build_image_job(runner, api):
     image_name = str_of_length(129)
     metadata = {
         "program": "blah/test.py",
@@ -321,7 +341,7 @@ def test_build_image_job(runner):
             )
         )
         job_builder = JobBuilder(settings)
-        artifact = job_builder.build()
+        artifact = job_builder.build(api)
         assert artifact is not None
         assert artifact.name == make_artifact_name_safe(f"job-{image_name}")
         assert artifact.type == "job"
@@ -339,10 +359,10 @@ def test_set_disabled():
     assert job_builder.disable == "testtest"
 
 
-def test_no_metadata_file():
+def test_no_metadata_file(runner, api):
     settings = SettingsStatic(
         make_proto_settings(**{"files_dir": "./", "disable_job_creation": False})
     )
     job_builder = JobBuilder(settings)
-    artifact = job_builder.build()
+    artifact = job_builder.build(api)
     assert artifact is None

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3762,6 +3762,36 @@ class Api:
             response["updateArtifactManifest"]["artifactManifest"]["file"],
         )
 
+    def update_artifact_metadata(
+        self, artifact_id: str, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Set the metadata of the given artifact version."""
+        mutation = gql(
+            """
+        mutation UpdateArtifact(
+            $artifactID: ID!,
+            $metadata: JSONString,
+        ) {
+            updateArtifact(input: {
+                artifactID: $artifactID,
+                metadata: $metadata,
+            }) {
+                artifact {
+                    id
+                }
+            }
+        }
+        """
+        )
+        response = self.gql(
+            mutation,
+            variable_values={
+                "artifactID": artifact_id,
+                "metadata": json.dumps(metadata),
+            },
+        )
+        return response["updateArtifact"]["artifact"]
+
     def _resolve_client_id(
         self,
         client_id: str,

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Un
 import wandb
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.data_types._dtypes import TypeRegistry
+from wandb.sdk.internal.internal_api import Api
 from wandb.sdk.lib.filenames import DIFF_FNAME, METADATA_FNAME, REQUIREMENTS_FNAME
 from wandb.util import make_artifact_name_safe
 
@@ -23,7 +24,7 @@ else:
 _logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from wandb.proto.wandb_internal_pb2 import ArtifactRecord, UseArtifactRecord
+    from wandb.proto.wandb_internal_pb2 import ArtifactRecord
 
 FROZEN_REQUIREMENTS_FNAME = "requirements.frozen.txt"
 JOB_FNAME = "wandb-job.json"
@@ -101,12 +102,6 @@ class JobSourceDict(TypedDict, total=False):
     input_types: Dict[str, Any]
     output_types: Dict[str, Any]
     runtime: Optional[str]
-    _partial: Optional[str]  # flag to indicate incomplete job
-
-
-class PartialJobSourceDict(TypedDict):
-    job_name: str
-    job_source_info: JobSourceDict
 
 
 class ArtifactInfoForJob(TypedDict):
@@ -141,7 +136,7 @@ class JobBuilder:
     _summary: Optional[Dict[str, Any]]
     _logged_code_artifact: Optional[ArtifactInfoForJob]
     _disable: bool
-    _partial_source: Optional[PartialJobSourceDict]
+    _partial_source_id: Optional[str]  # Partial job source artifact id.
     _aliases: List[str]
     _job_seq_id: Optional[str]
     _job_version_alias: Optional[str]
@@ -158,7 +153,7 @@ class JobBuilder:
         self._job_seq_id = None
         self._job_version_alias = None
         self._disable = settings.disable_job_creation
-        self._partial_source = None
+        self._partial_source_id = None
         self._aliases = []
         self._source_type: Optional[Literal["repo", "artifact", "image"]] = (
             settings.job_source  # type: ignore[assignment]
@@ -179,6 +174,17 @@ class JobBuilder:
     @disable.setter
     def disable(self, val: bool) -> None:
         self._disable = val
+
+    @property
+    def input_types(self) -> Dict[str, Any]:
+        return TypeRegistry.type_of(self._config).to_json()
+
+    @property
+    def output_types(self) -> Dict[str, Any]:
+        return TypeRegistry.type_of(self._summary).to_json()
+
+    def set_partial_source_id(self, source_id: str) -> None:
+        self._partial_source_id = source_id
 
     def _handle_server_artifact(
         self, res: Optional[Dict], artifact: "ArtifactRecord"
@@ -413,6 +419,7 @@ class JobBuilder:
 
     def build(
         self,
+        api: Api,
         build_context: Optional[str] = None,
         dockerfile: Optional[str] = None,
     ) -> Optional[Artifact]:
@@ -430,6 +437,20 @@ class JobBuilder:
             otherwise None.
         """
         _logger.info("Attempting to build job artifact")
+
+        # If a partial job was used, write the input/output types to the metadata
+        # rather than building a new job version.
+        if self._partial_source_id is not None:
+            new_metadata = {
+                "input_types": {"@wandb.config": self.input_types},
+                "output_types": self.output_types,
+            }
+            api.update_artifact_metadata(
+                self._partial_source_id,
+                new_metadata,
+            )
+            return None
+
         if not os.path.exists(
             os.path.join(self._settings.files_dir, REQUIREMENTS_FNAME)
         ):
@@ -463,78 +484,60 @@ class JobBuilder:
         name: Optional[str] = None
         source_info: Optional[JobSourceDict] = None
 
-        if self._partial_source is not None:
-            # construct source from downloaded partial job metadata
-            name = self._partial_source["job_name"]
-            source_info = self._partial_source["job_source_info"]
-            # add input/output types now that we are actually running a run
-            source_info.update(
-                {"input_types": input_types, "output_types": output_types}
-            )
-            # set source_type to determine whether to add diff file to artifact
-            source_type = source_info.get("source_type")
-        else:
-            # configure job from environment
-            source_type = self._get_source_type(metadata)
-            if not source_type:
-                # if source_type is None, then we don't have enough information to build a job
-                # if the user intended to create a job, warn.
-                if (
-                    self._settings.job_name
-                    or self._settings.job_source
-                    or self._source_type
-                ):
-                    self._log_if_verbose(
-                        "No source type found, not creating job artifact", "warn"
-                    )
-                return None
-
-            program_relpath = self._get_program_relpath(source_type, metadata)
+        # configure job from environment
+        source_type = self._get_source_type(metadata)
+        if not source_type:
+            # if source_type is None, then we don't have enough information to build a job
+            # if the user intended to create a job, warn.
             if (
-                not metadata.get("_partial")
-                and source_type != "image"
-                and not program_relpath
+                self._settings.job_name
+                or self._settings.job_source
+                or self._source_type
             ):
                 self._log_if_verbose(
-                    "No program path found, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job",
-                    "warn",
+                    "No source type found, not creating job artifact", "warn"
                 )
-                return None
+            return None
 
-            source, name = self._build_job_source(
-                source_type,
-                program_relpath,
-                metadata,
+        program_relpath = self._get_program_relpath(source_type, metadata)
+        if source_type != "image" and not program_relpath:
+            self._log_if_verbose(
+                "No program path found, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job",
+                "warn",
             )
-            if source is None:
-                return None
+            return None
 
-            if build_context:
-                source["build_context"] = build_context  # type: ignore[typeddict-item]
-            if dockerfile:
-                source["dockerfile"] = dockerfile  # type: ignore[typeddict-item]
+        source, name = self._build_job_source(
+            source_type,
+            program_relpath,
+            metadata,
+        )
+        if source is None:
+            return None
 
-            # Pop any keys that are initialized to None. The current TypedDict
-            # system for source dicts requires all keys to be present, but we
-            # don't want to include keys that are None in the final dict.
-            for key in list(source.keys()):
-                if source[key] is None:  # type: ignore[literal-required]
-                    source.pop(key)  # type: ignore[literal-require,misc]
+        if build_context:
+            source["build_context"] = build_context  # type: ignore[typeddict-item]
+        if dockerfile:
+            source["dockerfile"] = dockerfile  # type: ignore[typeddict-item]
 
-            source_info = {
-                "_version": str(get_min_supported_for_source_dict(source) or "v0"),
-                "source_type": source_type,
-                "source": source,
-                "input_types": input_types,
-                "output_types": output_types,
-                "runtime": runtime,
-            }
+        # Pop any keys that are initialized to None. The current TypedDict
+        # system for source dicts requires all keys to be present, but we
+        # don't want to include keys that are None in the final dict.
+        for key in list(source.keys()):
+            if source[key] is None:  # type: ignore[literal-required]
+                source.pop(key)  # type: ignore[literal-require,misc]
+
+        source_info = {
+            "_version": str(get_min_supported_for_source_dict(source) or "v0"),
+            "source_type": source_type,
+            "source": source,
+            "input_types": input_types,
+            "output_types": output_types,
+            "runtime": runtime,
+        }
 
         assert source_info is not None
         assert name is not None
-        if metadata.get("_partial"):
-            assert not self._partial_source, "partial job has partial output"
-            source_info.update({"_partial": metadata["_partial"]})
 
         artifact = JobArtifact(name)
 
@@ -620,48 +623,3 @@ class JobBuilder:
 
     def _has_image_job_ingredients(self, metadata: Dict[str, Any]) -> bool:
         return metadata.get("docker") is not None
-
-
-def convert_use_artifact_to_job_source(
-    use_artifact: "UseArtifactRecord",
-) -> PartialJobSourceDict:
-    source_info = use_artifact.partial.source_info
-    source_info_dict: JobSourceDict = {
-        "_version": "v0",
-        "source_type": source_info.source_type,
-        "runtime": source_info.runtime,
-    }
-    if source_info.source_type == "repo":
-        entrypoint = [str(x) for x in source_info.source.git.entrypoint]
-        git_source: GitSourceDict = {
-            "git": {
-                "remote": source_info.source.git.git_info.remote,
-                "commit": source_info.source.git.git_info.commit,
-            },
-            "entrypoint": entrypoint,
-            "notebook": source_info.source.git.notebook,
-            "build_context": None,
-            "dockerfile": None,
-        }
-        source_info_dict.update({"source": git_source})
-    elif source_info.source_type == "artifact":
-        entrypoint = [str(x) for x in source_info.source.artifact.entrypoint]
-        artifact_source: ArtifactSourceDict = {
-            "artifact": source_info.source.artifact.artifact,
-            "entrypoint": entrypoint,
-            "notebook": source_info.source.artifact.notebook,
-            "build_context": None,
-            "dockerfile": None,
-        }
-        source_info_dict.update({"source": artifact_source})
-    elif source_info.source_type == "image":
-        image_source: ImageSourceDict = {
-            "image": source_info.source.image.image,
-        }
-        source_info_dict.update({"source": image_source})
-
-    partal_job_source_dict: PartialJobSourceDict = {
-        "job_name": use_artifact.partial.job_name.split(":")[0],
-        "job_source_info": source_info_dict,
-    }
-    return partal_job_source_dict

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -39,7 +39,6 @@ from wandb.sdk.internal import (
     datastore,
     file_stream,
     internal_api,
-    job_builder,
     sender_config,
     update,
 )
@@ -1440,9 +1439,7 @@ class SendManager:
             self._job_builder.disable = True
         elif use.partial.job_name:
             # job is partial, let job builder rebuild job, set job source dict
-            self._job_builder._partial_source = (
-                job_builder.convert_use_artifact_to_job_source(record.use_artifact)
-            )
+            self._job_builder.set_partial_source_id(use.id)
 
     def send_request_log_artifact(self, record: "Record") -> None:
         assert record.control.req_resp
@@ -1618,7 +1615,8 @@ class SendManager:
         summary_dict = self._cached_summary.copy()
         summary_dict.pop("_wandb", None)
         self._job_builder.set_summary(summary_dict)
-        artifact = self._job_builder.build()
+
+        artifact = self._job_builder.build(api=self._api)
         if artifact is not None and self._run is not None:
             proto_artifact = self._interface._make_artifact(artifact)
             proto_artifact.run_id = self._run.run_id

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -185,6 +185,7 @@ def _create_job(
 
     # build job artifact, loads wandb-metadata and creates wandb-job.json here
     artifact = job_builder.build(
+        api.api,
         dockerfile=dockerfile,
         build_context=build_context,
     )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18438

This PR modifies the core and legacy job builder to never create a new job version when a partial job is used.

Partial jobs are created by the `wandb job create` or `wandb launch -u` commands. They include source information but no input or output type info. When a run created from a partial job finishes, the job builder constructs a new, non-partial job version with the input and output info saved into the `wandb-job.json` file.

Jobs now support having i/o types stored in artifact version metadata, which can be mutated without producing a new job version. Partial jobs now write `_partial` key to the metadata that can be used to identify partial jobs. If a partial job is detected the job builder will overwrite the artifact metadata with the i/o types.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
