### PR TITLE
chore: improve wandb-core missing error

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1972,9 +1972,9 @@ def get_core_path() -> str:
     if not bin_path.exists():
         raise WandbCoreNotAvailableError(
             "Looks like wandb-core is not compiled for your system"
-            f" ({platform.platform()}): file {bin_path} does not exist."
-            " Please contact support at support@wandb.com to request"
-            " `wandb-core` support for your system."
+            f" ({platform.platform()}). Please contact support at"
+            " support@wandb.com to request `wandb-core` support"
+            f" for your system. File does not exist: {bin_path}"
         )
 
     return str(bin_path)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1971,9 +1971,10 @@ def get_core_path() -> str:
     bin_path = pathlib.Path(__file__).parent / "bin" / "wandb-core"
     if not bin_path.exists():
         raise WandbCoreNotAvailableError(
-            f"Looks like wandb-core is not compiled for your system ({platform.platform()}):"
-            " Please contact support at support@wandb.com to request `wandb-core`"
-            " support for your system."
+            "Looks like wandb-core is not compiled for your system"
+            f" ({platform.platform()}): file {bin_path} does not exist."
+            " Please contact support at support@wandb.com to request"
+            " `wandb-core` support for your system."
         )
 
     return str(bin_path)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1971,10 +1971,9 @@ def get_core_path() -> str:
     bin_path = pathlib.Path(__file__).parent / "bin" / "wandb-core"
     if not bin_path.exists():
         raise WandbCoreNotAvailableError(
-            "Looks like wandb-core is not compiled for your system"
-            f" ({platform.platform()}). Please contact support at"
-            " support@wandb.com to request `wandb-core` support"
-            f" for your system. File does not exist: {bin_path}"
+            f"File not found: {bin_path}."
+            "Please contact support at support@wandb.com."
+            f"Your platform is: {platform.platform()}."
         )
 
     return str(bin_path)


### PR DESCRIPTION
Includes the `wandb-core` file path to help debugging, as this is often the first thing we ask users to check. Example:

> wandb.errors.errors.WandbCoreNotAvailableError: Looks like wandb-core is not compiled for your system (macOS-14.1-arm64-arm-64bit). Please contact support at support@wandb.com to request `wandb-core` support for your system. File does not exist: /Users/timoffex/Documents/workspace/wandb/wandb/bin/wandb-core

This might even be enough for users to debug themselves, in cases where the issue is their `PATH`.