### PR TITLE
chore(sdk): Fix Windows CI pip upgrade issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ commands:
     steps:
       - run:
           name: Install Python dependencies
-          command: pip install -U nox pip uv
+          command: python -m pip install -U nox pip uv
           no_output_timeout: 5m
 
       - run:
@@ -442,8 +442,7 @@ jobs:
                 no_output_timeout: 30m
             - run:
                 name: Install requirements
-                command: |
-                  pip install -U pip tox
+                command: python -m pip install -U pip tox
                 no_output_timeout: 5m
             - run:
                 name: Run tests
@@ -569,7 +568,7 @@ jobs:
       - install_go
       - run:
           name: Install Python dependencies
-          command: pip install -U tox nox pip uv
+          command: python -m pip install -U tox nox pip uv
           no_output_timeout: 5m
       - run:
           name: Ensure proto files were generated
@@ -636,7 +635,7 @@ jobs:
             - install_go
             - run:
                 name: Install Python dependencies
-                command: pip install -U tox nox pip uv
+                command: python -m pip install -U tox nox pip uv
                 no_output_timeout: 5m
             - restore_cache_tox
             - run:
@@ -694,7 +693,7 @@ jobs:
       - install_go
       - run:
           name: Install Python dependencies
-          command: pip install -U tox nox pip uv
+          command: python -m pip install -U tox nox pip uv
           no_output_timeout: 5m
       - restore_cache_tox
       - run:
@@ -747,7 +746,7 @@ jobs:
           name:
           command: |
             go install github.com/google/go-containerregistry/cmd/gcrane@latest
-            pip install -U pip nox requests uv
+            python -m pip install -U pip nox requests uv
             nox -s local-testcontainer-registry
           no_output_timeout: 5m
 


### PR DESCRIPTION
Description
-----------
Instead of `pip install -U pip`, use `python -m pip install -U pip`.

- [x] I updated CHANGELOG.md, or it's not applicable
