### PR TITLE
refactor: delete deprecated handle wait

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1842,9 +1842,8 @@ class Artifact:
             skip_cache=skip_cache,
             path_prefix=path_prefix,
         )
-        result = handle.wait(timeout=-1)
+        result = handle.wait_or(timeout=None)
 
-        assert result is not None
         response = result.response.download_artifact_response
         if response.error_message:
             raise ValueError(f"Error downloading artifact: {response.error_message}")

--- a/wandb/sdk/mailbox/handles.py
+++ b/wandb/sdk/mailbox/handles.py
@@ -83,27 +83,6 @@ class MailboxHandle:
         with self._lock:
             return self._result
 
-    def wait(self, *, timeout: float) -> pb.Result | None:
-        """DEPRECATED. Wait for a response or a timeout.
-
-        Args:
-            timeout: A finite number of seconds or -1 to never time out.
-
-        Returns:
-            The result if it arrives before the timeout or has already arrived.
-            On timeout, returns None.
-
-        Raises:
-            HandleAbandonedError: If the handle becomes abandoned.
-        """
-        try:
-            if timeout == -1:
-                return self.wait_or(timeout=None)
-            else:
-                return self.wait_or(timeout=timeout)
-        except TimeoutError:
-            return None
-
     def wait_or(self, *, timeout: float | None) -> pb.Result:
         """Wait for a response or a timeout.
 

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -80,7 +80,7 @@ class StreamRecord:
         self._wait_thread_active()
 
     def _wait_thread_active(self) -> None:
-        self._iface.deliver_status().wait(timeout=-1)
+        self._iface.deliver_status().wait_or(timeout=None)
 
     def join(self) -> None:
         self._iface.join()
@@ -331,20 +331,16 @@ class StreamMux:
             sampled_history_handle = stream.interface.deliver_request_sampled_history()
             internal_messages_handle = stream.interface.deliver_internal_messages()
 
-            result = internal_messages_handle.wait(timeout=-1)
-            assert result
+            result = internal_messages_handle.wait_or(timeout=None)
             internal_messages_response = result.response.internal_messages_response
 
-            result = poll_exit_handle.wait(timeout=-1)
-            assert result
+            result = poll_exit_handle.wait_or(timeout=None)
             poll_exit_response = result.response.poll_exit_response
 
-            result = sampled_history_handle.wait(timeout=-1)
-            assert result
+            result = sampled_history_handle.wait_or(timeout=None)
             sampled_history = result.response.sampled_history_response
 
-            result = final_summary_handle.wait(timeout=-1)
-            assert result
+            result = final_summary_handle.wait_or(timeout=None)
             final_summary = result.response.get_summary_response
 
             Run._footer(

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -999,10 +999,11 @@ class _WandbInit:
         assert backend.interface
 
         run_start_handle = backend.interface.deliver_run_start(run)
-        # TODO: add progress to let user know we are doing something
-        run_start_result = run_start_handle.wait(timeout=30)
-        if run_start_result is None:
-            run_start_handle.abandon()
+        try:
+            # TODO: add progress to let user know we are doing something
+            run_start_handle.wait_or(timeout=30)
+        except TimeoutError:
+            pass
 
         assert self._wl is not None
         self.run = run
@@ -1092,11 +1093,12 @@ def _attach(
     assert backend.interface
 
     attach_handle = backend.interface.deliver_attach(attach_id)
-    # TODO: add progress to let user know we are doing something
-    attach_result = attach_handle.wait(timeout=30)
-    if not attach_result:
-        attach_handle.abandon()
+    try:
+        # TODO: add progress to let user know we are doing something
+        attach_result = attach_handle.wait_or(timeout=30)
+    except TimeoutError:
         raise UsageError("Timeout attaching to run")
+
     attach_response = attach_result.response.attach_response
     if attach_response.error and attach_response.error.message:
         raise UsageError(f"Failed to attach to run: {attach_response.error.message}")

--- a/wandb/sdk/wandb_sync.py
+++ b/wandb/sdk/wandb_sync.py
@@ -61,8 +61,7 @@ def _sync(
     backend.interface._stream_id = stream_id  # type: ignore
 
     handle = backend.interface.deliver_finish_sync()
-    result = handle.wait(timeout=-1)
-    assert result and result.response
+    result = handle.wait_or(timeout=None)
     response = result.response.sync_response
     if response.url:
         termlog(f"Synced {p} to {util.app_url(response.url)}")


### PR DESCRIPTION
Deletes the `MailboxHandle.wait()` method and replaces all uses with `MailboxHandle.wait_or()`. The difference was that passing `timeout=-1` to `wait()` would cause it to block forever (even though `timeout=-0.9` or `timeout=-1.1` would cause it to timeout immediately).

Changes:

```py
wait(timeout=-1)      # Old
wait_or(timeout=None) # New

# Old:
result = wait(...)
assert result
# New:
result = wait_or(...)

# Old:
result = wait(...)
if result:
    ...
else:
    ...
# New:
try:
    result = wait_or(...)
except TimeoutError:
    ...
else:
    ...
```