### PR TITLE
feat(artifacts): restore reference entries from etag cache in wandb-core

### DIFF
--- a/core/pkg/utils/hash.go
+++ b/core/pkg/utils/hash.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"io"
@@ -71,4 +72,11 @@ func HexToB64(data string) (string, error) {
 	}
 	b64Str := base64.StdEncoding.EncodeToString(buf)
 	return b64Str, nil
+}
+
+// ComputeSHA256 computes the SHA256 hash of the given data.
+func ComputeSHA256(data []byte) []byte {
+	hasher := sha256.New()
+	hasher.Write(data)
+	return hasher.Sum(nil)
 }

--- a/core/pkg/utils/hash_test.go
+++ b/core/pkg/utils/hash_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/hex"
 	"os"
 	"testing"
 
@@ -45,4 +46,12 @@ func TestComputeHexMD5(t *testing.T) {
 
 	hexMD5 := ComputeHexMD5(data)
 	assert.Equal(t, expectedHexMD5, hexMD5)
+}
+
+func TestComputeSHA256(t *testing.T) {
+	data := []byte(`example data`)
+	expectedSHA256 := "44752f37272e944fd2c913a35342eaccdd1aaf189bae50676b301ab213fc5061"
+
+	hexSHA256 := hex.EncodeToString(ComputeSHA256(data))
+	assert.Equal(t, expectedSHA256, hexSHA256)
 }


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-20142](https://wandb.atlassian.net/browse/WB-20142)

Extend `artifacts.FileCache` so that it can restore manifest entries that are references using the etag cache.

Note that this code isn't currently (yet) ever invoked because reference artifacts are still handled in the Python core even when `wandb-core` is enabled, but this will change in a future PR. Since this doesn't cause a user-visible change I'm not updating the changelong.

A future PR <> will add writing through to the cache.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Added new unit tests for new behavior.

There's no test yet that verifies / forces the Go core to use the same cache paths as the Python core, but it's easy to verify that it works.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-20142]: https://wandb.atlassian.net/browse/WB-20142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ