### PR TITLE
refactor: no global run in old summary

### DIFF
--- a/wandb/old/summary.py
+++ b/wandb/old/summary.py
@@ -379,8 +379,6 @@ class FileSummary(Summary):
         if self._h5:
             self._h5.close()
             self._h5 = None
-        if wandb.run and wandb.run._jupyter_agent:
-            wandb.run._jupyter_agent.start()
 
 
 class HTTPSummary(Summary):


### PR DESCRIPTION
Removes `wandb.run` usage in `wandb/old/summary.py`.

This checked the `_jupyter_agent` property, which I think no longer exists. This code would likely have crashed with an AttributeError before. It is possible this is dead code.