### PR TITLE
refactor: delete unused Run._iface_port and _iface_pid fields

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -10,7 +10,6 @@ InterfaceRelay: Responses are routed to a relay queue (not matching uuids)
 
 import gzip
 import logging
-import os
 import time
 from abc import abstractmethod
 from pathlib import Path

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1416,7 +1416,7 @@ def init(  # noqa: C901
             init_telemetry.feature.set_init_id = True
         if run_settings.run_name is not None:
             init_telemetry.feature.set_init_name = True
-        if init_settings.run_tags is not None:
+        if run_settings.run_tags is not None:
             init_telemetry.feature.set_init_tags = True
 
         wi.set_run_id(run_settings)


### PR DESCRIPTION
Delete unused fields.

`_iface_port` and `_set_iface_port()` were completely unused. `_iface_pid` was also unused; `_set_iface_pid()`, however, was called from a `_hack_set_run()` method. Removing these fields brings us closer to deleting `_hack_set_run()`.