### PR TITLE
feat(launch): add upsert_run_queue to public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Added
+
+- Add `upsert_run_queue` method to `wandb.Api`. (@bcsherma in https://github.com/wandb/wandb/pull/8348)
+
 ### Fixed
 
 - Update the signature and docstring of `wandb.api.public.runs.Run.log_artifact()` to support artifact tags like `Run` instances returned by `wandb.init()`. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8414)
@@ -72,6 +76,7 @@ to disable this new behavior will be removed (@kptkin in https://github.com/wand
 - Skip uploading/downloading GCS reference artifact manifest entries corresponding to folders (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8084)
 
 ### Deprecated
+
 - Ability to disable the service process (`WANDB__DISABLE_SERVICE`) is deprecated and will be removed in the next minor release (@kptkin in https://github.com/wandb/wandb/pull/8193)
 
 ## [0.17.7] - 2024-08-15

--- a/tests/system_tests/test_launch/test_launch_public_api.py
+++ b/tests/system_tests/test_launch/test_launch_public_api.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import wandb
 import wandb.apis.public
@@ -43,6 +45,87 @@ def test_create_run_queue_template_variables_not_supported(runner, user, monkeyp
                 config=queue_config,
                 template_variables=queue_template_variables,
             )
+
+
+def test_upsert_run_queue(user):
+    """Test creating a run queue with upsert.
+
+    The `upsert_run_queue` method introspects gorilla to see if the
+    `upsertRunQueue` mutation is supported. If it is not, this test is skipped.
+    """
+    api = Api()
+    try:
+        queue = api.upsert_run_queue(
+            entity=user,
+            name="test-queue",
+            resource_type="local-container",
+            resource_config={"cpu": "{{cpu}}"},
+            template_variables={
+                "cpu": {
+                    "schema": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 4,
+                    },
+                }
+            },
+            external_links={"google": "https://google.com"},
+        )
+    except UnsupportedError:
+        return pytest.skip("upsertRunQueue not supported on server version.")
+    try:
+        assert queue.name == "test-queue"
+        assert queue.access == "PROJECT"
+        assert queue.type == "local-container"
+        assert queue.default_resource_config == {
+            "resource_args": {"local-container": {"cpu": "{{cpu}}"}}
+        }
+        assert queue.template_variables == [
+            {
+                "name": "cpu",
+                "schema": json.dumps(
+                    {"type": "integer", "minimum": 1, "maximum": 4},
+                    separators=(",", ":"),
+                ),
+            }
+        ]
+        assert queue.external_links == {
+            "links": [
+                {
+                    "label": "google",
+                    "url": "https://google.com",
+                }
+            ]
+        }
+
+        # Upsert the same queue with different values and check that the
+        # the fields are updated.
+        queue = api.upsert_run_queue(
+            entity=user,
+            name="test-queue",
+            resource_type="local-container",
+            resource_config={"cpu": 2},
+            external_links={"yahoo": "https://yahoo.com"},
+            template_variables={},
+        )
+        assert queue.default_resource_config == {
+            "resource_args": {
+                "local-container": {
+                    "cpu": 2,
+                },
+            }
+        }
+        assert queue.template_variables == []
+        assert queue.external_links == {
+            "links": [
+                {
+                    "label": "yahoo",
+                    "url": "https://yahoo.com",
+                }
+            ]
+        }
+    finally:
+        queue.delete()
 
 
 def test_run_queue(user):

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -204,6 +204,9 @@ class Api:
     def create_run_queue(self, *args, **kwargs):
         return self.api.create_run_queue(*args, **kwargs)
 
+    def upsert_run_queue(self, *args, **kwargs):
+        return self.api.upsert_run_queue(*args, **kwargs)
+
     def update_launch_agent_status(self, *args, **kwargs):
         return self.api.update_launch_agent_status(*args, **kwargs)
 

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -421,6 +421,121 @@ class Api:
             _default_resource_config=config,
         )
 
+    def upsert_run_queue(
+        self,
+        name: str,
+        resource_config: dict,
+        resource_type: "public.RunQueueResourceType",
+        entity: Optional[str] = None,
+        template_variables: Optional[dict] = None,
+        external_links: Optional[dict] = None,
+        prioritization_mode: Optional["public.RunQueuePrioritizationMode"] = None,
+    ):
+        """Upsert a run queue (launch).
+
+        Arguments:
+            name: (str) Name of the queue to create
+            entity: (str) Optional name of the entity to create the queue. If None, will use the configured or default entity.
+            resource_config: (dict) Optional default resource configuration to be used for the queue. Use handlebars (eg. "{{var}}") to specify template variables.
+            resource_type: (str) Type of resource to be used for the queue. One of "local-container", "local-process", "kubernetes", "sagemaker", or "gcp-vertex".
+            template_variables: (dict) A dictionary of template variable schemas to be used with the config. Expected format of:
+                {
+                    "var-name": {
+                        "schema": {
+                            "type": ("string", "number", or "integer"),
+                            "default": (optional value),
+                            "minimum": (optional minimum),
+                            "maximum": (optional maximum),
+                            "enum": [..."(options)"]
+                        }
+                    }
+                }
+            external_links: (dict) Optional dictionary of external links to be used with the queue. Expected format of:
+                {
+                    "name": "url"
+                }
+            prioritization_mode: (str) Optional version of prioritization to use. Either "V0" or None
+
+        Returns:
+            The upserted `RunQueue`.
+
+        Raises:
+            ValueError if any of the parameters are invalid
+            wandb.Error on wandb API errors
+        """
+        if entity is None:
+            entity = self.settings["entity"] or self.default_entity
+            if entity is None:
+                raise ValueError(
+                    "entity must be passed as a parameter, or set in settings"
+                )
+
+        if len(name) == 0:
+            raise ValueError("name must be non-empty")
+        if len(name) > 64:
+            raise ValueError("name must be less than 64 characters")
+
+        prioritization_mode = prioritization_mode or "DISABLED"
+        prioritization_mode = prioritization_mode.upper()
+        if prioritization_mode not in ["V0", "DISABLED"]:
+            raise ValueError(
+                "prioritization_mode must be 'V0' or 'DISABLED' if present"
+            )
+
+        if resource_type not in [
+            "local-container",
+            "local-process",
+            "kubernetes",
+            "sagemaker",
+            "gcp-vertex",
+        ]:
+            raise ValueError(
+                "resource_type must be one of 'local-container', 'local-process', 'kubernetes', 'sagemaker', or 'gcp-vertex'"
+            )
+
+        self.create_project(LAUNCH_DEFAULT_PROJECT, entity)
+        api = InternalApi(
+            default_settings={
+                "entity": entity,
+                "project": self.project(LAUNCH_DEFAULT_PROJECT),
+            },
+            retry_timedelta=RETRY_TIMEDELTA,
+        )
+        # User provides external_links as a dict with name: url format
+        # but backend stores it as a list of dicts with url and label keys.
+        external_links = external_links or {}
+        external_links = {
+            "links": [
+                {
+                    "label": key,
+                    "url": value,
+                }
+                for key, value in external_links.items()
+            ]
+        }
+        upsert_run_queue_result = api.upsert_run_queue(
+            name,
+            entity,
+            resource_type,
+            {"resource_args": {resource_type: resource_config}},
+            template_variables=template_variables,
+            external_links=external_links,
+            prioritization_mode=prioritization_mode,
+        )
+        if not upsert_run_queue_result["success"]:
+            raise wandb.Error("failed to create run queue")
+        schema_errors = (
+            upsert_run_queue_result.get("configSchemaValidationErrors") or []
+        )
+        for error in schema_errors:
+            wandb.termwarn(f"resource config validation: {error}")
+
+        return public.RunQueue(
+            client=self.client,
+            name=name,
+            entity=entity,
+        )
+
     def create_user(self, email, admin=False):
         """Create a new user.
 

--- a/wandb/apis/public/jobs.py
+++ b/wandb/apis/public/jobs.py
@@ -474,6 +474,12 @@ class RunQueue:
         return self._access
 
     @property
+    def external_links(self) -> Dict[str, str]:
+        if self._external_links is None:
+            self._get_metadata()
+        return self._external_links
+
+    @property
     def type(self) -> RunQueueResourceType:
         if self._type is None:
             if self._default_resource_config_id is None:
@@ -549,6 +555,7 @@ class RunQueue:
                         access
                         defaultResourceConfigID
                         prioritizationMode
+                        externalLinks
                     }
                 }
             }
@@ -565,6 +572,7 @@ class RunQueue:
         self._default_resource_config_id = res["project"]["runQueue"][
             "defaultResourceConfigID"
         ]
+        self._external_links = res["project"]["runQueue"]["externalLinks"]
         if self._default_resource_config_id is None:
             self._default_resource_config = {}
         self._prioritization_mode = res["project"]["runQueue"]["prioritizationMode"]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-19125
 
This PR adds `upsert_run_queue` to the public and internal apis. These hit the `UpsertRunQueue` mutation to create a run queue for launch. This can be used as follows:

```
import wandb

api = wandb.Api()

api.upsert_run_queue(
    name="docker-queue",
    resource_type="local-container",
    resource_config={"cpus": "{{cpus}}"},
    template_variables={
        "cpus": {
            "schema": {
                "type": "integer",
                "minimum": 1,
                "maximum": 4,
            },
        },
    },
    external_links={
        "google": "https://google.com",
    },
)

```

This provides a very similar but powerful alternative to the `create_run_queue` method.

This PR also adds `externalLinks` to the query for the `RunQueue` class in our public api, and adds an `external_links` `@property` on the class. This is useful for testing and also something we should do anyway.


- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

A new test has been added to check that all fields are written correctly on the first upsert and that new upserts override existing data. 

Since our CI now requires all system test pass with W&B `0.40.0` and this mutation is not present, the test calls `pytest.skip` if query introspection shows we are running against an incompatible server version.