### PR TITLE
chore(sdk): bump version in stubs

### DIFF
--- a/.bumpversion.wandb.cfg
+++ b/.bumpversion.wandb.cfg
@@ -35,6 +35,14 @@ values =
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
+[bumpversion:file:wandb/__init__.pyi]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:wandb/__init__.template.pyi]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
 [bumpversion:file:core/internal/version/version.go]
 search = Version = "{current_version}"
 replace = Version = "{new_version}"


### PR DESCRIPTION
Description
-----------
Include the `__init__.pyi` and `__init__.template.pyi` files in the bumpversion config since both have `__version__`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
