### PR TITLE
security(sdk): Adding unsafe flag to use_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Interpret non-octal strings with leading zeros as strings and not integers in sweep configs by @KyleGoyette https://github.com/wandb/wandb/pull/7649
 
+### Changed
+
+- Require `unsafe=True` in `use_model` calls that could potentially load and deserialize unsafe pickle files by @anandwandb https://github.com/wandb/wandb/pull/7663
+
 ## [0.17.0] - 2024-05-07
 
 ### Added

--- a/wandb/beta/workflows.py
+++ b/wandb/beta/workflows.py
@@ -183,7 +183,7 @@ def log_model(
     return model
 
 
-def use_model(aliased_path: str, trust: bool) -> "_SavedModel":
+def use_model(aliased_path: str, unsafe: bool = False) -> "_SavedModel":
     """Fetch a saved model from an alias.
 
     Under the hood, we use the alias to fetch the model artifact containing the
@@ -193,7 +193,7 @@ def use_model(aliased_path: str, trust: bool) -> "_SavedModel":
     Args:
         aliased_path: `str` - the following forms are valid: "name:version",
             "name:alias". May be prefixed with "entity/project".
-        trust: `bool` - must be True to indicate the user understands the risks
+        unsafe: `bool` - must be True to indicate the user understands the risks
             associated with loading external models.
 
     Returns:
@@ -202,12 +202,12 @@ def use_model(aliased_path: str, trust: bool) -> "_SavedModel":
     Example:
         ```python
         # Assuming the model with the name "my-simple-model" is trusted:
-        sm = use_model("my-simple-model:latest", trust=True)
+        sm = use_model("my-simple-model:latest", unsafe=True)
         model = sm.model_obj()
         ```
     """
-    if not trust:
-        raise ValueError("The 'trust' parameter must be set to True to load a model.")
+    if not unsafe:
+        raise ValueError("The 'unsafe' parameter must be set to True to load a model.")
 
     if ":" not in aliased_path:
         raise ValueError(

--- a/wandb/beta/workflows.py
+++ b/wandb/beta/workflows.py
@@ -183,7 +183,7 @@ def log_model(
     return model
 
 
-def use_model(aliased_path: str) -> "_SavedModel":
+def use_model(aliased_path: str, trust: bool) -> "_SavedModel":
     """Fetch a saved model from an alias.
 
     Under the hood, we use the alias to fetch the model artifact containing the
@@ -193,17 +193,22 @@ def use_model(aliased_path: str) -> "_SavedModel":
     Args:
         aliased_path: `str` - the following forms are valid: "name:version",
             "name:alias". May be prefixed with "entity/project".
+        trust: `bool` - must be True to indicate the user understands the risks
+            associated with loading external models.
 
     Returns:
         _SavedModel instance
 
     Example:
         ```python
-        # Assuming you have previously logged a model with the name "my-simple-model":
-        sm = use_model("my-simple-model:latest")
+        # Assuming the model with the name "my-simple-model" is trusted:
+        sm = use_model("my-simple-model:latest", trust=True)
         model = sm.model_obj()
         ```
     """
+    if not trust:
+        raise ValueError("The 'trust' parameter must be set to True to load a model.")
+
     if ":" not in aliased_path:
         raise ValueError(
             "aliased_path must be of the form 'name:alias' or 'name:version'."


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [SV-71](https://wandb.atlassian.net/browse/SV-71)

HiddenLayer has discovered three vulnerabilities while researching the Weights and Biases (WandB)
project, which this document describes in detail. As defined by MITRE’s CWE specification, these
vulnerabilities are Deserialization of Untrusted Data and Improper Control of Generation of Code ('Code
Injection'). These vulnerabilities allow for a threat actor to craft a malicious model which, when loaded,
can execute arbitrary code on the system. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[SV-71]: https://wandb.atlassian.net/browse/SV-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ