### PR TITLE
fix: log an error when we do not have access permission to the netrc file

### DIFF
--- a/tests/unit_tests/test_lib/test_apikey.py
+++ b/tests/unit_tests/test_lib/test_apikey.py
@@ -23,7 +23,7 @@ def test_write_netrc():
         (stat.S_IRUSR, "write"),
     ],
 )
-def test_write_netrc_permission_errors(tmp_path, mock_wandb_log, permission, error_msg):
+def test_netrc_permission_errors(tmp_path, mock_wandb_log, permission, error_msg):
     netrc_path = str(tmp_path / "netrc")
     os.environ["NETRC"] = netrc_path
     with open(netrc_path, "w") as f:
@@ -35,9 +35,10 @@ def test_write_netrc_permission_errors(tmp_path, mock_wandb_log, permission, err
     )
     assert not logged_in
     assert mock_wandb_log.warned(
-        f"You do not have {error_msg} permissions for {netrc_path}"
+        f"Cannot access {netrc_path}. In order to persist your API key,"
+        + "\nGrant read & write permissions for your user to the file,"
+        + '\nor specify a different file with the environment variable "NETRC={new_netrc_path}".'
     )
-    assert mock_wandb_log.warned("We will be unable to save/update your API key.")
 
 
 def test_write_netrc_permission_oserror(tmp_path, mock_wandb_log):
@@ -57,4 +58,3 @@ def test_write_netrc_permission_oserror(tmp_path, mock_wandb_log):
         )
         assert not logged_in
         assert mock_wandb_log.errored(f"Unable to read permissions for {netrc_path}")
-        assert mock_wandb_log.warned("We will be unable to save/update your API key.")

--- a/tests/unit_tests/test_lib/test_apikey.py
+++ b/tests/unit_tests/test_lib/test_apikey.py
@@ -1,6 +1,7 @@
 import os
 import stat
 
+import pytest
 from wandb import wandb_lib
 
 
@@ -14,31 +15,25 @@ def test_write_netrc():
         )
 
 
-def test_write_netrc_read_error(tmp_path, mock_wandb_log):
-    os.environ["NETRC"] = str(tmp_path / "netrc")
-    netrc_path = str(tmp_path / "netrc")
-    with open(netrc_path, "w") as f:
-        f.write("")
-    os.chmod(netrc_path, stat.S_IWUSR)
-    api_key = "X" * 40
-    logged_in = wandb_lib.apikey.write_netrc(
-        "http://localhost", "jacob-romero", api_key
-    )
-    assert not logged_in
-    assert mock_wandb_log.warned(f"You do not have read permissions for {netrc_path}")
-    assert mock_wandb_log.warned("We will be unable to save/update your API key.")
-
-
-def test_write_netrc_write_error(tmp_path, mock_wandb_log):
+@pytest.mark.parametrize(
+    "permission,error_msg",
+    [
+        (stat.S_IWUSR, "read"),
+        (stat.S_IRUSR, "write"),
+    ],
+)
+def test_write_netrc_permission_errors(tmp_path, mock_wandb_log, permission, error_msg):
     netrc_path = str(tmp_path / "netrc")
     os.environ["NETRC"] = netrc_path
     with open(netrc_path, "w") as f:
         f.write("")
-    os.chmod(netrc_path, stat.S_IRUSR)
+    os.chmod(netrc_path, permission)
     api_key = "X" * 40
     logged_in = wandb_lib.apikey.write_netrc(
         "http://localhost", "jacob-romero", api_key
     )
     assert not logged_in
-    assert mock_wandb_log.warned(f"You do not have write permissions for {netrc_path}")
+    assert mock_wandb_log.warned(
+        f"You do not have {error_msg} permissions for {netrc_path}"
+    )
     assert mock_wandb_log.warned("We will be unable to save/update your API key.")

--- a/tests/unit_tests/test_lib/test_apikey.py
+++ b/tests/unit_tests/test_lib/test_apikey.py
@@ -1,3 +1,6 @@
+import os
+import stat
+
 from wandb import wandb_lib
 
 
@@ -9,3 +12,33 @@ def test_write_netrc():
         assert f.read() == (
             "machine localhost\n  login vanpelt\n  password {}\n".format(api_key)
         )
+
+
+def test_write_netrc_read_error(tmp_path, mock_wandb_log):
+    os.environ["NETRC"] = str(tmp_path / "netrc")
+    netrc_path = str(tmp_path / "netrc")
+    with open(netrc_path, "w") as f:
+        f.write("")
+    os.chmod(netrc_path, stat.S_IWUSR)
+    api_key = "X" * 40
+    logged_in = wandb_lib.apikey.write_netrc(
+        "http://localhost", "jacob-romero", api_key
+    )
+    assert not logged_in
+    assert mock_wandb_log.warned(f"You do not have read permissions for {netrc_path}")
+    assert mock_wandb_log.warned("We will be unable to save/update your API key.")
+
+
+def test_write_netrc_write_error(tmp_path, mock_wandb_log):
+    netrc_path = str(tmp_path / "netrc")
+    os.environ["NETRC"] = netrc_path
+    with open(netrc_path, "w") as f:
+        f.write("")
+    os.chmod(netrc_path, stat.S_IRUSR)
+    api_key = "X" * 40
+    logged_in = wandb_lib.apikey.write_netrc(
+        "http://localhost", "jacob-romero", api_key
+    )
+    assert not logged_in
+    assert mock_wandb_log.warned(f"You do not have write permissions for {netrc_path}")
+    assert mock_wandb_log.warned("We will be unable to save/update your API key.")

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -221,13 +221,15 @@ def write_netrc(host: str, entity: str, key: str) -> bool:
     netrc_path = get_netrc_file_path()
     netrc_access = check_netrc_access(netrc_path)
 
-    if not netrc_access[_NetrcPermissions.NETRC_WRITE_ACCESS]:
-        wandb.termwarn(f"You do not have write permissions for {netrc_path}")
-        wandb.termwarn("We will be unable to save/update your API key.")
-        return False
-    if not netrc_access[_NetrcPermissions.NETRC_READ_ACCESS]:
-        wandb.termwarn(f"You do not have read permissions for {netrc_path}")
-        wandb.termwarn("We will be unable to save/update your API key.")
+    if (
+        not netrc_access[_NetrcPermissions.NETRC_WRITE_ACCESS]
+        or not netrc_access[_NetrcPermissions.NETRC_READ_ACCESS]
+    ):
+        wandb.termwarn(
+            f"Cannot access {netrc_path}. In order to persist your API key,"
+            + "\nGrant read & write permissions for your user to the file,"
+            + '\nor specify a different file with the environment variable "NETRC={new_netrc_path}".'
+        )
         return False
 
     try:
@@ -310,7 +312,8 @@ def api_key(settings: Optional["Settings"] = None) -> Optional[str]:
         netrc_access[_NetrcPermissions.NETRC_EXISTS]
         and not netrc_access[_NetrcPermissions.NETRC_READ_ACCESS]
     ):
-        wandb.termwarn(f"You do not have read permissions for {get_netrc_file_path()}")
-        wandb.termwarn("You will be prompted for your API key.")
+        wandb.termwarn(
+            f"Cannot access {get_netrc_file_path()}.\n" + "Prompting for API key."
+        )
 
     return None

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -211,7 +211,7 @@ def write_netrc(host: str, entity: str, key: str) -> Optional[bool]:
         )
         return False
 
-    normalized_host = urlparse(host).netloc.split(":")[0]
+    normalized_host = urlparse(host).netloc
     netrc_path = get_netrc_file_path()
     netrc_access = check_netrc_access(netrc_path)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-22789

What does the PR do? Include a concise description of the PR contents.
This PR fixes a lot of the weird behavior with writing the API key. This of note:
- Adds warning for no read/write permissions to the given netrc file.
- Does not log `Appending key for ...` if we do not have access or an error occurs
- Do not overwrite the netrc file if we do not have read permissions

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
