### PR TITLE
test(integrations): pin imageio-ffmpeg in requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,8 @@ hypothesis-fspaths
 Pillow
 pandas
 moviepy~=1.0.3
-imageio[ffmpeg]
+imageio
+imageio-ffmpeg==0.4.9
 matplotlib!=3.5.2
 soundfile
 rdkit; (sys_platform != 'darwin') or (sys_platform == 'darwin' and platform.machine != 'arm64')


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

This PR separates the `imageio` and `imageio-ffmpeg` dependencies in the `requirements_dev.txt` file and pins the `imageio-ffmpeg` package to version `0.4.9`: https://pypi.org/project/imageio-ffmpeg/#history.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

Executing unit tests locally with `nox -s "unit_tests" --python 3.9`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
