### PR TITLE
fix(core): Don't retry HTTP 422

### DIFF
--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -136,10 +136,14 @@ func (fs *fileStream) send(
 	case resp.StatusCode < 200 || resp.StatusCode > 300:
 		// If we reach here, that means all retries were exhausted. This could
 		// mean, for instance, that the user's internet connection broke.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+		_ = resp.Body.Close()
+
 		return fmt.Errorf(
-			"filestream: failed to upload: %v path=%v",
+			"filestream: failed to upload: %v path=%v: %s",
 			resp.Status,
 			req.Path,
+			string(body),
 		)
 	}
 

--- a/core/internal/filestream/retry_policy.go
+++ b/core/internal/filestream/retry_policy.go
@@ -63,6 +63,8 @@ func RetryPolicy(
 		return false, nil
 	case http.StatusRequestEntityTooLarge: // don't retry on 413 Content Too Large
 		return false, nil
+	case http.StatusUnprocessableEntity: // don't retry on 422 Unprocessable Content
+		return false, nil
 	case http.StatusNotImplemented: // don't retry on 501 not implemented
 		return false, nil
 	}


### PR DESCRIPTION
Description
---
Don't retry HTTP 422 Unprocessable Content errors in filestream.
