### PR TITLE
chore(sdk): make test not timeout and fail as 5 second timeout is too short and consistently failing on some branches

### DIFF
--- a/tests/unit_tests/test_lib/test_redir.py
+++ b/tests/unit_tests/test_lib/test_redir.py
@@ -183,7 +183,7 @@ def test_numpy(cls, capfd):
 
 
 @pytest.mark.parametrize("cls", impls)
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(300)
 def test_print_torch_model(cls, capfd):
     # https://github.com/wandb/wandb/issues/2097
     pytest.importorskip("torch")


### PR DESCRIPTION
Description
-----------
Make it so test_print_torch_model test isn't constantly failing

https://app.circleci.com/pipelines/github/wandb/wandb/46820/workflows/be4461f3-d605-4bc9-b37b-81f670b6bedc/jobs/1385322/tests