### PR TITLE
chore: set X-WANDB-USE-ASYNC-FILESTREAM header for GQL requests in shared mode

### DIFF
--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -109,6 +109,11 @@ func NewGraphQLClient(
 		"X-WANDB-USER-EMAIL": settings.GetEmail(),
 	}
 	maps.Copy(graphqlHeaders, settings.GetExtraHTTPHeaders())
+	// This header is used to indicate to the backend that the run is in shared
+	// mode to prevent a race condition when two UpsertRun requests are made
+	// simultaneously for the same run ID in shared mode. For regular runs, this
+	// would result in a 409 conflict error, but for shared runs, the backend
+	// returns a retryable error.
 	if settings.IsSharedMode() {
 		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
 	}

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -109,6 +109,9 @@ func NewGraphQLClient(
 		"X-WANDB-USER-EMAIL": settings.GetEmail(),
 	}
 	maps.Copy(graphqlHeaders, settings.GetExtraHTTPHeaders())
+	if settings.IsSharedMode() {
+		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
+	}
 
 	opts := api.ClientOptions{
 		RetryPolicy:        clients.CheckRetry,

--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -161,3 +161,14 @@ def test_init_param_not_set_telemetry(wandb_backend_spy):
         assert 14 not in features  # set_init_id
         assert 15 not in features  # set_init_tags
         assert 16 not in features  # set_init_config
+
+
+@pytest.mark.wandb_core_only
+def test_init_shared_mode_graphql_header(wandb_backend_spy):
+    """Test that a special header is set for GraphQL requests when using shared mode."""
+    with wandb.init(settings=wandb.Settings(mode="shared")) as run:
+        pass
+
+    with wandb_backend_spy.freeze() as snapshot:
+        headers = snapshot.graphql_headers(run_id=run.id)
+        assert headers["x-wandb-use-async-filestream"] == "true"


### PR DESCRIPTION
Fixes the SDK side of WB-23039.

The `X-WANDB-USE-ASYNC-FILESTREAM` header in the `GraphQL` client is used to indicate to the backend that the run is in shared mode to prevent a race condition when two UpsertRun requests are made simultaneously for the same run ID in shared mode. For regular runs, this would result in a 409 conflict error, but for shared runs, the backend returns a retryable error.