### PR TITLE
fix: use correct go binary path when building c# client on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,12 +500,12 @@ workflows:
           codecov_flags: unit
           parallelism: 4
 
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
-          #       - /^release-.*/
-          #       - /^.*-ci-win$/
+          filters:
+            branches:
+              only:
+                - main
+                - /^release-.*/
+                - /^.*-ci-win$/
 
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,12 +500,12 @@ workflows:
           codecov_flags: unit
           parallelism: 4
 
-          filters:
-            branches:
-              only:
-                - main
-                - /^release-.*/
-                - /^.*-ci-win$/
+          # filters:
+          #   branches:
+          #     only:
+          #       - main
+          #       - /^release-.*/
+          #       - /^.*-ci-win$/
 
           matrix:
             parameters:

--- a/experimental/client-csharp/src/Wandb/Wandb.csproj
+++ b/experimental/client-csharp/src/Wandb/Wandb.csproj
@@ -8,16 +8,16 @@
     <WandbCoreDir>$(MSBuildProjectDirectory)/wandb-core</WandbCoreDir>
     <GoSrcDir>$(MSBuildProjectDirectory)/../../../../core</GoSrcDir>
   </PropertyGroup>
-    <PropertyGroup>
+  <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
   <ItemGroup>
-      <Protobuf Include="$(MSBuildProjectDirectory)/../../../../wandb/proto/*.proto" ProtoRoot="$(MSBuildProjectDirectory)/../../../../">
-        <OutputDir>$(ProjectDir)Generated</OutputDir>
-        <CompileOutputs>true</CompileOutputs>
-        <GrpcServices>None</GrpcServices>
-      </Protobuf>
+    <Protobuf Include="$(MSBuildProjectDirectory)/../../../../wandb/proto/*.proto" ProtoRoot="$(MSBuildProjectDirectory)/../../../../">
+      <OutputDir>$(ProjectDir)Generated</OutputDir>
+      <CompileOutputs>true</CompileOutputs>
+      <GrpcServices>None</GrpcServices>
+    </Protobuf>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.28.0" />
@@ -47,8 +47,11 @@
     <PropertyGroup>
       <GoBinaryPath Condition="'$(OS)' == 'Windows_NT'">wandb-core.exe</GoBinaryPath>
       <GoBinaryPath Condition="'$(OS)' != 'Windows_NT'">wandb-core</GoBinaryPath>
+      <LdFlags>-s -w</LdFlags>
+      <GoBinaryOutputPath>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(GoBinaryPath)'))</GoBinaryOutputPath>
+      <MainGoFile>$([System.IO.Path]::Combine('cmd', 'wandb-core', 'main.go'))</MainGoFile>
     </PropertyGroup>
-    <Exec Command="go build -ldflags='-s -w' -mod=vendor -o $(MSBuildProjectDirectory)/$(GoBinaryPath) cmd/wandb-core/main.go" WorkingDirectory="$(GoSrcDir)"/>
+    <Exec Command="go build -ldflags=&quot;$(LdFlags)&quot; -mod=vendor -o &quot;$(GoBinaryOutputPath)&quot; &quot;$(MainGoFile)&quot;" WorkingDirectory="$(GoSrcDir)" />
     <ItemGroup>
       <None Include="$(GoBinaryPath)">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Ensure we use the correct go binary path when building the experimental C# client on Windows.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
