### PR TITLE
feat: implement 'best' define_metric summary type in wandb-core

### DIFF
--- a/core/internal/runmetric/runmetric_test.go
+++ b/core/internal/runmetric/runmetric_test.go
@@ -14,7 +14,6 @@ func TestGlobMetricWildcard(t *testing.T) {
 		IsExplicit:   true,
 		NoSummary:    false,
 		SummaryTypes: 0,
-		MetricGoal:   metricGoalUnset,
 	}
 
 	mh.globMetrics["*"] = definedMetric
@@ -40,7 +39,6 @@ func TestGlobMetricEndingWildcard(t *testing.T) {
 		IsExplicit:   true,
 		NoSummary:    false,
 		SummaryTypes: 0,
-		MetricGoal:   metricGoalUnset,
 	}
 
 	mh.globMetrics["xyz/*"] = definedMetric

--- a/core/internal/runsummary/metricsummary.go
+++ b/core/internal/runsummary/metricsummary.go
@@ -107,6 +107,12 @@ func (ms *metricSummary) ToMarshallableValue() any {
 		summary["mean"] = ms.total / float64(ms.count)
 	}
 
+	if ms.track.HasAny(BestMaximize) {
+		summary["best"] = ms.max
+	} else if ms.track.HasAny(BestMinimize) {
+		summary["best"] = ms.min
+	}
+
 	return summary
 }
 

--- a/core/internal/runsummary/runsummary_test.go
+++ b/core/internal/runsummary/runsummary_test.go
@@ -46,10 +46,19 @@ func TestSummaryTypes(t *testing.T) {
 	rh1.SetInt(pathtree.PathOf("x"), 1)
 	rh2.SetFloat(pathtree.PathOf("x"), 3.0)
 	rh3.SetFloat(pathtree.PathOf("x"), 2.3)
+	rh1.SetInt(pathtree.PathOf("y"), 1)
+	rh2.SetFloat(pathtree.PathOf("y"), 3.0)
+	rh3.SetFloat(pathtree.PathOf("y"), 2.3)
 
 	rs.ConfigureMetric(
 		pathtree.PathOf("x"), false,
-		runsummary.Min|runsummary.Max|runsummary.Mean|runsummary.Latest,
+		runsummary.Min|runsummary.Max|runsummary.Mean|
+			runsummary.Latest|
+			runsummary.BestMaximize,
+	)
+	rs.ConfigureMetric(
+		pathtree.PathOf("y"), false,
+		runsummary.BestMinimize,
 	)
 	_, _ = rs.UpdateSummaries(rh1)
 	_, _ = rs.UpdateSummaries(rh2)
@@ -63,8 +72,10 @@ func TestSummaryTypes(t *testing.T) {
 				"min": 1,
 				"max": 3.0,
 				"mean": 2.1,
-				"last": 2.3
-			}
+				"last": 2.3,
+				"best": 3.0
+			},
+			"y": {"best": 1}
 		}`,
 		string(encoded))
 }

--- a/core/internal/runsummary/type.go
+++ b/core/internal/runsummary/type.go
@@ -8,6 +8,15 @@ const (
 	Min
 	Max
 	Mean
+
+	// BestMaximize is like Max, but is stored in the "best" key.
+	BestMaximize
+
+	// BestMinimize is like Min, but is stored in the "best" key.
+	//
+	// If both BestMaximize and BestMinimize are set,
+	// BestMaximize takes precedence.
+	BestMinimize
 )
 
 func (f SummaryTypeFlags) IsEmpty() bool {

--- a/tests/system_tests/test_core/test_metric_full.py
+++ b/tests/system_tests/test_core/test_metric_full.py
@@ -68,6 +68,24 @@ def test_metric_none(wandb_backend_spy):
         assert "val2" not in summary
 
 
+@pytest.mark.parametrize(
+    "goal,expected",
+    [
+        ("minimize", 1),
+        ("maximize", 4),
+    ],
+)
+def test_metric_best(goal, expected):
+    with wandb.init(mode="offline") as run:
+        run.define_metric("val", summary="best", goal=goal)
+        run.log({"val": 2})
+        run.log({"val": 1})
+        run.log({"val": 4})
+        run.log({"val": 3})
+
+        assert run.summary["val"]["best"] == expected
+
+
 def test_metric_sum_none(wandb_backend_spy):
     with wandb.init() as run:
         run.define_metric("val")


### PR DESCRIPTION
Make `run.define_metric(name, summary="best", goal=...)` work in `wandb-core`.

I was updating `test_metric_full.py` in an effort to get rid of `test_metric_internal.py` (which doesn't test `wandb-core`), and found that it was lacking the `test_summary_best` test. After I added this test, I saw that it failed in `wandb-core` and remembered that this is missing in `wandb-core`.