### PR TITLE
fix: avoid outputting footer in silent mode

### DIFF
--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -73,6 +73,11 @@ func (s *Settings) GetCredentialsFile() string {
 	return s.Proto.CredentialsFile.GetValue()
 }
 
+// Whether we are in silent mode.
+func (s *Settings) IsSilent() bool {
+	return s.Proto.Silent.GetValue()
+}
+
 // Whether we are in offline mode.
 func (s *Settings) IsOffline() bool {
 	return s.Proto.XOffline.GetValue()

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -398,6 +398,11 @@ func (s *Stream) FinishAndClose(exitCode int32) {
 }
 
 func printFooter(settings *settings.Settings) {
+	// Silent mode disables any footer output
+	if settings.IsSilent() {
+		return
+	}
+
 	formatter := pfxout.New(
 		pfxout.WithColor("wandb", pfxout.BrightBlue),
 	)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes #9807


What does the PR do? Include a concise description of the PR contents.

In implicit finish mode we use wandb-core to print the footer, in that case we weren't respecting the silent setting.
This PR adds a check for silent mode to make sure to respect the silent setting.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
