### PR TITLE
chore: auto-generate x_label in shared mode if not provided

### DIFF
--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -161,3 +161,22 @@ def test_init_param_not_set_telemetry(wandb_backend_spy):
         assert 14 not in features  # set_init_id
         assert 15 not in features  # set_init_tags
         assert 16 not in features  # set_init_config
+
+
+@pytest.mark.wandb_core_only
+def test_shared_mode_x_label(wandb_backend_spy):
+    """Test that reinit with a run active returns the same run."""
+    with wandb.init(
+        settings=wandb.Settings(
+            mode="shared",
+        )
+    ) as run:
+        assert run.settings.x_label is not None
+
+    with wandb.init(
+        settings=wandb.Settings(
+            mode="shared",
+            x_label="node-rank",
+        )
+    ) as run:
+        assert run.settings.x_label == "node-rank"

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -877,7 +877,7 @@ class _WandbInit:
                 tel.feature.core = True
             if settings._shared:
                 wandb.termwarn(
-                    "The `_shared` feature is experimental and may change. "
+                    "The `shared` mode feature is experimental and may change. "
                     "Please contact support@wandb.com for guidance and to report any issues."
                 )
                 tel.feature.shared_mode = True
@@ -920,6 +920,16 @@ class _WandbInit:
                 f"Starting a new run with run id {run.id}."
             )
         error: wandb.Error | None = None
+
+        # In shared mode, generate a unique label if not provided.
+        # The label is used to distinguish between system metrics and console logs
+        # from different writers to the same run.
+        if settings._shared and not settings.x_label:
+            # TODO: If executed in a known distributed environment (e.g. Ray or SLURM),
+            #   use the env vars to generate a label (e.g. SLURM_JOB_ID or RANK)
+            prefix = settings.host or ""
+            label = runid.generate_id()
+            settings.x_label = f"{prefix}-{label}" if prefix else label
 
         timeout = settings.init_timeout
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -515,8 +515,6 @@ class Settings(BaseModel, validate_assignment=True):
 
     This is used to group data by on the frontend and can be used to distinguish data
     from different processes in a distributed training job.
-
-    TODO: in shared mode, generate a unique label if not provided.
     """
 
     x_live_policy_rate_limit: int | None = None
@@ -1356,8 +1354,8 @@ class Settings(BaseModel, validate_assignment=True):
                 f"couldn't find {self.notebook_name}.",
             )
 
-        # host and username are populated by apply_env_vars if corresponding env
-        # vars exist -- but if they don't, we'll fill them in here
+        # host is populated by update_from_env_vars if the corresponding env
+        # vars exist -- but if they don't, we'll fill them in here.
         if self.host is None:
             self.host = socket.gethostname()  # type: ignore
 


### PR DESCRIPTION
When running in shared mode, it is expected that there are multiple writers to the same run ID. The `x_label` setting is used to distinguish system metrics and console logs originating from different processes. This PR ensures `x_label` is generated if not provided by the user in shared mode.