### PR TITLE
refactor: mailbox wait_with_progress

### DIFF
--- a/tests/unit_tests/test_wait_with_progress.py
+++ b/tests/unit_tests/test_wait_with_progress.py
@@ -1,0 +1,113 @@
+import asyncio
+import unittest.mock
+from typing import NoReturn
+
+import pytest
+import wandb.sdk.mailbox as mb
+from wandb.proto import wandb_internal_pb2 as pb
+
+
+async def _loop_forever() -> NoReturn:
+    while True:
+        await asyncio.sleep(1)
+
+
+def test_short_timeout_uses_blocking_wait():
+    # We mock here as otherwise it is not possible to distinguish
+    # the use of wait_or() from wait_async().
+    handle = unittest.mock.Mock()
+    handle.wait_or.return_value = "test-value"
+
+    result = mb.wait_with_progress(
+        handle,
+        timeout=1,
+        progress_after=2,
+        display_progress=_loop_forever,
+    )
+
+    handle.wait_or.assert_called_once()
+    _, kwargs = handle.wait_or.call_args
+    assert kwargs["timeout"] == pytest.approx(1, rel=0.1)
+    assert result == "test-value"
+
+
+def test_delivered_returns_immediately():
+    handle1 = mb.MailboxHandle("address1")
+    handle2 = mb.MailboxHandle("address2")
+    result1 = pb.Result(uuid="abc")
+    result2 = pb.Result(uuid="xyz")
+    handle1.deliver(result1)
+    handle2.deliver(result2)
+
+    values = mb.wait_all_with_progress(
+        [handle1, handle2],
+        timeout=10,
+        progress_after=1,
+        display_progress=_loop_forever,
+    )
+
+    assert values == [result1, result2]
+
+
+def test_wait_all_same_handle_ok():
+    handle = mb.MailboxHandle("address")
+    result = pb.Result(uuid="abc")
+    handle.deliver(result)
+
+    values = mb.wait_all_with_progress(
+        [handle, handle, handle],
+        timeout=10,
+        progress_after=1,
+        display_progress=_loop_forever,
+    )
+
+    assert values == [result, result, result]
+
+
+def test_abandoned_raises_immediately():
+    handle = mb.MailboxHandle("address")
+    handle.abandon()
+
+    with pytest.raises(mb.HandleAbandonedError):
+        mb.wait_with_progress(
+            handle,
+            timeout=None,
+            progress_after=1,
+            display_progress=_loop_forever,
+        )
+
+
+def test_runs_and_cancels_display_callback():
+    handle = mb.MailboxHandle("address")
+    result = pb.Result()
+    cancelled = False
+
+    async def deliver_handle():
+        nonlocal cancelled
+        handle.deliver(result)
+        try:
+            await _loop_forever()
+        except asyncio.CancelledError:
+            cancelled = True
+
+    value = mb.wait_with_progress(
+        handle,
+        timeout=None,
+        progress_after=0,
+        display_progress=deliver_handle,
+    )
+
+    assert value is result
+    assert cancelled
+
+
+def test_times_out():
+    handle = mb.MailboxHandle("address")
+
+    with pytest.raises(TimeoutError):
+        mb.wait_with_progress(
+            handle,
+            timeout=0.002,
+            progress_after=0.001,
+            display_progress=_loop_forever,
+        )

--- a/wandb/sdk/mailbox/__init__.py
+++ b/wandb/sdk/mailbox/__init__.py
@@ -11,3 +11,4 @@ continuously reads data from the service and passes it to the mailbox.
 
 from .handles import HandleAbandonedError, MailboxHandle
 from .mailbox import Mailbox
+from .wait_with_progress import wait_all_with_progress, wait_with_progress

--- a/wandb/sdk/mailbox/wait_with_progress.py
+++ b/wandb/sdk/mailbox/wait_with_progress.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Coroutine, List, cast
+
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.lib import asyncio_compat
+
+from . import handles
+
+
+def wait_with_progress(
+    handle: handles.MailboxHandle,
+    *,
+    timeout: float | None,
+    progress_after: float,
+    display_progress: Callable[[], Coroutine[Any, Any, None]],
+) -> pb.Result:
+    """Wait for a handle, possibly displaying progress to the user.
+
+    Equivalent to passing a single handle to `wait_all_with_progress`.
+    """
+    return wait_all_with_progress(
+        [handle],
+        timeout=timeout,
+        progress_after=progress_after,
+        display_progress=display_progress,
+    )[0]
+
+
+def wait_all_with_progress(
+    handle_list: list[handles.MailboxHandle],
+    *,
+    timeout: float | None,
+    progress_after: float,
+    display_progress: Callable[[], Coroutine[Any, Any, None]],
+) -> list[pb.Result]:
+    """Wait for multiple handles, possibly displaying progress to the user.
+
+    Args:
+        handle_list: The handles to wait for.
+        timeout: A number of seconds after which to raise a TimeoutError,
+            or None if this should never timeout.
+        progress_after: A number of seconds after which to start the
+            display_progress callback. Starting the callback creates a thread
+            and starts an asyncio loop, so we want to avoid doing it if
+            the handle is resolved quickly.
+        display_progress: An asyncio function that displays progress to
+            the user. This function is executed on a new thread and cancelled
+            if the timeout is exceeded.
+
+    Returns:
+        A list where the Nth item is the Nth handle's result.
+
+    Raises:
+        TimeoutError: If the overall timeout expires.
+        HandleAbandonedError: If any handle becomes abandoned.
+        Exception: Any exception from the display function is propagated.
+    """
+    if not handle_list:
+        return []
+
+    if timeout is not None and timeout <= progress_after:
+        return _wait_handles(handle_list, timeout=timeout)
+
+    start_time = time.monotonic()
+
+    try:
+        return _wait_handles(handle_list, timeout=progress_after)
+    except TimeoutError:
+        pass
+
+    async def progress_loop_with_timeout() -> list[pb.Result]:
+        with asyncio_compat.cancel_on_exit(display_progress()):
+            if timeout is not None:
+                elapsed_time = time.monotonic() - start_time
+                remaining_timeout = timeout - elapsed_time
+            else:
+                remaining_timeout = None
+
+            return await _wait_handles_async(
+                handle_list,
+                timeout=remaining_timeout,
+            )
+
+    return asyncio_compat.run(progress_loop_with_timeout)
+
+
+def _wait_handles(
+    handle_list: list[handles.MailboxHandle],
+    *,
+    timeout: float,
+) -> list[pb.Result]:
+    """Wait for multiple mailbox handles.
+
+    Returns:
+        Each handle's result, in the same order as the given handles.
+
+    Raises:
+        TimeoutError: If the overall timeout expires.
+        HandleAbandonedError: If any handle becomes abandoned.
+    """
+    results: list[pb.Result] = []
+
+    start_time = time.monotonic()
+    for handle in handle_list:
+        elapsed_time = time.monotonic() - start_time
+        remaining_timeout = timeout - elapsed_time
+        results.append(handle.wait_or(timeout=remaining_timeout))
+
+    return results
+
+
+async def _wait_handles_async(
+    handle_list: list[handles.MailboxHandle],
+    *,
+    timeout: float | None,
+) -> list[pb.Result]:
+    """Asynchronously wait for multiple mailbox handles.
+
+    Just like _wait_handles.
+    """
+    results: list[pb.Result | None] = [None for _ in handle_list]
+
+    async def wait_single(index: int) -> None:
+        handle = handle_list[index]
+        results[index] = await handle.wait_async(timeout=timeout)
+
+    async with asyncio_compat.open_task_group() as task_group:
+        for index in range(len(handle_list)):
+            task_group.start_soon(wait_single(index))
+
+    # NOTE: `list` is not subscriptable until Python 3.10, so we use List.
+    return cast(List[pb.Result], results)


### PR DESCRIPTION
Implements `wait_with_progress`, which replaces the old  `MailboxProbe` / `MailboxProgress` mechanism.

Basic usage:

```python
async def display_progress() -> NoReturn:
    # This function never returns. It is cancelled by wait_with_progress
    # on timeout or when the handle gets a result or is abandoned.
    while True:
        update_screen()
        await asyncio.sleep(0.1)

wait_with_progress(
    handle,
    timeout=30,
    progress_after=1,
    display_progress=display_progress,
)
```

Using `asyncio` allows `display_progress` to poll (e.g. RequestPollExit) and update the screen simultaneously---at independent rates!---by starting two tasks (not shown above).
