### PR TITLE
chore: fix failing unit tests due to click dependency update

### DIFF
--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -306,7 +306,7 @@ def test_docker_run_nvidia(runner, docker):
 
 def test_docker(runner, docker):
     with runner.isolated_filesystem():
-        result = runner.invoke(cli.docker, ["test"])
+        result = runner.invoke(cli.docker, ["test"], input="n")
         docker.assert_called_once_with(
             [
                 "docker",
@@ -335,7 +335,7 @@ def test_docker(runner, docker):
 
 
 def test_docker_basic(runner, docker, git_repo):
-    result = runner.invoke(cli.docker, ["test:abc123"])
+    result = runner.invoke(cli.docker, ["test:abc123"], input="n")
     assert "Launching docker container" in result.output
     docker.assert_called_once_with(
         [
@@ -365,7 +365,7 @@ def test_docker_basic(runner, docker, git_repo):
 
 
 def test_docker_sha(runner, docker):
-    result = runner.invoke(cli.docker, ["test@sha256:abc123"])
+    result = runner.invoke(cli.docker, ["test@sha256:abc123"], input="n")
     docker.assert_called_once_with(
         [
             "docker",
@@ -394,7 +394,7 @@ def test_docker_sha(runner, docker):
 
 
 def test_docker_no_dir(runner, docker):
-    result = runner.invoke(cli.docker, ["test:abc123", "--no-dir"])
+    result = runner.invoke(cli.docker, ["test:abc123", "--no-dir"], input="n")
     docker.assert_called_once_with(
         [
             "docker",
@@ -420,7 +420,9 @@ def test_docker_no_dir(runner, docker):
 
 def test_docker_no_interactive_custom_command(runner, docker, git_repo):
     result = runner.invoke(
-        cli.docker, ["test:abc123", "--no-tty", "--cmd", "python foo.py"]
+        cli.docker,
+        ["test:abc123", "--no-tty", "--cmd", "python foo.py"],
+        input="n",
     )
     docker.assert_called_once_with(
         [
@@ -452,7 +454,7 @@ def test_docker_no_interactive_custom_command(runner, docker, git_repo):
 
 def test_docker_jupyter(runner, docker):
     with runner.isolated_filesystem():
-        result = runner.invoke(cli.docker, ["test", "--jupyter"])
+        result = runner.invoke(cli.docker, ["test", "--jupyter"], input="n")
         docker.assert_called_once_with(
             [
                 "docker",
@@ -490,7 +492,7 @@ def test_docker_jupyter(runner, docker):
 
 def test_docker_args(runner, docker):
     with runner.isolated_filesystem():
-        result = runner.invoke(cli.docker, ["test", "-v", "/tmp:/tmp"])
+        result = runner.invoke(cli.docker, ["test", "-v", "/tmp:/tmp"], input="n")
         docker.assert_called_with(
             [
                 "docker",


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

This PR fixes consistent test failures related to `wand docker` cli tests. This was caused by an update with our dependency `click` in version `v8.2.1`, which changed the behavior with how the `CliRunner` is handling input when there is a prompt but no more input provided. (see click [issue here](https://github.com/pallets/click/pull/2934), and the [fix here](https://github.com/pallets/click/pull/2934))

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- running unit tests for `tests/unit_tests/test_cli.py`


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
