### PR TITLE
chore(launch): Support getting the partition from aws environments

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_environment/test_aws.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_environment/test_aws.py
@@ -239,3 +239,25 @@ async def test_upload_file(mocker):
     with pytest.raises(LaunchError) as e:
         await environment.upload_file("source_file", "s3a://bucket/key")
         assert e.content == "Destination s3a://bucket/key is not a valid s3 URI."
+
+
+@pytest.mark.asyncio
+async def test_get_partition(mocker):
+    client = MagicMock()
+    session = MagicMock()
+    session.client.return_value = client
+    client.get_caller_identity.return_value = {
+        "Account": "123456789012",
+        "Arn": "arn:aws",
+    }
+
+    async def _mock_get_session(*args, **kwargs):
+        return session
+
+    mocker.patch(
+        "wandb.sdk.launch.environment.aws_environment.AwsEnvironment.get_session",
+        _mock_get_session,
+    )
+    environment = _get_environment()
+    part = await environment.get_partition()
+    assert part == "aws"

--- a/tests/pytest_tests/unit_tests/test_launch/test_environment/test_aws.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_environment/test_aws.py
@@ -248,7 +248,7 @@ async def test_get_partition(mocker):
     session.client.return_value = client
     client.get_caller_identity.return_value = {
         "Account": "123456789012",
-        "Arn": "arn:aws",
+        "Arn": "arn:aws:iam::123456789012:user/JohnDoe",
     }
 
     async def _mock_get_session(*args, **kwargs):

--- a/wandb/sdk/launch/runner/sagemaker_runner.py
+++ b/wandb/sdk/launch/runner/sagemaker_runner.py
@@ -179,7 +179,10 @@ class SageMakerRunner(AbstractRunner):
         caller_id = client.get_caller_identity()
         account_id = caller_id["Account"]
         _logger.info(f"Using account ID {account_id}")
-        role_arn = get_role_arn(given_sagemaker_args, self.backend_config, account_id)
+        partition = await self.environment.get_partition()
+        role_arn = get_role_arn(
+            given_sagemaker_args, self.backend_config, account_id, partition
+        )
 
         # Create a sagemaker client to launch the job.
         sagemaker_client = session.client("sagemaker")
@@ -405,7 +408,10 @@ async def launch_sagemaker_job(
 
 
 def get_role_arn(
-    sagemaker_args: Dict[str, Any], backend_config: Dict[str, Any], account_id: str
+    sagemaker_args: Dict[str, Any],
+    backend_config: Dict[str, Any],
+    account_id: str,
+    partition: str,
 ) -> str:
     """Get the role arn from the sagemaker args or the backend config."""
     role_arn = sagemaker_args.get("RoleArn") or sagemaker_args.get("role_arn")
@@ -416,7 +422,7 @@ def get_role_arn(
             "AWS sagemaker require a string RoleArn set this by adding a `RoleArn` key to the sagemaker"
             "field of resource_args"
         )
-    if role_arn.startswith("arn:aws:iam::"):
+    if role_arn.startswith(f"arn:{partition}:iam::"):
         return role_arn  # type: ignore
 
-    return f"arn:aws:iam::{account_id}:role/{role_arn}"
+    return f"arn:{partition}:iam::{account_id}:role/{role_arn}"

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -69,6 +69,7 @@ GCP_ARTIFACT_REGISTRY_URI_REGEX = re.compile(
 )
 
 S3_URI_RE = re.compile(r"s3://([^/]+)(/(.*))?")
+ARN_PARTITION_RE = re.compile(r"^arn:([^:]+):[^:]*:[^:]*:[^:]*:[^:]*$")
 GCS_URI_RE = re.compile(r"gs://([^/]+)(?:/(.*))?")
 AZURE_BLOB_REGEX = re.compile(
     r"^https://([^\.]+)\.blob\.core\.windows\.net/([^/]+)/?(.*)$"

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -69,12 +69,12 @@ GCP_ARTIFACT_REGISTRY_URI_REGEX = re.compile(
 )
 
 S3_URI_RE = re.compile(r"s3://([^/]+)(/(.*))?")
-ARN_PARTITION_RE = re.compile(r"^arn:([^:]+):[^:]*:[^:]*:[^:]*:[^:]*$")
 GCS_URI_RE = re.compile(r"gs://([^/]+)(?:/(.*))?")
 AZURE_BLOB_REGEX = re.compile(
     r"^https://([^\.]+)\.blob\.core\.windows\.net/([^/]+)/?(.*)$"
 )
 
+ARN_PARTITION_RE = re.compile(r"^arn:([^:]+):[^:]*:[^:]*:[^:]*:[^:]*$")
 
 PROJECT_SYNCHRONOUS = "SYNCHRONOUS"
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Right now the aws environment always assumes users are on the aws partition. This breaks the Sagemaker runner for those on different aws partitions. This fixes that

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
