### PR TITLE
fix(artifacts): skip downloading/uploading gcs folders

### DIFF
--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -150,7 +150,11 @@ class ArtifactManifestEntry:
 
         # Skip checking the cache (and possibly downloading) if the file already exists
         # and has the digest we're expecting.
-        if os.path.exists(dest_path) and self.digest == md5_file_b64(dest_path):
+        if (
+            os.path.exists(dest_path)
+            and not os.path.isdir(dest_path)
+            and self.digest == md5_file_b64(dest_path)
+        ):
             return FilePathStr(dest_path)
 
         if self.ref is not None:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-20135](https://wandb.atlassian.net/browse/WB-20135)
- Fixes [WB-20136](https://wandb.atlassian.net/browse/WB-20136)

This PR does the following:
- on uploading a GCS reference artifact, filters out any objects if their name ends with a forward slash (basically, filters out directories from having a manifest entry created)
- on downloading a GCS reference artifact, we skip downloading if it is a directory
  - if the reference ends with a forward slash OR if it doesnt have an extension and cannot be found unless we add a forward slash, we determine it is a directory (we haven't saved these paths with the final "/" in the manifest entries)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
