### PR TITLE
fix(keras): uncaught exc when WandbModelCheckpoint.save_best_only

### DIFF
--- a/wandb/integration/keras/callbacks/model_checkpoint.py
+++ b/wandb/integration/keras/callbacks/model_checkpoint.py
@@ -153,7 +153,7 @@ class WandbModelCheckpoint(callbacks.ModelCheckpoint):
             else:
                 raise FileNotFoundError(f"No such file or directory {filepath}")
             wandb.log_artifact(model_checkpoint_artifact, aliases=aliases or [])
-        except ValueError:
+        except FileNotFoundError:
             # This error occurs when `save_best_only=True` and the model
             # checkpoint is not saved for that epoch/batch. Since TF/Keras
             # is giving friendly log, we can avoid clustering the stdout.


### PR DESCRIPTION
Description
-----------
the wrong exception was being checked for a missing checkpoint due to save_best_only being set.

I am assuming the ValueError was some older code before the new one that throws FileNotFoundError

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Passing the callback to model.fit with `WandbModelCheckpoint(..., save_best_only=True)`
