### PR TITLE
chore: set X-WANDB-USE-ASYNC-FILESTREAM header in GQL client in shared mode

### DIFF
--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -109,6 +109,14 @@ func NewGraphQLClient(
 		"X-WANDB-USER-EMAIL": settings.GetEmail(),
 	}
 	maps.Copy(graphqlHeaders, settings.GetExtraHTTPHeaders())
+	// This header is used to indicate to the backend that the run is in shared
+	// mode to prevent a race condition when two UpsertRun requests are made
+	// simultaneously for the same run ID in shared mode. For regular runs, this
+	// would result in a 409 conflict error, but for shared runs, the backend
+	// returns a retryable error.
+	if settings.IsSharedMode() {
+		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
+	}
 
 	opts := api.ClientOptions{
 		RetryPolicy:        clients.CheckRetry,


### PR DESCRIPTION
Fixes the SDK side of WB-23039.

The `X-WANDB-USE-ASYNC-FILESTREAM` header in the `GraphQL` client is used to indicate to the backend that the run is in shared mode to prevent a race condition when two UpsertRun requests are made simultaneously for the same run ID in shared mode. For regular runs, this would result in a 409 conflict error, but for shared runs, the backend returns a retryable error.