### PR TITLE
refactor: don't use global run in wandb verify

### DIFF
--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -132,7 +132,10 @@ def check_run(api: Api) -> bool:
     f.close()
 
     with wandb.init(
-        id=nice_id("check_run"), reinit=True, config=config, project=PROJECT_NAME
+        id=nice_id("check_run"),
+        reinit=True,
+        config=config,
+        project=PROJECT_NAME,
     ) as run:
         run_id = run.id
         entity = run.entity
@@ -155,7 +158,7 @@ def check_run(api: Api) -> bool:
                 "Failed to log to media. Contact W&B for support."
             )
 
-        wandb.save(filepath)
+        run.save(filepath)
     public_api = wandb.Api()
     prev_run = public_api.run(f"{entity}/{PROJECT_NAME}/{run_id}")
     # raise Exception(prev_run.__dict__)
@@ -379,7 +382,7 @@ def check_graphql_put(api: Api, host: str) -> Tuple[bool, Optional[str]]:
         project=PROJECT_NAME,
         config={"test": "put to graphql"},
     ) as run:
-        wandb.save(gql_fp)
+        run.save(gql_fp)
     public_api = wandb.Api()
     prev_run = public_api.run(f"{run.entity}/{PROJECT_NAME}/{run.id}")
     if prev_run is None:


### PR DESCRIPTION
Replaces `wandb.save()` by `run.save()` in two spots.