### PR TITLE
chore(launch): reduce W&B Launch Docker image size

### DIFF
--- a/tools/launch_release/build/Dockerfile
+++ b/tools/launch_release/build/Dockerfile
@@ -1,8 +1,15 @@
-FROM python:3.9-slim-bullseye
-LABEL maintainer='Weights & Biases <support@wandb.com>'
+ARG REF="main"
 
-# Install Go.
-COPY --from=golang:1.23-alpine /usr/local/go/ /usr/local/go/
+ARG PYTHON_VERSION=3.12
+ARG GOLANG_VERSION=1.24
+ARG RUST_VERSION=1.85.0
+
+FROM golang:${GOLANG_VERSION}-alpine as golang
+FROM rust:${RUST_VERSION}-slim-bullseye as rust
+FROM python:${PYTHON_VERSION}-slim-bullseye as builder
+
+# Install Go
+COPY --from=golang /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Set Go environment paths
@@ -12,26 +19,36 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 # Set up Go workspace directories
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
-# Install Rust using Rustup
-RUN apt-get update && apt-get install -y curl && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    apt-get remove -y curl && apt-get -qy autoremove && \
-    apt-get clean && rm -r /var/lib/apt/lists/*
-ENV PATH="/root/.cargo/bin:${PATH}"
+# Install Rust
+COPY --from=rust /usr/local/cargo /usr/local/cargo
+COPY --from=rust /usr/local/rustup /usr/local/rustup
 
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV RUST_VERSION=${RUST_VERSION}
+ENV PATH="/usr/local/cargo/bin:${PATH}"
 
-# install git
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y git gcc python3-dev \
-    && apt-get -qy autoremove \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
+# Install other dependencies
+RUN apt-get update && apt-get install -y gcc wget unzip
+RUN pip install --upgrade pip build
 
-# required pip packages
-ARG REF="main"
-RUN pip install --upgrade pip && \
-    pip uninstall -y setuptools && \
-    pip install --no-cache-dir git+https://github.com/wandb/wandb.git@$REF#egg=wandb[launch]
-# user set up
+# Build W&B wheel
+WORKDIR /tmp
+ARG REF
+RUN wget https://github.com/wandb/wandb/archive/${REF}.zip -O wandb.zip && unzip wandb.zip && rm wandb.zip && mv wandb-* wandb
+
+WORKDIR /tmp/wandb
+RUN python -m build -w
+
+# Prepare actual image
+FROM python:${PYTHON_VERSION}-slim-bullseye
+LABEL maintainer='Weights & Biases <support@wandb.com>'
+
+COPY --from=builder /tmp/wandb/dist/*.whl /tmp
+
+RUN pip install --no-cache-dir $(ls /tmp/*.whl)[launch] && rm /tmp/*.whl
+
+# User set up
 RUN useradd -m -s /bin/bash --create-home --no-log-init -u 1000 -g 0 launch_agent
 USER launch_agent
 WORKDIR /home/launch_agent


### PR DESCRIPTION
Description
-----------
(Assuming `tools/launch_release/build/Dockerfile` is used to build https://hub.docker.com/r/wandb/launch-agent )
I found the W&B Launch Agent Docker image to be unexpectedly large, using 3.09 GB when pulled into Docker.

Checking the Dockerfile various issues become apparent: The Go and Rust toolchains remain in the final image, and `apt-get upgrade` replaces large parts of the distribution base image.

To address the size, find a proposal Dockerfile for a multi stage Docker build first building a wheel, then installing it in a rather empty image, ensuring a smaller result. Additionally, Python is bumped to 3.12, and Rust is taken from the Rust Docker image  similar to Go.

Potentially using alpine-based base images might further reduce the size, but switching from glibc to muslc might need more careful consideration.

Size reduction uncompressed by roughly 2.3 GiB, compressed layer sized I have not checked but it should be of similar significance.

```
REPOSITORY           TAG                    IMAGE ID       CREATED          SIZE
wandb_launch-agent   multistage                            32 minutes ago   764MB
wandb/launch-agent   0.19.3                 622e6714f5cf   6 weeks ago      3.09GB
```

Testing
-------

The Docker image was started and started successfully. However, no in-depth tests were performed.