### PR TITLE
fix: explicitly build gpu_stats binary

### DIFF
--- a/gpu_stats/hatch.py
+++ b/gpu_stats/hatch.py
@@ -31,6 +31,8 @@ def build_gpu_stats(
         "build",
         "--release",
         "--message-format=json",
+        "--bin",
+        "gpu_stats",
     )
 
     try:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
...Now that there are two binaries (gpu_stats + build_proto).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
