### PR TITLE
chore(core): Add `@override` to method to silence lint

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -8,6 +8,7 @@ import sysconfig
 from typing import Any, Dict, List
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from typing_extensions import override
 
 # A small hack to allow importing build scripts from the source tree.
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
@@ -27,6 +28,7 @@ _WANDB_BUILD_SKIP_APPLE = "WANDB_BUILD_SKIP_APPLE"
 
 
 class CustomBuildHook(BuildHookInterface):
+    @override
     def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
         if self.target_name == "wheel":
             self._prepare_wheel(build_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "typing_extensions"]
 build-backend = "hatchling.build"
 
 [project]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,5 @@
 -r requirements_test.txt
 
-typing_extensions
-
 pytest
 hypothesis
 hypothesis-fspaths


### PR DESCRIPTION
Description
---
We should be marking overridden methods with `@override` (introduced in PEP 698). This silences the Ruff's D102 lint (requiring public methods to have docstrings) because the method in the base class provides the docstring, and it also makes the intention more explicit.

The import is from `typing_extensions` rather than `typing` because `typing.override` was added in Python 3.12.
