### PR TITLE
fix: fix broken docs links

### DIFF
--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -505,7 +505,7 @@ def log(
     [guides to logging](https://docs.wandb.ai/guides/track/log) for examples,
     from 3D molecular structures and segmentation masks to PR curves and histograms.
     You can use `wandb.Table` to log structured data. See our
-    [guide to logging tables](https://docs.wandb.ai/guides/data-vis/log-tables)
+    [guide to logging tables](https://docs.wandb.ai/guides/tables/tables-walkthrough)
     for details.
 
     The W&B UI organizes metrics with a forward slash (`/`) in their name

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -6,7 +6,7 @@ flexible containers for information, like tables and HTML, and more.
 For more on logging media, see [our guide](https://docs.wandb.com/guides/track/log/media)
 
 For more on logging structured data for interactive dataset and model analysis,
-see [our guide to W&B Tables](https://docs.wandb.com/guides/data-vis).
+see [our guide to W&B Tables](https://docs.wandb.com/guides/tables/).
 
 All of these special data types are subclasses of WBValue. All the data types
 serialize to JSON, since that is what wandb uses to save the objects locally

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1706,7 +1706,7 @@ class Run:
         [guides to logging](https://docs.wandb.ai/guides/track/log) for examples,
         from 3D molecular structures and segmentation masks to PR curves and histograms.
         You can use `wandb.Table` to log structured data. See our
-        [guide to logging tables](https://docs.wandb.ai/guides/data-vis/log-tables)
+        [guide to logging tables](https://docs.wandb.ai/guides/tables/tables-walkthrough)
         for details.
 
         The W&B UI organizes metrics with a forward slash (`/`) in their name


### PR DESCRIPTION
Fix broken docs links that show up here: 

- https://docs.wandb.ai/ref/python/log/
- https://docs.wandb.ai/ref/python/run/
- https://docs.wandb.ai/ref/python/data-types/

Description
-----------

- Fixes WB-DOCS-990

Some of the docs links are not working; this fixes them.

- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------

URLs resolve in browser with HTTP 200 response