### PR TITLE
fix: add missing depency of backport types for py<=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "platformdirs",
     "typing_extensions>=4.4,<5; python_version < '3.12'",
     "pydantic>2,<3",
+    "eval_type_backport; python_version < '3.10'",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
What does the PR do? Include a concise description of the PR contents.

pydentic requires this package for python <= 3.9 to support modern typing.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
