### PR TITLE
fix: delete file API fails when passing internal project id

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,4 +29,5 @@ Section headings should be at level 3 (e.g. `### Added`).
     - Bug introduced in 0.19.0
 - Fixed an error being thrown when logging `jpg`/`jpeg` images containing transparency data (@jacobromero in https://github.com/wandb/wandb/pull/9527)
 - `wandb.init(resume_from=...)` now works without explicitly specifying the run's `id` (@kptkin in https://github.com/wandb/wandb/pull/9572)
-- Fixed an error that would occur when trying to delete files with the Public API. (@jacobromero in https://github.com/wandb/wandb/pull/9604)
+- Deleting files with the Public API works again (@jacobromero in https://github.com/wandb/wandb/pull/9604)
+    - Bug introduced in 0.19.1

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,3 +29,4 @@ Section headings should be at level 3 (e.g. `### Added`).
     - Bug introduced in 0.19.0
 - Fixed an error being thrown when logging `jpg`/`jpeg` images containing transparency data (@jacobromero in https://github.com/wandb/wandb/pull/9527)
 - `wandb.init(resume_from=...)` now works without explicitly specifying the run's `id` (@kptkin in https://github.com/wandb/wandb/pull/9572)
+- Fixed an error that would occur when trying to delete files with the Public API. (@jacobromero in https://github.com/wandb/wandb/pull/9604)

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -81,6 +81,7 @@ def stub_run_gql_once(user, wandb_backend_spy):
                     "internalId": "testinternalid",
                     "run": {
                         "id": id,
+                        "projectId": "123",
                         "tags": [],
                         "name": "test",
                         "displayName": "test",

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -36,6 +36,7 @@ WANDB_INTERNAL_KEYS = {"_wandb", "wandb_version"}
 
 RUN_FRAGMENT = """fragment RunFragment on Run {
     id
+    projectId
     tags
     name
     displayName
@@ -444,7 +445,11 @@ class Run(Attrs):
                 raise ValueError("Could not find run {}".format(self))
             self._attrs = response["project"]["run"]
             self._state = self._attrs["state"]
-            self._project_internal_id = response["project"].get("internalId", None)
+
+            self._project_internal_id = (
+                int(self._attrs["projectId"]) if "projectId" in self._attrs else None
+            )
+
             if self._include_sweeps and self.sweep_name and not self.sweep:
                 # There may be a lot of runs. Don't bother pulling them all
                 # just for the sake of this one.

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -422,7 +422,6 @@ class Run(Attrs):
             """
         query Run($project: String!, $entity: String!, $name: String!) {{
             project(name: $project, entityName: $entity) {{
-                {}
                 run(name: $name) {{
                     ...RunFragment
                 }}
@@ -430,8 +429,6 @@ class Run(Attrs):
         }}
         {}
         """.format(
-                # Only query internalId if the server supports it
-                "internalId" if self._server_provides_internal_id_for_project() else "",
                 RUN_FRAGMENT,
             )
         )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-23206

What does the PR do? Include a concise description of the PR contents.

This PR fixes a bug where the delete file API would fail due to 
`CommError: could not unmarshal "..." (string) into int32: incompatible type (Error 500: Internal Server Error)`
Due to the SDK passing an base64 encoded string of the project ID but the server expecting the integer version of the project id.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- Test script 
```
import wandb
import numpy as np

run = wandb.init(project="testDelete")
run_id = run.id

image = wandb.Image(np.random.rand(100, 100, 3))
run.log({"image": image})
run.finish()

api = wandb.Api()
run = api.run(f"testDelete/{run_id}")
print(run.entity)
for file in run.files():
    print(file)
    file.delete()
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
