### PR TITLE
chore(launch): handle non-zero exit code when no args passed for wandb launch-sweep test

### DIFF
--- a/tests/system_tests/test_launch/test_launch_sweep_cli.py
+++ b/tests/system_tests/test_launch/test_launch_sweep_cli.py
@@ -11,7 +11,15 @@ from wandb.sdk.launch.utils import LAUNCH_DEFAULT_PROJECT
 
 def _run_cmd_check_msg(cmd: List[str], assert_str: str) -> None:
     """Helper for asserting a statement is in logs."""
-    out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        print(f"\nCommand failed with return code {e.returncode}")
+        print(f"Command: {' '.join(cmd)}")
+        print("\nOutput:")
+        print(e.output.decode())
+        print("\nTraceback:")
+        raise
     assert assert_str in out.decode("utf-8")
 
 

--- a/tests/system_tests/test_launch/test_launch_sweep_cli.py
+++ b/tests/system_tests/test_launch/test_launch_sweep_cli.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import sys
 from typing import List
 
 import pytest
@@ -26,7 +27,7 @@ def test_launch_sweep_param_validation(user):
     base = ["wandb", "launch-sweep"]
     # In python 3.12, Click returns with an exit code of 2 when there are
     # missing arguments.
-    if wandb.env.PYTHON_VERSION >= (3, 12):
+    if sys.version_info >= (3, 12):
         with pytest.raises(subprocess.CalledProcessError):
             _run_cmd_check_msg(base, "Usage: wandb launch-sweep [OPTIONS]")
     else:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

In Python3.12 when there are no required arguments, but also `no_args_is_help` for a  Click CLI command, the command returns with an exit code of 2 instead of 0 (as in python3.8). This was causing the test to fail in 3.12.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
