### PR TITLE
chore: add error message cache to reduce sentry traffic in nvidia_gpu_stats

### DIFF
--- a/nvidia_gpu_stats/Cargo.lock
+++ b/nvidia_gpu_stats/Cargo.lock
@@ -622,7 +622,7 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "nvidia_gpu_stats"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "nix",

--- a/nvidia_gpu_stats/Cargo.toml
+++ b/nvidia_gpu_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvidia_gpu_stats"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Description
-----------
Adds error message cache to reduce sentry traffic in nvidia_gpu_stats.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
