### PR TITLE
chore(core): add panic debug ability

### DIFF
--- a/core/hatch.py
+++ b/core/hatch.py
@@ -46,12 +46,15 @@ def build_wandb_core(
 
     vendor_flags = ["-mod=vendor"]
 
+    debug_flags = ["-gcflags=all=-N -l"]
+
     # We have to invoke Go from the directory with go.mod, hence the
     # paths relative to ./core
     subprocess.check_call(
         [
             str(go_binary),
             "build",
+            *debug_flags,
             *coverage_flags,
             *race_detect_flags,
             *ld_flags,
@@ -75,8 +78,8 @@ def _go_linker_flags(
 ) -> str:
     """Returns linker flags for the Go binary as a string."""
     flags = [
-        "-s",  # Omit the symbol table and debug info.
-        "-w",  # Omit the DWARF symbol table.
+        # "-s",  # Omit the symbol table and debug info.
+        # "-w",  # Omit the DWARF symbol table.
         # Set the Git commit variable in the main package.
         "-X",
         f"main.commit={wandb_commit_sha or 'unknown'}",

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -134,6 +134,14 @@ func streamLogger(settings *settings.Settings, sentryClient *sentry_ext.Client) 
 	logger.Info("using version", "core version", version.Version)
 	logger.Info("created symlink", "path", targetPath)
 
+	// Log some environment variables so we know they were enabled
+	envVars := []string{"GOTRACEBACK", "_WANDB_DEBUG_PANIC_MALFORMED"}
+	for _, envVar := range envVars {
+		if value, exists := os.LookupEnv(envVar); exists {
+			logger.Info("Using environment variable", envVar, value)
+		}
+	}
+
 	tags := observability.Tags{
 		"run_id":   settings.GetRunID(),
 		"run_url":  settings.GetRunURL(),


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

To use this branch:
```
go install github.com/go-delve/delve/cmd/dlv@latest
cat >debug.sh <EOF
cat debug.sh
SITE=`python -c 'import site; print(site.getsitepackages()[0])'`
COREPATH="/var/lib/apport/coredump/"
PROG="wandb/bin/wandb-core"
CORE=`ls $COREPATH | tail -1`
dlv core $SITE/$PROG $COREPATH/$CORE
EOF
chmod +x debug.sh

ulimit -c unlimited
GOTRACEBACK=crash _WANDB_DEBUG_PANIC_MALFORMED=true python train.py

./debug.sh
```


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

Testing, add this to sender.go
```
diff --git a/core/pkg/server/sender.go b/core/pkg/server/sender.go
index dc409f520..c715dec10 100644
--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -1364,6 +1364,10 @@ func (s *Sender) sendRequestStopStatus(record *service.Record, _ *service.StopSt
                }
        } else {
                response, err := gql.RunStoppedStatus(s.ctx, s.graphqlClient, &entity, &project, runId)
+
+               // inject
+               err = fmt.Errorf(`sender: sendStopStatus: INJECT failed to get run stopped status: api: failed sending: POST https://api.wandb.ai/graphql giving up after 1 attempt(s): Post "https://api.wandb.ai/graphql": stream error: stream ID 431; PROTOCOL_ERROR; invalid header field name "\x00\x00\x00\x00\x00\x00\x00\x00t-type-options"`)
+
                switch {
                case err != nil:
                        // if there is an error, we don't know if the run should stop
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
