### PR TITLE
refactor: work around bug in notebook test

### DIFF
--- a/tests/assets/notebooks/init_finishes_previous.ipynb
+++ b/tests/assets/notebooks/init_finishes_previous.ipynb
@@ -6,9 +6,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import time\n",
+    "\n",
     "import wandb\n",
     "\n",
     "run1 = wandb.init()\n",
+    "\n",
+    "# TODO(WB-23893): Remove after fixing bug.\n",
+    "#\n",
+    "# The sleep is necessary because both runs have the same ID because the notebook\n",
+    "# test fixture sets the WANDB_RUN_ID environment variable. If the runs are\n",
+    "# created too close together, they get assigned the same directory which causes\n",
+    "# a crash.\n",
+    "time.sleep(1)\n",
+    "\n",
     "run2 = wandb.init()"
    ]
   },


### PR DESCRIPTION
Adds a `time.sleep(1)` between initializing runs with `reinit="finish_previous"` to avoid issues caused by both runs getting assigned the same directory.