### PR TITLE
chore: split noop definitions per platform in system monitor

### DIFF
--- a/core/pkg/monitor/noop_darwin.go
+++ b/core/pkg/monitor/noop_darwin.go
@@ -1,0 +1,92 @@
+//go:build darwin
+
+package monitor
+
+import (
+	"github.com/wandb/wandb/core/pkg/observability"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// GPUNvidia is a dummy implementation of the Asset interface for Nvidia GPUs.
+type GPUNvidia struct {
+	name             string
+	pid              int32
+	samplingInterval float64
+	logger           *observability.CoreLogger
+}
+
+func NewGPUNvidia(logger *observability.CoreLogger, pid int32, samplingInterval float64) *GPUNvidia {
+	return &GPUNvidia{
+		name:             "gpu",
+		pid:              pid,
+		samplingInterval: samplingInterval,
+		logger:           logger,
+	}
+}
+
+func (g *GPUNvidia) Name() string { return g.name }
+
+func (g *GPUNvidia) Sample() (map[string]any, error) { return nil, nil }
+
+func (g *GPUNvidia) IsAvailable() bool { return false }
+
+func (g *GPUNvidia) Probe() *spb.MetadataRequest {
+	return nil
+}
+
+// GPUAMD is a dummy implementation of the Asset interface for AMD GPUs.
+type GPUAMD struct {
+	name   string
+	logger *observability.CoreLogger
+}
+
+func NewGPUAMD(logger *observability.CoreLogger) *GPUAMD {
+	return &GPUAMD{
+		name:   "gpu",
+		logger: logger,
+	}
+}
+
+func (g *GPUAMD) Name() string { return g.name }
+
+func (g *GPUAMD) Sample() (map[string]any, error) { return nil, nil }
+
+func (g *GPUAMD) IsAvailable() bool { return false }
+
+func (g *GPUAMD) Probe() *spb.MetadataRequest {
+	return nil
+}
+
+// Trainium is a dummy implementation of the Asset interface for Trainium.
+type Trainium struct {
+	name                    string
+	pid                     int32
+	samplingInterval        float64
+	logger                  *observability.CoreLogger
+	neuronMonitorConfigPath string
+}
+
+func NewTrainium(
+	logger *observability.CoreLogger,
+	pid int32,
+	samplingInterval float64,
+	neuronMonitorConfigPath string,
+) *Trainium {
+	return &Trainium{
+		name:                    "trainium",
+		pid:                     pid,
+		samplingInterval:        samplingInterval,
+		logger:                  logger,
+		neuronMonitorConfigPath: neuronMonitorConfigPath,
+	}
+}
+
+func (t *Trainium) Name() string { return t.name }
+
+func (t *Trainium) Sample() (map[string]any, error) { return nil, nil }
+
+func (t *Trainium) IsAvailable() bool { return false }
+
+func (t *Trainium) Probe() *spb.MetadataRequest {
+	return nil
+}

--- a/core/pkg/monitor/noop_linux.go
+++ b/core/pkg/monitor/noop_linux.go
@@ -4,8 +4,7 @@ package monitor
 
 import spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 
-// GPUApple is a dummy implementation of the Asset interface for Apple GPUs
-// for non-MacOS platforms.
+// GPUApple is a dummy implementation of the Asset interface for Apple GPUs.
 type GPUApple struct {
 	name string
 }

--- a/core/pkg/monitor/noop_windows.go
+++ b/core/pkg/monitor/noop_windows.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build windows
 
 package monitor
 
@@ -7,36 +7,26 @@ import (
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
-// GPUNvidia is a dummy implementation of the Asset interface for Nvidia GPUs
-// for non-Linux platforms.
-type GPUNvidia struct {
-	name             string
-	pid              int32
-	samplingInterval float64
-	logger           *observability.CoreLogger
+// GPUApple is a dummy implementation of the Asset interface for Apple GPUs.
+type GPUApple struct {
+	name string
 }
 
-func NewGPUNvidia(logger *observability.CoreLogger, pid int32, samplingInterval float64) *GPUNvidia {
-	return &GPUNvidia{
-		name:             "gpu",
-		pid:              pid,
-		samplingInterval: samplingInterval,
-		logger:           logger,
-	}
+func NewGPUApple() *GPUApple {
+	return &GPUApple{name: "gpu"}
 }
 
-func (g *GPUNvidia) Name() string { return g.name }
+func (g *GPUApple) Name() string { return g.name }
 
-func (g *GPUNvidia) Sample() (map[string]any, error) { return nil, nil }
+func (g *GPUApple) Sample() (map[string]any, error) { return nil, nil }
 
-func (g *GPUNvidia) IsAvailable() bool { return false }
+func (g *GPUApple) IsAvailable() bool { return false }
 
-func (g *GPUNvidia) Probe() *spb.MetadataRequest {
+func (g *GPUApple) Probe() *spb.MetadataRequest {
 	return nil
 }
 
-// GPUAMD is a dummy implementation of the Asset interface for AMD GPUs
-// for non-Linux platforms.
+// GPUAMD is a dummy implementation of the Asset interface for AMD GPUs.
 type GPUAMD struct {
 	name   string
 	logger *observability.CoreLogger
@@ -59,8 +49,7 @@ func (g *GPUAMD) Probe() *spb.MetadataRequest {
 	return nil
 }
 
-// Trainium is a dummy implementation of the Asset interface for Trainium
-// for non-Linux platforms.
+// Trainium is a dummy implementation of the Asset interface for Trainium.
 type Trainium struct {
 	name                    string
 	pid                     int32


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Make noop files platform-specific at the cost of minor code duplication. I think it's better to be explicit.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
