### PR TITLE
fix(sdk): prevent issues due to bugs in earlier botocore versions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Fix uploading large artifacts when using Azure Blob Storage. (@amulya-musipatla in https://github.com/wandb/wandb/pull/8946)
 - Fix error when reinitializing a run, caused by accessing a removed attribute. (@MathisTLD in https://github.com/wandb/wandb/pull/8912)
 - Fixed occasional deadlock when using `multiprocessing` to update a single run from multiple processes (@timoffex in https://github.com/wandb/wandb/pull/9126)
+- Prevent errors from bugs in older versions of `botocore < 1.5.76` (@amusipatla-wandb, @tonyyli-wandb in https://github.com/wandb/wandb/pull/9015)
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,12 @@ wb = "wandb.cli.cli:cli"
 [project.optional-dependencies]
 kubeflow = ["kubernetes", "minio", "google-cloud-storage", "sh"]
 gcp = ["google-cloud-storage"]
-aws = ["boto3"]
+aws = [
+    "boto3",
+    "botocore>=1.5.76",
+    # https://github.com/boto/botocore/pull/1107
+    # https://github.com/boto/botocore/pull/1230
+]
 azure = ["azure-identity", "azure-storage-blob"]
 media = [
     "numpy",
@@ -81,12 +86,11 @@ media = [
 ]
 sweeps = ["sweeps>=0.2.0"]
 launch = [
+    "wandb[aws]",
     "awscli",
     "azure-identity",
     "azure-containerregistry",
     "azure-storage-blob",
-    "boto3",
-    "botocore",
     "chardet",
     "google-auth",
     "google-cloud-aiplatform",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -58,7 +58,11 @@ responses
 prometheus_client
 google-cloud-aiplatform
 
-boto3!=1.35.56
+# See:
+# - https://github.com/boto/botocore/pull/1107
+# - https://github.com/boto/botocore/pull/1230
+boto3
+botocore>=1.5.76
 
 .[perf]
 .[launch]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-21788](https://wandb.atlassian.net/browse/WB-21788)

(fixed via @amusipatla-wandb too)

Requires `botocore>=1.5.76` in order to prevent errors due to the following issues:
- https://github.com/boto/botocore/issues/1079 (fixed by https://github.com/boto/botocore/pull/1107 in `botocore>=1.4.87`)
  - Note: Issue refers to Python 3.6, but this issue was reproducible in Python 3.8 and Python 3.9 as well.
- https://github.com/boto/boto3/issues/1144 (fixed by https://github.com/boto/botocore/pull/1230 in `botocore>=1.5.76`)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Locally, by running (and passing) system tests while artificially pinning `botocore==1.5.76`.  Pinning `botocore==1.5.75` or earlier will result in test failures due to one of the aforementioned, now-fixed issues.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-21788]: https://wandb.atlassian.net/browse/WB-21788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ