### PR TITLE
fix: handle correctly multiple summary types in define_metric

### DIFF
--- a/core/internal/runmetric/definedmetric.go
+++ b/core/internal/runmetric/definedmetric.go
@@ -56,8 +56,6 @@ func (m definedMetric) With(
 	if record.Summary != nil {
 		m.NoSummary = record.Summary.None
 
-		m.SummaryTypes = 0
-
 		if record.Summary.Min {
 			m.SummaryTypes |= runsummary.Min
 		}

--- a/tests/system_tests/test_core/test_metric_full.py
+++ b/tests/system_tests/test_core/test_metric_full.py
@@ -342,7 +342,6 @@ def test_metric_nested_glob(wandb_backend_spy):
         assert summary["this"] == {"that": {"min": 2, "max": 4}}
 
 
-@pytest.mark.skip_wandb_core(reason="bug in wandb-core; WB-22812")
 @pytest.mark.parametrize("name", ["m", "*"])
 def test_metric_overwrite_false(wandb_backend_spy, name):
     with wandb.init() as run:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-22812

What does the PR do? Include a concise description of the PR contents.

This PR fixes the behavior where we used to reset the configuration of a new setting was provided.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
