### PR TITLE
fix(core): ensure nvidia_gpu_stats captures gpu metrics when libnvidia-ml.so is unavailable

### DIFF
--- a/nvidia_gpu_stats/src/gpu_nvidia.rs
+++ b/nvidia_gpu_stats/src/gpu_nvidia.rs
@@ -2,7 +2,6 @@ use crate::metrics::Metrics;
 use nvml_wrapper::enum_wrappers::device::{Clock, TemperatureSensor};
 use nvml_wrapper::error::NvmlError;
 use nvml_wrapper::{Device, Nvml};
-use std::ffi::OsStr;
 use sysinfo::{Pid, System};
 
 pub struct NvidiaGpu {
@@ -18,7 +17,7 @@ impl NvidiaGpu {
         // We follow go-nvml example and attempt to load libnvidia-ml.so.1 directly, see:
         // https://github.com/NVIDIA/go-nvml/blob/0e815c71ca6e8184387d8b502b2ef2d2722165b9/pkg/nvml/lib.go#L30
         let nvml = Nvml::builder()
-            .lib_path(OsStr::new("libnvidia-ml.so.1"))
+            .lib_path("libnvidia-ml.so.1".as_ref())
             .init()?;
         let cuda_version = nvml.sys_cuda_driver_version()?;
         format!(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-20394
- Fixes #8137

The Cldfire/nvml-wrapper crate we use in nvidia_gpu_stats by default looks for `libnvidia-ml.so`, which is normally just a symlink to `libnvidia-ml.so.1` and not always available.

To solve, we follow go-nvml: [go-nvml/pkg/nvml/lib.go at 0e815c71ca6e8184387d8b502b2ef2d2722165b9 · NVIDIA/go-nvml](https://github.com/NVIDIA/go-nvml/blob/0e815c71ca6e8184387d8b502b2ef2d2722165b9/pkg/nvml/lib.go#L30) and attempt to directly load `libnvidia-ml.so.1`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
