### PR TITLE
chore: make tools/inpect_tool.py stanalone/executable with uv

### DIFF
--- a/tools/inspect_tool.py
+++ b/tools/inspect_tool.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#   "fire",
+#   "wandb",
+# ]
+# ///
+
 import fire
 import wandb
 from wandb.proto import wandb_internal_pb2


### PR DESCRIPTION
Description
-----------
Adds [Inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata) for `tools/inspect_tool.py` to make it standalone / executable with `uv`:

```shell
uv run tools/inspect_tool.py
```
