### PR TITLE
fix(artifacts): raise for invalid artifact names

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,3 +17,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `run.log_code` correctly sets the run configs `code_path` value. (@jacobromero in https://github.com/wandb/wandb/pull/9753)
 - Correctly use `WANDB_CONFIG_DIR` for determining system settings file path (@jacobromero in https://github.com/wandb/wandb/pull/9711)
+- Prevent invalid `Artifact` and `ArtifactCollection` names (which would make them unloggable), explicitly raising a `ValueError` when attempting to assign an invalid name. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8773)

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -17,6 +17,7 @@ import wandb
 import wandb.data_types as data_types
 import wandb.sdk.artifacts.artifact_file_cache as artifact_file_cache
 from wandb import Artifact, util
+from wandb.sdk.artifacts._validators import ARTIFACT_NAME_MAXLEN
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.artifact_state import ArtifactState
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
@@ -1632,7 +1633,30 @@ def test_change_artifact_collection_type(user):
         assert artifact.type == "lucas_type"
 
 
-def test_save_artifact_sequence(user, api):
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "a" * (ARTIFACT_NAME_MAXLEN + 1),  # Name too long
+        "my/artifact",  # Invalid character(s)
+    ],
+)
+def test_setting_invalid_artifact_collection_name(user, api, invalid_name):
+    """Setting an invalid name on an existing ArtifactCollection should fail and raise an error."""
+    orig_name = "valid-name"
+
+    with wandb.init() as run:
+        artifact = Artifact(orig_name, "data")
+        run.log_artifact(artifact)
+
+    collection = api.artifact_collection(type_name="data", name=orig_name)
+
+    with pytest.raises(ValueError):
+        collection.name = invalid_name
+
+    assert collection.name == orig_name
+
+
+def test_save_artifact_sequence(monkeypatch, user, api):
     with wandb.init() as run:
         artifact = Artifact("sequence_name", "data")
         run.log_artifact(artifact)

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -59,6 +59,7 @@ from wandb.sdk.artifacts._generated import (
     RunOutputArtifactsProjectRunOutputArtifacts,
 )
 from wandb.sdk.artifacts._graphql_fragments import omit_artifact_fields
+from wandb.sdk.artifacts._validators import validate_artifact_name
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.lib import deprecate
 
@@ -290,7 +291,7 @@ class ArtifactCollection:
         self.client = client
         self.entity = entity
         self.project = project
-        self._name = name
+        self._name = validate_artifact_name(name)
         self._saved_name = name
         self._type = type
         self._saved_type = type
@@ -430,8 +431,8 @@ class ArtifactCollection:
         return self._name
 
     @name.setter
-    def name(self, name: List[str]) -> None:
-        self._name = name
+    def name(self, name: str) -> None:
+        self._name = validate_artifact_name(name)
 
     @property
     def type(self):

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 REGISTRY_PREFIX: Final[str] = "wandb-registry-"
 MAX_ARTIFACT_METADATA_KEYS: Final[int] = 100
 
+ARTIFACT_NAME_MAXLEN: Final[int] = 128
+ARTIFACT_NAME_INVALID_CHARS: Final[frozenset[str]] = frozenset({"/"})
+
 
 # For mypy checks
 @overload
@@ -41,6 +44,27 @@ def always_list(obj: Any, base_type: Any = (str, bytes)) -> list[T]:
     https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.always_iterable
     """
     return [obj] if isinstance(obj, base_type) else list(obj)
+
+
+def validate_artifact_name(name: str) -> str:
+    """Validate the artifact name, returning it if successful.
+
+    Raises:
+        ValueError: If the artifact name is invalid.
+    """
+    if len(name) > ARTIFACT_NAME_MAXLEN:
+        short_name = f"{name[:ARTIFACT_NAME_MAXLEN]} ..."
+        raise ValueError(
+            f"Artifact name is longer than {ARTIFACT_NAME_MAXLEN} characters: {short_name!r}"
+        )
+
+    if ARTIFACT_NAME_INVALID_CHARS.intersection(name):
+        raise ValueError(
+            "Artifact names must not contain any of the following characters: "
+            f"{', '.join(sorted(ARTIFACT_NAME_INVALID_CHARS))}.  Got: {name!r}"
+        )
+
+    return name
 
 
 def validate_aliases(aliases: Collection[str] | str) -> list[str]:

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -40,6 +40,7 @@ from wandb.sdk.artifacts._validators import (
     ensure_not_finalized,
     is_artifact_registry_project,
     validate_aliases,
+    validate_artifact_name,
     validate_tags,
 )
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
@@ -164,7 +165,7 @@ class Artifact:
         self._sequence_client_id: str = runid.generate_id(128)
         self._entity: str | None = None
         self._project: str | None = None
-        self._name: str = name  # includes version after saving
+        self._name: str = validate_artifact_name(name)  # includes version after saving
         self._version: str | None = None
         self._source_entity: str | None = None
         self._source_project: str | None = None


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- [WB-21718](https://wandb.atlassian.net/browse/WB-21718)

Validates `Artifact` names on instantiation, raising a `ValueError` if the name is expected to be invalid (i.e. the artifact cannot be logged).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21718]: https://wandb.atlassian.net/browse/WB-21718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ