### PR TITLE
fix: round floating point numbers in wandb.histogram to avoid floating point precision issues.

### DIFF
--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -78,6 +78,26 @@ def test_np_histogram():
     assert len(wbhist.histogram) == 10
 
 
+def test_np_histogram_rounds_data():
+    precision = np.finfo(float).precision
+
+    # This number is just above the precision of the float for the machine
+    histogram_number = 0.123 + (10 ** -(precision + 1))
+
+    data = np.array([histogram_number])
+    wbhist = wandb.Histogram(data, num_bins=4)
+
+    # Check that out data will only map to one bin
+    are_close = np.isclose(
+        wbhist.bins, histogram_number, rtol=np.finfo(float).resolution
+    )
+    assert np.count_nonzero(are_close) == 1
+    bin_idx = np.where(are_close)[0][0]
+
+    assert wbhist.bins[bin_idx] == np.round(histogram_number, precision)
+    assert wbhist.histogram[bin_idx] == 1
+
+
 def test_manual_histogram():
     wbhist = wandb.Histogram(
         np_histogram=(

--- a/wandb/sdk/data_types/histogram.py
+++ b/wandb/sdk/data_types/histogram.py
@@ -74,6 +74,9 @@ class Histogram(WBValue):
                 "numpy", required="Auto creation of histograms requires numpy"
             )
 
+            max_precision = np.finfo(float).precision
+            sequence = [round(x, max_precision) for x in sequence]
+
             histogram, bins = np.histogram(sequence, bins=num_bins)
             self.histogram = histogram.tolist()
             self.bins = bins.tolist()

--- a/wandb/sdk/data_types/histogram.py
+++ b/wandb/sdk/data_types/histogram.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
@@ -49,8 +51,8 @@ class Histogram(WBValue):
 
     def __init__(
         self,
-        sequence: Optional[Sequence] = None,
-        np_histogram: Optional["NumpyHistogram"] = None,
+        sequence: Sequence[int | float] | None = None,
+        np_histogram: NumpyHistogram | None = None,
         num_bins: int = 64,
     ) -> None:
         if np_histogram:
@@ -74,8 +76,9 @@ class Histogram(WBValue):
                 "numpy", required="Auto creation of histograms requires numpy"
             )
 
-            max_precision = np.finfo(float).precision
-            sequence = [round(x, max_precision) for x in sequence]
+            if sequence is not None:
+                max_precision = np.finfo(float).precision
+                sequence = [round(x, max_precision) for x in sequence]
 
             histogram, bins = np.histogram(sequence, bins=num_bins)
             self.histogram = histogram.tolist()

--- a/wandb/sdk/data_types/histogram.py
+++ b/wandb/sdk/data_types/histogram.py
@@ -77,6 +77,9 @@ class Histogram(WBValue):
             )
 
             if sequence is not None:
+                # Round values to max system precision to avoid numpy histogram binning errors.
+                # This fixes an issue where numpy creates incorrect histogram bins when values
+                # have more decimal places than supported by system floating point precision.
                 max_precision = np.finfo(float).precision
                 sequence = [round(x, max_precision) for x in sequence]
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-21547

What does the PR do? Include a concise description of the PR contents.

This PR fixes an issue when passing data to `wandb.histogram` where the number exceeds the precision supported on the machine then it could truncate the data incorrectly. Specifically this happens in numpy when trying to determine the proper bins for a histogram.
Instead we will use the numpy provided info of the system support precision and round the data.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- Test script
```python
import wandb
import numpy as np

run = wandb.project="npfix")

hist = wandb.Histogram(
    [0.1230000000000001],
    num_bins=4,
)

run.log({"hist": hist})
run.finish()
```

### Before this change
![image](https://github.com/user-attachments/assets/f3f10d2c-edc8-4d32-8417-7e084e73b760)

### After this change
![image](https://github.com/user-attachments/assets/889829d8-13ca-40e7-adc5-bd44f63f9c8d)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
