### PR TITLE
chore(sdk): clean up wandb/lib/printer.py

### DIFF
--- a/tests/unit_tests/test_lib/test_printer.py
+++ b/tests/unit_tests/test_lib/test_printer.py
@@ -1,17 +1,17 @@
 import pytest
-from wandb.sdk.lib.printer import CRITICAL, DEBUG, NOTSET, PrinterTerm
+from wandb.sdk.lib import printer as p
 
 
 @pytest.mark.parametrize("level", [1.3, {}, []])
 def test_printer_invalid_level_type(level):
-    printer = PrinterTerm()
+    printer = p.get_printer(False)
     with pytest.raises(ValueError, match="Unknown status level"):
         printer.display("test string", level=level)
 
 
 @pytest.mark.parametrize("level", ["random", ""])
 def test_printer_invalid_level_str(level):
-    printer = PrinterTerm()
+    printer = p.get_printer(False)
     with pytest.raises(ValueError, match="Unknown level name"):
         printer.display("test string", level=level)
 
@@ -19,13 +19,13 @@ def test_printer_invalid_level_str(level):
 @pytest.mark.parametrize(
     "level, prefix",
     [
-        (CRITICAL, "wandb: ERROR"),
-        (DEBUG, "wandb:"),
-        (NOTSET, "wandb:"),
+        (p.CRITICAL, "wandb: ERROR"),
+        (p.DEBUG, "wandb:"),
+        (p.NOTSET, "wandb:"),
     ],
 )
 def test_printer_levels(level, prefix, capsys):
-    printer = PrinterTerm()
+    printer = p.get_printer(False)
     printer.display("test string", level=level)
     outerr = capsys.readouterr()
     assert outerr.out == ""

--- a/wandb/sdk/lib/printer.py
+++ b/wandb/sdk/lib/printer.py
@@ -392,7 +392,7 @@ class _PrinterJupyter(Printer):
         return f'{ipython.TABLE_STYLES}<div class="wandb-row">{row}</div>'
 
 
-def get_printer(_jupyter: bool) -> Printer:
-    if _jupyter:
+def get_printer(jupyter: bool) -> Printer:
+    if jupyter:
         return _PrinterJupyter()
     return _PrinterTerm()

--- a/wandb/sdk/lib/progress.py
+++ b/wandb/sdk/lib/progress.py
@@ -11,7 +11,7 @@ from . import printer as p
 
 
 def print_sync_dedupe_stats(
-    printer: p.PrinterJupyter | p.PrinterTerm,
+    printer: p.Printer,
     final_result: wandb_internal_pb2.PollExitResponse,
 ) -> None:
     """Print how much W&B sync reduced the amount of uploaded data.
@@ -31,7 +31,7 @@ def print_sync_dedupe_stats(
 
 @contextlib.contextmanager
 def progress_printer(
-    printer: p.PrinterJupyter | p.PrinterTerm,
+    printer: p.Printer,
 ) -> Iterator[ProgressPrinter]:
     """Context manager providing an object for printing run progress."""
     with printer.dynamic_text() as text_area:
@@ -44,7 +44,7 @@ class ProgressPrinter:
 
     def __init__(
         self,
-        printer: p.PrinterJupyter | p.PrinterTerm,
+        printer: p.Printer,
         progress_text_area: p.DynamicText | None,
     ) -> None:
         self._printer = printer


### PR DESCRIPTION
* Use `__future__` annotations
* Rename `_Printer` => `Printer`
* Rename `PrinterTerm` => `_PrinterTerm`
* Rename `PrinterJupyter` => `_PrinterJupyter`
* Replace usage of `_html` attribute outside of module by public `supports_html` property