### PR TITLE
fix(artifacts): allow artifact.add, artifact.add_file to overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 ## Unreleased
 
+### Added
+
+- Add a boolean `overwrite` param to `Artifact.add()`/`Artifact.add_file()` to allow overwrite of previously-added artifact files (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8553)
+
 ### Fixed
 
 - Add missing type hints of the `wandb.plot` module in the package stub (@kptkin in https://github.com/wandb/wandb/pull/8667)
@@ -18,9 +22,11 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Fix downloading azure reference artifacts with `skip_cache=True` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8706)
 - Fix multipart uploads for files with no content type defined in headers (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8716)
 - Fixed tensorboard failing to sync when logging batches of images. (@jacobromero in https://github.com/wandb/wandb/pull/8641)
+- Fixed behavior of `mode='x'`/`mode='w'` in `Artifact.new_file()` to conform to Python's built-in file modes (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8553)
 
 ### Changed
 - Added internal method, api._artifact(), to fetch artifacts so that usage events are not created if not called by an external user. (@ibindlish in https://github.com/wandb/wandb/pull/8674)
+- Changed default `mode` in `Artifact.new_file()` from `'w'` to `'x'` to accurately reflect existing default behavior (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8553)
 
 ## [0.18.5] - 2024-10-17
 
@@ -37,7 +43,6 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Added a warning message indicating that the `fps` argument will be ignored when creating a wandb.Video object from a file path string or a bytes object. (@jacobromero in https://github.com/wandb/wandb/pull/8585)
 - Update docstrings for `logged_artifacts` and `used_artifacts` methods in `Run` class (@trane293 in https://github.com/wandb/wandb/pull/8624)
 - The `_show_operation_stats` setting enables a preview of a better `run.finish()` UX (@timoffex in https://github.com/wandb/wandb/pull/8644)
-- Add a boolean `overwrite` param to `Artifact.add()`/`Artifact.add_file()` to allow overwrite of previously-added artifact files (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8553)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Added a warning message indicating that the `fps` argument will be ignored when creating a wandb.Video object from a file path string or a bytes object. (@jacobromero in https://github.com/wandb/wandb/pull/8585)
 - Update docstrings for `logged_artifacts` and `used_artifacts` methods in `Run` class (@trane293 in https://github.com/wandb/wandb/pull/8624)
 - The `_show_operation_stats` setting enables a preview of a better `run.finish()` UX (@timoffex in https://github.com/wandb/wandb/pull/8644)
+- Add a boolean `overwrite` param to `Artifact.add()`/`Artifact.add_file()` to allow overwrite of previously-added artifact files (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8553)
 
 ### Fixed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,15 +97,19 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 
 @pytest.fixture(scope="session")
-def assets_path() -> Generator[Callable, None, None]:
-    def assets_path_fn(path: Path) -> Path:
-        return Path(__file__).resolve().parent / "assets" / path
+def assets_path() -> Generator[Callable[[StrPath], Path], None, None]:
+    assets_dir = Path(__file__).resolve().parent / "assets"
+
+    def assets_path_fn(path: StrPath) -> Path:
+        return assets_dir / path
 
     yield assets_path_fn
 
 
 @pytest.fixture
-def copy_asset(assets_path) -> Generator[Callable, None, None]:
+def copy_asset(
+    assets_path,
+) -> Generator[Callable[[StrPath, StrPath | None], Path], None, None]:
     def copy_asset_fn(path: StrPath, dst: StrPath | None = None) -> Path:
         src = assets_path(path)
         if src.is_file():
@@ -363,7 +367,7 @@ def clean_up():
 
 
 @pytest.fixture
-def api():
+def api() -> wandb.PublicApi:
     return Api()
 
 

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -1,3 +1,4 @@
+import filecmp
 import os
 import shutil
 import unittest.mock
@@ -14,7 +15,7 @@ import responses
 import wandb
 import wandb.data_types as data_types
 import wandb.sdk.artifacts.artifact_file_cache as artifact_file_cache
-from wandb import util
+from wandb import Artifact, util
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.artifact_state import ArtifactState
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
@@ -284,6 +285,11 @@ def mock_http(artifact, path=False, headers=None):
     return mock
 
 
+@pytest.fixture
+def artifact() -> Artifact:
+    return Artifact(type="dataset", name="data-artifact")
+
+
 def test_unsized_manifest_entry_real_file():
     f = Path("some/file.txt")
     f.parent.mkdir(parents=True, exist_ok=True)
@@ -298,10 +304,8 @@ def test_unsized_manifest_entry():
     assert "No such file" in str(e.value)
 
 
-def test_add_one_file():
-    with open("file1.txt", "w") as f:
-        f.write("hello")
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_one_file(artifact):
+    Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
 
     assert artifact.digest == "a00c2239f036fb656c1dcbf9a32d89b4"
@@ -312,10 +316,8 @@ def test_add_one_file():
     }
 
 
-def test_add_named_file():
-    with open("file1.txt", "w") as f:
-        f.write("hello")
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_named_file(artifact):
+    Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt", name="great-file.txt")
 
     assert artifact.digest == "585b9ada17797e37c9cbab391e69b8c5"
@@ -326,8 +328,7 @@ def test_add_named_file():
     }
 
 
-def test_add_new_file():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_new_file(artifact):
     with artifact.new_file("file1.txt") as f:
         f.write("hello")
 
@@ -339,27 +340,23 @@ def test_add_new_file():
     }
 
 
-def test_add_after_finalize():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_after_finalize(artifact):
     artifact.finalize()
     with pytest.raises(ArtifactFinalizedError) as e:
         artifact.add_file("file1.txt")
     assert "Can't modify finalized artifact" in str(e.value)
 
 
-def test_add_new_file_encode_error(capsys):
+def test_add_new_file_encode_error(capsys, artifact):
     with pytest.raises(UnicodeEncodeError):
-        artifact = wandb.Artifact(type="dataset", name="my-arty")
         with artifact.new_file("wave.txt", mode="w", encoding="ascii") as f:
             f.write("∂²u/∂t²=c²·∂²u/∂x²")
     assert "ERROR Failed to open the provided file" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize("overwrite", [True, False])
-def test_add_file_again_after_edit(overwrite):
+def test_add_file_again_after_edit(overwrite, artifact):
     filepath = Path("file1.txt")
-
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
 
     filepath.write_text("hello")
     artifact.add_file(str(filepath), overwrite=overwrite)
@@ -371,11 +368,9 @@ def test_add_file_again_after_edit(overwrite):
         artifact.add_file(str(filepath), overwrite=overwrite)
 
 
-def test_add_dir():
-    with open("file1.txt", "w") as f:
-        f.write("hello")
+def test_add_dir(artifact):
+    Path("file1.txt").write_text("hello")
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_dir(".")
 
     assert artifact.digest == "a00c2239f036fb656c1dcbf9a32d89b4"
@@ -386,10 +381,8 @@ def test_add_dir():
     }
 
 
-def test_add_named_dir():
-    with open("file1.txt", "w") as f:
-        f.write("hello")
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_named_dir(artifact):
+    Path("file1.txt").write_text("hello")
     artifact.add_dir(".", name="subdir")
 
     assert artifact.digest == "a757208d042e8627b2970d72a71bed5b"
@@ -401,8 +394,7 @@ def test_add_named_dir():
     }
 
 
-def test_multi_add():
-    artifact = wandb.Artifact(type="dataset", name="poly-art")
+def test_multi_add(artifact):
     size = 2**27  # 128MB, large enough that it takes >1ms to add.
     filename = "data.bin"
     with open(filename, "wb") as f:
@@ -419,12 +411,11 @@ def test_multi_add():
     assert manifest["contents"][filename]["size"] == size
 
 
-def test_add_reference_local_file(tmp_path):
+def test_add_reference_local_file(tmp_path, artifact):
     file = tmp_path / "file1.txt"
     file.write_text("hello")
     uri = file.as_uri()
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     e = artifact.add_reference(uri)[0]
     assert e.ref_target() == uri
 
@@ -437,13 +428,12 @@ def test_add_reference_local_file(tmp_path):
     }
 
 
-def test_add_reference_local_file_no_checksum(tmp_path):
+def test_add_reference_local_file_no_checksum(tmp_path, artifact):
     file = tmp_path / "file1.txt"
     file.write_text("hello")
     uri = file.as_uri()
 
     size = os.path.getsize(file)
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_reference(uri, checksum=False)
 
     assert artifact.digest == "415f3bca4b095cbbbbc47e0d44079e05"
@@ -455,18 +445,14 @@ def test_add_reference_local_file_no_checksum(tmp_path):
     }
 
 
-def test_add_reference_local_dir():
-    with open("file1.txt", "w") as f:
-        f.write("hello")
+def test_add_reference_local_dir(artifact):
+    Path("file1.txt").write_text("hello")
     os.mkdir("nest")
-    with open("nest/file2.txt", "w") as f:
-        f.write("my")
+    Path("nest/file2.txt").write_text("my")
     os.mkdir("nest/nest")
-    with open("nest/nest/file3.txt", "w") as f:
-        f.write("dude")
+    Path("nest/nest/file3.txt").write_text("dude")
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
-    artifact.add_reference("file://" + os.getcwd())
+    artifact.add_reference(f"file://{os.getcwd()}")
 
     assert artifact.digest == "72414374bfd4b0f60a116e7267845f71"
     manifest = artifact.manifest.to_manifest_json()
@@ -487,88 +473,79 @@ def test_add_reference_local_dir():
     }
 
 
-def test_add_reference_local_dir_no_checksum():
-    path_1 = os.path.join("file1.txt")
-    with open(path_1, "w") as f:
-        f.write("hello")
-    size_1 = os.path.getsize(path_1)
+def test_add_reference_local_dir_no_checksum(artifact):
+    path_1 = Path("file1.txt")
+    path_1.parent.mkdir(parents=True, exist_ok=True)
+    path_1.write_text("hello")
+    size_1 = path_1.stat().st_size
 
-    path_2 = os.path.join("nest", "file2.txt")
-    os.mkdir("nest")
-    with open(path_2, "w") as f:
-        f.write("my")
-    size_2 = os.path.getsize(path_2)
+    path_2 = Path("nest/file2.txt")
+    path_2.parent.mkdir(parents=True, exist_ok=True)
+    path_2.write_text("my")
+    size_2 = path_2.stat().st_size
 
-    path_3 = os.path.join("nest", "nest", "file3.txt")
-    os.mkdir("nest/nest")
-    with open(path_3, "w") as f:
-        f.write("dude")
-    size_3 = os.path.getsize(path_3)
+    path_3 = Path("nest", "nest", "file3.txt")
+    path_3.parent.mkdir(parents=True, exist_ok=True)
+    path_3.write_text("dude")
+    size_3 = path_3.stat().st_size
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
-    artifact.add_reference("file://" + os.getcwd(), checksum=False)
+    here = Path.cwd()
+    artifact.add_reference(f"file://{here!s}", checksum=False)
 
     assert artifact.digest == "3d0e6471486eec5070cf9351bacaa103"
     manifest = artifact.manifest.to_manifest_json()
     assert manifest["contents"]["file1.txt"] == {
         "digest": md5_string(str(size_1)),
-        "ref": "file://" + os.path.join(os.getcwd(), "file1.txt"),
+        "ref": f"file://{here!s}/file1.txt",
         "size": size_1,
     }
     assert manifest["contents"]["nest/file2.txt"] == {
         "digest": md5_string(str(size_2)),
-        "ref": "file://" + os.path.join(os.getcwd(), "nest", "file2.txt"),
+        "ref": f"file://{here!s}/nest/file2.txt",
         "size": size_2,
     }
     assert manifest["contents"]["nest/nest/file3.txt"] == {
         "digest": md5_string(str(size_3)),
-        "ref": "file://" + os.path.join(os.getcwd(), "nest", "nest", "file3.txt"),
+        "ref": f"file://{here!s}/nest/nest/file3.txt",
         "size": size_3,
     }
 
 
-def test_add_reference_local_dir_with_name():
-    with open("file1.txt", "w") as f:
-        f.write("hello")
-    os.mkdir("nest")
-    with open("nest/file2.txt", "w") as f:
-        f.write("my")
-    os.mkdir("nest/nest")
-    with open("nest/nest/file3.txt", "w") as f:
-        f.write("dude")
+def test_add_reference_local_dir_with_name(artifact):
+    Path("file1.txt").write_text("hello")
+    Path("nest").mkdir(parents=True, exist_ok=True)
+    Path("nest/file2.txt").write_text("my")
+    Path("nest/nest").mkdir(parents=True, exist_ok=True)
+    Path("nest/nest/file3.txt").write_text("dude")
 
-    print(os.listdir("."))
-
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
-    artifact.add_reference("file://" + os.getcwd(), name="top")
+    here = Path.cwd()
+    artifact.add_reference(f"file://{here!s}", name="top")
 
     assert artifact.digest == "f718baf2d4c910dc6ccd0d9c586fa00f"
     manifest = artifact.manifest.to_manifest_json()
     assert manifest["contents"]["top/file1.txt"] == {
         "digest": "XUFAKrxLKna5cZ2REBfFkg==",
-        "ref": "file://" + os.path.join(os.getcwd(), "top", "file1.txt"),
+        "ref": f"file://{here!s}/top/file1.txt",
         "size": 5,
     }
     assert manifest["contents"]["top/nest/file2.txt"] == {
         "digest": "aGTzidmHZDa8h3j/Bx0bbA==",
-        "ref": "file://" + os.path.join(os.getcwd(), "top", "nest", "file2.txt"),
+        "ref": f"file://{here!s}/top/nest/file2.txt",
         "size": 2,
     }
     assert manifest["contents"]["top/nest/nest/file3.txt"] == {
         "digest": "E7c+2uhEOZC+GqjxpIO8Jw==",
-        "ref": "file://"
-        + os.path.join(os.getcwd(), "top", "nest", "nest", "file3.txt"),
+        "ref": f"file://{here!s}/top/nest/nest/file3.txt",
         "size": 4,
     }
 
 
-def test_add_reference_local_dir_by_uri(tmp_path):
+def test_add_reference_local_dir_by_uri(tmp_path, artifact):
     ugly_path = tmp_path / "i=D" / "has !@#$%^&[]()|',`~ awful taste in file names"
     ugly_path.mkdir(parents=True)
     file = ugly_path / "file.txt"
     file.write_text("sorry")
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_reference(ugly_path.as_uri())
     manifest = artifact.manifest.to_manifest_json()
     assert manifest["contents"]["file.txt"] == {
@@ -578,8 +555,7 @@ def test_add_reference_local_dir_by_uri(tmp_path):
     }
 
 
-def test_add_s3_reference_object():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_s3_reference_object(artifact):
     mock_boto(artifact)
     artifact.add_reference("s3://my-bucket/my_object.pb")
 
@@ -593,14 +569,12 @@ def test_add_s3_reference_object():
     }
 
 
-def test_add_s3_reference_object_directory():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_s3_reference_object_directory(artifact):
     mock_boto(artifact, path=True)
     artifact.add_reference("s3://my-bucket/my_dir/")
 
     assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
     manifest = artifact.manifest.to_manifest_json()
-    print(manifest)
     assert manifest["contents"]["my_object.pb"] == {
         "digest": "1234567890abcde",
         "ref": "s3://my-bucket/my_dir",
@@ -609,8 +583,7 @@ def test_add_s3_reference_object_directory():
     }
 
 
-def test_add_s3_reference_object_no_version():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_s3_reference_object_no_version(artifact):
     mock_boto(artifact, version_id=None)
     artifact.add_reference("s3://my-bucket/my_object.pb")
 
@@ -624,8 +597,7 @@ def test_add_s3_reference_object_no_version():
     }
 
 
-def test_add_s3_reference_object_with_version():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_s3_reference_object_with_version(artifact):
     mock_boto(artifact)
     artifact.add_reference("s3://my-bucket/my_object.pb?versionId=2")
 
@@ -639,8 +611,7 @@ def test_add_s3_reference_object_with_version():
     }
 
 
-def test_add_s3_reference_object_with_name():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_s3_reference_object_with_name(artifact):
     mock_boto(artifact)
     artifact.add_reference("s3://my-bucket/my_object.pb", name="renamed.pb")
 
@@ -654,27 +625,24 @@ def test_add_s3_reference_object_with_name():
     }
 
 
-def test_add_s3_reference_path(runner, capsys):
+def test_add_s3_reference_path(runner, capsys, artifact):
+    mock_boto(artifact, path=True)
+    artifact.add_reference("s3://my-bucket/")
+
+    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
+    manifest = artifact.manifest.to_manifest_json()
+    assert manifest["contents"]["my_object.pb"] == {
+        "digest": "1234567890abcde",
+        "ref": "s3://my-bucket/my_object.pb",
+        "extra": {"etag": "1234567890abcde", "versionID": "1"},
+        "size": 10,
+    }
+    _, err = capsys.readouterr()
+    assert "Generating checksum" in err
+
+
+def test_add_s3_reference_path_with_content_type(runner, capsys, artifact):
     with runner.isolated_filesystem():
-        artifact = wandb.Artifact(type="dataset", name="my-arty")
-        mock_boto(artifact, path=True)
-        artifact.add_reference("s3://my-bucket/")
-
-        assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
-        manifest = artifact.manifest.to_manifest_json()
-        assert manifest["contents"]["my_object.pb"] == {
-            "digest": "1234567890abcde",
-            "ref": "s3://my-bucket/my_object.pb",
-            "extra": {"etag": "1234567890abcde", "versionID": "1"},
-            "size": 10,
-        }
-        _, err = capsys.readouterr()
-        assert "Generating checksum" in err
-
-
-def test_add_s3_reference_path_with_content_type(runner, capsys):
-    with runner.isolated_filesystem():
-        artifact = wandb.Artifact(type="dataset", name="my-arty")
         mock_boto(artifact, path=False, content_type="application/x-directory")
         artifact.add_reference("s3://my-bucket/my_dir")
 
@@ -690,17 +658,14 @@ def test_add_s3_reference_path_with_content_type(runner, capsys):
         assert "Generating checksum" in err
 
 
-def test_add_s3_max_objects():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_s3_max_objects(artifact):
     mock_boto(artifact, path=True)
     with pytest.raises(ValueError):
         artifact.add_reference("s3://my-bucket/", max_objects=1)
 
 
-def test_add_reference_s3_no_checksum():
-    with open("file1.txt", "w") as f:
-        f.write("hello")
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_reference_s3_no_checksum(artifact):
+    Path("file1.txt").write_text("hello")
     mock_boto(artifact)
     # TODO: Should we require name in this case?
     artifact.add_reference("s3://my_bucket/file1.txt", checksum=False)
@@ -713,8 +678,7 @@ def test_add_reference_s3_no_checksum():
     }
 
 
-def test_add_gs_reference_object():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_gs_reference_object(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb")
 
@@ -728,8 +692,9 @@ def test_add_gs_reference_object():
     }
 
 
-def test_load_gs_reference_object_without_generation_and_mismatched_etag():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_load_gs_reference_object_without_generation_and_mismatched_etag(
+    artifact,
+):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb")
     artifact._state = ArtifactState.COMMITTED
@@ -741,8 +706,7 @@ def test_load_gs_reference_object_without_generation_and_mismatched_etag():
         entry.download()
 
 
-def test_add_gs_reference_object_with_version():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_gs_reference_object_with_version(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb#2")
 
@@ -756,8 +720,7 @@ def test_add_gs_reference_object_with_version():
     }
 
 
-def test_add_gs_reference_object_with_name():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_gs_reference_object_with_name(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb", name="renamed.pb")
 
@@ -771,9 +734,8 @@ def test_add_gs_reference_object_with_name():
     }
 
 
-def test_add_gs_reference_path(runner, capsys):
+def test_add_gs_reference_path(runner, capsys, artifact):
     with runner.isolated_filesystem():
-        artifact = wandb.Artifact(type="dataset", name="my-arty")
         mock_gcs(artifact, path=True)
         artifact.add_reference("gs://my-bucket/")
 
@@ -789,8 +751,7 @@ def test_add_gs_reference_path(runner, capsys):
         assert "Generating checksum" in err
 
 
-def test_add_gs_reference_object_no_md5():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_gs_reference_object_no_md5(artifact):
     mock_gcs(artifact, hash=False)
     artifact.add_reference("gs://my-bucket/my_object.pb")
 
@@ -804,16 +765,14 @@ def test_add_gs_reference_object_no_md5():
     }
 
 
-def test_add_gs_reference_with_dir_paths():
-    artifact = wandb.Artifact(type="dataset", name="my-folder-arty")
+def test_add_gs_reference_with_dir_paths(artifact):
     mock_gcs(artifact, override_blob_name="my_folder/")
     artifact.add_reference("gs://my-bucket/my_folder/")
 
     assert len(artifact.manifest.entries) == 0
 
 
-def test_load_gs_reference_with_dir_paths():
-    artifact = wandb.Artifact(type="dataset", name="my-folder-arty")
+def test_load_gs_reference_with_dir_paths(artifact):
     mock = mock_gcs(artifact, override_blob_name="my_folder/")
     artifact.add_reference("gs://my-bucket/my_folder/")
 
@@ -843,110 +802,79 @@ def test_load_gs_reference_with_dir_paths():
         gcs_handler.load_path(entry, local=True)
 
 
-def test_add_azure_reference_no_checksum(mock_azure_handler):
-    artifact = wandb.Artifact("my_artifact", type="my_type")
-    entries = artifact.add_reference(
-        "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob",
-        checksum=False,
-    )
-    assert len(entries) == 1
-    assert entries[0].path == "nonexistent-blob"
-    assert (
-        entries[0].ref
-        == "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob"
-    )
-    assert (
-        entries[0].digest
-        == "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob"
-    )
-    assert entries[0].size is None
-    assert entries[0].extra == {}
-
-    # with name
-    artifact = wandb.Artifact("my_artifact", type="my_type")
-    entries = artifact.add_reference(
-        "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob",
-        name="my-name",
-        checksum=False,
-    )
-    assert len(entries) == 1
-    assert entries[0].path == "my-name"
-    assert (
-        entries[0].ref
-        == "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob"
-    )
-    assert (
-        entries[0].digest
-        == "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob"
-    )
-    assert entries[0].size is None
-    assert entries[0].extra == {}
-
-    # with version
-    artifact = wandb.Artifact("my_artifact", type="my_type")
-    entries = artifact.add_reference(
-        "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob?versionId=v2",
-        checksum=False,
-    )
-    assert len(entries) == 1
-    assert entries[0].path == "nonexistent-blob"
-    assert (
-        entries[0].ref
-        == "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob"
-    )
-    assert (
-        entries[0].digest
-        == "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob"
-    )
-    assert entries[0].size is None
-    assert entries[0].extra == {}
+@pytest.fixture
+def my_artifact() -> Artifact:
+    """A test artifact with a custom type."""
+    return Artifact("my_artifact", type="my_type")
 
 
-def test_add_azure_reference(mock_azure_handler):
-    artifact = wandb.Artifact("my_artifact", type="my_type")
-    entries = artifact.add_reference(
-        "https://myaccount.blob.core.windows.net/my-container/my-blob"
-    )
-    assert len(entries) == 1
-    assert entries[0].path == "my-blob"
-    assert (
-        entries[0].ref == "https://myaccount.blob.core.windows.net/my-container/my-blob"
-    )
-    assert entries[0].digest == "my-blob version None"
-    assert entries[0].size == 42
-    assert entries[0].extra == {"etag": "my-blob version None"}
+@pytest.mark.parametrize("name", [None, "my-name"])
+@pytest.mark.parametrize("version_id", [None, "v2"])
+def test_add_azure_reference_no_checksum(
+    mock_azure_handler, my_artifact, name, version_id
+):
+    uri = "https://myaccount.blob.core.windows.net/my-container/nonexistent-blob"
 
-    # with name
-    artifact = wandb.Artifact("my_artifact", type="my_type")
-    entries = artifact.add_reference(
-        "https://myaccount.blob.core.windows.net/my-container/my-blob", name="my-name"
-    )
-    assert len(entries) == 1
-    assert entries[0].path == "my-name"
-    assert (
-        entries[0].ref == "https://myaccount.blob.core.windows.net/my-container/my-blob"
-    )
-    assert entries[0].digest == "my-blob version None"
-    assert entries[0].size == 42
-    assert entries[0].extra == {"etag": "my-blob version None"}
+    if version_id and name:
+        entries = my_artifact.add_reference(
+            f"{uri}?versionId={version_id}", name=name, checksum=False
+        )
+    elif version_id and not name:
+        entries = my_artifact.add_reference(
+            f"{uri}?versionId={version_id}", checksum=False
+        )
+    elif (not version_id) and name:
+        entries = my_artifact.add_reference(uri, name=name, checksum=False)
+    else:
+        entries = my_artifact.add_reference(uri, checksum=False)
 
-    # with version
-    artifact = wandb.Artifact("my_artifact", type="my_type")
-    entries = artifact.add_reference(
-        "https://myaccount.blob.core.windows.net/my-container/my-blob?versionId=v2"
-    )
     assert len(entries) == 1
-    assert entries[0].path == "my-blob"
-    assert (
-        entries[0].ref == "https://myaccount.blob.core.windows.net/my-container/my-blob"
-    )
-    assert entries[0].digest == "my-blob version v2"
-    assert entries[0].size == 42
-    assert entries[0].extra == {"etag": "my-blob version v2", "versionID": "v2"}
+    entry = entries[0]
+    assert entry.path == "nonexistent-blob" if (name is None) else name
+    assert entry.ref == uri
+    assert entry.digest == uri
+    assert entry.size is None
+    assert entry.extra == {}
+
+
+@pytest.mark.parametrize("name", [None, "my-name"])
+@pytest.mark.parametrize("version_id", [None, "v2"])
+def test_add_azure_reference(mock_azure_handler, my_artifact, name, version_id):
+    uri = "https://myaccount.blob.core.windows.net/my-container/my-blob"
+
+    if version_id and name:
+        entries = my_artifact.add_reference(f"{uri}?versionId={version_id}", name=name)
+    elif version_id and not name:
+        entries = my_artifact.add_reference(f"{uri}?versionId={version_id}")
+    elif (not version_id) and name:
+        entries = my_artifact.add_reference(uri, name=name)
+    else:
+        entries = my_artifact.add_reference(uri)
+
+    assert len(entries) == 1
+    entry = entries[0]
+
+    if name is None:
+        assert entry.path == "my-blob"
+    else:
+        assert entry.path == name
+
+    if version_id is None:
+        assert entry.digest == "my-blob version None"
+        assert entry.extra == {"etag": "my-blob version None"}
+    else:
+        assert entry.digest == f"my-blob version {version_id}"
+        assert entry.extra == {
+            "etag": f"my-blob version {version_id}",
+            "versionID": version_id,
+        }
+
+    assert entry.ref == uri
+    assert entry.size == 42
 
 
 def test_add_azure_reference_directory(mock_azure_handler):
-    artifact = wandb.Artifact("my_artifact", type="my_type")
+    artifact = Artifact("my_artifact", type="my_type")
     entries = artifact.add_reference(
         "https://myaccount.blob.core.windows.net/my-container/my-dir"
     )
@@ -969,7 +897,7 @@ def test_add_azure_reference_directory(mock_azure_handler):
     assert entries[1].extra == {"etag": "my-dir/b version None"}
 
     # with name
-    artifact = wandb.Artifact("my_artifact", type="my_type")
+    artifact = Artifact("my_artifact", type="my_type")
     entries = artifact.add_reference(
         "https://myaccount.blob.core.windows.net/my-container/my-dir", name="my-name"
     )
@@ -1018,8 +946,7 @@ def test_add_azure_reference_max_objects(mock_azure_handler):
         assert entries[1].extra == {"etag": "my-dir/b version None"}
 
 
-def test_add_http_reference_path():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_http_reference_path(artifact):
     mock_http(
         artifact,
         headers={
@@ -1041,12 +968,11 @@ def test_add_http_reference_path():
     }
 
 
-def test_add_reference_named_local_file(tmp_path):
+def test_add_reference_named_local_file(tmp_path, artifact):
     file = tmp_path / "file1.txt"
     file.write_text("hello")
     uri = file.as_uri()
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_reference(uri, name="great-file.txt")
 
     assert artifact.digest == "585b9ada17797e37c9cbab391e69b8c5"
@@ -1058,8 +984,7 @@ def test_add_reference_named_local_file(tmp_path):
     }
 
 
-def test_add_reference_unknown_handler():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_add_reference_unknown_handler(artifact):
     artifact.add_reference("ref://example.com/somefile.txt", name="ref")
 
     assert artifact.digest == "410ade94865e89ebe1f593f4379ac228"
@@ -1072,14 +997,13 @@ def test_add_reference_unknown_handler():
 
 
 @pytest.mark.parametrize("name_type", [str, Path, PurePosixPath, PureWindowsPath])
-def test_remove_file(name_type):
+def test_remove_file(name_type, artifact):
     file1 = Path("file1.txt")
     file1.parent.mkdir(parents=True, exist_ok=True)
     file1.write_text("hello")
     file2 = Path("file2.txt")
     file2.write_text("hello")
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_file(file1)
     artifact.add_file(file2, name="renamed.txt")
 
@@ -1090,17 +1014,14 @@ def test_remove_file(name_type):
 
 
 @pytest.mark.parametrize("name_type", [str, Path, PurePosixPath, PureWindowsPath])
-def test_remove_directory(name_type):
+def test_remove_directory(name_type, artifact):
     file1 = Path("bar/foo/file1.txt")
     file1.parent.mkdir(parents=True, exist_ok=True)
     file1.write_text("hello")
     file2 = Path("bar/foo/file2.txt")
     file2.write_text("hello2")
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_dir("bar")
-
-    print(artifact.manifest.entries)
 
     assert len(artifact.manifest.entries) == 2
 
@@ -1109,12 +1030,11 @@ def test_remove_directory(name_type):
     assert artifact.manifest.entries == {}
 
 
-def test_remove_non_existent():
+def test_remove_non_existent(artifact):
     file1 = Path("baz/foo/file1.txt")
     file1.parent.mkdir(parents=True, exist_ok=True)
     file1.write_text("hello")
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_dir("baz")
 
     with pytest.raises(FileNotFoundError):
@@ -1125,8 +1045,7 @@ def test_remove_non_existent():
     assert len(artifact.manifest.entries) == 1
 
 
-def test_remove_manifest_entry():
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
+def test_remove_manifest_entry(artifact):
     entry = artifact.add_reference(Path(__file__).as_uri())[0]
 
     artifact.remove(entry)
@@ -1190,7 +1109,7 @@ def test_artifact_table_deserialize_timestamp_column():
     }
 
     for art in (artifact_json, artifact_json_non_null):
-        artifact = wandb.Artifact(name="test", type="test")
+        artifact = Artifact(name="test", type="test")
         timestamp_idx = art["columns"].index("Date Time")
         table = wandb.Table.from_json(art, artifact)
         assert [row[timestamp_idx] for row in table.data] == [
@@ -1201,10 +1120,9 @@ def test_artifact_table_deserialize_timestamp_column():
         ]
 
 
-def test_add_obj_wbimage_no_classes(assets_path):
+def test_add_obj_wbimage_no_classes(assets_path, artifact):
     im_path = str(assets_path("2x2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     wb_image = wandb.Image(
         im_path,
         masks={
@@ -1217,10 +1135,9 @@ def test_add_obj_wbimage_no_classes(assets_path):
         artifact.add(wb_image, "my-image")
 
 
-def test_add_obj_wbimage(assets_path):
+def test_add_obj_wbimage(assets_path, artifact):
     im_path = str(assets_path("2x2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     wb_image = wandb.Image(im_path, classes=[{"id": 0, "name": "person"}])
     artifact.add(wb_image, "my-image")
 
@@ -1243,22 +1160,21 @@ def test_add_obj_wbimage(assets_path):
 
 
 @pytest.mark.parametrize("overwrite", [True, False])
-def test_add_obj_wbimage_again_after_edit(tmp_path, assets_path, copy_asset, overwrite):
+def test_add_obj_wbimage_again_after_edit(
+    tmp_path, assets_path, copy_asset, overwrite, artifact
+):
     orig_path1 = assets_path("test.png")
     orig_path2 = assets_path("2x2.png")
-    contents1 = orig_path1.read_bytes()
-    contents2 = orig_path2.read_bytes()
-    assert contents1 != contents2  # Consistency check
+    assert filecmp.cmp(orig_path1, orig_path2) is False  # Consistency check
 
     im_path = tmp_path / "image.png"
 
     copied_path = copy_asset(orig_path1.name, im_path)
     assert im_path == copied_path  # Consistency check
-    assert im_path.read_bytes() == contents1
+    assert filecmp.cmp(orig_path1, im_path) is True  # Consistency check
 
     image_name = "my-image"
 
-    artifact = wandb.Artifact(type="dataset", name="artifact")
     wb_image = wandb.Image(str(im_path))
     artifact.add(wb_image, image_name, overwrite=overwrite)
 
@@ -1271,7 +1187,7 @@ def test_add_obj_wbimage_again_after_edit(tmp_path, assets_path, copy_asset, ove
     # Modify the object, keeping the path unchanged
     copied_path = copy_asset(orig_path2.name, im_path)
     assert im_path == copied_path  # Consistency check
-    assert im_path.read_bytes() == contents2
+    assert filecmp.cmp(orig_path2, im_path) is True  # Consistency check
 
     wb_image = wandb.Image(str(im_path))
     artifact.add(wb_image, image_name, overwrite=overwrite)
@@ -1287,10 +1203,9 @@ def test_add_obj_wbimage_again_after_edit(tmp_path, assets_path, copy_asset, ove
     assert manifest_contents1.keys() == manifest_contents2.keys()
 
 
-def test_add_obj_using_brackets(assets_path):
+def test_add_obj_using_brackets(assets_path, artifact):
     im_path = str(assets_path("2x2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     wb_image = wandb.Image(im_path, classes=[{"id": 0, "name": "person"}])
     artifact["my-image"] = wb_image
 
@@ -1315,37 +1230,35 @@ def test_add_obj_using_brackets(assets_path):
         _ = artifact["my-image"]
 
 
-def test_duplicate_wbimage_from_file(assets_path):
+@pytest.mark.parametrize("add_duplicate", [True, False], ids=["duplicate", "unique"])
+def test_duplicate_wbimage_from_file(assets_path, artifact, add_duplicate):
     im_path_1 = str(assets_path("test.png"))
     im_path_2 = str(assets_path("test2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="artifact")
     wb_image_1 = wandb.Image(im_path_1)
-    wb_image_2 = wandb.Image(im_path_2)
-    artifact.add(wb_image_1, "my-image_1")
-    artifact.add(wb_image_2, "my-image_2")
-    assert len(artifact.manifest.entries) == 4
+    wb_image_2 = wandb.Image(im_path_1) if add_duplicate else wandb.Image(im_path_2)
 
-    artifact = wandb.Artifact(type="dataset", name="artifact")
-    wb_image_1 = wandb.Image(im_path_1)
-    wb_image_2 = wandb.Image(im_path_1)
     artifact.add(wb_image_1, "my-image_1")
     artifact.add(wb_image_2, "my-image_2")
-    assert len(artifact.manifest.entries) == 3
+
+    if add_duplicate:
+        assert len(artifact.manifest.entries) == 3
+    else:
+        assert len(artifact.manifest.entries) == 4
 
 
 def test_deduplicate_wbimage_from_array():
     im_data_1 = np.random.rand(300, 300, 3)
     im_data_2 = np.random.rand(300, 300, 3)
 
-    artifact = wandb.Artifact(type="dataset", name="artifact")
+    artifact = Artifact(type="dataset", name="artifact")
     wb_image_1 = wandb.Image(im_data_1)
     wb_image_2 = wandb.Image(im_data_2)
     artifact.add(wb_image_1, "my-image_1")
     artifact.add(wb_image_2, "my-image_2")
     assert len(artifact.manifest.entries) == 4
 
-    artifact = wandb.Artifact(type="dataset", name="artifact")
+    artifact = Artifact(type="dataset", name="artifact")
     wb_image_1 = wandb.Image(im_data_1)
     wb_image_2 = wandb.Image(im_data_2)
     wb_image_3 = wandb.Image(im_data_1)  # yes, should be 1
@@ -1355,29 +1268,28 @@ def test_deduplicate_wbimage_from_array():
     assert len(artifact.manifest.entries) == 5
 
 
-def test_deduplicate_wbimagemask_from_array():
+@pytest.mark.parametrize("add_duplicate", [True, False], ids=["duplicate", "unique"])
+def test_deduplicate_wbimagemask_from_array(artifact, add_duplicate):
     im_data_1 = np.random.randint(0, 10, (300, 300))
     im_data_2 = np.random.randint(0, 10, (300, 300))
 
-    artifact = wandb.Artifact(type="dataset", name="artifact")
     wb_imagemask_1 = data_types.ImageMask({"mask_data": im_data_1}, key="test")
-    wb_imagemask_2 = data_types.ImageMask({"mask_data": im_data_2}, key="test2")
+    wb_imagemask_2 = data_types.ImageMask(
+        {"mask_data": im_data_1 if add_duplicate else im_data_2}, key="test2"
+    )
+
     artifact.add(wb_imagemask_1, "my-imagemask_1")
     artifact.add(wb_imagemask_2, "my-imagemask_2")
-    assert len(artifact.manifest.entries) == 4
 
-    artifact = wandb.Artifact(type="dataset", name="artifact")
-    wb_imagemask_1 = data_types.ImageMask({"mask_data": im_data_1}, key="test")
-    wb_imagemask_2 = data_types.ImageMask({"mask_data": im_data_1}, key="test2")
-    artifact.add(wb_imagemask_1, "my-imagemask_1")
-    artifact.add(wb_imagemask_2, "my-imagemask_2")
-    assert len(artifact.manifest.entries) == 3
+    if add_duplicate:
+        assert len(artifact.manifest.entries) == 3
+    else:
+        assert len(artifact.manifest.entries) == 4
 
 
-def test_add_obj_wbimage_classes_obj(assets_path):
+def test_add_obj_wbimage_classes_obj(assets_path, artifact):
     im_path = str(assets_path("2x2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     classes = wandb.Classes([{"id": 0, "name": "person"}])
     wb_image = wandb.Image(im_path, classes=classes)
     artifact.add(wb_image, "my-image")
@@ -1399,10 +1311,9 @@ def test_add_obj_wbimage_classes_obj(assets_path):
     }
 
 
-def test_add_obj_wbimage_classes_obj_already_added(assets_path):
+def test_add_obj_wbimage_classes_obj_already_added(assets_path, artifact):
     im_path = str(assets_path("2x2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     classes = wandb.Classes([{"id": 0, "name": "person"}])
     artifact.add(classes, "my-classes")
     wb_image = wandb.Image(im_path, classes=classes)
@@ -1429,10 +1340,9 @@ def test_add_obj_wbimage_classes_obj_already_added(assets_path):
     }
 
 
-def test_add_obj_wbimage_image_already_added(assets_path):
+def test_add_obj_wbimage_image_already_added(assets_path, artifact):
     im_path = str(assets_path("2x2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     artifact.add_file(im_path)
     wb_image = wandb.Image(im_path, classes=[{"id": 0, "name": "person"}])
     artifact.add(wb_image, "my-image")
@@ -1451,10 +1361,9 @@ def test_add_obj_wbimage_image_already_added(assets_path):
     }
 
 
-def test_add_obj_wbtable_images(assets_path):
+def test_add_obj_wbtable_images(assets_path, artifact):
     im_path = str(assets_path("2x2.png"))
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     wb_image = wandb.Image(im_path, classes=[{"id": 0, "name": "person"}])
     wb_table = wandb.Table(["examples"])
     wb_table.add_data(wb_image)
@@ -1476,7 +1385,7 @@ def test_add_obj_wbtable_images(assets_path):
     }
 
 
-def test_add_obj_wbtable_images_duplicate_name(assets_path):
+def test_add_obj_wbtable_images_duplicate_name(assets_path, artifact):
     img_1 = str(assets_path("2x2.png"))
     img_2 = str(assets_path("test2.png"))
 
@@ -1485,7 +1394,6 @@ def test_add_obj_wbtable_images_duplicate_name(assets_path):
     os.mkdir("dir2")
     shutil.copy(img_2, "dir2/img.png")
 
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     wb_image_1 = wandb.Image(os.path.join("dir1", "img.png"))
     wb_image_2 = wandb.Image(os.path.join("dir2", "img.png"))
     wb_table = wandb.Table(["examples"])
@@ -1507,18 +1415,13 @@ def test_add_obj_wbtable_images_duplicate_name(assets_path):
     }
 
 
-def test_add_partition_folder():
+def test_add_partition_folder(artifact):
     table_name = "dataset"
     table_parts_dir = "dataset_parts"
-    artifact_name = "simple_dataset"
-    artifact_type = "dataset"
 
-    artifact = wandb.Artifact(artifact_name, type=artifact_type)
     partition_table = wandb.data_types.PartitionedTable(parts_path=table_parts_dir)
     artifact.add(partition_table, table_name)
     manifest = artifact.manifest.to_manifest_json()
-    print(manifest)
-    print(artifact.digest)
     assert artifact.digest == "c6a4d80ed84fd68df380425ded894b19"
     assert manifest["contents"]["dataset.partitioned-table.json"] == {
         "digest": "uo/SjoAO+O7pcSfg+yhlDg==",
@@ -1536,7 +1439,9 @@ def test_add_partition_folder():
     ],
 )
 def test_http_storage_handler_uses_etag_for_digest(
-    headers: Optional[Mapping[str, str]], expected_digest: Optional[str]
+    headers: Optional[Mapping[str, str]],
+    expected_digest: Optional[str],
+    artifact,
 ):
     with responses.RequestsMock() as rsps, requests.Session() as session:
         rsps.add(
@@ -1547,18 +1452,18 @@ def test_http_storage_handler_uses_etag_for_digest(
         )
         handler = HTTPHandler(session)
 
-        art = wandb.Artifact("test", type="dataset")
         [entry] = handler.store_path(
-            art, "https://example.com/foo.json?bar=abc", "foo.json"
+            artifact, "https://example.com/foo.json?bar=abc", "foo.json"
         )
         assert entry.path == "foo.json"
         assert entry.ref == "https://example.com/foo.json?bar=abc"
         assert entry.digest == expected_digest
 
 
-def test_s3_storage_handler_load_path_missing_reference(monkeypatch, wandb_init):
+def test_s3_storage_handler_load_path_missing_reference(
+    monkeypatch, wandb_init, artifact
+):
     # Create an artifact that references a non-existent S3 object.
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, version_id="")
     artifact.add_reference("s3://my-bucket/my_object.pb")
 
@@ -1582,7 +1487,7 @@ def test_s3_storage_handler_load_path_missing_reference(monkeypatch, wandb_init)
 
 def test_change_artifact_collection_type(monkeypatch, wandb_init):
     with wandb_init() as run:
-        artifact = wandb.Artifact("image_data", "data")
+        artifact = Artifact("image_data", "data")
         run.log_artifact(artifact)
 
     with wandb_init() as run:
@@ -1594,14 +1499,14 @@ def test_change_artifact_collection_type(monkeypatch, wandb_init):
         assert artifact.type == "lucas_type"
 
 
-def test_save_artifact_sequence(monkeypatch, wandb_init):
+def test_save_artifact_sequence(monkeypatch, wandb_init, api):
     with wandb_init() as run:
-        artifact = wandb.Artifact("sequence_name", "data")
+        artifact = Artifact("sequence_name", "data")
         run.log_artifact(artifact)
         artifact.wait()
 
         artifact = run.use_artifact("sequence_name:latest")
-        collection = wandb.Api().artifact_collection("data", "sequence_name")
+        collection = api.artifact_collection("data", "sequence_name")
         collection.description = "new description"
         collection.name = "new_name"
         collection.type = "new_type"
@@ -1624,14 +1529,14 @@ def test_save_artifact_sequence(monkeypatch, wandb_init):
         assert len(collection.tags) == 1 and collection.tags[0] == "new_tag"
 
 
-def test_save_artifact_portfolio(monkeypatch, wandb_init):
+def test_save_artifact_portfolio(monkeypatch, wandb_init, api):
     with wandb_init() as run:
-        artifact = wandb.Artifact("image_data", "data")
+        artifact = Artifact("image_data", "data")
         run.log_artifact(artifact)
         artifact.link("portfolio_name")
         artifact.wait()
 
-        portfolio = wandb.Api().artifact_collection("data", "portfolio_name")
+        portfolio = api.artifact_collection("data", "portfolio_name")
         portfolio.description = "new description"
         portfolio.name = "new_name"
         with pytest.raises(ValueError):
@@ -1654,10 +1559,9 @@ def test_save_artifact_portfolio(monkeypatch, wandb_init):
 
 
 def test_s3_storage_handler_load_path_missing_reference_allowed(
-    monkeypatch, wandb_init, capsys
+    monkeypatch, wandb_init, capsys, artifact
 ):
     # Create an artifact that references a non-existent S3 object.
-    artifact = wandb.Artifact(type="dataset", name="my-arty")
     mock_boto(artifact, version_id="")
     artifact.add_reference("s3://my-bucket/my_object.pb")
 
@@ -1705,10 +1609,9 @@ def test_s3_storage_handler_load_path_uses_cache(tmp_path):
     assert local_path == path
 
 
-def test_tracking_storage_handler():
-    art = wandb.Artifact("test", "dataset")
+def test_tracking_storage_handler(artifact):
     handler = TrackingHandler()
-    [entry] = handler.store_path(art, path="/path/to/file.txt", name="some-file")
+    [entry] = handler.store_path(artifact, path="/path/to/file.txt", name="some-file")
     assert entry.path == "some-file"
     assert entry.ref == "/path/to/file.txt"
     assert entry.digest == entry.ref
@@ -1750,11 +1653,10 @@ def test_manifest_json_invalid_version(version):
 
 @pytest.mark.flaky
 @pytest.mark.xfail(reason="flaky")
-def test_cache_cleanup_allows_upload(wandb_init, tmp_path, monkeypatch):
+def test_cache_cleanup_allows_upload(wandb_init, tmp_path, monkeypatch, artifact):
     monkeypatch.setenv("WANDB_CACHE_DIR", str(tmp_path))
     cache = artifact_file_cache.get_artifact_file_cache()
 
-    artifact = wandb.Artifact(type="dataset", name="survive-cleanup")
     with open("test-file", "wb") as f:
         f.truncate(2**20)
         f.flush()
@@ -1781,36 +1683,36 @@ def test_cache_cleanup_allows_upload(wandb_init, tmp_path, monkeypatch):
 
 
 def test_artifact_ttl_setter_getter():
-    art = wandb.Artifact("test", type="test")
+    art = Artifact("test", type="test")
     with pytest.raises(ArtifactNotLoggedError):
-        print(art.ttl)
+        _ = art.ttl
     assert art._ttl_duration_seconds is None
     assert art._ttl_changed is False
     assert art._ttl_is_inherited
 
-    art = wandb.Artifact("test", type="test")
+    art = Artifact("test", type="test")
     art.ttl = None
     assert art.ttl is None
     assert art._ttl_duration_seconds is None
     assert art._ttl_changed
     assert art._ttl_is_inherited is False
 
-    art = wandb.Artifact("test", type="test")
+    art = Artifact("test", type="test")
     art.ttl = ArtifactTTL.INHERIT
     with pytest.raises(ArtifactNotLoggedError):
-        print(art.ttl)
+        _ = art.ttl
     assert art._ttl_duration_seconds is None
     assert art._ttl_changed
     assert art._ttl_is_inherited
 
     ttl_timedelta = timedelta(days=100)
-    art = wandb.Artifact("test", type="test")
+    art = Artifact("test", type="test")
     art.ttl = ttl_timedelta
     assert art.ttl == ttl_timedelta
     assert art._ttl_duration_seconds == int(ttl_timedelta.total_seconds())
     assert art._ttl_changed
     assert art._ttl_is_inherited is False
 
-    art = wandb.Artifact("test", type="test")
+    art = Artifact("test", type="test")
     with pytest.raises(ValueError):
         art.ttl = timedelta(days=-1)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1446,7 +1446,7 @@ class Artifact:
         val = obj.to_json(self)
         name = obj.with_suffix(name)
         entry = self.manifest.get_entry_by_path(name)
-        if (overwrite is False) and (entry is not None):
+        if (not overwrite) and (entry is not None):
             return entry
 
         if is_tmp_name:

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1145,7 +1145,7 @@ class Artifact:
     @contextlib.contextmanager
     @ensure_not_finalized
     def new_file(
-        self, name: str, mode: str = "w", encoding: str | None = None
+        self, name: str, mode: str = "x", encoding: str | None = None
     ) -> Iterator[IO]:
         """Open a new temporary file and add it to the artifact.
 
@@ -1162,24 +1162,28 @@ class Artifact:
             ArtifactFinalizedError: You cannot make changes to the current artifact
             version because it is finalized. Log a new artifact version instead.
         """
+        overwrite: bool = "x" not in mode
+
         if self._tmp_dir is None:
             self._tmp_dir = tempfile.TemporaryDirectory()
         path = os.path.join(self._tmp_dir.name, name.lstrip("/"))
-        if os.path.exists(path):
-            raise ValueError(f"File with name {name!r} already exists at {path!r}")
 
         filesystem.mkdir_exists_ok(os.path.dirname(path))
         try:
             with util.fsync_open(path, mode, encoding) as f:
                 yield f
+        except FileExistsError:
+            raise ValueError(f"File with name {name!r} already exists at {path!r}")
         except UnicodeEncodeError as e:
             termerror(
-                f"Failed to open the provided file (UnicodeEncodeError: {e}). Please "
+                f"Failed to open the provided file ({type(e).__name__}: {e}). Please "
                 f"provide the proper encoding."
             )
             raise e
 
-        self.add_file(path, name=name, policy="immutable", skip_cache=True)
+        self.add_file(
+            path, name=name, policy="immutable", skip_cache=True, overwrite=overwrite
+        )
 
     @ensure_not_finalized
     def add_file(
@@ -1189,6 +1193,7 @@ class Artifact:
         is_tmp: bool | None = False,
         skip_cache: bool | None = False,
         policy: Literal["mutable", "immutable"] | None = "mutable",
+        overwrite: bool = False,
     ) -> ArtifactManifestEntry:
         """Add a local file to the artifact.
 
@@ -1198,13 +1203,14 @@ class Artifact:
                 to the basename of the file.
             is_tmp: If true, then the file is renamed deterministically to avoid
                 collisions.
-            skip_cache: If set to `True`, W&B will not copy files to the cache after uploading.
+            skip_cache: If `True`, W&B will not copy files to the cache after uploading.
             policy: By default, set to "mutable". If set to "mutable", create a temporary copy of the
                 file to prevent corruption during upload. If set to "immutable", disable
                 protection and rely on the user not to delete or change the file.
+            overwrite: If `True`, overwrite the file if it already exists.
 
         Returns:
-            The added manifest entry
+            The added manifest entry.
 
         Raises:
             ArtifactFinalizedError: You cannot make changes to the current artifact
@@ -1212,7 +1218,7 @@ class Artifact:
             ValueError: Policy must be "mutable" or "immutable"
         """
         if not os.path.isfile(local_path):
-            raise ValueError("Path is not a file: {}".format(local_path))
+            raise ValueError(f"Path is not a file: {local_path!r}")
 
         name = LogicalPath(name or os.path.basename(local_path))
         digest = md5_file_b64(local_path)
@@ -1224,7 +1230,12 @@ class Artifact:
             name = os.path.join(file_path, ".".join(file_name_parts))
 
         return self._add_local_file(
-            name, local_path, digest=digest, skip_cache=skip_cache, policy=policy
+            name,
+            local_path,
+            digest=digest,
+            skip_cache=skip_cache,
+            policy=policy,
+            overwrite=overwrite,
         )
 
     @ensure_not_finalized
@@ -1373,7 +1384,9 @@ class Artifact:
         return manifest_entries
 
     @ensure_not_finalized
-    def add(self, obj: WBValue, name: StrPath) -> ArtifactManifestEntry:
+    def add(
+        self, obj: WBValue, name: StrPath, overwrite: bool = False
+    ) -> ArtifactManifestEntry:
         """Add wandb.WBValue `obj` to the artifact.
 
         Args:
@@ -1381,6 +1394,7 @@ class Artifact:
                 PartitionedTable, Table, Classes, ImageMask, BoundingBoxes2D, Audio,
                 Image, Video, Html, Object3D
             name: The path within the artifact to add the object.
+            overwrite: If True, overwrite existing objects with the same file path (if applicable).
 
         Returns:
             The added manifest entry
@@ -1399,7 +1413,7 @@ class Artifact:
         # Validate that the object is one of the correct wandb.Media types
         # TODO: move this to checking subclass of wandb.Media once all are
         # generally supported
-        allowed_types = [
+        allowed_types = (
             data_types.Bokeh,
             data_types.JoinedTable,
             data_types.PartitionedTable,
@@ -1414,13 +1428,10 @@ class Artifact:
             data_types.Object3D,
             data_types.Molecule,
             data_types._SavedModel,
-        ]
-
-        if not any(isinstance(obj, t) for t in allowed_types):
+        )
+        if not isinstance(obj, allowed_types):
             raise ValueError(
-                "Found object of type {}, expected one of {}.".format(
-                    obj.__class__, allowed_types
-                )
+                f"Found object of type {obj.__class__}, expected one of: {allowed_types}"
             )
 
         obj_id = id(obj)
@@ -1435,26 +1446,20 @@ class Artifact:
         val = obj.to_json(self)
         name = obj.with_suffix(name)
         entry = self.manifest.get_entry_by_path(name)
-        if entry is not None:
+        if (overwrite is False) and (entry is not None):
             return entry
-
-        def do_write(f: IO) -> None:
-            import json
-
-            # TODO: Do we need to open with utf-8 codec?
-            f.write(json.dumps(val, sort_keys=True))
 
         if is_tmp_name:
             file_path = os.path.join(self._TMP_DIR.name, str(id(self)), name)
             folder_path, _ = os.path.split(file_path)
-            if not os.path.exists(folder_path):
-                os.makedirs(folder_path)
-            with open(file_path, "w") as tmp_f:
-                do_write(tmp_f)
+            os.makedirs(folder_path, exist_ok=True)
+            with open(file_path, "w", encoding="utf-8") as tmp_f:
+                json.dump(val, tmp_f, sort_keys=True)
         else:
-            with self.new_file(name) as f:
+            filemode = "w" if overwrite else "x"
+            with self.new_file(name, mode=filemode, encoding="utf-8") as f:
+                json.dump(val, f, sort_keys=True)
                 file_path = f.name
-                do_write(f)
 
         # Note, we add the file from our temp directory.
         # It will be added again later on finalize, but succeed since
@@ -1466,7 +1471,7 @@ class Artifact:
             obj._set_artifact_target(self, entry.path)
 
         if is_tmp_name:
-            if os.path.exists(file_path):
+            with contextlib.suppress(FileNotFoundError):
                 os.remove(file_path)
 
         return entry
@@ -1478,11 +1483,12 @@ class Artifact:
         digest: B64MD5 | None = None,
         skip_cache: bool | None = False,
         policy: Literal["mutable", "immutable"] | None = "mutable",
+        overwrite: bool = False,
     ) -> ArtifactManifestEntry:
         policy = policy or "mutable"
         if policy not in ["mutable", "immutable"]:
             raise ValueError(
-                f"Invalid policy `{policy}`. Policy may only be `mutable` or `immutable`."
+                f"Invalid policy {policy!r}. Policy may only be `mutable` or `immutable`."
             )
         upload_path = path
         if policy == "mutable":
@@ -1500,7 +1506,7 @@ class Artifact:
             local_path=upload_path,
             skip_cache=skip_cache,
         )
-        self.manifest.add_entry(entry)
+        self.manifest.add_entry(entry, overwrite=overwrite)
         self._added_local_paths[os.fspath(path)] = entry
         return entry
 

--- a/wandb/sdk/artifacts/artifact_manifest.py
+++ b/wandb/sdk/artifacts/artifact_manifest.py
@@ -48,18 +48,19 @@ class ArtifactManifest:
     def digest(self) -> HexMD5:
         raise NotImplementedError
 
-    def add_entry(self, entry: ArtifactManifestEntry) -> None:
-        if (
-            entry.path in self.entries
-            and entry.digest != self.entries[entry.path].digest
-        ):
-            raise ValueError("Cannot add the same path twice: {}".format(entry.path))
-        self.entries[entry.path] = entry
+    def add_entry(self, entry: ArtifactManifestEntry, overwrite: bool = False) -> None:
+        path = entry.path
+        if not overwrite:
+            prev_entry = self.entries.get(path)
+            if prev_entry and (entry.digest != prev_entry.digest):
+                raise ValueError(f"Cannot add the same path twice: {path!r}")
+        self.entries[path] = entry
 
     def remove_entry(self, entry: ArtifactManifestEntry) -> None:
-        if entry.path not in self.entries:
+        try:
+            del self.entries[entry.path]
+        except LookupError:
             raise FileNotFoundError(f"Cannot remove missing entry: '{entry.path}'")
-        del self.entries[entry.path]
 
     def get_entry_by_path(self, path: str) -> ArtifactManifestEntry | None:
         return self.entries.get(path)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-21304](https://wandb.atlassian.net/browse/WB-21304)

Adds a boolean `overwrite` param to 
- `Artifact.add()`
- `Artifact.add_file()`

...in order to allow overwriting previously-added artifact files with the same path(s).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

See added tests in: [tests/system_tests/test_artifacts/test_wandb_artifacts.py](https://github.com/wandb/wandb/pull/8553/files#diff-7a050cfc8b89eecc7a18cf87031e103df052f0da99cfa8a37a5fc40940736efa)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21304]: https://wandb.atlassian.net/browse/WB-21304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ