### PR TITLE
chore(sdk): bump go runtime version to 1.22.6

### DIFF
--- a/.bumpversion.go.cfg
+++ b/.bumpversion.go.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.22.5
+current_version = 1.22.6
 commit = False
 tag = False
 allow_dirty = True

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ parameters:
     default: 1
   go_version:
     type: string
-    default: "1.22.5"
+    default: "1.22.6"
   container_registry:
     type: string
     default: "us-central1-docker.pkg.dev"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,9 +218,16 @@ pip install -U nox uv
 
 ### Setting up Go
 
-Install Go version `1.22.5` following the instructions [here](https://go.dev/doc/install) or using your package manager, for example:
+Install Go version `1.22.6` following the instructions [here](https://go.dev/doc/install) or using your package manager, for example:
 ```shell
 brew install go@1.22
+```
+
+### Setting up Rust on Linux
+
+If you are developing on a Linux machine, you will need the Rust toolchain to build the `nvidia_gpu_stats` binary used to monitor Nvidia GPUs on Linux. Refer to the official Rust [docs](https://www.rust-lang.org/tools/install) and install it by running:
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 ### Building/installing the package

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/wandb/wandb/core
 
-go 1.22.5
+go 1.22.6
 
 require (
 	github.com/Khan/genqlient v0.7.0

--- a/experimental/client-go/go.mod
+++ b/experimental/client-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/wandb/wandb/experimental/client-go
 
-go 1.22.5
+go 1.22.6
 
 require (
 	github.com/wandb/segmentio-encoding v0.0.0-20240626235424-a08f80ebfb91


### PR DESCRIPTION
Description
-----------
Bump go runtime version to 1.22.6.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
