### PR TITLE
chore(sweeps): Dont reuse service in launched sweep runs

### DIFF
--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -43,6 +43,8 @@ class AgentProcess:
                 kwargs = dict(creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
             else:
                 kwargs = dict(preexec_fn=os.setpgrp)
+            if env.get(wandb.env.SERVICE):
+                env.pop(wandb.env.SERVICE)
             self._popen = subprocess.Popen(command, env=env, **kwargs)
         elif function:
             self._proc = multiprocessing.Process(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Pops the WANDB_SERVICE env var from the subprocess environment for sweep runs, causing them to spin up their own service

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
