### PR TITLE
fix(core): Use http.NoBody when uploading empty file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Fixed
 
 - Allow `define_metric("x", step_metric="x")` when using core (@timoffex in https://github.com/wandb/wandb/pull/8107)
+- Correctly upload empty files when using core (@timoffex in https://github.com/wandb/wandb/pull/8109)
 
 ## [0.17.6] - 2024-08-08
 


### PR DESCRIPTION
Description
---
WB-18265, WB-20153

Ensures that zero-byte file uploads still include the Content-Length header.

The bug is caused by an interaction between a confusing contract in net/http and a somewhat poor implementation of `NewRequest` in retryablehttp:

* `http.Request.ContentLength == 0` is treated as "unknown". I don't know what that means exactly, but it results in a Content-Length not being sent at least sometimes (if not all the time). I don't know if we're sometimes succeeding without a Content-Length.
* To set an explicit zero ContentLength, net/http expects the body to be the `http.NoBody` constant.
* `retryablehttp.NewRequest` has a type-switch on the body
  * If given a `Reader`, retryablehttp reads the entire body into a buffer after which it checks its length. If the length is zero, it uses `http.NoBody` as the body.
  * But if given a `ReadSeeker`, another case takes priority. Although retryablehttp can infer the content length if the body has a `Len` method (we do), it does not have an `http.NoBody` special case in this branch.
