### PR TITLE
chore(launch): clean launch agent mock between launch kubernetes tests

### DIFF
--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -11,6 +11,7 @@ import wandb.sdk.launch.runner.kubernetes_runner
 from kubernetes_asyncio import client
 from kubernetes_asyncio.client import ApiException
 from wandb.sdk.launch._project_spec import LaunchProject
+from wandb.sdk.launch.agent.agent import LaunchAgent
 from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.runner.kubernetes_monitor import (
     CustomResource,
@@ -37,6 +38,13 @@ def clean_monitor():
     LaunchKubernetesMonitor._instance = None
     yield
     LaunchKubernetesMonitor._instance = None
+
+
+@pytest.fixture
+def clean_agent():
+    LaunchAgent._instance = None
+    yield
+    LaunchAgent._instance = None
 
 
 @pytest.fixture
@@ -713,6 +721,7 @@ async def test_launch_kube_base_image_works(
     test_api,
     manifest,
     clean_monitor,
+    clean_agent,
     tmpdir,
 ):
     """Test that runner works as expected with base image jobs."""
@@ -852,6 +861,7 @@ async def test_launch_kube_failed(
     test_api,
     manifest,
     clean_monitor,
+    clean_agent,
 ):
     """Test that we can launch a kubernetes job."""
     mock_batch_api.jobs = {"test-job": manifest}
@@ -905,6 +915,7 @@ async def test_launch_kube_api_secret_failed(
     test_api,
     manifest,
     clean_monitor,
+    clean_agent,
 ):
     async def mock_maybe_create_imagepull_secret(*args, **kwargs):
         return None
@@ -971,6 +982,7 @@ async def test_launch_kube_pod_schedule_warning(
     test_api,
     manifest,
     clean_monitor,
+    clean_agent,
 ):
     mock_batch_api.jobs = {"test-job": MockDict(manifest)}
     job_tracker = MagicMock()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- [Slack thread](https://weightsandbiases.slack.com/archives/C0108SLEP6K/p1738180653893699)

Some Launch-related tests are failing because the `LaunchAgent` is being instantiated before the test. This adds a fixture to clear the `LaunchAgent` before running the affected tests.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
The test is flaky so it's hard to say for sure, but it passes locally and in CI.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
