### PR TITLE
fix: capture nvidia gpu stats on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,32 +287,6 @@ jobs:
           python: <<parameters.python>>
           session: <<parameters.session>>
 
-  gpu-win:
-    executor:
-      name: win/server-2019-cuda
-      shell: bash.exe
-    steps:
-      - checkout
-      - run:
-          name: Install Python
-          command: >
-            nuget.exe install python \
-              -Version 3.12 \
-              -ExcludeVersion \
-              -OutputDirectory "/c/nox-tests-python" &&
-            setx PATH '/c/nox-tests-python/python/tools;%PATH%'
-      - run:
-          name: "Install system deps: ffmpeg"
-          command: choco install -y ffmpeg
-      - run:
-          # We install mingw so that gcc is available, which is needed for cgo.
-          name: "Install system deps: mingw"
-          command: choco install -y mingw --version 12.2 --allow-downgrade
-
-      - install_go
-      - install_rust
-      - run: '&"C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe"'
-
   nox-tests-macos:
     parameters:
       parallelism: { type: integer }
@@ -536,9 +510,6 @@ workflows:
           matrix:
             parameters:
               python: ["3.9", "3.12"]
-
-      # TODO: rm me
-      - gpu-win
 
       #
       # System tests on Linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,6 +287,32 @@ jobs:
           python: <<parameters.python>>
           session: <<parameters.session>>
 
+  gpu-win:
+    executor:
+      name: win/server-2019-cuda
+      shell: bash.exe
+    steps:
+      - checkout
+      - run:
+          name: Install Python
+          command: >
+            nuget.exe install python \
+              -Version 3.12 \
+              -ExcludeVersion \
+              -OutputDirectory "/c/nox-tests-python" &&
+            setx PATH '/c/nox-tests-python/python/tools;%PATH%'
+      - run:
+          name: "Install system deps: ffmpeg"
+          command: choco install -y ffmpeg
+      - run:
+          # We install mingw so that gcc is available, which is needed for cgo.
+          name: "Install system deps: mingw"
+          command: choco install -y mingw --version 12.2 --allow-downgrade
+
+      - install_go
+      - install_rust
+      - run: '&"C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe"'
+
   nox-tests-macos:
     parameters:
       parallelism: { type: integer }
@@ -510,6 +536,9 @@ workflows:
           matrix:
             parameters:
               python: ["3.9", "3.12"]
+
+      # TODO: rm me
+      - gpu-win
 
       #
       # System tests on Linux

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,11 +28,5 @@
     "./experimental/client-rust/Cargo.toml"
   ],
   "python.analysis.autoImportCompletions": true,
-  "python.analysis.typeCheckingMode": "off",
-  "go.buildFlags": [
-    "-race"
-  ],
-  "go.testFlags": [
-    "-race"
-  ],
+  "python.analysis.typeCheckingMode": "off"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ### Fixed
 
+- Capture Nvidia GPU stats on Windows (@dmitryduev in https://github.com/wandb/wandb/pull/8524)
 - Fixed a regression introduced in v0.18.2 that affected capturing the names of Nvidia GPU devices (@dmitryduev in https://github.com/wandb/wandb/pull/8503)
 - `run.log_artifact()` no longer blocks other data uploads until the artifact upload finishes (@timoffex in https://github.com/wandb/wandb/pull/8466)
 - Fixed media dependency for rdkit updated from `rdkit-pypi` to `rdkit` (@jacobromero in https://github.com/wandb/wandb/compare/WB-20894)

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || windows
 
 package monitor
 

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -78,6 +78,7 @@ func NewGPUNvidia(
 	if cmdPath == "" {
 		var err error
 		cmdPath, err = getCmdPath()
+		fmt.Println("cmdPath", cmdPath)
 		if err != nil {
 			return nil
 		}
@@ -101,6 +102,7 @@ func NewGPUNvidia(
 
 	// Get a pipe to read from the command's stdout.
 	stdout, err := g.cmd.StdoutPipe()
+	fmt.Println(err)
 	if err != nil {
 		g.logger.CaptureError(
 			fmt.Errorf("monitor: %v: error getting stdout pipe: %v for command: %v", g.name, err, g.cmd),
@@ -109,6 +111,7 @@ func NewGPUNvidia(
 	}
 
 	if err := g.cmd.Start(); err != nil {
+		fmt.Println(err)
 		g.logger.CaptureError(
 			fmt.Errorf("monitor: %v: error starting command %v: %v", g.name, g.cmd, err),
 		)
@@ -234,6 +237,7 @@ func (g *GPUNvidia) Close() {
 
 // Probe gathers metadata about the GPU hardware.
 func (g *GPUNvidia) Probe() *spb.MetadataRequest {
+	fmt.Println("probe", g.IsAvailable())
 	if !g.IsAvailable() {
 		return nil
 	}

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -24,7 +24,7 @@ func getCmdPath() (string, error) {
 		return "", err
 	}
 	exDirPath := filepath.Dir(ex)
-	exPath := filepath.Join(exDirPath, "nvidia_gpu_stats")
+	exPath := filepath.Join(exDirPath, "nvidia_gpu_stats.exe")
 
 	if _, err := os.Stat(exPath); os.IsNotExist(err) {
 		return "", err

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -24,7 +25,12 @@ func getCmdPath() (string, error) {
 		return "", err
 	}
 	exDirPath := filepath.Dir(ex)
-	exPath := filepath.Join(exDirPath, "nvidia_gpu_stats.exe")
+	exPath := filepath.Join(exDirPath, "nvidia_gpu_stats")
+
+	// append .exe if running on Windows
+	if runtime.GOOS == "windows" {
+		exPath += ".exe"
+	}
 
 	if _, err := os.Stat(exPath); os.IsNotExist(err) {
 		return "", err

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/wandb/wandb/core/internal/observability"
@@ -33,19 +32,16 @@ func getCmdPath() (string, error) {
 	return exPath, nil
 }
 
-// isRunning checks if the command is running by sending a signal to the process.
+// isRunning checks if the command is running.
 func isRunning(cmd *exec.Cmd) bool {
 	if cmd.Process == nil {
 		return false
 	}
-
-	process, err := os.FindProcess(cmd.Process.Pid)
-	if err != nil {
+	// Check if the process has exited
+	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 		return false
 	}
-
-	err = process.Signal(syscall.Signal(0))
-	return err == nil
+	return true
 }
 
 // GPUNvidia monitors NVIDIA GPU stats using the nvidia_gpu_stats command.

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -84,7 +84,6 @@ func NewGPUNvidia(
 	if cmdPath == "" {
 		var err error
 		cmdPath, err = getCmdPath()
-		fmt.Println("cmdPath", cmdPath)
 		if err != nil {
 			return nil
 		}
@@ -108,7 +107,6 @@ func NewGPUNvidia(
 
 	// Get a pipe to read from the command's stdout.
 	stdout, err := g.cmd.StdoutPipe()
-	fmt.Println(err)
 	if err != nil {
 		g.logger.CaptureError(
 			fmt.Errorf("monitor: %v: error getting stdout pipe: %v for command: %v", g.name, err, g.cmd),
@@ -117,7 +115,6 @@ func NewGPUNvidia(
 	}
 
 	if err := g.cmd.Start(); err != nil {
-		fmt.Println(err)
 		g.logger.CaptureError(
 			fmt.Errorf("monitor: %v: error starting command %v: %v", g.name, g.cmd, err),
 		)
@@ -243,7 +240,6 @@ func (g *GPUNvidia) Close() {
 
 // Probe gathers metadata about the GPU hardware.
 func (g *GPUNvidia) Probe() *spb.MetadataRequest {
-	fmt.Println("probe", g.IsAvailable())
 	if !g.IsAvailable() {
 		return nil
 	}

--- a/core/pkg/monitor/gpu_nvidia.go
+++ b/core/pkg/monitor/gpu_nvidia.go
@@ -156,10 +156,7 @@ func (g *GPUNvidia) isRunning() bool {
 
 	g.cmdMutex.Lock()
 	defer g.cmdMutex.Unlock()
-	if g.cmd.Process == nil {
-		return false
-	}
-	return true
+	return g.cmd.Process != nil
 }
 
 // waitWithTimeout waits for the process to exit, but times out after the given duration.

--- a/core/pkg/monitor/monitor.go
+++ b/core/pkg/monitor/monitor.go
@@ -207,6 +207,14 @@ func (sm *SystemMonitor) GetState() int32 {
 
 // probe gathers system information from all assets and merges their metadata.
 func (sm *SystemMonitor) probe() *spb.MetadataRequest {
+	defer func() {
+		if err := recover(); err != nil {
+			sm.logger.CaptureError(
+				fmt.Errorf("monitor: panic: %v", err),
+			)
+		}
+	}()
+
 	systemInfo := spb.MetadataRequest{}
 	for _, asset := range sm.assets {
 		probeResponse := asset.Probe()

--- a/core/pkg/monitor/noop_windows.go
+++ b/core/pkg/monitor/noop_windows.go
@@ -26,38 +26,6 @@ func (g *GPUApple) Probe() *spb.MetadataRequest {
 	return nil
 }
 
-// GPUNvidia is a dummy implementation of the Asset interface for Nvidia GPUs.
-type GPUNvidia struct {
-	name             string
-	pid              int32
-	samplingInterval float64
-	logger           *observability.CoreLogger
-}
-
-func NewGPUNvidia(
-	logger *observability.CoreLogger,
-	pid int32,
-	samplingInterval float64,
-	cmdPath string,
-) *GPUNvidia {
-	return &GPUNvidia{
-		name:             "gpu",
-		pid:              pid,
-		samplingInterval: samplingInterval,
-		logger:           logger,
-	}
-}
-
-func (g *GPUNvidia) Name() string { return g.name }
-
-func (g *GPUNvidia) Sample() (map[string]any, error) { return nil, nil }
-
-func (g *GPUNvidia) IsAvailable() bool { return false }
-
-func (g *GPUNvidia) Probe() *spb.MetadataRequest {
-	return nil
-}
-
 // GPUAMD is a dummy implementation of the Asset interface for AMD GPUs.
 type GPUAMD struct {
 	name   string

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -101,11 +101,9 @@ class CustomBuildHook(BuildHookInterface):
 
     def _include_nvidia_gpu_stats(self) -> bool:
         """Returns whether we should produce a wheel with nvidia_gpu_stats."""
-        return (
-            not _get_env_bool(_WANDB_BUILD_SKIP_NVIDIA, default=False)
-            # TODO: Add support for Windows.
-            and self._target_platform().goos == "linux"
-        )
+        return not _get_env_bool(
+            _WANDB_BUILD_SKIP_NVIDIA, default=False
+        ) and self._target_platform().goos in ("linux", "windows")
 
     def _is_platform_wheel(self) -> bool:
         """Returns whether we're producing a platform-specific wheel."""

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -131,6 +131,8 @@ class CustomBuildHook(BuildHookInterface):
 
     def _build_nvidia_gpu_stats(self) -> List[str]:
         output = pathlib.Path("wandb", "bin", "nvidia_gpu_stats")
+        if self._target_platform().goos == "windows":
+            output = output.with_suffix(".exe")
 
         self.app.display_waiting("Building nvidia_gpu_stats Rust binary...")
         hatch_nvidia_gpu_stats.build_nvidia_gpu_stats(

--- a/nvidia_gpu_stats/hatch.py
+++ b/nvidia_gpu_stats/hatch.py
@@ -1,6 +1,7 @@
 """Builds the nvidia_gpu_stats binary for monitoring NVIDIA GPUs."""
 
 import pathlib
+import platform
 import subprocess
 
 
@@ -25,6 +26,9 @@ def build_nvidia_gpu_stats(
     """
     rust_pkg_root = pathlib.Path("./nvidia_gpu_stats")
     built_binary_path = rust_pkg_root / "target" / "release" / "nvidia_gpu_stats"
+
+    if platform.system().lower() == "windows":
+        built_binary_path = built_binary_path.with_suffix(".exe")
 
     cmd = (
         str(cargo_binary),

--- a/nvidia_gpu_stats/hatch.py
+++ b/nvidia_gpu_stats/hatch.py
@@ -1,7 +1,6 @@
 """Builds the nvidia_gpu_stats binary for monitoring NVIDIA GPUs."""
 
 import pathlib
-import platform
 import subprocess
 
 

--- a/nvidia_gpu_stats/hatch.py
+++ b/nvidia_gpu_stats/hatch.py
@@ -27,9 +27,6 @@ def build_nvidia_gpu_stats(
     rust_pkg_root = pathlib.Path("./nvidia_gpu_stats")
     built_binary_path = rust_pkg_root / "target" / "release" / "nvidia_gpu_stats"
 
-    if platform.system().lower() == "windows":
-        built_binary_path = built_binary_path.with_suffix(".exe")
-
     cmd = (
         str(cargo_binary),
         "build",

--- a/nvidia_gpu_stats/src/gpu_nvidia.rs
+++ b/nvidia_gpu_stats/src/gpu_nvidia.rs
@@ -119,7 +119,6 @@ impl NvidiaGpu {
         // We follow go-nvml example and attempt to load libnvidia-ml.so.1 directly, see:
         // https://github.com/NVIDIA/go-nvml/blob/0e815c71ca6e8184387d8b502b2ef2d2722165b9/pkg/nvml/lib.go#L30
         let lib_path = get_lib_path()?;
-        println!("Using NVML library: {:?}", lib_path);
 
         let nvml = Nvml::builder().lib_path(lib_path.as_os_str()).init()?;
         let cuda_version = nvml.sys_cuda_driver_version()?;

--- a/nvidia_gpu_stats/src/gpu_nvidia.rs
+++ b/nvidia_gpu_stats/src/gpu_nvidia.rs
@@ -5,6 +5,13 @@ use nvml_wrapper::{Device, Nvml};
 use std::collections::HashSet;
 use std::fs::read_to_string;
 
+#[cfg(target_os = "windows")]
+const LIB_PATH: &str = "nvml.dll";
+
+// #[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
+const LIB_PATH: &str = "libnvidia-ml.so.1";
+
 /// Static information about a GPU.
 #[derive(Default)]
 struct GpuStaticInfo {
@@ -70,13 +77,11 @@ pub struct NvidiaGpu {
 
 impl NvidiaGpu {
     pub fn new() -> Result<Self, NvmlError> {
-        // Nvml::init() attempts to load libnvidia-ml.so which is usually a symlink
+        // On Linux, Nvml::init() attempts to load libnvidia-ml.so which is usually a symlink
         // to libnvidia-ml.so.1 and not available in certain environments.
         // We follow go-nvml example and attempt to load libnvidia-ml.so.1 directly, see:
         // https://github.com/NVIDIA/go-nvml/blob/0e815c71ca6e8184387d8b502b2ef2d2722165b9/pkg/nvml/lib.go#L30
-        let nvml = Nvml::builder()
-            .lib_path("libnvidia-ml.so.1".as_ref())
-            .init()?;
+        let nvml = Nvml::builder().lib_path(LIB_PATH.as_ref()).init()?;
         let cuda_version = nvml.sys_cuda_driver_version()?;
         format!(
             "{}.{}",

--- a/nvidia_gpu_stats/src/gpu_nvidia.rs
+++ b/nvidia_gpu_stats/src/gpu_nvidia.rs
@@ -187,6 +187,7 @@ impl NvidiaGpu {
         our_pids.iter().any(|&p| device_pids.contains(&p))
     }
 
+    /// Get descendant process IDs for a given parent PID.
     #[cfg(target_os = "linux")]
     fn get_descendant_pids(&self, parent_pid: i32) -> Result<Vec<i32>, std::io::Error> {
         use std::collections::HashSet;
@@ -226,8 +227,6 @@ impl NvidiaGpu {
         // TODO: Implement for other platforms
         false
     }
-
-    /// Get descendant process IDs for a given parent PID.
 
     /// Samples GPU metrics using NVML.
     ///

--- a/nvidia_gpu_stats/src/gpu_nvidia.rs
+++ b/nvidia_gpu_stats/src/gpu_nvidia.rs
@@ -2,7 +2,6 @@ use crate::metrics::Metrics;
 use nvml_wrapper::enum_wrappers::device::{Clock, TemperatureSensor};
 use nvml_wrapper::error::NvmlError;
 use nvml_wrapper::{Device, Nvml};
-use std::error::Error;
 use std::path::PathBuf;
 
 /// Static information about a GPU.

--- a/nvidia_gpu_stats/src/main.rs
+++ b/nvidia_gpu_stats/src/main.rs
@@ -1,7 +1,5 @@
 use clap::Parser;
-use nix::unistd::getppid;
 use sentry::types::Dsn;
-use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
 use std::collections::HashSet;
 use std::env;
 use std::io;
@@ -41,6 +39,41 @@ fn parse_bool(s: &str) -> bool {
     }
 }
 
+/// Listen for signals to gracefully shutdown the program
+#[cfg(target_os = "linux")]
+fn setup_signal_handler(running: Arc<AtomicBool>) -> Result<(), Box<dyn std::error::Error>> {
+    use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
+    let mut signals = Signals::new(TERM_SIGNALS)?;
+    thread::spawn(move || {
+        for _sig in signals.forever() {
+            running.store(false, Ordering::Relaxed);
+            break;
+        }
+    });
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn setup_signal_handler(_running: Arc<AtomicBool>) -> Result<(), Box<dyn std::error::Error>> {
+    // Windows doesn't support the same signal handling as Unix, so we can't
+    // gracefully shutdown the program. Instead, we rely on the parent process
+    // to kill the program when it's done.
+    Ok(())
+}
+
+/// Check if the parent process is still alive
+#[cfg(target_os = "linux")]
+fn is_parent_alive(ppid: i32) -> bool {
+    use nix::unistd::getppid;
+    getppid() == nix::unistd::Pid::from_raw(ppid)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_parent_alive(_ppid: i32) -> bool {
+    // TODO: Implement for other platforms
+    true
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse command-line arguments
     let args = Args::parse();
@@ -70,22 +103,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         e
     })?;
 
-    // TODO:
-    // Set the parent-death signal to SIGTERM
-    // set_pdeathsig(Signal::SIGTERM)?;
-
     // Set up a flag to control the main sampling loop
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
 
     // Set up signal handler for graceful shutdown
-    let mut signals = Signals::new(TERM_SIGNALS)?;
-    thread::spawn(move || {
-        for _sig in signals.forever() {
-            r.store(false, Ordering::Relaxed);
-            break;
-        }
-    });
+    setup_signal_handler(r)?;
 
     // Error cache to minimize duplicate error messages sent to Sentry
     let mut error_cache: HashSet<String> = HashSet::new();
@@ -93,13 +116,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Main sampling loop. Will run until the parent process is no longer alive or a signal is received.
     while running.load(Ordering::Relaxed) {
         let sampling_start = Instant::now();
+
+        // Check if parent process is still alive and break loop if not
+        if args.ppid > 0 && !is_parent_alive(args.ppid) {
+            break;
+        }
+
+        let mut metrics = Metrics::new();
+
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs_f64();
 
-        // Sample GPU metrics
-        let mut metrics = Metrics::new();
+        // Sample Nvidia GPU metrics
         if let Err(e) = nvidia_gpu.sample_metrics(&mut metrics, args.pid) {
             let error_message = e.to_string();
             if !error_cache.contains(&error_message) {
@@ -122,11 +152,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     sentry::capture_error(&e);
                 }
             }
-        }
-
-        // Check if parent process is still alive and break loop if not
-        if getppid() != nix::unistd::Pid::from_raw(args.ppid) {
-            break;
         }
 
         // Sleep to maintain requested sampling interval

--- a/nvidia_gpu_stats/src/main.rs
+++ b/nvidia_gpu_stats/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let sampling_start = Instant::now();
 
         // Check if parent process is still alive and break loop if not
-        if args.ppid > 0 && !is_parent_alive(args.ppid) {
+        if !is_parent_alive(args.ppid) {
             break;
         }
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-20401
- Fixes #8417

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Used this job in CircleCI to test:

```yaml
jobs:
  ...
  gpu-win:
    executor:
      name: win/server-2019-cuda
      shell: bash.exe
    steps:
      - checkout
      - run:
          name: Install Python
          command: >
            nuget.exe install python \
              -Version 3.12 \
              -ExcludeVersion \
              -OutputDirectory "/c/nox-tests-python" &&
            setx PATH '/c/nox-tests-python/python/tools;%PATH%'
      - run:
          name: "Install system deps: ffmpeg"
          command: choco install -y ffmpeg
      - run:
          # We install mingw so that gcc is available, which is needed for cgo.
          name: "Install system deps: mingw"
          command: choco install -y mingw --version 12.2 --allow-downgrade

      - install_go
      - install_rust
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
