### PR TITLE
chore: add protobuf version constraint to requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -29,6 +29,7 @@ ipython<8.13; python_version < '3.9'
 ipykernel
 nbclient
 
+
 tensorflow~=2.18.0; python_version >= '3.9'
 
 tensorflow==2.13.1; python_version < '3.9' and sys_platform != 'darwin'
@@ -40,7 +41,6 @@ protobuf==3.20.3; python_version < '3.9' and sys_platform != 'darwin'
 # puts an upper bound on typing_extensions, conflicting with another package.
 tensorflow-macos==2.9.2; python_version < '3.9' and sys_platform == 'darwin'
 protobuf==3.19.6; python_version < '3.9' and sys_platform == 'darwin'
-
 
 
 scikit-learn

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -29,13 +29,16 @@ ipython<8.13; python_version < '3.9'
 ipykernel
 nbclient
 
-tensorflow~=2.18; python_version >= '3.12'
-tensorflow~=2.13; python_version < '3.12' and sys_platform != 'darwin'
-tensorflow-macos~=2.9; python_version < '3.12' and sys_platform == 'darwin' and platform.machine == 'arm64'
+tensorflow~=2.18.0; python_version >= '3.9'
+
+# tensorflow-macos==2.13.1 (required by tensorflow==2.13.1)
+# puts an upper bound on typing_extensions, conflicting with another package.
+tensorflow==2.13.1; python_version < '3.9' and sys_platform != 'darwin'
+tensorflow-macos==2.9.2; python_version < '3.9' and sys_platform == 'darwin'
 
 # This is a transitive dependency of `tensorflow` via `tensorboard`
 # which fails to specify an upper bound causing import errors.
-protobuf~=3.20; python_version < '3.12'
+protobuf==3.19.6; python_version < '3.9'
 
 scikit-learn
 torch

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -32,14 +32,13 @@ nbclient
 
 tensorflow~=2.18.0; python_version >= '3.9'
 
-tensorflow==2.13.1; python_version < '3.9' and sys_platform != 'darwin'
+tensorflow==2.9.2; python_version < '3.9' and sys_platform != 'darwin'
+# tensorflow==2.9.2 does not provide arm64 wheels for macOS.
+# This was fixed in later versions of tensorflow.
+tensorflow-macos==2.9.2; python_version < '3.9' and sys_platform == 'darwin'
+
 # This is a transitive dependency of `tensorflow` via `tensorboard`
 # which fails to specify an upper bound causing import errors.
-protobuf==3.20.3; python_version < '3.9' and sys_platform != 'darwin'
-
-# tensorflow-macos==2.13.1 (required by tensorflow==2.13.1)
-# puts an upper bound on typing_extensions, conflicting with another package.
-tensorflow-macos==2.9.2; python_version < '3.9' and sys_platform == 'darwin'
 protobuf==3.19.6; python_version < '3.9' and sys_platform == 'darwin'
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -29,10 +29,15 @@ ipython<8.13; python_version < '3.9'
 ipykernel
 nbclient
 
+tensorflow~=2.18; python_version >= '3.12'
+tensorflow~=2.13; python_version < '3.12' and sys_platform != 'darwin'
+tensorflow-macos~=2.9; python_version < '3.12' and sys_platform == 'darwin' and platform.machine == 'arm64'
+
+# This is a transitive dependency of `tensorflow` via `tensorboard`
+# which fails to specify an upper bound causing import errors.
+protobuf~=3.20; python_version < '3.12'
+
 scikit-learn
-tensorboard
-tensorflow; python_version > '3.8'
-tensorflow-macos; python_version < '3.11' and sys_platform == 'darwin' and platform.machine == 'arm64'
 torch
 torchvision
 jax[cpu]


### PR DESCRIPTION
Cleans up the `tensorflow` dependencies and fixes an issue in the resolved Python 3.8 dependencies where `tensorboard` breaks because of a `protobuf` that's too new.

See https://github.com/wandb/wandb/pull/8679 for the reasoning behind using stricter version constraints in this file.

There are multiple valid choices for the versions. I picked `tensorflow==2.9.2` and `tensorflow-macos==2.9.2` because they have the same `protobuf` constraint, leading to the simplest requirements specification.