### PR TITLE
chore: track memory consumption in tests with pytest-memray

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -115,8 +115,8 @@ def run_pytest(
 
     # Track and report memory usage with memray.
     pytest_opts.append("--memray")
-    # Show the 20 tests that allocate most memory.
-    pytest_opts.append("--most-allocations=20")
+    # Show the 5 tests that allocate most memory.
+    pytest_opts.append("--most-allocations=5")
 
     # Output test results for tooling.
     junitxml = _NOX_PYTEST_RESULTS_DIR / session_file_name / "junit.xml"
@@ -173,6 +173,7 @@ def unit_tests(session: nox.Session) -> None:
     run_pytest(
         session,
         paths=session.posargs or ["tests/unit_tests"],
+        # TODO: consider relaxing this once the test memory usage is under control.
         opts={"n": "8"},
     )
 
@@ -199,6 +200,7 @@ def system_tests(session: nox.Session) -> None:
                 "--ignore=tests/system_tests/test_experimental",
             ]
         ),
+        # TODO: consider relaxing this once the test memory usage is under control.
         opts={"n": "8"},
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,6 +113,11 @@ def run_pytest(
     # Print 20 slowest tests.
     pytest_opts.append(f"--durations={opts.get('durations', 20)}")
 
+    # Track and report memory usage with memray.
+    pytest_opts.append("--memray")
+    # Show the 20 tests that allocate most memory.
+    pytest_opts.append("--most-allocations=20")
+
     # Output test results for tooling.
     junitxml = _NOX_PYTEST_RESULTS_DIR / session_file_name / "junit.xml"
     pytest_opts.append(f"--junitxml={junitxml}")

--- a/noxfile.py
+++ b/noxfile.py
@@ -173,6 +173,7 @@ def unit_tests(session: nox.Session) -> None:
     run_pytest(
         session,
         paths=session.posargs or ["tests/unit_tests"],
+        opts={"n": "8"},
     )
 
 
@@ -198,6 +199,7 @@ def system_tests(session: nox.Session) -> None:
                 "--ignore=tests/system_tests/test_experimental",
             ]
         ),
+        opts={"n": "8"},
     )
 
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,6 +6,7 @@ pytest-split~=0.8.2
 pytest-mock~=3.11
 pytest-timeout~=2.3
 pytest-flakefinder~=1.1
+pytest-memray~=1.7
 pyfakefs~=5.7
 parameterized~=0.9.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,15 @@ from wandb.sdk.lib.paths import StrPath  # noqa: E402
 # --------------------------------
 
 
+@pytest.fixture
+def disable_memray(pytestconfig):
+    """Disables the memray plugin for the duration of the test."""
+    memray_plugin = pytestconfig.pluginmanager.get_plugin("memray_manager")
+    pytestconfig.pluginmanager.unregister(memray_plugin)
+    yield
+    pytestconfig.pluginmanager.register(memray_plugin, "memray_manager")
+
+
 @pytest.fixture(autouse=True)
 def setup_wandb_env_variables(monkeypatch: pytest.MonkeyPatch) -> None:
     """Configures wandb env variables to suitable defaults for tests."""

--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -37,7 +37,10 @@ def test_opener_rejects_append_mode(artifact_file_cache):
 
 
 def test_opener_works_across_filesystem_boundaries(
-    tmp_path, artifact_file_cache, fs: FakeFilesystem
+    tmp_path,
+    artifact_file_cache,
+    fs: FakeFilesystem,
+    disable_memray,  # FakeFilesystem breaks memray
 ):
     # This isn't ideal, we'd rather test e.g. `Artifact.download` directly.
     #

--- a/tests/unit_tests/test_lib/test_hashutil.py
+++ b/tests/unit_tests/test_lib/test_hashutil.py
@@ -108,7 +108,12 @@ def test_md5_file_hashes_on_three_files(bin_data, txt_data, bin_data2):
         pytest.param(50 * 1024, id="50kB"),
     ],
 )
-def test_md5_file_hashes_on_mounted_filesystem(filesize, tmp_path, fs: FakeFilesystem):
+def test_md5_file_hashes_on_mounted_filesystem(
+    filesize,
+    tmp_path,
+    fs: FakeFilesystem,
+    disable_memray,  # FakeFilesystem breaks memray
+):
     # Some setup we have to do to get this test to play well with `pyfakefs`.
     # Note: Cast to str looks redundant but is intentional (for python<=3.10).
     # https://pytest-pyfakefs.readthedocs.io/en/latest/troubleshooting.html#pathlib-path-objects-created-outside-of-tests


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Track memory usage of our tests with pytest-memray. 
Results are reported at the end of a testing session, which looks like this:

```
================================ MEMRAY REPORT =================================
Allocation results for tests/unit_tests/test_data_types.py::test_matplotlib_plotly_with_multiple_axes[no_wandb_core] at the high watermark

         📦 Total memory allocated: 140.0MiB
         📏 Total allocations: 3128
         📊 Histogram of allocation sizes: | █   |
         🥇 Biggest allocating functions:
...
```



<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
