### PR TITLE
chore: reenable tensorboard tests for wandb-core

### DIFF
--- a/tests/system_tests/test_functional/test_tensorboard/test_tb_w_sb3.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_tb_w_sb3.py
@@ -1,16 +1,12 @@
 """Test stable_baselines3 integration."""
 
 import gymnasium as gym
-import pytest
 import wandb
 from stable_baselines3 import PPO
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv
 
 
-@pytest.mark.skip_wandb_core(
-    reason="There seems to be some issues with the implementation"
-)
 def test_sb3_tensorboard(wandb_init, relay_server):
     """Integration test for Stable Baselines 3 TensorBoard callback."""
     with relay_server() as relay:

--- a/tests/system_tests/test_functional/test_tensorboard/test_tensorboardX.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_tensorboardX.py
@@ -6,10 +6,6 @@ import wandb
 from tensorboardX import SummaryWriter
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="mismatched implementation details",
-)
 def test_add_scalar(wandb_init, wandb_backend_spy):
     with wandb_init(sync_tensorboard=True) as run:
         with SummaryWriter() as writer:
@@ -26,10 +22,6 @@ def test_add_scalar(wandb_init, wandb_backend_spy):
     wandb.tensorboard.unpatch()
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="mismatched implementation details",
-)
 def test_add_image(wandb_init, wandb_backend_spy):
     with wandb_init(sync_tensorboard=True) as run:
         with SummaryWriter() as writer:

--- a/tests/system_tests/test_functional/test_tensorboard/test_tf_summary.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_tf_summary.py
@@ -23,14 +23,13 @@ PR_CURVE_SPEC = {
                     "name": "runSets",
                     "args": [{"name": "runSets", "value": "${runSets}"}],
                     "fields": [
-                        {"name": "id", "fields": []},
-                        {"name": "name", "fields": []},
-                        {"name": "_defaultColorIndex", "fields": []},
+                        {"name": "id"},
+                        {"name": "name"},
+                        {"name": "_defaultColorIndex"},
                         {
                             "name": "summaryTable",
-                            "fields": [],
                             "args": [
-                                {"name": "tableKey", "value": "test_pr/pr_curves_table"}
+                                {"name": "tableKey", "value": "test_pr/pr_curves"}
                             ],
                         },
                     ],
@@ -41,10 +40,6 @@ PR_CURVE_SPEC = {
 }
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="hangs on processing data",
-)
 def test_histogram(wandb_init, relay_server):
     with relay_server() as relay:
         with wandb_init(sync_tensorboard=True) as run:
@@ -72,10 +67,6 @@ def test_histogram(wandb_init, relay_server):
     wandb.tensorboard.unpatch()
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="hangs on processing data",
-)
 def test_image(wandb_init, relay_server):
     with relay_server() as relay:
         with wandb_init(sync_tensorboard=True) as run:
@@ -133,10 +124,6 @@ def test_batch_images(wandb_init, relay_server):
     wandb.tensorboard.unpatch()
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="hangs on processing data",
-)
 def test_scalar(wandb_init, relay_server):
     with relay_server() as relay:
         scalars = [0.345, 0.234, 0.123]
@@ -160,10 +147,7 @@ def test_scalar(wandb_init, relay_server):
     wandb.tensorboard.unpatch()
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="hangs on processing data",
-)
+@pytest.mark.wandb_core_only
 def test_add_pr_curve(relay_server, wandb_init):
     with relay_server() as relay:
         with wandb_init(sync_tensorboard=True) as run:
@@ -189,10 +173,7 @@ def test_add_pr_curve(relay_server, wandb_init):
     wandb.tensorboard.unpatch()
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="hangs on processing data",
-)
+@pytest.mark.wandb_core_only
 def test_add_pr_curve_plugin(relay_server, wandb_init):
     with relay_server() as relay:
         with wandb_init(sync_tensorboard=True) as run:
@@ -223,7 +204,7 @@ def test_add_pr_curve_plugin(relay_server, wandb_init):
 
         summary = relay.context.get_run_summary(run.id)
         assert summary["global_step"] == 0
-        assert summary["test_pr/pr_curves_table"]["_type"] == "table-file"
+        assert summary["test_pr/pr_curves"]["_type"] == "table-file"
 
     wandb.tensorboard.unpatch()
 
@@ -272,10 +253,6 @@ def test_compat_tensorboard(relay_server, wandb_init):
     wandb.tensorboard.unpatch()
 
 
-@pytest.mark.skip_wandb_core(
-    feature="tensorboard",
-    reason="hangs on processing data",
-)
 def test_tb_sync_with_explicit_step_and_log(
     wandb_init,
     relay_server,


### PR DESCRIPTION
Description
-----------

What does the PR do? Include a concise description of the PR contents.

This PR enables most tensorboard tests that were disabled for wandb-core.

One more test needs a deeper investigation as to why it times out during circleci runs:
https://github.com/wandb/wandb/blob/main/tests/system_tests/test_functional/test_tensorboard/test_torch_tb.py#L13-L38

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

- nox -s "functional_tests" --python 3.12 -- tests/system_tests/test_functional/test_tensorboard
  - `39 passed, 2 skipped, 11 warnings in 240.81s (0:04:00)`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
