### PR TITLE
chore(launch): disable tests/unit_tests/test_launch/test_inputs/test_internal.py::test_handle_config_file_input_pydantic

### DIFF
--- a/tests/unit_tests/test_launch/test_inputs/test_internal.py
+++ b/tests/unit_tests/test_launch/test_inputs/test_internal.py
@@ -207,6 +207,7 @@ def test_handle_config_file_input(mocker):
     platform.system().lower() == "windows",
     reason="Doesn't work on Windows",
 )
+@pytest.mark.skip(reason="TODO: This test is failing on Pydantic 2.9.0.")
 def test_handle_config_file_input_pydantic(
     mocker,
     expected_json_schema,


### PR DESCRIPTION
Description
-----------
Pydantic 2.9.0 release broke this test: tests/unit_tests/test_launch/test_inputs/test_internal.py::test_handle_config_file_input_pydantic, disabled for now to unblock the ci.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
