### PR TITLE
fix(core): Fix race condition in fakedelay.go

### DIFF
--- a/core/internal/runfiles/upload_batcher.go
+++ b/core/internal/runfiles/upload_batcher.go
@@ -58,10 +58,11 @@ func (b *uploadBatcher) Add(files []string) {
 	}
 
 	if !b.isQueued {
-		b.addWG.Add(1)
 		b.isQueued = true
 
+		b.addWG.Add(1)
 		go func() {
+			defer b.addWG.Done()
 			<-b.delay.Wait()
 			b.uploadBatch()
 		}()
@@ -86,6 +87,4 @@ func (b *uploadBatcher) uploadBatch() {
 	}
 
 	b.upload(filesSlice)
-
-	b.addWG.Done()
 }

--- a/core/internal/waitingtest/fakedelay.go
+++ b/core/internal/waitingtest/fakedelay.go
@@ -101,11 +101,15 @@ func (d *FakeDelay) IsZero() bool {
 }
 
 func (d *FakeDelay) Wait() <-chan struct{} {
-	if d.IsZero() {
+	if d == nil {
 		return completedDelay()
 	}
 
 	d.mu.Lock()
+
+	if d.isZero {
+		return completedDelay()
+	}
 
 	if !d.allowsWait {
 		panic("tried to Wait() on a FakeDelay after the final Tick()")


### PR DESCRIPTION
Description
---
Fixes `FakeDelay::Wait()` which was doing the following:

1. Checking `isZero` while holding a lock
2. Briefly releasing the lock
3. Locking it again, then waiting for `isZero` to change

On rare occasions, `isZero` could change during (2), causing (3) to block forever.
