### PR TITLE
refactor: don't use global run in printer.py

### DIFF
--- a/tests/unit_tests/test_lib/test_printer.py
+++ b/tests/unit_tests/test_lib/test_printer.py
@@ -1,10 +1,12 @@
 import pytest
+import wandb
 from wandb.sdk.lib import printer as p
 
 
 @pytest.mark.parametrize("level", [1.3, {}, []])
 def test_printer_invalid_level_type(level):
     printer = p.new_printer()
+
     with pytest.raises(ValueError, match="Unknown status level"):
         printer.display("test string", level=level)
 
@@ -12,6 +14,7 @@ def test_printer_invalid_level_type(level):
 @pytest.mark.parametrize("level", ["random", ""])
 def test_printer_invalid_level_str(level):
     printer = p.new_printer()
+
     with pytest.raises(ValueError, match="Unknown level name"):
         printer.display("test string", level=level)
 
@@ -26,7 +29,23 @@ def test_printer_invalid_level_str(level):
 )
 def test_printer_levels(level, prefix, capsys):
     printer = p.new_printer()
+
     printer.display("test string", level=level)
+
     outerr = capsys.readouterr()
     assert outerr.out == ""
     assert outerr.err == f"{prefix} test string\n"
+
+
+def test_printer_term_silent(capsys):
+    printer = p._PrinterTerm(settings=wandb.Settings(silent=True))
+
+    printer.display("something")
+    printer.progress_update("update")
+    printer.progress_close("close")
+    with printer.dynamic_text() as text_area:
+        assert text_area is None
+
+    outerr = capsys.readouterr()
+    assert not outerr.out
+    assert not outerr.err

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Type, Union
 
 import wandb
 from wandb import util
-from wandb.sdk.lib import filesystem, printer_asyncio, runid
+from wandb.sdk.lib import filesystem, printer, printer_asyncio, runid
 
 from . import _dtypes
 from ._private import MEDIA_TMP
@@ -136,6 +136,7 @@ class Video(BatchableMedia):
                 )
             fps = fps or 4
             printer_asyncio.run_async_with_spinner(
+                printer.new_printer(),
                 "Encoding video...",
                 functools.partial(self.encode, fps=fps),
             )

--- a/wandb/sdk/lib/printer.py
+++ b/wandb/sdk/lib/printer.py
@@ -20,6 +20,7 @@ import click
 
 import wandb
 from wandb.errors import term
+from wandb.sdk import wandb_setup
 
 from . import ipython, sparkline
 
@@ -98,12 +99,21 @@ _JUPYTER_PANEL_STYLES = """
 """
 
 
-def new_printer() -> Printer:
-    """Returns a new printer based on the environment we're in."""
+def new_printer(settings: wandb.Settings | None = None) -> Printer:
+    """Returns a printer appropriate for the environment we're in.
+
+    Args:
+        settings: The settings of a run. If not provided and `wandb.setup()`
+            has been called, then global settings are used. Otherwise,
+            settings (such as silent mode) are ignored.
+    """
+    if not settings and (singleton := wandb_setup.singleton()):
+        settings = singleton.settings
+
     if ipython.in_jupyter():
-        return _PrinterJupyter()
+        return _PrinterJupyter(settings=settings)
     else:
-        return _PrinterTerm()
+        return _PrinterTerm(settings=settings)
 
 
 class Printer(abc.ABC):
@@ -281,13 +291,18 @@ class DynamicText(abc.ABC):
 
 
 class _PrinterTerm(Printer):
-    def __init__(self) -> None:
+    def __init__(self, *, settings: wandb.Settings | None) -> None:
         super().__init__()
+        self._settings = settings
         self._progress = itertools.cycle(["-", "\\", "|", "/"])
 
     @override
     @contextlib.contextmanager
     def dynamic_text(self) -> Iterator[DynamicText | None]:
+        if self._settings and self._settings.silent:
+            yield None
+            return
+
         with term.dynamic_text() as handle:
             if not handle:
                 yield None
@@ -301,6 +316,9 @@ class _PrinterTerm(Printer):
         *,
         level: str | int | None = None,
     ) -> None:
+        if self._settings and self._settings.silent:
+            return
+
         text = "\n".join(text) if isinstance(text, (list, tuple)) else text
         self._display_fn_mapping(level)(text)
 
@@ -323,10 +341,16 @@ class _PrinterTerm(Printer):
 
     @override
     def progress_update(self, text: str, percent_done: float | None = None) -> None:
+        if self._settings and self._settings.silent:
+            return
+
         wandb.termlog(f"{next(self._progress)} {text}", newline=False)
 
     @override
     def progress_close(self, text: str | None = None) -> None:
+        if self._settings and self._settings.silent:
+            return
+
         text = text or " " * 79
         wandb.termlog(text)
 
@@ -422,8 +446,9 @@ class _DynamicTermText(DynamicText):
 
 
 class _PrinterJupyter(Printer):
-    def __init__(self) -> None:
+    def __init__(self, *, settings: wandb.Settings | None) -> None:
         super().__init__()
+        self._settings = settings
         self._progress = ipython.jupyter_progress_bar()
 
         from IPython import display
@@ -433,6 +458,10 @@ class _PrinterJupyter(Printer):
     @override
     @contextlib.contextmanager
     def dynamic_text(self) -> Iterator[DynamicText | None]:
+        if self._settings and self._settings.silent:
+            yield None
+            return
+
         handle = self._ipython_display.display(
             self._ipython_display.HTML(""),
             display_id=True,
@@ -452,7 +481,7 @@ class _PrinterJupyter(Printer):
         *,
         level: str | int | None = None,
     ) -> None:
-        if wandb.run and wandb.run._settings.silent:
+        if self._settings and self._settings.silent:
             return
 
         text = "<br>".join(text) if isinstance(text, (list, tuple)) else text
@@ -507,7 +536,7 @@ class _PrinterJupyter(Printer):
         text: str,
         percent_done: float | None = None,
     ) -> None:
-        if not self._progress:
+        if (self._settings and self._settings.silent) or not self._progress:
             return
 
         if percent_done is None:

--- a/wandb/sdk/lib/printer_asyncio.py
+++ b/wandb/sdk/lib/printer_asyncio.py
@@ -7,19 +7,20 @@ _T = TypeVar("_T")
 
 
 def run_async_with_spinner(
+    spinner_printer: printer.Printer,
     text: str,
     func: Callable[[], _T],
 ) -> _T:
     """Run a slow function while displaying a loading icon.
 
     Args:
+        spinner_printer: The printer to use to display text.
         text: The text to display next to the spinner while the function runs.
         func: The function to run.
 
     Returns:
         The result of func.
     """
-    spinner_printer = printer.new_printer()
 
     async def _loop_run_with_spinner() -> _T:
         func_running = asyncio.Event()

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -693,7 +693,7 @@ class Run:
 
         _datatypes_set_callback(self._datatypes_callback)
 
-        self._printer = printer.new_printer()
+        self._printer = printer.new_printer(settings)
 
         self._torch_history: wandb_torch.TorchHistory | None = None  # type: ignore
 


### PR DESCRIPTION
Instead of checking whether `wandb.run` has `silent` set to True in its settings, use the global settings. This matches the behavior for terminal output which relies on `termsetup()` whose `_silent` parameter can only come from an explicit `silent` setting passed to `wandb.setup()`.