### PR TITLE
chore(artifacts): lax regex to also allow urls without regions

### DIFF
--- a/tests/unit_tests/test_file/test_file_public_api.py
+++ b/tests/unit_tests/test_file/test_file_public_api.py
@@ -25,6 +25,16 @@ def test_path_uri_s3_url(mock_client, termwarn_spy):
     termwarn_spy.assert_not_called()
 
 
+def test_path_uri_s3_url_no_datacenter(mock_client, termwarn_spy):
+    attrs = {
+        "directUrl": "https://my-bucket.s3.amazonaws.com/wandb-artifacts/my-artifact.txt"
+    }
+    file = File(mock_client, attrs)
+
+    assert file.path_uri == "s3://my-bucket/wandb-artifacts/my-artifact.txt"
+    termwarn_spy.assert_not_called()
+
+
 def test_path_uri_non_s3_url(mock_client, termwarn_spy):
     attrs = {
         "directUrl": "https://storage.googleapis.com/wandb-artifacts/my-artifact.txt"

--- a/wandb/apis/public/utils.py
+++ b/wandb/apis/public/utils.py
@@ -8,6 +8,7 @@ def parse_s3_url_to_s3_uri(url) -> str:
     Arguments:
         url (str): The S3 URL to convert, in the format
                    'http(s)://<bucket>.s3.<region>.amazonaws.com/<key>'.
+                   or 'http(s)://<bucket>.s3.amazonaws.com/<key>'
 
     Returns:
         str: The corresponding S3 URI in the format 's3://<bucket>/<key>'.
@@ -16,7 +17,7 @@ def parse_s3_url_to_s3_uri(url) -> str:
         ValueError: If the provided URL is not a valid S3 URL.
     """
     # Regular expression to match S3 URL pattern
-    s3_pattern = r"^https?://([^.]+)\.s3\.([^.]+)\.amazonaws\.com/(.+)$"
+    s3_pattern = r"^https?://([^.]+)\.s3\..*amazonaws\.com/(.+)$"
     parsed_url = urlparse(url)
 
     # Check if it's an S3 URL

--- a/wandb/apis/public/utils.py
+++ b/wandb/apis/public/utils.py
@@ -17,7 +17,7 @@ def parse_s3_url_to_s3_uri(url) -> str:
         ValueError: If the provided URL is not a valid S3 URL.
     """
     # Regular expression to match S3 URL pattern
-    s3_pattern = r"^https?://([^.]+)\.s3\..*amazonaws\.com/(.+)$"
+    s3_pattern = r"^https?://.*s3.*amazonaws\.com.*"
     parsed_url = urlparse(url)
 
     # Check if it's an S3 URL


### PR DESCRIPTION
Description
-----------
Some aws urls don't have regions in them, so make sure s3 parsers also account for that

Testing
-------
Used BYOB to run 
```
api = wandb.Api(overrides={"entity": "my-entity"})
artifact = api.artifact("my-entity/test/test_simple_file:v0")
for f in artifact.files():
    print("file: ", f.path_url)
```
