### PR TITLE
refactor: improve gqlmock error messages

### DIFF
--- a/core/internal/gqlmock/assert.go
+++ b/core/internal/gqlmock/assert.go
@@ -4,15 +4,36 @@ import (
 	"testing"
 
 	"github.com/Khan/genqlient/graphql"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// AssertMatches asserts that a GQL request matches a gomock Matcher.
-func AssertRequest(t *testing.T, expected gomock.Matcher, req *graphql.Request) {
-	assert.True(t, expected.Matches(req),
-		"expected <%v> but got query\n====\n%v\n====\nwith variables %v",
-		expected,
-		req.Query,
-		jsonMarshallToMap(req.Variables))
+// AssertVariables asserts that a GQL request's variables match the expected
+// values.
+func AssertVariables(
+	t *testing.T,
+	req *graphql.Request,
+	varMatchers ...*gqlVarMatcher,
+) {
+	t.Helper()
+
+	varmap := jsonMarshallToMap(req.Variables)
+	require.NotNil(t, varmap)
+
+	for _, variable := range varMatchers {
+		value, found := variable.Extract(varmap)
+
+		if !found {
+			t.Logf(
+				"Variable %s not in the request.",
+				variable.Path)
+			t.Fail()
+		} else if !variable.Value.Matches(value) {
+			t.Logf(
+				"Expected variable %s to match <%v> but got %#v",
+				variable.Path,
+				variable.Value,
+				value)
+			t.Fail()
+		}
+	}
 }

--- a/core/internal/gqlmock/gqlmock.go
+++ b/core/internal/gqlmock/gqlmock.go
@@ -184,8 +184,9 @@ type notStubbedError struct {
 
 func (e *notStubbedError) Error() string {
 	return fmt.Sprintf(
-		"gqlmock: no stub for request with query '%v' and with variables '%v'",
-		e.req.Query,
-		jsonMarshallToMap(e.req.Variables),
+		"gqlmock: no stub for request with"+
+			" query\n====\n%s\n====\nwith variables\n%s",
+		indent(1, e.req.Query),
+		indent(1, prettyPrintVariables(e.req)),
 	)
 }

--- a/core/internal/gqlmock/gqlmock_test.go
+++ b/core/internal/gqlmock/gqlmock_test.go
@@ -18,7 +18,7 @@ func TestUnstubbedRequest_ErrorContainsRequest(t *testing.T) {
 		context.Background(),
 		&graphql.Request{
 			Query: "hero { name }",
-			Variables: map[string]string{
+			Variables: map[string]any{
 				"x": "y",
 			},
 		},
@@ -26,7 +26,7 @@ func TestUnstubbedRequest_ErrorContainsRequest(t *testing.T) {
 	)
 
 	assert.ErrorContains(t, err, "hero { name }")
-	assert.ErrorContains(t, err, "map[x:y]")
+	assert.ErrorContains(t, err, `x: "y"`)
 }
 
 func TestStubbedRequest_UsesStub(t *testing.T) {

--- a/core/internal/gqlmock/matchers.go
+++ b/core/internal/gqlmock/matchers.go
@@ -1,7 +1,9 @@
 package gqlmock
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/Khan/genqlient/graphql"
@@ -11,6 +13,46 @@ import (
 // WithOpName matches any GraphQL request with the given OpName.
 func WithOpName(opName string) gomock.Matcher {
 	return &opNameMatcher{opName}
+}
+
+// WithVariables matches any GraphQL request with the given variables.
+func WithVariables(varMatchers ...*gqlVarMatcher) gomock.Matcher {
+	return &queryVariablesMatcher{varMatchers}
+}
+
+// GQLVar matches a query variable with the right name and value.
+//
+// If the name contains periods, it is treated as a path. For example,
+// the name "key1.key2" corresponds to the "key2" field of the JSON object
+// passed as "key1" to a GQL query.
+//
+// If the value is expected to be a JSON string, consider using the JSONEq
+// matcher. Otherwise, gomock.Eq() is generally appropriate.
+//
+// Note that array variables in GraphQL are passed with type `[]any`.
+func GQLVar(name string, value gomock.Matcher) *gqlVarMatcher {
+	return &gqlVarMatcher{Path: name, Value: value}
+}
+
+// JSONEq matches a string or pointer to a string that's JSON-equivalent
+// to the value.
+func JSONEq(valueJSON string) gomock.Matcher {
+	var value any
+
+	err := json.Unmarshal([]byte(valueJSON), &value)
+	if err != nil {
+		panic(fmt.Errorf("could not unmarshal %q as JSON: %v", valueJSON, err))
+	}
+
+	marshaled, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Errorf("could not marshal as JSON: %v", err))
+	}
+
+	return &jsonMatcher{
+		marshaledValue:   string(marshaled),
+		unmarshaledValue: value,
+	}
 }
 
 type opNameMatcher struct {
@@ -30,27 +72,45 @@ func (m *opNameMatcher) String() string {
 	return fmt.Sprintf("has OpName '%v'", m.opName)
 }
 
-// GQLVar matches a query variable with the right name and value.
-type GQLVarMatcher struct {
-	Name  string
+type gqlVarMatcher struct {
+	Path  string
 	Value gomock.Matcher
 }
 
-func GQLVar(name string, value gomock.Matcher) *GQLVarMatcher {
-	return &GQLVarMatcher{Name: name, Value: value}
+// Extract returns the variable's value in the unmarshaled JSON object.
+//
+// The second return value indicates whether the value was found or not.
+func (m *gqlVarMatcher) Extract(varmap map[string]any) (any, bool) {
+	parts := strings.Split(m.Path, ".")
+
+	prefix := parts[:len(parts)-1]
+	key := parts[len(parts)-1]
+
+	for _, part := range prefix {
+		item, exists := varmap[part]
+
+		if !exists {
+			return nil, false
+		}
+
+		submap, ok := item.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		varmap = submap
+	}
+
+	value, found := varmap[key]
+	return value, found
 }
 
-func (m *GQLVarMatcher) String() string {
-	return fmt.Sprintf("variable '%v' %v", m.Name, m.Value)
-}
-
-// WithVariables matches any GraphQL request with the given variables.
-func WithVariables(varMatchers ...*GQLVarMatcher) gomock.Matcher {
-	return &queryVariablesMatcher{varMatchers}
+func (m *gqlVarMatcher) String() string {
+	return fmt.Sprintf("variable '%v' %v", m.Path, m.Value)
 }
 
 type queryVariablesMatcher struct {
-	varMatchers []*GQLVarMatcher
+	varMatchers []*gqlVarMatcher
 }
 
 func (m *queryVariablesMatcher) Matches(x any) bool {
@@ -64,17 +124,10 @@ func (m *queryVariablesMatcher) Matches(x any) bool {
 		return false
 	}
 
-	// Match values at nested paths, if needed
 	for _, variable := range m.varMatchers {
-		var curr interface{}
-		curr = varmap
-		for _, key := range strings.Split(variable.Name, ".") {
-			if curr == nil {
-				return false
-			}
-			curr = curr.(map[string]any)[key]
-		}
-		if !variable.Value.Matches(curr) {
+		value, found := variable.Extract(varmap)
+
+		if !found || !variable.Value.Matches(value) {
 			return false
 		}
 	}
@@ -83,5 +136,46 @@ func (m *queryVariablesMatcher) Matches(x any) bool {
 }
 
 func (m *queryVariablesMatcher) String() string {
-	return fmt.Sprintf("has variables %v", m.varMatchers)
+	var matcherDescriptions []string
+
+	for _, matcher := range m.varMatchers {
+		matcherDescriptions = append(matcherDescriptions, matcher.String())
+	}
+
+	return fmt.Sprintf(
+		"has variables [%s]",
+		strings.Join(matcherDescriptions, ", "),
+	)
+}
+
+type jsonMatcher struct {
+	marshaledValue   string
+	unmarshaledValue any
+}
+
+func (m *jsonMatcher) Matches(x any) bool {
+	var str string
+
+	switch val := x.(type) {
+	case string:
+		str = val
+	case *string:
+		if val == nil {
+			return false
+		} else {
+			str = *val
+		}
+	}
+
+	var unmarshaled any
+	err := json.Unmarshal([]byte(str), &unmarshaled)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(unmarshaled, m.unmarshaledValue)
+}
+
+func (m *jsonMatcher) String() string {
+	return fmt.Sprintf("is JSON-equivalent to %s", m.marshaledValue)
 }

--- a/core/internal/gqlmock/prettyprint.go
+++ b/core/internal/gqlmock/prettyprint.go
@@ -1,0 +1,64 @@
+package gqlmock
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Khan/genqlient/graphql"
+)
+
+// indent returns the string with each line indented by the given amount.
+//
+// Each indent is two spaces.
+func indent(n int, s string) string {
+	return prefixLines(strings.Repeat("  ", n), s)
+}
+
+// prefixLines returns the given string with a prefix appended to each line.
+//
+// If the string is the empty string, an empty string is returned.
+func prefixLines(prefix, s string) string {
+	if s == "" {
+		return ""
+	}
+
+	result := strings.Builder{}
+
+	found := true
+	for found {
+		var before, after string
+		before, after, found = strings.Cut(s, "\n")
+
+		result.WriteString(prefix)
+		result.WriteString(before)
+		if found {
+			result.WriteString("\n")
+		}
+
+		s = after
+	}
+
+	return result.String()
+}
+
+// prettyPrintVariables returns a string with the given GQL request's variables.
+func prettyPrintVariables(req *graphql.Request) string {
+	result := strings.Builder{}
+
+	varMap := jsonMarshallToMap(req.Variables)
+
+	nWritten := 0
+	for key, value := range varMap {
+		result.WriteString(key)
+		result.WriteString(": ")
+		_, _ = fmt.Fprintf(&result, "%#v", value)
+
+		if nWritten < len(varMap) {
+			result.WriteString("\n")
+		}
+
+		nWritten++
+	}
+
+	return result.String()
+}

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -128,12 +128,10 @@ func TestSendRun(t *testing.T) {
 
 	requests := mockGQL.AllRequests()
 	assert.Len(t, requests, 1)
-	gqlmock.AssertRequest(t,
-		gqlmock.WithVariables(
-			gqlmock.GQLVar("project", gomock.Eq("testProject")),
-			gqlmock.GQLVar("entity", gomock.Eq("testEntity")),
-		),
-		requests[0])
+	gqlmock.AssertVariables(t,
+		requests[0],
+		gqlmock.GQLVar("project", gomock.Eq("testProject")),
+		gqlmock.GQLVar("entity", gomock.Eq("testEntity")))
 }
 
 // Verify that arguments are properly passed through to graphql
@@ -171,15 +169,13 @@ func TestSendLinkArtifact(t *testing.T) {
 
 	requests := mockGQL.AllRequests()
 	assert.Len(t, requests, 1)
-	gqlmock.AssertRequest(t,
-		gqlmock.WithVariables(
-			gqlmock.GQLVar("projectName", gomock.Eq("portfolioProject")),
-			gqlmock.GQLVar("entityName", gomock.Eq("portfolioEntity")),
-			gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
-			gqlmock.GQLVar("clientId", gomock.Eq(nil)),
-			gqlmock.GQLVar("artifactId", gomock.Eq("serverId")),
-		),
-		requests[0])
+	gqlmock.AssertVariables(t,
+		requests[0],
+		gqlmock.GQLVar("projectName", gomock.Eq("portfolioProject")),
+		gqlmock.GQLVar("entityName", gomock.Eq("portfolioEntity")),
+		gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
+		gqlmock.GQLVar("clientId", gomock.Eq(nil)),
+		gqlmock.GQLVar("artifactId", gomock.Eq("serverId")))
 
 	// 2. When only clientId is sent, clientId is used
 	linkArtifact = &spb.Record{
@@ -207,15 +203,13 @@ func TestSendLinkArtifact(t *testing.T) {
 
 	requests = mockGQL.AllRequests()
 	assert.Len(t, requests, 2)
-	gqlmock.AssertRequest(t,
-		gqlmock.WithVariables(
-			gqlmock.GQLVar("projectName", gomock.Eq("portfolioProject")),
-			gqlmock.GQLVar("entityName", gomock.Eq("portfolioEntity")),
-			gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
-			gqlmock.GQLVar("clientId", gomock.Eq("clientId")),
-			gqlmock.GQLVar("artifactId", gomock.Eq(nil)),
-		),
-		requests[1])
+	gqlmock.AssertVariables(t,
+		requests[1],
+		gqlmock.GQLVar("projectName", gomock.Eq("portfolioProject")),
+		gqlmock.GQLVar("entityName", gomock.Eq("portfolioEntity")),
+		gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
+		gqlmock.GQLVar("clientId", gomock.Eq("clientId")),
+		gqlmock.GQLVar("artifactId", gomock.Eq(nil)))
 
 	// 3. When only serverId is sent, serverId is used
 	linkArtifact = &spb.Record{
@@ -243,15 +237,13 @@ func TestSendLinkArtifact(t *testing.T) {
 
 	requests = mockGQL.AllRequests()
 	assert.Len(t, requests, 3)
-	gqlmock.AssertRequest(t,
-		gqlmock.WithVariables(
-			gqlmock.GQLVar("projectName", gomock.Eq("portfolioProject")),
-			gqlmock.GQLVar("entityName", gomock.Eq("portfolioEntity")),
-			gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
-			gqlmock.GQLVar("clientId", gomock.Eq(nil)),
-			gqlmock.GQLVar("artifactId", gomock.Eq("serverId")),
-		),
-		requests[2])
+	gqlmock.AssertVariables(t,
+		requests[2],
+		gqlmock.GQLVar("projectName", gomock.Eq("portfolioProject")),
+		gqlmock.GQLVar("entityName", gomock.Eq("portfolioEntity")),
+		gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
+		gqlmock.GQLVar("clientId", gomock.Eq(nil)),
+		gqlmock.GQLVar("artifactId", gomock.Eq("serverId")))
 }
 
 func TestSendUseArtifact(t *testing.T) {
@@ -398,16 +390,14 @@ func TestLinkRegistryArtifact(t *testing.T) {
 				assert.Len(t, requests, numExpectedRequests)
 
 				// Confirms that the request is incorrectly put into link artifact graphql request
-				gqlmock.AssertRequest(t,
-					gqlmock.WithVariables(
-						gqlmock.GQLVar("projectName", gomock.Eq(registryProject)),
-						// Here the entity name is not orgEntityName_123 and this will fail if actually called
-						gqlmock.GQLVar("entityName", gomock.Not(gomock.Eq("orgEntityName_123"))),
-						gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
-						gqlmock.GQLVar("clientId", gomock.Eq("clientId123")),
-						gqlmock.GQLVar("artifactId", gomock.Nil()),
-					),
-					requests[numExpectedRequests-1])
+				gqlmock.AssertVariables(t,
+					requests[numExpectedRequests-1],
+					gqlmock.GQLVar("projectName", gomock.Eq(registryProject)),
+					// Here the entity name is not orgEntityName_123 and this will fail if actually called
+					gqlmock.GQLVar("entityName", gomock.Not(gomock.Eq("orgEntityName_123"))),
+					gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
+					gqlmock.GQLVar("clientId", gomock.Eq("clientId123")),
+					gqlmock.GQLVar("artifactId", gomock.Nil()))
 			} else {
 				// If no error, check that we are passing in the correct org entity name into linkArtifact
 				assert.Empty(t, tc.errorMessage)
@@ -415,15 +405,13 @@ func TestLinkRegistryArtifact(t *testing.T) {
 				requests := mockGQL.AllRequests()
 				assert.Len(t, requests, numExpectedRequests)
 
-				gqlmock.AssertRequest(t,
-					gqlmock.WithVariables(
-						gqlmock.GQLVar("projectName", gomock.Eq(registryProject)),
-						gqlmock.GQLVar("entityName", gomock.Eq("orgEntityName_123")),
-						gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
-						gqlmock.GQLVar("clientId", gomock.Eq("clientId123")),
-						gqlmock.GQLVar("artifactId", gomock.Nil()),
-					),
-					requests[numExpectedRequests-1])
+				gqlmock.AssertVariables(t,
+					requests[numExpectedRequests-1],
+					gqlmock.GQLVar("projectName", gomock.Eq(registryProject)),
+					gqlmock.GQLVar("entityName", gomock.Eq("orgEntityName_123")),
+					gqlmock.GQLVar("artifactPortfolioName", gomock.Eq("portfolioName")),
+					gqlmock.GQLVar("clientId", gomock.Eq("clientId123")),
+					gqlmock.GQLVar("artifactId", gomock.Nil()))
 			}
 		})
 	}

--- a/core/pkg/artifacts/saver_test.go
+++ b/core/pkg/artifacts/saver_test.go
@@ -102,9 +102,7 @@ func TestSaveGraphQLRequest(t *testing.T) {
 	requests := mockGQL.AllRequests()
 	assert.Len(t, requests, 4)
 	createArtifactRequest := requests[1]
-	gqlmock.AssertRequest(t,
-		gqlmock.WithVariables(
-			gqlmock.GQLVar("input.entityName", gomock.Eq("test-entity")),
-		),
-		createArtifactRequest)
+	gqlmock.AssertVariables(t,
+		createArtifactRequest,
+		gqlmock.GQLVar("input.entityName", gomock.Eq("test-entity")))
 }


### PR DESCRIPTION
Makes internal/gqlmock error messages nicer, replaces `AssertRequest` by `AssertVariables` to remove a bit of indentation, and adds the `JSONEq` matcher that corresponds to the `assert.JSONEq()` statement.

The `JSONEq` matcher is used in a later PR, but added here to reduce noise in that PR.