### PR TITLE
refactor: small code improvements in printer_asyncio.py

### DIFF
--- a/wandb/sdk/lib/printer_asyncio.py
+++ b/wandb/sdk/lib/printer_asyncio.py
@@ -1,5 +1,4 @@
 import asyncio
-import functools
 from typing import Callable, TypeVar
 
 from wandb.sdk.lib import asyncio_compat, printer
@@ -11,10 +10,10 @@ def run_async_with_spinner(
     text: str,
     func: Callable[[], _T],
 ) -> _T:
-    """Run an async function and display a loading icon while it runs.
+    """Run a slow function while displaying a loading icon.
 
     Args:
-        text: The text to display next to the spinner, while the function runs.
+        text: The text to display next to the spinner while the function runs.
         func: The function to run.
 
     Returns:
@@ -22,10 +21,7 @@ def run_async_with_spinner(
     """
     spinner_printer = printer.new_printer()
 
-    async def _loop_run_with_spinner(
-        text: str,
-        func: Callable,
-    ) -> _T:
+    async def _loop_run_with_spinner() -> _T:
         func_running = asyncio.Event()
 
         async def update_spinner() -> None:
@@ -46,4 +42,4 @@ def run_async_with_spinner(
             func_running.set()
             return res
 
-    return asyncio_compat.run(functools.partial(_loop_run_with_spinner, text, func))
+    return asyncio_compat.run(_loop_run_with_spinner)


### PR DESCRIPTION
* Updated docstring as `func` is not "async", just slow
* Removed unnecessary usage of `functools` to pass parameters to `_loop_run_with_spinner` that it can already access