### PR TITLE
fix: test failures due to fastcore upgrade to 1.8.0

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - Boolean values for the `reinit` setting are deprecated; use "return_previous" and "finish_previous" instead (@timoffex in https://github.com/wandb/wandb/pull/9557)
 - The "wandb" logger is configured with `propagate=False` at import time, whereas it previously happened when starting a run. This may change the messages observed by the root logger in some workflows (@timoffex in https://github.com/wandb/wandb/pull/9540)
+- Metaflow now requires `plum-dispatch` package. (@jacobromero in https://github.com/wandb/wandb/pull/9599)
 
 ### Fixed
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -50,7 +50,7 @@ jax[cpu]
 lightning
 ray[air,tune]
 
-fastcore
+plum-dispatch
 pyarrow
 metaflow
 xgboost

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -51,7 +51,7 @@ lightning
 ray[air,tune]
 
 # Latest version of plum-dispatch tested is 2.5.7
-plum-dispatch>=2.0.0,<=2.5.7
+plum-dispatch>=2.0.0,<3.0.0
 pyarrow
 metaflow
 xgboost

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -50,7 +50,8 @@ jax[cpu]
 lightning
 ray[air,tune]
 
-plum-dispatch
+# Latest version of plum-dispatch tested is 2.5.7
+plum-dispatch>=2.0.0,<=2.5.7
 pyarrow
 metaflow
 xgboost


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

This PR fixes some tests that are failing due to a fastcore release ([v1.8.0](https://github.com/AnswerDotAI/fastcore/releases/tag/1.8.0)) which removes the `@typedispatch` annotation. [Migration guide](https://answerdotai.github.io/fasttransform/fastcore_migration_guide.html) suggests using plum-dispatch's `@dispatch` decorator as a replacement.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
