### PR TITLE
chore(sdk): Pin imageio-ffmpeg<=0.4.9

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ Pillow
 pandas
 moviepy~=1.0.3
 imageio[ffmpeg]
+imageio-ffmpeg<=0.4.9  # Pin to avoid breaking changes in 0.5.0 released May 31
 matplotlib!=3.5.2
 soundfile
 rdkit; (sys_platform != 'darwin') or (sys_platform == 'darwin' and platform.machine != 'arm64')


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
`ffmpeg<=0.5.0` released on May 31 is breaking tests

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
