### PR TITLE
chore: improve apple gpu stats monitor

### DIFF
--- a/apple_stats/hatch.py
+++ b/apple_stats/hatch.py
@@ -51,7 +51,6 @@ def build_applestats(output_path: pathlib.PurePath) -> None:
             " package that doesn't collect Apple system metrics."
         ) from e
 
-    # Copy the built binary to the output path
     built_binary = (
         source_path  # break line for readability
         / ".build"
@@ -60,8 +59,3 @@ def build_applestats(output_path: pathlib.PurePath) -> None:
         / "AppleStats"
     )
     subprocess.check_call(["cp", str(built_binary), str(output_path)])
-
-
-if __name__ == "__main__":
-    output_path = pathlib.Path("path/to/output/AppleStats")
-    build_applestats(output_path)

--- a/apple_stats/hatch.py
+++ b/apple_stats/hatch.py
@@ -1,6 +1,7 @@
-"""Builds the AppleStats Swift binary for monitoring system metrics on macOS."""
+"""Builds the AppleStats Swift binary for monitoring system metrics on arm64 macOS."""
 
 import pathlib
+import platform
 import subprocess
 
 
@@ -9,7 +10,7 @@ class AppleStatsBuildError(Exception):
 
 
 def build_applestats(output_path: pathlib.PurePath) -> None:
-    """Builds the AppleStats universal Swift binary.
+    """Builds the AppleStats Swift binary for arm64.
 
     NOTE: Swift creates a cache in a directory called ".build/" which speeds
     up subsequent builds but can cause issues when changing the commands here.
@@ -19,32 +20,24 @@ def build_applestats(output_path: pathlib.PurePath) -> None:
         output_path: The path where to output the binary, relative to the
             workspace root.
     """
+    if platform.machine() != "arm64":
+        raise AppleStatsBuildError("This script only builds for arm64 architecture.")
+
     source_path = pathlib.Path("./apple_stats")
 
-    def arch_output_path(arch: str) -> pathlib.Path:
-        return (
-            source_path  # (break line for readability)
-            / ".build"
-            / f"{arch}-apple-macosx"
-            / "release"
-            / "AppleStats"
-        )
-
-    base_cmd = [
+    cmd = [
         "swift",
         "build",
         "--configuration",
         "release",
         "-Xswiftc",
         "-cross-module-optimization",
+        "--arch",
+        "arm64",
     ]
 
-    cmd_x86_64 = base_cmd + ["--arch", "x86_64"]
-    cmd_arm64 = base_cmd + ["--arch", "arm64"]
-
     try:
-        subprocess.check_call(cmd_x86_64, cwd=source_path)
-        subprocess.check_call(cmd_arm64, cwd=source_path)
+        subprocess.check_call(cmd, cwd=source_path)
     except subprocess.CalledProcessError as e:
         raise AppleStatsBuildError(
             "Failed to build the `apple_stats` Swift binary. If you didn't"
@@ -58,13 +51,17 @@ def build_applestats(output_path: pathlib.PurePath) -> None:
             " package that doesn't collect Apple system metrics."
         ) from e
 
-    subprocess.check_call(
-        [
-            "lipo",
-            "-create",
-            arch_output_path("x86_64"),
-            arch_output_path("arm64"),
-            "-output",
-            str(output_path),
-        ]
+    # Copy the built binary to the output path
+    built_binary = (
+        source_path  # break line for readability
+        / ".build"
+        / "arm64-apple-macosx"
+        / "release"
+        / "AppleStats"
     )
+    subprocess.check_call(["cp", str(built_binary), str(output_path)])
+
+
+if __name__ == "__main__":
+    output_path = pathlib.Path("path/to/output/AppleStats")
+    build_applestats(output_path)

--- a/core/pkg/monitor/gpu_amd.go
+++ b/core/pkg/monitor/gpu_amd.go
@@ -1,4 +1,4 @@
-//go:build linux && !libwandb_core
+//go:build linux
 
 package monitor
 

--- a/core/pkg/monitor/gpu_amd_test.go
+++ b/core/pkg/monitor/gpu_amd_test.go
@@ -1,4 +1,4 @@
-//go:build linux && !libwandb_core
+//go:build linux
 
 package monitor_test
 

--- a/core/pkg/monitor/gpu_apple_test.go
+++ b/core/pkg/monitor/gpu_apple_test.go
@@ -1,0 +1,37 @@
+//go:build darwin
+
+package monitor_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/pkg/monitor"
+)
+
+const mockGPUStatsOutput = `{"m1Gpu1":57.583431243896484,"m3Gpu6":0,"m3Gpu2":0,"m3Gpu5":0,"vendor":"sppci_vendor_Apple","PC10":0,"m1Gpu3":55.276527404785156,"vram":"Unknown","recoveryCount":0,"m3Gpu7":0,"m1Gpu2":58.314537048339844,"cores":24,"gpuPowerPMVR":8.4271249771118164,"tilerUtilization":0,"m2Gpu2":0,"systemPower":19.567802429199219,"m1Gpu4":55.203269958496094,"m3Gpu4":0,"gpuCurrent":0,"PC22":0,"inUseSystemMemory":698499072,"m2Gpu1":0,"m3Gpu1":0,"renderUtilization":0,"PC20":0,"PC40":0,"PC12":0,"m3Gpu8":0,"m3Gpu3":0,"allocatedSystemMemory":3188637696,"name":"Apple M1 Max","utilization":29,"gpuPowerPGTR":0,"gpuVoltage":0,"gpuPower":0,"gpuPowerPG0R":0}`
+
+func TestGPUAppleSample(t *testing.T) {
+	tmpDir := t.TempDir()
+	execPath := filepath.Join(tmpDir, "apple_gpu_stats")
+	err := os.WriteFile(execPath, []byte("#!/bin/sh\necho '"+mockGPUStatsOutput+"'"), 0755)
+	require.NoError(t, err)
+
+	defer os.Remove(execPath)
+
+	gpu := monitor.GPUApple{ExecPath: execPath}
+
+	sample, err := gpu.Sample()
+	require.NoError(t, err)
+
+	assert.Equal(t, 0.0, sample["gpu.0.powerWatts"])
+	assert.Equal(t, 19.567802429199219, sample["system.powerWatts"])
+	assert.Equal(t, float64(0), sample["gpu.0.recoveryCount"])
+	assert.Equal(t, float64(29), sample["gpu.0.gpu"])
+	assert.Equal(t, float64(3188637696), sample["gpu.0.memoryAllocatedBytes"])
+	assert.Equal(t, float64(698499072), sample["gpu.0.memoryUsed"])
+	assert.InDelta(t, 56.59444141387939, sample["gpu.0.temp"], 0.00001) // Average of m1Gpu1, m1Gpu2, m1Gpu3, m1Gpu4
+}

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -1,4 +1,4 @@
-//go:build linux && !libwandb_core
+//go:build linux
 
 package monitor
 

--- a/core/pkg/monitor/noop.go
+++ b/core/pkg/monitor/noop.go
@@ -1,4 +1,4 @@
-//go:build !linux || libwandb_core
+//go:build !linux
 
 package monitor
 
@@ -7,6 +7,8 @@ import (
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
+// GPUNvidia is a dummy implementation of the Asset interface for Nvidia GPUs
+// for non-Linux platforms.
 type GPUNvidia struct {
 	name             string
 	pid              int32
@@ -33,6 +35,8 @@ func (g *GPUNvidia) Probe() *spb.MetadataRequest {
 	return nil
 }
 
+// GPUAMD is a dummy implementation of the Asset interface for AMD GPUs
+// for non-Linux platforms.
 type GPUAMD struct {
 	name   string
 	logger *observability.CoreLogger
@@ -55,6 +59,8 @@ func (g *GPUAMD) Probe() *spb.MetadataRequest {
 	return nil
 }
 
+// Trainium is a dummy implementation of the Asset interface for Trainium
+// for non-Linux platforms.
 type Trainium struct {
 	name                    string
 	pid                     int32

--- a/core/pkg/monitor/noop_linux.go
+++ b/core/pkg/monitor/noop_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package monitor
+
+import spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+
+// GPUApple is a dummy implementation of the Asset interface for Apple GPUs
+// for non-MacOS platforms.
+type GPUApple struct {
+	name string
+}
+
+func NewGPUApple() *GPUApple {
+	return &GPUApple{name: "gpu"}
+}
+
+func (g *GPUApple) Name() string { return g.name }
+
+func (g *GPUApple) Sample() (map[string]any, error) { return nil, nil }
+
+func (g *GPUApple) IsAvailable() bool { return false }
+
+func (g *GPUApple) Probe() *spb.MetadataRequest {
+	return nil
+}

--- a/core/pkg/monitor/querymap.go
+++ b/core/pkg/monitor/querymap.go
@@ -1,6 +1,7 @@
-//go:build darwin
-
 package monitor
+
+// suppress golangci-lint unused code warning as it is only used on darwin
+var _ = queryMapNumber
 
 // queryMapNumber reads a number-valued property from a JSON object.
 //

--- a/core/pkg/monitor/querymap.go
+++ b/core/pkg/monitor/querymap.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package monitor
 
 // queryMapNumber reads a number-valued property from a JSON object.

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -88,11 +88,15 @@ class CustomBuildHook(BuildHookInterface):
         return not self._must_build_universal()
 
     def _include_apple_stats(self) -> bool:
-        """Returns whether we should produce a wheel with apple_gpu_stats."""
+        """Returns whether we should produce a wheel with apple_gpu_stats.
+
+        The Apple GPU stats binary is only built for macOS arm64.
+        """
         return (
             not self._must_build_universal()
             and not _get_env_bool(_WANDB_BUILD_SKIP_APPLE, default=False)
             and self._target_platform().goos == "darwin"
+            and self._target_platform().goarch == "arm64"
         )
 
     def _include_nvidia_gpu_stats(self) -> bool:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-20633.

In this PR:
- Only build the `apple_gpu_stats` binary for arm64 macs as it's not intended for x86 macs.
- Clean up the Apple GPU monitoring code, add docs and tests.
- On Linux and Windows, include only dummy stubs for `GPUApple` in the `wandb-core` binary.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Added a unit test for `GPUApple`, manually tested on an old  x86 MacBook.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
