### PR TITLE
refactor(core): Remove unused ctx and fwdChan

### DIFF
--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -194,7 +194,9 @@ func (as *ArtifactSaver) upsertManifest(
 }
 
 func (as *ArtifactSaver) uploadFiles(
-	artifactID string, manifest *Manifest, manifestID string, _ chan<- *service.Record,
+	artifactID string,
+	manifest *Manifest,
+	manifestID string,
 ) error {
 	// Prepare GQL input for files that (might) need to be uploaded.
 	namedFileSpecs := map[string]gql.CreateArtifactFileSpecInput{}
@@ -585,7 +587,11 @@ func (as *ArtifactSaver) resolveClientIDReferences(manifest *Manifest) error {
 	return nil
 }
 
-func (as *ArtifactSaver) uploadManifest(manifestFile string, uploadUrl *string, uploadHeaders []string, _ chan<- *service.Record) error {
+func (as *ArtifactSaver) uploadManifest(
+	manifestFile string,
+	uploadUrl *string,
+	uploadHeaders []string,
+) error {
 	resultChan := make(chan *filetransfer.Task)
 	task := &filetransfer.Task{
 		FileKind: filetransfer.RunFileKindArtifact,
@@ -624,7 +630,7 @@ func (as *ArtifactSaver) deleteStagingFiles(manifest *Manifest) {
 	}
 }
 
-func (as *ArtifactSaver) Save(ch chan<- *service.Record) (artifactID string, rerr error) {
+func (as *ArtifactSaver) Save() (artifactID string, rerr error) {
 	manifest, err := NewManifestFromProto(as.Artifact.Manifest)
 	if err != nil {
 		return "", err
@@ -671,7 +677,7 @@ func (as *ArtifactSaver) Save(ch chan<- *service.Record) (artifactID string, rer
 		return "", fmt.Errorf("ArtifactSaver.createManifest: %w", err)
 	}
 
-	err = as.uploadFiles(artifactID, &manifest, manifestAttrs.Id, ch)
+	err = as.uploadFiles(artifactID, &manifest, manifestAttrs.Id)
 	if err != nil {
 		return "", fmt.Errorf("ArtifactSaver.uploadFiles: %w", err)
 	}
@@ -692,7 +698,7 @@ func (as *ArtifactSaver) Save(ch chan<- *service.Record) (artifactID string, rer
 		return "", fmt.Errorf("ArtifactSaver.upsertManifest: %w", err)
 	}
 
-	err = as.uploadManifest(manifestFile, uploadUrl, uploadHeaders, ch)
+	err = as.uploadManifest(manifestFile, uploadUrl, uploadHeaders)
 	if err != nil {
 		return "", fmt.Errorf("ArtifactSaver.uploadManifest: %w", err)
 	}

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -486,7 +486,7 @@ func (s *Sender) sendJobFlush() {
 	saver := artifacts.NewArtifactSaver(
 		s.ctx, s.logger, s.graphqlClient, s.fileTransferManager, artifact, 0, "",
 	)
-	if _, err = saver.Save(s.fwdChan); err != nil {
+	if _, err = saver.Save(); err != nil {
 		s.logger.Error(
 			"sender: sendDefer: failed to save job artifact", "error", err,
 		)
@@ -1233,7 +1233,7 @@ func (s *Sender) sendArtifact(_ *service.Record, msg *service.ArtifactRecord) {
 	saver := artifacts.NewArtifactSaver(
 		s.ctx, s.logger, s.graphqlClient, s.fileTransferManager, msg, 0, "",
 	)
-	artifactID, err := saver.Save(s.fwdChan)
+	artifactID, err := saver.Save()
 	if err != nil {
 		err = fmt.Errorf("sender: sendArtifact: failed to log artifact ID: %s; error: %s", artifactID, err)
 		s.logger.Error("sender: sendArtifact:", "error", err)
@@ -1246,7 +1246,7 @@ func (s *Sender) sendRequestLogArtifact(record *service.Record, msg *service.Log
 	saver := artifacts.NewArtifactSaver(
 		s.ctx, s.logger, s.graphqlClient, s.fileTransferManager, msg.Artifact, msg.HistoryStep, msg.StagingDir,
 	)
-	artifactID, err := saver.Save(s.fwdChan)
+	artifactID, err := saver.Save()
 	if err != nil {
 		response.ErrorMessage = err.Error()
 	} else {
@@ -1398,7 +1398,7 @@ func (s *Sender) sendRequestStopStatus(record *service.Record, _ *service.StopSt
 
 func (s *Sender) sendRequestSenderRead(_ *service.Record, _ *service.SenderReadRequest) {
 	if s.store == nil {
-		store := NewStore(s.ctx, s.settings.GetSyncFile().GetValue())
+		store := NewStore(s.settings.GetSyncFile().GetValue())
 		err := store.Open(os.O_RDONLY)
 		if err != nil {
 			s.logger.CaptureError(

--- a/core/pkg/server/store.go
+++ b/core/pkg/server/store.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -64,9 +63,6 @@ func (o *HeaderOptions) Valid() bool {
 
 // Store is the persistent store for a stream
 type Store struct {
-	// ctx is the context for the store
-	ctx context.Context
-
 	// name is the name of the underlying file
 	name string
 
@@ -81,8 +77,8 @@ type Store struct {
 }
 
 // NewStore creates a new store
-func NewStore(ctx context.Context, fileName string) *Store {
-	return &Store{ctx: ctx, name: fileName}
+func NewStore(fileName string) *Store {
+	return &Store{name: fileName}
 }
 
 // Open opens the store

--- a/core/pkg/server/store_test.go
+++ b/core/pkg/server/store_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"io"
 	"os"
 	"testing"
@@ -56,7 +55,7 @@ func TestOpenCreateStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 
@@ -70,14 +69,14 @@ func TestOpenReadStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 
 	err = store.Close()
 	assert.NoError(t, err)
 
-	store2 := server.NewStore(context.Background(), tmpFile.Name())
+	store2 := server.NewStore(tmpFile.Name())
 	err = store2.Open(os.O_RDONLY)
 	assert.NoError(t, err)
 
@@ -91,7 +90,7 @@ func TestReadWriteRecord(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 	defer store.Close()
 
 	err = store.Open(os.O_WRONLY)
@@ -105,7 +104,7 @@ func TestReadWriteRecord(t *testing.T) {
 	err = store.Close()
 	assert.NoError(t, err)
 
-	store2 := server.NewStore(context.Background(), tmpFile.Name())
+	store2 := server.NewStore(tmpFile.Name())
 	err = store2.Open(os.O_RDONLY)
 	assert.NoError(t, err)
 	defer store2.Close()
@@ -126,7 +125,7 @@ func TestCorruptFile(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 	defer store.Close()
 
 	err = store.Open(os.O_WRONLY)
@@ -142,7 +141,7 @@ func TestCorruptFile(t *testing.T) {
 	err = store.Close()
 	assert.NoError(t, err)
 
-	store2 := server.NewStore(context.Background(), tmpFile.Name())
+	store2 := server.NewStore(tmpFile.Name())
 	err = store2.Open(os.O_RDONLY)
 	assert.NoError(t, err)
 	defer store2.Close()
@@ -161,7 +160,7 @@ func TestStoreInvalidHeader(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 
 	// Intentionally writing bad header data
 	err = os.WriteFile(tmpFile.Name(), []byte("Invalid"), 0644)
@@ -173,7 +172,7 @@ func TestStoreInvalidHeader(t *testing.T) {
 
 // TestStoreHeader_Write_Error is intended to test the error scenario when writing the header
 func TestStoreHeader_Write_Error(t *testing.T) {
-	store := server.NewStore(context.Background(), "non_existent_dir/file")
+	store := server.NewStore("non_existent_dir/file")
 	err := store.Open(os.O_WRONLY)
 	assert.Error(t, err)
 }
@@ -185,7 +184,7 @@ func TestInvalidFlag(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 	err = store.Open(9999) // 9999 is an invalid flag
 	assert.Errorf(t, err, "invalid flag %d", 9999)
 }
@@ -197,7 +196,7 @@ func TestWriteToClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 
@@ -216,7 +215,7 @@ func TestReadFromClosedStore(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store := server.NewStore(context.Background(), tmpFile.Name())
+	store := server.NewStore(tmpFile.Name())
 	err = store.Open(os.O_WRONLY)
 	assert.NoError(t, err)
 

--- a/core/pkg/server/stream.go
+++ b/core/pkg/server/stream.go
@@ -242,7 +242,7 @@ func NewStream(ctx context.Context, settings *settings.Settings, _ string, sentr
 		},
 	)
 
-	s.writer = NewWriter(s.ctx,
+	s.writer = NewWriter(
 		WriterParams{
 			Logger:   s.logger,
 			Settings: s.settings.Proto,

--- a/core/pkg/server/writer.go
+++ b/core/pkg/server/writer.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -35,9 +34,6 @@ type WriterParams struct {
 // if the message is to be persisted it writes them to the log.
 // It also sends the messages to the sender.
 type Writer struct {
-	// ctx is the context for the writer
-	ctx context.Context
-
 	// settings is the settings for the writer
 	settings *service.Settings
 
@@ -61,9 +57,8 @@ type Writer struct {
 }
 
 // NewWriter returns a new Writer
-func NewWriter(ctx context.Context, params WriterParams) *Writer {
+func NewWriter(params WriterParams) *Writer {
 	w := &Writer{
-		ctx:      ctx,
 		wg:       sync.WaitGroup{},
 		logger:   params.Logger,
 		settings: params.Settings,
@@ -81,7 +76,7 @@ func (w *Writer) startStore() {
 	w.storeChan = make(chan *service.Record, BufferSize*8)
 
 	var err error
-	w.store = NewStore(w.ctx, w.settings.GetSyncFile().GetValue())
+	w.store = NewStore(w.settings.GetSyncFile().GetValue())
 	err = w.store.Open(os.O_WRONLY)
 	if err != nil {
 		w.logger.CaptureFatalAndPanic(


### PR DESCRIPTION
Description
---
Removes instances where the `ctx` or `loopBackChan` is passed but never used to make them easier to reason about.