### PR TITLE
fix(sdk): correctly upload console log files when resuming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ### Fixed
 
+- Correctly upload console output log files when resuming runs by @kptkin in https://github.com/wandb/wandb/pull/7694
 - Interpret non-octal strings with leading zeros as strings and not integers in sweep configs by @KyleGoyette https://github.com/wandb/wandb/pull/7649
 - Support Azure repo URI format in Launch @KyleGoyette https://github.com/wandb/wandb/pull/7664
 
 ### Changed
 
+- Change naming scheme for console output logs from `output.log` to `logs/YYYYMMDD_HHmmss.ms_output.log` by @kptkin in https://github.com/wandb/wandb/pull/7694
 - Require `unsafe=True` in `use_model` calls that could potentially load and deserialize unsafe pickle files by @anandwandb https://github.com/wandb/wandb/pull/7663
 - Update order in api.runs() to ascending to prevent duplicate responses by @thanos-wandb https://github.com/wandb/wandb/pull/7675
 - Eliminate signed URL timeout errors during artifact file uploads in core by @moredatarequired in https://github.com/wandb/wandb/pull/7586

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -113,7 +113,7 @@ type Handler struct {
 // NewHandler creates a new handler
 func NewHandler(
 	ctx context.Context,
-	params *HandlerParams,
+	params HandlerParams,
 ) *Handler {
 	return &Handler{
 		ctx:                   ctx,

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -29,7 +29,6 @@ import (
 const (
 	MetaFileName         = "wandb-metadata.json"
 	SummaryFileName      = "wandb-summary.json"
-	OutputFileName       = "output.log"
 	DiffFileName         = "diff.patch"
 	RequirementsFileName = "requirements.txt"
 	ConfigFileName       = "config.yaml"

--- a/core/pkg/server/handler_test.go
+++ b/core/pkg/server/handler_test.go
@@ -14,7 +14,7 @@ func makeHandler(
 	outChan chan *service.Result,
 ) *server.Handler {
 	h := server.NewHandler(context.Background(),
-		&server.HandlerParams{
+		server.HandlerParams{
 			Logger:          observability.NewNoOpLogger(),
 			Settings:        &service.Settings{},
 			FwdChan:         fwdChan,

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -152,7 +152,7 @@ type Sender struct {
 func NewSender(
 	ctx context.Context,
 	cancel context.CancelFunc,
-	params *SenderParams,
+	params SenderParams,
 ) *Sender {
 
 	s := &Sender{
@@ -1020,10 +1020,12 @@ func (s *Sender) sendOutputRaw(_ *service.Record, outputRaw *service.OutputRawRe
 	fullFilePath := filepath.Join(s.settings.GetFilesDir().GetValue(), s.outputFileName)
 	logPath := filepath.Dir(fullFilePath)
 	// check if the directory exists
-
-	if err := os.MkdirAll(logPath, 0755); err != nil {
-		s.logger.Error("sender: sendOutput: failed to create output file directory", "error", err)
-		return
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
+		// create the directory
+		if err := os.MkdirAll(logPath, 0755); err != nil {
+			s.logger.Error("sender: sendOutput: failed to create output file directory", "error", err)
+			return
+		}
 	}
 
 	// append line to file

--- a/core/pkg/server/sender_test.go
+++ b/core/pkg/server/sender_test.go
@@ -70,7 +70,7 @@ func makeSender(client graphql.Client, recordChan chan *service.Record, resultCh
 	sender := server.NewSender(
 		ctx,
 		cancel,
-		&server.SenderParams{
+		server.SenderParams{
 			Logger:              logger,
 			Settings:            settings.Proto,
 			Backend:             backend,

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/wandb/wandb/core/internal/filestream"
@@ -225,6 +226,10 @@ func NewStream(settings *settings.Settings, _ string) *Stream {
 			FwdChan:             s.loopBackChan,
 			OutChan:             make(chan *service.Result, BufferSize),
 			Mailbox:             mailbox,
+			OutputFileName: filepath.Join(
+				"logs",
+				fmt.Sprintf("%s_output.log", time.Now().Format("20060102_150405")),
+			),
 		},
 	)
 

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -185,7 +185,7 @@ func NewStream(settings *settings.Settings, _ string) *Stream {
 	mailbox := mailbox.NewMailbox()
 
 	s.handler = NewHandler(s.ctx,
-		&HandlerParams{
+		HandlerParams{
 			Logger:            s.logger,
 			Settings:          s.settings.Proto,
 			FwdChan:           make(chan *service.Record, BufferSize),
@@ -202,7 +202,7 @@ func NewStream(settings *settings.Settings, _ string) *Stream {
 	)
 
 	s.writer = NewWriter(s.ctx,
-		&WriterParams{
+		WriterParams{
 			Logger:   s.logger,
 			Settings: s.settings.Proto,
 			FwdChan:  make(chan *service.Record, BufferSize),
@@ -212,7 +212,7 @@ func NewStream(settings *settings.Settings, _ string) *Stream {
 	s.sender = NewSender(
 		s.ctx,
 		s.cancel,
-		&SenderParams{
+		SenderParams{
 			Logger:              s.logger,
 			Settings:            s.settings.Proto,
 			Backend:             backendOrNil,
@@ -228,7 +228,7 @@ func NewStream(settings *settings.Settings, _ string) *Stream {
 			Mailbox:             mailbox,
 			OutputFileName: filepath.Join(
 				"logs",
-				fmt.Sprintf("%s_output.log", time.Now().Format("20060102_150405")),
+				fmt.Sprintf("%s_output.log", time.Now().Format("20060102_150405.000000")),
 			),
 		},
 	)

--- a/core/pkg/server/writer.go
+++ b/core/pkg/server/writer.go
@@ -60,7 +60,7 @@ type Writer struct {
 }
 
 // NewWriter returns a new Writer
-func NewWriter(ctx context.Context, params *WriterParams) *Writer {
+func NewWriter(ctx context.Context, params WriterParams) *Writer {
 	w := &Writer{
 		ctx:      ctx,
 		wg:       sync.WaitGroup{},

--- a/tests/pytest_tests/system_tests/test_core/test_resume.py
+++ b/tests/pytest_tests/system_tests/test_core/test_resume.py
@@ -1,3 +1,4 @@
+import pytest
 import wandb
 
 
@@ -57,3 +58,35 @@ def test_resume_tags_add_at_resume(user, test_settings):
     run.tags += ("tag7",)
     assert run.tags == ("tag4", "tag5", "tag7")
     run.finish()
+
+
+@pytest.mark.wandb_core_only
+def test_resume_output_log(user, relay_server, test_settings):
+    with relay_server() as relay:
+        run = wandb.init(
+            project="output",
+            settings=test_settings({"console": "auto"}),
+        )
+        run_id = run.id
+        print(f"started {run_id}")
+        run.finish()
+
+        run = wandb.init(
+            id=run_id,
+            resume="must",
+            project="output",
+            settings=test_settings({"console": "auto"}),
+        )
+        print(f"resumed {run_id}")
+        run.log({"metric": 1})
+        run.finish()
+
+    # should produce two files, e.g.:
+    # logs/20240522_144304.516302_output.log and
+    # logs/20240522_144306.374584_output.log
+    log_files = [
+        f
+        for f in relay.context.get_run_uploaded_files(run_id)
+        if f.endswith("output.log")
+    ]
+    assert len(set(log_files)) == 2


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18313
- Fixes #4727

Output log files will from now on be called YYYYMMDD_HHmmss.ms_output.log and placed in the logs folder in the run dir. This solves the issue where we would overwrite logs when resuming runs.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
