### PR TITLE
feat(sdk): add url method to wandb.Artifact

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -465,6 +465,16 @@ class Artifact:
         return self._version
 
     @property
+    def url(self):
+        """
+        Constructs the URL of the artifact.
+        
+        Returns:
+            str: The URL of the artifact.
+        """
+        return f"{wandb.api.app_url}/{self._entity}/{self._project}/artifacts/{self._type}/{self._name}"
+    
+    @property
     @ensure_logged
     def collection(self) -> ArtifactCollection:
         """The collection this artifact was retrieved from.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes: https://wandb.atlassian.net/browse/WB-21940

What does the PR do? Include a concise description of the PR contents.

Allows users to directly access the URL of an artifact. This code:

```
import wandb
import numpy as np
api = wandb.Api()
artifact = api.artifact("luis_team_test/test_artifact_table/test_table:v2")
print(artifact.url)
```
Now returns:
```
https://wandb.ai/luis_team_test/test_artifact_table/artifacts/table/test_table:v2
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
