### PR TITLE
refactor(sdk): Improve `util.py::merge_dicts()`

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1748,21 +1748,39 @@ def make_docker_image_name_safe(name: str) -> str:
     return trimmed if trimmed else "image"
 
 
-def merge_dicts(source: Dict[str, Any], destination: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively merge two dictionaries."""
+def merge_dicts(
+    source: Dict[str, Any],
+    destination: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Recursively merge two dictionaries.
+
+    This mutates the destination and its nested dictionaries and lists.
+
+    Instances of `dict` are recursively merged and instances of `list`
+    are appended to the destination. If the destination type is not
+    `dict` or `list`, respectively, the key is overwritten with the
+    source value.
+
+    For all other types, the source value overwrites the destination value.
+    """
     for key, value in source.items():
         if isinstance(value, dict):
-            # get node or create one
-            node = destination.setdefault(key, {})
-            merge_dicts(value, node)
-        else:
-            if isinstance(value, list):
-                if key in destination:
-                    destination[key].extend(value)
-                else:
-                    destination[key] = value
+            node = destination.get(key)
+            if isinstance(node, dict):
+                merge_dicts(value, node)
             else:
                 destination[key] = value
+
+        elif isinstance(value, list):
+            dest_value = destination.get(key)
+            if isinstance(dest_value, list):
+                dest_value.extend(value)
+            else:
+                destination[key] = value
+
+        else:
+            destination[key] = value
+
     return destination
 
 


### PR DESCRIPTION
Description
---
Fixes a KeyError thrown in `merge_dicts` if the destination dictionary has a value type that doesn't match the source. This seems like it was overlooked rather than done intentionally. I ran into this in a test.

NOTE: If the destination dictionary has a NumPy array, this will now overwrite rather than extend it. I don't think we were relying on this, but I wouldn't put it past our code... There aren't many `merge_dicts` usages, and none of them look suspicious to me.
