### PR TITLE
refactor: avoid global run in wandb ipython magic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,7 +305,6 @@ module = [
     "wandb.sdk.verify.*",
     "wandb.trigger.*",
     "wandb.wandb_summary.*",
-    "wandb.jupyter.*",
     "wandb.sync.*",
     "wandb.sdk.integration_utils.*",
     "wandb.plot.*",

--- a/tests/assets/notebooks/magic.ipynb
+++ b/tests/assets/notebooks/magic.ipynb
@@ -3,59 +3,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "import wandb"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "wandb.init()"
-   ],
    "metadata": {
     "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
+   "outputs": [],
    "source": [
     "%%wandb\n",
-    "wandb.log({\"test\": 1})"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "import wandb\n",
+    "with wandb.init() as run:\n",
+    "    pass"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "%wandb test/test/test"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "source": [
-    "wandb.Api().project(\"test\").display()"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "wandb.finish()"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "%wandb does/not/exist"
+   ]
   }
  ],
  "metadata": {

--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -45,24 +45,14 @@ def test_init_finishes_previous_by_default(notebook):
 
 
 def test_magic(notebook):
-    base_url = os.getenv("WANDB_BASE_URL")
-    assert base_url
-
     with notebook("magic.ipynb") as nb:
         nb.execute_all()
-        iframes = 0
-        text = ""
-        for c, cell in enumerate(nb.cells):
-            for i, out in enumerate(cell["outputs"]):
-                print(f"CELL {c} output {i}: ", out)  # noqa: T201
-                if not out.get("data", {}).get("text/html"):
-                    continue
-                if c == 0 and i == 0:
-                    assert "display:none" in out
-                text += out["data"]["text/html"]
-            iframes += 1
-        assert base_url in text
-        assert iframes == 6
+
+        assert "<iframe" in nb.cell_output_html(0)
+        assert "CommError" in nb.cell_output_text(1)
+        assert nb.cell_output_html(1) == (
+            "Path 'does/not/exist' does not refer to a W&B object you can access."
+        )
 
 
 def test_notebook_exits(user, assets_path):
@@ -213,33 +203,6 @@ def test_mocked_notebook_run_display(user, mocked_ipython):
     for i, html in enumerate(displayed_html):
         print(f"[{i}]: {html}")  # noqa: T201
     assert any("<iframe" in html for html in displayed_html)
-
-
-def test_mocked_notebook_magic(user, run_id, mocked_ipython):
-    magic = wandb.jupyter.WandBMagics(None)
-    s = wandb.Settings()
-    s.update_from_env_vars(os.environ)
-    basic_settings = {
-        "api_key": user,
-        "base_url": s.base_url,
-        "run_id": run_id,
-    }
-    magic.wandb(
-        "",
-        """with wandb.init(settings=wandb.Settings(**{})):
-        wandb.log({{"a": 1}})""".format(basic_settings),
-    )
-    displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
-    for i, html in enumerate(displayed_html):
-        print(f"[{i}]: {html}")  # noqa: T201
-    assert wandb.jupyter.__IFrame is None
-    assert any("<iframe" in html for html in displayed_html)
-    run_uri = f"{user}/uncategorized/runs/{run_id}"
-    magic.wandb(run_uri)
-    displayed_html = [args[0].strip() for args, _ in mocked_ipython.html.call_args_list]
-    for i, html in enumerate(displayed_html):
-        print(f"[{i}]: {html}")  # noqa: T201
-    assert any(f"{run_uri}?jupyter=true" in html for html in displayed_html)
 
 
 def test_code_saving(notebook):

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -6,9 +6,12 @@ import os
 import re
 import shutil
 import sys
+import traceback
 from base64 import b64encode
+from typing import Any
 
 import IPython
+import IPython.display
 import requests
 from IPython.core.magic import Magics, line_cell_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
@@ -21,69 +24,92 @@ from wandb.sdk.lib import filesystem
 
 logger = logging.getLogger(__name__)
 
-__IFrame = None
+
+def display_if_magic_is_used(run: wandb_run.Run) -> bool:
+    """Display a run's page if the cell has the %%wandb cell magic.
+
+    Args:
+        run: The run to display.
+
+    Returns:
+        Whether the %%wandb cell magic was present.
+    """
+    if not _current_cell_wandb_magic:
+        return False
+
+    _current_cell_wandb_magic.display_if_allowed(run)
+    return True
 
 
-def maybe_display():
-    """Display a run if the user added cell magic and we have run."""
-    if __IFrame is not None:
-        return __IFrame.maybe_display()
-    return False
+class _WandbCellMagicState:
+    """State for a cell with the %%wandb cell magic."""
+
+    def __init__(self, *, height: int) -> None:
+        """Initializes the %%wandb cell magic state.
+
+        Args:
+            height: The desired height for displayed iframes.
+        """
+        self._height = height
+        self._already_displayed = False
+
+    def display_if_allowed(self, run: wandb_run.Run) -> None:
+        """Display a run's iframe if one is not already displayed.
+
+        Args:
+            run: The run to display.
+        """
+        if self._already_displayed:
+            return
+        self._already_displayed = True
+
+        _display_wandb_run(run, height=self._height)
 
 
-class IFrame:
-    def __init__(self, path=None, opts=None):
-        self.path = path
-        self.api = wandb.Api()
-        self.opts = opts or {}
-        self.displayed = False
-        self.height = self.opts.get("height", 420)
+_current_cell_wandb_magic: _WandbCellMagicState | None = None
 
-    def maybe_display(self) -> bool:
-        if not self.displayed and (self.path or wandb.run):
-            IPython.display.display(self)
-        return self.displayed
 
-    def _repr_html_(self) -> str:
-        try:
-            self.displayed = True
+def _display_by_wandb_path(path: str, *, height: int) -> None:
+    """Display a wandb object (usually in an iframe) given its URI.
 
-            # Display the explicit resource if specified.
-            if isinstance(self.path, str):
-                return self.api.from_path(self.path).to_html(
-                    self.height,
-                    hidden=False,
-                )
+    Args:
+        path: A path to a run, sweep, project, report, etc.
+        height: Height of the iframe in pixels.
+    """
+    api = wandb.Api()
 
-            # Otherwise, display the global run, if there is one.
-            elif wandb.run:
-                return wandb.run.to_html(self.height, hidden=False)
+    try:
+        obj = api.from_path(path)
 
-            # Otherwise, display the user's project.
-            elif wandb.Api().api_key is None:
-                return (
-                    "You must be logged in to display wandb in Jupyter."
-                    " Please run `wandb.login()`."
-                )
-            else:
-                return self.api.project(
-                    "/".join(
-                        [
-                            wandb.Api().default_entity,
-                            wandb.util.auto_project_name(None),
-                        ]
-                    )
-                ).to_html(self.height, hidden=False)
+        IPython.display.display_html(
+            obj.to_html(height=height),
+            raw=True,
+        )
+    except wandb.Error:
+        traceback.print_exc()
+        IPython.display.display_html(
+            f"Path {path!r} does not refer to a W&B object you can access.",
+            raw=True,
+        )
 
-        except Exception as e:
-            return f"Error displaying wandb object.<br/>{e}"
+
+def _display_wandb_run(run: wandb_run.Run, *, height: int) -> None:
+    """Display a run (usually in an iframe).
+
+    Args:
+        run: The run to display.
+        height: Height of the iframe in pixels.
+    """
+    IPython.display.display_html(
+        run.to_html(height=height),
+        raw=True,
+    )
 
 
 @magics_class
 class WandBMagics(Magics):
-    def __init__(self, shell, require_interaction=False):
+    def __init__(self, shell):
         super().__init__(shell)
-        self.options = {}
 
     @magic_arguments()
     @argument(
@@ -100,29 +126,46 @@ class WandBMagics(Magics):
         help="The height of the iframe in pixels.",
     )
     @line_cell_magic
-    def wandb(self, line, cell=None):
-        """Display wandb resources in jupyter.  This can be used as cell or line magic.
+    def wandb(self, line: str, cell: str | None = None) -> None:
+        """Display wandb resources in Jupyter.
 
-        %wandb USERNAME/PROJECT/runs/RUN_ID
-        ---
-        %%wandb -h 1024
-        with wandb.init() as run:
-            run.log({"loss": 1})
+        This can be used as a line magic:
+
+            %wandb USERNAME/PROJECT/runs/RUN_ID
+
+        Or as a cell magic:
+
+            %%wandb -h 1024
+            with wandb.init() as run:
+                run.log({"loss": 1})
         """
-        # Record options
+        global _current_cell_wandb_magic
+
         args = parse_argstring(self.wandb, line)
-        self.options["height"] = args.height
-        iframe = IFrame(args.path, opts=self.options)
-        displayed = iframe.maybe_display()
-        if cell is not None:
-            if not displayed:
-                # Store the IFrame globally and attempt to display if we have a run
-                cell = (
-                    f"wandb.jupyter.__IFrame = wandb.jupyter.IFrame(opts={self.options})\n"
-                    + cell
-                    + "\nwandb.jupyter.__IFrame = None"
-                )
+        path: str | None = args.path
+        height: int = args.height
+
+        if path:
+            _display_by_wandb_path(path, height=height)
+            displayed = True
+        elif wandb.run:
+            _display_wandb_run(wandb.run, height=height)
+            displayed = True
+        else:
+            displayed = False
+
+        # If this is being used as a line magic ("%wandb"), we are done.
+        # When used as a cell magic ("%%wandb"), we must run the cell.
+        if cell is None:
+            return
+
+        if not displayed:
+            _current_cell_wandb_magic = _WandbCellMagicState(height=height)
+
+        try:
             IPython.get_ipython().run_cell(cell)
+        finally:
+            _current_cell_wandb_magic = None
 
 
 def notebook_metadata_from_jupyter_servers_and_kernel_id():
@@ -217,7 +260,7 @@ def jupyter_servers_and_kernel_id():
     Used to query for the name of the notebook.
     """
     try:
-        import ipykernel
+        import ipykernel  # type: ignore
 
         kernel_id = re.search(
             "kernel-(.*).json", ipykernel.connect.get_connection_file()
@@ -264,8 +307,8 @@ def attempt_colab_login(
     referrer: str | None = None,
 ):
     """This renders an iframe to wandb in the hopes it posts back an api key."""
-    from google.colab import output
-    from google.colab._message import MessageError
+    from google.colab import output  # type: ignore
+    from google.colab._message import MessageError  # type: ignore
     from IPython import display
 
     display.display(
@@ -312,7 +355,7 @@ def attempt_colab_login(
 
 class Notebook:
     def __init__(self, settings: wandb.Settings) -> None:
-        self.outputs = {}
+        self.outputs: dict[int, Any] = {}
         self.settings = settings
         self.shell = IPython.get_ipython()
 
@@ -418,7 +461,7 @@ class Notebook:
     def save_history(self, run: wandb_run.Run):
         """This saves all cell executions in the current session as a new notebook."""
         try:
-            from nbformat import v4, validator, write
+            from nbformat import v4, validator, write  # type: ignore
         except ImportError:
             wandb.termerror(
                 "The nbformat package was not found."

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2583,10 +2583,8 @@ class Run:
         # would like to move _set_global to _on_ready to unify _on_start and _on_attach
         # (we want to do the set globals after attach)
         # TODO(console) However _console_start calls Redirect that uses `wandb.run` hence breaks
-        # TODO(jupyter) However _header calls _header_run_info that uses wandb.jupyter that uses
-        #               `wandb.run` and hence breaks
         self._set_globals()
-        self._header(settings=self._settings, printer=self._printer)
+        self._header()
 
         if self._settings.save_code and self._settings.code_dir is not None:
             self.log_code(self._settings.code_dir)
@@ -3958,59 +3956,41 @@ class Run:
     # ------------------------------------------------------------------------------
     # HEADER
     # ------------------------------------------------------------------------------
-    # Note: All the header methods are static methods since we want to share the printing logic
-    # with the service execution path that doesn't have access to the run instance
-    @staticmethod
-    def _header(
-        *,
-        settings: Settings,
-        printer: printer.Printer,
-    ) -> None:
-        Run._header_wandb_version_info(settings=settings, printer=printer)
-        Run._header_sync_info(settings=settings, printer=printer)
-        Run._header_run_info(settings=settings, printer=printer)
+    def _header(self) -> None:
+        self._header_wandb_version_info()
+        self._header_sync_info()
+        self._header_run_info()
 
-    @staticmethod
-    def _header_wandb_version_info(
-        *,
-        settings: Settings,
-        printer: printer.Printer,
-    ) -> None:
-        if settings.quiet or settings.silent:
+    def _header_wandb_version_info(self) -> None:
+        if self._settings.quiet or self._settings.silent:
             return
 
         # TODO: add this to a higher verbosity level
-        printer.display(f"Tracking run with wandb version {wandb.__version__}")
+        self._printer.display(f"Tracking run with wandb version {wandb.__version__}")
 
-    @staticmethod
-    def _header_sync_info(
-        *,
-        settings: Settings,
-        printer: printer.Printer,
-    ) -> None:
-        if settings._offline:
-            printer.display(
+    def _header_sync_info(self) -> None:
+        if self._settings._offline:
+            self._printer.display(
                 [
-                    f"W&B syncing is set to {printer.code('`offline`')} in this directory.  ",
-                    f"Run {printer.code('`wandb online`')} or set {printer.code('WANDB_MODE=online')} "
-                    "to enable cloud syncing.",
+                    f"W&B syncing is set to {self._printer.code('`offline`')}"
+                    f" in this directory. Run {self._printer.code('`wandb online`')}"
+                    f" or set {self._printer.code('WANDB_MODE=online')}"
+                    " to enable cloud syncing.",
                 ]
             )
         else:
-            info = [f"Run data is saved locally in {printer.files(settings.sync_dir)}"]
-            if not printer.supports_html:
+            sync_dir = self._settings.sync_dir
+            info = [f"Run data is saved locally in {self._printer.files(sync_dir)}"]
+            if not self._printer.supports_html:
                 info.append(
-                    f"Run {printer.code('`wandb offline`')} to turn off syncing."
+                    f"Run {self._printer.code('`wandb offline`')} to turn off syncing."
                 )
-            if not settings.quiet and not settings.silent:
-                printer.display(info)
+            if not self._settings.quiet and not self._settings.silent:
+                self._printer.display(info)
 
-    @staticmethod
-    def _header_run_info(
-        *,
-        settings: Settings,
-        printer: printer.Printer,
-    ) -> None:
+    def _header_run_info(self) -> None:
+        settings, printer = self._settings, self._printer
+
         if settings._offline or settings.silent:
             return
 
@@ -4030,7 +4010,7 @@ class Run:
         if printer.supports_html:
             import wandb.jupyter
 
-            if not wandb.jupyter.maybe_display():
+            if not wandb.jupyter.display_if_magic_is_used(self):
                 run_line = f"<strong>{printer.link(run_url, run_name)}</strong>"
                 project_line, sweep_line = "", ""
 


### PR DESCRIPTION
Refactors the wandb IPython magic (`%%wandb` / `%wandb`) to avoid using the global run when displaying a run as part of `wandb.init()`.

The old `maybe_display()` function was only called when printing the Run header when initializing a run, but it used `wandb.run` to decide what to display. Now it accepts a run explicitly.

`wandb.run` is still used when running the `%wandb` magic on its own, like

```python
# --- Cell 1 ---
run = wandb.init()

# --- Cell 2 ---
# This creates an iframe displaying the above run's page.
%wandb -h 600
```

On the other hand, this uses the explicit run and will continue to work when `wandb.run` is removed:

```python
%%wandb -h 600
with wandb.init() as run:
    ...
```