### PR TITLE
chore: always use latest image in local_wandb_server

### DIFF
--- a/tools/local_wandb_server.py
+++ b/tools/local_wandb_server.py
@@ -359,6 +359,7 @@ def _start_container(
     """
     docker_flags = [
         "--detach",
+        *["--pull", "always"],  # Always get latest image.
         *["-e", "WANDB_ENABLE_TEST_CONTAINER=true"],
         *["--name", name],
         *["--volume", f"{name}-vol:/vol"],


### PR DESCRIPTION
Description
---
Pass `--pull always` to the `docker run` command. This only affects local test runs and does not affect CI.