### PR TITLE
chore(sdk): specify pydantic version 2.6 to support union in earlier python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "setproctitle",
     "platformdirs",
     "typing_extensions>=4.4,<5; python_version < '3.12'",
-    "pydantic>2,<3",
+    "pydantic>=2.6,<3",
     "eval_type_backport; python_version < '3.10'",
 ]
 classifiers = [


### PR DESCRIPTION
Description
-----------
Need to switch to later pydantic version to support `|` in older python versions

Testing
-------
I'm on python v3.9.13 and I had pydantic `2.5.3` which was erroring when i ran wandb
Switching to pydantic `2.6.0` fixed the typing errors

