### PR TITLE
chore: add tenacity to requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -23,6 +23,7 @@ plotly
 bokeh
 
 tqdm
+tenacity
 
 ipython
 ipython<8.13; python_version < '3.9'


### PR DESCRIPTION
Description
-----------
Its absence there started breaking the importer (unit) tests, see e.g. https://app.circleci.com/pipelines/github/wandb/wandb/43686/workflows/7111a909-3850-4de1-ac13-6289e457a6de/jobs/1337484?invite=true#step-106-158059_67. I'd guess that some other dependency dropped a dep on it, and it was working for us as it was implicit.
