### PR TITLE
chore(sdk): specify versions requirements_test.txt

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,18 +1,19 @@
-pytest
-pytest-asyncio
-pytest-cov
-pytest-xdist
-pytest-split
-pytest-mock
-pytest-timeout
-pytest-flakefinder
-pyfakefs
-parameterized
+pytest~=7.4
+pytest-asyncio~=0.21.2
+pytest-cov~=4.1
+pytest-xdist~=3.5
+pytest-split~=0.8.2
+pytest-mock~=3.11
+pytest-timeout~=2.3
+pytest-flakefinder~=1.1
+pyfakefs~=5.7
+parameterized~=0.9.0
 
-flask>2.0.0
-pandas
-responses
+flask~=2.2
+pandas~=1.3; python_version <= '3.10'
+pandas~=2.2; python_version > '3.10'
+responses~=0.23.3
 
-coverage[toml]
+coverage[toml]~=7.2
 
-pyte~=0.8  # Terminal emulator for testing interactions with the terminal.
+pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.


### PR DESCRIPTION
Description
---
NOTE: This was originally https://github.com/wandb/wandb/pull/8653 which got mistakenly merged into a branch that wasn't main.

---

Adds version constraints to `requirements_test.txt`. While package dependency versions should be loose, requirements files should be strict. I chose to use `~=` (compatible version) rather than `==` (exact version) so that we don't have to update these as often, but using exact versions would also work (in which case we should set up dependabot for this file).

Using explicit versions can also help debug issues in CI or development environments.

NOTE: `pyte~=0.8` would match `0.9`, which is wrong, since in major version 0, minor increases may cause incompatible changes. Using `pyte~=0.8.0` works like `pyte >= 0.8.0, pyte < 0.9`.
