### PR TITLE
Introducing Weights & Biases Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <a href="https://anaconda.org/conda-forge/wandb"><img src="https://img.shields.io/conda/vn/conda-forge/wandb" /></a>
 <a href="https://circleci.com/gh/wandb/wandb"><img src="https://img.shields.io/circleci/build/github/wandb/wandb/main" /></a>
 <a href="https://codecov.io/gh/wandb/wandb"><img src="https://img.shields.io/codecov/c/gh/wandb/wandb" /></a>
+<a href="https://gurubase.io/g/weights-and-biases"><img src="https://img.shields.io/badge/Gurubase-Ask%20Weights%20%26%20Biases%20Guru-006BFF" /></a>
 </p>
 <p align='center'>
 <a href="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Intro_to_Weights_%26_Biases.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" /></a>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Weights & Biases Guru](https://gurubase.io/g/weights-and-biases) to Gurubase. Weights & Biases Guru uses the data from this repo and data from the [docs](https://docs.wandb.ai/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Weights & Biases Guru", which highlights that Weights & Biases now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Weights & Biases Guru in Gurubase, just let me know that's totally fine.
