### PR TITLE
chore: reduce parallelism in functional tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 import platform
@@ -5,7 +7,7 @@ import re
 import shutil
 import time
 from contextlib import contextmanager
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable
 
 import nox
 
@@ -66,7 +68,7 @@ def site_packages_dir(session: nox.Session) -> pathlib.Path:
         )
 
 
-def get_circleci_splits(session: nox.Session) -> Optional[Tuple[int, int]]:
+def get_circleci_splits(session: nox.Session) -> tuple[int, int] | None:
     """Returns the test splitting arguments from our CircleCI config.
 
     When using test splitting, CircleCI sets the CIRCLE_NODE_TOTAL and
@@ -87,10 +89,12 @@ def get_circleci_splits(session: nox.Session) -> Optional[Tuple[int, int]]:
 
 def run_pytest(
     session: nox.Session,
-    paths: List[str],
+    paths: list[str],
+    opts: dict[str, str] | None = None,
 ) -> None:
     session_file_name = get_session_file_name(session)
 
+    opts = opts or {}
     pytest_opts = []
     pytest_env = {
         "USERNAME": session.env.get("USERNAME"),
@@ -107,7 +111,7 @@ def run_pytest(
     }
 
     # Print 20 slowest tests.
-    pytest_opts.append("--durations=20")
+    pytest_opts.append(f"--durations={opts.get('durations', 20)}")
 
     # Output test results for tooling.
     junitxml = _NOX_PYTEST_RESULTS_DIR / session_file_name / "junit.xml"
@@ -115,10 +119,10 @@ def run_pytest(
     session.notify("combine_test_results")
 
     # (pytest-timeout) Per-test timeout.
-    pytest_opts.append("--timeout=300")
+    pytest_opts.append(f"--timeout={opts.get('timeout', 300)}")
 
     # (pytest-xdist) Run tests in parallel.
-    pytest_opts.append("-n=auto")
+    pytest_opts.append(f"-n={opts.get('n', 'auto')}")
 
     # (pytest-split) Run a subset of tests only (for external parallelism).
     (circle_node_index, circle_node_total) = get_circleci_splits(session)
@@ -239,6 +243,7 @@ def functional_tests(session: nox.Session):
     run_pytest(
         session,
         paths=(session.posargs or ["tests/system_tests/test_functional"]),
+        opts={"n": 4},
     )
 
 
@@ -342,7 +347,7 @@ def local_testcontainer_registry(session: nox.Session) -> None:
     To run this for a specific release tag, use:
     nox -s local-testcontainer-registry -- <release_tag>
     """
-    tags: List[str] = session.posargs or []
+    tags: list[str] = session.posargs or []
 
     import subprocess
 
@@ -362,7 +367,7 @@ def local_testcontainer_registry(session: nox.Session) -> None:
 
         return data
 
-    def get_release_tag_and_commit_hash(tags: List[str]):
+    def get_release_tag_and_commit_hash(tags: list[str]):
         if not tags:
             # Get the latest release tag and commit hash
             query = """
@@ -611,7 +616,7 @@ def mypy_report(session: nox.Session) -> None:
     )
 
 
-def python_coverage_env(session: nox.Session) -> Dict[str, str]:
+def python_coverage_env(session: nox.Session) -> dict[str, str]:
     """Returns environment variables configuring Python coverage output.
 
     Configures the 'coverage' tool https://coverage.readthedocs.io/en/latest/
@@ -630,7 +635,7 @@ def python_coverage_env(session: nox.Session) -> Dict[str, str]:
     return {"COVERAGE_FILE": str(pycovfile.absolute())}
 
 
-def go_coverage_env(session: nox.Session) -> Dict[str, str]:
+def go_coverage_env(session: nox.Session) -> dict[str, str]:
     """Returns environment variables configuring Go coverage output.
 
     Intended for use with the "coverage" session.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- For functional tests, the default n=auto spins up too many workers on CircleCI as it's based on the number of detected CPUs in the system, and doesn't take into account the number of available CPUs in the container, which results in OOM errors.
- Fixed a keras/tb test

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
