### PR TITLE
chore(core): temporarily disable artifact downloads with core

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1658,13 +1658,14 @@ class Artifact:
         if env.is_offline() or util._is_offline():
             raise RuntimeError("Cannot download artifacts in offline mode.")
 
-        if is_require_core():
-            return self._download_using_core(
-                root=root,
-                allow_missing_references=allow_missing_references,
-                skip_cache=bool(skip_cache),
-                path_prefix=path_prefix,
-            )
+        # TODO: re-enable this once artifact download with core is re-implemented
+        # if is_require_core():
+        #     return self._download_using_core(
+        #         root=root,
+        #         allow_missing_references=allow_missing_references,
+        #         skip_cache=bool(skip_cache),
+        #         path_prefix=path_prefix,
+        #     )
         return self._download(
             root=root,
             allow_missing_references=allow_missing_references,
@@ -1693,6 +1694,7 @@ class Artifact:
             settings = wl.settings.to_proto()
             # TODO: remove this
             tmp_dir = pathlib.Path(tempfile.mkdtemp())
+
             settings.sync_dir.value = str(tmp_dir)
             settings.sync_file.value = str(tmp_dir / f"{stream_id}.wandb")
             settings.files_dir.value = str(tmp_dir / "files")
@@ -1737,11 +1739,6 @@ class Artifact:
         if response.error_message:
             raise ValueError(f"Error downloading artifact: {response.error_message}")
 
-        if wandb.run is None:
-            backend.cleanup()
-            # TODO: remove this
-            shutil.rmtree(tmp_dir)
-
         return FilePathStr(root)
 
     def _download(
@@ -1751,8 +1748,8 @@ class Artifact:
         skip_cache: Optional[bool] = None,
         path_prefix: Optional[StrPath] = None,
     ) -> FilePathStr:
-        # todo: remove once artifact reference downloads are supported in core
-        require_core = is_require_core()
+        # TODO: remove once artifact reference downloads are supported in core
+        # require_core = is_require_core()
 
         nfiles = len(self.manifest.entries)
         size = sum(e.size or 0 for e in self.manifest.entries.values())
@@ -1804,9 +1801,10 @@ class Artifact:
                 cursor = attrs["pageInfo"]["endCursor"]
                 for edge in attrs["edges"]:
                     entry = self.get_entry(edge["node"]["name"])
-                    if require_core and entry.ref is None:
-                        # Handled by core
-                        continue
+                    # TODO: uncomment once artifact downloads are supported in core
+                    # if require_core and entry.ref is None:
+                    #     # Handled by core
+                    #     continue
                     entry._download_url = edge["node"]["directUrl"]
                     if (not path_prefix) or entry.path.startswith(str(path_prefix)):
                         active_futures.add(executor.submit(download_entry, entry))

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -171,10 +171,12 @@ class RunStatusChecker:
         interface: InterfaceBase,
         stop_polling_interval: int = 15,
         retry_polling_interval: int = 5,
+        internal_messages_polling_interval: int = 10,
     ) -> None:
         self._interface = interface
         self._stop_polling_interval = stop_polling_interval
         self._retry_polling_interval = retry_polling_interval
+        self._internal_messages_polling_interval = internal_messages_polling_interval
 
         self._join_event = threading.Event()
 
@@ -323,7 +325,7 @@ class RunStatusChecker:
             self._loop_check_status(
                 lock=self._internal_messages_lock,
                 set_handle=lambda x: setattr(self, "_internal_messages_handle", x),
-                timeout=1,
+                timeout=self._internal_messages_polling_interval,
                 request=self._interface.deliver_internal_messages,
                 process=_process_internal_messages,
             )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Hopefully fixes WB-20421.

`wandb/sdk/artifacts/artifact.py::_download_using_core` comes with an overhead of `wandb-core` / stream management in a non-standard way resulting in a significant slowdown compared to the non-core path. 
Note that the latter does not use `wandb-service` and instead does everything in the user process.

Disabled the codepath using core for now until a refactor is done.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
