### PR TITLE
fix(sdk): correctly infer TB root directory

### DIFF
--- a/core/internal/paths/longestcommonprefix.go
+++ b/core/internal/paths/longestcommonprefix.go
@@ -1,0 +1,41 @@
+package paths
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// LongestCommonPrefix returns the longest path that every given path
+// starts with.
+func LongestCommonPrefix(paths []AbsolutePath) (*AbsolutePath, error) {
+	if len(paths) < 2 {
+		return nil, errors.New("too few paths")
+	}
+
+	longestPrefix := strings.Split(
+		string(paths[0]),
+		string(filepath.Separator),
+	)
+
+	for _, path := range paths[1:] {
+		pathParts := strings.Split(string(path), string(filepath.Separator))
+
+		for i, part := range longestPrefix {
+			if part != pathParts[i] {
+				longestPrefix = longestPrefix[:i]
+				break
+			}
+		}
+	}
+
+	rootDir, err := Absolute(
+		strings.Join(longestPrefix, string(filepath.Separator)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error making path absolute: %v", err)
+	}
+
+	return rootDir, nil
+}

--- a/core/internal/paths/longestcommonprefix_test.go
+++ b/core/internal/paths/longestcommonprefix_test.go
@@ -1,0 +1,40 @@
+package paths_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/internal/paths"
+)
+
+func absPath(t *testing.T, path string) paths.AbsolutePath {
+	p, err := paths.Absolute(path)
+	require.NoError(t, err)
+	return *p
+}
+
+func TestLongestCommonPrefix(t *testing.T) {
+	prefix, err := paths.LongestCommonPrefix(
+		[]paths.AbsolutePath{
+			absPath(t, "/one/two"),
+			absPath(t, "/one/two/three"),
+			absPath(t, "/one/four"),
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t,
+		absPath(t, "/one"),
+		*prefix,
+	)
+}
+
+func TestLongestCommonPrefix_TooFewDirectories(t *testing.T) {
+	prefix, err := paths.LongestCommonPrefix(
+		[]paths.AbsolutePath{absPath(t, "/one/two")},
+	)
+
+	assert.ErrorContains(t, err, "too few paths")
+	assert.Nil(t, prefix)
+}

--- a/core/internal/paths/longestcommonprefix_test.go
+++ b/core/internal/paths/longestcommonprefix_test.go
@@ -19,7 +19,7 @@ func TestLongestCommonPrefix(t *testing.T) {
 		[]paths.AbsolutePath{
 			absPath(t, "/one/two"),
 			absPath(t, "/one/two/three"),
-			absPath(t, "/one/four"),
+			absPath(t, "/one/ten"),
 		},
 	)
 

--- a/core/internal/tensorboard/tensorboard.go
+++ b/core/internal/tensorboard/tensorboard.go
@@ -243,25 +243,10 @@ func (tb *TBHandler) updateRootDirFromLogDir(
 	tb.trackedDirs = append(tb.trackedDirs, newLogDir)
 
 	if len(tb.trackedDirs) > 1 {
-		longestPrefix := string(tb.trackedDirs[0])
+		rootDir, err := paths.LongestCommonPrefix(tb.trackedDirs)
 
-		for _, path := range tb.trackedDirs[1:] {
-			pathRunes := []rune(string(path))
-
-			for i, char := range longestPrefix {
-				if char != pathRunes[i] {
-					longestPrefix = longestPrefix[:i]
-					break
-				}
-			}
-		}
-
-		rootDir, err := paths.Absolute(longestPrefix)
 		if err != nil {
-			return fmt.Errorf(
-				"tensorboard: error while inferring root dir: %v",
-				err,
-			)
+			return fmt.Errorf("tensorboard: %v", err)
 		}
 
 		tb.rootDir = rootDir


### PR DESCRIPTION
Description
---
Fixes WB-20666.

Instead of naively taking a string prefix of the log directories, define a `paths.LongestCommonPrefix` utility that compares path components.
