### PR TITLE
refactor: remove wandb-core message from wandb.init()

### DIFF
--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -14,10 +14,10 @@ import tempfile
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from wandb import _sentry, termlog
+from wandb import _sentry
 from wandb.env import core_debug, error_reporting_enabled, is_require_legacy_service
 from wandb.errors import Error, WandbCoreNotAvailableError
-from wandb.errors.links import url_registry
+from wandb.errors.term import termlog, termwarn
 from wandb.util import get_core_path, get_module
 
 from . import _startup_debug, port_file
@@ -163,13 +163,15 @@ class _Service:
                     service_args.extend(["--log-level", "-4"])
 
                 exec_cmd_list = []
-                termlog(
-                    "Using wandb-core as the SDK backend.  Please refer to "
-                    f"{url_registry.url('wandb-core')} for more information.",
-                    repeat=False,
-                )
             else:
                 service_args.extend(["wandb", "service", "--debug"])
+                termwarn(
+                    "Using legacy-service, which is deprecated. If this is"
+                    " unintentional, you can fix it by ensuring you do not call"
+                    " `wandb.require('legacy-service')` and do not set the"
+                    " WANDB_X_REQUIRE_LEGACY_SERVICE environment"
+                    " variable."
+                )
 
             service_args += [
                 "--port-filename",


### PR DESCRIPTION
Fixes WB-24478.

Instead of printing a message when the user is on `wandb-core`, which has been the norm for a long time now, print a warning on init when the user is on `legacy-service`.

The new warning is in addition to the warning printed at the end of each `legacy-service` run. Having it at the start can help users (realistically, only developers) notice if they're accidentally using `legacy-service`.

To test:

* `python -c 'import wandb; wandb.init()'`
* `WANDB_X_REQUIRE_LEGACY_SERVICE=true python -c 'import wandb; wandb.init()'`