### PR TITLE
refactor: remove unused communicate_login and publish_login

### DIFF
--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -307,8 +307,6 @@ func (h *Handler) handleRequest(record *spb.Record) {
 		// The above been removed from the client but are kept here for now.
 		// Should be removed in the future.
 
-	case *spb.Request_Login:
-		h.handleRequestLogin(record)
 	case *spb.Request_RunStatus:
 		h.handleRequestRunStatus(record)
 	case *spb.Request_Metadata:
@@ -373,13 +371,6 @@ func (h *Handler) handleRequest(record *spb.Record) {
 	default:
 		h.logger.CaptureFatalAndPanic(
 			fmt.Errorf("handler: handleRequest: unknown request type %T", x))
-	}
-}
-
-func (h *Handler) handleRequestLogin(record *spb.Record) {
-	// TODO: implement login if it is needed
-	if record.GetControl().GetReqResp() {
-		h.respond(record, &spb.Response{})
 	}
 }
 

--- a/core/pkg/service_go_proto/wandb_internal.pb.go
+++ b/core/pkg/service_go_proto/wandb_internal.pb.go
@@ -5744,7 +5744,7 @@ func (*ResumeResponse) Descriptor() ([]byte, []int) {
 	return file_wandb_proto_wandb_internal_proto_rawDescGZIP(), []int{60}
 }
 
-// LoginRequest: wandb/sdk/wandb_login
+// Old request, no longer used for logging in (if it ever was).
 type LoginRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/gpu_stats/src/wandb_internal.rs
+++ b/gpu_stats/src/wandb_internal.rs
@@ -1841,8 +1841,7 @@ pub struct ResumeRequest {
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResumeResponse {}
-///
-/// LoginRequest: wandb/sdk/wandb_login
+/// Old request, no longer used for logging in (if it ever was).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoginRequest {
     #[prost(string, tag = "1")]

--- a/wandb/proto/v3/wandb_internal_pb2.pyi
+++ b/wandb/proto/v3/wandb_internal_pb2.pyi
@@ -2011,9 +2011,7 @@ class ResumeResponse(google.protobuf.message.Message):
 global___ResumeResponse = ResumeResponse
 
 class LoginRequest(google.protobuf.message.Message):
-    """
-    LoginRequest: wandb/sdk/wandb_login
-    """
+    """Old request, no longer used for logging in (if it ever was)."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 

--- a/wandb/proto/v4/wandb_internal_pb2.pyi
+++ b/wandb/proto/v4/wandb_internal_pb2.pyi
@@ -2073,9 +2073,7 @@ global___ResumeResponse = ResumeResponse
 
 @typing_extensions.final
 class LoginRequest(google.protobuf.message.Message):
-    """
-    LoginRequest: wandb/sdk/wandb_login
-    """
+    """Old request, no longer used for logging in (if it ever was)."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 

--- a/wandb/proto/v5/wandb_internal_pb2.pyi
+++ b/wandb/proto/v5/wandb_internal_pb2.pyi
@@ -2080,9 +2080,7 @@ global___ResumeResponse = ResumeResponse
 
 @typing.final
 class LoginRequest(google.protobuf.message.Message):
-    """
-    LoginRequest: wandb/sdk/wandb_login
-    """
+    """Old request, no longer used for logging in (if it ever was)."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 

--- a/wandb/proto/wandb_internal.proto
+++ b/wandb/proto/wandb_internal.proto
@@ -681,9 +681,7 @@ message ResumeRequest {
 
 message ResumeResponse {}
 
-/*
- * LoginRequest: wandb/sdk/wandb_login
- */
+// Old request, no longer used for logging in (if it ever was).
 message LoginRequest {
   string api_key = 1;
   _RequestInfo _info = 200;

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -205,9 +205,6 @@ class HandleManager:
         # defer is used to drive the sender finish state machine
         self._dispatch_record(record, always_send=True)
 
-    def handle_request_login(self, record: Record) -> None:
-        self._dispatch_record(record)
-
     def handle_request_python_packages(self, record: Record) -> None:
         self._dispatch_record(record)
 

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -544,23 +544,6 @@ class SendManager:
                 logger.warning(f"Error emptying retry queue: {e}")
         self._respond_result(result)
 
-    def send_request_login(self, record: "Record") -> None:
-        # TODO: do something with api_key or anonymous?
-        # TODO: return an error if we aren't logged in?
-        self._api.reauth()
-        viewer = self.get_viewer_info()
-        server_info = self.get_server_info()
-        # self._login_flags = json.loads(viewer.get("flags", "{}"))
-        # self._login_entity = viewer.get("entity")
-        if server_info:
-            logger.info(f"Login server info: {server_info}")
-        self._entity = viewer.get("entity")
-        if record.control.req_resp:
-            result = proto_util._result_from_record(record)
-            if self._entity:
-                result.response.login_response.active_entity = self._entity
-            self._respond_result(result)
-
     def send_exit(self, record: "Record") -> None:
         # track where the exit came from
         self._record_exit = record


### PR DESCRIPTION
Removes `communicate_login` and `publish_login` methods from `InterfaceShared` as they are not used anywhere, and the former relies on the old `communicate` mechanism.

Since these are not used and were never saved to any transaction logs (due to being local), I also removed all the corresponding handling code in `wandb-core` and `legacy-service`.