### PR TITLE
chore(sdk): reduce long-operation threshold to 10m

### DIFF
--- a/core/pkg/server/sender.go
+++ b/core/pkg/server/sender.go
@@ -280,7 +280,7 @@ outerLoop:
 
 				continue outerLoop
 
-			case <-time.After(30 * time.Minute):
+			case <-time.After(10 * time.Minute):
 				if i < 6 {
 					s.logger.CaptureWarn(
 						"sender: taking a long time",


### PR DESCRIPTION
Description
---
Reduces the threshold before logging that an operation is taking too long from 30m to 10m, to match the threshold we use in `runwork`.