### PR TITLE
chore(sdk): allow terminal emulation in tests

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,3 +14,5 @@ pandas
 responses
 
 coverage[toml]
+
+pyte~=0.8  # Terminal emulator for testing interactions with the terminal.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Generator, Iterable, Optional, Union
 
 import pyte
 import pyte.modes
-
 from wandb.errors import term
 
 # Don't write to Sentry in wandb.
@@ -203,7 +202,7 @@ class EmulatedTerminal:
         self._screen.set_mode(pyte.modes.LNM)  # \n implies \r
         self._stream = pyte.Stream(self._screen)
 
-    def read_stderr(self) -> list[str]:
+    def read_stderr(self) -> "list[str]":
         """Returns the text in the emulated terminal.
 
         This processes the stderr text captured by pytest since the last

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from queue import Queue
 from typing import Any, Callable, Generator, Iterable, Optional, Union
 
+import pyte
+import pyte.modes
+
+from wandb.errors import term
+
 # Don't write to Sentry in wandb.
 #
 # For wandb-core, this setting is configured below.
@@ -114,6 +119,13 @@ def copy_asset(assets_path) -> Generator[Callable, None, None]:
 # --------------------------------
 
 
+@pytest.fixture(autouse=True)
+def reset_logger():
+    """Resets the `wandb.errors.term` module before each test."""
+    wandb.termsetup(wandb.Settings(silent=False), None)
+    term._dynamic_blocks = []
+
+
 class MockWandbTerm:
     """Helper to test wandb.term*() calls.
 
@@ -180,6 +192,66 @@ def mock_wandb_log() -> Generator[MockWandbTerm, None, None]:
             patched["termwarn"],
             patched["termerror"],
         )
+
+
+class EmulatedTerminal:
+    """The return value of the emulated_terminal fixture."""
+
+    def __init__(self, capsys: pytest.CaptureFixture[str]):
+        self._capsys = capsys
+        self._screen = pyte.Screen(80, 24)
+        self._screen.set_mode(pyte.modes.LNM)  # \n implies \r
+        self._stream = pyte.Stream(self._screen)
+
+    def read_stderr(self) -> list[str]:
+        """Returns the text in the emulated terminal.
+
+        This processes the stderr text captured by pytest since the last
+        invocation and returns the updated state of the screen. Empty lines
+        at the top and bottom of the screen and empty text at the end of
+        any line are trimmed.
+
+        NOTE: This resets pytest's stderr and stdout buffers. You should not
+        use this with anything else that uses capsys.
+        """
+        self._stream.feed(self._capsys.readouterr().err)
+
+        lines = [line.rstrip() for line in self._screen.display]
+
+        n_empty_at_start = 0
+        for i in range(len(lines)):
+            if not lines[i]:
+                n_empty_at_start += 1
+            else:
+                break
+
+        n_empty_at_end = 0
+        for i in range(len(lines)):
+            if not lines[-1 - i]:
+                n_empty_at_end += 1
+            else:
+                break
+
+        return lines[n_empty_at_start:-n_empty_at_end]
+
+
+@pytest.fixture()
+def emulated_terminal(monkeypatch, capsys) -> EmulatedTerminal:
+    """Emulates a terminal for the duration of a test.
+
+    This makes functions in the `wandb.errors.term` module act as if
+    stderr is a terminal.
+    """
+
+    monkeypatch.setenv("TERM", "xterm")
+
+    monkeypatch.setattr(term, "_sys_stderr_isatty", lambda: True)
+
+    # Make click pretend we're a TTY, so it doesn't strip ANSI sequences.
+    # This is fragile and could break when click is updated.
+    monkeypatch.setattr("click._compat.isatty", lambda *args, **kwargs: True)
+
+    return EmulatedTerminal(capsys)
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
Makes an `emulated_terminal` fixture available for all tests to allow testing code that uses ANSI escape sequences.