### PR TITLE
refactor: _WandbSetup._get_logger() cannot return None

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,3 +34,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Removed
 
 - The `wandb.wandb_sdk.wandb_setup._setup()` function's `reset` parameter has been removed. Note that this is a private function, even though there appear to be usages outside of the repo. Please `wandb.teardown()` instead of `_setup(reset=True)`. (@timoffex in https://github.com/wandb/wandb/pull/9165)
+- In the private `wandb.wandb_sdk.wandb_setup` module, the `logger` and `_set_logger` symbols have been removed (@timoffex in https://github.com/wandb/wandb/pull/9195)


### PR DESCRIPTION
`_WandbSetup._get_logger()` could never return `None` (unless a user patched `wandb_setup.logger` directly). This PR replaces the module-level `logger` variable and `_set_logger` function by an instance variable and fixes the types.

These are private symbols, but I documented this in the changelog just in case. I recall some users patching our internal logging functionalities in the past.