### PR TITLE
refactor: always use 'function' scope for the user fixture

### DIFF
--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -228,7 +228,7 @@ class BackendFixtureFactory:
                 self._send(cmd.path, data=asdict(cmd))
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def backend_fixture_factory(
     worker_id: str,
     local_wandb_backend: LocalWandbBackendAddress,

--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -232,7 +232,10 @@ class BackendFixtureFactory:
 def backend_fixture_factory(
     worker_id: str,
     local_wandb_backend: LocalWandbBackendAddress,
+    use_local_wandb_backend,
 ) -> Generator[BackendFixtureFactory, None, None]:
+    _ = use_local_wandb_backend
+
     base_url = local_wandb_backend.fixture_service_url
     with BackendFixtureFactory(base_url, worker_id=worker_id) as factory:
         yield factory

--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -228,11 +228,10 @@ class BackendFixtureFactory:
                 self._send(cmd.path, data=asdict(cmd))
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def backend_fixture_factory(
     worker_id: str,
     local_wandb_backend: LocalWandbBackendAddress,
-    use_local_wandb_backend,
 ) -> Generator[BackendFixtureFactory, None, None]:
     base_url = local_wandb_backend.fixture_service_url
     with BackendFixtureFactory(base_url, worker_id=worker_id) as factory:

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 from .wandb_backend_spy import WandbBackendProxy, WandbBackendSpy, spy_proxy
 
-#: See https://docs.pytest.org/en/stable/how-to/plugins.html#requiring-loading-plugins-in-a-test-module-or-conftest-file
+# https://docs.pytest.org/en/stable/how-to/plugins.html#requiring-loading-plugins-in-a-test-module-or-conftest-file
 pytest_plugins = ("tests.system_tests.backend_fixtures",)
 
 
@@ -25,22 +25,16 @@ def wandb_verbose(request):
     return request.config.getoption("--wandb-verbose", default=False)
 
 
-@pytest.fixture(scope="session")
-def session_username(backend_fixture_factory) -> str:
-    return backend_fixture_factory.make_user()
-
-
 @pytest.fixture(scope="function")
-def user(mocker, session_username, use_local_wandb_backend) -> Iterator[str]:
-    _ = use_local_wandb_backend
-
+def user(mocker, backend_fixture_factory) -> Iterator[str]:
+    username = backend_fixture_factory.make_user()
     envvars = {
-        "WANDB_API_KEY": session_username,
-        "WANDB_ENTITY": session_username,
-        "WANDB_USERNAME": session_username,
+        "WANDB_API_KEY": username,
+        "WANDB_ENTITY": username,
+        "WANDB_USERNAME": username,
     }
     mocker.patch.dict(os.environ, envvars)
-    yield session_username
+    yield username
 
 
 @pytest.fixture(scope="session")

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -31,7 +31,9 @@ def session_username(backend_fixture_factory) -> str:
 
 
 @pytest.fixture(scope="function")
-def user(mocker, session_username) -> Iterator[str]:
+def user(mocker, session_username, use_local_wandb_backend) -> Iterator[str]:
+    _ = use_local_wandb_backend
+
     envvars = {
         "WANDB_API_KEY": session_username,
         "WANDB_ENTITY": session_username,

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -25,7 +25,7 @@ def wandb_verbose(request):
     return request.config.getoption("--wandb-verbose", default=False)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def user(mocker, backend_fixture_factory) -> Iterator[str]:
     username = backend_fixture_factory.make_user()
     envvars = {

--- a/tests/system_tests/test_importers/test_wandb/conftest.py
+++ b/tests/system_tests/test_importers/test_wandb/conftest.py
@@ -16,11 +16,7 @@ from PIL import Image
 from rdkit import Chem
 
 
-def determine_scope(fixture_name, config):
-    return config.getoption("--user-scope")
-
-
-@pytest.fixture(scope=determine_scope)
+@pytest.fixture
 def user2(backend_importers_fixture_factory):
     return backend_importers_fixture_factory.make_user()
 


### PR DESCRIPTION
Originally this PR tried to make 'user' session-scoped, but many artifacts, launch and sweep tests fail: https://app.circleci.com/pipelines/github/wandb/wandb/43365/workflows/741a125e-f337-4b70-8193-5b598a24ca88/jobs/1333011/tests. We may be able to use function-scoped users for these but have a session-scoped user for other tests, but a better direction is to make the user fixture fast enough for this to not matter.