### PR TITLE
chore(sdk): bump version to 0.17.9.dev1

### DIFF
--- a/.bumpversion.wandb.cfg
+++ b/.bumpversion.wandb.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.8.dev1
+current_version = 0.17.8
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/.bumpversion.wandb.cfg
+++ b/.bumpversion.wandb.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.8
+current_version = 0.17.9.dev1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+## [0.17.8] - 2024-08-28
+
 ### Added
 
 - Capture SM (Streaming Multiprocessor), memory, and graphics clock speed (MHz), (un)corrected error counts, fan speed (%), and encoder utilization for Nvidia GPU devices when using core (@dmitryduev in https://github.com/wandb/wandb/pull/8144)

--- a/core/internal/version/version.go
+++ b/core/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 import "strings"
 
-const Version = "0.17.8"
+const Version = "0.17.9.dev1"
 
 const MinServerVersion = "0.40.0"
 

--- a/core/internal/version/version.go
+++ b/core/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 import "strings"
 
-const Version = "0.17.8.dev1"
+const Version = "0.17.8"
 
 const MinServerVersion = "0.40.0"
 

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -8,7 +8,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.17.8"
+__version__ = "0.17.9.dev1"
 
 from typing import Optional
 

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -8,7 +8,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.17.8.dev1"
+__version__ = "0.17.8"
 
 from typing import Optional
 

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -75,7 +75,7 @@ from wandb.sdk.wandb_run import Run
 from wandb.sdk.wandb_setup import _WandbSetup
 from wandb.wandb_controller import _WandbController
 
-__version__: str = "0.17.8"
+__version__: str = "0.17.9.dev1"
 
 run: Optional[Run] = None
 config = wandb_config.Config

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -75,7 +75,7 @@ from wandb.sdk.wandb_run import Run
 from wandb.sdk.wandb_setup import _WandbSetup
 from wandb.wandb_controller import _WandbController
 
-__version__: str = "0.17.8.dev1"
+__version__: str = "0.17.8"
 
 run: Optional[Run] = None
 config = wandb_config.Config

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -75,7 +75,7 @@ from wandb.sdk.wandb_run import Run
 from wandb.sdk.wandb_setup import _WandbSetup
 from wandb.wandb_controller import _WandbController
 
-__version__: str = "0.17.8"
+__version__: str = "0.17.9.dev1"
 
 run: Optional[Run] = None
 config = wandb_config.Config

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -75,7 +75,7 @@ from wandb.sdk.wandb_run import Run
 from wandb.sdk.wandb_setup import _WandbSetup
 from wandb.wandb_controller import _WandbController
 
-__version__: str = "0.17.8.dev1"
+__version__: str = "0.17.8"
 
 run: Optional[Run] = None
 config = wandb_config.Config


### PR DESCRIPTION
Description
-----------
[chore(sdk): bump version to 0.17.9.dev1](https://github.com/wandb/wandb/commit/03f7f43b385a3b17f9239c5f49a8344fdc3a468b)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
