### PR TITLE
chore: fix ancient disable service code path

### DIFF
--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -62,7 +62,8 @@ class SettingsStatic(Settings):
                 else:
                     value = None
 
-            data[key] = value
+            if value is not None:
+                data[key] = value
 
         if len(forks_specified) > 1:
             raise ValueError(

--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -13,13 +13,19 @@ class SettingsStatic(Settings):
     """
 
     def __init__(self, proto: wandb_settings_pb2.Settings) -> None:
-        self._from_proto(proto)
-        object.__setattr__(self, "_proto", proto)
+        data = self._proto_to_dict(proto)
+        super().__init__(**data)
 
-    def _from_proto(self, proto: wandb_settings_pb2.Settings) -> None:
+    def _proto_to_dict(self, proto: wandb_settings_pb2.Settings) -> dict:
+        data = {}
+
         forks_specified: list[str] = []
         for key in Settings.model_fields:  # type: ignore [attr-defined]
             value: Any = None
+
+            field_info = Settings.model_fields[key]
+            annotation = str(field_info.annotation)
+
             if key == "_stats_open_metrics_filters":
                 # todo: it's an underscored field, refactor into
                 #  something more elegant?
@@ -50,14 +56,20 @@ class SettingsStatic(Settings):
             else:
                 if proto.HasField(key):  # type: ignore [arg-type]
                     value = getattr(proto, key).value
+                    # Convert to list if the field is a sequence
+                    if any(t in annotation for t in ("tuple", "Sequence", "list")):
+                        value = list(value)
                 else:
                     value = None
-            object.__setattr__(self, key, value)
+
+            data[key] = value
 
         if len(forks_specified) > 1:
             raise ValueError(
                 "Only one of fork_from or resume_from can be specified, not both"
             )
+
+        return data
 
     def __setattr__(self, name: str, value: object) -> None:
         raise AttributeError("Error: SettingsStatic is a readonly object")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-22264

There apparently was a regression in the ancient code path for disable service (that is, using neither core, nor old python service). 
Note that this code path is slated for removal in the near future (in 0.20 most likely), and we print a warning message about that.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
```shell
WANDB_DISABLE_SERVICE=true python -c "import wandb; run = wandb.init(); run.finish()"
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
