### PR TITLE
feat(sdk): allow setting run state in Run.create()

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -400,7 +400,14 @@ class Run(Attrs):
         return new_name
 
     @classmethod
-    def create(cls, api, run_id=None, project=None, entity=None, state: Literal["running", "pending"] = "running"):
+    def create(
+        cls,
+        api,
+        run_id=None,
+        project=None,
+        entity=None,
+        state: Literal["running", "pending"] = "running",
+    ):
         """Create a run for the given project."""
         run_id = run_id or runid.generate_id()
         project = project or api.settings.get("project") or "uncategorized"
@@ -421,7 +428,12 @@ class Run(Attrs):
         }
         """
         )
-        variables = {"entity": entity, "project": project, "name": run_id, "state": state}
+        variables = {
+            "entity": entity,
+            "project": project,
+            "name": run_id,
+            "state": state,
+        }
         res = api.client.execute(mutation, variable_values=variables)
         res = res["upsertBucket"]["bucket"]
         return Run(

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -400,14 +400,14 @@ class Run(Attrs):
         return new_name
 
     @classmethod
-    def create(cls, api, run_id=None, project=None, entity=None):
+    def create(cls, api, run_id=None, project=None, entity=None, state: Optional[str] = "running"):
         """Create a run for the given project."""
         run_id = run_id or runid.generate_id()
         project = project or api.settings.get("project") or "uncategorized"
         mutation = gql(
             """
-        mutation UpsertBucket($project: String, $entity: String, $name: String!) {
-            upsertBucket(input: {modelName: $project, entityName: $entity, name: $name}) {
+        mutation UpsertBucket($project: String, $entity: String, $name: String!, $state: String) {
+            upsertBucket(input: {modelName: $project, entityName: $entity, name: $name, state: $state}) {
                 bucket {
                     project {
                         name
@@ -421,7 +421,7 @@ class Run(Attrs):
         }
         """
         )
-        variables = {"entity": entity, "project": project, "name": run_id}
+        variables = {"entity": entity, "project": project, "name": run_id, "state": state}
         res = api.client.execute(mutation, variable_values=variables)
         res = res["upsertBucket"]["bucket"]
         return Run(
@@ -437,7 +437,7 @@ class Run(Attrs):
                 "tags": [],
                 "description": None,
                 "notes": None,
-                "state": "running",
+                "state": state,
             },
         )
 

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -400,7 +400,7 @@ class Run(Attrs):
         return new_name
 
     @classmethod
-    def create(cls, api, run_id=None, project=None, entity=None, state: Optional[str] = "running"):
+    def create(cls, api, run_id=None, project=None, entity=None, state: Literal["running", "pending"] = "running"):
         """Create a run for the given project."""
         run_id = run_id or runid.generate_id()
         project = project or api.settings.get("project") or "uncategorized"


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-24994

What does the PR do? Include a concise description of the PR contents.

Allows setting the state of a run in Run.create(). The server returns an error if it's not a valid state
![image](https://github.com/user-attachments/assets/386451ca-a1ea-4b92-8714-9c56546bdf5a)

Code to test:
````
import wandb
from wandb.apis.public import Run
import itertools, uuid, requests, json

api = wandb.Api()
entity  = "luis-bergua-weights-biases"
project = "test_create_run_api"

states = ["running", "pending", "finished", "failed", "crashed", "killed", "preempted", "preempting", "invalid_state"]

for s in states:
    run_name = f"state-test-{s}-{uuid.uuid4().hex[:8]}"
    try:
        run = Run.create(api=api, project=project, entity=entity, state=s, run_id=run_name)
        print(f"{run_name:30} -> create() returned state = {run.state}")

        run.load(force=True)
        print(f"{'':30}    after load()   state = {run.state}")

        remote_state = api.run(f"{run.entity}/{run.project}/{run.id}").state
        print(f"{'':30}    server query   state = {remote_state}")

    except requests.HTTPError as e:          # should not fire for valid values
        print(f"{run_name:30} -> HTTP {e.response.status_code}")
        print(json.dumps(e.response.json(), indent=2))
    print("-" * 60)
````
Output:
````
state-test-running-8be9148c    -> create() returned state = running
                                  after load()   state = running
                                  server query   state = running
------------------------------------------------------------
state-test-pending-0b8e3fd0    -> create() returned state = pending
                                  after load()   state = pending
                                  server query   state = pending
------------------------------------------------------------
state-test-finished-989f3c32   -> create() returned state = finished
                                  after load()   state = finished
                                  server query   state = finished
------------------------------------------------------------
state-test-failed-e1613fd7     -> create() returned state = failed
                                  after load()   state = failed
                                  server query   state = failed
------------------------------------------------------------
state-test-crashed-5fd3f3a3    -> create() returned state = crashed
                                  after load()   state = crashed
                                  server query   state = crashed
------------------------------------------------------------
state-test-killed-3cb86935     -> create() returned state = killed
                                  after load()   state = killed
                                  server query   state = killed
------------------------------------------------------------
state-test-preempted-54905dd9  -> create() returned state = preempted
                                  after load()   state = preempted
                                  server query   state = preempted
------------------------------------------------------------
state-test-preempting-1391ca64 -> create() returned state = preempting
                                  after load()   state = preempting
                                  server query   state = preempting
------------------------------------------------------------
state-test-invalid_state-3aabcd1f -> HTTP 400
{
  "errors": [
    {
      "message": "invalid run state \"invalid_state\"",
      "path": [
        "upsertBucket"
      ]
    }
  ],
  "data": {
    "upsertBucket": null
  }
}
------------------------------------------------------------
````

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [X] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

Docs
-------
https://wandb.atlassian.net/browse/DOCS-1525
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
