### PR TITLE
fix: files would not be uploaded if specified directory was created in the middle of a run

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1248,6 +1248,20 @@ class Settings(BaseModel, validate_assignment=True):
         """
         root_dir = self.root_dir or ""
 
+        if root_dir and not os.path.exists(root_dir):
+            termwarn(
+                "root_dir doesn't exist, attempting to create it",
+                repeat=False,
+            )
+            try:
+                os.makedirs(root_dir, exist_ok=True)
+            except Exception:
+                termwarn(
+                    "Failed to create root_dir, using system temp directory",
+                    repeat=False,
+                )
+                self.root_dir = tempfile.gettempdir()
+
         # We use the hidden version if it already exists, otherwise non-hidden.
         if os.path.exists(os.path.join(root_dir, ".wandb")):
             __stage_dir__ = ".wandb" + os.sep

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1256,11 +1256,7 @@ class Settings(BaseModel, validate_assignment=True):
             try:
                 os.makedirs(root_dir, exist_ok=True)
             except Exception:
-                termwarn(
-                    "Failed to create root_dir, using system temp directory",
-                    repeat=False,
-                )
-                self.root_dir = tempfile.gettempdir()
+                pass
 
         # We use the hidden version if it already exists, otherwise non-hidden.
         if os.path.exists(os.path.join(root_dir, ".wandb")):
@@ -1277,6 +1273,7 @@ class Settings(BaseModel, validate_assignment=True):
             path = os.path.join(
                 tempfile.gettempdir(), __stage_dir__ or ("wandb" + os.sep)
             )
+            self.root_dir = path
 
         return os.path.expanduser(path)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-21010

What does the PR do? Include a concise description of the PR contents.

When a user specifies a directory to use for a run e.g. `wandb.init(settings=wandb.Settings(root_dir="rundir"))` then later the directory gets created, this causes some data to get lost, as it will be placed in the system temp directory.

This PR fixes that by attempting to create the user specified directory if possible.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
test script
```
import wandb
import numpy as np

with wandb.init(
    settings=wandb.Settings(
        root_dir="missingdir",
    )
) as run:
    img = np.random.randint(0, 255, (100, 100, 3))
    run.log({"test": wandb.Image(img, file_type="png")})

    import os

    os.makedirs("missingdir", exist_ok=True)

    img = np.random.randint(0, 255, (100, 100, 3))
    run.log({"test2": wandb.Image(img, file_type="png")}
```

### Before these changes

![image](https://github.com/user-attachments/assets/029c882f-4400-4682-baa9-a5ae4bdf1c34)
![image](https://github.com/user-attachments/assets/7fb07406-ec8a-44f8-8e63-c80106e7f006)

### After these changes
![image](https://github.com/user-attachments/assets/01c80d4a-c0a3-4b8c-9ab6-98702bfb40a2)
![image](https://github.com/user-attachments/assets/87ad037e-9b2d-4cf7-9070-f1c4156b2bbd)


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
