### PR TITLE
fix: tensorboard sync fails when writing images in a batch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Fixed
 
 - Fixed typing issue of `wandb.Api` (@bdvllrs in https://github.com/wandb/wandb/pull/8548)
+- Fixed an issue handling batches of images when syncing tensorboard (@jacobromero in https://github.com/wandb/wandb/pull/8615)
 
 ### Changed
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-21449

What does the PR do? Include a concise description of the PR contents.

This PR fixes and issue where wandb-core was failing to process multiple images when syncing a batch of image with tensorboard.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?
- sample script
```python
run = wandb.init(project="sample", sync_tensorboard=True)

file_writer = tf.summary.create_file_writer(logdir)

with file_writer.as_default():
    num_images = 10
    img_tensor = np.random.rand(num_images, 10, 10, 3)
    tf.summary.image("Training data", img_tensor, max_outputs=num_images, step=0)

file_writer.close()
run.finish()
```

- Unit test added

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
