### PR TITLE
chore(sdk): use retryablehttp's default retry policy for file transfer

### DIFF
--- a/core/internal/filetransfer/file_transfer_retry_policy.go
+++ b/core/internal/filetransfer/file_transfer_retry_policy.go
@@ -13,14 +13,7 @@ func FileTransferRetryPolicy(
 	resp *http.Response,
 	err error,
 ) (bool, error) {
-	// Abort on any error from the HTTP transport.
-	//
-	// This happens if reading the file fails, for example if it is a directory
-	// or if it doesn't exist. retryablehttp's default policy for this situation
-	// is to retry, which we do not want.
-	if err != nil {
-		return false, err
-	}
+	// TODO(WB-18702): Add explicit cases for (non-)retryable errors.
 
 	return retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err)
 }


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18702, I hope

use retryablehttp's default retry policy for file transfer

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
