### PR TITLE
chore: don't fork pytest worker

### DIFF
--- a/tests/system_tests/test_functional/multiprocessing/test_mp.py
+++ b/tests/system_tests/test_functional/multiprocessing/test_mp.py
@@ -5,11 +5,7 @@ import pytest
 
 @pytest.mark.parametrize(
     "start_method",
-    [
-        "spawn",
-        "forkserver",
-        "fork",
-    ],
+    ["spawn", "forkserver"],
 )
 @pytest.mark.wandb_core_only
 def test_share_child_base_spawn(user, start_method, relay_server, execute_script):


### PR DESCRIPTION
Tests under `tests/system_tests/test_functional/` currently use `runpy` to run test scripts, which means if the test script forks, it forks the pytest process. This is problematic.