### PR TITLE
chore: improve behavior of Run::DefineMetric in experimental c# client

### DIFF
--- a/experimental/client-csharp/examples/Basic/Program.cs
+++ b/experimental/client-csharp/examples/Basic/Program.cs
@@ -19,6 +19,8 @@ class Program
             await run1.UpdateConfig(new Dictionary<string, object> { { "batch_size", 64 } });
             await run1.DefineMetric("recall", "epoch", SummaryType.Max | SummaryType.Mean);
             await run1.DefineMetric("loss", "epoch", SummaryType.Min);
+            // hide the epoch metric from the UI:
+            await run1.DefineMetric("epoch", hidden: true);
 
             // Log metrics:
             await run1.Log(new Dictionary<string, object> { { "loss", 0.5 }, { "recall", 0.8 }, { "epoch", 1 } });
@@ -40,6 +42,7 @@ class Program
             await run2.UpdateConfig(new Dictionary<string, object> { { "learning_rate", 3e-4 } });
             await run2.DefineMetric("recall", "epoch", SummaryType.Max | SummaryType.Mean);
             await run2.DefineMetric("loss", "epoch", SummaryType.Min);
+            await run2.DefineMetric("epoch", hidden: true);
 
             // Log more metrics:
             await run2.Log(new Dictionary<string, object> { { "loss", 0.1 }, { "recall", 0.99 }, { "epoch", 4 } });

--- a/experimental/client-csharp/src/Wandb/Internal/SocketInterface.cs
+++ b/experimental/client-csharp/src/Wandb/Internal/SocketInterface.cs
@@ -186,7 +186,7 @@ namespace Wandb.Internal
         /// <returns>A task representing the asynchronous operation.</returns>
         public async Task PublishMetricDefinition(
             string name,
-            string stepMetric,
+            string? stepMetric,
             SummaryType? summary,
             bool? hidden
         )
@@ -194,10 +194,13 @@ namespace Wandb.Internal
             var metricDefinition = new MetricRecord
             {
                 Name = name,
-                StepMetric = stepMetric,
                 Options = new MetricOptions { },
                 Summary = new MetricSummary { }
             };
+            if (stepMetric != null)
+            {
+                metricDefinition.StepMetric = stepMetric;
+            }
             if (hidden == true)
             {
                 metricDefinition.Options.Hidden = true;

--- a/experimental/client-csharp/src/Wandb/Run.cs
+++ b/experimental/client-csharp/src/Wandb/Run.cs
@@ -137,7 +137,7 @@ namespace Wandb
         /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task DefineMetric(
             string name,
-            string stepMetric,
+            string? stepMetric = null,
             SummaryType? summary = null,
             bool? hidden = false
         )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Make it clearer how to hide a metric from the UI with a statement like:
```csharp
await run.DefineMetric("epoch", hidden: true);
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
