### PR TITLE
chore(sdk): Ignore all .pb.go files in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,11 @@ ignore:
   - "core/pkg/service"
   - "core/internal/gql"
 
+  # Ignore all generated proto files.
+  - "**/*.pb.go"
+  - "**/*_pb2.py"
+  - "**/*_pb2.pyi"
+
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
Description
---
Adds `**/*.pb.go` to the codecov `ignore` setting. This came up because the protos for the TB integration are under `core/internal/tensorboard/tbproto/` rather than `wandb/proto/` where they wouldn't belong.
