### PR TITLE
feat: change default login behavior for wandb login to verify API key

### DIFF
--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -449,7 +449,7 @@ def login(
     host: Optional[str] = None,
     force: Optional[bool] = None,
     timeout: Optional[int] = None,
-    verify: bool = False,
+    verify: bool = True,
 ) -> bool:
     """Set up W&B login credentials.
 

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -166,7 +166,7 @@ def login(
     host: Optional[str] = None,
     force: Optional[bool] = None,
     timeout: Optional[int] = None,
-    verify: bool = False,
+    verify: bool = True,
 ) -> bool:
     """<sdk/wandb_login.py::login>"""
     ...

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -224,7 +224,7 @@ def projects(entity, display=True):
 @click.option("--anonymously", default=False, is_flag=True, help="Log in anonymously")
 @click.option(
     "--verify/--no-verify",
-    default=False,
+    default=True,
     is_flag=True,
     help="Skip verifification of login credentials",
 )

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -44,7 +44,7 @@ def login(
     host: Optional[str] = None,
     force: Optional[bool] = None,
     timeout: Optional[int] = None,
-    verify: bool = False,
+    verify: bool = True,
 ) -> bool:
     """Set up W&B login credentials.
 
@@ -297,7 +297,7 @@ def _login(
     host: Optional[str] = None,
     force: Optional[bool] = None,
     timeout: Optional[int] = None,
-    verify: bool = False,
+    verify: bool = True,
     _backend=None,
     _silent: Optional[bool] = None,
     _disable_warning: Optional[bool] = None,


### PR DESCRIPTION
Description
-----------

What does the PR do? Include a concise description of the PR contents.

This change alters the default behavior for `wandb login` and `wandb.login(...)` to validate the users API key unless explicitly disabled with `wandb login --no-verify` or `wandb.login(verify=False)`.

The motivation behind this change is to provide feedback to users that the provided API key is invalid sooner in the login flow. As well as provide a clearer error message when a login key is invalid during the initialization of a run.

Previously if an API key was invalid then a user would get the following error when doing `wandb.init()`
```
ERROR failed to upsert bucket: returned error 401 Unauthorized: {"errors":[{"message":"user is not logged in","path":["upsertBucket"],"extensions":{"code":"PERMISSION_ERROR"}}],"data":{"upsertBucket":null}}
```
which is unclear that the API key could be invalid.

Now if an api key is invalid a user will see the following
```
wandb.errors.errors.AuthenticationError: API key verification failed. Make sure your API key is valid.
```


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->