### PR TITLE
fix(launch): allow for repeated $ref usage in _replace_refs_and_allofs function

### DIFF
--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -143,7 +143,7 @@ def _replace_refs_and_allofs(schema: dict, defs: Optional[dict]) -> dict:
         # Reference found, replace it with its definition
         def_key = schema.pop("$ref").split("#/$defs/")[1]
         # Also run recursive replacement in case a ref contains more refs
-        ret = _replace_refs_and_allofs(defs.pop(def_key), defs)
+        ret = _replace_refs_and_allofs(defs[def_key], defs)
     for key, val in schema.items():
         if isinstance(val, dict):
             # Step into dicts recursively


### PR DESCRIPTION
Description
-----------
- Fixes WB-21393
- Fixes #8562


This PR addresses an issue where the `_replace_refs_and_allofs` function fails when the same `$ref` is used multiple times in a schema. Previously, the function removed/popped definitions from `defs` upon encountering them, causing a `KeyError` when the same reference was needed again later in the schema.

Changes Made:
- Modified the `_replace_refs_and_allofs` function to copy `$ref` definitions from `defs` instead of popping them, ensuring that the same reference can be reused multiple times without causing errors.


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
