### PR TITLE
fix(artifacts): add_reference with checksum=False should only log new version if URI changes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,3 +25,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - Fixed a performance issue causing slow instantiation of `wandb.Artifact`, which in turn slowed down fetching artifacts in various API methods. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9355)
 - Some errors from `wandb.Api` have better string representations (@timoffex in https://github.com/wandb/wandb/pull/9361)
+- Fixed a bug causing `Artifact.add_reference()` with `checksum=False` to log new versions of local reference artifacts without changes to the reference URI. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9326)

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Mapping, Optional
+from typing import Iterator, Mapping, Optional
 from urllib.parse import quote
 
 import numpy as np
@@ -32,6 +32,7 @@ from wandb.sdk.artifacts.storage_handlers.http_handler import HTTPHandler
 from wandb.sdk.artifacts.storage_handlers.s3_handler import S3Handler
 from wandb.sdk.artifacts.storage_handlers.tracking_handler import TrackingHandler
 from wandb.sdk.lib.hashutil import md5_string
+from wandb.sdk.wandb_run import Run
 
 
 def mock_boto(artifact, path=False, content_type=None, version_id="1"):
@@ -437,13 +438,127 @@ def test_add_reference_local_file_no_checksum(tmp_path, artifact):
     size = os.path.getsize(file)
     artifact.add_reference(uri, checksum=False)
 
-    assert artifact.digest == "415f3bca4b095cbbbbc47e0d44079e05"
+    expected_entry_digest = md5_string(uri)
+
+    # With checksum=False, the artifact digest will depend on its files'
+    # absolute paths.  The working test directory isn't fixed from run
+    # to run, so there isn't much benefit in asserting on the exact hash here.
+    # The following are just some basic consistency/sanity checks.
+    assert isinstance(artifact.digest, str)
+    assert len(artifact.digest) == 32
+    assert int(artifact.digest, 16) != 0  # nonzero hexadecimal literal
+
+    assert artifact.digest != expected_entry_digest
+
     manifest = artifact.manifest.to_manifest_json()
     assert manifest["contents"]["file1.txt"] == {
-        "digest": md5_string(str(size)),
+        "digest": expected_entry_digest,
         "ref": uri,
         "size": size,
     }
+
+
+class TestAddReferenceLocalFileNoChecksumTwice:
+    @pytest.fixture
+    def run(self, user) -> Iterator[Run]:
+        with wandb.init() as run:
+            yield run
+
+    @pytest.fixture
+    def orig_data(self) -> str:
+        """The contents of the original file."""
+        return "hello"
+
+    @pytest.fixture
+    def orig_fpath(self, tmp_path_factory) -> Path:
+        """The path to the original file."""
+        # Use a factory to generate unique filepaths per test
+        return tmp_path_factory.mktemp("orig_path") / "file1.txt"
+
+    @pytest.fixture
+    def orig_artifact(self, orig_fpath, orig_data, artifact, run) -> Artifact:
+        """The original, logged artifact in the sequence collection."""
+        file_path = orig_fpath
+        file_path.write_text(orig_data)
+
+        # Create the reference artifact and log it while bypassing the checksum
+        artifact.add_reference(file_path.as_uri(), checksum=False)
+        logged_artifact = run.log_artifact(artifact)
+        logged_artifact.wait()
+
+        # Assumption/consistency check
+        assert logged_artifact.version == "v0"
+
+        return logged_artifact
+
+    @pytest.fixture
+    def new_data(self) -> str:
+        """The contents of the new file."""
+        return "goodbye"
+
+    @pytest.fixture
+    def new_fpath(self, tmp_path_factory) -> Path:
+        """The path to the new file."""
+        return tmp_path_factory.mktemp("new_path") / "file2.txt"
+
+    @pytest.fixture
+    def new_artifact(self, orig_artifact) -> Artifact:
+        """A new artifact with the same name and type, but not yet logged."""
+        return wandb.Artifact(orig_artifact.name.split(":")[0], type=orig_artifact.type)
+
+    def test_adding_ref_with_same_uri_and_same_data_creates_no_new_version(
+        self, run, orig_fpath, orig_data, orig_artifact, new_artifact
+    ):
+        fpath = orig_fpath
+        fpath.write_text(orig_data)
+
+        # Create the second reference artifact and log it
+        new_artifact.add_reference(fpath.as_uri(), checksum=False)
+        new_artifact = run.log_artifact(new_artifact)
+        new_artifact.wait()
+
+        assert new_artifact.version == orig_artifact.version
+
+    def test_adding_ref_with_same_uri_and_new_data_creates_no_new_version(
+        self, run, orig_fpath, new_data, orig_artifact, new_artifact
+    ):
+        # Keep the original filepath, but overwrite its contents
+        fpath = orig_fpath
+        fpath.write_text(new_data)
+
+        # Create the second reference artifact and log it
+        new_artifact.add_reference(fpath.as_uri(), checksum=False)
+        new_artifact = run.log_artifact(new_artifact)
+        new_artifact.wait()
+
+        assert new_artifact.version == orig_artifact.version
+
+    def test_adding_ref_with_new_uri_and_same_data_creates_new_version(
+        self, run, new_fpath, orig_data, orig_artifact, new_artifact
+    ):
+        # Keep the original filepath, but overwrite its contents
+        fpath = new_fpath
+        fpath.write_text(orig_data)
+
+        # Create the second reference artifact and log it
+        new_artifact.add_reference(fpath.as_uri(), checksum=False)
+        new_artifact = run.log_artifact(new_artifact)
+        new_artifact.wait()
+
+        assert new_artifact.version != orig_artifact.version
+
+    def test_adding_ref_with_new_uri_and_new_data_creates_new_version(
+        self, run, new_fpath, new_data, orig_artifact, new_artifact
+    ):
+        fpath = new_fpath
+        fpath.write_text(new_data)
+
+        # Create the second reference artifact and log it
+        new_artifact.add_reference(fpath.as_uri(), checksum=False)
+        new_artifact = run.log_artifact(new_artifact)
+        new_artifact.wait()
+
+        assert new_artifact.version != orig_artifact.version
 
 
 def test_add_reference_local_dir(artifact):
@@ -479,35 +594,54 @@ def test_add_reference_local_dir_no_checksum(artifact):
     path_1.parent.mkdir(parents=True, exist_ok=True)
     path_1.write_text("hello")
     size_1 = path_1.stat().st_size
+    uri_1 = path_1.resolve().as_uri()
 
     path_2 = Path("nest/file2.txt")
     path_2.parent.mkdir(parents=True, exist_ok=True)
     path_2.write_text("my")
     size_2 = path_2.stat().st_size
+    uri_2 = path_2.resolve().as_uri()
 
     path_3 = Path("nest", "nest", "file3.txt")
     path_3.parent.mkdir(parents=True, exist_ok=True)
     path_3.write_text("dude")
     size_3 = path_3.stat().st_size
+    uri_3 = path_3.resolve().as_uri()
 
     here = Path.cwd()
-    artifact.add_reference(f"file://{here!s}", checksum=False)
+    root_uri = here.resolve().as_uri()
+    artifact.add_reference(root_uri, checksum=False)
 
-    assert artifact.digest == "3d0e6471486eec5070cf9351bacaa103"
+    expected_entry_digest_1 = md5_string(uri_1)
+    expected_entry_digest_2 = md5_string(uri_2)
+    expected_entry_digest_3 = md5_string(uri_3)
+
+    # With checksum=False, the artifact digest will depend on its files'
+    # absolute paths.  The working test directory isn't fixed from run
+    # to run, so there isn't much benefit in asserting on the exact hash here.
+    # The following are just some basic consistency/sanity checks.
+    assert isinstance(artifact.digest, str)
+    assert len(artifact.digest) == 32
+    assert int(artifact.digest, 16) != 0  # nonzero hexadecimal literal
+
+    assert artifact.digest != expected_entry_digest_1
+    assert artifact.digest != expected_entry_digest_2
+    assert artifact.digest != expected_entry_digest_3
+
     manifest = artifact.manifest.to_manifest_json()
     assert manifest["contents"]["file1.txt"] == {
-        "digest": md5_string(str(size_1)),
-        "ref": f"file://{here!s}/file1.txt",
+        "digest": expected_entry_digest_1,
+        "ref": uri_1,
         "size": size_1,
     }
     assert manifest["contents"]["nest/file2.txt"] == {
-        "digest": md5_string(str(size_2)),
-        "ref": f"file://{here!s}/nest/file2.txt",
+        "digest": expected_entry_digest_2,
+        "ref": uri_2,
         "size": size_2,
     }
     assert manifest["contents"]["nest/nest/file3.txt"] == {
-        "digest": md5_string(str(size_3)),
-        "ref": f"file://{here!s}/nest/nest/file3.txt",
+        "digest": expected_entry_digest_3,
+        "ref": uri_3,
         "size": size_3,
     }
 

--- a/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Sequence
 from urllib.parse import ParseResult
 
@@ -83,11 +84,15 @@ class LocalFileHandler(StorageHandler):
         # Note, we follow symlinks for files contained within the directory
         entries = []
 
+        # If checksum=False, the file's hash should only
+        # depend on its absolute path/URI, not its contents
+
+        # Closure func for calculating the file hash from its path
         def md5(path: str) -> B64MD5:
             return (
                 md5_file_b64(path)
                 if checksum
-                else md5_string(str(os.stat(path).st_size))
+                else md5_string(Path(path).resolve().as_uri())
             )
 
         if os.path.isdir(local_path):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-22558](https://wandb.atlassian.net/browse/WB-22558)

Fixes the calculation of file hashes when adding a local reference file with `checksum=False` (i.e. when calling `artifact.add_reference("file:///...", checksum=False)`).

Although this is discouraged in documentation, the behavior of `checksum=False` on local files and other types of reference artifacts should be consistent (S3, etc).  Specifically, adding local references with `checksum=False` will only result in logging a new artifact version if the reference **URI** changes (and ignoring the file contents).

This expectation also means that with `checksum=False`, calculated file hashes/digests will only depend on the (absolute) reference path.  For local files, `checksum=False` hashes were calculated from file sizes.  This PR changes changes that so `checksum=False` hashes are calculated from file URIs.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

System tests added and updated in `tests/system_tests/test_artifacts/test_wandb_artifacts.py` to cover/reflect the fixed behavior

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-22558]: https://wandb.atlassian.net/browse/WB-22558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ