### PR TITLE
chore: add artifacts to pydantic v1 unit tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -204,6 +204,7 @@ def unit_tests_pydantic_v1(session: nox.Session) -> None:
             "tests/unit_tests/test_wandb_metadata.py",
             "tests/unit_tests/test_wandb_run.py",
             "tests/unit_tests/test_pydantic_v1_compat.py",
+            "tests/unit_tests/test_artifacts",
         ],
         opts={"n": "4"},
     )


### PR DESCRIPTION
Description
-----------
Adds `tests/unit_tests/test_artifacts` to the list of test paths for Pydantic v1 compatibility testing.

Pydantic, while useful, can introduce unexpected/unforeseen side effects -- moreso since we currently aim to support both pydantic v1 and v2 in most parts of the SDK.

This change adds a partial -- but still useful -- extra safeguard against inadvertently breaking Pydantic v1 compatibility in artifacts-related code paths.

Testing
-------
Verified that the unit tests for artifacts are now included -- and passing -- in the `unit_tests_pydantic_v1` nox sessions.