### PR TITLE
refactor: rewrite RunParams and clean up fork/rewind/resume.go

### DIFF
--- a/core/internal/runbranch/fork.go
+++ b/core/internal/runbranch/fork.go
@@ -30,15 +30,10 @@ func NewForkBranch(
 	}
 }
 
-// ApplyChanges applies the changes to the run params based on the fork
-// information
-func (fb *ForkBranch) ApplyChanges(
-	params *RunParams,
-	runpath RunPath,
-) (*RunParams, error) {
-
+// UpdateForFork sets run metadata for forking.
+func (fb *ForkBranch) UpdateForFork(params *RunParams) error {
 	if fb.metricName != "_step" {
-		return nil, &BranchError{
+		return &BranchError{
 			Err: nil,
 			Response: &spb.ErrorInfo{
 				Code:    spb.ErrorInfo_UNSUPPORTED,
@@ -47,8 +42,8 @@ func (fb *ForkBranch) ApplyChanges(
 		}
 	}
 
-	if fb.metricRunID == runpath.RunID {
-		return nil, &BranchError{
+	if fb.metricRunID == params.RunID {
+		return &BranchError{
 			Err: nil,
 			Response: &spb.ErrorInfo{
 				Code:    spb.ErrorInfo_USAGE,
@@ -57,12 +52,7 @@ func (fb *ForkBranch) ApplyChanges(
 		}
 	}
 
-	r := params.Clone()
-	r.Merge(
-		&RunParams{
-			Forked:       true,
-			StartingStep: int64(fb.metricValue) + 1,
-		},
-	)
-	return r, nil
+	params.Forked = true
+	params.StartingStep = int64(fb.metricValue) + 1
+	return nil
 }

--- a/core/internal/runbranch/fork_test.go
+++ b/core/internal/runbranch/fork_test.go
@@ -9,55 +9,42 @@ import (
 
 // Test that forked run id must be different from the current run id
 func TestForkSameRunIDs(t *testing.T) {
-
-	params, err := runbranch.NewForkBranch(
+	err := runbranch.NewForkBranch(
 		"runid",
 		"_step",
 		0,
-	).ApplyChanges(
-		&runbranch.RunParams{},
-		runbranch.RunPath{RunID: "runid"},
-	)
+	).UpdateForFork(&runbranch.RunParams{RunID: "runid"})
 
-	assert.Nil(t, params, "GetUpdates should return nil params")
-	assert.NotNil(t, err, "GetUpdates should return an error")
-	assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
-	assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
+	assert.NotNil(t, err)
+	assert.IsType(t, &runbranch.BranchError{}, err)
+	assert.NotNil(t, err.(*runbranch.BranchError).Response)
 }
 
 // Test that forked metric name must be "_step", which is the only supported
 // metric name currently
 func TestForkUnsupportedMetricName(t *testing.T) {
 
-	params, err := runbranch.NewForkBranch(
+	err := runbranch.NewForkBranch(
 		"runid",
 		"other",
 		0,
-	).ApplyChanges(
-		&runbranch.RunParams{},
-		runbranch.RunPath{RunID: "other"},
-	)
+	).UpdateForFork(&runbranch.RunParams{RunID: "other"})
 
-	assert.Nil(t, params, "GetUpdates should return nil params")
-	assert.NotNil(t, err, "GetUpdates should return an error")
-	assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
-	assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
+	assert.NotNil(t, err)
+	assert.IsType(t, &runbranch.BranchError{}, err)
+	assert.NotNil(t, err.(*runbranch.BranchError).Response)
 }
 
 // Test that GetUpdates correctly applies the changes to the run params
 func TestForkGetUpdatesValid(t *testing.T) {
-
-	params, err := runbranch.NewForkBranch(
+	params := &runbranch.RunParams{RunID: "other"}
+	err := runbranch.NewForkBranch(
 		"runid",
 		"_step",
 		10,
-	).ApplyChanges(
-		&runbranch.RunParams{},
-		runbranch.RunPath{RunID: "other"},
-	)
+	).UpdateForFork(params)
 
-	assert.Nil(t, err, "GetUpdates should not return an error")
-	assert.NotNil(t, params, "GetUpdates should return params")
-	assert.True(t, params.Forked, "GetUpdates should set Forked to true")
-	assert.Equal(t, int64(11), params.StartingStep, "GetUpdates should set StartingStep")
+	assert.Nil(t, err)
+	assert.True(t, params.Forked)
+	assert.Equal(t, int64(11), params.StartingStep)
 }

--- a/core/internal/runbranch/resume_test.go
+++ b/core/internal/runbranch/resume_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/gqlmock"
 	"github.com/wandb/wandb/core/internal/runbranch"
+	"github.com/wandb/wandb/core/internal/runconfig"
 )
 
 type ResumeResponse struct {
@@ -42,8 +43,7 @@ func TestNeverResumeEmptyResponse(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"never")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.Nil(t, params, "GetUpdates should return nil when response is empty")
+	err := resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
 
@@ -57,8 +57,7 @@ func TestAllowResumeEmptyResponse(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"allow")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.Nil(t, params, "GetUpdates should return nil when response is empty")
+	err := resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
 
@@ -72,8 +71,7 @@ func TestMustResumeEmptyResponse(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"must")
-	updates, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.Nil(t, updates, "GetUpdates should return nil when response is invalid")
+	err := resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.NotNil(t, err, "GetUpdates should return an error")
 	assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 	assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
@@ -90,8 +88,7 @@ func TestMustResumeNilResponse(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"must")
-	updates, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.Nil(t, updates, "GetUpdates should return nil when response is invalid")
+	err := resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.NotNil(t, err, "GetUpdates should return an error")
 	assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 	assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
@@ -125,8 +122,7 @@ func TestNeverResumeNoneEmptyResponse(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"never")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.Nil(t, params, "GetUpdates should return nil when response is empty")
+	err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.NotNil(t, err, "GetUpdates should return an error")
 	assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 	assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
@@ -160,8 +156,7 @@ func TestMustResumeNoTelemetryInConfig(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"must")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.Nil(t, params, "GetUpdates should return nil when response is empty")
+	err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.NotNil(t, err, "GetUpdates should return an error")
 	assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 }
@@ -202,8 +197,7 @@ func TestAllowResumeNoneEmptyResponse(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"allow")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
+	err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
 
@@ -242,8 +236,7 @@ func TestMustResumeNoneEmptyResponse(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"must")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
+	err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
 
@@ -283,8 +276,8 @@ func TestMustResumeValidHistory(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"must")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
+	params := &runbranch.RunParams{}
+	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Equal(t, int64(2), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(50), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
@@ -327,8 +320,8 @@ func TestMustResumeZeroHisotry(t *testing.T) {
 		context.Background(),
 		mockGQL,
 		"must")
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
+	params := &runbranch.RunParams{}
+	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
@@ -372,8 +365,8 @@ func TestMustResumeHistoryTailStepZero(t *testing.T) {
 		mockGQL,
 		"must")
 
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
+	params := &runbranch.RunParams{}
+	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Equal(t, int64(1), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
@@ -417,8 +410,8 @@ func TestMustResumeValidSummary(t *testing.T) {
 		mockGQL,
 		"must")
 
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
+	params := &runbranch.RunParams{}
+	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Equal(t, int64(2), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(40), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
@@ -440,7 +433,7 @@ func TestMustResumeValidConfig(t *testing.T) {
 	eventsLineCount := 0
 	logLineCount := 0
 	history := "[]"
-	config := `{"lr": {"value": 0.001}}`
+	configStr := `{"lr": {"value": 0.001}}`
 	summary := "{}"
 	rr := ResumeResponse{
 		Model: Model{
@@ -451,7 +444,7 @@ func TestMustResumeValidConfig(t *testing.T) {
 				LogLineCount:     &logLineCount,
 				HistoryTail:      &history,
 				SummaryMetrics:   &summary,
-				Config:           &config,
+				Config:           &configStr,
 				EventsTail:       "[]",
 				WandbConfig:      `{"t": 1}`,
 			},
@@ -470,14 +463,15 @@ func TestMustResumeValidConfig(t *testing.T) {
 		mockGQL,
 		"must")
 
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+	params := &runbranch.RunParams{}
+	config := runconfig.New()
+	err = resumeState.UpdateForResume(params, config)
 	assert.Nil(t, err, "GetUpdates should not return an error")
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
-	assert.Len(t, params.Config, 1, "GetUpdates should return correct config")
-	assert.Equal(t, 0.001, params.Config["lr"], "GetUpdates should return correct config")
+	assert.Len(t, config.CloneTree(), 1, "GetUpdates should return correct config")
+	assert.Equal(t, 0.001, config.CloneTree()["lr"], "GetUpdates should return correct config")
 }
 
 func TestMustResumeValidTags(t *testing.T) {
@@ -518,9 +512,9 @@ func TestMustResumeValidTags(t *testing.T) {
 		mockGQL,
 		"must")
 
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+	params := &runbranch.RunParams{}
+	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
@@ -567,9 +561,9 @@ func TestMustResumeValidStorageId(t *testing.T) {
 		mockGQL,
 		"must")
 
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+	params := &runbranch.RunParams{}
+	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
@@ -615,9 +609,9 @@ func TestMustResumeValidEvents(t *testing.T) {
 		mockGQL,
 		"must")
 
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+	params := &runbranch.RunParams{}
+	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
-	assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
 	assert.Equal(t, int32(50), params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
@@ -705,11 +699,10 @@ func TestMustResumeNullValue(t *testing.T) {
 				mockGQL,
 				"must")
 
-			params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+			err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 			assert.NotNil(t, err, "GetUpdates should return an error")
 			assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 			assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
-			assert.Nil(t, params, "GetUpdates should return nil when response is empty")
 		})
 	}
 }
@@ -782,13 +775,11 @@ func TestAllowResumeNullValue(t *testing.T) {
 				mockGQL,
 				"allow")
 
-			params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+			err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 			assert.NotNil(t, err, "GetUpdates should return an error")
 			if _, ok := err.(*runbranch.BranchError); ok {
 				t.Errorf("expected a BranchError but got %T", err)
 			}
-
-			assert.Nil(t, params, "GetUpdates should return nil when response is empty")
 		})
 	}
 }
@@ -845,11 +836,10 @@ func TestMustResumeInvalidHistory(t *testing.T) {
 				mockGQL,
 				"must")
 
-			params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+			err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 			assert.NotNil(t, err, "GetUpdates should return an error")
 			assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 			assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
-			assert.Nil(t, params, "GetUpdates should return nil when response is empty")
 		})
 	}
 }
@@ -892,11 +882,11 @@ func TestMustResumeInvalidSummary(t *testing.T) {
 		mockGQL,
 		"must")
 
-	params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+	err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 	assert.NotNil(t, err, "GetUpdates should return an error")
 	assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 	assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
-	assert.Nil(t, params, "GetUpdates should return nil when response is empty")
+	assert.Nil(t, nil, "GetUpdates should return nil when response is empty")
 }
 
 func TestMustResumeInvalidConfig(t *testing.T) {
@@ -954,11 +944,10 @@ func TestMustResumeInvalidConfig(t *testing.T) {
 				mockGQL,
 				"must")
 
-			params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+			err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 			assert.NotNil(t, err, "GetUpdates should return an error")
 			assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
 			assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
-			assert.Nil(t, params, "GetUpdates should return nil when response is empty")
 		})
 	}
 }
@@ -1015,9 +1004,9 @@ func TestNotNeverResumeFileStreamOffset(t *testing.T) {
 				context.Background(),
 				mockGQL,
 				tc.value)
-			params, err := resumeState.GetUpdates(nil, runbranch.RunPath{})
+			params := &runbranch.RunParams{}
+			err = resumeState.UpdateForResume(params, runconfig.New())
 			assert.Nil(t, err, "GetUpdates should not return an error")
-			assert.NotNil(t, params, "GetUpdates should return nil when response is empty")
 			assert.Len(t, params.FileStreamOffset, 3, "GetUpdates should return correct file stream offset")
 			assert.Equal(t, 10, params.FileStreamOffset[filestream.HistoryChunk], "GetUpdates should return correct file stream offset")
 			assert.Equal(t, 13, params.FileStreamOffset[filestream.EventsChunk], "GetUpdates should return correct file stream offset")
@@ -1034,7 +1023,7 @@ func TestExtractRunState(t *testing.T) {
 	logLineCount := 15
 	history := `["{\"_step\":4,\"_runtime\":100}"]`
 	summary := `{"loss": 0.5, "_runtime": 120, "_wandb": {"runtime": 130}, "_step": 4}`
-	config := `{"lr": {"value": 0.001}, "batch_size": {"value": 32}}`
+	configStr := `{"lr": {"value": 0.001}, "batch_size": {"value": 32}}`
 	eventsTail := `["{\"_runtime\":110}", "{\"_runtime\":120}"]`
 	storageId := "test_storage_id"
 
@@ -1047,7 +1036,7 @@ func TestExtractRunState(t *testing.T) {
 				LogLineCount:     &logLineCount,
 				HistoryTail:      &history,
 				SummaryMetrics:   &summary,
-				Config:           &config,
+				Config:           &configStr,
 				EventsTail:       eventsTail,
 				Tags:             []string{"test", "extract"},
 				WandbConfig:      `{"t": 1}`,
@@ -1069,16 +1058,15 @@ func TestExtractRunState(t *testing.T) {
 		mockGQL,
 		"allow")
 
-	runPath := runbranch.RunPath{
+	params := &runbranch.RunParams{
 		Entity:  "test-entity",
 		Project: "test-project",
 		RunID:   "test-run-id",
 	}
-
-	params, err := resumeState.GetUpdates(nil, runPath)
+	config := runconfig.New()
+	err = resumeState.UpdateForResume(params, config)
 
 	assert.Nil(t, err, "GetUpdates should not return an error")
-	assert.NotNil(t, params, "GetUpdates should return params")
 
 	// Test FileStreamOffset
 	assert.Equal(t, historyLineCount, params.FileStreamOffset[filestream.HistoryChunk], "Incorrect history line count")
@@ -1102,8 +1090,9 @@ func TestExtractRunState(t *testing.T) {
 	assert.Equal(t, int64(130), wandbRuntime, "Incorrect wandb runtime in summary")
 
 	// Test Config
-	assert.Equal(t, 0.001, params.Config["lr"], "Incorrect learning rate in config")
-	assert.Equal(t, int64(32), params.Config["batch_size"], "Incorrect batch size in config")
+	configTree := config.CloneTree()
+	assert.Equal(t, 0.001, configTree["lr"], "Incorrect learning rate in config")
+	assert.Equal(t, int64(32), configTree["batch_size"], "Incorrect batch size in config")
 
 	// Test Tags
 	assert.Equal(t, []string{"test", "extract"}, params.Tags, "Incorrect tags")
@@ -1258,21 +1247,18 @@ func TestExtractRunStateNilCases(t *testing.T) {
 				mockGQL,
 				"must") // Use "must" to ensure errors are returned
 
-			runPath := runbranch.RunPath{
+			params := &runbranch.RunParams{
 				Entity:  "test-entity",
 				Project: "test-project",
 				RunID:   "test-run-id",
 			}
-
-			params, err := resumeState.GetUpdates(nil, runPath)
+			err = resumeState.UpdateForResume(params, runconfig.New())
 
 			if tc.expectError {
 				assert.NotNil(t, err, "GetUpdates should return an error")
-				assert.Nil(t, params, "GetUpdates should return nil params when there's an error")
 				assert.Contains(t, err.Error(), tc.errorContains, "Error message should contain expected text")
 			} else {
 				assert.Nil(t, err, "GetUpdates should not return an error")
-				assert.NotNil(t, params, "GetUpdates should return params")
 			}
 		})
 	}
@@ -1318,22 +1304,17 @@ func TestExtractRunStateAdjustsStartTime(t *testing.T) {
 		mockGQL,
 		"must")
 
-	runPath := runbranch.RunPath{
-		Entity:  "test-entity",
-		Project: "test-project",
-		RunID:   "test-run-id",
-	}
-
 	// Set a non-zero StartTime in the input RunParams
 	initialStartTime := time.Now()
-	initialParams := &runbranch.RunParams{
+	params := &runbranch.RunParams{
 		StartTime: initialStartTime,
+		Entity:    "test-entity",
+		Project:   "test-project",
+		RunID:     "test-run-id",
 	}
-
-	params, err := resumeState.GetUpdates(initialParams, runPath)
+	err = resumeState.UpdateForResume(params, runconfig.New())
 
 	assert.Nil(t, err, "GetUpdates should not return an error")
-	assert.NotNil(t, params, "GetUpdates should return params")
 
 	// Check that StartTime was adjusted correctly
 	expectedStartTime := initialStartTime.Add(time.Duration(-130) * time.Second)

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/wandb/simplejsonext"
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/debounce"
@@ -146,6 +147,8 @@ type Sender struct {
 
 	// startState tracks the initial state of a run handling
 	// potential branching with resume, fork, and rewind.
+	//
+	// It is nil initially.
 	startState *runbranch.RunParams
 
 	// telemetry record internal implementation of telemetry
@@ -291,7 +294,6 @@ func NewSender(
 		mailbox:       params.Mailbox,
 		runSummary:    params.RunSummary,
 		outChan:       params.OutChan,
-		startState:    runbranch.NewRunParams(),
 		configDebouncer: debounce.NewDebouncer(
 			configDebouncerRateLimit,
 			configDebouncerBurstSize,
@@ -545,7 +547,9 @@ func (s *Sender) sendRequest(record *spb.Record, request *spb.Request) {
 // updateSettings updates the settings from the run record upon a run start
 // with the information from the server
 func (s *Sender) updateSettings() {
-	if s.settings == nil || !s.startState.Initialized {
+	if s.startState == nil {
+		s.logger.CaptureError(
+			errors.New("sender: updateSettings: no start state"))
 		return
 	}
 
@@ -570,10 +574,6 @@ func (s *Sender) updateSettings() {
 // sendRequestRunStart sends a run start request to start all the stream
 // components that need to be started and to update the settings
 func (s *Sender) sendRequestRunStart(_ *spb.RunStartRequest) {
-	// mark the run state as initialized, indicating the run has started and was
-	// successfully upserted on the server.
-	s.startState.Initialized = true
-
 	s.updateSettings()
 
 	if s.fileStream != nil {
@@ -901,23 +901,38 @@ func (s *Sender) serializeConfig(format runconfig.Format) ([]byte, error) {
 	return serializedConfig, nil
 }
 
-func (s *Sender) sendForkRun(record *spb.Record, run *spb.RunRecord) {
+// setConfigOnRunRecord sets the record's Config field to the current config.
+func (s *Sender) setConfigOnRunRecord(record *spb.RunRecord) {
+	record.Config = &spb.ConfigRecord{}
 
+	for key, value := range s.runConfig.CloneTree() {
+		valueJSON, _ := simplejsonext.MarshalToString(map[string]any{
+			"value": value,
+		})
+
+		record.Config.Update = append(record.Config.Update,
+			&spb.ConfigItem{
+				Key:       key,
+				ValueJson: valueJSON,
+			})
+	}
+}
+
+func (s *Sender) sendForkRun(record *spb.Record, run *spb.RunRecord) {
 	fork := s.settings.GetForkFrom()
-	update, err := runbranch.NewForkBranch(
+	err := runbranch.NewForkBranch(
 		fork.GetRun(),
 		fork.GetMetric(),
 		fork.GetValue(),
-	).ApplyChanges(s.startState, runbranch.RunPath{
-		Entity:  s.startState.Entity,
-		Project: s.startState.Project,
-		RunID:   s.startState.RunID,
-	})
+	).UpdateForFork(s.startState)
 
 	if err != nil {
+		s.startState = nil
+
 		s.logger.CaptureError(
 			fmt.Errorf("send: sendRun: failed to update run state: %s", err),
 		)
+
 		// provide more info about the error to the user
 		if errType, ok := err.(*runbranch.BranchError); ok {
 			if errType.Response != nil {
@@ -928,18 +943,18 @@ func (s *Sender) sendForkRun(record *spb.Record, run *spb.RunRecord) {
 					s.respond(record, result)
 				}
 			}
-			return
 		}
+
+		return
 	}
 
-	s.startState.Merge(update)
-
-	s.upsertRun(record, run)
+	s.upsertRun(record, run, true /*updateStartState*/)
 }
 
 func (s *Sender) sendRewindRun(record *spb.Record, run *spb.RunRecord) {
-
-	// if there is no client we can't do anything so we just return
+	// The client is nil if we're offline, in which case we cannot rewind.
+	//
+	// FIXME: This should return an error instead of silently doing nothing.
 	if s.graphqlClient == nil {
 		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
 			s.respond(record,
@@ -952,23 +967,22 @@ func (s *Sender) sendRewindRun(record *spb.Record, run *spb.RunRecord) {
 	}
 
 	rewind := s.settings.GetResumeFrom()
-	update, err := runbranch.NewRewindBranch(
+	err := runbranch.NewRewindBranch(
 		s.runWork.BeforeEndCtx(),
 		s.graphqlClient,
 		rewind.GetRun(),
 		rewind.GetMetric(),
 		rewind.GetValue(),
-	).ApplyChanges(s.startState, runbranch.RunPath{
-		Entity:  s.startState.Entity,
-		Project: s.startState.Project,
-		RunID:   s.startState.RunID,
-	})
+	).UpdateForRewind(s.startState, s.runConfig)
 
 	if err != nil {
+		s.startState = nil
+
 		s.logger.Error(
 			"send: sendRun: failed to update run state",
 			"error", err,
 		)
+
 		// provide more info about the error to the user
 		if errType, ok := err.(*runbranch.BranchError); ok {
 			if errType.Response != nil {
@@ -979,27 +993,23 @@ func (s *Sender) sendRewindRun(record *spb.Record, run *spb.RunRecord) {
 					s.respond(record, result)
 				}
 			}
-			return
 		}
+
+		return
 	}
 
-	s.startState.Merge(update)
-	// Merge the resumed config into the run config
-	s.runConfig.MergeResumedConfig(s.startState.Config)
-
 	if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-		proto.Merge(run, s.startState.Proto())
-		s.respond(record,
-			&spb.RunUpdateResult{
-				Run: run,
-			},
-		)
+		updatedRun := proto.CloneOf(run)
+		s.startState.SetOnProto(updatedRun)
+		s.setConfigOnRunRecord(updatedRun)
+		s.respond(record, &spb.RunUpdateResult{Run: updatedRun})
 	}
 }
 
 func (s *Sender) sendResumeRun(record *spb.Record, run *spb.RunRecord) {
-
-	// if there is no client we can't do anything so we just return
+	// The client is nil if we're offline, in which case we cannot resume.
+	//
+	// FIXME: This should return an error instead of silently doing nothing.
 	if s.graphqlClient == nil {
 		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
 			s.respond(record,
@@ -1011,20 +1021,19 @@ func (s *Sender) sendResumeRun(record *spb.Record, run *spb.RunRecord) {
 		return
 	}
 
-	update, err := runbranch.NewResumeBranch(
+	err := runbranch.NewResumeBranch(
 		s.runWork.BeforeEndCtx(),
 		s.graphqlClient,
 		s.settings.GetResume(),
-	).GetUpdates(s.startState, runbranch.RunPath{
-		Entity:  s.startState.Entity,
-		Project: s.startState.Project,
-		RunID:   s.startState.RunID,
-	})
+	).UpdateForResume(s.startState, s.runConfig)
 
 	if err != nil {
+		s.startState = nil
+
 		s.logger.CaptureError(
 			fmt.Errorf("send: sendRun: failed to update run state: %s", err),
 		)
+
 		// provide more info about the error to the user
 		if errType, ok := err.(*runbranch.BranchError); ok {
 			if errType.Response != nil {
@@ -1034,24 +1043,16 @@ func (s *Sender) sendResumeRun(record *spb.Record, run *spb.RunRecord) {
 					}
 					s.respond(record, result)
 				}
-				return
 			}
 		}
-	}
-	s.startState.Merge(update)
 
-	// On the first invocation of sendRun, we overwrite the tags if the user
-	// has set them in wandb.init(). Otherwise, we keep the tags from the
-	// original run.
-	if len(run.Tags) == 0 {
-		run.Tags = append(run.Tags, s.startState.Tags...)
+		return
 	}
 
-	// Merge the resumed config into the run config
-	s.runConfig.MergeResumedConfig(s.startState.Config)
-
-	proto.Merge(run, s.startState.Proto())
-	s.upsertRun(record, run)
+	updatedRun := proto.CloneOf(run)
+	s.startState.SetOnProto(updatedRun)
+	s.setConfigOnRunRecord(updatedRun)
+	s.upsertRun(record, updatedRun, true /*updateStartState*/)
 }
 
 // sendRun sends a run record to the server and updates the run record
@@ -1062,15 +1063,6 @@ func (s *Sender) sendRun(record *spb.Record, run *spb.RunRecord) {
 	//  consequent updates are fire-and-forget and thus don't have a mailbox
 	//  slot.
 	//  We should probably separate the initial upsert from the updates.
-
-	var ok bool
-	runClone, ok := proto.Clone(run).(*spb.RunRecord)
-	if !ok {
-		err := errors.New("failed to clone run record")
-		s.logger.CaptureFatalAndPanic(
-			fmt.Errorf("send: sendRun: failed to send run: %s", err),
-		)
-	}
 
 	// The first run record sent by the client is encoded incorrectly,
 	// causing it to overwrite the entire "_wandb" config key rather than
@@ -1088,54 +1080,49 @@ func (s *Sender) sendRun(record *spb.Record, run *spb.RunRecord) {
 	proto.Merge(s.telemetry, run.Telemetry)
 	s.updateConfigPrivate()
 
-	if !s.startState.Initialized {
-
-		// update the run state with the initial run record
-		s.startState.Merge(&runbranch.RunParams{
-			RunID:       runClone.GetRunId(),
-			Project:     runClone.GetProject(),
-			Entity:      runClone.GetEntity(),
-			DisplayName: runClone.GetDisplayName(),
-			StorageID:   runClone.GetStorageId(),
-			SweepID:     runClone.GetSweepId(),
-			StartTime:   runClone.GetStartTime().AsTime(),
-		})
-
-		isResume := s.settings.GetResume()
-		isRewind := s.settings.GetResumeFrom()
-		isFork := s.settings.GetForkFrom()
-		switch {
-		case isResume != "" && isRewind != nil || isResume != "" && isFork != nil || isRewind != nil && isFork != nil:
-			if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-				s.respond(record,
-					&spb.RunUpdateResult{
-						Error: &spb.ErrorInfo{
-							Code: spb.ErrorInfo_USAGE,
-							Message: "`resume`, `fork_from`, and `resume_from` are mutually exclusive. " +
-								"Please specify only one of them.",
-						},
-					},
-				)
-			}
-			s.logger.Error("sender: sendRun: user provided more than one of resume, rewind, or fork")
-		case isResume != "":
-			s.sendResumeRun(record, runClone)
-		case isRewind != nil:
-			s.sendRewindRun(record, runClone)
-		case isFork != nil:
-			s.sendForkRun(record, runClone)
-		default:
-			s.upsertRun(record, runClone)
-		}
+	// If startState isn't nil, then we are updating an initialized run.
+	if s.startState != nil {
+		s.upsertRun(record, run, false /*updateStartState*/)
 		return
 	}
 
-	s.upsertRun(record, runClone)
+	s.startState = runbranch.NewRunParams(run, s.settings)
+
+	isResume := s.settings.GetResume()
+	isRewind := s.settings.GetResumeFrom()
+	isFork := s.settings.GetForkFrom()
+	switch {
+	case isResume != "" && isRewind != nil || isResume != "" && isFork != nil || isRewind != nil && isFork != nil:
+		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
+			s.respond(record,
+				&spb.RunUpdateResult{
+					Error: &spb.ErrorInfo{
+						Code: spb.ErrorInfo_USAGE,
+						Message: "`resume`, `fork_from`, and `resume_from` are mutually exclusive. " +
+							"Please specify only one of them.",
+					},
+				},
+			)
+		}
+		s.logger.Error("sender: sendRun: user provided more than one of resume, rewind, or fork")
+	case isResume != "":
+		s.sendResumeRun(record, run)
+	case isRewind != nil:
+		s.sendRewindRun(record, run)
+	case isFork != nil:
+		s.sendForkRun(record, run)
+	default:
+		s.upsertRun(record, run, true /*updateStartState*/)
+	}
 }
 
-func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
-
-	// if there is no graphql client, we don't need to do anything
+//gocyclo:ignore
+func (s *Sender) upsertRun(
+	record *spb.Record,
+	run *spb.RunRecord,
+	updateStartState bool,
+) {
+	// The client is nil if we're offline, in which case we cannot upsert.
 	if s.graphqlClient == nil {
 		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
 			s.respond(record,
@@ -1166,7 +1153,7 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 		// if this times out, we mark the run as done as there is
 		// no need to proceed with it
 		ctx = s.mailbox.Add(ctx, s.runWork.SetDone, mailboxSlot)
-	} else if !s.startState.Initialized {
+	} else if updateStartState {
 		// this should never happen:
 		// the initial run upsert record should have a mailbox slot set by the client
 		s.logger.CaptureFatalAndPanic(
@@ -1236,7 +1223,7 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 	// manage the state of the run
 	if data == nil || data.GetUpsertBucket() == nil || data.GetUpsertBucket().GetBucket() == nil {
 		s.logger.Error("sender: upsertRun: upsert bucket response is empty")
-	} else if !s.startState.Initialized {
+	} else if updateStartState {
 		// only update the state once on the initial run upsert, the subsequent
 		// updates are fire-and-forget
 
@@ -1252,31 +1239,36 @@ func (s *Sender) upsertRun(record *spb.Record, run *spb.RunRecord) {
 			projectName = project.GetName()
 		}
 
-		fileStreamOffset := make(fs.FileStreamOffsetMap)
-		fileStreamOffset[fs.HistoryChunk] = nullify.ZeroIfNil(bucket.GetHistoryLineCount())
+		s.startState.FileStreamOffset[fs.HistoryChunk] = nullify.ZeroIfNil(
+			bucket.GetHistoryLineCount(),
+		)
 
-		params := &runbranch.RunParams{
-			StorageID:        bucket.GetId(),
-			Entity:           nullify.ZeroIfNil(&entityName),
-			Project:          nullify.ZeroIfNil(&projectName),
-			RunID:            bucket.GetName(),
-			DisplayName:      nullify.ZeroIfNil(bucket.GetDisplayName()),
-			SweepID:          nullify.ZeroIfNil(bucket.GetSweepName()),
-			FileStreamOffset: fileStreamOffset,
+		if storageID := bucket.GetId(); storageID != "" {
+			s.startState.StorageID = storageID
 		}
-
-		s.startState.Merge(params)
+		if entityName != "" {
+			s.startState.Entity = entityName
+		}
+		if projectName != "" {
+			s.startState.Project = projectName
+		}
+		if runID := bucket.GetName(); runID != "" {
+			s.startState.RunID = runID
+		}
+		if displayName := nullify.ZeroIfNil(bucket.GetDisplayName()); displayName != "" {
+			s.startState.DisplayName = displayName
+		}
+		if sweepID := nullify.ZeroIfNil(bucket.GetSweepName()); sweepID != "" {
+			s.startState.SweepID = sweepID
+		}
 	}
 
 	if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
 		// This will be done only for the initial run upsert record
 		// the consequent updates are fire-and-forget
-		proto.Merge(run, s.startState.Proto())
-		s.respond(record,
-			&spb.RunUpdateResult{
-				Run: run,
-			},
-		)
+		updatedRun := proto.CloneOf(run)
+		s.startState.SetOnProto(updatedRun)
+		s.respond(record, &spb.RunUpdateResult{Run: updatedRun})
 	}
 }
 
@@ -1327,7 +1319,7 @@ func (s *Sender) upsertConfig() {
 	if s.graphqlClient == nil {
 		return
 	}
-	if !s.startState.Initialized {
+	if s.startState == nil {
 		s.logger.Error("sender: upsertConfig: RunRecord is nil")
 		return
 	}
@@ -1386,7 +1378,7 @@ func (s *Sender) uploadSummaryFile() {
 		return
 	}
 
-	if !s.startState.Initialized {
+	if s.startState == nil {
 		return
 	}
 
@@ -1416,7 +1408,7 @@ func (s *Sender) uploadConfigFile() {
 		return
 	}
 
-	if !s.startState.Initialized {
+	if s.startState == nil {
 		return
 	}
 
@@ -1525,7 +1517,7 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 		return
 	}
 
-	if !s.startState.Initialized {
+	if s.startState == nil {
 		s.logger.CaptureFatalAndPanic(
 			errors.New("sender: sendAlert: RunRecord not set"))
 	}


### PR DESCRIPTION
Cleans up `internal/runbranch` in wandb-core to prepare for an UpsertBucket-related refactor:

* Simplified `RunParams` and organized it for better readability
* Changed fork/rewind/resume.go to modify the `RunParams` in-place instead of returning updates that are then merged
* Instead of accepting `RunParams` and `RunPath`, fork/rewind/resume.go read the entity/project/run ID from `RunParams`. The `RunPath` parameter was always derived from `RunParams` in `Sender`.
* Removed the `Config` field of `RunParams` and made rewind/resume.go accept and mutate a `RunConfig` directly

In the `Sender`, `startState` now starts out as `nil` and becomes set when processing the first `RunRecord` (if an error occurs, it is set back to `nil`).

`Sender` no longer clones the `RunRecord` at the start of `sendRun`: it is cloned immediately before it is mutated (by merging `startState.Proto()` into it) wherever that happens.