### PR TITLE
chore: sort computed metric label hashes for openmetrics collector in system monitor

### DIFF
--- a/core/pkg/monitor/openmetrics_test.go
+++ b/core/pkg/monitor/openmetrics_test.go
@@ -270,7 +270,7 @@ func TestCache(t *testing.T) {
 	metricName := "DCGM_FI_DEV_POWER_USAGE"
 	metricLabels := map[string]string{"pod": "wandb-1337"}
 
-	hash := om.GenerateLabelHash(metricLabels)
+	hash := monitor.GenerateLabelHash(metricLabels)
 	// check that metricName+hash is not in the cache
 	_, ok := om.Cache().Get(metricName + hash)
 	assert.False(t, ok)


### PR DESCRIPTION
The hashes are computed from labels extracted for individual metrics and are used to provide a stable indexing / mapping when collecting metrics from an OpenMetrics/Prometheus endpoint.

This PR ensures labels are sorted before computing hashes.

Example of an OpenMetrics metric:
```
DCGM_FI_DEV_GPU_TEMP{DCGM_FI_DEV_SERIAL="175212400829", DCGM_FI_DEV_VBIOS_VERSION="96.00.A5.00.01", Hostname="l1337", UUID="GPU-66f74c59-1fd7-7943-526e-cdb89a69516b", cluster="ml-dev", container="exporter", device="nvidia6", endpoint="metrics", gpu="6", instance="10.0.0.102:9400", job="metrics/dcgm-exporter", modelName="NVIDIA H100 80GB HBM3", node="l1337", region="US-WEST-02", uuid="GPU-66f74c59-1fd7-7943-526e-cdb89a69516b"} => 24 @[1738025769]
```