### PR TITLE
fix: windows throws ValueError when running from a different drive.

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,3 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Changed
 
 - Upgrade go version for `wandb-core` from 1.23.x to 1.24.x (@kptkin in https://github.com/wandb/wandb/pull/9590)
+
+### Fixed
+
+- Fixed ValueError on Windows when running a W&B script from a different drive (@jacobromero in https://github.com/wandb/wandb/pull/9677)

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -809,3 +809,18 @@ def test_json_dump_uncompressed_with_numpy_datatypes():
     iostr = io.StringIO()
     util.json_dump_uncompressed(data, iostr)
     assert iostr.getvalue() == '{"a": [1, 2.0, 3]}'
+
+
+@pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="Drive letters are only relevant on Windows",
+)
+@pytest.mark.parametrize(
+    "path1,path2,expected",
+    [
+        ("C:\\foo", "C:\\bar", True),
+        ("C:\\foo", "D:\\bar", False),
+    ],
+)
+def test_are_windows_paths_on_same_drive(path1, path2, expected):
+    assert util.are_windows_paths_on_same_drive(path1, path2) == expected

--- a/tests/unit_tests/test_wandb_settings.py
+++ b/tests/unit_tests/test_wandb_settings.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import pathlib
+import platform
 import subprocess
 import sys
 import tempfile
@@ -527,3 +528,23 @@ def test_rewind(setting):
 def test_computed_settings_included_in_model_dump():
     settings = Settings(mode="offline")
     assert settings.model_dump()["_offline"] is True
+
+
+@pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="Drive letters are only relevant on Windows",
+)
+@pytest.mark.parametrize(
+    "root_dir,expected_result",
+    [
+        ("C:\\other", lambda x: x is not None),
+        ("D:\\other", lambda x: x is None),
+    ],
+)
+def test_program_relpath_windows(root_dir, expected_result):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_file_path = os.path.join(temp_dir, "test_file.py")
+        with open(test_file_path, "w") as f:
+            f.write("# Test file for program_relpath testing")
+        result = Settings._get_program_relpath(test_file_path, root_dir)
+        assert expected_result(result)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1662,6 +1662,12 @@ class Settings(BaseModel, validate_assignment=True):
         if not root:
             return None
 
+        # On Windows if the program and root are on different drives,
+        # Python will raise a ValueError.
+        if platform.system() == "Windows":
+            if not util.are_windows_paths_on_same_drive(program, root):
+                return None
+
         full_path_to_program = os.path.join(
             root, os.path.relpath(os.getcwd(), root), program
         )

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1438,6 +1438,12 @@ def auto_project_name(program: Optional[str]) -> str:
     return str(project.replace(os.sep, "_"))
 
 
+def are_windows_paths_on_same_drive(path1: str, path2: str) -> bool:
+    path1 = pathlib.Path(path1).resolve()
+    path2 = pathlib.Path(path2).resolve()
+    return path1.drive == path2.drive
+
+
 # TODO(hugh): Deprecate version here and use wandb/sdk/lib/paths.py
 def to_forward_slash_path(path: str) -> str:
     if platform.system() == "Windows":


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

When running a W&B script on Windows from a different drive than the drive the script is located on will cause a ValueError when attempting to determine the relative [path of the program](https://github.com/wandb/wandb/blob/main/wandb/sdk/wandb_settings.py#L1669)

This change checks the drives for both the root directory and the program file location to determine if they both exist on the same drive.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
