### PR TITLE
refactor: change Mailbox to operate on ServerRequest / ServerResponse

### DIFF
--- a/tests/unit_tests/test_mailbox.py
+++ b/tests/unit_tests/test_mailbox.py
@@ -5,6 +5,7 @@ import unittest.mock
 
 import pytest
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.proto import wandb_server_pb2 as spb
 from wandb.sdk import mailbox as mb
 from wandb.sdk.lib import asyncio_compat
 
@@ -36,34 +37,32 @@ def invalid_timeout(request):
 
 def test_wait_already_delivered(any_timeout):
     mailbox = mb.Mailbox()
-    request = pb.Record()
+    request = spb.ServerRequest()
     handle = mailbox.require_response(request)
-    result = pb.Record()
-    result.control.mailbox_slot = request.control.mailbox_slot
+    response = spb.ServerResponse(request_id=request.request_id)
 
-    mailbox.deliver(result)
-    handle_result = handle.wait_or(timeout=any_timeout)
+    mailbox.deliver(response)
+    handle_response = handle.wait_or(timeout=any_timeout)
 
-    assert result is handle_result
+    assert response is handle_response
 
 
 @pytest.mark.asyncio
 async def test_wait_async_already_delivered(any_timeout):
     mailbox = mb.Mailbox()
-    request = pb.Record()
+    request = spb.ServerRequest()
     handle = mailbox.require_response(request)
-    result = pb.Record()
-    result.control.mailbox_slot = request.control.mailbox_slot
+    response = spb.ServerResponse(request_id=request.request_id)
 
-    mailbox.deliver(result)
-    handle_result = await handle.wait_async(timeout=any_timeout)
+    mailbox.deliver(response)
+    handle_response = await handle.wait_async(timeout=any_timeout)
 
-    assert result is handle_result
+    assert response is handle_response
 
 
 def test_wait_abandoned(any_timeout):
     mailbox = mb.Mailbox()
-    handle = mailbox.require_response(pb.Record())
+    handle = mailbox.require_response(spb.ServerRequest())
 
     handle.abandon()
     with pytest.raises(mb.HandleAbandonedError):
@@ -73,7 +72,7 @@ def test_wait_abandoned(any_timeout):
 @pytest.mark.asyncio
 async def test_wait_async_abandoned(any_timeout):
     mailbox = mb.Mailbox()
-    handle = mailbox.require_response(pb.Record())
+    handle = mailbox.require_response(spb.ServerRequest())
 
     handle.abandon()
     with pytest.raises(mb.HandleAbandonedError):
@@ -82,7 +81,7 @@ async def test_wait_async_abandoned(any_timeout):
 
 def test_wait_timeout(immediate_timeout):
     mailbox = mb.Mailbox()
-    handle = mailbox.require_response(pb.Record())
+    handle = mailbox.require_response(spb.ServerRequest())
 
     with pytest.raises(TimeoutError):
         handle.wait_or(timeout=immediate_timeout)
@@ -91,7 +90,7 @@ def test_wait_timeout(immediate_timeout):
 @pytest.mark.asyncio
 async def test_wait_async_timeout(immediate_timeout):
     mailbox = mb.Mailbox()
-    handle = mailbox.require_response(pb.Record())
+    handle = mailbox.require_response(spb.ServerRequest())
 
     with pytest.raises(TimeoutError):
         await handle.wait_async(timeout=immediate_timeout)
@@ -99,7 +98,7 @@ async def test_wait_async_timeout(immediate_timeout):
 
 def test_wait_invalid_timeout(invalid_timeout):
     mailbox = mb.Mailbox()
-    handle = mailbox.require_response(pb.Record())
+    handle = mailbox.require_response(spb.ServerRequest())
 
     with pytest.raises(ValueError, match="Timeout must be finite or None."):
         handle.wait_or(timeout=invalid_timeout)
@@ -108,7 +107,7 @@ def test_wait_invalid_timeout(invalid_timeout):
 @pytest.mark.asyncio
 async def test_wait_async_invalid_timeout(invalid_timeout):
     mailbox = mb.Mailbox()
-    handle = mailbox.require_response(pb.Record())
+    handle = mailbox.require_response(spb.ServerRequest())
 
     with pytest.raises(ValueError, match="Timeout must be finite or None."):
         await handle.wait_async(timeout=invalid_timeout)
@@ -117,10 +116,9 @@ async def test_wait_async_invalid_timeout(invalid_timeout):
 @pytest.mark.parametrize("kind", ["deliver", "abandon"])
 def test_unblocks_wait(kind):
     mailbox = mb.Mailbox()
-    request = pb.Record()
+    request = spb.ServerRequest()
     handle = mailbox.require_response(request)
-    result = pb.Result()
-    result.control.mailbox_slot = request.control.mailbox_slot
+    response = spb.ServerResponse(request_id=request.request_id)
 
     about_to_wait = threading.Event()
     done_waiting = threading.Event()
@@ -142,7 +140,7 @@ def test_unblocks_wait(kind):
     about_to_wait.wait()
 
     if kind == "deliver":
-        mailbox.deliver(result)
+        mailbox.deliver(response)
         assert done_waiting.wait(timeout=1)
     else:
         handle.abandon()
@@ -153,10 +151,9 @@ def test_unblocks_wait(kind):
 @pytest.mark.parametrize("kind", ["deliver", "abandon"])
 async def test_unblocks_wait_async(kind):
     mailbox = mb.Mailbox()
-    request = pb.Record()
+    request = spb.ServerRequest()
     handle = mailbox.require_response(request)
-    result = pb.Result()
-    result.control.mailbox_slot = request.control.mailbox_slot
+    response = spb.ServerResponse(request_id=request.request_id)
 
     about_to_wait = asyncio.Event()
     done_waiting = asyncio.Event()
@@ -183,7 +180,7 @@ async def test_unblocks_wait_async(kind):
         await asyncio.sleep(0)
 
         if kind == "deliver":
-            mailbox.deliver(result)
+            mailbox.deliver(response)
             asyncio.wait_for(done_waiting.wait(), timeout=1)
         else:
             handle.abandon()
@@ -192,6 +189,14 @@ async def test_unblocks_wait_async(kind):
 
 def test_require_response_sets_address():
     mailbox = mb.Mailbox()
+    request = spb.ServerRequest()
+    mailbox.require_response(request)
+
+    assert len(request.request_id) == 12
+
+
+def test_require_response_sets_mailbox_slot():
+    mailbox = mb.Mailbox()
     record = pb.Record()
     mailbox.require_response(record)
 
@@ -199,6 +204,15 @@ def test_require_response_sets_address():
 
 
 def test_require_response_raises_if_address_is_set():
+    mailbox = mb.Mailbox()
+    request = spb.ServerRequest()
+    mailbox.require_response(request)
+
+    with pytest.raises(ValueError, match="already has an address"):
+        mailbox.require_response(request)
+
+
+def test_require_response_raises_if_mailbox_slot_is_set():
     mailbox = mb.Mailbox()
     record = pb.Record()
     mailbox.require_response(record)
@@ -212,47 +226,51 @@ def test_require_response_raises_if_closed():
     mailbox.close()
 
     with pytest.raises(mb.MailboxClosedError):
-        mailbox.require_response(pb.Record())
+        mailbox.require_response(spb.ServerRequest())
 
 
 def test_deliver_unknown_address():
     mailbox = mb.Mailbox()
-    result = pb.Result()
-    result.control.mailbox_slot = "unknown"
+    response = spb.ServerResponse()
+    response.request_id = "unknown"
 
     # Should pass.
-    mailbox.deliver(result)
+    mailbox.deliver(response)
 
 
 def test_deliver_no_address(caplog):
     mailbox = mb.Mailbox()
 
-    mailbox.deliver(pb.Result())
+    mailbox.deliver(spb.ServerResponse())
 
-    assert "Received response with no mailbox slot." in caplog.text
+    assert "Received response with no mailbox slot" in caplog.text
 
 
 def test_deliver_after_abandon():
-    handle = mb.MailboxHandle("test-address")
+    mailbox = mb.Mailbox()
+    request = spb.ServerRequest()
+    handle = mailbox.require_response(request)
 
     handle.abandon()
-    handle.deliver(pb.Result())
+    handle.deliver(spb.ServerResponse(request_id=request.request_id))
 
-    assert handle._result is None
+    assert handle._response is None
 
 
 def test_deliver_twice_raises_error():
-    handle = mb.MailboxHandle("test-address")
-    handle.deliver(pb.Result())
+    mailbox = mb.Mailbox()
+    request = spb.ServerRequest()
+    handle = mailbox.require_response(request)
+    handle.deliver(spb.ServerResponse(request_id=request.request_id))
 
     with pytest.raises(ValueError, match="has already been delivered"):
-        handle.deliver(pb.Result())
+        handle.deliver(spb.ServerResponse(request_id=request.request_id))
 
 
 def test_close_abandons_handles():
     mailbox = mb.Mailbox()
-    handle1 = mailbox.require_response(pb.Record())
-    handle2 = mailbox.require_response(pb.Record())
+    handle1 = mailbox.require_response(spb.ServerRequest())
+    handle2 = mailbox.require_response(spb.ServerRequest())
 
     mailbox.close()
 
@@ -261,24 +279,29 @@ def test_close_abandons_handles():
 
 
 def test_cancel_abandons_handle():
-    handle = mb.MailboxHandle("test-address")
+    mailbox = mb.Mailbox()
+    request = spb.ServerRequest()
+    handle = mailbox.require_response(request)
     iface_mock = unittest.mock.Mock()
 
     handle.cancel(iface_mock)
 
-    iface_mock.publish_cancel.assert_called_once_with("test-address")
+    iface_mock.publish_cancel.assert_called_once_with(request.request_id)
     assert handle._abandoned
 
 
 def test_check_returns_none_before_delivered():
-    handle = mb.MailboxHandle("test-address")
+    mailbox = mb.Mailbox()
+    handle = mailbox.require_response(spb.ServerRequest())
 
     assert handle.check() is None
 
 
 def test_check_returns_result():
-    handle = mb.MailboxHandle("test-address")
-    result = pb.Result()
-    handle.deliver(result)
+    mailbox = mb.Mailbox()
+    request = spb.ServerRequest()
+    handle = mailbox.require_response(request)
+    response = spb.ServerResponse(request_id=request.request_id)
+    mailbox.deliver(response)
 
-    assert handle.check() is result
+    assert handle.check() is response

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -397,7 +397,7 @@ class InterfaceShared(InterfaceBase):
         handle = mailbox.require_response(record)
         self._publish(record)
 
-        return handle
+        return handle.map(lambda resp: resp.result_communicate)
 
     def _deliver_run(self, run: pb.RunRecord) -> MailboxHandle:
         record = self._make_record(run=run)

--- a/wandb/sdk/interface/router_queue.py
+++ b/wandb/sdk/interface/router_queue.py
@@ -4,9 +4,12 @@ Router to manage responses from a queue.
 
 """
 
-import queue
-from typing import TYPE_CHECKING, Optional
+from __future__ import annotations
 
+import queue
+from typing import TYPE_CHECKING
+
+from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.mailbox import Mailbox
 
 from .router import MessageRouter
@@ -14,29 +17,27 @@ from .router import MessageRouter
 if TYPE_CHECKING:
     from queue import Queue
 
-    from wandb.proto import wandb_internal_pb2 as pb
-
 
 class MessageQueueRouter(MessageRouter):
-    _request_queue: "Queue[pb.Record]"
-    _response_queue: "Queue[pb.Result]"
+    _request_queue: Queue[pb.Record]
+    _response_queue: Queue[pb.Result]
 
     def __init__(
         self,
-        request_queue: "Queue[pb.Record]",
-        response_queue: "Queue[pb.Result]",
-        mailbox: Optional[Mailbox] = None,
+        request_queue: Queue[pb.Record],
+        response_queue: Queue[pb.Result],
+        mailbox: Mailbox | None = None,
     ) -> None:
         self._request_queue = request_queue
         self._response_queue = response_queue
         super().__init__(mailbox=mailbox)
 
-    def _read_message(self) -> Optional["pb.Result"]:
+    def _read_message(self) -> pb.Result | None:
         try:
             msg = self._response_queue.get(timeout=1)
         except queue.Empty:
             return None
         return msg
 
-    def _send_message(self, record: "pb.Record") -> None:
+    def _send_message(self, record: pb.Record) -> None:
         self._request_queue.put(record)

--- a/wandb/sdk/interface/router_relay.py
+++ b/wandb/sdk/interface/router_relay.py
@@ -4,8 +4,12 @@ Router to manage responses from a queue with relay.
 
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.proto import wandb_server_pb2 as spb
 from wandb.sdk.mailbox import Mailbox
 
 from .router_queue import MessageQueueRouter
@@ -13,26 +17,34 @@ from .router_queue import MessageQueueRouter
 if TYPE_CHECKING:
     from queue import Queue
 
-    from wandb.proto import wandb_internal_pb2 as pb
-
 
 class MessageRelayRouter(MessageQueueRouter):
-    _relay_queue: "Queue[pb.Result]"
+    _relay_queue: Queue[pb.Result]
 
     def __init__(
         self,
-        request_queue: "Queue[pb.Record]",
-        response_queue: "Queue[pb.Result]",
-        relay_queue: "Queue[pb.Result]",
+        request_queue: Queue[pb.Record],
+        response_queue: Queue[pb.Result],
+        relay_queue: Queue[pb.Result],
         mailbox: Mailbox,
     ) -> None:
         self._relay_queue = relay_queue
         super().__init__(
-            request_queue=request_queue, response_queue=response_queue, mailbox=mailbox
+            request_queue=request_queue,
+            response_queue=response_queue,
+            mailbox=mailbox,
         )
 
-    def _handle_msg_rcv(self, msg: "pb.Result") -> None:
-        if msg.control.relay_id:
-            self._relay_queue.put(msg)
-            return
-        super()._handle_msg_rcv(msg)
+    def _handle_msg_rcv(self, msg: pb.Result | spb.ServerResponse) -> None:
+        if isinstance(msg, pb.Result):
+            relay_msg = msg
+        else:
+            relay_msg = msg.result_communicate
+
+        # This is legacy-service logic for returning responses to the client.
+        # A different thread reads the "relay queue" and writes responses on
+        # the socket.
+        if relay_msg.control.relay_id:
+            self._relay_queue.put(relay_msg)
+        else:
+            super()._handle_msg_rcv(msg)

--- a/wandb/sdk/interface/router_sock.py
+++ b/wandb/sdk/interface/router_sock.py
@@ -4,15 +4,14 @@ Router to manage responses from a socket client.
 
 """
 
-from typing import TYPE_CHECKING, Optional
+from __future__ import annotations
 
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.proto import wandb_server_pb2 as spb
 from wandb.sdk.lib.sock_client import SockClient, SockClientClosedError
 from wandb.sdk.mailbox import Mailbox
 
 from .router import MessageRouter, MessageRouterClosedError
-
-if TYPE_CHECKING:
-    from wandb.proto import wandb_internal_pb2 as pb
 
 
 class MessageSockRouter(MessageRouter):
@@ -23,15 +22,11 @@ class MessageSockRouter(MessageRouter):
         self._sock_client = sock_client
         super().__init__(mailbox=mailbox)
 
-    def _read_message(self) -> Optional["pb.Result"]:
+    def _read_message(self) -> spb.ServerResponse | None:
         try:
-            resp = self._sock_client.read_server_response(timeout=1)
+            return self._sock_client.read_server_response(timeout=1)
         except SockClientClosedError as e:
             raise MessageRouterClosedError from e
-        if not resp:
-            return None
-        msg = resp.result_communicate
-        return msg
 
-    def _send_message(self, record: "pb.Record") -> None:
+    def _send_message(self, record: pb.Record) -> None:
         self._sock_client.send_record_communicate(record)

--- a/wandb/sdk/mailbox/__init__.py
+++ b/wandb/sdk/mailbox/__init__.py
@@ -9,15 +9,16 @@ The Mailbox handles matching responses to requests. An internal thread
 continuously reads data from the service and passes it to the mailbox.
 """
 
-from .handles import HandleAbandonedError, MailboxHandle
 from .mailbox import Mailbox, MailboxClosedError
+from .mailbox_handle import HandleAbandonedError, MailboxHandle, MailboxHandleT
 from .wait_with_progress import wait_all_with_progress, wait_with_progress
 
 __all__ = [
-    "HandleAbandonedError",
-    "MailboxHandle",
     "Mailbox",
     "MailboxClosedError",
+    "HandleAbandonedError",
+    "MailboxHandle",
+    "MailboxHandleT",
     "wait_all_with_progress",
     "wait_with_progress",
 ]

--- a/wandb/sdk/mailbox/mailbox.py
+++ b/wandb/sdk/mailbox/mailbox.py
@@ -6,8 +6,10 @@ import string
 import threading
 
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.proto import wandb_server_pb2 as spb
 
-from . import handles
+from .mailbox_handle import MailboxHandleT
+from .response_handle import MailboxResponseHandle
 
 _logger = logging.getLogger(__name__)
 
@@ -19,22 +21,25 @@ class MailboxClosedError(Exception):
 class Mailbox:
     """Matches service responses to requests.
 
-    The mailbox can set an address on a Record and create a handle for
+    The mailbox can set an address on a server request and create a handle for
     waiting for a response to that record. Responses are delivered by calling
     `deliver()`. The `close()` method abandons all handles in case the
     service process becomes unreachable.
     """
 
     def __init__(self) -> None:
-        self._handles: dict[str, handles.MailboxHandle] = {}
+        self._handles: dict[str, MailboxResponseHandle] = {}
         self._handles_lock = threading.Lock()
         self._closed = False
 
-    def require_response(self, request: pb.Record) -> handles.MailboxHandle:
+    def require_response(
+        self,
+        request: spb.ServerRequest | pb.Record,
+    ) -> MailboxHandleT[spb.ServerResponse]:
         """Set a response address on a request.
 
         Args:
-            request: The request on which to set a mailbox slot.
+            request: The request on which to set a request ID or mailbox slot.
                 This is mutated. An address must not already be set.
 
         Returns:
@@ -45,17 +50,24 @@ class Mailbox:
                 no new responses are expected to be delivered and new handles
                 cannot be created.
         """
-        if address := request.control.mailbox_slot:
-            raise ValueError(f"Request already has an address ({address})")
+        if isinstance(request, spb.ServerRequest):
+            if address := request.request_id:
+                raise ValueError(f"Request already has an address ({address})")
 
-        address = self._new_address()
-        request.control.mailbox_slot = address
+            address = self._new_address()
+            request.request_id = address
+        else:
+            if address := request.control.mailbox_slot:
+                raise ValueError(f"Request already has an address ({address})")
+
+            address = self._new_address()
+            request.control.mailbox_slot = address
 
         with self._handles_lock:
             if self._closed:
                 raise MailboxClosedError()
 
-            handle = handles.MailboxHandle(address)
+            handle = MailboxResponseHandle(address)
             self._handles[address] = handle
 
         return handle
@@ -80,18 +92,20 @@ class Mailbox:
 
         return address
 
-    def deliver(self, result: pb.Result) -> None:
+    def deliver(self, response: spb.ServerResponse) -> None:
         """Deliver a response from the service.
 
         If the response address is invalid, this does nothing.
         It is a no-op if the mailbox has been closed.
         """
-        address = result.control.mailbox_slot
+        address = response.request_id
         if not address:
-            _logger.error(
-                "Received response with no mailbox slot."
-                f" Kind: {result.WhichOneof('result_type')}"
-            )
+            kind: str | None = response.WhichOneof("server_response_type")
+            if kind == "result_communicate":
+                result_type = response.result_communicate.WhichOneof("result_type")
+                kind = f"result_communicate.{result_type}"
+
+            _logger.error(f"Received response with no mailbox slot: {kind}")
             return
 
         with self._handles_lock:
@@ -102,7 +116,7 @@ class Mailbox:
         # It is not an error if there is no handle for the address:
         # handles can be abandoned if the result is no longer needed.
         if handle:
-            handle.deliver(result)
+            handle.deliver(response)
 
     def close(self) -> None:
         """Indicate no further responses will be delivered.

--- a/wandb/sdk/mailbox/mailbox_handle.py
+++ b/wandb/sdk/mailbox/mailbox_handle.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import abc
+import sys
+from typing import TYPE_CHECKING, Callable, Generic, TypeVar
+
+from wandb.proto import wandb_internal_pb2 as pb
+
+# Necessary to break an import loop.
+if TYPE_CHECKING:
+    from wandb.sdk.interface import interface
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+
+_T = TypeVar("_T")
+_S = TypeVar("_S")
+
+
+class HandleAbandonedError(Exception):
+    """The handle has no response and has been abandoned."""
+
+
+class MailboxHandleT(abc.ABC, Generic[_T]):
+    """A thread-safe handle that allows waiting for a response to a request."""
+
+    def map(self, fn: Callable[[_T], _S]) -> MailboxHandleT[_S]:
+        """Returns a transformed handle.
+
+        Methods on the returned handle call methods on this handle, but the
+        response type is derived using the given function.
+
+        Args:
+            fn: A function to apply to this handle's result to get the new
+                handle's result. The function should be pure and fast.
+        """
+        return _MailboxMappedHandle(self, fn)
+
+    @abc.abstractmethod
+    def abandon(self) -> None:
+        """Abandon the handle, indicating it will not receive a response."""
+
+    @abc.abstractmethod
+    def cancel(self, iface: interface.InterfaceBase) -> None:
+        """Cancel the handle, requesting any associated work to not complete.
+
+        This automatically abandons the handle, as a response is no longer
+        guaranteed.
+
+        Args:
+            iface: The interface on which to publish the cancel request.
+        """
+
+    @abc.abstractmethod
+    def check(self) -> _T | None:
+        """Returns the response if it's ready."""
+
+    @abc.abstractmethod
+    def wait_or(self, *, timeout: float | None) -> _T:
+        """Wait for a response or a timeout.
+
+        Args:
+            timeout: A finite number of seconds or None to never time out.
+                If less than or equal to zero, times out immediately unless
+                the response is available.
+
+        Returns:
+            The response if it arrives before the timeout or has already arrived.
+
+        Raises:
+            TimeoutError: If the timeout is reached.
+            HandleAbandonedError: If the handle becomes abandoned.
+        """
+
+    @abc.abstractmethod
+    async def wait_async(self, *, timeout: float | None) -> _T:
+        """Wait for a response or timeout.
+
+        This must run in an `asyncio` event loop.
+
+        Args:
+            timeout: A finite number of seconds or None to never time out.
+
+        Returns:
+            The response if it arrives before the timeout or has already arrived.
+
+        Raises:
+            TimeoutError: If the timeout is reached.
+            HandleAbandonedError: If the handle becomes abandoned.
+        """
+
+
+MailboxHandle = MailboxHandleT[pb.Result]
+
+
+class _MailboxMappedHandle(Generic[_S], MailboxHandleT[_S]):
+    """A mailbox handle whose result is derived from another handle."""
+
+    def __init__(
+        self,
+        handle: MailboxHandleT[_T],
+        fn: Callable[[_T], _S],
+    ) -> None:
+        self._handle = handle
+        self._fn = fn
+
+    @override
+    def abandon(self) -> None:
+        self._handle.abandon()
+
+    @override
+    def cancel(self, iface: interface.InterfaceBase) -> None:
+        self._handle.cancel(iface)
+
+    @override
+    def check(self) -> _S | None:
+        if response := self._handle.check():
+            return self._fn(response)
+        else:
+            return None
+
+    @override
+    def wait_or(self, *, timeout: float | None) -> _S:
+        return self._fn(self._handle.wait_or(timeout=timeout))
+
+    @override
+    async def wait_async(self, *, timeout: float | None) -> _S:
+        response = await self._handle.wait_async(timeout=timeout)
+        return self._fn(response)


### PR DESCRIPTION
Generalize `Mailbox` to work on the `ServerRequest` / `ServerResponse` level instead of `Record` / `Result`.

`MailboxHandleT` is a generic class that replaces `MailboxHandle` to allow for both `MailboxHandleT[pb.Result]` and `MailboxHandleT[spb.ServerResponse]`. `MailboxHandle` is an alias to `MailboxHandleT[pb.Result]` to keep this PR small, but the next PR completes the renaming.

`Mailbox.deliver()` now requires `spb.ServerResponse` instead of `pb.Result`. The only callsite is in `MessageRouter`, which I updated. Unfortunately, `legacy-service` uses `MessageRouter` internally, so it has to continue to handle the `pb.Result` codepath. To do this, it creates an `spb.ServerResponse()` and sets its `result_communicate` to the given `pb.Result`.