### PR TITLE
fix: prevent zombification of nvidia_gpu_stats

### DIFF
--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -152,10 +152,7 @@ func (g *GPUNvidia) waitWithTimeout(timeout time.Duration) {
 	}()
 
 	select {
-	case err := <-done:
-		if err != nil {
-			g.logger.CaptureError(fmt.Errorf("monitor: %v: error waiting for process to exit: %v", g.name, err))
-		}
+	case <-done:
 	case <-time.After(timeout):
 		// Timeout occurred
 		g.logger.CaptureError(fmt.Errorf("monitor: %v: timeout waiting for process to exit", g.name))
@@ -214,9 +211,7 @@ func (g *GPUNvidia) Close() {
 		return
 	}
 	// send signal to the process to exit
-	if err := g.cmd.Process.Signal(os.Kill); err != nil {
-		g.logger.Error("monitor: %v: error sending signal to process: %v", g.name, err)
-	}
+	_ = g.cmd.Process.Signal(os.Kill)
 	// We must ensure that the command is waited for to avoid zombie processes.
 	g.waitWithTimeout(5 * time.Second)
 }

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -1,4 +1,4 @@
-//go:bu ild linux
+//go:build linux
 
 package monitor
 

--- a/core/pkg/monitor/noop_darwin.go
+++ b/core/pkg/monitor/noop_darwin.go
@@ -8,31 +8,31 @@ import (
 )
 
 // GPUNvidia is a dummy implementation of the Asset interface for Nvidia GPUs.
-// type GPUNvidia struct {
-// 	name             string
-// 	pid              int32
-// 	samplingInterval float64
-// 	logger           *observability.CoreLogger
-// }
+type GPUNvidia struct {
+	name             string
+	pid              int32
+	samplingInterval float64
+	logger           *observability.CoreLogger
+}
 
-// func NewGPUNvidia(logger *observability.CoreLogger, pid int32, samplingInterval float64) *GPUNvidia {
-// 	return &GPUNvidia{
-// 		name:             "gpu",
-// 		pid:              pid,
-// 		samplingInterval: samplingInterval,
-// 		logger:           logger,
-// 	}
-// }
+func NewGPUNvidia(logger *observability.CoreLogger, pid int32, samplingInterval float64) *GPUNvidia {
+	return &GPUNvidia{
+		name:             "gpu",
+		pid:              pid,
+		samplingInterval: samplingInterval,
+		logger:           logger,
+	}
+}
 
-// func (g *GPUNvidia) Name() string { return g.name }
+func (g *GPUNvidia) Name() string { return g.name }
 
-// func (g *GPUNvidia) Sample() (map[string]any, error) { return nil, nil }
+func (g *GPUNvidia) Sample() (map[string]any, error) { return nil, nil }
 
-// func (g *GPUNvidia) IsAvailable() bool { return false }
+func (g *GPUNvidia) IsAvailable() bool { return false }
 
-// func (g *GPUNvidia) Probe() *spb.MetadataRequest {
-// 	return nil
-// }
+func (g *GPUNvidia) Probe() *spb.MetadataRequest {
+	return nil
+}
 
 // GPUAMD is a dummy implementation of the Asset interface for AMD GPUs.
 type GPUAMD struct {

--- a/core/pkg/monitor/noop_darwin.go
+++ b/core/pkg/monitor/noop_darwin.go
@@ -8,31 +8,31 @@ import (
 )
 
 // GPUNvidia is a dummy implementation of the Asset interface for Nvidia GPUs.
-type GPUNvidia struct {
-	name             string
-	pid              int32
-	samplingInterval float64
-	logger           *observability.CoreLogger
-}
+// type GPUNvidia struct {
+// 	name             string
+// 	pid              int32
+// 	samplingInterval float64
+// 	logger           *observability.CoreLogger
+// }
 
-func NewGPUNvidia(logger *observability.CoreLogger, pid int32, samplingInterval float64) *GPUNvidia {
-	return &GPUNvidia{
-		name:             "gpu",
-		pid:              pid,
-		samplingInterval: samplingInterval,
-		logger:           logger,
-	}
-}
+// func NewGPUNvidia(logger *observability.CoreLogger, pid int32, samplingInterval float64) *GPUNvidia {
+// 	return &GPUNvidia{
+// 		name:             "gpu",
+// 		pid:              pid,
+// 		samplingInterval: samplingInterval,
+// 		logger:           logger,
+// 	}
+// }
 
-func (g *GPUNvidia) Name() string { return g.name }
+// func (g *GPUNvidia) Name() string { return g.name }
 
-func (g *GPUNvidia) Sample() (map[string]any, error) { return nil, nil }
+// func (g *GPUNvidia) Sample() (map[string]any, error) { return nil, nil }
 
-func (g *GPUNvidia) IsAvailable() bool { return false }
+// func (g *GPUNvidia) IsAvailable() bool { return false }
 
-func (g *GPUNvidia) Probe() *spb.MetadataRequest {
-	return nil
-}
+// func (g *GPUNvidia) Probe() *spb.MetadataRequest {
+// 	return nil
+// }
 
 // GPUAMD is a dummy implementation of the Asset interface for AMD GPUs.
 type GPUAMD struct {


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
The `nvidia_gpu_stats` process used to collect Nvidia GPU metrics must be waited on in `gpu_nvidia.go` to prevent the zombification of the former.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
