### PR TITLE
refactor(artifacts): add ArtifactManifestEntry.to_json()

### DIFF
--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -18,7 +18,24 @@ from wandb.sdk.lib.hashutil import (
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
 
 if TYPE_CHECKING:
+    import sys
+
     from wandb.sdk.artifacts.artifact import Artifact
+
+    if sys.version_info >= (3, 8):
+        from typing import TypedDict
+    else:
+        from typing_extensions import TypedDict
+
+    class DictEntry(TypedDict, total=False):
+        path: str
+        digest: str
+        skip_cache: bool
+        ref: str
+        birthArtifactID: str
+        size: int
+        extra: Dict
+        local_path: str
 
 
 class ArtifactManifestEntry:
@@ -198,6 +215,25 @@ class ArtifactManifestEntry:
             + "/"
             + self.path
         )
+
+    def to_json(self) -> "DictEntry":
+        contents: DictEntry = {
+            "path": self.path,
+            "digest": self.digest,
+        }
+        if self.size is not None:
+            contents["size"] = self.size
+        if self.ref:
+            contents["ref"] = self.ref
+        if self.birth_artifact_id:
+            contents["birthArtifactID"] = self.birth_artifact_id
+        if self.local_path:
+            contents["local_path"] = self.local_path
+        if self.skip_cache:
+            contents["skip_cache"] = self.skip_cache
+        if self.extra:
+            contents["extra"] = self.extra
+        return contents
 
     def _is_artifact_reference(self) -> bool:
         return self.ref is not None and urlparse(self.ref).scheme == "wandb-artifact"

--- a/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
+++ b/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
@@ -1,6 +1,6 @@
 """Artifact manifest v1."""
 
-from typing import Any, Dict, Mapping, Optional
+from typing import Dict, Mapping, Optional
 
 from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
@@ -54,27 +54,12 @@ class ArtifactManifestV1(ArtifactManifest):
         super().__init__(storage_policy, entries=entries)
 
     def to_manifest_json(self) -> Dict:
-        """This is the JSON that's stored in wandb_manifest.json.
-
-        If include_local is True we also include the local paths to files. This is
-        used to represent an artifact that's waiting to be saved on the current
-        system. We don't need to include the local paths in the artifact manifest
-        contents.
-        """
+        """This is the JSON that's stored in wandb_manifest.json."""
         contents = {}
         for entry in sorted(self.entries.values(), key=lambda k: k.path):
-            json_entry: Dict[str, Any] = {
-                "digest": entry.digest,
-            }
-            if entry.birth_artifact_id:
-                json_entry["birthArtifactID"] = entry.birth_artifact_id
-            if entry.ref:
-                json_entry["ref"] = entry.ref
-            if entry.extra:
-                json_entry["extra"] = entry.extra
-            if entry.size is not None:
-                json_entry["size"] = entry.size
-            contents[entry.path] = json_entry
+            entry_json = entry.to_json()
+            path = entry_json.pop("path")
+            contents[path] = entry_json
         return {
             "version": self.__class__.version(),
             "storagePolicy": self.storage_policy.name(),


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Split off from <>, minor refactor to enable manifest entries to report their own JSON.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Covered by existing manifest tests.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
