### PR TITLE
chore: enable cgo for macos10/amd64 builds

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -134,6 +134,9 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=10.14
             CGO_ENABLED=0
+            GOARCH=amd64
+            GOOS=darwin
+            GOFLAGS="-ldflags=-w -s -buildmode=pie -X=darwin/ios.MinVersion=10.14"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -86,12 +86,10 @@ jobs:
       ##################################################
       - name: Downgrade Go version
         run: |
-          sed -i '' 's/1.23.4/1.22.10/' core/go.mod
+          sed -i '' 's/1.23.4/1.22.12/' core/go.mod
 
       ##################################################
-      # Non-Linux: install Go
-      #
-      # See comment above CIBW_BEFORE_ALL_LINUX.
+      # Install Go.
       ##################################################
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -69,7 +69,7 @@ jobs:
   build-macos-10-wheels:
     name: Build wheels for MacOS 10.x
     needs: prepare-release
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -96,11 +96,6 @@ jobs:
         with:
           go-version-file: core/go.mod
 
-      - name: Set Go build environment
-        run: |
-          echo "CGO_ENABLED=0" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
-
       ##################################################
       # Vendor dependencies
       ##################################################
@@ -138,6 +133,7 @@ jobs:
               -v {wheel}
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=10.14
+            CGO_ENABLED=0
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -69,7 +69,7 @@ jobs:
   build-macos-10-wheels:
     name: Build wheels for MacOS 10.x
     needs: prepare-release
-    runs-on: macos-14
+    runs-on: macos-13
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -136,7 +136,7 @@ jobs:
             CGO_ENABLED=0
             GOARCH=amd64
             GOOS=darwin
-            GOFLAGS="-ldflags=-w -s -buildmode=pie -X=darwin/ios.MinVersion=10.14"
+            GOFLAGS="-ldflags=-w -s -buildmode=pie -X=darwin/ios.MinVersion=10.14 -macosx-version-min=10.14"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -98,8 +98,8 @@ jobs:
 
       - name: Set Go build environment
         run: |
-          echo "CGO_CFLAGS=-mmacosx-version-min=10.14" >> $GITHUB_ENV
-          echo "CGO_LDFLAGS=-mmacosx-version-min=10.14" >> $GITHUB_ENV
+          echo "CGO_ENABLED=0" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
 
       ##################################################
       # Vendor dependencies

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -133,10 +133,6 @@ jobs:
               -v {wheel}
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=10.14
-            CGO_ENABLED=0
-            GOARCH=amd64
-            GOOS=darwin
-            GOFLAGS="-ldflags=-w -s -buildmode=pie -X=darwin/ios.MinVersion=10.14 -macosx-version-min=10.14"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -96,6 +96,11 @@ jobs:
         with:
           go-version-file: core/go.mod
 
+      - name: Set Go build environment
+        run: |
+          echo "CGO_CFLAGS=-mmacosx-version-min=10.14" >> $GITHUB_ENV
+          echo "CGO_LDFLAGS=-mmacosx-version-min=10.14" >> $GITHUB_ENV
+
       ##################################################
       # Vendor dependencies
       ##################################################

--- a/core/hatch.py
+++ b/core/hatch.py
@@ -94,4 +94,7 @@ def _go_env(
         # -race requires cgo.
         env["CGO_ENABLED"] = "1"
 
+    if target_system == "darwin" and target_arch == "amd64":
+        env["CGO_ENABLED"] = "1"
+
     return env

--- a/core/hatch.py
+++ b/core/hatch.py
@@ -95,6 +95,12 @@ def _go_env(
         env["CGO_ENABLED"] = "1"
 
     if target_system == "darwin" and target_arch == "amd64":
+        # When CGO is disabled, the Go compiler's internal linker does not respect
+        # the MACOSX_DEPLOYMENT_TARGET value to lower the minimum OS version, which we rely on
+        # for building wheels for MacOS 10.x in CI. Instead, it embeds a minimum target
+        # based on the SDK in the CI runner, which as of 2025-02-20 is 11.0.
+        # To work around this, we enable CGO and force the Go compiler to use
+        # the system linker, which respects MACOSX_DEPLOYMENT_TARGET.
         env["CGO_ENABLED"] = "1"
 
     return env


### PR DESCRIPTION
Description
-----------
When CGO is disabled, the Go compiler's internal linker does not respect the MACOSX_DEPLOYMENT_TARGET value to lower the minimum OS version, which we rely on for building wheels for MacOS 10.x in CI. Instead, it embeds a minimum target based on the SDK in the CI runner, which as of 2025-02-20 is 11.0.
To work around this, we enable CGO and force the Go compiler to use the system linker, which respects MACOSX_DEPLOYMENT_TARGET.

Testing
-------
Sample dry release run proving that it works: https://github.com/wandb/wandb/actions/runs/13447475773/job/37575849970.
