### PR TITLE
fix: strings with glob charaters were not being uploaded with wandb-core

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,3 +12,5 @@ Add here any changes made in a PR that are relevant to end users. Allowed sectio
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+- fixed some charaters([?\*) would cause file uploads to fail with wandb-core (@jacobromero in https://github.com/wandb/wandb/pull/9475)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,4 +13,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
-- fixed some charaters([?\*) would cause file uploads to fail with wandb-core (@jacobromero in https://github.com/wandb/wandb/pull/9475)
+- fixed media file paths with glob characters ([?\*) would cause file uploads to fail with wandb-core (@jacobromero in https://github.com/wandb/wandb/pull/9475)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,4 +13,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
-- fixed media file paths with glob characters ([?\*) would cause file uploads to fail with wandb-core (@jacobromero in https://github.com/wandb/wandb/pull/9475)
+- fixed an issue where media file paths containing special characters (?, *, ], [ or \) would cause file uploads to fail in `wandb-core`. (@jacobromero in https://github.com/wandb/wandb/pull/9475)

--- a/tests/system_tests/test_core/test_wandb.py
+++ b/tests/system_tests/test_core/test_wandb.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pytest
 import requests
 import wandb
@@ -462,6 +463,16 @@ def test_log_table_offline_no_network(user, monkeypatch):
     run.finish()
     assert num_network_calls_made == 0
     assert run.offline is True
+
+
+def test_log_with_glob_chars(user, wandb_backend_spy):
+    run = wandb.init()
+    run.log({"[glob chars]": wandb.Image(np.random.randint(0, 255, (100, 100, 3)))})
+    run.finish()
+
+    with wandb_backend_spy.freeze() as snapshot:
+        uploaded_files = snapshot.uploaded_files(run_id=run.id)
+        assert any("[glob chars]" in f for f in uploaded_files)
 
 
 # ----------------------------------

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -1,4 +1,3 @@
-import glob
 import io
 import os
 import platform
@@ -1435,66 +1434,6 @@ def test_partitioned_table():
 ################################################################################
 # Test various data types
 ################################################################################
-
-
-def test_media_keys_escaped_as_glob_for_publish(mock_run):
-    media_to_test = [
-        wandb.Image(
-            np.zeros((28, 28)),
-            masks={
-                "overlay": {
-                    "mask_data": np.array(
-                        [
-                            [1, 2, 2, 2],
-                            [2, 3, 3, 4],
-                            [4, 4, 4, 4],
-                            [4, 4, 4, 2],
-                        ]
-                    ),
-                    "class_labels": {
-                        1: "car",
-                        2: "pedestrian",
-                        3: "tractor",
-                        4: "cthululu",
-                    },
-                },
-            },
-        ),
-        wandb.data_types.ImageMask(
-            {
-                "mask_data": np.random.randint(0, 10, (300, 300)),
-            },
-            key="test",
-        ),
-        wandb.Table(
-            data=[
-                [1, 2, 3],
-                [4, 5, 6],
-            ]
-        ),
-        wandb.Graph(),
-        wandb.Audio(
-            np.random.uniform(-1, 1, 44100),
-            sample_rate=44100,
-        ),
-    ]
-
-    for media in media_to_test:
-        run = mock_run(use_magic_mock=True)
-        weird_key = "[weirdkey]"
-        media.bind_to_run(run, weird_key, 0)
-        published_globs = [
-            g
-            for (
-                [files_dict],
-                [],
-            ) in run._backend.interface.publish_files.call_args_list
-            for g, _ in files_dict["files"]
-        ]
-        assert not any(weird_key in g for g in published_globs), published_globs
-        assert any(
-            glob.escape(weird_key) in g for g in published_globs
-        ), published_globs
 
 
 def test_numpy_arrays_to_list():

--- a/tests/unit_tests/test_sender.py
+++ b/tests/unit_tests/test_sender.py
@@ -1,6 +1,9 @@
+import glob
 from unittest.mock import MagicMock
 
+import pytest
 import yaml
+from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.internal.sender import SendManager
 from wandb.sdk.internal.settings_static import SettingsStatic
 
@@ -23,3 +26,37 @@ def test_config_save_preserve_order(tmp_path, test_settings):
     saved_config.pop("wandb_version")
 
     assert saved_config == original_config
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "file_with_*.txt",
+        "file_with_?.txt",
+        "file_with_[.txt",
+    ],
+)
+def test_send_file_with_glob_characters_is_escaped(tmp_path, test_settings, file_path):
+    dir_watcher = MagicMock()
+    settings = test_settings({"x_files_dir": str(tmp_path)})
+    sender = SendManager(
+        settings=SettingsStatic(settings.to_proto()),
+        record_q=MagicMock(),
+        result_q=MagicMock(),
+        interface=MagicMock(),
+        context_keeper=MagicMock(),
+    )
+    sender._dir_watcher = dir_watcher
+
+    files_record = pb.FilesRecord()
+    file = files_record.files.add()
+    file.path = file_path
+    file.policy = pb.FilesItem.PolicyType.NOW
+
+    record = pb.Record()
+    record.files.CopyFrom(files_record)
+
+    sender.send_files(record)
+    assert dir_watcher.update_policy.call_count == 1
+    assert dir_watcher.update_policy.call_args[0][0] == glob.escape(file_path)
+    assert str(dir_watcher.update_policy.call_args[0][1]) == "now"

--- a/tests/unit_tests/test_sender.py
+++ b/tests/unit_tests/test_sender.py
@@ -29,6 +29,7 @@ def test_config_save_preserve_order(tmp_path, test_settings):
     assert saved_config == original_config
 
 
+@pytest.mark.skip_wandb_core
 @pytest.mark.parametrize(
     "file_path",
     [

--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -233,6 +233,7 @@ class DirWatcher:
             self._savename_file_policies[save_name] = policy
         else:
             self._user_file_policies[policy].add(path)
+
         for src_path in glob.glob(os.path.join(self._dir, path)):
             save_name = LogicalPath(os.path.relpath(src_path, self._dir))
             feh = self._get_file_event_handler(src_path, save_name)
@@ -285,7 +286,7 @@ class DirWatcher:
     #     return LogicalPath(os.path.relpath(path, self._dir))
 
     def _on_file_modified(self, event: "wd_events.FileModifiedEvent") -> None:
-        logger.info(f"file/dir modified: { event.src_path}")
+        logger.info(f"file/dir modified: {event.src_path}")
         if os.path.isdir(event.src_path):
             return None
         save_name = LogicalPath(os.path.relpath(event.src_path, self._dir))

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1,6 +1,7 @@
 """sender."""
 
 import contextlib
+import glob
 import gzip
 import json
 import logging
@@ -1408,7 +1409,8 @@ class SendManager:
         for k in files.files:
             # TODO(jhr): fix paths with directories
             self._save_file(
-                interface.GlobStr(k.path), interface.file_enum_to_policy(k.policy)
+                interface.GlobStr(glob.escape(k.path)),
+                interface.file_enum_to_policy(k.policy),
             )
 
     def send_header(self, record: "Record") -> None:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1332,7 +1332,7 @@ class Run:
     def _datatypes_callback(self, fname: str) -> None:
         if not self._backend or not self._backend.interface:
             return
-        files: FilesDict = dict(files=[(GlobStr(glob.escape(fname)), "now")])
+        files: FilesDict = dict(files=[(GlobStr(fname), "now")])
         self._backend.interface.publish_files(files)
 
     def _pop_all_charts(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-22927
- Fixes WB-11116

What does the PR do? Include a concise description of the PR contents.

This PR fixes a bug which some characters (`[`, `?`, `*`) would be escaped and cause the file upload to fail. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- Wandb core test
```
import numpy as np
import wandb

run = wandb.init(
    project="sample-image-upload-long",
)
img = np.random.randint(0, 255, (100, 100, 3))
image_path_buggy = "Validation/Plots/ex30[]]"
run.log({
    f"media/images/{image_path_buggy}": wandb.Image(img),
})
run.finish()
```
![image](https://github.com/user-attachments/assets/995fb6fe-c349-417a-b6d7-e4b57ada2a09)

- Wandb legacy test
```
import numpy as np
import wandb

wandb.require("legacy-service")
run = wandb.init(
    project="sample-image-upload-long",
)
img = np.random.randint(0, 255, (100, 100, 3))
image_path_buggy = "Validation/Plots/ex30[]]"
run.log({
    f"media/images/{image_path_buggy}": wandb.Image(img),
})
run.finish()
```
![image](https://github.com/user-attachments/assets/16c6ac06-c326-45a8-a366-701309e8ac2f)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
