### PR TITLE
chore: work around jupyter parallelism bug in notebook tests

### DIFF
--- a/tests/system_tests/test_notebooks/.gitignore
+++ b/tests/system_tests/test_notebooks/.gitignore
@@ -1,0 +1,2 @@
+# Produced by conftest.py in this directory.
+.test_notebooks.lock


### PR DESCRIPTION
Works around https://github.com/jupyter/jupyter_client/issues/487 in tests, which run in parallel due to pytest-xdist, by holding a file lock while starting up the kernel.