### PR TITLE
fix: object has no attribute when deleting file for a run

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,3 +36,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Prevent invalid `Artifact` and `ArtifactCollection` names (which would make them unloggable), explicitly raising a `ValueError` when attempting to assign an invalid name. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8773)
 - Prevent pydantic `ConfigError` in Pydantic v1 environments from not calling `.model_rebuild()/.update_forward_refs()` on generated types with ForwardRef fields (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9795)
 - `wandb.init()` no longer raises `Permission denied` error when the wandb directory is not writable or readable (@jacobromero in https://github.com/wandb/wandb/pull/9751)
+- Calling `file.delete()` on files queried via `api.Runs(...)` no longer raises `CommError` (@jacobromero in https://github.com/wandb/wandb/pull/9748)
+    - Bug introduced in 0.19.1

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -487,6 +487,101 @@ def test_projects(user, wandb_backend_spy):
     assert sum([1 for _ in projects]) == 2
 
 
+def test_delete_files_for_multiple_runs(
+    user,
+    wandb_backend_spy,
+):
+    gql = wandb_backend_spy.gql
+    body = {
+        "data": {
+            "project": {
+                "runCount": 2,
+                "runs": {
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "test",
+                                "id": "test",
+                                "sweep_name": None,
+                            },
+                        },
+                        {
+                            "node": {
+                                "name": "test",
+                                "id": "test2",
+                                "sweep_name": None,
+                            },
+                        },
+                    ],
+                    "pageInfo": {
+                        "endCursor": None,
+                        "hasNextPage": False,
+                    },
+                },
+            },
+        },
+    }
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="Runs"),
+        gql.once(content=body),
+    )
+
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="RunFiles"),
+        gql.Constant(
+            content={
+                "data": {
+                    "project": {
+                        "run": {
+                            "files": {
+                                "edges": [
+                                    {
+                                        "node": {
+                                            "id": "RmlsZToxODMw",
+                                            "name": "test.txt",
+                                            "state": "finished",
+                                            "user": {
+                                                "name": "test",
+                                                "username": "test",
+                                            },
+                                        }
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                }
+            }
+        ),
+    )
+    delete_spy = gql.Constant(content={"data": {"deleteFiles": {"success": True}}})
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="deleteFiles"),
+        delete_spy,
+    )
+
+    runs = Api().runs(f"{user}/test")
+    for run in runs:
+        file = run.files()[0]
+        file.delete()
+
+        # For system tests on newer server version, the projectId is provided
+        if file._server_accepts_project_id_for_delete_file():
+            assert "projectId" in delete_spy.requests[0].variables
+            assert "projectId" in delete_spy.requests[0].query
+            assert delete_spy.requests[0].variables == {
+                "files": [file.id],
+                "projectId": runs[0]._project_internal_id,
+            }
+        # For some older server versions, the projectId is not provided
+        else:
+            assert "projectId" not in delete_spy.requests[0].variables
+            assert "projectId" not in delete_spy.requests[0].query
+            assert delete_spy.requests[0].variables == {
+                "files": [file.id],
+            }
+
+
 def test_delete_file(
     user,
     stub_run_gql_once,

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -61,36 +61,35 @@ RUN_FRAGMENT = """fragment RunFragment on Run {
 }"""
 
 
+@normalize_exceptions
+def _server_provides_internal_id_for_project(client) -> bool:
+    """Returns True if the server allows us to query the internalId field for a project.
+
+    This check is done by utilizing GraphQL introspection in the available fields on the Project type.
+    """
+    query_string = """
+       query ProbeRunInput {
+            RunType: __type(name:"Run") {
+                fields {
+                    name
+                }
+            }
+        }
+    """
+
+    # Only perform the query once to avoid extra network calls
+    query = gql(query_string)
+    res = client.execute(query)
+    return "projectId" in [
+        x["name"] for x in (res.get("RunType", {}).get("fields", [{}]))
+    ]
+
+
 class Runs(SizedPaginator["Run"]):
     """An iterable collection of runs associated with a project and optional filter.
 
     This is generally used indirectly via the `Api`.runs method.
     """
-
-    QUERY = gql(
-        """
-        query Runs($project: String!, $entity: String!, $cursor: String, $perPage: Int = 50, $order: String, $filters: JSONString) {{
-            project(name: $project, entityName: $entity) {{
-                internalId
-                runCount(filters: $filters)
-                readOnly
-                runs(filters: $filters, after: $cursor, first: $perPage, order: $order) {{
-                    edges {{
-                        node {{
-                            ...RunFragment
-                        }}
-                        cursor
-                    }}
-                    pageInfo {{
-                        endCursor
-                        hasNextPage
-                    }}
-                }}
-            }}
-        }}
-        {}
-        """.format(RUN_FRAGMENT)
-    )
 
     def __init__(
         self,
@@ -102,6 +101,35 @@ class Runs(SizedPaginator["Run"]):
         per_page: int = 50,
         include_sweeps: bool = True,
     ):
+        self.QUERY = gql(
+            """
+            query Runs($project: String!, $entity: String!, $cursor: String, $perPage: Int = 50, $order: String, $filters: JSONString) {{
+                project(name: $project, entityName: $entity) {{
+                    internalId
+                    runCount(filters: $filters)
+                    readOnly
+                    runs(filters: $filters, after: $cursor, first: $perPage, order: $order) {{
+                        edges {{
+                            node {{
+                                {}
+                                ...RunFragment
+                            }}
+                            cursor
+                        }}
+                        pageInfo {{
+                            endCursor
+                            hasNextPage
+                        }}
+                    }}
+                }}
+            }}
+            {}
+            """.format(
+                "projectId" if _server_provides_internal_id_for_project(client) else "",
+                RUN_FRAGMENT,
+            )
+        )
+
         self.entity = entity
         self.project = project
         self._project_internal_id = None
@@ -429,7 +457,9 @@ class Run(Attrs):
         }}
         {}
         """.format(
-                "projectId" if self._server_provides_internal_id_for_project() else "",
+                "projectId"
+                if _server_provides_internal_id_for_project(self.client)
+                else "",
                 RUN_FRAGMENT,
             )
         )
@@ -444,10 +474,6 @@ class Run(Attrs):
             self._attrs = response["project"]["run"]
             self._state = self._attrs["state"]
 
-            self._project_internal_id = (
-                int(self._attrs["projectId"]) if "projectId" in self._attrs else None
-            )
-
             if self._include_sweeps and self.sweep_name and not self.sweep:
                 # There may be a lot of runs. Don't bother pulling them all
                 # just for the sake of this one.
@@ -458,6 +484,10 @@ class Run(Attrs):
                     self.sweep_name,
                     withRuns=False,
                 )
+
+        self._project_internal_id = (
+            int(self._attrs["projectId"]) if "projectId" in self._attrs else None
+        )
 
         try:
             self._attrs["summaryMetrics"] = (
@@ -911,32 +941,6 @@ class Run(Attrs):
             tags=tags,
         )
         return artifact
-
-    @normalize_exceptions
-    def _server_provides_internal_id_for_project(self) -> bool:
-        """Returns True if the server allows us to query the internalId field for a project.
-
-        This check is done by utilizing GraphQL introspection in the available fields on the Project type.
-        """
-        query_string = """
-           query ProbeRunInput {
-                RunType: __type(name:"Run") {
-                    fields {
-                        name
-                    }
-                }
-            }
-        """
-
-        # Only perform the query once to avoid extra network calls
-        if self.server_provides_internal_id_field is None:
-            query = gql(query_string)
-            res = self.client.execute(query)
-            self.server_provides_internal_id_field = "projectId" in [
-                x["name"] for x in (res.get("RunType", {}).get("fields", [{}]))
-            ]
-
-        return self.server_provides_internal_id_field
 
     @property
     def summary(self):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-23845
- Fixes https://github.com/wandb/wandb/issues/9588

What does the PR do? Include a concise description of the PR contents.

Recently the ability to include the `projectId` while calling `File.delete()`, to improve performance. However, `projectId` was not being queried when the user would query multiple runs at once with `api.runs(...)`


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- System tests added
- Test script
```python
import wandb

api = wandb.Api()
runs = api.runs("jacobromero/sometestproject")

for run in runs:
  for file in run.files:
    if file.name == "output.log":
      file.delete()
      print("file deleted.")
```

#### After this change
```
file deleted.
```

#### Before this change
```
Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/test/api.py", line 15, in <module>
    file.delete()
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/normalize.py", line 79, in wrapper
    raise CommError(message, err).with_traceback(sys.exc_info()[2])
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/normalize.py", line 25, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/public/files.py", line 204, in delete
    variable_values["projectId"] = self.run._project_internal_id
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/attrs.py", line 51, in __getattr__
    raise AttributeError(f"{repr(self)!r} object has no attribute {name!r}")
wandb.errors.errors.CommError: '<Run wandb/jpr-video-test/nwojbz66 (finished)>' object has no attribute '_project_internal_id'
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
