### PR TITLE
refactor(core): Replace `pathtree.Tree()` by alternatives

### DIFF
--- a/core/internal/pathtree/pathtree.go
+++ b/core/internal/pathtree/pathtree.go
@@ -40,7 +40,7 @@ func NewFrom(tree TreeData) *PathTree {
 //
 // This always allocates a new map.
 func (pt *PathTree) CloneTree() TreeData {
-	return deepCopy(pt.tree)
+	return toNestedMaps(pt.tree)
 }
 
 // Set changes the value of the leaf node at the given path.
@@ -218,12 +218,12 @@ func getOrMakeSubtree(
 // Returns a deep copy of the given tree.
 //
 // Slice values are copied by reference, which is fine for our use case.
-func deepCopy(tree TreeData) TreeData {
-	clone := make(TreeData)
+func toNestedMaps(tree TreeData) map[string]any {
+	clone := make(map[string]any)
 	for key, value := range tree {
 		switch value := value.(type) {
 		case TreeData:
-			clone[key] = deepCopy(value)
+			clone[key] = toNestedMaps(value)
 		default:
 			clone[key] = value
 		}

--- a/core/internal/pathtree/pathtree.go
+++ b/core/internal/pathtree/pathtree.go
@@ -9,7 +9,7 @@ import "github.com/wandb/segmentio-encoding/json"
 //   - Any caller-provided type
 //
 // TODO: Remove this---it should not be exported.
-type TreeData = map[string]any
+type TreeData map[string]any
 
 // TreePath is a list of strings mapping to a value.
 type TreePath []string

--- a/core/internal/pathtree/pathtree.go
+++ b/core/internal/pathtree/pathtree.go
@@ -45,6 +45,8 @@ func (pt *PathTree) CloneTree() TreeData {
 
 // Set changes the value of the leaf node at the given path.
 //
+// Map values do not affect the tree structure---see SetSubtree instead.
+//
 // If the path doesn't refer to a node in the tree, nodes are inserted
 // and a new leaf is created.
 //
@@ -56,6 +58,23 @@ func (pt *PathTree) Set(path TreePath, value any) {
 
 	subtree := getOrMakeSubtree(pt.tree, pathPrefix)
 	subtree[key] = value
+}
+
+// SetSubtree recusrively replaces the subtree at the given path.
+//
+// The subtree is represented by a map from strings to subtrees or
+// leaf values. This tree structure is copied to update the path
+// tree.
+func (pt *PathTree) SetSubtree(path TreePath, subtree map[string]any) {
+	// TODO: this is inefficient---it has repeated getOrMakeSubtree calls
+	for key, value := range subtree {
+		switch x := value.(type) {
+		case map[string]any:
+			pt.SetSubtree(append(path, key), x)
+		default:
+			pt.Set(append(path, key), x)
+		}
+	}
 }
 
 // Remove deletes a node from the tree.

--- a/core/internal/pathtree/pathtree_test.go
+++ b/core/internal/pathtree/pathtree_test.go
@@ -1,108 +1,102 @@
 package pathtree_test
 
 import (
-	"reflect"
-	"sort"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/pathtree"
 )
 
-func TestNewPathTree(t *testing.T) {
-	pt := pathtree.New()
-	if pt == nil {
-		t.Error("NewPathTree() should not return nil")
-	}
-	if pt.Tree() == nil {
-		t.Error("NewPathTree() tree should not be nil")
-	}
+func TestSet_NewNode(t *testing.T) {
+	tree := pathtree.New()
+
+	tree.Set(pathtree.TreePath{"a", "b"}, 1)
+	tree.Set(pathtree.TreePath{"a", "c", "d"}, 2)
+
+	ab, abExists := tree.GetLeaf(pathtree.TreePath{"a", "b"})
+	acd, acdExists := tree.GetLeaf(pathtree.TreePath{"a", "c", "d"})
+	assert.True(t, abExists)
+	assert.Equal(t, 1, ab)
+	assert.True(t, acdExists)
+	assert.Equal(t, 2, acd)
 }
 
-func TestNewPathTreeFrom(t *testing.T) {
-	treeData := pathtree.TreeData{
-		"config": map[string]interface{}{
-			"setting1": "value1",
-		},
-	}
-	pt := pathtree.NewFrom(treeData)
-	if pt == nil {
-		t.Error("NewPathTreeFrom() should not return nil")
-	}
-	if pt.Tree() == nil {
-		t.Error("NewPathTreeFrom() tree should not be nil")
-	}
-	if !reflect.DeepEqual(pt.Tree(), treeData) {
-		t.Errorf("Expected %v, got %v", treeData, pt.Tree())
-	}
+func TestSet_OverwriteLeaf(t *testing.T) {
+	tree := pathtree.New()
+
+	tree.Set(pathtree.TreePath{"a"}, 1)
+	tree.Set(pathtree.TreePath{"a", "b"}, 2)
+
+	a, aExists := tree.GetLeaf(pathtree.TreePath{"a"})
+	ab, abExists := tree.GetLeaf(pathtree.TreePath{"a", "b"})
+	assert.False(t, aExists)
+	assert.Nil(t, a)
+	assert.True(t, abExists)
+	assert.Equal(t, 2, ab)
 }
 
-func TestApplyRemove(t *testing.T) {
+func TestRemove_Leaf(t *testing.T) {
+	tree := pathtree.New()
 
-	treeData := pathtree.TreeData{
-		"setting0": float64(69),
-		"config": map[string]interface{}{
-			"setting1": 42,
-			"setting2": "goodbye",
-		},
-	}
-	pt := pathtree.NewFrom(treeData)
-	items := []*pathtree.PathItem{
-		{[]string{"config", "setting1"}, ""},
-	}
-	pt.ApplyRemove(items)
+	tree.Set(pathtree.TreePath{"a", "b"}, 1)
+	tree.Set(pathtree.TreePath{"a", "c"}, 2)
+	tree.Remove(pathtree.TreePath{"a", "b"})
 
-	expectedTree := pathtree.TreeData{
-		"setting0": float64(69),
-		"config": map[string]interface{}{
-			"setting2": "goodbye",
-		},
-	}
+	ab, abExists := tree.GetLeaf(pathtree.TreePath{"a", "b"})
+	ac, acExists := tree.GetLeaf(pathtree.TreePath{"a", "c"})
+	assert.False(t, abExists)
+	assert.Nil(t, ab)
+	assert.True(t, acExists)
+	assert.Equal(t, 2, ac)
+}
 
-	if !reflect.DeepEqual(pt.Tree(), expectedTree) {
-		t.Errorf("Expected %v, got %v", expectedTree, pt.Tree())
-	}
+func TestRemove_Node(t *testing.T) {
+	tree := pathtree.New()
+
+	tree.Set(pathtree.TreePath{"a", "b", "c"}, 1)
+	tree.Set(pathtree.TreePath{"a", "d"}, 2)
+	tree.Remove(pathtree.TreePath{"a", "b"})
+
+	abc, abcExists := tree.GetLeaf(pathtree.TreePath{"a", "b", "c"})
+	ad, adExists := tree.GetLeaf(pathtree.TreePath{"a", "d"})
+	assert.False(t, abcExists)
+	assert.Nil(t, abc)
+	assert.True(t, adExists)
+	assert.Equal(t, 2, ad)
+}
+
+func TestGetLeaf_UnderLeaf(t *testing.T) {
+	tree := pathtree.New()
+
+	tree.Set(pathtree.TreePath{"a"}, 1)
+
+	x, exists := tree.GetLeaf(pathtree.TreePath{"a", "b"})
+	assert.False(t, exists)
+	assert.Nil(t, x)
 }
 
 func TestFlatten(t *testing.T) {
+	tree := pathtree.New()
 
-	treeData := pathtree.TreeData{
-		"config": map[string]interface{}{
-			"setting1": "value1",
-			"nested": map[string]interface{}{
-				"setting2": 42,
-			},
-		},
-	}
-	pt := pathtree.NewFrom(treeData)
-	leaves := pt.Flatten()
+	tree.Set(pathtree.TreePath{"a", "b"}, 1)
+	tree.Set(pathtree.TreePath{"a", "c"}, 2)
+	tree.Set(pathtree.TreePath{"a", "d", "e"}, 3)
+	leaves := tree.Flatten()
 
-	expectedLeaves := []pathtree.PathItem{
-		{Path: []string{"config", "setting1"}, Value: "value1"},
-		{Path: []string{"config", "nested", "setting2"}, Value: 42},
-	}
-	// Sort slices by joining keys into a single string
-	sort.Slice(leaves, func(i, j int) bool {
-		return strings.Join(leaves[i].Path, ".") < strings.Join(leaves[j].Path, ".")
-	})
-
-	sort.Slice(expectedLeaves, func(i, j int) bool {
-		return strings.Join(expectedLeaves[i].Path, ".") < strings.Join(expectedLeaves[j].Path, ".")
-	})
-
-	if !reflect.DeepEqual(leaves, expectedLeaves) {
-		t.Errorf("Expected %v, got %v", expectedLeaves, leaves)
-	}
-}
-
-// TestFlattenEmptyTree checks behavior with an empty tree.
-func TestFlattenEmptyTree(t *testing.T) {
-
-	pt := pathtree.New()
-
-	items := pt.Flatten()
-
-	if len(items) != 0 {
-		t.Errorf("Expected no items, got %d", len(items))
-	}
+	assert.Len(t, leaves, 3)
+	assert.Contains(t, leaves,
+		pathtree.PathItem{
+			Path:  pathtree.TreePath{"a", "b"},
+			Value: 1,
+		})
+	assert.Contains(t, leaves,
+		pathtree.PathItem{
+			Path:  pathtree.TreePath{"a", "c"},
+			Value: 2,
+		})
+	assert.Contains(t, leaves,
+		pathtree.PathItem{
+			Path:  pathtree.TreePath{"a", "d", "e"},
+			Value: 3,
+		})
 }

--- a/core/internal/runconfig/runconfig.go
+++ b/core/internal/runconfig/runconfig.go
@@ -73,7 +73,12 @@ func (rc *RunConfig) ApplyChangeRecord(
 			continue
 		}
 
-		rc.pathTree.Set(keyPath(item), value)
+		switch x := value.(type) {
+		case map[string]any:
+			rc.pathTree.SetSubtree(keyPath(item), x)
+		default:
+			rc.pathTree.Set(keyPath(item), x)
+		}
 	}
 
 	for _, item := range configRecord.GetRemove() {

--- a/core/internal/runconfig/runconfig.go
+++ b/core/internal/runconfig/runconfig.go
@@ -2,6 +2,7 @@ package runconfig
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/wandb/segmentio-encoding/json"
 	"github.com/wandb/wandb/core/internal/corelib"
@@ -166,9 +167,7 @@ func (rc *RunConfig) addUnsetKeysFromSubtree(
 	}
 
 	// Clone `prefix` so that it's safe to use for appending.
-	// Set the capacity to length+1 since we always append one
-	// more element.
-	prefixCopy := prefix[: len(prefix) : len(prefix)+1]
+	prefixCopy := slices.Clone(prefix)
 
 	for key, value := range oldConfig {
 		if rc.pathTree.HasNode(pathtree.TreePath{key}) {

--- a/core/internal/runconfig/runconfig.go
+++ b/core/internal/runconfig/runconfig.go
@@ -165,12 +165,18 @@ func (rc *RunConfig) addUnsetKeysFromSubtree(
 		}
 	}
 
+	// Clone `prefix` so that it's safe to use for appending.
+	// Set the capacity to length+1 since we always append one
+	// more element.
+	prefixCopy := prefix[: len(prefix) : len(prefix)+1]
+
 	for key, value := range oldConfig {
 		if rc.pathTree.HasNode(pathtree.TreePath{key}) {
 			continue
 		}
 
-		subtreePath := append(prefix, key)
+		subtreePath := prefixCopy
+		subtreePath = append(subtreePath, key)
 		switch x := value.(type) {
 		case map[string]any:
 			rc.pathTree.SetSubtree(subtreePath, x)

--- a/core/internal/runconfig/runconfig_test.go
+++ b/core/internal/runconfig/runconfig_test.go
@@ -41,7 +41,7 @@ func TestConfigUpdate(t *testing.T) {
 				"d": 123.0,
 			},
 		},
-		runConfig.Tree(),
+		runConfig.CloneTree(),
 	)
 }
 
@@ -65,7 +65,7 @@ func TestConfigRemove(t *testing.T) {
 
 	assert.Equal(t,
 		pathtree.TreeData{"b": pathtree.TreeData{"d": 123.0}},
-		runConfig.Tree(),
+		runConfig.CloneTree(),
 	)
 }
 
@@ -111,7 +111,7 @@ func TestAddTelemetryAndMetrics(t *testing.T) {
 				"m": []map[int]interface{}{},
 			},
 		},
-		runConfig.Tree(),
+		runConfig.CloneTree(),
 	)
 }
 
@@ -125,7 +125,7 @@ func TestCloneTree(t *testing.T) {
 			"text": "xyz",
 		},
 	})
-	cloned, _ := runConfig.CloneTree()
+	cloned := runConfig.CloneTree()
 	assert.Equal(t,
 		pathtree.TreeData{
 			"number": 9,
@@ -148,6 +148,6 @@ func TestCloneTree(t *testing.T) {
 				"text": "xyz",
 			},
 		},
-		runConfig.Tree(),
+		runConfig.CloneTree(),
 	)
 }

--- a/core/internal/runconfig/runconfig_test.go
+++ b/core/internal/runconfig/runconfig_test.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/corelib"
-	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
 func TestConfigUpdate(t *testing.T) {
-	runConfig := runconfig.NewFrom(pathtree.TreeData{
-		"b": pathtree.TreeData{
+	runConfig := runconfig.NewFrom(map[string]any{
+		"b": map[string]any{
 			"c": 321.0,
 			"d": 123.0,
 		},
@@ -34,9 +33,9 @@ func TestConfigUpdate(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		pathtree.TreeData{
+		map[string]any{
 			"a": 1.0,
-			"b": pathtree.TreeData{
+			"b": map[string]any{
 				"c": "text",
 				"d": 123.0,
 			},
@@ -46,9 +45,9 @@ func TestConfigUpdate(t *testing.T) {
 }
 
 func TestConfigRemove(t *testing.T) {
-	runConfig := runconfig.NewFrom(pathtree.TreeData{
+	runConfig := runconfig.NewFrom(map[string]any{
 		"a": 9,
-		"b": pathtree.TreeData{
+		"b": map[string]any{
 			"c": 321.0,
 			"d": 123.0,
 		},
@@ -64,15 +63,15 @@ func TestConfigRemove(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		pathtree.TreeData{"b": pathtree.TreeData{"d": 123.0}},
+		map[string]any{"b": map[string]any{"d": 123.0}},
 		runConfig.CloneTree(),
 	)
 }
 
 func TestConfigSerialize(t *testing.T) {
-	runConfig := runconfig.NewFrom(pathtree.TreeData{
+	runConfig := runconfig.NewFrom(map[string]any{
 		"number": 9,
-		"nested": pathtree.TreeData{
+		"nested": map[string]any{
 			"list": []string{"a", "b", "c"},
 			"text": "xyz",
 		},
@@ -105,8 +104,8 @@ func TestAddTelemetryAndMetrics(t *testing.T) {
 	)
 
 	assert.Equal(t,
-		pathtree.TreeData{
-			"_wandb": pathtree.TreeData{
+		map[string]any{
+			"_wandb": map[string]any{
 				"t": corelib.ProtoEncodeToDict(telemetry),
 				"m": []map[int]interface{}{},
 			},
@@ -118,18 +117,18 @@ func TestAddTelemetryAndMetrics(t *testing.T) {
 func ignoreError(_err error) {}
 
 func TestCloneTree(t *testing.T) {
-	runConfig := runconfig.NewFrom(pathtree.TreeData{
+	runConfig := runconfig.NewFrom(map[string]any{
 		"number": 9,
-		"nested": pathtree.TreeData{
+		"nested": map[string]any{
 			"list": []string{"a", "b", "c"},
 			"text": "xyz",
 		},
 	})
 	cloned := runConfig.CloneTree()
 	assert.Equal(t,
-		pathtree.TreeData{
+		map[string]any{
 			"number": 9,
-			"nested": pathtree.TreeData{
+			"nested": map[string]any{
 				"list": []string{"a", "b", "c"},
 				"text": "xyz",
 			},
@@ -139,11 +138,11 @@ func TestCloneTree(t *testing.T) {
 	assert.NotEqual(t, runConfig, cloned)
 	// Delete elements from the cloned tree and check that the original is unchanged.
 	delete(cloned, "number")
-	delete(cloned["nested"].(pathtree.TreeData), "list")
+	delete(cloned["nested"].(map[string]any), "list")
 	assert.Equal(t,
-		pathtree.TreeData{
+		map[string]any{
 			"number": 9,
-			"nested": pathtree.TreeData{
+			"nested": map[string]any{
 				"list": []string{"a", "b", "c"},
 				"text": "xyz",
 			},

--- a/core/internal/runhistory/runhistory.go
+++ b/core/internal/runhistory/runhistory.go
@@ -62,7 +62,12 @@ func (rh *RunHistory) ApplyChangeRecord(
 			continue
 		}
 
-		rh.pathTree.Set(keyPath(item), update)
+		switch x := update.(type) {
+		case map[string]any:
+			rh.pathTree.SetSubtree(keyPath(item), x)
+		default:
+			rh.pathTree.Set(keyPath(item), x)
+		}
 	}
 }
 
@@ -113,23 +118,6 @@ func (rh *RunHistory) Flatten() ([]*service.HistoryItem, error) {
 	}
 
 	return history, nil
-}
-
-// GetNumber returns the value of a number-valued metric.
-func (rh *RunHistory) GetNumber(path ...string) (float64, bool) {
-	value, exists := rh.pathTree.GetLeaf(pathtree.TreePath(path))
-	if !exists {
-		return 0, false
-	}
-
-	switch x := value.(type) {
-	case int64:
-		return float64(x), true
-	case float64:
-		return x, true
-	default:
-		return 0, false
-	}
 }
 
 // Contains returns whether there is a value for a metric.

--- a/core/internal/runhistory/runhistory.go
+++ b/core/internal/runhistory/runhistory.go
@@ -25,12 +25,6 @@ func New() *RunHistory {
 	}
 }
 
-func NewFrom(tree pathtree.TreeData) *RunHistory {
-	return &RunHistory{
-		pathTree: pathtree.NewFrom(tree),
-	}
-}
-
 // NewWithStep creates a new RunHistory with the given step.
 //
 // The step is the step of the run that this history is for.

--- a/core/internal/runhistory/runhistory.go
+++ b/core/internal/runhistory/runhistory.go
@@ -53,7 +53,6 @@ func (rh *RunHistory) ApplyChangeRecord(
 	historyRecord []*service.HistoryItem,
 	onError func(error),
 ) {
-	updates := make([]*pathtree.PathItem, 0, len(historyRecord))
 	for _, item := range historyRecord {
 		var update interface{}
 		// custom unmarshal function that handles NaN and +-Inf
@@ -62,13 +61,9 @@ func (rh *RunHistory) ApplyChangeRecord(
 			onError(err)
 			continue
 		}
-		updates = append(updates,
-			&pathtree.PathItem{
-				Path:  keyPath(item),
-				Value: update,
-			})
+
+		rh.pathTree.Set(keyPath(item), update)
 	}
-	rh.pathTree.ApplyUpdate(updates, onError)
 }
 
 // Serialize the object to send to the backend.

--- a/core/internal/runhistory/runhistory_test.go
+++ b/core/internal/runhistory/runhistory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runhistory"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -31,12 +32,14 @@ func TestApplyUpdate(t *testing.T) {
 			t.Error("onError should not be called", err)
 		})
 
-	setting1, ok := rh.GetNumber("setting1")
-	assert.True(t, ok)
-	assert.EqualValues(t, 69, setting1)
-	setting2, ok := rh.GetNumber("config", "setting2", "value")
-	assert.True(t, ok)
-	assert.EqualValues(t, 42, setting2)
+	encoded, err := rh.Serialize()
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{
+			"setting1": 69,
+			"config": {"setting2": {"value": 42}}
+		}`,
+		string(encoded))
 }
 
 func key(item *service.HistoryItem) []string {

--- a/core/internal/runhistory/runhistory_test.go
+++ b/core/internal/runhistory/runhistory_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runhistory"
 	"github.com/wandb/wandb/core/pkg/service"
 )
@@ -96,12 +95,12 @@ func TestApplyUpdateSpecialValues(t *testing.T) {
 }
 
 func TestSerialize(t *testing.T) {
-	treeData := pathtree.TreeData{
-		"config": map[string]interface{}{
-			"setting1": "value1",
-		},
-	}
-	rh := runhistory.NewFrom(treeData)
+	rh := runhistory.New()
+
+	rh.ApplyChangeRecord([]*service.HistoryItem{
+		{Key: "config", ValueJson: `{"setting1":"value1"}`},
+	}, func(err error) {})
+
 	actualJson, err := rh.Serialize()
 	if err != nil {
 		t.Fatal("Serialize failed:", err)

--- a/core/internal/runhistory/runhistory_test.go
+++ b/core/internal/runhistory/runhistory_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runhistory"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -30,18 +31,12 @@ func TestApplyUpdate(t *testing.T) {
 			t.Error("onError should not be called", err)
 		})
 
-	expectedTree := pathtree.TreeData{
-		"setting1": float64(69),
-		"config": pathtree.TreeData{
-			"setting2": pathtree.TreeData{
-				"value": float64(42),
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(rh.Tree(), expectedTree) {
-		t.Errorf("Expected %v, got %v", expectedTree, rh.Tree())
-	}
+	setting1, ok := rh.GetNumber("setting1")
+	assert.True(t, ok)
+	assert.EqualValues(t, 69, setting1)
+	setting2, ok := rh.GetNumber("config", "setting2", "value")
+	assert.True(t, ok)
+	assert.EqualValues(t, 42, setting2)
 }
 
 func key(item *service.HistoryItem) []string {

--- a/core/internal/runresume/resume_test.go
+++ b/core/internal/runresume/resume_test.go
@@ -271,8 +271,9 @@ func TestUpdate(t *testing.T) {
 				}
 
 				if tc.expectConfigUpdate {
-					require.Len(t, configCopy.Tree(), 1)
-					value, ok := configCopy.Tree()["lr"]
+					tree := configCopy.CloneTree()
+					require.Len(t, tree, 1)
+					value, ok := tree["lr"]
 					require.True(t, ok, "Expected key 'lr' in config")
 					assert.Equal(t, 0.001, value)
 				}

--- a/core/internal/runresume/runresume.go
+++ b/core/internal/runresume/runresume.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/gql"
-	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/pkg/observability"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -255,7 +254,6 @@ func (r *State) updateConfig(
 	bucket *Bucket,
 	config *runconfig.RunConfig,
 ) error {
-
 	resumed := bucket.GetConfig()
 	if resumed == nil {
 		err := fmt.Errorf("sender: updateConfig: no config found in resume response")
@@ -265,7 +263,7 @@ func (r *State) updateConfig(
 	// If we are unable to parse the config, we should fail if resume is set to
 	// must for any other case of resume status, it is fine to ignore it
 	// TODO: potential issue with unsupported types like NaN/Inf
-	var cfg map[string]interface{}
+	var cfg map[string]any
 
 	if err := json.Unmarshal([]byte(*resumed), &cfg); err != nil {
 		err = fmt.Errorf(
@@ -273,15 +271,15 @@ func (r *State) updateConfig(
 		return err
 	}
 
-	deserializedConfig := make(pathtree.TreeData)
+	deserializedConfig := make(map[string]any)
 	for key, value := range cfg {
-		valueDict, ok := value.(map[string]interface{})
+		valueDict, ok := value.(map[string]any)
 
 		if !ok {
 			r.logger.Error(
 				fmt.Sprintf(
 					"sender: updateConfig: config value for '%v'"+
-						" is not a map[string]interface{}",
+						" is not a map[string]any",
 					key,
 				),
 			)

--- a/core/internal/runresume/runresume.go
+++ b/core/internal/runresume/runresume.go
@@ -290,16 +290,7 @@ func (r *State) updateConfig(
 		}
 	}
 
-	err := config.MergeResumedConfig(deserializedConfig)
-	if err != nil {
-		r.logger.Error(
-			fmt.Sprintf(
-				"sender: updateConfig: failed to merge"+
-					" resumed config: %s",
-				err,
-			),
-		)
-	}
+	config.MergeResumedConfig(deserializedConfig)
 	return nil
 }
 

--- a/core/internal/runsummary/runsummary.go
+++ b/core/internal/runsummary/runsummary.go
@@ -34,10 +34,10 @@ func New(params Params) *RunSummary {
 	return rs
 }
 
-func statsTreeFromPathTree(tree pathtree.TreeData) *Node {
+func statsTreeFromPathTree(tree map[string]any) *Node {
 	stats := NewNode()
 	for k, v := range tree {
-		if subtree, ok := v.(pathtree.TreeData); ok {
+		if subtree, ok := v.(map[string]any); ok {
 			stats.nodes[k] = statsTreeFromPathTree(subtree)
 		} else {
 			stats.nodes[k] = &Node{
@@ -46,14 +46,6 @@ func statsTreeFromPathTree(tree pathtree.TreeData) *Node {
 		}
 	}
 	return stats
-}
-
-func NewFrom(tree pathtree.TreeData) *RunSummary {
-	return &RunSummary{
-		pathTree: pathtree.NewFrom(tree),
-		stats:    statsTreeFromPathTree(tree),
-		mh:       runmetric.NewMetricHandler(),
-	}
 }
 
 // GetSummaryTypes matches the path against the defined metrics and returns the
@@ -242,7 +234,7 @@ func (rs *RunSummary) Flatten() ([]*service.SummaryItem, error) {
 }
 
 // CloneTree clones the tree. This is useful for creating a snapshot of the tree.
-func (rs *RunSummary) CloneTree() pathtree.TreeData {
+func (rs *RunSummary) CloneTree() map[string]any {
 	return rs.pathTree.CloneTree()
 }
 

--- a/core/internal/runsummary/runsummary.go
+++ b/core/internal/runsummary/runsummary.go
@@ -180,8 +180,12 @@ func (rs *RunSummary) ApplyChangeRecord(
 			update = updateMap
 		}
 
-		rs.pathTree.Set(keyPath(item), update)
-
+		switch x := update.(type) {
+		case map[string]any:
+			rs.pathTree.SetSubtree(keyPath(item), x)
+		default:
+			rs.pathTree.Set(keyPath(item), x)
+		}
 	}
 
 	for _, item := range summaryRecord.GetRemove() {

--- a/core/internal/runsummary/runsummary.go
+++ b/core/internal/runsummary/runsummary.go
@@ -238,20 +238,18 @@ func (rs *RunSummary) Flatten() ([]*service.SummaryItem, error) {
 }
 
 // CloneTree clones the tree. This is useful for creating a snapshot of the tree.
-func (rs *RunSummary) CloneTree() (pathtree.TreeData, error) {
-
+func (rs *RunSummary) CloneTree() pathtree.TreeData {
 	return rs.pathTree.CloneTree()
 }
 
-// Tree returns the tree data.
-func (rs *RunSummary) Tree() pathtree.TreeData {
-
-	return rs.pathTree.Tree()
+// Get returns the summary value for a metric.
+func (rs *RunSummary) Get(key string) (any, bool) {
+	return rs.pathTree.GetLeaf(pathtree.TreePath{key})
 }
 
 // Serializes the object to send to the backend.
 func (rs *RunSummary) Serialize() ([]byte, error) {
-	return json.Marshal(rs.Tree())
+	return rs.pathTree.ToExtendedJSON()
 }
 
 // keyPath returns the key path for the given config item.

--- a/core/internal/runsummary/runsummary.go
+++ b/core/internal/runsummary/runsummary.go
@@ -34,20 +34,6 @@ func New(params Params) *RunSummary {
 	return rs
 }
 
-func statsTreeFromPathTree(tree map[string]any) *Node {
-	stats := NewNode()
-	for k, v := range tree {
-		if subtree, ok := v.(map[string]any); ok {
-			stats.nodes[k] = statsTreeFromPathTree(subtree)
-		} else {
-			stats.nodes[k] = &Node{
-				stats: &Stats{},
-			}
-		}
-	}
-	return stats
-}
-
 // GetSummaryTypes matches the path against the defined metrics and returns the
 // requested summary type for the metric.
 //

--- a/core/internal/runsummary/runsummary_test.go
+++ b/core/internal/runsummary/runsummary_test.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runsummary"
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
 func TestApplyUpdate(t *testing.T) {
-
-	rh := runsummary.New(runsummary.Params{})
+	rs := runsummary.New(runsummary.Params{})
 	summary := &service.SummaryRecord{
 		Update: []*service.SummaryItem{
 			{
@@ -27,27 +27,24 @@ func TestApplyUpdate(t *testing.T) {
 		},
 	}
 
-	rh.ApplyChangeRecord(summary,
+	rs.ApplyChangeRecord(summary,
 		func(err error) {
 			t.Error("onError should not be called", err)
 		})
 
-	expectedTree := pathtree.TreeData{
-		"setting1": float64(69),
-		"config": pathtree.TreeData{
-			"setting2": pathtree.TreeData{
-				"value": float64(42),
+	assert.Equal(t,
+		pathtree.TreeData{
+			"setting1": float64(69),
+			"config": pathtree.TreeData{
+				"setting2": pathtree.TreeData{
+					"value": float64(42),
+				},
 			},
 		},
-	}
-
-	if !reflect.DeepEqual(rh.Tree(), expectedTree) {
-		t.Errorf("Expected %v, got %v", expectedTree, rh.Tree())
-	}
+		rs.CloneTree())
 }
 
 func TestApplyRemove(t *testing.T) {
-
 	rs := runsummary.NewFrom(pathtree.TreeData{
 		"setting0": 69,
 		"config": pathtree.TreeData{
@@ -68,16 +65,14 @@ func TestApplyRemove(t *testing.T) {
 			t.Error("onError should not be called", err)
 		})
 
-	expectedTree := pathtree.TreeData{
-		"setting0": int(69),
-		"config": pathtree.TreeData{
-			"setting1": int(42),
+	assert.Equal(t,
+		pathtree.TreeData{
+			"setting0": int(69),
+			"config": pathtree.TreeData{
+				"setting1": int(42),
+			},
 		},
-	}
-
-	if !reflect.DeepEqual(rs.Tree(), expectedTree) {
-		t.Errorf("Expected %v, got %v", expectedTree, rs.Tree())
-	}
+		rs.CloneTree())
 }
 
 func key(item *service.SummaryItem) []string {

--- a/core/internal/runsummary/runsummary_test.go
+++ b/core/internal/runsummary/runsummary_test.go
@@ -47,7 +47,8 @@ func TestApplyRemove(t *testing.T) {
 	rs.ApplyChangeRecord(&service.SummaryRecord{
 		Update: []*service.SummaryItem{
 			{Key: "setting0", ValueJson: "69"},
-			{Key: "config", ValueJson: `{"setting1": 42, "setting2": "goodbye"}`},
+			{NestedKey: []string{"config", "setting1"}, ValueJson: "42"},
+			{NestedKey: []string{"config", "setting2"}, ValueJson: `"goodbye"`},
 		},
 	}, func(err error) {})
 	summary := &service.SummaryRecord{

--- a/core/internal/runsummary/runsummary_test.go
+++ b/core/internal/runsummary/runsummary_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runsummary"
 	"github.com/wandb/wandb/core/pkg/service"
 )
@@ -44,13 +43,13 @@ func TestApplyUpdate(t *testing.T) {
 }
 
 func TestApplyRemove(t *testing.T) {
-	rs := runsummary.NewFrom(pathtree.TreeData{
-		"setting0": 69,
-		"config": pathtree.TreeData{
-			"setting1": 42,
-			"setting2": "goodbye",
+	rs := runsummary.New(runsummary.Params{})
+	rs.ApplyChangeRecord(&service.SummaryRecord{
+		Update: []*service.SummaryItem{
+			{Key: "setting0", ValueJson: "69"},
+			{Key: "config", ValueJson: `{"setting1": 42, "setting2": "goodbye"}`},
 		},
-	})
+	}, func(err error) {})
 	summary := &service.SummaryRecord{
 		Remove: []*service.SummaryItem{
 			{
@@ -132,12 +131,12 @@ func TestApplyUpdateSpecialValues(t *testing.T) {
 }
 
 func TestSerialize(t *testing.T) {
-	treeData := pathtree.TreeData{
-		"config": map[string]interface{}{
-			"setting1": "value1",
+	rs := runsummary.New(runsummary.Params{})
+	rs.ApplyChangeRecord(&service.SummaryRecord{
+		Update: []*service.SummaryItem{
+			{Key: "config", ValueJson: `{"setting1":"value1"}`},
 		},
-	}
-	rs := runsummary.NewFrom(treeData)
+	}, func(err error) {})
 	actualJson, err := rs.Serialize()
 	if err != nil {
 		t.Fatal("Serialize failed:", err)

--- a/core/internal/runsummary/runsummary_test.go
+++ b/core/internal/runsummary/runsummary_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/runsummary"
 	"github.com/wandb/wandb/core/pkg/service"
@@ -32,16 +33,14 @@ func TestApplyUpdate(t *testing.T) {
 			t.Error("onError should not be called", err)
 		})
 
-	assert.Equal(t,
-		pathtree.TreeData{
-			"setting1": float64(69),
-			"config": pathtree.TreeData{
-				"setting2": pathtree.TreeData{
-					"value": float64(42),
-				},
-			},
-		},
-		rs.CloneTree())
+	encoded, err := rs.Serialize()
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{
+			"setting1": 69,
+			"config": {"setting2": {"value": 42}}
+		}`,
+		string(encoded))
 }
 
 func TestApplyRemove(t *testing.T) {
@@ -65,14 +64,14 @@ func TestApplyRemove(t *testing.T) {
 			t.Error("onError should not be called", err)
 		})
 
-	assert.Equal(t,
-		pathtree.TreeData{
-			"setting0": int(69),
-			"config": pathtree.TreeData{
-				"setting1": int(42),
-			},
-		},
-		rs.CloneTree())
+	encoded, err := rs.Serialize()
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{
+			"setting0": 69,
+			"config": {"setting1": 42}
+		}`,
+		string(encoded))
 }
 
 func key(item *service.SummaryItem) []string {

--- a/core/pkg/launch/job_builder.go
+++ b/core/pkg/launch/job_builder.go
@@ -612,7 +612,7 @@ func (j *JobBuilder) Build(
 		if j.runConfig == nil {
 			sourceInfo.InputTypes = data_types.ResolveTypes(map[string]interface{}{})
 		} else {
-			sourceInfo.InputTypes = data_types.ResolveTypes(j.runConfig.Tree())
+			sourceInfo.InputTypes = data_types.ResolveTypes(j.runConfig.CloneTree())
 		}
 	}
 

--- a/core/pkg/launch/wandb_config.go
+++ b/core/pkg/launch/wandb_config.go
@@ -51,12 +51,7 @@ func (p *launchWandbConfigParameters) exclude() []ConfigPath {
 // If there are any errors in the process, the function logs them and returns
 // an unknown type representation. The errors should never happen in practice.
 func (j *JobBuilder) inferRunConfigTypes() (*data_types.TypeRepresentation, error) {
-	tree, err := j.runConfig.CloneTree()
-	if err != nil {
-		return nil, err
-	}
-
-	config := NewConfigFrom(tree)
+	config := NewConfigFrom(j.runConfig.CloneTree())
 	typeInfo := data_types.ResolveTypes(
 		config.filterTree(
 			j.wandbConfigParameters.include(),

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -1326,15 +1326,13 @@ func (h *Handler) imputeStepMetric(item *service.HistoryItem) *service.HistoryIt
 	}
 
 	// check if step metric is already in history
-	// TODO: avoid using the Tree method
-	if _, ok := h.runHistory.Tree()[key]; ok {
+	if h.runHistory.Contains(key) {
 		return nil
 	}
 
-	// TODO: avoid using the tree representation of the summary
 	// TODO: avoid using json marshalling
 	// we use the summary value of the metric as the algorithm for imputing the step metric
-	if value, ok := h.runSummary.Tree()[key]; ok {
+	if value, ok := h.runSummary.Get(key); ok {
 		v, err := json.Marshal(value)
 		if err != nil {
 			h.logger.CaptureError(

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -465,13 +465,7 @@ func (s *Sender) sendJobFlush() {
 	}
 	s.jobBuilder.SetRunConfig(*s.runConfig)
 
-	output, err := s.runSummary.CloneTree()
-	if err != nil {
-		s.logger.Error(
-			"sender: sendJobFlush: failed to copy run summary", "error", err,
-		)
-		return
-	}
+	output := s.runSummary.CloneTree()
 
 	artifact, err := s.jobBuilder.Build(s.ctx, s.graphqlClient, output)
 	if err != nil {


### PR DESCRIPTION
Description
---
Removes `pathtree.Tree()` which is dangerous to use and cleans up all former usages of it.

A few places are modified to use `CloneTree()`, some others `GetLeaf()`, and I also added `ToExtendedJSON()` for serialization use-cases.
