### PR TITLE
feat(artifacts): add multipart download to download large file in parallel

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Added
 
 - `is_link` property to artifacts to determine if an artifact is a link artifact (such as in the Registry) or source artifact. (@estellazx in https://github.com/wandb/wandb/pull/9764)
+- Multipart download for artifact file larger than 2GB, user can control it directly using `artifact.download(multipart=True)`. (@pingleiwandb in https://github.com/wandb/wandb/pull/9738)
 
 ### Fixed
 

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -2,9 +2,11 @@ import functools
 import queue
 import shutil
 import unittest.mock as mock
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
 from string import ascii_letters, digits
-from typing import TYPE_CHECKING, Any, Mapping, Optional
+from typing import IO, TYPE_CHECKING, Any, AnyStr, ContextManager, Mapping, Optional
 from unittest.mock import Mock
 
 import pytest
@@ -513,8 +515,87 @@ def test_artifact_multipart_download_threshold():
     assert policy._should_multipart_download(5070 * mb, None)
 
 
-# TODO: test network error handling, we already verified manually it works.
-# TODO: test disk write handling, which we are were relying on cache_open for both network and disk error
-# def test_artifact_multipart_download_network_error(monkeypatch):
-#     policy = WandbStoragePolicy()
-#     policy._multipart_file_download(None, None, None)
+class MockOpener:
+    """Wrap a file as a Opener."""
+
+    def __init__(self, file: IO):
+        self.file = file
+
+    def __call__(self, mode: str = "r") -> ContextManager[IO]:
+        @contextmanager
+        def _fake_context():
+            yield self.file
+
+        return _fake_context()
+
+
+def test_artifact_multipart_download_network_error():
+    policy = WandbStoragePolicy()
+    # Disable retries and backoff to avoid timeout in test
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=0)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    policy._session = session
+
+    class CountOnlyFile(IO):
+        def __init__(self):
+            self.write_count = 0
+            self.seek_count = 0
+
+        def seek(self, offset: int, whence: int = 0) -> int:
+            self.seek_count += 1
+            return offset
+
+        def write(self, s: AnyStr) -> int:
+            self.write_count += 1
+            return len(s)
+
+    file = CountOnlyFile()
+    opener = MockOpener(file)
+    with pytest.raises(requests.exceptions.ConnectionError):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            policy._multipart_file_download(
+                executor, "https://invalid.com", 4 * 1024 * 1024 * 1024, opener
+            )
+    assert file.seek_count == 0
+    assert file.write_count == 0
+
+
+def test_artifact_multipart_download_disk_error():
+    policy = WandbStoragePolicy()
+
+    class ThrowFile(IO):
+        def seek(self, offset: int, whence: int = 0) -> int:
+            raise ValueError("I/O operation on closed file")
+
+    class MockResponse:
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size: int = 1024):
+            return [b"test"]
+
+    class MockSession:
+        def __init__(self):
+            self.get_count = 0
+
+        def get(self, url: str, stream: bool = False, headers: dict = None):
+            self.get_count += 1
+            return MockResponse()
+
+    session = MockSession()
+    policy._session = session
+
+    file = ThrowFile()
+    opener = MockOpener(file)
+    with pytest.raises(ValueError):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            policy._multipart_file_download(
+                executor,
+                "https://mocked.com",
+                500 * 1024 * 1024,  # 500MB should have 5 parts
+                opener,
+            )
+    # After first get call has errors, reamining get call should return without making the call.
+    assert session.get_count < 5

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -502,3 +502,19 @@ def test_download_with_pathlib_root(monkeypatch):
     root = list(artifact._download_roots)[0]
     path_parts = custom_path.parts
     assert Path(root).parts[-len(path_parts) :] == path_parts
+
+
+def test_artifact_multipart_download_threshold():
+    policy = WandbStoragePolicy()
+    mb = 1024 * 1024
+    assert policy._should_multipart_download(100 * mb, True)
+    assert not policy._should_multipart_download(100 * mb, None)
+    assert not policy._should_multipart_download(2080 * mb, False)
+    assert policy._should_multipart_download(5070 * mb, None)
+
+
+# TODO: test network error handling, we already verified manually it works.
+# TODO: test disk write handling, which we are were relying on cache_open for both network and disk error
+# def test_artifact_multipart_download_network_error(monkeypatch):
+#     policy = WandbStoragePolicy()
+#     policy._multipart_file_download(None, None, None)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1862,6 +1862,7 @@ class Artifact:
         allow_missing_references: bool = False,
         skip_cache: bool | None = None,
         path_prefix: StrPath | None = None,
+        multipart: bool | None = None,
     ) -> FilePathStr:
         """Download the contents of the artifact to the specified root directory.
 
@@ -1878,6 +1879,10 @@ class Artifact:
                 specified download directory.
             path_prefix: If specified, only files with a path that starts with the given
                 prefix will be downloaded. Uses unix format (forward slashes).
+            multipart: If set to `None` (default), the artifact will be downloaded
+                in parallel using multipart download if individual file size is greater than
+                2GB. If set to `True` or `False`, the artifact will be downloaded in
+                parallel or serially regardless of the file size.
 
         Returns:
             The path to the downloaded contents.
@@ -1901,6 +1906,7 @@ class Artifact:
             allow_missing_references=allow_missing_references,
             skip_cache=skip_cache,
             path_prefix=path_prefix,
+            multipart=multipart,
         )
 
     def _download_using_core(
@@ -1970,6 +1976,7 @@ class Artifact:
         allow_missing_references: bool = False,
         skip_cache: bool | None = None,
         path_prefix: StrPath | None = None,
+        multipart: bool | None = None,
     ) -> FilePathStr:
         nfiles = len(self.manifest.entries)
         size = sum(e.size or 0 for e in self.manifest.entries.values())
@@ -1986,6 +1993,7 @@ class Artifact:
 
         def _download_entry(
             entry: ArtifactManifestEntry,
+            executor: concurrent.futures.Executor,
             api_key: str | None,
             cookies: dict | None,
             headers: dict | None,
@@ -1995,7 +2003,12 @@ class Artifact:
             _thread_local_api_settings.headers = headers
 
             try:
-                entry.download(root, skip_cache=skip_cache)
+                entry.download(
+                    root,
+                    skip_cache=skip_cache,
+                    executor=executor,
+                    multipart=multipart,
+                )
             except FileNotFoundError as e:
                 if allow_missing_references:
                     wandb.termwarn(str(e))
@@ -2006,14 +2019,14 @@ class Artifact:
                 return
             download_logger.notify_downloaded()
 
-        download_entry = partial(
-            _download_entry,
-            api_key=_thread_local_api_settings.api_key,
-            cookies=_thread_local_api_settings.cookies,
-            headers=_thread_local_api_settings.headers,
-        )
-
         with concurrent.futures.ThreadPoolExecutor(64) as executor:
+            download_entry = partial(
+                _download_entry,
+                executor=executor,
+                api_key=_thread_local_api_settings.api_key,
+                cookies=_thread_local_api_settings.cookies,
+                headers=_thread_local_api_settings.headers,
+            )
             active_futures = set()
             has_next_page = True
             cursor = None
@@ -2049,8 +2062,9 @@ class Artifact:
             hours = int(delta // 3600)
             minutes = int((delta - hours * 3600) // 60)
             seconds = delta - hours * 3600 - minutes * 60
+            speed = size / 1024 / 1024 / delta
             termlog(
-                f"Done. {hours}:{minutes}:{seconds:.1f}",
+                f"Done. {hours}:{minutes}:{seconds:.1f} ({speed:.1f}MB/s)",
                 prefix=False,
             )
         return FilePathStr(root)

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import IO, TYPE_CHECKING, ContextManager, Iterator
+from typing import IO, ContextManager, Iterator, Protocol
 
 import wandb
 from wandb import env, util
@@ -19,12 +19,10 @@ from wandb.sdk.lib.filesystem import files_in
 from wandb.sdk.lib.hashutil import B64MD5, ETag, b64_to_hex_id
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 
-if TYPE_CHECKING:
-    from typing import Protocol
 
-    class Opener(Protocol):
-        def __call__(self, mode: str = ...) -> ContextManager[IO]:
-            pass
+class Opener(Protocol):
+    def __call__(self, mode: str = ...) -> ContextManager[IO]:
+        pass
 
 
 def _get_sys_umask_threadsafe() -> int:

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import logging
 import os
@@ -130,7 +131,11 @@ class ArtifactManifestEntry:
         return self._parent_artifact
 
     def download(
-        self, root: str | None = None, skip_cache: bool | None = None
+        self,
+        root: str | None = None,
+        skip_cache: bool | None = None,
+        executor: concurrent.futures.Executor | None = None,
+        multipart: bool | None = None,
     ) -> FilePathStr:
         """Download this artifact entry to the specified root path.
 
@@ -170,7 +175,11 @@ class ArtifactManifestEntry:
             )
         else:
             cache_path = self._parent_artifact.manifest.storage_policy.load_file(
-                self._parent_artifact, self, dest_path=override_cache_path
+                self._parent_artifact,
+                self,
+                dest_path=override_cache_path,
+                executor=executor,
+                multipart=multipart,
             )
 
         if skip_cache:

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 from typing import TYPE_CHECKING, Sequence
 
 from wandb.sdk.internal.internal_api import Api as InternalApi
@@ -40,6 +41,8 @@ class StoragePolicy:
         artifact: Artifact,
         manifest_entry: ArtifactManifestEntry,
         dest_path: str | None = None,
+        executor: concurrent.futures.Executor | None = None,
+        multipart: bool | None = None,
     ) -> FilePathStr:
         raise NotImplementedError
 


### PR DESCRIPTION
Description
-----------

- Fixes WB-24073

### Background

The existing download logic in Python (and in the temporarily disabled Go core) uses a **single HTTP request** to download objects from the object store (e.g., GCS, S3), regardless of file size.

However, for large files, it is more efficient to use **multiple HTTP range requests in parallel**, as recommended in [AWS S3 performance guideline](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-guidelines.html#optimizing-performance-guidelines-get-range) and [GCS sliced object download](https://cloud.google.com/storage/docs/sliced-object-downloads)

Other tools and SDKs—such as [`s3transfer`](https://github.com/boto/s3transfer) and `gcloud storage cp` already implemented this optimization by default for large object downloads.

Artifact upload already runs multipart upload in parallel for file large than 2GB (in go core). This PR implements the multipart parallel download and introduced a optional `multipart` parameter to switch it on/off regardless of file size.

### Design

Multiple threads to download different chunks and one thread to write to file. This is base on the (no longer in use) logic in s3transfer's [MultipartDownloader](https://github.com/boto/s3transfer/blob/e6a2ac3ebd17380d9f94be00bb5021fac8e0b48b/s3transfer/__init__.py#L521) (s3 has switched to use the C based common run time CRT.)

Considering the python code will be dead code/removed once we (re)enable go core for download:

No additional performance tuning

- I didn't try asynio/httpx for potential better performance, just requests and thread pool like we are doing right now for multiple files within one artifact
- **Hard code the chunk size, threads etc.** No knobs for user to optimize performance base on their file size/hardware. btw: For go version, there will be tuning and better automatic default
   - The hard coded values matches (also hard coded) upload (2GB file, 100MB chunk), matching upload part size is 
recommended for downloading multipart uploaded objects
   - The tuning on the python SDK may not work the same when switching to go (e.g. go routine vs thread)
 
Keep behavior same as existing download to reduce size of the change, although existing behavior may not be optimal

- Use the thread pool created for multi file download for multi part download, pass the executor down from caller.
- No progress indicator during download, the only change is adding MB/s after entire artifact download is done.
- Error handling
   - Existing download logic hangs and raise error after a while (at least 10s) when I turn off my wifi during download and end up with cryptic ssl error from urlib3 `requests.exceptions.SSLError: [SYS] unknown error (_ssl.c:2580)`. Manually verified multipart download has same result, i.e. exit with error.
   - Cleaning up the tmp file relies on all error raise inside `with cache_open` so I put the wait future and rethrow logic in it

### Performance

Benchmark is using sweep to do grid search where file size and sdk are hyper parameters and the 'goal' is to maximize the speed https://api.wandb.ai/links/reg-team-2/dgfqap5m (NOTE: I am still cleaning up the code for benchmark and there will be a more complete benchmark on S3,  network/disk baseline etc.)

In short, 4x improvement but still 4x slower than `gcloud storage cp` when running on GCP.
`gcloud` is faster because it defaults to multiprocess worker and creates connection to different storage host. 
We are able to achieve same speed in go code when turning off httpKeepAlive during benchmark.
For Python, I decided to continue using multi thread for now to reduce the change size and move on to go code.

- existing sdk 100MB/s
- this PR 300-500MB/s
- `gcloud storage cp` speed is 1100-1600MB/s

## TODO

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

- System test a 101MB file, verify hash of downloaded file
- Unit test for error handling
- Manual test network failure by switching wifi on/off. Not sure how to test disk failure in real word though ...  find a desktop and hot unplug the ssd?

Manual test script

```python
import wandb
import os
import shutil
import time
import argparse
import sys

def clean_artifacts():
    if os.path.exists("artifacts"):
        shutil.rmtree("artifacts")

def download_artifact(artifact: wandb.Artifact, parallel: bool, gb: int):
    clean_artifacts()

    start_time = time.time()
    print(f"Downloading {gb}GB {'parallel' if parallel else 'serial'}")
    artifact.download(skip_cache=True, multipart=parallel)
    duration = time.time() - start_time
    print(f"Time spent on {'parallel' if parallel else 'serial'} downloading {gb}GB: {duration} seconds. Speed: {gb * 1024 / duration} MB/s")

def benchmark_download(gb: int, multipart: bool):
    # wandb.login()
    api = wandb.Api()
    artifact = api.artifact(
        f"reg-team-2/pinglei-benchmark-artifact-exp-v1-files/{gb}gb:latest", type="dataset"
    )

    download_artifact(artifact, multipart, gb)

# python3 test_multipart_download.py --size 10 --multipart True
if __name__ == "__main__":
    parser = argparse.ArgumentParser(description='Benchmark artifact download performance')
    parser.add_argument('--size', type=int, required=True, help='Size of the artifact in GB')
    parser.add_argument('--multipart', type=bool, required=True, help='Use multipart download')
    
    args = parser.parse_args()
    
    try:
        benchmark_download(args.size, args.multipart)
    except ValueError:
        print("Error: GB size must be an integer")
        sys.exit(1)

```