### PR TITLE
refactor: console capture redo

### DIFF
--- a/tests/system_tests/test_functional/console_capture/patch_stdout_and_stderr.py
+++ b/tests/system_tests/test_functional/console_capture/patch_stdout_and_stderr.py
@@ -1,0 +1,40 @@
+"""Exits with code 0 if stdout and stderr callbacks are triggered.
+
+On success, prints "I AM STDOUT" to stdout and "I AM STDERR" to stderr.
+On error, prints additional text to stderr.
+"""
+
+import sys
+
+from wandb.sdk.lib import console_capture
+
+_got_stdout = False
+_got_stderr = False
+
+
+def _on_stdout(s, n):
+    global _got_stdout
+    _got_stdout = True
+
+
+def _on_stderr(s, n):
+    global _got_stderr
+    _got_stderr = True
+
+
+if __name__ == "__main__":
+    console_capture.capture_stdout(_on_stdout)
+    console_capture.capture_stderr(_on_stderr)
+
+    sys.stdout.write("I AM STDOUT\n")
+    sys.stderr.write("I AM STDERR\n")
+
+    if not _got_stdout:
+        sys.stderr.write("Didn't intercept stdout!")
+        sys.exit(1)
+
+    if not _got_stderr:
+        sys.stderr.write("Didn't intercept stderr!")
+        sys.exit(1)
+
+    sys.exit(0)

--- a/tests/system_tests/test_functional/console_capture/patching_exception.py
+++ b/tests/system_tests/test_functional/console_capture/patching_exception.py
@@ -1,0 +1,57 @@
+"""Exits with code 0 if an exception patching stdout is rethrown."""
+
+import io
+import sys
+from typing import TextIO
+
+
+class _TestError(Exception):
+    pass
+
+
+class MyStdout(io.TextIOBase):
+    def __init__(self, delegate: TextIO) -> None:
+        self._delegate = delegate
+
+    def __setattr__(self, name, value):
+        if name == "write":
+            raise _TestError()
+        return super().__setattr__(name, value)
+
+
+if __name__ == "__main__":
+    sys.stdout = MyStdout(sys.stdout)
+
+    # This will attempt to overwrite `sys.stdout.write` on import,
+    # which will raise an error that must not be propagated.
+    from wandb.sdk.lib import console_capture  # noqa: E402
+
+    try:
+        console_capture.capture_stdout(lambda *unused: None)
+    except console_capture.CannotCaptureConsoleError as e:
+        if e.__cause__ and isinstance(e.__cause__, _TestError):
+            print("[stdout] Caught _TestError!", file=sys.stderr)  # noqa: T201
+        else:
+            print(  # noqa: T201
+                "[stdout] Caught error, but its cause is not _TestError!",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        print("[stdout] No error!", file=sys.stderr)  # noqa: T201
+        sys.exit(1)
+
+    try:
+        console_capture.capture_stderr(lambda *unused: None)
+    except console_capture.CannotCaptureConsoleError as e:
+        if e.__cause__ and isinstance(e.__cause__, _TestError):
+            print("[stderr] Caught _TestError!", file=sys.stderr)  # noqa: T201
+        else:
+            print(  # noqa: T201
+                "[stderr] Caught error, but its cause is not _TestError!",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        print("[stderr] No error!", file=sys.stderr)  # noqa: T201
+        sys.exit(1)

--- a/tests/system_tests/test_functional/console_capture/test_console_capture.py
+++ b/tests/system_tests/test_functional/console_capture/test_console_capture.py
@@ -1,0 +1,34 @@
+import pathlib
+import subprocess
+
+import pytest
+
+
+@pytest.mark.wandb_core_only(reason="Test does not depend on service process.")
+def test_patch_stdout_and_stderr():
+    script = pathlib.Path(__file__).parent / "patch_stdout_and_stderr.py"
+
+    proc = subprocess.Popen(
+        ["python", str(script)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    exit_code = proc.wait()  # on error, stderr may have useful details
+    assert proc.stderr.read() == b"I AM STDERR\n"
+    assert proc.stdout.read() == b"I AM STDOUT\n"
+    assert exit_code == 0
+
+
+@pytest.mark.wandb_core_only(reason="Test does not depend on service process.")
+def test_patching_exception():
+    script = pathlib.Path(__file__).parent / "patching_exception.py"
+
+    subprocess.check_call(["python", str(script)])
+
+
+@pytest.mark.wandb_core_only(reason="Test does not depend on service process.")
+def test_uncapturing():
+    script = pathlib.Path(__file__).parent / "uncapturing.py"
+
+    subprocess.check_call(["python", str(script)])

--- a/tests/system_tests/test_functional/console_capture/uncapturing.py
+++ b/tests/system_tests/test_functional/console_capture/uncapturing.py
@@ -1,0 +1,42 @@
+"""Exits with code 0 if callbacks can be unregistered."""
+
+import io
+import sys
+
+from wandb.sdk.lib import console_capture
+
+received_by_hooks = io.StringIO()
+
+
+def _stdout_hook1(data: str | bytes, written: int, /):
+    received_by_hooks.write("[hook1]" + str(data[:written]))
+
+
+def _stdout_hook2(data: str | bytes, written: int, /):
+    received_by_hooks.write("[hook2]" + str(data[:written]))
+
+
+if __name__ == "__main__":
+    undo_stdout_hook1 = console_capture.capture_stdout(_stdout_hook1)
+    undo_stdout_hook2 = console_capture.capture_stdout(_stdout_hook2)
+
+    print("Line 1.")  # noqa: T201
+    undo_stdout_hook1()
+    print("Line 2.")  # noqa: T201
+    undo_stdout_hook2()
+    print("Line 3 (not received.)")  # noqa: T201
+
+    received = received_by_hooks.getvalue()
+    if (
+        received
+        != (
+            "[hook1]Line 1."  # (line-break for readability)
+            "[hook2]Line 1."
+            "[hook1]\n"  # NOTE: print() makes two write() calls!
+            "[hook2]\n"
+            "[hook2]Line 2."
+            "[hook2]\n"
+        )
+    ):
+        print(f"Wrong data: {received!r}", file=sys.stderr)  # noqa: T201
+        sys.exit(1)

--- a/wandb/sdk/lib/console_capture.py
+++ b/wandb/sdk/lib/console_capture.py
@@ -1,0 +1,169 @@
+"""Module for intercepting stdout/stderr.
+
+This patches the `write()` method of `stdout` and `stderr` on import.
+Once patched, it is not possible to unpatch or repatch, though individual
+callbacks can be removed.
+
+We assume that all other writing methods on the object delegate to `write()`,
+like `writelines()`. This is not guaranteed to be true, but it is true for
+common implementations. In particular, CPython's implementation of IOBase's
+`writelines()` delegates to `write()`.
+
+It is important to note that this technique interacts poorly with other
+code that performs similar patching if it also allows unpatching as this
+discards our modification. This is why we patch on import and do not support
+unpatching:
+
+    with contextlib.redirect_stderr(...):
+        from ... import console_capture
+        # Here, everything works fine.
+    # Here, callbacks are never called again.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from typing import IO, AnyStr, Callable, Protocol
+
+
+class CannotCaptureConsoleError(Exception):
+    """The module failed to patch stdout or stderr."""
+
+
+class _WriteCallback(Protocol):
+    """A callback that receives intercepted bytes or string data."""
+
+    def __call__(
+        self,
+        data: bytes | str,
+        written: int,
+        /,
+    ) -> None:
+        """Intercept data passed to `write()`.
+
+        Args:
+            data: The object passed to stderr's or stdout's `write()`.
+            written: The number of bytes or characters written.
+                This is the return value of `write()`.
+        """
+
+
+_module_lock = threading.Lock()
+
+_patch_exception: CannotCaptureConsoleError | None = None
+
+_next_callback_id: int = 1
+
+_stdout_callbacks: dict[int, _WriteCallback] = {}
+_stderr_callbacks: dict[int, _WriteCallback] = {}
+
+
+def capture_stdout(callback: _WriteCallback) -> Callable[[], None]:
+    """Install a callback that runs after every write to sys.stdout.
+
+    Args:
+        callback: A callback to invoke after running `sys.stdout.write`.
+            This may be called from any thread, so it must be thread-safe.
+            Exceptions are propagated to the caller of `write`.
+            See `_WriteCallback` for the exact protocol.
+
+    Returns:
+        A function to uninstall the callback.
+
+    Raises:
+        CannotCaptureConsoleError: If patching failed on import.
+    """
+    with _module_lock:
+        if _patch_exception:
+            raise _patch_exception
+
+        return _insert_disposably(
+            _stdout_callbacks,
+            callback,
+        )
+
+
+def capture_stderr(callback: _WriteCallback) -> Callable[[], None]:
+    """Install a callback that runs after every write to sys.sdterr.
+
+    Args:
+        callback: A callback to invoke after running `sys.stderr.write`.
+            This may be called from any thread, so it must be thread-safe.
+            Exceptions are propagated to the caller of `write`.
+            See `_WriteCallback` for the exact protocol.
+
+    Returns:
+        A function to uninstall the callback.
+
+    Raises:
+        CannotCaptureConsoleError: If patching failed on import.
+    """
+    with _module_lock:
+        if _patch_exception:
+            raise _patch_exception
+
+        return _insert_disposably(
+            _stderr_callbacks,
+            callback,
+        )
+
+
+def _insert_disposably(
+    callback_dict: dict[int, _WriteCallback],
+    callback: _WriteCallback,
+) -> Callable[[], None]:
+    global _next_callback_id
+    id = _next_callback_id
+    _next_callback_id += 1
+
+    disposed = False
+
+    def dispose() -> None:
+        nonlocal disposed
+
+        with _module_lock:
+            if disposed:
+                return
+
+            del callback_dict[id]
+
+            disposed = True
+
+    callback_dict[id] = callback
+    return dispose
+
+
+def _patch(
+    stdout_or_stderr: IO[AnyStr],
+    callbacks: dict[int, _WriteCallback],
+) -> None:
+    orig_write: Callable[[AnyStr], int]
+
+    def write_with_callbacks(s: AnyStr, /) -> int:
+        n = orig_write(s)
+
+        # We make a copy here because callbacks could, in theory, modify
+        # the list of callbacks.
+        with _module_lock:
+            callbacks_copy = list(callbacks.values())
+
+        for cb in callbacks_copy:
+            cb(s, n)
+
+        return n
+
+    orig_write = stdout_or_stderr.write
+
+    # mypy==1.14.1 fails to type-check this:
+    #   Incompatible types in assignment (expression has type
+    #   "Callable[[bytes], int]", variable has type overloaded function)
+    stdout_or_stderr.write = write_with_callbacks  # type: ignore
+
+
+try:
+    _patch(sys.stdout, _stdout_callbacks)
+    _patch(sys.stderr, _stderr_callbacks)
+except Exception as _patch_exception_cause:
+    _patch_exception = CannotCaptureConsoleError()
+    _patch_exception.__cause__ = _patch_exception_cause


### PR DESCRIPTION
Creates `console_capture.py` for patching `stderr` and `stdout`'s `write` methods.

The original way of doing this is in `redirect.py`, and I replace it in the next PR. `redirect.py` only allows a single hook at a time which forces us to only have a single run at a time. It also isn't thread-safe and doesn't document important edge cases (or much else).