### PR TITLE
chore: introduce CHANGELOG.unreleased.md

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -50,9 +50,7 @@ jobs:
 
       - name: Update CHANGELOG.md
         if: ${{ inputs.update-changelog }}
-        run: |
-          DATE=$(date +'%Y-%m-%d')
-          sed -i "s/## Unreleased/## Unreleased\n\n## [${{ github.event.inputs.version }}] - $DATE/" CHANGELOG.md
+        run: python tools/changelog.py --version ${{ github.event.inputs.version }}
 
       - name: Lint changes
         run: |

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Update CHANGELOG.md
         if: ${{ inputs.update-changelog }}
-        run: python tools/changelog.py --version ${{ github.event.inputs.version }}
+        run: |
+          python tools/changelog.py \
+            --version ${{ github.event.inputs.version }}
 
       - name: Lint changes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Starting with the 0.16.4 release on March 5, 2024, the format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-Please add to the relevant subsections under Unreleased below on every PR where this is applicable.
+Unreleased changes are in [CHANGELOG.unreleased.md](CHANGELOG.unreleased.md).
 
-## Unreleased
-
-### Fixed
-
-- Fix `api.artifact()` to correctly pass the `enable_tracking` argument to the `Artifact._from_name()` method (@ibindlish in https://github.com/wandb/wandb/pull/8803)
-
-### Added
-
-- Added `create_and_run_agent` to `__all__` in `wandb/sdk/launch/__init__.py` to expose it as a public API (@marijncv in https://github.com/wandb/wandb/pull/8621)
-
-### Deprecated
-
-- The `quiet` argument to `wandb.run.finish()` is deprecated, use `wandb.Settings(quiet=...)` to set this instead. (@kptkin in https://github.com/wandb/wandb/pull/8794)
+<!-- tools/changelog.py: insert here -->
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -1,0 +1,24 @@
+# Unreleased changes
+
+Add here any changes made in a PR that are relevant to end users. Allowed sections:
+
+* Fixed
+* Changed
+* Added
+* Deprecated
+
+Section headings should be at level 3 (e.g. `### Added`).
+
+## Unreleased
+
+### Fixed
+
+- Fix `api.artifact()` to correctly pass the `enable_tracking` argument to the `Artifact._from_name()` method (@ibindlish in https://github.com/wandb/wandb/pull/8803)
+
+### Added
+
+- Added `create_and_run_agent` to `__all__` in `wandb/sdk/launch/__init__.py` to expose it as a public API (@marijncv in https://github.com/wandb/wandb/pull/8621)
+
+### Deprecated
+
+- The `quiet` argument to `wandb.run.finish()` is deprecated, use `wandb.Settings(quiet=...)` to set this instead. (@kptkin in https://github.com/wandb/wandb/pull/8794)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -2,23 +2,29 @@
 
 Add here any changes made in a PR that are relevant to end users. Allowed sections:
 
-* Fixed
-* Changed
-* Added
-* Deprecated
+* Added - for new features.
+* Changed  - for changes in existing functionality.
+* Deprecated - for soon-to-be removed features.
+* Removed - for now removed features.
+* Fixed - for any bug fixes.
+* Security -  in case of vulnerabilities.
 
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
-### Fixed
-
-- Fix `api.artifact()` to correctly pass the `enable_tracking` argument to the `Artifact._from_name()` method (@ibindlish in https://github.com/wandb/wandb/pull/8803)
-
 ### Added
 
 - Added `create_and_run_agent` to `__all__` in `wandb/sdk/launch/__init__.py` to expose it as a public API (@marijncv in https://github.com/wandb/wandb/pull/8621)
 
+### Changed
+
+- Tables logged in offline mode now have updated keys to artifact paths when syncing. To revert to old behavior, use setting `allow_offline_artifacts = False`. (@domphan-wandb in https://github.com/wandb/wandb/pull/8792)
+
 ### Deprecated
 
 - The `quiet` argument to `wandb.run.finish()` is deprecated, use `wandb.Settings(quiet=...)` to set this instead. (@kptkin in https://github.com/wandb/wandb/pull/8794)
+
+### Fixed
+
+- Fix `api.artifact()` to correctly pass the `enable_tracking` argument to the `Artifact._from_name()` method (@ibindlish in https://github.com/wandb/wandb/pull/8803)

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -1,0 +1,61 @@
+import os
+from datetime import datetime
+
+import click
+
+
+@click.command()
+@click.option(
+    "--version",
+    required=True,
+    help="The version being released.",
+)
+def main(version: str):
+    """Update CHANGELOG files for a new release."""
+    changes = _cut_unreleased()
+    _insert_changelog(version=version, changes=changes)
+
+
+def _cut_unreleased() -> str:
+    """Cut the "Unreleased" section from CHANGELOG.unreleased.md.
+
+    Returns:
+        The "Unreleased" section as a string.
+    """
+    with open("CHANGELOG.unreleased.md") as f:
+        lines = f.readlines()
+        start_line = lines.index("## Unreleased\n") + 1
+
+    with open("CHANGELOG.unreleased.md", "w") as f:
+        f.writelines(lines[:start_line])
+
+    return "".join(lines[start_line:])
+
+
+def _insert_changelog(*, version: str, changes: str):
+    """Insert a new section into CHANGELOG.md."""
+    date = datetime.now().strftime("%Y-%m-%d")
+
+    # NOTE: This syntax requires Python 3.8+.
+    with (
+        open("CHANGELOG.md") as changelog_in,
+        open("CHANGELOG.md.tmp", "w") as changelog_out,
+    ):
+        while line := changelog_in.readline():
+            changelog_out.writelines([line])
+
+            if "tools/changelog.py: insert here" in line:
+                changelog_out.writelines(
+                    [
+                        "\n",
+                        f"## [{version}] - {date}\n",
+                        changes,
+                    ]
+                )
+
+    os.unlink("CHANGELOG.md")
+    os.rename("CHANGELOG.md.tmp", "CHANGELOG.md")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Require PRs to put unreleased changes into `CHANGELOG.unreleased.md` instead of `CHANGELOG.md` to avoid having the changes appear in the wrong section if a release happens before the PR is merged.