### PR TITLE
fix(launch): repo jobs use correct default python version

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_create_job.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_create_job.py
@@ -123,12 +123,12 @@ def test_get_entrypoint():
 
     program_relpath = builder._get_program_relpath(job_source, metadata)
     entrypoint = builder._get_entrypoint(program_relpath, metadata)
-    assert entrypoint == ["python", "main.py"]
+    assert entrypoint == ["python3", "main.py"]
 
     metadata = {"python": "3.9", "codePath": "main.py", "_partial": "v0"}
     program_relpath = builder._get_program_relpath(job_source, metadata)
     entrypoint = builder._get_entrypoint(program_relpath, metadata)
-    assert entrypoint == ["python", "main.py"]
+    assert entrypoint == ["python3", "main.py"]
 
     metadata = {"codePath": "main.py"}
     program_relpath = builder._get_program_relpath(job_source, metadata)

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -338,7 +338,7 @@ def _create_repo_metadata(
             with open(os.path.join(local_dir, ".python-version")) as f:
                 python_version = f.read().strip().splitlines()[0]
         else:
-            _, python_version = get_current_python_version()
+            python_version, _ = get_current_python_version()
 
     python_version = _clean_python_version(python_version)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This PR changes a line from 

```python
_, python_version = get_current_python_version()
```

to

```python
python_version, _ = get_current_python_version()
```

The first argument returned by `get_current_python_version` is what we actually want to assign `python_version` to. The second return value is just the major version. This was leading to repo jobs being created by `wandb launch -u` having `3` as their python version and crashing when we tried to launch them.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
