### PR TITLE
chore(artifacts): use fewer examples for hypothesis file hashing tests

### DIFF
--- a/tests/pytest_tests/unit_tests/test_lib/test_hashutil.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_hashutil.py
@@ -2,7 +2,7 @@ import base64
 import hashlib
 from typing import Optional
 
-from hypothesis import given
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 from wandb.sdk.lib import hashutil
 
@@ -63,6 +63,9 @@ def test_md5_file_hex_single_file(data):
 
 
 @given(st.binary(), st.text(), st.binary())
+@settings(max_examples=10)
+@example(b"g", "", b"\xb6DZ")
+@example(b"\x1b\xb7", "¬\U000f0c9a", b"\xb7\xb7")
 def test_md5_file_b64_three_files(data1, text, data2):
     write_file("a.bin", "wb", data1)
     write_file("b.txt", "w", text, encoding="utf-8")
@@ -75,6 +78,9 @@ def test_md5_file_b64_three_files(data1, text, data2):
 
 
 @given(st.binary(), st.text(), st.binary())
+@settings(max_examples=10)
+@example(b"g", "", b"\xb6DZ")
+@example(b"\x1b\xb7", "¬\U000f0c9a", b"\xb7\xb7")
 def test_md5_file_hex_three_files(data1, text, data2):
     write_file("a.bin", "wb", data1)
     write_file("b.txt", "w", text, encoding="utf-8")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-20049](https://wandb.atlassian.net/browse/WB-20049)

This tests is occasionally flaky; the issue seems to be timeouts, and the test "normally" takes 100's of milliseconds. There's no reason we should be running so many examples in CI, so this just caps it at 10 + two examples that have failed in CI (but seem to be fine themselves).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Test run time reduced by 90%; no observed flakes yet.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-20049]: https://wandb.atlassian.net/browse/WB-20049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ