### PR TITLE
fix(sdk): properly encode infinite scalars from tensorboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Fixed
+
+- Infinite scalars logged in TensorBoard are uploaded successfully rather than skipped (@timoffex in https://github.com/wandb/wandb/pull/8380)
+
 ### Changed
 
 - Default to capturing requirements.txt in Run.log_code by @KyleGoyette https://github.com/wandb/wandb/pull/7864

--- a/core/internal/tensorboard/tfeventconverter.go
+++ b/core/internal/tensorboard/tfeventconverter.go
@@ -55,7 +55,7 @@ func (h *TFEventConverter) ConvertNext(
 
 			switch value := value.GetValue().(type) {
 			case *tbproto.Summary_Value_SimpleValue:
-				processScalarsSimpleValue(emitter, tag, value.SimpleValue)
+				processScalarsSimpleValue(emitter, tag, value.SimpleValue, logger)
 
 			case *tbproto.Summary_Value_Histo:
 				processHistogramsProto(emitter, tag, value.Histo, logger)

--- a/core/internal/tensorboard/tfeventconverter_test.go
+++ b/core/internal/tensorboard/tfeventconverter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"log/slog"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -241,6 +242,12 @@ func TestConvertScalar(t *testing.T) {
 	converter.ConvertNext(
 		emitter,
 		summaryEvent(123, 0.345,
+			scalarValue("epoch_loss", "scalars", float32(math.Inf(1)))),
+		observability.NewNoOpLogger(),
+	)
+	converter.ConvertNext(
+		emitter,
+		summaryEvent(123, 0.345,
 			tensorValue("epoch_loss", "scalars", []int{0}, 2.5)),
 		observability.NewNoOpLogger(),
 	)
@@ -258,6 +265,7 @@ func TestConvertScalar(t *testing.T) {
 	assert.Equal(t,
 		[]mockEmitter_EmitHistory{
 			{pathtree.PathOf("train/epoch_loss"), "0.5"},
+			{pathtree.PathOf("train/epoch_loss"), "Infinity"},
 			{pathtree.PathOf("train/epoch_loss"), "2.5"},
 			{pathtree.PathOf("train/epoch_loss"), "10.5"},
 		},

--- a/core/internal/tensorboard/tfeventconverterscalars.go
+++ b/core/internal/tensorboard/tfeventconverterscalars.go
@@ -2,8 +2,8 @@ package tensorboard
 
 import (
 	"fmt"
-	"strconv"
 
+	"github.com/wandb/simplejsonext"
 	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/tensorboard/tbproto"
 	"github.com/wandb/wandb/core/pkg/observability"
@@ -18,7 +18,7 @@ func processScalars(
 ) {
 	switch value := value.GetValue().(type) {
 	case *tbproto.Summary_Value_SimpleValue:
-		processScalarsSimpleValue(emitter, tag, value.SimpleValue)
+		processScalarsSimpleValue(emitter, tag, value.SimpleValue, logger)
 
 	case *tbproto.Summary_Value_Tensor:
 		tensor, err := tensorFromProto(value.Tensor)
@@ -35,10 +35,14 @@ func processScalars(
 			return
 		}
 
-		emitter.EmitHistory(
-			pathtree.PathOf(tag),
-			strconv.FormatFloat(scalar, 'f', -1, 64),
-		)
+		floatJSON, err := simplejsonext.MarshalToString(scalar)
+		if err != nil {
+			logger.CaptureError(
+				fmt.Errorf("tensorboard: error encoding scalar: %v", err))
+			return
+		}
+
+		emitter.EmitHistory(pathtree.PathOf(tag), floatJSON)
 
 	default:
 		logger.CaptureError(
@@ -53,9 +57,14 @@ func processScalarsSimpleValue(
 	emitter Emitter,
 	tag string,
 	value float32,
+	logger *observability.CoreLogger,
 ) {
-	emitter.EmitHistory(
-		pathtree.PathOf(tag),
-		strconv.FormatFloat(float64(value), 'f', -1, 64),
-	)
+	floatJSON, err := simplejsonext.MarshalToString(value)
+	if err != nil {
+		logger.CaptureError(
+			fmt.Errorf("tensorboard: error encoding scalar: %v", err))
+		return
+	}
+
+	emitter.EmitHistory(pathtree.PathOf(tag), floatJSON)
 }


### PR DESCRIPTION
Description
---
Fixes WB-20897.

Always use `simplejsonext` to produce values in the expected format.