### PR TITLE
refactor: delete InterfaceShared._communicate

### DIFF
--- a/wandb/sdk/interface/interface_sock.py
+++ b/wandb/sdk/interface/interface_sock.py
@@ -11,7 +11,6 @@ from wandb.sdk.mailbox import Mailbox
 
 from ..lib.sock_client import SockClient
 from .interface_shared import InterfaceShared
-from .message_future import MessageFuture
 from .router_sock import MessageSockRouter
 
 if TYPE_CHECKING:
@@ -46,13 +45,3 @@ class InterfaceSock(InterfaceShared):
     def _publish(self, record: "pb.Record", local: Optional[bool] = None) -> None:
         self._assign(record)
         self._sock_client.send_record_publish(record)
-
-    def _communicate_async(
-        self, rec: "pb.Record", local: Optional[bool] = None
-    ) -> MessageFuture:
-        self._assign(rec)
-        assert self._router
-        if self._process_check and self._process and not self._process.is_alive():
-            raise Exception("The wandb backend process has shutdown")
-        future = self._router.send_and_receive(rec, local=local)
-        return future


### PR DESCRIPTION
Replaces `_communicate_shutdown()` by `_deliver_shutdown()` and deletes `InterfaceShared._communicate()` and `_communicate_async()` as they are no longer used.

`handler.go` and `handler.py` both respond to `RequestShutdown` immediately without checking `req_resp` or `uuid`.