### PR TITLE
revert(artifacts): remove faulty azure download unit test

### DIFF
--- a/core/internal/filetransfer/file_transfer_azure_test.go
+++ b/core/internal/filetransfer/file_transfer_azure_test.go
@@ -173,16 +173,6 @@ func TestAzureFileTransfer_Download(t *testing.T) {
 			ft:      ftFile1,
 		},
 		{
-			name: "Returns error if manifest entry reference does not exist in azure",
-			task: &filetransfer.ReferenceArtifactDownloadTask{
-				FileKind:     filetransfer.RunFileKindArtifact,
-				PathOrPrefix: "test-download-file.txt",
-				Reference:    "https://fake_account.blob.core.windows.net/fake_container/fake_file.txt",
-			},
-			wantErr: true,
-			ft:      ftFile1,
-		},
-		{
 			name: "Downloads expected content when checksum matches (and not versioned)",
 			task: &filetransfer.ReferenceArtifactDownloadTask{
 				FileKind:     filetransfer.RunFileKindArtifact,


### PR DESCRIPTION
Description
-----------
This PR removes a test that tries to setup an Azure container client, which fails in CI because there are no credentials to use

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
tested locally and made sure none of the other tests are trying to set up that client

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
