### PR TITLE
chore(sdk): add better errors/warnings for resume_from/fork_from

### DIFF
--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -668,12 +668,28 @@ func (s *Sender) serializeConfig(format runconfig.Format) (string, error) {
 	return string(serializedConfig), nil
 }
 
-func (s *Sender) sendForkRun(_ *service.Record, _ *service.RunRecord) {
-	// TODO: implement fork
+func (s *Sender) sendForkRun(record *service.Record, _ *service.RunRecord) {
+	if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
+		result := &service.RunUpdateResult{
+			Error: &service.ErrorInfo{
+				Code:    service.ErrorInfo_UNSUPPORTED,
+				Message: "`fork_from` is not yet supported",
+			},
+		}
+		s.respond(record, result)
+	}
 }
 
-func (s *Sender) sendRewindRun(_ *service.Record, _ *service.RunRecord) {
-	// TODO: implement rewind
+func (s *Sender) sendRewindRun(record *service.Record, _ *service.RunRecord) {
+	if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
+		result := &service.RunUpdateResult{
+			Error: &service.ErrorInfo{
+				Code:    service.ErrorInfo_UNSUPPORTED,
+				Message: "`resume_from` is not yet supported",
+			},
+		}
+		s.respond(record, result)
+	}
 }
 
 func (s *Sender) sendResumeRun(record *service.Record, run *service.RunRecord) {
@@ -788,13 +804,14 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 			if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
 				result := &service.RunUpdateResult{
 					Error: &service.ErrorInfo{
-						Code:    service.ErrorInfo_USAGE,
-						Message: "provide only one of resume, rewind or fork",
+						Code: service.ErrorInfo_USAGE,
+						Message: "`resume`, `fork_from`, and `resume_from` are mutually exclusive. " +
+							"Please specify only one of them.",
 					},
 				}
 				s.respond(record, result)
 			}
-			s.logger.Error("sender: sendRun: provide only one of resume, rewind or fork")
+			s.logger.Error("sender: sendRun: user provided more than one of resume, rewind, or fork")
 			return
 		case isResume != "":
 			s.sendResumeRun(record, runClone)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1882,9 +1882,10 @@ class Settings(SettingsData):
         if self.resume_from is None:
             return
 
-        if self.run_id is not None:
+        if self.run_id is not None and (self.resume_from.run != self.run_id):
             wandb.termwarn(
-                "You cannot specify both run_id and resume_from. " "Ignoring run_id."
+                "Both `run_id` and `resume_from` have been specified with different ids. "
+                "`run_id` will be ignored."
             )
         self.update({"run_id": self.resume_from.run}, source=Source.INIT)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-19659

What does the PR do? Include a concise description of the PR contents.

Based on a user feedback added explicit error messages for `wandb-core` not supporting fork_from/resume_from
As well as slightly modified the warning for `resume_from`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
