### PR TITLE
fix(sdk): calling run.update no longer wipes run's config

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -504,7 +504,7 @@ class Run(Attrs):
         """Persist changes to the run object to the wandb backend."""
         mutation = gql(
             """
-        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString!, $groupName: String) {{
+        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString, $groupName: String) {{
             upsertBucket(input: {{id: $id, description: $description, displayName: $display_name, notes: $notes, tags: $tags, config: $config, groupName: $groupName}}) {{
                 bucket {{
                     ...RunFragment
@@ -564,7 +564,7 @@ class Run(Attrs):
         config = {}
         for k, v in self.config.items():
             config[k] = {"value": v, "desc": None}
-        return json.dumps(config)
+        return json.dumps(config) if config else None
 
     def _exec(self, query, **kwargs):
         """Execute a query against the cloud backend."""


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-20737](https://wandb.atlassian.net/browse/WB-20737)
- [Slack thread](https://weightsandbiases.slack.com/archives/C01KQ5KTDC3/p1725551845904209)

Referencing an existing run object using `api.run()` and calling `run.update()` causes the run's config, including any telemetry, to be wiped. This causes the run to be un-resumeable, since our run resume logic relies on checking whether the run config has telemetry.

The reason the config gets wiped is because in `UpsertBucket`, we check [whether the Config field is specifically null](https://github.com/wandb/core/blob/e9e39549bd88a365146b3586bf0495905e6fd572/services/gorilla/pkg/runupdates/run_updater.go#L236), and overwrite the config if it's not. But if the user never touches the run object's `config` field, it's not null, it's `"{}"`, so the config gets overwritten with an empty dict. Sending null instead of `"{}"` fixes the behavior.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Run the following three scripts:

1. Start a run that fails
```
import wandb

from const import RUN_ID
wandb.require("core")

wandb.init(entity="tim-hays", project="resume", id=RUN_ID, resume="allow")
wandb.log({"metric": 1})
bad.call()  # intentionally error
```

2. Write something to the run and call run.update
```
import wandb

from const import RUN_ID
wandb.require("core")

api = wandb.Api()
run = api.run(f'tim-hays/resume/{RUN_ID}')

run.summary["new"] = 1
run.update()
```

3. Try to resume the run
```
import wandb

from const import RUN_ID
wandb.require("core")

wandb.init(entity="tim-hays", project="resume", id=RUN_ID, resume="must")
wandb.log({"metric": 2})
```

This fails before the fix (see the Jira ticket or Slack thread for the error message), but succeeds after the fix.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-20737]: https://wandb.atlassian.net/browse/WB-20737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ