### PR TITLE
chore(sdk): add internal helper to extract the only item from an iterable

### DIFF
--- a/tests/unit_tests/test_iterutils.py
+++ b/tests/unit_tests/test_iterutils.py
@@ -1,0 +1,31 @@
+from itertools import repeat, tee
+
+from hypothesis import example, given
+from hypothesis.strategies import integers, iterables, sampled_from
+from pytest import raises
+from wandb._iterutils import one
+
+
+@given(iterable=iterables(integers(), min_size=1, max_size=1))
+def test_one_on_single_item_iterable(iterable):
+    """Check that `one()` returns the only item in a single-item iterable."""
+    # Copy the iterator so we can get the expected result from the first copy,
+    # while passing the second copy to the tested function.
+    test_iterable, ref_iterable = tee(iterable)
+    expected = next(ref_iterable)
+    assert one(test_iterable) == expected
+
+
+@given(iterable=sampled_from([tuple(), [], iter([]), range(0), set(), dict()]))
+def test_one_on_empty_iterable(iterable):
+    """Check that `one()` raises an error on an empty iterable."""
+    with raises(ValueError):
+        one(iterable)
+
+
+@example(iterable=repeat(1))  # Test at least one infinite iterator
+@given(iterable=iterables(integers(), min_size=2, max_size=5))
+def test_one_on_multi_item_iterable(iterable):
+    """Check that `one()` raises an error on a multi-item iterable."""
+    with raises(ValueError):
+        one(iterable)

--- a/wandb/_iterutils.py
+++ b/wandb/_iterutils.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Iterable, TypeVar
+
+T = TypeVar("T")
+
+
+def one(
+    iterable: Iterable[T],
+    too_short: Exception | None = None,
+    too_long: Exception | None = None,
+) -> T:
+    """Return the only item in the iterable.
+
+    Note:
+        This is intended **only** as an internal helper/convenience function,
+        and its implementation is directly adapted from `more_itertools.one`.
+        Users needing similar functionality are strongly encouraged to use
+        that library instead:
+        https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.one
+
+    Args:
+        iterable: The iterable to get the only item from.
+        too_short: Custom exception to raise if the iterable has no items.
+        too_long: Custom exception to raise if the iterable has multiple items.
+
+    Raises:
+        ValueError or `too_short`: If the iterable has no items.
+        ValueError or `too_long`: If the iterable has multiple items.
+    """
+    # For a general iterable, avoid inadvertently iterating through all values,
+    # which may be costly or impossible (e.g. if infinite).  Only check that:
+
+    # ... the first item exists
+    it = iter(iterable)
+    try:
+        obj = next(it)
+    except StopIteration as e:
+        raise too_short or ValueError("Expected 1 item in iterable, got 0") from e
+
+    # ...the second item doesn't
+    try:
+        _ = next(it)
+    except StopIteration:
+        return obj
+    raise too_long or ValueError("Expected 1 item in iterable, got multiple")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Adds a helper function `one()` to extract the only item from an iterable (raising an error if the iterable has too few/many items). 

Intended primarily for internal use, though as implemented, it's technically a public function.  That said, users who may discover the function and wish to use it are strongly encouraged to use `more-itertools.one()` instead, as the implementation here was only lightly adapted from `more-itertools`.

Note: The primary reason for reimplementing, as opposed to importing directly from `more-itertools`, was to prevent adding a required install dependency at this time.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
