### PR TITLE
fix: checks against invalid anonymous settings value.

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Fix error when reinitializing a run, caused by accessing a removed attribute. (@MathisTLD in https://github.com/wandb/wandb/pull/8912)
 - Fixed occasional deadlock when using `multiprocessing` to update a single run from multiple processes (@timoffex in https://github.com/wandb/wandb/pull/9126)
 - Prevent errors from bugs in older versions of `botocore < 1.5.76` (@amusipatla-wandb, @tonyyli-wandb in https://github.com/wandb/wandb/pull/9015)
+- Fixed various checks against invalid `anonymous` settings value. (@jacobromero in https://github.com/wandb/wandb/pull/9193)
 
 ### Removed
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2321,7 +2321,9 @@ class Api:
             "commit": commit,
             "displayName": display_name,
             "notes": notes,
-            "host": None if self.settings().get("anonymous") == "true" else host,
+            "host": None
+            if self.settings().get("anonymous") in ["allow", "must"]
+            else host,
             "debug": env.is_debug(env=self._environ),
             "repo": repo,
             "program": program_path,

--- a/wandb/sdk/internal/system/system_info.py
+++ b/wandb/sdk/internal/system/system_info.py
@@ -190,7 +190,7 @@ class SystemInfo:
             # get the git repo info
             data = self._probe_git(data)
 
-        if self.settings.anonymous != "true":
+        if self.settings.anonymous not in ["allow", "must"]:
             data["host"] = self.settings.host
             data["username"] = self.settings.username
             data["executable"] = sys.executable

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -250,7 +250,7 @@ def write_key(
         )
 
     if anonymous:
-        api.set_setting("anonymous", "true", globally=True, persist=True)
+        api.set_setting("anonymous", "must", globally=True, persist=True)
     else:
         api.clear_setting("anonymous", globally=True, persist=True)
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3267,7 +3267,7 @@ class Run:
         use_after_commit: bool = False,
     ) -> Artifact:
         api = internal.Api()
-        if api.settings().get("anonymous") == "true":
+        if api.settings().get("anonymous") in ["allow", "must"]:
             wandb.termwarn(
                 "Artifacts logged anonymously cannot be claimed and expire after 7 days."
             )
@@ -3864,8 +3864,8 @@ class Run:
             f'{printer.emoji("rocket")} View run at {printer.link(run_url)}',
         )
 
-        # TODO(settings) use `wandb_settings` (if self.settings.anonymous == "true":)
-        if run_name and Api().api.settings().get("anonymous") == "true":
+        # TODO(settings) use `wandb_settings` (if self.settings.anonymous in ["allow", "must"]:)
+        if run_name and Api().api.settings().get("anonymous") in ["allow", "must"]:
             printer.display(
                 (
                     "Do NOT share these links with anyone."

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1262,7 +1262,7 @@ class Settings(BaseModel, validate_assignment=True):
     def _get_url_query_string(self) -> str:
         """Construct the query string for project, run, and sweep URLs."""
         # TODO: remove dependency on Api()
-        if Api().settings().get("anonymous") != "true":
+        if Api().settings().get("anonymous") not in ["allow", "must"]:
             return ""
 
         api_key = apikey.api_key(settings=self)


### PR DESCRIPTION
Description
-----------
What does the PR do? Include a concise description of the PR contents.

This PR fixes multiple checks against an invalid settings value for anonymous mode.

Following up this PR a check if the current user for the run has `accountType == ANONYMOUS` will allow better enforcement of data collected for anonymous runs.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
