### PR TITLE
fix(core): '_wandb.runtime' => [_wandb, runtime]

### DIFF
--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -1001,7 +1001,7 @@ func (h *Handler) updateRunTiming() {
 		RecordType: &service.Record_Summary{
 			Summary: &service.SummaryRecord{
 				Update: []*service.SummaryItem{{
-					Key:       "_wandb.runtime",
+					NestedKey: []string{"_wandb", "runtime"},
 					ValueJson: strconv.Itoa(runtime),
 				}},
 			},


### PR DESCRIPTION
Description
---
Logs the `_wandb.runtime` using a nested metric rather than a dot-separated key to fix regression introduced in #8004.

Testing
---
Create a run and finish it immediately. See the uploaded `wandb-summary.json` file (note that on the workspace overview page, the summary is always flattened in the UI, so there is no difference there).
