### PR TITLE
chore: attempt to fix test_asyncio_compat_run flake

### DIFF
--- a/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
+++ b/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
@@ -1,8 +1,11 @@
 import asyncio
 import sys
+import threading
+import time
 
 from wandb.sdk.lib import asyncio_compat
 
+_got_cancelled_lock = threading.Lock()
 _got_cancelled = False
 
 
@@ -11,33 +14,38 @@ async def pass_if_cancelled() -> None:
 
     try:
         print("TEST READY", flush=True)  # noqa: T201
+        print(f"Ready at {time.monotonic()}", file=sys.stderr)  # noqa: T201
         await asyncio.sleep(5)
 
     except asyncio.CancelledError:
         # The test sends a SIGINT to the process, which we expect
         # asyncio_compat.run() to turn into task cancellation.
-        _got_cancelled = True
+        with _got_cancelled_lock:
+            _got_cancelled = True
 
 
 if __name__ == "__main__":
     try:
         asyncio_compat.run(pass_if_cancelled)
     except KeyboardInterrupt:
-        if _got_cancelled:
+        with _got_cancelled_lock:
+            cancelled = _got_cancelled
+
+        if cancelled:
             print(  # noqa: T201
-                "PASS: Cancelled by KeyboardInterrupt!",
+                f"PASS: Cancelled by KeyboardInterrupt ({time.monotonic()})",
                 file=sys.stderr,
             )
             sys.exit(0)
         else:
             print(  # noqa: T201
-                "FAIL: Interrupted but not cancelled!",
+                f"FAIL: Interrupted but not cancelled ({time.monotonic()})",
                 file=sys.stderr,
             )
             sys.exit(1)
     else:
         print(  # noqa: T201
-            "FAIL: Not interrupted by parent.",
+            f"FAIL: Not interrupted by parent ({time.monotonic()})",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tests/system_tests/test_functional/asyncio_compat_run/test_asyncio_compat_run.py
+++ b/tests/system_tests/test_functional/asyncio_compat_run/test_asyncio_compat_run.py
@@ -2,7 +2,10 @@ import pathlib
 import signal
 import subprocess
 
+import pytest
 
+
+@pytest.mark.wandb_core_only(reason="does not depend on service")
 def test_asyncio_compat_run_stops_on_keyboard_interrupt():
     script = pathlib.Path(__file__).parent / "pass_if_cancelled.py"
     proc = subprocess.Popen(

--- a/wandb/sdk/lib/asyncio_compat.py
+++ b/wandb/sdk/lib/asyncio_compat.py
@@ -53,7 +53,7 @@ class _Runner:
     """
 
     def __init__(self) -> None:
-        self._lock = threading.Condition()
+        self._lock = threading.Lock()
 
         self._is_cancelled = False
         self._started = False


### PR DESCRIPTION
Prints timestamps in the test for future debugging, and protects access to `_got_cancelled` with a lock to ensure it is synchronized.

The test [fails on rare occasion](https://app.circleci.com/pipelines/github/wandb/wandb/45473/workflows/f02fd269-1721-4922-931f-b199d06e2d1c/jobs/1363571/tests) with the message `FAIL: Interrupted but not cancelled`. Since the `__exit__` of the `ThreadPoolExecutor` used by `asyncio_compat.run` blocks until the future completes, there are only two ways this can happen:

1. The KeyboardInterrupt is really not received by the main thread and the asyncio task is not cancelled
2. The asyncio task is cancelled, but the main thread does not observe the new value of `_got_cancelled`

If the problem is (2), the lock will fix it. If the problem is (1), the timestamps will make that clear.

---

Note that [StackOverflow](https://stackoverflow.com/a/53780395) suggests that (2) isn't possible in Python, but this could be implementation dependent ([PEP 583](https://peps.python.org/pep-0583) attempted to state some guarantees but was withdrawn). In other languages, it can happen if the two threads run on different CPUs, and the new value of the variable is stored in a CPU cache. We use Cython in CI so all threads should run on the same CPU, but maybe there's some other race that I'm not seeing.