### PR TITLE
chore(sdk): automatically open a dev1 version bump PR upon a release

### DIFF
--- a/.github/workflows/generate-docodile-documentation.yml
+++ b/.github/workflows/generate-docodile-documentation.yml
@@ -30,9 +30,30 @@ jobs: # update the docs.
           fi
 
       - uses: wandb/docugen@v0.4.4
+        id: docugen
         with:
           docodile-branch: main
           wandb-branch: $WANDB_BRANCH
           generate-sdk-docs: true
           generate-weave-docs: false
           access-token: ${{ secrets.DOCUGEN_ACCESS_TOKEN }}
+
+      - name: Extract PR URL
+        id: extract_url
+        run: |
+          PR_URL=$(echo "${{ steps.docugen.outputs.stdout }}" | grep -oP 'https://github\.com/wandb/docodile/pull/\d+')
+          echo "PR_URL=$PR_URL" >> $GITHUB_OUTPUT
+
+  notify-slack:
+    needs: update-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.SLACK_DOCS_CHANNEL_ID }}
+          slack-message: |
+            W&B SDK ${{ github.event.release.tag_name || github.event.inputs.ref }} documentation update:
+            PR: ${{ needs.update-docs.outputs.PR_URL }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -379,7 +379,7 @@ jobs:
           files: |
             wandb-${{ github.event.inputs.version }}.zip
             wandb-${{ github.event.inputs.version }}.tar.gz
-          draft: true
+          draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
   slack:
@@ -396,7 +396,7 @@ jobs:
           python -m pip install wandb==${{ github.event.inputs.version }}
       - name: Post to Slack
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.27.0
         with:
           # Slack channel id, channel name, or user id to post message.
           # See also: https://api.slack.com/methods/chat.postMessage#channels

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -350,6 +350,48 @@ jobs:
         with:
           password: ${{ secrets.PYPI_TOKEN }}
 
+  create-dev-branch:
+    name: Create dev branch and PR
+    needs: pypi-publish
+    runs-on: ubuntu-latest
+    if: ${{ inputs.update-changelog && !inputs.dry-run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release-${{ github.event.inputs.version }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install bump2version
+        run: pip install bump2version
+
+      - name: Setup git config
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Create and switch to dev branch
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ github.event.inputs.version }}"
+          new_version="${major}.${minor}.$((patch + 1)).dev1"
+          git checkout -b bump-${new_version}
+          bump2version patch --no-tag --no-commit --config-file .bumpversion.wandb.cfg --new-version ${new_version}
+          git commit -am "chore(sdk): bump version to ${new_version}"
+          git push -u origin bump-${new_version}
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ github.event.inputs.version }}"
+          new_version="${major}.${minor}.$((patch + 1)).dev1"
+          gh pr create --base main --head bump-${new_version} --title "chore(sdk): bump version to ${new_version}" --body "This PR bumps the version to the next dev version after the release of ${{ github.event.inputs.version }}."
+
+
   publish-release-notes:
     name: Publish Release Notes
     needs: pypi-publish
@@ -379,7 +421,7 @@ jobs:
           files: |
             wandb-${{ github.event.inputs.version }}.zip
             wandb-${{ github.event.inputs.version }}.tar.gz
-          draft: false
+          draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
   slack:
@@ -396,7 +438,7 @@ jobs:
           python -m pip install wandb==${{ github.event.inputs.version }}
       - name: Post to Slack
         id: slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v1.24.0
         with:
           # Slack channel id, channel name, or user id to post message.
           # See also: https://api.slack.com/methods/chat.postMessage#channels


### PR DESCRIPTION
Description
-----------
Update the release action to automatically open a `<major>.<minor>.<patch+1>.dev1` version bump PR upon a successful non-rc release (that is, a one that publishes release notes).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
