### PR TITLE
fix(core): capture broken pipe panic in nvidia_gpu_stats

### DIFF
--- a/nvidia_gpu_stats/src/metrics.rs
+++ b/nvidia_gpu_stats/src/metrics.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::io;
 
 /// System metrics storage.
 ///
@@ -28,7 +29,7 @@ impl Metrics {
     }
 
     /// Print the metrics as a JSON string to stdout.
-    pub fn print_json(&self) -> Result<(), serde_json::Error> {
+    pub fn print_json(&self) -> io::Result<()> {
         let json_output = serde_json::to_string(&self.metrics)?;
         println!("{}", json_output);
         Ok(())


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Fixes WB-20405

Gracefully capture broken pipe panic in nvidia_gpu_stats.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
