### PR TITLE
fix(core): flush history record correctly in shared mode

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # check the basic semantic compliance of the PR title
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v5.0.2
+      - uses: amannn/action-semantic-pull-request@v5.5.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -46,27 +46,3 @@ jobs:
           wip: true
           validateSingleCommit: false
           validateSingleCommitMatchesPrTitle: false
-
-#       - name: Checkout repository
-#         uses: actions/checkout@v3
-
-#       # check the PR title against the conventional commit format
-#       - name: Set up Python
-#         uses: actions/setup-python@v4
-#         with:
-#           python-version: "3.9"
-
-#       - name: Install dependencies
-#         run: pip install pygithub openai tenacity
-
-#       - name: Get PR number
-#         id: get_pr_number
-#         run: |
-#           pr_url="${{ github.event.pull_request.url }}"
-#           pr_number="${pr_url##*/}"
-#           echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
-
-#       - name: Run script to check the title
-#         id: check_title
-#         run: |
-#           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} python tools/pr-title-bot.py check ${{ steps.get_pr_number.outputs.pr_number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ### Fixed
 
+- Fix `define_metric` behavior for multiple metrics in `shared` mode by @dmitryduev in https://github.com/wandb/wandb/pull/7715
 - Correctly pass in project name to internal api from run while calling run.use_artifact() by @ibindlish in https://github.com/wandb/wandb/pull/7701
 - Correctly upload console output log files when resuming runs enabled with `console_multipart` setting by @kptkin in https://github.com/wandb/wandb/pull/7694 and @dmitryduev in
 - Interpret non-octal strings with leading zeros as strings and not integers in sweep configs by @KyleGoyette https://github.com/wandb/wandb/pull/7649

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,6 +251,7 @@ pip install -U pre-commit
 
 To install all of our pre-commit hooks run:
 ```shell
+./core/scripts/code-checks.sh update
 pre-commit install
 ```
 

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -1131,6 +1131,7 @@ func (h *Handler) handlePartialHistoryAsync(request *service.PartialHistoryReque
 		h.handleHistory(&service.HistoryRecord{
 			Item: items,
 		})
+		h.runHistory = runhistory.New()
 	}
 }
 

--- a/tests/pytest_tests/system_tests/test_core/test_metric_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_metric_full.py
@@ -1,4 +1,30 @@
 import pytest
+import wandb
+
+
+@pytest.mark.wandb_core_only
+def test_mode_shared(user, relay_server, test_settings):
+    metrics = [f"metric_{i}" for i in range(2)]
+
+    with relay_server() as relay:
+        run = wandb.init(settings=test_settings({"mode": "shared"}))
+        run.define_metric(name="metric_*", step_metric="train_step")
+
+        for train_step in range(3):
+            for metric in metrics:
+                run.log(
+                    {
+                        "train_step": train_step,
+                        metric: train_step * 2,
+                    }
+                )
+
+        run.finish()
+
+    # assert that relay.context.history["metric_i"] both have three NaN values
+    # because a history update should look like {"train_step": <step>, "metric_i": <value>}
+    for metric in metrics:
+        assert relay.context.history[metric].isnull().sum() == 3
 
 
 def test_metric_default(relay_server, wandb_init):

--- a/tests/pytest_tests/system_tests/test_core/test_metric_full.py
+++ b/tests/pytest_tests/system_tests/test_core/test_metric_full.py
@@ -4,6 +4,7 @@ import wandb
 
 @pytest.mark.wandb_core_only
 def test_mode_shared(user, relay_server, test_settings):
+    # test that history records are properly flushed
     metrics = [f"metric_{i}" for i in range(2)]
 
     with relay_server() as relay:

--- a/tests/pytest_tests/system_tests/test_functional/test_mode_shared.py
+++ b/tests/pytest_tests/system_tests/test_functional/test_mode_shared.py
@@ -1,4 +1,3 @@
-import importlib.util
 import pathlib
 import runpy
 from unittest import mock
@@ -6,10 +5,7 @@ from unittest import mock
 import pytest
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("wandb-core") is None,
-    reason="shared mode only available in wandb-core",
-)
+@pytest.mark.wandb_core_only
 def test_mode_shared(user, relay_server, copy_asset):
     # copy assets to test directory:
     pathlib.Path("scripts").mkdir()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
We were not flushing the history record and instead kept accumulating stuff, which produces some weird result when saved to leveldb and sent to the backend.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
