### PR TITLE
refactor(artifacts): use a common function for setting artifact attributes

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -814,51 +814,18 @@ class Artifact:
         return self
 
     def _populate_after_save(self, artifact_id: str) -> None:
-        fields = InternalApi().server_artifact_introspection()
-
-        supports_ttl = "ttlIsInherited" in fields
-        ttl_duration_seconds = "ttlDurationSeconds" if supports_ttl else ""
-        ttl_is_inherited = "ttlIsInherited" if supports_ttl else ""
-
-        supports_tags = "tags" in fields
-        tags = "tags {name}" if supports_tags else ""
-
         query_template = f"""
             query ArtifactByIDShort($id: ID!) {{
                 artifact(id: $id) {{
-                    artifactSequence {{
-                        project {{
-                            entityName
-                            name
-                        }}
-                        name
-                    }}
-                    versionIndex
-                    {ttl_duration_seconds}
-                    {ttl_is_inherited}
-                    aliases {{
-                        artifactCollection {{
-                            project {{
-                                entityName
-                                name
-                            }}
-                            name
-                        }}
-                        alias
-                    }}
-                    {tags!s}
-                    state
+                    ...ArtifactFragment
                     currentManifest {{
                         file {{
                             directUrl
                         }}
                     }}
-                    commitHash
-                    fileCount
-                    createdAt
-                    updatedAt
                 }}
             }}
+            {self._get_gql_artifact_fragment()}
         """
 
         query = gql(query_template)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -199,19 +199,19 @@ class Artifact:
             return artifact
 
         query = gql(
-            """
-            query ArtifactByID($id: ID!) {
-                artifact(id: $id) {
+            f"""
+            query ArtifactByID($id: ID!) {{
+                artifact(id: $id) {{
                     ...ArtifactFragment
-                    currentManifest {
-                        file {
+                    currentManifest {{
+                        file {{
                             directUrl
-                        }
-                    }
-                }
-            }
+                        }}
+                    }}
+                }}
+            }}
+            {cls._get_gql_artifact_fragment()}
             """
-            + cls._get_gql_artifact_fragment()
         )
         response = client.execute(
             query,
@@ -234,20 +234,20 @@ class Artifact:
         cls, entity: str, project: str, name: str, client: RetryingClient
     ) -> Artifact:
         query = gql(
-            """
+            f"""
             query ArtifactByName(
                 $entityName: String!,
                 $projectName: String!,
                 $name: String!
-            ) {
-                project(name: $projectName, entityName: $entityName) {
-                    artifact(name: $name) {
+            ) {{
+                project(name: $projectName, entityName: $entityName) {{
+                    artifact(name: $name) {{
                         ...ArtifactFragment
-                    }
-                }
-            }
+                    }}
+                }}
+            }}
+            {cls._get_gql_artifact_fragment()}
             """
-            + cls._get_gql_artifact_fragment()
         )
         response = client.execute(
             query,

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -844,6 +844,7 @@ class Artifact:
         self._created_at = attrs["createdAt"]
         self._updated_at = attrs["updatedAt"]
         self._final = True
+        self._save_future = None
 
     @normalize_exceptions
     def _update(self) -> None:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-21209](https://wandb.atlassian.net/browse/WB-21209)

Refactor `Artifact._from_attrs` and `Artifact._populate_after_save` to share a common method.

Note that this is **not** a pure refactor. The behavior of these two methods should have probably been the same, but it wasn't.

Previously, `_populate_after_save` did the following that `_from_attrs` did not; now they both:

- set `_ttl_changed` to False

Previously, `_from_attrs` did the following that `_populate_after_save` did not; now they both:
- set `_saved_aliases`
- set `_saved_tags`
- set `_type` (probably not necessary for `populate`
- set `_description`
- set `metadata`
- set `_final` to True

Previously, neither of them set `_save_future` back to None, but now the both do.

Version handling is slightly different from what `_populate_after_save` did; this doesn't break any tests and I think is more correct, but it's hard to tell. More broadly, `_populate_after_save`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
I've added one test (`test_linked_artifact_update`) to ensure that the wait call doesn't cause unexpected behavior when used on linked artifacts.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21209]: https://wandb.atlassian.net/browse/WB-21209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ