### PR TITLE
chore(sdk): ensure generating module stubs works on py<3.9

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 -r requirements_test.txt
 
-pytest
+astunparse; python_version < '3.9'
+
 hypothesis
 hypothesis-fspaths
 

--- a/tools/generate_stubs.py
+++ b/tools/generate_stubs.py
@@ -38,8 +38,16 @@ Note:
 import ast
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Dict, Optional
+
+if sys.version_info >= (3, 9):
+    unparse = ast.unparse
+else:
+    import astunparse
+
+    unparse = astunparse.unparse
 
 
 def extract_docstring(file_path: Path, location: str) -> Optional[str]:
@@ -219,8 +227,8 @@ def verify_signatures(wandb_root: Path, output: str, template: str) -> int:
                 source_args.defaults,
             )
 
-        source_sig = ast.unparse(source_args)
-        output_sig = ast.unparse(output_func.args)
+        source_sig = unparse(source_args)
+        output_sig = unparse(output_func.args)
 
         if source_sig != output_sig:
             print(f"Signature mismatch for '{func_name}':")


### PR DESCRIPTION
Description
-----------
generate_stubs.py used in pre-push hook requires a new-ish feature of `ast`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
