### PR TITLE
refactor: improve run decorator types

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -753,7 +753,7 @@ class _WandbInit:
             def __call__(self, *args: Any, **kwargs: Any) -> _ChainableNoOp:
                 return _ChainableNoOp()
 
-        drun.log_artifact = _ChainableNoOpField()  # type: ignore[method-assign]
+        drun.log_artifact = _ChainableNoOpField()  # type: ignore
         # attributes
         drun._start_time = time.time()
         drun._starting_step = 0


### PR DESCRIPTION
Improves run decorator types so that Pylance can correctly infer decorated method arguments and return values.

I'm not sure if it is a recent Pylance change, but annotating a decorator as returning a `Callable` (with no parameters) causes Pylance to treat a method's return type as `Any`. For example, VSCode fails to find the reference to `Artifact.download()` in `Run.use_model()` because of this!

This PR also removes the unnecessary `_run_decorator` wrapper class, renames decorators, adds documentation, and cleans up implementations. I also removed the `only_warn` parameter from `_raise_if_finished` (formerly `_noop_on_finish`), which was only used by `_console_raw_callback`. This is OK because `StreamRawWrapper` catches exceptions.