### PR TITLE
refactor(core): Move some error message properties to tags

### DIFF
--- a/core/internal/filetransfer/file_transfer_manager.go
+++ b/core/internal/filetransfer/file_transfer_manager.go
@@ -101,11 +101,11 @@ func (fm *fileTransferManager) AddTask(task *Task) {
 		if task.Err != nil {
 			fm.logger.CaptureError(
 				fmt.Errorf(
-					"filetransfer: uploader: error uploading path=%s url=%s: %v",
-					task.Path,
-					task.Url,
+					"filetransfer: uploader: error uploading: %v",
 					task.Err,
-				))
+				),
+				"path", task.Path,
+				"url", task.Url)
 		}
 
 		// Execute the callback.

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -2,6 +2,7 @@ package runfiles
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -115,10 +116,10 @@ func (u *uploader) Process(record *service.FilesRecord) {
 			}); err != nil {
 				u.logger.CaptureError(
 					fmt.Errorf(
-						"runfiles: error watching file %s: %v",
-						file.GetPath(),
+						"runfiles: error watching file: %v",
 						err,
-					))
+					),
+					"path", file.GetPath())
 			}
 
 		case service.FilesItem_END:
@@ -273,11 +274,12 @@ func (u *uploader) upload(runPaths []paths.RelativePath) {
 
 		if len(createRunFilesResponse.CreateRunFiles.Files) != len(runPaths) {
 			u.logger.CaptureError(
-				fmt.Errorf(
-					"runfiles: CreateRunFiles returned %d files but expected %d",
-					len(createRunFilesResponse.CreateRunFiles.Files),
-					len(runPaths),
-				))
+				errors.New(
+					"runfiles: CreateRunFiles returned"+
+						" unexpected number of files"),
+				"actual", len(createRunFilesResponse.CreateRunFiles.Files),
+				"expected", len(runPaths),
+			)
 			u.uploadWG.Add(-len(runPaths))
 			return
 		}


### PR DESCRIPTION
Description
---
In `file_transfer_manager.go` and `runfiles/uploader.go`, replaces some dynamic text in error strings by `CaptureError` tags.
