### PR TITLE
docs(sdk): update add_reference() docstring

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1300,7 +1300,8 @@ class Artifact:
                 automatic integrity validation. Disabling checksumming will speed up
                 artifact creation but reference directories will not iterated through so the
                 objects in the directory will not be saved to the artifact. We recommend
-                adding reference objects in the case checksumming is false.
+                setting `checksum=False` when adding reference objects, in which case
+                a new version will only be created if the reference URI changes.
             max_objects: The maximum number of objects to consider when adding a
                 reference that points to directory or bucket store prefix. By default,
                 the maximum number of objects allowed for Amazon S3,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
This minor PR adds a line to the add_reference() function about the behaviour when checksum=False for a directory. More specifically, if the checksum argument is set to False, add_reference() will not create a new version of the artifact.

More discussion on [Slack](https://weightsandbiases.slack.com/archives/C04656QPFHN/p1718370664829409).

Fixes [WB-18037](https://wandb.atlassian.net/browse/WB-18037)
Fixes [DOCS-898](https://wandb.atlassian.net/browse/DOCS-898)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?
Tested locally.
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18037]: https://wandb.atlassian.net/browse/WB-18037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-898]: https://wandb.atlassian.net/browse/DOCS-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ