### PR TITLE
refactor: communicate_artifact => deliver_artifact

### DIFF
--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -391,9 +391,12 @@ class InterfaceShared(InterfaceBase):
         rec = self._make_record(use_artifact=use_artifact)
         self._publish(rec)
 
-    def _communicate_artifact(self, log_artifact: pb.LogArtifactRequest) -> Any:
+    def _deliver_artifact(
+        self,
+        log_artifact: pb.LogArtifactRequest,
+    ) -> MailboxHandle:
         rec = self._make_request(log_artifact=log_artifact)
-        return self._communicate_async(rec)
+        return self._deliver_record(rec)
 
     def _deliver_download_artifact(
         self, download_artifact: pb.DownloadArtifactRequest

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1491,7 +1491,6 @@ class SendManager:
             self._job_builder.set_partial_source_id(use.id)
 
     def send_request_log_artifact(self, record: "Record") -> None:
-        assert record.control.req_resp
         result = proto_util._result_from_record(record)
         artifact = record.request.log_artifact.artifact
         history_step = record.request.log_artifact.history_step

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3238,7 +3238,7 @@ class Run:
         self._assert_can_log_artifact(artifact)
         if self._backend and self._backend.interface:
             if not self._settings._offline:
-                future = self._backend.interface.communicate_artifact(
+                handle = self._backend.interface.deliver_artifact(
                     self,
                     artifact,
                     aliases,
@@ -3248,7 +3248,7 @@ class Run:
                     is_user_created=is_user_created,
                     use_after_commit=use_after_commit,
                 )
-                artifact._set_save_future(future, self._public_api().client)
+                artifact._set_save_handle(handle, self._public_api().client)
             else:
                 self._backend.interface.publish_artifact(
                     self,


### PR DESCRIPTION
Rewrite `communicate_artifact`, which used the old `MessageFuture` abstraction, as `deliver_artifact` using `Mailbox`.

NOTE: The records used to set `req_resp` and `uuid`, and now they use `mailbox_slot`. I updated `sender.py` because it asserted `req_resp` was set; otherwise, I don't see these used in `sender.py` or `sender.go`, and `handler.py`/`handler.go` simply forward the request.

This was used by `run.log_artifact()`. To test it manually, create a large file called `large_file.txt` and run:

```python
import wandb 
 
 
artifact = wandb.Artifact(name="large_artifact", type="junk") 
artifact.add_file(local_path="large_file.txt") 

run = wandb.init() 
run.log_artifact(artifact) 
 
print(f"state: {artifact.state}")  
print("waiting...")
# Setting to None succeeds; setting to 0 raises TimeoutError.
artifact.wait(timeout=...)
print("done waiting!") 
```