### PR TITLE
refactor: new mailbox implementation

### DIFF
--- a/tests/unit_tests/test_new_mailbox.py
+++ b/tests/unit_tests/test_new_mailbox.py
@@ -1,0 +1,279 @@
+import asyncio
+import math
+import threading
+import unittest.mock
+
+import pytest
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk import mailbox as mb
+from wandb.sdk.lib import asyncio_compat
+
+
+@pytest.fixture(params=[-9.4, -1, 0, 99.1, None])
+def any_timeout(request):
+    """An arbitrary timeout value.
+
+    - A negative number
+    - Negative one (which may be special)
+    - Zero (which may be special)
+    - A positive number
+    - None
+    """
+    return request.param
+
+
+@pytest.fixture(params=[-3.2, -1, 0])
+def immediate_timeout(request):
+    """A timeout value that should be an immediate timeout.
+
+    Not intended for the `wait()` method, which treats -1 specially.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[math.inf, math.nan])
+def invalid_timeout(request):
+    """A value that cannot be used as a timeout."""
+    return request.param
+
+
+def test_wait_already_delivered(any_timeout):
+    mailbox = mb.Mailbox()
+    request = pb.Record()
+    handle = mailbox.require_response(request)
+    result = pb.Record()
+    result.control.mailbox_slot = request.control.mailbox_slot
+
+    mailbox.deliver(result)
+    handle_result = handle.wait_or(timeout=any_timeout)
+
+    assert result is handle_result
+
+
+@pytest.mark.asyncio
+async def test_wait_async_already_delivered(any_timeout):
+    mailbox = mb.Mailbox()
+    request = pb.Record()
+    handle = mailbox.require_response(request)
+    result = pb.Record()
+    result.control.mailbox_slot = request.control.mailbox_slot
+
+    mailbox.deliver(result)
+    handle_result = await handle.wait_async(timeout=any_timeout)
+
+    assert result is handle_result
+
+
+def test_wait_abandoned(any_timeout):
+    mailbox = mb.Mailbox()
+    handle = mailbox.require_response(pb.Record())
+
+    handle.abandon()
+    with pytest.raises(mb.HandleAbandonedError):
+        handle.wait_or(timeout=any_timeout)
+
+
+@pytest.mark.asyncio
+async def test_wait_async_abandoned(any_timeout):
+    mailbox = mb.Mailbox()
+    handle = mailbox.require_response(pb.Record())
+
+    handle.abandon()
+    with pytest.raises(mb.HandleAbandonedError):
+        await handle.wait_async(timeout=any_timeout)
+
+
+def test_wait_timeout(immediate_timeout):
+    mailbox = mb.Mailbox()
+    handle = mailbox.require_response(pb.Record())
+
+    with pytest.raises(TimeoutError):
+        handle.wait_or(timeout=immediate_timeout)
+
+
+@pytest.mark.asyncio
+async def test_wait_async_timeout(immediate_timeout):
+    mailbox = mb.Mailbox()
+    handle = mailbox.require_response(pb.Record())
+
+    with pytest.raises(TimeoutError):
+        await handle.wait_async(timeout=immediate_timeout)
+
+
+def test_wait_invalid_timeout(invalid_timeout):
+    mailbox = mb.Mailbox()
+    handle = mailbox.require_response(pb.Record())
+
+    with pytest.raises(ValueError, match="Timeout must be finite or None."):
+        handle.wait_or(timeout=invalid_timeout)
+
+
+@pytest.mark.asyncio
+async def test_wait_async_invalid_timeout(invalid_timeout):
+    mailbox = mb.Mailbox()
+    handle = mailbox.require_response(pb.Record())
+
+    with pytest.raises(ValueError, match="Timeout must be finite or None."):
+        await handle.wait_async(timeout=invalid_timeout)
+
+
+@pytest.mark.parametrize("kind", ["deliver", "abandon"])
+def test_unblocks_wait(kind):
+    mailbox = mb.Mailbox()
+    request = pb.Record()
+    handle = mailbox.require_response(request)
+    result = pb.Result()
+    result.control.mailbox_slot = request.control.mailbox_slot
+
+    about_to_wait = threading.Event()
+    done_waiting = threading.Event()
+    abandoned = threading.Event()
+
+    def wait_for_handle():
+        about_to_wait.set()
+        try:
+            handle.wait_or(timeout=5)
+            done_waiting.set()
+        except mb.HandleAbandonedError:
+            abandoned.set()
+
+    t = threading.Thread(target=wait_for_handle)
+    t.start()
+
+    # Once we observe the event, it's very likely (but not guaranteed)
+    # that the thread is blocked in `wait_or`.
+    about_to_wait.wait()
+
+    if kind == "deliver":
+        mailbox.deliver(result)
+        assert done_waiting.wait(timeout=1)
+    else:
+        handle.abandon()
+        assert abandoned.wait(timeout=1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["deliver", "abandon"])
+async def test_unblocks_wait_async(kind):
+    mailbox = mb.Mailbox()
+    request = pb.Record()
+    handle = mailbox.require_response(request)
+    result = pb.Result()
+    result.control.mailbox_slot = request.control.mailbox_slot
+
+    about_to_wait = asyncio.Event()
+    done_waiting = asyncio.Event()
+    abandoned = asyncio.Event()
+
+    async def wait_for_handle():
+        about_to_wait.set()
+        try:
+            await handle.wait_async(timeout=5)
+            done_waiting.set()
+        except mb.HandleAbandonedError:
+            abandoned.set()
+
+    async with asyncio_compat.open_task_group() as task_group:
+        task_group.start_soon(wait_for_handle())
+
+        # When we observe the event, wait_for_handle should be suspended
+        # immediately before the wait_async. Using sleep(0) a few times lets
+        # wait_for_handle progress just far enough to make sure it's blocked on
+        # the internal `evt.wait()` instead of short-circuiting.
+        await about_to_wait.wait()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        if kind == "deliver":
+            mailbox.deliver(result)
+            asyncio.wait_for(done_waiting.wait(), timeout=1)
+        else:
+            handle.abandon()
+            asyncio.wait_for(abandoned.wait(), timeout=1)
+
+
+def test_require_response_sets_address():
+    mailbox = mb.Mailbox()
+    record = pb.Record()
+    mailbox.require_response(record)
+
+    assert len(record.control.mailbox_slot) == 12
+
+
+def test_require_response_raises_if_address_is_set():
+    mailbox = mb.Mailbox()
+    record = pb.Record()
+    mailbox.require_response(record)
+
+    with pytest.raises(ValueError, match="already has an address"):
+        mailbox.require_response(record)
+
+
+def test_deliver_unknown_address():
+    mailbox = mb.Mailbox()
+    result = pb.Result()
+    result.control.mailbox_slot = "unknown"
+
+    # Should pass.
+    mailbox.deliver(result)
+
+
+def test_deliver_no_address(caplog):
+    mailbox = mb.Mailbox()
+
+    mailbox.deliver(pb.Result())
+
+    assert "Received response with no mailbox slot." in caplog.text
+
+
+def test_deliver_after_abandon():
+    handle = mb.MailboxHandle("test-address")
+
+    handle.abandon()
+    handle.deliver(pb.Result())
+
+    assert handle._result is None
+
+
+def test_deliver_twice_raises_error():
+    handle = mb.MailboxHandle("test-address")
+    handle.deliver(pb.Result())
+
+    with pytest.raises(ValueError, match="has already been delivered"):
+        handle.deliver(pb.Result())
+
+
+def test_close_abandons_handles():
+    mailbox = mb.Mailbox()
+    handle1 = mailbox.require_response(pb.Record())
+    handle2 = mailbox.require_response(pb.Record())
+
+    mailbox.close()
+
+    assert handle1._abandoned
+    assert handle2._abandoned
+
+
+def test_cancel_abandons_handle():
+    handle = mb.MailboxHandle("test-address")
+    iface_mock = unittest.mock.Mock()
+
+    handle.cancel(iface_mock)
+
+    iface_mock.publish_cancel.assert_called_once_with("test-address")
+    assert handle._abandoned
+
+
+def test_check_returns_none_before_delivered():
+    handle = mb.MailboxHandle("test-address")
+
+    assert handle.check() is None
+
+
+def test_check_returns_result():
+    handle = mb.MailboxHandle("test-address")
+    result = pb.Result()
+    handle.deliver(result)
+
+    assert handle.check() is result

--- a/wandb/sdk/mailbox/__init__.py
+++ b/wandb/sdk/mailbox/__init__.py
@@ -1,0 +1,13 @@
+"""A message protocol for the internal service process.
+
+The core of W&B is implemented by a side process that asynchronously uploads
+data. The client process (such as this Python code) sends requests to the
+service, and for some requests, the service eventually sends a response.
+
+The client can send multiple requests before the service provides a response.
+The Mailbox handles matching responses to requests. An internal thread
+continuously reads data from the service and passes it to the mailbox.
+"""
+
+from .handles import HandleAbandonedError, MailboxHandle
+from .mailbox import Mailbox

--- a/wandb/sdk/mailbox/handles.py
+++ b/wandb/sdk/mailbox/handles.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import threading
+from typing import TYPE_CHECKING
+
+from wandb.proto import wandb_internal_pb2 as pb
+
+# Necessary to break an import loop.
+if TYPE_CHECKING:
+    from wandb.sdk.interface import interface
+
+
+class HandleAbandonedError(Exception):
+    """The handle has no result and has been abandoned."""
+
+
+class MailboxHandle:
+    """A thread-safe handle that allows waiting for a response to a request."""
+
+    def __init__(self, address: str) -> None:
+        self._address = address
+        self._lock = threading.Lock()
+        self._event = threading.Event()
+
+        self._abandoned = False
+        self._result: pb.Result | None = None
+
+        self._asyncio_events: dict[asyncio.Event, _AsyncioEvent] = dict()
+
+    def deliver(self, result: pb.Result) -> None:
+        """Deliver the response.
+
+        This may only be called once. It is an error to respond to the same
+        request more than once. It is a no-op if the handle has been abandoned.
+        """
+        with self._lock:
+            if self._abandoned:
+                return
+
+            if self._result:
+                raise ValueError(
+                    f"A response has already been delivered to {self._address}."
+                )
+
+            self._result = result
+            self._signal_done()
+
+    def cancel(self, iface: interface.InterfaceBase) -> None:
+        """Cancel the handle, requesting any associated work to not complete.
+
+        This automatically abandons the handle, as a response is no longer
+        guaranteed.
+
+        Args:
+            interface: The interface on which to publish the cancel request.
+        """
+        iface.publish_cancel(self._address)
+        self.abandon()
+
+    def abandon(self) -> None:
+        """Abandon the handle, indicating it will not receive a response."""
+        with self._lock:
+            self._abandoned = True
+            self._signal_done()
+
+    def _signal_done(self) -> None:
+        """Indicate that the handle either got a result or became abandoned.
+
+        The lock must be held.
+        """
+        # Unblock threads blocked on `wait_or`.
+        self._event.set()
+
+        # Unblock asyncio loops blocked on `wait_async`.
+        for asyncio_event in self._asyncio_events.values():
+            asyncio_event.set_threadsafe()
+        self._asyncio_events.clear()
+
+    def check(self) -> pb.Result | None:
+        """Returns the result if it's ready."""
+        with self._lock:
+            return self._result
+
+    def wait(self, *, timeout: float) -> pb.Result | None:
+        """DEPRECATED. Wait for a response or a timeout.
+
+        Args:
+            timeout: A finite number of seconds or -1 to never time out.
+
+        Returns:
+            The result if it arrives before the timeout or has already arrived.
+            On timeout, returns None.
+
+        Raises:
+            HandleAbandonedError: If the handle becomes abandoned.
+        """
+        try:
+            if timeout == -1:
+                return self.wait_or(timeout=None)
+            else:
+                return self.wait_or(timeout=timeout)
+        except TimeoutError:
+            return None
+
+    def wait_or(self, *, timeout: float | None) -> pb.Result:
+        """Wait for a response or a timeout.
+
+        This is called `wait_or` because it replaces a method called `wait`
+        with different semantics.
+
+        Args:
+            timeout: A finite number of seconds or None to never time out.
+                If less than or equal to zero, times out immediately unless
+                the result is available.
+
+        Returns:
+            The result if it arrives before the timeout or has already arrived.
+
+        Raises:
+            TimeoutError: If the timeout is reached.
+            HandleAbandonedError: If the handle becomes abandoned.
+        """
+        if timeout is not None and not math.isfinite(timeout):
+            raise ValueError("Timeout must be finite or None.")
+
+        if not self._event.wait(timeout=timeout):
+            raise TimeoutError(
+                f"Timed out waiting for response on {self._address}",
+            )
+
+        with self._lock:
+            if self._result:
+                return self._result
+
+            assert self._abandoned
+            raise HandleAbandonedError()
+
+    async def wait_async(self, *, timeout: float | None) -> pb.Result:
+        """Wait for a response or timeout.
+
+        This must run in an `asyncio` event loop.
+
+        Args:
+            timeout: A finite number of seconds or None to never time out.
+
+        Returns:
+            The result if it arrives before the timeout or has already arrived.
+
+        Raises:
+            TimeoutError: If the timeout is reached.
+            HandleAbandonedError: If the handle becomes abandoned.
+        """
+        if timeout is not None and not math.isfinite(timeout):
+            raise ValueError("Timeout must be finite or None.")
+
+        evt = asyncio.Event()
+        self._add_asyncio_event(asyncio.get_event_loop(), evt)
+
+        try:
+            await asyncio.wait_for(evt.wait(), timeout=timeout)
+
+        except (asyncio.TimeoutError, TimeoutError) as e:
+            with self._lock:
+                if self._result:
+                    return self._result
+                elif self._abandoned:
+                    raise HandleAbandonedError()
+                else:
+                    raise TimeoutError(
+                        f"Timed out waiting for response on {self._address}"
+                    ) from e
+
+        else:
+            with self._lock:
+                if self._result:
+                    return self._result
+
+                assert self._abandoned
+                raise HandleAbandonedError()
+
+        finally:
+            self._forget_asyncio_event(evt)
+
+    def _add_asyncio_event(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        event: asyncio.Event,
+    ) -> None:
+        """Add an event to signal when a result is received.
+
+        If a result already exists, this notifies the event loop immediately.
+        """
+        asyncio_event = _AsyncioEvent(loop, event)
+
+        with self._lock:
+            if self._result or self._abandoned:
+                asyncio_event.set_threadsafe()
+            else:
+                self._asyncio_events[event] = asyncio_event
+
+    def _forget_asyncio_event(self, event: asyncio.Event) -> None:
+        """Cancel signalling an event when a result is received."""
+        with self._lock:
+            self._asyncio_events.pop(event, None)
+
+
+class _AsyncioEvent:
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        event: asyncio.Event,
+    ):
+        self._loop = loop
+        self._event = event
+
+    def set_threadsafe(self) -> None:
+        """Set the asyncio event in its own loop."""
+        self._loop.call_soon_threadsafe(self._event.set)

--- a/wandb/sdk/mailbox/mailbox.py
+++ b/wandb/sdk/mailbox/mailbox.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+import secrets
+import string
+import threading
+
+from wandb.proto import wandb_internal_pb2 as pb
+
+from . import handles
+
+_logger = logging.getLogger(__name__)
+
+
+class Mailbox:
+    """Matches service responses to requests.
+
+    The mailbox can set an address on a Record and create a handle for
+    waiting for a response to that record. Responses are delivered by calling
+    `deliver()`. The `close()` method abandons all handles in case the
+    service process becomes unreachable.
+    """
+
+    def __init__(self) -> None:
+        self._handles: dict[str, handles.MailboxHandle] = {}
+        self._handles_lock = threading.Lock()
+
+    def require_response(self, request: pb.Record) -> handles.MailboxHandle:
+        """Set a response address on a request.
+
+        Args:
+            request: The request on which to set a mailbox slot.
+                This is mutated. An address must not already be set.
+
+        Returns:
+            A handle for waiting for the response to the request.
+        """
+        if address := request.control.mailbox_slot:
+            raise ValueError(f"Request already has an address ({address})")
+
+        address = self._new_address()
+        request.control.mailbox_slot = address
+
+        with self._handles_lock:
+            handle = handles.MailboxHandle(address)
+            self._handles[address] = handle
+
+        return handle
+
+    def _new_address(self) -> str:
+        """Returns an unused address for a request.
+
+        Assumes `_handles_lock` is held.
+        """
+
+        def generate():
+            return "".join(
+                secrets.choice(string.ascii_lowercase + string.digits)
+                for i in range(12)
+            )
+
+        address = generate()
+
+        # Being extra cautious. This loop will almost never be entered.
+        while address in self._handles:
+            address = generate()
+
+        return address
+
+    def deliver(self, result: pb.Result) -> None:
+        """Deliver a response from the service.
+
+        If the response address is invalid, this does nothing.
+        """
+        address = result.control.mailbox_slot
+        if not address:
+            _logger.error(
+                "Received response with no mailbox slot."
+                f" Kind: {result.WhichOneof('result_type')}"
+            )
+            return
+
+        with self._handles_lock:
+            handle = self._handles.pop(address, None)
+
+        # It is not an error if there is no handle for the address:
+        # handles can be abandoned if the result is no longer needed.
+        if handle:
+            handle.deliver(result)
+
+    def close(self) -> None:
+        """Indicate no further responses will be delivered.
+
+        Abandons all handles.
+        """
+        with self._handles_lock:
+            _logger.info(
+                f"Closing mailbox, abandoning {len(self._handles)} handles.",
+            )
+
+            for handle in self._handles.values():
+                handle.abandon()
+            self._handles.clear()


### PR DESCRIPTION
A reimplementation of `mailbox.py` with tests and documentation, that works with `asyncio`.

This PR does not delete the old mailbox, and no code uses the new mailbox yet.

## Design notes

The `MailboxProbe` / `MailboxProgress` mechanism in the old implementation relied heavily on callbacks and was undocumented / untyped making it difficult to use. The new mailbox provides an async interface for the same purpose, see PR #9382.

The `wait()` method on `MailboxHandle` is there for compatibility with old code, so that it's possible to migrate incrementally.

The old mailbox's "keepalive" mechanism is replaced by a `Mailbox.close()` method which the Router is meant to call when it stops reading new messages (in a `finally` block).

## test_new_mailbox.py

The test file is a little repetitive because it tests both the sync (`wait_or`) and async (`wait_async`) versions of the same functionality. Most tests are short and simple, but the `test_unblocks_wait_*` tests are more involved as they attempt to test concurrency.

I don't call it `test_mailbox.py` because `pytest` doesn't like when multiple test files have the same name (even in different directories). I'll rename it after deleting the old mailbox.