### PR TITLE
fix: set default disk paths in settings to track with the system monitor

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -306,7 +306,11 @@ class Settings(BaseModel, validate_assignment=True):
         None
     )
     # System paths to monitor for disk usage.
-    x_stats_disk_paths: Sequence[str] | None = None
+    x_stats_disk_paths: Sequence[str] | None = Field(
+        default_factory=lambda: ("/", "/System/Volumes/Data")
+        if platform.system() == "Darwin"
+        else ("/",)
+    )
     # Number of system metric samples to buffer in memory in the wandb-core process.
     # Can be accessed via run._system_metrics.
     x_stats_buffer_size: int = 0


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Missed the default value in a recent refactor.
- Added "/System/Volumes/Data" to the MacOS default

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
