### PR TITLE
chore: use volatile ECC counter instead of aggregate for system dashboard

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Changed
 - Temporarily disabled collecting per-core CPU utilization stats (@dmitryduev in https://github.com/wandb/wandb/pull/9350)
+- Changed Nvidia GPU ECC counters from aggregated to volatile (@gritukan in https://github.com/wandb/wandb/pull/9347)
 
 ### Fixed
 

--- a/gpu_stats/src/gpu_nvidia.rs
+++ b/gpu_stats/src/gpu_nvidia.rs
@@ -526,6 +526,12 @@ impl NvidiaGpu {
 
             // Corrected Memory Errors
             if availability.corrected_memory_errors {
+                // NOTE: Nvidia GPUs provide two ECC counters: volatile and aggregate.
+                // The volatile counter resets on driver or GPU reset, while the
+                // aggregate counter persists for the GPU's lifetime. After row
+                // remapping repairs ECC errors, the aggregate counter remains
+                // non-zero and can falsely indicate a problem. Using the volatile
+                // counter avoids this confusion.
                 match device.memory_error_counter(
                     nvml_wrapper::enum_wrappers::device::MemoryError::Corrected,
                     nvml_wrapper::enum_wrappers::device::EccCounter::Volatile,

--- a/gpu_stats/src/gpu_nvidia.rs
+++ b/gpu_stats/src/gpu_nvidia.rs
@@ -528,7 +528,7 @@ impl NvidiaGpu {
             if availability.corrected_memory_errors {
                 match device.memory_error_counter(
                     nvml_wrapper::enum_wrappers::device::MemoryError::Corrected,
-                    nvml_wrapper::enum_wrappers::device::EccCounter::Aggregate,
+                    nvml_wrapper::enum_wrappers::device::EccCounter::Volatile,
                     nvml_wrapper::enum_wrappers::device::MemoryLocation::Device,
                 ) {
                     Ok(errors) => {
@@ -547,7 +547,7 @@ impl NvidiaGpu {
             if availability.uncorrected_memory_errors {
                 match device.memory_error_counter(
                     nvml_wrapper::enum_wrappers::device::MemoryError::Uncorrected,
-                    nvml_wrapper::enum_wrappers::device::EccCounter::Aggregate,
+                    nvml_wrapper::enum_wrappers::device::EccCounter::Volatile,
                     nvml_wrapper::enum_wrappers::device::MemoryLocation::Device,
                 ) {
                     Ok(errors) => {


### PR DESCRIPTION
Description
-----------

In Nvidia GPUs there are two ECC counters: volatile and aggregate. Volatile counter is being reset whenever driver is reloaded or GPU is reset. Aggregate counter is intended to be kept during all the GPU lifetime. When ECC error occurs because of memory corruption, one of the common actions is applying the memory row remapping (i.e. using redundant memory areas instead of damaged) that fixed ECC cause but does not reset the aggregate counter. This can be confusing since healthy (after row remapping) GPU will appear as broken according to ECC metric on the system dashboard. I propose to use volatile counter here that is less misleading in such cases.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
