### PR TITLE
chore: update login message for notebook environments to not show "press ctrl+c to quit"

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -134,10 +134,8 @@ def prompt_api_key(  # noqa: C901
         )
 
     key = None
-    api_ask = (
-        f"{log_string}: Paste an API key from your profile and hit enter, "
-        "or press ctrl+c to quit"
-    )
+    api_ask_suffix = ", or press ctrl+c to quit" if not jupyter else ""
+    api_ask = f"{log_string}: Paste an API key from your profile and hit enter{api_ask_suffix}"
     if result == LOGIN_CHOICE_ANON:
         key = api.create_anonymous_api_key()
     elif result == LOGIN_CHOICE_NEW:

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -134,8 +134,11 @@ def prompt_api_key(  # noqa: C901
         )
 
     key = None
-    api_ask_suffix = ", or press ctrl+c to quit" if not jupyter else ""
-    api_ask = f"{log_string}: Paste an API key from your profile and hit enter{api_ask_suffix}"
+    api_ask = (
+        f"{log_string}: Paste an API key from your profile and hit enter"
+        if jupyter
+        else f"{log_string}: Paste an API key from your profile and hit enter, or press ctrl+c to quit"
+    )
     if result == LOGIN_CHOICE_ANON:
         key = api.create_anonymous_api_key()
     elif result == LOGIN_CHOICE_NEW:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-9180

What does the PR do? Include a concise description of the PR contents.

In various notebook environments there are different ways to interrupt to send an interrupt command. Right now we print out a message with "or press ctrl+c to quit" which does nothing in jupyter or colab notebooks. This PR removes that part of the string when running in a notebook/jupyter env.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
<img width="818" alt="image" src="https://github.com/user-attachments/assets/4d1cd897-a12b-47ac-a7f4-4aaaa2ab181f" />

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
