### PR TITLE
fix: handle non-consecutive TPU device IDs in system monitor

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,3 +16,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Fix incorrectly reported device counts and duty cycle measurements for TPUs with single devices per chip / multiple devices on the host and make TPU metrics sampling more robust (@dmitryduev in https://github.com/wandb/wandb/pull/9266)
+- Handle non-consecutive TPU device IDs in system monitor (@dmitryduev in https://github.com/wandb/wandb/pull/9276)

--- a/core/pkg/monitor/tpu_test.go
+++ b/core/pkg/monitor/tpu_test.go
@@ -30,7 +30,7 @@ func (m *mockRuntimeMetricServiceClient) GetRuntimeMetric(ctx context.Context, i
 }
 
 // Helper function to create a metric with given device ID and value
-func createMetric(deviceID int64, value interface{}) *tpuproto.Metric {
+func createMetric(deviceID int64, value any) *tpuproto.Metric {
 	metric := &tpuproto.Metric{
 		Attribute: &tpuproto.Attribute{
 			Value: &tpuproto.AttrValue{
@@ -55,7 +55,7 @@ func createMetric(deviceID int64, value interface{}) *tpuproto.Metric {
 }
 
 // Helper function to compare numeric values regardless of their exact type
-func compareNumeric(t *testing.T, name string, got, want interface{}) {
+func compareNumeric(t *testing.T, name string, got, want any) {
 	switch gotVal := got.(type) {
 	case int64:
 		if wantVal, ok := want.(float64); ok {
@@ -93,7 +93,7 @@ func TestTPUSingleDeviceComplete(t *testing.T) {
 		t.Fatalf("Sample() error = %v", err)
 	}
 
-	metrics := make(map[string]interface{})
+	metrics := make(map[string]any)
 	for _, item := range data.Item {
 		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
 	}
@@ -140,7 +140,7 @@ func TestTPUV2MultiDevice(t *testing.T) {
 		t.Fatalf("Sample() error = %v", err)
 	}
 
-	metrics := make(map[string]interface{})
+	metrics := make(map[string]any)
 	for _, item := range data.Item {
 		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
 	}
@@ -191,7 +191,7 @@ func TestTPUPartialMetrics(t *testing.T) {
 		t.Fatalf("Sample() error = %v", err)
 	}
 
-	metrics := make(map[string]interface{})
+	metrics := make(map[string]any)
 	for _, item := range data.Item {
 		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
 	}
@@ -248,7 +248,7 @@ func TestTPUNonSequentialDeviceIDs(t *testing.T) {
 		t.Fatalf("Sample() error = %v", err)
 	}
 
-	metrics := make(map[string]interface{})
+	metrics := make(map[string]any)
 	for _, item := range data.Item {
 		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
 	}

--- a/core/pkg/monitor/tpu_test.go
+++ b/core/pkg/monitor/tpu_test.go
@@ -29,62 +29,103 @@ func (m *mockRuntimeMetricServiceClient) GetRuntimeMetric(ctx context.Context, i
 	}, nil
 }
 
-func TestTPUSample(t *testing.T) {
+// Helper function to create a metric with given device ID and value
+func createMetric(deviceID int64, value interface{}) *tpuproto.Metric {
+	metric := &tpuproto.Metric{
+		Attribute: &tpuproto.Attribute{
+			Value: &tpuproto.AttrValue{
+				Attr: &tpuproto.AttrValue_IntAttr{
+					IntAttr: deviceID,
+				},
+			},
+		},
+		Measure: &tpuproto.Metric_Gauge{
+			Gauge: &tpuproto.Gauge{},
+		},
+	}
+
+	switch v := value.(type) {
+	case int64:
+		metric.GetGauge().Value = &tpuproto.Gauge_AsInt{AsInt: v}
+	case float64:
+		metric.GetGauge().Value = &tpuproto.Gauge_AsDouble{AsDouble: v}
+	}
+
+	return metric
+}
+
+// Helper function to compare numeric values regardless of their exact type
+func compareNumeric(t *testing.T, name string, got, want interface{}) {
+	switch gotVal := got.(type) {
+	case int64:
+		if wantVal, ok := want.(float64); ok {
+			if float64(gotVal) != wantVal {
+				t.Errorf("%s = %v (int64), want %v (float64)", name, gotVal, wantVal)
+			}
+		}
+	case float64:
+		if wantVal, ok := want.(float64); ok {
+			if gotVal != wantVal {
+				t.Errorf("%s = %v, want %v", name, gotVal, wantVal)
+			}
+		}
+	default:
+		t.Errorf("%s has unexpected type %T", name, got)
+	}
+}
+
+func TestTPUSingleDeviceComplete(t *testing.T) {
+	mockClient := &mockRuntimeMetricServiceClient{
+		metrics: map[monitor.TPUMetricName][]*tpuproto.Metric{
+			monitor.TPUTotalMemory:  {createMetric(0, int64(16000000000))}, // 16 GiB
+			monitor.TPUMemoryUsage:  {createMetric(0, int64(8000000000))},  // 8 GiB
+			monitor.TPUDutyCyclePct: {createMetric(0, float64(75.0))},      // 75%
+		},
+	}
+
+	tpu := &monitor.TPU{}
+	tpu.SetName("tpu")
+	tpu.SetClient(mockClient)
+	tpu.SetChip(monitor.TPUChip{Name: "v4", HbmGiB: 16, DevicesPerChip: 1}, 1)
+
+	data, err := tpu.Sample()
+	if err != nil {
+		t.Fatalf("Sample() error = %v", err)
+	}
+
+	metrics := make(map[string]interface{})
+	for _, item := range data.Item {
+		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
+	}
+
+	expectedMetrics := map[string]float64{
+		"tpu.0.memoryUsage":      50.0,
+		"tpu.0.memoryUsageBytes": 8000000000,
+		"tpu.0.dutyCycle":        75.0,
+	}
+
+	for key, expected := range expectedMetrics {
+		if val, ok := metrics[key]; !ok {
+			t.Errorf("Missing metric %s", key)
+		} else {
+			compareNumeric(t, key, val, expected)
+		}
+	}
+}
+
+func TestTPUV2MultiDevice(t *testing.T) {
 	mockClient := &mockRuntimeMetricServiceClient{
 		metrics: map[monitor.TPUMetricName][]*tpuproto.Metric{
 			monitor.TPUTotalMemory: {
-				{
-					Attribute: &tpuproto.Attribute{
-						Value: &tpuproto.AttrValue{
-							Attr: &tpuproto.AttrValue_IntAttr{
-								IntAttr: 0,
-							},
-						},
-					},
-					Measure: &tpuproto.Metric_Gauge{
-						Gauge: &tpuproto.Gauge{
-							Value: &tpuproto.Gauge_AsInt{
-								AsInt: 16000000000, // 16 GiB
-							},
-						},
-					},
-				},
+				createMetric(0, int64(8000000000)), // Device 0: 8 GiB
+				createMetric(1, int64(8000000000)), // Device 1: 8 GiB
 			},
 			monitor.TPUMemoryUsage: {
-				{
-					Attribute: &tpuproto.Attribute{
-						Value: &tpuproto.AttrValue{
-							Attr: &tpuproto.AttrValue_IntAttr{
-								IntAttr: 0,
-							},
-						},
-					},
-					Measure: &tpuproto.Metric_Gauge{
-						Gauge: &tpuproto.Gauge{
-							Value: &tpuproto.Gauge_AsInt{
-								AsInt: 8000000000, // 8 GiB
-							},
-						},
-					},
-				},
+				createMetric(0, int64(4000000000)), // Device 0: 4 GiB
+				createMetric(1, int64(2000000000)), // Device 1: 2 GiB
 			},
 			monitor.TPUDutyCyclePct: {
-				{
-					Attribute: &tpuproto.Attribute{
-						Value: &tpuproto.AttrValue{
-							Attr: &tpuproto.AttrValue_IntAttr{
-								IntAttr: 0,
-							},
-						},
-					},
-					Measure: &tpuproto.Metric_Gauge{
-						Gauge: &tpuproto.Gauge{
-							Value: &tpuproto.Gauge_AsDouble{
-								AsDouble: 75.0,
-							},
-						},
-					},
-				},
+				createMetric(0, float64(80.0)), // Chip 0 (applies to both devices)
 			},
 		},
 	}
@@ -92,31 +133,140 @@ func TestTPUSample(t *testing.T) {
 	tpu := &monitor.TPU{}
 	tpu.SetName("tpu")
 	tpu.SetClient(mockClient)
-	tpu.SetChip(monitor.TPUChip{
-		Name:           "v42",
-		HbmGiB:         16,
-		DevicesPerChip: 1,
-	}, 1,
-	)
+	tpu.SetChip(monitor.TPUChip{Name: "v2", HbmGiB: 8, DevicesPerChip: 2}, 1)
 
 	data, err := tpu.Sample()
 	if err != nil {
 		t.Fatalf("Sample() error = %v", err)
 	}
 
-	expectedMemoryUsageKey := "tpu.0.memoryUsage"
-	expectedDutyCycleKey := "tpu.0.dutyCycle"
-
-	metrics := make(map[string]any)
+	metrics := make(map[string]interface{})
 	for _, item := range data.Item {
 		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
 	}
 
-	if metrics[expectedMemoryUsageKey].(int64) != int64(50) {
-		t.Errorf("Expected memory usage 50, got %v", metrics[expectedMemoryUsageKey])
+	expectedMetrics := map[string]float64{
+		"tpu.0.memoryUsage":      50.0,
+		"tpu.0.memoryUsageBytes": 4000000000,
+		"tpu.0.dutyCycle":        80.0,
+		"tpu.1.memoryUsage":      25.0,
+		"tpu.1.memoryUsageBytes": 2000000000,
+		"tpu.1.dutyCycle":        80.0,
 	}
 
-	if metrics[expectedDutyCycleKey].(int64) != int64(75) {
-		t.Errorf("Expected duty cycle 75, got %v", metrics[expectedDutyCycleKey])
+	for key, expected := range expectedMetrics {
+		if val, ok := metrics[key]; !ok {
+			t.Errorf("Missing metric %s", key)
+		} else {
+			compareNumeric(t, key, val, expected)
+		}
+	}
+}
+
+func TestTPUPartialMetrics(t *testing.T) {
+	mockClient := &mockRuntimeMetricServiceClient{
+		metrics: map[monitor.TPUMetricName][]*tpuproto.Metric{
+			monitor.TPUTotalMemory: {
+				createMetric(0, int64(16000000000)),
+				createMetric(1, int64(16000000000)),
+			},
+			monitor.TPUMemoryUsage: {
+				createMetric(0, int64(8000000000)),
+				// Device 1 memory usage missing
+			},
+			monitor.TPUDutyCyclePct: {
+				createMetric(0, float64(75.0)),
+				createMetric(1, float64(80.0)),
+			},
+		},
+	}
+
+	tpu := &monitor.TPU{}
+	tpu.SetName("tpu")
+	tpu.SetClient(mockClient)
+	tpu.SetChip(monitor.TPUChip{Name: "v4", HbmGiB: 16, DevicesPerChip: 1}, 2)
+
+	data, err := tpu.Sample()
+	if err != nil {
+		t.Fatalf("Sample() error = %v", err)
+	}
+
+	metrics := make(map[string]interface{})
+	for _, item := range data.Item {
+		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
+	}
+
+	expectedMetrics := map[string]float64{
+		"tpu.0.memoryUsage":      50.0,
+		"tpu.0.memoryUsageBytes": 8000000000,
+		"tpu.0.dutyCycle":        75.0,
+		"tpu.1.dutyCycle":        80.0,
+	}
+
+	for key, expected := range expectedMetrics {
+		if val, ok := metrics[key]; !ok {
+			t.Errorf("Missing metric %s", key)
+		} else {
+			compareNumeric(t, key, val, expected)
+		}
+	}
+
+	// Verify memory metrics for device 1 are missing
+	if _, exists := metrics["tpu.1.memoryUsage"]; exists {
+		t.Error("tpu.1.memoryUsage should not exist")
+	}
+	if _, exists := metrics["tpu.1.memoryUsageBytes"]; exists {
+		t.Error("tpu.1.memoryUsageBytes should not exist")
+	}
+}
+
+func TestTPUNonSequentialDeviceIDs(t *testing.T) {
+	mockClient := &mockRuntimeMetricServiceClient{
+		metrics: map[monitor.TPUMetricName][]*tpuproto.Metric{
+			monitor.TPUTotalMemory: {
+				createMetric(42, int64(16000000000)),
+				createMetric(46, int64(16000000000)),
+			},
+			monitor.TPUMemoryUsage: {
+				createMetric(42, int64(8000000000)),
+				createMetric(46, int64(4000000000)),
+			},
+			monitor.TPUDutyCyclePct: {
+				createMetric(42, float64(75.0)),
+				createMetric(46, float64(80.0)),
+			},
+		},
+	}
+
+	tpu := &monitor.TPU{}
+	tpu.SetName("tpu")
+	tpu.SetClient(mockClient)
+	tpu.SetChip(monitor.TPUChip{Name: "v4", HbmGiB: 16, DevicesPerChip: 1}, 2)
+
+	data, err := tpu.Sample()
+	if err != nil {
+		t.Fatalf("Sample() error = %v", err)
+	}
+
+	metrics := make(map[string]interface{})
+	for _, item := range data.Item {
+		metrics[item.Key], _ = simplejsonext.UnmarshalString(item.ValueJson)
+	}
+
+	expectedMetrics := map[string]float64{
+		"tpu.42.memoryUsage":      50.0,
+		"tpu.42.memoryUsageBytes": 8000000000,
+		"tpu.42.dutyCycle":        75.0,
+		"tpu.46.memoryUsage":      25.0,
+		"tpu.46.memoryUsageBytes": 4000000000,
+		"tpu.46.dutyCycle":        80.0,
+	}
+
+	for key, expected := range expectedMetrics {
+		if val, ok := metrics[key]; !ok {
+			t.Errorf("Missing metric %s", key)
+		} else {
+			compareNumeric(t, key, val, expected)
+		}
 	}
 }


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Follow up on #9266.

Fixes the issue where non-consecutive TPU device IDs were not handled properly -- we assumed device ids always run from 0 to `n_chips * n_devices_per_chip`, which may not be true, for example, for newer TPU devices/slices in GKE jobs, that can get ids such as:
```
Connected to libtpu at grpc://localhost:8431...
TPU Utilization                                
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Device ┃ Memory usage          ┃ Duty cycle ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ 122    │ 24.37 GiB / 95.74 GiB │      0.00% │
│ 123    │ 24.37 GiB / 95.74 GiB │      0.00% │
│ 126    │ 24.37 GiB / 95.74 GiB │      0.00% │
│ 127    │ 24.37 GiB / 95.74 GiB │      0.00% │
└────────┴───────────────────────┴────────────┘
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
- Added unit tests.
- Tested on my TPU-enabled GKE cluster.
  - https://wandb.ai/dimaduev/wandb/runs/pf8hjqmx

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
