### PR TITLE
feat: track retried Go errors in wboperation

### DIFF
--- a/core/internal/api/logging.go
+++ b/core/internal/api/logging.go
@@ -47,8 +47,11 @@ func withRetryLogging(
 			switch {
 			case resp == nil && err == nil:
 				logger.Error("api: retrying HTTP request, no error or response")
+
 			case err != nil:
 				logger.Info("api: retrying error", "error", err)
+				wboperation.Get(ctx).MarkRetryingError(err)
+
 			case resp.StatusCode >= 400:
 				// TODO: Log the request body.
 				logger.Info(

--- a/core/internal/wboperation/wboperation.go
+++ b/core/internal/wboperation/wboperation.go
@@ -220,6 +220,19 @@ func (op *WandbOperation) MarkRetryingHTTPError(responseStatus string) {
 	op.errorStatus = fmt.Sprintf("retrying HTTP %s", responseStatus)
 }
 
+// MarkRetryingError sets the operation's error status.
+//
+// There should be a corresponding call to `ClearError`.
+func (op *WandbOperation) MarkRetryingError(err error) {
+	if op == nil {
+		return
+	}
+
+	op.mu.Lock()
+	defer op.mu.Unlock()
+	op.errorStatus = fmt.Sprintf("retrying: %s", err)
+}
+
 // NewProgress creates a progress bar for the operation.
 //
 // Returns nil and an error if the operation already has a progress instance.

--- a/core/internal/wboperation/wboperation_test.go
+++ b/core/internal/wboperation/wboperation_test.go
@@ -2,6 +2,7 @@ package wboperation_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,16 @@ func TestHTTPError(t *testing.T) {
 
 	proto := ops.ToProto()
 	assert.Equal(t, "retrying HTTP 123", proto.Operations[0].ErrorStatus)
+}
+
+func TestGoError(t *testing.T) {
+	ops := wboperation.NewOperations()
+	op := ops.New("test operation")
+
+	op.MarkRetryingError(errors.New("test: example"))
+
+	proto := ops.ToProto()
+	assert.Equal(t, "retrying: test: example", proto.Operations[0].ErrorStatus)
 }
 
 func TestClearError(t *testing.T) {


### PR DESCRIPTION
Description
---
If an HTTP operation fails with a Go error, such as due to a protocol issue, mention that in the current operation's status. An example might look like this:

> retrying: tls: failed to parse certificate from server: x509: negative serial number

NOTE: In this case, the corresponding `ClearError` is in `api/send.go` after `retryableHTTP.Do()` returns.