### PR TITLE
runs API: Remove noisy print statement

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,3 +21,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - The stop button correctly interrupts runs whose main Python thread is running C code, sleeping, etc. (@timoffex in https://github.com/wandb/wandb/pull/9094)
+- Remove unintentional print that occurs when inspecting `wandb.Api().runs()` (@tomtseng in https://github.com/wandb/wandb/pull/9101)

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -924,11 +924,6 @@ class Run(Attrs):
         if self.server_provides_internal_id_field is None:
             query = gql(query_string)
             res = self.client.execute(query)
-            print(
-                "internalId"
-                in [x["name"] for x in (res.get("ProjectType", {}).get("fields", [{}]))]
-            )
-
             self.server_provides_internal_id_field = "internalId" in [
                 x["name"] for x in (res.get("ProjectType", {}).get("fields", [{}]))
             ]


### PR DESCRIPTION
Description
-----------

https://github.com/wandb/wandb/pull/8837 included a `print()` statement, presumably for debugging, but the result is that a bool is printed to the console many times (possibly dozens or hundreds of times depending on the run group queried) when inspecting a `wandb.Api().runs()` instance. This print statement should be removed or at least be toggleable. This PR removes the print statement. 


Testing
-------
Manual testing: Prior to this change, inspecting the runs in given by an `wandb.Api().runs()` call would print `True\n` many times to the console, whereas afterwards it does not.
