### PR TITLE
fix(core): fix data race in netrc.go

### DIFF
--- a/core/internal/auth/netrc.go
+++ b/core/internal/auth/netrc.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 )
 
 type netrcLine struct {
@@ -20,13 +19,6 @@ type netrcLine struct {
 	Login    string
 	Password string
 }
-
-var (
-	// netrcOnce sync.Once
-	netrc []netrcLine
-	// netrcErr  error
-	netrcMu sync.Mutex
-)
 
 func parseNetrc(data string) []netrcLine {
 	// See https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
@@ -105,9 +97,6 @@ func NetrcPath() (string, error) {
 }
 
 func ReadNetrc() ([]netrcLine, error) {
-	netrcMu.Lock()
-	defer netrcMu.Unlock()
-
 	path, err := NetrcPath()
 	if err != nil {
 		// netrcErr = err
@@ -116,14 +105,10 @@ func ReadNetrc() ([]netrcLine, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		// if !os.IsNotExist(err) {
-		// 	netrcErr = err
-		// }
 		return []netrcLine{}, err
 	}
 
-	netrc = parseNetrc(string(data))
-	return netrc, nil
+	return parseNetrc(string(data)), nil
 }
 
 func GetNetrcLogin(machine string) (string, string, error) {

--- a/core/internal/auth/netrc.go
+++ b/core/internal/auth/netrc.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	// "sync"
+	"sync"
 )
 
 type netrcLine struct {
@@ -25,6 +25,7 @@ var (
 	// netrcOnce sync.Once
 	netrc []netrcLine
 	// netrcErr  error
+	netrcMu sync.Mutex
 )
 
 func parseNetrc(data string) []netrcLine {
@@ -104,6 +105,9 @@ func NetrcPath() (string, error) {
 }
 
 func ReadNetrc() ([]netrcLine, error) {
+	netrcMu.Lock()
+	defer netrcMu.Unlock()
+
 	path, err := NetrcPath()
 	if err != nil {
 		// netrcErr = err


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Triggered a data race with this simple script:

```python
import multiprocessing

import wandb


def run_experiment(params):
    with wandb.init(config=params):
        # Run experiment
        pass


if __name__ == "__main__":
    # Start backend and set global config
    wandb.setup(settings={"project": "my_project"})

    # Define experiment parameters
    experiment_params = [
        {"learning_rate": 0.01, "epochs": 10},
        {"learning_rate": 0.001, "epochs": 20},
    ]

    # Start multiple processes, each running a separate experiment
    processes = []
    for params in experiment_params:
        p = multiprocessing.Process(target=run_experiment, args=(params,))
        p.start()
        processes.append(p)

    # Wait for all processes to complete
    for p in processes:
        p.join()

    # Optional: Explicitly shut down the backend
    wandb.teardown()
```

```
wandb: Using wandb-core as the SDK backend. Please refer to https://wandb.me/wandb-core for more information.
warning: GOCOVERDIR not set, no coverage data emitted
wandb: Currently logged in as: dima. Use `wandb login --relogin` to force relogin
wandb: Currently logged in as: dima. Use `wandb login --relogin` to force relogin
==================
WARNING: DATA RACE
Write at 0x00010115e080 by goroutine 22:
  github.com/wandb/wandb/core/internal/auth.ReadNetrc()
      /Users/dimaduev/dev/sdk/core/internal/auth/netrc.go:121 +0xe0
  github.com/wandb/wandb/core/internal/auth.GetNetrcLogin()
      /Users/dimaduev/dev/sdk/core/internal/auth/netrc.go:126 +0x7c
  github.com/wandb/wandb/core/internal/settings.(*Settings).EnsureAPIKey()
      /Users/dimaduev/dev/sdk/core/internal/settings/settings.go:45 +0x390
  github.com/wandb/wandb/core/pkg/server.(*Connection).handleInformInit()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:261 +0x1b0
  github.com/wandb/wandb/core/pkg/server.(*Connection).handleServerRequest()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:229 +0x408
  github.com/wandb/wandb/core/pkg/server.(*Connection).HandleConnection.func2()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:98 +0x44

Previous write at 0x00010115e080 by goroutine 19:
  github.com/wandb/wandb/core/internal/auth.ReadNetrc()
      /Users/dimaduev/dev/sdk/core/internal/auth/netrc.go:121 +0xe0
  github.com/wandb/wandb/core/internal/auth.GetNetrcLogin()
      /Users/dimaduev/dev/sdk/core/internal/auth/netrc.go:126 +0x7c
  github.com/wandb/wandb/core/internal/settings.(*Settings).EnsureAPIKey()
      /Users/dimaduev/dev/sdk/core/internal/settings/settings.go:45 +0x390
  github.com/wandb/wandb/core/pkg/server.(*Connection).handleInformInit()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:261 +0x1b0
  github.com/wandb/wandb/core/pkg/server.(*Connection).handleServerRequest()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:229 +0x408
  github.com/wandb/wandb/core/pkg/server.(*Connection).HandleConnection.func2()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:98 +0x44

Goroutine 22 (running) created at:
  github.com/wandb/wandb/core/pkg/server.(*Connection).HandleConnection()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:97 +0x288
  github.com/wandb/wandb/core/pkg/server.(*Server).serve.func1()
      /Users/dimaduev/dev/sdk/core/pkg/server/server.go:152 +0xa4

Goroutine 19 (running) created at:
  github.com/wandb/wandb/core/pkg/server.(*Connection).HandleConnection()
      /Users/dimaduev/dev/sdk/core/pkg/server/connection.go:97 +0x288
  github.com/wandb/wandb/core/pkg/server.(*Server).serve.func1()
      /Users/dimaduev/dev/sdk/core/pkg/server/server.go:152 +0xa4
==================
wandb: Tracking run with wandb version 0.17.7.dev1
wandb: Run data is saved locally in /Users/dimaduev/dev/sdk/.wandb/run-20240813_131400-ollgx2vs
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run vibrant-energy-10
wandb: ⭐️ View project at http://localhost:8080/dima/sdk
wandb: 🚀 View run at http://localhost:8080/dima/sdk/runs/ollgx2vs
wandb: Tracking run with wandb version 0.17.7.dev1
wandb: Run data is saved locally in /Users/dimaduev/dev/sdk/.wandb/run-20240813_131400-cyjt1gyi
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run breezy-smoke-10
wandb: ⭐️ View project at http://localhost:8080/dima/sdk
wandb: 🚀 View run at http://localhost:8080/dima/sdk/runs/cyjt1gyi
wandb:                                                                                
wandb:                                                                                
wandb: 🚀 View run vibrant-energy-10 at: http://localhost:8080/dima/sdk/runs/ollgx2vs
wandb: ⭐️ View project at: http://localhost:8080/dima/sdk
wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./.wandb/run-20240813_131400-ollgx2vs/logs
wandb: 🚀 View run breezy-smoke-10 at: http://localhost:8080/dima/sdk/runs/cyjt1gyi
wandb: ⭐️ View project at: http://localhost:8080/dima/sdk
wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./.wandb/run-20240813_131400-cyjt1gyi/logs
Found 1 data race(s)
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
