### PR TITLE
fix(core): Exit if parent dies even after teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Capture SM (Streaming Multiprocessor), memory, and graphics clock speed (MHz), (un)corrected error counts, fan speed (%), and encoder utilization for Nvidia GPU devices when using core (@dmitryduev in https://github.com/wandb/wandb/pull/8144)
 
+### Fixed
+
+- Kill service process if user process dies even after a teardown signal (@timoffex in https://github.com/wandb/wandb/pull/8153)
+
 ## [0.17.7] - 2024-08-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ### Fixed
 
-- Kill service process if user process dies even after a teardown signal (@timoffex in https://github.com/wandb/wandb/pull/8153)
+- Avoid leaving behind wandb-core process if user hits Ctrl+C twice (@timoffex in https://github.com/wandb/wandb/pull/8153)
 
 ## [0.17.7] - 2024-08-15
 

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -118,7 +118,5 @@ func main() {
 		return
 	}
 	srv.SetDefaultLoggerPath(loggerPath)
-	srv.Start()
-	srv.Wait()
-	srv.Close()
+	srv.Serve()
 }

--- a/core/pkg/server/server.go
+++ b/core/pkg/server/server.go
@@ -92,7 +92,9 @@ func NewServer(
 
 // exitWhenParentIsGone exits the process if the parent process is killed.
 func (s *Server) exitWhenParentIsGone() {
-	for os.Getppid() != s.parentPid {
+	slog.Info("Will exit if parent process dies.", "ppid", s.parentPid)
+
+	for os.Getppid() == s.parentPid {
 		time.Sleep(IntervalCheckParentPidMilliseconds * time.Millisecond)
 	}
 


### PR DESCRIPTION
Description
---
Fixes WB-19983.

When a user hits Ctrl+C twice, the service process receives a teardown signal (first Ctrl+C) and the user's process is killed (second Ctrl+C, while in an atexit handler). When this happens, the service process should shut itself down immediately rather than waiting for uploads to complete.
