### PR TITLE
fix(sdk): guard against unexpected pynvml errors when probing GPU info

### DIFF
--- a/wandb/sdk/internal/system/assets/gpu.py
+++ b/wandb/sdk/internal/system/assets/gpu.py
@@ -410,5 +410,7 @@ class GPU:
 
         except pynvml.NVMLError:
             pass
+        except Exception as e:
+            logger.error(f"Error Probing GPU: {e}")
 
         return info


### PR DESCRIPTION
bypass pynvml

Description
-----------

- Fixes #7770 
- Fixes #7168

There is an issue with pynvml upstream where it is unable to get driver version of the latest nvidia driver and is breaking a lot of tools, one of which is wandb.
Unfortunately pynvml is closed so we have to make changes in our tools to handle it.
The issue seems to be in pynvml.nvmlDeviceGetName which throws an error.

This is a minimal fix where I handle the error thrown by the GPU probe


- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

I ran this on my local code and verified it as working.
