### PR TITLE
fix: resuming a run would overwrite image masks

### DIFF
--- a/core/internal/runconfig/runconfig.go
+++ b/core/internal/runconfig/runconfig.go
@@ -130,8 +130,9 @@ func (rc *RunConfig) MergeResumedConfig(oldConfig map[string]any) {
 	// Add any top-level keys that aren't already set.
 	rc.addUnsetKeysFromSubtree(oldConfig, nil)
 
-	// When resuming a run, we want to ensure the some of the old keys from the config are maintained.
-	// So we have this logic here to add back in any keys that were in the old config but not in the new config
+	// When resuming a run, we want to ensure the some of the old configs keys
+	// are maintained. So we have this logic here to add back
+	// any keys that were in the old config but not in the new config
 	for _, key := range []string{"viz", "visualize", "mask/class_labels"} {
 		rc.addUnsetKeysFromSubtree(oldConfig, []string{"_wandb", key})
 	}

--- a/core/internal/runconfig/runconfig.go
+++ b/core/internal/runconfig/runconfig.go
@@ -130,18 +130,11 @@ func (rc *RunConfig) MergeResumedConfig(oldConfig map[string]any) {
 	// Add any top-level keys that aren't already set.
 	rc.addUnsetKeysFromSubtree(oldConfig, nil)
 
-	// When a user logs visualizations, we unfortunately store them in the
-	// run's config. When resuming a run, we want to avoid erasing previously
-	// logged visualizations, hence this special handling.
-	rc.addUnsetKeysFromSubtree(
-		oldConfig,
-		[]string{"_wandb", "visualize"},
-	)
-
-	rc.addUnsetKeysFromSubtree(
-		oldConfig,
-		[]string{"_wandb", "viz"},
-	)
+	// When resuming a run, we want to ensure the some of the old keys from the config are maintained.
+	// So we have this logic here to add back in any keys that were in the old config but not in the new config
+	for _, key := range []string{"viz", "visualize", "mask/class_labels"} {
+		rc.addUnsetKeysFromSubtree(oldConfig, []string{"_wandb", key})
+	}
 }
 
 func (rc *RunConfig) addUnsetKeysFromSubtree(

--- a/tests/system_tests/test_core/test_resume.py
+++ b/tests/system_tests/test_core/test_resume.py
@@ -103,12 +103,12 @@ def test_resume_output_log(wandb_backend_spy):
 
 
 def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
-    img_array = np.zeros((100, 100, 3), dtype=np.uint8)
-    mask_array = np.zeros((100, 100), dtype=np.uint8)
-    mask_array[30:70, 30:70] = 1
+    img_array = np.zeros((2, 2, 3), dtype=np.uint8)
+    mask_array = np.zeros((1, 1), dtype=np.uint8)
+    mask_array[0, 0] = 1
     class_labels = {1: "square"}
 
-    with wandb.init(project="config_preservation") as run:
+    with wandb.init() as run:
         run.log(
             {
                 "test_image": wandb.Image(
@@ -123,12 +123,9 @@ def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
             }
         )
 
-        run_id = run.id
-        run.finish()
-
     # Verify the config from the initial run
     with wandb_backend_spy.freeze() as snapshot:
-        config = snapshot.config(run_id=run_id)
+        config = snapshot.config(run_id=run.id)
         assert "_wandb" in config
         wandb_config = config["_wandb"]["value"]
 
@@ -138,9 +135,8 @@ def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
 
     # Resume the run
     with wandb.init(
-        id=run_id,
+        id=run.id,
         resume="must",
-        project="config_preservation",
     ) as run:
         run.log(
             {
@@ -158,7 +154,7 @@ def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
 
     # Validate config after resuming and adding another item
     with wandb_backend_spy.freeze() as snapshot:
-        resumed_config = snapshot.config(run_id=run_id)
+        resumed_config = snapshot.config(run_id=run.id)
         assert "_wandb" in resumed_config
         resumed_wandb_config = resumed_config["_wandb"]["value"]
 

--- a/tests/system_tests/test_core/test_resume.py
+++ b/tests/system_tests/test_core/test_resume.py
@@ -142,7 +142,5 @@ def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
         resumed_config = snapshot.config(run_id=run.id)
         class_labels = resumed_config["_wandb"]["value"]["mask/class_labels"]
 
-        assert "test_image_wandb_delimeter_prediction" in resumed_item_config
-        assert (
-            "test_image_after_resume_wandb_delimeter_prediction" in resumed_item_config
-        )
+        assert "test_image_wandb_delimeter_prediction" in class_labels
+        assert "test_image_after_resume_wandb_delimeter_prediction" in class_labels

--- a/tests/system_tests/test_core/test_resume.py
+++ b/tests/system_tests/test_core/test_resume.py
@@ -123,21 +123,7 @@ def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
             }
         )
 
-    # Verify the config from the initial run
-    with wandb_backend_spy.freeze() as snapshot:
-        config = snapshot.config(run_id=run.id)
-        assert "_wandb" in config
-        wandb_config = config["_wandb"]["value"]
-
-        item_config = wandb_config.get("mask/class_labels", {})
-        initial_item_keys = set(item_config.keys())
-        assert len(initial_item_keys) > 0
-
-    # Resume the run
-    with wandb.init(
-        id=run.id,
-        resume="must",
-    ) as run:
+    with wandb.init(id=run.id, resume="must") as run:
         run.log(
             {
                 "test_image_after_resume": wandb.Image(
@@ -152,18 +138,13 @@ def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
             }
         )
 
-    # Validate config after resuming and adding another item
     with wandb_backend_spy.freeze() as snapshot:
         resumed_config = snapshot.config(run_id=run.id)
         assert "_wandb" in resumed_config
         resumed_wandb_config = resumed_config["_wandb"]["value"]
-
         resumed_item_config = resumed_wandb_config.get("mask/class_labels", {})
-        resumed_item_keys = set(resumed_item_config.keys())
 
-        # Verify that all original keys are preserved
-        assert initial_item_keys.issubset(resumed_item_keys)
-
-        # Verify that we have new keys
-        new_keys = resumed_item_keys - initial_item_keys
-        assert len(new_keys) > 0
+        assert "test_image_wandb_delimeter_prediction" in resumed_item_config
+        assert (
+            "test_image_after_resume_wandb_delimeter_prediction" in resumed_item_config
+        )

--- a/tests/system_tests/test_core/test_resume.py
+++ b/tests/system_tests/test_core/test_resume.py
@@ -140,9 +140,7 @@ def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
 
     with wandb_backend_spy.freeze() as snapshot:
         resumed_config = snapshot.config(run_id=run.id)
-        assert "_wandb" in resumed_config
-        resumed_wandb_config = resumed_config["_wandb"]["value"]
-        resumed_item_config = resumed_wandb_config.get("mask/class_labels", {})
+        class_labels = resumed_config["_wandb"]["value"]["mask/class_labels"]
 
         assert "test_image_wandb_delimeter_prediction" in resumed_item_config
         assert (

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -47,8 +47,9 @@ class ConfigState:
         # Add any top-level keys that aren't already set.
         self._add_unset_keys_from_subtree(old_config_tree, [])
 
-        # When resuming a run, we want to ensure the some of the old keys from the config are maintained.
-        # So we have this logic here to add back in any keys that were in the old config but not in the new config
+        # When resuming a run, we want to ensure the some of the old configs keys
+        # are maintained. So we have this logic here to add back
+        # any keys that were in the old config but not in the new config
         for key in ["viz", "visualize", "mask/class_labels"]:
             self._add_unset_keys_from_subtree(
                 old_config_tree,

--- a/wandb/sdk/internal/sender_config.py
+++ b/wandb/sdk/internal/sender_config.py
@@ -47,17 +47,13 @@ class ConfigState:
         # Add any top-level keys that aren't already set.
         self._add_unset_keys_from_subtree(old_config_tree, [])
 
-        # Unfortunately, when a user logs visualizations, we store them in the
-        # run's config. When resuming a run, we want to avoid erasing previously
-        # logged visualizations, hence this special handling:
-        self._add_unset_keys_from_subtree(
-            old_config_tree,
-            [_WANDB_INTERNAL_KEY, "visualize"],
-        )
-        self._add_unset_keys_from_subtree(
-            old_config_tree,
-            [_WANDB_INTERNAL_KEY, "viz"],
-        )
+        # When resuming a run, we want to ensure the some of the old keys from the config are maintained.
+        # So we have this logic here to add back in any keys that were in the old config but not in the new config
+        for key in ["viz", "visualize", "mask/class_labels"]:
+            self._add_unset_keys_from_subtree(
+                old_config_tree,
+                [_WANDB_INTERNAL_KEY, key],
+            )
 
     def _add_unset_keys_from_subtree(
         self,

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1551,9 +1551,6 @@ class Run:
         # Grab the config from resuming
         if run_obj.config:
             c_dict = config_util.dict_no_value_from_proto_list(run_obj.config.update)
-            # TODO: Windows throws a wild error when this is set...
-            if "_wandb" in c_dict:
-                del c_dict["_wandb"]
             # We update the config object here without triggering the callback
             self._config._update(c_dict, allow_val_change=True, ignore_locked=True)
         # Update the summary, this will trigger an un-needed graphql request :(


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-15237

What does the PR do? Include a concise description of the PR contents.

When resuming a run, the image mask is not carried over to the new run config. This causes the original image to lose any image masks which it had.
This change adds `masks/class_labels` config key as one of the keys which should be copied over during run resume.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
