### PR TITLE
fix(core): Fix race condition in `runconsolelogs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Fixed
 
 - Use `sys.exit()` instead of `os._exit()` if an internal subprocess exits with a non-zero code (@timoffex in https://github.com/wandb/wandb/pull/7866)
+- Fix an occasional race condition when using `core` that could affect run logs (@timoffex in https://github.com/wandb/wandb/pull/7889)
 
 ## [0.17.3] - 2024-06-24
 

--- a/core/internal/filestreamtest/filestreamtest.go
+++ b/core/internal/filestreamtest/filestreamtest.go
@@ -35,7 +35,7 @@ func (fs *FakeFileStream) GetRequest(
 	fullRequest := &filestream.FileStreamRequest{}
 
 	for _, update := range fs.GetUpdates() {
-		update.Apply(filestream.UpdateContext{
+		_ = update.Apply(filestream.UpdateContext{
 			MakeRequest: func(request *filestream.FileStreamRequest) {
 				fullRequest.Merge(request)
 			},

--- a/core/internal/runconsolelogs/debouncedwriter_test.go
+++ b/core/internal/runconsolelogs/debouncedwriter_test.go
@@ -6,22 +6,22 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wandb/wandb/core/internal/runconsolelogs"
+	. "github.com/wandb/wandb/core/internal/runconsolelogs"
 	"github.com/wandb/wandb/core/internal/sparselist"
 	"golang.org/x/time/rate"
 )
 
 func TestInvokesCallback(t *testing.T) {
-	flushes := make(chan sparselist.SparseList[runconsolelogs.RunLogsLine], 1)
-	writer := runconsolelogs.NewDebouncedWriter(
+	flushes := make(chan sparselist.SparseList[*RunLogsLine], 1)
+	writer := NewDebouncedWriter(
 		rate.NewLimiter(rate.Inf, 1),
 		context.Background(),
-		func(lines sparselist.SparseList[runconsolelogs.RunLogsLine]) {
+		func(lines sparselist.SparseList[*RunLogsLine]) {
 			flushes <- lines
 		},
 	)
 
-	line := runconsolelogs.RunLogsLine{}
+	line := &RunLogsLine{}
 	line.Content = []rune("content")
 	writer.OnChanged(1, line)
 	writer.Wait()
@@ -37,17 +37,17 @@ func TestInvokesCallback(t *testing.T) {
 
 func TestRespectsCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	flushes := make(chan sparselist.SparseList[runconsolelogs.RunLogsLine], 1)
-	writer := runconsolelogs.NewDebouncedWriter(
+	flushes := make(chan sparselist.SparseList[*RunLogsLine], 1)
+	writer := NewDebouncedWriter(
 		rate.NewLimiter(rate.Inf, 1),
 		ctx,
-		func(lines sparselist.SparseList[runconsolelogs.RunLogsLine]) {
+		func(lines sparselist.SparseList[*RunLogsLine]) {
 			flushes <- lines
 		},
 	)
 
 	cancel()
-	writer.OnChanged(1, runconsolelogs.RunLogsLine{})
+	writer.OnChanged(1, &RunLogsLine{})
 	writer.Wait()
 
 	select {

--- a/core/internal/runconsolelogs/filestreamwriter.go
+++ b/core/internal/runconsolelogs/filestreamwriter.go
@@ -14,12 +14,12 @@ type filestreamWriter struct {
 }
 
 func (w *filestreamWriter) SendChanged(
-	changes sparselist.SparseList[RunLogsLine],
+	changes sparselist.SparseList[*RunLogsLine],
 ) {
 	// Generate timestamps in the Python ISO format (microseconds without Z)
 	const rfc3339Micro = "2006-01-02T15:04:05.000000Z07:00"
 
-	lines := sparselist.Map(changes, func(line RunLogsLine) string {
+	lines := sparselist.Map(changes, func(line *RunLogsLine) string {
 		timestamp := strings.TrimSuffix(
 			line.Timestamp.UTC().Format(rfc3339Micro), "Z")
 

--- a/core/internal/runconsolelogs/outputfilewriter.go
+++ b/core/internal/runconsolelogs/outputfilewriter.go
@@ -34,9 +34,9 @@ func NewOutputFileWriter(
 }
 
 func (w *outputFileWriter) WriteToFile(
-	changes sparselist.SparseList[RunLogsLine],
+	changes sparselist.SparseList[*RunLogsLine],
 ) {
-	lines := sparselist.Map(changes, func(line RunLogsLine) string {
+	lines := sparselist.Map(changes, func(line *RunLogsLine) string {
 		return string(line.Content)
 	})
 

--- a/core/internal/runconsolelogs/runconsolelogs_test.go
+++ b/core/internal/runconsolelogs/runconsolelogs_test.go
@@ -1,0 +1,51 @@
+package runconsolelogs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/internal/filestreamtest"
+	"github.com/wandb/wandb/core/internal/paths"
+	. "github.com/wandb/wandb/core/internal/runconsolelogs"
+	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/sparselist"
+	"github.com/wandb/wandb/core/pkg/observability"
+	"github.com/wandb/wandb/core/pkg/service"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestFileStreamUpdates(t *testing.T) {
+	settingsProto := &service.Settings{
+		FilesDir: wrapperspb.String(t.TempDir()),
+	}
+	fileStream := filestreamtest.NewFakeFileStream()
+	outputFile, _ := paths.Relative("output.log")
+	sender := New(Params{
+		ConsoleOutputFile: *outputFile,
+		Settings:          settings.From(settingsProto),
+		Logger:            observability.NewNoOpLogger(),
+		Ctx:               context.Background(),
+		LoopbackChan:      make(chan<- *service.Record, 10),
+		FileStreamOrNil:   fileStream,
+		GetNow: func() time.Time {
+			return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		},
+	})
+
+	sender.StreamLogs(&service.OutputRawRecord{Line: "line1\n"})
+	sender.StreamLogs(&service.OutputRawRecord{Line: "line2\n"})
+	sender.StreamLogs(&service.OutputRawRecord{Line: "\x1b[Aline2 - modified\n"})
+	sender.Finish()
+
+	request := fileStream.GetRequest(settingsProto)
+	assert.Equal(t,
+		[]sparselist.Run[string]{
+			{Start: 0, Items: []string{
+				"ERROR 2024-01-01T00:00:00.000000 line1",
+				"ERROR 2024-01-01T00:00:00.000000 line2 - modified",
+			}},
+		},
+		request.ConsoleLines.ToRuns())
+}

--- a/core/internal/terminalemulator/lines.go
+++ b/core/internal/terminalemulator/lines.go
@@ -1,5 +1,7 @@
 package terminalemulator
 
+import "slices"
+
 // LineSupplier returns lines for a terminal emulator to use.
 type LineSupplier interface {
 	// NextLine returns a new line below the previous ones.
@@ -39,4 +41,12 @@ func (l *LineContent) PutChar(c rune, offset int) bool {
 
 	l.Content[offset] = c
 	return true
+}
+
+// Clone returns a deep copy of the line content.
+func (l LineContent) Clone() LineContent {
+	return LineContent{
+		MaxLength: l.MaxLength,
+		Content:   slices.Clone(l.Content),
+	}
 }


### PR DESCRIPTION
Description
---
Fixes a race condition caused by the buffering goroutine using the mutable `RunLogsLine`.

Testing
---
Caught by enabling race detection in https://github.com/wandb/wandb/pull/7862.

I also added a new test which (occasionally) fails without `line.Clone()` in `debouncedwriter.go` if you run with `go test -race`.
