### PR TITLE
refactor: better debugging in router.py

### DIFF
--- a/wandb/sdk/interface/router.py
+++ b/wandb/sdk/interface/router.py
@@ -71,8 +71,8 @@ class MessageRouter:
                 # resulting in EOFError.  message_loop needs to exit..
                 logger.warning("EOFError seen in message_loop")
                 break
-            except MessageRouterClosedError:
-                logger.warning("message_loop has been closed")
+            except MessageRouterClosedError as e:
+                logger.warning("message_loop has been closed", exc_info=e)
                 break
             if not msg:
                 continue

--- a/wandb/sdk/interface/router_sock.py
+++ b/wandb/sdk/interface/router_sock.py
@@ -25,8 +25,8 @@ class MessageSockRouter(MessageRouter):
     def _read_message(self) -> Optional["pb.Result"]:
         try:
             resp = self._sock_client.read_server_response(timeout=1)
-        except SockClientClosedError:
-            raise MessageRouterClosedError
+        except SockClientClosedError as e:
+            raise MessageRouterClosedError from e
         if not resp:
             return None
         msg = resp.result_communicate

--- a/wandb/sdk/lib/sock_client.py
+++ b/wandb/sdk/lib/sock_client.py
@@ -256,10 +256,8 @@ class SockClient:
                 data = self._sock.recv(self._bufsize)
             except socket.timeout:
                 break
-            except ConnectionResetError:
-                raise SockClientClosedError
-            except OSError:
-                raise SockClientClosedError
+            except OSError as e:
+                raise SockClientClosedError from e
             finally:
                 if timeout:
                     self._sock.settimeout(None)


### PR DESCRIPTION
Log the cause of a MessageRouterClosedError to distinguish between empty reads and OS errors.

Note that ConnectionResetError subclasses OSError, so it didn't need its own `except` clause.