### PR TITLE
chore: respect private env variables with the name change

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -205,8 +205,8 @@ if "dev" in __version__:
     )
 
     # Enable new features in dev versions.
-    os.environ["WANDB__SHOW_OPERATION_STATS"] = os.environ.get(
-        "WANDB__SHOW_OPERATION_STATS",
+    os.environ["WANDB_X_SHOW_OPERATION_STATS"] = os.environ.get(
+        "WANDB_X_SHOW_OPERATION_STATS",
         "true",
     )
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -885,6 +885,7 @@ class Settings(BaseModel, validate_assignment=True):
     def update_from_env_vars(self, environ: dict[str, Any]):
         """Update settings from environment variables."""
         env_prefix: str = "WANDB_"
+        private_env_prefix: str = env_prefix + "_"
         special_env_var_names = {
             "WANDB_DISABLE_SERVICE": "x_disable_service",
             "WANDB_SERVICE_TRANSPORT": "x_service_transport",
@@ -904,6 +905,8 @@ class Settings(BaseModel, validate_assignment=True):
 
             if setting in special_env_var_names:
                 key = special_env_var_names[setting]
+            elif setting.startswith(private_env_prefix):
+                key = "x_" + setting[len(private_env_prefix) :].lower()
             else:
                 # otherwise, strip the prefix and convert to lowercase
                 key = setting[len(env_prefix) :].lower()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

When users pass env variables with `WANDB__` prefix make sure to convert it to `WANDB_X_` prefix, to make sure we respect these settings.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
