### PR TITLE
refactor(sdk): Correctly chain exception in wandb_manager.py

### DIFF
--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -114,17 +114,21 @@ class _Manager:
 
         try:
             svc_iface._svc_connect(port=port)
+
         except ConnectionRefusedError as e:
             if not psutil.pid_exists(self._token.pid):
                 message = (
-                    "Connection to wandb service failed "
-                    "since the process is not available. "
+                    "Connection to wandb service failed"
+                    " because the process is not available."
                 )
             else:
-                message = f"Connection to wandb service failed: {e}. "
-            raise ManagerConnectionRefusedError(message)
+                message = "Connection to wandb service failed."
+            raise ManagerConnectionRefusedError(message) from e
+
         except Exception as e:
-            raise ManagerConnectionError(f"Connection to wandb service failed: {e}")
+            raise ManagerConnectionError(
+                "Connection to wandb service failed.",
+            ) from e
 
     def __init__(self, settings: "Settings") -> None:
         """Connects to the internal service, starting it if necessary."""


### PR DESCRIPTION
Description
---
Uses `raise ... from` in `wandb_manager.py` to produce a nicer exception. I noticed this when I hit an exception in CI which was displayed by showing "ConnectionRefusedError" first, followed by "During handling of the above exception, another exception occurred:" for the resulting "ManagerConnectionRefusedError". This was mildly confusing.
