### PR TITLE
feat(core): Tell user if we're rate-limiting

### DIFF
--- a/core/internal/api/api_test.go
+++ b/core/internal/api/api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/api"
+	"github.com/wandb/wandb/core/pkg/observability"
 )
 
 func TestSend(t *testing.T) {
@@ -101,7 +102,13 @@ func newClient(
 	baseURL, err := url.Parse(baseURLString)
 	require.NoError(t, err)
 
-	backend := api.New(api.BackendOptions{BaseURL: baseURL})
+	opts.RateLimitDomain = "test"
+
+	backend := api.New(api.BackendOptions{
+		BaseURL: baseURL,
+		Logger:  observability.NewNoOpLogger().Logger,
+		Printer: observability.NewPrinter(),
+	})
 	return backend.NewClient(opts)
 }
 

--- a/core/internal/api/transport.go
+++ b/core/internal/api/transport.go
@@ -1,32 +1,49 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/wandb/wandb/core/pkg/observability"
 	"golang.org/x/time/rate"
 )
 
-// A rate-limited HTTP transport for requests to the W&B backend.
+// RateLimitTransport rate-limits requests to the W&B backend.
 //
 // Implements [http.RoundTripper] for use as a transport for an HTTP client.
 type RateLimitedTransport struct {
 	delegate http.RoundTripper
+	printer  *observability.Printer
 
-	// Rate limit for all outgoing requests.
+	// rateLimitDomain is a human-readable string that's included in printed
+	// messages about rate limits.
+	//
+	// In W&B there are at least two rate-limit domains: "Filestream" and
+	// "GraphQL". This string helps the user know which limit they are
+	// hitting.
+	rateLimitDomain string
+
+	// rateLimiter is the rate limit for all outgoing requests.
 	rateLimiter *rate.Limiter
 
-	// Dynamic adjustments to the rate-limit based on server backpressure.
+	// rlTracker makes dynamic adjustments to the rate-limit based on
+	// server backpressure.
 	rlTracker *RateLimitTracker
 }
 
 // Rate-limits an HTTP transport for the W&B backend.
 func NewRateLimitedTransport(
+	rateLimitDomain string,
 	delegate http.RoundTripper,
+	printer *observability.Printer,
 ) *RateLimitedTransport {
 	return &RateLimitedTransport{
-		delegate:    delegate,
-		rateLimiter: rate.NewLimiter(maxRequestsPerSecond, maxBurst),
+		delegate:        delegate,
+		printer:         printer,
+		rateLimiter:     rate.NewLimiter(maxRequestsPerSecond, maxBurst),
+		rateLimitDomain: rateLimitDomain,
 		rlTracker: NewRateLimitTracker(RateLimitTrackerParams{
 			MinPerSecond: minRequestsPerSecond,
 			MaxPerSecond: maxRequestsPerSecond,
@@ -41,11 +58,29 @@ func NewRateLimitedTransport(
 func (transport *RateLimitedTransport) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
-	if err := transport.rateLimiter.Wait(req.Context()); err != nil {
-		// Errors happen if:
-		//   - The request is canceled
-		//   - The rate limit exceeds the request deadline
-		return nil, err
+	wait := transport.rateLimiter.Reserve()
+
+	// Should never happen!
+	if !wait.OK() {
+		return nil, errors.New("api: rate limit seems to be zero")
+	}
+
+	if wait.Delay() > 0 {
+		transport.printer.
+			AtMostEvery(10*time.Second).
+			Writef(
+				"Rate-limited (%s). Current limit: %.2f requests per second.",
+				transport.rateLimitDomain,
+				transport.rateLimiter.Limit())
+
+		select {
+		case <-time.After(wait.Delay()):
+			// Go do the request!
+		case <-req.Context().Done():
+			return nil, fmt.Errorf(
+				"api: while waiting for rate limit: %v",
+				req.Context().Err())
+		}
 	}
 
 	transport.rlTracker.TrackRequest()

--- a/core/internal/api/transportpeeker.go
+++ b/core/internal/api/transportpeeker.go
@@ -5,6 +5,9 @@ import (
 )
 
 type Peeker interface {
+	// Peek inspects the request and response.
+	//
+	// If it reads the response body, it must replace it.
 	Peek(*http.Request, *http.Response)
 }
 

--- a/core/pkg/observability/peeker.go
+++ b/core/pkg/observability/peeker.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
@@ -26,8 +25,6 @@ func (p *Peeker) Read() []*service.HttpResponse {
 
 	return responses
 }
-
-var _ api.Peeker = &Peeker{}
 
 func (p *Peeker) Peek(_ *http.Request, resp *http.Response) {
 	if resp == nil || resp.Body == nil {

--- a/core/pkg/server/sender_test.go
+++ b/core/pkg/server/sender_test.go
@@ -50,7 +50,7 @@ func makeSender(client graphql.Client, recordChan chan *service.Record, resultCh
 	settings := wbsettings.From(&service.Settings{
 		RunId: &wrapperspb.StringValue{Value: "run1"},
 	})
-	backend := server.NewBackend(logger, settings)
+	backend := server.NewBackend(logger, observability.NewPrinter(), settings)
 	fileStream := server.NewFileStream(
 		backend, logger, observability.NewPrinter(), settings, nil)
 	fileTransferManager := server.NewFileTransferManager(

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -166,7 +166,7 @@ func NewStream(settings *settings.Settings, _ string, sentryClient *sentry.Clien
 	peeker := &observability.Peeker{}
 	terminalPrinter := observability.NewPrinter()
 
-	backendOrNil := NewBackend(s.logger, settings)
+	backendOrNil := NewBackend(s.logger, terminalPrinter, settings)
 	fileTransferStats := filetransfer.NewFileTransferStats()
 	fileWatcher := watcher.New(watcher.Params{Logger: s.logger})
 	tbHandler := tensorboard.NewTBHandler(tensorboard.Params{

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -25,6 +25,7 @@ import (
 // NewBackend returns a Backend or nil if we're offline.
 func NewBackend(
 	logger *observability.CoreLogger,
+	printer *observability.Printer,
 	settings *settings.Settings,
 ) *api.Backend {
 	if settings.IsOffline() {
@@ -38,6 +39,7 @@ func NewBackend(
 	return api.New(api.BackendOptions{
 		BaseURL: baseURL,
 		Logger:  logger.Logger,
+		Printer: printer,
 		APIKey:  settings.GetAPIKey(),
 	})
 }
@@ -54,6 +56,7 @@ func NewGraphQLClient(
 	maps.Copy(graphqlHeaders, settings.Proto.GetXExtraHttpHeaders().GetValue())
 
 	httpClient := backend.NewClient(api.ClientOptions{
+		RateLimitDomain: "GraphQL",
 		RetryPolicy:     clients.CheckRetry,
 		RetryMax:        int(settings.Proto.GetXGraphqlRetryMax().GetValue()),
 		RetryWaitMin:    clients.SecondsToDuration(settings.Proto.GetXGraphqlRetryWaitMinSeconds().GetValue()),
@@ -80,6 +83,7 @@ func NewFileStream(
 	}
 
 	fileStreamRetryClient := backend.NewClient(api.ClientOptions{
+		RateLimitDomain: "Filestream",
 		RetryPolicy:     filestream.RetryPolicy,
 		RetryMax:        int(settings.Proto.GetXFileStreamRetryMax().GetValue()),
 		RetryWaitMin:    clients.SecondsToDuration(settings.Proto.GetXFileStreamRetryWaitMinSeconds().GetValue()),


### PR DESCRIPTION
Description
---
Print a message if the SDK is slowing itself down due to rate limits.

Fixes WB-18468.

Testing
---

This script rapidly makes ~300 filestream requests (the current batching implementation reduces this from 1000):

```python
import time
import wandb

wandb.require("core")

with wandb.init(entity="YOUR_USER") as run:
    for i in range(1000):
        run.log({"x": (i/1000)**2})
        time.sleep(0.05)
```

Messages:

```
wandb: Using wandb-core as the SDK backend. Please refer to https://wandb.me/wandb-core for more information.
wandb: Currently logged in as: timoffex. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.17.1.dev1
wandb: Run data is saved locally in *****
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run confused-plasma-24
wandb: ⭐️ View project at https://wandb.ai/timoffex/uncategorized
wandb: 🚀 View run at https://wandb.ai/timoffex/uncategorized/runs/oug6l4dp
wandb: WARNING Rate-limited (Filestream). Current limit: 3.58 requests per second.
wandb: WARNING Rate-limited (Filestream). Current limit: 3.02 requests per second.
wandb: WARNING Rate-limited (Filestream). Current limit: 3.15 requests per second.
wandb: WARNING Rate-limited (Filestream). Current limit: 3.70 requests per second.
wandb: WARNING Rate-limited (Filestream). Current limit: 3.58 requests per second.
wandb:
wandb:
wandb: Run history:
wandb: x ▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▃▃▃▃▄▄▄▄▄▄▄▅▅▅▅▅▆▆▆▆▇▇███
wandb:
wandb: Run summary:
wandb: x 0.998
wandb:
wandb: 🚀 View run confused-plasma-24 at: https://wandb.ai/timoffex/uncategorized/runs/oug6l4dp
wandb: ⭐️ View project at: https://wandb.ai/timoffex/uncategorized
wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./wandb/run-20240606_121711-oug6l4dp/logs
```

Note: the rate limit is an estimate based on responses from the backend. In my test, the target Filestream limit is 5 QPS.