### PR TITLE
chore: move validation of resume mutex into settings

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1225,16 +1225,6 @@ def init(  # noqa: C901
     """
     wandb._assert_is_user_process()  # type: ignore
 
-    num_resume_options_set = (
-        (fork_from is not None)  # wrap
-        + (resume is not None)
-        + (resume_from is not None)
-    )
-    if num_resume_options_set > 1:
-        raise ValueError(
-            "You cannot specify more than one of `fork_from`, `resume`, or `resume_from`"
-        )
-
     init_settings = Settings()
     if isinstance(settings, dict):
         init_settings = Settings(**settings)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -331,6 +331,24 @@ class Settings(BaseModel, validate_assignment=True):
                 new_values[key] = values[key]
         return new_values
 
+    @model_validator(mode="after")
+    def validate_mutual_exclusion_of_branching_args(self):
+        if (
+            sum(
+                o is not None
+                for o in [
+                    self.fork_from,
+                    self.resume,
+                    self.resume_from,
+                ]
+            )
+            > 1
+        ):
+            raise ValueError(
+                "`fork_from`, `resume`, or `resume_from` are mutually exclusive. "
+                "Please specify only one of them."
+            )
+
     # Field validators.
 
     @field_validator("x_disable_service", mode="after")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Minor clean up, moving the validation logic for resume, resume_from,, fork_from into settings.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
