### PR TITLE
fix: metric name path could write to paths outside of the run directory when starting a metric with a slash or by directory traversal

### DIFF
--- a/tests/unit_tests/test_media/test_media_logging.py
+++ b/tests/unit_tests/test_media/test_media_logging.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import wandb
+from bokeh.plotting import figure
+from rdkit import Chem
+from wandb import data_types
+
+data = np.random.randint(255, size=(1000))
+
+
+@pytest.fixture
+def audio_media() -> wandb.Audio:
+    audio_data = np.random.uniform(-1, 1, 44100)
+    return wandb.Audio(audio_data, sample_rate=44100)
+
+
+@pytest.fixture
+def video_media() -> wandb.Video:
+    frames = np.random.randint(low=0, high=256, size=(10, 3, 100, 100), dtype=np.uint8)
+    return wandb.Video(frames)
+
+
+@pytest.fixture
+def image_media() -> wandb.Image:
+    return wandb.Image(np.ones(shape=(32, 32)))
+
+
+@pytest.fixture
+def table_media() -> wandb.Table:
+    return wandb.Table(data=[[1]], columns=["A"])
+
+
+@pytest.fixture
+def graph_media() -> wandb.Graph:
+    graph = wandb.Graph()
+    node_a = data_types.Node("a", "Node A", size=(4,))
+    node_b = data_types.Node("b", "Node B", size=(16,))
+    graph.add_node(node_a)
+    graph.add_node(node_b)
+    graph.add_edge(node_a, node_b)
+    return graph
+
+
+@pytest.fixture
+def bokeh_media() -> data_types.Bokeh:
+    x = [1, 2]
+    y = [6, 7]
+    p = figure(title="simple line example", x_axis_label="x", y_axis_label="y")
+    p.line(x, y, legend_label="Temp.", line_width=2)
+    return data_types.Bokeh(p)
+
+
+@pytest.fixture
+def html_media() -> wandb.Html:
+    return wandb.Html("<html><body><h1>Hello, World!</h1></body></html>")
+
+
+@pytest.fixture
+def molecule_media() -> wandb.Molecule:
+    m = Chem.MolFromSmiles("Cc1ccccc1")
+    return wandb.Molecule.from_rdkit(m)
+
+
+@pytest.fixture
+def object3d_media() -> wandb.Object3D:
+    point_cloud = np.random.rand(100, 3)
+    return wandb.Object3D(point_cloud)
+
+
+@pytest.fixture
+def plotly_media() -> wandb.Plotly:
+    fig, ax = plt.subplots(2)
+    ax[0].plot([1, 2, 3])
+    ax[1].plot([1, 2, 3])
+    wandb.Plotly.make_plot_media(plt)
+    return wandb.Plotly(fig)
+
+
+@pytest.mark.parametrize(
+    "media_object",
+    [
+        "table_media",
+        "image_media",
+        "video_media",
+        "audio_media",
+        "graph_media",
+        "bokeh_media",
+        "html_media",
+        "molecule_media",
+        "object3d_media",
+        "plotly_media",
+    ],
+)
+def test_log_media_saves_to_run_directory(mock_run, request, media_object):
+    run = mock_run(use_magic_mock=True)
+    media_object = request.getfixturevalue(media_object)
+
+    media_object.bind_to_run(run, "/media/path", 0)
+
+    # Assert media object is saved under the run directory
+    assert media_object._path.startswith(run.dir)
+
+
+def test_log_media_with_path_traversal(mock_run, image_media):
+    run = mock_run()
+    image_media.bind_to_run(run, "../../../image", 0)
+
+    # Resolve to path to verify no path traversals
+    resolved_path = str(Path(image_media._path).resolve())
+    assert resolved_path.startswith(run.dir)
+
+
+def test_log_media_prefixed_with_multiple_slashes(mock_run, image_media):
+    run = mock_run()
+    image_media.bind_to_run(run, "////image", 0)
+
+    resolved_path = str(Path(image_media._path).resolve())
+    assert resolved_path.startswith(run.dir)

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -27,6 +27,35 @@ SYS_PLATFORM = platform.system()
 def _wb_filename(
     key: Union[str, int], step: Union[str, int], id: Union[str, int], extension: str
 ) -> str:
+    """Generates a safe filename/path for storing media files, using the provided key, step, and id.
+
+    The filename is made safe by:
+    1. Removing any leading slashes to prevent writing to absolute paths
+    2. Replacing '.' and '..' with underscores to prevent directory traversal attacks
+
+    If the key contains slashes (e.g. 'images/cats/fluffy.jpg'), subdirectories will be created:
+        media/
+          images/
+            cats/
+              fluffy.jpg_step_id.ext
+
+    Args:
+        key: Name/path for the media file
+        step: Training step number
+        id: Unique identifier
+        extension: File extension (e.g. '.jpg', '.mp3')
+
+    Returns:
+        A sanitized filename string in the format: key_step_id.extension
+    """
+    # Avoid writing to absolute paths by striping any leading slashes.
+    key = str(key).lstrip("/")
+
+    # Avoid directory traversal by replacing dots with underscores.
+    keys = key.split("/")
+    keys = [k.replace(".", "_") if k in (os.curdir, os.pardir) else k for k in keys]
+    key = os.sep.join(keys)
+
     return f"{str(key)}_{str(step)}_{str(id)}{extension}"
 
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18169
- Fixes WB-10232

What does the PR do? Include a concise description of the PR contents.

This PR fixes an issue when metric names started with a slash `/` wandb would attempt to write the file as an absolute path.
This PR also fixes a potential bug where a metric name containing `..` could write to another directory via path traversal.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?
- Tests added
- Test script
```python
import wandb
import numpy as np

imarray = np.random.rand(10,10,3) * 255

with wandb.init(project='slash_key') as run:
        wandb.log({
        "//epoch/accuracy": 0.75,
        "/epoch/loss": 0.5,
        "/.../epoch/imagetest": wandb.Image(imarray),
        "/.../ep.o.ch/im@getest2": wandb.Image(imarray),
        "/////test/image": wandb.Image(imarray),
        "../test/image": wandb.Image(imarray),
    })
    wandb.log({
        "//epoch/accuracy": 0.89,
        "/epoch/loss": 0.25,
        "/.../epoch/imagetest": wandb.Image(imarray),
        "/.../ep.o.ch/im@getest2": wandb.Image(imarray),
        "/////test/image": wandb.Image(imarray),
        "../test/image": wandb.Image(imarray),
    })
```
![image](https://github.com/user-attachments/assets/50c82e28-e777-4cb9-b232-4c998a4485c2)

![image](https://github.com/user-attachments/assets/5d74c8c4-530f-4b8f-952e-46b1b3fb587e)

![image](https://github.com/user-attachments/assets/0fb7368d-8b07-4cdc-a7fc-ca28cea05b7c)
