### PR TITLE
refactor: log token on unmarshal error

### DIFF
--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -220,10 +220,19 @@ func (nc *Connection) processIncomingData() {
 	for scanner.Scan() {
 		msg := &spb.ServerRequest{}
 		if err := proto.Unmarshal(scanner.Bytes(), msg); err != nil {
+			dataLen := len(scanner.Bytes())
+			dataTrunc := scanner.Bytes()
+			if len(dataTrunc) > 1<<10 {
+				dataTrunc = dataTrunc[:1<<10]
+			}
+
 			slog.Error(
 				"connection: unmarshalling error, breaking connection",
 				"error", err,
-				"id", nc.id)
+				"id", nc.id,
+				"token_len", dataLen,
+				"token_1kb", dataTrunc,
+			)
 
 			// Stop the server because a client is misbehaving, and it is no
 			// longer guaranteed that the server will receive a teardown


### PR DESCRIPTION
In the extremely rare case of failing to parse incoming data on a connection, log the first 1KB of the token.

This will show up as a base64-encoded string in the log file:

1. We use a JSONHandler, which [documents](https://pkg.go.dev/log/slog#JSONHandler.Handle) it formats values using `json.Encoder`
2. `json.Encoder` [documents](https://pkg.go.dev/encoding/json#Marshal) it outputs `[]byte` as a base64-encoded string