### PR TITLE
chore: add constraints on moviepy >=1.0.0

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,3 +12,7 @@ Add here any changes made in a PR that are relevant to end users. Allowed sectio
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Changed
+
+- changed moviepy constraint to >=1.0.0 (@jacobromero in https://github.com/wandb/wandb/pull/9419)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ aws = [
 azure = ["azure-identity", "azure-storage-blob"]
 media = [
     "numpy",
-    "moviepy",
+    "moviepy>=1.0.0",
     # imageio is a dependency of moviepy but incase that changes we also pin it here
     "imageio",
     "pillow",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ hypothesis-fspaths
 Pillow
 pandas
 polars
-moviepy
+moviepy >= 1.0.0
 imageio[ffmpeg]
 matplotlib
 soundfile


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.
This PR adds a constraint for installing moviepy to be >=1.0.0 since older version do not work with the W&B SDK.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
