### PR TITLE
chore(sdk): Bump _communicate default timeout to 30s

### DIFF
--- a/.bumpversion.wandb.cfg
+++ b/.bumpversion.wandb.cfg
@@ -35,6 +35,14 @@ values =
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
+[bumpversion:file:wandb/__init__.pyi]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:wandb/__init__.template.pyi]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
 [bumpversion:file:core/internal/version/version.go]
 search = Version = "{current_version}"
 replace = Version = "{new_version}"


### PR DESCRIPTION
Description
---
Bumps an internal timeout to 30s to potentially help with an issue where the 5s timeout may be hit during `wandb.init()` on certain systems.