### PR TITLE
fix: correctly handle private system metrics

### DIFF
--- a/core/internal/filestream/updatestats.go
+++ b/core/internal/filestream/updatestats.go
@@ -2,7 +2,6 @@ package filestream
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/wandb/simplejsonext"
@@ -25,10 +24,6 @@ func (u *StatsUpdate) Apply(ctx UpdateContext) error {
 	row["_runtime"] = timestamp.AsTime().Sub(u.StartTime).Seconds()
 
 	for _, item := range u.Record.Item {
-		// skip underscored keys
-		if strings.HasPrefix(item.Key, "_") {
-			continue
-		}
 		val, err := simplejsonext.UnmarshalString(item.ValueJson)
 		if err != nil {
 			ctx.Logger.CaptureError(

--- a/gpu_stats/Cargo.lock
+++ b/gpu_stats/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gpu_stats"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "clap",

--- a/gpu_stats/Cargo.toml
+++ b/gpu_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu_stats"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/gpu_stats/src/gpu_apple.rs
+++ b/gpu_stats/src/gpu_apple.rs
@@ -542,8 +542,8 @@ impl ThreadSafeSampler {
         let mut gpu_apple = AppleInfo {
             ..Default::default()
         };
-        if let Some(&value) = samples.get("_apple.chip_name") {
-            gpu_apple.name = value.to_string();
+        if let Some(&MetricValue::String(ref s)) = samples.get("_apple.chip_name") {
+            gpu_apple.name = s.clone();
         }
         if let Some(&value) = samples.get("_apple.ecpu_cores") {
             if let MetricValue::Int(ecpu_cores) = value {

--- a/gpu_stats/src/gpu_nvidia.rs
+++ b/gpu_stats/src/gpu_nvidia.rs
@@ -675,13 +675,13 @@ impl NvidiaGpu {
         metadata_request.gpu_count = n_gpu;
         // TODO: do not assume all GPUs are the same
         if let Some(value) = samples.get("_gpu.0.name") {
-            if let MetricValue::String(gpu_name) = value {
-                metadata_request.gpu_type = gpu_name.to_string();
+            if let MetricValue::String(ref gpu_name) = value {
+                metadata_request.gpu_type = gpu_name.clone();
             }
         }
         if let Some(value) = samples.get("_cuda_version") {
-            if let MetricValue::String(cuda_version) = value {
-                metadata_request.cuda_version = cuda_version.to_string();
+            if let MetricValue::String(ref cuda_version) = value {
+                metadata_request.cuda_version = cuda_version.clone();
             }
         }
 
@@ -690,7 +690,9 @@ impl NvidiaGpu {
                 ..Default::default()
             };
             if let Some(value) = samples.get(&format!("_gpu.{}.name", i)) {
-                gpu_nvidia.name = value.to_string();
+                if let MetricValue::String(ref gpu_name) = value {
+                    gpu_nvidia.name = gpu_name.clone();
+                }
             }
             if let Some(value) = samples.get(&format!("_gpu.{}.memoryTotal", i)) {
                 if let MetricValue::Int(memory_total) = value {
@@ -705,7 +707,9 @@ impl NvidiaGpu {
             }
             // architecture
             if let Some(value) = samples.get(&format!("_gpu.{}.architecture", i)) {
-                gpu_nvidia.architecture = value.to_string();
+                if let MetricValue::String(ref architecture) = value {
+                    gpu_nvidia.architecture = architecture.clone();
+                }
             }
             metadata_request.gpu_nvidia.push(gpu_nvidia);
         }

--- a/gpu_stats/src/main.rs
+++ b/gpu_stats/src/main.rs
@@ -282,9 +282,12 @@ impl SystemMonitor for SystemMonitorImpl {
 
         let stats_items: Vec<StatsItem> = all_metrics
             .iter()
-            .map(|(name, value)| StatsItem {
-                key: name.to_string(),
-                value_json: value.to_string(),
+            .filter(|(name, _)| !name.starts_with('_')) // Skip internal metrics
+            .filter_map(|(name, value)| {
+                serde_json::to_string(value).ok().map(|json_str| StatsItem {
+                    key: name.to_string(),
+                    value_json: json_str,
+                })
             })
             .collect();
 

--- a/gpu_stats/src/metrics.rs
+++ b/gpu_stats/src/metrics.rs
@@ -1,16 +1,9 @@
-#[derive(Debug, Clone)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)] // This makes the enum serialize to just the inner value without the variant name
 pub enum MetricValue {
     Int(i64),
     Float(f64),
     String(String),
-}
-
-impl ToString for MetricValue {
-    fn to_string(&self) -> String {
-        match self {
-            MetricValue::Int(i) => i.to_string(),
-            MetricValue::Float(f) => f.to_string(),
-            MetricValue::String(s) => s.to_string(),
-        }
-    }
 }

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1202,7 +1202,10 @@ class SendManager:
         start_us = self._run.start_time.ToMicroseconds()
         d = dict()
         for item in stats.item:
-            d[item.key] = json.loads(item.value_json)
+            try:
+                d[item.key] = json.loads(item.value_json)
+            except json.JSONDecodeError:
+                logger.error("error decoding stats json: %s", item.value_json)
         row: Dict[str, Any] = dict(system=d)
         self._flatten(row)
         row["_wandb"] = True


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes #9047

This PR fixes an issue in 0.19.0 where I missed properly skipping private system metrics in a refactor: was only skipping in the sender, but not in the writer, which exposed another issue where offline runs would not sync because of a bug in json serialization of string "metrics" in gpu_stats.

Additionally, offline sync will now skip stats items that fail to serialize.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
