### PR TITLE
fix(artifacts): fix azure downloads when `skip_cache=True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Add missing type hints of the `wandb.plot` module in the package stub (@kptkin in https://github.com/wandb/wandb/pull/8667)
 - Fix limiting azure reference artifact uploads to `max_objects` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8703)
+- Fix downloading azure reference artifacts with `skip_cache=True` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8706)
 
 ## [0.18.5] - 2024-10-17
 

--- a/wandb/sdk/artifacts/storage_handlers/azure_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/azure_handler.py
@@ -28,6 +28,9 @@ class AzureHandler(StorageHandler):
             ".blob.core.windows.net"
         )
 
+    def __init__(self, scheme: str | None = None) -> None:
+        self._cache = get_artifact_file_cache()
+
     def load_path(
         self,
         manifest_entry: ArtifactManifestEntry,
@@ -37,7 +40,7 @@ class AzureHandler(StorageHandler):
         if not local:
             return manifest_entry.ref
 
-        path, hit, cache_open = get_artifact_file_cache().check_etag_obj_path(
+        path, hit, cache_open = self._cache.check_etag_obj_path(
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),
             manifest_entry.size or 0,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This PR fixes downloading azure reference artifacts when `skip_cache=True` by setting `_cache` on the Azure handler. This field is assumed to exist when loading reference artifacts [here](https://github.com/wandb/wandb/blob/b588b252066bb25cfa00e3558375690014a1430f/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py#L183), and because it didn't for the azure handler, we previously did not download the artifacts when we chose to skip caching.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
tested by downloading locally with `skip_cache=True`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
