### PR TITLE
refactor: allow multiple streams per connection in core

### DIFF
--- a/core/internal/stream/stream_mux.go
+++ b/core/internal/stream/stream_mux.go
@@ -39,7 +39,7 @@ func (sm *StreamMux) GetStream(streamId string) (*Stream, error) {
 	sm.mutex.RLock()
 	defer sm.mutex.RUnlock()
 	if stream, ok := sm.mux[streamId]; !ok {
-		return nil, fmt.Errorf("stream not found")
+		return nil, fmt.Errorf("stream %s not found", streamId)
 	} else {
 		return stream, nil
 	}


### PR DESCRIPTION
Removes the `nc.stream` field and replaces it by calls to `streamMux.GetStream()`.

The risk is if we ever send messages without a stream ID to wandb-core, they will not be processed. `InterfaceSock` assigns a stream ID on all outgoing records; `ServiceConnection` in `service_connection.py` assigns a stream ID on Init, Finish, Attach and Start requests.

I have not checked other clients, but note that they would not work with legacy-service since it always requires the stream ID to be set.