### PR TITLE
chore: rename/refactor use of `InternalApi._check_server_feature_with_fallback()`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Generator, Iterable, Iterator
 
 import pyte
 import pyte.modes
+from pytest_mock import MockerFixture
 from wandb.errors import term
 
 # Don't write to Sentry in wandb.
@@ -349,20 +350,16 @@ def local_netrc(filesystem_isolate):
 
 
 @pytest.fixture
-def dummy_api_key():
+def dummy_api_key() -> str:
     return "1824812581259009ca9981580f8f8a9012409eee"
 
 
 @pytest.fixture
-def patch_apikey(dummy_api_key):
-    with unittest.mock.patch.object(
-        wandb.sdk.lib.apikey, "isatty", return_value=True
-    ), unittest.mock.patch.object(
-        wandb.sdk.lib.apikey, "input", return_value=1
-    ), unittest.mock.patch.object(
-        wandb.sdk.lib.apikey, "getpass", return_value=dummy_api_key
-    ):
-        yield
+def patch_apikey(mocker: MockerFixture, dummy_api_key: str):
+    mocker.patch.object(wandb.sdk.lib.apikey, "isatty", return_value=True)
+    mocker.patch.object(wandb.sdk.lib.apikey, "input", return_value=1)
+    mocker.patch.object(wandb.sdk.lib.apikey, "getpass", return_value=dummy_api_key)
+    yield
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -839,9 +839,9 @@ def test_server_feature_checks(
 
     if expected_error:
         with pytest.raises(Exception, match="Some random error"):
-            api._server_features().get(feature, False)
+            api._server_supports(feature)
     else:
-        result = api._server_features().get(feature, False)
+        result = api._server_supports(feature)
         assert result == expected_result
 
 

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -318,7 +318,6 @@ class Api:
             )
         )
         self._client = RetryingClient(self._base_client)
-        self._server_features_cache: Optional[dict[str, bool]] = None
 
     def create_project(self, name: str, entity: str) -> None:
         """Create a new project.
@@ -1539,8 +1538,10 @@ class Api:
         Returns:
             A registry iterator.
         """
-        if not InternalApi()._check_server_feature_with_fallback(
-            ServerFeature.ARTIFACT_REGISTRY_SEARCH
+        if (
+            not InternalApi()
+            ._server_features()
+            .get(ServerFeature.ARTIFACT_REGISTRY_SEARCH)
         ):
             raise RuntimeError(
                 "Registry search API is not enabled on this wandb server version. "
@@ -1577,8 +1578,10 @@ class Api:
             registry.save()
             ```
         """
-        if not InternalApi()._check_server_feature_with_fallback(
-            ServerFeature.ARTIFACT_REGISTRY_SEARCH
+        if (
+            not InternalApi()
+            ._server_features()
+            .get(ServerFeature.ARTIFACT_REGISTRY_SEARCH)
         ):
             raise RuntimeError(
                 "api.registry() is not enabled on this wandb server version. "
@@ -1635,8 +1638,10 @@ class Api:
             )
             ```
         """
-        if not InternalApi()._check_server_feature_with_fallback(
-            ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION
+        if (
+            not InternalApi()
+            ._server_features()
+            .get(ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION)
         ):
             raise RuntimeError(
                 "create_registry api is not enabled on this wandb server version. "

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1538,11 +1538,7 @@ class Api:
         Returns:
             A registry iterator.
         """
-        if (
-            not InternalApi()
-            ._server_features()
-            .get(ServerFeature.ARTIFACT_REGISTRY_SEARCH)
-        ):
+        if not InternalApi()._server_supports(ServerFeature.ARTIFACT_REGISTRY_SEARCH):
             raise RuntimeError(
                 "Registry search API is not enabled on this wandb server version. "
                 "Please upgrade your server version or contact support at support@wandb.com."
@@ -1578,11 +1574,7 @@ class Api:
             registry.save()
             ```
         """
-        if (
-            not InternalApi()
-            ._server_features()
-            .get(ServerFeature.ARTIFACT_REGISTRY_SEARCH)
-        ):
+        if not InternalApi()._server_supports(ServerFeature.ARTIFACT_REGISTRY_SEARCH):
             raise RuntimeError(
                 "api.registry() is not enabled on this wandb server version. "
                 "Please upgrade your server version or contact support at support@wandb.com."
@@ -1638,10 +1630,8 @@ class Api:
             )
             ```
         """
-        if (
-            not InternalApi()
-            ._server_features()
-            .get(ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION)
+        if not InternalApi()._server_supports(
+            ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION
         ):
             raise RuntimeError(
                 "create_registry api is not enabled on this wandb server version. "
@@ -1788,19 +1778,18 @@ class Api:
             ALWAYS_SUPPORTED_EVENTS,
         )
 
-        server_features = InternalApi()._server_features()
-        return bool(
-            (
-                (event is None)
-                or (event in ALWAYS_SUPPORTED_EVENTS)
-                or server_features.get(f"AUTOMATION_EVENT_{event.value}")
-            )
-            and (
-                (action is None)
-                or (action in ALWAYS_SUPPORTED_ACTIONS)
-                or server_features.get(f"AUTOMATION_ACTION_{action.value}")
-            )
+        api = InternalApi()
+        supports_event = (
+            (event is None)
+            or (event in ALWAYS_SUPPORTED_EVENTS)
+            or api._server_supports(f"AUTOMATION_EVENT_{event.value}")
         )
+        supports_action = (
+            (action is None)
+            or (action in ALWAYS_SUPPORTED_ACTIONS)
+            or api._server_supports(f"AUTOMATION_ACTION_{action.value}")
+        )
+        return supports_event and supports_action
 
     def _omitted_automation_fragments(self) -> Set[str]:
         """Returns the names of unsupported automation-related fragments.

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -716,8 +716,10 @@ class ArtifactFiles(SizedPaginator["public.File"]):
         names: Optional[Sequence[str]] = None,
         per_page: int = 50,
     ):
-        self.query_via_membership = InternalApi()._check_server_feature_with_fallback(
-            ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES
+        self.query_via_membership = (
+            InternalApi()
+            ._server_features()
+            .get(ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES)
         )
         self.artifact = artifact
 

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -716,10 +716,8 @@ class ArtifactFiles(SizedPaginator["public.File"]):
         names: Optional[Sequence[str]] = None,
         per_page: int = 50,
     ):
-        self.query_via_membership = (
-            InternalApi()
-            ._server_features()
-            .get(ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES)
+        self.query_via_membership = InternalApi()._server_supports(
+            ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES
         )
         self.artifact = artifact
 

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -296,8 +296,10 @@ class Registry:
 
     def save(self) -> None:
         """Save registry attributes to the backend."""
-        if not InternalApi()._check_server_feature_with_fallback(
-            ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION
+        if (
+            not InternalApi()
+            ._server_features()
+            .get(ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION)
         ):
             raise RuntimeError(
                 "saving the registry is not enabled on this wandb server version. "

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -296,10 +296,8 @@ class Registry:
 
     def save(self) -> None:
         """Save registry attributes to the backend."""
-        if (
-            not InternalApi()
-            ._server_features()
-            .get(ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION)
+        if not InternalApi()._server_supports(
+            ServerFeature.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION
         ):
             raise RuntimeError(
                 "saving the registry is not enabled on this wandb server version. "

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2053,12 +2053,8 @@ class Artifact:
         retryable_exceptions=(requests.RequestException),
     )
     def _fetch_file_urls(self, cursor: str | None, per_page: int | None = 5000) -> Any:
-        if (
-            InternalApi()
-            ._server_supports()
-            .get(
-                pb.ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES  # type: ignore
-            )
+        if InternalApi()._server_supports(
+            pb.ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES
         ):
             query = gql(
                 """

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2053,8 +2053,12 @@ class Artifact:
         retryable_exceptions=(requests.RequestException),
     )
     def _fetch_file_urls(self, cursor: str | None, per_page: int | None = 5000) -> Any:
-        if InternalApi()._check_server_feature_with_fallback(
-            pb.ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES  # type: ignore
+        if (
+            InternalApi()
+            ._server_features()
+            .get(
+                pb.ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES  # type: ignore
+            )
         ):
             query = gql(
                 """

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2055,7 +2055,7 @@ class Artifact:
     def _fetch_file_urls(self, cursor: str | None, per_page: int | None = 5000) -> Any:
         if (
             InternalApi()
-            ._server_features()
+            ._server_supports()
             .get(
                 pb.ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES  # type: ignore
             )

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -387,7 +387,7 @@ class WandbStoragePolicy(StoragePolicy):
                 api.settings("base_url"), entity_name, md5_hex
             )
         elif storage_layout == StorageLayout.V2:
-            if api._server_features().get(
+            if api._server_supports(
                 ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILE_DOWNLOAD_HANDLER  # type: ignore
             ):
                 return "{}/artifactsV2/{}/{}/{}/{}/{}/{}/{}".format(

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -387,7 +387,7 @@ class WandbStoragePolicy(StoragePolicy):
                 api.settings("base_url"), entity_name, md5_hex
             )
         elif storage_layout == StorageLayout.V2:
-            if api._check_server_feature_with_fallback(
+            if api._server_features().get(
                 ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILE_DOWNLOAD_HANDLER  # type: ignore
             ):
                 return "{}/artifactsV2/{}/{}/{}/{}/{}/{}/{}".format(

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -868,7 +868,7 @@ class Api:
         _, _, mutations = self.server_info_introspection()
         return "updateRunQueueItemWarning" in mutations
 
-    def _server_features(self) -> dict[str, bool]:
+    def _server_features(self) -> Dict[str, bool]:
         # NOTE: Avoid caching via `@cached_property`, due to undocumented
         # locking behavior before Python 3.12.
         # See: https://github.com/python/cpython/issues/87634
@@ -890,7 +890,7 @@ class Api:
                 self._server_features_cache = {}
         return self._server_features_cache
 
-    def _server_supports(self, feature: str | ServerFeature.ValueType) -> bool:
+    def _server_supports(self, feature: Union[str, ServerFeature.ValueType]) -> bool:
         """Return whether the current server supports the given feature.
 
         This also caches the underlying lookup of server feature flags,

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -890,7 +890,7 @@ class Api:
                 self._server_features_cache = {}
         return self._server_features_cache
 
-    def _server_supports(self, feature: Union[str, ServerFeature.ValueType]) -> bool:
+    def _server_supports(self, feature: Union[int, str]) -> bool:
         """Return whether the current server supports the given feature.
 
         This also caches the underlying lookup of server feature flags,

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -893,14 +893,14 @@ class Api:
                 self._server_feature_cache = {}
             else:
                 raise
-
-        info = ServerFeaturesQuery.model_validate(response).server_info
-        if info and (feats := info.features):
-            by_name = {f.name: f.is_enabled for f in feats if f}
-            by_value = {v: by_name.get(k, False) for k, v in ServerFeature.items()}
-            self._server_feature_cache = {**by_value, **by_name}  # type: ignore[dict-item]
         else:
-            self._server_feature_cache = {}
+            info = ServerFeaturesQuery.model_validate(response).server_info
+            if info and (feats := info.features):
+                by_name = {f.name: f.is_enabled for f in feats if f}
+                by_value = {v: by_name.get(k, False) for k, v in ServerFeature.items()}
+                self._server_feature_cache = {**by_value, **by_name}  # type: ignore[dict-item]
+            else:
+                self._server_feature_cache = {}
 
         return MappingProxyType(self._server_feature_cache)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-24861](https://wandb.atlassian.net/browse/WB-24861)

Follow-up change to address previous comment from #8896: https://github.com/wandb/wandb/pull/8896#discussion_r2069636870

Renames redundant `InternalApi._check_server_feature_with_fallback()` method.  Refactors affected code accordingly.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
N/A - relies on existing unit/system tests that check server feature flag-related behavior.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-24861]: https://wandb.atlassian.net/browse/WB-24861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ