### PR TITLE
refactor: delete the _global_run_stack

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2111,15 +2111,6 @@ class Run:
         with telemetry.context(run=self) as tel:
             tel.feature.finish = True
 
-        # Pop this run (hopefully) from the run stack, to support the "reinit"
-        # functionality of wandb.init().
-        #
-        # TODO: It's not clear how _global_run_stack could have length other
-        # than 1 at this point in the code. If you're reading this, consider
-        # refactoring this thing.
-        if self._wl and len(self._wl._global_run_stack) > 0:
-            self._wl._global_run_stack.pop()
-
         # Run hooks that need to happen before the last messages to the
         # internal service, like Jupyter hooks.
         for hook in self._teardown_hooks:

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -28,7 +28,6 @@ from .lib import config_util, server
 
 if TYPE_CHECKING:
     from wandb.sdk.lib.service_connection import ServiceConnection
-    from wandb.sdk.wandb_run import Run
     from wandb.sdk.wandb_settings import Settings
 
 
@@ -89,9 +88,6 @@ class _WandbSetup:
         self._config: dict | None = None
         self._server: server.Server | None = None
         self._pid = pid
-
-        # keep track of multiple runs, so we can unwind with join()s
-        self._global_run_stack: list[Run] = []
 
         # TODO(jhr): defer strict checks until settings are fully initialized
         #            and logging is ready


### PR DESCRIPTION
Removes the `_WandbSetup._global_run_stack` field as all the ways we use it can be done with `wandb.run`.

Its only use was in `wandb.init()`, which called `finish()` on its latest item if `reinit` is true, but this is equivalent to calling `finish()` on `wandb.run`.