### PR TITLE
chore: move rust protobuf binding generation script closer to source

### DIFF
--- a/gpu_stats/tools/generate-proto.sh
+++ b/gpu_stats/tools/generate-proto.sh
@@ -2,9 +2,11 @@
 
 set -e
 
+# Navigate one directory up to execute the cargo command
+# from the root of the gpu_stats project.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR/.."
 
-# Run the Rust proto generation
+# Run the Rust proto generation.
 echo "[INFO] generate-proto.sh: Generating Rust protobuf files"
 cargo run --bin build_proto

--- a/gpu_stats/tools/generate-proto.sh
+++ b/gpu_stats/tools/generate-proto.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/.."
+
+# Run the Rust proto generation
+echo "[INFO] generate-proto.sh: Generating Rust protobuf files"
+cargo run --bin build_proto

--- a/noxfile.py
+++ b/noxfile.py
@@ -483,9 +483,7 @@ def local_testcontainer_registry(session: nox.Session) -> None:
 def proto_rust(session: nox.Session) -> None:
     """Generate Rust bindings for protobufs."""
     session.run("./core/api/proto/install-protoc.sh", "23.4", external=True)
-    # cargo run --bin build_proto
-    session.cd("gpu_stats")
-    session.run("cargo", "run", "--bin", "build_proto", external=True)
+    session.run("./gpu_stats/tools/generate-proto.sh", external=True)
 
 
 @nox.session(python=False, name="proto-go", tags=["proto"])


### PR DESCRIPTION
Description
-----------
..as the cargo build command belongs with the gpu_stats project and shouldn't be in the noxfile.


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
