### PR TITLE
fix: log_code function would not properly set the config code path

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,3 +12,7 @@ Add here any changes made in a PR that are relevant to end users. Allowed sectio
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- `run.log_code` correctly sets the run configs `code_path` value. (@jacobromero in https://github.com/wandb/wandb/pull/9753)

--- a/tests/system_tests/test_core/test_wandb_run.py
+++ b/tests/system_tests/test_core/test_wandb_run.py
@@ -30,14 +30,19 @@ def test_log_nan_inf(wandb_backend_spy):
         assert history[0]["nested"]["neg_inf"] < 0
 
 
-def test_log_code(user):
-    with wandb.init(mode="offline") as run:
+def test_log_code(user, wandb_backend_spy):
+    with wandb.init() as run:
         with open("test.py", "w") as f:
             f.write('print("test")')
         with open("big_file.h5", "w") as f:
             f.write("Not that big")
         art = run.log_code()
         assert sorted(art.manifest.entries.keys()) == ["test.py"]
+
+    with wandb_backend_spy.freeze() as snapshot:
+        config = snapshot.config(run_id=run.id)
+        assert "code_path" in config["_wandb"]["value"]
+        assert config["_wandb"]["value"]["code_path"] == art.name
 
 
 def test_log_code_include(user):

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1222,7 +1222,14 @@ class Run:
             )
             return None
 
-        return self._log_artifact(art)
+        artifact = self._log_artifact(art)
+
+        self._config.update(
+            {"_wandb": {"code_path": artifact.name}},
+            allow_val_change=True,
+        )
+
+        return artifact
 
     @_log_to_run
     def get_sweep_url(self) -> str | None:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-21466

What does the PR do? Include a concise description of the PR contents.

The frontend for W&B checks for the key `code_path` in the run config to determine if the `code` sidebar tab should be displayed. The SDK only sets the `code_path` key in the config if the user sets `wandb.init(save_code=True)`. But will not set this if a user explicitly logs their code via the `run.log_code` function.
This PR updates the config to include the code path when a user calls `run.log_code`.

This change aligns with the way the frontend determins which code to display in the `code` tab as well, which will look for the last artifact with the type `code`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- system tests added
- test script
```python
import os

import wandb

os.makedirs("./test", exist_ok=True)

with open("./test/some_file.py", "w") as f:
    f.write("print('Hello, World!')\n")

with wandb.init(
    project="jpr-codelogging-test",
    save_code=False,
) as run:
   run.log_code(
        root="./test",
        name=f"{run.id}_log_code",
    )
    run.log({"test": 1})
```

#### After
<img width="550" alt="image" src="https://github.com/user-attachments/assets/9ab8836c-78eb-44f1-8253-a9615f9e51fe" />

<img width="550" alt="image" src="https://github.com/user-attachments/assets/8ffdf14f-38cb-44e0-b997-ede0622c4a34" />

Code was not uploaded in the run files
<img width="550" alt="image" src="https://github.com/user-attachments/assets/4be2a3cd-4aa0-4f41-8495-4d09570808a9" />


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
