### PR TITLE
chore: remove accidental log statement

### DIFF
--- a/wandb/sdk/lib/redirect.py
+++ b/wandb/sdk/lib/redirect.py
@@ -657,7 +657,6 @@ class StreamRawWrapper(RedirectBase):
         for cb in self.cbs:
             try:
                 cb(written_data)
-                logger.info("StreamRawWrapper callback %s", written_data)
             except Exception:
                 logger.exception("error in %s callback", self.src)
 


### PR DESCRIPTION
Removes an INFO-level log statement added in a previous PR that was used for debugging.