### PR TITLE
chore: fix flaky run.metadata test with legacy service

### DIFF
--- a/tests/system_tests/test_core/test_wandb_metadata.py
+++ b/tests/system_tests/test_core/test_wandb_metadata.py
@@ -37,6 +37,7 @@ def test_metadata_ops(user, disabled: bool):
     run.finish()
 
 
+@pytest.mark.wandb_core_only
 def test_metadata_access(user):
     with wandb.init() as run:
         run.log({"acc": 1})

--- a/tests/system_tests/test_core/test_wandb_metadata.py
+++ b/tests/system_tests/test_core/test_wandb_metadata.py
@@ -37,7 +37,6 @@ def test_metadata_ops(user, disabled: bool):
     run.finish()
 
 
-@pytest.mark.wandb_core_only
 def test_metadata_access(user):
     with wandb.init() as run:
         run.log({"acc": 1})

--- a/tests/system_tests/test_core/test_wandb_metadata.py
+++ b/tests/system_tests/test_core/test_wandb_metadata.py
@@ -44,12 +44,10 @@ def test_metadata_access(user):
         assert run._metadata is not None
         run._metadata.email = "lol@wandb.ai"
 
-        with open(run.settings.log_internal) as f:
-            debug_log = f.readlines()
+    with open(run.settings.log_internal) as f:
+        debug_log = f.readlines()
 
-        joined = "".join(debug_log)
+    joined = "".join(debug_log)
 
-        if run.settings.x_require_legacy_service:
-            assert (
-                "Metadata updates are ignored when using the legacy service" in joined
-            )
+    if run.settings.x_require_legacy_service:
+        assert "Metadata updates are ignored when using the legacy service" in joined


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fix indentation issue in `tests/system_tests/test_core/test_wandb_metadata.py::test_metadata_access`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
