### PR TITLE
refactor(sdk): remove cancellation ctx in runconsolelogs

### DIFF
--- a/core/internal/runconsolelogs/debouncedwriter.go
+++ b/core/internal/runconsolelogs/debouncedwriter.go
@@ -10,9 +10,8 @@ import (
 
 // debouncedWriter buffers and rate limits line modifications.
 type debouncedWriter struct {
-	mu  sync.Mutex
-	wg  sync.WaitGroup
-	ctx context.Context
+	mu sync.Mutex
+	wg sync.WaitGroup
 
 	isFlushing bool
 	flush      func(sparselist.SparseList[*RunLogsLine])
@@ -27,11 +26,9 @@ type debouncedWriter struct {
 // Stops invoking `flush` after the context is cancelled.
 func NewDebouncedWriter(
 	rateLimit *rate.Limiter,
-	ctx context.Context,
 	flush func(sparselist.SparseList[*RunLogsLine]),
 ) *debouncedWriter {
 	return &debouncedWriter{
-		ctx:       ctx,
 		flush:     flush,
 		rateLimit: rateLimit,
 	}
@@ -56,9 +53,9 @@ func (b *debouncedWriter) OnChanged(lineNum int, line *RunLogsLine) {
 
 func (b *debouncedWriter) loopFlushBuffer() {
 	for {
-		err := b.rateLimit.Wait(b.ctx)
+		err := b.rateLimit.Wait(context.Background())
 		if err != nil {
-			// Cancelled or deadline exceeded.
+			// Not possible: canceled or deadline exceeded.
 			return
 		}
 

--- a/core/internal/runconsolelogs/runconsolelogs.go
+++ b/core/internal/runconsolelogs/runconsolelogs.go
@@ -95,7 +95,6 @@ func New(params Params) *Sender {
 
 	writer := NewDebouncedWriter(
 		rate.NewLimiter(rate.Every(10*time.Millisecond), 1),
-		params.ExtraWork.BeforeEndCtx(),
 		func(lines sparselist.SparseList[*RunLogsLine]) {
 			if fileWriter != nil {
 				fileWriter.WriteToFile(lines)


### PR DESCRIPTION
Description
---
Removes BeforeEndCtx() in runconsolelogs as it is not actually utilized.

It was meant to short-circuit the writer to prevent further writes to the output.log file in case runconsolelogs.Sender.Finish() isn't invoked (but runwork.RunWork.Close() is), but there's no point in that as the file is only used if Finish() happens.
