### PR TITLE
fix(sdk): Raise ImportError on protobuf version mismatch

### DIFF
--- a/wandb/proto/wandb_internal_pb2.py
+++ b/wandb/proto/wandb_internal_pb2.py
@@ -8,3 +8,9 @@ elif protobuf_version == "4":
     from wandb.proto.v4.wandb_internal_pb2 import *
 elif protobuf_version == "5":
     from wandb.proto.v5.wandb_internal_pb2 import *
+else:
+    raise ImportError(
+        "Failed to import protobufs for protobuf version"
+        f" {google.protobuf.__version__}. `wandb` only works with major"
+        " versions 3, 4 and 5 of the protobuf package.",
+    )


### PR DESCRIPTION
Description
---
Raise an `ImportError` instead of silently leaving `wandb_internal_pb2.py` empty if the `protobuf` version is wrong, causing `import wandb` to fail with uninformative errors like "module 'wandb.proto.wandb_internal_pb2' has no attribute 'Result'" in random spots like 'wandb/sdk/lib/mailbox.py:103'.

Testing
---
If you delete the non-failing cases locally and try importing `wandb`, you see this:

```
>>> import wandb
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/timoffex/Documents/workspace/wandb/wandb/__init__.py", line 27, in <module>
    from wandb import sdk as wandb_sdk
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/__init__.py", line 25, in <module>
    from .artifacts.artifact import Artifact
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/artifacts/artifact.py", line 46, in <module>
    from wandb.apis.normalize import normalize_exceptions
  File "/Users/timoffex/Documents/workspace/wandb/wandb/apis/__init__.py", line 43, in <module>
    from .internal import Api as InternalApi  # noqa
  File "/Users/timoffex/Documents/workspace/wandb/wandb/apis/internal.py", line 3, in <module>
    from wandb.sdk.internal.internal_api import Api as InternalApi
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/internal/internal_api.py", line 48, in <module>
    from ..lib import credentials, retry
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/retry.py", line 17, in <module>
    from .mailbox import ContextCancelledError
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/mailbox.py", line 10, in <module>
    from wandb.proto import wandb_internal_pb2 as pb
  File "/Users/timoffex/Documents/workspace/wandb/wandb/proto/wandb_internal_pb2.py", line 13, in <module>
    raise ImportError(
ImportError: Failed to import protobufs for protobuf version 5.27.1. `wandb` only works with major versions 3, 4 and 5 of the protobuf package.
```
