### PR TITLE
refactor: paths.LongestCommonPrefixStr and paths.Join, tests

### DIFF
--- a/core/internal/paths/longestcommonprefix_test.go
+++ b/core/internal/paths/longestcommonprefix_test.go
@@ -1,6 +1,7 @@
 package paths_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,4 +38,35 @@ func TestLongestCommonPrefix_TooFewDirectories(t *testing.T) {
 
 	assert.ErrorContains(t, err, "too few paths")
 	assert.Nil(t, prefix)
+}
+
+func TestLongestCommonPrefixStr_OfSingleString_IsInput(t *testing.T) {
+	prefix := paths.LongestCommonPrefixStr(
+		slices.Values([]string{"some/strange//path/"}),
+		"/",
+	)
+
+	assert.Equal(t, "some/strange//path/", prefix)
+}
+
+func TestLongestCommonPrefixStr_OfNothing_Empty(t *testing.T) {
+	prefix := paths.LongestCommonPrefixStr(
+		slices.Values([]string{}),
+		"/",
+	)
+
+	assert.Equal(t, "", prefix)
+}
+
+func TestLongestCommonPrefixStr_ComparesComponents(t *testing.T) {
+	prefix := paths.LongestCommonPrefixStr(
+		slices.Values([]string{
+			"parent_child",
+			"parent_children",
+		}),
+		"_",
+	)
+
+	// NOTE: Not "parent_child".
+	assert.Equal(t, "parent", prefix)
 }

--- a/core/internal/paths/paths.go
+++ b/core/internal/paths/paths.go
@@ -87,10 +87,16 @@ func Absolute(path string) (*AbsolutePath, error) {
 // Relative returns the path if it's relative, or returns an error.
 func Relative(path string) (*RelativePath, error) {
 	if filepath.IsAbs(path) {
-		return nil, fmt.Errorf("path is not relative: %s", path)
+		return nil, fmt.Errorf("path is not relative: %q", path)
 	}
 
 	return toPtr(RelativePath(filepath.Clean(path))), nil
+}
+
+// Join appends a relative path to an absolute path.
+func (path1 AbsolutePath) Join(path2 RelativePath) AbsolutePath {
+	// NOTE: filepath.Join() calls Clean() on the result.
+	return AbsolutePath(filepath.Join(string(path1), string(path2)))
 }
 
 // RelativeTo returns an equivalent path that is relative to the given path.

--- a/core/internal/paths/paths_notwindows_test.go
+++ b/core/internal/paths/paths_notwindows_test.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+package paths_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/internal/paths"
+)
+
+func TestAbsolute_RemovesTrailingSlash(t *testing.T) {
+	path, err := paths.Absolute("/remove/slash/")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/remove/slash", string(*path))
+}
+
+func TestAbsolute_GivenRelativePath_JoinsToCWD(t *testing.T) {
+	cwd, err := paths.CWD()
+	require.NoError(t, err)
+
+	path, err := paths.Absolute(".")
+	require.NoError(t, err)
+
+	assert.Equal(t, string(*cwd), string(*path))
+}
+
+func TestRelative_CleansPath(t *testing.T) {
+	path, err := paths.Relative("./../parent/../parent2/child/..")
+
+	require.NoError(t, err)
+	assert.Equal(t, "../parent2", string(*path))
+}
+
+func TestRelative_GivenAbsolutePath_Fails(t *testing.T) {
+	path, err := paths.Relative("/absolute/path")
+
+	assert.Nil(t, path)
+	assert.ErrorContains(t, err, `path is not relative: "/absolute/path"`)
+}
+
+func TestJoin(t *testing.T) {
+	path1, err := paths.Absolute("/absolute/path")
+	require.NoError(t, err)
+	path2, err := paths.Relative("../relative/path")
+	require.NoError(t, err)
+
+	result := path1.Join(*path2)
+
+	assert.Equal(t, "/absolute/relative/path", string(result))
+}
+
+func TestIsLocal_LocalPath_True(t *testing.T) {
+	path, err := paths.Relative("local/../path")
+	require.NoError(t, err)
+
+	assert.True(t, path.IsLocal())
+}
+
+func TestIsLocal_NonLocalPath_False(t *testing.T) {
+	path, err := paths.Relative("../non/local/path")
+	require.NoError(t, err)
+
+	assert.False(t, path.IsLocal())
+}


### PR DESCRIPTION
Adds two new functions to `paths` and adds some missing unit tests.

The functions are used in later PRs: `LongestCommonPrefixStr` is the core logic of `LongestCommonPrefix` but not necessarily requiring a real system path, which is used when comparing cloud URLs in `internal/tensorboard`.

`paths.Join` is natural to have here, but I didn't add it before because it wasn't needed.