### PR TITLE
fix(artifacts): fix multipart upload when content type not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Add missing type hints of the `wandb.plot` module in the package stub (@kptkin in https://github.com/wandb/wandb/pull/8667)
 - Fix limiting azure reference artifact uploads to `max_objects` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8703)
 - Fix downloading azure reference artifacts with `skip_cache=True` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8706)
+- Fix multipart uploads for files with no content type defined in headers (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8716)
 
 ## [0.18.5] - 2024-10-17
 
@@ -84,7 +85,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Allow all users to read cache files when core is enabled (@moredatarequired in https://github.com/wandb/wandb/pull/8362)
 - Infinite scalars logged in TensorBoard are uploaded successfully rather than skipped (@timoffex in https://github.com/wandb/wandb/pull/8380)
-- Properly respect `WANDB_ERROR_REPORTING=false`.  This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
+- Properly respect `WANDB_ERROR_REPORTING=false`. This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
 
 ### Changed
 
@@ -104,8 +105,8 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Changed
 
 - The new "core" backend, previously activated using wandb.require("core"), is now used by default. To revert to the legacy behavior,
-add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
-to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
+  add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
+  to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
 
 ## [0.17.9] - 2024-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 
 - Allow all users to read cache files when core is enabled (@moredatarequired in https://github.com/wandb/wandb/pull/8362)
 - Infinite scalars logged in TensorBoard are uploaded successfully rather than skipped (@timoffex in https://github.com/wandb/wandb/pull/8380)
-- Properly respect `WANDB_ERROR_REPORTING=false`. This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
+- Properly respect `WANDB_ERROR_REPORTING=false`.  This fixes a regression introduced in 0.18.0 (@kptkin in https://github.com/wandb/wandb/pull/8379)
 
 ### Changed
 
@@ -105,8 +105,8 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 ### Changed
 
 - The new "core" backend, previously activated using wandb.require("core"), is now used by default. To revert to the legacy behavior,
-  add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
-  to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
+add `wandb.require("legacy-service")` at the beginning of your script. Note: In the upcoming minor release, the option
+to disable this new behavior will be removed (@kptkin in https://github.com/wandb/wandb/pull/7777)
 
 ## [0.17.9] - 2024-09-05
 

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -553,10 +553,7 @@ func (as *ArtifactSaver) uploadMultipart(
 	partResponses := make(chan partResponse, len(partData))
 	// TODO: add mid-upload cancel.
 
-	contentType, err := getContentType(fileInfo.uploadHeaders)
-	if err != nil {
-		return uploadResult{name: fileInfo.name, err: err}
-	}
+	contentType := getContentType(fileInfo.uploadHeaders)
 
 	partInfo := fileInfo.multipartUploadInfo
 	for i, part := range partInfo {
@@ -635,13 +632,13 @@ func (as *ArtifactSaver) uploadMultipart(
 	return uploadResult{name: fileInfo.name, err: err}
 }
 
-func getContentType(headers []string) (string, error) {
+func getContentType(headers []string) string {
 	for _, h := range headers {
 		if strings.HasPrefix(h, "Content-Type:") {
-			return strings.TrimPrefix(h, "Content-Type:"), nil
+			return strings.TrimPrefix(h, "Content-Type:")
 		}
 	}
-	return "", fmt.Errorf("content-type header is required for multipart uploads")
+	return ""
 }
 
 func getChunkSize(fileSize int64) int64 {


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-21562](https://wandb.atlassian.net/browse/WB-21562)

This PR fixes a bug where we threw an error when trying to upload large files with no content type. Previously, we just appended an empty string for these cases to the request header, which is what we now do. 

See this line for non-core implementation: https://github.com/wandb/wandb/blob/b588b252066bb25cfa00e3558375690014a1430f/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py#L238

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
tested locally with the script in the ticket

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21562]: https://wandb.atlassian.net/browse/WB-21562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ