### PR TITLE
fix: user provided base_url was not provided to wandb.login

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,3 +24,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Fixed ValueError on Windows when running a W&B script from a different drive (@jacobromero in https://github.com/wandb/wandb/pull/9678)
+- Fix base_url setting was not provided to wandb.login (@jacobromero in https://github.com/wandb/wandb/pull/9703)

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -179,6 +179,7 @@ class _WandbInit:
 
         wandb_login._login(
             anonymous=run_settings.anonymous,
+            host=run_settings.base_url,
             force=run_settings.force,
             _disable_warning=True,
             _silent=run_settings.quiet or run_settings.silent,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

This PR passes the user provided host/base_url to `wandb.login` to ensure the correct host is logged in.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- Before this change

```
python

﻿﻿>>> import wandb
>>> wandb.init(settings=wandb.Settings(base_url="https://staging-aws.wandb.io"))
﻿wandb: Using wandb-core as the SDK backend.  Please refer to https://wandb.me/wandb-core for more information.
wandb: (1) Create a W&B account
wandb: (2) Use an existing W&B account
wandb: (3) Don't visualize my results
wandb: Enter your choice:
```

- After this change

```
python

>>> import wandb
>>> wandb.init(settings=wandb.Settings(base_url="https://staging-aws.wandb.io"))
wandb: Using wandb-core as the SDK backend.  Please refer to https://wandb.me/wandb-core for more information.
wandb: Currently logged in as: jacob-romero to https://staging-aws.wandb.io. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.19.10.dev1
wandb: Run data is saved locally in /Users/jacob.romero/workspace/test/wandb/run-20250409_111644-rxggzv23
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run sweet-armadillo-20
wandb: ⭐️ View project at https://staging-aws.wandb.io/jacob-romero/uncategorized
wandb: 🚀 View run at https://staging-aws.wandb.io/jacob-romero/uncategorized/runs/rxggzv23
<wandb.sdk.wandb_run.Run object at 0x10693be60>
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
