### PR TITLE
fix: fixes users not being able to define metrics with a dot (.) in the metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Update the signature and docstring of `wandb.api.public.runs.Run.log_artifact()` to support artifact tags like `Run` instances returned by `wandb.init()`. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8414)
 - Add docstring for `wandb.watch` to support auto-complete (@kptkin in https://github.com/wandb/wandb/pull/8425)
 - Fix glob matching in define metric to work with logged keys containing `/` (@KyleGoyette in https://github.com/wandb/wandb/pull/8434)
-- Fix metric names not being able to container a dot (`.`) (@jacobromero in https://github.com/wandb/wandb/pull/8445)
+- Allow `a\.b` syntax in run.define_metric to refer to a dotted metric name (@jacobromero in https://github.com/wandb/wandb/pull/8445)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Update the signature and docstring of `wandb.api.public.runs.Run.log_artifact()` to support artifact tags like `Run` instances returned by `wandb.init()`. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8414)
 - Add docstring for `wandb.watch` to support auto-complete (@kptkin in https://github.com/wandb/wandb/pull/8425)
 - Fix glob matching in define metric to work with logged keys containing `/` (@KyleGoyette in https://github.com/wandb/wandb/pull/8434)
+- Fix metric names not being able to container a dot (`.`) (@jacobromero in https://github.com/wandb/wandb/pull/8445)
 
 ### Added
 

--- a/core/internal/runmetric/runmetric.go
+++ b/core/internal/runmetric/runmetric.go
@@ -208,8 +208,7 @@ func (mh *MetricHandler) splitEscapedDottedMetricName(metricName string) []strin
 
 	isEscaped := false
 	for i := 0; i < len(metricName); i++ {
-		switch isEscaped {
-		case false:
+		if !isEscaped {
 			switch metricName[i] {
 			// When the current character is a dot, and it has not been escaped then we want to split the metric name.
 			case '.':
@@ -221,7 +220,7 @@ func (mh *MetricHandler) splitEscapedDottedMetricName(metricName string) []strin
 			default:
 				sb.WriteByte(metricName[i])
 			}
-		case true:
+		} else {
 			switch metricName[i] {
 			case '.':
 				sb.WriteByte('.')

--- a/core/internal/runmetric/runmetric.go
+++ b/core/internal/runmetric/runmetric.go
@@ -209,7 +209,7 @@ func (mh *MetricHandler) splitEscapedDottedMetricName(metricName string) []strin
 	isEscaped := false
 	for i := 0; i < len(metricName); i++ {
 		switch isEscaped {
-		case true:
+		case false:
 			switch metricName[i] {
 			// When the current character is a dot, and it has not been escaped then we want to split the metric name.
 			case '.':
@@ -221,7 +221,7 @@ func (mh *MetricHandler) splitEscapedDottedMetricName(metricName string) []strin
 			default:
 				sb.WriteByte(metricName[i])
 			}
-		case false:
+		case true:
 			switch metricName[i] {
 			case '.':
 				sb.WriteByte('.')

--- a/tests/system_tests/test_core/test_metric_full.py
+++ b/tests/system_tests/test_core/test_metric_full.py
@@ -423,18 +423,18 @@ def test_metric_dotted(relay_server, wandb_init):
     with relay_server() as relay:
         run = wandb_init()
         run_id = run.id
-        run.define_metric("this\\.that", summary="min")
-        run.log({"this.that": 3})
-        run.log({"this.that": 2})
-        run.log({"this.that": 4})
+        run.define_metric("test\\this\\.that", summary="min")
+        run.log({"test\\this.that": 3})
+        run.log({"test\\this.that": 2})
+        run.log({"test\\this.that": 4})
         run.finish()
 
     summary = relay.context.get_run_summary(run_id)
     metrics = relay.context.get_run_metrics(run_id)
 
-    assert summary["this.that"] == {"min": 2}
+    assert summary["test\\this.that"] == {"min": 2}
     assert len(metrics) == 1
-    assert metrics[0] == {"1": "this\\.that", "7": [1], "6": [3]}
+    assert metrics[0] == {"1": "test\\this\\.that", "7": [1], "6": [3]}
 
 
 def test_metric_nested_glob(relay_server, wandb_init):

--- a/tests/system_tests/test_core/test_metric_full.py
+++ b/tests/system_tests/test_core/test_metric_full.py
@@ -418,7 +418,6 @@ def test_metric_nested_mult(relay_server, wandb_init):
     assert metrics[0] == {"1": "this.that", "7": [1, 2], "6": [3]}
 
 
-@pytest.mark.skip_wandb_core(feature="define_metric")
 def test_metric_dotted(relay_server, wandb_init):
     """Escape dots in metric definitions."""
     with relay_server() as relay:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-20622

What does the PR do? Include a concise description of the PR contents.

This PR allows users to provide metrics with dots `.` in the name when calling `run.define_metric` by escaping the dot.. (e.g. `a\.b`)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?
- unit tests
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-20622]: https://wandb.atlassian.net/browse/WB-20622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ