### PR TITLE
fix(sdk): robustly handle netrc file on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ### Fixed
 
+- Correctly name the netrc file on Windows as `_netrc` by @dmitryduev in https://github.com/wandb/wandb/pull/7844
 - With core enabled, nested `tqdm` bars show up correctly in the Logs tab (@timoffex in https://github.com/wandb/wandb/pull/7825)
 - Fix W&B Launch registry ECR regex separating tag on forward slash and period @KyleGoyette https://github.com/wandb/wandb/pull/7837
 

--- a/core/internal/auth/netrc.go
+++ b/core/internal/auth/netrc.go
@@ -79,7 +79,7 @@ func parseNetrc(data string) []netrcLine {
 	return nrc
 }
 
-func netrcPath() (string, error) {
+func NetrcPath() (string, error) {
 	if env := os.Getenv("NETRC"); env != "" {
 		return env, nil
 	}
@@ -87,6 +87,15 @@ func netrcPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	// if either .netrc or _netrc file exists, use it
+	for _, name := range []string{".netrc", "_netrc"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return filepath.Join(dir, name), nil
+		}
+	}
+
+	// otherwise, use _netrc on Windows and .netrc on other systems
 	base := ".netrc"
 	if runtime.GOOS == "windows" {
 		base = "_netrc"
@@ -95,7 +104,7 @@ func netrcPath() (string, error) {
 }
 
 func ReadNetrc() ([]netrcLine, error) {
-	path, err := netrcPath()
+	path, err := NetrcPath()
 	if err != nil {
 		// netrcErr = err
 		return []netrcLine{}, err

--- a/core/internal/auth/netrc_test.go
+++ b/core/internal/auth/netrc_test.go
@@ -1,0 +1,101 @@
+package auth_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/wandb/wandb/core/pkg/auth"
+)
+
+func TestNetrcPath(t *testing.T) {
+	// Save original environment and restore it after the test
+	origEnv := os.Getenv("NETRC")
+	origHome := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("NETRC", origEnv)
+		os.Setenv("HOME", origHome)
+	}()
+
+	t.Run("NETRC environment variable set", func(t *testing.T) {
+		os.Setenv("NETRC", "/custom/path/.netrc")
+		path, err := auth.NetrcPath()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if path != "/custom/path/.netrc" {
+			t.Errorf("Expected path %s, got %s", "/custom/path/.netrc", path)
+		}
+	})
+
+	t.Run("Home directory not found", func(t *testing.T) {
+		os.Setenv("NETRC", "")
+		os.Setenv("HOME", "")
+		_, err := auth.NetrcPath()
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Existing .netrc file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		os.Setenv("HOME", tempDir)
+		os.Setenv("NETRC", "")
+
+		netrcPath := filepath.Join(tempDir, ".netrc")
+		_, err := os.Create(netrcPath)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		path, err := auth.NetrcPath()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if path != netrcPath {
+			t.Errorf("Expected path %s, got %s", netrcPath, path)
+		}
+	})
+
+	t.Run("Existing _netrc file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		os.Setenv("HOME", tempDir)
+		os.Setenv("NETRC", "")
+
+		netrcPath := filepath.Join(tempDir, "_netrc")
+		_, err := os.Create(netrcPath)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		path, err := auth.NetrcPath()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if path != netrcPath {
+			t.Errorf("Expected path %s, got %s", netrcPath, path)
+		}
+	})
+
+	t.Run("No existing netrc file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		os.Setenv("HOME", tempDir)
+		os.Setenv("NETRC", "")
+
+		path, err := auth.NetrcPath()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		expectedBase := ".netrc"
+		if runtime.GOOS == "windows" {
+			expectedBase = "_netrc"
+		}
+		expectedPath := filepath.Join(tempDir, expectedBase)
+
+		if path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, path)
+		}
+	})
+}

--- a/core/internal/auth/netrc_test.go
+++ b/core/internal/auth/netrc_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/wandb/wandb/core/pkg/auth"
+	"github.com/wandb/wandb/core/internal/auth"
 )
 
 func TestNetrcPath(t *testing.T) {

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/wandb/wandb/core/pkg/auth"
+	"github.com/wandb/wandb/core/internal/auth"
 	"github.com/wandb/wandb/core/pkg/service"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )

--- a/tests/pytest_tests/unit_tests_old/conftest.py
+++ b/tests/pytest_tests/unit_tests_old/conftest.py
@@ -334,7 +334,10 @@ def local_netrc(monkeypatch):
         # TODO: this seems overkill...
         origexpand = os.path.expanduser
         # Touch that netrc
-        open(".netrc", "wb").close()
+
+        netrc_file = ".netrc" if platform.system() != "Windows" else "_netrc"
+
+        open(netrc_file, "wb").close()
 
         def expand(path):
             if "netrc" in path:

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2848,7 +2848,7 @@ class Api:
             request_headers = e.request.headers if e.request is not None else ""
             logger.error(f"upload_file request headers: {request_headers}")
             response_content = e.response.content if e.response is not None else ""
-            logger.error(f"upload_file response body: {response_content}")
+            logger.error(f"upload_file response body: {response_content!r}")
             status_code = e.response.status_code if e.response is not None else 0
             # S3 reports retryable request timeouts out-of-band
             is_aws_retryable = (

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2780,9 +2780,9 @@ class Api:
         except requests.exceptions.RequestException as e:
             logger.error(f"upload_file exception {url}: {e}")
             request_headers = e.request.headers if e.request is not None else ""
-            logger.error(f"upload_file request headers: {request_headers}")
+            logger.error(f"upload_file request headers: {request_headers!r}")
             response_content = e.response.content if e.response is not None else ""
-            logger.error(f"upload_file response body: {response_content}")
+            logger.error(f"upload_file response body: {response_content!r}")
             status_code = e.response.status_code if e.response is not None else 0
             # S3 reports retryable request timeouts out-of-band
             is_aws_retryable = status_code == 400 and "RequestTimeout" in str(

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -6,7 +6,7 @@ import stat
 import sys
 import textwrap
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Union
 from urllib.parse import urlparse
 
 # import Literal

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -1,6 +1,7 @@
 """apikey util."""
 
 import os
+import platform
 import stat
 import sys
 import textwrap
@@ -57,7 +58,10 @@ def get_netrc_file_path() -> str:
     netrc_file = os.environ.get("NETRC")
     if netrc_file:
         return os.path.expanduser(netrc_file)
-    return os.path.join(os.path.expanduser("~"), ".netrc")
+
+    netrc_file = ".netrc" if platform.system() != "Windows" else "_netrc"
+
+    return os.path.join(os.path.expanduser("~"), netrc_file)
 
 
 def prompt_api_key(  # noqa: C901

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -64,7 +64,7 @@ def get_netrc_file_path() -> str:
     # if either .netrc or _netrc exists in the home directory, use that
     for netrc_file in NETRC_FILES:
         home_dir = os.path.expanduser("~")
-        if os.path.exists(home_dir, netrc_file):
+        if os.path.exists(os.path.join(home_dir, netrc_file)):
             return os.path.join(home_dir, netrc_file)
 
     # otherwise, use .netrc on non-Windows platforms and _netrc on Windows


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-19324

The netrc file on Windows should be named `_netrc` (for historical reasons, I believe). However, sometimes it's called .netrc like everywhere else. This PR implements the following logic:
- if NETRC env var is set, use that as the path
- If either ~/.netrc or ~/_netrc exists, use it on either platform
- If not, use ~/.netrc on non-win systems and ~/_netrc on win.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Verified that the fix works on a Win VM.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
