### PR TITLE
chore: stop capturing events of sending exit after closed

### DIFF
--- a/core/internal/runwork/runwork.go
+++ b/core/internal/runwork/runwork.go
@@ -131,7 +131,7 @@ func (rw *runWork) AddWorkOrCancel(
 	case <-rw.closed:
 		// Here, internalWork is closed or about to be closed,
 		// so we should drop the record.
-		rw.logger.CaptureError(errRecordAfterClose, "work", work)
+		rw.logger.Warn(errRecordAfterClose.Error(), "work", work)
 		return
 
 	default:

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -1447,8 +1447,7 @@ func (s *Sender) sendRequestRunFinishWithoutExit(record *spb.Record, _ *spb.RunF
 // sendExit sends an exit record to the server and triggers the shutdown of the stream
 func (s *Sender) sendExit(record *spb.Record) {
 	if s.exitRecord != nil {
-		s.logger.CaptureError(
-			errors.New("sender: received Exit record more than once, ignoring"))
+		s.logger.Warn("sender: received Exit record more than once, ignoring")
 		return
 	}
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

There is no added value to keep capturing these events, as we know it happens and had enough data how often it happens.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
