### PR TITLE
feat(launch): Support Pydantic models for specifying job input schemas

### DIFF
--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -237,7 +237,11 @@ def handle_run_config_input(
     If there is no active run, the include and exclude paths are staged and sent
     when a run is created.
     """
-    if isinstance(input_schema, BaseModel):
+    # Support both input_schema=Schema or input_schema=Schema()
+    if isinstance(input_schema, BaseModel) or (
+        hasattr(input_schema, "model_json_schema")
+        and callable(input_schema.model_json_schema)
+    ):
         input_schema = _convert_model_to_jsonschema(input_schema)
     arguments = JobInputArguments(
         include=include,

--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -227,7 +227,7 @@ def handle_config_file_input(
 def handle_run_config_input(
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
-    input_schema: Optional[dict | BaseModel] = None,
+    input_schema: Optional[Any] = None,
 ):
     """Declare wandb.config as an overridable configuration for a launch job.
 

--- a/wandb/sdk/launch/inputs/manage.py
+++ b/wandb/sdk/launch/inputs/manage.py
@@ -2,12 +2,14 @@
 
 from typing import List, Optional
 
+from pydantic import BaseModel
+
 
 def manage_config_file(
     path: str,
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
-    input_schema: Optional[dict] = None,
+    input_schema: Optional[dict | BaseModel] = None,
 ):
     r"""Declare an overridable configuration file for a launch job.
 
@@ -58,7 +60,7 @@ def manage_config_file(
 def manage_wandb_config(
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
-    input_schema: Optional[dict] = None,
+    input_schema: Optional[dict | BaseModel] = None,
 ):
     r"""Declare wandb.config as an overridable configuration for a launch job.
 

--- a/wandb/sdk/launch/inputs/manage.py
+++ b/wandb/sdk/launch/inputs/manage.py
@@ -1,15 +1,13 @@
 """Functions for declaring overridable configuration for launch jobs."""
 
-from typing import List, Optional
-
-from pydantic import BaseModel
+from typing import Any, List, Optional
 
 
 def manage_config_file(
     path: str,
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
-    input_schema: Optional[dict | BaseModel] = None,
+    input_schema: Optional[Any] = None,
 ):
     r"""Declare an overridable configuration file for a launch job.
 
@@ -46,8 +44,8 @@ def manage_config_file(
             relative and must not contain backwards traversal, i.e. `..`.
         include (List[str]): A list of keys to include in the configuration file.
         exclude (List[str]): A list of keys to exclude from the configuration file.
-        input_schema (dict): A JSON Schema describing which attributes will be
-            editable from the Launch drawer.
+        input_schema (dict | Pydantic model): A JSON Schema or Pydantic model
+            describing which attributes will be editable from the Launch drawer.
 
     Raises:
         LaunchError: If the path is not valid, or if there is no active run.
@@ -60,7 +58,7 @@ def manage_config_file(
 def manage_wandb_config(
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
-    input_schema: Optional[dict | BaseModel] = None,
+    input_schema: Optional[Any] = None,
 ):
     r"""Declare wandb.config as an overridable configuration for a launch job.
 
@@ -92,8 +90,8 @@ def manage_wandb_config(
     Args:
         include (List[str]): A list of subtrees to include in the configuration.
         exclude (List[str]): A list of subtrees to exclude from the configuration.
-        input_schema (dict): A JSON Schema describing which attributes will be
-            editable from the Launch drawer.
+        input_schema (dict | Pydantic model): A JSON Schema or Pydantic model
+            describing which attributes will be editable from the Launch drawer.
 
     Raises:
         LaunchError: If there is no active run.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-19646](https://wandb.atlassian.net/browse/WB-19646)

Allows users to use a Pydantic model to set `input_schema`. For example, if their model class is named `class Schema:`, they can either do
-  `launch.manage_wandb_config(..., input_schema=Schema)`, or
- `s = Schema(...)`, `launch.manage_wandb_config(..., input_schema=s)`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
A unit test was added to make sure the conversion works as expected. I also used the following script to test manually and verify the schema makes it to the job metadata:

```
from enum import Enum
from pydantic import BaseModel, Field
import wandb
from wandb.sdk import launch

wandb.require("core")

config = {
    "trainer": {
        "learning_rate": 0.01,
        "batch_size": 32,
        "model": "resnet",
        "dataset": "cifar10",
        "private": {
            "key": "value",
        },
    },
    "seed": 42,
}


class DatasetEnum(str, Enum):
    cifar10 = "cifar10"
    cifar100 = "cifar100"


class Trainer(BaseModel):
    learning_rate: float = Field(description="Learning rate of the model")
    batch_size: int = Field(ge=1, le=256, description="Number of samples per batch")
    dataset: DatasetEnum = Field(description="Name of the dataset to use")


class Schema(BaseModel):
    trainer: Trainer


# t = Trainer(learning_rate=2.5, batch_size=32, dataset=DatasetEnum.cifar10)
# s = Schema(trainer=t)

with wandb.init(config=config) as run:
    launch.manage_wandb_config(
        include=["trainer"],
        exclude=["trainer.private"],
        input_schema=Schema, # Optionally: input_schema=s,
    )
    # Do machine learning here
    run.log_code()
    wandb.finish()

```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
