### PR TITLE
refactor: remove `_router` from `InterfaceShared`

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -74,7 +74,7 @@ from wandb.sdk.lib.deprecate import Deprecated, deprecate
 from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
 from wandb.sdk.lib.runid import generate_id
-from wandb.sdk.mailbox import Mailbox, MailboxHandle
+from wandb.sdk.mailbox import MailboxHandle
 
 reset_path = util.vendor_setup()
 
@@ -1829,12 +1829,7 @@ class Artifact:
             service = wl.ensure_service()
             service.inform_init(settings=settings, run_id=stream_id)
 
-            mailbox = Mailbox()
-            backend = Backend(
-                settings=wl.settings,
-                service=service,
-                mailbox=mailbox,
-            )
+            backend = Backend(settings=wl.settings, service=service)
             backend.ensure_launched()
 
             assert backend.interface

--- a/wandb/sdk/backend/backend.py
+++ b/wandb/sdk/backend/backend.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 import wandb
 from wandb.sdk.interface.interface import InterfaceBase
 from wandb.sdk.interface.interface_queue import InterfaceQueue
+from wandb.sdk.interface.router_queue import MessageQueueRouter
 from wandb.sdk.internal.internal import wandb_internal
 from wandb.sdk.internal.settings_static import SettingsStatic
 from wandb.sdk.mailbox import Mailbox
@@ -49,17 +50,18 @@ class BackendThread(threading.Thread):
 class Backend:
     # multiprocessing context or module
     _multiprocessing: multiprocessing.context.BaseContext
+
     interface: Optional[InterfaceBase]
+    _router: Optional[MessageQueueRouter]
+
     _internal_pid: Optional[int]
     wandb_process: Optional[multiprocessing.process.BaseProcess]
     _settings: Settings
     record_q: Optional["RecordQueue"]
     result_q: Optional["ResultQueue"]
-    _mailbox: Mailbox
 
     def __init__(
         self,
-        mailbox: Mailbox,
         settings: Settings,
         log_level: Optional[int] = None,
         service: "Optional[service_connection.ServiceConnection]" = None,
@@ -68,12 +70,14 @@ class Backend:
         self.record_q = None
         self.result_q = None
         self.wandb_process = None
+
         self.interface = None
+        self._router = None
+
         self._internal_pid = None
         self._settings = settings
         self._log_level = log_level
         self._service = service
-        self._mailbox = mailbox
 
         self._multiprocessing = multiprocessing  # type: ignore
         self._multiprocessing_setup()
@@ -136,7 +140,6 @@ class Backend:
         if self._service:
             assert self._settings.run_id
             self.interface = self._service.make_interface(
-                self._mailbox,
                 stream_id=self._settings.run_id,
             )
             return
@@ -190,11 +193,17 @@ class Backend:
 
         self._module_main_uninstall()
 
+        mailbox = Mailbox()
         self.interface = InterfaceQueue(
             process=self.wandb_process,
             record_q=self.record_q,  # type: ignore
             result_q=self.result_q,  # type: ignore
-            mailbox=self._mailbox,
+            mailbox=mailbox,
+        )
+        self._router = MessageQueueRouter(
+            request_queue=self.record_q,  # type: ignore
+            response_queue=self.result_q,  # type: ignore
+            mailbox=mailbox,
         )
 
     def server_status(self) -> None:
@@ -207,6 +216,8 @@ class Backend:
         self._done = True
         if self.interface:
             self.interface.join()
+        if self._router:
+            self._router.join()
         if self.wandb_process:
             self.wandb_process.join()
 

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -4,8 +4,6 @@ InterfaceBase: The abstract class
 InterfaceShared: Common routines for socket and queue based implementations
 InterfaceQueue: Use multiprocessing queues to send and receive messages
 InterfaceSock: Use socket to send and receive messages
-InterfaceRelay: Responses are routed to a relay queue (not matching uuids)
-
 """
 
 import gzip

--- a/wandb/sdk/interface/interface_queue.py
+++ b/wandb/sdk/interface/interface_queue.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Optional
 from wandb.sdk.mailbox import Mailbox
 
 from .interface_shared import InterfaceShared
-from .router_queue import MessageQueueRouter
 
 if TYPE_CHECKING:
     from queue import Queue
@@ -34,12 +33,6 @@ class InterfaceQueue(InterfaceShared):
         self.result_q = result_q
         self._process = process
         super().__init__(mailbox=mailbox)
-
-    def _init_router(self) -> None:
-        if self.record_q and self.result_q:
-            self._router = MessageQueueRouter(
-                self.record_q, self.result_q, mailbox=self._mailbox
-            )
 
     def _publish(self, record: "pb.Record", local: Optional[bool] = None) -> None:
         if self._process and not self._process.is_alive():

--- a/wandb/sdk/interface/interface_relay.py
+++ b/wandb/sdk/interface/interface_relay.py
@@ -1,17 +1,17 @@
 """InterfaceRelay - Derived from InterfaceQueue using RelayRouter to preserve uuid req/resp.
 
 See interface.py for how interface classes relate to each other.
-
 """
 
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.mailbox import Mailbox
 
 from .interface_queue import InterfaceQueue
-from .router_relay import MessageRelayRouter
 
 if TYPE_CHECKING:
     from queue import Queue
@@ -22,14 +22,13 @@ logger = logging.getLogger("wandb")
 
 class InterfaceRelay(InterfaceQueue):
     _mailbox: Mailbox
-    relay_q: Optional["Queue[pb.Result]"]
 
     def __init__(
         self,
         mailbox: Mailbox,
-        record_q: Optional["Queue[pb.Record]"] = None,
-        result_q: Optional["Queue[pb.Result]"] = None,
-        relay_q: Optional["Queue[pb.Result]"] = None,
+        record_q: Queue[pb.Record],
+        result_q: Queue[pb.Result],
+        relay_q: Queue[pb.Result],
     ) -> None:
         self.relay_q = relay_q
         super().__init__(
@@ -37,12 +36,3 @@ class InterfaceRelay(InterfaceQueue):
             result_q=result_q,
             mailbox=mailbox,
         )
-
-    def _init_router(self) -> None:
-        if self.record_q and self.result_q and self.relay_q:
-            self._router = MessageRelayRouter(
-                request_queue=self.record_q,
-                response_queue=self.result_q,
-                relay_queue=self.relay_q,
-                mailbox=self._mailbox,
-            )

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -14,24 +14,14 @@ from wandb.sdk.mailbox import Mailbox, MailboxHandle
 from wandb.util import json_dumps_safer, json_friendly
 
 from .interface import InterfaceBase
-from .router import MessageRouter
 
 logger = logging.getLogger("wandb")
 
 
 class InterfaceShared(InterfaceBase):
-    _router: Optional[MessageRouter]
-    _mailbox: Optional[Mailbox]
-
-    def __init__(self, mailbox: Optional[Any] = None) -> None:
+    def __init__(self, mailbox: Optional[Mailbox] = None) -> None:
         super().__init__()
-        self._router = None
         self._mailbox = mailbox
-        self._init_router()
-
-    @abstractmethod
-    def _init_router(self) -> None:
-        raise NotImplementedError
 
     def _publish_output(self, outdata: pb.OutputRecord) -> None:
         rec = pb.Record()
@@ -499,9 +489,3 @@ class InterfaceShared(InterfaceBase):
     ) -> MailboxHandle[pb.Result]:
         record = self._make_request(run_status=run_status)
         return self._deliver_record(record)
-
-    def join(self) -> None:
-        super().join()
-
-        if self._router:
-            self._router.join()

--- a/wandb/sdk/interface/interface_sock.py
+++ b/wandb/sdk/interface/interface_sock.py
@@ -11,7 +11,6 @@ from wandb.sdk.mailbox import Mailbox
 
 from ..lib.sock_client import SockClient
 from .interface_shared import InterfaceShared
-from .router_sock import MessageSockRouter
 
 if TYPE_CHECKING:
     from wandb.proto import wandb_internal_pb2 as pb
@@ -21,21 +20,15 @@ logger = logging.getLogger("wandb")
 
 
 class InterfaceSock(InterfaceShared):
-    _mailbox: Mailbox
-
     def __init__(
         self,
         sock_client: SockClient,
         mailbox: Mailbox,
         stream_id: str,
     ) -> None:
-        # _sock_client is used when abstract method _init_router() is called by constructor
-        self._sock_client = sock_client
         super().__init__(mailbox=mailbox)
+        self._sock_client = sock_client
         self._stream_id = stream_id
-
-    def _init_router(self) -> None:
-        self._router = MessageSockRouter(self._sock_client, mailbox=self._mailbox)
 
     def _assign(self, record: Any) -> None:
         assert self._stream_id

--- a/wandb/sdk/lib/service_connection.py
+++ b/wandb/sdk/lib/service_connection.py
@@ -10,10 +10,11 @@ from wandb.proto import wandb_settings_pb2
 from wandb.sdk import wandb_settings
 from wandb.sdk.interface.interface import InterfaceBase
 from wandb.sdk.interface.interface_sock import InterfaceSock
+from wandb.sdk.interface.router_sock import MessageSockRouter
 from wandb.sdk.lib import service_token
 from wandb.sdk.lib.exit_hooks import ExitHooks
-from wandb.sdk.lib.sock_client import SockClient, SockClientTimeoutError
-from wandb.sdk.mailbox import Mailbox
+from wandb.sdk.lib.sock_client import SockClient, SockClientClosedError
+from wandb.sdk.mailbox import HandleAbandonedError, Mailbox, MailboxClosedError
 from wandb.sdk.service import service
 
 
@@ -115,6 +116,9 @@ class ServiceConnection:
         """Returns a new ServiceConnection.
 
         Args:
+            mailbox: The mailbox to use for all communication over the socket.
+            router: A handle to the thread that reads from the socket and
+                updates the mailbox.
             client: A socket that's connected to the service.
             proc: The service process if we own it, or None otherwise.
             cleanup: A callback to run on teardown before doing anything.
@@ -124,9 +128,12 @@ class ServiceConnection:
         self._torn_down = False
         self._cleanup = cleanup
 
-    def make_interface(self, mailbox: Mailbox, stream_id: str) -> InterfaceBase:
+        self._mailbox = Mailbox()
+        self._router = MessageSockRouter(self._client, self._mailbox)
+
+    def make_interface(self, stream_id: str) -> InterfaceBase:
         """Returns an interface for communicating with the service."""
-        return InterfaceSock(self._client, mailbox, stream_id=stream_id)
+        return InterfaceSock(self._client, self._mailbox, stream_id=stream_id)
 
     def send_record(self, record: pb.Record) -> None:
         """Sends data to the service."""
@@ -141,13 +148,13 @@ class ServiceConnection:
         request = spb.ServerInformInitRequest()
         request.settings.CopyFrom(settings)
         request._info.stream_id = run_id
-        self._client.send(inform_init=request)
+        self._client.send_server_request(spb.ServerRequest(inform_init=request))
 
     def inform_finish(self, run_id: str) -> None:
         """Sends an finish request to the service."""
         request = spb.ServerInformFinishRequest()
         request._info.stream_id = run_id
-        self._client.send(inform_finish=request)
+        self._client.send_server_request(spb.ServerRequest(inform_finish=request))
 
     def inform_attach(
         self,
@@ -157,18 +164,26 @@ class ServiceConnection:
 
         Raises a WandbAttachFailedError if attaching is not possible.
         """
-        request = spb.ServerInformAttachRequest()
-        request._info.stream_id = attach_id
+        request = spb.ServerRequest()
+        request.inform_attach._info.stream_id = attach_id
 
         try:
-            response = self._client.send_and_recv(inform_attach=request)
+            handle = self._mailbox.require_response(request)
+            self._client.send_server_request(request)
+            response = handle.wait_or(timeout=10)
             return response.inform_attach_response.settings
-        except SockClientTimeoutError:
+
+        except (MailboxClosedError, HandleAbandonedError, SockClientClosedError):
             raise WandbAttachFailedError(
-                "Could not attach because the run does not belong to"
+                "Failed to attach: the service process is not running.",
+            ) from None
+
+        except TimeoutError:
+            raise WandbAttachFailedError(
+                "Failed to attach because the run does not belong to"
                 " the current service process, or because the service"
                 " process is busy (unlikely)."
-            )
+            ) from None
 
     def inform_start(
         self,
@@ -179,7 +194,7 @@ class ServiceConnection:
         request = spb.ServerInformStartRequest()
         request.settings.CopyFrom(settings)
         request._info.stream_id = run_id
-        self._client.send(inform_start=request)
+        self._client.send_server_request(spb.ServerRequest(inform_start=request))
 
     def teardown(self, exit_code: int) -> int:
         """Shuts down the service process and returns its exit code.
@@ -207,10 +222,15 @@ class ServiceConnection:
         # Clear the service token to prevent new connections from being made.
         service_token.clear_service_token()
 
-        self._client.send(
-            inform_teardown=spb.ServerInformTeardownRequest(
-                exit_code=exit_code,
-            )
+        # Stop reading responses on the socket.
+        self._router.join()
+
+        self._client.send_server_request(
+            spb.ServerRequest(
+                inform_teardown=spb.ServerInformTeardownRequest(
+                    exit_code=exit_code,
+                )
+            ),
         )
 
         return self._proc.join()

--- a/wandb/sdk/service/server_sock.py
+++ b/wandb/sdk/service/server_sock.py
@@ -44,7 +44,10 @@ class SockServerInterfaceReaderThread(threading.Thread):
     _stopped: "Event"
 
     def __init__(
-        self, clients: ClientDict, iface: "InterfaceRelay", stopped: "Event"
+        self,
+        clients: ClientDict,
+        iface: "InterfaceRelay",
+        stopped: "Event",
     ) -> None:
         self._iface = iface
         self._clients = clients
@@ -53,7 +56,6 @@ class SockServerInterfaceReaderThread(threading.Thread):
         self._stopped = stopped
 
     def run(self) -> None:
-        assert self._iface.relay_q
         while not self._stopped.is_set():
             try:
                 result = self._iface.relay_q.get(timeout=1)

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -21,15 +21,13 @@ import psutil
 import wandb
 import wandb.util
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.interface.interface_relay import InterfaceRelay
+from wandb.sdk.interface.router_relay import MessageRelayRouter
 from wandb.sdk.internal.settings_static import SettingsStatic
 from wandb.sdk.lib import asyncio_compat, progress
 from wandb.sdk.lib import printer as printerlib
 from wandb.sdk.mailbox import Mailbox, MailboxHandle, wait_all_with_progress
 from wandb.sdk.wandb_run import Run
-
-from ..interface.interface_relay import InterfaceRelay
-
-# from wandb.sdk.wandb_settings import Settings
 
 
 class StreamThread(threading.Thread):
@@ -62,6 +60,12 @@ class StreamRecord:
         self._record_q = queue.Queue()
         self._result_q = queue.Queue()
         self._relay_q = queue.Queue()
+        self._router = MessageRelayRouter(
+            request_queue=self._record_q,
+            response_queue=self._result_q,
+            relay_queue=self._relay_q,
+            mailbox=self._mailbox,
+        )
         self._iface = InterfaceRelay(
             record_q=self._record_q,
             result_q=self._result_q,
@@ -80,6 +84,7 @@ class StreamRecord:
 
     def join(self) -> None:
         self._iface.join()
+        self._router.join()
         if self._thread:
             self._thread.join()
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -42,7 +42,7 @@ from . import wandb_login, wandb_setup
 from .backend.backend import Backend
 from .lib import SummaryDisabled, filesystem, module, paths, printer, telemetry
 from .lib.deprecate import Deprecated, deprecate
-from .mailbox import Mailbox, wait_with_progress
+from .mailbox import wait_with_progress
 from .wandb_helper import parse_config
 from .wandb_run import Run, TeardownHook, TeardownStage
 from .wandb_settings import Settings
@@ -793,12 +793,7 @@ class _WandbInit:
         else:
             service = None
 
-        mailbox = Mailbox()
-        backend = Backend(
-            settings=settings,
-            service=service,
-            mailbox=mailbox,
-        )
+        backend = Backend(settings=settings, service=service)
         backend.ensure_launched()
         self._logger.info("backend started and connected")
 
@@ -1085,8 +1080,7 @@ def _attach(
     )
 
     # TODO: consolidate this codepath with wandb.init()
-    mailbox = Mailbox()
-    backend = Backend(settings=settings, service=service, mailbox=mailbox)
+    backend = Backend(settings=settings, service=service)
     backend.ensure_launched()
     logger.info("attach backend started and connected")
 

--- a/wandb/sdk/wandb_sync.py
+++ b/wandb/sdk/wandb_sync.py
@@ -7,7 +7,6 @@ from wandb.errors.term import termerror, termlog
 from . import wandb_setup
 from .backend.backend import Backend
 from .lib.runid import generate_id
-from .mailbox import Mailbox
 
 if TYPE_CHECKING:
     from wandb.proto import wandb_internal_pb2
@@ -49,12 +48,7 @@ def _sync(
     service = wl.ensure_service()
     service.inform_init(settings=settings, run_id=stream_id)
 
-    mailbox = Mailbox()
-    backend = Backend(
-        settings=wl.settings,
-        service=service,
-        mailbox=mailbox,
-    )
+    backend = Backend(settings=wl.settings, service=service)
     backend.ensure_launched()
 
     assert backend.interface


### PR DESCRIPTION
Separate `MessageRouter` from `InterfaceShared`. A `MessageRouter` is a handle on a thread that delivers results from the service into a `Mailbox`.

This PR also updates `inform_attach` to use `Mailbox` and removes the deprecated `SockClient.send_and_recv` mechanism. This is necessary because `send_and_recv` assumes nothing else is reading on the socket, but this PR causes a reader thread to be created earlier in `wandb_init.py::_attach()`.

There can only be one `MessageSockRouter` per socket, and there is only one socket connection to the service per client process. If `InterfaceShared` owns `MessageSockRouter`, then there can only be one `InterfaceShared` instance at a time, and therefore only a single run at a time.

This PR makes code that instantiates `InterfaceShared` be responsible for managing a `MessageRouter`. There are only three such places:

* In `Backend`, when using the `x_disable_service` setting
* In `ServiceConnection`, in normal operation
    * The `ServiceConnection` owns a socket, so it also owns the router
    * The router thread lives as long as the socket is around, until `wandb.teardown()`
* In `streams.py` in `legacy-service`
    * Each `StreamRecord`, corresponding to an active run, owns an `InterfaceQueue` and a `MessageQueueRouter`
