### PR TITLE
fix(core): Don't flatten summary in sendJobFlush()

### DIFF
--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -470,7 +470,7 @@ func (s *Sender) sendJobFlush() {
 	}
 	s.jobBuilder.SetRunConfig(*s.runConfig)
 
-	output := s.runSummary.ToMap()
+	output := s.runSummary.ToNestedMaps()
 
 	artifact, err := s.jobBuilder.Build(s.ctx, s.graphqlClient, output)
 	if err != nil {


### PR DESCRIPTION
Description
---
Uses the nested-maps representation of the summary in `sendJobsFlush` because it seems like the structure might matter. Removes the last remaining spot where we flatten summary keys.
