### PR TITLE
refactor(core): Move variable into scope where it's used

### DIFF
--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -83,8 +83,6 @@ func (fs *fileStream) startTransmitting(
 	// Internal channel of actual requests to make.
 	transmissions := make(chan *FsTransmitData)
 
-	state := CollectorState{}
-
 	transmitWG := &sync.WaitGroup{}
 	transmitWG.Add(1)
 	go func() {
@@ -110,6 +108,8 @@ func (fs *fileStream) startTransmitting(
 	}()
 
 	go func() {
+		state := CollectorState{}
+
 		// Batch and send updates.
 		//
 		// We try to batch updates that happen in quick succession by waiting a


### PR DESCRIPTION
Description
---

```go
// Before:
thing := ...
go func() {
	use(thing)
}()

// After:
go func() {
	thing := ...
	use(thing)
}()
```
