### PR TITLE
refactor(sdk): Remove os._exit() from Run.finish(), and clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Changed
+
+- `run.finish()` may raise an exception in cases where previously it would `os._exit()` (@timoffex in https://github.com/wandb/wandb/pull/7921)
+
 ## [0.17.4] - 2024-07-03
 
 ### Added

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2100,36 +2100,54 @@ class Run:
         return self._finish(exit_code, quiet)
 
     def _finish(
-        self, exit_code: Optional[int] = None, quiet: Optional[bool] = None
+        self,
+        exit_code: Optional[int] = None,
+        quiet: Optional[bool] = None,
     ) -> None:
-        if quiet is not None:
-            self._quiet = quiet
+        logger.info(f"finishing run {self._get_path()}")
         with telemetry.context(run=self) as tel:
             tel.feature.finish = True
-        logger.info(f"finishing run {self._get_path()}")
-        # detach jupyter hooks / others that needs to happen before backend shutdown
+
+        if quiet is not None:
+            self._quiet = quiet
+
+        self._is_finished = True
+
+        # Pop this run (hopefully) from the run stack, to support the "reinit"
+        # functionality of wandb.init().
+        #
+        # TODO: It's not clear how _global_run_stack could have length other
+        # than 1 at this point in the code. If you're reading this, consider
+        # refactoring this thing.
+        if self._wl and len(self._wl._global_run_stack) > 0:
+            self._wl._global_run_stack.pop()
+
+        # Run hooks that need to happen before the last messages to the
+        # internal service, like Jupyter hooks.
         for hook in self._teardown_hooks:
             if hook.stage == TeardownStage.EARLY:
                 hook.call()
 
-        self._atexit_cleanup(exit_code=exit_code)
-        if self._wl and len(self._wl._global_run_stack) > 0:
-            self._wl._global_run_stack.pop()
-        # detach logger / others meant to be run after we've shutdown the backend
-        for hook in self._teardown_hooks:
-            if hook.stage == TeardownStage.LATE:
-                hook.call()
-        self._teardown_hooks = []
-        module.unset_globals()
+        try:
+            self._atexit_cleanup(exit_code=exit_code)
 
-        # inform manager this run is finished
-        manager = self._wl and self._wl._get_manager()
-        if manager:
-            manager._inform_finish(run_id=self._run_id)
+            # Run hooks that should happen after the last messages to the
+            # internal service, like detaching the logger.
+            for hook in self._teardown_hooks:
+                if hook.stage == TeardownStage.LATE:
+                    hook.call()
+            self._teardown_hooks = []
 
-        self._is_finished = True
-        # end sentry session
-        wandb._sentry.end_session()
+            # Inform the service that we're done sending messages for this run.
+            #
+            # TODO: Why not do this in _atexit_cleanup()?
+            manager = self._wl and self._wl._get_manager()
+            if manager:
+                manager._inform_finish(run_id=self._run_id)
+
+        finally:
+            module.unset_globals()
+            wandb._sentry.end_session()
 
     @_run_decorator._noop
     @_run_decorator._attach
@@ -2345,36 +2363,51 @@ class Run:
             return
         self._atexit_cleanup_called = True
 
-        exit_code = exit_code or self._hooks.exit_code if self._hooks else 0
+        exit_code = (
+            exit_code  #
+            or (self._hooks and self._hooks.exit_code)
+            or 0
+        )
+        self._exit_code = exit_code
         logger.info(f"got exitcode: {exit_code}")
+
+        # Delete this run's "resume" file if the run finished successfully.
+        #
+        # This is used by the "auto" resume mode, which resumes from the last
+        # failed (or unfinished/crashed) run. If we reach this line, then this
+        # run shouldn't be a candidate for "auto" resume.
         if exit_code == 0:
-            # Cleanup our resume file on a clean exit
             if os.path.exists(self._settings.resume_fname):
                 os.remove(self._settings.resume_fname)
 
-        self._exit_code = exit_code
-        report_failure = False
         try:
             self._on_finish()
-        except KeyboardInterrupt as ki:
-            if wandb.wandb_agent._is_running():
-                raise ki
-            wandb.termerror("Control-C detected -- Run data was not synced")
-            if not self._settings._notebook:
-                os._exit(-1)
+
+        except KeyboardInterrupt:
+            if not wandb.wandb_agent._is_running():
+                wandb.termerror("Control-C detected -- Run data was not synced")
+            raise
+
         except Exception as e:
-            if not self._settings._notebook:
-                report_failure = True
             self._console_stop()
             self._backend.cleanup()
             logger.error("Problem finishing run", exc_info=e)
             wandb.termerror("Problem finishing run")
             traceback.print_exc()
-        else:
-            self._on_final()
-        finally:
-            if report_failure:
-                os._exit(-1)
+            raise
+
+        Run._footer(
+            sampled_history=self._sampled_history,
+            final_summary=self._final_summary,
+            poll_exit_response=self._poll_exit_response,
+            server_info_response=self._server_info_response,
+            check_version_response=self._check_version,
+            internal_messages_response=self._internal_messages_response,
+            reporter=self._reporter,
+            quiet=self._quiet,
+            settings=self._settings,
+            printer=self._printer,
+        )
 
     def _console_start(self) -> None:
         logger.info("atexit reg")
@@ -2658,20 +2691,6 @@ class Run:
         import_telemetry_set = telemetry.list_telemetry_imports()
         for module_name in import_telemetry_set:
             unregister_post_import_hook(module_name, run_id)
-
-    def _on_final(self) -> None:
-        self._footer(
-            sampled_history=self._sampled_history,
-            final_summary=self._final_summary,
-            poll_exit_response=self._poll_exit_response,
-            server_info_response=self._server_info_response,
-            check_version_response=self._check_version,
-            internal_messages_response=self._internal_messages_response,
-            reporter=self._reporter,
-            quiet=self._quiet,
-            settings=self._settings,
-            printer=self._printer,
-        )
 
     @_run_decorator._noop_on_finish()
     @_run_decorator._attach

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2393,7 +2393,6 @@ class Run:
             self._backend.cleanup()
             logger.error("Problem finishing run", exc_info=e)
             wandb.termerror("Problem finishing run")
-            traceback.print_exc()
             raise
 
         Run._footer(

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2111,8 +2111,6 @@ class Run:
         if quiet is not None:
             self._quiet = quiet
 
-        self._is_finished = True
-
         # Pop this run (hopefully) from the run stack, to support the "reinit"
         # functionality of wandb.init().
         #
@@ -2127,6 +2125,10 @@ class Run:
         for hook in self._teardown_hooks:
             if hook.stage == TeardownStage.EARLY:
                 hook.call()
+
+        # Early-stage hooks may use methods that require _is_finished
+        # to be False, so we set this after running those hooks.
+        self._is_finished = True
 
         try:
             self._atexit_cleanup(exit_code=exit_code)


### PR DESCRIPTION
Description
---
Stops calling `os._exit()` when an exception is encountered in `Run._atexit_cleanup()` and refactors the surrounding code. We should not use `os._exit()`.

Semantic changes:

* I removed `_backend.cleanup()` in the exception handler in `_atexit_cleanup`---this just sends a shutdown request to the service.
    * With core, this request is a no-op.
    * Without core, this was killing the handler without killing the process, causing `streams.py::StreamMux::_finish_all()` to block forever in the `mailbox.wait_all()` step on exit, blocking the user process forever waiting for the service to die. This was unnecessary because `_finish_all()` calls `join()` on each stream at the end which sends the same shutdown signal that `_backend.cleanup()` was sending.
* We re-raise exceptions rather than using `os._exit()`, meaning the user's script (or notebook) can continue running after if it catches the exception.
* Previously, `run.finish()` could error out silently in a Jupyter notebook, but now it propagates errors.
* Since we don't `os._exit()`, some code can run after an exception. I made `module.unset_globals()` and `wandb._sentry.end_session()` always execute in a `finally` clause.
* There are some ordering changes in `run._finish()` that should not bother anyone, but could result in different behavior.

Testing
---
For the happy path:

```python
import wandb

run = wandb.init()
run.finish()

run = wandb.init()
# Ctrl-D here, make sure run finished.
```

For testing the behavior when an exception occurs, I inserted a `raise ValueError()` in `Run._on_finish()` and tried an explicit `run.finish()`. The exception is propagated to the interpreter, and each run shows up as "crashed" in the UI. When exiting the interpreter, a run footer is shown for every run---this is probably not the desired behavior, but it's no worse than before (where the interpreter would crash due to `os._exit()`).

Tested with and without core.