### PR TITLE
fix: correctly interrupt main thread

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,3 +12,8 @@ Add here any changes made in a PR that are relevant to end users. Allowed sectio
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- The stop button correctly interrupts runs whose main Python thread is running
+  C code, sleeping, etc. (@timoffex in https://github.com/wandb/wandb/pull/9094)

--- a/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
+++ b/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
@@ -1,0 +1,25 @@
+"""Starts a W&B run and exits with code 1 if it's not interrupted."""
+
+import sys
+import time
+
+import wandb
+
+if __name__ == "__main__":
+    with wandb.init():
+        try:
+            start_time = time.monotonic()
+            time.sleep(30)
+        except KeyboardInterrupt:
+            # Something like _thread.interrupt_main() would raise a
+            # KeyboardInterrupt exception at the end of the sleep, instead of
+            # interrupting the sleep.
+            if time.monotonic() - start_time >= 29:
+                print("FAIL: Got KeyboardInterrupt too late!", file=sys.stderr)
+                sys.exit(1)
+
+            print("PASS: KeyboardInterrupt detected!", file=sys.stderr)
+            sys.exit(0)
+
+    print("FAIL: No KeyboardInterrupt detected!", file=sys.stderr)
+    sys.exit(1)

--- a/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
+++ b/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
@@ -3,9 +3,12 @@
 import sys
 import time
 
+import coverage
 import wandb
 
 if __name__ == "__main__":
+    coverage.process_startup()
+
     with wandb.init():
         try:
             start_time = time.monotonic()

--- a/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
+++ b/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
@@ -3,12 +3,9 @@
 import sys
 import time
 
-import coverage
 import wandb
 
 if __name__ == "__main__":
-    coverage.process_startup()
-
     with wandb.init():
         try:
             start_time = time.monotonic()

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -1,0 +1,14 @@
+import os
+import pathlib
+import subprocess
+
+
+def test_run_stops_if_asked(wandb_backend_spy):
+    gql = wandb_backend_spy.gql
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="RunStoppedStatus"),
+        gql.Constant(content={"data": {"project": {"run": {"stopped": True}}}}),
+    )
+
+    script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"
+    subprocess.check_call(["python", str(script)], env=os.environ)

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -11,4 +11,10 @@ def test_run_stops_if_asked(wandb_backend_spy):
     )
 
     script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"
-    subprocess.check_call(["python", str(script)], env=os.environ)
+    subprocess.check_call(
+        ["python", str(script)],
+        env={
+            "COVERAGE_PROCESS_START": "1",
+            **os.environ,
+        },
+    )

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -1,13 +1,25 @@
 import os
 import pathlib
 import subprocess
+from typing import Any
+
+
+def _run_stopped_response(stopped: bool) -> dict[str, Any]:
+    return {"data": {"project": {"run": {"stopped": stopped}}}}
 
 
 def test_run_stops_if_asked(wandb_backend_spy):
     gql = wandb_backend_spy.gql
     wandb_backend_spy.stub_gql(
         gql.Matcher(operation="RunStoppedStatus"),
-        gql.Constant(content={"data": {"project": {"run": {"stopped": True}}}}),
+        gql.Sequence(
+            [
+                # Respond False to the first check so that the True response
+                # is more likely to be observed during time.sleep().
+                gql.Constant(content=_run_stopped_response(False)),
+                gql.Constant(content=_run_stopped_response(True)),
+            ]
+        ),
     )
 
     script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"

--- a/wandb/sdk/lib/interrupt.py
+++ b/wandb/sdk/lib/interrupt.py
@@ -1,0 +1,37 @@
+"""Utility to send an interrupt (Ctrl+C) signal to the main thread.
+
+This is necessary because Windows and POSIX use different models for Ctrl+C
+interrupts.
+"""
+
+import platform
+import signal
+import threading
+
+
+def interrupt_main():
+    """Interrupt the main Python thread with a SIGINT signal.
+
+    In POSIX, signal.pthread_kill() is the most reliable way to send a signal
+    to the main thread.
+
+    os.kill() is often recommended, but it isn't guaranteed to deliver the
+    signal to the main OS thread. Likewise, signal.raise_signal() delivers
+    the signal to the current thread in POSIX. The issue is that if any other
+    thread receives the signal, Python will set an internal flag and process it
+    on the main thread at the next opportunity. If the main thread is executing
+    C code or is blocked on a syscall (e.g. time.sleep(999999)) the signal
+    handler won't execute until that's done---i.e. Python won't preempt the OS
+    thread on its own.
+
+    On Windows, pthread_kill is not available and os.kill() ignores its
+    second argument and always kills the process. However,
+    signal.raise_signal() does the right thing.
+    """
+    if platform.system() == "Windows":
+        signal.raise_signal(signal.SIGINT)
+    else:
+        signal.pthread_kill(
+            threading.main_thread().ident,
+            signal.SIGINT,
+        )

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import _thread as thread
 import atexit
 import functools
 import glob
@@ -73,6 +72,7 @@ from .lib import (
     deprecate,
     filenames,
     filesystem,
+    interrupt,
     ipython,
     module,
     printer,
@@ -287,7 +287,7 @@ class RunStatusChecker:
                 # TODO(frz): This check is required
                 # until WB-3606 is resolved on server side.
                 if not wandb.agents.pyagent.is_running():  # type: ignore
-                    thread.interrupt_main()
+                    interrupt.interrupt_main()
                     return
 
         try:


### PR DESCRIPTION
Description
---
Fixes WB-18098, making the stop button more reliable.


Testing
---
Run the following:

```python
import time
import wandb

wandb.init()
time.sleep(9999)
```

Then press the stop button in the run's Overview tab, next to its State property. Prior to this fix, the stop button would not interrupt the sleep on any platform.

Tested manually on macOS and Windows. Tested on Linux via system-tests.