### PR TITLE
chore: remove the derived_summary from default setting

### DIFF
--- a/tools/perf/scripts/bench_run_log.py
+++ b/tools/perf/scripts/bench_run_log.py
@@ -463,7 +463,6 @@ class Experiment:
                 config=result_data if self.run_id is None else None,
                 settings=wandb.Settings(
                     init_timeout=init_timeout,
-                    x_server_side_derived_summary=True,
                 ),
             )
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Remove derived_summary from default setting as it is supported on certain version of the backend. Will use env variable to configure it instead.


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [X] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Locally

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
