### PR TITLE
fix: public API error messages

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,3 +20,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Fixed a performance issue causing slow instantiation of `wandb.Artifact`, which in turn slowed down fetching artifacts in various API methods. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9355)
+- Some errors from `wandb.Api` have better string representations (@timoffex in https://github.com/wandb/wandb/pull/9361)

--- a/tests/unit_tests/test_normalize.py
+++ b/tests/unit_tests/test_normalize.py
@@ -1,51 +1,91 @@
-import json
+from __future__ import annotations
+
+import re
+from typing import NoReturn
 
 import pytest
 import requests
 from wandb.apis.normalize import normalize_exceptions
-from wandb.errors import CommError, Error
+from wandb.errors import CommError
 
 
-def raise_exception():
-    raise Exception("test")
+def raise_exception(msg: str):
+    raise Exception(msg)
 
 
-def response_factory(status_code, json_data=None):
+def http_response(
+    status_code: int,
+    body: bytes | None = None,
+    reason: str | None = None,
+):
     response = requests.Response()
-    if json_data is not None:
-        response._content = json.dumps(json_data).encode()
+    if body is not None:
+        response._content = body
+    if reason is not None:
+        response.reason = reason
     response.status_code = status_code
     return response
 
 
-def raise_http_error(response):
-    raise requests.HTTPError("HTTP error occurred", response=response)
+def test_exception():
+    @normalize_exceptions
+    def fn():
+        raise Exception("test")
+
+    with pytest.raises(CommError, match="test"):
+        fn()
 
 
-def raise_wandb_error():
-    raise Error("W&B error occurred")
+@normalize_exceptions
+def raise_http_error(response: requests.Response) -> NoReturn:
+    raise requests.HTTPError(response=response)
+
+
+def test_empty_http_error():
+    resp = http_response(404)
+
+    with pytest.raises(CommError, match="HTTP 404"):
+        raise_http_error(resp)
+
+
+def test_http_error_with_reason():
+    resp = http_response(404, reason="Not Found")
+
+    with pytest.raises(CommError, match=re.escape("HTTP 404 (Not Found)")):
+        raise_http_error(resp)
 
 
 @pytest.mark.parametrize(
-    "func, args, error, message",
+    "body, message",
     [
-        (raise_exception, (), CommError, "test"),
-        (raise_http_error, (response_factory(404),), CommError, r"<Response \[404\]>"),
-        (
-            raise_http_error,
-            (response_factory(404, {"errors": "not found"}),),
-            CommError,
-            r"<Response \[404\]>",
-        ),
-        (
-            raise_http_error,
-            (response_factory(404, {"errors": ["not found"]}),),
-            CommError,
-            "not found",
-        ),
-        (raise_wandb_error, (), Error, "W&B error occurred"),
+        (b"not JSON", "HTTP 500: not JSON"),
+        (b'"JSON string"', 'HTTP 500: "JSON string"'),
+        (b'{"bad field": 123}', 'HTTP 500: {"bad field": 123}'),
+        (b'{"error": 123}', 'HTTP 500: {"error": 123}'),
+        (b'{"errors": 123}', 'HTTP 500: {"errors": 123}'),
+        (b'{"errors": "string"}', 'HTTP 500: {"errors": "string"}'),
     ],
 )
-def test_normalize_http_error(func, args, error, message):
-    with pytest.raises(error, match=message):
-        normalize_exceptions(func)(*args)
+def test_http_error_invalid_body(body, message):
+    resp = http_response(500, body=body)
+
+    with pytest.raises(CommError, match=re.escape(message)):
+        raise_http_error(resp)
+
+
+@pytest.mark.parametrize(
+    "body, message",
+    [
+        (b'{"error": "string"}', "HTTP 500: string"),
+        (b'{"error": {"message": "message"}}', "HTTP 500: message"),
+        (
+            b'{"errors": ["string", {"message": "nested message"}]}',
+            "HTTP 500: string; nested message",
+        ),
+    ],
+)
+def test_http_error_valid_body(body, message):
+    resp = http_response(500, body=body)
+
+    with pytest.raises(CommError, match=re.escape(message)):
+        raise_http_error(resp)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -854,20 +854,52 @@ def no_retry_4xx(e: Exception) -> bool:
 
 
 def parse_backend_error_messages(response: requests.Response) -> List[str]:
-    errors: List[str] = []
+    """Returns error messages stored in a backend response.
+
+    If the response is not in an expected format, an empty list is returned.
+
+    Args:
+        response: A response to an HTTP request to the W&B server.
+    """
     try:
         data = response.json()
-    except ValueError:
-        return errors
+    except requests.JSONDecodeError:
+        return []
 
-    if "errors" in data and isinstance(data["errors"], list):
-        for error in data["errors"]:
-            # Our tests and potentially some api endpoints return a string error?
-            if isinstance(error, str):
-                error = {"message": error}
-            if "message" in error:
-                errors.append(error["message"])
-    return errors
+    if not isinstance(data, dict):
+        return []
+
+    # Backend error values are returned in one of two ways:
+    # - A string containing the error message
+    # - A JSON object with a "message" field that is a string
+    def get_message(err: Any) -> Optional[str]:
+        if isinstance(error, str):
+            return error
+        elif (
+            isinstance(error, dict)
+            and (message := error.get("message"))
+            and isinstance(message, str)
+        ):
+            return message
+        else:
+            return None
+
+    # The response can contain an "error" field with a single error
+    # or an "errors" field with a list of errors.
+    if error := data.get("error"):
+        message = get_message(error)
+        return [message] if message else []
+
+    elif (errors := data.get("errors")) and isinstance(errors, list):
+        messages: List[str] = []
+        for error in errors:
+            message = get_message(error)
+            if message:
+                messages.append(message)
+        return messages
+
+    else:
+        return []
 
 
 def no_retry_auth(e: Any) -> bool:
@@ -1266,7 +1298,7 @@ def prompt_choices(
 ) -> str:
     """Allow a user to choose from a list of options."""
     for i, choice in enumerate(choices):
-        wandb.termlog(f"({i+1}) {choice}")
+        wandb.termlog(f"({i + 1}) {choice}")
 
     idx = -1
     while idx < 0 or idx > len(choices) - 1:


### PR DESCRIPTION
Fixes the string representation of HTTP errors encountered by the public API.

The `parse_backend_error_messages` function now properly handles the `{"error": "message"}` and `{"error": {"message": "value"}}` formats.

When the response body is not in a known format, `normalize.py` now includes the response body text instead of the `Response` object, whose string representation was `<Response: status>`.

