### PR TITLE
refactor(sdk): stop writing output.log after error

### DIFF
--- a/core/internal/runconsolelogs/outputfilewriter.go
+++ b/core/internal/runconsolelogs/outputfilewriter.go
@@ -1,7 +1,6 @@
 package runconsolelogs
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -33,19 +32,16 @@ func NewOutputFileWriter(
 	return &outputFileWriter{outputFile: outputFile, logger: logger}, nil
 }
 
+// WriteToFile makes changes to the underlying file.
+//
+// It returns an error if writing fails, such as if the file is deleted
+// or corrupted. In that case, the file should not be written to again.
 func (w *outputFileWriter) WriteToFile(
 	changes sparselist.SparseList[*RunLogsLine],
-) {
+) error {
 	lines := sparselist.Map(changes, func(line *RunLogsLine) string {
 		return string(line.Content)
 	})
 
-	err := w.outputFile.UpdateLines(lines)
-	if err != nil {
-		w.logger.CaptureError(
-			fmt.Errorf(
-				"runconsolelogs: failed to write to file: %v",
-				err,
-			))
-	}
+	return w.outputFile.UpdateLines(lines)
 }

--- a/core/internal/runconsolelogs/runconsolelogs.go
+++ b/core/internal/runconsolelogs/runconsolelogs.go
@@ -99,7 +99,16 @@ func New(params Params) *Sender {
 		rate.NewLimiter(rate.Every(10*time.Millisecond), 1),
 		func(lines sparselist.SparseList[*RunLogsLine]) {
 			if fileWriter != nil {
-				fileWriter.WriteToFile(lines)
+				err := fileWriter.WriteToFile(lines)
+
+				if err != nil {
+					params.Logger.CaptureError(
+						fmt.Errorf(
+							"runconsolelogs: failed to write to file: %v",
+							err,
+						))
+					fileWriter = nil
+				}
 			}
 
 			if fsWriter != nil {


### PR DESCRIPTION
Description
---
Stops writing to `output.log` after the first error.

The most common error that happens is when users delete their wandb directory before stopping a run. There are also more rare failures related to mounted file systems and disk issues where we can't guarantee the file isn't corrupted, so we should stop writing to it. Any content that was successfully written is uploaded at the end of the run.