### PR TITLE
refactor: delete unused Mailbox.wait method

### DIFF
--- a/wandb/sdk/lib/mailbox.py
+++ b/wandb/sdk/lib/mailbox.py
@@ -341,16 +341,6 @@ class Mailbox:
     def enable_keepalive(self) -> None:
         self._keepalive = True
 
-    def wait(
-        self,
-        handle: MailboxHandle,
-        *,
-        timeout: float,
-        on_progress: Optional[Callable[[MailboxProgress], None]] = None,
-        cancel: bool = False,
-    ) -> Optional[pb.Result]:
-        return handle.wait(timeout=timeout, on_progress=on_progress, cancel=cancel)
-
     def _time(self) -> float:
         return time.monotonic()
 


### PR DESCRIPTION
The `Mailbox.wait()` method, which just calls `MailboxHandle.wait()`, is not used anywhere and can be removed.