### PR TITLE
chore: add loading animation while encoding video

### DIFF
--- a/tests/unit_tests/test_lib/test_printer_asyncio.py
+++ b/tests/unit_tests/test_lib/test_printer_asyncio.py
@@ -1,28 +1,28 @@
+from __future__ import annotations
+
 import contextlib
-import time
-from typing import Any, Iterator, List
-from unittest.mock import patch
+from typing import Any, Iterator
 
 import pytest
 from wandb.sdk.lib import printer, printer_asyncio
 from wandb.sdk.lib.printer import _PrinterTerm
 
 
-class PrinterWrapper(_PrinterTerm):
-    """A test printer that captures text set with set_text."""
+class MockDynamicTextPrinter(_PrinterTerm):
+    """Test printer that captures text set through dynamic text."""
 
     def __init__(self) -> None:
         super().__init__()
-        self._captured_text: List[str] = []
+        self._captured_text: list[str] = []
 
     @property
-    def captured_text(self) -> List[str]:
+    def captured_text(self) -> list[str]:
         return self._captured_text
 
     @contextlib.contextmanager
     def dynamic_text(self) -> Iterator[printer.DynamicText | None]:
         class TestDynamicText(printer.DynamicText):
-            def __init__(self, printer: PrinterWrapper) -> None:
+            def __init__(self, printer: MockDynamicTextPrinter) -> None:
                 self._printer = printer
 
             def set_text(self, text: str) -> None:
@@ -31,30 +31,27 @@ class PrinterWrapper(_PrinterTerm):
         yield TestDynamicText(self)
 
 
-def test_run_async_with_spinner():
-    test_printer = PrinterWrapper()
+def test_run_async_with_spinner(monkeypatch):
+    test_printer = MockDynamicTextPrinter()
+    monkeypatch.setattr(printer, "new_printer", lambda: test_printer)
 
-    with patch.object(printer, "new_printer", return_value=test_printer):
+    def slow_func() -> int:
+        return 42
 
-        def slow_func() -> int:
-            time.sleep(0.5)
-            return 42
-
-        result = printer_asyncio.run_async_with_spinner("Loading", slow_func)
-        assert result == 42
-        assert len(test_printer.captured_text) > 0
-        assert all("Loading" in text for text in test_printer.captured_text)
+    result = printer_asyncio.run_async_with_spinner("Loading", slow_func)
+    assert result == 42
+    assert len(test_printer.captured_text) > 0
+    assert all("Loading" in text for text in test_printer.captured_text)
 
 
-def test_run_async_with_spinner_exception():
-    test_printer = PrinterWrapper()
+def test_run_async_with_spinner_exception(monkeypatch):
+    test_printer = MockDynamicTextPrinter()
+    monkeypatch.setattr(printer, "new_printer", lambda: test_printer)
 
-    with patch.object(printer, "new_printer", return_value=test_printer):
+    def failing_func() -> Any:
+        raise ValueError("Test error")
 
-        def failing_func() -> Any:
-            raise ValueError("Test error")
-
-        with pytest.raises(ValueError, match="Test error"):
-            printer_asyncio.run_async_with_spinner("Loading", failing_func)
-        assert len(test_printer.captured_text) > 0
-        assert all("Loading" in text for text in test_printer.captured_text)
+    with pytest.raises(ValueError, match="Test error"):
+        printer_asyncio.run_async_with_spinner("Loading", failing_func)
+    assert len(test_printer.captured_text) > 0
+    assert all("Loading" in text for text in test_printer.captured_text)

--- a/tests/unit_tests/test_lib/test_printer_asyncio.py
+++ b/tests/unit_tests/test_lib/test_printer_asyncio.py
@@ -1,0 +1,60 @@
+import contextlib
+import time
+from typing import Any, Iterator, List
+from unittest.mock import patch
+
+import pytest
+from wandb.sdk.lib import printer, printer_asyncio
+from wandb.sdk.lib.printer import _PrinterTerm
+
+
+class PrinterWrapper(_PrinterTerm):
+    """A test printer that captures text set with set_text."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._captured_text: List[str] = []
+
+    @property
+    def captured_text(self) -> List[str]:
+        return self._captured_text
+
+    @contextlib.contextmanager
+    def dynamic_text(self) -> Iterator[printer.DynamicText | None]:
+        class TestDynamicText(printer.DynamicText):
+            def __init__(self, printer: PrinterWrapper) -> None:
+                self._printer = printer
+
+            def set_text(self, text: str) -> None:
+                self._printer._captured_text.append(text)
+
+        yield TestDynamicText(self)
+
+
+def test_run_async_with_spinner():
+    test_printer = PrinterWrapper()
+
+    with patch.object(printer, "new_printer", return_value=test_printer):
+
+        def slow_func() -> int:
+            time.sleep(0.5)
+            return 42
+
+        result = printer_asyncio.run_async_with_spinner("Loading", slow_func)
+        assert result == 42
+        assert len(test_printer.captured_text) > 0
+        assert all("Loading" in text for text in test_printer.captured_text)
+
+
+def test_run_async_with_spinner_exception():
+    test_printer = PrinterWrapper()
+
+    with patch.object(printer, "new_printer", return_value=test_printer):
+
+        def failing_func() -> Any:
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError, match="Test error"):
+            printer_asyncio.run_async_with_spinner("Loading", failing_func)
+        assert len(test_printer.captured_text) > 0
+        assert all("Loading" in text for text in test_printer.captured_text)

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Type, Union
 
 import wandb
 from wandb import util
-from wandb.sdk.lib import filesystem, runid
+from wandb.sdk.lib import filesystem, printer_asyncio, runid
 
 from . import _dtypes
 from ._private import MEDIA_TMP
@@ -74,9 +74,7 @@ class Video(BatchableMedia):
 
         run = wandb.init()
         # axes are (time, channel, height, width)
-        frames = np.random.randint(
-            low=0, high=256, size=(10, 3, 100, 100), dtype=np.uint8
-        )
+        frames = np.random.randint(low=0, high=256, size=(10, 3, 100, 100), dtype=np.uint8)
         run.log({"video": wandb.Video(frames, fps=4)})
         ```
     """
@@ -137,7 +135,7 @@ class Video(BatchableMedia):
                     "wandb.Video accepts a file path or numpy like data as input"
                 )
             fps = fps or 4
-            util.run_async_with_spinner(
+            printer_asyncio.run_async_with_spinner(
                 "Encoding video...",
                 functools.partial(self.encode, fps=fps),
             )

--- a/wandb/sdk/lib/printer_asyncio.py
+++ b/wandb/sdk/lib/printer_asyncio.py
@@ -25,7 +25,7 @@ def run_async_with_spinner(
     async def _loop_run_with_spinner(
         text: str,
         func: Callable,
-    ) -> None:
+    ) -> _T:
         func_running = asyncio.Event()
 
         async def update_spinner() -> None:

--- a/wandb/sdk/lib/printer_asyncio.py
+++ b/wandb/sdk/lib/printer_asyncio.py
@@ -1,0 +1,49 @@
+import asyncio
+import functools
+from typing import Callable, TypeVar
+
+from wandb.sdk.lib import asyncio_compat, printer
+
+_T = TypeVar("_T")
+
+
+def run_async_with_spinner(
+    text: str,
+    func: Callable[[], _T],
+) -> _T:
+    """Run an async function and display a loading icon while it runs.
+
+    Args:
+        text: The text to display next to the spinner, while the function runs.
+        func: The function to run.
+
+    Returns:
+        The result of func.
+    """
+    spinner_printer = printer.new_printer()
+
+    async def _loop_run_with_spinner(
+        text: str,
+        func: Callable,
+    ) -> None:
+        func_running = asyncio.Event()
+
+        async def update_spinner() -> None:
+            tick = 0
+            with spinner_printer.dynamic_text() as text_area:
+                if text_area:
+                    while not func_running.is_set():
+                        spinner = spinner_printer.loading_symbol(tick)
+                        text_area.set_text(f"{spinner} {text}")
+                        tick += 1
+                        await asyncio.sleep(0.1)
+                else:
+                    spinner_printer.display(text)
+
+        async with asyncio_compat.open_task_group() as group:
+            group.start_soon(update_spinner())
+            res = await asyncio.get_running_loop().run_in_executor(None, func)
+            func_running.set()
+            return res
+
+    return asyncio_compat.run(functools.partial(_loop_run_with_spinner, text, func))

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1,4 +1,3 @@
-import asyncio
 import colorsys
 import contextlib
 import dataclasses
@@ -38,7 +37,6 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
     Dict,
     Generator,
@@ -66,7 +64,7 @@ from wandb.errors import (
     term,
 )
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
-from wandb.sdk.lib import asyncio_compat, filesystem, printer, runid
+from wandb.sdk.lib import filesystem, runid
 from wandb.sdk.lib.json_util import dump, dumps
 from wandb.sdk.lib.paths import FilePathStr, StrPath
 
@@ -1997,45 +1995,3 @@ class NonOctalStringDumper(yaml.Dumper):
         if tag == "tag:yaml.org,2002:str" and value.startswith("0") and len(value) > 1:
             return super().represent_scalar(tag, value, style="'")
         return super().represent_scalar(tag, value, style)
-
-
-def run_async_with_spinner(
-    text: str,
-    func: Callable[[], Awaitable[Any]],
-) -> None:
-    """Run an async function and display a loading icon while it runs.
-
-    Args:
-        text: The text to display next to the spinner, while the function runs.
-        func: The function to run.
-
-    Returns:
-        The result of func.
-    """
-    spinner_printer = printer.new_printer()
-
-    async def _loop_run_with_spinner(
-        text: str,
-        func: Callable[[], Awaitable[any]],
-    ) -> None:
-        func_running = asyncio.Event()
-
-        async def update_spinner() -> None:
-            tick = 0
-            with spinner_printer.dynamic_text() as text_area:
-                if text_area:
-                    while not func_running.is_set():
-                        spinner = spinner_printer.loading_symbol(tick)
-                        text_area.set_text(f"{spinner} {text}...")
-                        tick += 1
-                        await asyncio.sleep(0.1)
-                else:
-                    spinner_printer.display(text)
-
-        async with asyncio_compat.open_task_group() as group:
-            group.start_soon(update_spinner())
-            res = await asyncio.get_running_loop().run_in_executor(None, func)
-            func_running.set()
-            return res
-
-    return asyncio_compat.run(functools.partial(_loop_run_with_spinner, text, func))


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-5971

What does the PR do? Include a concise description of the PR contents.
When creating a wandb.Video object with a numpy array of video frames it appears like the SDK is hanging. This is due to the fact that under the hood we are actually encoding the video and saving to a file. This PR adds a loading spinner while encoding the video to communicate that the SDK is encoding the video data.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- Sample script
```python
import wandb
import numpy as np

fps = 10
video_length = 30  # seconds
video_length_frames = fps * video_length
frames = np.random.randint(0, 256, (video_length_frames, 3, 100, 100), dtype=np.uint8)

with wandb.init(mode="offline") as run:
    run.log({"video": wandb.Video(frames, format="mp4")})

```

https://github.com/user-attachments/assets/8f4d4b9a-24dd-4da1-8a53-431f1a75d751


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
