### PR TITLE
refactor: delete no-op wandb.Run._on_init

### DIFF
--- a/tests/unit_tests/test_wandb_init.py
+++ b/tests/unit_tests/test_wandb_init.py
@@ -73,7 +73,6 @@ def test_init_reinit(test_settings):
         assert interface_instance.deliver_run_start.call_count == 1
         assert backend_instance.ensure_launched.call_count == 1
         assert run_instance._on_start.call_count == 1
-        assert run_instance._on_init.call_count == 1
         assert last_run_instance.finish.call_count == 1
 
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -871,8 +871,6 @@ class _WandbInit:
                 tel.feature.resumed = run_result.run.resumed
         run._set_run_obj(run_result.run)
 
-        run._on_init()
-
         logger.info("starting run threads in backend")
         # initiate run (stats and metadata probing)
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2428,10 +2428,6 @@ class Run:
             self._output_writer.close()
             self._output_writer = None
 
-    def _on_init(self) -> None:
-        if self._settings._offline:
-            return
-
     def _on_start(self) -> None:
         # would like to move _set_global to _on_ready to unify _on_start and _on_attach
         # (we want to do the set globals after attach)


### PR DESCRIPTION
Grepping the repository for `_on_init` shows no other references. In an old commit, this used to print version statistics; I'm not sure when that got removed, but now it does nothing.