### PR TITLE
fix: avoid race condition by updating the run state once

### DIFF
--- a/core/internal/runbranch/state.go
+++ b/core/internal/runbranch/state.go
@@ -51,7 +51,7 @@ type RunParams struct {
 
 	FileStreamOffset filestream.FileStreamOffsetMap
 
-	Intialized bool
+	Initialized bool
 }
 
 func (r *RunParams) Proto() *spb.RunRecord {

--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -395,7 +395,7 @@ func (s *Sender) sendRequest(record *spb.Record, request *spb.Request) {
 // updateSettings updates the settings from the run record upon a run start
 // with the information from the server
 func (s *Sender) updateSettings() {
-	if s.settings == nil || !s.startState.Intialized {
+	if s.settings == nil || !s.startState.Initialized {
 		return
 	}
 
@@ -874,8 +874,7 @@ func (s *Sender) sendRun(record *spb.Record, run *spb.RunRecord) {
 	proto.Merge(s.telemetry, run.Telemetry)
 	s.updateConfigPrivate()
 
-	if !s.startState.Intialized {
-		s.startState.Intialized = true
+	if !s.startState.Initialized {
 
 		// update the run state with the initial run record
 		s.startState.Merge(&runbranch.RunParams{
@@ -905,19 +904,18 @@ func (s *Sender) sendRun(record *spb.Record, run *spb.RunRecord) {
 				)
 			}
 			s.logger.Error("sender: sendRun: user provided more than one of resume, rewind, or fork")
-			return
 		case isResume != "":
 			s.sendResumeRun(record, runClone)
-			return
 		case isRewind != nil:
 			s.sendRewindRun(record, runClone)
-			return
 		case isFork != nil:
 			s.sendForkRun(record, runClone)
-			return
 		default:
-			// no branching, just send the run
+			s.upsertRun(record, runClone)
 		}
+		// mark the run state as initialized after the initial run upsert
+		s.startState.Initialized = true
+		return
 	}
 
 	s.upsertRun(record, runClone)
@@ -952,7 +950,7 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 		// if this times out, we mark the run as done as there is
 		// no need to proceed with it
 		ctx = s.mailbox.Add(ctx, s.runWork.SetDone, mailboxSlot)
-	} else if !s.startState.Intialized {
+	} else if !s.startState.Initialized {
 		// this should never happen:
 		// the initial run upsert record should have a mailbox slot set by the client
 		s.logger.CaptureFatalAndPanic(
@@ -1017,7 +1015,9 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 	// manage the state of the run
 	if data == nil || data.GetUpsertBucket() == nil || data.GetUpsertBucket().GetBucket() == nil {
 		s.logger.Error("sender: upsertRun: upsert bucket response is empty")
-	} else {
+	} else if !s.startState.Initialized {
+		// only update the state once on the initial run upsert, the subsequent
+		// updates are fire-and-forget
 
 		bucket := data.GetUpsertBucket().GetBucket()
 
@@ -1106,7 +1106,7 @@ func (s *Sender) upsertConfig() {
 	if s.graphqlClient == nil {
 		return
 	}
-	if !s.startState.Intialized {
+	if !s.startState.Initialized {
 		s.logger.Error("sender: upsertConfig: RunRecord is nil")
 		return
 	}
@@ -1283,7 +1283,7 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 		return
 	}
 
-	if !s.startState.Intialized {
+	if !s.startState.Initialized {
 		s.logger.CaptureFatalAndPanic(
 			errors.New("sender: sendAlert: RunRecord not set"))
 	}
@@ -1462,7 +1462,7 @@ func (s *Sender) sendRequestSync(record *spb.Record, request *spb.SyncRequest) {
 			}
 
 			var url string
-			if !s.startState.Intialized {
+			if !s.startState.Initialized {
 				baseUrl := s.settings.GetBaseUrl().GetValue()
 				baseUrl = strings.Replace(baseUrl, "api.", "", 1)
 				url = fmt.Sprintf("%s/%s/%s/runs/%s",


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-20863

What does the PR do? Include a concise description of the PR contents.

Minimal change to avoid race condition when sending a run update, we used to update the run state every time we send run update, however part of the update includes the filstream offset, which after the first run update can be used in other call-sites, hence we limit the update to the first run update. Also from a conceptual point of view, it doesn't make sense to update the initial run state after every upsert

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
