### PR TITLE
fix: html media object raises IsADirectoryError

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -62,7 +62,7 @@ When preparing a release that can include breaking changes, consider applying ch
     - Deprecated after 0.19.8 (https://github.com/wandb/wandb/pull/9557)
     - Can do after September 2025
 
-- Deprecate `data_is_not_path` and add `path` keyword argument to explicitly handle files.
+- Deprecate `data_is_not_path` flag in `wandb.Html` and add `path` keyword argument to explicitly handle files paths.
     - Owner: @jacobromero
-    - Deprecated after 0.19.10
+    - Deprecated after 0.19.9
     - Can do in >=0.20

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -61,3 +61,8 @@ When preparing a release that can include breaking changes, consider applying ch
     - Owner: @timoffex
     - Deprecated after 0.19.8 (https://github.com/wandb/wandb/pull/9557)
     - Can do after September 2025
+
+- Deprecate `data_is_not_path` and add `path` keyword argument to explicitly handle files.
+    - Owner: @jacobromero
+    - Deprecated after 0.19.10
+    - Can do in >=0.20

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,8 +16,8 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Added
 
 - The new `reinit="create_new"` setting causes `wandb.init()` to create a new run even if other runs are active, without finishing the other runs (in contrast to `reinit="finish_previous"`). This will eventually become the default (@timoffex in https://github.com/wandb/wandb/pull/9562)
-
 - Added `Artifact.history_step` to return the nearest run step at which history metrics were logged for the artifact's source run (@ibindlish in https://github.com/wandb/wandb/pull/9732)
+- Added `data_is_not_path` flag to skip file checks when initializing `wandb.Html` with a sting that points to a file.
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -40,4 +40,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - Fixed ValueError on Windows when running a W&B script from a different drive (@jacobromero in https://github.com/wandb/wandb/pull/9678)
 - Fix base_url setting was not provided to wandb.login (@jacobromero in https://github.com/wandb/wandb/pull/9703)
-- Fix `IsADirectoryError` when providing a path to a directory when creating a `wandb.html` object (@jacobromero in https://github.com/wandb/wandb/pull/9728)
+- `wandb.Html()` no longer raises `IsADirectoryError` with a value that matched a directory on the users system. (@jacobromero in https://github.com/wandb/wandb/pull/9728)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -40,3 +40,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - Fixed ValueError on Windows when running a W&B script from a different drive (@jacobromero in https://github.com/wandb/wandb/pull/9678)
 - Fix base_url setting was not provided to wandb.login (@jacobromero in https://github.com/wandb/wandb/pull/9703)
+- Fix `IsADirectoryError` when providing a path to a directory when creating a `wandb.html` object (@jacobromero in https://github.com/wandb/wandb/pull/9728)

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -1,6 +1,7 @@
 import io
 import os
 import platform
+import tempfile
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -1428,6 +1429,50 @@ def test_partitioned_table():
     assert len([(ndx, row) for ndx, row in partition_table.iterrows()]) == 0
     assert partition_table == wandb.data_types.PartitionedTable(parts_path="parts")
     assert partition_table != wandb.data_types.PartitionedTable(parts_path="parts2")
+
+
+################################################################################
+# Test wandb.Html
+################################################################################
+
+
+def test_wandb_html_with_directory():
+    dir = tempfile.gettempdir()
+
+    html = wandb.Html(dir, inject=False)
+
+    assert html._is_tmp is True
+    assert html._path is not None
+    assert os.path.exists(html._path)
+    with open(html._path) as f:
+        assert f.read() == dir
+
+
+def test_wandb_html_with_html_file():
+    with tempfile.NamedTemporaryFile("w", suffix=".html") as file:
+        file.write("Hello, world!")
+        file.flush()
+
+        html = wandb.Html(file.name, inject=False)
+
+        assert html._is_tmp is False
+        assert html._path is not None
+        assert html._path == file.name
+        assert os.path.exists(html._path)
+        with open(html._path) as f:
+            assert f.read() == "Hello, world!"
+
+
+def test_wandb_html_with_non_html_file():
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write("Hello, world!")
+        file.flush()
+
+        html = wandb.Html(file.name, inject=False)
+
+        assert html._is_tmp is True
+        with open(html._path) as f:
+            assert f.read() == file.name
 
 
 ################################################################################

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -1463,6 +1463,19 @@ def test_wandb_html_with_html_file():
             assert f.read() == "Hello, world!"
 
 
+def test_wandb_html_with_html_file_skip_file_check():
+    with tempfile.NamedTemporaryFile("w", suffix=".html") as file:
+        file.write("Hello, world!")
+        file.flush()
+
+        html = wandb.Html(file.name, inject=False, data_is_not_path=True)
+
+        assert html._is_tmp is True
+        assert html._path is not None
+        with open(html._path) as f:
+            assert f.read() == file.name
+
+
 def test_wandb_html_with_non_html_file():
     with tempfile.NamedTemporaryFile("w") as file:
         file.write("Hello, world!")

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -1,7 +1,6 @@
 import io
 import os
 import platform
-import tempfile
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -1436,56 +1435,51 @@ def test_partitioned_table():
 ################################################################################
 
 
-def test_wandb_html_with_directory():
-    dir = tempfile.gettempdir()
-
-    html = wandb.Html(dir, inject=False)
+def test_wandb_html_with_directory(tmp_path):
+    html = wandb.Html(str(tmp_path), inject=False)
 
     assert html._is_tmp is True
     assert html._path is not None
     assert os.path.exists(html._path)
     with open(html._path) as f:
-        assert f.read() == dir
+        assert f.read() == str(tmp_path)
 
 
-def test_wandb_html_with_html_file():
-    with tempfile.NamedTemporaryFile("w", suffix=".html") as file:
-        file.write("Hello, world!")
-        file.flush()
+def test_wandb_html_with_html_file(tmp_path):
+    html_file = tmp_path / "index.html"
+    html_file.write_text("Hello, world!")
 
-        html = wandb.Html(file.name, inject=False)
+    html = wandb.Html(str(html_file), inject=False)
 
-        assert html._is_tmp is False
-        assert html._path is not None
-        assert html._path == file.name
-        assert os.path.exists(html._path)
-        with open(html._path) as f:
-            assert f.read() == "Hello, world!"
-
-
-def test_wandb_html_with_html_file_skip_file_check():
-    with tempfile.NamedTemporaryFile("w", suffix=".html") as file:
-        file.write("Hello, world!")
-        file.flush()
-
-        html = wandb.Html(file.name, inject=False, data_is_not_path=True)
-
-        assert html._is_tmp is True
-        assert html._path is not None
-        with open(html._path) as f:
-            assert f.read() == file.name
+    assert html._is_tmp is False
+    assert html._path is not None
+    assert html._path == str(html_file)
+    assert os.path.exists(html._path)
+    with open(html._path) as f:
+        assert f.read() == "Hello, world!"
 
 
-def test_wandb_html_with_non_html_file():
-    with tempfile.NamedTemporaryFile("w") as file:
-        file.write("Hello, world!")
-        file.flush()
+def test_wandb_html_with_html_file_skip_file_check(tmp_path):
+    html_file = tmp_path / "index.html"
+    html_file.write_text("Hello, world!")
 
-        html = wandb.Html(file.name, inject=False)
+    html = wandb.Html(str(html_file), inject=False, data_is_not_path=True)
 
-        assert html._is_tmp is True
-        with open(html._path) as f:
-            assert f.read() == file.name
+    assert html._is_tmp is True
+    assert html._path is not None
+    with open(html._path) as f:
+        assert f.read() == str(html_file)
+
+
+def test_wandb_html_with_non_html_file(tmp_path):
+    file = tmp_path / "index.txt"
+    file.write_text("Hello, world!")
+
+    html = wandb.Html(str(file), inject=False)
+
+    assert html._is_tmp is True
+    with open(html._path) as f:
+        assert f.read() == str(file)
 
 
 ################################################################################

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Html(BatchableMedia):
+    """A class for logging HTML content to W&B."""
+
     _log_type = "html-file"
 
     def __init__(
@@ -24,17 +26,17 @@ class Html(BatchableMedia):
         inject: bool = True,
         data_is_not_path: bool = False,
     ) -> None:
-        """A class for logging HTML to W&B.
+        """Creates a W&B HTML object.
 
         It can be initialized by providing a path to a file:
-        ```python
+        ```
         with wandb.init() as run:
             run.log({"html": wandb.Html("./index.html")})
         ```
 
         Alternatively, it can be initialized by providing literal HTML,
         in either a string or IO object:
-        ```python
+        ```
         with wandb.init() as run:
             run.log({"html": wandb.Html("<h1>Hello, world!</h1>")})
         ```

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -16,20 +16,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Html(BatchableMedia):
-    """Wandb class for arbitrary html.
-
-    Args:
-        data: (string or io object)
-            HTML can be initialized by providing either a path to a file,
-            or literal HTML in a string or io object.
-            If `data` matches a path to a file on your system,
-            the contents of this file will be used for the HTML value displayed on W&b.
-        inject: (boolean) Add a stylesheet to the HTML object.  If set
-            to False the HTML will pass through unchanged.
-        data_is_not_path: (boolean) If set to True, the data will be
-            treated as a path to a file.
-    """
-
     _log_type = "html-file"
 
     def __init__(
@@ -38,6 +24,30 @@ class Html(BatchableMedia):
         inject: bool = True,
         data_is_not_path: bool = False,
     ) -> None:
+        """A class for logging HTML to W&B.
+
+        It can be initialized by providing a path to a file:
+        ```python
+        with wandb.init() as run:
+            run.log({"html": wandb.Html("./index.html")})
+        ```
+
+        Alternatively, it can be initialized by providing literal HTML,
+        in either a string or IO object:
+        ```python
+        with wandb.init() as run:
+            run.log({"html": wandb.Html("<h1>Hello, world!</h1>")})
+        ```
+
+        Args:
+            data:
+                A string that is a path to a file with the extension ".html",
+                or a string or IO object containing literal HTML.
+            inject: Add a stylesheet to the HTML object. If set
+                to False the HTML will pass through unchanged.
+            data_is_not_path: If set to False, the data will be
+                treated as a path to a file.
+        """
         super().__init__()
         data_is_path = (
             isinstance(data, str)

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -26,17 +26,24 @@ class Html(BatchableMedia):
             the contents of this file will be used for the HTML value displayed on W&b.
         inject: (boolean) Add a stylesheet to the HTML object.  If set
             to False the HTML will pass through unchanged.
+        data_is_not_path: (boolean) If set to True, the data will be
+            treated as a path to a file.
     """
 
     _log_type = "html-file"
 
-    def __init__(self, data: Union[str, "TextIO"], inject: bool = True) -> None:
+    def __init__(
+        self,
+        data: Union[str, "TextIO"],
+        inject: bool = True,
+        data_is_not_path: bool = False,
+    ) -> None:
         super().__init__()
         data_is_path = (
             isinstance(data, str)
             and os.path.isfile(data)
             and os.path.splitext(data)[1] == ".html"
-        )
+        ) and not data_is_not_path
         data_path = ""
         if data_is_path:
             assert isinstance(data, str)

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -19,7 +19,11 @@ class Html(BatchableMedia):
     """Wandb class for arbitrary html.
 
     Args:
-        data: (string or io object) HTML to display in wandb
+        data: (string or io object)
+            HTML can be initialized by providing either a path to a file,
+            or literal HTML in a string or io object.
+            If `data` matches a path to a file on your system,
+            the contents of this file will be used for the HTML value displayed on W&b.
         inject: (boolean) Add a stylesheet to the HTML object.  If set
             to False the HTML will pass through unchanged.
     """
@@ -28,7 +32,11 @@ class Html(BatchableMedia):
 
     def __init__(self, data: Union[str, "TextIO"], inject: bool = True) -> None:
         super().__init__()
-        data_is_path = isinstance(data, str) and os.path.exists(data)
+        data_is_path = (
+            isinstance(data, str)
+            and os.path.isfile(data)
+            and os.path.splitext(data)[1] == ".html"
+        )
         data_path = ""
         if data_is_path:
             assert isinstance(data, str)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-24403
- Fixes #9648

What does the PR do? Include a concise description of the PR contents.

This change updates the documentation for the `html.py` media object to more clearly specify that an HTML data type can be initialized with a path to a file, and will use the files contents first if such a file exists.
Additionally there was a bug which the SDK would attempt to open and read a directory if a valid path was provided on creation on an HTML datatype (see testing below).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- Unit tests added
- Test script
```python
import wandb

with wandb.init(project="htmltest") as run:
    run.log({"html": wandb.Html(".")})
```

##### after this change
```
wandb: Using wandb-core as the SDK backend.  Please refer to https://wandb.me/wandb-core for more information.
warning: GOCOVERDIR not set, no coverage data emitted
wandb: Currently logged in as: jacob-romero (wandb) to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.19.10.dev1
wandb: Run data is saved locally in /Users/jacob.romero/workspace/test/wandb/run-20250415_194939-mq6nw8ky
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run deft-capybara-6
wandb: ⭐️ View project at https://wandb.ai/wandb/htmltest
wandb: 🚀 View run at https://wandb.ai/wandb/htmltest/runs/mq6nw8ky
wandb:
wandb: 🚀 View run deft-capybara-6 at: https://wandb.ai/wandb/htmltest/runs/mq6nw8ky
wandb: ⭐️ View project at: https://wandb.ai/wandb/htmltest
wandb: Synced 6 W&B file(s), 1 media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./wandb/run-20250415_194939-mq6nw8ky/logs
```

##### before this change
```
wandb: Using wandb-core as the SDK backend.  Please refer to https://wandb.me/wandb-core for more information.
warning: GOCOVERDIR not set, no coverage data emitted
wandb: Currently logged in as: jacob-romero (wandb) to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.19.10.dev1
wandb: Run data is saved locally in /Users/jacob.romero/workspace/test/wandb/run-20250415_194858-nwarppm5
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run laced-frost-5
wandb: ⭐️ View project at https://wandb.ai/wandb/htmltest
wandb: 🚀 View run at https://wandb.ai/wandb/htmltest/runs/nwarppm5
Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/test/htmltest.py", line 4, in <module>
    run.log({"html": wandb.Html(".")})
                     ^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/sdk/data_types/html.py", line 40, in __init__
    with open(data_path, encoding="utf-8") as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '.'
wandb:
wandb: 🚀 View run laced-frost-5 at: https://wandb.ai/wandb/htmltest/runs/nwarppm5
wandb: ⭐️ View project at: https://wandb.ai/wandb/htmltest
wandb: Synced 6 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./wandb/run-20250415_194858-nwarppm5/logs
Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/test/htmltest.py", line 4, in <module>
    run.log({"html": wandb.Html(".")})
                     ^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/sdk/data_types/html.py", line 40, in __init__
    with open(data_path, encoding="utf-8") as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '.'
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
