### PR TITLE
chore(sdk): Un-revert #7974

### DIFF
--- a/wandb/integration/openai/fine_tuning.py
+++ b/wandb/integration/openai/fine_tuning.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import io
 import json
@@ -16,13 +17,13 @@ from wandb.util import parse_version
 
 openai = util.get_module(
     name="openai",
-    required="`openai` not installed. This integration requires `openai`. To fix, please `pip install openai`",
-    lazy="False",
+    required="This integration requires `openai`. To install, please run `pip install openai`",
+    lazy=False,
 )
 
-if parse_version(openai.__version__) < parse_version("1.0.1"):
+if parse_version(openai.__version__) < parse_version("1.12.0"):
     raise wandb.Error(
-        f"This integration requires openai version 1.0.1 and above. Your current version is {openai.__version__} "
+        f"This integration requires openai version 1.12.0 and above. Your current version is {openai.__version__} "
         "To fix, please `pip install -U openai`"
     )
 
@@ -228,7 +229,14 @@ class WandbLogger:
         # check results are present
         try:
             results_id = fine_tune.result_files[0]
-            results = cls.openai_client.files.content(file_id=results_id).text
+            try:
+                encoded_results = cls.openai_client.files.content(
+                    file_id=results_id
+                ).read()
+                results = base64.b64decode(encoded_results).decode("utf-8")
+            except Exception:
+                # attempt to read as text, works for older jobs
+                results = cls.openai_client.files.content(file_id=results_id).text
         except openai.NotFoundError:
             if show_individual_warnings:
                 wandb.termwarn(


### PR DESCRIPTION
Description
---
Reapplies #7974 which got erroneously reverted in #8086.

The revert was caused by the PR being updated through the GitHub UI by one contributor while concurrently being updated locally by its author.

---

The details are kind of interesting:

I use spacedentist/spr to manage remote branches for my PRs. `spr` creates commits on the GitHub branch by diffing it against my local state. A merge commit was added to the remote branch by pressing the Update button on GitHub which included the changes from #7974, but my local branch was still based off of an older commit on `main`, so the diff included the inverse of the additional commits from `main`.

This is where things break: Due to the merge commit, the merge base between `main` and the PR branch became the head of `main`, but my PR's diff from `main` included reverting it back to its original base commit on `main`. So squashing the PR onto `main` reverted all changes after the PR's base commit (fortunately this was only a single change).
