### PR TITLE
chore(sdk): add helper to rewrite graphql requests for compatibility

### DIFF
--- a/tests/unit_tests/test_api_utils.py
+++ b/tests/unit_tests/test_api_utils.py
@@ -1,9 +1,14 @@
+from textwrap import dedent
+
 import pytest
 from wandb.apis.public.utils import (
     fetch_org_from_settings_or_entity,
+    gql_compat,
     parse_org_from_registry_path,
 )
 from wandb.sdk.internal.internal_api import _OrgNames
+from wandb_gql import gql
+from wandb_graphql import print_ast
 
 
 @pytest.mark.parametrize(
@@ -95,3 +100,100 @@ def test_multiple_orgs_raises_error(mock_fetch_orgs_and_org_entities_from_entity
     settings = {"organization": None, "entity": "multi-org-user-entity"}
     with pytest.raises(ValueError, match="Multiple organizations found for entity"):
         fetch_org_from_settings_or_entity(settings)
+
+
+def test_gql_compat():
+    """Test that gql_compat rewrites a GraphQL request by omitting the expected parts."""
+    omit_fragments = ["ArtifactInfo"]
+    omit_variables = ["ttlDurationSeconds", "tagsToAdd", "tagsToDelete"]
+    omit_fields = ["ttlDurationSeconds", "ttlIsInherited", "tags"]
+
+    # GraphQL query with fragments on different types
+    orig_query_str = dedent(
+        """\
+        mutation updateArtifact(
+            $artifactID: ID!
+            $description: String
+            $metadata: JSONString
+            $ttlDurationSeconds: Int64
+            $tagsToAdd: [TagInput!]
+            $tagsToDelete: [TagInput!]
+            $aliases: [ArtifactAliasInput!]
+        ) {
+            updateArtifact(
+                input: {
+                    artifactID: $artifactID,
+                    description: $description,
+                    metadata: $metadata,
+                    ttlDurationSeconds: $ttlDurationSeconds,
+                    tagsToAdd: $tagsToAdd,
+                    tagsToDelete: $tagsToDelete,
+                    aliases: $aliases
+                }
+            ) {
+                artifact {
+                    ...ArtifactIdAndName
+                    ... ArtifactInfo
+                    ttlDurationSeconds
+                    ttlIsInherited
+                    tags {name}
+                }
+            }
+        }
+        fragment ArtifactIdAndName on Artifact {
+            id
+            name
+        }
+        fragment ArtifactInfo on Artifact {
+            description
+            versionIndex
+        }
+        """
+    )
+    expected_query_str = dedent(
+        """\
+        mutation updateArtifact(
+            $artifactID: ID!
+            $description: String
+            $metadata: JSONString
+            $aliases: [ArtifactAliasInput!]
+        ) {
+            updateArtifact(
+                input: {
+                    artifactID: $artifactID,
+                    description: $description,
+                    metadata: $metadata,
+                    aliases: $aliases
+                }
+            ) {
+                artifact {
+                    ...ArtifactIdAndName
+                }
+            }
+        }
+        fragment ArtifactIdAndName on Artifact {
+            id
+            name
+        }
+        """
+    )
+
+    # Omit the Artifact type fragments
+    compat_query = gql_compat(
+        orig_query_str,
+        omit_fragments=omit_fragments,
+        omit_variables=omit_variables,
+        omit_fields=omit_fields,
+    )
+
+    # Normalize the expected and actual query strings for consistent comparison
+    expected_query_str = print_ast(gql(expected_query_str))
+    expected_query_str = "\n".join(
+        line for line in expected_query_str.splitlines() if line.strip()
+    )
+    compat_query_str = "\n".join(
+        line for line in print_ast(compat_query).splitlines() if line.strip()
+    )
+
+    assert compat_query_str != orig_query_str
+    assert compat_query_str == expected_query_str

--- a/wandb/apis/public/utils.py
+++ b/wandb/apis/public/utils.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Set
 from urllib.parse import urlparse
 
 from wandb_gql import gql
@@ -110,15 +110,15 @@ def fetch_org_from_settings_or_entity(
 class _GQLCompatRewriter(visitor.Visitor):
     """GraphQL AST visitor to rewrite queries/mutations to be compatible with older server versions."""
 
-    omit_variables: set[str]
-    omit_fragments: set[str]
-    omit_fields: set[str]
+    omit_variables: Set[str]
+    omit_fragments: Set[str]
+    omit_fields: Set[str]
 
     def __init__(
         self,
-        omit_variables: Iterable[str] | None = None,
-        omit_fragments: Iterable[str] | None = None,
-        omit_fields: Iterable[str] | None = None,
+        omit_variables: Optional[Iterable[str]] = None,
+        omit_fragments: Optional[Iterable[str]] = None,
+        omit_fields: Optional[Iterable[str]] = None,
     ):
         self.omit_variables = set(omit_variables or ())
         self.omit_fragments = set(omit_fragments or ())
@@ -170,9 +170,9 @@ class _GQLCompatRewriter(visitor.Visitor):
 
 def gql_compat(
     request_string: str,
-    omit_variables: Iterable[str] | None = None,
-    omit_fragments: Iterable[str] | None = None,
-    omit_fields: Iterable[str] | None = None,
+    omit_variables: Optional[Iterable[str]] = None,
+    omit_fragments: Optional[Iterable[str]] = None,
+    omit_fields: Optional[Iterable[str]] = None,
 ) -> ast.Document:
     """Rewrite a GraphQL request string to ensure compatibility with older server versions.
 

--- a/wandb/apis/public/utils.py
+++ b/wandb/apis/public/utils.py
@@ -1,7 +1,10 @@
 import re
 from enum import Enum
-from typing import Optional
+from typing import Any, Iterable, Optional
 from urllib.parse import urlparse
+
+from wandb_gql import gql
+from wandb_graphql.language import ast, visitor
 
 from wandb._iterutils import one
 from wandb.sdk.artifacts._validators import is_artifact_registry_project
@@ -102,3 +105,96 @@ def fetch_org_from_settings_or_entity(
         )
         organization = entity_org.display_name
     return organization
+
+
+class _GQLCompatRewriter(visitor.Visitor):
+    """GraphQL AST visitor to rewrite queries/mutations to be compatible with older server versions."""
+
+    omit_variables: set[str]
+    omit_fragments: set[str]
+    omit_fields: set[str]
+
+    def __init__(
+        self,
+        omit_variables: Iterable[str] | None = None,
+        omit_fragments: Iterable[str] | None = None,
+        omit_fields: Iterable[str] | None = None,
+    ):
+        self.omit_variables = set(omit_variables or ())
+        self.omit_fragments = set(omit_fragments or ())
+        self.omit_fields = set(omit_fields or ())
+
+    def enter_VariableDefinition(self, node: ast.VariableDefinition, *_, **__) -> Any:  # noqa: N802
+        if node.variable.name.value in self.omit_variables:
+            return visitor.REMOVE
+        return node
+
+    def enter_ObjectField(self, node: ast.ObjectField, *_, **__) -> Any:  # noqa: N802
+        # For context, note that e.g.:
+        #
+        #   {description: $description
+        #   ...}
+        #
+        # Is parsed as:
+        #
+        #   ObjectValue(fields=[
+        #     ObjectField(name=Name(value='description'), value=Variable(name=Name(value='description'))),
+        #   ...])
+        if (
+            isinstance(var := node.value, ast.Variable)
+            and var.name.value in self.omit_variables
+        ):
+            return visitor.REMOVE
+
+    def enter_Argument(self, node: ast.Argument, *_, **__) -> Any:  # noqa: N802
+        if node.name.value in self.omit_variables:
+            return visitor.REMOVE
+
+    def enter_FragmentDefinition(self, node: ast.FragmentDefinition, *_, **__) -> Any:  # noqa: N802
+        if node.name.value in self.omit_fragments:
+            return visitor.REMOVE
+
+    def enter_FragmentSpread(self, node: ast.FragmentSpread, *_, **__) -> Any:  # noqa: N802
+        if node.name.value in self.omit_fragments:
+            return visitor.REMOVE
+
+    def enter_Field(self, node: ast.Field, *_, **__) -> Any:  # noqa: N802
+        if node.name.value in self.omit_fields:
+            return visitor.REMOVE
+
+    def leave_Field(self, node: ast.Field, *_, **__) -> Any:  # noqa: N802
+        # If the field had a selection set, but now it's empty, remove the field entirely
+        if (node.selection_set is not None) and (not node.selection_set.selections):
+            return visitor.REMOVE
+
+
+def gql_compat(
+    request_string: str,
+    omit_variables: Iterable[str] | None = None,
+    omit_fragments: Iterable[str] | None = None,
+    omit_fields: Iterable[str] | None = None,
+) -> ast.Document:
+    """Rewrite a GraphQL request string to ensure compatibility with older server versions.
+
+    Args:
+        request_string (str): The GraphQL request string to rewrite.
+        omit_variables (Iterable[str] | None): Names of variables to remove from the request string.
+        omit_fragments (Iterable[str] | None): Names of fragments to remove from the request string.
+        omit_fields (Iterable[str] | None): Names of fields to remove from the request string.
+
+    Returns:
+        str: Modified GraphQL request string with fragments on omitted types removed.
+    """
+    # Parse the request into a GraphQL AST
+    doc = gql(request_string)
+
+    if not (omit_variables or omit_fragments or omit_fields):
+        return doc
+
+    # Visit the AST with our visitor to filter out unwanted fragments
+    rewriter = _GQLCompatRewriter(
+        omit_variables=omit_variables,
+        omit_fragments=omit_fragments,
+        omit_fields=omit_fields,
+    )
+    return visitor.visit(doc, rewriter)


### PR DESCRIPTION
## Description

Adds a new `gql_compat()` helper function (in `wandb.apis.public.utils`) that allows GraphQL queries to be rewritten for compatibility with older server versions. The function optionally scrubs any of the following items from a GQL query or mutation:
- variables (by name)
- fragment definitions and spreads (by name)
- selected response fields (by name)


## Testing

Added `test_gql_compat()` unit test