### PR TITLE
feat(artifacts): add a `tags` filter to `wandb.Api.artifacts()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Add docstring for `wandb.watch` to support auto-complete (@kptkin in https://github.com/wandb/wandb/pull/8425)
 - Fix glob matching in define metric to work with logged keys containing `/` (@KyleGoyette in https://github.com/wandb/wandb/pull/8434)
 
+### Added
+
+- Add `tags` parameter to `wandb.Api.artifacts()` to filter artifacts by tag. (@moredatarequired in https://github.com/wandb/wandb/pull/8440)
+
 ## [0.18.1] - 2024-09-16
 
 ### Fixed

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -996,7 +996,11 @@ class Api:
 
     @normalize_exceptions
     def artifacts(
-        self, type_name: str, name: str, per_page: Optional[int] = 50
+        self,
+        type_name: str,
+        name: str,
+        per_page: Optional[int] = 50,
+        tags: Optional[List[str]] = None,
     ) -> "public.Artifacts":
         """Return an `Artifacts` collection from the given parameters.
 
@@ -1005,13 +1009,20 @@ class Api:
             name: (str) An artifact collection name. May be prefixed with entity/project.
             per_page: (int, optional) Sets the page size for query pagination.  None will use the default size.
                 Usually there is no reason to change this.
+            tags: (list[str], optional) Only return artifacts with all of these tags.
 
         Returns:
             An iterable `Artifacts` object.
         """
         entity, project, collection_name = self._parse_artifact_path(name)
         return public.Artifacts(
-            self.client, entity, project, collection_name, type_name, per_page=per_page
+            self.client,
+            entity,
+            project,
+            collection_name,
+            type_name,
+            per_page=per_page,
+            tags=tags,
         )
 
     @normalize_exceptions

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -757,12 +757,18 @@ class Artifacts(Paginator):
         filters: Optional[Mapping[str, Any]] = None,
         order: Optional[str] = None,
         per_page: int = 50,
+        tags: Optional[List[str]] = None,
     ):
         self.entity = entity
         self.collection_name = collection_name
         self.type = type
         self.project = project
         self.filters = {"state": "COMMITTED"} if filters is None else filters
+        if tags is not None:
+            if len(tags) == 1:
+                self.filters["tags.name"] = tags[0]
+            else:
+                self.filters["$and"] = self.filters.get("$and", []) + [{"tags.name": tag} for tag in tags]
         self.order = order
         variables = {
             "project": self.project,

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -768,7 +768,9 @@ class Artifacts(Paginator):
             if len(tags) == 1:
                 self.filters["tags.name"] = tags[0]
             else:
-                self.filters["$and"] = self.filters.get("$and", []) + [{"tags.name": tag} for tag in tags]
+                self.filters["$and"] = self.filters.get("$and", []) + [
+                    {"tags.name": tag} for tag in tags
+                ]
         self.order = order
         variables = {
             "project": self.project,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-21061](https://wandb.atlassian.net/browse/WB-21061)

Enable tag filtering by sending a (conjunctive) set of tags to the backend as a filter for retrieval.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Adds a new test for getting artifacts by tag

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21061]: https://wandb.atlassian.net/browse/WB-21061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ