### PR TITLE
refactor: use runupserter, delete old Sender code

### DIFF
--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -247,8 +247,6 @@ func (h *Handler) handleRecord(record *spb.Record) {
 		h.handleMetric(record)
 	case *spb.Record_Request:
 		h.handleRequest(record)
-	case *spb.Record_Run:
-		h.handleRun(record)
 	case *spb.Record_Summary:
 		h.handleSummary(x.Summary)
 	case *spb.Record_Tbrecord:
@@ -740,14 +738,6 @@ func (h *Handler) handleRequestResume() {
 	h.systemMonitor.Resume()
 }
 
-func (h *Handler) handleRun(record *spb.Record) {
-	h.fwdRecordWithControl(record,
-		func(control *spb.Control) {
-			control.AlwaysSend = true
-		},
-	)
-}
-
 func (h *Handler) handleRequestRunFinishWithoutExit(record *spb.Record) {
 	h.runTimer.Pause()
 	h.updateRunTiming()
@@ -1138,8 +1128,4 @@ func (h *Handler) handleRequestSampledHistory(record *spb.Record) {
 			},
 		},
 	})
-}
-
-func (h *Handler) GetRun() *spb.RunRecord {
-	return h.runRecord
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -1,7 +1,6 @@
 package stream
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -11,11 +10,8 @@ import (
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
-	"google.golang.org/protobuf/proto"
 
-	"github.com/wandb/simplejsonext"
 	"github.com/wandb/wandb/core/internal/api"
-	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/debounce"
 	"github.com/wandb/wandb/core/internal/featurechecker"
 	fs "github.com/wandb/wandb/core/internal/filestream"
@@ -26,16 +22,12 @@ import (
 	"github.com/wandb/wandb/core/internal/nullify"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/paths"
-	"github.com/wandb/wandb/core/internal/runbranch"
-	"github.com/wandb/wandb/core/internal/runconfig"
 	"github.com/wandb/wandb/core/internal/runconsolelogs"
 	"github.com/wandb/wandb/core/internal/runfiles"
-	"github.com/wandb/wandb/core/internal/runmetric"
 	"github.com/wandb/wandb/core/internal/runsummary"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/tensorboard"
-	"github.com/wandb/wandb/core/internal/version"
 	"github.com/wandb/wandb/core/internal/watcher"
 	"github.com/wandb/wandb/core/internal/wboperation"
 	"github.com/wandb/wandb/core/pkg/artifacts"
@@ -45,8 +37,6 @@ import (
 )
 
 const (
-	configDebouncerRateLimit  = 1 / 30.0 // todo: audit rate limit
-	configDebouncerBurstSize  = 1        // todo: audit burst size
 	summaryDebouncerRateLimit = 1 / 30.0 // todo: audit rate limit
 	summaryDebouncerBurstSize = 1        // todo: audit burst size
 	ConsoleFileName           = "output.log"
@@ -66,6 +56,7 @@ type SenderParams struct {
 	TBHandler           *tensorboard.TBHandler
 	GraphqlClient       graphql.Client
 	Peeker              *observability.Peeker
+	StreamRun           *StreamRun
 	RunSummary          *runsummary.RunSummary
 	Mailbox             *mailbox.Mailbox
 	OutChan             chan *spb.Result
@@ -145,29 +136,14 @@ type Sender struct {
 	// tbHandler integrates W&B with TensorBoard
 	tbHandler *tensorboard.TBHandler
 
-	// startState tracks the initial state of a run handling
-	// potential branching with resume, fork, and rewind.
-	//
-	// It is nil initially.
-	startState *runbranch.RunParams
-
-	// telemetry record internal implementation of telemetry
-	telemetry *spb.TelemetryRecord
-
-	// runConfigMetrics tracks explicitly defined run metrics.
-	runConfigMetrics *runmetric.RunConfigMetrics
-
-	// configDebouncer is the debouncer for config updates
-	configDebouncer *debounce.Debouncer
-
 	// summaryDebouncer is the debouncer for summary updates
 	summaryDebouncer *debounce.Debouncer
 
+	// streamRun is this stream's run state.
+	streamRun *StreamRun
+
 	// runSummary is the full summary for the run
 	runSummary *runsummary.RunSummary
-
-	// Keep track of config which is being updated incrementally
-	runConfig *runconfig.RunConfig
 
 	// Keep track of exit record to pass to file stream when the time comes
 	exitRecord *spb.Record
@@ -251,27 +227,8 @@ func NewSender(
 		).Enabled,
 	}
 
-	// If the server doesn't support expanding defined metric globs, and the user
-	// has requested it, we default to the client-side expansion of defined metric
-	// globs.
-	serverSupportsExpandGlobMetrics := params.FeatureProvider.GetFeature(
-		spb.ServerFeature_EXPAND_DEFINED_METRIC_GLOBS,
-	).Enabled
-	if !serverSupportsExpandGlobMetrics &&
-		params.Settings.IsEnableServerSideExpandGlobMetrics() {
-		params.Logger.Warn(
-			"server does not support expanding defined metric globs, defaulting to client-side expansion",
-		)
-	}
-
 	s := &Sender{
-		runWork:   params.RunWork,
-		runConfig: runconfig.New(),
-		telemetry: &spb.TelemetryRecord{CoreVersion: version.Version},
-		runConfigMetrics: runmetric.NewRunConfigMetrics(
-			serverSupportsExpandGlobMetrics &&
-				params.Settings.IsEnableServerSideExpandGlobMetrics(),
-		),
+		runWork:             params.RunWork,
 		logger:              params.Logger,
 		operations:          params.Operations,
 		settings:            params.Settings,
@@ -292,13 +249,9 @@ func NewSender(
 		networkPeeker: params.Peeker,
 		graphqlClient: params.GraphqlClient,
 		mailbox:       params.Mailbox,
+		streamRun:     params.StreamRun,
 		runSummary:    params.RunSummary,
 		outChan:       params.OutChan,
-		configDebouncer: debounce.NewDebouncer(
-			configDebouncerRateLimit,
-			configDebouncerBurstSize,
-			params.Logger,
-		),
 		summaryDebouncer: debounce.NewDebouncer(
 			summaryDebouncerRateLimit,
 			summaryDebouncerBurstSize,
@@ -340,7 +293,6 @@ func (s *Sender) Do(allWork <-chan runwork.Work) {
 		s.observeSentinel(work)
 
 		// TODO: reevaluate the logic here
-		s.configDebouncer.Debounce(s.upsertConfig)
 		s.summaryDebouncer.Debounce(s.streamSummary)
 		s.mu.Unlock()
 
@@ -467,8 +419,6 @@ func (s *Sender) sendRecord(record *spb.Record) {
 		// no-op
 	case *spb.Record_Final:
 		// no-op
-	case *spb.Record_Run:
-		s.sendRun(record, x.Run)
 	case *spb.Record_Exit:
 		s.sendExit(record)
 	case *spb.Record_Alert:
@@ -547,41 +497,52 @@ func (s *Sender) sendRequest(record *spb.Record, request *spb.Request) {
 // updateSettings updates the settings from the run record upon a run start
 // with the information from the server
 func (s *Sender) updateSettings() {
-	if s.startState == nil {
-		s.logger.CaptureError(
-			errors.New("sender: updateSettings: no start state"))
+	upserter, _ := s.streamRun.GetRunUpserter()
+	if s.settings == nil || upserter == nil {
 		return
 	}
 
 	// StartTime should be generally thought of as the Run last modified time
 	// as it gets updated at a run branching point, such as resume, fork, or rewind
-	if s.settings.GetStartTime().IsZero() && !s.startState.StartTime.IsZero() {
-		s.settings.UpdateStartTime(s.startState.StartTime)
+	startTime := upserter.StartTime()
+	if s.settings.GetStartTime().IsZero() && !startTime.IsZero() {
+		s.settings.UpdateStartTime(startTime)
 	}
 
+	runPath := upserter.RunPath()
+
 	// TODO: verify that this is the correct update logic
-	if s.startState.Entity != "" {
-		s.settings.UpdateEntity(s.startState.Entity)
+	if runPath.Entity != "" {
+		s.settings.UpdateEntity(runPath.Entity)
 	}
-	if s.startState.Project != "" {
-		s.settings.UpdateProject(s.startState.Project)
+	if runPath.Project != "" {
+		s.settings.UpdateProject(runPath.Project)
 	}
-	if s.startState.DisplayName != "" {
-		s.settings.UpdateDisplayName(s.startState.DisplayName)
+	if displayName := upserter.DisplayName(); displayName != "" {
+		s.settings.UpdateDisplayName(displayName)
 	}
 }
 
 // sendRequestRunStart sends a run start request to start all the stream
 // components that need to be started and to update the settings
 func (s *Sender) sendRequestRunStart(_ *spb.RunStartRequest) {
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureError(
+			fmt.Errorf("sender: sendRequestRunStart: %v", err))
+		return
+	}
+
 	s.updateSettings()
+
+	runPath := upserter.RunPath()
 
 	if s.fileStream != nil {
 		s.fileStream.Start(
-			s.startState.Entity,
-			s.startState.Project,
-			s.startState.RunID,
-			s.startState.FileStreamOffset,
+			runPath.Entity,
+			runPath.Project,
+			runPath.RunID,
+			upserter.FileStreamOffsets(),
 		)
 	}
 }
@@ -614,6 +575,12 @@ func (s *Sender) sendJobFlush() {
 		return
 	}
 
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureError(fmt.Errorf("sender: sendJobFlush: %v", err))
+		return
+	}
+
 	output := s.runSummary.ToNestedMaps()
 
 	op := s.operations.New("saving job artifact")
@@ -622,7 +589,7 @@ func (s *Sender) sendJobFlush() {
 	artifact, err := s.jobBuilder.Build(
 		op.Context(s.runWork.BeforeEndCtx()),
 		s.graphqlClient,
-		s.runConfig.CloneTree(),
+		upserter.ConfigMap(),
 		output,
 	)
 	if err != nil {
@@ -690,9 +657,10 @@ func (s *Sender) finishRunSync() {
 		s.summaryDebouncer.Stop()
 		s.uploadSummaryFile()
 
-		s.configDebouncer.SetNeedsDebounce()
-		s.configDebouncer.Flush(s.upsertConfig)
-		s.configDebouncer.Stop()
+		upserter, _ := s.streamRun.GetRunUpserter()
+		if upserter != nil {
+			upserter.Finish()
+		}
 		s.uploadConfigFile()
 	})
 
@@ -830,10 +798,13 @@ func (s *Sender) finishFileStream() {
 }
 
 func (s *Sender) sendTelemetry(_ *spb.Record, telemetry *spb.TelemetryRecord) {
-	proto.Merge(s.telemetry, telemetry)
-	s.updateConfigPrivate()
-	// TODO(perf): improve when debounce config is added, for now this sends all the time
-	s.configDebouncer.SetNeedsDebounce()
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureError(fmt.Errorf("sender: sendTelemetry: %v", err))
+		return
+	}
+
+	upserter.UpdateTelemetry(telemetry)
 }
 
 func (s *Sender) sendPreempting(record *spb.RunPreemptingRecord) {
@@ -886,398 +857,6 @@ func (s *Sender) sendUseArtifact(record *spb.Record) {
 	s.jobBuilder.HandleUseArtifactRecord(record)
 }
 
-// Inserts W&B-internal information into the run configuration.
-func (s *Sender) updateConfigPrivate() {
-	s.runConfig.AddTelemetryAndMetrics(
-		s.telemetry,
-		s.runConfigMetrics.ToRunConfigData(),
-	)
-}
-
-// Serializes the run configuration to send to the backend.
-func (s *Sender) serializeConfig(format runconfig.Format) ([]byte, error) {
-	serializedConfig, err := s.runConfig.Serialize(format)
-
-	if err != nil {
-		err = fmt.Errorf("failed to marshal config: %s", err)
-		s.logger.Error("sender: serializeConfig", "error", err)
-		return nil, err
-	}
-
-	return serializedConfig, nil
-}
-
-// setConfigOnRunRecord sets the record's Config field to the current config.
-func (s *Sender) setConfigOnRunRecord(record *spb.RunRecord) {
-	record.Config = &spb.ConfigRecord{}
-
-	for key, value := range s.runConfig.CloneTree() {
-		valueJSON, _ := simplejsonext.MarshalToString(map[string]any{
-			"value": value,
-		})
-
-		record.Config.Update = append(record.Config.Update,
-			&spb.ConfigItem{
-				Key:       key,
-				ValueJson: valueJSON,
-			})
-	}
-}
-
-func (s *Sender) sendForkRun(record *spb.Record, run *spb.RunRecord) {
-	fork := run.GetBranchPoint()
-	err := runbranch.NewForkBranch(
-		fork.GetRun(),
-		fork.GetMetric(),
-		fork.GetValue(),
-	).UpdateForFork(s.startState)
-
-	if err != nil {
-		s.startState = nil
-
-		s.logger.CaptureError(
-			fmt.Errorf("send: sendRun: failed to update run state: %s", err),
-		)
-
-		// provide more info about the error to the user
-		if errType, ok := err.(*runbranch.BranchError); ok {
-			if errType.Response != nil {
-				if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-					result := &spb.RunUpdateResult{
-						Error: errType.Response,
-					}
-					s.respond(record, result)
-				}
-			}
-		}
-
-		return
-	}
-
-	s.upsertRun(record, run, true /*updateStartState*/)
-}
-
-func (s *Sender) sendRewindRun(record *spb.Record, run *spb.RunRecord) {
-	// The client is nil if we're offline, in which case we cannot rewind.
-	//
-	// FIXME: This should return an error instead of silently doing nothing.
-	if s.graphqlClient == nil {
-		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-			s.respond(record,
-				&spb.RunUpdateResult{
-					Run: run,
-				},
-			)
-		}
-		return
-	}
-
-	rewind := run.GetBranchPoint()
-	err := runbranch.NewRewindBranch(
-		s.runWork.BeforeEndCtx(),
-		s.graphqlClient,
-		rewind.GetRun(),
-		rewind.GetMetric(),
-		rewind.GetValue(),
-	).UpdateForRewind(s.startState, s.runConfig)
-
-	if err != nil {
-		s.startState = nil
-
-		s.logger.Error(
-			"send: sendRun: failed to update run state",
-			"error", err,
-		)
-
-		// provide more info about the error to the user
-		if errType, ok := err.(*runbranch.BranchError); ok {
-			if errType.Response != nil {
-				if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-					result := &spb.RunUpdateResult{
-						Error: errType.Response,
-					}
-					s.respond(record, result)
-				}
-			}
-		}
-
-		return
-	}
-
-	if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-		updatedRun := proto.CloneOf(run)
-		s.startState.SetOnProto(updatedRun)
-		s.setConfigOnRunRecord(updatedRun)
-		s.respond(record, &spb.RunUpdateResult{Run: updatedRun})
-	}
-}
-
-func (s *Sender) sendResumeRun(record *spb.Record, run *spb.RunRecord) {
-	// The client is nil if we're offline, in which case we cannot resume.
-	//
-	// FIXME: This should return an error instead of silently doing nothing.
-	if s.graphqlClient == nil {
-		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-			s.respond(record,
-				&spb.RunUpdateResult{
-					Run: run,
-				},
-			)
-		}
-		return
-	}
-
-	err := runbranch.NewResumeBranch(
-		s.runWork.BeforeEndCtx(),
-		s.graphqlClient,
-		s.settings.GetResume(),
-	).UpdateForResume(s.startState, s.runConfig)
-
-	if err != nil {
-		s.startState = nil
-
-		s.logger.CaptureError(
-			fmt.Errorf("send: sendRun: failed to update run state: %s", err),
-		)
-
-		// provide more info about the error to the user
-		if errType, ok := err.(*runbranch.BranchError); ok {
-			if errType.Response != nil {
-				if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-					result := &spb.RunUpdateResult{
-						Error: errType.Response,
-					}
-					s.respond(record, result)
-				}
-			}
-		}
-
-		return
-	}
-
-	updatedRun := proto.CloneOf(run)
-	s.startState.SetOnProto(updatedRun)
-	s.setConfigOnRunRecord(updatedRun)
-	s.upsertRun(record, updatedRun, true /*updateStartState*/)
-}
-
-// sendRun sends a run record to the server and updates the run record
-func (s *Sender) sendRun(record *spb.Record, run *spb.RunRecord) {
-	// TODO: we use the same record type for the initial run upsert and the
-	//  follow-up run updates, such as setting the name, tags, and notes.
-	//  The client only expects a response for the initial upsert, the
-	//  consequent updates are fire-and-forget and thus don't have a mailbox
-	//  slot.
-	//  We should probably separate the initial upsert from the updates.
-
-	// The first run record sent by the client is encoded incorrectly,
-	// causing it to overwrite the entire "_wandb" config key rather than
-	// just the necessary part ("_wandb/code_path"). This can overwrite
-	// the config from a resumed run, so we have to do this first.
-	//
-	// Logically, it would make more sense to instead start with the
-	// resumed config and apply updates on top of it.
-	s.runConfig.ApplyChangeRecord(run.Config,
-		func(err error) {
-			s.logger.CaptureError(
-				fmt.Errorf("error updating run config: %v", err))
-		})
-
-	proto.Merge(s.telemetry, run.Telemetry)
-	s.updateConfigPrivate()
-
-	// If startState isn't nil, then we are updating an initialized run.
-	if s.startState != nil {
-		s.upsertRun(record, run, false /*updateStartState*/)
-		return
-	}
-
-	s.startState = runbranch.NewRunParams(run, s.settings)
-
-	isResume := s.settings.GetResume()
-	isRewind := run.GetBranchPoint().GetRun() == run.RunId
-	isFork := !isRewind && run.GetBranchPoint().GetRun() != ""
-	switch {
-	case isResume != "" && isRewind || isResume != "" && isFork || isRewind && isFork:
-		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-			s.respond(record,
-				&spb.RunUpdateResult{
-					Error: &spb.ErrorInfo{
-						Code: spb.ErrorInfo_USAGE,
-						Message: "`resume`, `fork_from`, and `resume_from` are mutually exclusive. " +
-							"Please specify only one of them.",
-					},
-				},
-			)
-		}
-		s.logger.Error("sender: sendRun: user provided more than one of resume, rewind, or fork")
-	case isResume != "":
-		s.sendResumeRun(record, run)
-	case isRewind:
-		s.sendRewindRun(record, run)
-	case isFork:
-		s.sendForkRun(record, run)
-	default:
-		s.upsertRun(record, run, true /*updateStartState*/)
-	}
-}
-
-//gocyclo:ignore
-func (s *Sender) upsertRun(
-	record *spb.Record,
-	run *spb.RunRecord,
-	updateStartState bool,
-) {
-	// The client is nil if we're offline, in which case we cannot upsert.
-	if s.graphqlClient == nil {
-		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-			s.respond(record,
-				&spb.RunUpdateResult{
-					Run: run,
-				})
-		}
-		return
-	}
-
-	// start a new context with an additional argument from the parent context
-	// this is used to pass the retry function to the graphql client
-	ctx := context.WithValue(
-		s.runWork.BeforeEndCtx(),
-		clients.CtxRetryPolicyKey,
-		clients.UpsertBucketRetryPolicy,
-	)
-
-	operation := s.operations.New("creating run")
-	defer operation.Finish()
-	ctx = operation.Context(ctx)
-
-	// if the record has a mailbox slot, create a new cancelable context
-	// and store the cancel function in the message registry so that
-	// the context can be canceled if requested by the client
-	mailboxSlot := record.GetControl().GetMailboxSlot()
-	if mailboxSlot != "" {
-		// if this times out, we mark the run as done as there is
-		// no need to proceed with it
-		ctx = s.mailbox.Add(ctx, s.runWork.SetDone, mailboxSlot)
-	} else if updateStartState {
-		// this should never happen:
-		// the initial run upsert record should have a mailbox slot set by the client
-		s.logger.CaptureFatalAndPanic(
-			errors.New("sender: upsertRun: mailbox slot not set"),
-		)
-	}
-
-	config, _ := s.serializeConfig(runconfig.FormatJson)
-	configStr := string(config)
-
-	var commit, repo string
-	git := run.GetGit()
-	if git != nil {
-		commit = git.GetCommit()
-		repo = git.GetRemoteUrl()
-	}
-
-	program := s.settings.GetProgram()
-
-	var host string
-	if !s.settings.IsDisableMachineInfo() {
-		host = run.Host
-	}
-
-	data, err := gql.UpsertBucket(
-		ctx,                                // ctx
-		s.graphqlClient,                    // client
-		nullify.NilIfZero(run.StorageId),   // id, required for auth checks when writing to a resumed run
-		&run.RunId,                         // name
-		nullify.NilIfZero(run.Project),     // project
-		nullify.NilIfZero(run.Entity),      // entity
-		nullify.NilIfZero(run.RunGroup),    // groupName
-		nil,                                // description
-		nullify.NilIfZero(run.DisplayName), // displayName
-		nullify.NilIfZero(run.Notes),       // notes
-		nullify.NilIfZero(commit),          // commit
-		&configStr,                         // config
-		nullify.NilIfZero(host),            // host
-		nil,                                // debug
-		nullify.NilIfZero(program),         // program
-		nullify.NilIfZero(repo),            // repo
-		nullify.NilIfZero(run.JobType),     // jobType
-		nil,                                // state
-		nullify.NilIfZero(run.SweepId),     // sweep
-		run.Tags,                           // tags []string,
-		nil,                                // summaryMetrics
-	)
-
-	if err != nil {
-		err = fmt.Errorf("failed to upsert bucket: %s", err)
-		s.logger.Error("sender: upsertRun:", "error", err)
-		// TODO(sync): make this more robust in case of a failed UpsertBucket request.
-		//  Need to inform the sync service that this ops failed.
-		if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-			s.respond(record,
-				&spb.RunUpdateResult{
-					Error: &spb.ErrorInfo{
-						Message: err.Error(),
-						Code:    spb.ErrorInfo_COMMUNICATION,
-					},
-				},
-			)
-		}
-		return
-	}
-
-	// manage the state of the run
-	if data == nil || data.GetUpsertBucket() == nil || data.GetUpsertBucket().GetBucket() == nil {
-		s.logger.Error("sender: upsertRun: upsert bucket response is empty")
-	} else if updateStartState {
-		// only update the state once on the initial run upsert, the subsequent
-		// updates are fire-and-forget
-
-		bucket := data.GetUpsertBucket().GetBucket()
-
-		project := bucket.GetProject()
-		var projectName, entityName string
-		if project == nil {
-			s.logger.Error("sender: upsertRun: project is nil")
-		} else {
-			entity := project.GetEntity()
-			entityName = entity.GetName()
-			projectName = project.GetName()
-		}
-
-		s.startState.FileStreamOffset[fs.HistoryChunk] = nullify.ZeroIfNil(
-			bucket.GetHistoryLineCount(),
-		)
-
-		if storageID := bucket.GetId(); storageID != "" {
-			s.startState.StorageID = storageID
-		}
-		if entityName != "" {
-			s.startState.Entity = entityName
-		}
-		if projectName != "" {
-			s.startState.Project = projectName
-		}
-		if runID := bucket.GetName(); runID != "" {
-			s.startState.RunID = runID
-		}
-		if displayName := nullify.ZeroIfNil(bucket.GetDisplayName()); displayName != "" {
-			s.startState.DisplayName = displayName
-		}
-		if sweepID := nullify.ZeroIfNil(bucket.GetSweepName()); sweepID != "" {
-			s.startState.SweepID = sweepID
-		}
-	}
-
-	if record.GetControl().GetReqResp() || record.GetControl().GetMailboxSlot() != "" {
-		// This will be done only for the initial run upsert record
-		// the consequent updates are fire-and-forget
-		updatedRun := proto.CloneOf(run)
-		s.startState.SetOnProto(updatedRun)
-		s.respond(record, &spb.RunUpdateResult{Run: updatedRun})
-	}
-}
-
 // sendHistory sends a history record to the file stream,
 // which will then send it to the server
 func (s *Sender) sendHistory(record *spb.HistoryRecord) {
@@ -1321,70 +900,8 @@ func (s *Sender) sendSummary(_ *spb.Record, summary *spb.SummaryRecord) {
 	s.summaryDebouncer.SetNeedsDebounce()
 }
 
-func (s *Sender) upsertConfig() {
-	if s.graphqlClient == nil {
-		return
-	}
-	if s.startState == nil {
-		s.logger.Error("sender: upsertConfig: RunRecord is nil")
-		return
-	}
-
-	s.updateConfigPrivate()
-	config, err := s.serializeConfig(runconfig.FormatJson)
-	if err != nil {
-		s.logger.Error("sender: upsertConfig: failed to serialize config", "error", err)
-		return
-	}
-	if len(config) == 0 {
-		return
-	}
-	configStr := string(config)
-
-	ctx := context.WithValue(
-		s.runWork.BeforeEndCtx(),
-		clients.CtxRetryPolicyKey,
-		clients.UpsertBucketRetryPolicy,
-	)
-
-	operation := s.operations.New("updating run config")
-	defer operation.Finish()
-	ctx = operation.Context(ctx)
-
-	_, err = gql.UpsertBucket(
-		ctx,                                     // ctx
-		s.graphqlClient,                         // client
-		nil,                                     // id
-		&s.startState.RunID,                     // name
-		nullify.NilIfZero(s.startState.Project), // project
-		nullify.NilIfZero(s.startState.Entity),  // entity
-		nil,                                     // groupName
-		nil,                                     // description
-		nil,                                     // displayName
-		nil,                                     // notes
-		nil,                                     // commit
-		&configStr,                              // config
-		nil,                                     // host
-		nil,                                     // debug
-		nil,                                     // program
-		nil,                                     // repo
-		nil,                                     // jobType
-		nil,                                     // state
-		nil,                                     // sweep
-		nil,                                     // tags []string,
-		nil,                                     // summaryMetrics
-	)
-	if err != nil {
-		s.logger.Error("sender: sendConfig:", "error", err)
-	}
-}
-
 func (s *Sender) uploadSummaryFile() {
 	if s.runfilesUploader == nil {
-		return
-	}
-
-	if s.startState == nil {
 		return
 	}
 
@@ -1414,15 +931,17 @@ func (s *Sender) uploadConfigFile() {
 		return
 	}
 
-	if s.startState == nil {
-		return
-	}
-
 	if !s.settings.IsPrimary() {
 		return
 	}
 
-	config, err := s.serializeConfig(runconfig.FormatYaml)
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureError(fmt.Errorf("sender: uploadConfigFile: %v", err))
+		return
+	}
+
+	config, err := upserter.ConfigYAML()
 	if err != nil {
 		s.logger.CaptureError(
 			fmt.Errorf("sender: failed to serialize run config: %v", err))
@@ -1473,17 +992,15 @@ func (s *Sender) scheduleFileUpload(
 	return nil
 }
 
-// sendConfig sends a config record to the server via an upsertBucket mutation
-// and updates the in memory config
+// sendConfig updates the run's config and schedules an upload.
 func (s *Sender) sendConfig(_ *spb.Record, configRecord *spb.ConfigRecord) {
-	if configRecord != nil {
-		s.runConfig.ApplyChangeRecord(configRecord,
-			func(err error) {
-				s.logger.CaptureError(
-					fmt.Errorf("error updating run config: %v", err))
-			})
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureError(fmt.Errorf("sender: sendConfig: %v", err))
+		return
 	}
-	s.configDebouncer.SetNeedsDebounce()
+
+	upserter.UpdateConfig(configRecord)
 }
 
 // sendSystemMetrics sends a system metrics record via the file stream
@@ -1492,22 +1009,27 @@ func (s *Sender) sendSystemMetrics(record *spb.StatsRecord) {
 		return
 	}
 
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureError(fmt.Errorf("sender: sendSystemMetrics: %v", err))
+		return
+	}
+
 	// This is a sanity check to ensure that the start time is set
 	// before sending system metrics, it should always be set
 	// when the run is initialized
 	// If it's not set, we log an error and return
-	if s.startState.StartTime.IsZero() {
+	startTime := upserter.StartTime()
+	if startTime.IsZero() {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: sendSystemMetrics: start time not set"),
-			"startState",
-			s.startState,
-		)
+			errors.New("sender: sendSystemMetrics: start time not set"))
 		return
 	}
 
 	s.fileStream.StreamUpdate(&fs.StatsUpdate{
-		StartTime: s.startState.StartTime,
-		Record:    record})
+		StartTime: startTime,
+		Record:    record,
+	})
 }
 
 func (s *Sender) sendOutput(_ *spb.Record, _ *spb.OutputRecord) {
@@ -1523,19 +1045,22 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 		return
 	}
 
-	if s.startState == nil {
-		s.logger.CaptureFatalAndPanic(
-			errors.New("sender: sendAlert: RunRecord not set"))
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureFatalAndPanic(fmt.Errorf("sender: sendAlert: %v", err))
+		return
 	}
+	runPath := upserter.RunPath()
+
 	// TODO: handle invalid alert levels
 	severity := gql.AlertSeverity(alert.Level)
 
 	data, err := gql.NotifyScriptableRunAlert(
 		s.runWork.BeforeEndCtx(),
 		s.graphqlClient,
-		s.startState.Entity,
-		s.startState.Project,
-		s.startState.RunID,
+		runPath.Entity,
+		runPath.Project,
+		runPath.RunID,
 		alert.Title,
 		alert.Text,
 		&severity,
@@ -1581,25 +1106,14 @@ func (s *Sender) sendExit(record *spb.Record) {
 }
 
 // sendMetric updates the metrics in the run config.
-func (s *Sender) sendMetric(record *spb.Record, _ *spb.MetricRecord) {
-	// If server-side expand glob metrics is enabled, we don't need to send internal metrics
-	// as these were expanded internally by the client.
-	//
-	// Note: we still send these metrics from the handler to the writer to ensure they are
-	// available in the transaction log for offline runs that may be synced to a server that
-	// does not support expanding glob metrics.
-	if s.runConfigMetrics.IsServerExpandGlobMetrics() && record.GetMetric().GetExpandedFromGlob() {
-		return
-	}
-
-	err := s.runConfigMetrics.ProcessRecord(record.GetMetric())
-
+func (s *Sender) sendMetric(_ *spb.Record, metrics *spb.MetricRecord) {
+	upserter, err := s.streamRun.GetRunUpserter()
 	if err != nil {
 		s.logger.CaptureError(fmt.Errorf("sender: sendMetric: %v", err))
 		return
 	}
 
-	s.configDebouncer.SetNeedsDebounce()
+	upserter.UpdateMetrics(metrics)
 }
 
 // sendFiles uploads files according to a FilesRecord
@@ -1716,59 +1230,67 @@ func (s *Sender) sendRequestDownloadArtifact(record *spb.Record, msg *spb.Downlo
 }
 
 func (s *Sender) sendRequestStopStatus(record *spb.Record, _ *spb.StopStatusRequest) {
+	respondShouldStop := func(shouldStop bool) {
+		s.respond(record, &spb.Response{
+			ResponseType: &spb.Response_StopStatusResponse{
+				StopStatusResponse: &spb.StopStatusResponse{
+					RunShouldStop: shouldStop,
+				},
+			},
+		})
+	}
+
+	upserter, err := s.streamRun.GetRunUpserter()
+	if err != nil {
+		s.logger.CaptureError(
+			fmt.Errorf("sender: sendRequestStopStatus: %v", err))
+		respondShouldStop(false)
+		return
+	}
 
 	// TODO: unify everywhere to use settings
-	entity := s.startState.Entity
-	project := s.startState.Project
-	runId := s.startState.RunID
-
-	var stopResponse *spb.StopStatusResponse
+	runPath := upserter.RunPath()
+	entity := runPath.Entity
+	project := runPath.Project
+	runId := runPath.RunID
 
 	// if any of the entity, project or runId is empty, we can't make the request
 	if entity == "" || project == "" || runId == "" {
 		s.logger.Error("sender: sendStopStatus: entity, project, runId are empty")
-		stopResponse = &spb.StopStatusResponse{
-			RunShouldStop: false,
-		}
-	} else {
-		response, err := gql.RunStoppedStatus(
-			s.runWork.BeforeEndCtx(),
-			s.graphqlClient,
-			&entity,
-			&project,
-			runId,
-		)
-		switch {
-		case err != nil:
-			// if there is an error, we don't know if the run should stop
-			s.logger.CaptureError(
-				fmt.Errorf(
-					"sender: sendStopStatus: failed to get run stopped status: %v",
-					err,
-				))
-			stopResponse = &spb.StopStatusResponse{
-				RunShouldStop: false,
-			}
-		case response == nil || response.GetProject() == nil || response.GetProject().GetRun() == nil:
-			// if there is no response, we don't know if the run should stop
-			stopResponse = &spb.StopStatusResponse{
-				RunShouldStop: false,
-			}
-		default:
-			stopped := nullify.ZeroIfNil(response.GetProject().GetRun().GetStopped())
-			stopResponse = &spb.StopStatusResponse{
-				RunShouldStop: stopped,
-			}
-		}
+		respondShouldStop(false)
+		return
 	}
 
-	s.respond(record,
-		&spb.Response{
-			ResponseType: &spb.Response_StopStatusResponse{
-				StopStatusResponse: stopResponse,
-			},
-		},
+	response, err := gql.RunStoppedStatus(
+		s.runWork.BeforeEndCtx(),
+		s.graphqlClient,
+		&entity,
+		&project,
+		runId,
 	)
+
+	if err != nil {
+		// if there is an error, we don't know if the run should stop
+		s.logger.CaptureError(
+			fmt.Errorf(
+				"sender: sendStopStatus: failed to get run stopped status: %v",
+				err,
+			))
+		respondShouldStop(false)
+		return
+	}
+
+	if response != nil &&
+		response.GetProject() != nil &&
+		response.GetProject().GetRun() != nil {
+		respondShouldStop(
+			nullify.ZeroIfNil(response.GetProject().GetRun().GetStopped()),
+		)
+		return
+	}
+
+	// By default, don't stop the run.
+	respondShouldStop(false)
 }
 
 func (s *Sender) sendRequestJobInput(request *spb.JobInputRequest) {

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -21,20 +21,6 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-const validUpsertBucketResponse = `{
-	"upsertBucket": {
-		"bucket": {
-			"displayName": "FakeName",
-			"project": {
-				"name": "FakeProject",
-				"entity": {
-					"name": "FakeEntity"
-				}
-			}
-		}
-	}
-}`
-
 const validLinkArtifactResponse = `{
 	"linkArtifact": { "versionIndex": 0 }
 }`
@@ -92,47 +78,6 @@ func makeSender(client graphql.Client, resultChan chan *spb.Result) *stream.Send
 		},
 	)
 	return sender
-}
-
-// Verify that project and entity are properly passed through to graphql
-func TestSendRun(t *testing.T) {
-	mockGQL := gqlmock.NewMockClient()
-	mockGQL.StubMatchOnce(
-		gqlmock.WithOpName("UpsertBucket"),
-		validUpsertBucketResponse,
-	)
-	outChan := make(chan *spb.Result, 1)
-	sender := makeSender(mockGQL, outChan)
-
-	run := &spb.Record{
-		RecordType: &spb.Record_Run{
-			Run: &spb.RunRecord{
-				Config: &spb.ConfigRecord{
-					Update: []*spb.ConfigItem{
-						{
-							Key:       "_wandb",
-							ValueJson: "{}",
-						},
-					},
-				},
-				RunId:   "testRun",
-				Project: "testProject",
-				Entity:  "testEntity",
-			}},
-		Control: &spb.Control{
-			MailboxSlot: "junk",
-		},
-	}
-
-	sender.SendRecord(run)
-	<-outChan
-
-	requests := mockGQL.AllRequests()
-	assert.Len(t, requests, 1)
-	gqlmock.AssertVariables(t,
-		requests[0],
-		gqlmock.GQLVar("project", gomock.Eq("testProject")),
-		gqlmock.GQLVar("entity", gomock.Eq("testEntity")))
 }
 
 // Verify that arguments are properly passed through to graphql

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wandb/wandb/core/internal/randomid"
 	"github.com/wandb/wandb/core/internal/runfiles"
 	"github.com/wandb/wandb/core/internal/runsummary"
+	"github.com/wandb/wandb/core/internal/runupserter"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/sentry_ext"
 	"github.com/wandb/wandb/core/internal/settings"
@@ -41,6 +42,20 @@ const BufferSize = 32
 type Stream struct {
 	// runWork is a channel of records to process.
 	runWork runwork.RunWork
+
+	// run is the state of the run controlled by this stream.
+	run *StreamRun
+
+	// operations tracks the status of asynchronous work.
+	operations *wboperation.WandbOperations
+
+	// featureProvider checks server capabilities.
+	featureProvider *featurechecker.ServerFeaturesCache
+
+	// graphqlClientOrNil is used for GraphQL operations to the W&B backend.
+	//
+	// It is nil for offline runs.
+	graphqlClientOrNil graphql.Client
 
 	// logger is the logger for the stream
 	logger *observability.CoreLogger
@@ -151,8 +166,6 @@ type StreamParams struct {
 func NewStream(
 	params StreamParams,
 ) *Stream {
-	operations := wboperation.NewOperations()
-
 	logger := streamLogger(
 		params.Settings,
 		params.Sentry,
@@ -161,6 +174,8 @@ func NewStream(
 	)
 	s := &Stream{
 		runWork:      runwork.New(BufferSize, logger),
+		run:          NewStreamRun(),
+		operations:   wboperation.NewOperations(),
 		logger:       logger,
 		settings:     params.Settings,
 		sentryClient: params.Sentry,
@@ -179,12 +194,11 @@ func NewStream(
 		Logger:    s.logger,
 		Settings:  s.settings,
 	})
-	var graphqlClientOrNil graphql.Client
 	var fileStreamOrNil filestream.FileStream
 	var fileTransferManagerOrNil filetransfer.FileTransferManager
 	var runfilesUploaderOrNil runfiles.Uploader
 	if backendOrNil != nil {
-		graphqlClientOrNil = NewGraphQLClient(
+		s.graphqlClientOrNil = NewGraphQLClient(
 			backendOrNil,
 			params.Settings,
 			peeker,
@@ -193,7 +207,7 @@ func NewStream(
 		fileStreamOrNil = NewFileStream(
 			backendOrNil,
 			s.logger,
-			operations,
+			s.operations,
 			terminalPrinter,
 			params.Settings,
 			peeker,
@@ -207,18 +221,18 @@ func NewStream(
 		runfilesUploaderOrNil = NewRunfilesUploader(
 			s.runWork,
 			s.logger,
-			operations,
+			s.operations,
 			params.Settings,
 			fileStreamOrNil,
 			fileTransferManagerOrNil,
 			fileWatcher,
-			graphqlClientOrNil,
+			s.graphqlClientOrNil,
 		)
 	}
 
-	featureProvider := featurechecker.NewServerFeaturesCache(
+	s.featureProvider = featurechecker.NewServerFeaturesCache(
 		s.runWork.BeforeEndCtx(),
-		graphqlClientOrNil,
+		s.graphqlClientOrNil,
 		s.logger,
 	)
 
@@ -249,7 +263,7 @@ func NewStream(
 			FwdChan:           make(chan runwork.Work, BufferSize),
 			Logger:            s.logger,
 			Mailbox:           mailbox,
-			Operations:        operations,
+			Operations:        s.operations,
 			OutChan:           make(chan *spb.Result, BufferSize),
 			Settings:          s.settings,
 			SystemMonitor: monitor.NewSystemMonitor(
@@ -266,7 +280,7 @@ func NewStream(
 	s.sender = NewSender(
 		SenderParams{
 			Logger:              s.logger,
-			Operations:          operations,
+			Operations:          s.operations,
 			Settings:            s.settings,
 			Backend:             backendOrNil,
 			FileStream:          fileStreamOrNil,
@@ -276,12 +290,13 @@ func NewStream(
 			RunfilesUploader:    runfilesUploaderOrNil,
 			TBHandler:           tbHandler,
 			Peeker:              peeker,
+			StreamRun:           s.run,
 			RunSummary:          runsummary.New(),
-			GraphqlClient:       graphqlClientOrNil,
+			GraphqlClient:       s.graphqlClientOrNil,
 			OutChan:             make(chan *spb.Result, BufferSize),
 			Mailbox:             mailbox,
 			RunWork:             s.runWork,
-			FeatureProvider:     featureProvider,
+			FeatureProvider:     s.featureProvider,
 		},
 	)
 
@@ -386,7 +401,40 @@ func (s *Stream) Start() {
 // HandleRecord handles the given record by sending it to the stream's handler.
 func (s *Stream) HandleRecord(record *spb.Record) {
 	s.logger.Debug("handling record", "record", record.GetRecordType())
-	s.runWork.AddWork(runwork.WorkFromRecord(record))
+
+	var work runwork.Work
+
+	if record.GetRun() != nil {
+		work = &runupserter.RunUpdateWork{
+			Record: record,
+
+			StreamRunUpserter: s.run,
+			Respond: func(record *spb.Record, result *spb.RunUpdateResult) {
+				// Write to the sender's output channel because this is called
+				// in the Sender goroutine.
+				s.sender.outChan <- &spb.Result{
+					ResultType: &spb.Result_RunResult{
+						RunResult: result,
+					},
+					Control: record.Control,
+					Uuid:    record.Uuid,
+				}
+			},
+
+			Settings:           s.settings,
+			BeforeRunEndCtx:    s.runWork.BeforeEndCtx(),
+			Operations:         s.operations,
+			FeatureProvider:    s.featureProvider,
+			GraphqlClientOrNil: s.graphqlClientOrNil,
+			Logger:             s.logger,
+		}
+	} else {
+		// Legacy style for handling records where the code to process them
+		// lives in handler.go and sender.go directly.
+		work = runwork.WorkFromRecord(record)
+	}
+
+	s.runWork.AddWork(work)
 }
 
 // Close waits for all run messages to be fully processed.

--- a/core/internal/stream/streamrun.go
+++ b/core/internal/stream/streamrun.go
@@ -1,0 +1,51 @@
+package stream
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/wandb/wandb/core/internal/runupserter"
+)
+
+// StreamRun is the stream's run state.
+type StreamRun struct {
+	mu sync.Mutex
+
+	// upserter tracks and syncs some of the stream's run's metadata.
+	//
+	// It is nil before the run is initialized.
+	upserter *runupserter.RunUpserter
+}
+
+func NewStreamRun() *StreamRun {
+	return &StreamRun{}
+}
+
+// SetRunUpserter sets the stream's run upserter.
+//
+// It is an error to call this more than once.
+func (sr *StreamRun) SetRunUpserter(upserter *runupserter.RunUpserter) error {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	if sr.upserter != nil {
+		return errors.New("stream: run is already set")
+	}
+
+	sr.upserter = upserter
+	return nil
+}
+
+// GetRunUpserter returns the stream's run upserter.
+//
+// Returns an error if no run upserter has been set.
+func (sr *StreamRun) GetRunUpserter() (*runupserter.RunUpserter, error) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	if sr.upserter == nil {
+		return nil, errors.New("stream: no run")
+	}
+
+	return sr.upserter, nil
+}

--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -147,29 +147,6 @@ def test_shared_mode_x_label(user):
 
 
 @pytest.mark.wandb_core_only
-def test_resume_from_run_id_is_not_set(wandb_backend_spy):
-    run_id = runid.generate_id()
-
-    gql = wandb_backend_spy.gql
-    data = {
-        "data": {
-            "rewindRun": {
-                "rewoundRun": {"id": run_id},
-            },
-        }
-    }
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="RewindRun"),
-        gql.once(content=data, status=200),
-    )
-
-    with wandb.init(resume_from=f"{run_id}?_step=10") as rewound_run:
-        pass
-
-    assert rewound_run.id == run_id
-
-
-@pytest.mark.wandb_core_only
 @pytest.mark.parametrize("skip_transaction_log", [True, False])
 def test_skip_transaction_log(user, skip_transaction_log):
     """Test that the skip transaction log setting works correctly.


### PR DESCRIPTION
Replaces all old UpsertBucket code with `internal/runupserter`.

`RunUpserter` lives on a `Stream` and is operated on by `RunUpdateWork` in the sender goroutine. `Handler` and `Sender` no longer receive `RunRecord` and the corresponding code has been removed---when we implement syncing in wandb-core, we will create `RunUpdateWork` from `RunRecord` values the same way it happens in the `Stream` in this PR.

Unlike the old code in `Sender`, `RunUpserter` can batch updates to run parameters (such as its notes and tags) with updates to the run config in a single upload. Also, the updates happen asynchronously and do not block the `Sender` from doing other work.

