### PR TITLE
fix: update hypothesis version constraint after fix release

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -29,21 +29,12 @@ coverage[toml]~=7.6
 
 pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.
 
-hypothesis<6.131.1
-# Stopgap fix until we can resolve sys.modules-related error, inadvertently introduced by hypothesis==6.131.1.
-# This manifests in CI as RuntimeErrors like:
+# Avoids:
+# - perf issues introduced in v6.131.1 but fixed in follow-up patches
+# - unlikely but possible race condition, fixed in v6.131.3 (https://github.com/HypothesisWorks/hypothesis/pull/4363)
 #
-#     .0 = <dict_valueiterator object at ...>
-#
-#         return tuple(
-#             module
-#     >       for module in sys.modules.values()
-#             if (
-#                 getattr(module, "__file__", None) is not None
-#                 and _is_local_module_file(module.__file__)
-#             )
-#         )
-#     E   RuntimeError: dictionary changed size during iteration
-#
-#     .../site-packages/hypothesis/internal/constants_ast.py:147: RuntimeError
+# Note: hypothesis dropped support for python 3.8 in v6.114.0 (https://hypothesis.readthedocs.io/en/latest/changelog.html#v6-114-0)
+hypothesis>=6.131.7; python_version >= '3.9'
+hypothesis; python_version < '3.9'
+
 hypothesis-fspaths


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-24525](https://wandb.atlassian.net/browse/WB-24525)

`hypothesis` released v6.131.3 yesterday, which fixes the (race condition) issue described in #9737 and which was previously causing unit tests to fail in CI.

This PR updates the version constraint accordingly.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-24525]: https://wandb.atlassian.net/browse/WB-24525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ