### PR TITLE
fix: possible logic error in _console_start with x_disable_service

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2415,7 +2415,7 @@ class Run:
         logger.info("atexit reg")
         self._hooks = ExitHooks()
 
-        if not self._wl or self._wl.settings.x_disable_service:
+        if self.settings.x_disable_service:
             self._hooks.hook()
             # NB: manager will perform atexit hook like behavior for outstanding runs
             atexit.register(lambda: self._atexit_cleanup())


### PR DESCRIPTION
The function should use the run's setting for `x_disable_service`, not the singleton value, especially after https://github.com/wandb/wandb/pull/9172.