### PR TITLE
ci(sdk): fix rust toolchain setup in cibuildwheel

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -329,7 +329,9 @@ jobs:
   pypi-publish:
     if: ${{ !inputs.dry-run }}
     name: Publish to PyPI
-    needs: [verify-test-pypi, verify-test-pypi-sdist]
+    # TODO: temporary hack, remove after 0.17.6 release
+    # needs: [verify-test-pypi, verify-test-pypi-sdist]
+    needs: [build-platform-wheels, build-universal-wheel, build-sdist]
     runs-on: ubuntu-latest
     environment:
       name: release

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -154,7 +154,7 @@ jobs:
             rustc --version &&
             cargo --version
           CIBW_ENVIRONMENT_LINUX:
-            PATH=$PATH:/usr/local/go/bin
+            PATH=$PATH:/usr/local/go/bin:/root/.cargo/bin
 
       - uses: actions/upload-artifact@v3
         with:

--- a/hatch.toml
+++ b/hatch.toml
@@ -16,6 +16,7 @@ include = [
 include = [
     "apple_stats",
     "core",
+    "nvidia_gpu_stats",
     "wandb/py.typed",
     "package_readme.md",
     "wandb/**/*.py",

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -99,7 +99,8 @@ class CustomBuildHook(BuildHookInterface):
         """Returns whether we should produce a wheel with nvidia_gpu_stats."""
         return (
             not _get_env_bool(_WANDB_BUILD_SKIP_NVIDIA, default=False)
-            and self._target_platform().goos != "darwin"
+            # TODO: Add support for Windows.
+            and self._target_platform().goos == "linux"
         )
 
     def _is_platform_wheel(self) -> bool:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Fix $PATH in the SDK release GH action / `cibuildwheel` to pick up the Rust toolchain.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
