### PR TITLE
refactor: show operation stats on init

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Changed
 
 - changed moviepy constraint to >=1.0.0 (@jacobromero in https://github.com/wandb/wandb/pull/9419)
+- `wandb.init()` displays more detailed information, in particular when it is stuck retrying HTTP errors (@timoffex in https://github.com/wandb/wandb/pull/9431)
 
 ### Removed
 

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -1124,7 +1124,7 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 		clients.UpsertBucketRetryPolicy,
 	)
 
-	operation := s.operations.New("updating run metadata")
+	operation := s.operations.New("creating run")
 	defer operation.Finish()
 	ctx = operation.Context(ctx)
 

--- a/tests/unit_tests/test_lib/test_progress.py
+++ b/tests/unit_tests/test_lib/test_progress.py
@@ -14,14 +14,20 @@ def dynamic_progress_printer(
     # Ensure dynamic text is supported.
     _ = emulated_terminal
 
-    with progress.progress_printer(p.new_printer()) as progress_printer:
+    with progress.progress_printer(
+        p.new_printer(),
+        "DEFAULT TEXT",
+    ) as progress_printer:
         yield progress_printer
 
 
 @pytest.fixture()
 def static_progress_printer() -> Iterator[progress.ProgressPrinter]:
     """A ProgressPrinter that writes to a file or dumb terminal."""
-    with progress.progress_printer(p.new_printer()) as progress_printer:
+    with progress.progress_printer(
+        p.new_printer(),
+        "DEFAULT TEXT",
+    ) as progress_printer:
         yield progress_printer
 
 
@@ -166,4 +172,4 @@ def test_remaining_operations(emulated_terminal, dynamic_progress_printer):
 def test_no_operations_text(emulated_terminal, dynamic_progress_printer):
     dynamic_progress_printer.update([pb.PollExitResponse()])
 
-    assert emulated_terminal.read_stderr() == ["wandb: ⢿ Finishing up..."]
+    assert emulated_terminal.read_stderr() == ["wandb: ⢿ DEFAULT TEXT"]

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -979,6 +979,10 @@ class InterfaceBase:
     def _deliver_exit(self, exit_data: pb.RunExitRecord) -> MailboxHandle:
         raise NotImplementedError
 
+    @abstractmethod
+    def deliver_operation_stats(self) -> MailboxHandle:
+        raise NotImplementedError
+
     def deliver_poll_exit(self) -> MailboxHandle:
         poll_exit = pb.PollExitRequest()
         return self._deliver_poll_exit(poll_exit)

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -103,6 +103,7 @@ class InterfaceShared(InterfaceBase):
         stop_status: Optional[pb.StopStatusRequest] = None,
         internal_messages: Optional[pb.InternalMessagesRequest] = None,
         network_status: Optional[pb.NetworkStatusRequest] = None,
+        operation_stats: Optional[pb.OperationStatsRequest] = None,
         poll_exit: Optional[pb.PollExitRequest] = None,
         partial_history: Optional[pb.PartialHistoryRequest] = None,
         sampled_history: Optional[pb.SampledHistoryRequest] = None,
@@ -145,6 +146,8 @@ class InterfaceShared(InterfaceBase):
             request.internal_messages.CopyFrom(internal_messages)
         elif network_status:
             request.network_status.CopyFrom(network_status)
+        elif operation_stats:
+            request.operations.CopyFrom(operation_stats)
         elif poll_exit:
             request.poll_exit.CopyFrom(poll_exit)
         elif partial_history:
@@ -452,6 +455,10 @@ class InterfaceShared(InterfaceBase):
 
     def _deliver_exit(self, exit_data: pb.RunExitRecord) -> MailboxHandle:
         record = self._make_record(exit=exit_data)
+        return self._deliver_record(record)
+
+    def deliver_operation_stats(self):
+        record = self._make_request(operation_stats=pb.OperationStatsRequest())
         return self._deliver_record(record)
 
     def _deliver_poll_exit(self, poll_exit: pb.PollExitRequest) -> MailboxHandle:

--- a/wandb/sdk/lib/progress.py
+++ b/wandb/sdk/lib/progress.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
-from typing import Iterable, Iterator
+import time
+from typing import Iterable, Iterator, NoReturn
 
 from wandb import env
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.interface import interface
+from wandb.sdk.lib import asyncio_compat
 
 from . import printer as p
 
@@ -30,11 +34,67 @@ def print_sync_dedupe_stats(
     printer.display(f"W&B sync reduced upload amount by {frac:.1%}")
 
 
+async def loop_printing_operation_stats(
+    progress: ProgressPrinter,
+    interface: interface.InterfaceBase,
+) -> None:
+    """Poll and display ongoing tasks in the internal service process.
+
+    This never returns and must be cancelled. This is meant to be used with
+    `mailbox.wait_with_progress()`.
+
+    Args:
+        progress: The printer to update with operation stats.
+        interface: The interface to use to poll for updates.
+
+    Raises:
+        HandleAbandonedError: If the mailbox associated with the interface
+            becomes closed.
+        Exception: Any other problem communicating with the service process.
+    """
+    stats: pb.OperationStats | None = None
+
+    async def loop_update_screen() -> NoReturn:
+        while True:
+            if stats:
+                progress.update(stats)
+            await asyncio.sleep(0.1)
+
+    async def loop_poll_stats() -> NoReturn:
+        nonlocal stats
+        while True:
+            start_time = time.monotonic()
+
+            handle = interface.deliver_operation_stats()
+            result = await handle.wait_async(timeout=None)
+            stats = result.response.operations_response.operation_stats
+
+            elapsed_time = time.monotonic() - start_time
+            if elapsed_time < 0.5:
+                await asyncio.sleep(0.5 - elapsed_time)
+
+    async with asyncio_compat.open_task_group() as task_group:
+        task_group.start_soon(loop_update_screen())
+        task_group.start_soon(loop_poll_stats())
+
+
 @contextlib.contextmanager
-def progress_printer(printer: p.Printer) -> Iterator[ProgressPrinter]:
-    """Context manager providing an object for printing run progress."""
+def progress_printer(
+    printer: p.Printer,
+    default_text: str,
+) -> Iterator[ProgressPrinter]:
+    """Context manager providing an object for printing run progress.
+
+    Args:
+        printer: The printer to use.
+        default_text: The text to show if no information is available.
+    """
     with printer.dynamic_text() as text_area:
-        yield ProgressPrinter(printer, text_area)
+        yield ProgressPrinter(
+            printer,
+            text_area,
+            default_text=default_text,
+        )
         printer.progress_close()
 
 
@@ -45,23 +105,27 @@ class ProgressPrinter:
         self,
         printer: p.Printer,
         progress_text_area: p.DynamicText | None,
+        default_text: str,
     ) -> None:
         # Not implemented by the legacy service.
         self._show_operation_stats = not env.is_require_legacy_service()
         self._printer = printer
         self._progress_text_area = progress_text_area
+        self._default_text = default_text
         self._tick = 0
         self._last_printed_line = ""
 
     def update(
         self,
-        progress: list[pb.PollExitResponse],
+        progress: list[pb.PollExitResponse] | pb.OperationStats,
     ) -> None:
         """Update the displayed information."""
         if not progress:
             return
 
-        if self._show_operation_stats:
+        if isinstance(progress, pb.OperationStats):
+            self._update_operation_stats([progress])
+        elif self._show_operation_stats:
             self._update_operation_stats(
                 list(response.operation_stats for response in progress)
             )
@@ -79,6 +143,7 @@ class ProgressPrinter:
                 self._progress_text_area,
                 max_lines=6,
                 loading_symbol=self._printer.loading_symbol(self._tick),
+                default_text=self._default_text,
             ).display(stats_list)
 
         else:
@@ -169,11 +234,13 @@ class _DynamicOperationStatsPrinter:
         text_area: p.DynamicText,
         max_lines: int,
         loading_symbol: str,
+        default_text: str,
     ) -> None:
         self._printer = printer
         self._text_area = text_area
         self._max_lines = max_lines
         self._loading_symbol = loading_symbol
+        self._default_text = default_text
 
         self._lines: list[str] = []
         self._ops_shown = 0
@@ -199,9 +266,9 @@ class _DynamicOperationStatsPrinter:
 
         if len(self._lines) == 0:
             if self._loading_symbol:
-                self._text_area.set_text(f"{self._loading_symbol} Finishing up...")
+                self._text_area.set_text(f"{self._loading_symbol} {self._default_text}")
             else:
-                self._text_area.set_text("Finishing up...")
+                self._text_area.set_text(self._default_text)
         else:
             self._text_area.set_text("\n".join(self._lines))
 

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -309,7 +309,10 @@ class StreamMux:
             handle = stream.interface.deliver_exit(exit_code)
             exit_handles.append(handle)
 
-        with progress.progress_printer(printer) as progress_printer:
+        with progress.progress_printer(
+            printer,
+            default_text="Finishing up...",
+        ) as progress_printer:
             # todo: should we wait for the max timeout (?) of all exit handles or just wait forever?
             # timeout = max(stream._settings._exit_timeout for stream in streams.values())
             wait_all_with_progress(

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2594,7 +2594,10 @@ class Run:
         else:
             exit_handle = self._backend.interface.deliver_finish_without_exit()
 
-        with progress.progress_printer(self._printer) as progress_printer:
+        with progress.progress_printer(
+            self._printer,
+            default_text="Finishing up...",
+        ) as progress_printer:
             # Wait for the run to complete.
             wait_with_progress(
                 exit_handle,


### PR DESCRIPTION
Fixes WB-23194.

Display a message during `wandb.init()` that describes the work being done and any errors.

Before, `wandb.init()` would simply print `wandb: Waiting for wandb.init()...` with an old-style spinner.

Now `wandb.init()` prints:

```
wandb: ⢿ creating run (4.2s)
```

with a new style spinner. If there is an error, the message is updated to something like:

```
wandb: ⢿ creating run (4.2s)
wandb:   ↳ ⢿ retrying HTTP 409 Conflict
```

In the future, this can be extended to display the HTTP response body as well in case it contains a useful error message from the backend.