### PR TITLE
chore(sdk): bump go runtime version to 1.23.4

### DIFF
--- a/.bumpversion.go.cfg
+++ b/.bumpversion.go.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.3
+current_version = 1.23.4
 commit = False
 tag = False
 allow_dirty = True
@@ -19,7 +19,7 @@ replace = {new_version}
 search = {current_version}
 replace = {new_version}
 
-[bumpversion:file:experimental/client-go/go.mod]
+[bumpversion:file:experimental/go-sdk/go.mod]
 search = {current_version}
 replace = {new_version}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 parameters:
   go_version:
     type: string
-    default: "1.23.3"
+    default: "1.23.4"
   server_image:
     type: string
     default: "us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -86,7 +86,7 @@ jobs:
       ##################################################
       - name: Downgrade Go version
         run: |
-          sed -i '' 's/1.23.3/1.22.8/' core/go.mod
+          sed -i '' 's/1.23.4/1.22.8/' core/go.mod
 
       ##################################################
       # Non-Linux: install Go

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,4 +15,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Changed
 
-- Improved error message for failing tensorboard.patch() calls to show the option to call tensorboard.unpatch() first (@daniel-bogdoll in https://github.com/wandb/wandb/pull/8938) 
+- Improved error message for failing tensorboard.patch() calls to show the option to call tensorboard.unpatch() first (@daniel-bogdoll in https://github.com/wandb/wandb/pull/8938)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ pip install -U nox uv
 
 ### Setting up Go
 
-Install Go version `1.23.3` following the instructions [here](https://go.dev/doc/install) or using your package manager, for example:
+Install Go version `1.23.4` following the instructions [here](https://go.dev/doc/install) or using your package manager, for example:
 ```shell
 brew install go@1.23
 ```

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/wandb/wandb/core
 
-go 1.23.3
+go 1.23.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0

--- a/experimental/go-sdk/go.mod
+++ b/experimental/go-sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/wandb/wandb/experimental/client-go
 
-go 1.23.3
+go 1.23.4
 
 require (
 	github.com/wandb/wandb/core v0.0.0-20241004233953-869540fcb62c


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
See https://go.dev/doc/devel/release#go1.23.minor.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
