### PR TITLE
refactor: remove writing api key during user prompt function.

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -104,7 +104,6 @@ def prompt_api_key(  # noqa: C901
         log_string = term.LOG_STRING_NOCOLOR
         key = wandb.jupyter.attempt_colab_login(app_url)  # type: ignore
         if key is not None:
-            write_key(settings, key, api=api)
             return key  # type: ignore
 
     if anon_mode == "must":
@@ -123,24 +122,19 @@ def prompt_api_key(  # noqa: C901
             choices, input_timeout=settings.login_timeout, jupyter=jupyter
         )
 
+    key = None
     api_ask = (
         f"{log_string}: Paste an API key from your profile and hit enter, "
         "or press ctrl+c to quit"
     )
     if result == LOGIN_CHOICE_ANON:
         key = api.create_anonymous_api_key()
-
-        write_key(settings, key, api=api, anonymous=True)
-        return key  # type: ignore
     elif result == LOGIN_CHOICE_NEW:
         key = browser_callback(signup=True) if browser_callback else None
 
         if not key:
             wandb.termlog(f"Create an account here: {app_url}/authorize?signup=true")
             key = input_callback(api_ask).strip()
-
-        write_key(settings, key, api=api)
-        return key  # type: ignore
     elif result == LOGIN_CHOICE_EXISTS:
         key = browser_callback() if browser_callback else None
 
@@ -158,8 +152,6 @@ def prompt_api_key(  # noqa: C901
                 f"You can find your API key in your browser here: {app_url}/authorize"
             )
             key = input_callback(api_ask).strip()
-        write_key(settings, key, api=api)
-        return key  # type: ignore
     elif result == LOGIN_CHOICE_NOTTY:
         # TODO: Needs refactor as this needs to be handled by caller
         return False
@@ -172,8 +164,9 @@ def prompt_api_key(  # noqa: C901
             browser_callback() if jupyter and browser_callback else (None, False)
         )
 
-        write_key(settings, key, api=api)
-        return key  # type: ignore
+    if not key:
+        raise ValueError("No API key specified.")
+    return key
 
 
 def write_netrc(host: str, entity: str, key: str) -> Optional[bool]:

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -181,7 +181,7 @@ class _WandbLogin:
                 "`wandb login` from the command line."
             )
         if key:
-            apikey.write_key(self._settings, key)
+            apikey.write_key(self._settings, key, anonymous=self.is_anonymous)
 
     def update_session(
         self,


### PR DESCRIPTION
Description
-----------
What does the PR do? Include a concise description of the PR contents.
This PR removes the side effect of immediately writing the API key when the user is prompted, and instead does it in an explicit function call.
Additionally the `noop` settings check has been moved to the common `_login` function.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
