### PR TITLE
fix(sdk): fix error message when media dependency is missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ azure = ["azure-identity", "azure-storage-blob"]
 media = [
     "numpy",
     "moviepy",
+    # imageio is a dependency of moviepy but incase that changes we also pin it here
+    "imageio",
     "pillow",
     "bokeh",
     "soundfile",

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -34,7 +34,7 @@ def write_gif_with_image_io(
 ) -> None:
     imageio = util.get_module(
         "imageio",
-        required='wandb.Video requires imageio when passing raw data. Install with "pip install imageio"',
+        required='wandb.Video requires imageio when passing raw data. Install with "pip install wandb[media]"',
     )
 
     writer = imageio.save(filename, fps=clip.fps, quantizer=0, palettesize=256, loop=0)
@@ -130,7 +130,7 @@ class Video(BatchableMedia):
     def encode(self) -> None:
         mpy = util.get_module(
             "moviepy.editor",
-            required='wandb.Video requires moviepy and imageio when passing raw data.  Install with "pip install moviepy imageio"',
+            required='wandb.Video requires moviepy when passing raw data.  Install with "pip install wandb[media]"',
         )
         tensor = self._prepare_video(self.data)
         _, self._height, self._width, self._channels = tensor.shape  # type: ignore


### PR DESCRIPTION
Description
-----------

This makes our error message clearer and ensures we have imageio even if moviepy somehow stops depending on it.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
