### PR TITLE
refactor: unconditionally import from typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "PyYAML",
     "setproctitle",
     "platformdirs",
-    "typing_extensions>=4.4,<5",
+    "typing_extensions>=4.8,<5",
     "pydantic<3",
     "eval_type_backport; python_version < '3.10'",
 ]

--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -12,12 +12,6 @@ from typing import Any, ClassVar, Final, Literal
 
 import httpx
 
-if sys.version_info < (3, 12):
-    from typing_extensions import dataclass_transform
-else:
-    from typing import dataclass_transform
-
-
 #: The root directory of this repo.
 REPO_ROOT: Final[Path] = Path(__file__).parent.parent.parent
 
@@ -66,7 +60,6 @@ def connect_to_local_wandb_backend(name: str) -> LocalWandbBackendAddress:
 
 
 @dataclass(frozen=True)
-@dataclass_transform(frozen_default=True)
 class FixtureCmd:
     path: ClassVar[str]  # e.g. "db/user"
 

--- a/tests/system_tests/test_notebooks/conftest.py
+++ b/tests/system_tests/test_notebooks/conftest.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import sys
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, List
+from typing import Dict, List
 from unittest.mock import MagicMock
 
 import filelock
@@ -17,13 +17,8 @@ import wandb
 import wandb.util
 from nbclient import NotebookClient
 from nbclient.client import CellExecutionError
+from typing_extensions import Any, Generator, override
 from wandb.sdk.lib import ipython
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    from typing_extensions import override
-
 
 _NOTEBOOK_LOCKFILE = os.path.join(
     os.path.dirname(__file__),

--- a/tests/system_tests/wandb_backend_spy/gql_match.py
+++ b/tests/system_tests/wandb_backend_spy/gql_match.py
@@ -6,21 +6,10 @@ import abc
 import dataclasses
 import json
 import re
-import sys
 import threading
-from typing import Any
 
 import fastapi
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    from typing_extensions import override
-
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+from typing_extensions import Any, TypeAlias, override
 
 # Matches queries containing a line in one of the following forms:
 #   mutation OpName(

--- a/wandb/sdk/internal/run.py
+++ b/wandb/sdk/internal/run.py
@@ -5,12 +5,7 @@ Semi-stubbed run for internal process use.
 
 """
 
-import sys
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    from typing_extensions import override
+from typing_extensions import override
 
 from wandb.sdk import wandb_run
 

--- a/wandb/sdk/internal/system/assets/aggregators.py
+++ b/wandb/sdk/internal/system/assets/aggregators.py
@@ -1,10 +1,4 @@
-import sys
-from typing import Union
-
-if sys.version_info >= (3, 9):
-    from collections.abc import Sequence
-else:
-    from typing import Sequence
+from typing import Sequence, Union
 
 Number = Union[int, float]
 

--- a/wandb/sdk/lib/fsm.py
+++ b/wandb/sdk/lib/fsm.py
@@ -28,26 +28,11 @@ Usage:
     ```
 """
 
-import sys
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import (
-    Callable,
-    Dict,
-    Generic,
-    Optional,
-    Protocol,
-    Sequence,
-    Type,
-    TypeVar,
-    Union,
-    runtime_checkable,
-)
+from typing import Callable, Dict, Generic, Optional, Sequence, Type, Union
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+from typing_extensions import Protocol, TypeAlias, TypeVar, runtime_checkable
 
 T_FsmInputs = TypeVar("T_FsmInputs", contravariant=True)
 T_FsmContext = TypeVar("T_FsmContext")

--- a/wandb/sdk/lib/printer.py
+++ b/wandb/sdk/lib/printer.py
@@ -9,16 +9,11 @@ import platform
 import sys
 from typing import Callable, Iterator
 
-import wandb.util
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    from typing_extensions import override
-
 import click
+from typing_extensions import override
 
 import wandb
+import wandb.util
 from wandb.errors import term
 from wandb.sdk import wandb_setup
 

--- a/wandb/sdk/mailbox/mailbox_handle.py
+++ b/wandb/sdk/mailbox/mailbox_handle.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 import abc
-import sys
-from typing import TYPE_CHECKING, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic
+
+from typing_extensions import TypeVar, override
 
 # Necessary to break an import loop.
 if TYPE_CHECKING:
     from wandb.sdk.interface import interface
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    from typing_extensions import override
 
 
 _T = TypeVar("_T")

--- a/wandb/sdk/mailbox/response_handle.py
+++ b/wandb/sdk/mailbox/response_handle.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import math
-import sys
 import threading
 from typing import TYPE_CHECKING
+
+from typing_extensions import override
 
 from wandb.proto import wandb_server_pb2 as spb
 
@@ -13,11 +14,6 @@ from .mailbox_handle import HandleAbandonedError, MailboxHandle
 # Necessary to break an import loop.
 if TYPE_CHECKING:
     from wandb.sdk.interface import interface
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    from typing_extensions import override
 
 
 class MailboxResponseHandle(MailboxHandle[spb.ServerResponse]):

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -21,12 +21,9 @@ import platform
 import sys
 import tempfile
 import time
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Literal, Protocol, Sequence
+from typing import TYPE_CHECKING, Iterable, Iterator, Sequence
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
+from typing_extensions import Any, Literal, Protocol, Self
 
 import wandb
 import wandb.env

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -18,25 +18,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import IntEnum
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-    NamedTuple,
-    Sequence,
-    TextIO,
-    TypeVar,
-)
-
-from wandb.sdk.artifacts._internal_artifact import InternalArtifact
-
-if sys.version_info < (3, 10):
-    from typing_extensions import Concatenate, ParamSpec
-else:
-    from typing import Concatenate, ParamSpec
+from typing import TYPE_CHECKING, Callable, Sequence, TextIO, TypeVar
 
 import requests
+from typing_extensions import Any, Concatenate, Literal, NamedTuple, ParamSpec
 
 import wandb
 import wandb.env
@@ -56,6 +41,7 @@ from wandb.proto.wandb_internal_pb2 import (
     Result,
     RunRecord,
 )
+from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.internal import job_builder
 from wandb.sdk.lib import asyncio_compat, wb_logging

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -36,10 +36,8 @@ from types import ModuleType
 from typing import (
     IO,
     TYPE_CHECKING,
-    Any,
     Callable,
     Dict,
-    Generator,
     Iterable,
     List,
     Mapping,
@@ -47,17 +45,12 @@ from typing import (
     Sequence,
     TextIO,
     Tuple,
-    TypeVar,
     Union,
 )
 
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeGuard
-else:
-    from typing import TypeGuard
-
 import requests
 import yaml
+from typing_extensions import Any, Generator, TypeGuard, TypeVar
 
 import wandb
 import wandb.env


### PR DESCRIPTION
Instead of checking the Python version and importing either from `typing` or `typing_extensions`, always prefer to import from `typing_extensions`. Only import from `typing` if Ruff complains about [deprecated imports](https://docs.astral.sh/ruff/rules/deprecated-import/) (some symbols, like Dict, List and Union).

I only updated files that have a conditional import. There are many other files where we import from `typing` where we could import from `typing_extensions`, but updating them manually just for the sake of consistency doesn't seem worth it.