### PR TITLE
fix: inconsistent image normalization for wandb.Image

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -73,3 +73,7 @@ When preparing a release that can include breaking changes, consider applying ch
     - Owner: @kptkin
     - Deprecated in 0.20.0 (https://github.com/wandb/wandb/pull/9837)
     - Can do in >=0.21
+
+- Remove normalization of image data on `wandb.Image`
+    - Owner: @jacobromero
+    - can do in >=0.21

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,7 +29,7 @@ This version removes the ability to disable the `service` process. This is a bre
 - Added support for initializing some Media objects with `pathlib.Path` (@jacobromero in https://github.com/wandb/wandb/pull/9692)
 - New setting `x_skip_transaction_log` that allows to skip the transaction log. Note: Should be used with caution, as it removes the gurantees about
     recoverability. (@kptkin in https://github.com/wandb/wandb/pull/9064)
-- `normalized` parameter to `wandb.Image` initialization to normalize pixel values for Images initialized with a numpy array or pytorch tensor. (@jacobromero in https://github.com/wandb/wandb/pull/9786)
+- `normalized` parameter to `wandb.Image` initialization to normalize pixel values for Images initialized with a numpy array or pytorch tensor. (@jacobromero in https://github.com/wandb/wandb/pull/9883)
 
 ### Removed
 
@@ -46,3 +46,4 @@ This version removes the ability to disable the `service` process. This is a bre
   - This error could have manifested when using W&B Sweeps
 - Offline runs with requested branching (fork or rewind) sync correctly (@dmitryduev in https://github.com/wandb/wandb/pull/9876)
 - Log exception as string when raising exception in Job wait_until_running method (@KyleGoyette in https://github.com/wandb/wandb/pull/9607)
+- `wandb.Image` initialized with tensorflow data would be normalized differently than when initialized with a numpy array (@jacobromero in https://github.com/wandb/wandb/pull/9883)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ This version removes the ability to disable the `service` process. This is a bre
 - Added support for initializing some Media objects with `pathlib.Path` (@jacobromero in https://github.com/wandb/wandb/pull/9692)
 - New setting `x_skip_transaction_log` that allows to skip the transaction log. Note: Should be used with caution, as it removes the gurantees about
     recoverability. (@kptkin in https://github.com/wandb/wandb/pull/9064)
+- `normalized` parameter to `wandb.Image` initialization to normalize pixel values for Images initialized with a numpy array or pytorch tensor. (@jacobromero in https://github.com/wandb/wandb/pull/9786)
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,7 +29,7 @@ This version removes the ability to disable the `service` process. This is a bre
 - Added support for initializing some Media objects with `pathlib.Path` (@jacobromero in https://github.com/wandb/wandb/pull/9692)
 - New setting `x_skip_transaction_log` that allows to skip the transaction log. Note: Should be used with caution, as it removes the gurantees about
     recoverability. (@kptkin in https://github.com/wandb/wandb/pull/9064)
-- `normalized` parameter to `wandb.Image` initialization to normalize pixel values for Images initialized with a numpy array or pytorch tensor. (@jacobromero in https://github.com/wandb/wandb/pull/9883)
+- `normalize` parameter to `wandb.Image` initialization to normalize pixel values for Images initialized with a numpy array or pytorch tensor. (@jacobromero in https://github.com/wandb/wandb/pull/9883)
 
 ### Removed
 

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -433,15 +433,6 @@ def test_image_normalization_numpy_pytorch_equal(scale):
     assert np.all(np.array(wb_image.image) == np.array(wb_image_torch.image))
 
 
-def test_image_normalization_with_small_values_scales_to_range():
-    img = np.linspace(0, 10, 4 * 4 * 3).reshape([4, 4, 3]) * 1e-8
-    expected_scale = np.linspace(0, 255, 4 * 4 * 3).reshape([4, 4, 3]).astype(np.uint8)
-    wb_image = wandb.Image(img)
-
-    assert not np.all(np.array(wb_image.image) == 0)
-    assert np.all(np.array(wb_image.image) == expected_scale)
-
-
 ################################################################################
 # Test wandb.Audio
 ################################################################################

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -1053,12 +1053,12 @@ def test_table_column_style():
     assert [ndx._table == table1 for ndx in ndxs]
 
     # Test More Images and ndarrays
-    rand_1 = np.random.randint(256, size=(32, 32))
-    rand_2 = np.random.randint(256, size=(32, 32))
-    rand_3 = np.random.randint(256, size=(32, 32))
-    img_1 = wandb.Image(rand_1)
-    img_2 = wandb.Image(rand_2)
-    img_3 = wandb.Image(rand_3)
+    rand_1 = np.random.randint(256, size=(2, 2, 3))
+    rand_2 = np.random.randint(256, size=(2, 2, 3))
+    rand_3 = np.random.randint(256, size=(2, 2, 3))
+    img_1 = wandb.Image(rand_1, normalize=False)
+    img_2 = wandb.Image(rand_2, normalize=False)
+    img_3 = wandb.Image(rand_3, normalize=False)
 
     table2 = wandb.Table(columns=[], data=[])
     table2.add_column("np_data", [rand_1, rand_2])

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -419,6 +419,29 @@ def test_image_masks_with_pytorch_tensors():
     wandb.Image(image, masks={"predictions": {"mask_data": mask}})
 
 
+@pytest.mark.parametrize(
+    "scale",
+    [1e-8, 1e-5, 1e0, 1e1, -1e-8, -1e-5, -1e0, -1e1],
+)
+def test_image_normalization_numpy_pytorch_equal(scale):
+    img = np.random.uniform(low=0, high=1, size=[4, 4, 3]) * scale
+    torch_img = torch.from_numpy(img.transpose(2, 0, 1))
+
+    wb_image = wandb.Image(img)
+    wb_image_torch = wandb.Image(torch_img)
+
+    assert np.all(np.array(wb_image.image) == np.array(wb_image_torch.image))
+
+
+def test_image_normalization_with_small_values_scales_to_range():
+    img = np.linspace(0, 10, 4 * 4 * 3).reshape([4, 4, 3]) * 1e-8
+    expected_scale = np.linspace(0, 255, 4 * 4 * 3).reshape([4, 4, 3]).astype(np.uint8)
+    wb_image = wandb.Image(img)
+
+    assert not np.all(np.array(wb_image.image) == 0)
+    assert np.all(np.array(wb_image.image) == expected_scale)
+
+
 ################################################################################
 # Test wandb.Audio
 ################################################################################
@@ -1030,9 +1053,9 @@ def test_table_column_style():
     assert [ndx._table == table1 for ndx in ndxs]
 
     # Test More Images and ndarrays
-    rand_1 = np.random.randint(255, size=(32, 32))
-    rand_2 = np.random.randint(255, size=(32, 32))
-    rand_3 = np.random.randint(255, size=(32, 32))
+    rand_1 = np.random.randint(256, size=(32, 32))
+    rand_2 = np.random.randint(256, size=(32, 32))
+    rand_3 = np.random.randint(256, size=(32, 32))
     img_1 = wandb.Image(rand_1)
     img_2 = wandb.Image(rand_2)
     img_3 = wandb.Image(rand_3)

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -64,65 +64,7 @@ def _server_accepts_artifact_path(run: "LocalRun") -> bool:
 
 
 class Image(BatchableMedia):
-    """Format images for logging to W&B.
-
-    Args:
-        data_or_path: (numpy array, string, io) Accepts numpy array of
-            image data, or a PIL image. The class attempts to infer
-            the data format and converts it.
-        mode: (string) The PIL mode for an image. Most common are "L", "RGB",
-            "RGBA". Full explanation at https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
-        caption: (string) Label for display of image.
-
-    Note : When logging a `torch.Tensor` as a `wandb.Image`, images are normalized. If you do not want to normalize your images, please convert your tensors to a PIL Image.
-
-    Examples:
-        ### Create a wandb.Image from a numpy array
-        ```python
-        import numpy as np
-        import wandb
-
-        with wandb.init() as run:
-            examples = []
-            for i in range(3):
-                pixels = np.random.randint(low=0, high=256, size=(100, 100, 3))
-                image = wandb.Image(pixels, caption=f"random field {i}")
-                examples.append(image)
-            run.log({"examples": examples})
-        ```
-
-        ### Create a wandb.Image from a PILImage
-        ```python
-        import numpy as np
-        from PIL import Image as PILImage
-        import wandb
-
-        with wandb.init() as run:
-            examples = []
-            for i in range(3):
-                pixels = np.random.randint(
-                    low=0, high=256, size=(100, 100, 3), dtype=np.uint8
-                )
-                pil_image = PILImage.fromarray(pixels, mode="RGB")
-                image = wandb.Image(pil_image, caption=f"random field {i}")
-                examples.append(image)
-            run.log({"examples": examples})
-        ```
-
-        ### log .jpg rather than .png (default)
-        ```python
-        import numpy as np
-        import wandb
-
-        with wandb.init() as run:
-            examples = []
-            for i in range(3):
-                pixels = np.random.randint(low=0, high=256, size=(100, 100, 3))
-                image = wandb.Image(pixels, caption=f"random field {i}", file_type="jpg")
-                examples.append(image)
-            run.log({"examples": examples})
-        ```
-    """
+    """A class for logging images to W&B."""
 
     MAX_ITEMS = 108
 
@@ -152,7 +94,81 @@ class Image(BatchableMedia):
         boxes: Optional[Union[Dict[str, "BoundingBoxes2D"], Dict[str, dict]]] = None,
         masks: Optional[Union[Dict[str, "ImageMask"], Dict[str, dict]]] = None,
         file_type: Optional[str] = None,
+        normalize: bool = True,
     ) -> None:
+        """Initialize a wandb.Image object.
+
+        Args:
+            data_or_path: Accepts numpy array/pytorch tensor of image data,
+                a PIL image object, or a path to an image file.
+                If a numpy array or pytorch tensor,
+                the image data will be saved to the given file type.
+                - pytorch tensor should be in the format (channel, height, width)
+                - numpy array should be in the format (height, width, channel)
+            mode: The PIL mode for an image. Most common are "L", "RGB",
+                "RGBA". Full explanation at https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
+            caption: Label for display of image.
+            grouping: The grouping number for the image.
+            classes: A list of class information for the image,
+                used for labeling bounding boxes, and image masks.
+            boxes: A dictionary containing bounding box information for the image.
+                see: https://docs.wandb.ai/ref/python/data-types/boundingboxes2d/
+            masks: A dictionary containing mask information for the image.
+                see: https://docs.wandb.ai/ref/python/data-types/imagemask/
+            file_type: The file type to save the image as.
+                This parameter has no effect if data_or_path is a path to an image file.
+            normalize: If True, normalize the image pixel values to fall within the range of [0, 255].
+                Normalize is only applied if data_or_path is a numpy array or pytorch tensor.
+
+        Examples:
+            ### Create a wandb.Image from a numpy array
+            ```python
+            import numpy as np
+            import wandb
+
+            with wandb.init() as run:
+                examples = []
+                for i in range(3):
+                    pixels = np.random.randint(low=0, high=256, size=(100, 100, 3))
+                    image = wandb.Image(pixels, caption=f"random field {i}")
+                    examples.append(image)
+                run.log({"examples": examples})
+            ```
+
+            ### Create a wandb.Image from a PILImage
+            ```python
+            import numpy as np
+            from PIL import Image as PILImage
+            import wandb
+
+            with wandb.init() as run:
+                examples = []
+                for i in range(3):
+                    pixels = np.random.randint(
+                        low=0, high=256, size=(100, 100, 3), dtype=np.uint8
+                    )
+                    pil_image = PILImage.fromarray(pixels, mode="RGB")
+                    image = wandb.Image(pil_image, caption=f"random field {i}")
+                    examples.append(image)
+                run.log({"examples": examples})
+            ```
+
+            ### log .jpg rather than .png (default)
+            ```python
+            import numpy as np
+            import wandb
+
+            with wandb.init() as run:
+                examples = []
+                for i in range(3):
+                    pixels = np.random.randint(low=0, high=256, size=(100, 100, 3))
+                    image = wandb.Image(
+                        pixels, caption=f"random field {i}", file_type="jpg"
+                    )
+                    examples.append(image)
+                run.log({"examples": examples})
+            ```
+        """
         super().__init__(caption=caption)
         # TODO: We should remove grouping, it's a terrible name and I don't
         # think anyone uses it.
@@ -178,7 +194,7 @@ class Image(BatchableMedia):
             else:
                 self._initialize_from_path(data_or_path)
         else:
-            self._initialize_from_data(data_or_path, mode, file_type)
+            self._initialize_from_data(data_or_path, mode, file_type, normalize)
         self._set_initialization_meta(
             grouping, caption, classes, boxes, masks, file_type
         )
@@ -291,6 +307,7 @@ class Image(BatchableMedia):
         data: "ImageDataType",
         mode: Optional[str] = None,
         file_type: Optional[str] = None,
+        normalize: bool = True,
     ) -> None:
         pil_image = util.get_module(
             "PIL.Image",
@@ -312,17 +329,19 @@ class Image(BatchableMedia):
         elif isinstance(data, pil_image.Image):
             self._image = data
         elif util.is_pytorch_tensor_typename(util.get_full_typename(data)):
-            vis_util = util.get_module(
-                "torchvision.utils", "torchvision is required to render images"
-            )
             if hasattr(data, "requires_grad") and data.requires_grad:
                 data = data.detach()  # type: ignore
             if hasattr(data, "dtype") and str(data.dtype) == "torch.uint8":
                 data = data.to(float)
-            data = vis_util.make_grid(data, normalize=True)
             mode = mode or self.guess_mode(data, file_type)
+            data = data.permute(1, 2, 0).cpu().numpy()
+            data = self.normalize_and_convert_to_uint8(data) if normalize else data
+
+            if data.ndim > 2:
+                data = data.squeeze()
+
             self._image = pil_image.fromarray(
-                data.mul(255).clamp(0, 255).byte().permute(1, 2, 0).cpu().numpy(),
+                data,
                 mode=mode,
             )
         else:
@@ -332,8 +351,9 @@ class Image(BatchableMedia):
                 data = data.squeeze()  # get rid of trivial dimensions as a convenience
 
             mode = mode or self.guess_mode(data, file_type)
+            data = self.normalize_and_convert_to_uint8(data) if normalize else data
             self._image = pil_image.fromarray(
-                self.to_uint8(data),
+                data,
                 mode=mode,
             )
 
@@ -488,7 +508,7 @@ class Image(BatchableMedia):
         else:
             num_channels = data.shape[-1]
 
-        if ndims == 2:
+        if ndims == 2 or num_channels == 1:
             return "L"
         elif num_channels == 3:
             return "RGB"
@@ -508,28 +528,17 @@ class Image(BatchableMedia):
             )
 
     @classmethod
-    def to_uint8(cls, data: "np.ndarray") -> "np.ndarray":
-        """Convert image data to uint8.
-
-        Convert floating point image on the range [0,1] and integer images on the range
-        [0,255] to uint8, clipping if necessary.
-        """
+    def normalize_and_convert_to_uint8(cls, data: "np.ndarray") -> "np.ndarray":
+        """Normalizes and converts image pixel values to uint8 in the range [0, 255]."""
         np = util.get_module(
             "numpy",
             required="wandb.Image requires numpy if not supplying PIL Images: pip install numpy",
         )
 
-        # I think it's better to check the image range vs the data type, since many
-        # image libraries will return floats between 0 and 255
-
-        # some images have range -1...1 or 0-1
-        dmin = np.min(data)
-        if dmin < 0:
-            data = (data - np.min(data)) / np.ptp(data)
-        if np.max(data) <= 1.0:
-            data = (data * 255).astype(np.int32)
-
-        # assert issubclass(data.dtype.type, np.integer), 'Illegal image format.'
+        # Scale data to [0, 255] range
+        data = data - np.min(data)
+        data = data / np.ptp(data)
+        data = 255 * data
         return data.clip(0, 255).astype(np.uint8)
 
     @classmethod

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -567,6 +567,8 @@ class Image(BatchableMedia):
             required="wandb.Image requires numpy if not supplying PIL Images: pip install numpy",
         )
 
+        # if an image has negative values, set all values to be in the range [0, 1]
+        # This can lead to inconsistent behavior when an image has only a single negative value
         if np.min(data) < 0 and np.ptp(data) != 0:
             data = (data - np.min(data)) / np.ptp(data)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-15801
- Fixes #6287, #7377

What does the PR do? Include a concise description of the PR contents.
When normalizing image values, during the creation of a `wandb.Image` from data (numpy array, or pytorch tensor) there are inconsistencies in the output image. 

Specifically tensorflow will always do a min/max normalization. While for numpy arrays we would only do a min/max normalization when the array contained a negative value. This led to some images being completely dark for numpy data, but normalized for tensorflow data. This PR aligns the behavior for both numpy and tensorflow, and adds a new `normalize` parameter to prevent W&B from modifying the data at all.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- Unit tests added
- repro script
```python
import numpy as np
import wandb
import torch

img = np.random.uniform(low=0, high=1, size=[2, 4, 3])
torch_img = torch.from_numpy(img.transpose(2, 0, 1))
values = [1e-8, 1e-5, 1e0, 1e1]

with wandb.init(
    project="image-norm-test",
) as run:
    for value in values:
        wandb_np_img_norm = wandb.Image(img * value)
        wandb_torch_img_norm = wandb.Image(torch_img * value)

        run.log({f"np_img_norm_{str(value)}": wandb_np_img_norm})
        run.log({f"torch_img_norm_{str(value)}": wandb_torch_img_norm})
```

#### After this change
![image](https://github.com/user-attachments/assets/50a37697-373f-4e29-8cf1-5b80ac28e97a)
![image](https://github.com/user-attachments/assets/55bd11c5-1cb4-4e1f-b889-2a10e32996d8)
![image](https://github.com/user-attachments/assets/eeea15bc-6f85-46f2-b1c9-f8972c598387)
![image](https://github.com/user-attachments/assets/0aadf7bc-7fe8-4878-8caf-93970bf2f20d)


#### Before this change
![image](https://github.com/user-attachments/assets/0db38f7a-3f09-4f47-9e52-52d90c4d16dd)
![image](https://github.com/user-attachments/assets/1701b131-222f-43f5-9c93-28a772ead821)
![image](https://github.com/user-attachments/assets/846bf23b-4646-427a-8509-c89391d02b43)
![image](https://github.com/user-attachments/assets/de9eea41-9c15-4e4d-9c14-3dfca14ffe86)


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
