### PR TITLE
chore(core): add ability to disable sentry reporting in nvidia_gpu_stats

### DIFF
--- a/nvidia_gpu_stats/src/main.rs
+++ b/nvidia_gpu_stats/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use nix::unistd::getppid;
+use sentry::types::Dsn;
 use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
+use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -29,18 +31,35 @@ struct Args {
     interval: f64,
 }
 
+fn parse_bool(s: &str) -> bool {
+    match s.to_lowercase().as_str() {
+        "true" | "1" => true,
+        "false" | "0" => false,
+        _ => true,
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse command-line arguments
     let args = Args::parse();
 
-    // initialize Sentry
-    let _guard = sentry::init((
-        "https://9e9d0694aa7ccd41aeb5bc34aadd716a@o151352.ingest.us.sentry.io/4506068829470720",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            ..Default::default()
-        },
-    ));
+    let error_reporting_enabled = env::var("WANDB_ERROR_REPORTING")
+        .map(|v| parse_bool(&v))
+        .unwrap_or(true);
+
+    let dsn: Option<Dsn> = if error_reporting_enabled {
+        "https://9e9d0694aa7ccd41aeb5bc34aadd716a@o151352.ingest.us.sentry.io/4506068829470720"
+            .parse()
+            .ok()
+    } else {
+        None
+    };
+
+    let _guard = sentry::init(sentry::ClientOptions {
+        dsn,
+        release: sentry::release_name!(),
+        ..Default::default()
+    });
 
     // Initialize NVIDIA GPU
     let nvidia_gpu = NvidiaGpu::new().map_err(|e| {


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-20399

Make `nvidia_gpu_stats` respect the WANDB_ERROR_REPORTING env var.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
