### PR TITLE
chore(sdk): re-enable keras+tb+wandb tests

### DIFF
--- a/tests/system_tests/test_functional/test_tensorboard/test_keras_tb_callback.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_keras_tb_callback.py
@@ -57,7 +57,7 @@ def test_tb_callback(relay_server, user):
         # The test configured Keras to logs histograms and their images
         # every 5 steps.
         for tag in ["kernel/histogram", "bias/histogram", "kernel/image", "bias/image"]:
-            steps = history.loc["global_step", tag].dropna()["global_step"].tolist()
+            steps = history[["global_step", tag]].dropna()["global_step"].tolist()
             assert steps == [0, 5]
 
 


### PR DESCRIPTION
Description
---
Adds a test for using W&B in the Keras TB callback with core enabled. It's very similar to the legacy test, except:

* In core, we use an empty namespace because no root_dir is specified, whereas the legacy service uses the directory name of the tfevents file as the namespace resulting in keys like "train/bias/histogram" rather than "bias/histogram". Personally, I think the "train/" prefix isn't useful here, and using the dirname of the tfevents file might have odd edge cases that I'd rather avoid.
* The legacy service combines events for the same global_step, causing global_step to match the W&B step. In core, there are 28 W&B steps rather than 10. Although the legacy behavior is slightly nicer since the W&B step is the default X axis, users can always plot values against global_step, so I'm not sure whether porting this is worthwhile.

With core: https://wandb.ai/wandb/uncategorized/runs/pqlcqiur/workspace?nw=nwusertimoffex
With legacy service: https://wandb.ai/wandb/uncategorized/runs/9l71grqj?nw=nwusertimoffex