### PR TITLE
chore(sdk): only error and show the full graphql error message in debug mode

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -395,7 +395,8 @@ class Api:
             response = err.response
             assert response is not None
             logger.error(f"{response.status_code} response executing GraphQL.")
-            logger.error(response.text)
+            if env.is_debug(env=self._environ):
+                logger.error(response.text)
             for error in parse_backend_error_messages(response):
                 wandb.termerror(f"Error while calling W&B API: {error} ({response})")
             raise


### PR DESCRIPTION
Description
-----------
https://wandb.atlassian.net/browse/WB-21798
Make it so that in a graphql error it just shows the error message in terminal and not the entire response text. In debug mode we put in debug logs

Testing
-------
Tested locally
