### PR TITLE
fix(sdk): correctly log retries

### DIFF
--- a/core/internal/api/logging.go
+++ b/core/internal/api/logging.go
@@ -37,12 +37,15 @@ func withRetryLogging(
 	}
 
 	return func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		willRetry, err := policy(ctx, resp, err)
+		willRetry, newErr := policy(ctx, resp, err)
+		if newErr != nil {
+			err = newErr
+		}
 
 		if willRetry {
 			switch {
 			case resp == nil && err == nil:
-				logger.Info("api: retrying HTTP request, no error or response")
+				logger.Error("api: retrying HTTP request, no error or response")
 			case err != nil:
 				logger.Info("api: retrying error", "error", err)
 			case resp.StatusCode >= 400:

--- a/tests/system_tests/test_core/test_file_stream.py
+++ b/tests/system_tests/test_core/test_file_stream.py
@@ -179,6 +179,6 @@ def test_connection_reset(
         regex_pattern = log_line_match_eof(user, run.project, run.id)
         matches = regex_pattern.findall(internal_log)
 
-        # There are 2 retries, each of which generates 2 log messages.
-        assert len(matches) == 4
+        assert len(matches) == 2
+        # Each retry generates 2 log messages.
         assert internal_log.count(': EOF"') == 4

--- a/tests/system_tests/test_core/test_file_stream.py
+++ b/tests/system_tests/test_core/test_file_stream.py
@@ -178,7 +178,7 @@ def test_connection_reset(
         internal_log = f.read()
         regex_pattern = log_line_match_eof(user, run.project, run.id)
         matches = regex_pattern.findall(internal_log)
-        # we should have 2 retries
+
+        # There are 2 retries, each of which generates 2 log messages.
         assert len(matches) == 4
-        # assert we see EOF in the logs twice
         assert internal_log.count(': EOF"') == 4

--- a/tests/system_tests/test_core/test_file_stream.py
+++ b/tests/system_tests/test_core/test_file_stream.py
@@ -179,6 +179,6 @@ def test_connection_reset(
         regex_pattern = log_line_match_eof(user, run.project, run.id)
         matches = regex_pattern.findall(internal_log)
         # we should have 2 retries
-        assert len(matches) == 2
+        assert len(matches) == 4
         # assert we see EOF in the logs twice
-        assert internal_log.count(': EOF"') == 2
+        assert internal_log.count(': EOF"') == 4


### PR DESCRIPTION
Description
---
`retryablehttp.CheckRetry`'s documentation states that it only returns an error to override the error returned by the client. A nil error means that the original error is used.

Without this fix, disconnecting WiFi and running `wandb.init()` logs mysterious "api: retrying HTTP request, no error or response" messages. With this fix, the log message is "api: retrying error","error":"Post \"https://api.wandb.ai/graphql\": dial tcp: lookup api.wandb.ai: no such host".
