### PR TITLE
feat(sdk): add methods to fetch integrations from wandb.Api

### DIFF
--- a/wandb/apis/public/integrations.py
+++ b/wandb/apis/public/integrations.py
@@ -113,6 +113,8 @@ class WebhookIntegrations(Paginator["WebhookIntegration"]):
 
     def convert_objects(self) -> Iterable[WebhookIntegration]:
         """Parse the page data into a list of Integrations."""
+        from wandb.automations import WebhookIntegration
+
         page = self.last_response
         return [WebhookIntegration.model_validate(edge.node) for edge in page.edges]
 
@@ -160,5 +162,7 @@ class SlackIntegrations(Paginator["SlackIntegration"]):
 
     def convert_objects(self) -> list[SlackIntegration]:
         """Parse the page data into a list of Integrations."""
+        from wandb.automations import SlackIntegration
+
         page = self.last_response
         return [SlackIntegration.model_validate(edge.node) for edge in page.edges]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-22611](https://wandb.atlassian.net/browse/WB-22611)
- Docs: [DOCS-1164](https://wandb.atlassian.net/browse/DOCS-1164)

Adds methods to fetch existing Slack and GenericWebhook integrations from instances of `wandb.Api`.  Among other things, this will be needed to programmatically define new Automations

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-22611]: https://wandb.atlassian.net/browse/WB-22611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOCS-1164]: https://wandb.atlassian.net/browse/DOCS-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ