### PR TITLE
refactor: update test_console.py

### DIFF
--- a/tests/system_tests/test_core/test_console.py
+++ b/tests/system_tests/test_core/test_console.py
@@ -3,18 +3,14 @@ import re
 import time
 from unittest import mock
 
-import numpy as np
 import pytest
+import tqdm
 import wandb
 import wandb.sdk.lib.redirect
 import wandb.util
 from click.testing import CliRunner
 from wandb.cli import cli
 from wandb.sdk.lib import runid
-
-console_modes = ["wrap"]
-if os.name != "nt":
-    console_modes.append("redirect")
 
 
 def _wait_for_legacy_service_transaction_log():
@@ -51,139 +47,152 @@ def _wait_for_legacy_service_transaction_log():
     time.sleep(2)
 
 
-@pytest.mark.parametrize("console", console_modes)
-def test_run_with_console_redirect(user, capfd, console):
-    tqdm = pytest.importorskip("tqdm")
-
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="redirect mode does not work on Windows",
+)
+@pytest.mark.skip_wandb_core(reason="redirect mode not implemented in core")
+def test_console_redirect(wandb_backend_spy, capfd):
     with capfd.disabled():
-        with wandb.init(settings={"console": console}):
-            print(np.random.randint(64, size=(40, 40, 40, 40)))  # noqa: T201
+        with wandb.init(settings={"console": "redirect"}) as run:
+            # Write directly to the stdout file descriptor.
+            with open(1, mode="wb", closefd=False) as stdout:
+                stdout.write(b"Testing...\n")
+                stdout.write(b"abc")
 
-            for _ in tqdm.tqdm(range(100)):
-                time.sleep(0.02)
+                # Check that terminal emulation is used:
+                stdout.write(b"\rxyz")  # replace abc by xyz
+                stdout.write(b"\x1b[A\rV")  # replace T in testing by V
 
-            print("\n" * 1000)  # noqa: T201
-            print("---------------")  # noqa: T201
-            time.sleep(1)
-
-
-@pytest.mark.parametrize("console", console_modes)
-def test_offline_compression(user, capfd, console):
-    tqdm = pytest.importorskip("tqdm")
-
-    # map to old style wrap implementation until test is refactored
-    if console == "wrap":
-        console = "wrap_emu"
-    with capfd.disabled():
-        with wandb.init(settings={"console": console, "mode": "offline"}) as run:
-            run_dir, run_id = run.dir, run.id
-
-            for _ in tqdm.tqdm(range(100), ncols=139, ascii=" 123456789#"):
-                time.sleep(0.05)
-
-            print("\n" * 1000)  # noqa: T201
-
-            print("QWERT")  # noqa: T201
-            print("YUIOP")  # noqa: T201
-            print("12345")  # noqa: T201
-
-            print("\x1b[A\r\x1b[J\x1b[A\r\x1b[1J")  # noqa: T201
-
-        _wait_for_legacy_service_transaction_log()
-
-        binary_log_file = (
-            os.path.join(os.path.dirname(run_dir), "run-" + run_id) + ".wandb"
-        )
-        binary_log = (
-            CliRunner()
-            .invoke(cli.sync, ["--view", "--verbose", binary_log_file])
-            .stdout
-        )
-
-        # Only a single output record per stream is written when the run finishes
-        re_output = re.compile(r"^Record: num: \d+\noutput {", flags=re.MULTILINE)
-        assert len(re_output.findall(binary_log)) == 2
-
-        # Only final state of progress bar is logged
-        assert binary_log.count("#") == 100, binary_log.count
-
-        # Intermediate states are not logged
-        assert "QWERT" not in binary_log
-        assert "YUIOP" not in binary_log
-        assert "12345" not in binary_log
-        assert "UIOP" in binary_log
+    with wandb_backend_spy.freeze() as snapshot:
+        output = snapshot.output(run_id=run.id)
+        assert 0 in output
+        assert 1 in output
+        assert "Vesting..." in output[0]
+        assert "xyz" in output[1]
+        assert "abc" not in output[1]
 
 
-@pytest.mark.parametrize("console", console_modes)
-@pytest.mark.parametrize("numpy", [True, False])
+def test_console_wrap_raw(wandb_backend_spy):
+    with wandb.init(settings={"console": "wrap_raw"}) as run:
+        print("Testing...")  # noqa: T201
+        print("abc", end="")  # noqa: T201
+        print("\rxyz", end="")  # noqa: T201
+        print("\x1b[A\rV", end="")  # noqa: T201
+
+    with wandb_backend_spy.freeze() as snapshot:
+        output = snapshot.output(run_id=run.id)
+        assert 0 in output
+        assert 1 in output
+        assert "Vesting..." in output[0]
+        assert "xyz" in output[1]
+        assert "abc" not in output[1]
+
+
+@pytest.mark.skip_wandb_core(reason="wrap_emu mode not implemented in core")
+def test_console_wrap_emu(wandb_backend_spy):
+    with wandb.init(settings={"console": "wrap_emu"}) as run:
+        print("Testing...")  # noqa: T201
+        print("abc", end="")  # noqa: T201
+        print("\rxyz", end="")  # noqa: T201
+        print("\x1b[A\rV", end="")  # noqa: T201
+
+    with wandb_backend_spy.freeze() as snapshot:
+        output = snapshot.output(run_id=run.id)
+        assert 0 in output
+        assert 1 in output
+        assert "Vesting..." in output[0]
+        assert "xyz" in output[1]
+        assert "abc" not in output[1]
+
+
+def test_offline_compression(user):
+    with wandb.init(settings={"console": "wrap_emu", "mode": "offline"}) as run:
+        run_dir, run_id = run.dir, run.id
+
+        for _ in tqdm.tqdm(range(100), ncols=139, ascii=" 123456789#"):
+            time.sleep(0.05)
+
+        print("\n" * 1000)  # noqa: T201
+
+        print("QWERT")  # noqa: T201
+        print("YUIOP")  # noqa: T201
+        print("12345")  # noqa: T201
+
+        print("\x1b[A\r\x1b[J\x1b[A\r\x1b[1J")  # noqa: T201
+
+    _wait_for_legacy_service_transaction_log()
+
+    binary_log_file = os.path.join(os.path.dirname(run_dir), "run-" + run_id) + ".wandb"
+    binary_log = (
+        CliRunner().invoke(cli.sync, ["--view", "--verbose", binary_log_file]).stdout
+    )
+
+    # Only a single output record per stream is written when the run finishes
+    re_output = re.compile(r"^Record: num: \d+\noutput {", flags=re.MULTILINE)
+    assert len(re_output.findall(binary_log)) == 2
+
+    # Only final state of progress bar is logged
+    assert binary_log.count("#") == 100, binary_log.count
+
+    # Intermediate states are not logged
+    assert "QWERT" not in binary_log
+    assert "YUIOP" not in binary_log
+    assert "12345" not in binary_log
+    assert "UIOP" in binary_log
+
+
 @pytest.mark.timeout(300)
-def test_very_long_output(user, capfd, console, numpy):
+def test_very_long_output(user):
     # https://wandb.atlassian.net/browse/WB-5437
-    with capfd.disabled():
-        with mock.patch.object(
-            wandb.wandb_sdk.lib.redirect,
-            "np",
-            wandb.sdk.lib.redirect._Numpy() if not numpy else np,
-        ):
-            with wandb.init(
-                settings={
-                    "console": console,
-                    "mode": "offline",
-                    "run_id": runid.generate_id(),
-                }
-            ) as run:
-                run_dir, run_id = run.dir, run.id
-                print("LOG" * 1000000)  # noqa: T201
-                print("\x1b[31m\x1b[40m\x1b[1mHello\x01\x1b[22m\x1b[39m" * 100)  # noqa: T201
-                print("===finish===")  # noqa: T201
+    with wandb.init(
+        settings={
+            # To test the TerminalEmulator, we do not use "wrap_raw".
+            "console": "wrap_emu",
+            "mode": "offline",
+            "run_id": runid.generate_id(),
+        }
+    ) as run:
+        run_dir, run_id = run.dir, run.id
+        print("LOG" * 1000000)  # noqa: T201
+        print("\x1b[31m\x1b[40m\x1b[1mHello\x01\x1b[22m\x1b[39m" * 100)  # noqa: T201
+        print("===finish===")  # noqa: T201
 
-            _wait_for_legacy_service_transaction_log()
+    _wait_for_legacy_service_transaction_log()
 
-            binary_log_file = (
-                os.path.join(os.path.dirname(run_dir), "run-" + run_id) + ".wandb"
-            )
-            binary_log = (
-                CliRunner()
-                .invoke(cli.sync, ["--view", "--verbose", binary_log_file])
-                .stdout
-            )
+    binary_log_file = os.path.join(os.path.dirname(run_dir), "run-" + run_id) + ".wandb"
+    binary_log = (
+        CliRunner().invoke(cli.sync, ["--view", "--verbose", binary_log_file]).stdout
+    )
 
-            assert "\\033[31m\\033[40m\\033[1mHello" in binary_log
-            assert binary_log.count("LOG") == 1000000
-            assert "===finish===" in binary_log
+    assert "\\033[31m\\033[40m\\033[1mHello" in binary_log
+    assert binary_log.count("LOG") == 1000000
+    assert "===finish===" in binary_log
 
 
-@pytest.mark.parametrize("console", console_modes)
-def test_no_numpy(user, capfd, console):
-    with capfd.disabled():
-        with mock.patch.object(
-            wandb.wandb_sdk.lib.redirect,
-            "np",
-            wandb.sdk.lib.redirect._Numpy(),
-        ):
-            with wandb.init(settings={"console": console}) as run:
-                print("\x1b[31m\x1b[40m\x1b[1mHello\x01\x1b[22m\x1b[39m")  # noqa: T201
+@pytest.mark.skip_wandb_core(reason="wrap_emu mode not implemented in core")
+def test_no_numpy(wandb_backend_spy):
+    with mock.patch.object(
+        wandb.wandb_sdk.lib.redirect,
+        "np",
+        wandb.sdk.lib.redirect._Numpy(),
+    ):
+        # Use "wrap_emu" to make sure TerminalEmulator's usage of _Numpy works.
+        with wandb.init(settings={"console": "wrap_emu"}) as run:
+            print("\x1b[31m\x1b[40m\x1b[1mHello\x01\x1b[22m\x1b[39m")  # noqa: T201
 
-            _wait_for_legacy_service_transaction_log()
+    with wandb_backend_spy.freeze() as snapshot:
+        output = snapshot.output(run_id=run.id)
 
-            binary_log_file = (
-                os.path.join(os.path.dirname(run.dir), "run-" + run.id) + ".wandb"
-            )
-            _ = (
-                CliRunner()
-                .invoke(cli.sync, ["--view", "--verbose", binary_log_file])
-                .stdout
-            )
+        assert 0 in output
+        assert "\x1b[31m\x1b[40m\x1b[1mHello" in output[0]
 
 
-@pytest.mark.parametrize("console", console_modes)
-def test_memory_leak2(user, capfd, console):
-    # map to old style wrap implementation until test is refactored
-    if console == "wrap":
-        console = "wrap_emu"
-    with capfd.disabled():
-        with wandb.init(settings={"console": console}) as run:
-            for _ in range(1000):
-                print("ABCDEFGH")  # noqa: T201
-            time.sleep(3)
-            assert len(run._out_redir._emulator.buffer) < 1000
+def test_memory_leak2(user):
+    # This appears to test this:
+    #   https://github.com/wandb/wandb/pull/2111/files#r640819752
+    with wandb.init(settings={"console": "wrap_emu"}) as run:
+        for _ in range(1000):
+            print("ABCDEFGH")  # noqa: T201
+        time.sleep(3)
+        assert len(run._out_redir._emulator.buffer) < 1000

--- a/tests/system_tests/wandb_backend_spy/spy.py
+++ b/tests/system_tests/wandb_backend_spy/spy.py
@@ -274,7 +274,7 @@ class WandbBackendSnapshot:
             history_parsed[offset] = json.loads(line)
         return history_parsed
 
-    def output(self, *, run_id: str) -> dict[int, Any]:
+    def output(self, *, run_id: str) -> dict[int, str]:
         """Returns the run's console logs uploaded via FileStream.
 
         The file is represented as a dict that maps integer offsets to

--- a/wandb/sdk/lib/console_capture.py
+++ b/wandb/sdk/lib/console_capture.py
@@ -18,6 +18,9 @@ unpatching:
         from ... import console_capture
         # Here, everything works fine.
     # Here, callbacks are never called again.
+
+In particular, it does not work with some combinations of pytest's
+`capfd` / `capsys` fixtures and pytest's `--capture` option.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
* Makes most tests run without `capfd`, which interacts poorly with `console_capture.py`
* Simplifies and speeds up some tests