### PR TITLE
feat(artifacts): add client-side tag filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Add docstring for `wandb.watch` to support auto-complete (@kptkin in https://github.com/wandb/wandb/pull/8425)
 - Fix glob matching in define metric to work with logged keys containing `/` (@KyleGoyette in https://github.com/wandb/wandb/pull/8434)
 
+### Added
+
+- Add `tags` parameter to `wandb.Api.artifacts()` to filter artifacts by tag. (@moredatarequired in https://github.com/wandb/wandb/pull/8441)
+
 ## [0.18.1] - 2024-09-16
 
 ### Fixed

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
@@ -241,6 +241,50 @@ def test_log_artifact_with_invalid_tags(tmp_path, user, wandb_init, api, invalid
             run.log_artifact(artifact, tags=invalid_tags)
 
 
+def test_retrieve_artifacts_by_tags(user, wandb_init, server_supports_artifact_tags):
+    project = "test"
+    artifact_name = "test-artifact"
+    artifact_type = "test-type"
+
+    with wandb_init(entity=user, project=project) as run:
+        for i in range(10):
+            artifact = wandb.Artifact(name=artifact_name, type=artifact_type)
+            with artifact.new_file(f"{i}.txt", "w") as f:
+                f.write("testing")
+            run.log_artifact(artifact)
+
+    artifact_name = f"{user}/{project}/{artifact_name}"
+
+    for logged_artifact in Api().artifacts(type_name=artifact_type, name=artifact_name):
+        version = int(logged_artifact.version.strip("v"))
+        if version % 3 == 0:
+            logged_artifact.tags.append("fizz")
+        if version % 5 == 0:
+            logged_artifact.tags.append("buzz")
+        logged_artifact.save()
+
+    # Retrieve all artifacts with a given tag.
+    artifacts = Api().artifacts(
+        type_name=artifact_type, name=artifact_name, tags=["fizz"]
+    )
+    retrieved_artifacts = list(artifacts)
+    if server_supports_artifact_tags:
+        assert len(retrieved_artifacts) == 4  # v0, v3, v6, v9
+    else:
+        assert len(retrieved_artifacts) == 0
+
+    # Retrieve only the artifacts that match multiple tags.
+    artifacts = Api().artifacts(
+        type_name=artifact_type, name=artifact_name, tags=["fizz", "buzz"]
+    )
+    retrieved_artifacts = list(artifacts)
+    if server_supports_artifact_tags:
+        assert len(retrieved_artifacts) == 1
+        assert retrieved_artifacts[0].version == "v0"
+    else:
+        assert len(retrieved_artifacts) == 0
+
+
 def test_update_aliases_on_artifact(user, wandb_init):
     project = "test"
     run = wandb_init(entity=user, project=project)

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1111,7 +1111,11 @@ class Api:
 
     @normalize_exceptions
     def artifacts(
-        self, type_name: str, name: str, per_page: Optional[int] = 50
+        self,
+        type_name: str,
+        name: str,
+        per_page: Optional[int] = 50,
+        tags: Optional[List[str]] = None,
     ) -> "public.Artifacts":
         """Return an `Artifacts` collection from the given parameters.
 
@@ -1120,13 +1124,20 @@ class Api:
             name: (str) An artifact collection name. May be prefixed with entity/project.
             per_page: (int, optional) Sets the page size for query pagination.  None will use the default size.
                 Usually there is no reason to change this.
+            tags: (list[str], optional) Only return artifacts with all of these tags.
 
         Returns:
             An iterable `Artifacts` object.
         """
         entity, project, collection_name = self._parse_artifact_path(name)
         return public.Artifacts(
-            self.client, entity, project, collection_name, type_name, per_page=per_page
+            self.client,
+            entity,
+            project,
+            collection_name,
+            type_name,
+            per_page=per_page,
+            tags=tags,
         )
 
     @normalize_exceptions

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -837,8 +837,8 @@ class Artifacts(Paginator):
             return None
 
     def convert_objects(self):
-        if self.last_response["project"]["artifactType"]["artifactCollection"] is None:
-            return []
+        collection = self.last_response["project"]["artifactType"]["artifactCollection"]
+        artifact_edges = collection.get("artifacts", {}).get("edges", [])
         artifacts = (
             wandb.Artifact._from_attrs(
                 self.entity,
@@ -847,18 +847,12 @@ class Artifacts(Paginator):
                 a["node"],
                 self.client,
             )
-            for a in self.last_response["project"]["artifactType"][
-                "artifactCollection"
-            ]["artifacts"]["edges"]
+            for a in artifact_edges
         )
-        if self.tags:
-            required_tags = set(self.tags)
-            artifacts = (
-                artifact
-                for artifact in artifacts
-                if required_tags.issubset(artifact.tags)
-            )
-        return list(artifacts)
+        required_tags = set(self.tags or [])
+        return [
+            artifact for artifact in artifacts if required_tags.issubset(artifact.tags)
+        ]
 
 
 class RunArtifacts(Paginator):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-21061](https://wandb.atlassian.net/browse/WB-21061)

A simpler, more performant solution is #8440, but as of now the backend doesn't support that filter properly.

Instead, this implements a very basic client-side filter when getting artifacts that match a set of tags. It should be compatible with upgrading to a server-side solution once one becomes available.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Adds a basic test for getting artifacts matching one or multiple tags

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21061]: https://wandb.atlassian.net/browse/WB-21061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ