### PR TITLE
chore(sdk): add automations codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,9 @@
 # ML Workflows team
 /core/pkg/artifacts/ @wandb/mlw-team
 /wandb/sdk/artifacts/ @wandb/mlw-team
+/wandb/sdk/automations/ @wandb/mlw-team
 /tests/system_tests/test_artifacts/ @wandb/mlw-team
+/tests/system_tests/test_automations/ @wandb/mlw-team
 /tests/unit_tests/test_artifacts/ @wandb/mlw-team
+/tests/unit_tests/test_automations/ @wandb/mlw-team
 /tests/unit_tests/test_launch/ @wandb/mlw-team


### PR DESCRIPTION
Description
-----------
Assigns @wandb/mlw-team as owner for automations files.  These files will be added in subsequent PRs.

This PR can be merged anytime.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
N/A

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
