### PR TITLE
fix(sdk): Reports API: Fix backend name mapping for ScatterPlots

### DIFF
--- a/wandb/apis/reports/v2/interface.py
+++ b/wandb/apis/reports/v2/interface.py
@@ -895,9 +895,9 @@ class ScatterPlot(Panel):
         obj = internal.ScatterPlot(
             config=internal.ScatterPlotConfig(
                 chart_title=self.title,
-                x_axis=_metric_to_backend(self.x),
-                y_axis=_metric_to_backend(self.y),
-                z_axis=_metric_to_backend(self.z),
+                x_axis=_metric_to_backend_pc(self.x),
+                y_axis=_metric_to_backend_pc(self.y),
+                z_axis=_metric_to_backend_pc(self.z),
                 x_axis_min=self.range_x[0],
                 x_axis_max=self.range_x[1],
                 y_axis_min=self.range_y[0],

--- a/wandb/apis/reports/v2/interface.py
+++ b/wandb/apis/reports/v2/interface.py
@@ -37,7 +37,7 @@ TextLike = Union[str, "TextWithInlineComments", "Link", "InlineLatex", "InlineCo
 TextLikeField = Union[TextLike, LList[TextLike]]
 SpecialMetricType = Union["Config", "SummaryMetric", "Metric"]
 MetricType = Union[str, SpecialMetricType]
-ParallelCoordinatesMetric = Union[str, "Config", "SummaryMetric"]
+SummaryOrConfigOnlyMetric = Union[str, "Config", "SummaryMetric"]
 RunId = str
 
 
@@ -101,7 +101,8 @@ class Layout(Base):
 
 
 @dataclass(config=dataclass_config)
-class Block(Base): ...
+class Block(Base):
+    ...
 
 
 @dataclass(config=ConfigDict(validate_assignment=True, extra="allow", slots=True))
@@ -706,7 +707,8 @@ class Twitter(Block):
 
 
 @dataclass(config=dataclass_config)
-class WeaveBlock(Block): ...
+class WeaveBlock(Block):
+    ...
 
 
 BlockTypes = Union[
@@ -870,9 +872,9 @@ class LinePlot(Panel):
 @dataclass(config=dataclass_config)
 class ScatterPlot(Panel):
     title: Optional[str] = None
-    x: Optional[MetricType] = None
-    y: Optional[MetricType] = None
-    z: Optional[MetricType] = None
+    x: Optional[SummaryOrConfigOnlyMetric] = None
+    y: Optional[SummaryOrConfigOnlyMetric] = None
+    z: Optional[SummaryOrConfigOnlyMetric] = None
     range_x: Range = Field(default_factory=lambda: (None, None))
     range_y: Range = Field(default_factory=lambda: (None, None))
     range_z: Range = Field(default_factory=lambda: (None, None))
@@ -929,9 +931,9 @@ class ScatterPlot(Panel):
 
         obj = cls(
             title=model.config.chart_title,
-            x=_metric_to_frontend(model.config.x_axis),
-            y=_metric_to_frontend(model.config.y_axis),
-            z=_metric_to_frontend(model.config.z_axis),
+            x=_metric_to_frontend_pc(model.config.x_axis),
+            y=_metric_to_frontend_pc(model.config.y_axis),
+            z=_metric_to_frontend_pc(model.config.z_axis),
             range_x=(model.config.x_axis_min, model.config.x_axis_max),
             range_y=(model.config.y_axis_min, model.config.y_axis_max),
             range_z=(model.config.z_axis_min, model.config.z_axis_max),
@@ -1094,7 +1096,7 @@ class CodeComparer(Panel):
 
 @dataclass(config=dataclass_config)
 class ParallelCoordinatesPlotColumn(Base):
-    metric: ParallelCoordinatesMetric
+    metric: SummaryOrConfigOnlyMetric
     display_name: Optional[str] = None
     inverted: Optional[bool] = None
     log: Optional[bool] = None
@@ -1811,7 +1813,7 @@ def _metric_to_frontend(x: str):
     return Metric(name)
 
 
-def _metric_to_backend_pc(x: Optional[ParallelCoordinatesMetric]):
+def _metric_to_backend_pc(x: Optional[SummaryOrConfigOnlyMetric]):
     if x is None:
         return x
     if isinstance(x, str):  # Same as SummaryMetric


### PR DESCRIPTION
Description
-----------
This PR:
1. Fixes `ScatterPlot` to use the Parallel Coordinates Plot style of backend metric naming
2. Updates `ParallelCoordinatesMetric` to `SummaryOrConfigOnlyMetric` to be more explicit about supported metric types

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
