### PR TITLE
fix: skip underscorred nvidia gpu metrics

### DIFF
--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -163,6 +163,7 @@ func (g *GPUNvidia) Sample() (map[string]any, error) {
 	metrics := make(map[string]any)
 
 	for metric, value := range g.sample {
+		fmt.Println(metric, value)
 		// skip metrics that start with "_", some of which are internal metrics
 		// TODO: other metrics lack aggregation on the frontend; could be added in the future.
 		if strings.HasPrefix(metric, "_") {

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -163,7 +163,6 @@ func (g *GPUNvidia) Sample() (map[string]any, error) {
 	metrics := make(map[string]any)
 
 	for metric, value := range g.sample {
-		fmt.Println(metric, value)
 		// skip metrics that start with "_", some of which are internal metrics
 		// TODO: other metrics lack aggregation on the frontend; could be added in the future.
 		if strings.HasPrefix(metric, "_") {
@@ -174,7 +173,7 @@ func (g *GPUNvidia) Sample() (map[string]any, error) {
 		}
 	}
 
-	return g.sample, nil
+	return metrics, nil
 }
 
 func (g *GPUNvidia) IsAvailable() bool {


### PR DESCRIPTION
Description
-----------
Return filtered metrics instead of the raw sample in `GPUNvidia.Sample`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
