### PR TITLE
chore: pin pre-commit ruff version and reformat

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,11 +20,6 @@ jobs:
     - name: setup env
       run: |
         ./core/scripts/code-checks.sh update
-    - name: install ruff
-      run: pip install ruff
-    # remove this once we upgrade to Python 3.9+
-    - name: install astunparse
-      run: pip install astunparse
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --hook-stage pre-push --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ default_stages:
 default_install_hook_types: [pre-push, pre-commit]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.8.2"
+    rev: "v0.11.5"
     hooks:
       - id: ruff
         args: [--fix]
@@ -58,7 +58,7 @@ repos:
         language: "python"
         pass_filenames: false
         always_run: true
-        additional_dependencies: ["ruff", "astunparse>=1.6.3"]
+        additional_dependencies: ["ruff", "astunparse~=1.6"]
         description: "Generates stubs for wandb module"
       - id: go-generate-proto
         name: "go-generate-proto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,9 +89,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
         if wandb_core_only:
             # Don't merge tests like this. Implement the feature first.
-            assert (
-                not skip_wandb_core
-            ), "Cannot mark test both skip_wandb_core and wandb_core_only"
+            assert not skip_wandb_core, (
+                "Cannot mark test both skip_wandb_core and wandb_core_only"
+            )
 
             values = [False]
             ids = ["wandb_core"]

--- a/tests/system_tests/test_core/test_cli_full.py
+++ b/tests/system_tests/test_core/test_cli_full.py
@@ -210,7 +210,7 @@ def test_login_key_prompt(monkeypatch):
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli.login, input=f"{'A'*40}\n")
+        result = runner.invoke(cli.login, input=f"{'A' * 40}\n")
         assert result.exit_code == 0
         with open(get_netrc_file_path()) as f:
             generated_netrc = f.read()

--- a/tests/system_tests/test_core/test_wandb_integration.py
+++ b/tests/system_tests/test_core/test_wandb_integration.py
@@ -91,9 +91,9 @@ def test_dir_on_import():
         assert not os.path.isdir(default_path), "Unexpected directory at {}".format(
             default_path
         )
-        assert not os.path.isdir(
-            custom_env_path
-        ), f"Unexpected directory at {custom_env_path}"
+        assert not os.path.isdir(custom_env_path), (
+            f"Unexpected directory at {custom_env_path}"
+        )
 
 
 def test_dir_on_init(user):

--- a/tests/system_tests/test_functional/console_capture/uncapturing.py
+++ b/tests/system_tests/test_functional/console_capture/uncapturing.py
@@ -27,16 +27,13 @@ if __name__ == "__main__":
     print("Line 3 (not received.)")  # noqa: T201
 
     received = received_by_hooks.getvalue()
-    if (
-        received
-        != (
-            "[hook1]Line 1."  # (line-break for readability)
-            "[hook2]Line 1."
-            "[hook1]\n"  # NOTE: print() makes two write() calls!
-            "[hook2]\n"
-            "[hook2]Line 2."
-            "[hook2]\n"
-        )
+    if received != (
+        "[hook1]Line 1."  # (line-break for readability)
+        "[hook2]Line 1."
+        "[hook1]\n"  # NOTE: print() makes two write() calls!
+        "[hook2]\n"
+        "[hook2]Line 2."
+        "[hook2]\n"
     ):
         print(f"Wrong data: {received!r}", file=sys.stderr)  # noqa: T201
         sys.exit(1)

--- a/tests/unit_tests/test_wandb_run.py
+++ b/tests/unit_tests/test_wandb_run.py
@@ -227,8 +227,7 @@ def test_deprecated_run_log_sync(mock_run, mock_wandb_log):
     run.log(dict(this=1), sync=True)
 
     assert mock_wandb_log.warned(
-        "`sync` argument is deprecated"
-        " and does not affect the behaviour of `wandb.log`"
+        "`sync` argument is deprecated and does not affect the behaviour of `wandb.log`"
     )
 
 

--- a/tools/cloud_tool.py
+++ b/tools/cloud_tool.py
@@ -182,8 +182,7 @@ class GCE:
             "--maintenance-policy",
             self.config.maintenance_policy,
             "--image",
-            f"projects/{self.config.project}/global/images/"
-            f"{self.config.vm_image_name}",
+            f"projects/{self.config.project}/global/images/{self.config.vm_image_name}",
             "--boot-disk-size",
             self.config.disk_size,
             "--boot-disk-type",

--- a/tools/generate-tool.py
+++ b/tools/generate-tool.py
@@ -98,9 +98,9 @@ def check_files(paths: List[PurePath]) -> None:
         with temp_fname() as temp_file:
             generate_file(p, temp_file)
             format_file(temp_file)
-            assert filecmp.cmp(
-                generated_path, temp_file
-            ), f"expected: {open(temp_file).read()}"
+            assert filecmp.cmp(generated_path, temp_file), (
+                f"expected: {open(temp_file).read()}"
+            )
 
 
 def main() -> None:

--- a/tools/local_wandb_server.py
+++ b/tools/local_wandb_server.py
@@ -305,8 +305,7 @@ def _check_health(health_url: str, timeout: int = 1) -> bool:
     start_time = time.monotonic()
 
     _echo_info(
-        f"Waiting up to {timeout} second(s)"
-        f" until {health_url} responds with HTTP 200."
+        f"Waiting up to {timeout} second(s) until {health_url} responds with HTTP 200."
     )
 
     while True:

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1477,7 +1477,9 @@ class Api:
 
             Find all collections in the registries with the name "my_collection" and the tag "my_tag"
             ```python
-            api.registries().collections(filter={"name": "my_collection", "tag": "my_tag"})
+            api.registries().collections(
+                filter={"name": "my_collection", "tag": "my_tag"}
+            )
             ```
 
             Find all artifact versions in the registries with a collection name that contains "my_collection" and a version that has the alias "best"

--- a/wandb/integration/catboost/catboost.py
+++ b/wandb/integration/catboost/catboost.py
@@ -22,7 +22,11 @@ class WandbCallback:
 
     Example:
         ```
-        train_pool = Pool(train[features], label=train["label"], cat_features=cat_features)
+        train_pool = Pool(
+            train[features],
+            label=train["label"],
+            cat_features=cat_features,
+        )
         test_pool = Pool(test[features], label=test["label"], cat_features=cat_features)
 
         model = CatBoostRegressor(
@@ -130,7 +134,11 @@ def log_summary(
 
     Example:
         ```python
-        train_pool = Pool(train[features], label=train["label"], cat_features=cat_features)
+        train_pool = Pool(
+            train[features],
+            label=train["label"],
+            cat_features=cat_features,
+        )
         test_pool = Pool(test[features], label=test["label"], cat_features=cat_features)
 
         model = CatBoostRegressor(

--- a/wandb/integration/gym/__init__.py
+++ b/wandb/integration/gym/__init__.py
@@ -9,8 +9,7 @@ _gym_version_lt_0_26: Optional[bool] = None
 _gymnasium_version_lt_1_0_0: Optional[bool] = None
 
 _required_error_msg = (
-    "Couldn't import the gymnasium python package, "
-    "install with `pip install gymnasium`"
+    "Couldn't import the gymnasium python package, install with `pip install gymnasium`"
 )
 GymLib = Literal["gym", "gymnasium"]
 

--- a/wandb/integration/kfp/kfp_patch.py
+++ b/wandb/integration/kfp/kfp_patch.py
@@ -271,10 +271,10 @@ def create_component_from_func(
         Example of a component function declaring file input and output::
 
             def catboost_train_classifier(
-                training_data_path: InputPath("CSV"),  # Path to input data file of type "CSV"
-                trained_model_path: OutputPath(
-                    "CatBoostModel"
-                ),  # Path to output data file of type "CatBoostModel"
+                # Path to input data file of type "CSV"
+                training_data_path: InputPath("CSV"),
+                # Path to output data file of type "CatBoostModel"
+                trained_model_path: OutputPath("CatBoostModel"),
                 number_of_trees: int = 100,  # Small output of type "Integer"
             ) -> NamedTuple(
                 "Outputs",

--- a/wandb/integration/sb3/sb3.py
+++ b/wandb/integration/sb3/sb3.py
@@ -106,9 +106,9 @@ class WandbCallback(BaseCallback):
             os.makedirs(self.model_save_path, exist_ok=True)
             self.path = os.path.join(self.model_save_path, "model.zip")
         else:
-            assert (
-                self.model_save_freq == 0
-            ), "to use the `model_save_freq` you have to set the `model_save_path` parameter"
+            assert self.model_save_freq == 0, (
+                "to use the `model_save_freq` you have to set the `model_save_path` parameter"
+            )
 
     def _init_callback(self) -> None:
         d = {}

--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -102,7 +102,11 @@ class WandBUltralyticsCallback:
         model = YOLO("yolov8n.pt")
 
         # add wandb callback
-        add_wandb_callback(model, max_validation_batches=2, enable_model_checkpointing=True)
+        add_wandb_callback(
+            model,
+            max_validation_batches=2,
+            enable_model_checkpointing=True,
+        )
 
         # train
         model.train(data="coco128.yaml", epochs=5, imgsz=640)
@@ -454,7 +458,11 @@ def add_wandb_callback(
         model = YOLO("yolov8n.pt")
 
         # add wandb callback
-        add_wandb_callback(model, max_validation_batches=2, enable_model_checkpointing=True)
+        add_wandb_callback(
+            model,
+            max_validation_batches=2,
+            enable_model_checkpointing=True,
+        )
 
         # train
         model.train(data="coco128.yaml", epochs=5, imgsz=640)

--- a/wandb/plot/confusion_matrix.py
+++ b/wandb/plot/confusion_matrix.py
@@ -150,7 +150,7 @@ def confusion_matrix(
     else:
         class_idx = set(preds).union(set(y_true))
         n_classes = len(class_idx)
-        class_names = [f"Class_{i+1}" for i in range(n_classes)]
+        class_names = [f"Class_{i + 1}" for i in range(n_classes)]
 
     # Create a mapping from class name to index
     class_mapping = {val: i for i, val in enumerate(sorted(list(class_idx)))}

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -124,9 +124,9 @@ class Media(WBValue):
         self._path = path
         self._is_tmp = is_tmp
         self._extension = extension
-        assert extension is None or path.endswith(
-            extension
-        ), f'Media file extension "{extension}" must occur at the end of path "{path}".'
+        assert extension is None or path.endswith(extension), (
+            f'Media file extension "{extension}" must occur at the end of path "{path}".'
+        )
 
         with open(self._path, "rb") as f:
             self._sha256 = hashlib.sha256(f.read()).hexdigest()
@@ -244,13 +244,14 @@ class Media(WBValue):
                 json_obj["_latest_artifact_path"] = artifact_entry_latest_url
 
             if artifact_entry_url is None or self.is_bound():
-                assert self.is_bound(), "Value of type {} must be bound to a run with bind_to_run() before being serialized to JSON.".format(
-                    type(self).__name__
+                assert self.is_bound(), (
+                    f"Value of type {type(self).__name__} must be bound to"
+                    " a run with bind_to_run() before being serialized to JSON."
                 )
 
-                assert (
-                    self._run is run
-                ), "We don't support referring to media files across runs."
+                assert self._run is run, (
+                    "We don't support referring to media files across runs."
+                )
 
                 # The following two assertions are guaranteed to pass
                 # by definition is_bound, but are needed for

--- a/wandb/sdk/data_types/base_types/wb_value.py
+++ b/wandb/sdk/data_types/base_types/wb_value.py
@@ -195,20 +195,20 @@ class WBValue:
     def _set_artifact_source(
         self, artifact: "Artifact", name: Optional[str] = None
     ) -> None:
-        assert (
-            self._artifact_source is None
-        ), "Cannot update artifact_source. Existing source: {}/{}".format(
-            self._artifact_source.artifact, self._artifact_source.name
+        assert self._artifact_source is None, (
+            "Cannot update artifact_source. Existing source: {}/{}".format(
+                self._artifact_source.artifact, self._artifact_source.name
+            )
         )
         self._artifact_source = _WBValueArtifactSource(artifact, name)
 
     def _set_artifact_target(
         self, artifact: "Artifact", name: Optional[str] = None
     ) -> None:
-        assert (
-            self._artifact_target is None
-        ), "Cannot update artifact_target. Existing target: {}/{}".format(
-            self._artifact_target.artifact, self._artifact_target.name
+        assert self._artifact_target is None, (
+            "Cannot update artifact_target. Existing target: {}/{}".format(
+                self._artifact_target.artifact, self._artifact_target.name
+            )
         )
         self._artifact_target = _WBValueArtifactTarget(artifact, name)
 

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -117,7 +117,11 @@ class Image(BatchableMedia):
             examples = []
             for i in range(3):
                 pixels = np.random.randint(low=0, high=256, size=(100, 100, 3))
-                image = wandb.Image(pixels, caption=f"random field {i}", file_type="jpg")
+                image = wandb.Image(
+                    pixels,
+                    caption=f"random field {i}",
+                    file_type="jpg",
+                )
                 examples.append(image)
             run.log({"examples": examples})
         ```

--- a/wandb/sdk/data_types/saved_model.py
+++ b/wandb/sdk/data_types/saved_model.py
@@ -252,9 +252,9 @@ class _SavedModel(WBValue, Generic[SavedModelObjType]):
         self._model_obj = None
 
     def _set_obj(self, model_obj: Any) -> None:
-        assert model_obj is not None and self._validate_obj(
-            model_obj
-        ), f"Invalid model object {model_obj}"
+        assert model_obj is not None and self._validate_obj(model_obj), (
+            f"Invalid model object {model_obj}"
+        )
         self._model_obj = model_obj
 
     def _dump(self, target_path: str) -> None:

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -276,9 +276,9 @@ class Table(Media):
             self.add_data(*row)
 
     def _init_from_ndarray(self, ndarray, columns, optional=True, dtype=None):
-        assert util.is_numpy_array(
-            ndarray
-        ), "ndarray argument expects a `numpy.ndarray` object"
+        assert util.is_numpy_array(ndarray), (
+            "ndarray argument expects a `numpy.ndarray` object"
+        )
         self.data = []
         self._assert_valid_columns(columns)
         self.columns = columns
@@ -287,9 +287,9 @@ class Table(Media):
             self.add_data(*row)
 
     def _init_from_dataframe(self, dataframe, columns, optional=True, dtype=None):
-        assert util.is_pandas_data_frame(
-            dataframe
-        ), "dataframe argument expects a `pandas.core.frame.DataFrame` object"
+        assert util.is_pandas_data_frame(dataframe), (
+            "dataframe argument expects a `pandas.core.frame.DataFrame` object"
+        )
         self.data = []
         columns = list(dataframe.columns)
         self._assert_valid_columns(columns)
@@ -349,18 +349,18 @@ class Table(Media):
         is_fk = isinstance(wbtype, _ForeignKeyType)
         is_fi = isinstance(wbtype, _ForeignIndexType)
         if is_pk or is_fk or is_fi:
-            assert (
-                not optional
-            ), "Primary keys, foreign keys, and foreign indexes cannot be optional."
+            assert not optional, (
+                "Primary keys, foreign keys, and foreign indexes cannot be optional."
+            )
 
         if (is_fk or is_fk) and id(wbtype.params["table"]) == id(self):
             raise AssertionError("Cannot set a foreign table reference to same table.")
 
         if is_pk:
-            assert (
-                self._pk_col is None
-            ), "Cannot have multiple primary keys - {} is already set as the primary key.".format(
-                self._pk_col
+            assert self._pk_col is None, (
+                "Cannot have multiple primary keys - {} is already set as the primary key.".format(
+                    self._pk_col
+                )
             )
 
         # Update the column type
@@ -387,10 +387,10 @@ class Table(Media):
             other.columns, self.columns
         )
         eq = eq and self._column_types == other._column_types
-        assert (
-            not should_assert or eq
-        ), "Found column type {}, expected column type {}".format(
-            other._column_types, self._column_types
+        assert not should_assert or eq, (
+            "Found column type {}, expected column type {}".format(
+                other._column_types, self._column_types
+            )
         )
         if eq:
             for row_ndx in range(len(self.data)):
@@ -400,13 +400,13 @@ class Table(Media):
                     if util.is_numpy_array(_eq):
                         _eq = ((_eq * -1) + 1).sum() == 0
                     eq = eq and _eq
-                    assert (
-                        not should_assert or eq
-                    ), "Unequal data at row_ndx {} col_ndx {}: found {}, expected {}".format(
-                        row_ndx,
-                        col_ndx,
-                        other.data[row_ndx][col_ndx],
-                        self.data[row_ndx][col_ndx],
+                    assert not should_assert or eq, (
+                        "Unequal data at row_ndx {} col_ndx {}: found {}, expected {}".format(
+                            row_ndx,
+                            col_ndx,
+                            other.data[row_ndx][col_ndx],
+                            self.data[row_ndx][col_ndx],
+                        )
                     )
                     if not eq:
                         return eq
@@ -807,9 +807,9 @@ class Table(Media):
         assert isinstance(data, list) or is_np
         assert isinstance(optional, bool)
         is_first_col = len(self.columns) == 0
-        assert is_first_col or len(data) == len(
-            self.data
-        ), f"Expected length {len(self.data)}, found {len(data)}"
+        assert is_first_col or len(data) == len(self.data), (
+            f"Expected length {len(self.data)}, found {len(data)}"
+        )
 
         # Add the new data
         for ndx in range(max(len(data), len(self.data))):

--- a/wandb/sdk/data_types/trace_tree.py
+++ b/wandb/sdk/data_types/trace_tree.py
@@ -261,14 +261,14 @@ class Trace:
             A Span object.
         """
         if kind is not None:
-            assert (
-                kind.upper() in SpanKind.__members__
-            ), "Invalid span kind, can be one of 'LLM', 'AGENT', 'CHAIN', 'TOOL'"
+            assert kind.upper() in SpanKind.__members__, (
+                "Invalid span kind, can be one of 'LLM', 'AGENT', 'CHAIN', 'TOOL'"
+            )
             kind = SpanKind(kind.upper())
         if status_code is not None:
-            assert (
-                status_code.upper() in StatusCode.__members__
-            ), "Invalid status code, can be one of 'SUCCESS' or 'ERROR'"
+            assert status_code.upper() in StatusCode.__members__, (
+                "Invalid status code, can be one of 'SUCCESS' or 'ERROR'"
+            )
             status_code = StatusCode(status_code.upper())
         if inputs is not None:
             assert isinstance(inputs, dict), "Inputs must be a dictionary"
@@ -419,9 +419,9 @@ class Trace:
         Args:
             value: The kind of the trace to be set.
         """
-        assert (
-            value.upper() in SpanKind.__members__
-        ), "Invalid span kind, can be one of 'LLM', 'AGENT', 'CHAIN', 'TOOL'"
+        assert value.upper() in SpanKind.__members__, (
+            "Invalid span kind, can be one of 'LLM', 'AGENT', 'CHAIN', 'TOOL'"
+        )
         self._span.span_kind = SpanKind(value.upper())
 
     def log(self, name: str) -> None:
@@ -431,8 +431,8 @@ class Trace:
             name: The name of the trace to be logged
         """
         trace_tree = WBTraceTree(self._span, self._model_dict)
-        assert (
-            wandb.run is not None
-        ), "You must call wandb.init() before logging a trace"
+        assert wandb.run is not None, (
+            "You must call wandb.init() before logging a trace"
+        )
         assert len(name.strip()) > 0, "You must provide a valid name to log the trace"
         wandb.run.log({name: trace_tree})

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -74,7 +74,12 @@ class Video(BatchableMedia):
 
         run = wandb.init()
         # axes are (time, channel, height, width)
-        frames = np.random.randint(low=0, high=256, size=(10, 3, 100, 100), dtype=np.uint8)
+        frames = np.random.randint(
+            low=0,
+            high=256,
+            size=(10, 3, 100, 100),
+            dtype=np.uint8,
+        )
         run.log({"video": wandb.Video(frames, fps=4)})
         ```
     """

--- a/wandb/sdk/internal/datastore.py
+++ b/wandb/sdk/internal/datastore.py
@@ -124,10 +124,10 @@ class DataStore:
         header = self._fp.read(LEVELDBLOG_HEADER_LEN)
         if len(header) == 0:
             return None
-        assert (
-            len(header) == LEVELDBLOG_HEADER_LEN
-        ), "record header is {} bytes instead of the expected {}".format(
-            len(header), LEVELDBLOG_HEADER_LEN
+        assert len(header) == LEVELDBLOG_HEADER_LEN, (
+            "record header is {} bytes instead of the expected {}".format(
+                len(header), LEVELDBLOG_HEADER_LEN
+            )
         )
         fields = struct.unpack("<IHB", header)
         checksum, dlength, dtype = fields
@@ -135,9 +135,9 @@ class DataStore:
         self._index += LEVELDBLOG_HEADER_LEN
         data = self._fp.read(dlength)
         checksum_computed = zlib.crc32(data, self._crc[dtype]) & 0xFFFFFFFF
-        assert (
-            checksum == checksum_computed
-        ), "record checksum is invalid, data may be corrupt"
+        assert checksum == checksum_computed, (
+            "record checksum is invalid, data may be corrupt"
+        )
         self._index += dlength
         return dtype, data
 
@@ -160,9 +160,9 @@ class DataStore:
         if dtype == LEVELDBLOG_FULL:
             return data
 
-        assert (
-            dtype == LEVELDBLOG_FIRST
-        ), f"expected record to be type {LEVELDBLOG_FIRST} but found {dtype}"
+        assert dtype == LEVELDBLOG_FIRST, (
+            f"expected record to be type {LEVELDBLOG_FIRST} but found {dtype}"
+        )
         while True:
             offset = self._index % LEVELDBLOG_BLOCK_LEN
             record = self.scan_record()
@@ -172,9 +172,9 @@ class DataStore:
             if dtype == LEVELDBLOG_LAST:
                 data += new_data
                 break
-            assert (
-                dtype == LEVELDBLOG_MIDDLE
-            ), f"expected record to be type {LEVELDBLOG_MIDDLE} but found {dtype}"
+            assert dtype == LEVELDBLOG_MIDDLE, (
+                f"expected record to be type {LEVELDBLOG_MIDDLE} but found {dtype}"
+            )
             data += new_data
         return data
 
@@ -185,18 +185,18 @@ class DataStore:
             LEVELDBLOG_HEADER_MAGIC,
             LEVELDBLOG_HEADER_VERSION,
         )
-        assert (
-            len(data) == LEVELDBLOG_HEADER_LEN
-        ), f"header size is {len(data)} bytes, expected {LEVELDBLOG_HEADER_LEN}"
+        assert len(data) == LEVELDBLOG_HEADER_LEN, (
+            f"header size is {len(data)} bytes, expected {LEVELDBLOG_HEADER_LEN}"
+        )
         self._fp.write(data)
         self._index += len(data)
 
     def _read_header(self):
         header = self._fp.read(LEVELDBLOG_HEADER_LEN)
-        assert (
-            len(header) == LEVELDBLOG_HEADER_LEN
-        ), "header is {} bytes instead of the expected {}".format(
-            len(header), LEVELDBLOG_HEADER_LEN
+        assert len(header) == LEVELDBLOG_HEADER_LEN, (
+            "header is {} bytes instead of the expected {}".format(
+                len(header), LEVELDBLOG_HEADER_LEN
+            )
         )
         ident, magic, version = struct.unpack("<4sHB", header)
         if ident != strtobytes(LEVELDBLOG_HEADER_IDENT):

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -75,7 +75,7 @@ class DefaultFilePolicy:
 
         # get key size and convert to MB
         key_sizes = [(k, len(json.dumps(v))) for k, v in loaded.items()]
-        key_msg = [f"{k}: {v/1048576:.5f} MB" for k, v in key_sizes]
+        key_msg = [f"{k}: {v / 1048576:.5f} MB" for k, v in key_sizes]
         wandb.termerror(f"Step: {loaded['_step']} | {key_msg}", repeat=False)
         self.has_debug_log = True
 
@@ -664,8 +664,7 @@ def request_with_retry(
                 e.response is not None and e.response.status_code == 429
             ):
                 err_str = (
-                    "Filestream rate limit exceeded, "
-                    f"retrying in {delay:.1f} seconds. "
+                    f"Filestream rate limit exceeded, retrying in {delay:.1f} seconds. "
                 )
                 if retry_callback:
                     retry_callback(e.response.status_code, err_str)

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -371,9 +371,9 @@ class LaunchProject:
 
     def set_job_entry_point(self, command: List[str]) -> "EntryPoint":
         """Set job entrypoint for the project."""
-        assert (
-            self._entry_point is None
-        ), "Cannot set entry point twice. Use LaunchProject.override_entrypoint"
+        assert self._entry_point is None, (
+            "Cannot set entry point twice. Use LaunchProject.override_entrypoint"
+        )
         new_entrypoint = EntryPoint(name=command[-1], command=command)
         self._entry_point = new_entrypoint
         return new_entrypoint

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -76,9 +76,9 @@ class JobSpecAndQueue:
 def _convert_access(access: str) -> str:
     """Convert access string to a value accepted by wandb."""
     access = access.upper()
-    assert (
-        access == "PROJECT" or access == "USER"
-    ), "Queue access must be either project or user"
+    assert access == "PROJECT" or access == "USER", (
+        "Queue access must be either project or user"
+    )
     return access
 
 

--- a/wandb/sdk/launch/agent/job_status_tracker.py
+++ b/wandb/sdk/launch/agent/job_status_tracker.py
@@ -44,7 +44,9 @@ class JobAndRunStatusTracker:
             self.run_id is not None
             and self.project is not None
             and self.entity is not None
-        ), "Job tracker does not contain run info. Update with run info before checking if run stopped"
+        ), (
+            "Job tracker does not contain run info. Update with run info before checking if run stopped"
+        )
         check_stop = event_loop_thread_exec(api.api.check_stop_requested)
         try:
             return bool(await check_stop(self.project, self.entity, self.run_id))

--- a/wandb/sdk/launch/environment/gcp_environment.py
+++ b/wandb/sdk/launch/environment/gcp_environment.py
@@ -94,8 +94,7 @@ class GcpEnvironment(AbstractEnvironment):
         region = config.get("region", None)
         if not region:
             raise LaunchError(
-                "Could not create GcpEnvironment from config. Missing 'region' "
-                "field."
+                "Could not create GcpEnvironment from config. Missing 'region' field."
             )
         return cls(region=region)
 

--- a/wandb/sdk/launch/runner/sagemaker_runner.py
+++ b/wandb/sdk/launch/runner/sagemaker_runner.py
@@ -69,7 +69,7 @@ class SagemakerSubmittedRun(AbstractRun):
             )
             assert "events" in res
             return "\n".join(
-                [f'{event["timestamp"]}:{event["message"]}' for event in res["events"]]
+                [f"{event['timestamp']}:{event['message']}" for event in res["events"]]
             )
         except self.log_client.exceptions.ResourceNotFoundException:
             wandb.termwarn(

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -699,7 +699,7 @@ class Scheduler(ABC):
         if entry_point:
             wandb.termwarn(
                 f"{LOG_PREFIX}Sweep command {entry_point} will override"
-                f' {"job" if _job else "image_uri"} entrypoint'
+                f" {'job' if _job else 'image_uri'} entrypoint"
             )
 
         # override resource and args of job

--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -199,7 +199,7 @@ def create_sweep_command(command: Optional[List] = None) -> List:
             for m in matches[::-1]:
                 # Default to just leaving as is if environment variable does not exist
                 _var: str = os.environ.get(m.group(1), m.group(1))
-                command[i] = f"{command[i][:m.start()]}{_var}{command[i][m.end():]}"
+                command[i] = f"{command[i][: m.start()]}{_var}{command[i][m.end() :]}"
     return command
 
 

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -323,8 +323,7 @@ def validate_launch_spec_source(launch_spec: Dict[str, Any]) -> None:
     docker_image = launch_spec.get("docker", {}).get("docker_image")
     if bool(job) == bool(docker_image):
         raise LaunchError(
-            "Exactly one of job or docker_image must be specified in the launch "
-            "spec."
+            "Exactly one of job or docker_image must be specified in the launch spec."
         )
 
 
@@ -381,9 +380,9 @@ def diff_pip_requirements(req_1: List[str], req_2: List[str]) -> Dict[str, str]:
             else:
                 raise ValueError(f"Unable to parse pip requirements file line: {line}")
             if _name is not None:
-                assert re.match(
-                    _VALID_PIP_PACKAGE_REGEX, _name
-                ), f"Invalid pip package name {_name}"
+                assert re.match(_VALID_PIP_PACKAGE_REGEX, _name), (
+                    f"Invalid pip package name {_name}"
+                )
                 d[_name] = _version
         return d
 

--- a/wandb/sdk/lib/service_token.py
+++ b/wandb/sdk/lib/service_token.py
@@ -31,8 +31,7 @@ def get_service_token() -> ServiceToken | None:
 
     if version != _CURRENT_VERSION:
         raise ValueError(
-            f"Expected version {_CURRENT_VERSION},"
-            f" but got {version} (token={token})"
+            f"Expected version {_CURRENT_VERSION}, but got {version} (token={token})"
         )
     if transport not in _SUPPORTED_TRANSPORTS:
         raise ValueError(


### PR DESCRIPTION
Instead of installing `ruff` and `astunparse` in the GitHub action before running `pre-commit`, let `pre-commit` install the versions specified in `.pre-commit-config.yaml`.

The `pip install` commands in the GH action did not specify version constraints, ~so the latest version of each package was used. The current `ruff` version is `0.11.5`, but when running `pre-commit` locally, the older versions `0.8.2` in `.pre-commit-config.yaml` was used, causing formatting errors in CI.~ EDIT: not sure if this is true or the cause of the problems, but updating to the latest formatter is still helpful.