### PR TITLE
refactor: annotate `wandb.Run.summary` field

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -587,6 +587,8 @@ class Run:
     _launch_artifacts: dict[str, Any] | None
     _printer: printer.Printer
 
+    summary: wandb_summary.Summary
+
     def __init__(
         self,
         settings: Settings,


### PR DESCRIPTION
Without this, MyPy cannot infer the type of `run.summary` (but Pylance can because of the assignment in `_init()`). There are probably other similar cases; this just came up in https://app.graphite.dev/github/pr/wandb/wandb/9834/chore(sdk)-handle-resumed-runs-when-logging-tables-incrementally#comment-PRRC_kwDOBSC9Os59Ex_G.