### PR TITLE
fix: make sure media is counted correctly

### DIFF
--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/Khan/genqlient/graphql"
@@ -121,8 +122,14 @@ func (u *uploader) Process(record *spb.FilesRecord) {
 		}
 		runPath := *maybeRunPath
 
-		u.knownFile(runPath).
-			SetCategory(filetransfer.RunFileKindFromProto(file.GetType()))
+		category := filetransfer.RunFileKindFromProto(file.GetType())
+		// Files under media/ always count as media files, but the client does
+		// not always mark their type.
+		if category == filetransfer.RunFileKindOther &&
+			strings.HasPrefix(file.GetPath(), "media") {
+			category = filetransfer.RunFileKindMedia
+		}
+		u.knownFile(runPath).SetCategory(category)
 
 		switch file.GetPolicy() {
 		case spb.FilesItem_NOW:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Correctly report the type of the file that being send to `wandb-core` for the following example:

```python
import wandb
import numpy as np

with wandb.init() as run:
    for i in range(10):
        image = np.zeros((10, 10, 3), dtype=np.uint8)
        run.log({"image": wandb.Image(image)})
```
Before:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/99f859aa-b42f-4e1b-aec2-e3c995245be1" />

After:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/817f45e7-f079-441a-8e8c-e14aaacb4fb0" />

media files were reported as other, which are usually user saved files, after the change these files are correctly reported as media files.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
