### PR TITLE
fix(core): only try to insert steps for active history lines

### DIFF
--- a/core/internal/runmetric/runmetric.go
+++ b/core/internal/runmetric/runmetric.go
@@ -115,16 +115,14 @@ func (mh *MetricHandler) UpdateMetrics(
 	return mh.createGlobMetrics(history)
 }
 
-// InsertStepMetrics inserts an automatic step metric for every metric
-// that has a step metric defined and is not already present in the
-// history.
+// InsertStepMetrics inserts an automatic step metric for every defined
+// metric with step_sync set to true.
 func (mh *MetricHandler) InsertStepMetrics(
 	history *runhistory.RunHistory,
 ) {
 	history.ForEachKey(func(path pathtree.TreePath) bool {
 		key := strings.Join(path.Labels(), ".")
 		metricDef, ok := mh.definedMetrics[key]
-		// This should never happen, but we'll skip the metric if it does.
 		if !ok {
 			return true
 		}
@@ -149,7 +147,6 @@ func (mh *MetricHandler) InsertStepMetrics(
 		if !ok {
 			return true
 		}
-		// Set the latest value as the step value.
 		history.SetFloat(stepMetricPath, latest)
 		return true
 	})

--- a/core/internal/runmetric/runmetric.go
+++ b/core/internal/runmetric/runmetric.go
@@ -129,8 +129,7 @@ func (mh *MetricHandler) InsertStepMetrics(
 			return true
 		}
 
-		// Skip metrics that dont have a step defined or are not
-		// meant to be step synced.
+		// Skip any metrics that do not need to be synced.
 		if metricDef.Step == "" || !metricDef.SyncStep {
 			return true
 		}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Update the logic that insert a step if sync_step is set, instead of iterating over all the steps we iterate over the current history keys and insert only for these that need to be synced

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
