### PR TITLE
refactor: clean up notebook test fixture

### DIFF
--- a/tests/system_tests/test_notebooks/conftest.py
+++ b/tests/system_tests/test_notebooks/conftest.py
@@ -1,6 +1,7 @@
 import io
 import os
 import pathlib
+import re
 import shutil
 import sys
 from contextlib import contextmanager
@@ -77,34 +78,26 @@ def mocked_ipython(monkeypatch):
 
 
 class WandbNotebookClient(NotebookClient):
-    def execute_all(self, store_history: bool = True) -> list:
-        executed_cells = []
-
+    def execute_all(self, store_history: bool = True) -> None:
+        """Execute all cells in order."""
         for idx, cell in enumerate(self.nb.cells):
-            # the first cell is the setup cell
-            nb_cell_id = idx + 1
             try:
-                # print(cell)
-                executed_cell = super().execute_cell(
+                super().execute_cell(
                     cell=cell,
                     cell_index=idx,
                     store_history=False if idx == 0 else store_history,
                 )
             except CellExecutionError as e:
-                print("Cell output before exception:")  # noqa: T201
-                print("=============================")  # noqa: T201
-                for output in cell["outputs"]:
-                    if output["output_type"] == "stream":
-                        print(output["text"])  # noqa: T201
-                raise e
-            for output in executed_cell["outputs"]:
-                if output["output_type"] == "error" and nb_cell_id != 0:
-                    print(f"Error in cell: {nb_cell_id}")  # noqa: T201
-                    print("\n".join(output["traceback"]))  # noqa: T201
-                    raise ValueError(output["evalue"])
-            executed_cells.append(executed_cell)
-
-        return executed_cells
+                if sys.stderr.isatty():
+                    raise
+                else:
+                    # Strip ANSI sequences in non-TTY environments,
+                    # particularly in CI.
+                    raise CellExecutionError(
+                        _strip_ansi(e.traceback),
+                        e.ename,
+                        e.evalue,
+                    ) from None
 
     @property
     def cells(self):
@@ -163,24 +156,27 @@ class WandbNotebookClient(NotebookClient):
 
 @pytest.fixture
 def run_id() -> str:
-    """Fixture to return a fixed run id for testing."""
+    """A fixed run ID for testing."""
     return "lovely-dawn-32"
 
 
 @pytest.fixture
 def notebook(user, run_id, assets_path):
-    """Fixture to load a notebook and work with it.
+    """A context manager to run a notebook.
 
-    This launches a live server,
-    configures a notebook to use it, and enables
-    devs to execute arbitrary cells.
-    See test_notebooks.py for usage.
+    The context manager returns a WandbNotebookClient that can be used to
+    execute cells and retrieve their output.
+
+    Args:
+        nb_name: The notebook file to load from the assets directory.
+        kernel_name: The kernel to use to run the notebook.
+        notebook_type: Whether to configure wandb to treat this as a Jupyter
+            (web) or iPython (console) notebook.
+        save_code: Whether to enable wandb code saving in the setup cell.
+        skip_api_key_env: Whether to pretend that no API key is set to cause
+            wandb to attempt to log in.
     """
-    # wandb-related env vars:
-    wandb_env = {k: v for k, v in os.environ.items() if k.startswith("WANDB")}
-
-    # lovely-dawn-32 is run id we use for testing
-    wandb_env["WANDB_RUN_ID"] = run_id
+    _ = user  # Run all notebooks with a fake logged-in user.
 
     @contextmanager
     def notebook_loader(
@@ -189,64 +185,55 @@ def notebook(user, run_id, assets_path):
         notebook_type: ipython.PythonType = "jupyter",
         save_code: bool = True,
         skip_api_key_env: bool = False,
-        **kwargs: Any,
     ):
-        """Sets up a copy of the provided notebook name in a temporary directory.
+        # Copy the notebook to the current directory for code-saving to work.
+        #
+        # This relies on another auto-use fixture to point CWD at a temporary
+        # path.
+        nb_path = assets_path(pathlib.Path("notebooks", nb_name))
+        shutil.copy(nb_path, nb_name)
 
-        As part of the setup process all environment variables starting with 'WANDB',
-        are copied into the notebook as an initial setup cell.
-
-        Args:
-            nb_name: The name of the notebook to load from the assets directory.
-            kernel_name: The name given to the kernel used to run the notebook.
-            notebook_type: The type of notebook to use, from the ipython.PythonType list.
-            save_code: Whether to set the WANDB_SAVE_CODE environment variable in the setup cell.
-            skip_api_key_env: Whether to delete the WANDB_API_KEY environment variable in the setup cell.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            A context manager yielding a WandbNotebookClient object. Which can be used to execute
-            the notebook cells and retrieve the output.
-        """
-        nb_path = assets_path(pathlib.Path("notebooks") / nb_name)
-        shutil.copy(nb_path, os.path.join(os.getcwd(), os.path.basename(nb_path)))
+        # Read the notebook.
         with open(nb_path) as f:
-            nb = nbformat.read(f, as_version=4)
+            nb_node: nbformat.NotebookNode = nbformat.read(f, as_version=4)
 
-        # set up extra env vars and do monkey-patching.
-        # in particular, we import and patch wandb.
-        # this goes in the first cell of the notebook.
+        wandb_env = {k: v for k, v in os.environ.items() if k.startswith("WANDB")}
+        wandb_env["WANDB_RUN_ID"] = run_id
+        if save_code:
+            wandb_env["WANDB_SAVE_CODE"] = "true"
+            wandb_env["WANDB_NOTEBOOK_NAME"] = nb_name
+        else:
+            wandb_env["WANDB_SAVE_CODE"] = "false"
+            wandb_env["WANDB_NOTEBOOK_NAME"] = ""
 
         setup_cell = io.StringIO()
 
-        # env vars, particularly to point the sdk at the live test server (local_testcontainer):
-        if not save_code:
-            wandb_env["WANDB_SAVE_CODE"] = "false"
-            wandb_env["WANDB_NOTEBOOK_NAME"] = ""
-        else:
-            wandb_env["WANDB_SAVE_CODE"] = "true"
-            wandb_env["WANDB_NOTEBOOK_NAME"] = nb_name
+        # Forward any WANDB environment variables to the notebook.
         setup_cell.write("import os\n")
         for k, v in wandb_env.items():
+            if skip_api_key_env and k == "WANDB_API_KEY":
+                continue
+
             setup_cell.write(f"os.environ['{k}'] = '{v}'\n")
-        # make wandb think we're in a specific type of notebook:
+
+        # Make wandb think we're in a specific type of notebook.
         setup_cell.write(
-            "import pytest\n"
-            "mp = pytest.MonkeyPatch()\n"
-            "import wandb\n"
-            f"mp.setattr(wandb.sdk.lib.ipython, '_get_python_type', lambda: '{notebook_type}')\n"
+            "from wandb.sdk.lib import ipython\n"
+            f"ipython._get_python_type = lambda: '{notebook_type}'\n",
         )
 
-        if skip_api_key_env:
-            setup_cell.write("mp.delenv('WANDB_API_KEY')\n")
+        nb_node.cells.insert(0, nbformat.v4.new_code_cell(setup_cell.getvalue()))
 
-        # inject:
-        nb.cells.insert(0, nbformat.v4.new_code_cell(setup_cell.getvalue()))
-
-        client = WandbNotebookClient(nb, kernel_name=kernel_name)
-        with client.setup_kernel(**kwargs):
+        client = WandbNotebookClient(nb_node, kernel_name=kernel_name)
+        with client.setup_kernel():
             yield client
 
-    notebook_loader.base_url = wandb_env.get("WANDB_BASE_URL")
-
     return notebook_loader
+
+
+_ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
+
+
+def _strip_ansi(value: str) -> str:
+    """Remove ANSI escape sequences from the string."""
+    return _ANSI_RE.sub("", value)

--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -46,6 +46,9 @@ def test_init_finishes_previous_by_default(notebook):
 
 
 def test_magic(notebook):
+    base_url = os.getenv("WANDB_BASE_URL")
+    assert base_url
+
     with notebook("magic.ipynb") as nb:
         nb.execute_all()
         iframes = 0
@@ -59,7 +62,7 @@ def test_magic(notebook):
                     assert "display:none" in out
                 text += out["data"]["text/html"]
             iframes += 1
-        assert notebook.base_url in text
+        assert base_url in text
         assert iframes == 6
 
 
@@ -73,11 +76,14 @@ def test_notebook_exits(user, assets_path):
 
 
 def test_notebook_metadata_jupyter(mocked_module, notebook):
+    base_url = os.getenv("WANDB_BASE_URL")
+    assert base_url
+
     with mock.patch("ipykernel.connect.get_connection_file") as ipyconnect:
         ipyconnect.return_value = "kernel-12345.json"
         serverapp = mocked_module("jupyter_server.serverapp")
         serverapp.list_running_servers.return_value = [
-            {"url": notebook.base_url, "notebook_dir": "/test"}
+            {"url": base_url, "notebook_dir": "/test"}
         ]
         with mock.patch.object(
             wandb.jupyter.requests,


### PR DESCRIPTION
Improves docs, removes code that doesn't do anything, reorganizes things to make more sense.

Strips ANSI escape sequences from cell execution errors when the output is not a TTY so that stack traces are readable in CI.