### PR TITLE
refactor(core): Don't double-log errors in `store.go`

### DIFF
--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -1298,7 +1298,7 @@ func (s *Sender) sendRequestStopStatus(record *service.Record, _ *service.StopSt
 
 func (s *Sender) sendRequestSenderRead(_ *service.Record, _ *service.SenderReadRequest) {
 	if s.store == nil {
-		store := NewStore(s.ctx, s.settings.GetSyncFile().GetValue(), s.logger)
+		store := NewStore(s.ctx, s.settings.GetSyncFile().GetValue())
 		err := store.Open(os.O_RDONLY)
 		if err != nil {
 			s.logger.CaptureError("sender: sendSenderRead: failed to create store", err)

--- a/core/pkg/server/store.go
+++ b/core/pkg/server/store.go
@@ -3,11 +3,10 @@ package server
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/wandb/wandb/core/pkg/observability"
 
 	"github.com/wandb/wandb/core/pkg/leveldb"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -79,18 +78,11 @@ type Store struct {
 
 	// db is the underlying database
 	db *os.File
-
-	// logger is the logger for the store
-	logger *observability.CoreLogger
 }
 
 // NewStore creates a new store
-func NewStore(ctx context.Context, fileName string, logger *observability.CoreLogger) *Store {
-	sr := &Store{ctx: ctx,
-		name:   fileName,
-		logger: logger,
-	}
-	return sr
+func NewStore(ctx context.Context, fileName string) *Store {
+	return &Store{ctx: ctx, name: fileName}
 }
 
 // Open opens the store
@@ -99,76 +91,70 @@ func (sr *Store) Open(flag int) error {
 	case os.O_RDONLY:
 		f, err := os.Open(sr.name)
 		if err != nil {
-			sr.logger.CaptureError("can't open file", err)
-			return err
+			return fmt.Errorf("store: failed to open file: %v", err)
 		}
 		sr.db = f
 		sr.reader = leveldb.NewReaderExt(f, leveldb.CRCAlgoIEEE)
 		header := NewHeader()
 		if err := header.UnmarshalBinary(sr.db); err != nil {
-			sr.logger.CaptureError("can't read header", err)
-			return err
+			return fmt.Errorf("store: failed to read header: %v", err)
 		}
 		if !header.Valid() {
-			err := fmt.Errorf("invalid header")
-			sr.logger.CaptureError("can't read header", err)
-			return err
+			return errors.New("store: invalid header")
 		}
 		return nil
 	case os.O_WRONLY:
 		f, err := os.Create(sr.name)
 		if err != nil {
-			sr.logger.CaptureError("can't open file", err)
-			return err
+			return fmt.Errorf("store: failed to open file: %v", err)
 		}
 		sr.db = f
 		sr.writer = leveldb.NewWriterExt(f, leveldb.CRCAlgoIEEE)
 		header := NewHeader()
 		if err := header.MarshalBinary(sr.db); err != nil {
-			sr.logger.CaptureError("can't write header", err)
-			return err
+			return fmt.Errorf("store: failed to write header: %v", err)
 		}
 		return nil
 	default:
 		// TODO: generalize this?
-		err := fmt.Errorf("invalid flag %d", flag)
-		sr.logger.CaptureError("can't open file", err)
-		return err
+		return fmt.Errorf("store: invalid flag %d", flag)
 	}
 }
 
 // Close closes the store
 func (sr *Store) Close() error {
+	errs := []error{}
+
 	if sr.writer != nil {
 		err := sr.writer.Close()
 		if err != nil {
-			sr.logger.CaptureError("can't close file", err)
+			errs = append(errs, fmt.Errorf("store: failed closing writer: %v", err))
 		}
 	}
 
-	err := sr.db.Close()
-	if err != nil {
-		sr.logger.CaptureError("can't close file", err)
-	}
+	db := sr.db
 	sr.db = nil
-	return err
+
+	err := db.Close()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("store: failed closing file: %v", err))
+	}
+
+	return errors.Join(errs...)
 }
 
 func (sr *Store) Write(msg *service.Record) error {
 	writer, err := sr.writer.Next()
 	if err != nil {
-		sr.logger.CaptureError("can't write header", err)
-		return err
+		return fmt.Errorf("store: can't get next record: %v", err)
 	}
 	out, err := proto.Marshal(msg)
 	if err != nil {
-		sr.logger.CaptureError("can't write header", err)
-		return err
+		return fmt.Errorf("store: can't marshal proto: %v", err)
 	}
 
 	if _, err = writer.Write(out); err != nil {
-		sr.logger.CaptureError("can't write header", err)
-		return err
+		return fmt.Errorf("store: can't write proto: %v", err)
 	}
 	return nil
 }
@@ -178,34 +164,32 @@ func (sr *Store) WriteDirectlyToDB(data []byte) (int, error) {
 	return sr.db.Write(data)
 }
 
+// Reads the next record from the database.
+//
+// Returns nil and an error on failure. On EOF, error is [io.EOF].
 func (sr *Store) Read() (*service.Record, error) {
 	// check if db is closed
 	if sr.db == nil {
-		err := fmt.Errorf("db is closed")
-		sr.logger.CaptureError("can't read record", err)
-		return nil, err
+		return nil, fmt.Errorf("store: db is closed")
 	}
 
 	reader, err := sr.reader.Next()
 	if err == io.EOF {
-		return nil, err
+		return nil, io.EOF
 	}
 
 	if err != nil {
-		sr.logger.CaptureError("can't read record", err)
 		sr.reader.Recover()
-		return nil, err
+		return nil, fmt.Errorf("store: failed to get next record: %v", err)
 	}
 	buf, err := io.ReadAll(reader)
 	if err != nil {
-		sr.logger.CaptureError("can't read record", err)
 		sr.reader.Recover()
-		return nil, err
+		return nil, fmt.Errorf("store: error reading: %v", err)
 	}
 	msg := &service.Record{}
 	if err = proto.Unmarshal(buf, msg); err != nil {
-		sr.logger.CaptureError("can't read record", err)
-		return nil, err
+		return nil, fmt.Errorf("store: failed to unmarshal: %v", err)
 	}
 	return msg, nil
 }

--- a/core/pkg/server/store_test.go
+++ b/core/pkg/server/store_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wandb/wandb/core/pkg/observability"
 	"github.com/wandb/wandb/core/pkg/server"
 	"github.com/wandb/wandb/core/pkg/service"
 )
@@ -57,8 +56,7 @@ func TestOpenCreateStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 
@@ -72,15 +70,14 @@ func TestOpenReadStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 
 	err = store.Close()
 	assert.NoError(t, err)
 
-	store2 := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store2 := server.NewStore(context.Background(), tmpFile.Name())
 	err = store2.Open(os.O_RDONLY)
 	assert.NoError(t, err)
 
@@ -94,8 +91,7 @@ func TestReadWriteRecord(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 	defer store.Close()
 
 	err = store.Open(os.O_WRONLY)
@@ -109,7 +105,7 @@ func TestReadWriteRecord(t *testing.T) {
 	err = store.Close()
 	assert.NoError(t, err)
 
-	store2 := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store2 := server.NewStore(context.Background(), tmpFile.Name())
 	err = store2.Open(os.O_RDONLY)
 	assert.NoError(t, err)
 	defer store2.Close()
@@ -130,8 +126,7 @@ func TestCorruptFile(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 	defer store.Close()
 
 	err = store.Open(os.O_WRONLY)
@@ -147,7 +142,7 @@ func TestCorruptFile(t *testing.T) {
 	err = store.Close()
 	assert.NoError(t, err)
 
-	store2 := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store2 := server.NewStore(context.Background(), tmpFile.Name())
 	err = store2.Open(os.O_RDONLY)
 	assert.NoError(t, err)
 	defer store2.Close()
@@ -166,8 +161,7 @@ func TestStoreInvalidHeader(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 
 	// Intentionally writing bad header data
 	err = os.WriteFile(tmpFile.Name(), []byte("Invalid"), 0644)
@@ -179,8 +173,7 @@ func TestStoreInvalidHeader(t *testing.T) {
 
 // TestStoreHeader_Write_Error is intended to test the error scenario when writing the header
 func TestStoreHeader_Write_Error(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), "non_existent_dir/file", logger)
+	store := server.NewStore(context.Background(), "non_existent_dir/file")
 	err := store.Open(os.O_WRONLY)
 	assert.Error(t, err)
 }
@@ -192,8 +185,7 @@ func TestInvalidFlag(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 	err = store.Open(9999) // 9999 is an invalid flag
 	assert.Errorf(t, err, "invalid flag %d", 9999)
 }
@@ -205,8 +197,7 @@ func TestWriteToClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 
@@ -225,8 +216,7 @@ func TestReadFromClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	logger := observability.NewNoOpLogger()
-	store := server.NewStore(context.Background(), tmpFile.Name(), logger)
+	store := server.NewStore(context.Background(), tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 

--- a/core/pkg/server/writer.go
+++ b/core/pkg/server/writer.go
@@ -80,7 +80,7 @@ func (w *Writer) startStore() {
 	w.storeChan = make(chan *service.Record, BufferSize*8)
 
 	var err error
-	w.store = NewStore(w.ctx, w.settings.GetSyncFile().GetValue(), w.logger)
+	w.store = NewStore(w.ctx, w.settings.GetSyncFile().GetValue())
 	err = w.store.Open(os.O_WRONLY)
 	if err != nil {
 		w.logger.CaptureFatalAndPanic("writer: startStore: error creating store", err)
@@ -90,7 +90,7 @@ func (w *Writer) startStore() {
 	go func() {
 		for record := range w.storeChan {
 			if err = w.store.Write(record); err != nil {
-				w.logger.Error("writer: startStore: error storing record", "error", err)
+				w.logger.CaptureError("writer: startStore: error storing record", err)
 			}
 		}
 


### PR DESCRIPTION
Description
---
Removes logging from `store.go` since all errors are logged by the callers.
