### PR TITLE
refactor: move API key verification to common _login method

### DIFF
--- a/tests/system_tests/test_core/test_wandb_login.py
+++ b/tests/system_tests/test_core/test_wandb_login.py
@@ -4,15 +4,16 @@ import pytest
 import wandb
 
 
-def test_login_valid_key(user):
-    logged_in = wandb.login()
+@pytest.mark.parametrize("verify", [None, True])
+def test_login_valid_key(user, verify):
+    logged_in = wandb.login(verify=verify)
     assert logged_in
 
 
 def test_login_invalid_key(user):
     with mock.patch.dict("os.environ", {"WANDB_API_KEY": "I" * 40}):
         with pytest.raises(wandb.errors.AuthenticationError):
-            wandb.login()
+            wandb.login(verify=True)
 
 
 def test_login_invalid_key_no_verify(user):

--- a/tests/system_tests/test_core/test_wandb_login.py
+++ b/tests/system_tests/test_core/test_wandb_login.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+import wandb
+
+
+def test_login_valid_key(user):
+    logged_in = wandb.login()
+    assert logged_in
+
+
+def test_login_invalid_key(user):
+    with mock.patch.dict("os.environ", {"WANDB_API_KEY": "I" * 40}):
+        with pytest.raises(wandb.errors.AuthenticationError):
+            wandb.login()
+
+
+def test_login_invalid_key_no_verify(user):
+    with mock.patch.dict("os.environ", {"WANDB_API_KEY": "I" * 40}):
+        logged_in = wandb.login(verify=False)
+        assert logged_in

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -14,15 +14,19 @@ settings.register_profile(
 settings.load_profile("ci")
 
 
+# This fixture is an autouse fixture to ensure that any wandb.login() calls
+# will be mocked to return a viewer server info response by default.
 @pytest.fixture(autouse=True)
-def mock_servier_viewer_api_call():
+def mock_server_viewer_api_call():
     with mock.patch(
-        "wandb.sdk.internal.internal_api.Api.viewer_server_info",
-        return_value=(
-            {"viewer_server_info": {"id": "1234567890", "entity": "test_entity"}},
-            {},
-        ),
-    ):
+        "wandb.sdk.wandb_setup._WandbSetup.viewer",
+    ) as mock_viewer:
+        mock_viewer.__get__ = mock.Mock(
+            return_value={
+                "id": "1234567890",
+                "entity": "test_entity",
+            },
+        )
         yield
 
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from queue import Queue
 from typing import Callable, Dict, Generator, List
-from unittest import mock
 
 import pytest
 from hypothesis import settings
@@ -12,20 +11,6 @@ settings.register_profile(
     deadline=timedelta(seconds=1),
 )
 settings.load_profile("ci")
-
-
-@pytest.fixture(autouse=True)
-def make_wandb_login_verify_pass():
-    """Patch wandb.login() to bypass network operation to verify API keys.
-
-    Any API key that is in a valid format will be considered valid without
-    attempting a connection to the server.
-    """
-    with mock.patch(
-        "wandb.apis.internal.Api.validate_api_key",
-        return_value=True,
-    ):
-        yield
 
 
 # --------------------------------

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -14,10 +14,13 @@ settings.register_profile(
 settings.load_profile("ci")
 
 
-# This fixture is an autouse fixture to ensure that any wandb.login() calls
-# will be mocked to return a viewer server info response by default.
 @pytest.fixture(autouse=True)
-def mock_server_viewer_api_call():
+def make_wandb_login_verify_pass():
+    """Patch wandb.login() to bypass network operation to verify API keys.
+
+    Any API key that is in a valid format will be considered valid without
+    attempting a connection to the server.
+    """
     with mock.patch(
         "wandb.sdk.wandb_setup._WandbSetup.viewer",
     ) as mock_viewer:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from queue import Queue
 from typing import Callable, Dict, Generator, List
+from unittest import mock
 
 import pytest
 from hypothesis import settings
@@ -11,6 +12,18 @@ settings.register_profile(
     deadline=timedelta(seconds=1),
 )
 settings.load_profile("ci")
+
+
+@pytest.fixture(autouse=True)
+def mock_servier_viewer_api_call():
+    with mock.patch(
+        "wandb.sdk.internal.internal_api.Api.viewer_server_info",
+        return_value=(
+            {"viewer_server_info": {"id": "1234567890", "entity": "test_entity"}},
+            {},
+        ),
+    ):
+        yield
 
 
 # --------------------------------

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -22,14 +22,9 @@ def make_wandb_login_verify_pass():
     attempting a connection to the server.
     """
     with mock.patch(
-        "wandb.sdk.wandb_setup._WandbSetup.viewer",
-    ) as mock_viewer:
-        mock_viewer.__get__ = mock.Mock(
-            return_value={
-                "id": "1234567890",
-                "entity": "test_entity",
-            },
-        )
+        "wandb.apis.internal.Api.validate_api_key",
+        return_value=True,
+    ):
         yield
 
 

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -152,7 +152,11 @@ def test_login_sets_api_base_url(local_settings):
 
 
 def test_login_invalid_key():
-    with mock.patch.dict("os.environ", WANDB_API_KEY="X" * 40):
+    with mock.patch.dict("os.environ", WANDB_API_KEY="X" * 40), mock.patch(
+        "wandb.sdk.internal.internal_api.Api.viewer_server_info",
+        # Simulates the server did not respond with "viewer" in the response.
+        return_value=({}, {}),
+    ):
         wandb.ensure_configured()
         with pytest.raises(wandb.errors.AuthenticationError):
             wandb.login(verify=True)

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -153,12 +153,9 @@ def test_login_sets_api_base_url(local_settings):
 
 def test_login_invalid_key():
     with mock.patch.dict("os.environ", WANDB_API_KEY="X" * 40), mock.patch(
-        "wandb.sdk.wandb_setup._WandbSetup.viewer",
-    ) as mock_viewer:
-        # Simulates the server did not respond with "viewer" in the response.
-        # Which occurs when the API key is invalid.
-        mock_viewer.__get__ = mock.Mock(return_value={})
-
+        "wandb.apis.internal.Api.validate_api_key",
+        return_value=False,
+    ):
         wandb.ensure_configured()
         with pytest.raises(wandb.errors.AuthenticationError):
             wandb.login(verify=True)

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -153,10 +153,12 @@ def test_login_sets_api_base_url(local_settings):
 
 def test_login_invalid_key():
     with mock.patch.dict("os.environ", WANDB_API_KEY="X" * 40), mock.patch(
-        "wandb.sdk.internal.internal_api.Api.viewer_server_info",
+        "wandb.sdk.wandb_setup._WandbSetup.viewer",
+    ) as mock_viewer:
         # Simulates the server did not respond with "viewer" in the response.
-        return_value=({}, {}),
-    ):
+        # Which occurs when the API key is invalid.
+        mock_viewer.__get__ = mock.Mock(return_value={})
+
         wandb.ensure_configured()
         with pytest.raises(wandb.errors.AuthenticationError):
             wandb.login(verify=True)

--- a/tests/unit_tests/test_wandb_settings.py
+++ b/tests/unit_tests/test_wandb_settings.py
@@ -487,7 +487,6 @@ def test_setup_offline(test_settings):
     login_settings = test_settings().copy()
     login_settings.mode = "offline"
     assert wandb.setup(settings=login_settings)._get_entity() is None
-    assert wandb.setup(settings=login_settings)._load_viewer() is None
 
 
 def test_mutual_exclusion_of_branching_args():

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -63,6 +63,9 @@ class Api:
     def git(self):
         return self.api.git
 
+    def validate_api_key(self, key: str) -> bool:
+        return self.api.validate_api_key(key)
+
     def file_current(self, *args):
         return self.api.file_current(*args)
 

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -63,8 +63,8 @@ class Api:
     def git(self):
         return self.api.git
 
-    def validate_api_key(self, key: str) -> bool:
-        return self.api.validate_api_key(key)
+    def validate_api_key(self) -> bool:
+        return self.api.validate_api_key()
 
     def file_current(self, *args):
         return self.api.file_current(*args)

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -64,6 +64,7 @@ class Api:
         return self.api.git
 
     def validate_api_key(self) -> bool:
+        """Returns whether the API key stored on initialization is valid."""
         return self.api.validate_api_key()
 
     def file_current(self, *args):

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -222,7 +222,12 @@ def projects(entity, display=True):
     "--relogin", default=None, is_flag=True, help="Force relogin if already logged in."
 )
 @click.option("--anonymously", default=False, is_flag=True, help="Log in anonymously")
-@click.option("--verify", default=False, is_flag=True, help="Verify login credentials")
+@click.option(
+    "--verify/--no-verify",
+    default=False,
+    is_flag=True,
+    help="Skip verifification of login credentials",
+)
 @display_error
 def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):
     # TODO: move CLI to wandb-core backend

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -226,7 +226,7 @@ def projects(entity, display=True):
     "--verify/--no-verify",
     default=False,
     is_flag=True,
-    help="Skip verifification of login credentials",
+    help="Verify login credentials",
 )
 @display_error
 def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -403,7 +403,7 @@ class Api:
                 wandb.termerror(f"Error while calling W&B API: {error} ({response})")
             raise
 
-    def validate_api_key(self, key: str) -> bool:
+    def validate_api_key(self) -> bool:
         res = self.execute(gql("query { viewer { id } }"))
         return res["viewer"] is not None
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -243,6 +243,7 @@ class Api:
         ),
         environ: MutableMapping = os.environ,
         retry_callback: Optional[Callable[[int, str], Any]] = None,
+        api_key: Optional[str] = None,
     ) -> None:
         self._environ = environ
         self._global_context = context.Context()
@@ -284,7 +285,9 @@ class Api:
         self._extra_http_headers.update(_thread_local_api_settings.headers or {})
 
         auth = None
-        if self.access_token is not None:
+        if api_key:
+            auth = ("api", api_key)
+        elif self.access_token is not None:
             self._extra_http_headers["Authorization"] = f"Bearer {self.access_token}"
         elif _thread_local_api_settings.cookies is None:
             auth = ("api", self.api_key or "")
@@ -399,6 +402,10 @@ class Api:
             for error in parse_backend_error_messages(response):
                 wandb.termerror(f"Error while calling W&B API: {error} ({response})")
             raise
+
+    def validate_api_key(self, key: str) -> bool:
+        res = self.execute(gql("query { viewer { id } }"))
+        return res["viewer"] is not None
 
     def set_current_run_id(self, run_id: str) -> None:
         self._current_run_id = run_id

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -406,7 +406,7 @@ class Api:
     def validate_api_key(self) -> bool:
         """Returns whether the API key stored on initialization is valid."""
         res = self.execute(gql("query { viewer { id } }"))
-        return res["viewer"] is not None
+        return res is not None and res["viewer"] is not None
 
     def set_current_run_id(self, run_id: str) -> None:
         self._current_run_id = run_id

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -404,6 +404,7 @@ class Api:
             raise
 
     def validate_api_key(self) -> bool:
+        """Returns whether the API key stored on initialization is valid."""
         res = self.execute(gql("query { viewer { id } }"))
         return res["viewer"] is not None
 

--- a/wandb/sdk/lib/server.py
+++ b/wandb/sdk/lib/server.py
@@ -25,6 +25,7 @@ class Server:
     def query_with_timeout(self, timeout: int | float = 5) -> None:
         if self._settings.x_disable_viewer:
             return
+
         async_viewer = util.async_call(self._api.viewer_server_info, timeout=timeout)
         try:
             viewer_tuple, viewer_thread = async_viewer()
@@ -36,3 +37,10 @@ class Server:
         # TODO(jhr): should we kill the thread?
         self._viewer, self._serverinfo = viewer_tuple
         self._flags = json.loads(self._viewer.get("flags", "{}"))
+
+    @property
+    def viewer(self) -> dict[str, Any]:
+        if not self._viewer and not self._settings._offline:
+            self.query_with_timeout()
+
+        return self._viewer

--- a/wandb/sdk/lib/server.py
+++ b/wandb/sdk/lib/server.py
@@ -45,7 +45,7 @@ class Server:
 
         The viewer contains information about the currently authenticated user, including:
         see the GraphQL viewer query defined here:
-        https://github.com/wandb/wandb/blob/main/wandb/sdk/internal/internal_api.py#L948-L966
+        https://github.com/wandb/wandb/blob/230213f8bb6c9ad0c9736e82b00a23e84e73cfae/wandb/sdk/internal/internal_api.py#L948-L966
 
         Returns:
             dict: The viewer information dictionary, or empty dict if unavailable

--- a/wandb/sdk/lib/server.py
+++ b/wandb/sdk/lib/server.py
@@ -40,15 +40,17 @@ class Server:
 
     @property
     def viewer(self) -> dict[str, Any]:
-        """
-        Returns the viewer information queried from the backend `viewer` GraphQL API.
+        """Returns information about the currently authenticated user.
 
-        The viewer contains information about the currently authenticated user, including:
-        see the GraphQL viewer query defined here:
-        https://github.com/wandb/wandb/blob/230213f8bb6c9ad0c9736e82b00a23e84e73cfae/wandb/sdk/internal/internal_api.py#L948-L966
+        If the API key is valid, the following is returned:
+        - id
+        - entity
+        - username
+        - flags
+        - teams
 
-        Returns:
-            dict: The viewer information dictionary, or empty dict if unavailable
+        If the API key is not valid or the server is not reachable,
+        an empty dict is returned.
         """
         if not self._viewer and not self._settings._offline:
             self.query_with_timeout()

--- a/wandb/sdk/lib/server.py
+++ b/wandb/sdk/lib/server.py
@@ -40,6 +40,16 @@ class Server:
 
     @property
     def viewer(self) -> dict[str, Any]:
+        """
+        Returns the viewer information queried from the backend `viewer` GraphQL API.
+
+        The viewer contains information about the currently authenticated user, including:
+        see the GraphQL viewer query defined here:
+        https://github.com/wandb/wandb/blob/main/wandb/sdk/internal/internal_api.py#L948-L966
+
+        Returns:
+            dict: The viewer information dictionary, or empty dict if unavailable
+        """
         if not self._viewer and not self._settings._offline:
             self.query_with_timeout()
 

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -268,7 +268,7 @@ class _WandbLogin:
 
 def _verify_login(key: str) -> bool:
     api = InternalApi(api_key=key)
-    is_api_key_valid = api.validate_api_key(key)
+    is_api_key_valid = api.validate_api_key()
 
     if not is_api_key_valid:
         raise AuthenticationError(

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -317,7 +317,7 @@ def _login(
         timeout=timeout,
     )
 
-    if wlogin._settings._offline:
+    if wlogin._settings._offline and not wlogin._settings.x_cli_only_mode:
         wandb.termwarn("Unable to verify login in offline mode.")
         return False
     elif wandb.util._is_kaggle() and not wandb.util._has_internet():

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -267,19 +267,18 @@ class _WandbLogin:
         return key
 
 
-def _verify_login(key: str) -> bool:
+def _verify_login(key: str) -> None:
     api = InternalApi(api_key=key)
 
     try:
         is_api_key_valid = api.validate_api_key()
+
+        if not is_api_key_valid:
+            raise AuthenticationError(
+                "API key verification failed. Make sure your API key is valid."
+            )
     except ConnectionError:
         raise AuthenticationError("Unable to connect to server to verify API token.")
-
-    if not is_api_key_valid:
-        raise AuthenticationError(
-            "API key verification failed. Make sure your API key is valid."
-        )
-    return True
 
 
 def _login(
@@ -295,7 +294,7 @@ def _login(
     _silent: Optional[bool] = None,
     _disable_warning: Optional[bool] = None,
     _entity: Optional[str] = None,
-):
+) -> bool:
     if wandb.run is not None:
         if not _disable_warning:
             wandb.termwarn("Calling wandb.login() after wandb.init() has no effect.")
@@ -351,4 +350,4 @@ def _login(
     if verify:
         _verify_login(key)
 
-    return wlogin._key or False
+    return True if key else False

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -8,6 +8,7 @@ import os
 from typing import Literal, Optional, Tuple
 
 import click
+from requests.exceptions import ConnectionError
 
 import wandb
 from wandb.errors import AuthenticationError, UsageError
@@ -268,7 +269,11 @@ class _WandbLogin:
 
 def _verify_login(key: str) -> bool:
     api = InternalApi(api_key=key)
-    is_api_key_valid = api.validate_api_key()
+
+    try:
+        is_api_key_valid = api.validate_api_key()
+    except ConnectionError:
+        raise AuthenticationError("Unable to connect to server to verify API token.")
 
     if not is_api_key_valid:
         raise AuthenticationError(

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -279,6 +279,8 @@ def _verify_login(key: str) -> None:
             )
     except ConnectionError:
         raise AuthenticationError("Unable to connect to server to verify API token.")
+    except Exception:
+        raise AuthenticationError("An error occurred while verifying the API key.")
 
 
 def _login(

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -177,42 +177,30 @@ class _WandbSetup:
     def _get_entity(self) -> str | None:
         if self._settings and self._settings._offline:
             return None
-        if self._server is None:
-            self._load_viewer()
-        assert self._server is not None
-        entity = self._server._viewer.get("entity")
+        entity = self.viewer.get("entity")
         return entity
 
     def _get_username(self) -> str | None:
         if self._settings and self._settings._offline:
             return None
-        if self._server is None:
-            self._load_viewer()
-        assert self._server is not None
-        return self._server._viewer.get("username")
+        return self.viewer.get("username")
 
     def _get_teams(self) -> list[str]:
         if self._settings and self._settings._offline:
             return []
-        if self._server is None:
-            self._load_viewer()
-        assert self._server is not None
-        teams = self._server._viewer.get("teams")
+        teams = self.viewer.get("teams")
         if teams:
             teams = [team["node"]["name"] for team in teams["edges"]]
         return teams or []
 
-    def _load_viewer(self) -> None:
-        if self._settings and self._settings._offline:
-            return
-        s = server.Server(settings=self._settings)
-        s.query_with_timeout()
-        self._server = s
+    @property
+    def viewer(self) -> dict[str, Any]:
+        if self._server is None:
+            self._server = server.Server(settings=self._settings)
+
+        return self._server.viewer
 
     def _load_user_settings(self) -> dict[str, Any] | None:
-        if self._server is None:
-            self._load_viewer()
-
         # offline?
         if self._server is None:
             return None
@@ -222,7 +210,7 @@ class _WandbSetup:
         if "code_saving_enabled" in flags:
             user_settings["save_code"] = flags["code_saving_enabled"]
 
-        email = self._server._viewer.get("email", None)
+        email = self.viewer.get("email", None)
         if email:
             user_settings["email"] = email
 

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -279,12 +279,6 @@ class _WandbSetup:
 
         return self._connection
 
-    def verify_api_key(self, key: str) -> bool:
-        self._settings.api_key = key
-        self._server = server.Server(settings=self._settings)
-
-        return self._server._api.validate_api_key(key)
-
 
 _singleton: _WandbSetup | None = None
 """The W&B library singleton, or None if not yet set up.

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -279,6 +279,12 @@ class _WandbSetup:
 
         return self._connection
 
+    def verify_api_key(self, key: str) -> bool:
+        self._settings.api_key = key
+        self._server = server.Server(settings=self._settings)
+
+        return self._server._api.validate_api_key(key)
+
 
 _singleton: _WandbSetup | None = None
 """The W&B library singleton, or None if not yet set up.


### PR DESCRIPTION
Description
-----------

What does the PR do? Include a concise description of the PR contents.

This change moves the login API key verification from `wandb_login.py::login()` to `wandb_login.py#_WandbLogin::_login` since this function is used by the previous function as well as directly by `wandb.init()`. Providing a common place path to validating API keys.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


