### PR TITLE
fix(sdk): fix glob matching in define metric to work with logged keys containing `/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Allow all users to read cache files when core is enabled (@moredatarequired in https://github.com/wandb/wandb/pull/8362)
 - Infinite scalars logged in TensorBoard are uploaded successfully rather than skipped (@timoffex in https://github.com/wandb/wandb/pull/8380)
-- Properly respect `WANDB_ERROR_REPORTING=false`. This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
+- Properly respect `WANDB_ERROR_REPORTING=false`.  This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
 
 ### Changed
 
@@ -43,8 +43,8 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Changed
 
 - The new "core" backend, previously activated using wandb.require("core"), is now used by default. To revert to the legacy behavior,
-  add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
-  to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
+add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
+to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
 
 ## [0.17.9] - 2024-09-05
 
@@ -72,7 +72,6 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Skip uploading/downloading GCS reference artifact manifest entries corresponding to folders (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8084)
 
 ### Deprecated
-
 - Ability to disable the service process (`WANDB__DISABLE_SERVICE`) is deprecated and will be removed in the next minor release (@kptkin in https://github.com/wandb/wandb/pull/8193)
 
 ## [0.17.7] - 2024-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Update the signature and docstring of `wandb.api.public.runs.Run.log_artifact()` to support artifact tags like `Run` instances returned by `wandb.init()`. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8414)
 - Add docstring for `wandb.watch` to support auto-complete (@kptkin in https://github.com/wandb/wandb/pull/8425)
-- fix glob matching in define metric to work with logged keys containing `/` @KyleGoyette https://github.com/wandb/wandb/pull/8434
+- Fix glob matching in define metric to work with logged keys containing `/` (@KyleGoyette in https://github.com/wandb/wandb/pull/8434)
 
 ## [0.18.1] - 2024-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Update the signature and docstring of `wandb.api.public.runs.Run.log_artifact()` to support artifact tags like `Run` instances returned by `wandb.init()`. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8414)
 - Add docstring for `wandb.watch` to support auto-complete (@kptkin in https://github.com/wandb/wandb/pull/8425)
+- fix glob matching in define metric to work with logged keys containing `/` @KyleGoyette https://github.com/wandb/wandb/pull/8434
 
 ## [0.18.1] - 2024-09-16
 
@@ -22,7 +23,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Allow all users to read cache files when core is enabled (@moredatarequired in https://github.com/wandb/wandb/pull/8362)
 - Infinite scalars logged in TensorBoard are uploaded successfully rather than skipped (@timoffex in https://github.com/wandb/wandb/pull/8380)
-- Properly respect `WANDB_ERROR_REPORTING=false`.  This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
+- Properly respect `WANDB_ERROR_REPORTING=false`. This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
 
 ### Changed
 
@@ -42,8 +43,8 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Changed
 
 - The new "core" backend, previously activated using wandb.require("core"), is now used by default. To revert to the legacy behavior,
-add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
-to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
+  add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
+  to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
 
 ## [0.17.9] - 2024-09-05
 
@@ -71,6 +72,7 @@ to disable this new behavior will be removed (@kptkin in https://github.com/wand
 - Skip uploading/downloading GCS reference artifact manifest entries corresponding to folders (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8084)
 
 ### Deprecated
+
 - Ability to disable the service process (`WANDB__DISABLE_SERVICE`) is deprecated and will be removed in the next minor release (@kptkin in https://github.com/wandb/wandb/pull/8193)
 
 ## [0.17.7] - 2024-08-15

--- a/core/internal/runmetric/runmetric.go
+++ b/core/internal/runmetric/runmetric.go
@@ -187,10 +187,8 @@ func (mh *MetricHandler) createGlobMetrics(
 // a glob metric, and otherwise returns nil.
 func (mh *MetricHandler) matchGlobMetric(key string) (definedMetric, bool) {
 	for glob, metric := range mh.globMetrics {
-		// filepath doesn't match wildcards if the user has specified a section
-		// using `/` in the logged value. So, we can't use filepath.Match here.
-		// since globs can only be used as a suffix, we can just remove the
-		//  wild card, then check if the key starts with the glob
+		// since globs can only be used as a suffix, and we only support wildcard
+		// we can just remove the wild card, then check if the key starts with the glob
 		trimmedGlob := strings.TrimSuffix(glob, "*")
 		match := strings.HasPrefix(key, trimmedGlob)
 		if !match {

--- a/core/internal/runmetric/runmetric.go
+++ b/core/internal/runmetric/runmetric.go
@@ -2,7 +2,6 @@ package runmetric
 
 import (
 	"errors"
-	"path/filepath"
 	"strings"
 
 	"github.com/wandb/wandb/core/internal/pathtree"
@@ -188,9 +187,13 @@ func (mh *MetricHandler) createGlobMetrics(
 // a glob metric, and otherwise returns nil.
 func (mh *MetricHandler) matchGlobMetric(key string) (definedMetric, bool) {
 	for glob, metric := range mh.globMetrics {
-		match, err := filepath.Match(glob, key)
-
-		if err != nil || !match {
+		// filepath doesn't match wildcards if the user has specified a section
+		// using `/` in the logged value. So, we can't use filepath.Match here.
+		// since globs can only be used as a suffix, we can just remove the
+		//  wild card, then check if the key starts with the glob
+		trimmedGlob := strings.TrimSuffix(glob, "*")
+		match := strings.HasPrefix(key, trimmedGlob)
+		if !match {
 			continue
 		}
 

--- a/core/internal/runmetric/runmetric_test.go
+++ b/core/internal/runmetric/runmetric_test.go
@@ -1,0 +1,57 @@
+package runmetric
+
+import (
+	"testing"
+)
+
+func TestGlobMetricWildcard(t *testing.T) {
+	mh := New()
+
+	definedMetric := definedMetric{
+		SyncStep:     true,
+		Step:         "step_metric",
+		IsHidden:     false,
+		IsExplicit:   true,
+		NoSummary:    false,
+		SummaryTypes: 0,
+		MetricGoal:   metricGoalUnset,
+	}
+
+	mh.globMetrics["*"] = definedMetric
+
+	match, ok := mh.matchGlobMetric("test")
+	if !ok || match != definedMetric {
+		t.Errorf("Expected match, got %v", match)
+	}
+
+	match, ok = mh.matchGlobMetric("test/stuff")
+	if !ok || match != definedMetric {
+		t.Errorf("Expected match, got %v", match)
+	}
+}
+
+func TestGlobMetricEndingWildcard(t *testing.T) {
+	mh := New()
+
+	definedMetric := definedMetric{
+		SyncStep:     true,
+		Step:         "step_metric",
+		IsHidden:     false,
+		IsExplicit:   true,
+		NoSummary:    false,
+		SummaryTypes: 0,
+		MetricGoal:   metricGoalUnset,
+	}
+
+	mh.globMetrics["xyz/*"] = definedMetric
+
+	match, ok := mh.matchGlobMetric("test")
+	if ok || match == definedMetric {
+		t.Errorf("Expected not to match, got %v", match)
+	}
+	match, ok = mh.matchGlobMetric("xyz/test")
+	if !ok || match != definedMetric {
+		t.Errorf("Expected match, got %v", match)
+	}
+
+}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- [Fixes WB-20950](https://wandb.atlassian.net/browse/WB-20950)

Uses a starts with strategy instead of direct glob matching for defined metrics

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
