### PR TITLE
feat(artifacts): allow `tags` to be a single string

### DIFF
--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
@@ -265,7 +265,7 @@ def test_retrieve_artifacts_by_tags(user, wandb_init, server_supports_artifact_t
 
     # Retrieve all artifacts with a given tag.
     artifacts = Api().artifacts(
-        type_name=artifact_type, name=artifact_name, tags=["fizz"]
+        type_name=artifact_type, name=artifact_name, tags="fizz"
     )
     retrieved_artifacts = list(artifacts)
     if server_supports_artifact_tags:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -3,7 +3,7 @@
 import json
 import re
 from copy import copy
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Sequence, Union
 
 from wandb_gql import Client, gql
 
@@ -757,14 +757,14 @@ class Artifacts(Paginator):
         filters: Optional[Mapping[str, Any]] = None,
         order: Optional[str] = None,
         per_page: int = 50,
-        tags: Optional[List[str]] = None,
+        tags: Optional[Union[str, List[str]]] = None,
     ):
         self.entity = entity
         self.collection_name = collection_name
         self.type = type
         self.project = project
         self.filters = {"state": "COMMITTED"} if filters is None else filters
-        self.tags = tags
+        self.tags = [tags] if isinstance(tags, str) else tags
         self.order = order
         variables = {
             "project": self.project,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Allow the `tags` argument to `Api.Artifacts()` to be a string instead of a list, interpreting it to be a list with just that element. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Updated test to check this usage pattern.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
