### PR TITLE
fix(core): Correctly sample history metrics with nested keys

### DIFF
--- a/core/internal/runhistory/runhistorysampler.go
+++ b/core/internal/runhistory/runhistorysampler.go
@@ -1,0 +1,81 @@
+package runhistory
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/wandb/wandb/core/internal/sampler"
+	"github.com/wandb/wandb/core/pkg/service"
+)
+
+// RunHistorySampler tracks a sample of each metric in the run's history.
+type RunHistorySampler struct {
+	samples map[metricKey]*sampler.ReservoirSampler[float32]
+}
+
+func NewRunHistorySampler() *RunHistorySampler {
+	return &RunHistorySampler{
+		samples: make(map[metricKey]*sampler.ReservoirSampler[float32]),
+	}
+}
+
+// SampleNext updates all samples with the next history row.
+//
+// This must be called on history rows in order.
+func (s *RunHistorySampler) SampleNext(history *service.HistoryRecord) {
+	for _, item := range history.Item {
+		var value float32
+		if err := json.Unmarshal([]byte(item.ValueJson), &value); err != nil {
+			// Skip items that we cannot sample.
+			continue
+		}
+
+		key := getMetricKey(item)
+
+		sample, ok := s.samples[key]
+		if !ok {
+			sample = sampler.NewReservoirSampler[float32](48, 0.0005)
+			s.samples[key] = sample
+		}
+
+		sample.Add(value)
+	}
+}
+
+// Get returns all the samples.
+func (s *RunHistorySampler) Get() []*service.SampledHistoryItem {
+	items := make([]*service.SampledHistoryItem, 0, len(s.samples))
+
+	for metricKey, sample := range s.samples {
+		items = append(items,
+			sampledHistoryItem(metricKey, sample.Sample()))
+	}
+
+	return items
+}
+
+// metricKey is the slash-separated path for a metric.
+type metricKey string
+
+// getMetricKey returns a representation of the item's key.
+func getMetricKey(item *service.HistoryItem) metricKey {
+	if item.Key != "" {
+		return metricKey(item.Key)
+	} else {
+		return metricKey(strings.Join(item.NestedKey, "/"))
+	}
+}
+
+// sampledHistoryItem creates an item with the correct key field.
+func sampledHistoryItem(
+	key metricKey,
+	values []float32,
+) *service.SampledHistoryItem {
+	return &service.SampledHistoryItem{
+		// NOTE: We only set Key, not NestedKey! It turns out the Python
+		// code does not handle NestedKey and expects the slash-separated
+		// result in Key instead.
+		Key:         string(key),
+		ValuesFloat: values,
+	}
+}

--- a/core/internal/runhistory/runhistorysampler.go
+++ b/core/internal/runhistory/runhistorysampler.go
@@ -1,9 +1,9 @@
 package runhistory
 
 import (
-	"encoding/json"
 	"strings"
 
+	"github.com/segmentio/encoding/json"
 	"github.com/wandb/wandb/core/internal/sampler"
 	"github.com/wandb/wandb/core/pkg/service"
 )


### PR DESCRIPTION
Description
---
The sampler implementation in `handler.go` was not reading the `NestedKey` field of `HistoryItem`. This pulls out history sampling logic into a dedicated `runhistorysampler.go` file and implements it properly.

There is a bug in Python where it doesn't _read_ the `nested_key` field. I left a comment about it in `runhistorysampler.go`. Amazingly, this is countered by a bug in the Python TensorBoard integration, which seems to produce items that use `key` instead of `nested_key`, causing them to have sparklines anyway.

Testing
---
The following doesn't print a sparkline with the Python implementation but does with `wandb.require("core")`:

```python
with wandb.init() as run:
    for x in range(100):
        run.log({"my": {"value": x}})
```

The TensorBoard integration with and without core prints sparklines.
