### PR TITLE
refactor: support per run logging

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Changed
 
 - Boolean values for the `reinit` setting are deprecated; use "return_previous" and "finish_previous" instead (@timoffex in https://github.com/wandb/wandb/pull/9557)
+- The "wandb" logger is configured with `propagate=False` at import time, whereas it previously happened when starting a run. This may change the messages observed by the root logger in some workflows (@timoffex in https://github.com/wandb/wandb/pull/9540)
 
 ### Fixed
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@ tenacity
 ipython
 ipython<8.13; python_version < '3.9'
 ipykernel
-nbclient
+nbclient~=0.10.1
 
 
 tensorflow~=2.18.0; python_version >= '3.9'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import pathlib
 import platform
@@ -10,7 +11,7 @@ import unittest.mock
 from itertools import takewhile
 from pathlib import Path
 from queue import Queue
-from typing import Any, Callable, Generator, Iterable
+from typing import Any, Callable, Generator, Iterable, Iterator
 
 import pyte
 import pyte.modes
@@ -140,6 +141,25 @@ def copy_asset(
 # --------------------------------
 # Misc Fixtures
 # --------------------------------
+
+
+@pytest.fixture()
+def wandb_caplog(
+    caplog: pytest.LogCaptureFixture,
+) -> Iterator[pytest.LogCaptureFixture]:
+    """Modified caplog fixture that detect wandb log messages.
+
+    The wandb logger is configured to not propagate messages to the root logger,
+    so caplog does not work out of the box.
+    """
+
+    logger = logging.getLogger("wandb")
+
+    logger.addHandler(caplog.handler)
+    try:
+        yield caplog
+    finally:
+        logger.removeHandler(caplog.handler)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/system_tests/test_functional/wb_logging/last_resort.py
+++ b/tests/system_tests/test_functional/wb_logging/last_resort.py
@@ -1,0 +1,19 @@
+import logging
+
+if __name__ == "__main__":
+    logger = logging.getLogger("wandb")
+
+    # logging.lastResort by default outputs to stderr. Check that this is true.
+    logger.warning("lastResort (before configuring)")
+
+    # Import wandb to trigger wb_logging.configure_wandb_logger().
+    import wandb  # noqa: F401
+
+    # configure_wandb_logger() should prevent lastResort from being used for
+    # messages logged to the "wandb" logger.
+    logger.warning("lastResort (after configuring -- not output)")
+
+    # Another way the message can be suppressed is if the "wandb" logger's level
+    # is set above WARNING. Verify that this isn't the case.
+    logger.addHandler(logging.StreamHandler())
+    logger.warning("stream handler (after configuring)")

--- a/tests/system_tests/test_functional/wb_logging/test_wb_logging_last_resort.py
+++ b/tests/system_tests/test_functional/wb_logging/test_wb_logging_last_resort.py
@@ -1,0 +1,19 @@
+import pathlib
+import subprocess
+
+import pytest
+
+
+@pytest.mark.wandb_core_only(reason="does not depend on service")
+def test_wb_logging_last_resort():
+    script = pathlib.Path(__file__).parent / "last_resort.py"
+
+    output = subprocess.check_output(
+        ["python", str(script)],
+        stderr=subprocess.STDOUT,
+    ).splitlines()
+
+    assert output == [
+        b"lastResort (before configuring)",
+        b"stream handler (after configuring)",
+    ]

--- a/tests/system_tests/test_launch/test_launch_cli.py
+++ b/tests/system_tests/test_launch/test_launch_cli.py
@@ -207,7 +207,7 @@ def test_launch_supplied_docker_image(
     assert "test:tag" in result.output
 
 
-def test_launch_supplied_logfile(runner, monkeypatch, caplog, user):
+def test_launch_supplied_logfile(runner, monkeypatch, wandb_caplog, user):
     """Test that the logfile is set properly when supplied via the CLI."""
 
     def patched_pop_empty_queue(self, queue):
@@ -226,7 +226,7 @@ def test_launch_supplied_logfile(runner, monkeypatch, caplog, user):
     )
 
     with runner.isolated_filesystem():
-        with caplog.at_level("INFO"):
+        with wandb_caplog.at_level("INFO"):
             result = runner.invoke(
                 cli.launch_agent,
                 [

--- a/tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/unit_tests/test_lib/test_filesystem.py
@@ -555,11 +555,11 @@ def test_system_preferred_path():
         assert system_preferred_path(path) == path
 
 
-def test_system_preferred_path_warning(caplog):
+def test_system_preferred_path_warning(wandb_caplog):
     path = Path("path:with/colon.txt")
     with mock.patch("platform.system", return_value="Windows"):
         system_preferred_path(path, warn=True)
-        assert f"Replacing ':' in {path} with '-'" in caplog.text
+        assert f"Replacing ':' in {path} with '-'" in wandb_caplog.text
 
 
 def test_mkdir_allow_fallback_success(tmp_path):
@@ -587,8 +587,8 @@ def test_mkdir_allow_fallback_with_uncreatable_directory(tmp_path):
             mkdir_allow_fallback(dir_name)
 
 
-def test_mkdir_allow_fallback_with_warning(caplog, tmp_path):
+def test_mkdir_allow_fallback_with_warning(wandb_caplog, tmp_path):
     dir_name = tmp_path / "direct\0ry"
     new_name = tmp_path / "direct-ry"
     assert mkdir_allow_fallback(dir_name) == new_name
-    assert f"Creating '{new_name}' instead of '{dir_name}'" in caplog.text
+    assert f"Creating '{new_name}' instead of '{dir_name}'" in wandb_caplog.text

--- a/tests/unit_tests/test_mailbox.py
+++ b/tests/unit_tests/test_mailbox.py
@@ -238,12 +238,12 @@ def test_deliver_unknown_address():
     mailbox.deliver(response)
 
 
-def test_deliver_no_address(caplog):
+def test_deliver_no_address(wandb_caplog):
     mailbox = mb.Mailbox()
 
     mailbox.deliver(spb.ServerResponse())
 
-    assert "Received response with no mailbox slot" in caplog.text
+    assert "Received response with no mailbox slot" in wandb_caplog.text
 
 
 def test_deliver_after_abandon():

--- a/tests/unit_tests/test_wb_logging.py
+++ b/tests/unit_tests/test_wb_logging.py
@@ -1,0 +1,59 @@
+import contextlib
+import logging
+import pathlib
+from typing import Iterator
+
+import pytest
+from wandb.sdk.lib import wb_logging
+
+wb_logging.configure_wandb_logger()
+
+
+@contextlib.contextmanager
+def _wandb_file_handler(
+    run_id: str,
+    path: pathlib.Path,
+) -> Iterator[None]:
+    handler = wb_logging.add_file_handler(run_id, path)
+    try:
+        yield
+    finally:
+        handler.close()
+        logging.getLogger("wandb").removeHandler(handler)
+
+
+@pytest.mark.wandb_core_only(reason="does not depend on service")
+def test_filters_log_messages(tmp_path: pathlib.Path):
+    run1_log_path = tmp_path / "run1.log"
+    run2_log_path = tmp_path / "run2.log"
+    logger = logging.getLogger("wandb")
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(_wandb_file_handler("run1", run1_log_path))
+        stack.enter_context(_wandb_file_handler("run2", run2_log_path))
+
+        logger.info("1: both runs")
+        with wb_logging.log_to_run("run1"):
+            logger.info("2: only run1")
+            with wb_logging.log_to_run("run2"):
+                logger.info("3: only run2")
+            with wb_logging.log_to_all_runs():
+                logger.info("4: both runs")
+            logger.info("5: only run1")
+            with wb_logging.log_to_run(None):
+                logger.info("6: both runs")
+
+    run1_lines = run1_log_path.read_text().splitlines()
+    assert len(run1_lines) == 5
+    assert run1_lines[0].endswith("] [no run ID] 1: both runs")
+    assert run1_lines[1].endswith("] 2: only run1")
+    assert run1_lines[2].endswith("] [all runs] 4: both runs")
+    assert run1_lines[3].endswith("] 5: only run1")
+    assert run1_lines[4].endswith("] [no run ID] 6: both runs")
+
+    run2_lines = run2_log_path.read_text().splitlines()
+    assert len(run2_lines) == 4
+    assert run2_lines[0].endswith("] [no run ID] 1: both runs")
+    assert run2_lines[1].endswith("] 3: only run2")
+    assert run2_lines[2].endswith("] [all runs] 4: both runs")
+    assert run2_lines[3].endswith("] [no run ID] 6: both runs")

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -18,6 +18,10 @@ from wandb.errors import Error
 # This needs to be early as other modules call it.
 from wandb.errors.term import termsetup, termlog, termerror, termwarn
 
+# Configure the logger as early as possible for consistent behavior.
+from wandb.sdk.lib import wb_logging as _wb_logging
+_wb_logging.configure_wandb_logger()
+
 from wandb import sdk as wandb_sdk
 
 import wandb

--- a/wandb/sdk/lib/wb_logging.py
+++ b/wandb/sdk/lib/wb_logging.py
@@ -1,0 +1,161 @@
+"""Logging configuration for the "wandb" logger.
+
+Most log statements in wandb are made in the context of a run and should be
+redirected to that run's log file (usually named 'debug.log'). This module
+provides a context manager to temporarily set the current run ID and registers
+a global handler for the 'wandb' logger that sends log statements to the right
+place.
+
+All functions in this module are threadsafe.
+
+NOTE: The pytest caplog fixture will fail to capture logs from the wandb logger
+because they are not propagated to the root logger.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import logging
+import pathlib
+from typing import Iterator
+
+
+class _NotRunSpecific:
+    """Sentinel for `not_run_specific()`."""
+
+
+_NOT_RUN_SPECIFIC = _NotRunSpecific()
+
+
+_run_id: contextvars.ContextVar[str | _NotRunSpecific | None] = contextvars.ContextVar(
+    "_run_id",
+    default=None,
+)
+
+_logger = logging.getLogger("wandb")
+
+
+def configure_wandb_logger() -> None:
+    """Configures the global 'wandb' logger.
+
+    The wandb logger is not intended to be customized by users. Instead, it is
+    used as a mechanism to redirect log messages into wandb run-specific log
+    files.
+
+    This function is idempotent: calling it multiple times has the same effect.
+    """
+    # Send all DEBUG and above messages to registered handlers.
+    #
+    # Per-run handlers can set different levels.
+    _logger.setLevel(logging.DEBUG)
+
+    # Do not propagate wandb logs to the root logger, which the user may have
+    # configured to point elsewhere. All wandb log messages should go to a run's
+    # log file.
+    _logger.propagate = False
+
+    # If no handlers are configured for the 'wandb' logger, don't activate the
+    # "lastResort" handler which sends messages to stderr with a level of
+    # WARNING by default.
+    #
+    # This occurs in wandb code that runs outside the context of a Run and
+    # not as part of the CLI.
+    #
+    # Most such code uses the `termlog` / `termwarn` / `termerror` methods
+    # to communicate with the user. When that code executes while a run is
+    # active, its logger messages go to that run's log file.
+    if not _logger.handlers:
+        _logger.addHandler(logging.NullHandler())
+
+
+@contextlib.contextmanager
+def log_to_run(run_id: str | None) -> Iterator[None]:
+    """Direct all wandb log messages to the given run.
+
+    Args:
+        id: The current run ID, or None if actions in the context manager are
+            not associated to a specific run. In the latter case, log messages
+            will go to all runs.
+
+    Usage:
+
+        with wb_logging.run_id(...):
+            ... # Log messages here go to the specified run's logger.
+    """
+    token = _run_id.set(run_id)
+    try:
+        yield
+    finally:
+        _run_id.reset(token)
+
+
+@contextlib.contextmanager
+def log_to_all_runs() -> Iterator[None]:
+    """Direct wandb log messages to all runs.
+
+    Unlike `log_to_run(None)`, this indicates an intentional choice.
+    This is often convenient to use as a decorator:
+
+        @wb_logging.log_to_all_runs()
+        def my_func():
+            ... # Log messages here go to the specified run's logger.
+    """
+    token = _run_id.set(_NOT_RUN_SPECIFIC)
+    try:
+        yield
+    finally:
+        _run_id.reset(token)
+
+
+def add_file_handler(run_id: str, filepath: pathlib.Path) -> logging.Handler:
+    """Direct log messages for a run to a file.
+
+    Args:
+        run_id: The run for which to create a log file.
+        filepath: The file to write log messages to.
+
+    Returns:
+        The added handler which can then be configured further or removed
+        from the 'wandb' logger directly.
+
+        The default logging level is INFO.
+    """
+    handler = logging.FileHandler(filepath)
+    handler.setLevel(logging.INFO)
+    handler.addFilter(_RunIDFilter(run_id))
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)-7s %(threadName)-10s:%(process)d"
+            " [%(filename)s:%(funcName)s():%(lineno)s]%(run_id_tag)s"
+            " %(message)s"
+        )
+    )
+
+    _logger.addHandler(handler)
+    return handler
+
+
+class _RunIDFilter(logging.Filter):
+    """Filters out messages logged for a different run."""
+
+    def __init__(self, run_id: str) -> None:
+        """Create a _RunIDFilter.
+
+        Args:
+            run_id: Allows messages when the run ID is this or None.
+        """
+        self._run_id = run_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        run_id = _run_id.get()
+
+        if run_id is None:
+            record.run_id_tag = " [no run ID]"
+            return True
+        elif isinstance(run_id, _NotRunSpecific):
+            record.run_id_tag = " [all runs]"
+            return True
+        else:
+            record.run_id_tag = ""
+            return run_id == self._run_id

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -10,6 +10,7 @@ For more on using `wandb.init()`, including code snippets, check out our
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import dataclasses
 import json
@@ -20,7 +21,7 @@ import platform
 import sys
 import tempfile
 import time
-from typing import Any, Literal, Sequence
+from typing import Any, Iterator, Literal, Sequence
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -29,13 +30,13 @@ else:
 
 import wandb
 import wandb.env
-from wandb import trigger
+from wandb import env, trigger
 from wandb.errors import CommError, Error, UsageError
 from wandb.errors.links import url_registry
 from wandb.errors.util import ProtobufErrorHandler
 from wandb.integration import sagemaker
 from wandb.sdk.lib import ipython as wb_ipython
-from wandb.sdk.lib import progress, runid
+from wandb.sdk.lib import progress, runid, wb_logging
 from wandb.sdk.lib.paths import StrPath
 from wandb.util import _is_artifact_representation
 
@@ -510,37 +511,6 @@ class _WandbInit:
             else:
                 config_target.setdefault(k, v)
 
-    def _create_logger(self, log_fname: str) -> logging.Logger:
-        """Returns a logger configured to write to a file.
-
-        This adds a run_id to the log, in case of multiple processes on the same
-        machine. Currently, there is no way to disable logging after it's
-        enabled.
-        """
-        handler = logging.FileHandler(log_fname)
-        handler.setLevel(logging.INFO)
-
-        formatter = logging.Formatter(
-            "%(asctime)s %(levelname)-7s %(threadName)-10s:%(process)d "
-            "[%(filename)s:%(funcName)s():%(lineno)s] %(message)s"
-        )
-
-        handler.setFormatter(formatter)
-
-        logger = logging.getLogger("wandb")
-        logger.propagate = False
-        logger.addHandler(handler)
-        # TODO: make me configurable
-        logger.setLevel(logging.DEBUG)
-        self._teardown_hooks.append(
-            TeardownHook(
-                lambda: (handler.close(), logger.removeHandler(handler)),  # type: ignore
-                TeardownStage.LATE,
-            )
-        )
-
-        return logger
-
     def _safe_symlink(
         self, base: str, target: str, name: str, delete: bool = False
     ) -> None:
@@ -627,8 +597,14 @@ class _WandbInit:
 
         ipython.display_pub.publish = publish
 
-    def setup_run_log_directory(self, settings: Settings) -> None:
-        """Set up logging from settings."""
+    @contextlib.contextmanager
+    def setup_run_log_directory(self, settings: Settings) -> Iterator[None]:
+        """Set up the run's log directory.
+
+        This is a context manager that closes and unregisters the log handler
+        in case of an uncaught exception, so that future logged messages do not
+        modify this run's log file.
+        """
         filesystem.mkdir_exists_ok(os.path.dirname(settings.log_user))
         filesystem.mkdir_exists_ok(os.path.dirname(settings.log_internal))
         filesystem.mkdir_exists_ok(os.path.dirname(settings.sync_file))
@@ -655,9 +631,41 @@ class _WandbInit:
                 delete=True,
             )
 
-        self._wl._early_logger_flush(self._create_logger(settings.log_user))
-        self._logger.info(f"Logging user logs to {settings.log_user}")
-        self._logger.info(f"Logging internal logs to {settings.log_internal}")
+        assert settings.run_id
+        handler = wb_logging.add_file_handler(
+            settings.run_id,
+            pathlib.Path(settings.log_user),
+        )
+
+        if env.is_debug():
+            handler.setLevel(logging.DEBUG)
+
+        disposed = False
+
+        def dispose_handler() -> None:
+            nonlocal disposed
+
+            if not disposed:
+                disposed = True
+                logging.getLogger("wandb").removeHandler(handler)
+                handler.close()
+
+        try:
+            self._teardown_hooks.append(
+                TeardownHook(
+                    call=dispose_handler,
+                    stage=TeardownStage.LATE,
+                )
+            )
+
+            self._wl._early_logger_flush(logging.getLogger("wandb"))
+            self._logger.info(f"Logging user logs to {settings.log_user}")
+            self._logger.info(f"Logging internal logs to {settings.log_internal}")
+
+            yield
+        except Exception:
+            dispose_handler()
+            raise
 
     def make_disabled_run(self, config: _ConfigParts) -> Run:
         """Returns a Run-like object where all methods are no-ops.
@@ -1464,34 +1472,38 @@ def init(  # noqa: C901
 
         wi.set_run_id(run_settings)
 
-        run_config = wi.make_run_config(
-            settings=run_settings,
-            config=config,
-            config_exclude_keys=config_exclude_keys,
-            config_include_keys=config_include_keys,
-        )
+        with contextlib.ExitStack() as exit_stack:
+            exit_stack.enter_context(wb_logging.log_to_run(run_settings.run_id))
 
-        if run_settings._noop:
-            return wi.make_disabled_run(run_config)
+            run_config = wi.make_run_config(
+                settings=run_settings,
+                config=config,
+                config_exclude_keys=config_exclude_keys,
+                config_include_keys=config_include_keys,
+            )
 
-        wi.setup_run_log_directory(run_settings)
-        if run_settings._jupyter:
-            wi.monkeypatch_ipython(run_settings)
+            if run_settings._noop:
+                return wi.make_disabled_run(run_config)
 
-        if monitor_gym:
-            _monkeypatch_openai_gym()
+            exit_stack.enter_context(wi.setup_run_log_directory(run_settings))
 
-        if wandb.patched["tensorboard"]:
-            # NOTE: The user may have called the patch function directly.
-            init_telemetry.feature.tensorboard_patch = True
-        if run_settings.sync_tensorboard:
-            _monkeypatch_tensorboard()
-            init_telemetry.feature.tensorboard_sync = True
+            if run_settings._jupyter:
+                wi.monkeypatch_ipython(run_settings)
 
-        if run_settings.x_server_side_derived_summary:
-            init_telemetry.feature.server_side_derived_summary = True
+            if monitor_gym:
+                _monkeypatch_openai_gym()
 
-        return wi.init(run_settings, run_config)
+            if wandb.patched["tensorboard"]:
+                # NOTE: The user may have called the patch function directly.
+                init_telemetry.feature.tensorboard_patch = True
+            if run_settings.sync_tensorboard:
+                _monkeypatch_tensorboard()
+                init_telemetry.feature.tensorboard_sync = True
+
+            if run_settings.x_server_side_derived_summary:
+                init_telemetry.feature.server_side_derived_summary = True
+
+            return wi.init(run_settings, run_config)
 
     except KeyboardInterrupt as e:
         if wl:

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 import wandb
 import wandb.integration.sagemaker as sagemaker
-from wandb.sdk.lib import import_hooks
+from wandb.sdk.lib import import_hooks, wb_logging
 
 from . import wandb_settings
 from .lib import config_util, server
@@ -294,6 +294,7 @@ def singleton() -> _WandbSetup | None:
         return None
 
 
+@wb_logging.log_to_all_runs()
 def _setup(
     settings: Settings | None = None,
     start_service: bool = True,
@@ -382,6 +383,7 @@ def setup(settings: Settings | None = None) -> _WandbSetup:
     return _setup(settings=settings)
 
 
+@wb_logging.log_to_all_runs()
 def teardown(exit_code: int | None = None) -> None:
     """Waits for wandb to finish and frees resources.
 


### PR DESCRIPTION
Defines the `wb_logging` module to filter out log messages for other runs from a run's log file.

Since most of our log statements don't include a run ID, to support multiple simultaneous active runs we need to direct only relevant log messages to each run's `debug.log` file. Without this PR, all log messages go to all runs' log files. With this PR, log messages that are known to be irrelevant to a run (due to `wb_logging.log_to_run(...)` being used for another run ID) are filtered out.

Messages logged outside the context of `wb_logging.log_to_run` are written to all runs' log files with a `[no run ID]` prefix. This can happen if we forget to use `wb_logging.log_to_run()` somewhere, or if a message really is not run-specific.

This only affects logging handlers added through `wb_logging.add_file_handler()`, so it does not affect log messages from `legacy-service` which go to `debug-internal.log` or those from the CLI. I am not sure where messages from the public API go; I think we do not store them?

NOTE: There is old code that uses logging to output to the console, which was always wrong but worked on occasion. I found one instance of this in our Jupyter code and fixed all messages that look like they should be user-facing, but I don't have a way to find all instances.