### PR TITLE
refactor: raise MailboxClosedError when creating handle in closed mailbox

### DIFF
--- a/tests/unit_tests/test_mailbox.py
+++ b/tests/unit_tests/test_mailbox.py
@@ -207,6 +207,14 @@ def test_require_response_raises_if_address_is_set():
         mailbox.require_response(record)
 
 
+def test_require_response_raises_if_closed():
+    mailbox = mb.Mailbox()
+    mailbox.close()
+
+    with pytest.raises(mb.MailboxClosedError):
+        mailbox.require_response(pb.Record())
+
+
 def test_deliver_unknown_address():
     mailbox = mb.Mailbox()
     result = pb.Result()

--- a/wandb/sdk/mailbox/__init__.py
+++ b/wandb/sdk/mailbox/__init__.py
@@ -10,5 +10,14 @@ continuously reads data from the service and passes it to the mailbox.
 """
 
 from .handles import HandleAbandonedError, MailboxHandle
-from .mailbox import Mailbox
+from .mailbox import Mailbox, MailboxClosedError
 from .wait_with_progress import wait_all_with_progress, wait_with_progress
+
+__all__ = [
+    "HandleAbandonedError",
+    "MailboxHandle",
+    "Mailbox",
+    "MailboxClosedError",
+    "wait_all_with_progress",
+    "wait_with_progress",
+]

--- a/wandb/sdk/mailbox/mailbox.py
+++ b/wandb/sdk/mailbox/mailbox.py
@@ -12,6 +12,10 @@ from . import handles
 _logger = logging.getLogger(__name__)
 
 
+class MailboxClosedError(Exception):
+    """The mailbox has been closed and cannot be used."""
+
+
 class Mailbox:
     """Matches service responses to requests.
 
@@ -24,6 +28,7 @@ class Mailbox:
     def __init__(self) -> None:
         self._handles: dict[str, handles.MailboxHandle] = {}
         self._handles_lock = threading.Lock()
+        self._closed = False
 
     def require_response(self, request: pb.Record) -> handles.MailboxHandle:
         """Set a response address on a request.
@@ -34,6 +39,11 @@ class Mailbox:
 
         Returns:
             A handle for waiting for the response to the request.
+
+        Raises:
+            MailboxClosedError: If the mailbox has been closed, in which case
+                no new responses are expected to be delivered and new handles
+                cannot be created.
         """
         if address := request.control.mailbox_slot:
             raise ValueError(f"Request already has an address ({address})")
@@ -42,6 +52,9 @@ class Mailbox:
         request.control.mailbox_slot = address
 
         with self._handles_lock:
+            if self._closed:
+                raise MailboxClosedError()
+
             handle = handles.MailboxHandle(address)
             self._handles[address] = handle
 
@@ -71,6 +84,7 @@ class Mailbox:
         """Deliver a response from the service.
 
         If the response address is invalid, this does nothing.
+        It is a no-op if the mailbox has been closed.
         """
         address = result.control.mailbox_slot
         if not address:
@@ -81,6 +95,8 @@ class Mailbox:
             return
 
         with self._handles_lock:
+            # NOTE: If the mailbox is closed, this returns None because
+            # we clear the dict.
             handle = self._handles.pop(address, None)
 
         # It is not an error if there is no handle for the address:
@@ -94,6 +110,8 @@ class Mailbox:
         Abandons all handles.
         """
         with self._handles_lock:
+            self._closed = True
+
             _logger.info(
                 f"Closing mailbox, abandoning {len(self._handles)} handles.",
             )

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -56,9 +56,9 @@ class StreamRecord:
     _settings: SettingsStatic
     _started: bool
 
-    def __init__(self, settings: SettingsStatic, mailbox: Mailbox) -> None:
+    def __init__(self, settings: SettingsStatic) -> None:
         self._started = False
-        self._mailbox = mailbox
+        self._mailbox = Mailbox()
         self._record_q = queue.Queue()
         self._result_q = queue.Queue()
         self._relay_q = queue.Queue()
@@ -133,7 +133,6 @@ class StreamMux:
     _action_q: queue.Queue[StreamAction]
     _stopped: Event
     _pid_checked_ts: float | None
-    _mailbox: Mailbox
 
     def __init__(self) -> None:
         self._streams_lock = threading.Lock()
@@ -143,7 +142,6 @@ class StreamMux:
         self._stopped = Event()
         self._action_q = queue.Queue()
         self._pid_checked_ts = None
-        self._mailbox = Mailbox()
 
     def _get_stopped_event(self) -> Event:
         # TODO: clean this up, there should be a better way to abstract this
@@ -200,7 +198,7 @@ class StreamMux:
             return stream
 
     def _process_add(self, action: StreamAction) -> None:
-        stream = StreamRecord(action._data, mailbox=self._mailbox)
+        stream = StreamRecord(action._data)
         # run_id = action.stream_id  # will want to fix if a streamid != runid
         settings = action._data
         thread = StreamThread(


### PR DESCRIPTION
Raise an error instead of allowing the creation of a handle to which a response will never be delivered.

This PR also updates `StreamRecord` in `legacy-service` to own its own `Mailbox` instead of sharing one from `StreamMux`. A `StreamRecord` corresponds to a Run and starts up a `MessageRouter` that delivers responses to the mailbox. When the run ends, the `MessageRouter` closes the mailbox, so it cannot be reused by future runs.

There was no need for StreamRecords to share a Mailbox because a Record delivered to a stream can only get a Result from that same stream. Using different Mailbox instances can never result in a situation where `require_response` is called on one `Mailbox` and the result is delivered to another.