### PR TITLE
fix: remove platform arch check in apple_stats/hatch.py

### DIFF
--- a/apple_stats/hatch.py
+++ b/apple_stats/hatch.py
@@ -1,7 +1,6 @@
 """Builds the AppleStats Swift binary for monitoring system metrics on arm64 macOS."""
 
 import pathlib
-import platform
 import subprocess
 
 

--- a/apple_stats/hatch.py
+++ b/apple_stats/hatch.py
@@ -20,9 +20,6 @@ def build_applestats(output_path: pathlib.PurePath) -> None:
         output_path: The path where to output the binary, relative to the
             workspace root.
     """
-    if platform.machine() != "arm64":
-        raise AppleStatsBuildError("This script only builds for arm64 architecture.")
-
     source_path = pathlib.Path("./apple_stats")
 
     cmd = [


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Removed the platform arch check in apple_stats/hatch.py as it's hatch_build's responsibility to decide whether to call build_applestats in the first place.

Prevents a situation like this: https://github.com/wandb/wandb/actions/runs/10800478179/job/29958598454#step:5:473 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
