### PR TITLE
refactor(artifacts): remove sentry logs for GCS File Transfer set up

### DIFF
--- a/core/internal/filetransfer/file_transfers.go
+++ b/core/internal/filetransfer/file_transfers.go
@@ -37,7 +37,7 @@ func NewFileTransfers(
 	if err == nil {
 		filetransfers.GCS = gcsFileTransfer
 	} else {
-		logger.CaptureError(err)
+		logger.Error("Unable to set up GCS file transfer", "error", err)
 	}
 
 	return filetransfers


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
This PR stops logging gcs client instantiation issues to sentry and instead just logs it to the debug log, as this is expected to fail whenever someone doesn't have gcloud authentication set up and is only relevant if they actually need to use the client, in which case we fail later.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
