### PR TITLE
fix: a smooth waitForRateLimit experience

### DIFF
--- a/core/internal/filestream/collectloop.go
+++ b/core/internal/filestream/collectloop.go
@@ -46,8 +46,6 @@ func (cl CollectLoop) Start(
 
 // waitForRateLimit merges requests until the rate limit allows us
 // to transmit data.
-// waitForRateLimit merges requests until the rate limit allows us
-// to transmit data.
 func (cl CollectLoop) waitForRateLimit(
 	buffer *FileStreamRequest,
 	requests <-chan *FileStreamRequest,

--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -141,7 +141,7 @@ func NewFileStream(params FileStreamParams) FileStream {
 
 	fs.transmitRateLimit = params.TransmitRateLimit
 	if fs.transmitRateLimit == nil {
-		fs.transmitRateLimit = rate.NewLimiter(rate.Every(defaultTransmitInterval), 1)
+		fs.transmitRateLimit = rate.NewLimiter(rate.Every(defaultTransmitInterval), 5)
 	}
 
 	return fs

--- a/core/internal/filestream/transmitloop.go
+++ b/core/internal/filestream/transmitloop.go
@@ -1,9 +1,6 @@
 package filestream
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/wandb/wandb/core/internal/waiting"
 )
 
@@ -48,7 +45,6 @@ func (tr TransmitLoop) Start(
 			}
 
 			tr.HeartbeatStopwatch.Reset()
-			fmt.Println("Sending request", time.Now())
 			err := tr.Send(x, feedback)
 
 			if err != nil {

--- a/core/internal/filestream/transmitloop.go
+++ b/core/internal/filestream/transmitloop.go
@@ -1,6 +1,9 @@
 package filestream
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/wandb/wandb/core/internal/waiting"
 )
 
@@ -45,6 +48,7 @@ func (tr TransmitLoop) Start(
 			}
 
 			tr.HeartbeatStopwatch.Reset()
+			fmt.Println("Sending request", time.Now())
 			err := tr.Send(x, feedback)
 
 			if err != nil {

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -187,7 +187,7 @@ func NewFileStream(
 	}
 
 	if txInterval := settings.GetFileStreamTransmitInterval(); txInterval > 0 {
-		params.TransmitRateLimit = rate.NewLimiter(rate.Every(txInterval), 1)
+		params.TransmitRateLimit = rate.NewLimiter(rate.Every(txInterval), 5)
 	}
 
 	return filestream.NewFileStream(params)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Added some burst to the rate limiter, just in case

Looks like the waitForRateLimit func is causing unnecessary delays by always waiting, even when the rate limit would allow transmission, so:

- Check if there's actually any delay needed from the rate limiter (reservation.Delay() == 0). If not, return immediately
- Create the timer only once instead of in each loop iteration and clean it up the timer with defer timer.Stop()

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
