### PR TITLE
feat(launch): Add prior runs when creating a sweep from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Added
+
+- Add prior runs when creating a sweep from the CLI by @TimH98 in https://github.com/wandb/wandb/pull/7803
+
 ### Fixed
 
 - Fix "UnicodeDecodeError: 'charmap'" when opening HTML files on Windows by specifying UTF-8 encoding by @KilnOfTheSecondFlame in https://github.com/wandb/wandb/pull/7730

--- a/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
@@ -119,10 +119,7 @@ def test_upsert_sweep(monkeypatch):
             "increment": {"values": [0.1, 0.2, 0.3]},
         },
     }
-    upsert_kwargs = {
-        "config": sweep_config,
-        "prior_runs": run_ids
-    }
+    upsert_kwargs = {"config": sweep_config, "prior_runs": run_ids}
     resp = _api.api.upsert_sweep(**upsert_kwargs)
 
     assert resp == (mock_sweep_name, [])
@@ -130,4 +127,7 @@ def test_upsert_sweep(monkeypatch):
     call_kwargs = _api.api.gql.call_args.kwargs
     assert "$priorRunsFilters: JSONString" in call_args[0]
     assert "priorRunsFilters: $priorRunsFilters" in call_args[0]
-    assert call_kwargs["variable_values"]["priorRunsFilters"] == '{"$or": [{"name": "abc"}, {"name": "def"}]}'
+    assert (
+        call_kwargs["variable_values"]["priorRunsFilters"]
+        == '{"$or": [{"name": "abc"}, {"name": "def"}]}'
+    )

--- a/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_internal_api.py
@@ -97,3 +97,37 @@ def test_push_to_run_queue_by_name(monkeypatch):
         "runSpec": "{}",
         "priority": 2,
     }
+
+
+def test_upsert_sweep(monkeypatch):
+    _api = internal.Api()
+    mock_sweep_name = "test-sweep"
+    mock_gql_response = {"upsertSweep": {"sweep": {"name": mock_sweep_name}}}
+    _api.api.gql = MagicMock(return_value=mock_gql_response)
+    monkeypatch.setattr(wandb.sdk.internal.internal_api, "gql", lambda x: x)
+
+    run_ids = ["abc", "def"]
+    sweep_config = {
+        "job": "fake-job:v1",
+        "method": "bayes",
+        "metric": {
+            "name": "loss_metric",
+            "goal": "minimize",
+        },
+        "parameters": {
+            "epochs": {"value": 1},
+            "increment": {"values": [0.1, 0.2, 0.3]},
+        },
+    }
+    upsert_kwargs = {
+        "config": sweep_config,
+        "prior_runs": run_ids
+    }
+    resp = _api.api.upsert_sweep(**upsert_kwargs)
+
+    assert resp == (mock_sweep_name, [])
+    call_args = _api.api.gql.call_args[0]
+    call_kwargs = _api.api.gql.call_args.kwargs
+    assert "$priorRunsFilters: JSONString" in call_args[0]
+    assert "priorRunsFilters: $priorRunsFilters" in call_args[0]
+    assert call_kwargs["variable_values"]["priorRunsFilters"] == '{"$or": [{"name": "abc"}, {"name": "def"}]}'

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -880,6 +880,13 @@ def sync(
     default=False,
     help="Resume a sweep to continue running new runs.",
 )
+@click.option(
+    "--prior_run",
+    "-R",
+    "prior_runs",
+    multiple=True,
+    default=None,
+)
 @click.argument("config_yaml_or_sweep_id")
 @click.pass_context
 @display_error
@@ -897,6 +904,7 @@ def sweep(
     cancel,
     pause,
     resume,
+    prior_runs,
     config_yaml_or_sweep_id,
 ):
     state_args = "stop", "cancel", "pause", "resume"
@@ -1038,6 +1046,7 @@ def sweep(
         project=project,
         entity=entity,
         obj_id=sweep_obj_id,
+        prior_runs=prior_runs,
     )
     sweep_utils.handle_sweep_config_violations(warnings)
 
@@ -1104,6 +1113,13 @@ def sweep(
     default=None,
     help="Resume a launch sweep by passing an 8-char sweep id. Queue required",
 )
+@click.option(
+    "--prior_run",
+    "-R",
+    "prior_runs",
+    multiple=True,
+    default=None,
+)
 @click.argument("config", required=False, type=click.Path(exists=True))
 @click.pass_context
 @display_error
@@ -1114,6 +1130,7 @@ def launch_sweep(
     queue,
     config,
     resume_id,
+    prior_runs,
 ):
     api = _get_cling_api()
     env = os.environ
@@ -1298,6 +1315,7 @@ def launch_sweep(
         obj_id=sweep_obj_id,  # if resuming
         launch_scheduler=launch_scheduler_with_queue,
         state="PENDING",
+        prior_runs=prior_runs,
     )
     sweep_utils.handle_sweep_config_violations(warnings)
     # Log nicely formatted sweep information

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -886,6 +886,7 @@ def sync(
     "prior_runs",
     multiple=True,
     default=None,
+    help="ID of an existing run to add to this sweep",
 )
 @click.argument("config_yaml_or_sweep_id")
 @click.pass_context
@@ -1119,6 +1120,7 @@ def sweep(
     "prior_runs",
     multiple=True,
     default=None,
+    help="ID of an existing run to add to this sweep",
 )
 @click.argument("config", required=False, type=click.Path(exists=True))
 @click.pass_context

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3038,6 +3038,7 @@ class Api:
         project: Optional[str] = None,
         entity: Optional[str] = None,
         state: Optional[str] = None,
+        prior_runs: Optional[List[str]] = None,
     ) -> Tuple[str, List[str]]:
         """Upsert a sweep object.
 
@@ -3050,6 +3051,7 @@ class Api:
             project (str): project to use
             entity (str): entity to use
             state (str): state
+            prior_runs (list): IDs of existing runs to add to the sweep
         """
         project_query = """
             project {
@@ -3070,7 +3072,8 @@ class Api:
             $projectName: String,
             $controller: JSONString,
             $scheduler: JSONString,
-            $state: String
+            $state: String,
+            $priorRunsFilters: JSONString,
         ) {
             upsertSweep(input: {
                 id: $id,
@@ -3080,7 +3083,8 @@ class Api:
                 projectName: $projectName,
                 controller: $controller,
                 scheduler: $scheduler,
-                state: $state
+                state: $state,
+                priorRunsFilters: $priorRunsFilters,
             }) {
                 sweep {
                     name
@@ -3129,6 +3133,9 @@ class Api:
         config_str = yaml.dump(
             json.loads(json.dumps(config)), Dumper=util.NonOctalStringDumper
         )
+        filters = None
+        if prior_runs:
+            filters = json.dumps({"$or": [{"name": r} for r in prior_runs]})
 
         err: Optional[Exception] = None
         for mutation in mutations:
@@ -3142,6 +3149,7 @@ class Api:
                     "controller": controller,
                     "launchScheduler": launch_scheduler,
                     "scheduler": scheduler,
+                    "priorRunsFilters": filters,
                 }
                 if state:
                     variables["state"] = state


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-19251](https://wandb.atlassian.net/browse/WB-19251)

We already have the ability to add already-completed runs to a sweep from the UI. This PR adds the ability to do the same using the command line, using `wandb sweep -R <run id> -R <run id> ...`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------

A unit test was added.

Tested manually using the following: `wandb sweep -R cq35n9a1 -R oobmkxxw sweep_config.yaml -e tim-hays -p debugging`, and confirming in the UI that the sweep had the two runs added to it (the contents of the runs and the sweep config are not important).

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-19251]: https://wandb.atlassian.net/browse/WB-19251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ