### PR TITLE
fix(core): do not expect control.mailbox_slot for run record updates

### DIFF
--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -701,6 +701,14 @@ func (s *Sender) checkAndUpdateResumeState(record *service.Record) error {
 // sendRun sends a run record to the server and updates the run record
 func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 	if s.graphqlClient != nil {
+		// TODO: we use the same record type for the initial run upsert and the
+		//  follow-up run updates, such as setting the name, tags, and notes.
+		//  The client only expects a response for the initial upsert, the
+		//  consequent updates are fire-and-forget and thus don't have a mailbox
+		//  slot.
+		//  We should probably separate the initial upsert from the updates.
+		runRecordSet := s.RunRecord != nil
+
 		// The first run record sent by the client is encoded incorrectly,
 		// causing it to overwrite the entire "_wandb" config key rather than
 		// just the necessary part ("_wandb/code_path"). This can overwrite
@@ -717,7 +725,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 		proto.Merge(s.telemetry, run.Telemetry)
 		s.updateConfigPrivate()
 
-		if s.RunRecord == nil {
+		if !runRecordSet {
 			var ok bool
 			s.RunRecord, ok = proto.Clone(run).(*service.RunRecord)
 			if !ok {
@@ -759,9 +767,12 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			// if this times out, we cancel the global context
 			// as there is no need to proceed with the run
 			ctx = s.mailbox.Add(ctx, s.cancel, mailboxSlot)
-		} else {
-			// this should never happen
-			s.logger.CaptureError(errors.New("sender: sendRun: no mailbox slot"))
+		} else if !runRecordSet {
+			// this should never happen:
+			// the initial run upsert record should have a mailbox slot set by the client
+			s.logger.CaptureFatalAndPanic(
+				errors.New("sender: sendRun: mailbox slot not set"),
+			)
 		}
 
 		data, err := gql.UpsertBucket(

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -707,7 +707,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 		//  consequent updates are fire-and-forget and thus don't have a mailbox
 		//  slot.
 		//  We should probably separate the initial upsert from the updates.
-		runRecordSet := s.RunRecord != nil
+		runRecordIsSet := s.RunRecord != nil
 
 		// The first run record sent by the client is encoded incorrectly,
 		// causing it to overwrite the entire "_wandb" config key rather than
@@ -725,7 +725,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 		proto.Merge(s.telemetry, run.Telemetry)
 		s.updateConfigPrivate()
 
-		if !runRecordSet {
+		if !runRecordIsSet {
 			var ok bool
 			s.RunRecord, ok = proto.Clone(run).(*service.RunRecord)
 			if !ok {
@@ -767,7 +767,7 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			// if this times out, we cancel the global context
 			// as there is no need to proceed with the run
 			ctx = s.mailbox.Add(ctx, s.cancel, mailboxSlot)
-		} else if !runRecordSet {
+		} else if !runRecordIsSet {
 			// this should never happen:
 			// the initial run upsert record should have a mailbox slot set by the client
 			s.logger.CaptureFatalAndPanic(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-19375

We use the same record type for the initial run upsert and the follow-up run updates, such as setting the name, tags, and notes. The client only expects a response for the initial upsert, the consequent updates are fire-and-forget and thus don't have a mailbox slot. But we were always expecting one and wrongfully capturing an error.
TODO: We should probably separate the initial upsert from the updates.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
