### PR TITLE
chore: update ubuntu to 22.04 in release sdk action

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -223,7 +223,7 @@ jobs:
           #
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_SKIP: cp36-* cp37-*
-          CIBW_ARCHS_LINUX: ppc64le #aarch64 is handled by build-linux-arm64-wheels
+          CIBW_ARCHS_LINUX: x86_64 #aarch64 is handled by build-linux-arm64-wheels
           CIBW_ARCHS_MACOS: x86_64 arm64 # arm64 == aarch64
 
           # Work around https://github.com/matthew-brett/delocate/issues/204

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   prepare-release:
     name: Prepare release (${{ inputs.version }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - windows-2019
           - macos-14
 
@@ -372,7 +372,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - windows-2019
           - macos-14
         use_legacy_service: [false, true]

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -222,8 +222,8 @@ jobs:
           # make it invalid, breaking the job.
           #
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_SKIP: cp36-*
-          CIBW_ARCHS_LINUX: x86_64 #aarch64 is handled by build-linux-arm64-wheels
+          CIBW_SKIP: cp36-* cp37-*
+          CIBW_ARCHS_LINUX: x86_64 ppc64le armv7l #aarch64 is handled by build-linux-arm64-wheels
           CIBW_ARCHS_MACOS: x86_64 arm64 # arm64 == aarch64
 
           # Work around https://github.com/matthew-brett/delocate/issues/204

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -167,7 +167,7 @@ jobs:
           #
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_SKIP: cp36-* cp37-*
-          CIBW_ARCHS_LINUX: aarch64 armv7l
+          CIBW_ARCHS_LINUX: aarch64
           CIBW_BEFORE_ALL_LINUX: >
             export DOWNLOAD_GOVERSION=$( grep '^go' core/go.mod | cut -d' ' -f2 ) &&
             curl -L https://golang.org/dl/go$DOWNLOAD_GOVERSION.linux-arm64.tar.gz > go.tar.gz &&
@@ -223,7 +223,7 @@ jobs:
           #
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_SKIP: cp36-* cp37-*
-          CIBW_ARCHS_LINUX: x86_64 ppc64le #aarch64 is handled by build-linux-arm64-wheels
+          CIBW_ARCHS_LINUX: ppc64le #aarch64 is handled by build-linux-arm64-wheels
           CIBW_ARCHS_MACOS: x86_64 arm64 # arm64 == aarch64
 
           # Work around https://github.com/matthew-brett/delocate/issues/204

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -166,8 +166,8 @@ jobs:
           # make it invalid, breaking the job.
           #
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_SKIP: cp36-*
-          CIBW_ARCHS_LINUX: aarch64
+          CIBW_SKIP: cp36-* cp37-*
+          CIBW_ARCHS_LINUX: aarch64 armv7l
           CIBW_BEFORE_ALL_LINUX: >
             export DOWNLOAD_GOVERSION=$( grep '^go' core/go.mod | cut -d' ' -f2 ) &&
             curl -L https://golang.org/dl/go$DOWNLOAD_GOVERSION.linux-arm64.tar.gz > go.tar.gz &&
@@ -223,7 +223,7 @@ jobs:
           #
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           CIBW_SKIP: cp36-* cp37-*
-          CIBW_ARCHS_LINUX: x86_64 ppc64le armv7l #aarch64 is handled by build-linux-arm64-wheels
+          CIBW_ARCHS_LINUX: x86_64 ppc64le #aarch64 is handled by build-linux-arm64-wheels
           CIBW_ARCHS_MACOS: x86_64 arm64 # arm64 == aarch64
 
           # Work around https://github.com/matthew-brett/delocate/issues/204


### PR DESCRIPTION
Description
-----------
GH is deprecating the 20.04 images on 4/15/25 and is currently doing brown-outs.

