### PR TITLE
fix(artifacts): fix slow instantiation of Artifact from GQL responses

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,3 +12,7 @@ Add here any changes made in a PR that are relevant to end users. Allowed sectio
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- Fixed a performance issue causing slow instantiation of `wandb.Artifact`, which in turn slowed down fetching artifacts in various API methods. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9355)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -15,10 +15,22 @@ import stat
 import tempfile
 import time
 from copy import copy
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import partial
 from pathlib import PurePosixPath
-from typing import IO, TYPE_CHECKING, Any, Dict, Iterator, Literal, Sequence, Type, cast
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    Literal,
+    Sequence,
+    Type,
+    cast,
+    final,
+)
 from urllib.parse import quote, urljoin, urlparse
 
 import requests
@@ -72,6 +84,14 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from wandb.sdk.interface.message_future import MessageFuture
+
+
+@final
+@dataclass
+class _DeferredArtifactManifest:
+    """A lightweight wrapper around the manifest URL, used to indicate deferred loading of the actual manifest."""
+
+    url: str
 
 
 class Artifact:
@@ -170,14 +190,9 @@ class Artifact:
         self._incremental: bool = incremental
         self._use_as: str | None = use_as
         self._state: ArtifactState = ArtifactState.PENDING
-
-        # Not ideal that we have separate attributes to track the state of the
-        # artifact manifest, but necessary workaround for now.
-        self._manifest_url: str | None = None
-        self._manifest: ArtifactManifest | None = ArtifactManifestV1(
-            self._storage_policy
+        self._manifest: ArtifactManifest | _DeferredArtifactManifest | None = (
+            ArtifactManifestV1(self._storage_policy)
         )
-
         self._commit_hash: str | None = None
         self._file_count: int | None = None
         self._created_at: str | None = None
@@ -381,9 +396,11 @@ class Artifact:
         self._state = ArtifactState(attrs["state"])
 
         try:
-            self._manifest_url = attrs["currentManifest"]["file"]["directUrl"]
+            manifest_url = attrs["currentManifest"]["file"]["directUrl"]
         except (LookupError, TypeError):
-            self._manifest_url = None
+            self._manifest = None
+        else:
+            self._manifest = _DeferredArtifactManifest(manifest_url)
 
         self._commit_hash = attrs["commitHash"]
         self._file_count = attrs["fileCount"]
@@ -774,10 +791,13 @@ class Artifact:
         The manifest lists all of its contents, and can't be changed once the artifact
         has been logged.
         """
-        if self._manifest is not None:
+        if isinstance(self._manifest, _DeferredArtifactManifest):
+            # A deferred manifest URL flags a deferred download request,
+            # so fetch the manifest to override the placeholder object
+            self._manifest = self._load_manifest(self._manifest.url)
             return self._manifest
 
-        if self._manifest_url is None:
+        if self._manifest is None:
             query = gql(
                 """
                 query ArtifactManifest(
@@ -807,9 +827,9 @@ class Artifact:
                 },
             )
             attrs = response["project"]["artifact"]
-            self._manifest_url = attrs["currentManifest"]["file"]["directUrl"]
+            manifest_url = attrs["currentManifest"]["file"]["directUrl"]
+            self._manifest = self._load_manifest(manifest_url)
 
-        self._manifest = self._load_manifest(self._manifest_url)
         return self._manifest
 
     @property

--- a/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
@@ -59,7 +59,7 @@ class WBLocalArtifactHandler(StorageHandler):
         target_artifact = artifact_instance_cache.get(client_id)
         if not isinstance(target_artifact, wandb.Artifact):
             raise RuntimeError("Local Artifact not found - invalid reference")
-        target_entry = target_artifact._manifest.entries[target_path]  # type: ignore
+        target_entry = target_artifact.manifest.entries[target_path]  # type: ignore
         if target_entry is None:
             raise RuntimeError("Local entry not found - invalid reference")
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- [WB-22870](https://wandb.atlassian.net/browse/WB-22870)

Fixes slow (client-side) instantiation of `Artifact` objects due to a separate blocking HTTP request to fetch the artifact manifest.

This request can occur during internal calls to `Artifact._from_attrs()`, so this affects most code paths that parse an `Artifact` from GQL response data.

This PR "defers" the HTTP request -- by wrapping the request URL in an internal dataclass (since using Futures or similar probably risks unforeseen side effects) --until the getter on `artifact.manifest` is invoked.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
No intended change in functionality, so relying on existing tests to catch regressions.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-22870]: https://wandb.atlassian.net/browse/WB-22870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ