### PR TITLE
chore(sdk): drop unused python version constraint for typing-extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "PyYAML",
     "setproctitle",
     "platformdirs",
-    "typing_extensions>=4.4,<5; python_version < '3.12'",
+    "typing_extensions>=4.4,<5",
     "pydantic<3",
     "eval_type_backport; python_version < '3.10'",
 ]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Drops the `python_version < '3.12'` constraint on `typing-extensions`, which doesn't seem to be necessary: `pydantic` has required `typing-extensions` since `v1.10` (or earlier) regardless of Python version.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] <strike>I updated CHANGELOG.unreleased.md, or</strike> it's not applicable


Testing
-------
N/A

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
