### PR TITLE
refactor(core): Better error message in pathtree.go

### DIFF
--- a/core/internal/pathtree/pathtree.go
+++ b/core/internal/pathtree/pathtree.go
@@ -187,7 +187,7 @@ func getOrMakeSubtree(
 	tree TreeData,
 	path TreePath,
 ) (TreeData, error) {
-	for _, key := range path {
+	for i, key := range path {
 		node, exists := tree[key]
 		if !exists {
 			node = make(TreeData)
@@ -197,9 +197,8 @@ func getOrMakeSubtree(
 		subtree, ok := node.(TreeData)
 		if !ok {
 			return nil, fmt.Errorf(
-				"config: value at path %v is type %T, not a map",
-				path,
-				node,
+				"value at key %d (%v) in path %v is type %T, not a map",
+				i, key, path, node,
 			)
 		}
 


### PR DESCRIPTION
Description
---
Removes the "config:" prefix which is wrong and adds more info to the message.
