### PR TITLE
refactor(core): Rate limit printer messages based on format string

### DIFF
--- a/core/internal/filestream/updatehistory.go
+++ b/core/internal/filestream/updatehistory.go
@@ -43,7 +43,11 @@ func (u *HistoryUpdate) Apply(ctx UpdateContext) error {
 		)
 		ctx.Printer.
 			AtMostEvery(time.Minute).
-			Write("Skipped uploading run.log() data that exceeded size limit.")
+			Writef(
+				"Skipped uploading run.log() data that exceeded"+
+					" size limit (%d > %d).",
+				len(line),
+				maxFileLineBytes)
 	} else {
 		ctx.ModifyRequest(&collectorHistoryUpdate{
 			lines: []string{string(line)},

--- a/core/internal/filestream/updatesummary.go
+++ b/core/internal/filestream/updatesummary.go
@@ -40,7 +40,11 @@ func (u *SummaryUpdate) Apply(ctx UpdateContext) error {
 		)
 		ctx.Printer.
 			AtMostEvery(time.Minute).
-			Write("Skipped uploading summary data that exceeded size limit.")
+			Writef(
+				"Skipped uploading summary data that exceeded"+
+					" size limit (%d > %d).",
+				len(line),
+				maxFileLineBytes)
 	} else {
 		ctx.ModifyRequest(&collectorSummaryUpdate{
 			newSummary: string(line),

--- a/core/pkg/observability/printer_test.go
+++ b/core/pkg/observability/printer_test.go
@@ -12,7 +12,7 @@ func TestReadAfterWrite(t *testing.T) {
 	p := NewPrinter()
 
 	p.Write("message 1")
-	p.Write("message 2")
+	p.Writef("message %d", 2)
 
 	assert.Equal(t,
 		[]string{"message 1", "message 2"},
@@ -24,15 +24,15 @@ func TestRateLimitedWrite(t *testing.T) {
 	p := NewPrinter()
 	p.getNow = func() time.Time { return time.UnixMilli(nowMilli.Load()) }
 
-	p.AtMostEvery(time.Minute).Write("hey there") // first write
-	p.AtMostEvery(time.Minute).Write("hey there") // ignored
-	p.AtMostEvery(time.Minute).Write("hey there") // ignored
+	p.AtMostEvery(time.Minute).Writef("hey there %d", 1)
+	p.AtMostEvery(time.Minute).Writef("hey there %d", 2)
+	p.AtMostEvery(time.Minute).Writef("hey there %d", 3)
 	nowMilli.Add(time.Minute.Milliseconds())
-	p.AtMostEvery(time.Minute).Write("hey there") // second write
-	p.AtMostEvery(time.Minute).Write("hey there") // ignored
-	p.AtMostEvery(time.Minute).Write("hey there") // ignored
+	p.AtMostEvery(time.Minute).Writef("hey there %d", 4)
+	p.AtMostEvery(time.Minute).Writef("hey there %d", 5)
+	p.AtMostEvery(time.Minute).Writef("hey there %d", 6)
 
 	assert.Equal(t,
-		[]string{"hey there", "hey there"},
+		[]string{"hey there 1", "hey there 4"},
 		p.Read())
 }

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -1141,8 +1141,8 @@ func (h *Handler) handlePartialHistoryAsync(request *service.PartialHistoryReque
 		items, err := h.runHistory.Flatten()
 		if err != nil {
 			h.logger.CaptureError("Error flattening run history", err)
-			msg := "Failed to process history record, skipping syncing."
-			h.terminalPrinter.Write(msg)
+			h.terminalPrinter.Write(
+				"Failed to process history record, skipping syncing.")
 			return
 		}
 		h.handleHistory(&service.HistoryRecord{
@@ -1206,11 +1206,10 @@ func (h *Handler) handlePartialHistorySync(request *service.PartialHistoryReques
 			items, err := h.runHistory.Flatten()
 			if err != nil {
 				h.logger.CaptureError("Error flattening run history", err)
-				msg := fmt.Sprintf(
-					"Failed to process history record, for step %d, skipping...",
+				h.terminalPrinter.Writef(
+					"Failed to process history record for step %d, skipping...",
 					h.runHistory.GetStep(),
 				)
-				h.terminalPrinter.Write(msg)
 				return
 			}
 			history := &service.HistoryRecord{


### PR DESCRIPTION
Description
---
Changes the `Printer` to allow rate-limiting (`AtMostEvery(duration)`) messages containing dynamic data.

Testing
---
Unit tests.
