### PR TITLE
refactor: move Settings.handle_resume_logic into wandb_init.py

### DIFF
--- a/tests/system_tests/test_core/test_resume_auto.py
+++ b/tests/system_tests/test_core/test_resume_auto.py
@@ -30,7 +30,7 @@ def test_autoresume_second_run_loads():
     assert json.loads(resume_path.read_text()) == {"run_id": run1.id}
 
 
-def test_explicit_id_overrides_autoresume():
+def test_explicit_id_overrides_autoresume(mock_wandb_log):
     with pytest.raises(AutoResumeTestError):
         with wandb.init(mode="offline", resume="auto", id="auto-id"):
             raise AutoResumeTestError()
@@ -38,3 +38,7 @@ def test_explicit_id_overrides_autoresume():
         pass
 
     assert run2.id == "explicit"
+    assert mock_wandb_log.warned(
+        "Ignoring ID auto-id loaded due to resume='auto'"
+        " because the run ID is set to explicit."
+    )

--- a/tests/system_tests/test_core/test_resume_auto.py
+++ b/tests/system_tests/test_core/test_resume_auto.py
@@ -42,3 +42,27 @@ def test_explicit_id_overrides_autoresume(mock_wandb_log):
         "Ignoring ID auto-id loaded due to resume='auto'"
         " because the run ID is set to explicit."
     )
+
+
+def test_autoresume_bad_format():
+    with pytest.raises(AutoResumeTestError):
+        with wandb.init(mode="offline", resume="auto") as run1:
+            raise AutoResumeTestError()
+    pathlib.Path(run1.settings.resume_fname).write_text("not JSON")
+
+    with wandb.init(mode="offline", resume="auto") as run2:
+        pass
+
+    assert run2.id != run1.id
+
+
+def test_autoresume_no_id():
+    with pytest.raises(AutoResumeTestError):
+        with wandb.init(mode="offline", resume="auto") as run1:
+            raise AutoResumeTestError()
+    pathlib.Path(run1.settings.resume_fname).write_text(r"{}")
+
+    with wandb.init(mode="offline", resume="auto") as run2:
+        pass
+
+    assert run2.id != run1.id

--- a/tests/system_tests/test_core/test_resume_auto.py
+++ b/tests/system_tests/test_core/test_resume_auto.py
@@ -1,0 +1,40 @@
+import json
+import pathlib
+
+import pytest
+import wandb
+
+
+class AutoResumeTestError(Exception):
+    """Raised in auto-resume tests to leave behind an auto-resume file."""
+
+
+def test_autoresume_first_run_saves():
+    with pytest.raises(AutoResumeTestError):
+        with wandb.init(mode="offline", resume="auto") as run:
+            raise AutoResumeTestError()
+
+    resume_path = pathlib.Path(run.settings.resume_fname)
+    assert json.loads(resume_path.read_text()) == {"run_id": run.id}
+
+
+def test_autoresume_second_run_loads():
+    with pytest.raises(AutoResumeTestError):
+        with wandb.init(mode="offline", resume="auto") as run1:
+            raise AutoResumeTestError()
+    with pytest.raises(AutoResumeTestError):
+        with wandb.init(mode="offline", resume="auto") as run2:
+            raise AutoResumeTestError()
+
+    resume_path = pathlib.Path(run2.settings.resume_fname)
+    assert json.loads(resume_path.read_text()) == {"run_id": run1.id}
+
+
+def test_explicit_id_overrides_autoresume():
+    with pytest.raises(AutoResumeTestError):
+        with wandb.init(mode="offline", resume="auto", id="auto-id"):
+            raise AutoResumeTestError()
+    with wandb.init(mode="offline", resume="auto", id="explicit") as run2:
+        pass
+
+    assert run2.id == "explicit"

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1153,29 +1153,6 @@ class Settings(BaseModel, validate_assignment=True):
 
         return settings_proto
 
-    def handle_resume_logic(self):
-        """Handle logic for resuming runs."""
-        # handle auto resume logic
-        if self.resume == "auto":
-            if os.path.exists(self.resume_fname):
-                with open(self.resume_fname) as f:
-                    resume_run_id = json.load(f)["run_id"]
-                if self.run_id is None:
-                    self.run_id = resume_run_id
-                elif self.run_id != resume_run_id:
-                    wandb.termwarn(
-                        "Tried to auto resume run with "
-                        f"id {resume_run_id} but id {self.run_id} is set.",
-                    )
-        if self.run_id is None:
-            self.run_id = generate_id()
-
-        # persist run_id in case of failure
-        if self.resume == "auto" and self.resume_fname is not None:
-            filesystem.mkdir_exists_ok(self.wandb_dir)
-            with open(self.resume_fname, "w") as f:
-                f.write(json.dumps({"run_id": self.run_id}))
-
     @staticmethod
     def validate_url(url: str) -> None:
         """Validate a URL string."""

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -37,10 +37,9 @@ from wandb import env, termwarn, util
 from wandb.errors import UsageError
 from wandb.proto import wandb_settings_pb2
 
-from .lib import apikey, credentials, filesystem, ipython
+from .lib import apikey, credentials, ipython
 from .lib.gitlib import GitRepo
 from .lib.run_moment import RunMoment
-from .lib.runid import generate_id
 
 
 def _path_convert(*args: str) -> str:


### PR DESCRIPTION
Moves "resume logic" to where it's used and documents it.

I use offline mode in the tests to speed them up, but unfortunately `wandb.init()` still takes a while even in this case (especially with `legacy-service`).