### PR TITLE
refactor(core): Don't AlwaysSend Header record

### DIFF
--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -491,12 +491,7 @@ func (h *Handler) handleHeader(record *spb.Record) {
 		Producer:    versionString,
 		MinConsumer: version.MinServerVersion,
 	}
-	h.fwdRecordWithControl(
-		record,
-		func(control *spb.Control) {
-			control.AlwaysSend = false
-		},
-	)
+	h.fwdRecord(record)
 }
 
 func (h *Handler) handleRequestServerInfo(record *spb.Record) {


### PR DESCRIPTION
Description
---
The Header record is a no-op in the Sender, so there's no point in marking it "AlwaysSend" (which is a hacky mechanism to get records to the Sender in offline mode).
