### PR TITLE
refactor: remove "process_check" from InterfaceShared

### DIFF
--- a/wandb/sdk/interface/interface_queue.py
+++ b/wandb/sdk/interface/interface_queue.py
@@ -23,21 +23,17 @@ logger = logging.getLogger("wandb")
 
 
 class InterfaceQueue(InterfaceShared):
-    record_q: Optional["Queue[pb.Record]"]
-    result_q: Optional["Queue[pb.Result]"]
-    _mailbox: Optional[Mailbox]
-
     def __init__(
         self,
         record_q: Optional["Queue[pb.Record]"] = None,
         result_q: Optional["Queue[pb.Result]"] = None,
         process: Optional[BaseProcess] = None,
-        process_check: bool = True,
         mailbox: Optional[Mailbox] = None,
     ) -> None:
         self.record_q = record_q
         self.result_q = result_q
-        super().__init__(process=process, process_check=process_check, mailbox=mailbox)
+        self._process = process
+        super().__init__(mailbox=mailbox)
 
     def _init_router(self) -> None:
         if self.record_q and self.result_q:
@@ -46,7 +42,7 @@ class InterfaceQueue(InterfaceShared):
             )
 
     def _publish(self, record: "pb.Record", local: Optional[bool] = None) -> None:
-        if self._process_check and self._process and not self._process.is_alive():
+        if self._process and not self._process.is_alive():
             raise Exception("The wandb backend process has shutdown")
         if local:
             record.control.local = local

--- a/wandb/sdk/interface/interface_relay.py
+++ b/wandb/sdk/interface/interface_relay.py
@@ -5,7 +5,6 @@ See interface.py for how interface classes relate to each other.
 """
 
 import logging
-from multiprocessing.process import BaseProcess
 from typing import TYPE_CHECKING, Optional
 
 from wandb.proto import wandb_internal_pb2 as pb
@@ -31,15 +30,11 @@ class InterfaceRelay(InterfaceQueue):
         record_q: Optional["Queue[pb.Record]"] = None,
         result_q: Optional["Queue[pb.Result]"] = None,
         relay_q: Optional["Queue[pb.Result]"] = None,
-        process: Optional[BaseProcess] = None,
-        process_check: bool = True,
     ) -> None:
         self.relay_q = relay_q
         super().__init__(
             record_q=record_q,
             result_q=result_q,
-            process=process,
-            process_check=process_check,
             mailbox=mailbox,
         )
 

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -6,7 +6,6 @@ See interface.py for how interface classes relate to each other.
 
 import logging
 from abc import abstractmethod
-from multiprocessing.process import BaseProcess
 from typing import Any, Optional, cast
 
 from wandb.proto import wandb_internal_pb2 as pb
@@ -21,21 +20,12 @@ logger = logging.getLogger("wandb")
 
 
 class InterfaceShared(InterfaceBase):
-    process: Optional[BaseProcess]
-    _process_check: bool
     _router: Optional[MessageRouter]
     _mailbox: Optional[Mailbox]
 
-    def __init__(
-        self,
-        process: Optional[BaseProcess] = None,
-        process_check: bool = True,
-        mailbox: Optional[Any] = None,
-    ) -> None:
+    def __init__(self, mailbox: Optional[Any] = None) -> None:
         super().__init__()
-        self._process = process
         self._router = None
-        self._process_check = process_check
         self._mailbox = mailbox
         self._init_router()
 

--- a/wandb/sdk/interface/interface_sock.py
+++ b/wandb/sdk/interface/interface_sock.py
@@ -32,7 +32,6 @@ class InterfaceSock(InterfaceShared):
         # _sock_client is used when abstract method _init_router() is called by constructor
         self._sock_client = sock_client
         super().__init__(mailbox=mailbox)
-        self._process_check = False
         self._stream_id = stream_id
 
     def _init_router(self) -> None:

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import multiprocessing
 import queue
 import threading
 import time
@@ -63,13 +62,10 @@ class StreamRecord:
         self._record_q = queue.Queue()
         self._result_q = queue.Queue()
         self._relay_q = queue.Queue()
-        process = multiprocessing.current_process()
         self._iface = InterfaceRelay(
             record_q=self._record_q,
             result_q=self._result_q,
             relay_q=self._relay_q,
-            process=process,
-            process_check=False,
             mailbox=self._mailbox,
         )
         self._settings = settings


### PR DESCRIPTION
The `_process` and `_process_check` fields are only used by `InterfaceQueue`, so this PR removes them from `InterfaceShared`.

`Backend` is the only place that instantiates `InterfaceQueue` passing the `process` parameter.

`InterfaceRelay` inherits from `InterfaceQueue` and is only instantiated in `streams.py` with `_process_check` set to False, so it doesn't need the `process` parameter at all.