### PR TITLE
fix(sdk): show better error when attaching fails

### DIFF
--- a/wandb/sdk/lib/sock_client.py
+++ b/wandb/sdk/lib/sock_client.py
@@ -14,9 +14,11 @@ if TYPE_CHECKING:
 
 
 class SockClientClosedError(Exception):
-    """Socket has been closed."""
+    """Raised on operations on a closed socket."""
 
-    pass
+
+class SockClientTimeoutError(Exception):
+    """Raised if the server didn't respond before the timeout."""
 
 
 class SockBuffer:
@@ -182,8 +184,10 @@ class SockClient:
         # it should be relatively stable.
         # This pass would be solved as part of the fix in https://wandb.atlassian.net/browse/WB-8709
         response = self.read_server_response(timeout=1)
+
         if response is None:
-            raise Exception("No response")
+            raise SockClientTimeoutError("No response after 1 second.")
+
         return response
 
     def send(

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -944,9 +944,10 @@ def _attach(
     if not service:
         raise UsageError(f"Unable to attach to run {attach_id} (no service process)")
 
-    attach_settings = service.inform_attach(attach_id=attach_id)
-    if not attach_settings:
-        raise UsageError(f"Unable to attach to run {attach_id}")
+    try:
+        attach_settings = service.inform_attach(attach_id=attach_id)
+    except Exception as e:
+        raise UsageError(f"Unable to attach to run {attach_id}") from e
 
     settings: Settings = copy.copy(_wl._settings)
 


### PR DESCRIPTION
Description
---
Instead of raising "Exception: No response", raise "wandb.errors.errors.UsageError: Unable to attach to run rmlkh5ze".

The regression was introduced in e66e4765047fa06af6576f6feba265339dd69ee8 (not yet released).
