### PR TITLE
chore(core): add SLURM asset to capture SLURM-related env vars

### DIFF
--- a/core/pkg/monitor/slurm.go
+++ b/core/pkg/monitor/slurm.go
@@ -1,0 +1,56 @@
+package monitor
+
+import (
+	"os"
+	"strings"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// SLURM is used to capture SLURM-related environment variables
+type SLURM struct {
+	name string
+}
+
+func getSlurmEnvVars() map[string]string {
+	// capture SLURM-related environment variables
+	slurmVars := make(map[string]string)
+	for _, envVar := range os.Environ() {
+		keyValPair := strings.SplitN(envVar, "=", 2)
+		key := keyValPair[0]
+		value := keyValPair[1]
+
+		if strings.HasPrefix(key, "SLURM_") {
+			suffix := strings.ToLower(strings.TrimPrefix(key, "SLURM_"))
+			slurmVars[suffix] = value
+		}
+	}
+	return slurmVars
+}
+
+func NewSLURM() *SLURM {
+	return &SLURM{name: "slurm"}
+}
+
+func (g *SLURM) Name() string { return g.name }
+
+func (g *SLURM) Sample() (map[string]any, error) { return nil, nil }
+
+func (g *SLURM) IsAvailable() bool { return false }
+
+func (g *SLURM) Probe() *spb.MetadataRequest {
+	slurmVars := getSlurmEnvVars()
+	if len(slurmVars) == 0 {
+		return nil
+	}
+
+	systemInfo := &spb.MetadataRequest{}
+	for k, v := range getSlurmEnvVars() {
+		if systemInfo.Slurm == nil {
+			systemInfo.Slurm = make(map[string]string)
+		}
+		systemInfo.Slurm[k] = v
+	}
+
+	return systemInfo
+}

--- a/core/pkg/monitor/slurm_test.go
+++ b/core/pkg/monitor/slurm_test.go
@@ -1,0 +1,52 @@
+package monitor_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wandb/wandb/core/pkg/monitor"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestSLURMProbe(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		expected *spb.MetadataRequest
+	}{
+		{
+			name: "With SLURM environment variables",
+			envVars: map[string]string{
+				"SLURM_JOB_ID":   "12345",
+				"SLURM_JOB_NAME": "test_job",
+			},
+			expected: &spb.MetadataRequest{
+				Slurm: map[string]string{
+					"job_id":   "12345",
+					"job_name": "test_job",
+				},
+			},
+		},
+		{
+			name:     "Without SLURM environment variables",
+			envVars:  map[string]string{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up the test environment
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			slurm := monitor.NewSLURM()
+			result := slurm.Probe()
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Probe() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Description
-----------
Use a special asset to capture SLURM-related env vars.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
