### PR TITLE
refactor: fail Run.use_model early when offline

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3549,6 +3549,10 @@ class Run:
         Returns:
             path: (str) path to downloaded model artifact file(s).
         """
+        if self._settings._offline:
+            # Downloading artifacts is not supported when offline.
+            raise RuntimeError("`use_model` not supported in offline mode.")
+
         artifact = self.use_artifact(artifact_or_name=name)
         if "model" not in str(artifact.type.lower()):
             raise AssertionError(


### PR DESCRIPTION
Raise an error in `Run.use_model()` when running in offline mode. The check in `Artifact.download()` relies on `wandb.run` and this cannot easily be fixed, so it is better to make it the responsibility of callers.