### PR TITLE
refactor: asyncio compatibility tools

### DIFF
--- a/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
+++ b/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
@@ -1,0 +1,43 @@
+import asyncio
+import sys
+
+from wandb.sdk.lib import asyncio_compat
+
+_got_cancelled = False
+
+
+async def pass_if_cancelled() -> None:
+    global _got_cancelled
+
+    try:
+        print("TEST READY", flush=True)  # noqa: T201
+        await asyncio.sleep(5)
+
+    except asyncio.CancelledError:
+        # The test sends a SIGINT to the process, which we expect
+        # asyncio_compat.run() to turn into task cancellation.
+        _got_cancelled = True
+
+
+if __name__ == "__main__":
+    try:
+        asyncio_compat.run(pass_if_cancelled)
+    except KeyboardInterrupt:
+        if _got_cancelled:
+            print(  # noqa: T201
+                "PASS: Cancelled by KeyboardInterrupt!",
+                file=sys.stderr,
+            )
+            sys.exit(0)
+        else:
+            print(  # noqa: T201
+                "FAIL: Interrupted but not cancelled!",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        print(  # noqa: T201
+            "FAIL: Not interrupted by parent.",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/tests/system_tests/test_functional/asyncio_compat_run/test_asyncio_compat_run.py
+++ b/tests/system_tests/test_functional/asyncio_compat_run/test_asyncio_compat_run.py
@@ -1,0 +1,17 @@
+import pathlib
+import signal
+import subprocess
+
+
+def test_asyncio_compat_run_stops_on_keyboard_interrupt():
+    script = pathlib.Path(__file__).parent / "pass_if_cancelled.py"
+    proc = subprocess.Popen(
+        ["python", str(script)],
+        stdout=subprocess.PIPE,
+    )
+
+    # Wait for process to enter the asyncio loop, then send SIGINT.
+    assert proc.stdout.readline() == b"TEST READY\n"
+    proc.send_signal(signal.SIGINT)
+
+    assert proc.wait() == 0

--- a/tests/unit_tests/test_asyncio_compat.py
+++ b/tests/unit_tests/test_asyncio_compat.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Coroutine
+
+import pytest
+from wandb.sdk.lib import asyncio_compat
+
+
+async def _fail_after_timeout(
+    coro: Coroutine[Any, Any, Any],
+    failure_message: str,
+) -> None:
+    try:
+        await asyncio.wait_for(coro, timeout=1)
+    except (asyncio.TimeoutError, TimeoutError) as e:
+        raise AssertionError(failure_message) from e
+
+
+async def _yield() -> None:
+    """Allow other scheduled tasks to run."""
+    await asyncio.sleep(0)
+
+
+class _TaskGroupTester:
+    def __init__(self) -> None:
+        self._before_exit = asyncio.Event()
+        self._after_exit = asyncio.Event()
+
+    def start(
+        self,
+        subtasks: list[Coroutine[Any, Any, Any]],
+        main_task: Coroutine[Any, Any, Any] | None = None,
+    ) -> None:
+        """Start the tester.
+
+        This schedules a parallel task that opens a task group, adds
+        the given subtasks to it, and run the main task in the context
+        manager body.
+        """
+
+        async def run():
+            try:
+                async with asyncio_compat.open_task_group() as task_group:
+                    for subtask in subtasks:
+                        task_group.start_soon(subtask)
+
+                    if main_task:
+                        await main_task
+
+                    self._before_exit.set()
+            finally:
+                self._after_exit.set()
+
+        asyncio.create_task(run())
+
+    async def assert_blocked_on_exit(self) -> None:
+        """Assert the tester's blocked waiting for the task group to exit."""
+        await _fail_after_timeout(
+            self._before_exit.wait(),
+            "Didn't reach end of task group context manager.",
+        )
+        assert not self._after_exit.is_set()
+
+    async def assert_exits(self) -> None:
+        """Assert the tester has exited."""
+        await _fail_after_timeout(
+            self._after_exit.wait(),
+            "Didn't exit task group.",
+        )
+
+
+class _CancellationDetector:
+    def __init__(self) -> None:
+        self._cancelled = asyncio.Event()
+
+    async def expect_cancelled(self) -> None:
+        """A coroutine that detects if it is cancelled."""
+        try:
+            await asyncio.sleep(1)
+            raise AssertionError("Expected to get cancelled.")
+        except asyncio.CancelledError:
+            self._cancelled.set()
+
+    async def assert_cancelled(self) -> None:
+        """Assert the detector's task got started and cancelled.
+
+        This will not detect if the task is cancelled before it is scheduled.
+        """
+        await _fail_after_timeout(
+            self._cancelled.wait(),
+            "Task didn't get cancelled, or didn't start.",
+        )
+
+
+class _TestError(Exception):
+    """Intentional error raised in a test."""
+
+
+def test_compat_run_in_asyncio_context():
+    success = False
+
+    async def internal_wandb_thing():
+        nonlocal success
+        success = True
+
+    async def i_use_wandb_in_asyncio():
+        # NOTE: Using asyncio.run() inside an asyncio loop fails.
+        asyncio_compat.run(internal_wandb_thing)
+
+    asyncio.run(i_use_wandb_in_asyncio())
+
+    assert success
+
+
+@pytest.mark.asyncio
+async def test_cancel_on_exit_normal():
+    cd = _CancellationDetector()
+
+    with asyncio_compat.cancel_on_exit(cd.expect_cancelled()):
+        await _yield()
+
+    await cd.assert_cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cancel_on_exit_error_in_body():
+    cd = _CancellationDetector()
+
+    with pytest.raises(_TestError):
+        with asyncio_compat.cancel_on_exit(cd.expect_cancelled()):
+            await _yield()
+            raise _TestError()
+
+    await cd.assert_cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cancel_on_exit_error_in_task():
+    async def fail():
+        await _yield()
+        raise _TestError()
+
+    with pytest.raises(_TestError):
+        with asyncio_compat.cancel_on_exit(fail()):
+            await _yield()
+            await _yield()
+
+
+@pytest.mark.asyncio
+async def test_task_group_waits():
+    tester = _TaskGroupTester()
+    event = asyncio.Event()
+
+    tester.start(subtasks=[event.wait()])
+
+    await tester.assert_blocked_on_exit()
+    event.set()
+    await tester.assert_exits()
+
+
+@pytest.mark.asyncio
+async def test_task_group_cancels_on_body_error():
+    async def fail():
+        await _yield()
+        raise _TestError()
+
+    tester = _TaskGroupTester()
+    cd = _CancellationDetector()
+
+    tester.start(
+        subtasks=[cd.expect_cancelled()],
+        main_task=fail(),
+    )
+
+    await tester.assert_exits()
+    await cd.assert_cancelled()
+
+
+@pytest.mark.asyncio
+async def test_task_group_cancels_on_subtask_error():
+    async def fail():
+        await _yield()
+        raise _TestError()
+
+    tester = _TaskGroupTester()
+    cd1 = _CancellationDetector()
+    cd2 = _CancellationDetector()
+
+    tester.start(
+        subtasks=[
+            cd1.expect_cancelled(),
+            fail(),
+            cd2.expect_cancelled(),
+        ]
+    )
+
+    await tester.assert_exits()
+    await cd1.assert_cancelled()
+    await cd2.assert_cancelled()

--- a/wandb/sdk/lib/asyncio_compat.py
+++ b/wandb/sdk/lib/asyncio_compat.py
@@ -1,0 +1,210 @@
+"""Functions for compatibility with asyncio."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent
+import concurrent.futures
+import contextlib
+import threading
+from typing import Any, AsyncIterator, Callable, Coroutine, Iterator, TypeVar
+
+_T = TypeVar("_T")
+
+
+def run(fn: Callable[[], Coroutine[Any, Any, _T]]) -> _T:
+    """Run `fn` in an asyncio loop in a new thread.
+
+    This must always be used instead of `asyncio.run` which fails if there is
+    an active `asyncio` event loop in the current thread. Since `wandb` was not
+    originally designed with `asyncio` in mind, using `asyncio.run` would break
+    users who were calling `wandb` methods from an `asyncio` loop.
+
+    Note that due to starting a new thread, this is slightly slow.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        runner = _Runner()
+        future = executor.submit(runner.run, fn)
+
+        try:
+            return future.result()
+
+        finally:
+            runner.cancel()
+
+
+class _RunnerCancelledError(Exception):
+    """The `_Runner.run()` invocation was cancelled."""
+
+
+class _Runner:
+    """Runs an asyncio event loop allowing cancellation.
+
+    This is like `asyncio.run()`, except it provides a `cancel()` method
+    meant to be called in a `finally` block.
+
+    Without this, it is impossible to make `asyncio.run()` stop if it runs
+    in a non-main thread. In particular, a KeyboardInterrupt causes the
+    ThreadPoolExecutor above to block until the asyncio thread completes,
+    but there is no way to tell the asyncio thread to cancel its work.
+    A second KeyboardInterrupt makes ThreadPoolExecutor give up while the
+    asyncio thread still runs in the background, with terrible effects if it
+    prints to the user's terminal.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Condition()
+
+        self._is_cancelled = False
+        self._started = False
+        self._done = False
+
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._cancel_event: asyncio.Event | None = None
+
+    def run(self, fn: Callable[[], Coroutine[Any, Any, _T]]) -> _T:
+        """Run a coroutine in asyncio, cancelling it on `cancel()`.
+
+        Returns:
+            The result of the coroutine returned by `fn`.
+
+        Raises:
+            _RunnerCancelledError: If `cancel()` is called.
+        """
+        return asyncio.run(self._run_or_cancel(fn))
+
+    async def _run_or_cancel(
+        self,
+        fn: Callable[[], Coroutine[Any, Any, _T]],
+    ) -> _T:
+        with self._lock:
+            if self._is_cancelled:
+                raise _RunnerCancelledError()
+
+            self._loop = asyncio.get_running_loop()
+            self._cancel_event = asyncio.Event()
+            self._started = True
+
+        cancellation_task = asyncio.create_task(self._cancel_event.wait())
+        fn_task = asyncio.create_task(fn())
+
+        try:
+            await asyncio.wait(
+                [cancellation_task, fn_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if fn_task.done():
+                return fn_task.result()
+            else:
+                raise _RunnerCancelledError()
+
+        finally:
+            cancellation_task.cancel()
+            fn_task.cancel()
+
+            with self._lock:
+                self._done = True
+
+    def cancel(self) -> None:
+        """Cancel all asyncio work started by `run()`."""
+        with self._lock:
+            if self._is_cancelled:
+                return
+            self._is_cancelled = True
+
+            if self._done or not self._started:
+                # If the runner already finished, no need to cancel it.
+                #
+                # If the runner hasn't started the loop yet, then it will not
+                # as we already set _is_cancelled.
+                return
+
+            assert self._loop
+            assert self._cancel_event
+            self._loop.call_soon_threadsafe(self._cancel_event.set)
+
+
+class TaskGroup:
+    """Object that `open_task_group()` yields."""
+
+    def __init__(self) -> None:
+        self._tasks: list[asyncio.Task] = []
+
+    def start_soon(self, coro: Coroutine[Any, Any, Any]) -> None:
+        """Schedule a task in the group.
+
+        Args:
+            coro: The return value of the `async` function defining the task.
+        """
+        self._tasks.append(asyncio.create_task(coro))
+
+    async def _wait_all(self) -> None:
+        """Block until all tasks complete.
+
+        Raises:
+            Exception: If one or more tasks raises an exception, one of these
+                is raised arbitrarily.
+        """
+        done, _ = await asyncio.wait(
+            self._tasks,
+            # NOTE: Cancelling a task counts as a normal exit,
+            #   not an exception.
+            return_when=concurrent.futures.FIRST_EXCEPTION,
+        )
+
+        for task in done:
+            try:
+                if exc := task.exception():
+                    raise exc
+            except asyncio.CancelledError:
+                pass
+
+    def _cancel_all(self) -> None:
+        """Cancel all tasks."""
+        for task in self._tasks:
+            # NOTE: It is safe to cancel tasks that have already completed.
+            task.cancel()
+
+
+@contextlib.asynccontextmanager
+async def open_task_group() -> AsyncIterator[TaskGroup]:
+    """Create a task group.
+
+    `asyncio` gained task groups in Python 3.11.
+
+    This is an async context manager, meant to be used with `async with`.
+    On exit, it blocks until all subtasks complete. If any subtask fails, or if
+    the current task is cancelled, it cancels all subtasks in the group and
+    raises the subtask's exception. If multiple subtasks fail simultaneously,
+    one of their exceptions is chosen arbitrarily.
+
+    NOTE: Subtask exceptions do not propagate until the context manager exits.
+    This means that the task group cannot cancel code running inside the
+    `async with` block .
+    """
+    task_group = TaskGroup()
+
+    try:
+        yield task_group
+        await task_group._wait_all()
+    finally:
+        task_group._cancel_all()
+
+
+@contextlib.contextmanager
+def cancel_on_exit(coro: Coroutine[Any, Any, Any]) -> Iterator[None]:
+    """Schedule a task, cancelling it when exiting the context manager.
+
+    If the given coroutine raises an exception, that exception is raised
+    when exiting the context manager.
+    """
+    task = asyncio.create_task(coro)
+
+    try:
+        yield
+    finally:
+        if task.done() and (exception := task.exception()):
+            raise exception
+
+        task.cancel()


### PR DESCRIPTION
Adds `asyncio_compat.py` file with some important utilities for using `asyncio` safely.

In `asyncio`, cancelling a task does not cancel subtasks that it started. Python 3.11 adds a `TaskGroup` class to fix this, but we need custom code for Python 3.8 - 3.10.

Using `asyncio.run` inside an `asyncio` event loop is not allowed. In case any of our users call `wandb` functions in an `asyncio` context, the `asyncio_compat.run` function starts an `asyncio` loop in a new thread.