### PR TITLE
fix(public-api): make all sweep attrs accessible via api.project.sweeps

### DIFF
--- a/tests/pytest_tests/unit_tests_old/test_launch/test_public_api.py
+++ b/tests/pytest_tests/unit_tests_old/test_launch/test_public_api.py
@@ -5,6 +5,7 @@ def test_from_path(mock_server, api):
     sweep = api.from_path("test/test/sweeps/test")
     assert isinstance(sweep, wandb.apis.public.Sweep)
 
+
 def test_sweep(runner, mock_server, api):
     sweep = api.sweep("test/test/test")
     assert sweep.entity == "test"

--- a/tests/pytest_tests/unit_tests_old/test_launch/test_public_api.py
+++ b/tests/pytest_tests/unit_tests_old/test_launch/test_public_api.py
@@ -5,19 +5,6 @@ def test_from_path(mock_server, api):
     sweep = api.from_path("test/test/sweeps/test")
     assert isinstance(sweep, wandb.apis.public.Sweep)
 
-
-def test_project_sweeps(mock_server, api):
-    project = api.from_path("test")
-    psweeps = project.sweeps()
-    assert len(psweeps) == 1
-    assert psweeps[0].id == "testid"
-    assert psweeps[0].name == "testname"
-
-    no_sweeps_project = api.from_path("testnosweeps")
-    nspsweeps = no_sweeps_project.sweeps()
-    assert len(nspsweeps) == 0
-
-
 def test_sweep(runner, mock_server, api):
     sweep = api.sweep("test/test/test")
     assert sweep.entity == "test"

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -149,12 +149,6 @@ class Project(Attrs):
                 self.entity,
                 self.name,
                 e["node"]["name"],
-                attrs={
-                    "id": e["node"]["id"],
-                    "name": e["node"]["name"],
-                    "bestLoss": e["node"]["bestLoss"],
-                    "config": e["node"]["config"],
-                },
             )
             for e in ret["project"]["sweeps"]["edges"]
         ]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18415


What does the PR do? Include a concise description of the PR contents.

Allows users to access all attrs of a sweep when doing `api.project.sweep`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [X] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

Using this code:

```
import wandb

api = wandb.Api()

project = api.project(name="test_relation_sweep", entity="luis_team_test")
sweep = [sweep for sweep in project.sweeps() if sweep.id == "xrr345rs"][0]
try:
    print(sweep.runs)
    print(sweep.state)
except Exception as e:
    print("Project error")
    print(e)
```
Before:
```
[]
Project error
'<Sweep test-debug/pytorch-sweeps-demo/vdnc4y73 (Unknown State)>' object has no attribute 'state'
```
After:
```
<Runs luis_team_test/test_relation_sweep>
RUNNING
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
