### PR TITLE
ci(sdk): set target_commitish in publish-release-notes job in release-sdk GH action

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -371,6 +371,7 @@ jobs:
         with:
           name: v${{ github.event.inputs.version }}
           tag_name: v${{ github.event.inputs.version }}
+          target_commitish: release-${{ github.event.inputs.version }}
           body_path: release_notes.md
           files: |
             wandb-${{ github.event.inputs.version }}.zip


### PR DESCRIPTION
Description
-----------
The release-sdk GH action publishes a draft of Release Notes.
Publishing the generated release notes draft in turn triggers a gh action that generates a new Docs PR.
This PR ensures that target_commitish is pointed at the release branch with the correct released version. (It was pointing by default at main, which obviously has the .dev1 version, so all the generated links in the docs would be wrong)

See https://github.com/softprops/action-gh-release/blob/0ab9029cac4874ac25cd2d941052851bef4d66f4/README.md?plain=1#L191


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
