### PR TITLE
chore: skip installing latest gymnasium as it breaks sb3

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -43,8 +43,8 @@ urllib3
 docker
 catboost
 openai
-gymnasium
-stable_baselines3; python_version < '3.12'
+gymnasium < 1.0.0
+stable_baselines3
 
 responses
 prometheus_client

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -44,7 +44,7 @@ docker
 catboost
 openai
 gymnasium
-stable_baselines3
+stable_baselines3; python_version < '3.12'
 
 responses
 prometheus_client


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

when trying to resolve dependencies for sb3, uv uses gym, which doesn't seem to work.
sb3 has a strict requirement to use gymnasiun < 0.30 (https://github.com/DLR-RM/stable-baselines3/blob/56c153f048f1035f239b77d1569b240ace83c130/setup.py#L103), but since we install gymnasium 1.0 (the latest that was released, we get resolution issues)

This is a stop-gap we probably want better management of these conflicting dependencies

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
