### PR TITLE
refactor(core): Refactor fwdRecord for remaining Handler records

### DIFF
--- a/core/pkg/server/handler.go
+++ b/core/pkg/server/handler.go
@@ -1101,9 +1101,11 @@ func (h *Handler) flushPartialHistory(useStep bool, nextStep int64) {
 	for _, newMetric := range newMetricDefs {
 		// We don't mark the record 'Local' because partial history updates
 		// are not already written to the transaction log.
-		h.handleMetric(&spb.Record{
+		rec := &spb.Record{
 			RecordType: &spb.Record_Metric{Metric: newMetric},
-		})
+		}
+		h.handleMetric(rec)
+		h.fwdRecord(rec)
 	}
 	h.metricHandler.InsertStepMetrics(h.partialHistory)
 


### PR DESCRIPTION
Description
---
Moves the `fwdRecord` for History, Metric and Summary to `Handler.Do()`. Adds Exit, Header, Tbrecord, Request and Run records to the explicit no-forward list:

* Tbrecords terminate in the Handler
* Exit and Header modify their records before forwarding
* Request handlers call `fwdRecord` themselves; I'll update them in a separate PR

I'll make `fwdRecord` the `default` case in the next PR since that's a riskier change (it's hard to verify that a record type wasn't forgotten): https://github.com/wandb/wandb/pull/8236