### PR TITLE
chore(launch): Warn when wandb is missing from requirements

### DIFF
--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -486,6 +486,8 @@ class LaunchProject:
                         _logger.warn(f"Unable to parse requirements.txt: {e}")
                         continue
             requirements_line += "WANDB_ONLY_INCLUDE={} ".format(",".join(include_only))
+            if "wandb" not in requirements_line:
+                wandb.termwarn(f"{LOG_PREFIX}wandb is not present in requirements.txt.")
         return requirements_line
 
 

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -202,6 +202,10 @@ def get_requirements_section(
     if (base_path / "src" / "requirements.txt").exists():
         requirements_files += ["src/requirements.txt"]
         deps_install_line = "pip install -r requirements.txt"
+        with open(base_path / "src" / "requirements.txt") as f:
+            requirements = f.readlines()
+        if not any(["wandb" in r for r in requirements]):
+            wandb.termwarn(f"{LOG_PREFIX}wandb is not present in requirements.txt.")
         return PIP_TEMPLATE.format(
             buildx_optional_prefix=prefix,
             requirements_files=" ".join(requirements_files),
@@ -226,6 +230,10 @@ def get_requirements_section(
                 str(d) for d in contents.get("project", {}).get("dependencies", [])
             ]
             if project_deps:
+                if not any(["wandb" in d for d in project_deps]):
+                    wandb.termwarn(
+                        f"{LOG_PREFIX}wandb is not present as a dependency in pyproject.toml."
+                    )
                 with open(base_path / "src" / "requirements.txt", "w") as f:
                     f.write("\n".join(project_deps))
                 requirements_files += ["src/requirements.txt"]
@@ -251,6 +259,13 @@ def get_requirements_section(
 
         if not deps_install_line:
             raise LaunchError(f"No dependency sources found for {launch_project}")
+
+        with open(base_path / "src" / "requirements.frozen.txt") as f:
+            requirements = f.readlines()
+        if not any(["wandb" in r for r in requirements]):
+            wandb.termwarn(
+                f"{LOG_PREFIX}wandb is not present in requirements.frozen.txt."
+            )
 
         return PIP_TEMPLATE.format(
             buildx_optional_prefix=prefix,

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -374,6 +374,9 @@ def _create_artifact_metadata(
         with open(depspath) as f:
             requirements = f.read().splitlines()
 
+    if not any(["wandb" in r for r in requirements]):
+        wandb.termwarn("wandb is not present in requirements.txt.")
+
     if runtime:
         python_version = _clean_python_version(runtime)
     else:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18376](https://wandb.atlassian.net/browse/WB-18376)

Display a warning when the user tries to create or launch a job where `wandb` isn't in the `requirements.txt`, since it's generally required for a run to succeed.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Made a code job with no wandb in the `requirements.txt`


[WB-18376]: https://wandb.atlassian.net/browse/WB-18376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ