### PR TITLE
fix(core): correctly propagate the commit hash to version string

### DIFF
--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	// store commit hash in context
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, observability.Commit("commit"), commit)
+	ctx = context.WithValue(ctx, observability.Commit, commit)
 
 	var loggerPath string
 	if file, _ := observability.GetLoggerPath(); file != nil {

--- a/core/pkg/observability/util.go
+++ b/core/pkg/observability/util.go
@@ -8,8 +8,10 @@ import (
 	"time"
 )
 
-// Commit is a type for storing the commit hash
-type Commit string
+// this is for storing the commit hash in context.Context
+type commitType string
+
+const Commit = commitType("commit")
 
 // FileSystem interface to abstract file system operations
 type FileSystem interface {

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -243,7 +243,7 @@ func (nc *Connection) handleInformInit(msg *service.ServerInformInitRequest) {
 	streamId := msg.GetXInfo().GetStreamId()
 	slog.Info("connection init received", "streamId", streamId, "id", nc.id)
 
-	nc.stream = NewStream(settings, streamId, nc.sentryClient)
+	nc.stream = NewStream(nc.ctx, settings, streamId, nc.sentryClient)
 	nc.stream.AddResponders(ResponderEntry{nc, nc.id})
 	nc.stream.Start()
 	slog.Info("connection init completed", "streamId", streamId, "id", nc.id)

--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -505,7 +505,7 @@ func (h *Handler) handleRequestPollExit(record *service.Record) {
 
 func (h *Handler) handleHeader(record *service.Record) {
 	// populate with version info
-	versionString := fmt.Sprintf("%s+%s", version.Version, h.ctx.Value(observability.Commit("commit")))
+	versionString := fmt.Sprintf("%s+%s", version.Version, h.ctx.Value(observability.Commit))
 	record.GetHeader().VersionInfo = &service.VersionInfo{
 		Producer:    versionString,
 		MinConsumer: version.MinServerVersion,

--- a/core/pkg/server/handler_test.go
+++ b/core/pkg/server/handler_test.go
@@ -2,20 +2,23 @@ package server_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/internal/version"
 	"github.com/wandb/wandb/core/pkg/observability"
 	"github.com/wandb/wandb/core/pkg/server"
 	"github.com/wandb/wandb/core/pkg/service"
 )
 
 func makeHandler(
+	ctx context.Context,
 	inChan, fwdChan chan *service.Record,
 	outChan chan *service.Result,
 ) *server.Handler {
-	h := server.NewHandler(context.Background(),
+	h := server.NewHandler(ctx,
 		server.HandlerParams{
 			Logger:          observability.NewNoOpLogger(),
 			Settings:        &service.Settings{},
@@ -712,7 +715,7 @@ func TestHandlePartialHistory(t *testing.T) {
 			fwdChan := make(chan *service.Record, server.BufferSize)
 			outChan := make(chan *service.Result, server.BufferSize)
 
-			makeHandler(inChan, fwdChan, outChan)
+			makeHandler(context.Background(), inChan, fwdChan, outChan)
 
 			for _, d := range tc.input {
 				record := makePartialHistoryRecord(d)
@@ -811,7 +814,7 @@ func TestHandleHistory(t *testing.T) {
 			fwdChan := make(chan *service.Record, server.BufferSize)
 			outChan := make(chan *service.Result, server.BufferSize)
 
-			makeHandler(inChan, fwdChan, outChan)
+			makeHandler(context.Background(), inChan, fwdChan, outChan)
 
 			for _, d := range tc.input {
 				record := makeHistoryRecord(d)
@@ -838,4 +841,28 @@ func TestHandleHistory(t *testing.T) {
 		})
 	}
 
+}
+
+func TestHandleHeader(t *testing.T) {
+	inChan := make(chan *service.Record, server.BufferSize)
+	fwdChan := make(chan *service.Record, server.BufferSize)
+	outChan := make(chan *service.Result, server.BufferSize)
+
+	sha := "2a7314df06ab73a741dcb7bc5ecb50cda150b077"
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, observability.Commit, sha)
+	makeHandler(ctx, inChan, fwdChan, outChan)
+
+	record := &service.Record{
+		RecordType: &service.Record_Header{
+			Header: &service.HeaderRecord{},
+		},
+	}
+	inChan <- record
+
+	record = <-fwdChan
+
+	versionInfo := fmt.Sprintf("%s+%s", version.Version, sha)
+	assert.Equal(t, record.GetHeader().GetVersionInfo().GetProducer(), versionInfo, "wrong version info")
 }

--- a/core/pkg/server/handler_test.go
+++ b/core/pkg/server/handler_test.go
@@ -844,9 +844,9 @@ func TestHandleHistory(t *testing.T) {
 }
 
 func TestHandleHeader(t *testing.T) {
-	inChan := make(chan *service.Record, server.BufferSize)
-	fwdChan := make(chan *service.Record, server.BufferSize)
-	outChan := make(chan *service.Result, server.BufferSize)
+	inChan := make(chan *service.Record, 1)
+	fwdChan := make(chan *service.Record, 1)
+	outChan := make(chan *service.Result, 1)
 
 	sha := "2a7314df06ab73a741dcb7bc5ecb50cda150b077"
 

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -149,8 +149,16 @@ func streamLogger(settings *settings.Settings, sentryClient *sentry_ext.Client) 
 }
 
 // NewStream creates a new stream with the given settings and responders.
-func NewStream(settings *settings.Settings, _ string, sentryClient *sentry_ext.Client) *Stream {
+func NewStream(ctx context.Context, settings *settings.Settings, _ string, sentryClient *sentry_ext.Client) *Stream {
+	// we only need the passed context for the commit value
+	commit, ok := ctx.Value(observability.Commit).(string)
+	if !ok {
+		commit = ""
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
+	ctx = context.WithValue(ctx, observability.Commit, commit)
+
 	s := &Stream{
 		ctx:          ctx,
 		cancel:       cancel,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
We store the commit hash (passed in at build time) in the leveldb log header. This got broken at some point, this PR fixes it.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
