### PR TITLE
refactor(sdk): set tb sync telemetry for every run that uses it

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -273,8 +273,9 @@ class _WandbInit:
 
         tensorboard = kwargs.pop("tensorboard", None)
         sync_tensorboard = kwargs.pop("sync_tensorboard", None)
-        if tensorboard or sync_tensorboard and len(wandb.patched["tensorboard"]) == 0:
-            wandb.tensorboard.patch()  # type: ignore
+        if tensorboard or sync_tensorboard:
+            if len(wandb.patched["tensorboard"]) == 0:
+                wandb.tensorboard.patch()  # type: ignore
             with telemetry.context(obj=self._init_telemetry_obj) as tel:
                 tel.feature.tensorboard_sync = True
 


### PR DESCRIPTION
Description
---
We were only setting the tensorboard_sync telemetry field on the first run that used `sync_tensorboard=True`, but we should be setting it on every such run.