### PR TITLE
feat(core): Simple terminal emulator

### DIFF
--- a/tests/pytest_tests/system_tests/test_sweep/test_sweep_public_api.py
+++ b/tests/pytest_tests/system_tests/test_sweep/test_sweep_public_api.py
@@ -1,6 +1,8 @@
 import pytest
 import wandb
 from wandb import Api
+from wandb.apis.public.sweeps import Sweep
+from wandb_gql import gql
 
 from .test_wandb_sweep import (
     SWEEP_CONFIG_BAYES,
@@ -8,6 +10,31 @@ from .test_wandb_sweep import (
     SWEEP_CONFIG_GRID_NESTED,
     SWEEP_CONFIG_RANDOM,
     VALID_SWEEP_CONFIGS_MINIMAL,
+)
+
+SWEEP_QUERY = gql(
+    """
+query Sweep($project: String, $entity: String, $name: String!) {
+    project(name: $project, entityName: $entity) {
+        sweep(sweepName: $name) {
+            id
+            name
+            state
+            runCountExpected
+            bestLoss
+            config
+            priorRuns {
+                edges {
+                    node {
+                        id
+                        name
+                    }
+                }
+            }
+        }
+    }
+}
+"""
 )
 
 
@@ -22,20 +49,28 @@ from .test_wandb_sweep import (
     ids=["test grid", "test grid nested", "test bayes", "test random"],
 )
 def test_sweep_api_expected_run_count(
-    user, relay_server, sweep_config, expected_run_count
+    user, wandb_init, relay_server, sweep_config, expected_run_count
 ):
     _project = "test"
     with relay_server() as relay:
-        sweep_id = wandb.sweep(sweep_config, entity=user, project=_project)
+        run = wandb_init(entity=user, project=_project)
+        run_id = run.id
+        run.log({"x": 1})
+        run.finish()
+        sweep_id = wandb.sweep(
+            sweep_config, entity=user, project=_project, prior_runs=[run_id]
+        )
 
     for comm in relay.context.raw_data:
         q = comm["request"].get("query")
         print(q)
 
-    print(f"sweep_id{sweep_id}")
-    sweep = Api().sweep(f"{user}/{_project}/sweeps/{sweep_id}")
+    api = Api()
+    sweep = Sweep.get(api.client, user, _project, sweep_id, query=SWEEP_QUERY)
 
     assert sweep.expected_run_count == expected_run_count
+    assert len(sweep._attrs["priorRuns"]["edges"]) == 1
+    assert sweep._attrs["priorRuns"]["edges"][0]["node"]["name"] == run_id
 
 
 @pytest.mark.parametrize("sweep_config", VALID_SWEEP_CONFIGS_MINIMAL)

--- a/wandb/sdk/wandb_sweep.py
+++ b/wandb/sdk/wandb_sweep.py
@@ -1,5 +1,5 @@
 import urllib.parse
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import wandb
 from wandb import env
@@ -32,6 +32,7 @@ def sweep(
     sweep: Union[dict, Callable],
     entity: Optional[str] = None,
     project: Optional[str] = None,
+    prior_runs: Optional[List[str]] = None,
 ) -> str:
     """Initialize a hyperparameter sweep.
 
@@ -57,6 +58,7 @@ def sweep(
       project: The name of the project where W&B runs created from
         the sweep are sent to. If the project is not specified, the
         run is sent to a project labeled 'Uncategorized'.
+      prior_runs: The run IDs of existing runs to add to this sweep.
 
     Returns:
       sweep_id: str. A unique identifier for the sweep.
@@ -78,7 +80,7 @@ def sweep(
     if wandb.run is None:
         wandb_login._login(_silent=True)
     api = InternalApi()
-    sweep_id, warnings = api.upsert_sweep(sweep)
+    sweep_id, warnings = api.upsert_sweep(sweep, prior_runs=prior_runs)
     handle_sweep_config_violations(warnings)
     print("Create sweep with ID:", sweep_id)
     sweep_url = _get_sweep_url(api, sweep_id)


### PR DESCRIPTION
Description
---
Defines the 'terminalemulator' package with support for basic escape sequences:

* '\r' -- carriage return
* '\x1b[A' -- cursor up
* '\x1b[B' -- cursor down

These are used by `tqdm` when displaying nested progress bars. I'm not sure if `tqdm` uses any other escape sequences.

Testing
---
Unit tests, plus manual testing in the final PR in this series which wires everything up.
