### PR TITLE
chore(sdk): fix type annotation for wandb.Api to Type[PublicApi]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Fixed
+
+- Fixed typing issue of `wandb.Api` (@bdvllrs in https://github.com/wandb/wandb/pull/8548)
+
 ## [0.18.3] - 2024-10-01
 
 ### Added

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -64,7 +64,6 @@ from typing import (
     Literal,
     Optional,
     Sequence,
-    Type,
     Union,
 )
 
@@ -101,7 +100,7 @@ __version__: str = "0.18.4.dev1"
 run: Run | None
 config: wandb_config.Config
 summary: wandb_summary.Summary
-Api: Type[PublicApi]
+Api: type[PublicApi]
 
 # private attributes
 _sentry: Sentry

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -64,6 +64,7 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Type,
     Union,
 )
 
@@ -100,7 +101,7 @@ __version__: str = "0.18.4.dev1"
 run: Run | None
 config: wandb_config.Config
 summary: wandb_summary.Summary
-Api: PublicApi
+Api: Type[PublicApi]
 
 # private attributes
 _sentry: Sentry

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -64,7 +64,6 @@ from typing import (
     Literal,
     Optional,
     Sequence,
-    Type,
     Union,
 )
 
@@ -101,7 +100,7 @@ __version__: str = "0.18.4.dev1"
 run: Run | None
 config: wandb_config.Config
 summary: wandb_summary.Summary
-Api: Type[PublicApi]
+Api: type[PublicApi]
 
 # private attributes
 _sentry: Sentry

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -64,6 +64,7 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Type,
     Union,
 )
 
@@ -100,7 +101,7 @@ __version__: str = "0.18.4.dev1"
 run: Run | None
 config: wandb_config.Config
 summary: wandb_summary.Summary
-Api: PublicApi
+Api: Type[PublicApi]
 
 # private attributes
 _sentry: Sentry


### PR DESCRIPTION
# Description
What does the PR do? Include a concise description of the PR contents.

- Fixes: #8520

The type changes in #8447 introduced a type error for `wandb.Api` from `Type[PublicApi]` to `PublicApi`.