### PR TITLE
chore(sdk): fix lints in hatch files

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -127,6 +127,7 @@ class CustomBuildHook(BuildHookInterface):
                 "Did not find the 'cargo' binary. You need Rust to build wandb"
                 " from source. See https://www.rust-lang.org/tools/install.",
             )
+            raise AssertionError("unreachable")
 
         return pathlib.Path(cargo)
 
@@ -186,6 +187,7 @@ class CustomBuildHook(BuildHookInterface):
                 "Did not find the 'go' binary. You need Go to build wandb"
                 " from source. See https://go.dev/doc/install.",
             )
+            raise AssertionError("unreachable")
 
         return pathlib.Path(go)
 

--- a/nvidia_gpu_stats/hatch.py
+++ b/nvidia_gpu_stats/hatch.py
@@ -10,7 +10,7 @@ class NvidiaGpuStatsBuildError(Exception):
 
 def build_nvidia_gpu_stats(
     cargo_binary: pathlib.Path,
-    output_path: pathlib.PurePath,
+    output_path: pathlib.Path,
 ) -> None:
     """Builds the `nvidia_gpu_stats` Rust binary for monitoring NVIDIA GPUs.
 
@@ -23,7 +23,8 @@ def build_nvidia_gpu_stats(
         output_path: The path where to output the binary, relative to the
             workspace root.
     """
-    source_path = pathlib.Path("./nvidia_gpu_stats")
+    rust_pkg_root = pathlib.Path("./nvidia_gpu_stats")
+    built_binary_path = rust_pkg_root / "target" / "release" / "nvidia_gpu_stats"
 
     cmd = (
         str(cargo_binary),
@@ -32,7 +33,7 @@ def build_nvidia_gpu_stats(
     )
 
     try:
-        subprocess.check_call(cmd, cwd=source_path)
+        subprocess.check_call(cmd, cwd=rust_pkg_root)
     except subprocess.CalledProcessError as e:
         raise NvidiaGpuStatsBuildError(
             "Failed to build the `nvidia_gpu_stats` Rust binary. If you didn't"
@@ -45,6 +46,5 @@ def build_nvidia_gpu_stats(
         ) from e
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    source_path = source_path / "target" / "release" / "nvidia_gpu_stats"
-    source_path.replace(output_path)
+    built_binary_path.replace(output_path)
     output_path.chmod(0o755)


### PR DESCRIPTION
Description
---
Add `raise AssertionError()` in two spots after functions that never return so that `mypy` can properly narrow union types. Use `pathlib.Path` instead of `pathlib.PurePath` in a function that uses `pathlib.Path` methods.