### PR TITLE
Update wburls.py - WandB Server URL changed from wandb.me/wandb-server to wandb.ai/wandb-server

### DIFF
--- a/wandb/sdk/lib/wburls.py
+++ b/wandb/sdk/lib/wburls.py
@@ -32,7 +32,7 @@ class WBURLs:
             upgrade_server="https://wandb.me/server-upgrade",
             multiprocess="http://wandb.me/init-multiprocess",
             wandb_init="https://wandb.me/wandb-init",
-            wandb_server="https://wandb.me/wandb-server",
+            wandb_server="https://wandb.ai/wandb-server",
             wandb_define_metric="https://wandb.me/define-metric",
             wandb_core="https://wandb.me/wandb-core",
         )


### PR DESCRIPTION
Fix
Changed WandB Server URL from wandb.me/wandb-server to wandb.ai/wandb-server

- [x] I updated wburls.py accordingly.

Testing
-------
The old URL was broken. So, I changed it to a new URL and tested it by opening the new link via my forked repo.