### PR TITLE
fix: default reinit to "finish_previous" in notebooks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,15 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Added
+
+- The `reinit` setting can be set to `"default"` (@timoffex in https://github.com/wandb/wandb/pull/9569)
+
 ### Changed
 
 - Boolean values for the `reinit` setting are deprecated; use "return_previous" and "finish_previous" instead (@timoffex in https://github.com/wandb/wandb/pull/9557)
+
+### Fixed
+
+- Calling `wandb.init()` in a notebook finishes previous runs as previously documented (@timoffex in https://github.com/wandb/wandb/pull/9569)
+    - Bug introduced in 0.19.0

--- a/tests/assets/notebooks/init_finishes_previous.ipynb
+++ b/tests/assets/notebooks/init_finishes_previous.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import wandb\n",
+    "\n",
+    "run1 = wandb.init()\n",
+    "run2 = wandb.init()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"run1 finished? {run1._is_finished}\")\n",
+    "print(f\"run1 is run2? {run1 is run2}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -38,6 +38,13 @@ def test_one_cell(notebook, run_id):
         assert run_id in output
 
 
+def test_init_finishes_previous_by_default(notebook):
+    with notebook("init_finishes_previous.ipynb") as nb:
+        nb.execute_all()
+        output = nb.cell_output_text(1)
+        assert output == "run1 finished? True\nrun1 is run2? False\n"
+
+
 def test_magic(notebook):
     with notebook("magic.ipynb") as nb:
         nb.execute_all()

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -222,7 +222,15 @@ def init(
     mode: Literal["online", "offline", "disabled"] | None = None,
     force: bool | None = None,
     anonymous: Literal["never", "allow", "must"] | None = None,
-    reinit: bool | Literal["return_previous", "finish_previous"] | None = None,
+    reinit: (
+        bool
+        | Literal[
+            None,
+            "default",
+            "return_previous",
+            "finish_previous",
+        ]
+    ) = None,
     resume: bool | Literal["allow", "never", "must", "auto"] | None = None,
     resume_from: str | None = None,
     fork_from: str | None = None,

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -149,7 +149,15 @@ def init(
     mode: Literal["online", "offline", "disabled"] | None = None,
     force: bool | None = None,
     anonymous: Literal["never", "allow", "must"] | None = None,
-    reinit: bool | Literal["return_previous", "finish_previous"] | None = None,
+    reinit: (
+        bool
+        | Literal[
+            None,
+            "default",
+            "return_previous",
+            "finish_previous",
+        ]
+    ) = None,
     resume: bool | Literal["allow", "never", "must", "auto"] | None = None,
     resume_from: str | None = None,
     fork_from: str | None = None,

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -262,11 +262,20 @@ class Settings(BaseModel, validate_assignment=True):
     quiet: bool = False
     """Flag to suppress non-essential output."""
 
-    reinit: Literal["return_previous", "finish_previous"] | bool = "return_previous"
+    reinit: (
+        Literal[
+            "default",
+            "return_previous",
+            "finish_previous",
+        ]
+        | bool
+    ) = "default"
     """What to do when `wandb.init()` is called while a run is active.
 
     Options:
-    - "return_previous" (default): Return the active run.
+    - "default": Use "finish_previous" in notebooks and "return_previous"
+        otherwise.
+    - "return_previous": Return the active run.
     - "finish_previous": Finish the active run, then return a new one.
 
     Can also be a boolean, but this is deprecated. False is the same as


### PR DESCRIPTION
Adds a `"default"` option to `reinit` that behaves like `"finish_previous"` in notebooks and `"return_previous"` elsewhere.

Originally broken in 0.19.0 in https://github.com/wandb/wandb/pull/8649. The type of `reinit` used to be incorrectly annotated as `bool` but initialized to `None`. After that PR rewrote Settings using pydantic, `reinit` started to be initialized to `False` instead of `None`. Then https://github.com/wandb/wandb/pull/9445 removed the `settings._jupyter` check in `wandb_init.py` because 

```
settings.reinit or (settings._jupyter and settings.reinit is not False)
```

was equivalent to `settings.reinit` since `reinit` could not be `None`.