### PR TITLE
fix: installing media dependencies fails to find rdkit install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Fixed a regression introduced in v0.18.2 that affected the capturing of Nvidia GPU names. (@dmitryduev in https://github.com/wandb/wandb/pull/8503)
 - `run.log_artifact()` no longer blocks other data uploads until the artifact upload finishes (@timoffex in https://github.com/wandb/wandb/pull/8466)
+- Fixed media dependency for rdkit updated from `rdkit-pypi` to `rdkit` (@jacobromero in https://github.com/wandb/wandb/compare/WB-20894)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,13 @@ Get started with W&B in four steps:
 1. First, sign up for a [W&B account](https://wandb.ai/login?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=quickstart).
 
 2. Second, install the W&B SDK with [pip](https://pip.pypa.io/en/stable/). Navigate to your terminal and type the following command:
-
 ```bash
 pip install wandb
+```
+* If you plan to log media data (images, audio, video, etc.), install additional dependencies `media` extras:
+
+```bash
+pip install wandb[media]
 ```
 
 3. Third, log into W&B:

--- a/README.md
+++ b/README.md
@@ -90,13 +90,9 @@ Get started with W&B in four steps:
 1. First, sign up for a [W&B account](https://wandb.ai/login?utm_source=github&utm_medium=code&utm_campaign=wandb&utm_content=quickstart).
 
 2. Second, install the W&B SDK with [pip](https://pip.pypa.io/en/stable/). Navigate to your terminal and type the following command:
-```bash
-pip install wandb
-```
-* If you plan to log media data (images, audio, video, etc.), install additional dependencies `media` extras:
 
 ```bash
-pip install wandb[media]
+pip install wandb
 ```
 
 3. Third, log into W&B:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ media = [
     "bokeh",
     "soundfile",
     "plotly>=5.18.0",
-    "rdkit-pypi",
+    "rdkit",
 ]
 sweeps = ["sweeps>=0.2.0"]
 launch = [


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-20894

What does the PR do? Include a concise description of the PR contents.

This PR fixes one dependency installation failure when running `pip install wandb[media]`.  Additionally, it updates the README file with instructions of installing dependencies needed for working with media files.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

- `pip install wandb[media]`
  - before: `ERROR: Could not find a version that satisfies the requirement rdkit-pypi`
  - after: `﻿Successfully installed wandb-0.18.3.dev1`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
