### PR TITLE
fix(sdk): remove client_id key from shared mode

### DIFF
--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -1061,7 +1061,7 @@ func (h *Handler) flushPartialHistory(useStep bool, nextStep int64) {
 		h.runTimer.Elapsed().Seconds(),
 	)
 
-	if useStep {
+	if !h.settings.IsSharedMode() && useStep {
 		h.partialHistory.SetInt(
 			pathtree.PathOf("_step"),
 			h.partialHistoryStep,

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -1061,17 +1061,7 @@ func (h *Handler) flushPartialHistory(useStep bool, nextStep int64) {
 		h.runTimer.Elapsed().Seconds(),
 	)
 
-	// When running in "shared" mode, there can be multiple writers to the same
-	// run (for example running on different machines). In that case, the
-	// backend determines the step, and the client ID identifies which metrics
-	// came from the same writer. Otherwise, we must set the step explicitly.
-	if h.settings.IsSharedMode() {
-		// TODO: useStep must be false here
-		h.partialHistory.SetString(
-			pathtree.PathOf("_client_id"),
-			h.clientID,
-		)
-	} else if useStep {
+	if useStep {
 		h.partialHistory.SetInt(
 			pathtree.PathOf("_step"),
 			h.partialHistoryStep,


### PR DESCRIPTION
Description
-----------

Removes logging of `_client_id` when the user is using shared mode. This appears as an empty chart in the UI which is confusing. We may want to differentiate between different shared mode clients in the future, but we will probably put this in the header or as a config rather than as a history metric. 

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
How was this PR tested?

Built locally and tested in QA.