### PR TITLE
refactor: move some config initialization out of wandb_run.py

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -40,7 +40,7 @@ from wandb.util import _is_artifact_representation
 
 from . import wandb_login, wandb_setup
 from .backend.backend import Backend
-from .lib import SummaryDisabled, filesystem, module, printer, telemetry
+from .lib import SummaryDisabled, filesystem, module, paths, printer, telemetry
 from .lib.deprecate import Deprecated, deprecate
 from .lib.mailbox import Mailbox, MailboxProgress
 from .wandb_helper import parse_config
@@ -452,6 +452,23 @@ class _WandbInit:
                 config_target=result.launch_no_artifacts,
                 artifacts=result.artifacts,
             )
+
+        wandb_internal = result.base_no_artifacts.setdefault("_wandb", dict())
+
+        if settings.save_code and settings.program_relpath:
+            wandb_internal["code_path"] = paths.LogicalPath(
+                os.path.join("code", settings.program_relpath)
+            )
+        if settings.fork_from is not None:
+            wandb_internal["branch_point"] = {
+                "run_id": settings.fork_from.run,
+                "step": settings.fork_from.value,
+            }
+        if settings.resume_from is not None:
+            wandb_internal["branch_point"] = {
+                "run_id": settings.resume_from.run,
+                "step": settings.resume_from.value,
+            }
 
         return result
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -47,7 +47,7 @@ from wandb.sdk.lib.import_hooks import (
     register_post_import_hook,
     unregister_post_import_hook,
 )
-from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath
+from wandb.sdk.lib.paths import FilePathStr, StrPath
 from wandb.util import (
     _is_artifact_object,
     _is_artifact_string,
@@ -591,6 +591,10 @@ class Run:
         self._config._set_artifact_callback(self._config_artifact_callback)
         self._config._set_settings(self._settings)
 
+        # The _wandb key is always expected on the run config.
+        wandb_key = "_wandb"
+        self._config._update({wandb_key: dict()})
+
         # TODO: perhaps this should be a property that is a noop on a finished run
         self.summary = wandb_summary.Summary(
             self._summary_get_current_summary_callback,
@@ -654,30 +658,12 @@ class Run:
             process_context="user",
         )
 
-        # Populate config
-        config = config or dict()
-        wandb_key = "_wandb"
-        config.setdefault(wandb_key, dict())
         self._launch_artifact_mapping: dict[str, Any] = {}
         self._unique_launch_artifact_sequence_names: dict[str, Any] = {}
-        if self._settings.save_code and self._settings.program_relpath:
-            config[wandb_key]["code_path"] = LogicalPath(
-                os.path.join("code", self._settings.program_relpath)
-            )
 
-        if self._settings.fork_from is not None:
-            config[wandb_key]["branch_point"] = {
-                "run_id": self._settings.fork_from.run,
-                "step": self._settings.fork_from.value,
-            }
-
-        if self._settings.resume_from is not None:
-            config[wandb_key]["branch_point"] = {
-                "run_id": self._settings.resume_from.run,
-                "step": self._settings.resume_from.value,
-            }
-
-        self._config._update(config, ignore_locked=True)
+        # Populate config
+        config = config or dict()
+        self._config._update(config, allow_val_change=True, ignore_locked=True)
 
         if sweep_config:
             self._config.merge_locked(


### PR DESCRIPTION
Instead of initializing `_wandb/code_path` and `_wandb/branch_point` in `Run._init`, do it in `_WandbInit.make_run_config`.

# Safety

Their values depend solely on settings, which are finalized by the time `make_run_config` is called. The `result.base_no_artifacts` dict at the end of `_WandbInit.make_run_config` is the `config` dict at the start of `Run._init`---no changes to the config happen in between. Nothing in-between those calls depends on the config values either.

The only semantic change is that now, a disabled run will have the `_wandb` key in its config because `make_disabled_run` uses the result of `make_run_config`.

# Purpose

The `Run` constructor takes three "config" parameters and merges them into its `Config` object. These values cannot be combined and passed as one dict because the keys from `sweep_config` and `launch_config` must become "locked".

The `sweep_config` and `launch_config` parameters are not used outside of this because they are initialization concepts, not `Run` concepts.

`Run` should construct its own `Config`, since `Config` holds a back-reference to the `Run` and is therefore a part of `Run` rather than something that can exist independently---i.e. `Run` shouldn't accept a `Config` object in its constructor.

Since `Config` is mutable, an easy simplification is to initialize the `Run` with an empty `Config` and update it after which is where I'm trying to go with these PRs.