### PR TITLE
fix: inconsistent image normalization for wandb.Image

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ This version removes the ability to disable the `service` process. This is a bre
 ### Added
 
 - Support for pytorch.tensor for `masks` and `boxes` parameters when creating a `wandb.Image` object. (jacobromero in https://github.com/wandb/wandb/pull/9802)
+- `normalized` parameter to `wandb.Image` initialization to normalize pixel values for Images initialized with a numpy array or pytorch tensor. (@jacobromero in https://github.com/wandb/wandb/pull/9786)
 
 ### Removed
 

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -419,6 +419,29 @@ def test_image_masks_with_pytorch_tensors():
     wandb.Image(image, masks={"predictions": {"mask_data": mask}})
 
 
+@pytest.mark.parametrize(
+    "scale",
+    [1e-8, 1e-5, 1e0, 1e1, -1e-8, -1e-5, -1e0, -1e1],
+)
+def test_image_normalization_numpy_pytorch_equal(scale):
+    img = np.random.uniform(low=0, high=1, size=[4, 4, 3]) * scale
+    torch_img = torch.from_numpy(img.transpose(2, 0, 1))
+
+    wb_image = wandb.Image(img)
+    wb_image_torch = wandb.Image(torch_img)
+
+    assert np.all(np.array(wb_image.image) == np.array(wb_image_torch.image))
+
+
+def test_image_normalization_with_small_values_scales_to_range():
+    img = np.linspace(0, 10, 4 * 4 * 3).reshape([4, 4, 3]) * 1e-8
+    expected_scale = np.linspace(0, 255, 4 * 4 * 3).reshape([4, 4, 3]).astype(np.uint8)
+    wb_image = wandb.Image(img)
+
+    assert not np.all(np.array(wb_image.image) == 0)
+    assert np.all(np.array(wb_image.image) == expected_scale)
+
+
 ################################################################################
 # Test wandb.Audio
 ################################################################################
@@ -1030,9 +1053,9 @@ def test_table_column_style():
     assert [ndx._table == table1 for ndx in ndxs]
 
     # Test More Images and ndarrays
-    rand_1 = np.random.randint(255, size=(32, 32))
-    rand_2 = np.random.randint(255, size=(32, 32))
-    rand_3 = np.random.randint(255, size=(32, 32))
+    rand_1 = np.random.randint(256, size=(32, 32))
+    rand_2 = np.random.randint(256, size=(32, 32))
+    rand_3 = np.random.randint(256, size=(32, 32))
     img_1 = wandb.Image(rand_1)
     img_2 = wandb.Image(rand_2)
     img_3 = wandb.Image(rand_3)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-15801
- Fixes #6287, #7377

What does the PR do? Include a concise description of the PR contents.
When normalizing image values, during the creation of a `wandb.Image` from data (numpy array, or pytorch tensor) there are inconsistencies in the output image. 
For some small values normalized and converted image will be entirely black, or for small negative values the image will be entirely white. Additionally, between passing in a numpy array or a pytorch tensor would also yield different image results.

This PR uses the same normalization between the image data passed into the `wandb.Image` initialization function. As well as adds a flag to allow a user to normalize image data, since this can affect the output results of the image which might be undesirable for some users.


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- Unit tests added
- repro script
```python
import numpy as np
import wandb
import torch

img = np.random.uniform(low=0, high=1, size=[2, 4, 3])
torch_img = torch.from_numpy(img.transpose(2, 0, 1))
values = [1e-8, 1e-5, 1e0, 1e1]

with wandb.init(
    project="image-norm-test",
) as run:
    for value in values:
        wandb_np_img_norm = wandb.Image(img * value)
        wandb_torch_img_norm = wandb.Image(torch_img * value)

        run.log({f"np_img_norm_{str(value)}": wandb_np_img_norm})
        run.log({f"torch_img_norm_{str(value)}": wandb_torch_img_norm})
```

#### After this change
![image](https://github.com/user-attachments/assets/50a37697-373f-4e29-8cf1-5b80ac28e97a)
![image](https://github.com/user-attachments/assets/55bd11c5-1cb4-4e1f-b889-2a10e32996d8)
![image](https://github.com/user-attachments/assets/eeea15bc-6f85-46f2-b1c9-f8972c598387)
![image](https://github.com/user-attachments/assets/0aadf7bc-7fe8-4878-8caf-93970bf2f20d)


#### Before this change
![image](https://github.com/user-attachments/assets/0db38f7a-3f09-4f47-9e52-52d90c4d16dd)
![image](https://github.com/user-attachments/assets/1701b131-222f-43f5-9c93-28a772ead821)
![image](https://github.com/user-attachments/assets/846bf23b-4646-427a-8509-c89391d02b43)
![image](https://github.com/user-attachments/assets/de9eea41-9c15-4e4d-9c14-3dfca14ffe86)


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
