### PR TITLE
fix: replace pydantic's deprecated BaseModel.copy with model_copy in Settings object

### DIFF
--- a/wandb/sdk/backend/backend.py
+++ b/wandb/sdk/backend/backend.py
@@ -145,7 +145,7 @@ class Backend:
             return
 
         assert self._settings
-        settings = self._settings.copy()
+        settings = self._settings.model_copy()
         settings.x_log_level = self._log_level or logging.DEBUG
 
         start_method = settings.start_method

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -199,7 +199,7 @@ class _WandbInit:
         _set_logger(self._wl._get_logger())
 
         # Start with settings from wandb library singleton
-        settings = self._wl.settings.copy()
+        settings = self._wl.settings.model_copy()
 
         # handle custom sweep- and launch-related logic for init settings
         if settings.sweep_id:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Fixes #9151.

Replace pydantic's deprecated `BaseModel.copy()` with `BaseModel.model_copy()` in the Settings object.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
