### PR TITLE
fix(core): fix unsafe modification of protobuf in writer

### DIFF
--- a/core/pkg/server/writer.go
+++ b/core/pkg/server/writer.go
@@ -135,8 +135,8 @@ func (w *Writer) Close() {
 
 // writeRecord Writing messages to the append-only log,
 // and passing them to the sender.
-// We ensure that the messages are written to the log
-// before they are sent to the server.
+// Ensure that the messages are numbered and written to the transaction log
+// before network operations could block processing of the record.
 func (w *Writer) writeRecord(record *service.Record) {
 	switch record.RecordType.(type) {
 	case *service.Record_Request:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-19850

(Marked as fixes corruption, but it might not be the only fix. will reopen after merge)

This PR fixes a potential issue where the writer goroutine could modify the protobuf record after forwarding it to the sending goroutine.   Since we send references around, this is unsafe and needs to be avoided.

The comment in the function describes what the intended behavior was: first write the record before sending it.

To make this behavior more explicit, the `writeRecord` function was broken into two, one which modifies the protobuf, and the other that adds it to the store channel.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
