### PR TITLE
chore: fix mypy failures due to missing pkg_resources

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -581,7 +581,10 @@ def mypy_report(session: nox.Session) -> None:
         "types-pytz",
         "types-PyYAML",
         "types-requests",
-        "types-setuptools",
+        # Fix for removal of pkg_resources
+        # TODO(@jacobromero): remove version constraint
+        # after migrating away from pkg_resources
+        "types-setuptools < 80.7",
         "types-six",
         "types-tqdm",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ dependencies = [
     # setuptools is needed for distutils in dependencies after Python 3.12 :(
     # One such dependency is docker-pycreds, where the latest release is 0.4.0
     # which was released in 2018.
-    "setuptools",
+    # Pinning to 80.7 due to removal of pkg_resources causing CI failures.
+    # TODO(@jacobromero): remove version constraint
+    # after migrating away from pkg_resources
+    "setuptools<80.7",
     "protobuf>=3.12.0,!=4.21.0,!=5.28.0,<7; python_version < '3.9' and sys_platform == 'linux'",
     "protobuf>=3.15.0,!=4.21.0,!=5.28.0,<7; python_version == '3.9' and sys_platform == 'linux'",
     "protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; python_version > '3.9' and sys_platform == 'linux'",
@@ -222,8 +225,18 @@ ignore-decorators = [
 # - D102: Require docstrings in public methods
 # - D103: Require docstrings in public functions
 # - D417: Require descriptions for all arguments
-"!wandb/apis/public/api.py" = ["D101", "D102", "D103", "D417"]  # "Public API" module
-"!wandb/automations/**/*.py" = ["D101", "D102", "D103", "D417"] # Automations submodules
+"!wandb/apis/public/api.py" = [
+    "D101",
+    "D102",
+    "D103",
+    "D417",
+] # "Public API" module
+"!wandb/automations/**/*.py" = [
+    "D101",
+    "D102",
+    "D103",
+    "D417",
+] # Automations submodules
 
 "**/__init__.py" = ["E402", "F401"]
 "wandb/__init__.py" = ["I001"]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

code-check ci is failing because `pkg_resources` has been removed from the installation of `setuptools`. Starting in [setuptools v80.7.0](https://setuptools.pypa.io/en/stable/history.html#v80-7-0). 
`pkg_resources` is deprecated and should be moved to the various other files recommended [here](https://setuptools.pypa.io/en/latest/pkg_resources.html). For now we can pin the version and will work on migrating `pkg_resources` ([jira](https://wandb.atlassian.net/browse/WB-25032))

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
