### PR TITLE
fix(core): use correct headers for service account

### DIFF
--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -85,13 +85,17 @@ func NewGraphQLClient(
 	settings *settings.Settings,
 	peeker *observability.Peeker,
 ) graphql.Client {
-	// TODO: This is used for service account to associate the run with the
-	// correct user. Note that we are using environment variables here, instead
-	// of the settings object. This is because the settings object will populate
-	// both username and email and it might be incosistent with partial environment
-	// variables. We should consider using the settings object here.
-	// Leaving this as is for now just to avoid breakage, but we should consider
-	// refactoring this.
+	// TODO: This is used for the service account feature to associate the run
+	// with the specified user. Note that we are using environment variables
+	// here, instead of the settings object (which is ideally would be the only
+	// setting used). We are doing this because, the default setting populates
+	// the username with a value that not necessarily matches the username in
+	// our app. There is also a precedence issue, where if the username is set
+	// it will always be used, even if the email is set. Causing the owner of
+	// to be wrong.
+	// We should consider using the settings object here. But we need to make
+	// sure that the username setting is populated correctly. Leaving this as is
+	// for now just to avoid breakage in the service account feature.
 	graphqlHeaders := map[string]string{
 		"X-WANDB-USERNAME":   os.Getenv("WANDB_USERNAME"),
 		"X-WANDB-USER-EMAIL": os.Getenv("WANDB_USER_EMAIL"),

--- a/core/pkg/server/stream_init.go
+++ b/core/pkg/server/stream_init.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -84,9 +85,16 @@ func NewGraphQLClient(
 	settings *settings.Settings,
 	peeker *observability.Peeker,
 ) graphql.Client {
+	// TODO: This is used for service account to associate the run with the
+	// correct user. Note that we are using environment variables here, instead
+	// of the settings object. This is because the settings object will populate
+	// both username and email and it might be incosistent with partial environment
+	// variables. We should consider using the settings object here.
+	// Leaving this as is for now just to avoid breakage, but we should consider
+	// refactoring this.
 	graphqlHeaders := map[string]string{
-		"X-WANDB-USERNAME":   settings.Proto.GetUsername().GetValue(),
-		"X-WANDB-USER-EMAIL": settings.Proto.GetEmail().GetValue(),
+		"X-WANDB-USERNAME":   os.Getenv("WANDB_USERNAME"),
+		"X-WANDB-USER-EMAIL": os.Getenv("WANDB_USER_EMAIL"),
 	}
 	maps.Copy(graphqlHeaders, settings.Proto.GetXExtraHttpHeaders().GetValue())
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-19433

What does the PR do? Include a concise description of the PR contents.

Fixes an issue where a user uses service account, but provides only user_email, in that case we used to provide a wrong username that takes precedence over user_email and would assign the run to the wrong user. 

Now this logic matches the logic we have in our python code, but it seems that the real issue is that `username` has a specific usage in case of a service account, and auto populated breaks the assumption that it is always correct.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

manually tested to see that the attached user matches the one specified in this script:

```
import os
import random

import wandb

wandb.require("core")


os.environ["WANDB_USER_EMAIL"] = "user2@xyz.com"
os.environ["WANDB_USERNAME"] = "user2"

os.environ["WANDB_API_KEY"] = <service account api key>
os.environ["WANDB_ENTITY"] = <team with service account>

run = wandb.init(project="my_project")
run.finish()
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
