### PR TITLE
refactor: do not raise in Artifact.download() if an offline run exists

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Changed
+
+- `Artifact.download()` no longer raises an error when using `WANDB_MODE=offline` or when an offline run exists (@timoffex in https://github.com/wandb/wandb/pull/9695)
+
 ### Fixed
 
 - Fixed ValueError on Windows when running a W&B script from a different drive (@jacobromero in https://github.com/wandb/wandb/pull/9678)

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
@@ -32,28 +32,6 @@ def test_fetching_artifact_files(user):
     assert open(file_path).read() == "testing"
 
 
-def test_artifact_download_offline_mode(user, monkeypatch, tmp_path):
-    project = "test"
-
-    # Create the test file in the temporary directory
-    file_path = tmp_path / "boom.txt"
-    file_path.write_text("testing")
-
-    with wandb.init(entity=user, project=project) as run:
-        artifact = wandb.Artifact("test-artifact", "test-type")
-        artifact.add_file(str(file_path), "test-name")  # Convert Path to string
-        run.log_artifact(artifact, aliases=["sequence"])
-        artifact.wait()
-
-    # Use monkeypatch to set WANDB_MODE after creating the artifact
-    monkeypatch.setenv("WANDB_MODE", "offline")
-
-    with pytest.raises(
-        RuntimeError, match="Cannot download artifacts in offline mode."
-    ):
-        artifact.download()
-
-
 def test_save_aliases_after_logging_artifact(user):
     project = "test"
     run = wandb.init(entity=user, project=project)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1771,14 +1771,9 @@ class Artifact:
 
         Raises:
             ArtifactNotLoggedError: If the artifact is not logged.
-            RuntimeError: If the artifact is attempted to be downloaded in offline mode.
         """
         root = FilePathStr(str(root or self._default_root()))
         self._add_download_root(root)
-
-        # TODO: we need a better way to check for offline mode across the app, as this is an anti-pattern
-        if env.is_offline() or util._is_offline():
-            raise RuntimeError("Cannot download artifacts in offline mode.")
 
         # TODO: download artifacts using core when implemented
         # if is_require_core():


### PR DESCRIPTION
## Description

Removes the `util._is_offline()` check in `Artifact.download()` which relies on a global `wandb.run`.

This check was originally added in PR #8009 because of a crash in wandb-core, but the crash no longer happens.

## Testing

The repro in the PR that added the check can be used:

```python
# artifact_download_offline.py
import os

import wandb

os.environ["WANDB_MODE"] = "offline"
os.environ["WANDB_DEBUG"] = "true"


def download_artifact(artifact_name: str):
    artifact = wandb.Api().artifact(artifact_name)
    return artifact.download(root="/tmp/wandb_artifacts")


if __name__ == "__main__":
    # TODO: Set these to any existing run.
    run_path = "wandb/timoffex-test/r0sczcuf"
    project = "timoffex-test"

    # TODO: Set this to any existing artifact.
    artifact_name = "wandb/timoffex-test/trained-model:v2"

    with wandb.init(project=project) as run:
        run.restore(name="output.log", replace=True, run_path=run_path)

    artifact_path = download_artifact(artifact_name)
    print(f"Artifact downloaded to: {artifact_path}")
```

From this PR, the following uses core and works fine:

```
python artifact_download_offline.py
```

From 0.17.5 (the version at the time of the PR), the following stalls:

```
WANDB__REQUIRE_CORE=true python artifact_download_offline.py
```