### PR TITLE
chore(launch): Use uv instead of pip to install requirements

### DIFF
--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
@@ -130,7 +130,7 @@ def test_get_requirements_section_user_provided_requirements(
     ) == PIP_TEMPLATE.format(
         buildx_optional_prefix="RUN WANDB_DISABLE_CACHE=true",
         requirements_files="src/requirements.txt",
-        pip_install="pip install -r requirements.txt",
+        pip_install="uv pip install -r requirements.txt",
     )
     warn_msgs = mocker.termwarn.call_args.args
     assert any(
@@ -198,7 +198,7 @@ def test_get_requirements_section_pyproject(
     ) == PIP_TEMPLATE.format(
         buildx_optional_prefix="RUN WANDB_DISABLE_CACHE=true",
         requirements_files="src/requirements.txt",  # We convert into this format.
-        pip_install="pip install -r requirements.txt",
+        pip_install="uv pip install -r requirements.txt",
     )
     warn_msgs = mocker.termwarn.call_args.args
     assert any(

--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_build.py
@@ -130,7 +130,7 @@ def test_get_requirements_section_user_provided_requirements(
     ) == PIP_TEMPLATE.format(
         buildx_optional_prefix="RUN WANDB_DISABLE_CACHE=true",
         requirements_files="src/requirements.txt",
-        pip_install="uv pip install -r requirements.txt",
+        pip_install="pip install uv && uv pip install -r requirements.txt",
     )
     warn_msgs = mocker.termwarn.call_args.args
     assert any(
@@ -198,7 +198,7 @@ def test_get_requirements_section_pyproject(
     ) == PIP_TEMPLATE.format(
         buildx_optional_prefix="RUN WANDB_DISABLE_CACHE=true",
         requirements_files="src/requirements.txt",  # We convert into this format.
-        pip_install="uv pip install -r requirements.txt",
+        pip_install="pip install uv && uv pip install -r requirements.txt",
     )
     warn_msgs = mocker.termwarn.call_args.args
     assert any(

--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_context_manager.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_context_manager.py
@@ -50,7 +50,7 @@ def test_create_build_context_wandb_dockerfile(mock_git_project):
     assert (path / "src" / "entrypoint.py").exists()
     assert (path / "src" / "requirements.txt").exists()
     assert (
-        image_tag == "7fd24842"
+        image_tag == "62143254"
     )  # This is the hash of the Dockerfile + image_source_string.
 
 
@@ -145,5 +145,5 @@ def test_create_build_context_buildx_enabled(mocker, mock_git_project):
     assert (path / "src" / "entrypoint.py").exists()
     assert (path / "src" / "requirements.txt").exists()
     assert (
-        image_tag == "de70c825"
+        image_tag == "f17a9120"
     )  # This is the hash of the Dockerfile + image_source_string.

--- a/tests/pytest_tests/unit_tests/test_launch/test_builder/test_context_manager.py
+++ b/tests/pytest_tests/unit_tests/test_launch/test_builder/test_context_manager.py
@@ -46,11 +46,11 @@ def test_create_build_context_wandb_dockerfile(mock_git_project):
     path = pathlib.Path(path)
     dockerfile = (path / "Dockerfile.wandb").read_text()
     assert "FROM python:3.8" in dockerfile
-    assert "pip install -r requirements.txt" in dockerfile
+    assert "uv pip install -r requirements.txt" in dockerfile
     assert (path / "src" / "entrypoint.py").exists()
     assert (path / "src" / "requirements.txt").exists()
     assert (
-        image_tag == "0c0f4554"
+        image_tag == "7fd24842"
     )  # This is the hash of the Dockerfile + image_source_string.
 
 
@@ -140,10 +140,10 @@ def test_create_build_context_buildx_enabled(mocker, mock_git_project):
     path = pathlib.Path(path)
     dockerfile = (path / "Dockerfile.wandb").read_text()
     assert "FROM python:3.8" in dockerfile
-    assert "pip install -r requirements.txt" in dockerfile
+    assert "uv pip install -r requirements.txt" in dockerfile
     assert "RUN WANDB_DISABLE_CACHE=true" not in dockerfile
     assert (path / "src" / "entrypoint.py").exists()
     assert (path / "src" / "requirements.txt").exists()
     assert (
-        image_tag == "a3a51084"
+        image_tag == "de70c825"
     )  # This is the hash of the Dockerfile + image_source_string.

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -201,7 +201,7 @@ def get_requirements_section(
     # If there is a requirements.txt at root of build context, use that.
     if (base_path / "src" / "requirements.txt").exists():
         requirements_files += ["src/requirements.txt"]
-        deps_install_line = "uv pip install -r requirements.txt"
+        deps_install_line = "pip install uv && uv pip install -r requirements.txt"
         with open(base_path / "src" / "requirements.txt") as f:
             requirements = f.readlines()
         if not any(["wandb" in r for r in requirements]):
@@ -237,7 +237,9 @@ def get_requirements_section(
                 with open(base_path / "src" / "requirements.txt", "w") as f:
                     f.write("\n".join(project_deps))
                 requirements_files += ["src/requirements.txt"]
-                deps_install_line = "uv pip install -r requirements.txt"
+                deps_install_line = (
+                    "pip install uv && uv pip install -r requirements.txt"
+                )
                 return PIP_TEMPLATE.format(
                     buildx_optional_prefix=prefix,
                     requirements_files=" ".join(requirements_files),

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -201,7 +201,7 @@ def get_requirements_section(
     # If there is a requirements.txt at root of build context, use that.
     if (base_path / "src" / "requirements.txt").exists():
         requirements_files += ["src/requirements.txt"]
-        deps_install_line = "pip install -r requirements.txt"
+        deps_install_line = "uv pip install -r requirements.txt"
         with open(base_path / "src" / "requirements.txt") as f:
             requirements = f.readlines()
         if not any(["wandb" in r for r in requirements]):
@@ -237,7 +237,7 @@ def get_requirements_section(
                 with open(base_path / "src" / "requirements.txt", "w") as f:
                     f.write("\n".join(project_deps))
                 requirements_files += ["src/requirements.txt"]
-                deps_install_line = "pip install -r requirements.txt"
+                deps_install_line = "uv pip install -r requirements.txt"
                 return PIP_TEMPLATE.format(
                     buildx_optional_prefix=prefix,
                     requirements_files=" ".join(requirements_files),

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -39,6 +39,7 @@ def install_deps(
         deps (str[], None): The dependencies that failed to install
     """
     try:
+        subprocess.check_output(["pip", "install", "uv"], stderr=subprocess.STDOUT)
         # Include only uri if @ is present
         clean_deps = [d.split("@")[-1].strip() if "@" in d else d for d in deps]
         index_args = ["--extra-index-url", extra_index] if extra_index else []

--- a/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/builder/templates/_wandb_bootstrap.py
@@ -44,7 +44,7 @@ def install_deps(
         index_args = ["--extra-index-url", extra_index] if extra_index else []
         print("installing {}...".format(", ".join(clean_deps)))
         opts = opts or []
-        args = ["pip", "install"] + opts + clean_deps + index_args
+        args = ["uv", "pip", "install"] + opts + clean_deps + index_args
         sys.stdout.flush()
         subprocess.check_output(args, stderr=subprocess.STDOUT)
         return failed


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-19511](https://wandb.atlassian.net/browse/WB-19511)

Use uv to install packages instead of plain pip, since it's faster.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Unit tests were updated. Manually tested by launching an artifact job and confirming `uv` was used to install packages.

Timing improvement over vanilla pip install can be seen [here](https://weightsandbiases.slack.com/archives/C044BQJCB46/p1721339421654649?thread_ts=1721336121.262159&cid=C044BQJCB46) (summary: installation time of 1:17 reduced to 0:17)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-19511]: https://wandb.atlassian.net/browse/WB-19511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ