### PR TITLE
fix: pin hypothesis version (stopgap fix for failing hypothesis unit tests)

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -29,5 +29,21 @@ coverage[toml]~=7.6
 
 pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.
 
-hypothesis
+hypothesis<6.131.1
+# Stopgap fix until we can resolve sys.modules-related error, inadvertently introduced by hypothesis==6.131.1.
+# This manifests in CI as RuntimeErrors like:
+#
+#     .0 = <dict_valueiterator object at ...>
+#
+#         return tuple(
+#             module
+#     >       for module in sys.modules.values()
+#             if (
+#                 getattr(module, "__file__", None) is not None
+#                 and _is_local_module_file(module.__file__)
+#             )
+#         )
+#     E   RuntimeError: dictionary changed size during iteration
+#
+#     .../site-packages/hypothesis/internal/constants_ast.py:147: RuntimeError
 hypothesis-fspaths

--- a/tests/unit_tests/test_data_types_box3d.py
+++ b/tests/unit_tests/test_data_types_box3d.py
@@ -1,8 +1,8 @@
 from typing import Tuple
 
-import hypothesis
 import numpy as np
 import pytest
+from hypothesis import assume, given
 from hypothesis.strategies import floats, tuples
 from wandb import data_types
 
@@ -15,7 +15,7 @@ quaternions = tuples(
 )
 
 
-@hypothesis.given(
+@given(
     center=tuples(small_floats, small_floats, small_floats),
     size=tuples(small_floats, small_floats, small_floats),
     orientation=quaternions,
@@ -26,7 +26,7 @@ def test_box3d_always_box(
     orientation: "Tuple[float, float, float, float]",
 ):
     # Require a nonzero quaternion.
-    hypothesis.assume(any(q != pytest.approx(0) for q in orientation))
+    assume(any(q != pytest.approx(0) for q in orientation))
 
     box = data_types.box3d(
         center=center,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Stopgap fix to prevent `sys.modules`-related `RuntimeError`, which appears to have been inadvertently introduced on/after `hypothesis==6.131.1`.

In detail, this manifests in CI as `RuntimeError`s like:
```python
    .0 = <dict_valueiterator object at ...>

        return tuple(
            module
    >       for module in sys.modules.values()
            if (
                getattr(module, "__file__", None) is not None
                and _is_local_module_file(module.__file__)
            )
        )
    E   RuntimeError: dictionary changed size during iteration

    .../site-packages/hypothesis/internal/constants_ast.py:147: RuntimeError
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
