### PR TITLE
fix[sdk]: add --tags override for wandb sync

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -602,6 +602,12 @@ def sync_beta(
     help="Specifies the type of run for grouping related runs together.",
 )
 @click.option(
+    "--tags",
+    "tags",
+    multiple=True,
+    help="Used to label runs",
+)
+@click.option(
     "--sync-tensorboard/--no-sync-tensorboard",
     is_flag=True,
     default=None,
@@ -661,6 +667,7 @@ def sync(
     project=None,
     entity=None,
     job_type=None,  # trace this back to SyncManager
+    tags=None,
     sync_tensorboard=None,
     include_globs=None,
     exclude_globs=None,
@@ -737,6 +744,7 @@ def sync(
             entity=entity,
             run_id=run_id,
             job_type=job_type,
+            tags=tags,
             mark_synced=mark_synced,
             app_url=api.app_url,
             view=view,

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -46,6 +46,7 @@ class SyncThread(threading.Thread):
         entity=None,
         run_id=None,
         job_type=None,
+        tags=None,
         view=None,
         verbose=None,
         mark_synced=None,
@@ -63,6 +64,7 @@ class SyncThread(threading.Thread):
         self._entity = entity
         self._run_id = run_id
         self._job_type = job_type
+        self._tags = tags
         self._view = view
         self._verbose = verbose
         self._mark_synced = mark_synced
@@ -94,7 +96,9 @@ class SyncThread(threading.Thread):
                 pb.run.entity = self._entity
             if self._job_type:
                 pb.run.job_type = self._job_type
-            pb.control.req_resp = True
+            if self._tags:
+                del pb.run.tags[:]          # Clear existing tags
+                pb.run.tags.extend(self._tags)  # Add new tags from CLI
         elif record_type in ("output", "output_raw") and self._skip_console:
             return pb, exit_pb, True
         elif record_type == "exit":
@@ -331,6 +335,7 @@ class SyncManager:
         entity=None,
         run_id=None,
         job_type=None,
+        tags=None,
         mark_synced=None,
         app_url=None,
         view=None,
@@ -346,6 +351,7 @@ class SyncManager:
         self._entity = entity
         self._run_id = run_id
         self._job_type = job_type
+        self._tags = tags
         self._mark_synced = mark_synced
         self._app_url = app_url
         self._view = view
@@ -369,6 +375,7 @@ class SyncManager:
             entity=self._entity,
             run_id=self._run_id,
             job_type=self._job_type,
+            tags=self._tags,
             view=self._view,
             verbose=self._verbose,
             mark_synced=self._mark_synced,

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -97,7 +97,7 @@ class SyncThread(threading.Thread):
             if self._job_type:
                 pb.run.job_type = self._job_type
             if self._tags:
-                del pb.run.tags[:]          # Clear existing tags
+                del pb.run.tags[:]  # Clear existing tags
                 pb.run.tags.extend(self._tags)  # Add new tags from CLI
         elif record_type in ("output", "output_raw") and self._skip_console:
             return pb, exit_pb, True


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-188861](https://wandb.atlassian.net/browse/WB-18861)
- unblocks nvidia user: [slack thread ](https://weightsandbiases.slack.com/archives/C016YA15HB3/p1715724211957019)

What does the PR do? Include a concise description of the PR contents.
- adds a flag that overwrites the tags in wandb sync ([docs ref](https://docs.wandb.ai/ref/cli/wandb-sync#docusaurus_skipToContent_fallback))

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?
- was able to successfully log 1 or more tags utilizing the flag 

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
