### PR TITLE
chore(sdk): trigger docs generation upon release

### DIFF
--- a/.github/workflows/generate-docodile-documentation.yml
+++ b/.github/workflows/generate-docodile-documentation.yml
@@ -30,9 +30,30 @@ jobs: # update the docs.
           fi
 
       - uses: wandb/docugen@v0.4.4
+        id: docugen
         with:
           docodile-branch: main
           wandb-branch: $WANDB_BRANCH
           generate-sdk-docs: true
           generate-weave-docs: false
           access-token: ${{ secrets.DOCUGEN_ACCESS_TOKEN }}
+
+      - name: Extract PR URL
+        id: extract_url
+        run: |
+          PR_URL=$(echo "${{ steps.docugen.outputs.stdout }}" | grep -oP 'https://github\.com/wandb/docodile/pull/\d+')
+          echo "PR_URL=$PR_URL" >> $GITHUB_OUTPUT
+
+  notify-slack:
+    needs: update-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.SLACK_DOCS_CHANNEL_ID }}
+          slack-message: |
+            W&B SDK ${{ github.event.release.tag_name || github.event.inputs.ref }} documentation update:
+            PR: ${{ needs.update-docs.outputs.PR_URL }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -379,7 +379,7 @@ jobs:
           files: |
             wandb-${{ github.event.inputs.version }}.zip
             wandb-${{ github.event.inputs.version }}.tar.gz
-          draft: true
+          draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
   slack:
@@ -396,7 +396,7 @@ jobs:
           python -m pip install wandb==${{ github.event.inputs.version }}
       - name: Post to Slack
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.27.0
         with:
           # Slack channel id, channel name, or user id to post message.
           # See also: https://api.slack.com/methods/chat.postMessage#channels


### PR DESCRIPTION
Description
-----------
- Publish release notes upon a successful release to automatically trigger docs generation action
- Post on Slack in #docs channel when the docs PR is ready.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
