### PR TITLE
refactor(core): Upload more context with CaptureFatal

### DIFF
--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -186,7 +186,7 @@ func (fs *fileStream) Close() {
 // when we can't guarantee correctness, in which case we stop uploading
 // data but continue to save it to disk to avoid data loss.
 func (fs *fileStream) logFatalAndStopWorking(err error) {
-	fs.logger.CaptureFatal("filestream: fatal error", err)
+	fs.logger.CaptureFatal(fmt.Errorf("filestream: fatal error: %v", err))
 	fs.deadChanOnce.Do(func() {
 		close(fs.deadChan)
 		fs.printer.Write(

--- a/core/internal/filetransfer/file_transfer_manager.go
+++ b/core/internal/filetransfer/file_transfer_manager.go
@@ -181,8 +181,8 @@ func (fm *fileTransferManager) transfer(task *Task) error {
 	case DownloadTask:
 		err = fileTransfer.Download(task)
 	default:
-		err = fmt.Errorf("unknown task type")
-		fm.logger.CaptureFatalAndPanic("fileTransfer", err)
+		fm.logger.CaptureFatalAndPanic(
+			fmt.Errorf("fileTransfer: unknown task type: %v", task.Type))
 	}
 	return err
 }

--- a/core/pkg/artifacts/linker.go
+++ b/core/pkg/artifacts/linker.go
@@ -60,13 +60,21 @@ func (al *ArtifactLinker) Link() error {
 			nil,
 		)
 	default:
-		err = fmt.Errorf("LinkArtifact: %s, error: artifact must have either server id or client id", portfolioName)
-		al.Logger.CaptureFatalAndPanic("linkArtifact", err)
+		return fmt.Errorf(
+			"LinkArtifact: %s,"+
+				" error: artifact must have either server id or client id",
+			portfolioName,
+		)
 	}
+
 	if err != nil {
-		err = fmt.Errorf("LinkArtifact: %s, error: %+v response: %+v", portfolioName, err, response)
-		al.Logger.CaptureFatalAndPanic("linkArtifact", err)
-		return err
+		return fmt.Errorf(
+			"LinkArtifact: %s, error: %v, response: %v",
+			portfolioName,
+			err,
+			response,
+		)
 	}
+
 	return nil
 }

--- a/core/pkg/observability/logging.go
+++ b/core/pkg/observability/logging.go
@@ -100,20 +100,7 @@ func (cl *CoreLogger) SetTags(tags Tags) {
 	}
 }
 
-// CaptureError1 logs an error and sends it to Sentry.
-func (cl *CoreLogger) CaptureError1(err error, args ...any) {
-	cl.Logger.Error(err.Error(), args...)
-
-	if cl.captureException != nil {
-		cl.captureException(err, cl.tagsWithArgs(args...))
-	}
-}
-
 // CaptureError logs an error and sends it to Sentry.
-//
-// Deprecated: Use CaptureError1 instead, combining the 'msg' and 'err'
-// arguments using `fmt.Errorf`. This way, the context added by the message
-// is also visible in Sentry.
 func (cl *CoreLogger) CaptureError(msg string, err error, args ...any) {
 	args = append(args, "error", err)
 	cl.Logger.Error(msg, args...)

--- a/core/pkg/observability/logging.go
+++ b/core/pkg/observability/logging.go
@@ -100,65 +100,65 @@ func (cl *CoreLogger) SetTags(tags Tags) {
 	}
 }
 
-// CaptureError logs an error and sends it to sentry.
+// CaptureError1 logs an error and sends it to Sentry.
+func (cl *CoreLogger) CaptureError1(err error, args ...any) {
+	cl.Logger.Error(err.Error(), args...)
+
+	if cl.captureException != nil {
+		cl.captureException(err, cl.tagsWithArgs(args...))
+	}
+}
+
+// CaptureError logs an error and sends it to Sentry.
+//
+// Deprecated: Use CaptureError1 instead, combining the 'msg' and 'err'
+// arguments using `fmt.Errorf`. This way, the context added by the message
+// is also visible in Sentry.
 func (cl *CoreLogger) CaptureError(msg string, err error, args ...any) {
 	args = append(args, "error", err)
 	cl.Logger.Error(msg, args...)
-	if err != nil {
-		// send error to sentry:
-		if cl.captureException != nil {
-			// convert args to tags to pass to sentry:
-			tags := cl.tagsWithArgs(args...)
-			cl.captureException(err, tags)
-		}
+
+	if err != nil && cl.captureException != nil {
+		cl.captureException(err, cl.tagsWithArgs(args...))
 	}
 }
 
-// CaptureFatal logs an error at the fatal level and sends it to sentry.
-func (cl *CoreLogger) CaptureFatal(msg string, err error, args ...any) {
-	// TODO: make sure this level is printed nicely
-	args = append(args, "error", err)
-	cl.Logger.Log(context.TODO(), LevelFatal, msg, args...)
-	if err != nil {
-		// send error to sentry:
-		if cl.captureException != nil {
-			// convert args to tags to pass to sentry:
-			tags := cl.tagsWithArgs(args...)
-			cl.captureException(err, tags)
-		}
+// CaptureFatal logs a fatal error and sends it to Sentry.
+func (cl *CoreLogger) CaptureFatal(err error, args ...any) {
+	cl.Logger.Log(context.Background(), LevelFatal, err.Error(), args...)
+
+	if cl.captureException != nil {
+		cl.captureException(err, cl.tagsWithArgs(args...))
 	}
 }
 
-// CaptureFatalAndPanic logs an error at the fatal level and sends it to sentry.
-// It then panics.
-func (cl *CoreLogger) CaptureFatalAndPanic(msg string, err error, args ...any) {
-	cl.CaptureFatal(msg, err, args...)
+// CaptureFatalAndPanic logs a fatal error, sends it to Sentry and panics.
+func (cl *CoreLogger) CaptureFatalAndPanic(err error, args ...any) {
+	cl.CaptureFatal(err, args...)
 	if err != nil {
 		panic(err)
 	}
 }
 
-// CaptureWarn logs a warning and sends it to sentry.
+// CaptureWarn logs a warning and sends it to Sentry.
 func (cl *CoreLogger) CaptureWarn(msg string, args ...any) {
 	cl.Logger.Warn(msg, args...)
-	// send message to sentry:
+
 	if cl.captureMessage != nil {
-		tags := cl.tagsWithArgs(args...)
-		cl.captureMessage(msg, tags)
+		cl.captureMessage(msg, cl.tagsWithArgs(args...))
 	}
 }
 
-// CaptureInfo logs an info message and sends it to sentry.
+// CaptureInfo logs an info message and sends it to Sentry.
 func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 	cl.Logger.Info(msg, args...)
-	// send message to sentry:
+
 	if cl.captureMessage != nil {
-		tags := cl.tagsWithArgs(args...)
-		cl.captureMessage(msg, tags)
+		cl.captureMessage(msg, cl.tagsWithArgs(args...))
 	}
 }
 
-// Reraise is used to capture unexpected panics with sentry and reraise them.
+// Reraise reports panics to Sentry.
 func (cl *CoreLogger) Reraise(args ...any) {
 	if err := recover(); err != nil {
 		cl.reraise(err, cl.tagsWithArgs(args...))

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -239,11 +239,11 @@ func (h *Handler) handleRecord(record *service.Record) {
 	case *service.Record_UseArtifact:
 		h.handleUseArtifact(record)
 	case nil:
-		err := fmt.Errorf("handler: handleRecord: record type is nil")
-		h.logger.CaptureFatalAndPanic("error handling record", err)
+		h.logger.CaptureFatalAndPanic(
+			errors.New("handler: handleRecord: record type is nil"))
 	default:
-		err := fmt.Errorf("handler: handleRecord: unknown record type %T", x)
-		h.logger.CaptureFatalAndPanic("error handling record", err)
+		h.logger.CaptureFatalAndPanic(
+			fmt.Errorf("handler: handleRecord: unknown record type %T", x))
 	}
 }
 
@@ -320,11 +320,11 @@ func (h *Handler) handleRequest(record *service.Record) {
 	case *service.Request_JobInput:
 		h.handleRequestJobInput(record)
 	case nil:
-		err := fmt.Errorf("handler: handleRequest: request type is nil")
-		h.logger.CaptureFatalAndPanic("error handling request", err)
+		h.logger.CaptureFatalAndPanic(
+			errors.New("handler: handleRequest: request type is nil"))
 	default:
-		err := fmt.Errorf("handler: handleRequest: unknown request type %T", x)
-		h.logger.CaptureFatalAndPanic("error handling request", err)
+		h.logger.CaptureFatalAndPanic(
+			fmt.Errorf("handler: handleRequest: unknown request type %T", x))
 	}
 }
 
@@ -580,8 +580,8 @@ func (h *Handler) handleRequestRunStart(record *service.Record, request *service
 	h.runTimer.Start(&startTime)
 
 	if h.runRecord, ok = proto.Clone(run).(*service.RunRecord); !ok {
-		err := fmt.Errorf("handleRunStart: failed to clone run")
-		h.logger.CaptureFatalAndPanic("error handling run start", err)
+		h.logger.CaptureFatalAndPanic(
+			errors.New("handleRunStart: failed to clone run"))
 	}
 	h.fwdRecord(record)
 

--- a/core/pkg/server/responder.go
+++ b/core/pkg/server/responder.go
@@ -51,8 +51,8 @@ func (d *Dispatcher) handleRespond(result *service.Result) {
 	if responder, ok := d.responders[responderId]; ok {
 		responder.Respond(response)
 	} else {
-		err := fmt.Errorf("dispatch: no responder found: %s", responderId)
-		d.logger.CaptureFatalAndPanic("dispatch: no responder found", err)
+		d.logger.CaptureFatalAndPanic(
+			fmt.Errorf("dispatch: no responder found: %s", responderId))
 	}
 }
 

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -243,11 +244,11 @@ func (s *Sender) respond(record *service.Record, response any) {
 	case *service.RunUpdateResult:
 		s.respondRunUpdate(record, x)
 	case nil:
-		err := fmt.Errorf("sender: respond: nil response")
-		s.logger.CaptureFatalAndPanic("sender: respond: nil response", err)
+		s.logger.CaptureFatalAndPanic(
+			errors.New("sender: respond: nil response"))
 	default:
-		err := fmt.Errorf("sender: respond: unexpected type %T", x)
-		s.logger.CaptureFatalAndPanic("sender: respond: unexpected type", err)
+		s.logger.CaptureFatalAndPanic(
+			fmt.Errorf("sender: respond: unexpected type %T", x))
 	}
 }
 
@@ -343,11 +344,11 @@ func (s *Sender) sendRecord(record *service.Record) {
 	case *service.Record_Artifact:
 		s.sendArtifact(record, x.Artifact)
 	case nil:
-		err := fmt.Errorf("sender: sendRecord: nil RecordType")
-		s.logger.CaptureFatalAndPanic("sender: sendRecord: nil RecordType", err)
+		s.logger.CaptureFatalAndPanic(
+			errors.New("sender: sendRecord: nil RecordType"))
 	default:
-		err := fmt.Errorf("sender: sendRecord: unexpected type %T", x)
-		s.logger.CaptureFatalAndPanic("sender: sendRecord: unexpected type", err)
+		s.logger.CaptureFatalAndPanic(
+			fmt.Errorf("sender: sendRecord: unexpected type %T", x))
 	}
 }
 
@@ -375,11 +376,11 @@ func (s *Sender) sendRequest(record *service.Record, request *service.Request) {
 	case *service.Request_JobInput:
 		s.sendRequestJobInput(x.JobInput)
 	case nil:
-		err := fmt.Errorf("sender: sendRequest: nil RequestType")
-		s.logger.CaptureFatalAndPanic("sender: sendRequest: nil RequestType", err)
+		s.logger.CaptureFatalAndPanic(
+			errors.New("sender: sendRequest: nil RequestType"))
 	default:
-		err := fmt.Errorf("sender: sendRequest: unexpected type %T", x)
-		s.logger.CaptureFatalAndPanic("sender: sendRequest: unexpected type", err)
+		s.logger.CaptureFatalAndPanic(
+			fmt.Errorf("sender: sendRequest: unexpected type %T", x))
 	}
 }
 
@@ -559,8 +560,8 @@ func (s *Sender) sendRequestDefer(request *service.DeferRequest) {
 		// cancel tells the stream to close the loopback and input channels
 		s.cancel()
 	default:
-		err := fmt.Errorf("sender: sendDefer: unexpected state %v", request.State)
-		s.logger.CaptureFatalAndPanic("sender: sendDefer: unexpected state", err)
+		s.logger.CaptureFatalAndPanic(
+			fmt.Errorf("sender: sendDefer: unexpected state %v", request.State))
 	}
 }
 
@@ -598,7 +599,8 @@ func (s *Sender) sendLinkArtifact(record *service.Record) {
 	}
 	err := linker.Link()
 	if err != nil {
-		s.logger.CaptureFatalAndPanic("sender: sendLinkArtifact: link failure", err)
+		s.logger.CaptureFatalAndPanic(
+			fmt.Errorf("sender: sendLinkArtifact: link failure: %v", err))
 	}
 
 	// why is this here?
@@ -699,8 +701,8 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			var ok bool
 			s.RunRecord, ok = proto.Clone(run).(*service.RunRecord)
 			if !ok {
-				err := fmt.Errorf("failed to clone RunRecord")
-				s.logger.CaptureFatalAndPanic("sender: sendRun: ", err)
+				s.logger.CaptureFatalAndPanic(
+					errors.New("sender: sendRun: failed to clone RunRecord"))
 			}
 
 			if err := s.checkAndUpdateResumeState(record); err != nil {
@@ -1057,8 +1059,8 @@ func (s *Sender) sendAlert(_ *service.Record, alert *service.AlertRecord) {
 	}
 
 	if s.RunRecord == nil {
-		err := fmt.Errorf("sender: sendAlert: RunRecord not set")
-		s.logger.CaptureFatalAndPanic("sender received error", err)
+		s.logger.CaptureFatalAndPanic(
+			errors.New("sender: sendAlert: RunRecord not set"))
 	}
 	// TODO: handle invalid alert levels
 	severity := gql.AlertSeverity(alert.Level)

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -33,7 +33,8 @@ func NewBackend(
 
 	baseURL, err := url.Parse(settings.Proto.GetBaseUrl().GetValue())
 	if err != nil {
-		logger.CaptureFatalAndPanic("sender: failed to parse base URL", err)
+		logger.CaptureFatalAndPanic(
+			fmt.Errorf("sender: failed to parse base URL: %v", err))
 	}
 	return api.New(api.BackendOptions{
 		BaseURL: baseURL,

--- a/core/pkg/server/writer.go
+++ b/core/pkg/server/writer.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 
@@ -83,7 +84,8 @@ func (w *Writer) startStore() {
 	w.store = NewStore(w.ctx, w.settings.GetSyncFile().GetValue())
 	err = w.store.Open(os.O_WRONLY)
 	if err != nil {
-		w.logger.CaptureFatalAndPanic("writer: startStore: error creating store", err)
+		w.logger.CaptureFatalAndPanic(
+			fmt.Errorf("writer: startStore: error creating store: %v", err))
 	}
 
 	w.wg.Add(1)


### PR DESCRIPTION
Description
---
Refactors `CaptureFatal` and `CaptureFatalAndPanic` to include the error log message as well as the error.

```go
// BEFORE.
//
// This would log only 'err' in Sentry without the log message
// which contains important context.
logger.CaptureFatal(
	"sender: failed during XYZ",
	err,
)

// AFTER.
//
// All useful information is uploaded.
logger.CaptureFatal(
	fmt.Errorf("sender: failed during XYZ: %v", err))
```

I finished this refactor completely for `CaptureFatal` / `CaptureFatalAndPanic`. I'll do `CaptureError` in a separate PR as it involves more changes.
