### PR TITLE
refactor(core): Move `_client_id` logic to handler from filestream

### DIFF
--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -100,8 +100,6 @@ type fileStream struct {
 	// to prove the run is still alive.
 	heartbeatStopwatch waiting.Stopwatch
 
-	clientId string
-
 	// A channel that is closed if there is a fatal error.
 	deadChan     chan struct{}
 	deadChanOnce *sync.Once
@@ -113,7 +111,6 @@ type FileStreamParams struct {
 	Printer            *observability.Printer
 	ApiClient          api.Client
 	MaxItemsPerPush    int
-	ClientId           string
 	DelayProcess       waiting.Delay
 	HeartbeatStopwatch waiting.Stopwatch
 }
@@ -152,11 +149,6 @@ func NewFileStream(params FileStreamParams) FileStream {
 
 	if params.MaxItemsPerPush > 0 {
 		fs.maxItemsPerPush = params.MaxItemsPerPush
-	}
-
-	// TODO: this should become the default
-	if fs.settings.GetXShared().GetValue() && params.ClientId != "" {
-		fs.clientId = params.ClientId
 	}
 
 	return fs

--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -47,7 +47,6 @@ func (fs *fileStream) startProcessingUpdates(
 				},
 
 				Settings: fs.settings,
-				ClientID: fs.clientId,
 
 				Logger:  fs.logger,
 				Printer: fs.printer,

--- a/core/internal/filestream/update.go
+++ b/core/internal/filestream/update.go
@@ -18,7 +18,6 @@ type UpdateContext struct {
 	ModifyRequest func(CollectorStateUpdate)
 
 	Settings *service.Settings
-	ClientID string
 
 	Logger  *observability.CoreLogger
 	Printer *observability.Printer

--- a/core/internal/filestream/updatehistory.go
+++ b/core/internal/filestream/updatehistory.go
@@ -17,15 +17,6 @@ type HistoryUpdate struct {
 func (u *HistoryUpdate) Apply(ctx UpdateContext) error {
 	items := slices.Clone(u.Record.Item)
 
-	// when logging to the same run with multiple writers, we need to
-	// add a client id to the history record
-	if ctx.ClientID != "" {
-		items = append(items, &service.HistoryItem{
-			Key:       "_client_id",
-			ValueJson: fmt.Sprintf(`"%s"`, ctx.ClientID),
-		})
-	}
-
 	rh := runhistory.New()
 	rh.ApplyChangeRecord(
 		items,

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -60,9 +60,11 @@ type Handler struct {
 	// settings is the settings for the handler
 	settings *service.Settings
 
-	// clientID is used to allow multiple writers to log to the same run.
+	// clientID is an ID for this process.
 	//
-	// This is relevant in "shared" mode.
+	// This identifies the process that uploaded a set of metrics when
+	// running in "shared" mode, where there may be multiple writers for
+	// the same run.
 	clientID string
 
 	// logger is the logger for the handler

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -20,7 +20,6 @@ import (
 	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/watcher"
 	"github.com/wandb/wandb/core/pkg/observability"
-	"github.com/wandb/wandb/core/pkg/utils"
 )
 
 // NewBackend returns a Backend or nil if we're offline.
@@ -94,7 +93,6 @@ func NewFileStream(
 		Logger:    logger,
 		Printer:   printer,
 		ApiClient: fileStreamRetryClient,
-		ClientId:  utils.ShortID(32),
 	}
 
 	return filestream.NewFileStream(params)


### PR DESCRIPTION
Description
---
Creates the `_client_id` pseudo-metric in the Handler method that also sets `_step`, so that that method is the only place where new HistoryItems are created and so that the logic is more cohesive.
