### PR TITLE
fix: logging video does not respect fps argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `wandb.Video` fps argument not correctly uploading video with the provided framerate. (@jacobromero in https://github.com/wandb/wandb/pull/WB-18149)
+
 ## [0.18.3] - 2024-10-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ### Fixed
 
-- Fixed `wandb.Video` fps argument not correctly uploading video with the provided framerate. (@jacobromero in https://github.com/wandb/wandb/pull/WB-18149)
+- Fixed `wandb.Video` fps argument not correctly uploading video with the provided frame rate. (@jacobromero in https://github.com/wandb/wandb/pull/8545)
 
 ## [0.18.3] - 2024-10-01
 

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -12,6 +12,7 @@ import rdkit.Chem
 import responses
 import wandb
 from bokeh.plotting import figure
+from moviepy.editor import VideoFileClip
 from PIL import Image
 from wandb import data_types
 from wandb.sdk.data_types import _dtypes
@@ -644,6 +645,25 @@ def test_video_path_invalid():
         f.write("00000")
     with pytest.raises(ValueError):
         wandb.Video("video.avi")
+
+
+def test_video_file_encodes_with_new_fps():
+    # Create fake video
+    video_length = 3 * 24  # 3 seconds * 24 fps
+    frames = np.random.randint(
+        low=0, high=256, size=(video_length, 3, 10, 10), dtype=np.uint8
+    )
+    video = wandb.Video(frames, fps=24, format="mp4")
+
+    # Assert video is created with correct fps
+    assert video._path is not None
+    clip = VideoFileClip(video._path)
+    assert clip.fps == 24
+
+    # Assert video file is re-encoded with correct fps
+    vid = wandb.Video(video._path, fps=1)
+    clip = VideoFileClip(vid._path)
+    assert clip.fps == 1
 
 
 ################################################################################

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -114,6 +114,8 @@ class Video(BatchableMedia):
                 raise ValueError(
                     "wandb.Video accepts {} formats".format(", ".join(Video.EXTS))
                 )
+            # Maintain the original format if not specified
+            self._format = format or ext
             self.encode_video(data_or_path)
             # ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 data_or_path
         else:

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -148,9 +148,14 @@ class Video(BatchableMedia):
             required='wandb.Video requires moviepy when passing raw data.  Install with "pip install wandb[media]"',
         )
         clip = mpy.VideoFileClip(path)
-        clip = clip.set_fps(self._fps)
 
-        self.encode(clip)
+        # If the fps of the video is different from the desired fps then we need to re-encode the video
+        if self._fps != clip.fps:
+            clip = clip.set_fps(self._fps)
+            self.encode(clip)
+        # Otherwise don't do anything.
+        else:
+            self._set_file(path)
 
     def encode(self, clip) -> None:
         filename = os.path.join(

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -3,7 +3,7 @@ import os
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Type, Union
 
-from wandb import util
+from wandb import termwarn, util
 from wandb.sdk.lib import filesystem, runid
 
 from . import _dtypes
@@ -58,7 +58,9 @@ class Video(BatchableMedia):
             Channels should be (time, channel, height, width) or
             (batch, time, channel, height width)
         caption: (string) caption associated with the video for display
-        fps: (int) frames per second for video. Default is 4.
+        fps: (int)
+            frames per second for video. Default is 4.
+            If the fps of the video is different from the desired fps the media will be re-encoded to a temporary file.
         format: (string) format of video, necessary if initializing with path or io object.
 
     Examples:
@@ -151,6 +153,9 @@ class Video(BatchableMedia):
 
         # If the fps of the video is different from the desired fps then we need to re-encode the video
         if self._fps != clip.fps:
+            termwarn("Desired frame rate is different than current media frame rate.")
+            termwarn("Re-encoding video may take a while.")
+
             clip = clip.set_fps(self._fps)
             self.encode(clip)
         # Otherwise don't do anything.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18149

What does the PR do? Include a concise description of the PR contents.

This PR fixes a bug when logging a `wandb.Video` from a video file path, the `fps` argument is not being respected when the media is being uploaded.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

- manually running reproduction steps in [WB-18149](https://wandb.atlassian.net/browse/WB-18149)
- unit tests added

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-18149]: https://wandb.atlassian.net/browse/WB-18149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ