### PR TITLE
feat(sdk): add url method to wandb.Artifact

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -536,6 +536,24 @@ class Artifact:
     def description(self) -> str | None:
         """A description of the artifact."""
         return self._description
+    
+    @property
+    def url(self):
+        """
+        Constructs the URL of the artifact.
+
+        Returns:
+            str: The URL of the artifact.
+        """
+        if self.collection.is_sequence():
+            return f"{self._client.app_url}/{self._entity}/{self._project}/artifacts/{self._type}/{self._name}"
+        else:
+            if self._project.startswith("wandb-registry-"):
+                return f"{self._client.app_url}/"
+            elif self._type == "model" or self._project == "model-registry":
+                return f"{self._client.app_url}/"
+            else:
+                return f"{self._client.app_url}/"
 
     @description.setter
     def description(self, description: str | None) -> None:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

Allows users to directly access the URL of an artifact. This code:

```
import wandb
import numpy as np
api = wandb.Api()
artifact = api.artifact("luis_team_test/test_artifact_table/test_table:v2")
print(artifact.url)
```
Now returns:

`https://wandb.ai/luis_team_test/test_artifact_table/artifacts/table/test_table:v2`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
