### PR TITLE
chore: env var inheritance in nox 2025.2.9 sessions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
       - checkout
       - run:
           name: Install system deps
-          command: apt-get update && apt-get install -y libsndfile1 ffmpeg
+          command: apt-get update && apt-get install -y libsndfile1 ffmpeg git
       - install_go
       - install_rust
       - install_extras:

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,19 +97,17 @@ def run_pytest(
     opts = opts or {}
     pytest_opts = []
     pytest_env = {
-        "USERNAME": session.env.get("USERNAME") or os.environ.get("USERNAME"),
         "PATH": session.env.get("PATH") or os.environ.get("PATH"),
-        "USERPROFILE": session.env.get("USERPROFILE") or os.environ.get("USERPROFILE"),
+        "USERNAME": os.environ.get("USERNAME"),
+        "USERPROFILE": os.environ.get("USERPROFILE"),
         # Tool settings are often set here. We invoke Docker in system tests,
         # which uses auth information from the home directory.
-        "HOME": session.env.get("HOME") or os.environ.get("HOME"),
-        "CI": session.env.get("CI") or os.environ.get("CI"),
+        "HOME": os.environ.get("HOME"),
+        "CI": os.environ.get("CI"),
         # Required for the importers tests
-        "WANDB_TEST_SERVER_URL2": session.env.get("WANDB_TEST_SERVER_URL2")
-        or os.environ.get("WANDB_TEST_SERVER_URL2"),
+        "WANDB_TEST_SERVER_URL2": os.environ.get("WANDB_TEST_SERVER_URL2"),
         # Required for functional tests with openai
-        "OPENAI_API_KEY": session.env.get("OPENAI_API_KEY")
-        or os.environ.get("OPENAI_API_KEY"),
+        "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
     }
 
     # Print 20 slowest tests.

--- a/noxfile.py
+++ b/noxfile.py
@@ -98,7 +98,7 @@ def run_pytest(
     pytest_opts = []
     pytest_env = {
         "USERNAME": session.env.get("USERNAME"),
-        "PATH": session.env.get("PATH"),
+        "PATH": session.env.get("PATH") or os.environ.get("PATH"),
         "USERPROFILE": session.env.get("USERPROFILE"),
         # Tool settings are often set here. We invoke Docker in system tests,
         # which uses auth information from the home directory.

--- a/noxfile.py
+++ b/noxfile.py
@@ -107,7 +107,8 @@ def run_pytest(
         # Required for the importers tests
         "WANDB_TEST_SERVER_URL2": session.env.get("WANDB_TEST_SERVER_URL2"),
         # Required for functional tests with openai
-        "OPENAI_API_KEY": session.env.get("OPENAI_API_KEY"),
+        "OPENAI_API_KEY": session.env.get("OPENAI_API_KEY")
+        or os.environ.get("OPENAI_API_KEY"),
     }
 
     # Print 20 slowest tests.
@@ -173,7 +174,6 @@ def unit_tests(session: nox.Session) -> None:
         "-r",
         "requirements_dev.txt",
         # For test_reports:
-        ".[reports]",
         "polyfactory",
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -281,6 +281,8 @@ def experimental_tests(session: nox.Session):
     run_pytest(
         session,
         paths=(session.posargs or ["tests/system_tests/test_experimental"]),
+        # TODO: increase as more tests are added
+        opts={"n": "1"},
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,15 +97,16 @@ def run_pytest(
     opts = opts or {}
     pytest_opts = []
     pytest_env = {
-        "USERNAME": session.env.get("USERNAME"),
+        "USERNAME": session.env.get("USERNAME") or os.environ.get("USERNAME"),
         "PATH": session.env.get("PATH") or os.environ.get("PATH"),
-        "USERPROFILE": session.env.get("USERPROFILE"),
+        "USERPROFILE": session.env.get("USERPROFILE") or os.environ.get("USERPROFILE"),
         # Tool settings are often set here. We invoke Docker in system tests,
         # which uses auth information from the home directory.
-        "HOME": session.env.get("HOME"),
-        "CI": session.env.get("CI"),
+        "HOME": session.env.get("HOME") or os.environ.get("HOME"),
+        "CI": session.env.get("CI") or os.environ.get("CI"),
         # Required for the importers tests
-        "WANDB_TEST_SERVER_URL2": session.env.get("WANDB_TEST_SERVER_URL2"),
+        "WANDB_TEST_SERVER_URL2": session.env.get("WANDB_TEST_SERVER_URL2")
+        or os.environ.get("WANDB_TEST_SERVER_URL2"),
         # Required for functional tests with openai
         "OPENAI_API_KEY": session.env.get("OPENAI_API_KEY")
         or os.environ.get("OPENAI_API_KEY"),

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,6 +12,7 @@ pytest-flakefinder~=1.1
 pytest-memray~=1.7; sys_platform != 'win32'
 pyfakefs~=5.7
 parameterized~=0.9.0
+Faker<36.0.0; python_version < '3.9'
 
 flask~=2.2
 fastapi~=0.115.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,7 +12,7 @@ pytest-flakefinder~=1.1
 pytest-memray~=1.7; sys_platform != 'win32'
 pyfakefs~=5.7
 parameterized~=0.9.0
-Faker<36.0.0; python_version < '3.9'
+Faker<35.0.0; python_version < '3.9'
 
 flask~=2.2
 fastapi~=0.115.3


### PR DESCRIPTION
- Addresses the default nox behavior change in version 2025.2.9 where apparently os.environ is not propagated into session.env.
- Dependency fix for py3.8 fix.