### PR TITLE
refactor: run config usage in job_builder.go

### DIFF
--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -613,7 +613,6 @@ func (s *Sender) sendJobFlush() {
 	if s.jobBuilder == nil {
 		return
 	}
-	s.jobBuilder.SetRunConfig(*s.runConfig)
 
 	output := s.runSummary.ToNestedMaps()
 
@@ -623,6 +622,7 @@ func (s *Sender) sendJobFlush() {
 	artifact, err := s.jobBuilder.Build(
 		op.Context(s.runWork.BeforeEndCtx()),
 		s.graphqlClient,
+		s.runConfig.CloneTree(),
 		output,
 	)
 	if err != nil {

--- a/core/pkg/launch/wandb_config.go
+++ b/core/pkg/launch/wandb_config.go
@@ -51,8 +51,10 @@ func (p *launchWandbConfigParameters) exclude() []ConfigPath {
 //
 // If there are any errors in the process, the function logs them and returns
 // an unknown type representation. The errors should never happen in practice.
-func (j *JobBuilder) inferRunConfigTypes() (*data_types.TypeRepresentation, error) {
-	config := NewConfigFrom(j.runConfig.CloneTree())
+func (j *JobBuilder) inferRunConfigTypes(
+	runConfig map[string]any,
+) (*data_types.TypeRepresentation, error) {
+	config := NewConfigFrom(runConfig)
 	typeInfo := data_types.ResolveTypes(
 		config.filterTree(
 			j.wandbConfigParameters.include(),


### PR DESCRIPTION
Removes the SetRunConfig method on JobBuilder, replacing it by an explicit parameter to Build instead.