### PR TITLE
fix(core): Log error on StreamUpdate after Close in filestream

### DIFF
--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -196,6 +196,16 @@ func (fs *fileStream) Start(
 }
 
 func (fs *fileStream) StreamUpdate(update Update) {
+	defer func() {
+		if recoveredErr := recover(); recoveredErr != nil {
+			err, _ := recoveredErr.(error)
+			fs.logger.CaptureError(
+				"filestream: called StreamUpdate after Finish",
+				err,
+			)
+		}
+	}()
+
 	fs.logger.Debug("filestream: stream update", "update", update)
 	fs.processChan <- update
 }


### PR DESCRIPTION
Description
---
Avoid panicking and log an error to Sentry instead.

With our current code structure, it's difficult to guarantee that StreamUpdate is not called after Close, and in fact sometimes it is: I got a panic once while testing locally, but was unable to reproduce. This `recover()` is a temporary stopgap, but probably it will remain here for a long time until we can reign in how records are handled.

When it happens, it means we're failing to upload some data at the end of a run. These records likely come from asynchronous code in the service process that emits records, *not* from the user process.
