### PR TITLE
docs: change wandb.log to run.log in media documentation.

### DIFF
--- a/wandb/sdk/data_types/helper_types/bounding_boxes_2d.py
+++ b/wandb/sdk/data_types/helper_types/bounding_boxes_2d.py
@@ -53,7 +53,7 @@ class BoundingBoxes2D(JSONMetadata):
         import numpy as np
         import wandb
 
-        wandb.init()
+        run = wandb.init()
         image = np.random.randint(low=0, high=256, size=(200, 300, 3))
 
         class_labels = {0: "person", 1: "car", 2: "road", 3: "building"}
@@ -77,7 +77,11 @@ class BoundingBoxes2D(JSONMetadata):
                         },
                         {
                             # another box expressed in the pixel domain
-                            "position": {"middle": [150, 20], "width": 68, "height": 112},
+                            "position": {
+                                "middle": [150, 20],
+                                "width": 68,
+                                "height": 112,
+                            },
                             "domain": "pixel",
                             "class_id": 3,
                             "box_caption": "a building",
@@ -90,7 +94,7 @@ class BoundingBoxes2D(JSONMetadata):
             },
         )
 
-        wandb.log({"driving_scene": img})
+        run.log({"driving_scene": img})
         ```
 
         ### Log a bounding box overlay to a Table
@@ -99,7 +103,7 @@ class BoundingBoxes2D(JSONMetadata):
         import numpy as np
         import wandb
 
-        wandb.init()
+        run = wandb.init()
         image = np.random.randint(low=0, high=256, size=(200, 300, 3))
 
         class_labels = {0: "person", 1: "car", 2: "road", 3: "building"}
@@ -132,7 +136,11 @@ class BoundingBoxes2D(JSONMetadata):
                         },
                         {
                             # another box expressed in the pixel domain
-                            "position": {"middle": [150, 20], "width": 68, "height": 112},
+                            "position": {
+                                "middle": [150, 20],
+                                "width": 68,
+                                "height": 112,
+                            },
                             "domain": "pixel",
                             "class_id": 3,
                             "box_caption": "a building",
@@ -148,7 +156,7 @@ class BoundingBoxes2D(JSONMetadata):
 
         table = wandb.Table(columns=["image"])
         table.add_data(img)
-        wandb.log({"driving_scene": table})
+        run.log({"driving_scene": table})
         ```
     """
 

--- a/wandb/sdk/data_types/helper_types/image_mask.py
+++ b/wandb/sdk/data_types/helper_types/image_mask.py
@@ -38,7 +38,7 @@ class ImageMask(Media):
         import numpy as np
         import wandb
 
-        wandb.init()
+        run = wandb.init()
         image = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
         predicted_mask = np.empty((100, 100), dtype=np.uint8)
         ground_truth_mask = np.empty((100, 100), dtype=np.uint8)
@@ -58,14 +58,17 @@ class ImageMask(Media):
         masked_image = wandb.Image(
             image,
             masks={
-                "predictions": {"mask_data": predicted_mask, "class_labels": class_labels},
+                "predictions": {
+                    "mask_data": predicted_mask,
+                    "class_labels": class_labels,
+                },
                 "ground_truth": {
                     "mask_data": ground_truth_mask,
                     "class_labels": class_labels,
                 },
             },
         )
-        wandb.log({"img_with_masks": masked_image})
+        run.log({"img_with_masks": masked_image})
         ```
 
         ### Log a masked image inside a Table
@@ -74,7 +77,7 @@ class ImageMask(Media):
         import numpy as np
         import wandb
 
-        wandb.init()
+        run = wandb.init()
         image = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
         predicted_mask = np.empty((100, 100), dtype=np.uint8)
         ground_truth_mask = np.empty((100, 100), dtype=np.uint8)
@@ -103,7 +106,10 @@ class ImageMask(Media):
         masked_image = wandb.Image(
             image,
             masks={
-                "predictions": {"mask_data": predicted_mask, "class_labels": class_labels},
+                "predictions": {
+                    "mask_data": predicted_mask,
+                    "class_labels": class_labels,
+                },
                 "ground_truth": {
                     "mask_data": ground_truth_mask,
                     "class_labels": class_labels,
@@ -114,7 +120,7 @@ class ImageMask(Media):
 
         table = wandb.Table(columns=["image"])
         table.add_data(masked_image)
-        wandb.log({"random_field": table})
+        run.log({"random_field": table})
         ```
     """
 

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -71,10 +71,10 @@ class Video(BatchableMedia):
         import numpy as np
         import wandb
 
-        wandb.init()
+        run = wandb.init()
         # axes are (time, channel, height, width)
         frames = np.random.randint(low=0, high=256, size=(10, 3, 100, 100), dtype=np.uint8)
-        wandb.log({"video": wandb.Video(frames, fps=4)})
+        run.log({"video": wandb.Video(frames, fps=4)})
         ```
     """
 


### PR DESCRIPTION
Description
-----------
What does the PR do? Include a concise description of the PR contents.

This PR updates examples which explicitly do `wandb.log(...)` to be `run = wandb.init() ... run.log(...)`, which is the standard we want to push users towards.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
