### PR TITLE
fix(core): Don't send summary/config after finishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Allow `define_metric("x", step_metric="x")` when using core (@timoffex in https://github.com/wandb/wandb/pull/8107)
 - Correctly upload empty files when using core (@timoffex in https://github.com/wandb/wandb/pull/8109)
+- Fix occasional "send on closed channel" panic when finishing a run using core (@timoffex in https://github.com/wandb/wandb/pull/8140)
 
 ## [0.17.6] - 2024-08-08
 

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -514,12 +514,14 @@ func (s *Sender) sendRequestDefer(request *service.DeferRequest) {
 		s.fwdRequestDefer(request)
 	case service.DeferRequest_FLUSH_SUM:
 		s.summaryDebouncer.Flush(s.streamSummary)
+		s.summaryDebouncer.Stop()
 		s.uploadSummaryFile()
 		request.State++
 		s.fwdRequestDefer(request)
 	case service.DeferRequest_FLUSH_DEBOUNCER:
 		s.configDebouncer.SetNeedsDebounce()
 		s.configDebouncer.Flush(s.upsertConfig)
+		s.configDebouncer.Stop()
 		s.uploadConfigFile()
 		request.State++
 		s.fwdRequestDefer(request)


### PR DESCRIPTION
Description
---
Fixes WB-20395.

`Sender.Do()` invokes `Debounce()` after every record, potentially trying to send summary or config updates after the shutdown logic in the corresponding "defer" step. This PR adds a `Stop` method to `Debouncer` and calls it in the summary and config "defer" logic.
