### PR TITLE
Jpgtransparencyfix

### DIFF
--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -1524,3 +1524,14 @@ def test_log_uint8_image():
         path_im, torch_vision = np.array(path_im.image), np.array(torch_vision.image)
 
         assert np.array_equal(path_im, torch_vision)
+
+
+@pytest.mark.parametrize("file_type", ["jpeg", "jpg"])
+def test_init_image_jpeg_removes_transparency(file_type, mock_wandb_log):
+    img = np.random.rand(100, 100, 4) * 255
+    wandb.Image(img, file_type=file_type)
+
+    assert mock_wandb_log.warned(
+        "JPEG format does not support transparency. "
+        "Removing alpha channel from image.",
+    )

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -333,6 +333,17 @@ class Image(BatchableMedia):
         ), f"file_type must be one of {accepted_formats}"
         tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + "." + self.format)
         assert self._image is not None
+
+        # JPEG format does not support transparency.
+        # So we remove the alpha (transparency) channel.
+        if self.format in ["jpg", "jpeg"]:
+            wandb.termwarn(
+                "JPEG format does not support transparency. "
+                "Removing alpha channel from image.",
+                repeat=False,
+            )
+            self._image = self._image.convert("RGB")
+
         self._image.save(tmp_path, transparency=None)
         self._set_file(tmp_path, is_tmp=True)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-18272

What does the PR do? Include a concise description of the PR contents.

When attempting to log an image in `jpg` or `jpeg` format with alpha (transparency) data, this would result in the following error.
```
﻿OSError: cannot write mode RGBA as JPEG
```

To fix this, this PR uses Pillow's `convert` function to convert to `RGB` mode, removing transparency data. Additionally this will warn the user of the conversion.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

### Test script
```python
import wandb
import numpy as np

img = np.random.randint(0, 255, (512, 512, 4))

with wandb.init() as run:
    run.log({"Transparent Image": wandb.Image(img, file_type="jpg")})
```

#### running the script before the change
```
  File "/Users/jacob/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PIL/JpegImagePlugin.py", line 665, in _save
    rawmode = RAWMODE[im.mode]
              ~~~~~~~^^^^^^^^^
KeyError: 'RGBA'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jacob/workspace/test/mplrepro.py", line 17, in <module>
    wandb.log({"My Matplotlib Plot": wandb.Image(img, file_type="jpeg")})
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob/workspace/wandb/wandb/sdk/data_types/image.py", line 179, in __init__
    self._initialize_from_data(data_or_path, mode, file_type)
  File "/Users/jacob/workspace/wandb/wandb/sdk/data_types/image.py", line 340, in _initialize_from_data
    self._image.save(tmp_path, transparency=None)
  File "/Users/jacob/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PIL/Image.py", line 2596, in save
    save_handler(self, fp, filename)
  File "/Users/jacob/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PIL/JpegImagePlugin.py", line 668, in _save
    raise OSError(msg) from e
OSError: cannot write mode RGBA as JPEG
```

#### After this change
```
wandb: Using wandb-core as the SDK backend.  Please refer to https://wandb.me/wandb-core for more information.
...
wandb: WARNING JPEG format does not support transparency. Removing alpha channel from image.
...
wandb: Synced 5 W&B file(s), ` media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./wandb/run-20250227_130456-s4hapblz/logs

```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
