### PR TITLE
chore: make test_finetuning wandb_core_only

### DIFF
--- a/tests/system_tests/test_functional/openai/test_finetuning.py
+++ b/tests/system_tests/test_functional/openai/test_finetuning.py
@@ -1,9 +1,13 @@
 import os
 
+import pytest
 from openai import OpenAI
 from wandb.integration.openai.fine_tuning import WandbLogger
 
 
+@pytest.mark.wandb_core_only(
+    reason="This test is order-dependent and must only run once.",
+)
 def test_finetuning(wandb_backend_spy):
     # TODO: this does not test much, it should be improved
     client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])


### PR DESCRIPTION
Mark test wandb_core_only because it is order-dependent and cannot run twice.

When we run it twice, the second time it outputs a warning like

> wandb: WARNING Fine-tune ftjob-H3DHssnC1C82qfc3ePQWeP3V has already been logged successfully at http://127.0.0.1:32845/user-gw3-98exia799lz2/OpenAI-Fine-Tune/runs/ftjob-H3DHssnC1C82qfc3ePQWeP3V. Use `overwrite=****` if you want to overwrite previous run

Interestingly, this doesn't fail consistently: if the two instances run simultaneously, they can both pass.

The tested functionality does not appear to depend on the service process.