### PR TITLE
refactor: include backend error messages in operation stats

### DIFF
--- a/core/internal/api/backenderrors.go
+++ b/core/internal/api/backenderrors.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ErrorFromWBResponse extracts an error string from the response body if it is
+// in one of the usual formats returned by the W&B backend.
+//
+// If multiple errors are found, they are joined with a semicolon.
+func ErrorFromWBResponse(body []byte) string {
+	var resp any
+
+	err := json.Unmarshal(body, &resp)
+	if err != nil {
+		return ""
+	}
+
+	respMap, ok := resp.(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	errorField, exists := respMap["error"]
+	if exists {
+		return errorFromStringOrMap(errorField)
+	}
+
+	errorsField := respMap["errors"]
+	if errorsFieldList, ok := errorsField.([]any); ok {
+		var messages []string
+
+		for _, errorValue := range errorsFieldList {
+			errorMessage := errorFromStringOrMap(errorValue)
+			if len(errorMessage) > 0 {
+				messages = append(messages, errorMessage)
+			}
+		}
+
+		return strings.Join(messages, "; ")
+	}
+
+	return ""
+}
+
+// errorFromStringOrMap extracts an error message from an error value returned
+// by the W&B backend.
+//
+// Backend errors are returned in one of two ways:
+// - A string containing the error message
+// - A JSON object with a "message" field that is a string
+func errorFromStringOrMap(value any) string {
+	switch x := value.(type) {
+	case string:
+		return x
+	case map[string]any:
+		message := x["message"]
+		if messageStr, ok := message.(string); ok {
+			return messageStr
+		}
+	}
+
+	return ""
+}

--- a/core/internal/api/backenderrors_test.go
+++ b/core/internal/api/backenderrors_test.go
@@ -1,0 +1,46 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/internal/api"
+)
+
+func TestUnknownFormat(t *testing.T) {
+	unknownFormats := []string{
+		"not JSON",
+		`"JSON string"`,
+		`{"unknownField": 123}`,
+		`{"error": 123}`,
+		`{"errors": 123}`,
+		`{"errors": "string"}`,
+	}
+
+	for _, format := range unknownFormats {
+		t.Run(format, func(t *testing.T) {
+			assert.Empty(t, api.ErrorFromWBResponse([]byte(format)))
+		})
+	}
+}
+
+func TestKnownFormat(t *testing.T) {
+	type testCase struct {
+		body    string
+		message string
+	}
+
+	testCases := []testCase{
+		{`{"error": "string"}`, "string"},
+		{`{"error": {"message": "string"}}`, "string"},
+		{`{"errors": ["string1", {"message": "string2"}]}`, "string1; string2"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.body, func(t *testing.T) {
+			assert.Equal(t,
+				testCase.message,
+				api.ErrorFromWBResponse([]byte(testCase.body)))
+		})
+	}
+}

--- a/core/internal/wboperation/wboperation.go
+++ b/core/internal/wboperation/wboperation.go
@@ -206,18 +206,34 @@ func (op *WandbOperation) ClearError() {
 
 // MarkRetryingHTTPError sets the operation's error status.
 //
+// The `responseStatusCode` is the HTTP status code of the response, like 429.
 // The `responseStatus` must be a string in the form "429 Too Many Requests",
 // which is available as the Status field on an http.Response.
+// The `responseError` may be empty, or it may contain additional information
+// about the error.
 //
 // There should be a corresponding call to `ClearError`.
-func (op *WandbOperation) MarkRetryingHTTPError(responseStatus string) {
+func (op *WandbOperation) MarkRetryingHTTPError(
+	responseStatusCode int,
+	responseStatus string,
+	responseError string,
+) {
 	if op == nil {
 		return
 	}
 
 	op.mu.Lock()
 	defer op.mu.Unlock()
-	op.errorStatus = fmt.Sprintf("retrying HTTP %s", responseStatus)
+
+	if len(responseError) > 0 {
+		op.errorStatus = fmt.Sprintf(
+			"retrying HTTP %d: %s",
+			responseStatusCode,
+			responseError,
+		)
+	} else {
+		op.errorStatus = fmt.Sprintf("retrying HTTP %s", responseStatus)
+	}
 }
 
 // MarkRetryingError sets the operation's error status.

--- a/core/internal/wboperation/wboperation_test.go
+++ b/core/internal/wboperation/wboperation_test.go
@@ -96,14 +96,28 @@ func TestFinishNewestSubtask(t *testing.T) {
 	assert.Equal(t, "third", proto.Operations[0].Subtasks[1].Desc)
 }
 
-func TestHTTPError(t *testing.T) {
+func TestHTTPError_NoMessage(t *testing.T) {
 	ops := wboperation.NewOperations()
 	op := ops.New("test operation")
 
-	op.MarkRetryingHTTPError("123")
+	op.MarkRetryingHTTPError(429, "429 Too Many Requests", "")
 
 	proto := ops.ToProto()
-	assert.Equal(t, "retrying HTTP 123", proto.Operations[0].ErrorStatus)
+	assert.Equal(t,
+		"retrying HTTP 429 Too Many Requests",
+		proto.Operations[0].ErrorStatus)
+}
+
+func TestHTTPError_WithMessage(t *testing.T) {
+	ops := wboperation.NewOperations()
+	op := ops.New("test operation")
+
+	op.MarkRetryingHTTPError(409, "409 Conflict", "run has been deleted")
+
+	proto := ops.ToProto()
+	assert.Equal(t,
+		"retrying HTTP 409: run has been deleted",
+		proto.Operations[0].ErrorStatus)
 }
 
 func TestGoError(t *testing.T) {
@@ -120,7 +134,7 @@ func TestClearError(t *testing.T) {
 	ops := wboperation.NewOperations()
 	op := ops.New("test operation")
 
-	op.MarkRetryingHTTPError("123")
+	op.MarkRetryingHTTPError(429, "429 Too Many Requests", "")
 	op.ClearError()
 
 	proto := ops.ToProto()


### PR DESCRIPTION
When the HTTP response from the backend contains error messages in a known format, include them in operation stats, making `run.finish()` more informative and also `wandb.init()` (with PR #9431).

The logic is the same as in `wandb/util.py::parse_backend_error_messages()`, and the test cases are the same as those in `test_normalize.py`.