### PR TITLE
fix: wandb login anonymously would write invalid value to system settings file

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -250,7 +250,7 @@ def write_key(
         )
 
     if anonymous:
-        api.set_setting("anonymous", "true", globally=True, persist=True)
+        api.set_setting("anonymous", "must", globally=True, persist=True)
     else:
         api.clear_setting("anonymous", globally=True, persist=True)
 


### PR DESCRIPTION
Description
-----------
when logging in from the cli with `wandb login --anonymously` the value being written to the global settings file is invalid.

This can lead to a loop where running any wandb script would fail.

## Before the change
The config file with the invalid value
![image](https://github.com/user-attachments/assets/056b58d3-6bdf-464a-9ca2-6f5b75f8011e)

running a python script to log an integer gives
![image](https://github.com/user-attachments/assets/2c545b40-5949-4030-bd3b-18de0fad26f9)

## After this change
global settings file
![image](https://github.com/user-attachments/assets/b7f9a342-eda4-43df-b18a-9ff5e53b4399)

running a file works fine
![image](https://github.com/user-attachments/assets/f81595d8-d7a6-4209-8e8e-fa8fb7b1c014)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
