### PR TITLE
fix(sdk): persist job_type updates by adding jobType to upsertBucket mutation

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -506,8 +506,8 @@ class Run(Attrs):
         """Persist changes to the run object to the wandb backend."""
         mutation = gql(
             """
-        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString!, $groupName: String) {{
-            upsertBucket(input: {{id: $id, description: $description, displayName: $display_name, notes: $notes, tags: $tags, config: $config, groupName: $groupName}}) {{
+        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString!, $groupName: String, $jobType: String) {{
+            upsertBucket(input: {{id: $id, description: $description, displayName: $display_name, notes: $notes, tags: $tags, config: $config, groupName: $groupName, jobType: $jobType}}) {{
                 bucket {{
                     ...RunFragment
                 }}
@@ -525,6 +525,7 @@ class Run(Attrs):
             display_name=self.display_name,
             config=self.json_config,
             groupName=self.group,
+            jobType=self.job_type,
         )
         self.summary.update()
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-21873

This PR updates the `Run.update()` method to include the `jobType` parameter when persisting run state changes. Previously, programmatic updates to `run.job_type` were not reflected in the UI and not persisted in new API sessions. 

By adding `jobType` to the `upsertBucket` mutation, the backend now correctly stores and displays these updates.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
Verified by updating a run's `job_type` through the API and confirming that the change now appears in the UI after calling `run.update()`.

test code:
```
import wandb
api = wandb.Api()

run = api.run('entity/project/id')
print('logged job type', run.job_type)

run.job_type = 'new-type'
run.update()
print('same session type', run.job_type)

api = wandb.Api()
run = api.run('entity/project/id')
print('new session type', run.job_type)
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
