### PR TITLE
chore: update release-sdk action to use upload/download-artifact v4

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -332,9 +332,14 @@ jobs:
       - name: Download distribution
         uses: actions/download-artifact@v4
         with:
-          path: dist/
+          path: artifacts/
           pattern: wandb-sdk-distribution-*
-          merge-multiple: true
+
+      - name: Merge distributions
+        run: |
+          mkdir -p dist/
+          cp -r artifacts/*/* dist/
+          ls -la dist/
 
       - name: List distribution
         run: ls dist/

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -119,7 +119,9 @@ jobs:
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_BUILD: cp*-macosx* pp*-macosx*
           CIBW_SKIP: cp36-*
-          CIBW_ARCHS_MACOS: x86_64 arm64 # arm64 == aarch64
+          # arm64 is skipped because it still produces 11.0 wheels due to
+          # restrictions in the cibuildwheel package.
+          CIBW_ARCHS_MACOS: x86_64
 
           # Work around https://github.com/matthew-brett/delocate/issues/204
           # by adding `--ignore-missing-dependencies` to cibuildwheel's default
@@ -136,7 +138,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wandb-sdk-distribution-macos-10
+          name: wandb-sdk-distribution-macos-10-x86_64
           path: ./dist
 
   build-linux-arm64-wheels:
@@ -443,9 +445,15 @@ jobs:
       - name: Download distribution
         uses: actions/download-artifact@v4
         with:
-          path: dist/
+          path: artifacts/
           pattern: wandb-sdk-distribution-*
-          merge-multiple: true
+
+      - name: Merge distributions
+        run: |
+          mkdir -p dist/
+          cp -r artifacts/*/* dist/
+          ls -la dist/
+
       - name: List distribution
         run: ls dist/
       - name: Publish distribution to PyPI


### PR DESCRIPTION
Description
-----------
The `build-macos-10-wheels` and `build-platform-wheels` on `macos-14` steps in the release action somehow produce the same wheel for arm `wandb-0.19.4rc1-py3-none-macosx_11_0_arm64.whl`, but the former downgrades the go version and go dependencies before making the wheel. The new `download-artifact@v4` action corrupt the wheel (which is just a zip archive) with the `merge-multiple: true` flag. To fix, I:
- Skip the arm target on `build-macos-10-wheels`.
- Explicitly move wheels around as opposed to relying on the action to merge artifacts.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
