### PR TITLE
refactor(sdk): Move unregister_all_post_import_hooks

### DIFF
--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -13,7 +13,6 @@ import wandb
 from wandb import env, trigger
 from wandb.errors import Error
 from wandb.sdk.lib.exit_hooks import ExitHooks
-from wandb.sdk.lib.import_hooks import unregister_all_post_import_hooks
 
 if TYPE_CHECKING:
     from wandb.proto import wandb_settings_pb2

--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -163,8 +163,6 @@ class _Manager:
         This sends a teardown record to the process. An exception is raised if
         the process has already been shut down.
         """
-        unregister_all_post_import_hooks()
-
         if self._atexit_lambda:
             atexit.unregister(self._atexit_lambda)
             self._atexit_lambda = None

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -18,6 +18,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import wandb
+from wandb.sdk.lib import import_hooks
 
 from . import wandb_manager, wandb_settings
 from .lib import config_util, server, tracelog
@@ -268,6 +269,8 @@ class _WandbSetup__WandbSetup:  # noqa: N801
                     self._config = config_dict
 
     def _teardown(self, exit_code: Optional[int] = None) -> None:
+        import_hooks.unregister_all_post_import_hooks()
+
         if not self._manager:
             return
 


### PR DESCRIPTION
Description
---
Instead of doing this in the WandbManager which is responsible for the service process, do it in WandbSetup. This ensures that we run `unregister_all_post_import_hooks` if the user does `wandb.teardown()`; an implicit atexit teardown does not do this, but I don't think it matters since the process is exiting at that point.
