### PR TITLE
fix: skip memray profiling of tests on windows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ def run_pytest(
     # Print 20 slowest tests.
     pytest_opts.append(f"--durations={opts.get('durations', 20)}")
 
-    if platform.system().lower() != "windows":  # memray is not supported on Windows.
+    if platform.system() != "Windows":  # memray is not supported on Windows.
         # Track and report memory usage with memray.
         pytest_opts.append("--memray")
         # Show the 5 tests that allocate most memory.

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,10 +113,11 @@ def run_pytest(
     # Print 20 slowest tests.
     pytest_opts.append(f"--durations={opts.get('durations', 20)}")
 
-    # Track and report memory usage with memray.
-    pytest_opts.append("--memray")
-    # Show the 5 tests that allocate most memory.
-    pytest_opts.append("--most-allocations=5")
+    if platform.system().lower() != "windows":  # memray is not supported on Windows.
+        # Track and report memory usage with memray.
+        pytest_opts.append("--memray")
+        # Show the 5 tests that allocate most memory.
+        pytest_opts.append("--most-allocations=5")
 
     # Output test results for tooling.
     junitxml = _NOX_PYTEST_RESULTS_DIR / session_file_name / "junit.xml"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ pytest-split~=0.8.2
 pytest-mock~=3.11
 pytest-timeout~=2.3
 pytest-flakefinder~=1.1
-pytest-memray~=1.7
+pytest-memray~=1.7; sys_platform != 'win32'
 pyfakefs~=5.7
 parameterized~=0.9.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import shutil
 import time
 import unittest.mock
@@ -37,6 +38,9 @@ from wandb.sdk.lib.paths import StrPath  # noqa: E402
 
 @pytest.fixture
 def disable_memray(pytestconfig):
+    if platform.system() == "Windows":
+        # noop on Windows
+        return
     """Disables the memray plugin for the duration of the test."""
     memray_plugin = pytestconfig.pluginmanager.get_plugin("memray_manager")
     pytestconfig.pluginmanager.unregister(memray_plugin)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,14 +38,15 @@ from wandb.sdk.lib.paths import StrPath  # noqa: E402
 
 @pytest.fixture
 def disable_memray(pytestconfig):
+    """Disables the memray plugin for the duration of the test."""
     if platform.system() == "Windows":
         # noop on Windows
-        return
-    """Disables the memray plugin for the duration of the test."""
-    memray_plugin = pytestconfig.pluginmanager.get_plugin("memray_manager")
-    pytestconfig.pluginmanager.unregister(memray_plugin)
-    yield
-    pytestconfig.pluginmanager.register(memray_plugin, "memray_manager")
+        yield
+    else:
+        memray_plugin = pytestconfig.pluginmanager.get_plugin("memray_manager")
+        pytestconfig.pluginmanager.unregister(memray_plugin)
+        yield
+        pytestconfig.pluginmanager.register(memray_plugin, "memray_manager")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Because it's not available on Windows, and they say likely will never be.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
