### PR TITLE
refactor(core): Ignore filestream inputs after fatal error

### DIFF
--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -160,7 +160,11 @@ func (fs *fileStream) Start(
 
 func (fs *fileStream) StreamUpdate(update Update) {
 	fs.logger.Debug("filestream: stream update", "update", update)
-	fs.processChan <- update
+	select {
+	case fs.processChan <- update:
+	case <-fs.deadChan:
+		// Ignore everything if the filestream is dead.
+	}
 }
 
 func (fs *fileStream) FinishWithExit(exitCode int32) {


### PR DESCRIPTION
Description
---
Makes `StreamUpdate` return immediately after filestream has experienced a fatal error.

This just reduces the amount of resource usage in that case, but shouldn't have any observable effect otherwise.
