### PR TITLE
chore(artifacts): default to only testing 10 examples with hypothesis

### DIFF
--- a/tests/pytest_tests/__init__.py
+++ b/tests/pytest_tests/__init__.py
@@ -1,0 +1,4 @@
+from hypothesis import settings
+
+settings.register_profile("ci", max_examples=10)
+settings.load_profile("ci")

--- a/tests/pytest_tests/unit_tests/test_lib/test_hashutil.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_hashutil.py
@@ -57,6 +57,7 @@ def test_md5_file_b64_no_files():
 
 
 @given(st.binary())
+@settings(max_examples=10)
 def test_md5_file_hex_single_file(data):
     write_file("binfile", "wb", data)
     assert hashlib.md5(data).hexdigest() == hashutil.md5_file_hex("binfile")

--- a/tests/pytest_tests/unit_tests/test_lib/test_hashutil.py
+++ b/tests/pytest_tests/unit_tests/test_lib/test_hashutil.py
@@ -2,7 +2,7 @@ import base64
 import hashlib
 from typing import Optional
 
-from hypothesis import example, given, settings
+from hypothesis import example, given
 from hypothesis import strategies as st
 from wandb.sdk.lib import hashutil
 
@@ -57,14 +57,12 @@ def test_md5_file_b64_no_files():
 
 
 @given(st.binary())
-@settings(max_examples=10)
 def test_md5_file_hex_single_file(data):
     write_file("binfile", "wb", data)
     assert hashlib.md5(data).hexdigest() == hashutil.md5_file_hex("binfile")
 
 
 @given(st.binary(), st.text(), st.binary())
-@settings(max_examples=10)
 @example(b"g", "", b"\xb6DZ")
 @example(b"\x1b\xb7", "¬\U000f0c9a", b"\xb7\xb7")
 def test_md5_file_b64_three_files(data1, text, data2):
@@ -79,7 +77,6 @@ def test_md5_file_b64_three_files(data1, text, data2):
 
 
 @given(st.binary(), st.text(), st.binary())
-@settings(max_examples=10)
 @example(b"g", "", b"\xb6DZ")
 @example(b"\x1b\xb7", "¬\U000f0c9a", b"\xb7\xb7")
 def test_md5_file_hex_three_files(data1, text, data2):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-20049](https://wandb.atlassian.net/browse/WB-20049)

Since https://github.com/wandb/wandb/pull/8015 left at least one example that ran too long, this changes the default for hypothesis for all unit tests--even the non-file related tests were taking upwards of 100ms before.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-20049]: https://wandb.atlassian.net/browse/WB-20049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ