### PR TITLE
chore: band-aid a test in test_step_upload.py

### DIFF
--- a/tests/unit_tests/test_step_upload.py
+++ b/tests/unit_tests/test_step_upload.py
@@ -104,7 +104,7 @@ def make_api(**kwargs: Any) -> Mock:
 def finish_and_wait(command_queue: queue.Queue):
     done = threading.Event()
     command_queue.put(RequestFinish(callback=done.set))
-    assert done.wait(2)
+    assert done.wait(10)
 
 
 class UploadBlockingMockApi(Mock):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
There's a time-based wait in `tests/unit_tests/test_step_upload.py` that has started consistently failing in some Mac jobs.
These tests are slated for removal, so no big deal.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
