### PR TITLE
fix(artifacts): fix issues from #8017, including JSON decoding bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Added
 
 - Specify job input schemas when calling manage_config_file or manage_wandb_config to create a nicer UI when launching the job, by @TimH98 in https://github.com/wandb/wandb/pull/7907, https://github.com/wandb/wandb/pull/7924, https://github.com/wandb/wandb/pull/7971
+- Use the filesystem rather than protobuf messages to transport manifests with more than 100k entries to the core process @moredatarequired https://github.com/wandb/wandb/pull/7992
 
 ### Changed
 
@@ -24,7 +25,6 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Added
 
 - When using wandb-core, support multipart uploads to S3 @moredatarequired https://github.com/wandb/wandb/pull/7659
-- Use the filesystem rather than protobuf messages to transport manifests with more than 100k entries to the core process @moredatarequired https://github.com/wandb/wandb/pull/7992
 
 ### Changed
 

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -80,14 +80,14 @@ func NewManifestFromProto(proto *service.ArtifactManifest) (Manifest, error) {
 }
 
 func ManifestContentsFromFile(path string) (map[string]ManifestEntry, error) {
+	// Whether or not we successfully decode the manifest, we should clean up the file.
+	defer os.Remove(path)
+
 	manifestFile, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening manifest file: %w", err)
 	}
 	defer manifestFile.Close()
-
-	// Whether or not we successfully decode the manifest, we should clean up the file.
-	defer os.Remove(path)
 
 	// The file is gzipped and needs to be decompressed.
 	gzReader, err := gzip.NewReader(manifestFile)

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -28,13 +28,13 @@ type StoragePolicyConfig struct {
 
 type ManifestEntry struct {
 	// Fields from the service.ArtifactManifestEntry proto.
-	Digest          string                 `json:"digest"`
-	Ref             *string                `json:"ref,omitempty"`
-	Size            int64                  `json:"size"`
-	LocalPath       *string                `json:"local_path,omitempty"`
-	BirthArtifactID *string                `json:"birthArtifactID,omitempty"`
-	SkipCache       bool                   `json:"skip_cache"`
-	Extra           map[string]interface{} `json:"extra,omitempty"`
+	Digest          string         `json:"digest"`
+	Ref             *string        `json:"ref,omitempty"`
+	Size            int64          `json:"size"`
+	LocalPath       *string        `json:"local_path,omitempty"`
+	BirthArtifactID *string        `json:"birthArtifactID,omitempty"`
+	SkipCache       bool           `json:"skip_cache"`
+	Extra           map[string]any `json:"extra,omitempty"`
 	// Added and used during download.
 	DownloadURL *string `json:"-"`
 }
@@ -55,9 +55,9 @@ func NewManifestFromProto(proto *service.ArtifactManifest) (Manifest, error) {
 		manifest.Contents = contents
 	}
 	for _, entry := range proto.Contents {
-		extra := map[string]interface{}{}
+		extra := map[string]any{}
 		for _, item := range entry.Extra {
-			var value interface{}
+			var value any
 			err := json.Unmarshal([]byte(item.ValueJson), &value)
 			if err != nil {
 				return Manifest{}, fmt.Errorf(
@@ -102,7 +102,7 @@ func ManifestContentsFromFile(path string) (map[string]ManifestEntry, error) {
 
 	for scanner.Scan() {
 		var entry ManifestEntry
-		var record map[string]interface{}
+		var record map[string]any
 		line := scanner.Bytes()
 		if err := json.Unmarshal(line, &record); err != nil {
 			return nil, fmt.Errorf("could not unmarshal json: %w", err)
@@ -138,9 +138,9 @@ func ManifestContentsFromFile(path string) (map[string]ManifestEntry, error) {
 		}
 
 		// "extra" is itself a JSON object.
-		entry.Extra, ok = record["extra"].(map[string]interface{})
+		entry.Extra, ok = record["extra"].(map[string]any)
 		if !ok {
-			entry.Extra = make(map[string]interface{})
+			entry.Extra = make(map[string]any)
 		}
 		contents[path] = entry
 	}

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -55,7 +55,7 @@ func NewManifestFromProto(proto *service.ArtifactManifest) (Manifest, error) {
 		manifest.Contents = contents
 	}
 	for _, entry := range proto.Contents {
-		extra := map[string]any{}
+		extra := make(map[string]any, len(entry.Extra))
 		for _, item := range entry.Extra {
 			var value any
 			err := json.Unmarshal([]byte(item.ValueJson), &value)
@@ -116,21 +116,29 @@ func ManifestContentsFromFile(path string) (map[string]ManifestEntry, error) {
 		if !ok {
 			return nil, fmt.Errorf("record missing 'digest' key or not a string")
 		}
-		entry.Size, ok = record["size"].(int64)
+		size, ok := record["size"].(float64)
 		if !ok {
 			entry.Size = 0
+		} else {
+			entry.Size = int64(size)
 		}
-		entry.Ref, ok = record["ref"].(*string)
-		if !ok {
+		ref, ok := record["ref"].(string)
+		if !ok || ref == "" {
 			entry.Ref = nil
+		} else {
+			entry.Ref = &ref
 		}
-		entry.LocalPath, ok = record["local_path"].(*string)
-		if !ok {
+		localPath, ok := record["local_path"].(string)
+		if !ok || localPath == "" {
 			entry.LocalPath = nil
+		} else {
+			entry.LocalPath = &localPath
 		}
-		entry.BirthArtifactID, ok = record["birthArtifactID"].(*string)
-		if !ok {
+		birthArtifactID, ok := record["birthArtifactID"].(string)
+		if !ok || birthArtifactID == "" {
 			entry.BirthArtifactID = nil
+		} else {
+			entry.BirthArtifactID = &birthArtifactID
 		}
 		entry.SkipCache, ok = record["skip_cache"].(bool)
 		if !ok {
@@ -148,6 +156,7 @@ func ManifestContentsFromFile(path string) (map[string]ManifestEntry, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("error scanning file: %w", err)
 	}
+	fmt.Println("contents", contents)
 	return contents, nil
 }
 

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -156,7 +156,6 @@ func ManifestContentsFromFile(path string) (map[string]ManifestEntry, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("error scanning file: %w", err)
 	}
-	fmt.Println("contents", contents)
 	return contents, nil
 }
 

--- a/core/pkg/artifacts/manifest_test.go
+++ b/core/pkg/artifacts/manifest_test.go
@@ -29,8 +29,8 @@ func TestNewManifestFromProto(t *testing.T) {
 
 	manifest, err := NewManifestFromProto(proto)
 	assert.NoError(t, err)
-	assert.Equal(t, int32(1), manifest.Version)
-	assert.Equal(t, "policy", manifest.StoragePolicy)
+	assert.Equal(t, proto.Version, manifest.Version)
+	assert.Equal(t, proto.StoragePolicy, manifest.StoragePolicy)
 	assert.Equal(t, "value1", manifest.Contents["path1"].Extra["key1"])
 }
 

--- a/core/pkg/artifacts/manifest_test.go
+++ b/core/pkg/artifacts/manifest_test.go
@@ -1,0 +1,192 @@
+package artifacts
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/pkg/service"
+)
+
+func TestNewManifestFromProto(t *testing.T) {
+	proto := &service.ArtifactManifest{
+		Version:       1,
+		StoragePolicy: "policy",
+		Contents: []*service.ArtifactManifestEntry{
+			{
+				Path:   "path1",
+				Digest: "digest1",
+				Size:   123,
+				Extra: []*service.ExtraItem{
+					{Key: "key1", ValueJson: `"value1"`},
+				},
+			},
+		},
+	}
+
+	manifest, err := NewManifestFromProto(proto)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(1), manifest.Version)
+	assert.Equal(t, "policy", manifest.StoragePolicy)
+	assert.Equal(t, "value1", manifest.Contents["path1"].Extra["key1"])
+}
+
+func TestNewManifestFromProto_InvalidManifestFilePath(t *testing.T) {
+	proto := &service.ArtifactManifest{
+		Version:          1,
+		StoragePolicy:    "policy",
+		ManifestFilePath: "invalid/path/to/manifest.gz",
+	}
+
+	manifest, err := NewManifestFromProto(proto)
+	assert.Error(t, err)
+	assert.Empty(t, manifest.Contents)
+}
+
+func TestManifestContentsFromFile_MissingPath(t *testing.T) {
+	// Create a temporary gzipped file with manifest contents missing the "path" field
+	tmpFile, err := os.CreateTemp("", "manifest-*.jl.gz")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	gzWriter := gzip.NewWriter(tmpFile)
+	writer := bufio.NewWriter(gzWriter)
+	entryJson, _ := json.Marshal(map[string]any{
+		"digest": "digest1",
+		"size":   123,
+		"extra":  map[string]any{"key1": "value1"},
+	})
+	_, err = writer.Write(entryJson)
+	assert.NoError(t, err)
+	writer.Flush()
+	gzWriter.Close()
+	tmpFile.Close()
+
+	_, err = ManifestContentsFromFile(tmpFile.Name())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "record missing 'path' key or not a string")
+}
+
+func TestManifestContentsFromFile_MissingDigest(t *testing.T) {
+	// Create a temporary gzipped file with manifest contents missing the "digest" field
+	tmpFile, err := os.CreateTemp("", "manifest-*.jl.gz")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	gzWriter := gzip.NewWriter(tmpFile)
+	writer := bufio.NewWriter(gzWriter)
+	entryJson, _ := json.Marshal(map[string]any{
+		"path":  "path1",
+		"size":  123,
+		"extra": map[string]any{"key1": "value1"},
+	})
+	_, err = writer.Write(entryJson)
+	assert.NoError(t, err)
+	writer.Flush()
+	gzWriter.Close()
+	tmpFile.Close()
+
+	_, err = ManifestContentsFromFile(tmpFile.Name())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "record missing 'digest' key or not a string")
+}
+
+func TestManifestContentsFromFile(t *testing.T) {
+	// Create a temporary gzipped file with manifest contents
+	tmpFile, err := os.CreateTemp("", "manifest-*.jl.gz")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	gzWriter := gzip.NewWriter(tmpFile)
+	writer := bufio.NewWriter(gzWriter)
+	entry1 := map[string]any{
+		"path":   "path1",
+		"digest": "digest1",
+		"size":   int64(123),
+		// JSON is lossy w.r.t. numbers, so 65 (int) becomes 65.0 (float64)
+		"extra":           map[string]any{"key1": "value1", "key2": 65.0},
+		"local_path":      "local/path1",
+		"birthArtifactID": "birthArtifactID1",
+	}
+	entryJson, _ := json.Marshal(entry1)
+	_, err = writer.Write(entryJson)
+	assert.NoError(t, err)
+	err = writer.WriteByte('\n')
+	assert.NoError(t, err)
+	entry2 := map[string]any{
+		"path":       "path2",
+		"digest":     "etag1",
+		"ref":        "local/path2",
+		"skip_cache": true,
+	}
+	entryJson, _ = json.Marshal(entry2)
+	_, err = writer.Write(entryJson)
+	assert.NoError(t, err)
+	err = writer.WriteByte('\n')
+	assert.NoError(t, err)
+	writer.Flush()
+	gzWriter.Close()
+	tmpFile.Close()
+
+	contents, err := ManifestContentsFromFile(tmpFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, entry1["digest"], contents["path1"].Digest)
+	assert.Equal(t, entry1["size"], contents["path1"].Size)
+	assert.Nil(t, contents["path1"].Ref)
+	assert.Equal(t, entry1["extra"], contents["path1"].Extra)
+	assert.Equal(t, entry1["local_path"], *contents["path1"].LocalPath)
+	assert.Equal(t, entry1["birthArtifactID"], *contents["path1"].BirthArtifactID)
+	assert.False(t, contents["path1"].SkipCache)
+
+	assert.Equal(t, entry2["digest"], contents["path2"].Digest)
+	assert.Equal(t, int64(0), contents["path2"].Size)
+	assert.Equal(t, entry2["ref"], *contents["path2"].Ref)
+	assert.Equal(t, map[string]interface{}{}, contents["path2"].Extra)
+	assert.Nil(t, contents["path2"].LocalPath)
+	assert.Nil(t, contents["path2"].BirthArtifactID)
+	assert.True(t, contents["path2"].SkipCache)
+}
+
+func TestManifest_WriteToFile(t *testing.T) {
+	manifest := Manifest{
+		Version:       1,
+		StoragePolicy: "policy",
+		Contents: map[string]ManifestEntry{
+			"path1": {
+				Digest: "digest1",
+				Size:   123,
+				Extra:  map[string]any{"key1": "value1"},
+			},
+		},
+	}
+
+	filename, digest, size, err := manifest.WriteToFile()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, filename)
+	assert.NotEmpty(t, digest)
+	assert.NotZero(t, size)
+	defer os.Remove(filename)
+}
+
+func TestManifest_GetManifestEntryFromArtifactFilePath(t *testing.T) {
+	manifest := Manifest{
+		Contents: map[string]ManifestEntry{
+			"path1": {
+				Digest: "digest1",
+				Size:   123,
+				Extra:  map[string]any{"key1": "value1"},
+			},
+		},
+	}
+
+	entry, err := manifest.GetManifestEntryFromArtifactFilePath("path1")
+	assert.NoError(t, err)
+	assert.Equal(t, "digest1", entry.Digest)
+	assert.Equal(t, int64(123), entry.Size)
+
+	_, err = manifest.GetManifestEntryFromArtifactFilePath("nonexistent")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

@kptkin left some comments post-merge on #8017 which unveiled some significant issues. This is effectively a fix for that PR.

Most importantly, the types used during JSON decoding weren't correct and the errors were being silently ignored. The additional unit tests for the Go side decoding should cover every possible field and their defaults.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Added unit tests for functions from `manifest.go`, including extensive tests for reading the manifest from file.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
