### PR TITLE
refactor: clean up deprecate.py

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -32,13 +32,14 @@ from wandb.apis.public.utils import (
     fetch_org_from_settings_or_entity,
     parse_org_from_registry_path,
 )
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk.artifacts._validators import is_artifact_registry_project
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.launch.utils import LAUNCH_DEFAULT_PROJECT
 from wandb.sdk.lib import retry, runid
-from wandb.sdk.lib.deprecate import Deprecated, deprecate
+from wandb.sdk.lib.deprecate import deprecate
 from wandb.sdk.lib.gql_request import GraphQLSession
 
 if TYPE_CHECKING:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -12,6 +12,7 @@ from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import Paginator, SizedPaginator
 from wandb.errors.term import termlog
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk.artifacts._graphql_fragments import (
     ARTIFACT_FILES_FRAGMENT,
@@ -403,7 +404,7 @@ class ArtifactCollection:
     def change_type(self, new_type: str) -> None:
         """Deprecated, change type directly with `save` instead."""
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.artifact_collection__change_type,
+            field_name=Deprecated.artifact_collection__change_type,
             warning_message="ArtifactCollection.change_type(type) is deprecated, use ArtifactCollection.save() instead.",
         )
 

--- a/wandb/integration/keras/keras.py
+++ b/wandb/integration/keras/keras.py
@@ -12,8 +12,9 @@ import tensorflow as tf
 import tensorflow.keras.backend as K  # noqa: N812
 
 import wandb
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.sdk.integration_utils.data_logging import ValidationDataLogger
-from wandb.sdk.lib.deprecate import Deprecated, deprecate
+from wandb.sdk.lib.deprecate import deprecate
 from wandb.util import add_import_hook
 
 

--- a/wandb/integration/langchain/wandb_tracer.py
+++ b/wandb/integration/langchain/wandb_tracer.py
@@ -18,6 +18,7 @@ will be raised when importing this module.
 from packaging import version
 
 import wandb.util
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.sdk.lib import deprecate
 
 langchain = wandb.util.get_module(
@@ -40,7 +41,7 @@ class WandbTracer(WandbTracer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.langchain_tracer,
+            field_name=Deprecated.langchain_tracer,
             warning_message="This feature is deprecated and has been moved to `langchain`. Enable tracing by setting "
             "LANGCHAIN_WANDB_TRACING=true in your environment. See the documentation at "
             "https://python.langchain.com/docs/ecosystem/integrations/agent_with_wandb_tracing for guidance. "

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -31,6 +31,7 @@ from wandb.apis.public import ArtifactCollection, ArtifactFiles, RetryingClient,
 from wandb.data_types import WBValue
 from wandb.errors.term import termerror, termlog, termwarn
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.sdk.artifacts._graphql_fragments import _gql_artifact_fragment
 from wandb.sdk.artifacts._validators import (
     ensure_logged,
@@ -59,7 +60,7 @@ from wandb.sdk.data_types._dtypes import TypeRegistry
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.lib import filesystem, retry, runid, telemetry
-from wandb.sdk.lib.deprecate import Deprecated, deprecate
+from wandb.sdk.lib.deprecate import deprecate
 from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
 from wandb.sdk.lib.runid import generate_id

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -9,8 +9,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.sdk.lib import filesystem
-from wandb.sdk.lib.deprecate import Deprecated, deprecate
+from wandb.sdk.lib.deprecate import deprecate
 from wandb.sdk.lib.hashutil import (
     B64MD5,
     ETag,

--- a/wandb/sdk/lib/deprecate.py
+++ b/wandb/sdk/lib/deprecate.py
@@ -1,42 +1,33 @@
-__all__ = ["deprecate", "Deprecated"]
+from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import wandb
-from wandb.proto.wandb_deprecated import DEPRECATED_FEATURES, Deprecated
-from wandb.proto.wandb_telemetry_pb2 import Deprecated as TelemetryDeprecated
+from wandb.proto.wandb_deprecated import DEPRECATED_FEATURES
+from wandb.sdk.lib import telemetry
 
-# avoid cycle, use string type reference
+# Necessary to break import cycle.
 if TYPE_CHECKING:
-    from .. import wandb_run
-
-
-deprecated_field_names: Tuple[str, ...] = tuple(
-    str(v) for k, v in Deprecated.__dict__.items() if not k.startswith("_")
-)
+    from wandb import wandb_run
 
 
 def deprecate(
     field_name: DEPRECATED_FEATURES,
     warning_message: str,
-    run: Optional["wandb_run.Run"] = None,
+    run: wandb_run.Run | None = None,
 ) -> None:
     """Warn the user that a feature has been deprecated.
 
-    Also stores the information about the event in telemetry.
+    If a run is provided, the given field on its telemetry is updated.
+    Otherwise, the global run is used.
 
     Args:
-        field_name: The name of the feature that has been deprecated.
-                    Defined in wandb/proto/wandb_telemetry.proto::Deprecated
+        field_name: The field on the Deprecated proto for this deprecation.
         warning_message: The message to display to the user.
-        run: The run to whose telemetry the event will be added.
+        run: The run whose telemetry to update.
     """
-    known_fields = TelemetryDeprecated.DESCRIPTOR.fields_by_name.keys()
-    if field_name not in known_fields:
-        raise ValueError(
-            f"Unknown field name: {field_name}. Known fields: {known_fields}"
-        )
     _run = run or wandb.run
-    with wandb.wandb_lib.telemetry.context(run=_run) as tel:  # type: ignore[attr-defined]
+    with telemetry.context(run=_run) as tel:
         setattr(tel.deprecated, field_name, True)
+
     wandb.termwarn(warning_message, repeat=False)

--- a/wandb/sdk/lib/disabled.py
+++ b/wandb/sdk/lib/disabled.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.sdk.lib import deprecate
 
 
@@ -23,7 +24,7 @@ class RunDisabled:
 
     def __getattr__(self, name: str) -> Any:
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.run_disabled,
+            field_name=Deprecated.run_disabled,
             warning_message="RunDisabled is deprecated and is a no-op. "
             '`wandb.init(mode="disabled")` now returns and instance of `wandb.sdk.wandb_run.Run`.',
         )

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -35,6 +35,7 @@ from wandb.errors import CommError, Error, UsageError
 from wandb.errors.links import url_registry
 from wandb.errors.util import ProtobufErrorHandler
 from wandb.integration import sagemaker
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.sdk.lib import ipython as wb_ipython
 from wandb.sdk.lib import progress, runid, wb_logging
 from wandb.sdk.lib.paths import StrPath
@@ -43,7 +44,7 @@ from wandb.util import _is_artifact_representation
 from . import wandb_login, wandb_setup
 from .backend.backend import Backend
 from .lib import SummaryDisabled, filesystem, module, paths, printer, telemetry
-from .lib.deprecate import Deprecated, deprecate
+from .lib.deprecate import deprecate
 from .mailbox import wait_with_progress
 from .wandb_helper import parse_config
 from .wandb_run import Run, TeardownHook, TeardownStage

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -48,6 +48,7 @@ from wandb.errors import CommError, UnsupportedError, UsageError
 from wandb.errors.links import url_registry
 from wandb.integration.torch import wandb_torch
 from wandb.plot import CustomChart, Visualize
+from wandb.proto.wandb_deprecated import Deprecated
 from wandb.proto.wandb_internal_pb2 import (
     MetadataRequest,
     MetricRecord,
@@ -1041,11 +1042,12 @@ class Run:
     def mode(self) -> str:
         """For compatibility with `0.9.x` and earlier, deprecate eventually."""
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.run__mode,
+            field_name=Deprecated.run__mode,
             warning_message=(
                 "The mode property of wandb.run is deprecated "
                 "and will be removed in a future release."
             ),
+            run=self,
         )
         return "dryrun" if self._settings._offline else "run"
 
@@ -1089,7 +1091,7 @@ class Run:
         Please use `run.project` instead.
         """
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.run__project_name,
+            field_name=Deprecated.run__project_name,
             warning_message=(
                 "The project_name method is deprecated and will be removed in a"
                 " future release. Please use `run.project` instead."
@@ -1115,7 +1117,7 @@ class Run:
         Please use `run.project_url` instead.
         """
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.run__get_project_url,
+            field_name=Deprecated.run__get_project_url,
             warning_message=(
                 "The get_project_url method is deprecated and will be removed in a"
                 " future release. Please use `run.project_url` instead."
@@ -1234,7 +1236,7 @@ class Run:
         Please use `run.sweep_url` instead.
         """
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.run__get_sweep_url,
+            field_name=Deprecated.run__get_sweep_url,
             warning_message=(
                 "The get_sweep_url method is deprecated and will be removed in a"
                 " future release. Please use `run.sweep_url` instead."
@@ -1264,7 +1266,7 @@ class Run:
         Please use `run.url` instead.
         """
         deprecate.deprecate(
-            field_name=deprecate.Deprecated.run__get_url,
+            field_name=Deprecated.run__get_url,
             warning_message=(
                 "The get_url method is deprecated and will be removed in a"
                 " future release. Please use `run.url` instead."
@@ -2039,10 +2041,11 @@ class Run:
 
         if sync is not None:
             deprecate.deprecate(
-                field_name=deprecate.Deprecated.run__log_sync,
+                field_name=Deprecated.run__log_sync,
                 warning_message=(
                     "`sync` argument is deprecated and does not affect the behaviour of `wandb.log`"
                 ),
+                run=self,
             )
         if self._settings._shared and step is not None:
             wandb.termwarn(
@@ -2112,11 +2115,12 @@ class Run:
         if glob_str is None:
             # noop for historical reasons, run.save() may be called in legacy code
             deprecate.deprecate(
-                field_name=deprecate.Deprecated.run__save_no_args,
+                field_name=Deprecated.run__save_no_args,
                 warning_message=(
                     "Calling wandb.run.save without any arguments is deprecated."
                     "Changes to attributes are automatically persisted."
                 ),
+                run=self,
             )
             return True
 
@@ -2281,11 +2285,12 @@ class Run:
         """
         if quiet is not None:
             deprecate.deprecate(
-                field_name=deprecate.Deprecated.run__finish_quiet,
+                field_name=Deprecated.run__finish_quiet,
                 warning_message=(
                     "The `quiet` argument to `wandb.run.finish()` is deprecated, "
                     "use `wandb.Settings(quiet=...)` to set this instead."
                 ),
+                run=self,
             )
         return self._finish(exit_code)
 
@@ -2337,10 +2342,11 @@ class Run:
         """Deprecated alias for `finish()` - use finish instead."""
         if hasattr(self, "_telemetry_obj"):
             deprecate.deprecate(
-                field_name=deprecate.Deprecated.run__join,
+                field_name=Deprecated.run__join,
                 warning_message=(
                     "wandb.run.join() is deprecated, please use wandb.run.finish()."
                 ),
+                run=self,
             )
         self._finish(exit_code=exit_code)
 
@@ -2890,14 +2896,14 @@ class Run:
         """
         if summary and "copy" in summary:
             deprecate.deprecate(
-                deprecate.Deprecated.run__define_metric_copy,
+                Deprecated.run__define_metric_copy,
                 "define_metric(summary='copy') is deprecated and will be removed.",
                 self,
             )
 
         if (summary and "best" in summary) or goal is not None:
             deprecate.deprecate(
-                deprecate.Deprecated.run__define_metric_best_goal,
+                Deprecated.run__define_metric_best_goal,
                 "define_metric(summary='best', goal=...) is deprecated and will be removed. "
                 "Use define_metric(summary='min') or define_metric(summary='max') instead.",
                 self,


### PR DESCRIPTION
* Improves wording in the docstring
* Updates all calls to `deprecate` to pass an explicit run if it's available
    * The only places it's available and not passed were in `wandb_run.py`
    * After `reinit="create_new"` is merged, we can update the fallback to rely on the most recent active run rather than `wandb.run`
* Removes check for unknown field names, as it adds unnecessary complexity and `setattr` would throw anyway
    * I considered catching this and printing a warning, but type checking should catch this case anyway
* Removes `__all__` because `from deprecate import *` is not used anywhere in the codebase
* Removes `Deprecated` export and updates all imports to get it directly from `wandb.proto.wandb_deprecated`