### PR TITLE
fix: code coverage collection in subprocesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ test-results/
 .pytest_cache/
 .hypothesis/
 
-.coverage
+.coverage*
 coverage.xml
 coverage.txt
 cover-results/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,17 +148,16 @@ norecursedirs = [
     "dist",
 ]
 
+
 [tool.coverage.paths]
-source = ["wandb/", "**/site-packages/wandb/"]
+wandb = ["wandb/", "**/site-packages/wandb/"]
 
 [tool.coverage.run]
-# branch = true
 concurrency = ["multiprocessing", "thread"]
-source = ["wandb"]
 omit = ["**/wandb/vendor/**", "**/wandb/proto/**"]
 
 [tool.coverage.report]
-exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:", "@abstractmethod"]
+exclude_also = ["if TYPE_CHECKING:", "@abstractmethod"]
 omit = ["**/wandb/vendor/**", "**/wandb/proto/**"]
 ignore_errors = true
 


### PR DESCRIPTION
Makes code coverage count lines executed by subprocesses started by tests, such as in tests/system_tests/test_functional/multiprocessing/test_mp.py.

The key fix is in the `filesystem_isolate` fixture. It was also necessary to remove the `tool.coverage.run.source` setting in `pyproject.toml` because it fails to collect coverage this way. This setting actually does not apply in our normal usage of `pytest` in `noxfile.py`, where `--cov=""` overrides it.