### PR TITLE
refactor: share gpu_stats process between multiple runs

### DIFF
--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -142,6 +142,8 @@ type StreamParams struct {
 	Sentry     *sentry_ext.Client
 	LoggerPath string
 	LogLevel   slog.Level
+
+	GPUResourceManager *monitor.GPUResourceManager
 }
 
 // NewStream creates a new stream with the given settings and responders.
@@ -237,9 +239,14 @@ func NewStream(
 			Operations:        operations,
 			OutChan:           make(chan *spb.Result, BufferSize),
 			Settings:          s.settings,
-			SystemMonitor:     monitor.NewSystemMonitor(s.logger, s.settings, s.runWork),
-			TBHandler:         tbHandler,
-			TerminalPrinter:   terminalPrinter,
+			SystemMonitor: monitor.NewSystemMonitor(
+				s.logger,
+				s.settings,
+				s.runWork,
+				params.GPUResourceManager,
+			),
+			TBHandler:       tbHandler,
+			TerminalPrinter: terminalPrinter,
 		},
 	)
 

--- a/core/pkg/monitor/gpuresourcemanager.go
+++ b/core/pkg/monitor/gpuresourcemanager.go
@@ -1,0 +1,171 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type GPUResourceManagerRef int
+
+// GPUResourceManager manages costly resources used for GPU metrics.
+type GPUResourceManager struct {
+	mu sync.Mutex
+
+	// collectorProcess is the side process for reading GPU metrics.
+	collectorProcess *exec.Cmd
+
+	// collectorConn is the gRPC connection to the GPU collector process.
+	collectorConn *grpc.ClientConn
+
+	// collectorClient is the gRPC client for the SystemMonitorService.
+	collectorClient spb.SystemMonitorServiceClient
+
+	// refs is the set of users of the GPU collector process.
+	//
+	// The process is kept alive while this is nonempty. It is shut down when
+	// this becomes empty.
+	refs      map[GPUResourceManagerRef]struct{}
+	nextRefId int
+}
+
+// NewGPUResourceManager creates a GPUResourceManager.
+func NewGPUResourceManager() *GPUResourceManager {
+	return &GPUResourceManager{refs: map[GPUResourceManagerRef]struct{}{}}
+}
+
+// Acquire returns a gRPC client for the GPU monitoring process.
+//
+// The first call to Acquire starts the process. The returned reference ID
+// must eventually be passed to Release to free resources.
+func (m *GPUResourceManager) Acquire() (
+	spb.SystemMonitorServiceClient,
+	GPUResourceManagerRef,
+	error,
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.collectorConn == nil {
+		err := m.startGPUCollector()
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	refID := GPUResourceManagerRef(m.nextRefId)
+	m.nextRefId++
+	m.refs[refID] = struct{}{}
+	return m.collectorClient, refID, nil
+}
+
+// Release marks the reference unused.
+//
+// Releasing the same ref twice is a no-op.
+//
+// If the reference count hits zero, it shuts down the GPU collector process.
+func (m *GPUResourceManager) Release(ref GPUResourceManagerRef) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.refs, ref)
+	if len(m.refs) > 0 {
+		return
+	}
+
+	proc := m.collectorProcess
+	conn := m.collectorConn
+	client := m.collectorClient
+	m.collectorProcess = nil
+	m.collectorConn = nil
+	m.collectorClient = nil
+
+	go func() {
+		// We shut down the client on a best-effort basis.
+		// Any errors are ignored.
+		_, _ = client.TearDown(context.Background(), &spb.TearDownRequest{})
+		_ = conn.Close()
+
+		// NOTE: This may block indefinitely if the process fails to exit.
+		_ = proc.Wait()
+	}()
+}
+
+func (m *GPUResourceManager) startGPUCollector() error {
+	pf := NewPortfile()
+	if pf == nil {
+		return errors.New("monitor: could not create portfile")
+	}
+	defer func() { _ = pf.Delete() }()
+
+	cmdPath, err := getGPUCollectorCmdPath()
+	if err != nil {
+		return fmt.Errorf("monitor: could not get path to GPU binary: %v", err)
+	}
+
+	cmd := exec.Command(
+		cmdPath,
+		"--portfile", pf.path,
+		"--ppid", strconv.Itoa(os.Getpid()),
+	)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("monitor: could not start GPU binary: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	port, err := pf.Read(ctx)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		return fmt.Errorf("monitor: could not get GPU binary port: %v", err)
+	}
+
+	conn, err := grpc.NewClient(
+		fmt.Sprintf("127.0.0.1:%d", port),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+
+	if err != nil {
+		_ = cmd.Process.Kill()
+		return fmt.Errorf(
+			"monitor: could not make gRPC connection to GPU binary: %v",
+			err)
+	}
+
+	m.collectorProcess = cmd
+	m.collectorConn = conn
+	m.collectorClient = spb.NewSystemMonitorServiceClient(conn)
+	return nil
+}
+
+// getGPUCollectorCmdPath returns the path to the gpu_stats binary.
+func getGPUCollectorCmdPath() (string, error) {
+	ex, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	exDirPath := filepath.Dir(ex)
+	exPath := filepath.Join(exDirPath, "gpu_stats")
+
+	// append .exe if running on Windows
+	if runtime.GOOS == "windows" {
+		exPath += ".exe"
+	}
+
+	if _, err := os.Stat(exPath); os.IsNotExist(err) {
+		return "", err
+	}
+	return exPath, nil
+}

--- a/core/pkg/monitor/monitor_test.go
+++ b/core/pkg/monitor/monitor_test.go
@@ -16,6 +16,7 @@ func newTestSystemMonitor() *monitor.SystemMonitor {
 		observability.NewNoOpLogger(),
 		settings.From(&spb.Settings{}),
 		runworktest.New(),
+		monitor.NewGPUResourceManager(),
 	)
 }
 

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/stream"
 
+	"github.com/wandb/wandb/core/pkg/monitor"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -28,7 +29,9 @@ const (
 )
 
 type ConnectionParams struct {
-	StreamMux    *stream.StreamMux
+	StreamMux          *stream.StreamMux
+	GPUResourceManager *monitor.GPUResourceManager
+
 	Conn         net.Conn
 	SentryClient *sentry_ext.Client
 	Commit       string
@@ -57,6 +60,9 @@ type Connection struct {
 	// A map that associates stream IDs with active streams (or runs). This helps
 	// track the streams associated with this connection.
 	streamMux *stream.StreamMux
+
+	// gpuResourceManager is used by streams for system GPU metrics.
+	gpuResourceManager *monitor.GPUResourceManager
 
 	// id is the unique id for the connection
 	id string
@@ -90,18 +96,19 @@ func NewConnection(
 	params ConnectionParams,
 ) *Connection {
 	return &Connection{
-		connLifetimeCtx: serverLifetimeCtx,
-		stopServer:      stopServer,
-		streamMux:       params.StreamMux,
-		conn:            params.Conn,
-		commit:          params.Commit,
-		id:              params.Conn.RemoteAddr().String(), // TODO: check if this is properly unique
-		inChan:          make(chan *spb.ServerRequest, BufferSize),
-		outChan:         make(chan *spb.ServerResponse, BufferSize),
-		closed:          &atomic.Bool{},
-		sentryClient:    params.SentryClient,
-		loggerPath:      params.LoggerPath,
-		logLevel:        params.LogLevel,
+		connLifetimeCtx:    serverLifetimeCtx,
+		stopServer:         stopServer,
+		streamMux:          params.StreamMux,
+		gpuResourceManager: params.GPUResourceManager,
+		conn:               params.Conn,
+		commit:             params.Commit,
+		id:                 params.Conn.RemoteAddr().String(), // TODO: check if this is properly unique
+		inChan:             make(chan *spb.ServerRequest, BufferSize),
+		outChan:            make(chan *spb.ServerResponse, BufferSize),
+		closed:             &atomic.Bool{},
+		sentryClient:       params.SentryClient,
+		loggerPath:         params.LoggerPath,
+		logLevel:           params.LogLevel,
 	}
 }
 
@@ -344,11 +351,12 @@ func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
 
 	strm := stream.NewStream(
 		stream.StreamParams{
-			Settings:   settings,
-			Commit:     nc.commit,
-			LogLevel:   nc.logLevel,
-			Sentry:     sentryClient,
-			LoggerPath: nc.loggerPath,
+			Settings:           settings,
+			Commit:             nc.commit,
+			LogLevel:           nc.logLevel,
+			Sentry:             sentryClient,
+			LoggerPath:         nc.loggerPath,
+			GPUResourceManager: nc.gpuResourceManager,
 		},
 	)
 	strm.AddResponders(stream.ResponderEntry{Responder: nc, ID: nc.id})

--- a/core/pkg/server/server.go
+++ b/core/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/wandb/wandb/core/internal/sentry_ext"
 	"github.com/wandb/wandb/core/internal/stream"
+	"github.com/wandb/wandb/core/pkg/monitor"
 )
 
 const (
@@ -139,6 +140,7 @@ func (s *Server) serve() {
 	slog.Info("server is running", "addr", s.listener.Addr())
 
 	streamMux := stream.NewStreamMux()
+	gpuResourceManager := monitor.NewGPUResourceManager()
 
 	// Run a separate goroutine to handle incoming connections
 	for {
@@ -158,12 +160,13 @@ func (s *Server) serve() {
 					s.serverLifetimeCtx,
 					s.stopServer,
 					ConnectionParams{
-						Conn:         conn,
-						StreamMux:    streamMux,
-						SentryClient: s.sentryClient,
-						Commit:       s.commit,
-						LoggerPath:   s.loggerPath,
-						LogLevel:     s.logLevel,
+						Conn:               conn,
+						StreamMux:          streamMux,
+						GPUResourceManager: gpuResourceManager,
+						SentryClient:       s.sentryClient,
+						Commit:             s.commit,
+						LoggerPath:         s.loggerPath,
+						LogLevel:           s.logLevel,
 					},
 				).ManageConnectionData()
 


### PR DESCRIPTION
Factors out a `monitor.GPUResourceManager` struct that manages the `gpu_stats` process and whose lifetime is tied to the server rather than a run.

When using `reinit="allow"` (added in #9562) only a single `gpu_stats` process is started up when multiple runs are active. The process is killed when no runs are active.