### PR TITLE
fix: console log test expecting legacy vs structured format

### DIFF
--- a/tests/system_tests/test_functional/console/test_console.py
+++ b/tests/system_tests/test_functional/console/test_console.py
@@ -19,9 +19,7 @@ def test_tqdm(wandb_backend_spy):
         output = snapshot.output(run_id=run.id)
 
         assert "before progress" in output[0]
-        assert output[1].startswith("ERROR") and bool(
-            re.search(r"100%\|#+\| 10/10", output[1])
-        )
+        assert "error" in output[1] and bool(re.search(r"100%\|#+\| 10/10", output[1]))
         for i in range(10):
             assert f"progress {i}" in output[2 + i]
         assert "after progress" in output[12] and "error" in output[12]
@@ -61,11 +59,11 @@ def test_tqdm_nested(wandb_backend_spy):
         output = snapshot.output(run_id=run.id)
 
         assert "before progress" in output[0]
-        assert output[1].startswith("ERROR") and bool(
+        assert "error" in output[1] and bool(
             re.search(r"outer: 100%\|█+\| 5/5", output[1])
         )
         assert "done!" in output[2]
-        assert "after progress" in output[3] and output[3].startswith("ERROR")
+        assert "after progress" in output[3] and "error" in output[3]
         assert "final progress" in output[4]
 
 
@@ -79,6 +77,4 @@ def test_tqdm_post_finish(wandb_backend_spy):
 
     with wandb_backend_spy.freeze() as snapshot:
         output = snapshot.output(run_id=run.id)
-        assert output[0].startswith("ERROR") and bool(
-            re.search(r"40%\|█+\| 2/5", output[0])
-        )
+        assert "error" in output[0] and bool(re.search(r"40%\|█+\| 2/5", output[0]))

--- a/tests/system_tests/test_functional/console/test_console.py
+++ b/tests/system_tests/test_functional/console/test_console.py
@@ -24,7 +24,7 @@ def test_tqdm(wandb_backend_spy):
         )
         for i in range(10):
             assert f"progress {i}" in output[2 + i]
-        assert "after progress" in output[12] and output[12].startswith("ERROR")
+        assert "after progress" in output[12] and "error" in output[12]
         assert "final progress" in output[13]
 
 
@@ -41,7 +41,7 @@ def test_emoji(wandb_backend_spy):
         assert "before emoji" in output[0]
         for i in range(10):
             assert f"line-{i}-\N{GRINNING FACE}" in output[1 + i]
-        assert "after emoji" in output[11] and output[11].startswith("ERROR")
+        assert "after emoji" in output[11] and "error" in output[11]
 
 
 @pytest.mark.skip(reason="order seems to be wrong")


### PR DESCRIPTION
Description
-----------
The backend now supports structured console log format, and the SDK will now send structured logs in this case by default, which broke a couple tests.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
