### PR TITLE
refactor: rename MailboxHandleT to MailboxHandle

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -41,6 +41,7 @@ from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public import ArtifactCollection, ArtifactFiles, RetryingClient, Run
 from wandb.data_types import WBValue
 from wandb.errors.term import termerror, termlog, termwarn
+from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.artifacts._graphql_fragments import _gql_artifact_fragment
 from wandb.sdk.artifacts._validators import (
     ensure_logged,
@@ -158,7 +159,7 @@ class Artifact:
         self._tmp_dir: tempfile.TemporaryDirectory | None = None
         self._added_objs: dict[int, tuple[WBValue, ArtifactManifestEntry]] = {}
         self._added_local_paths: dict[str, ArtifactManifestEntry] = {}
-        self._save_handle: MailboxHandle | None = None
+        self._save_handle: MailboxHandle[pb.Result] | None = None
         self._download_roots: set[str] = set()
         # Set by new_draft(), otherwise the latest artifact will be used as the base.
         self._base_id: str | None = None
@@ -956,7 +957,7 @@ class Artifact:
 
     def _set_save_handle(
         self,
-        save_handle: MailboxHandle,
+        save_handle: MailboxHandle[pb.Result],
         client: RetryingClient,
     ) -> None:
         self._save_handle = save_handle

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -102,14 +102,14 @@ class InterfaceBase:
     def _publish_header(self, header: pb.HeaderRecord) -> None:
         raise NotImplementedError
 
-    def deliver_status(self) -> MailboxHandle:
+    def deliver_status(self) -> MailboxHandle[pb.Result]:
         return self._deliver_status(pb.StatusRequest())
 
     @abstractmethod
     def _deliver_status(
         self,
         status: pb.StatusRequest,
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
     def _make_config(
@@ -435,7 +435,7 @@ class InterfaceBase:
         entity: Optional[str] = None,
         project: Optional[str] = None,
         organization: Optional[str] = None,
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         link_artifact = pb.LinkArtifactRequest()
         if artifact.is_draft():
             link_artifact.client_id = artifact._client_id
@@ -452,7 +452,7 @@ class InterfaceBase:
     @abstractmethod
     def _deliver_link_artifact(
         self, link_artifact: pb.LinkArtifactRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
     @staticmethod
@@ -570,7 +570,7 @@ class InterfaceBase:
         is_user_created: bool = False,
         use_after_commit: bool = False,
         finalize: bool = True,
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         proto_run = self._make_run(run)
         proto_artifact = self._make_artifact(artifact)
         proto_artifact.run_id = proto_run.run_id
@@ -595,7 +595,7 @@ class InterfaceBase:
     def _deliver_artifact(
         self,
         log_artifact: pb.LogArtifactRequest,
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
     def deliver_download_artifact(
@@ -605,7 +605,7 @@ class InterfaceBase:
         allow_missing_references: bool,
         skip_cache: bool,
         path_prefix: Optional[str],
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         download_artifact = pb.DownloadArtifactRequest()
         download_artifact.artifact_id = artifact_id
         download_artifact.download_root = download_root
@@ -618,7 +618,7 @@ class InterfaceBase:
     @abstractmethod
     def _deliver_download_artifact(
         self, download_artifact: pb.DownloadArtifactRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
     def publish_artifact(
@@ -870,7 +870,9 @@ class InterfaceBase:
         return self._publish_job_input(request)
 
     @abstractmethod
-    def _publish_job_input(self, request: pb.JobInputRequest) -> MailboxHandle:
+    def _publish_job_input(
+        self, request: pb.JobInputRequest
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
     def join(self) -> None:
@@ -892,143 +894,165 @@ class InterfaceBase:
             logger.warning("handle abandoned while communicating shutdown")
 
     @abstractmethod
-    def _deliver_shutdown(self) -> MailboxHandle:
+    def _deliver_shutdown(self) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_run(self, run: "Run") -> MailboxHandle:
+    def deliver_run(self, run: "Run") -> MailboxHandle[pb.Result]:
         run_record = self._make_run(run)
         return self._deliver_run(run_record)
 
     def deliver_finish_sync(
         self,
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         sync = pb.SyncFinishRequest()
         return self._deliver_finish_sync(sync)
 
     @abstractmethod
-    def _deliver_finish_sync(self, sync: pb.SyncFinishRequest) -> MailboxHandle:
+    def _deliver_finish_sync(
+        self, sync: pb.SyncFinishRequest
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
     @abstractmethod
-    def _deliver_run(self, run: pb.RunRecord) -> MailboxHandle:
+    def _deliver_run(self, run: pb.RunRecord) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_run_start(self, run: "Run") -> MailboxHandle:
+    def deliver_run_start(self, run: "Run") -> MailboxHandle[pb.Result]:
         run_start = pb.RunStartRequest(run=self._make_run(run))
         return self._deliver_run_start(run_start)
 
     @abstractmethod
-    def _deliver_run_start(self, run_start: pb.RunStartRequest) -> MailboxHandle:
+    def _deliver_run_start(
+        self, run_start: pb.RunStartRequest
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_attach(self, attach_id: str) -> MailboxHandle:
+    def deliver_attach(self, attach_id: str) -> MailboxHandle[pb.Result]:
         attach = pb.AttachRequest(attach_id=attach_id)
         return self._deliver_attach(attach)
 
     @abstractmethod
-    def _deliver_attach(self, status: pb.AttachRequest) -> MailboxHandle:
+    def _deliver_attach(
+        self,
+        status: pb.AttachRequest,
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_stop_status(self) -> MailboxHandle:
+    def deliver_stop_status(self) -> MailboxHandle[pb.Result]:
         status = pb.StopStatusRequest()
         return self._deliver_stop_status(status)
 
     @abstractmethod
-    def _deliver_stop_status(self, status: pb.StopStatusRequest) -> MailboxHandle:
+    def _deliver_stop_status(
+        self,
+        status: pb.StopStatusRequest,
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_network_status(self) -> MailboxHandle:
+    def deliver_network_status(self) -> MailboxHandle[pb.Result]:
         status = pb.NetworkStatusRequest()
         return self._deliver_network_status(status)
 
     @abstractmethod
-    def _deliver_network_status(self, status: pb.NetworkStatusRequest) -> MailboxHandle:
+    def _deliver_network_status(
+        self,
+        status: pb.NetworkStatusRequest,
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_internal_messages(self) -> MailboxHandle:
+    def deliver_internal_messages(self) -> MailboxHandle[pb.Result]:
         internal_message = pb.InternalMessagesRequest()
         return self._deliver_internal_messages(internal_message)
 
     @abstractmethod
     def _deliver_internal_messages(
         self, internal_message: pb.InternalMessagesRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_get_summary(self) -> MailboxHandle:
+    def deliver_get_summary(self) -> MailboxHandle[pb.Result]:
         get_summary = pb.GetSummaryRequest()
         return self._deliver_get_summary(get_summary)
 
     @abstractmethod
-    def _deliver_get_summary(self, get_summary: pb.GetSummaryRequest) -> MailboxHandle:
+    def _deliver_get_summary(
+        self,
+        get_summary: pb.GetSummaryRequest,
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_get_system_metrics(self) -> MailboxHandle:
+    def deliver_get_system_metrics(self) -> MailboxHandle[pb.Result]:
         get_system_metrics = pb.GetSystemMetricsRequest()
         return self._deliver_get_system_metrics(get_system_metrics)
 
     @abstractmethod
     def _deliver_get_system_metrics(
         self, get_summary: pb.GetSystemMetricsRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_get_system_metadata(self) -> MailboxHandle:
+    def deliver_get_system_metadata(self) -> MailboxHandle[pb.Result]:
         get_system_metadata = pb.GetSystemMetadataRequest()
         return self._deliver_get_system_metadata(get_system_metadata)
 
     @abstractmethod
     def _deliver_get_system_metadata(
         self, get_system_metadata: pb.GetSystemMetadataRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_exit(self, exit_code: Optional[int]) -> MailboxHandle:
+    def deliver_exit(self, exit_code: Optional[int]) -> MailboxHandle[pb.Result]:
         exit_data = self._make_exit(exit_code)
         return self._deliver_exit(exit_data)
 
     @abstractmethod
-    def _deliver_exit(self, exit_data: pb.RunExitRecord) -> MailboxHandle:
+    def _deliver_exit(
+        self,
+        exit_data: pb.RunExitRecord,
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
     @abstractmethod
-    def deliver_operation_stats(self) -> MailboxHandle:
+    def deliver_operation_stats(self) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_poll_exit(self) -> MailboxHandle:
+    def deliver_poll_exit(self) -> MailboxHandle[pb.Result]:
         poll_exit = pb.PollExitRequest()
         return self._deliver_poll_exit(poll_exit)
 
     @abstractmethod
-    def _deliver_poll_exit(self, poll_exit: pb.PollExitRequest) -> MailboxHandle:
+    def _deliver_poll_exit(
+        self,
+        poll_exit: pb.PollExitRequest,
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_finish_without_exit(self) -> MailboxHandle:
+    def deliver_finish_without_exit(self) -> MailboxHandle[pb.Result]:
         run_finish_without_exit = pb.RunFinishWithoutExitRequest()
         return self._deliver_finish_without_exit(run_finish_without_exit)
 
     @abstractmethod
     def _deliver_finish_without_exit(
         self, run_finish_without_exit: pb.RunFinishWithoutExitRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_request_sampled_history(self) -> MailboxHandle:
+    def deliver_request_sampled_history(self) -> MailboxHandle[pb.Result]:
         sampled_history = pb.SampledHistoryRequest()
         return self._deliver_request_sampled_history(sampled_history)
 
     @abstractmethod
     def _deliver_request_sampled_history(
         self, sampled_history: pb.SampledHistoryRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_request_run_status(self) -> MailboxHandle:
+    def deliver_request_run_status(self) -> MailboxHandle[pb.Result]:
         run_status = pb.RunStatusRequest()
         return self._deliver_request_run_status(run_status)
 
     @abstractmethod
     def _deliver_request_run_status(
         self, run_status: pb.RunStatusRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -69,7 +69,9 @@ class InterfaceShared(InterfaceBase):
         rec = self._make_record(telemetry=telem)
         self._publish(rec)
 
-    def _publish_job_input(self, job_input: pb.JobInputRequest) -> MailboxHandle:
+    def _publish_job_input(
+        self, job_input: pb.JobInputRequest
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(job_input=job_input)
         return self._deliver_record(record)
 
@@ -342,19 +344,19 @@ class InterfaceShared(InterfaceBase):
     def _deliver_artifact(
         self,
         log_artifact: pb.LogArtifactRequest,
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         rec = self._make_request(log_artifact=log_artifact)
         return self._deliver_record(rec)
 
     def _deliver_download_artifact(
         self, download_artifact: pb.DownloadArtifactRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         rec = self._make_request(download_artifact=download_artifact)
         return self._deliver_record(rec)
 
     def _deliver_link_artifact(
         self, link_artifact: pb.LinkArtifactRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         rec = self._make_request(link_artifact=link_artifact)
         return self._deliver_record(rec)
 
@@ -369,7 +371,7 @@ class InterfaceShared(InterfaceBase):
     def _deliver_status(
         self,
         status: pb.StatusRequest,
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         req = self._make_request(status=status)
         return self._deliver_record(req)
 
@@ -381,7 +383,7 @@ class InterfaceShared(InterfaceBase):
         record = self._make_request(keepalive=keepalive)
         self._publish(record)
 
-    def _deliver_shutdown(self) -> MailboxHandle:
+    def _deliver_shutdown(self) -> MailboxHandle[pb.Result]:
         request = pb.Request(shutdown=pb.ShutdownRequest())
         record = self._make_record(request=request)
         return self._deliver_record(record)
@@ -391,7 +393,7 @@ class InterfaceShared(InterfaceBase):
         assert mailbox
         return mailbox
 
-    def _deliver_record(self, record: pb.Record) -> MailboxHandle:
+    def _deliver_record(self, record: pb.Record) -> MailboxHandle[pb.Result]:
         mailbox = self._get_mailbox()
 
         handle = mailbox.require_response(record)
@@ -399,35 +401,47 @@ class InterfaceShared(InterfaceBase):
 
         return handle.map(lambda resp: resp.result_communicate)
 
-    def _deliver_run(self, run: pb.RunRecord) -> MailboxHandle:
+    def _deliver_run(self, run: pb.RunRecord) -> MailboxHandle[pb.Result]:
         record = self._make_record(run=run)
         return self._deliver_record(record)
 
-    def _deliver_finish_sync(self, sync_finish: pb.SyncFinishRequest) -> MailboxHandle:
+    def _deliver_finish_sync(
+        self,
+        sync_finish: pb.SyncFinishRequest,
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(sync_finish=sync_finish)
         return self._deliver_record(record)
 
-    def _deliver_run_start(self, run_start: pb.RunStartRequest) -> MailboxHandle:
+    def _deliver_run_start(
+        self,
+        run_start: pb.RunStartRequest,
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(run_start=run_start)
         return self._deliver_record(record)
 
-    def _deliver_get_summary(self, get_summary: pb.GetSummaryRequest) -> MailboxHandle:
+    def _deliver_get_summary(
+        self,
+        get_summary: pb.GetSummaryRequest,
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(get_summary=get_summary)
         return self._deliver_record(record)
 
     def _deliver_get_system_metrics(
         self, get_system_metrics: pb.GetSystemMetricsRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(get_system_metrics=get_system_metrics)
         return self._deliver_record(record)
 
     def _deliver_get_system_metadata(
         self, get_system_metadata: pb.GetSystemMetadataRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(get_system_metadata=get_system_metadata)
         return self._deliver_record(record)
 
-    def _deliver_exit(self, exit_data: pb.RunExitRecord) -> MailboxHandle:
+    def _deliver_exit(
+        self,
+        exit_data: pb.RunExitRecord,
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_record(exit=exit_data)
         return self._deliver_record(record)
 
@@ -435,45 +449,54 @@ class InterfaceShared(InterfaceBase):
         record = self._make_request(operation_stats=pb.OperationStatsRequest())
         return self._deliver_record(record)
 
-    def _deliver_poll_exit(self, poll_exit: pb.PollExitRequest) -> MailboxHandle:
+    def _deliver_poll_exit(
+        self,
+        poll_exit: pb.PollExitRequest,
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(poll_exit=poll_exit)
         return self._deliver_record(record)
 
     def _deliver_finish_without_exit(
         self, run_finish_without_exit: pb.RunFinishWithoutExitRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(run_finish_without_exit=run_finish_without_exit)
         return self._deliver_record(record)
 
-    def _deliver_stop_status(self, stop_status: pb.StopStatusRequest) -> MailboxHandle:
+    def _deliver_stop_status(
+        self,
+        stop_status: pb.StopStatusRequest,
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(stop_status=stop_status)
         return self._deliver_record(record)
 
-    def _deliver_attach(self, attach: pb.AttachRequest) -> MailboxHandle:
+    def _deliver_attach(
+        self,
+        attach: pb.AttachRequest,
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(attach=attach)
         return self._deliver_record(record)
 
     def _deliver_network_status(
         self, network_status: pb.NetworkStatusRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(network_status=network_status)
         return self._deliver_record(record)
 
     def _deliver_internal_messages(
         self, internal_message: pb.InternalMessagesRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(internal_messages=internal_message)
         return self._deliver_record(record)
 
     def _deliver_request_sampled_history(
         self, sampled_history: pb.SampledHistoryRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(sampled_history=sampled_history)
         return self._deliver_record(record)
 
     def _deliver_request_run_status(
         self, run_status: pb.RunStatusRequest
-    ) -> MailboxHandle:
+    ) -> MailboxHandle[pb.Result]:
         record = self._make_request(run_status=run_status)
         return self._deliver_record(record)
 

--- a/wandb/sdk/mailbox/__init__.py
+++ b/wandb/sdk/mailbox/__init__.py
@@ -10,7 +10,7 @@ continuously reads data from the service and passes it to the mailbox.
 """
 
 from .mailbox import Mailbox, MailboxClosedError
-from .mailbox_handle import HandleAbandonedError, MailboxHandle, MailboxHandleT
+from .mailbox_handle import HandleAbandonedError, MailboxHandle
 from .wait_with_progress import wait_all_with_progress, wait_with_progress
 
 __all__ = [
@@ -18,7 +18,6 @@ __all__ = [
     "MailboxClosedError",
     "HandleAbandonedError",
     "MailboxHandle",
-    "MailboxHandleT",
     "wait_all_with_progress",
     "wait_with_progress",
 ]

--- a/wandb/sdk/mailbox/mailbox.py
+++ b/wandb/sdk/mailbox/mailbox.py
@@ -8,7 +8,7 @@ import threading
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_server_pb2 as spb
 
-from .mailbox_handle import MailboxHandleT
+from .mailbox_handle import MailboxHandle
 from .response_handle import MailboxResponseHandle
 
 _logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class Mailbox:
     def require_response(
         self,
         request: spb.ServerRequest | pb.Record,
-    ) -> MailboxHandleT[spb.ServerResponse]:
+    ) -> MailboxHandle[spb.ServerResponse]:
         """Set a response address on a request.
 
         Args:

--- a/wandb/sdk/mailbox/mailbox_handle.py
+++ b/wandb/sdk/mailbox/mailbox_handle.py
@@ -4,8 +4,6 @@ import abc
 import sys
 from typing import TYPE_CHECKING, Callable, Generic, TypeVar
 
-from wandb.proto import wandb_internal_pb2 as pb
-
 # Necessary to break an import loop.
 if TYPE_CHECKING:
     from wandb.sdk.interface import interface
@@ -24,10 +22,10 @@ class HandleAbandonedError(Exception):
     """The handle has no response and has been abandoned."""
 
 
-class MailboxHandleT(abc.ABC, Generic[_T]):
+class MailboxHandle(abc.ABC, Generic[_T]):
     """A thread-safe handle that allows waiting for a response to a request."""
 
-    def map(self, fn: Callable[[_T], _S]) -> MailboxHandleT[_S]:
+    def map(self, fn: Callable[[_T], _S]) -> MailboxHandle[_S]:
         """Returns a transformed handle.
 
         Methods on the returned handle call methods on this handle, but the
@@ -93,15 +91,12 @@ class MailboxHandleT(abc.ABC, Generic[_T]):
         """
 
 
-MailboxHandle = MailboxHandleT[pb.Result]
-
-
-class _MailboxMappedHandle(Generic[_S], MailboxHandleT[_S]):
+class _MailboxMappedHandle(Generic[_S], MailboxHandle[_S]):
     """A mailbox handle whose result is derived from another handle."""
 
     def __init__(
         self,
-        handle: MailboxHandleT[_T],
+        handle: MailboxHandle[_T],
         fn: Callable[[_T], _S],
     ) -> None:
         self._handle = handle

--- a/wandb/sdk/mailbox/response_handle.py
+++ b/wandb/sdk/mailbox/response_handle.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from wandb.proto import wandb_server_pb2 as spb
 
-from .mailbox_handle import HandleAbandonedError, MailboxHandleT
+from .mailbox_handle import HandleAbandonedError, MailboxHandle
 
 # Necessary to break an import loop.
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ else:
     from typing_extensions import override
 
 
-class MailboxResponseHandle(MailboxHandleT[spb.ServerResponse]):
+class MailboxResponseHandle(MailboxHandle[spb.ServerResponse]):
     """A general handle for any ServerResponse."""
 
     def __init__(self, address: str) -> None:

--- a/wandb/sdk/mailbox/wait_with_progress.py
+++ b/wandb/sdk/mailbox/wait_with_progress.py
@@ -5,13 +5,13 @@ from typing import Any, Callable, Coroutine, List, TypeVar, cast
 
 from wandb.sdk.lib import asyncio_compat
 
-from .mailbox_handle import MailboxHandleT
+from .mailbox_handle import MailboxHandle
 
 _T = TypeVar("_T")
 
 
 def wait_with_progress(
-    handle: MailboxHandleT[_T],
+    handle: MailboxHandle[_T],
     *,
     timeout: float | None,
     progress_after: float,
@@ -30,7 +30,7 @@ def wait_with_progress(
 
 
 def wait_all_with_progress(
-    handle_list: list[MailboxHandleT[_T]],
+    handle_list: list[MailboxHandle[_T]],
     *,
     timeout: float | None,
     progress_after: float,
@@ -88,7 +88,7 @@ def wait_all_with_progress(
 
 
 def _wait_handles(
-    handle_list: list[MailboxHandleT[_T]],
+    handle_list: list[MailboxHandle[_T]],
     *,
     timeout: float,
 ) -> list[_T]:
@@ -113,7 +113,7 @@ def _wait_handles(
 
 
 async def _wait_handles_async(
-    handle_list: list[MailboxHandleT[_T]],
+    handle_list: list[MailboxHandle[_T]],
     *,
     timeout: float | None,
 ) -> list[_T]:

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -290,7 +290,7 @@ class StreamMux:
 
         # fixme: for now we have a single printer for all streams,
         # and jupyter is disabled if at least single stream's setting set `_jupyter` to false
-        exit_handles: list[MailboxHandle] = []
+        exit_handles: list[MailboxHandle[pb.Result]] = []
 
         # only finish started streams, non started streams failed early
         started_streams: dict[str, StreamRecord] = {}

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -157,11 +157,11 @@ class RunStatusChecker:
     """
 
     _stop_status_lock: threading.Lock
-    _stop_status_handle: MailboxHandle | None
+    _stop_status_handle: MailboxHandle[Result] | None
     _network_status_lock: threading.Lock
-    _network_status_handle: MailboxHandle | None
+    _network_status_handle: MailboxHandle[Result] | None
     _internal_messages_lock: threading.Lock
-    _internal_messages_handle: MailboxHandle | None
+    _internal_messages_handle: MailboxHandle[Result] | None
 
     def __init__(
         self,
@@ -209,7 +209,7 @@ class RunStatusChecker:
     @staticmethod
     def _abandon_status_check(
         lock: threading.Lock,
-        handle: MailboxHandle | None,
+        handle: MailboxHandle[Result] | None,
     ):
         with lock:
             if handle:
@@ -224,7 +224,7 @@ class RunStatusChecker:
         request: Any,
         process: Any,
     ) -> None:
-        local_handle: MailboxHandle | None = None
+        local_handle: MailboxHandle[Result] | None = None
         join_requested = False
         while not join_requested:
             time_probe = time.monotonic()
@@ -542,7 +542,7 @@ class Run:
 
     _sampled_history: SampledHistoryResponse | None
     _final_summary: GetSummaryResponse | None
-    _poll_exit_handle: MailboxHandle | None
+    _poll_exit_handle: MailboxHandle[Result] | None
     _poll_exit_response: PollExitResponse | None
     _internal_messages_response: InternalMessagesResponse | None
 


### PR DESCRIPTION
Finish the refactor started in https://github.com/wandb/wandb/pull/9488 by renaming `MailboxHandleT` to `MailboxHandle` and updating types throughout the codebase.