### PR TITLE
fix(sdk): Pass extra headers from settings as default headers for file upload

### DIFF
--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -110,7 +110,7 @@ class UploadJob:
             logger.info("Skipped uploading %s", self.save_path)
             self._stats.set_file_deduped(self.save_name)
         else:
-            extra_headers = {}
+            extra_headers = self._api.self._extra_http_headers
             for upload_header in upload_headers:
                 key, val = upload_header.split(":", 1)
                 extra_headers[key] = val

--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -110,7 +110,7 @@ class UploadJob:
             logger.info("Skipped uploading %s", self.save_path)
             self._stats.set_file_deduped(self.save_name)
         else:
-            extra_headers = self._api.self._extra_http_headers
+            extra_headers = self._api._extra_http_headers
             for upload_header in upload_headers:
                 key, val = upload_header.split(":", 1)
                 extra_headers[key] = val

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -232,14 +232,14 @@ class Api:
 
         # todo: remove these hacky hacks after settings refactor is complete
         #  keeping this code here to limit scope and so that it is easy to remove later
-        extra_http_headers = self.settings("_extra_http_headers") or json.loads(
+        self._extra_http_headers = self.settings("_extra_http_headers") or json.loads(
             self._environ.get("WANDB__EXTRA_HTTP_HEADERS", "{}")
         )
-        extra_http_headers.update(_thread_local_api_settings.headers or {})
+        self._extra_http_headers.update(_thread_local_api_settings.headers or {})
 
         auth = None
         if self.access_token is not None:
-            extra_http_headers["Authorization"] = f"Bearer {self.access_token}"
+            self._extra_http_headers["Authorization"] = f"Bearer {self.access_token}"
         elif _thread_local_api_settings.cookies is None:
             auth = ("api", self.api_key or "")
 
@@ -253,7 +253,7 @@ class Api:
                     "User-Agent": self.user_agent,
                     "X-WANDB-USERNAME": env.get_username(env=self._environ),
                     "X-WANDB-USER-EMAIL": env.get_user_email(env=self._environ),
-                    **extra_http_headers,
+                    **self._extra_http_headers,
                 },
                 use_json=True,
                 # this timeout won't apply when the DNS lookup fails. in that case, it will be 60s


### PR DESCRIPTION


Description
-----------
With Wandb server installed behind another application which requires a header to be authenticated, file upload doesn't work because file upload doesn't use the header passed to the setting "extra HTTP headers".

This PR fixes it by passing the setting "extra HTTP headers" as default value for header for the file upload.
