### PR TITLE
fix(sdk): ensure paginator base types conform to iterator/collection protocols

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Relaxed the `pydantic` version requirement to support both v1 and v2 (@dmitryduev in https://github.com/wandb/wandb/pull/9605)
 - `wandb.init(dir=...)` now creates any nonexistent directories in `dir` if it has a parent directory that is writeable (@ringohoffman in https://github.com/wandb/wandb/pull/9545)
 - The server now supports fetching artifact files by providing additional collection information; updated the artifacts api to use the new endpoints instead (@ibindlish in https://github.com/wandb/wandb/pull/9551)
+- Paginated methods (and underlying paginators) that accept a `per_page` argument now only accept `int` values.  Default `per_page` values are set directly in method signatures, and explicitly passing `None` is no longer supported (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9201)
 
 ### Fixed
 

--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -1,75 +1,103 @@
-from typing import TYPE_CHECKING, Any, MutableMapping, Optional
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Iterator,
+    Mapping,
+    Protocol,
+    Sized,
+    TypeVar,
+    overload,
+)
 
 if TYPE_CHECKING:
-    from wandb_gql import Client
+    from wandb_graphql.language.ast import Document
+
+T = TypeVar("T")
 
 
-class Paginator:
-    QUERY = None
+# Structural type hint for the client instance
+class _Client(Protocol):
+    def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]: ...
+
+
+class Paginator(Iterator[T]):
+    """An iterator for paginated objects from GraphQL requests."""
+
+    QUERY: ClassVar[Document | None] = None
 
     def __init__(
         self,
-        client: "Client",
-        variables: MutableMapping[str, Any],
-        per_page: Optional[int] = None,
+        client: _Client,
+        variables: Mapping[str, Any],
+        per_page: int = 50,  # We don't allow unbounded paging
     ):
-        self.client = client
-        self.variables = variables
-        # We don't allow unbounded paging
-        self.per_page = per_page
-        if self.per_page is None:
-            self.per_page = 50
-        self.objects = []
-        self.index = -1
-        self.last_response = None
+        self.client: _Client = client
 
-    def __iter__(self):
+        # shallow copy partly guards against mutating the original input
+        self.variables: dict[str, Any] = dict(variables)
+
+        self.per_page: int = per_page
+        self.objects: list[T] = []
+        self.index: int = -1
+        self.last_response: object | None = None
+
+    def __iter__(self) -> Iterator[T]:
         self.index = -1
         return self
 
-    def __len__(self):
-        if self.length is None:
-            self._load_page()
-        if self.length is None:
-            raise ValueError("Object doesn't provide length")
-        return self.length
-
     @property
-    def length(self):
+    @abstractmethod
+    def more(self) -> bool:
+        """Whether there are more pages to be fetched."""
         raise NotImplementedError
 
     @property
-    def more(self):
+    @abstractmethod
+    def cursor(self) -> str | None:
+        """The start cursor to use for the next fetched page."""
         raise NotImplementedError
 
-    @property
-    def cursor(self):
+    @abstractmethod
+    def convert_objects(self) -> list[T]:
+        """Convert the last fetched response data into the iterated objects."""
         raise NotImplementedError
 
-    def convert_objects(self):
-        raise NotImplementedError
-
-    def update_variables(self):
+    def update_variables(self) -> None:
+        """Update the query variables for the next page fetch."""
         self.variables.update({"perPage": self.per_page, "cursor": self.cursor})
 
-    def _load_page(self):
-        if not self.more:
-            return False
-        self.update_variables()
+    def _update_response(self) -> None:
+        """Fetch and store the response data for the next page."""
         self.last_response = self.client.execute(
             self.QUERY, variable_values=self.variables
         )
+
+    def _load_page(self) -> bool:
+        """Fetch the next page, if any, returning True and storing the response if there was one."""
+        if not self.more:
+            return False
+        self.update_variables()
+        self._update_response()
         self.objects.extend(self.convert_objects())
         return True
 
-    def __getitem__(self, index):
+    @overload
+    def __getitem__(self, index: int) -> T: ...
+    @overload
+    def __getitem__(self, index: slice) -> list[T]: ...
+
+    def __getitem__(self, index: int | slice) -> T | list[T]:
         loaded = True
         stop = index.stop if isinstance(index, slice) else index
         while loaded and stop > len(self.objects) - 1:
             loaded = self._load_page()
         return self.objects[index]
 
-    def __next__(self):
+    def __next__(self) -> T:
         self.index += 1
         if len(self.objects) <= self.index:
             if not self._load_page():
@@ -79,3 +107,19 @@ class Paginator:
         return self.objects[self.index]
 
     next = __next__
+
+
+class SizedPaginator(Paginator[T], Sized):
+    """A Paginator for objects with a known total count."""
+
+    def __len__(self) -> int:
+        if self.length is None:
+            self._load_page()
+        if self.length is None:
+            raise ValueError("Object doesn't provide length")
+        return self.length
+
+    @property
+    @abstractmethod
+    def length(self) -> int | None:
+        raise NotImplementedError

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -755,15 +755,14 @@ class Api:
         return parts
 
     def projects(
-        self, entity: Optional[str] = None, per_page: Optional[int] = 200
+        self, entity: Optional[str] = None, per_page: int = 200
     ) -> "public.Projects":
         """Get projects for a given entity.
 
         Args:
             entity: (str) Name of the entity requested.  If None, will fall back to the
                 default entity passed to `Api`.  If no default entity, will raise a `ValueError`.
-            per_page: (int) Sets the page size for query pagination.  None will use the default size.
-                Usually there is no reason to change this.
+            per_page: (int) Sets the page size for query pagination.  Usually there is no reason to change this.
 
         Returns:
             A `Projects` object which is an iterable collection of `Project` objects.
@@ -806,7 +805,7 @@ class Api:
         return public.Project(self.client, entity, name, {})
 
     def reports(
-        self, path: str = "", name: Optional[str] = None, per_page: Optional[int] = 50
+        self, path: str = "", name: Optional[str] = None, per_page: int = 50
     ) -> "public.Reports":
         """Get reports for a given project path.
 
@@ -815,8 +814,7 @@ class Api:
         Args:
             path: (str) path to project the report resides in, should be in the form: "entity/project"
             name: (str, optional) optional name of the report requested.
-            per_page: (int) Sets the page size for query pagination.  None will use the default size.
-                Usually there is no reason to change this.
+            per_page: (int) Sets the page size for query pagination.  Usually there is no reason to change this.
 
         Returns:
             A `Reports` object which is an iterable collection of `BetaReport` objects.
@@ -1151,15 +1149,14 @@ class Api:
 
     @normalize_exceptions
     def artifact_collections(
-        self, project_name: str, type_name: str, per_page: Optional[int] = 50
+        self, project_name: str, type_name: str, per_page: int = 50
     ) -> "public.ArtifactCollections":
         """Return a collection of matching artifact collections.
 
         Args:
             project_name: (str) The name of the project to filter on.
             type_name: (str) The name of the artifact type to filter on.
-            per_page: (int, optional) Sets the page size for query pagination.  None will use the default size.
-                Usually there is no reason to change this.
+            per_page: (int) Sets the page size for query pagination.  Usually there is no reason to change this.
 
         Returns:
             An iterable `ArtifactCollections` object.
@@ -1224,7 +1221,7 @@ class Api:
         self,
         type_name: str,
         name: str,
-        per_page: Optional[int] = 50,
+        per_page: int = 50,
         tags: Optional[List[str]] = None,
     ) -> "public.Artifacts":
         """Return an `Artifacts` collection from the given parameters.
@@ -1232,8 +1229,7 @@ class Api:
         Args:
             type_name: (str) The type of artifacts to fetch.
             name: (str) An artifact collection name. May be prefixed with entity/project.
-            per_page: (int, optional) Sets the page size for query pagination.  None will use the default size.
-                Usually there is no reason to change this.
+            per_page: (int) Sets the page size for query pagination.  Usually there is no reason to change this.
             tags: (list[str], optional) Only return artifacts with all of these tags.
 
         Returns:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -10,7 +10,7 @@ from wandb_gql import Client, gql
 import wandb
 from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
-from wandb.apis.paginator import Paginator
+from wandb.apis.paginator import Paginator, SizedPaginator
 from wandb.errors.term import termlog
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk.artifacts._graphql_fragments import (
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from wandb.apis.public import RetryingClient, Run
 
 
-class ArtifactTypes(Paginator):
+class ArtifactTypes(Paginator["ArtifactType"]):
     QUERY = gql(
         """
         query ProjectArtifacts(
@@ -47,7 +47,7 @@ class ArtifactTypes(Paginator):
         client: Client,
         entity: str,
         project: str,
-        per_page: Optional[int] = 50,
+        per_page: int = 50,
     ):
         self.entity = entity
         self.project = project
@@ -60,7 +60,7 @@ class ArtifactTypes(Paginator):
         super().__init__(client, variable_values, per_page)
 
     @property
-    def length(self):
+    def length(self) -> None:
         # TODO
         return None
 
@@ -169,14 +169,14 @@ class ArtifactType:
         return f"<ArtifactType {self.type}>"
 
 
-class ArtifactCollections(Paginator):
+class ArtifactCollections(SizedPaginator["ArtifactCollection"]):
     def __init__(
         self,
         client: Client,
         entity: str,
         project: str,
         type_name: str,
-        per_page: Optional[int] = 50,
+        per_page: int = 50,
     ):
         self.entity = entity
         self.project = project
@@ -712,7 +712,7 @@ class ArtifactCollection:
         return f"<ArtifactCollection {self._name} ({self._type})>"
 
 
-class Artifacts(Paginator):
+class Artifacts(SizedPaginator["wandb.Artifact"]):
     """An iterable collection of artifact versions associated with a project and optional filter.
 
     This is generally used indirectly via the `Api`.artifact_versions method.
@@ -828,10 +828,8 @@ class Artifacts(Paginator):
         ]
 
 
-class RunArtifacts(Paginator):
-    def __init__(
-        self, client: Client, run: "Run", mode="logged", per_page: Optional[int] = 50
-    ):
+class RunArtifacts(SizedPaginator["wandb.Artifact"]):
+    def __init__(self, client: Client, run: "Run", mode="logged", per_page: int = 50):
         from wandb.sdk.artifacts.artifact import _gql_artifact_fragment
 
         output_query = gql(
@@ -946,7 +944,7 @@ class RunArtifacts(Paginator):
         ]
 
 
-class ArtifactFiles(Paginator):
+class ArtifactFiles(SizedPaginator["public.File"]):
     ARTIFACT_VERSION_FILES_QUERY = gql(
         f"""
         query ArtifactFiles(

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -12,7 +12,7 @@ import wandb
 from wandb import util
 from wandb.apis.attrs import Attrs
 from wandb.apis.normalize import normalize_exceptions
-from wandb.apis.paginator import Paginator
+from wandb.apis.paginator import SizedPaginator
 from wandb.apis.public import utils
 from wandb.apis.public.api import Api
 from wandb.apis.public.const import RETRY_TIMEDELTA
@@ -41,7 +41,7 @@ FILE_FRAGMENT = """fragment RunFilesFragment on Run {
 }"""
 
 
-class Files(Paginator):
+class Files(SizedPaginator["File"]):
     """An iterable collection of `File` objects."""
 
     QUERY = gql(

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -17,7 +17,7 @@ PROJECT_FRAGMENT = """fragment ProjectFragment on Project {
 }"""
 
 
-class Projects(Paginator):
+class Projects(Paginator["Project"]):
     """An iterable collection of `Project` objects."""
 
     QUERY = gql(
@@ -49,7 +49,8 @@ class Projects(Paginator):
         super().__init__(client, variables, per_page)
 
     @property
-    def length(self):
+    def length(self) -> None:
+        # For backwards compatibility, even though this isn't a SizedPaginator
         return None
 
     @property

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -9,11 +9,11 @@ from wandb_gql import gql
 import wandb
 from wandb.apis import public
 from wandb.apis.attrs import Attrs
-from wandb.apis.paginator import Paginator
+from wandb.apis.paginator import SizedPaginator
 from wandb.sdk.lib import ipython
 
 
-class Reports(Paginator):
+class Reports(SizedPaginator["BetaReport"]):
     """Reports is an iterable collection of `BetaReport` objects."""
 
     QUERY = gql(

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -24,7 +24,7 @@ from wandb.apis import public
 from wandb.apis.attrs import Attrs
 from wandb.apis.internal import Api as InternalApi
 from wandb.apis.normalize import normalize_exceptions
-from wandb.apis.paginator import Paginator
+from wandb.apis.paginator import SizedPaginator
 from wandb.apis.public.const import RETRY_TIMEDELTA
 from wandb.sdk.lib import ipython, json_util, runid
 from wandb.sdk.lib.paths import LogicalPath
@@ -61,7 +61,7 @@ RUN_FRAGMENT = """fragment RunFragment on Run {
 }"""
 
 
-class Runs(Paginator):
+class Runs(SizedPaginator["Run"]):
     """An iterable collection of runs associated with a project and optional filter.
 
     This is generally used indirectly via the `Api`.runs method.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-24075](https://wandb.atlassian.net/browse/WB-24075)

Refactors and adds type hints to `Paginator` base classes.
- Ensures `Paginator` formally implements the [`Iterator` protocol](https://docs.python.org/3.13/library/collections.abc.html#collections.abc.Iterator)
- Defines a separate `SizedPaginator` subclass for paginators that formally implement the [`Sized` protocol](https://docs.python.org/3.13/library/collections.abc.html#collections.abc.Sized) (i.e. by defining `__len__()`).

This allows common patterns like `list(paginator)` to work as expected on all wandb paginators, including those that haven't or can't implement `__len__()` -- e.g. for Integrations and Automations added in #9194 (upstack).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-24075]: https://wandb.atlassian.net/browse/WB-24075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ