### PR TITLE
chore(sdk): Add notice about wandb-core becoming opt-out

### DIFF
--- a/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
@@ -175,9 +175,8 @@ def test_mocked_notebook_html_default(wandb_init, run_id, mocked_ipython):
     displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
-    assert len(displayed_html) == 9
-    assert run_id in displayed_html[2]
-    assert "Run history:" in displayed_html[5]
+    assert any(run_id in html for html in displayed_html)
+    assert any("Run history:" in html for html in displayed_html)
 
 
 def test_mocked_notebook_html_quiet(wandb_init, run_id, mocked_ipython):
@@ -187,9 +186,8 @@ def test_mocked_notebook_html_quiet(wandb_init, run_id, mocked_ipython):
     displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
-    assert len(displayed_html) == 6
-    assert run_id in displayed_html[2]
-    assert "Run history:" not in displayed_html[5]
+    assert any(run_id in html for html in displayed_html)
+    assert not any("Run history:" in html for html in displayed_html)
 
 
 def test_mocked_notebook_run_display(wandb_init, mocked_ipython):
@@ -198,8 +196,7 @@ def test_mocked_notebook_run_display(wandb_init, mocked_ipython):
     displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
-    assert len(displayed_html) == 9
-    assert "<iframe" in displayed_html[5]
+    assert any("<iframe" in html for html in displayed_html)
 
 
 def test_mocked_notebook_magic(user, wandb_init, run_id, test_settings, mocked_ipython):
@@ -219,15 +216,13 @@ def test_mocked_notebook_magic(user, wandb_init, run_id, test_settings, mocked_i
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
     assert wandb.jupyter.__IFrame is None
-    # if versions are different this will fail (make sure you are up-to-date with master)
-    assert len(displayed_html) == 9
     assert "<iframe" in displayed_html[2]
     run_uri = f"{user}/uncategorized/runs/{run_id}"
     magic.wandb(run_uri)
     displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
-    assert f"{run_uri}?jupyter=true" in displayed_html[-1]
+    assert any(f"{run_uri}?jupyter=true" in html for html in displayed_html)
 
 
 @pytest.mark.flaky

--- a/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
@@ -175,7 +175,7 @@ def test_mocked_notebook_html_default(wandb_init, run_id, mocked_ipython):
     displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
-    assert len(displayed_html) == 8
+    assert len(displayed_html) == 9
     assert run_id in displayed_html[2]
     assert "Run history:" in displayed_html[5]
 
@@ -198,7 +198,7 @@ def test_mocked_notebook_run_display(wandb_init, mocked_ipython):
     displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
-    assert len(displayed_html) == 8
+    assert len(displayed_html) == 9
     assert "<iframe" in displayed_html[5]
 
 
@@ -220,7 +220,7 @@ def test_mocked_notebook_magic(user, wandb_init, run_id, test_settings, mocked_i
         print(f"[{i}]: {html}")
     assert wandb.jupyter.__IFrame is None
     # if versions are different this will fail (make sure you are up-to-date with master)
-    assert len(displayed_html) == 8
+    assert len(displayed_html) == 9
     assert "<iframe" in displayed_html[2]
     run_uri = f"{user}/uncategorized/runs/{run_id}"
     magic.wandb(run_uri)

--- a/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/pytest_tests/system_tests/test_notebooks/test_notebooks.py
@@ -216,7 +216,7 @@ def test_mocked_notebook_magic(user, wandb_init, run_id, test_settings, mocked_i
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")
     assert wandb.jupyter.__IFrame is None
-    assert "<iframe" in displayed_html[2]
+    assert any("<iframe" in html for html in displayed_html)
     run_uri = f"{user}/uncategorized/runs/{run_id}"
     magic.wandb(run_uri)
     displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -4146,7 +4146,7 @@ class Run:
             return
 
         printer.display(
-            "The new W&B backend becomes opt-out in version 0.18.0;",
+            "The new W&B backend becomes opt-out in version 0.18.0;"
             ' try it out with `wandb.require("core")`!'
             " See https://wandb.me/wandb-core for more information.",
             level="warn",

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3759,6 +3759,11 @@ class Run:
             settings=settings,
             printer=printer,
         )
+        Run._footer_notify_wandb_core(
+            quiet=quiet,
+            settings=settings,
+            printer=printer,
+        )
         Run._footer_local_warn(
             server_info_response=server_info_response,
             quiet=quiet,
@@ -4128,6 +4133,24 @@ class Run:
         package_problem = check_version.delete_message or check_version.yank_message
         if package_problem and check_version.upgrade_message:
             printer.display(check_version.upgrade_message)
+
+    @staticmethod
+    def _footer_notify_wandb_core(
+        *,
+        quiet: Optional[bool] = None,
+        settings: "Settings",
+        printer: Union["PrinterTerm", "PrinterJupyter"],
+    ) -> None:
+        """Prints a message advertising the upcoming core release."""
+        if quiet or settings._require_core:
+            return
+
+        printer.display(
+            'Enable the new W&B implementation with `wandb.require("core")`.'
+            " This will become opt-out starting with version 0.18.0."
+            " https://wandb.me/wandb-core.",
+            level="warn",
+        )
 
     @staticmethod
     def _footer_reporter_warn_err(

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -4146,9 +4146,9 @@ class Run:
             return
 
         printer.display(
-            'Enable the new W&B implementation with `wandb.require("core")`.'
-            " This will become opt-out starting with version 0.18.0."
-            " https://wandb.me/wandb-core.",
+            "The new W&B backend becomes opt-out in version 0.18.0;",
+            ' try it out with `wandb.require("core")`!'
+            " See https://wandb.me/wandb-core for more information.",
             level="warn",
         )
 


### PR DESCRIPTION
Description
---
Adds a notice that's printed at the end of every run that informs users that wandb>=0.18.0 will use wandb-core by default.

The notice is not printed if we're in "quiet" mode or if the run used core.

Testing
---
```
$ WANDB__REQUIRE_CORE=false python
>>> import wandb
>>> run = wandb.init()
>>> run.finish()

$ WANDB__REQUIRE_CORE=true python
>>> import wandb
>>> run = wandb.init()
>>> run.finish()
```
