### PR TITLE
chore(sdk): fix compatibility with MoviePy 2.0 by resolving imports dynamically

### DIFF
--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -153,12 +153,6 @@ class Video(BatchableMedia):
                 required='wandb.Video requires moviepy when passing raw data. Install with "pip install wandb[media]"',
             )
 
-        # Use the resolved module
-        if not hasattr(mpy, "ImageSequenceClip"):
-            raise wandb.Error(
-                'wandb.Video requires a compatible version of moviepy. Ensure "moviepy" is installed correctly.'
-            )
-
         tensor = self._prepare_video(self.data)
         _, self._height, self._width, self._channels = tensor.shape  # type: ignore
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-22017
- Fixes #8971
- Fixes #8972

This PR resolves a compatibility issue with `MoviePy 2.0.0+`, where the `wandb.Video` initialization fails with the error:
`wandb.Video requires moviepy when passing raw data. Install with "pip install wandb[media]"`
even if `moviepy` is installed.

The problem arises because `MoviePy 2.0` removed the `moviepy.editor` namespace, and the current `util.get_module` call in `video.py` is hardcoded to look for `moviepy.editor`, leading to failures on MoviePy 2.0+. Reference: https://moviepy-tburrows13.readthedocs.io/en/improve-docs/updating_to_v2.html#imports

This PR introduces:
- adjustments in `Video.encode` to dynamically determine the appropriate import path for `ImageSequenceClip`, ensuring compatibility with both 1.x and 2.x
- eliminates the need for pinning specific `moviepy` versions

Testing
-------
How was this PR tested?

- `pip install 'wandb[media]'`
- `python test.py`

`test.py`:
```
import numpy as np
import wandb

wandb.init()
frames = np.random.randint(low=0, high=256, size=(10, 3, 100, 100), dtype=np.uint8)
vid = wandb.Video(
    frames,
    caption="media: %s, task: %s, time: %s, pred: %s, label: %s",
    fps=4,
)
wandb.log({'video': vid})
wandb.finish()
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
