### PR TITLE
fix(core): Fix interface conversion error

### DIFF
--- a/core/internal/pathtree/pathtree.go
+++ b/core/internal/pathtree/pathtree.go
@@ -196,7 +196,8 @@ func (pt *PathTree) GetOrMakeLeaf(
 	subtree := pt.getOrMakeSubtree(path.Prefix())
 
 	value, exists := subtree[path.End()]
-	if !exists {
+	_, isTree := value.(*treeData)
+	if !exists || isTree {
 		value = makeDefault()
 		subtree[path.End()] = value
 	}

--- a/core/internal/pathtree/pathtree.go
+++ b/core/internal/pathtree/pathtree.go
@@ -176,16 +176,12 @@ func (pt *PathTree) GetLeaf(path TreePath) (any, bool) {
 	}
 
 	value, exists := subtree[path.End()]
-	if !exists {
+	_, isTree := value.(treeData)
+	if !exists || isTree {
 		return nil, false
 	}
 
-	switch value.(type) {
-	case treeData:
-		return nil, false
-	default:
-		return value, true
-	}
+	return value, true
 }
 
 // GetOrMakeLeaf returns the leaf value at path, creating one if necessary.
@@ -196,7 +192,7 @@ func (pt *PathTree) GetOrMakeLeaf(
 	subtree := pt.getOrMakeSubtree(path.Prefix())
 
 	value, exists := subtree[path.End()]
-	_, isTree := value.(*treeData)
+	_, isTree := value.(treeData)
 	if !exists || isTree {
 		value = makeDefault()
 		subtree[path.End()] = value

--- a/core/internal/pathtree/pathtree_test.go
+++ b/core/internal/pathtree/pathtree_test.go
@@ -96,6 +96,15 @@ func TestGetLeaf_PathIsNotLeaf(t *testing.T) {
 	assert.Nil(t, x)
 }
 
+func TestGetOrMakeLeaf_PathIsNotLeaf(t *testing.T) {
+	tree := pathtree.New()
+
+	tree.Set(pathtree.PathOf("a", "b"), 1)
+
+	x := tree.GetOrMakeLeaf(pathtree.PathOf("a"), func() any { return 2 })
+	assert.Equal(t, 2, x)
+}
+
 func TestFlatten(t *testing.T) {
 	tree := pathtree.New()
 

--- a/core/internal/pathtree/pathtree_test.go
+++ b/core/internal/pathtree/pathtree_test.go
@@ -86,6 +86,16 @@ func TestGetLeaf_UnderLeaf(t *testing.T) {
 	assert.Nil(t, x)
 }
 
+func TestGetLeaf_PathIsNotLeaf(t *testing.T) {
+	tree := pathtree.New()
+
+	tree.Set(pathtree.PathOf("a", "b"), 1)
+
+	x, exists := tree.GetLeaf(pathtree.PathOf("a"))
+	assert.False(t, exists)
+	assert.Nil(t, x)
+}
+
 func TestFlatten(t *testing.T) {
 	tree := pathtree.New()
 


### PR DESCRIPTION
Description
---
Fixes WB-20379.

Fixes a panic caused due to an incorrect interface conversion. This can happen if a user logs a metric at a nested path followed by a metric at a subpath of that path.