### PR TITLE
fix(sdk): preserve run order in Runs.histories() method

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -236,7 +236,6 @@ class Runs(Paginator):
             if not histories:
                 return pd.DataFrame()
             combined_df = pd.concat(histories)
-            combined_df.sort_values("run_id", inplace=True)
             combined_df.reset_index(drop=True, inplace=True)
             # sort columns for consistency
             combined_df = combined_df[(sorted(combined_df.columns))]
@@ -262,9 +261,9 @@ class Runs(Paginator):
                 histories.append(df)
             if not histories:
                 return pl.DataFrame()
-            combined_df = pl.concat(histories, how="align")
+            combined_df = pl.concat(histories, how="vertical")
             # sort columns for consistency
-            combined_df = combined_df.select(sorted(combined_df.columns)).sort("run_id")
+            combined_df = combined_df.select(sorted(combined_df.columns))
 
             return combined_df
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-22157
- Fixes #8969

This PR fixes an issue where the `Runs.histories()` method did not respect the order of runs specified in the `Runs` object. Previously, when using `Pandas` or `Polars` export format, the combined dataframe of `histories` was being sorted by `run_id`, which altered the original order of runs. This could lead to mismatches between run metadata and history data when iterating over runs.

This PR removes unnecessary sorting of the combined `DataFrame` by `run_id` in the `histories` method for both `Pandas` and `Polars` formats.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------

- Tested the `histories` method with multiple runs to verify that the order of runs in the combined `DataFrame` matches the order specified in the `Runs` object.
- Verified that both `Pandas` and `Polars` dataframes preserve the run order without unintended sorting.

```
runs = api.runs('entity/project')
hist1 = runs.histories(format='pandas')
hist2 = runs.histories(format='polars')
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
