### PR TITLE
refactor: remove util._is_offline() and its remaining uses

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1529,7 +1529,7 @@ class Artifact:
             return self._added_objs[obj_id][1]
 
         # If the object is coming from another artifact, save it as a reference
-        ref_path = obj._get_artifact_entry_ref_url()
+        ref_path = obj._get_artifact_entry_ref_url(run=None)
         if ref_path is not None:
             return self.add_reference(ref_path, type(obj).with_suffix(name))[0]
 

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -236,16 +236,17 @@ class Media(WBValue):
                 }
             )
 
-            artifact_entry_url = self._get_artifact_entry_ref_url()
+            artifact_entry_url = self._get_artifact_entry_ref_url(run)
             if artifact_entry_url is not None:
                 json_obj["artifact_path"] = artifact_entry_url
-            artifact_entry_latest_url = self._get_artifact_entry_latest_ref_url()
+            artifact_entry_latest_url = self._get_artifact_entry_latest_ref_url(run)
             if artifact_entry_latest_url is not None:
                 json_obj["_latest_artifact_path"] = artifact_entry_latest_url
 
             if artifact_entry_url is None or self.is_bound():
-                assert self.is_bound(), "Value of type {} must be bound to a run with bind_to_run() before being serialized to JSON.".format(
-                    type(self).__name__
+                assert self.is_bound(), (
+                    f"Value of type {type(self).__name__} must be bound to"
+                    " a run with bind_to_run() before being serialized to JSON."
                 )
 
                 assert (

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -402,7 +402,7 @@ class Image(BatchableMedia):
 
         if (
             not _server_accepts_artifact_path(run)
-            or self._get_artifact_entry_ref_url() is None
+            or self._get_artifact_entry_ref_url(run) is None
         ):
             super().bind_to_run(run, key, step, id_, ignore_copy_err=ignore_copy_err)
         if self._boxes is not None:

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -949,7 +949,7 @@ class PartitionedTable(Media):
             "_type": PartitionedTable._log_type,
         }
         if isinstance(artifact_or_run, wandb.wandb_sdk.wandb_run.Run):
-            artifact_entry_url = self._get_artifact_entry_ref_url()
+            artifact_entry_url = self._get_artifact_entry_ref_url(artifact_or_run)
             if artifact_entry_url is None:
                 raise ValueError(
                     "PartitionedTables must first be added to an Artifact before logging to a Run"
@@ -1109,7 +1109,7 @@ class JoinedTable(Media):
             "_type": JoinedTable._log_type,
         }
         if isinstance(artifact_or_run, wandb.wandb_sdk.wandb_run.Run):
-            artifact_entry_url = self._get_artifact_entry_ref_url()
+            artifact_entry_url = self._get_artifact_entry_ref_url(artifact_or_run)
             if artifact_entry_url is None:
                 raise ValueError(
                     "JoinedTables must first be added to an Artifact before logging to a Run"

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1752,20 +1752,6 @@ def _get_max_cli_version() -> Union[str, None]:
     return str(max_cli_version) if max_cli_version is not None else None
 
 
-def _is_offline() -> bool:
-    """Returns true if wandb is configured to be offline.
-
-    If there is an active run, returns whether the run is offline.
-    Otherwise, returns the default mode, which is affected by explicit settings
-    passed to `wandb.setup()`, environment variables, and W&B configuration
-    files.
-    """
-    if wandb.run:
-        return wandb.run.settings._offline
-    else:
-        return wandb.setup().settings._offline
-
-
 def ensure_text(
     string: Union[str, bytes], encoding: str = "utf-8", errors: str = "strict"
 ) -> str:


### PR DESCRIPTION
Removes `util._is_offline()` because it relies on the global `wandb.run`. Updates `WBValue`'s `_get_artifact_entry_ref_url()` and `_get_artifact_entry_latest_ref_url()` methods to use the settings from a `Run` object and assume online mode if it's not provided.