### PR TITLE
refactor: replace mailbox.ContextCancelledError

### DIFF
--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -52,9 +52,9 @@ from wandb.sdk.lib import (
     filesystem,
     proto_util,
     redirect,
+    retry,
     telemetry,
 )
-from wandb.sdk.lib.mailbox import ContextCancelledError
 from wandb.sdk.lib.proto_util import message_to_dict
 
 if TYPE_CHECKING:
@@ -388,7 +388,7 @@ class SendManager:
         try:
             self._api.set_local_context(api_context)
             send_handler(record)
-        except ContextCancelledError:
+        except retry.RetryCancelledError:
             logger.debug(f"Record cancelled: {record_type}")
             self._context_keeper.release(context_id)
         finally:

--- a/wandb/sdk/lib/mailbox.py
+++ b/wandb/sdk/lib/mailbox.py
@@ -24,10 +24,6 @@ class MailboxError(Error):
     """Generic Mailbox Exception."""
 
 
-class ContextCancelledError(MailboxError):
-    """Context cancelled Exception."""
-
-
 class _MailboxWaitAll:
     _event: threading.Event
     _lock: threading.Lock


### PR DESCRIPTION
Replace `mailbox.ContextCancelledError` by `retry.RetryCancelledError`.

This error is only raised in `retry.py` and only caught in `sender.py`. It subclasses `mailbox.MailboxError`, but this is only caught in `wandb_run.py` while running `MailboxHandle.wait()` which cannot throw `ContextCancelledError`.

There was no reason for this to be in `mailbox.py`.