### PR TITLE
chore: add moviepy CI constraint to fix functional test

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,9 @@ eval-type-backport~=0.2.0; python_version >= '3.8' and python_version < '3.10'
 Pillow
 pandas
 polars
-moviepy >= 1.0.0
+# Version 2.0.0 removes moviepy.editor, used by TensorBoard in some tests
+# to log videos.
+moviepy~=1.0
 imageio[ffmpeg]
 matplotlib
 soundfile


### PR DESCRIPTION
Constrains `moviepy` to versions compatible with `1.0` so that `tensorboardX` and `torch`'s versions of `SummaryWriter.add_video()` work. These seem to be vendored, so they use similar code that relies on importing `moviepy.editor`.