### PR TITLE
chore: pin uv to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ commands:
     steps:
       - run:
           name: Install Python dependencies
-          command: python -m pip install -U nox pip uv
+          command: python -m pip install -U nox pip "uv<0.7.0" # pin to unblock CI
           no_output_timeout: 5m
 
       - run:
@@ -121,7 +121,7 @@ commands:
     steps:
       - run:
           name: Upgrade pip and uv
-          command: python -m pip install -U pip uv
+          command: python -m pip install -U pip "uv<0.7.0" # pin to unblock CI
       - run:
           name: Install tool dependencies
           command: uv pip install --system -r requirements_dev.txt
@@ -401,7 +401,7 @@ jobs:
       - install_rust
       - run:
           name: Install Python dependencies
-          command: python -m pip install -U nox pip uv
+          command: python -m pip install -U nox pip "uv<0.7.0" # pin to unblock CI
           no_output_timeout: 5m
       - run:
           name: Ensure proto files were generated
@@ -449,7 +449,7 @@ jobs:
           name:
           command: |
             go install github.com/google/go-containerregistry/cmd/gcrane@latest
-            python -m pip install -U pip nox requests uv
+            python -m pip install -U pip nox requests "uv<0.7.0" # pin to unblock CI
             nox -s local-testcontainer-registry
           no_output_timeout: 5m
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Copy from https://github.com/wandb/weave/pull/4349 uv 0.70 changed the version command and it is breaking nox's backend detection logic https://github.com/wntrblm/nox/issues/953

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

Let Circle CI run and see if it passes ...