### PR TITLE
chore: skip broken botocore for now

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -59,6 +59,7 @@ prometheus_client
 google-cloud-aiplatform
 
 .[perf]
+botocore!=1.35.56
 .[launch]
 .[sweeps] ; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 .[azure]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

New version of botocore was released today and it seems that the api changed causing all code that uses boto to fail.
See release here: https://pypi.org/project/botocore/1.35.56/

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
