### PR TITLE
refactor: fix mypy finding in wandb_run.py::Run._set_run_obj when setting tags

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1496,7 +1496,7 @@ class Run:
         if run_obj.notes:
             self._settings.run_notes = run_obj.notes
         if run_obj.tags:
-            self._settings.run_tags = run_obj.tags
+            self._settings.run_tags = tuple(run_obj.tags)
         if run_obj.sweep_id:
             self._settings.sweep_id = run_obj.sweep_id
         if run_obj.host:


### PR DESCRIPTION
The type of `run_obj.tags` is an internal protobuf type for repeated scalar fields, but `self._settings.run_tags` expects `tuple[str, ...]`.

Testing:

```python
with wandb.init() as run1:
    pass

# Go to the run's overview page and add one or more tags.
# Then run:

run2 = wandb.init(id=run1.id, resume="must")
run2.tags  # This will print the tags set in the UI.
```
