### PR TITLE
fix(core): Call Finish() on TBHandler

### DIFF
--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -152,6 +152,16 @@ func NewStream(settings *settings.Settings, _ string, sentryClient *sentry.Clien
 		sentryClient: sentryClient,
 	}
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		// We log an error but continue anyway with an empty hostname string.
+		// Better behavior would be to inform the user and turn off any
+		// components that rely on the hostname, but it's not easy to do
+		// with our current code structure.
+		s.logger.CaptureError("could not get hostname", err)
+		hostname = ""
+	}
+
 	// TODO: replace this with a logger that can be read by the user
 	peeker := &observability.Peeker{}
 	terminalPrinter := observability.NewPrinter()
@@ -159,6 +169,12 @@ func NewStream(settings *settings.Settings, _ string, sentryClient *sentry.Clien
 	backendOrNil := NewBackend(s.logger, settings)
 	fileTransferStats := filetransfer.NewFileTransferStats()
 	fileWatcher := watcher.New(watcher.Params{Logger: s.logger})
+	tbHandler := tensorboard.NewTBHandler(tensorboard.Params{
+		OutputRecords: s.loopBackChan,
+		Logger:        s.logger,
+		Settings:      s.settings.Proto,
+		Hostname:      hostname,
+	})
 	var graphqlClientOrNil graphql.Client
 	var fileStreamOrNil filestream.FileStream
 	var fileTransferManagerOrNil filetransfer.FileTransferManager
@@ -190,30 +206,15 @@ func NewStream(settings *settings.Settings, _ string, sentryClient *sentry.Clien
 
 	mailbox := mailbox.NewMailbox()
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		// We log an error but continue anyway with an empty hostname string.
-		// Better behavior would be to inform the user and turn off any
-		// components that rely on the hostname, but it's not easy to do
-		// with our current code structure.
-		s.logger.CaptureError("could not get hostname", err)
-		hostname = ""
-	}
-
 	s.handler = NewHandler(s.ctx,
 		HandlerParams{
-			Logger:           s.logger,
-			Settings:         s.settings.Proto,
-			FwdChan:          make(chan *service.Record, BufferSize),
-			OutChan:          make(chan *service.Result, BufferSize),
-			SystemMonitor:    monitor.NewSystemMonitor(s.logger, s.settings.Proto, s.loopBackChan),
-			RunfilesUploader: runfilesUploaderOrNil,
-			TBHandler: tensorboard.NewTBHandler(tensorboard.Params{
-				OutputRecords: s.loopBackChan,
-				Logger:        s.logger,
-				Settings:      s.settings.Proto,
-				Hostname:      hostname,
-			}),
+			Logger:            s.logger,
+			Settings:          s.settings.Proto,
+			FwdChan:           make(chan *service.Record, BufferSize),
+			OutChan:           make(chan *service.Result, BufferSize),
+			SystemMonitor:     monitor.NewSystemMonitor(s.logger, s.settings.Proto, s.loopBackChan),
+			RunfilesUploader:  runfilesUploaderOrNil,
+			TBHandler:         tbHandler,
 			FileTransferStats: fileTransferStats,
 			RunSummary:        runsummary.New(),
 			MetricHandler:     NewMetricHandler(),
@@ -248,6 +249,7 @@ func NewStream(settings *settings.Settings, _ string, sentryClient *sentry.Clien
 			FileTransferManager: fileTransferManagerOrNil,
 			FileWatcher:         fileWatcher,
 			RunfilesUploader:    runfilesUploaderOrNil,
+			TBHandler:           tbHandler,
 			Peeker:              peeker,
 			RunSummary:          runsummary.New(),
 			GraphqlClient:       graphqlClientOrNil,


### PR DESCRIPTION
Description
---
Calls `TBHandler::Finish()` in the "defer" state machine in the sender. I added this method in a recent PR but forgot to invoke it.
