### PR TITLE
fix(artifacts): finished runs should await all logged artifacts

### DIFF
--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -497,6 +497,15 @@ def test_artifact_wait_failure(wandb_init, timeout):
     run.finish()
 
 
+def test_finished_run_automatically_awaits_artifact(wandb_init):
+    """Check that finishing a run automatically calls `Artifact.wait()` on all artifacts logged in that run."""
+    with wandb_init() as run:
+        artifact = wandb.Artifact("art", type="dataset")
+        run.log_artifact(artifact)
+
+    assert not artifact.is_draft()
+
+
 def test_check_existing_artifact_before_download(wandb_init, tmp_path, monkeypatch):
     """Don't re-download an artifact if it's already in the desired location."""
     cache_dir = tmp_path / "cache"

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -20,11 +20,11 @@ from datetime import datetime, timedelta, timezone
 from enum import IntEnum
 from types import TracebackType
 from typing import (
-    Collection,
-    Deque,
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
+    Deque,
     Dict,
     List,
     NamedTuple,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-21172](https://wandb.atlassian.net/browse/WB-21172)

Ensures that on finishing a run -- either by calling `run.finish()` explicitly or exiting the run context manager -- `artifact.wait()` is called on all artifacts so that they can call other `Artifact` methods that require the artifact to be logged.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21172]: https://wandb.atlassian.net/browse/WB-21172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ