### PR TITLE
chore(sdk): communicate_status => deliver_status

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -114,15 +114,14 @@ class InterfaceBase:
     def _publish_header(self, header: pb.HeaderRecord) -> None:
         raise NotImplementedError
 
-    def communicate_status(self) -> Optional[pb.StatusResponse]:
-        status = pb.StatusRequest()
-        resp = self._communicate_status(status)
-        return resp
+    def deliver_status(self) -> MailboxHandle:
+        return self._deliver_status(pb.StatusRequest())
 
     @abstractmethod
-    def _communicate_status(
-        self, status: pb.StatusRequest
-    ) -> Optional[pb.StatusResponse]:
+    def _deliver_status(
+        self,
+        status: pb.StatusRequest,
+    ) -> MailboxHandle:
         raise NotImplementedError
 
     def _make_config(

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -421,15 +421,12 @@ class InterfaceShared(InterfaceBase):
         rec = self._make_record(alert=proto_alert)
         self._publish(rec)
 
-    def _communicate_status(
-        self, status: pb.StatusRequest
-    ) -> Optional[pb.StatusResponse]:
+    def _deliver_status(
+        self,
+        status: pb.StatusRequest,
+    ) -> MailboxHandle:
         req = self._make_request(status=status)
-        resp = self._communicate(req, local=True)
-        if resp is None:
-            return None
-        assert resp.response.status_response
-        return resp.response.status_response
+        return self._deliver_record(req)
 
     def _publish_exit(self, exit_data: pb.RunExitRecord) -> None:
         rec = self._make_record(exit=exit_data)

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -745,8 +745,6 @@ class HandleManager:
         self._respond_result(result)
 
     def handle_request_status(self, record: Record) -> None:
-        # TODO(mempressure): do something better?
-        assert record.control.req_resp
         result = proto_util._result_from_record(record)
         self._respond_result(result)
 

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -81,9 +81,7 @@ class StreamRecord:
         self._wait_thread_active()
 
     def _wait_thread_active(self) -> None:
-        result = self._iface.communicate_status()
-        # TODO: using the default communicate timeout, is that enough? retries?
-        assert result
+        self._iface.deliver_status().wait(timeout=-1)
 
     def join(self) -> None:
         self._iface.join()


### PR DESCRIPTION
Description
---
Replaces `communicate_status()`, which uses the deprecated "communicate" verb and MessageRouter path, by `deliver_status()` which uses the newer Mailbox.

This changes a method in `streams.py` to wait indefinitely rather than with a 5s timeout. Users that previously hit the `AssertionError` in that method will now see either:

* A success, if the 5s timeout was just not enough (what we expect)
* A hanging process, if a response was never going to happen. This would be a bug.

We do not currently have a mechanism to propagate deadlines, but it would be more appropriate than using an indefinite timeout. The goal of this PR is to replace a deprecated codepath.

Testing
---
A simple `wandb.init()` script with `WANDB__REQUIRE_CORE=false` to trigger the `streams.py` change.

I grepped for "communicate_status" in the codebase to find all usages.
