### PR TITLE
feat(tables): Add support for mutable table logging

### DIFF
--- a/tests/system_tests/test_artifacts/test_data_types.py
+++ b/tests/system_tests/test_artifacts/test_data_types.py
@@ -122,3 +122,35 @@ def test_reference_table_artifacts(user, test_settings, wandb_backend_spy):
     run.log_artifact(art)
 
     run.finish()
+
+def test_table_mutation_logging(user, test_settings, wandb_backend_spy):
+    gql = wandb_backend_spy.gql
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="ServerInfo"),
+        gql.once(
+            content={
+                "data": {
+                    "serverInfo": {"cliVersionInfo": {"max_cli_version": "0.11.0"}}
+                }
+            },
+            status=200,
+        ),
+    )
+
+    run = wandb.init(settings=test_settings())
+    t = wandb.Table(
+        columns=["expected", "actual", "img"],
+        log_mode="MUTABLE"
+    )
+    t.add_data("Yes", "No", wandb.Image(np.ones(shape=(32, 32))))
+    run.log({"table": t})
+    t.add_data("Yes", "Yes", wandb.Image(np.ones(shape=(32, 32))))
+    run.log({"table": t})
+    t.add_data("No", "Yes", wandb.Image(np.ones(shape=(32, 32))))
+    run.log({"table": t})
+    t.get_column("expected")
+    run.log({"table": t})
+    run.finish()
+
+    run = wandb.Api().run(f"uncategorized/{run.id}")
+    assert len(run.logged_artifacts()) == 3


### PR DESCRIPTION
Enables the table object to be re-logged after mutations by using an opt-in `log_mode` param when initializing the Table.

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
