### PR TITLE
fix: fixes missing return value of validate_service_wait in wandb_settings.py

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,9 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Fixed
+- Fixed bug where setting WANDB__SERVICE_WAIT led to an exception during wandb.init (@TimSchneider42 in https://github.com/wandb/wandb/pull/9050)
+
 ### Changed
 
 - Improved error message for failing tensorboard.patch() calls to show the option to call tensorboard.unpatch() first (@daniel-bogdoll in https://github.com/wandb/wandb/pull/8938)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -516,7 +516,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_service_wait(cls, value):
         if value < 0:
             raise UsageError("Service wait time cannot be negative")
-        return
+        return value
 
     @field_validator("start_method")
     @classmethod


### PR DESCRIPTION
Hey, 

I noticed that in the latest version of wandb, setting `WANDB__SERVICE_WAIT` leads to wandb crashing with a `TypeError`:
```
TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```
The issue is that in wandb_settings.py, `validate_service_wait` does not return `value`. This PR fixes that.

Best,
Tim