### PR TITLE
chore(sdk): modify benchmark tool for opt-out core

### DIFF
--- a/tools/bench/bench.py
+++ b/tools/bench/bench.py
@@ -61,7 +61,9 @@ def run_parallel(args):
 
 def setup(args):
     if args.core == "true":
-        wandb.require("core")
+        os.environ["WANDB__REQUIRE_CORE"] = "true"
+    elif args.core == "false":
+        os.environ["WANDB__REQUIRE_CORE"] = "false"
 
 
 def teardown(args):


### PR DESCRIPTION
Description
-----------
Usage:
```
./bench.py --core false
```
Will make sure we are running without wandb-core even in opt-out mode (current dev environment)

Testing
-------
Manually tested as it is a performance tool and doesn't (yet) have any sanity tests.