### PR TITLE
chore: remove `wandb_init` from a set of system tests

### DIFF
--- a/tests/system_tests/test_api/test_public_api_run_summary.py
+++ b/tests/system_tests/test_api/test_public_api_run_summary.py
@@ -2,14 +2,13 @@ import pytest
 import wandb
 
 
-def test_delete_summary_metric_w_no_lazyload(wandb_init):
-    run = wandb_init(project="test")
-    run_id = run.id
+def test_delete_summary_metric_w_no_lazyload(user):
+    with wandb.init(project="test") as run:
+        run_id = run.id
 
-    metric = "test_val"
-    for i in range(10):
-        run.log({metric: i})
-    run.finish()
+        metric = "test_val"
+        for i in range(10):
+            run.log({metric: i})
 
     run = wandb.Api().run(f"test/{run_id}")
     del run.summary[metric]

--- a/tests/system_tests/test_core/test_cli_full.py
+++ b/tests/system_tests/test_core/test_cli_full.py
@@ -91,15 +91,14 @@ def test_init_existing_login(runner, user):
 
 
 @pytest.mark.xfail(reason="This test is flakey on CI")
-def test_pull(runner, wandb_init):
+def test_pull(runner, user):
     with runner.isolated_filesystem():
         project_name = "test_pull"
         file_name = "weights.h5"
-        run = wandb_init(project=project_name)
-        with open(file_name, "w") as f:
-            f.write("WEIGHTS")
-        run.save(file_name)
-        run.finish()
+        with wandb.init(project=project_name) as run:
+            with open(file_name, "w") as f:
+                f.write("WEIGHTS")
+            run.save(file_name)
 
         # delete the file so that we can pull it and check that it is there
         os.remove(file_name)

--- a/tests/system_tests/test_core/test_mode_disabled_full.py
+++ b/tests/system_tests/test_core/test_mode_disabled_full.py
@@ -7,22 +7,21 @@ import pytest
 import wandb
 
 
-def test_disabled_noop(wandb_init):
+def test_disabled_noop(user):
     """Make sure that all objects are dummy objects in noop case."""
-    run = wandb_init(mode="disabled")
-    run.log(dict(this=2))
-    run.finish()
+    with wandb.init(mode="disabled") as run:
+        run.log(dict(this=2))
 
 
-def test_disabled_dir(wandb_init):
+def test_disabled_dir(user):
     tmp_dir = "/tmp/dir"
     with mock.patch("tempfile.gettempdir", lambda: tmp_dir):
-        run = wandb_init(mode="disabled")
-    assert run.dir == tmp_dir
+        run = wandb.init(mode="disabled")
+        assert run.dir == tmp_dir
 
 
-def test_disabled_summary(wandb_init):
-    run = wandb_init(mode="disabled")
+def test_disabled_summary(user):
+    run = wandb.init(mode="disabled")
     run.summary["cat"] = 2
     run.summary["nested"] = dict(level=3)
     print(run.summary["cat"])
@@ -32,9 +31,9 @@ def test_disabled_summary(wandb_init):
     assert run.summary["nested"]["level"] == 3
 
 
-def test_disabled_globals(wandb_init):
+def test_disabled_globals(user):
     # Test wandb.* attributes
-    run = wandb_init(config={"foo": {"bar": {"x": "y"}}}, mode="disabled")
+    run = wandb.init(config={"foo": {"bar": {"x": "y"}}}, mode="disabled")
     wandb.log({"x": {"y": "z"}})
     wandb.log({"foo": {"bar": {"x": "y"}}})
     assert wandb.run == run
@@ -48,22 +47,22 @@ def test_disabled_globals(wandb_init):
     run.finish()
 
 
-def test_bad_url(wandb_init):
-    run = wandb_init(
+def test_bad_url(user):
+    run = wandb.init(
         settings=dict(mode="disabled", base_url="http://my-localhost:9000")
     )
     run.log({"acc": 0.9})
     run.finish()
 
 
-def test_no_dirs(wandb_init):
-    run = wandb_init(settings={"mode": "disabled"})
+def test_no_dirs(user):
+    run = wandb.init(settings={"mode": "disabled"})
     run.log({"acc": 0.9})
     run.finish()
     assert not os.path.isdir("wandb")
 
 
-def test_access_properties(wandb_init):
+def test_access_properties(user):
     run = wandb.init(mode="disabled")
     assert run.dir
     assert run.disabled


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
