### PR TITLE
refactor: record 'offline' telemetry near other telemetry

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -11,6 +11,7 @@ For more on using `wandb.init()`, including code snippets, check out our
 from __future__ import annotations
 
 import copy
+import dataclasses
 import json
 import logging
 import os
@@ -105,6 +106,25 @@ def _handle_launch_config(settings: Settings) -> dict[str, Any]:
     return launch_run_config
 
 
+@dataclasses.dataclass(frozen=True)
+class _ConfigParts:
+    base_no_artifacts: dict[str, Any]
+    """The run config passed to `init()` minus any artifact-valued keys."""
+
+    sweep_no_artifacts: dict[str, Any]
+    """The config loaded as part of a sweep minus any artifact-valued keys."""
+
+    launch_no_artifacts: dict[str, Any]
+    """The config loaded as part of Launch minus any artifact-valued keys."""
+
+    artifacts: dict[str, Any]
+    """Artifact keys removed from config dictionaries.
+
+    Due to implementation details of how a Run is constructed,
+    artifacts must be inserted into its config after initialization.
+    """
+
+
 class _WandbInit:
     def __init__(
         self,
@@ -120,9 +140,6 @@ class _WandbInit:
         """
 
         self.kwargs = None
-        self.sweep_config: dict[str, Any] = {}
-        self.launch_config: dict[str, Any] = {}
-        self.config: dict[str, Any] = {}
         self.run: Run | None = None
         self.backend: Backend | None = None
 
@@ -235,7 +252,7 @@ class _WandbInit:
             warn("run_id", init_settings.run_id)
             init_settings.run_id = None
 
-    def compute_run_settings(self, init_settings: Settings) -> Settings:
+    def make_run_settings(self, init_settings: Settings) -> Settings:
         """Returns the run's settings.
 
         Args:
@@ -360,14 +377,24 @@ class _WandbInit:
                 run_id=settings.run_id,
             )
 
-    def setup(
+    def make_run_config(
         self,
         settings: Settings,
         config: dict | str | None = None,
         config_exclude_keys: list[str] | None = None,
         config_include_keys: list[str] | None = None,
-    ) -> None:
-        """Compute the run's config and some telemetry."""
+    ) -> _ConfigParts:
+        """Construct the run's config.
+
+        Args:
+            settings: The run's finalized settings.
+            config: The config passed to `init()`.
+            config_exclude_keys: Deprecated. Keys to filter out from `config`.
+            config_include_keys: Deprecated. Keys to include from `config`.
+
+        Returns:
+            Initial values for the run's config.
+        """
         # TODO: remove this once officially deprecated
         if config_exclude_keys:
             self.deprecated_features_used["config_exclude_keys"] = (
@@ -383,29 +410,51 @@ class _WandbInit:
             exclude=config_exclude_keys,
         )
 
-        # Construct the run's config.
-        self.config = dict()
-        self.init_artifact_config: dict[str, Any] = dict()
+        result = _ConfigParts(
+            base_no_artifacts=dict(),
+            sweep_no_artifacts=dict(),
+            launch_no_artifacts=dict(),
+            artifacts=dict(),
+        )
 
         if not settings.sagemaker_disable and sagemaker.is_using_sagemaker():
             sagemaker_config = sagemaker.parse_sm_config()
-            self._split_artifacts_from_config(sagemaker_config, self.config)
+            self._split_artifacts_from_config(
+                sagemaker_config,
+                config_target=result.base_no_artifacts,
+                artifacts=result.artifacts,
+            )
             self._telemetry.feature.sagemaker = True
 
         if self._wl._config:
-            self._split_artifacts_from_config(self._wl._config, self.config)
+            self._split_artifacts_from_config(
+                self._wl._config,
+                config_target=result.base_no_artifacts,
+                artifacts=result.artifacts,
+            )
 
         if config and isinstance(config, dict):
-            self._split_artifacts_from_config(config, self.config)
+            self._split_artifacts_from_config(
+                config,
+                config_target=result.base_no_artifacts,
+                artifacts=result.artifacts,
+            )
 
-        self.sweep_config = dict()
-        sweep_config = self._wl._sweep_config or dict()
-        if sweep_config:
-            self._split_artifacts_from_config(sweep_config, self.sweep_config)
+        if self._wl._sweep_config:
+            self._split_artifacts_from_config(
+                self._wl._sweep_config,
+                config_target=result.sweep_no_artifacts,
+                artifacts=result.artifacts,
+            )
 
-        launch_config = _handle_launch_config(settings)
-        if launch_config:
-            self._split_artifacts_from_config(launch_config, self.launch_config)
+        if launch_config := _handle_launch_config(settings):
+            self._split_artifacts_from_config(
+                launch_config,
+                config_target=result.launch_no_artifacts,
+                artifacts=result.artifacts,
+            )
+
+        return result
 
     def teardown(self) -> None:
         # TODO: currently this is only called on failed wandb.init attempts
@@ -415,11 +464,14 @@ class _WandbInit:
             hook.call()
 
     def _split_artifacts_from_config(
-        self, config_source: dict, config_target: dict
+        self,
+        config_source: dict,
+        config_target: dict,
+        artifacts: dict,
     ) -> None:
         for k, v in config_source.items():
             if _is_artifact_representation(v):
-                self.init_artifact_config[k] = v
+                artifacts[k] = v
             else:
                 config_target.setdefault(k, v)
 
@@ -572,7 +624,7 @@ class _WandbInit:
         self._logger.info(f"Logging user logs to {settings.log_user}")
         self._logger.info(f"Logging internal logs to {settings.log_internal}")
 
-    def _make_run_disabled(self) -> Run:
+    def _make_run_disabled(self, config: _ConfigParts) -> Run:
         """Returns a Run-like object where all methods are no-ops.
 
         This method is used when wandb.init(mode="disabled") is called or WANDB_MODE=disabled
@@ -598,8 +650,8 @@ class _WandbInit:
         )
         # config, summary, and metadata objects
         drun._config = wandb.sdk.wandb_config.Config()
-        drun._config.update(self.sweep_config)
-        drun._config.update(self.config)
+        drun._config.update(config.sweep_no_artifacts)
+        drun._config.update(config.base_no_artifacts)
         drun.summary = SummaryDisabled()  # type: ignore
         drun._Run__metadata = wandb.sdk.wandb_metadata.Metadata()
 
@@ -684,18 +736,19 @@ class _WandbInit:
         percent_done = handle.percent_done
         self.printer.progress_update(line, percent_done=percent_done)
 
-    def init(self, settings: Settings) -> Run:  # noqa: C901
+    def init(self, settings: Settings, config: _ConfigParts) -> Run:  # noqa: C901
         self._logger.info("calling init triggers")
         trigger.call("on_init")
 
         assert self._wl is not None
 
         self._logger.info(
-            f"wandb.init called with sweep_config: {self.sweep_config}\nconfig: {self.config}"
+            f"wandb.init called with sweep_config: {config.sweep_no_artifacts}"
+            f"\nconfig: {config.base_no_artifacts}"
         )
 
         if settings._noop:
-            return self._make_run_disabled()
+            return self._make_run_disabled(config)
         if (
             settings.reinit or (settings._jupyter and settings.reinit is not False)
         ) and len(self._wl._global_run_stack) > 0:
@@ -742,10 +795,10 @@ class _WandbInit:
 
         # resuming needs access to the server, check server_status()?
         run = Run(
-            config=self.config,
+            config=config.base_no_artifacts,
             settings=settings,
-            sweep_config=self.sweep_config,
-            launch_config=self.launch_config,
+            sweep_config=config.sweep_no_artifacts,
+            launch_config=config.launch_no_artifacts,
         )
 
         # Populate initial telemetry
@@ -947,7 +1000,7 @@ class _WandbInit:
         # put artifacts in run config here
         # since doing so earlier will cause an error
         # as the run is not upserted
-        for k, v in self.init_artifact_config.items():
+        for k, v in config.artifacts.items():
             run.config.update({k: v}, allow_val_change=True)
         job_artifact = run._launch_artifact_mapping.get(
             wandb.util.LAUNCH_JOB_ARTIFACT_SLOT_NAME
@@ -1356,7 +1409,7 @@ def init(  # noqa: C901
         wi = _WandbInit(wl, init_telemetry)
 
         wi.maybe_login(init_settings)
-        run_settings = wi.compute_run_settings(init_settings)
+        run_settings = wi.make_run_settings(init_settings)
 
         if run_settings.run_id is not None:
             init_telemetry.feature.set_init_id = True
@@ -1383,14 +1436,14 @@ def init(  # noqa: C901
             _monkeypatch_tensorboard()
             init_telemetry.feature.tensorboard_sync = True
 
-        wi.setup(
+        run_config = wi.make_run_config(
             settings=run_settings,
             config=config,
             config_exclude_keys=config_exclude_keys,
             config_include_keys=config_include_keys,
         )
 
-        return wi.init(run_settings)
+        return wi.init(run_settings, run_config)
 
     except KeyboardInterrupt as e:
         if wl:


### PR DESCRIPTION
Collect telemetry on whether the run is offline immediately after inferring its settings.

NOTE: The original code, at first glance, looks like it could emit a telemetry record: `telemetry.context()` with a Run runs its `_telemetry_callback` which calls `_telemetry_flush`. It only doesn't emit a record because of the `_telemetry_obj_active` field which happens to be `False` at that time: it is set to `True` in `Run._on_ready` called from `Run._on_start` called at the end of `_WandbInit.init()`. The new code is straightforwardly correct without this analysis.