### PR TITLE
fix(sdk): update signature and docstring of `Run.log_artifact()` (in `wandb.apis.public.runs`) to also include artifact tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Fixed
+
+- Update the signature and docstring of `wandb.api.public.runs.Run.log_artifact()` to support artifact tags like `Run` instances returned by `wandb.init()`.
+
 ## [0.18.1] - 2024-09-16
 
 ### Fixed

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -796,7 +796,7 @@ class Run(Attrs):
     @normalize_exceptions
     def log_artifact(
         self,
-        artifact: wandb.Artifact,
+        artifact: "wandb.Artifact",
         aliases: Optional[Collection[str]] = None,
         tags: Optional[Collection[str]] = None,
     ):

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -28,7 +28,6 @@ from wandb.sdk.lib.paths import LogicalPath
 
 if TYPE_CHECKING:
     from wandb.apis.public import RetryingClient
-    from wandb.sdk.artifacts.artifact import Artifact
 
 WANDB_INTERNAL_KEYS = {"_wandb", "wandb_version"}
 
@@ -91,7 +90,7 @@ class Runs(Paginator):
 
     def __init__(
         self,
-        client: RetryingClient,
+        client: "RetryingClient",
         entity: str,
         project: str,
         filters: Optional[Dict[str, Any]] = None,
@@ -297,7 +296,7 @@ class Run(Attrs):
 
     def __init__(
         self,
-        client: RetryingClient,
+        client: "RetryingClient",
         entity: str,
         project: str,
         run_id: str,
@@ -797,7 +796,7 @@ class Run(Attrs):
     @normalize_exceptions
     def log_artifact(
         self,
-        artifact: "Artifact",
+        artifact: wandb.Artifact,
         aliases: Optional[Collection[str]] = None,
         tags: Optional[Collection[str]] = None,
     ):

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1,7 +1,5 @@
 """Public API: runs."""
 
-from __future__ import annotations
-
 import json
 import os
 import sys
@@ -799,7 +797,7 @@ class Run(Attrs):
     @normalize_exceptions
     def log_artifact(
         self,
-        artifact: Artifact,
+        artifact: "Artifact",
         aliases: Optional[Collection[str]] = None,
         tags: Optional[Collection[str]] = None,
     ):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes #8398 

Updates the signature and docstring of `wandb.apis.public.runs.Run` to more closely reflect those of `wandb.sdk.wandb_run.Run`.

Note for clarity: the latter type is the type that's returned by `wandb.init()` (e.g. when executing `with wandb.init(...) as run: ...`) and currently supports tags, while the former did not, prior to this PR.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
