### PR TITLE
chore: pick a free port for the test proxy server

### DIFF
--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -33,9 +33,6 @@ else:
     from typing_extensions import Literal
 
 
-_WANDB_BACKEND_PROXY_PORT = 8000
-
-
 class ConsoleFormatter:
     BOLD = "\033[1m"
     CODE = "\033[2m"
@@ -620,7 +617,6 @@ def wandb_backend_proxy_server(
 ) -> Generator[WandbBackendProxy, None, None]:
     """Session fixture that starts up a proxy server for the W&B backend."""
     with spy_proxy(
-        proxy_port=_WANDB_BACKEND_PROXY_PORT,
         target_host=local_wandb_backend._host,
         target_port=local_wandb_backend._base_port,
     ) as proxy:
@@ -657,7 +653,7 @@ def wandb_backend_spy(
     # Connect to the proxy to spy on requests:
     monkeypatch.setenv(
         "WANDB_BASE_URL",
-        f"http://127.0.0.1:{_WANDB_BACKEND_PROXY_PORT}",
+        f"http://127.0.0.1:{wandb_backend_proxy_server.port}",
     )
 
     with wandb_backend_proxy_server.spy() as spy:

--- a/tests/system_tests/wandb_backend_spy/proxy.py
+++ b/tests/system_tests/wandb_backend_spy/proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import socket
 import threading
 import time
 import traceback
@@ -16,17 +17,15 @@ from .spy import WandbBackendSpy
 
 @contextlib.contextmanager
 def spy_proxy(
-    proxy_port: int,
     target_host: str,
     target_port: int,
 ) -> Iterator[WandbBackendProxy]:
     """A context manager that proxies a W&B backend.
 
-    The proxy server will be available at 127.0.0.1 on the given port.
-    The server is shut down when the context manager exits.
+    The proxy server will be available at 127.0.0.1 on a port chosen by the
+    system. The server is shut down when the context manager exits.
 
     Args:
-        proxy_port: The port on which to run the proxy server.
         target_host: The hostname of the W&B backend to proxy.
         target_port: The port of the W&B backend to proxy.
 
@@ -35,12 +34,14 @@ def spy_proxy(
     """
 
     http_client = httpx.AsyncClient()
+    port = _get_free_port()
     spy = WandbBackendProxy(
         client=http_client,
         target_host=target_host,
         target_port=target_port,
+        local_port=port,
     )
-    server = uvicorn.Server(uvicorn.Config(spy._to_fast_api(), port=proxy_port))
+    server = uvicorn.Server(uvicorn.Config(spy._to_fast_api(), port=port))
 
     proxy_thread = threading.Thread(
         target=asyncio.run,
@@ -57,6 +58,13 @@ def spy_proxy(
             proxy_thread.join(timeout=30)
         except TimeoutError as e:
             raise AssertionError("Backend proxy server failed to shut down.") from e
+
+
+def _get_free_port() -> int:
+    """Returns a free port on the system."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
 
 
 async def _serve_then_close(
@@ -102,12 +110,14 @@ class WandbBackendProxy:
         client: httpx.AsyncClient,
         target_host: str,
         target_port: int,
+        local_port: int,
     ):
         self._lock = threading.Lock()
         self._client = client
         self._target_host = target_host
         self._target_port = target_port
         self._spy: WandbBackendSpy | None = None
+        self.port = local_port
 
     @contextlib.contextmanager
     def spy(self) -> Iterator[WandbBackendSpy]:


### PR DESCRIPTION
Description
---
Instead of hardcoding port 8000, pick a free port. This is only necessary when running multiple pytest invocations concurrently, such as when using pytest-xdist.