### PR TITLE
chore: temporarily disable collecting per-core CPU utilization stats

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,9 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - Added `wandb login --base-url {host_url}` to login as an alias of `wandb login --host {host_url}`. (@jacobromero in https://github.com/wandb/wandb/pull/9323)
 
+### Changed
+- Temporarily disabled collecting per-core CPU utilization stats (@dmitryduev in https://github.com/wandb/wandb/pull/9350)
+
 ### Fixed
 
 - Fixed a bug causing `offline` mode to make network requests when logging media artifacts. If you are using an older version of W&B Server that does not support offline artifact uploads, use the setting `allow_offline_artifacts=False` to revert to older compatible behavior. (@domphan-wandb in https://github.com/wandb/wandb/pull/9267)

--- a/core/pkg/monitor/cpu.go
+++ b/core/pkg/monitor/cpu.go
@@ -2,8 +2,6 @@ package monitor
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/process"
@@ -53,17 +51,18 @@ func (c *CPU) Sample() (*spb.StatsRecord, error) {
 	}
 
 	// total system CPU usage in percent
-	utilization, err := cpu.Percent(0, true)
-	if err != nil {
-		// do not log "not implemented yet" errors
-		if !strings.Contains(err.Error(), "not implemented yet") {
-			errs = append(errs, err)
-		}
-	} else {
-		for i, u := range utilization {
-			metrics[fmt.Sprintf("cpu.%d.cpu_percent", i)] = u
-		}
-	}
+	// TODO: make logging this configurable.
+	// utilization, err := cpu.Percent(0, true)
+	// if err != nil {
+	// 	// do not log "not implemented yet" errors
+	// 	if !strings.Contains(err.Error(), "not implemented yet") {
+	// 		errs = append(errs, err)
+	// 	}
+	// } else {
+	// 	for i, u := range utilization {
+	// 		metrics[fmt.Sprintf("cpu.%d.cpu_percent", i)] = u
+	// 	}
+	// }
 
 	if len(metrics) == 0 {
 		return nil, errors.Join(errs...)

--- a/wandb/sdk/internal/system/assets/cpu.py
+++ b/wandb/sdk/internal/system/assets/cpu.py
@@ -118,7 +118,7 @@ class CPU:
         self.name: str = self.__class__.__name__.lower()
         self.metrics: List[Metric] = [
             ProcessCpuPercent(settings.x_stats_pid),
-            CpuPercent(),
+            # CpuPercent(),
             ProcessCpuThreads(settings.x_stats_pid),
         ]
         self.metrics_monitor: MetricsMonitor = MetricsMonitor(


### PR DESCRIPTION
Description
-----------
TBU: In the next release, we'll introduce the ability to configure the set of system metrics to collect. Per-core CPU utilization will however be disabled by default, to reduce the number of metrics collect by default as it can get large on beefy systems and is not always useful vs, say, the aggregated/averaged process tree CPU utilization.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
