### PR TITLE
fix: prevent capturing hostname if disable machine info setting is set

### DIFF
--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -280,12 +280,17 @@ func (s *Settings) IsConsoleCaptureEnabled() bool {
 
 // Whether to create a job artifact for W&B Launch.
 func (s *Settings) IsJobCreationDisabled() bool {
-	return s.Proto.DisableJobCreation.GetValue()
+	return s.Proto.DisableJobCreation.GetValue() || s.Proto.XDisableMachineInfo.GetValue()
 }
 
 // The W&B sweep URL.
 func (s *Settings) GetSweepURL() string {
 	return s.Proto.SweepUrl.GetValue()
+}
+
+// Whether to disable machine info collection, such as hostname and hardware specs.
+func (s *Settings) GetDisableMachineInfo() bool {
+	return s.Proto.XDisableMachineInfo.GetValue()
 }
 
 // Update methods.

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -1057,6 +1057,11 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 
 	program := s.settings.GetProgram()
 
+	var host string
+	if !s.settings.GetDisableMachineInfo() {
+		host = run.Host
+	}
+
 	data, err := gql.UpsertBucket(
 		ctx,                                // ctx
 		s.graphqlClient,                    // client
@@ -1070,7 +1075,7 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 		nullify.NilIfZero(run.Notes),       // notes
 		nullify.NilIfZero(commit),          // commit
 		&configStr,                         // config
-		nullify.NilIfZero(run.Host),        // host
+		nullify.NilIfZero(host),            // host
 		nil,                                // debug
 		nullify.NilIfZero(program),         // program
 		nullify.NilIfZero(repo),            // repo


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Prevent capturing hostname if disable machine info setting is set.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
