### PR TITLE
chore: fix codecov for test_interrupt.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ norecursedirs = [
 ]
 
 [tool.coverage.paths]
-source = ["wandb"]
+source = ["wandb/", "**/site-packages/wandb/"]
 
 [tool.coverage.run]
 # branch = true

--- a/tests/system_tests/test_functional/conftest.py
+++ b/tests/system_tests/test_functional/conftest.py
@@ -1,8 +1,5 @@
-import os
 import pathlib
 import runpy
-import subprocess
-import sys
 from typing import Any
 from unittest import mock
 
@@ -11,44 +8,19 @@ import pytest
 
 @pytest.fixture
 def execute_script():
-    """Execute a script in the current interpreter using runpy.
+    # Define a helper function that will take in the script path and command-line arguments
+    def helper(train_script_path: pathlib.Path, *args: Any) -> None:
+        # sys_argv simulates the command-line arguments.
+        sys_argv = [str(train_script_path)] + list(args)
 
-    This fixture is a function that accepts the script's path and a list of
-    arguments to pass to it, as if invoking it on the command line. The script
-    runs with `__name__ == "__main__"`.
-    """
-
-    def helper(script_path: pathlib.Path, *args: Any) -> None:
-        sys_argv = [str(script_path)] + list(args)
-
+        # Patch sys.argv to replace the real command-line arguments with our simulated ones.
+        # This ensures that the target script sees the provided arguments when run.
         with mock.patch("sys.argv", sys_argv):
+            # Execute the target script at `train_script_path` in a similar way
+            # as if it was run directly from the command line.
             # runpy.run_path executes the script with the specified `run_name`.
-            # By using `run_name="__main__"`, we simulate the script being
-            # executed as if it were the main entry point, like running
-            # `python script.py`.
-            runpy.run_path(str(script_path), run_name="__main__")
-
-    return helper
-
-
-@pytest.fixture
-def check_call_script():
-    """Run a Python script in a new interpreter.
-
-    This is a replacement for `subprocess.check_call(["python", ...])`.
-    It calls the script and raises an error if its exit code is nonzero.
-
-    The PYTHONPATH is set to the current `sys.path`, so that the script imports
-    the same modules as the current interpreter.
-    """
-
-    def helper(script_path: pathlib.Path) -> None:
-        subprocess.check_call(
-            ["python", str(script_path)],
-            env={
-                **os.environ,
-                "PYTHONPATH": os.pathsep.join(sys.path),
-            },
-        )
+            # By using `run_name="__main__"`, we simulate the script being executed
+            # as if it were the main entry point, like running `python script.py`.
+            runpy.run_path(str(train_script_path), run_name="__main__")
 
     return helper

--- a/tests/system_tests/test_functional/conftest.py
+++ b/tests/system_tests/test_functional/conftest.py
@@ -1,5 +1,8 @@
+import os
 import pathlib
 import runpy
+import subprocess
+import sys
 from typing import Any
 from unittest import mock
 
@@ -8,19 +11,44 @@ import pytest
 
 @pytest.fixture
 def execute_script():
-    # Define a helper function that will take in the script path and command-line arguments
-    def helper(train_script_path: pathlib.Path, *args: Any) -> None:
-        # sys_argv simulates the command-line arguments.
-        sys_argv = [str(train_script_path)] + list(args)
+    """Execute a script in the current interpreter using runpy.
 
-        # Patch sys.argv to replace the real command-line arguments with our simulated ones.
-        # This ensures that the target script sees the provided arguments when run.
+    This fixture is a function that accepts the script's path and a list of
+    arguments to pass to it, as if invoking it on the command line. The script
+    runs with `__name__ == "__main__"`.
+    """
+
+    def helper(script_path: pathlib.Path, *args: Any) -> None:
+        sys_argv = [str(script_path)] + list(args)
+
         with mock.patch("sys.argv", sys_argv):
-            # Execute the target script at `train_script_path` in a similar way
-            # as if it was run directly from the command line.
             # runpy.run_path executes the script with the specified `run_name`.
-            # By using `run_name="__main__"`, we simulate the script being executed
-            # as if it were the main entry point, like running `python script.py`.
-            runpy.run_path(str(train_script_path), run_name="__main__")
+            # By using `run_name="__main__"`, we simulate the script being
+            # executed as if it were the main entry point, like running
+            # `python script.py`.
+            runpy.run_path(str(script_path), run_name="__main__")
+
+    return helper
+
+
+@pytest.fixture
+def check_call_script():
+    """Run a Python script in a new interpreter.
+
+    This is a replacement for `subprocess.check_call(["python", ...])`.
+    It calls the script and raises an error if its exit code is nonzero.
+
+    The PYTHONPATH is set to the current `sys.path`, so that the script imports
+    the same modules as the current interpreter.
+    """
+
+    def helper(script_path: pathlib.Path) -> None:
+        subprocess.check_call(
+            ["python", str(script_path)],
+            env={
+                **os.environ,
+                "PYTHONPATH": os.pathsep.join(sys.path),
+            },
+        )
 
     return helper

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 import subprocess
 from typing import Any

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -23,10 +23,4 @@ def test_run_stops_if_asked(wandb_backend_spy):
     )
 
     script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"
-    subprocess.check_call(
-        ["python", str(script)],
-        env={
-            "COVERAGE_PROCESS_START": "1",
-            **os.environ,
-        },
-    )
+    subprocess.check_call(["python", str(script)])

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -1,6 +1,4 @@
-import os
 import pathlib
-import subprocess
 from typing import Any
 
 
@@ -8,7 +6,7 @@ def _run_stopped_response(stopped: bool) -> dict[str, Any]:
     return {"data": {"project": {"run": {"stopped": stopped}}}}
 
 
-def test_run_stops_if_asked(wandb_backend_spy):
+def test_run_stops_if_asked(check_call_script, wandb_backend_spy):
     gql = wandb_backend_spy.gql
     wandb_backend_spy.stub_gql(
         gql.Matcher(operation="RunStoppedStatus"),
@@ -23,10 +21,4 @@ def test_run_stops_if_asked(wandb_backend_spy):
     )
 
     script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"
-    subprocess.check_call(
-        ["python", str(script)],
-        env={
-            "COVERAGE_PROCESS_START": "1",
-            **os.environ,
-        },
-    )
+    check_call_script(script)

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -1,4 +1,6 @@
+import os
 import pathlib
+import subprocess
 from typing import Any
 
 
@@ -6,7 +8,7 @@ def _run_stopped_response(stopped: bool) -> dict[str, Any]:
     return {"data": {"project": {"run": {"stopped": stopped}}}}
 
 
-def test_run_stops_if_asked(check_call_script, wandb_backend_spy):
+def test_run_stops_if_asked(wandb_backend_spy):
     gql = wandb_backend_spy.gql
     wandb_backend_spy.stub_gql(
         gql.Matcher(operation="RunStoppedStatus"),
@@ -21,4 +23,10 @@ def test_run_stops_if_asked(check_call_script, wandb_backend_spy):
     )
 
     script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"
-    check_call_script(script)
+    subprocess.check_call(
+        ["python", str(script)],
+        env={
+            "COVERAGE_PROCESS_START": "1",
+            **os.environ,
+        },
+    )


### PR DESCRIPTION
Description
---
`test_interrupt.py` didn't cover `wandb/sdk/lib/interrupt.py` because it covered `.nox/<site-packages>/wandb/sdk/lib/interrupt.py`. This is because the command `python pass_if_interrupted.py` ran from the test directory, not the repository root, and so `import wandb` loaded the `wandb` installed in the virtual environment, and the paths in the resulting `coverage.xml` file pointed to the venv files rather than the repository files.

Solution: tell `coverage.py` that `.nox/.../site-packages/wandb/` is the same as `wandb/`.

[After the fix: codecov reports coverage for `interrupt.py`.](https://app.codecov.io/gh/wandb/wandb/commit/13c367de5ee283fa2af892a7ba8029e57c53bdb2/blob/wandb/sdk/lib/interrupt.py)