### PR TITLE
fix: don't send telemetry after a run is finished

### DIFF
--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -198,6 +198,11 @@ class StreamMux:
             return stream_id in self._streams
 
     def get_stream(self, stream_id: str) -> StreamRecord:
+        """Returns the StreamRecord for the ID.
+
+        Raises:
+            KeyError: If a corresponding StreamRecord does not exist.
+        """
         with self._streams_lock:
             stream = self._streams[stream_id]
             return stream

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -816,8 +816,9 @@ class Run:
                     self._unique_launch_artifact_sequence_names[sequence_name] = item
 
     def _telemetry_callback(self, telem_obj: telemetry.TelemetryRecord) -> None:
-        if not hasattr(self, "_telemetry_obj"):
+        if not hasattr(self, "_telemetry_obj") or self._is_finished:
             return
+
         self._telemetry_obj.MergeFrom(telem_obj)
         self._telemetry_obj_dirty = True
         self._telemetry_flush()


### PR DESCRIPTION
Don't send telemetry, such as deprecation telemetry, after a run is finished. The service process does not expect records for a run after it is complete.

The following snippet was failing in `legacy-service`:

```python
import wandb

run = wandb.init()
run.finish()

run.mode  # This causes legacy-service to crash.
```

I also updated `legacy-service` to avoid crashes like this in the future.