### PR TITLE
fix(core): Allow metric to be own step in define_metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Fixed
+
+- Allow `define_metric("x", step_metric="x")` when using core (@timoffex in https://github.com/wandb/wandb/pull/8107)
+
 ## [0.17.6] - 2024-08-08
 
 ### Added

--- a/core/internal/runmetric/runconfigmetrics.go
+++ b/core/internal/runmetric/runconfigmetrics.go
@@ -1,9 +1,6 @@
 package runmetric
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/wandb/wandb/core/internal/corelib"
 	"github.com/wandb/wandb/core/pkg/service"
 )
@@ -30,27 +27,20 @@ func (rcm *RunConfigMetrics) ProcessRecord(record *service.MetricRecord) error {
 //
 // May succeed partially, in which case the returned slice contains all
 // metrics that were successfully encoded and the error is non-nil.
-func (rcm *RunConfigMetrics) ToRunConfigData() ([]map[string]any, error) {
-	var errs []error
+func (rcm *RunConfigMetrics) ToRunConfigData() []map[string]any {
 	var encodedMetrics []map[string]any
 	indexByName := make(map[string]int)
 
 	for name, metric := range rcm.handler.definedMetrics {
-		var err error
-		encodedMetrics, err = rcm.encodeToRunConfigData(
+		encodedMetrics = rcm.encodeToRunConfigData(
 			name,
 			metric,
 			encodedMetrics,
 			indexByName,
-			make(map[string]struct{}),
 		)
-
-		if err != nil {
-			errs = append(errs, err)
-		}
 	}
 
-	return encodedMetrics, errors.Join(errs...)
+	return encodedMetrics
 }
 
 func (rcm *RunConfigMetrics) encodeToRunConfigData(
@@ -58,47 +48,37 @@ func (rcm *RunConfigMetrics) encodeToRunConfigData(
 	metric definedMetric,
 	encodedMetrics []map[string]any,
 	indexByName map[string]int,
-	seenMetrics map[string]struct{},
-) ([]map[string]any, error) {
+) []map[string]any {
 	// Early exit if we already added the metric to the array.
 	if _, processed := indexByName[name]; processed {
-		return encodedMetrics, nil
+		return encodedMetrics
 	}
 
-	// Prevent infinite loops (note: indexByName is updated at the
-	// end of the method, so it's not suitable for this purpose.)
-	if _, seen := seenMetrics[name]; seen {
-		return encodedMetrics, fmt.Errorf("metric '%s' references itself", name)
-	}
-	seenMetrics[name] = struct{}{}
+	index := len(encodedMetrics)
+	indexByName[name] = index
+
+	// Save a spot in encodedMetrics, but encode `record` after we've
+	// fully built it at the end of the method.
+	encodedMetrics = append(encodedMetrics, nil)
 
 	record := metric.ToRecord(name)
+	defer func() {
+		encodedMetrics[index] = corelib.ProtoEncodeToDict(record)
+	}()
 
-	// Encode the step metric first because we need to pass the index
-	// to the UI.
 	if len(metric.Step) > 0 {
-		var err error
-		encodedMetrics, err = rcm.encodeToRunConfigData(
+		// Ensure step has an index.
+		encodedMetrics = rcm.encodeToRunConfigData(
 			metric.Step,
 			// If it doesn't exist, then it's an empty definition which is OK.
 			rcm.handler.definedMetrics[metric.Step],
 			encodedMetrics,
 			indexByName,
-			seenMetrics,
 		)
-
-		if err != nil {
-			return encodedMetrics, fmt.Errorf(
-				"failed to encode metric '%s': %v",
-				name,
-				err,
-			)
-		}
 
 		record.StepMetric = ""
 		record.StepMetricIndex = int32(indexByName[metric.Step] + 1)
 	}
 
-	indexByName[name] = len(encodedMetrics)
-	return append(encodedMetrics, corelib.ProtoEncodeToDict(record)), nil
+	return encodedMetrics
 }

--- a/core/internal/runmetric/runconfigmetrics_test.go
+++ b/core/internal/runmetric/runconfigmetrics_test.go
@@ -11,11 +11,11 @@ import (
 func TestMetricSelfStep(t *testing.T) {
 	rcm := runmetric.NewRunConfigMetrics()
 
-	rcm.ProcessRecord(&service.MetricRecord{
+	_ = rcm.ProcessRecord(&service.MetricRecord{
 		Name:       "x",
 		StepMetric: "y",
 	})
-	rcm.ProcessRecord(&service.MetricRecord{
+	_ = rcm.ProcessRecord(&service.MetricRecord{
 		Name:       "y",
 		StepMetric: "x",
 	})

--- a/core/internal/runmetric/runconfigmetrics_test.go
+++ b/core/internal/runmetric/runconfigmetrics_test.go
@@ -1,0 +1,32 @@
+package runmetric_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/internal/runmetric"
+	"github.com/wandb/wandb/core/pkg/service"
+)
+
+func TestMetricSelfStep(t *testing.T) {
+	rcm := runmetric.NewRunConfigMetrics()
+
+	rcm.ProcessRecord(&service.MetricRecord{
+		Name:       "x",
+		StepMetric: "y",
+	})
+	rcm.ProcessRecord(&service.MetricRecord{
+		Name:       "y",
+		StepMetric: "x",
+	})
+	config := rcm.ToRunConfigData()
+
+	assert.Len(t, config, 2)
+
+	xidx, yidx := 0, 1
+	if config[xidx]["1"] != "x" {
+		xidx, yidx = yidx, xidx
+	}
+	assert.Equal(t, config[xidx]["5"], 1+int64(yidx))
+	assert.Equal(t, config[yidx]["5"], 1+int64(xidx))
+}

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -643,17 +643,10 @@ func (s *Sender) sendUseArtifact(record *service.Record) {
 
 // Inserts W&B-internal information into the run configuration.
 func (s *Sender) updateConfigPrivate() {
-	metrics, err := s.runConfigMetrics.ToRunConfigData()
-
-	if err != nil {
-		s.logger.CaptureError(
-			fmt.Errorf(
-				"sender: failed to encode some metrics in the run config: %v",
-				err,
-			))
-	}
-
-	s.runConfig.AddTelemetryAndMetrics(s.telemetry, metrics)
+	s.runConfig.AddTelemetryAndMetrics(
+		s.telemetry,
+		s.runConfigMetrics.ToRunConfigData(),
+	)
 }
 
 // Serializes the run configuration to send to the backend.


### PR DESCRIPTION
Description
---
WB-20108

Fixes cases like `run.define_metric("x", step_metric="x")` when using core.

Testing
---
Unit test.
