### PR TITLE
chore: update wandb_settings tests to use wandb_backend_spy

### DIFF
--- a/tests/system_tests/test_core/test_wandb_settings.py
+++ b/tests/system_tests/test_core/test_wandb_settings.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import git
 import pytest
+import wandb
 from wandb import env
 
 
@@ -88,56 +89,54 @@ def test_sync_symlink_latest(wandb_init):
     run.finish()
 
 
-def test_manual_git_run_metadata_from_settings(
-    relay_server,
-    wandb_init,
-):
+def test_manual_git_run_metadata_from_settings(wandb_backend_spy):
     remote_url = "git@github.com:me/my-repo.git"
     commit = "29c15e893e36efad84001f4484b4813fbacd55a0"
-    with relay_server() as relay:
-        run = wandb_init(
-            settings={
-                "git_remote_url": remote_url,
-                "git_commit": commit,
-            },
-        )
+    run = wandb.init(
+        settings={
+            "git_remote_url": remote_url,
+            "git_commit": commit,
+        },
+    )
+    run.finish()
+
+    with wandb_backend_spy.freeze() as snapshot:
+        request_context = snapshot.request_context(run_id=run.id)
+        assert request_context[0]["repo"] == remote_url
+        assert request_context[0]["commit"] == commit
+
+
+def test_manual_git_run_metadata_from_environ(wandb_backend_spy):
+    remote_url = "git@github.com:me/my-repo.git"
+    commit = "29c15e893e36efad84001f4484b4813fbacd55a0"
+    with mock.patch.dict(
+        os.environ,
+        {
+            env.GIT_REMOTE_URL: remote_url,
+            env.GIT_COMMIT: commit,
+        },
+    ):
+        run = wandb.init()
         run.finish()
 
-        run_attrs = relay.context.get_run_attrs(run.id)
-        assert run_attrs.remote == remote_url
-        assert run_attrs.commit == commit
+    with wandb_backend_spy.freeze() as snapshot:
+        request_context = snapshot.request_context(run_id=run.id)
+        assert request_context[0]["repo"] == remote_url
+        assert request_context[0]["commit"] == commit
 
 
-def test_manual_git_run_metadata_from_environ(relay_server, wandb_init):
-    remote_url = "git@github.com:me/my-repo.git"
-    commit = "29c15e893e36efad84001f4484b4813fbacd55a0"
-    with relay_server() as relay:
-        with mock.patch.dict(
-            os.environ,
-            {
-                env.GIT_REMOTE_URL: remote_url,
-                env.GIT_COMMIT: commit,
-            },
-        ):
-            run = wandb_init()
-            run.finish()
-
-        run_attrs = relay.context.get_run_attrs(run.id)
-        assert run_attrs.remote == remote_url
-        assert run_attrs.commit == commit
-
-
-def test_git_root(runner, relay_server, wandb_init):
+def test_git_root(runner, wandb_backend_spy):
     path = "./foo"
     remote_url = "https://foo:@github.com/FooTest/Foo.git"
     with runner.isolated_filesystem():
         with git.Repo.init(path) as repo:
             repo.create_remote("origin", remote_url)
             repo.index.commit("initial commit")
-        with relay_server() as relay:
-            with mock.patch.dict(os.environ, {env.GIT_ROOT: path}):
-                run = wandb_init()
-                run.finish()
-            run_attrs = relay.context.get_run_attrs(run.id)
-            assert run_attrs.remote == repo.remote().url
-            assert run_attrs.commit == repo.head.commit.hexsha
+        with mock.patch.dict(os.environ, {env.GIT_ROOT: path}):
+            run = wandb.init()
+            run.finish()
+
+        with wandb_backend_spy.freeze() as snapshot:
+            request_context = snapshot.request_context(run_id=run.id)
+            assert request_context[0]["repo"] == remote_url
+            assert request_context[0]["commit"] == repo.head.commit.hexsha

--- a/tests/system_tests/wandb_backend_spy/spy.py
+++ b/tests/system_tests/wandb_backend_spy/spy.py
@@ -119,6 +119,9 @@ class WandbBackendSpy:
         run_id = variables["name"]
         run = self._runs.setdefault(run_id, _RunData())
 
+        # Store the request variables sent as part of the request.
+        run.request_context.append(variables)
+
         config = variables.get("config")
         if config is not None:
             run._config_json_string = config
@@ -313,6 +316,11 @@ class WandbBackendSnapshot:
         except KeyError as e:
             raise AssertionError(f"No metrics for run {run_id}") from e
 
+    def request_context(self, *, run_id: str) -> dict[str, Any]:
+        """Returns the request context for the run."""
+        spy = self._assert_valid()
+        return spy._runs[run_id].request_context
+
     def was_ever_preempting(self, *, run_id: str) -> bool:
         """Returns whether the run was ever marked 'preempting'."""
         spy = self._assert_valid()
@@ -333,3 +341,4 @@ class _RunData:
         self._file_stream_files: dict[str, dict[int, Any]] = {}
         self._config_json_string: str | None = None
         self._tags: list[str] = []
+        self.request_context: list[dict[str, Any]] = []


### PR DESCRIPTION
Description
-----------
What does the PR do? Include a concise description of the PR contents.

Migrates tests for `test_wandb_settings.py` to use `wandb_backend_spy`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?
- nox -s "system_tests" --python "3.12" -- tests/system_tests/test_core/test_wandb_settings.py
  - `= 20 passed, 39 warnings in 32.14s =`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
