### PR TITLE
refactor: remove third login abstraction layer

### DIFF
--- a/tests/system_tests/test_notebooks/conftest.py
+++ b/tests/system_tests/test_notebooks/conftest.py
@@ -191,6 +191,23 @@ def notebook(user, run_id, assets_path):
         skip_api_key_env: bool = False,
         **kwargs: Any,
     ):
+        """Sets up a copy of the provided notebook name in a temporary directory.
+
+        As part of the setup process all environment variables starting with 'WANDB',
+        are copied into the notebook as an initial setup cell.
+
+        Args:
+            nb_name: The name of the notebook to load from the assets directory.
+            kernel_name: The name given to the kernel used to run the notebook.
+            notebook_type: The type of notebook to use, from the ipython.PythonType list.
+            save_code: Whether to set the WANDB_SAVE_CODE environment variable in the setup cell.
+            skip_api_key_env: Whether to delete the WANDB_API_KEY environment variable in the setup cell.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A context manager yielding a WandbNotebookClient object. Which can be used to execute
+            the notebook cells and retrieve the output.
+        """
         nb_path = assets_path(pathlib.Path("notebooks") / nb_name)
         shutil.copy(nb_path, os.path.join(os.getcwd(), os.path.basename(nb_path)))
         with open(nb_path) as f:

--- a/tests/system_tests/test_notebooks/conftest.py
+++ b/tests/system_tests/test_notebooks/conftest.py
@@ -188,6 +188,7 @@ def notebook(user, run_id, assets_path):
         kernel_name: str = "wandb_python",
         notebook_type: ipython.PythonType = "jupyter",
         save_code: bool = True,
+        skip_api_key_env: bool = False,
         **kwargs: Any,
     ):
         nb_path = assets_path(pathlib.Path("notebooks") / nb_name)
@@ -216,8 +217,11 @@ def notebook(user, run_id, assets_path):
             "import pytest\n"
             "mp = pytest.MonkeyPatch()\n"
             "import wandb\n"
-            f"mp.setattr(wandb.sdk.lib.ipython, '_get_python_type', lambda: '{notebook_type}')"
+            f"mp.setattr(wandb.sdk.lib.ipython, '_get_python_type', lambda: '{notebook_type}')\n"
         )
+
+        if skip_api_key_env:
+            setup_cell.write("mp.delenv('WANDB_API_KEY')\n")
 
         # inject:
         nb.cells.insert(0, nbformat.v4.new_code_cell(setup_cell.getvalue()))

--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -22,7 +22,7 @@ def test_login_timeout(notebook, monkeypatch):
         "prompt_choices",
         lambda x, input_timeout=None, jupyter=True: x[0],
     )
-    with notebook("login_timeout.ipynb") as nb:
+    with notebook("login_timeout.ipynb", skip_api_key_env=True) as nb:
         nb.execute_all()
         output = nb.cell_output_text(1)
         assert "W&B disabled due to login timeout" in output

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -180,7 +180,6 @@ class _WandbInit:
             force=run_settings.force,
             _disable_warning=True,
             _silent=run_settings.quiet or run_settings.silent,
-            _entity=run_settings.entity,
         )
 
     def warn_env_vars_change_after_setup(self) -> None:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-8622
- Fixes WB-17065
- Fixes WB-15849

What does the PR do? Include a concise description of the PR contents.

This PR removes a third layer of abstraction by removing the `_WandbLogin.login` function, and restructures the `_login` function. This fixes multiple issues, such as writing invalid API keys to the netrc file, or not displaying the login message when in a notebook environment.


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
