### PR TITLE
fix(launch): fix job input schemas for newer Pydantic versions

### DIFF
--- a/tests/unit_tests/test_launch/test_inputs/test_internal.py
+++ b/tests/unit_tests/test_launch/test_inputs/test_internal.py
@@ -207,7 +207,6 @@ def test_handle_config_file_input(mocker):
     platform.system().lower() == "windows",
     reason="Doesn't work on Windows",
 )
-@pytest.mark.skip(reason="TODO: This test is failing on Pydantic 2.9.0.")
 def test_handle_config_file_input_pydantic(
     mocker,
     expected_json_schema,

--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -141,9 +141,9 @@ def _replace_refs_and_allofs(schema: dict, defs: Optional[dict]) -> dict:
     ret: Dict[str, Any] = {}
     if "$ref" in schema and defs:
         # Reference found, replace it with its definition
-        def_key = schema["$ref"].split("#/$defs/")[1]
+        def_key = schema.pop("$ref").split("#/$defs/")[1]
         # Also run recursive replacement in case a ref contains more refs
-        return _replace_refs_and_allofs(defs.pop(def_key), defs)
+        ret = _replace_refs_and_allofs(defs.pop(def_key), defs)
     for key, val in schema.items():
         if isinstance(val, dict):
             # Step into dicts recursively


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- [Slack thread](https://weightsandbiases.slack.com/archives/C01UUUHP153/p1725564705466629)

The way we were converting Pydantic models to JSONSchema was causing some keys to be dropped for pydantic>=2.9.0. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Tested against both Pydantic 2.7 and 2.9

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
