### PR TITLE
refactor: use settings.quiet instead of wandb.jupyter.quiet()

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `Artifact.download()` no longer raises an error when using `WANDB_MODE=offline` or when an offline run exists (@timoffex in https://github.com/wandb/wandb/pull/9695)
 
+### Removed
+
+- Dropped the `-q` / `--quiet` argument to the `wandb` magic in IPython / Jupyter; use the `quiet` run setting instead (@timoffex in https://github.com/wandb/wandb/pull/9705)
+
 ### Fixed
 
 - Fixed ValueError on Windows when running a W&B script from a different drive (@jacobromero in https://github.com/wandb/wandb/pull/9678)

--- a/tests/system_tests/test_notebooks/conftest.py
+++ b/tests/system_tests/test_notebooks/conftest.py
@@ -30,10 +30,6 @@ _NOTEBOOK_LOCKFILE = os.path.join(
     ".test_notebooks.lock",
 )
 
-# wandb.jupyter is lazy loaded, so we need to force it to load
-# before we can monkeypatch it
-wandb.jupyter.quiet()
-
 
 @pytest.fixture
 def mocked_module(monkeypatch):

--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -113,6 +113,9 @@ def test_notebook_metadata_no_servers(mocked_module):
 
 
 def test_notebook_metadata_colab(mocked_module):
+    # Needed for patching due to the lazy-load set up in wandb/__init__.py
+    import wandb.jupyter
+
     colab = mocked_module("google.colab")
     colab._message.blocking_request.return_value = {
         "ipynb": {"metadata": {"colab": {"name": "koalab.ipynb"}}}
@@ -136,6 +139,9 @@ def test_notebook_metadata_colab(mocked_module):
 
 
 def test_notebook_metadata_kaggle(mocked_module):
+    # Needed for patching due to the lazy-load set up in wandb/__init__.py
+    import wandb.jupyter
+
     os.environ["KAGGLE_KERNEL_RUN_TYPE"] = "test"
     kaggle = mocked_module("kaggle_session")
     kaggle_client = mock.MagicMock()

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -31,12 +31,6 @@ def maybe_display():
     return False
 
 
-def quiet():
-    if __IFrame is not None:
-        return __IFrame.opts.get("quiet")
-    return False
-
-
 class IFrame:
     def __init__(self, path=None, opts=None):
         self.path = path
@@ -98,13 +92,6 @@ class WandBMagics(Magics):
         help="Display the entire run project workspace",
     )
     @argument(
-        "-q",
-        "--quiet",
-        default=False,
-        action="store_true",
-        help="Display the minimal amount of output",
-    )
-    @argument(
         "-h",
         "--height",
         default=420,
@@ -125,7 +112,6 @@ class WandBMagics(Magics):
         args = parse_argstring(self.wandb, line)
         self.options["height"] = args.height
         self.options["workspace"] = args.workspace
-        self.options["quiet"] = args.quiet
         iframe = IFrame(args.path, opts=self.options)
         displayed = iframe.maybe_display()
         if cell is not None:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3945,8 +3945,7 @@ class Run:
                 run_line = f"<strong>{printer.link(run_url, run_name)}</strong>"
                 project_line, sweep_line = "", ""
 
-                # TODO(settings): make settings the source of truth
-                if not wandb.jupyter.quiet():  # type: ignore
+                if not settings.quiet:
                     doc_html = printer.link(url_registry.url("developer-guide"), "docs")
 
                     project_html = printer.link(project_url, "Weights & Biases")


### PR DESCRIPTION
Drops the `wandb.jupyter.quiet()` method and the `-q`/`--quiet` option to the `wandb` magic. The only use of this method was in `wandb_run.py` right below a TODO about using settings instead.

This is technically a breaking change, but the option does not appear to have ever been documented anywhere, and "broken" notebooks are trivial to fix.