### PR TITLE
fix: format specifier in WorkSentinel DebugInfo()

### DIFF
--- a/core/internal/runwork/sentinel.go
+++ b/core/internal/runwork/sentinel.go
@@ -28,5 +28,5 @@ func (s *workSentinel) Process(func(*spb.Record)) {}
 func (s *workSentinel) Sentinel() any { return s.value }
 
 func (s *workSentinel) DebugInfo() string {
-	return fmt.Sprintf("WorkSentinel(%s)", s.value)
+	return fmt.Sprintf("WorkSentinel(%v)", s.value)
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -69,7 +69,13 @@ type SenderParams struct {
 	RunWork             runwork.RunWork
 }
 
+// senderSentinel is used when flushing buffered work while finalizing a run.
 type senderSentinel int64
+
+// String returns a string representation of senderSentinel for debugging.
+func (s senderSentinel) String() string {
+	return fmt.Sprintf("senderSentinel(%d)", s)
+}
 
 // Sender is the sender for a stream it handles the incoming messages and sends to the server
 // or/and to the dispatcher/handler


### PR DESCRIPTION
Fixes the format specifier used in `WorkSentinel.DebugInfo()`. Using `%s` is incorrect when the argument (of interface type `any`) does not have the concrete type `string`. Specifically, it was producing the string

```
WorkSentinel(%!s(stream.senderSentinel=1))
```

Where `%!s` is `fmt.Sprintf`'s way of indicating that it caught and suppressed a panic. Now, with the added `String()` method on the `senderSentinel` type, the above becomes

```
WorkSentinel(senderSentinel(1))
```