### PR TITLE
feat(sdk): public `wandb.automations` submodules

### DIFF
--- a/tests/unit_tests/test_automations/conftest.py
+++ b/tests/unit_tests/test_automations/conftest.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import secrets
+from base64 import b64encode
+from functools import lru_cache
+from typing import TYPE_CHECKING, Union
+
+from hypothesis import settings
+from pytest import FixtureRequest, fixture, skip, xfail
+from pytest_mock import MockerFixture
+from typing_extensions import TypeAlias
+from wandb.apis.public import ArtifactCollection, Project
+
+if TYPE_CHECKING:
+    from wandb.automations import (
+        ActionType,
+        DoNothing,
+        DoNotification,
+        DoWebhook,
+        EventType,
+        OnAddArtifactAlias,
+        OnCreateArtifact,
+        OnLinkArtifact,
+        OnRunMetric,
+        ScopeType,
+    )
+    from wandb.automations.actions import InputAction
+    from wandb.automations.events import InputEvent
+
+# default Hypothesis settings
+settings.register_profile("default", max_examples=100)
+settings.load_profile("default")
+
+
+ScopableWandbType: TypeAlias = Union[ArtifactCollection, Project]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def make_graphql_id(prefix: str) -> str:
+    """Generate a string GraphQL ID for a wandb object, encoded as would be expected in a GraphQL response.
+
+    ID values returned by the GraphQL API are base64-encoded from strings
+    of the form: f"{string_name}:{integer_id}".
+
+    The original, decoded ID strings would have representations such as, e.g.:
+    - "Integration:123"
+    - "ArtifactCollection:101"
+    """
+    random_index: int = secrets.randbelow(1_000_000)
+    return b64encode(f"{prefix}:{random_index:d}".encode()).decode()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@fixture
+def integration_id() -> str:
+    """Generate a random integration ID for use in tests."""
+    return make_graphql_id(prefix="Integration")
+
+
+@fixture(scope="session")
+def artifact_collection(session_mocker: MockerFixture) -> ArtifactCollection:
+    """A simulated `ArtifactCollection` that could be returned by `wandb.Api`.
+
+    This might be typically fetched via `Api.artifact_collection()`,
+    `Api.artifact().collection`, etc.
+
+    For unit-testing purposes, this has been heavily mocked.
+    Tests relying on real `wandb.Api` calls should live in system tests.
+    """
+    mock_collection = session_mocker.Mock(spec=ArtifactCollection)
+    mock_collection.configure_mock(
+        **{
+            "id": make_graphql_id(prefix="ArtifactCollection"),
+            "name": "test-collection",
+            "type": "dataset",
+            "description": "This is a fake artifact collection.",
+            "entity": "test-entity",
+            "project": "test-project",
+            "is_sequence.return_value": False,
+        }
+    )
+    return mock_collection
+
+
+@fixture(scope="session")
+def project(session_mocker: MockerFixture) -> Project:
+    """A simulated `Project` that could be returned by `wandb.Api`.
+
+    This might be typically fetched via `Api.project()`, `Api.projects()`, etc.
+
+    For unit-testing purposes, this has been heavily mocked.
+    Tests relying on real `wandb.Api` calls should live in system tests.
+    """
+    mock_project = session_mocker.Mock(spec=Project)
+
+    mock_project.id = make_graphql_id(prefix="Project")
+    mock_project.entity = "test-entity"
+    mock_project.name = "test-project"
+
+    return mock_project
+
+
+# Exclude deprecated scope/event/action types from those expected to be exposed for valid behavior
+def valid_scopes() -> list[ScopeType]:
+    from wandb.automations import ScopeType
+
+    return sorted(ScopeType)
+
+
+def valid_events() -> list[EventType]:
+    from wandb.automations import EventType
+
+    return sorted(set(EventType) - {EventType.UPDATE_ARTIFACT_ALIAS})
+
+
+def valid_actions() -> list[ActionType]:
+    from wandb.automations import ActionType
+
+    return sorted(set(ActionType) - {ActionType.QUEUE_JOB})
+
+
+# Invalid (event, scope) combinations that should be skipped
+@lru_cache(maxsize=None)
+def invalid_events_and_scopes() -> set[tuple[EventType, ScopeType]]:
+    from wandb.automations import EventType, ScopeType
+
+    return {
+        (EventType.CREATE_ARTIFACT, ScopeType.PROJECT),
+        (EventType.RUN_METRIC, ScopeType.ARTIFACT_COLLECTION),
+    }
+
+
+@fixture(params=valid_scopes(), ids=lambda x: x.value)
+def scope_type(request: FixtureRequest) -> ScopeType:
+    """An automation scope type."""
+    return request.param
+
+
+@fixture(params=valid_events(), ids=lambda x: x.value)
+def event_type(request: FixtureRequest, scope_type: ScopeType) -> EventType:
+    """An automation event type."""
+    from wandb.automations import EventType
+
+    event_type = request.param
+
+    if (event_type, scope_type) in invalid_events_and_scopes():
+        skip(f"Event {event_type.value!r} doesn't support scope {scope_type.value!r}")
+
+    if event_type is EventType.RUN_METRIC_CHANGE:
+        xfail(f"Event {event_type.value!r} is not yet supported in the SDK")
+
+    return event_type
+
+
+@fixture(params=valid_actions(), ids=lambda x: x.value)
+def action_type(request: type[FixtureRequest]) -> ActionType:
+    """An automation action type."""
+    return request.param
+
+
+# ------------------------------------------------------------------------------
+# Scopes
+@fixture
+def scope(request: FixtureRequest, scope_type: ScopeType) -> ScopableWandbType:
+    """A (mocked) wandb object to use as the scope for an automation."""
+    from wandb.automations import ScopeType
+
+    scope2fixture: dict[ScopeType, str] = {
+        ScopeType.ARTIFACT_COLLECTION: artifact_collection.__name__,
+        ScopeType.PROJECT: project.__name__,
+    }
+    return request.getfixturevalue(scope2fixture[scope_type])
+
+
+# ------------------------------------------------------------------------------
+# Events
+@fixture
+def on_create_artifact(scope: ScopableWandbType) -> OnCreateArtifact:
+    """An event object for defining a **new** automation."""
+    from wandb.automations import OnCreateArtifact
+
+    return OnCreateArtifact(
+        scope=scope,
+    )
+
+
+@fixture
+def on_add_artifact_alias(scope: ScopableWandbType) -> OnAddArtifactAlias:
+    from wandb.automations import ArtifactEvent, OnAddArtifactAlias
+
+    return OnAddArtifactAlias(
+        scope=scope,
+        filter=ArtifactEvent.alias.matches_regex("^prod-.*"),
+    )
+
+
+@fixture
+def on_link_artifact(scope: ScopableWandbType) -> OnLinkArtifact:
+    from wandb.automations import ArtifactEvent, OnLinkArtifact
+
+    return OnLinkArtifact(
+        scope=scope,
+        filter=ArtifactEvent.alias.matches_regex("^prod-.*"),
+    )
+
+
+@fixture
+def on_run_metric(scope: ScopableWandbType) -> OnRunMetric:
+    from wandb.automations import OnRunMetric, RunEvent
+
+    return OnRunMetric(
+        scope=scope,
+        filter=RunEvent.metric("my-metric").average(window=5).gt(123.45),
+    )
+
+
+@fixture
+def event(request: FixtureRequest, event_type: EventType) -> InputEvent:
+    """An event object for defining a **new** automation."""
+    from wandb.automations import EventType
+
+    event2fixture: dict[EventType, str] = {
+        EventType.CREATE_ARTIFACT: on_create_artifact.__name__,
+        EventType.ADD_ARTIFACT_ALIAS: on_add_artifact_alias.__name__,
+        EventType.LINK_MODEL: on_link_artifact.__name__,
+        EventType.RUN_METRIC: on_run_metric.__name__,
+    }
+    return request.getfixturevalue(event2fixture[event_type])
+
+
+# ------------------------------------------------------------------------------
+# Actions
+@fixture
+def do_notification(integration_id: str) -> DoNotification:
+    from wandb.automations import DoNotification
+
+    return DoNotification(
+        integration_id=integration_id,
+        title="Test title",
+        text="Test message content",
+        level="INFO",
+    )
+
+
+@fixture
+def do_webhook(integration_id: str) -> DoWebhook:
+    from wandb.automations import DoWebhook
+
+    return DoWebhook(
+        integration_id=integration_id,
+        request_payload={"my-key": "my-value"},
+    )
+
+
+@fixture
+def do_nothing() -> DoNothing:
+    from wandb.automations import DoNothing
+
+    return DoNothing()
+
+
+@fixture
+def action(request: FixtureRequest, action_type: ActionType) -> InputAction:
+    """An action object for defining a **new** automation."""
+    from wandb.automations import ActionType
+
+    action2fixture: dict[ActionType, str] = {
+        ActionType.NOTIFICATION: do_notification.__name__,
+        ActionType.GENERIC_WEBHOOK: do_webhook.__name__,
+        ActionType.NO_OP: do_nothing.__name__,
+    }
+    return request.getfixturevalue(action2fixture[action_type])

--- a/tests/unit_tests/test_automations/test_actions.py
+++ b/tests/unit_tests/test_automations/test_actions.py
@@ -1,0 +1,74 @@
+import json
+
+from hypothesis import given
+from hypothesis.strategies import sampled_from
+from pytest import mark
+from wandb._pydantic import IS_PYDANTIC_V2
+from wandb.automations import DoNotification
+from wandb.automations._generated import AlertSeverity
+from wandb.automations.actions import DoWebhook
+from wandb.sdk.wandb_alerts import AlertLevel
+
+from ._strategies import gql_ids, printable_text
+
+VALID_ALERT_SEVERITY_ARG_VALUES = (
+    # Where possible, accept both enum and (case-insensitive) string types for `severity`.
+    *AlertSeverity,
+    *AlertLevel,
+    *(e.value.upper() for e in AlertSeverity),
+    *(e.value.lower() for e in AlertSeverity),
+)
+
+
+@mark.skipif(
+    not IS_PYDANTIC_V2,
+    reason="Unsupported in Pydantic v1: non-essential enhancement",
+)
+@given(
+    integration_id=gql_ids(),
+    title=printable_text(),
+    message=printable_text(),
+    severity=sampled_from(VALID_ALERT_SEVERITY_ARG_VALUES),
+)
+def test_notification_input_action_accepts_legacy_alert_args(
+    integration_id, title, message, severity
+):
+    """Notification actions accept legacy `wandb.Alert` kwargs for continuity/convenience."""
+
+    # Instantiate directly by the actual field names
+    from_normal_args = DoNotification(
+        integration_id=integration_id,
+        title=title,
+        message=message,
+        severity=severity,
+    )
+
+    # Instantiate by the legacy wandb.Alert arg names
+    from_legacy_args = DoNotification(
+        integration_id=integration_id,
+        title=title,
+        text=message,
+        level=severity,
+    )
+
+    assert from_legacy_args == from_normal_args
+    assert from_legacy_args.model_dump() == from_normal_args.model_dump()
+    assert from_legacy_args.model_dump_json() == from_normal_args.model_dump_json()
+
+
+def test_webhook_input_action_accepts_deserialized_payload(integration_id):
+    """Notification actions accept legacy `wandb.Alert` kwargs for continuity/convenience."""
+
+    payload = {"test": "test"}
+
+    # Instantiate directly by the actual field names
+    webhook_action = DoWebhook(
+        integration_id=integration_id,
+        request_payload=payload,
+    )
+
+    assert webhook_action.request_payload == payload
+
+    webhook_action_dict = webhook_action.model_dump()
+    assert isinstance(webhook_action_dict["requestPayload"], str)
+    assert json.loads(webhook_action_dict["requestPayload"]) == payload

--- a/tests/unit_tests/test_automations/test_automations.py
+++ b/tests/unit_tests/test_automations/test_automations.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+
+from pytest import mark
+from wandb.automations import (
+    ActionType,
+    DoNothing,
+    DoNotification,
+    DoWebhook,
+    EventType,
+    OnRunMetric,
+)
+from wandb.automations._utils import prepare_create_input
+from wandb.automations.events import RunMetricFilter
+
+pytestmark = [
+    mark.wandb_core_only,
+]
+
+
+class TestPrepareGraphQLInput:
+    """Checks for internal helpers that prepare input payloads for GraphQL requests."""
+
+    @mark.parametrize(
+        "name",
+        ["test-name"],
+    )
+    @mark.parametrize(
+        "description",
+        ["test-description", None],
+    )
+    @mark.parametrize(
+        "enabled",
+        [True, False],
+        ids=["enabled", "disabled"],
+    )
+    def test_prepare_create_input(
+        self,
+        scope,
+        scope_type,
+        event,
+        event_type,
+        action,
+        action_type,
+        name,
+        description,
+        enabled,
+    ):
+        """Check that we can instantiate a newly defined Automation (without actually sending it to the server)."""
+        # If we were to actually send this new Automation to the server,
+        # these would be passed as the GraphQL input variables
+        prepared_input_vars = prepare_create_input(
+            event >> action,
+            name=name,
+            description=description,
+            enabled=enabled,
+        ).model_dump(
+            exclude_none=True,
+        )
+
+        # This only checks the simpler key-value pairs (without nested payloads).
+        # We've omitted the more complicated event/action payloads, which will be checked separately.
+        expected = {
+            "name": name,
+            "enabled": enabled,
+            "scopeType": scope_type,
+            "scopeID": scope.id,
+            "triggeringEventType": event_type,
+            "triggeredActionType": action_type,
+        }
+        if description is not None:
+            expected["description"] = description
+
+        assert expected.items() <= prepared_input_vars.items()
+
+        # Check the event payload
+        event_filter_json = prepared_input_vars["eventFilter"]
+        if event_type is EventType.RUN_METRIC:
+            assert isinstance(event, OnRunMetric)
+            assert isinstance(event.filter, RunMetricFilter)
+
+            event_filter_dict = json.loads(prepared_input_vars["eventFilter"])
+
+            run_filter_dict = json.loads(event_filter_dict["run_filter"])
+            threshold_filter_dict = event_filter_dict["run_metric_filter"][
+                "threshold_filter"
+            ]
+
+            orig_run_filter = event.filter.run_filter
+            orig_run_metric_filter = event.filter.run_metric_filter
+            orig_threshold_filter = orig_run_metric_filter.threshold_filter
+
+            assert isinstance(run_filter_dict, dict)
+            assert isinstance(threshold_filter_dict, dict)
+
+            assert run_filter_dict.keys() == {"$and"}
+            assert run_filter_dict == orig_run_filter.model_dump()
+
+            assert threshold_filter_dict == {
+                "agg_op": orig_threshold_filter.agg,
+                "cmp_op": orig_threshold_filter.cmp,
+                "threshold": orig_threshold_filter.threshold,
+                "name": orig_threshold_filter.name,
+                "window_size": orig_threshold_filter.window,
+            }
+
+            assert threshold_filter_dict.keys() == {
+                "agg_op",
+                "cmp_op",
+                "threshold",
+                "name",
+                "window_size",
+            }
+
+        else:
+            # Event filter should be valid JSON and match what was passed the original event
+            assert json.loads(event_filter_json) == event.filter.model_dump()
+
+        # Check the action payload (triggeredActionConfig)
+        action_config = prepared_input_vars["triggeredActionConfig"]
+        if action_type is ActionType.NO_OP:
+            assert isinstance(action, DoNothing)
+
+            assert action_config == {
+                "noOpActionInput": {"noOp": True},
+            }
+
+        elif action_type is ActionType.NOTIFICATION:
+            assert isinstance(action, DoNotification)
+            assert action_config == {
+                "notificationActionInput": {
+                    "integrationID": action.integration_id,
+                    "title": action.title,
+                    "message": action.message,
+                    "severity": action.severity,
+                },
+            }
+
+        elif action_type is ActionType.GENERIC_WEBHOOK:
+            assert isinstance(action, DoWebhook)
+            assert action_config == {
+                "genericWebhookActionInput": {
+                    "integrationID": action.integration_id,
+                    "requestPayload": json.dumps(
+                        action.request_payload, separators=(",", ":")
+                    ),
+                },
+            }
+
+        else:
+            # This shouldn't happen unless we forget to test a new event or action
+            raise ValueError(f"Unhandled action type: {action_type}")

--- a/tests/unit_tests/test_automations/test_events.py
+++ b/tests/unit_tests/test_automations/test_events.py
@@ -1,0 +1,231 @@
+"""Tests on behavior of Automation events."""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis.strategies import integers, sampled_from
+from pytest import raises
+from wandb.apis.public import ArtifactCollection, Project
+from wandb.automations.events import (
+    Agg,
+    ArtifactEvent,
+    MetricThresholdFilter,
+    OnAddArtifactAlias,
+    OnCreateArtifact,
+    OnLinkArtifact,
+    OnRunMetric,
+    RunEvent,
+)
+
+from ._strategies import ints_or_floats, printable_text
+
+
+def test_declarative_run_filter():
+    run_filter = RunEvent.name.contains("my-run")
+    assert run_filter.model_dump() == {"display_name": {"$contains": "my-run"}}
+
+
+def test_declarative_artifact_filter():
+    artifact_filter = ArtifactEvent.alias.matches_regex("prod-.*")
+    assert artifact_filter.model_dump() == {"alias": {"$regex": "prod-.*"}}
+
+
+@given(
+    window=integers(1, 100),
+    agg=sampled_from([*Agg, *(e.value for e in Agg)]),
+    threshold=ints_or_floats(),
+)
+def test_run_metric_events_without_run_filter(
+    project: Project, window: int, agg: str, threshold: float
+):
+    name = "my-metric"
+    cmp = "$gt"
+
+    agg_enum = Agg(agg)
+    if agg_enum is Agg.AVERAGE:
+        threshold_filter = RunEvent.metric(name).average(window).gt(threshold)
+    elif agg_enum is Agg.MIN:
+        threshold_filter = RunEvent.metric(name).min(window).gt(threshold)
+    elif agg_enum is Agg.MAX:
+        threshold_filter = RunEvent.metric(name).max(window).gt(threshold)
+    else:
+        raise ValueError(f"Unhandled parameter: {agg=}")
+
+    event = OnRunMetric(scope=project, filter=threshold_filter)
+
+    # Check that
+    # - the metric filter has the expected contents
+    # - the run+metric filter is parsed/validated correctly by pydantic
+    expected_run_filter_dict = {"$and": []}
+    expected_threshold_filter = MetricThresholdFilter(
+        name=name, window_size=window, agg_op=agg, cmp_op=cmp, threshold=threshold
+    )
+
+    assert expected_threshold_filter == threshold_filter
+
+    assert expected_run_filter_dict == event.filter.run_filter.model_dump()
+    assert expected_threshold_filter == event.filter.run_metric_filter.threshold_filter
+
+
+@given(
+    window=integers(1, 100),
+    agg=sampled_from([*Agg, *(e.value for e in Agg)]),
+    threshold=ints_or_floats(),
+)
+def test_run_metric_events(
+    project: Project, window: int, agg: Agg | str, threshold: float
+):
+    name = "my-metric"
+    cmp = "$gt"
+
+    agg_enum = Agg(agg)
+    if agg_enum is Agg.AVERAGE:
+        threshold_filter = RunEvent.metric(name).average(window).gt(threshold)
+    elif agg_enum is Agg.MIN:
+        threshold_filter = RunEvent.metric(name).min(window).gt(threshold)
+    elif agg_enum is Agg.MAX:
+        threshold_filter = RunEvent.metric(name).max(window).gt(threshold)
+    else:
+        raise ValueError(f"Unhandled parameter: {agg=}")
+
+    run_filter = RunEvent.name.contains("my-run")
+
+    event = OnRunMetric(scope=project, filter=run_filter & threshold_filter)
+
+    # Check that
+    # - the metric filter has the expected contents
+    # - the run+metric filter is parsed/validated correctly by pydantic
+    expected_run_filter_dict = {"$and": [{"display_name": {"$contains": "my-run"}}]}
+    expected_threshold_filter = MetricThresholdFilter(
+        name=name, window_size=window, agg_op=agg, cmp_op=cmp, threshold=threshold
+    )
+
+    assert expected_run_filter_dict == event.filter.run_filter.model_dump()
+    assert expected_threshold_filter == event.filter.run_metric_filter.threshold_filter
+
+
+def test_link_artifact_events(project: Project):
+    alias_regex = "prod-.*"
+
+    event = OnLinkArtifact(
+        scope=project,
+        filter=ArtifactEvent.alias.matches_regex(alias_regex),
+    )
+
+    expected_filter_dict = {"$or": [{"$and": [{"alias": {"$regex": alias_regex}}]}]}
+    assert expected_filter_dict == event.filter.model_dump()
+
+
+def test_create_artifact_events(artifact_collection: ArtifactCollection):
+    alias_regex = "prod-.*"
+
+    event = OnCreateArtifact(
+        scope=artifact_collection,
+        filter=ArtifactEvent.alias.matches_regex(alias_regex),
+    )
+
+    expected_filter_dict = {"$or": [{"$and": [{"alias": {"$regex": alias_regex}}]}]}
+    assert expected_filter_dict == event.filter.model_dump()
+
+
+def test_add_artifact_alias_events(project: Project):
+    alias_regex = "prod-.*"
+
+    event = OnAddArtifactAlias(
+        scope=project,
+        filter=ArtifactEvent.alias.matches_regex(alias_regex),
+    )
+
+    expected_filter_dict = {"$or": [{"$and": [{"alias": {"$regex": alias_regex}}]}]}
+    assert expected_filter_dict == event.filter.model_dump()
+
+
+# Checks on self-consistency of syntactic sugar and other quality-of-life features
+@given(
+    name=printable_text(),
+    window=integers(1, 100),
+    threshold=ints_or_floats(),
+)
+def test_run_metric_operator_vs_method_syntax_is_equivalent(
+    name: str,
+    window: int,
+    threshold: float,
+):
+    """Check that metric thresholds defined via comparison operators vs method-call syntax are equivalent."""
+    metric_expressions = [
+        RunEvent.metric(name).average(window),  # Aggregate
+        RunEvent.metric(name).mean(window),  # Aggregate
+        RunEvent.metric(name).min(window),  # Aggregate
+        RunEvent.metric(name).max(window),  # Aggregate
+        RunEvent.metric(name),  # Single value
+    ]
+
+    for metric_expr in metric_expressions:
+        assert (metric_expr > threshold) == metric_expr.gt(threshold)
+        assert (metric_expr >= threshold) == metric_expr.gte(threshold)
+        assert (metric_expr < threshold) == metric_expr.lt(threshold)
+        assert (metric_expr <= threshold) == metric_expr.lte(threshold)
+
+
+def test_run_metric_threshold_cannot_be_aggregated_twice():
+    """Check that run metric thresholds forbid multiple aggregations."""
+    with raises(ValueError):
+        RunEvent.metric("my-metric").average(5).average(10)
+    with raises(ValueError):
+        RunEvent.metric("my-metric").average(10).max(5)
+
+
+@given(
+    name=printable_text(),
+    threshold=ints_or_floats(),
+    op=sampled_from([">", ">=", "<", "<="]),
+)
+def test_metric_filter_repr_without_agg(name: str, threshold: float, op: str):
+    """Check that the filter on a single-value metric has the expected human-readable representation."""
+    metric_expr = RunEvent.metric(name)
+
+    if op == ">":
+        threshold_filter = metric_expr.gt(threshold)
+    elif op == ">=":
+        threshold_filter = metric_expr.gte(threshold)
+    elif op == "<":
+        threshold_filter = metric_expr.lt(threshold)
+    elif op == "<=":
+        threshold_filter = metric_expr.lte(threshold)
+
+    assert repr(f"{name} {op} {threshold}") in repr(threshold_filter)
+
+
+@given(
+    name=printable_text(),
+    window=integers(1, 100),
+    threshold=ints_or_floats(),
+    op=sampled_from([">", ">=", "<", "<="]),
+    agg=sampled_from(list(Agg)),
+)
+def test_metric_filter_repr_with_agg(
+    name: str, window: int, threshold: float, op: str, agg: Agg
+):
+    """Check that the filter on an aggregated metric has the expected human-readable representation."""
+
+    if agg is Agg.AVERAGE:
+        metric_expr = RunEvent.metric(name).average(window)
+    elif agg is Agg.MIN:
+        metric_expr = RunEvent.metric(name).min(window)
+    elif agg is Agg.MAX:
+        metric_expr = RunEvent.metric(name).max(window)
+    else:
+        raise ValueError(f"Unhandled aggregation: {agg!r}")
+
+    if op == ">":
+        threshold_filter = metric_expr.gt(threshold)
+    elif op == ">=":
+        threshold_filter = metric_expr.gte(threshold)
+    elif op == "<":
+        threshold_filter = metric_expr.lt(threshold)
+    elif op == "<=":
+        threshold_filter = metric_expr.lte(threshold)
+    else:
+        raise ValueError(f"Unhandled comparison operator: {op!r}")
+
+    assert repr(f"{agg.value}({name}) {op} {threshold}") in repr(threshold_filter)

--- a/tests/unit_tests/test_automations/test_scopes.py
+++ b/tests/unit_tests/test_automations/test_scopes.py
@@ -1,0 +1,66 @@
+from wandb._pydantic import CompatBaseModel
+from wandb.apis.public import ArtifactCollection, Project
+from wandb.automations import ArtifactCollectionScope, ProjectScope, ScopeType
+from wandb.automations.scopes import ArtifactCollectionScopeTypes, AutomationScope
+
+
+class HasScope(CompatBaseModel):
+    scope: AutomationScope
+
+
+class HasCollectionScope(HasScope):
+    scope: ArtifactCollectionScope
+
+
+class HasProjectScope(HasScope):
+    scope: ProjectScope
+
+
+def test_scope_can_validate_from_wandb_artifact_collection(
+    artifact_collection: ArtifactCollection,
+):
+    """Check that we can parse an automation scope from a pre-existing `ArtifactCollection` type."""
+
+    validated = HasCollectionScope(scope=artifact_collection)
+    validated_scope = validated.scope
+
+    # ArtifactCollectionScope is defined as a Union type, so isinstance() checks won't work
+    # prior to python 3.10.  We need to check against a tuple of the unioned types.
+    # See:
+    # - https://docs.python.org/3/library/stdtypes.html#union-type
+    # - https://peps.python.org/pep-0604/
+
+    assert isinstance(validated_scope, ArtifactCollectionScopeTypes)
+    assert validated_scope.scope_type is ScopeType.ARTIFACT_COLLECTION
+    assert validated_scope.id == artifact_collection.id
+    assert validated_scope.name == artifact_collection.name
+
+    validated = HasScope(scope=artifact_collection)
+    validated_scope = validated.scope
+
+    assert isinstance(validated_scope, ArtifactCollectionScopeTypes)
+    assert validated_scope.scope_type is ScopeType.ARTIFACT_COLLECTION
+    assert validated_scope.id == artifact_collection.id
+    assert validated_scope.name == artifact_collection.name
+
+
+def test_scope_can_validate_from_wandb_project(
+    project: Project,
+):
+    """Check that we can parse an automation scope from a pre-existing `Project` type."""
+
+    validated = HasProjectScope(scope=project)
+    validated_scope = validated.scope
+
+    assert isinstance(validated_scope, ProjectScope)
+    assert validated_scope.scope_type is ScopeType.PROJECT
+    assert validated_scope.id == project.id
+    assert validated_scope.name == project.name
+
+    validated = HasScope(scope=project)
+    validated_scope = validated.scope
+
+    assert isinstance(validated_scope, ProjectScope)
+    assert validated_scope.scope_type is ScopeType.PROJECT
+    assert validated_scope.id == project.id
+    assert validated_scope.name == project.name

--- a/wandb/_pydantic/__init__.py
+++ b/wandb/_pydantic/__init__.py
@@ -1,13 +1,16 @@
 """Internal utilities for working with pydantic."""
 
-from .base import Base, CompatBaseModel, GQLBase, GQLId, SerializedToJson, Typename
-from .v1_compat import (
-    IS_PYDANTIC_V2,
-    AliasChoices,
-    computed_field,
-    field_validator,
-    model_validator,
+from .base import (
+    Base,
+    CompatBaseModel,
+    GQLBase,
+    GQLId,
+    SerializedToJson,
+    Typename,
+    ensure_json,
 )
+from .utils import IS_PYDANTIC_V2, pydantic_isinstance, to_json
+from .v1_compat import AliasChoices, computed_field, field_validator, model_validator
 
 __all__ = [
     "IS_PYDANTIC_V2",
@@ -21,4 +24,7 @@ __all__ = [
     "computed_field",
     "field_validator",
     "model_validator",
+    "pydantic_isinstance",
+    "to_json",
+    "ensure_json",
 ]

--- a/wandb/_pydantic/utils.py
+++ b/wandb/_pydantic/utils.py
@@ -1,0 +1,66 @@
+"""Internal utilities for working with Pydantic types and data."""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import suppress
+from typing import Any, Type
+
+import pydantic
+from pydantic import BaseModel, ValidationError
+from typing_extensions import TypeAlias
+
+PYTHON_VERSION = sys.version_info
+
+pydantic_major, *_ = pydantic.VERSION.split(".")
+IS_PYDANTIC_V2: bool = int(pydantic_major) >= 2
+
+
+BaseModelType: TypeAlias = Type[BaseModel]
+
+
+if IS_PYDANTIC_V2:
+    import pydantic_core  # pydantic_core is only installed by pydantic v2
+
+    def to_json(v: Any) -> str:
+        """Serialize a Python object to a JSON string."""
+        return pydantic_core.to_json(v, by_alias=True, round_trip=True).decode("utf-8")
+
+    def pydantic_isinstance(
+        v: Any, classinfo: BaseModelType | tuple[BaseModelType, ...]
+    ) -> bool:
+        """Return True if the object could be parsed into the given Pydantic type.
+
+        This is like a more lenient version of `isinstance()` for use with Pydantic.
+        In Pydantic v2, should be fast since the underlying implementation is in Rust,
+        and it may be preferable over `try:...except ValidationError:...`.
+
+        See: https://docs.pydantic.dev/latest/api/pydantic_core/#pydantic_core.SchemaValidator.isinstance_python
+        """
+        if isinstance(classinfo, tuple):
+            return any(
+                cls.__pydantic_validator__.isinstance_python(v) for cls in classinfo
+            )
+        cls = classinfo
+        return cls.__pydantic_validator__.isinstance_python(v)
+
+else:
+    # Pydantic v1 fallback implementations.
+    # These may be noticeably slower, but their primary goal is to ensure
+    # compatibility with Pydantic v1 so long as we need to support it.
+
+    from pydantic.json import pydantic_encoder  # Only valid in pydantic v1
+
+    def to_json(v: Any) -> str:
+        return json.dumps(v, default=pydantic_encoder)
+
+    def pydantic_isinstance(
+        v: Any, classinfo: BaseModelType | tuple[BaseModelType, ...]
+    ) -> bool:
+        classes = classinfo if isinstance(classinfo, tuple) else (classinfo,)
+        for cls in classes:
+            with suppress(ValidationError):
+                cls.model_validate(v)
+                return True
+        return False

--- a/wandb/_pydantic/v1_compat.py
+++ b/wandb/_pydantic/v1_compat.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import sys
 from functools import lru_cache
-from importlib.metadata import version
 from inspect import signature
 from typing import (
     TYPE_CHECKING,
@@ -19,6 +17,8 @@ from typing import (
 
 import pydantic
 from typing_extensions import ParamSpec
+
+from .utils import IS_PYDANTIC_V2, PYTHON_VERSION
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -40,12 +40,6 @@ if TYPE_CHECKING:
         def dict(self, **kwargs: Any) -> dict[str, Any]: ...
         def json(self, **kwargs: Any) -> str: ...
         def copy(self, **kwargs: Any) -> V1Model: ...
-
-
-PYTHON_VERSION = sys.version_info
-
-pydantic_major_version, *_ = version(pydantic.__name__).split(".")
-IS_PYDANTIC_V2: bool = int(pydantic_major_version) >= 2
 
 
 ModelT = TypeVar("ModelT")

--- a/wandb/automations/__init__.py
+++ b/wandb/automations/__init__.py
@@ -1,0 +1,81 @@
+from wandb._pydantic import IS_PYDANTIC_V2
+
+from . import _filters as filters
+from . import actions, automations, events, scopes
+from .actions import ActionType, DoNothing, DoNotification, DoWebhook
+from .automations import Automation, NewAutomation, PreparedAutomation
+from .events import (
+    ArtifactEvent,
+    EventType,
+    OnAddArtifactAlias,
+    OnCreateArtifact,
+    OnLinkArtifact,
+    OnRunMetric,
+    RunEvent,
+)
+from .integrations import Integration, SlackIntegration, WebhookIntegration
+from .scopes import ArtifactCollectionScope, ProjectScope, ScopeType
+
+# ----------------------------------------------------------------------------
+# WARNINGS on import
+if not IS_PYDANTIC_V2:
+    # Raises an error in Pydantic v1 environments, where the Automations API
+    # has not been tested and is unlikely to work as expected.
+    #
+    # Remove this when we either:
+    # - Drop support for Pydantic v1
+    # - Are able to implement (limited) Pydantic v1 support
+    raise ImportError(
+        "The W&B Automations API is not supported in Pydantic v1 at this time. "
+        "If at all possible, we currently recommend upgrading to Pydantic v2 to use this feature.",
+    )
+
+else:
+    # If Pydantic v2 is available, we can use the full Automations API
+    # but communicate to users that the API is still experimental and
+    # may change rapidly.
+    import warnings
+
+    warnings.warn(
+        "The W&B Automations API is currently experimental. Although we'll communicate "
+        "breaking changes in release notes and attempt to minimize them in general, "
+        "please know that such changes may occur between release versions without notice. "
+        "We strongly recommend pinning your `wandb` version when using the Automations API "
+        "to avoid unexpected breakages.",
+        FutureWarning,
+        stacklevel=1,
+    )
+# ----------------------------------------------------------------------------
+
+__all__ = [
+    "filters",
+    "scopes",
+    "events",
+    "actions",
+    "automations",
+    # Scopes
+    "ScopeType",
+    "ArtifactCollectionScope",
+    "ProjectScope",
+    # Events
+    "EventType",
+    "OnAddArtifactAlias",
+    "OnCreateArtifact",
+    "OnLinkArtifact",
+    "OnRunMetric",
+    "ArtifactEvent",
+    "RunEvent",
+    # Actions
+    "ActionType",
+    "DoNotification",
+    "DoWebhook",
+    "DoNothing",
+    # Automations
+    "Automation",
+    "NewAutomation",
+    "PreparedAutomation",
+    # Integrations
+    "Integration",
+    "SlackIntegration",
+    "WebhookIntegration",
+]

--- a/wandb/automations/_filters/__init__.py
+++ b/wandb/automations/_filters/__init__.py
@@ -1,4 +1,4 @@
-from .expressions import FilterExpr, FilterField
+from .expressions import FilterExpr, MongoLikeFilter
 from .operators import (
     And,
     Contains,
@@ -13,6 +13,7 @@ from .operators import (
     Nor,
     Not,
     NotIn,
+    Op,
     Or,
     Regex,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "Or",
     "Nor",
     "Not",
+    "Op",
     "Gt",
     "Lt",
     "Gte",
@@ -33,6 +35,6 @@ __all__ = [
     "Contains",
     "Exists",
     "Regex",
-    "FilterField",
     "FilterExpr",
+    "MongoLikeFilter",
 ]

--- a/wandb/automations/_filters/run_metrics.py
+++ b/wandb/automations/_filters/run_metrics.py
@@ -1,0 +1,183 @@
+# ruff: noqa: UP007
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Union, overload
+
+from pydantic import Field, PositiveInt, StrictFloat, StrictInt, field_validator
+from typing_extensions import Self, override
+
+from wandb._pydantic.base import Base, GQLBase
+
+from .expressions import FilterExpr
+from .operators import BaseOp, RichReprResult
+
+if TYPE_CHECKING:
+    from wandb.automations.events import RunMetricFilter
+
+# Maps MongoDB comparison operators -> Python literal (str) representations
+MONGO2PY_OPS: Final[dict[str, str]] = {
+    "$eq": "==",
+    "$ne": "!=",
+    "$gt": ">",
+    "$lt": "<",
+    "$gte": ">=",
+    "$lte": "<=",
+}
+# Reverse mapping from Python literal (str) -> MongoDB operator key
+PY2MONGO_OPS: Final[dict[str, str]] = {v: k for k, v in MONGO2PY_OPS.items()}
+
+
+class Agg(str, Enum):  # from `Aggregation`
+    """Supported run metric aggregation operations."""
+
+    MAX = "MAX"
+    MIN = "MIN"
+    AVERAGE = "AVERAGE"
+
+
+class ChangeType(str, Enum):  # from `RunMetricChangeType`
+    """Describes the metric change as absolute (arithmetic difference) or relative (decimal percentage)."""
+
+    ABSOLUTE = "ABSOLUTE"
+    RELATIVE = "RELATIVE"
+
+
+class ChangeDirection(str, Enum):  # from `RunMetricChangeDirection`
+    """Describes the direction of the metric change."""
+
+    INCREASE = "INCREASE"
+    DECREASE = "DECREASE"
+    ANY = "ANY"
+
+
+class _BaseMetricFilter(GQLBase):
+    name: str
+    """Name of the observed metric."""
+
+    agg: Optional[Agg]
+    """Aggregation operation, if any, to apply over the window size."""
+
+    window: PositiveInt
+    """Size of the window over which the metric is aggregated."""
+
+    # ------------------------------------------------------------------------------
+
+    threshold: Union[StrictInt, StrictFloat]
+    """Threshold value to compare against."""
+
+    @field_validator("agg", mode="before")
+    @classmethod
+    def _validate_agg(cls, v: Any) -> Any:
+        # Be helpful: e.g. "min" -> "MIN"
+        return v.strip().upper() if isinstance(v, str) else v
+
+    @overload
+    def __and__(self, other: BaseOp | FilterExpr) -> RunMetricFilter: ...
+    @overload
+    def __and__(self, other: Any) -> Any: ...
+    def __and__(self, other: BaseOp | FilterExpr | Any) -> RunMetricFilter | Any:
+        """Supports syntactic sugar for defining a triggering RunMetricEvent from `run_metric_filter & run_filter`."""
+        from wandb.automations.events import RunMetricFilter, _InnerRunMetricFilter
+
+        if isinstance(run_filter := other, (BaseOp, FilterExpr)):
+            # Assume `other` is a run filter, and we are building a RunMetricEvent.
+            # For the metric filter, delegate to the inner validator(s) to further wrap/nest as appropriate.
+            metric_filter = _InnerRunMetricFilter.model_validate(self)
+            return RunMetricFilter(
+                run_metric_filter=metric_filter, run_filter=run_filter
+            )
+        return other.__and__(self)  # Try switching the order of operands
+
+
+class MetricThresholdFilter(_BaseMetricFilter):  # from `RunMetricThresholdFilter`
+    """For run events, defines a metric filter comparing a metric against a user-defined threshold value."""
+
+    name: str
+    agg: Optional[Agg] = Field(default=None, alias="agg_op")
+    window: PositiveInt = Field(default=1, alias="window_size")
+
+    cmp: Literal["$gte", "$gt", "$lt", "$lte"] = Field(alias="cmp_op")
+    """Comparison operator used to compare the metric value (left) vs. the threshold value (right)."""
+
+    threshold: Union[StrictInt, StrictFloat]
+
+    @field_validator("cmp", mode="before")
+    @classmethod
+    def _validate_cmp(cls, v: Any) -> Any:
+        # Be helpful: e.g. ">" -> "$gt"
+        return PY2MONGO_OPS.get(v.strip(), v) if isinstance(v, str) else v
+
+    def __repr__(self) -> str:
+        metric = f"{self.agg.value}({self.name})" if self.agg else self.name
+        op = MONGO2PY_OPS.get(self.cmp, self.cmp)
+        expr = rf"{metric} {op} {self.threshold}"
+        return repr(expr)
+
+    @override
+    def __rich_repr__(self) -> RichReprResult:  # type: ignore[override]
+        yield None, repr(self)
+
+
+class MetricChangeFilter(_BaseMetricFilter):  # from `RunMetricChangeFilter`
+    # FIXME:
+    # - `prior_window` should be optional and default to `window` if not provided.
+    # - implement declarative syntax for `MetricChangeFilter` similar to `MetricThresholdFilter`.
+    # - split this into tagged union of relative/absolute change filters.
+
+    name: str
+    agg: Optional[Agg] = Field(default=None, alias="agg_op")
+
+    # FIXME: Set the `prior_window` to `window` if it's not provided, for convenience.
+    window: PositiveInt = Field(alias="current_window_size")
+    prior_window: PositiveInt = Field(alias="prior_window_size")
+    """Size of the preceding window over which the metric is aggregated."""
+
+    # NOTE: `cmp_op` isn't a field here.  In the backend, it's effectively `cmp_op` = "$gte"
+
+    change_type: ChangeType = Field(alias="change_type")
+    change_direction: ChangeDirection = Field(alias="change_dir")
+
+    threshold: Union[StrictInt, StrictFloat] = Field(alias="change_amount")
+
+
+class MetricOperand(Base):
+    name: str
+    agg: Optional[Agg] = Field(default=None, alias="agg_op")
+    window: PositiveInt = Field(default=1, alias="window_size")
+
+    def _agg(self, op: Agg, window: int) -> Self:
+        if self.agg is None:  # Prevent overwriting an existing aggregation operator
+            return self.model_copy(update={"agg": op, "window": window})
+        raise ValueError(f"Aggregation operator already set as: {self.agg!r}")
+
+    def max(self, window: int) -> Self:
+        return self._agg(Agg.MAX, window)
+
+    def min(self, window: int) -> Self:
+        return self._agg(Agg.MIN, window)
+
+    def average(self, window: int) -> Self:
+        return self._agg(Agg.AVERAGE, window)
+
+    # Aliased method for users familiar with e.g. torch/tf/numpy/pandas/polars/etc.
+    def mean(self, window: int) -> Self:
+        return self.average(window=window)
+
+    def gt(self, other: int | float) -> MetricThresholdFilter:
+        return MetricThresholdFilter(**dict(self), cmp="$gt", threshold=other)
+
+    def lt(self, other: int | float) -> MetricThresholdFilter:
+        return MetricThresholdFilter(**dict(self), cmp="$lt", threshold=other)
+
+    def gte(self, other: int | float) -> MetricThresholdFilter:
+        return MetricThresholdFilter(**dict(self), cmp="$gte", threshold=other)
+
+    def lte(self, other: int | float) -> MetricThresholdFilter:
+        return MetricThresholdFilter(**dict(self), cmp="$lte", threshold=other)
+
+    __gt__ = gt
+    __lt__ = lt
+    __ge__ = gte
+    __le__ = lte

--- a/wandb/automations/_utils.py
+++ b/wandb/automations/_utils.py
@@ -1,0 +1,123 @@
+# ruff: noqa: UP007  # Avoid using `X | Y` for union fields, as this can cause issues with pydantic < 2.6
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Protocol, TypedDict
+
+from wandb._pydantic import to_json
+from wandb.automations.events import InputEvent
+from wandb.automations.scopes import InputScope
+
+from ._generated import (
+    CreateFilterTriggerInput,
+    TriggeredActionConfig,
+    UpdateFilterTriggerInput,
+)
+from .actions import (
+    ActionType,
+    DoNothing,
+    DoNotification,
+    DoWebhook,
+    InputAction,
+    SavedAction,
+)
+
+if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
+    from .automations import Automation, NewAutomation
+
+
+class HasId(Protocol):
+    id: str
+
+
+def extract_id(obj: HasId | str) -> str:
+    return obj.id if hasattr(obj, "id") else obj
+
+
+# NOTE: `QueueJobActionInput` for defining a Launch job is deprecated,
+# so we deliberately don't currently expose it in the API for *creating* automations.
+_ACTION_CONFIG_KEYS: dict[ActionType, str] = {
+    ActionType.NOTIFICATION: "notification_action_input",
+    ActionType.GENERIC_WEBHOOK: "generic_webhook_action_input",
+    ActionType.NO_OP: "no_op_action_input",
+}
+
+
+class InputActionConfig(TriggeredActionConfig):
+    """A `TriggeredActionConfig` that prepares the action config for saving an automation."""
+
+    notification_action_input: Optional[DoNotification] = None
+    generic_webhook_action_input: Optional[DoWebhook] = None
+    no_op_action_input: Optional[DoNothing] = None
+
+
+def prepare_action_input(obj: InputAction | SavedAction) -> InputActionConfig:
+    """Return a `TriggeredActionConfig` as required in the input schema of CreateFilterTriggerInput."""
+    key = _ACTION_CONFIG_KEYS[obj.action_type]
+    # Delegate the validators for each ActionInput type to handle custom logic
+    # for converting from saved action types to an input action type.
+    return InputActionConfig.model_validate({key: obj})
+
+
+class AutomationParams(TypedDict, total=False):
+    """Keyword arguments that can be passed to create or update an automation."""
+
+    name: str
+    description: str
+    enabled: bool
+
+    scope: InputScope
+    event: InputEvent
+    action: InputAction
+
+
+def prepare_create_input(
+    obj: NewAutomation, **updates: Unpack[AutomationParams]
+) -> CreateFilterTriggerInput:
+    """Prepares the payload to create an automation in a GraphQL request."""
+    from .automations import PreparedAutomation
+
+    # Apply any updates to the properties of the automation
+    updated = obj.model_copy(update=updates)
+    prepared = PreparedAutomation.model_validate(updated)
+
+    # Prepare the input as required for the GraphQL request
+    return CreateFilterTriggerInput(
+        name=prepared.name,
+        description=prepared.description,
+        enabled=prepared.enabled,
+        scope_type=prepared.scope.scope_type,
+        scope_id=prepared.scope.id,
+        triggering_event_type=prepared.event.event_type,
+        event_filter=to_json(prepared.event.filter),
+        triggered_action_type=prepared.action.action_type,
+        triggered_action_config=prepare_action_input(prepared.action).model_dump(),
+    )
+
+
+def prepare_update_input(
+    obj: Automation, **updates: Unpack[AutomationParams]
+) -> UpdateFilterTriggerInput:
+    """Prepares the payload to update an automation in a GraphQL request."""
+    from .events import SavedEventFilter
+
+    updated = obj.model_copy(update=updates)
+
+    return UpdateFilterTriggerInput(
+        id=updated.id,
+        name=updated.name,
+        description=updated.description,
+        enabled=updated.enabled,
+        scope_type=updated.scope.scope_type,
+        scope_id=updated.scope.id,
+        triggering_event_type=updated.event.event_type,
+        event_filter=to_json(
+            updated.event.filter.filter
+            if isinstance(updated.event.filter, SavedEventFilter)
+            else updated.event.filter
+        ),
+        triggered_action_type=updated.action.action_type,
+        triggered_action_config=prepare_action_input(updated.action).model_dump(),
+    )

--- a/wandb/automations/_validators.py
+++ b/wandb/automations/_validators.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from functools import singledispatch
+from itertools import chain
+from typing import Any, TypeVar
+
+from ._filters import And, FilterExpr, In, Nor, Not, NotIn, Op, Or
+
+T = TypeVar("T")
+
+
+def validate_scope(v: Any) -> Any:
+    """Convert a familiar wandb `Project` or `ArtifactCollection` object to an automation scope."""
+    from wandb.apis.public import ArtifactCollection, Project
+
+    from .scopes import ProjectScope, _ArtifactPortfolioScope, _ArtifactSequenceScope
+
+    if isinstance(v, Project):
+        return ProjectScope(id=v.id, name=v.name)
+    if isinstance(v, ArtifactCollection):
+        cls = _ArtifactSequenceScope if v.is_sequence() else _ArtifactPortfolioScope
+        return cls(id=v.id, name=v.name)
+    return v
+
+
+@singledispatch
+def simplify_op(op: Op | FilterExpr) -> Op | FilterExpr:
+    """Simplify a MongoDB filter by removing and unnesting redundant operators."""
+    return op
+
+
+@simplify_op.register
+def _(op: And) -> Op:
+    # {"$and": []} -> {"$and": []}
+    if not (args := op.and_):
+        return op
+
+    # {"$and": [op]} -> op
+    if len(args) == 1:
+        return simplify_op(args[0])
+
+    # {"$and": [op, {"$and": [op2, ...]}]} -> {"$and": [op, op2, ...]}
+    flattened = chain.from_iterable(x.and_ if isinstance(x, And) else [x] for x in args)
+    return And(and_=map(simplify_op, flattened))
+
+
+@simplify_op.register
+def _(op: Or) -> Op:
+    # {"$or": []} -> {"$or": []}
+    if not (args := op.or_):
+        return op
+
+    # {"$or": [op]} -> op
+    if len(args) == 1:
+        return simplify_op(args[0])
+
+    # {"$or": [op, {"$or": [op2, ...]}]} -> {"$or": [op, op2, ...]}
+    flattened = chain.from_iterable(x.or_ if isinstance(x, Or) else [x] for x in args)
+    return Or(or_=map(simplify_op, flattened))
+
+
+@simplify_op.register
+def _(op: Not) -> Op:
+    inner = op.not_
+
+    # {"$not": {"$not": op}} -> op
+    # {"$not": {"$or": [op, ...]}} -> {"$nor": [op, ...]}
+    # {"$not": {"$nor": [op, ...]}} -> {"$or": [op, ...]}
+    # {"$not": {"$in": [op, ...]}} -> {"$nin": [op, ...]}
+    # {"$not": {"$nin": [op, ...]}} -> {"$in": [op, ...]}
+    if isinstance(inner, (Not, Or, Nor, In, NotIn)):
+        return simplify_op(~inner)
+    return Not(not_=simplify_op(inner))

--- a/wandb/automations/actions.py
+++ b/wandb/automations/actions.py
@@ -1,0 +1,205 @@
+"""Actions that are triggered by W&B Automations."""
+
+# ruff: noqa: UP007  # Avoid using `X | Y` for union fields, as this can cause issues with pydantic < 2.6
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import Field
+from typing_extensions import Self, TypeAlias, get_args
+
+from wandb._pydantic import (
+    SerializedToJson,
+    field_validator,
+    model_validator,
+    pydantic_isinstance,
+)
+
+from ._generated import (
+    AlertSeverity,
+    GenericWebhookActionFields,
+    GenericWebhookActionInput,
+    NoOpActionFields,
+    NoOpTriggeredActionInput,
+    NotificationActionFields,
+    NotificationActionInput,
+    QueueJobActionFields,
+    TriggeredActionType,
+)
+from .integrations import SlackIntegration, WebhookIntegration
+
+# Note: Pydantic doesn't like `list['JsonValue']` or `dict[str, 'JsonValue']`,
+# which causes a RecursionError.
+JsonValue: TypeAlias = Union[
+    List[Any],
+    Dict[str, Any],
+    # NOTE: For now, we're not expecting any doubly-serialized strings, as this makes validation logic easier, but revisit and revise if needed.
+    # str,
+    bool,
+    int,
+    float,
+    None,
+]
+
+# NOTE: Name shortened for readability and defined publicly for easier access
+ActionType = TriggeredActionType
+"""The type of action triggered by an automation."""
+
+
+# ------------------------------------------------------------------------------
+# Saved types: for parsing response data from saved automations
+
+
+# NOTE: `QueueJobActionInput` for defining a Launch job is deprecated,
+# so while we allow parsing it from previously saved Automations, we deliberately
+# don't currently expose it in the API for creating automations.
+class SavedLaunchJobAction(QueueJobActionFields):
+    action_type: Literal[ActionType.QUEUE_JOB] = ActionType.QUEUE_JOB
+
+
+class SavedNotificationAction(NotificationActionFields):
+    action_type: Literal[ActionType.NOTIFICATION] = ActionType.NOTIFICATION
+
+
+class SavedWebhookAction(GenericWebhookActionFields):
+    action_type: Literal[ActionType.GENERIC_WEBHOOK] = ActionType.GENERIC_WEBHOOK
+
+    # We override the type of the `requestPayload` field since the original GraphQL
+    # schema (and generated class) effectively defines it as a string, when we know
+    # and need to anticipate the expected structure of the JSON-serialized data.
+    request_payload: Optional[SerializedToJson[JsonValue]] = Field(  # type: ignore[assignment]
+        default=None, alias="requestPayload"
+    )
+
+
+class SavedNoOpAction(NoOpActionFields):
+    action_type: Literal[ActionType.NO_OP] = ActionType.NO_OP
+
+
+# for type annotations
+SavedAction = Union[
+    SavedLaunchJobAction,
+    SavedNotificationAction,
+    SavedWebhookAction,
+    SavedNoOpAction,
+]
+# for runtime type checks
+SavedActionTypes: tuple[type, ...] = get_args(SavedAction)
+
+
+# ------------------------------------------------------------------------------
+# Input types: for creating or updating automations
+class DoNotification(NotificationActionInput):
+    """Schema for defining a triggered notification action."""
+
+    action_type: Literal[ActionType.NOTIFICATION] = ActionType.NOTIFICATION
+
+    # Note: Validation aliases match arg names from `wandb.alert()` to allow
+    # continuity with previous API.
+    title: str = Field(default="", validation_alias="title")
+    message: str = Field(default="", validation_alias="text")
+    severity: AlertSeverity = Field(
+        default=AlertSeverity.INFO, validation_alias="level"
+    )
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def _validate_severity(cls, v: Any) -> Any:
+        # Be helpful by accepting case-insensitive strings
+        return v.upper() if isinstance(v, str) else v
+
+    @model_validator(mode="before")
+    @classmethod
+    def _from_saved(cls, v: Any) -> Any:
+        """Convert an action on a saved automation to a new/input action."""
+        if pydantic_isinstance(v, SavedNotificationAction):
+            return cls(
+                integration_id=v.integration.id,
+                title=v.title,
+                message=v.message,
+                severity=v.severity,
+            )
+        return v
+
+    @classmethod
+    def from_integration(
+        cls,
+        integration: SlackIntegration,
+        *,
+        title: str = "",
+        text: str = "",
+        level: AlertSeverity = AlertSeverity.INFO,
+    ) -> Self:
+        """Define a notification action that sends to the given (Slack) integration."""
+        integration = SlackIntegration.model_validate(integration)
+        return cls(
+            integration_id=integration.id,
+            title=title,
+            message=text,
+            severity=level,
+        )
+
+
+class DoWebhook(GenericWebhookActionInput):
+    """Schema for defining a triggered webhook action."""
+
+    action_type: Literal[ActionType.GENERIC_WEBHOOK] = ActionType.GENERIC_WEBHOOK
+
+    # overrides the generated field type to parse/serialize JSON strings
+    request_payload: Optional[SerializedToJson[JsonValue]] = Field(  # type: ignore[assignment]
+        default=None, alias="requestPayload"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _from_saved(cls, v: Any) -> Any:
+        """Convert an action on a saved automation to a new/input action."""
+        if pydantic_isinstance(v, SavedWebhookAction):
+            return cls(
+                integration_id=v.integration.id,
+                request_payload=v.request_payload,
+            )
+        return v
+
+    @classmethod
+    def from_integration(
+        cls,
+        integration: WebhookIntegration,
+        *,
+        request_payload: Optional[SerializedToJson[JsonValue]] = None,
+    ) -> Self:
+        """Define a webhook action that sends to the given (webhook) integration."""
+        integration = WebhookIntegration.model_validate(integration)
+        return cls(integration_id=integration.id, request_payload=request_payload)
+
+
+class DoNothing(NoOpTriggeredActionInput):
+    """Schema for defining a triggered no-op action."""
+
+    action_type: Literal[ActionType.NO_OP] = ActionType.NO_OP
+
+    no_op: bool = True  # prevent exclusion on `.model_dump(exclude_none=True)`
+
+    @field_validator("no_op", mode="before")
+    @classmethod
+    def _ensure_nonnull(cls, v: Any) -> Any:
+        # Ensuring the value isn't None complies with validation and
+        # prevents the field (and action data) from getting excluded on
+        # `.model_dump(exclude_none=True)`
+        return True if (v is None) else v
+
+
+DoNotification.model_rebuild()
+DoWebhook.model_rebuild()
+DoNothing.model_rebuild()
+
+
+# for type annotations
+InputAction = Union[
+    DoNotification,
+    DoWebhook,
+    DoNothing,
+]
+# for runtime type checks
+InputActionTypes: tuple[type, ...] = get_args(InputAction)

--- a/wandb/automations/automations.py
+++ b/wandb/automations/automations.py
@@ -1,0 +1,109 @@
+# ruff: noqa: UP007  # Avoid using `X | Y` for union fields, as this can cause issues with pydantic < 2.6
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import Field
+
+from wandb._pydantic import Base, GQLId
+
+from ._generated import TriggerFields, UserFields
+from .actions import InputAction, SavedAction
+from .events import InputEvent, SavedEvent
+from .scopes import InputScope, SavedScope
+
+if TYPE_CHECKING:
+    pass
+
+
+# ------------------------------------------------------------------------------
+# Saved types: for parsing response data from saved automations
+class Automation(TriggerFields):
+    """A local instance of a saved W&B automation."""
+
+    id: GQLId
+
+    created_by: UserFields = Field(repr=False, frozen=True, alias="createdBy")
+    created_at: datetime = Field(repr=False, frozen=True, alias="createdAt")
+    updated_at: Optional[datetime] = Field(repr=False, frozen=True, alias="updatedAt")
+
+    name: str
+    description: Optional[str]
+
+    scope: SavedScope = Field(discriminator="typename__")
+    event: SavedEvent
+    action: SavedAction = Field(discriminator="typename__", alias="triggeredAction")
+
+    enabled: bool
+
+    # def save(
+    #     self, api: Api | None = None, **updates: Unpack[AutomationParams]
+    # ) -> Automation:
+    #     """Save this existing automation to the server, applying any local changes.
+
+    #     Args:
+    #         api: The API instance to use.  If not provided, the default API instance is used.
+    #         updates:
+    #             Any final updates to apply to the automation before
+    #             saving it.  These override previously-set values, if any.
+
+    #     Returns:
+    #         The updated automation.
+    #     """
+    #     from wandb import Api
+
+    #     return (api or Api()).update_automation(self, **updates)
+
+    # def delete(self, api: Api | None = None) -> DeleteTriggerResult:
+    #     """Delete this automation from the server.
+
+    #     Args:
+    #         api: The API instance to use.  If not provided, the default API instance is used.
+    #     """
+    #     from wandb import Api
+
+    #     return (api or Api()).delete_automation(self)
+
+
+class NewAutomation(Base):
+    """An automation which can hold any of the fields of a NewAutomation, but may not be complete yet."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    enabled: bool = True
+
+    scope: Optional[InputScope] = Field(discriminator="typename__", default=None)
+    event: Optional[InputEvent] = Field(discriminator="event_type", default=None)
+    action: Optional[InputAction] = Field(discriminator="action_type", default=None)
+
+    # def save(
+    #     self, api: Api | None = None, **updates: Unpack[AutomationParams]
+    # ) -> Automation:
+    #     """Create this automation by saving it to the server.
+
+    #     Args:
+    #         api: The API instance to use.  If not provided, the default API instance is used.
+    #         updates:
+    #             Any final updates to apply to the automation before
+    #             saving it.  These override previously-set values, if any.
+
+    #     Returns:
+    #         The created automation.
+    #     """
+    #     from wandb import Api
+
+    #     return (api or Api()).create_automation(self, **updates)
+
+
+class PreparedAutomation(NewAutomation):
+    """A fully defined automation, ready to be sent to the server to create or update it."""
+
+    name: str
+    description: Optional[str] = None
+    enabled: bool = True
+
+    scope: InputScope
+    event: InputEvent
+    action: InputAction

--- a/wandb/automations/events.py
+++ b/wandb/automations/events.py
@@ -1,0 +1,235 @@
+"""Events that trigger W&B Automations."""
+
+# ruff: noqa: UP007  # Avoid using `X | Y` for union fields, as this can cause issues with pydantic < 2.6
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+
+from pydantic import Field
+from typing_extensions import Self, TypeAlias, get_args
+
+from wandb._pydantic import (
+    GQLBase,
+    SerializedToJson,
+    field_validator,
+    model_validator,
+    pydantic_isinstance,
+)
+
+from ._filters import And, MongoLikeFilter, Or
+from ._filters.expressions import FilterableField
+from ._filters.run_metrics import (
+    Agg,
+    MetricChangeFilter,
+    MetricOperand,
+    MetricThresholdFilter,
+)
+from ._generated import EventTriggeringConditionType, FilterEventFields
+from ._validators import simplify_op
+from .actions import InputAction, InputActionTypes
+from .scopes import ArtifactCollectionScope, InputScope, ProjectScope
+
+if TYPE_CHECKING:
+    from .automations import NewAutomation
+
+
+# NOTE: Re-defined publicly with a more readable name for easier access
+EventType = EventTriggeringConditionType
+"""The type of event that triggers an automation."""
+
+Agg = Agg
+
+
+# ------------------------------------------------------------------------------
+# Saved types: for parsing response data from saved automations
+
+
+# Note: In GQL responses containing saved automation data, the filter is wrapped in an extra `filter` key.
+class SavedEventFilter(GQLBase):
+    filter: SerializedToJson[MongoLikeFilter] = Field(default_factory=And)
+
+
+class _InnerRunMetricFilter(GQLBase):  # from `RunMetricFilter`
+    threshold_filter: Optional[MetricThresholdFilter] = None
+    change_filter: Optional[MetricChangeFilter] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_metric_filter(cls, v: Any) -> Any:
+        if pydantic_isinstance(v, MetricThresholdFilter):
+            return cls(threshold_filter=v)
+        if pydantic_isinstance(v, MetricChangeFilter):
+            return cls(change_filter=v)
+        return v
+
+    @model_validator(mode="after")
+    def _ensure_exactly_one_set(self) -> Self:
+        set_field_names = [name for name, val in self if (val is not None)]
+        if not set_field_names:
+            raise ValueError("Must specify a run metric filter")
+        if len(set_field_names) > 1:
+            names = ", ".join(map(repr, set_field_names))
+            raise ValueError(f"Must specify a single run metric filter, got: {names}")
+        return self
+
+
+class RunMetricFilter(GQLBase):  # from `RunMetricEvent`
+    run_filter: SerializedToJson[MongoLikeFilter] = Field(default_factory=And)
+    run_metric_filter: _InnerRunMetricFilter
+
+    #: Legacy field to define triggers on run metrics from absolute thresholds.  Use `run_metric_filter` instead.
+    metric_filter: Optional[SerializedToJson[MetricThresholdFilter]] = Field(
+        default=None,
+        deprecated="The `metric_filter` field is deprecated: use `run_metric_filter` instead.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_metric_filter(cls, v: Any) -> Any:
+        if pydantic_isinstance(v, (MetricThresholdFilter, MetricChangeFilter)):
+            # If we're only given an (unwrapped) metric filter, automatically wrap it
+            # in the appropriate nested structure, and use the default run filter.
+
+            # Delegate to the inner validator to further wrap the filter as appropriate.
+            return cls(run_metric_filter=_InnerRunMetricFilter.model_validate(v))
+        return v
+
+    @field_validator("run_filter", mode="after")
+    @classmethod
+    def _wrap_run_filter(cls, v: MongoLikeFilter) -> Any:
+        v_new = simplify_op(v)
+        return (
+            And.model_validate(v_new)
+            if pydantic_isinstance(v_new, And)
+            else And(and_=[v_new])
+        )
+
+
+# type alias defined for naming consistency/clarity
+SavedRunMetricFilter: TypeAlias = RunMetricFilter
+
+
+class SavedEvent(FilterEventFields):  # from `FilterEventTriggeringCondition`
+    """A more introspection-friendly representation of a triggering event from a saved automation."""
+
+    # We override the type of the `filter` field since the original GraphQL
+    # schema (and generated class) defines it as a JSONString (str), but we
+    # have more specific expectations for the structure of the JSON data.
+    filter: SerializedToJson[Union[SavedEventFilter, SavedRunMetricFilter]]
+
+
+# ------------------------------------------------------------------------------
+# Input types: for creating or updating automations
+
+
+# Note: The GQL input for "eventFilter" does NOT wrap the filter in an extra `filter` key, unlike the
+# eventFilter returned in responses for saved automations.
+class _BaseEventInput(GQLBase):
+    event_type: EventType
+    scope: InputScope
+    filter: SerializedToJson[Any]
+
+    def add_action(self, action: InputAction) -> NewAutomation:
+        """Define an executed action to be triggered by this event."""
+        from .automations import NewAutomation
+
+        if isinstance(action, InputActionTypes):
+            return NewAutomation(scope=self.scope, event=self, action=action)
+
+        raise TypeError(f"Expected a valid action, got: {type(action).__qualname__!r}")
+
+    def __rshift__(self, other: InputAction) -> NewAutomation:
+        """Supports `event >> action` as syntactic sugar to combine an event and action."""
+        return self.add_action(other)
+
+
+class _BaseMutationEventInput(_BaseEventInput):
+    event_type: EventType
+    scope: InputScope
+    filter: SerializedToJson[MongoLikeFilter] = Field(default_factory=And)
+
+    @field_validator("filter", mode="after")
+    @classmethod
+    def _wrap_filter(cls, v: Any) -> Any:
+        """Ensure the given filter is wrapped like: `{"$or": [{"$and": [<original_filter>]}]}`.
+
+        This is awkward but necessary, because the frontend expects this format.
+        """
+        v_new = simplify_op(v)
+        v_new = (
+            And.model_validate(v_new)
+            if pydantic_isinstance(v_new, And)
+            else And(and_=[v_new])
+        )
+        v_new = Or(or_=[v_new])
+        return v_new
+
+
+class OnLinkArtifact(_BaseMutationEventInput):
+    """A new artifact is linked to a collection."""
+
+    event_type: Literal[EventType.LINK_MODEL] = EventType.LINK_MODEL
+    scope: InputScope
+
+
+class OnAddArtifactAlias(_BaseMutationEventInput):
+    """A new alias is assigned to an artifact."""
+
+    event_type: Literal[EventType.ADD_ARTIFACT_ALIAS] = EventType.ADD_ARTIFACT_ALIAS
+    scope: InputScope
+
+
+class OnCreateArtifact(_BaseMutationEventInput):
+    """A new artifact is created."""
+
+    event_type: Literal[EventType.CREATE_ARTIFACT] = EventType.CREATE_ARTIFACT
+    scope: ArtifactCollectionScope
+
+
+class OnRunMetric(_BaseEventInput):
+    """A run metric satisfies a user-defined absolute threshold."""
+
+    event_type: Literal[EventType.RUN_METRIC] = EventType.RUN_METRIC
+    scope: ProjectScope
+    filter: SerializedToJson[RunMetricFilter]
+
+
+# for type annotations
+InputEvent = Union[
+    OnLinkArtifact,
+    OnAddArtifactAlias,
+    OnCreateArtifact,
+    OnRunMetric,
+]
+# for runtime type checks
+InputEventTypes: tuple[type, ...] = get_args(InputEvent)
+
+
+# ----------------------------------------------------------------------------
+
+
+class RunEvent:
+    name = FilterableField("display_name")
+    # `Run.name` is actually filtered on `Run.display_name` in the backend.
+    # We can't reasonably expect users to know this a priori, so
+    # automatically fix it here.
+
+    @staticmethod
+    def metric(name: str) -> MetricOperand:
+        """Define a metric filter condition."""
+        return MetricOperand(name=name)
+
+
+class ArtifactEvent:
+    alias = FilterableField()
+
+
+MetricThresholdFilter.model_rebuild()
+RunMetricFilter.model_rebuild()
+SavedEventFilter.model_rebuild()
+
+OnLinkArtifact.model_rebuild()
+OnAddArtifactAlias.model_rebuild()
+OnCreateArtifact.model_rebuild()
+OnRunMetric.model_rebuild()

--- a/wandb/automations/integrations.py
+++ b/wandb/automations/integrations.py
@@ -1,0 +1,26 @@
+from typing import Union
+
+from pydantic import Field
+
+from wandb._pydantic import GQLBase
+from wandb.automations._generated import (
+    GenericWebhookIntegrationFields,
+    SlackIntegrationFields,
+)
+
+
+class SlackIntegration(SlackIntegrationFields):
+    pass
+
+
+class WebhookIntegration(GenericWebhookIntegrationFields):
+    pass
+
+
+Integration = Union[SlackIntegration, WebhookIntegration]
+
+
+# For parsing integration instances from paginated responses
+class _IntegrationEdge(GQLBase):
+    cursor: str
+    node: Integration = Field(discriminator="typename__")

--- a/wandb/automations/scopes.py
+++ b/wandb/automations/scopes.py
@@ -1,0 +1,76 @@
+"""Scopes in which a W&B Automation can be triggered."""
+
+from __future__ import annotations
+
+from typing import Literal, Union
+
+from pydantic import BeforeValidator, Field
+from typing_extensions import Annotated, TypeAlias, get_args
+
+from wandb._pydantic import GQLBase
+from wandb.automations._generated import (
+    ArtifactPortfolioScopeFields,
+    ArtifactSequenceScopeFields,
+    ProjectScopeFields,
+)
+
+from ._generated import TriggerScopeType
+from ._validators import validate_scope
+
+# NOTE: Re-defined publicly with a more readable name for easier access
+ScopeType = TriggerScopeType
+"""The type of scope that triggers an automation."""
+
+
+class _BaseScope(GQLBase):
+    scope_type: ScopeType
+
+
+class _ArtifactSequenceScope(_BaseScope, ArtifactSequenceScopeFields):
+    """The ID and name of a "sequence"-type ArtifactCollection scope of an automation."""
+
+    scope_type: Literal[ScopeType.ARTIFACT_COLLECTION] = ScopeType.ARTIFACT_COLLECTION
+
+
+class _ArtifactPortfolioScope(_BaseScope, ArtifactPortfolioScopeFields):
+    """The ID and name of a "portfolio"-type ArtifactCollection scope of an automation."""
+
+    scope_type: Literal[ScopeType.ARTIFACT_COLLECTION] = ScopeType.ARTIFACT_COLLECTION
+
+
+# for type annotations
+ArtifactCollectionScope = Annotated[
+    Union[_ArtifactSequenceScope, _ArtifactPortfolioScope],
+    BeforeValidator(validate_scope),
+    Field(discriminator="typename__"),
+]
+"""The ID and name of the ArtifactCollection scope of an automation."""
+
+# for runtime type checks
+ArtifactCollectionScopeTypes: tuple[type, ...] = (
+    _ArtifactSequenceScope,
+    _ArtifactPortfolioScope,
+)
+
+
+class ProjectScope(_BaseScope, ProjectScopeFields):
+    """The ID and name of the Project scope of an automation."""
+
+    scope_type: Literal[ScopeType.PROJECT] = ScopeType.PROJECT
+
+
+# for type annotations
+AutomationScope: TypeAlias = Annotated[
+    Union[_ArtifactSequenceScope, _ArtifactPortfolioScope, ProjectScope],
+    BeforeValidator(validate_scope),
+    Field(discriminator="typename__"),
+]
+# for runtime type checks
+AutomationScopeTypes: tuple[type, ...] = get_args(AutomationScope)
+
+# Aliases for naming clarity/consistency
+SavedScope: TypeAlias = AutomationScope
+InputScope: TypeAlias = AutomationScope
+
+SavedScopeTypes: tuple[type, ...] = get_args(SavedScope)
+InputScopeTypes: tuple[type, ...] = get_args(InputScope)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-22035](https://wandb.atlassian.net/browse/WB-22035)
- Docs: [DOCS-1164](https://wandb.atlassian.net/browse/DOCS-1164)

Defines the initial `wandb.automations` subpackage<strike>, including generated code enabled by changes in #8901</strike> (EDIT: see #9693 now for generated code).

In particular, this includes both public (importable) types and private (internal) helpers for parsing, processing, and serializing:
- automations
- scopes
- events
- actions
- related integrations (ie slack/webhook)
- <strike>filters (conforming to the MongoDB query format/spec already used elsewhere in this API -- e.g. `{"$and": [{"display_name": "my-run"}, ...], ...}` etc)</strike> (handled in #9311)

Adds initial unit tests, albeit heavily mocked, for the above.

- Adds:
  - **A `wandb.automations` subpackage**
  - <strike>**All generated Python modules** from GraphQL schemas and queries</strike> (handled now in #9693)

Implementation of the Automations "public API" will be added in a subsequent PR (note: in this context, "public API" refers strictly to the methods defined on `wandb.apis.public.Api`, rather than "any full namespace without underscore prefixes").

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Various parameterized tests added to:
- `tests/unit_tests/test_automations/*.py`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-22035]: https://wandb.atlassian.net/browse/WB-22035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOCS-1164]: https://wandb.atlassian.net/browse/DOCS-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ