### PR TITLE
chore: remove pkg_resources dependency, add packaging dependency

### DIFF
--- a/landfill/standalone_tests/all_media_types.py
+++ b/landfill/standalone_tests/all_media_types.py
@@ -15,9 +15,9 @@ import wandb
 
 
 def dummy_torch_tensor(size, requires_grad=True):
-    from wandb.util import parse_version
+    from packaging.version import parse
 
-    if parse_version(torch.__version__) >= parse_version("0.4"):
+    if parse(torch.__version__) >= parse("0.4"):
         return torch.ones(size, requires_grad=requires_grad)
     else:
         return torch.autograd.Variable(torch.ones(size), requires_grad=requires_grad)

--- a/noxfile.py
+++ b/noxfile.py
@@ -571,6 +571,7 @@ def mypy_report(session: nox.Session) -> None:
         # https://github.com/python/mypy/issues/17166
         "mypy != 1.10.0",
         "numpy",
+        "packaging",
         "pandas-stubs",
         "pip",
         "platformdirs",
@@ -588,7 +589,7 @@ def mypy_report(session: nox.Session) -> None:
         # Fix for removal of pkg_resources
         # TODO(@jacobromero): remove version constraint
         # after migrating away from pkg_resources
-        "types-setuptools < 80.7",
+        "types-setuptools",
         "types-six",
         "types-tqdm",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,9 @@ dependencies = [
     "psutil>=5.0.0",
     "sentry-sdk>=2.0.0",
     "docker-pycreds>=0.4.0",
-    # setuptools is needed for distutils in dependencies after Python 3.12 :(
-    # One such dependency is docker-pycreds, where the latest release is 0.4.0
-    # which was released in 2018.
-    "setuptools==66.1.0",
+    # Prior versions of setuptools cause failures in tests.
+    # 66.1.0 is the oldest version that passes tests.
+    "setuptools>=66.1.0",
     "protobuf>=3.12.0,!=4.21.0,!=5.28.0,<7; python_version < '3.9' and sys_platform == 'linux'",
     "protobuf>=3.15.0,!=4.21.0,!=5.28.0,<7; python_version == '3.9' and sys_platform == 'linux'",
     "protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; python_version > '3.9' and sys_platform == 'linux'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "psutil>=5.0.0",
     "sentry-sdk>=2.0.0",
     "docker-pycreds>=0.4.0",
+    # setuptools is needed for distutils in dependencies after Python 3.12 :(
+    # One such dependency is docker-pycreds, where the latest release is 0.4.0
+    # which was released in 2018.
     # Prior versions of setuptools cause failures in tests.
     # 66.1.0 is the oldest version that passes tests.
     "setuptools>=66.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # Pinning to 80.7 due to removal of pkg_resources causing CI failures.
     # TODO(@jacobromero): remove version constraint
     # after migrating away from pkg_resources
-    "setuptools<80.7",
+    "setuptools",
     "protobuf>=3.12.0,!=4.21.0,!=5.28.0,<7; python_version < '3.9' and sys_platform == 'linux'",
     "protobuf>=3.15.0,!=4.21.0,!=5.28.0,<7; python_version == '3.9' and sys_platform == 'linux'",
     "protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; python_version > '3.9' and sys_platform == 'linux'",
@@ -34,6 +34,7 @@ dependencies = [
     "typing_extensions>=4.8,<5",
     "pydantic<3",
     "eval_type_backport; python_version < '3.10'",
+    "packaging",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,7 @@ dependencies = [
     # setuptools is needed for distutils in dependencies after Python 3.12 :(
     # One such dependency is docker-pycreds, where the latest release is 0.4.0
     # which was released in 2018.
-    # Pinning to 80.7 due to removal of pkg_resources causing CI failures.
-    # TODO(@jacobromero): remove version constraint
-    # after migrating away from pkg_resources
-    "setuptools",
+    "setuptools==66.1.0",
     "protobuf>=3.12.0,!=4.21.0,!=5.28.0,<7; python_version < '3.9' and sys_platform == 'linux'",
     "protobuf>=3.15.0,!=4.21.0,!=5.28.0,<7; python_version == '3.9' and sys_platform == 'linux'",
     "protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; python_version > '3.9' and sys_platform == 'linux'",

--- a/tests/unit_tests/test_launch/test_project/test_project.py
+++ b/tests/unit_tests/test_launch/test_project/test_project.py
@@ -199,6 +199,23 @@ def mock_project_args():
     }
 
 
+def test_project_parse_existing_requirements_invalid_requirement(
+    mocker, tmp_path, mock_project_args
+):
+    mocker.logger = MagicMock()
+    mocker.patch("wandb.sdk.launch._project_spec._logger", mocker.logger)
+    mocker.termwarn = MagicMock()
+    mocker.patch("wandb.termwarn", mocker.termwarn)
+    project = LaunchProject(**mock_project_args)
+    project.project_dir = tmp_path
+    (tmp_path / "requirements.txt").write_text("invalid requirement")
+
+    project.parse_existing_requirements()
+
+    mocker.logger.warning.assert_called_once()
+    assert "Unable to parse line" in mocker.logger.warning.call_args.args[0]
+
+
 def test_get_env_vars_dict(mock_project_args, test_api):
     """Test that env vars are correctly set from a launch project."""
     project = LaunchProject(**mock_project_args)

--- a/tests/unit_tests/test_launch/test_project/test_project.py
+++ b/tests/unit_tests/test_launch/test_project/test_project.py
@@ -200,20 +200,17 @@ def mock_project_args():
 
 
 def test_project_parse_existing_requirements_invalid_requirement(
-    mocker, tmp_path, mock_project_args
+    tmp_path,
+    mock_project_args,
+    wandb_caplog,
 ):
-    mocker.logger = MagicMock()
-    mocker.patch("wandb.sdk.launch._project_spec._logger", mocker.logger)
-    mocker.termwarn = MagicMock()
-    mocker.patch("wandb.termwarn", mocker.termwarn)
     project = LaunchProject(**mock_project_args)
     project.project_dir = tmp_path
     (tmp_path / "requirements.txt").write_text("invalid requirement")
 
     project.parse_existing_requirements()
 
-    mocker.logger.warning.assert_called_once()
-    assert "Unable to parse line" in mocker.logger.warning.call_args.args[0]
+    assert "Unable to parse line" in wandb_caplog.text
 
 
 def test_get_env_vars_dict(mock_project_args, test_api):

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -123,9 +123,9 @@ class RetryingClient:
         return self._server_info
 
     def version_supported(self, min_version: str) -> bool:  # noqa: D102  # User not encouraged to use this class directly
-        from wandb.util import parse_version
+        from packaging.version import parse
 
-        return parse_version(min_version) <= parse_version(
+        return parse(min_version) <= parse(
             self.server_info["cliVersionInfo"]["max_cli_version"]
         )
 

--- a/wandb/integration/gym/__init__.py
+++ b/wandb/integration/gym/__init__.py
@@ -39,11 +39,11 @@ def monitor():
         else:
             import gymnasium as gym  # type: ignore
 
-        from wandb.util import parse_version
+        from packaging.version import parse
 
-        gym_lib_version = parse_version(gym.__version__)
-        _gym_version_lt_0_26 = gym_lib_version < parse_version("0.26.0")
-        _gymnasium_version_lt_1_0_0 = gym_lib_version < parse_version("1.0.0a1")
+        gym_lib_version = parse(gym.__version__)
+        _gym_version_lt_0_26 = gym_lib_version < parse("0.26.0")
+        _gymnasium_version_lt_1_0_0 = gym_lib_version < parse("1.0.0a1")
 
     path = "path"  # Default path
     if gym_lib == "gymnasium" and not _gymnasium_version_lt_1_0_0:

--- a/wandb/integration/keras/callbacks/model_checkpoint.py
+++ b/wandb/integration/keras/callbacks/model_checkpoint.py
@@ -175,10 +175,10 @@ class WandbModelCheckpoint(callbacks.ModelCheckpoint):
     @property
     def is_old_tf_keras_version(self) -> Optional[bool]:
         if self._is_old_tf_keras_version is None:
-            from wandb.util import parse_version
+            from packaging.version import parse
 
             try:
-                if parse_version(tf.keras.__version__) < parse_version("2.6.0"):
+                if parse(tf.keras.__version__) < parse("2.6.0"):
                     self._is_old_tf_keras_version = True
                 else:
                     self._is_old_tf_keras_version = False

--- a/wandb/integration/keras/keras.py
+++ b/wandb/integration/keras/keras.py
@@ -20,10 +20,9 @@ from wandb.util import add_import_hook
 
 def _check_keras_version():
     from keras import __version__ as keras_version
+    from packaging.version import parse
 
-    from wandb.util import parse_version
-
-    if parse_version(keras_version) < parse_version("2.4.0"):
+    if parse(keras_version) < parse("2.4.0"):
         wandb.termwarn(
             f"Keras version {keras_version} is not fully supported. Required keras >= 2.4.0"
         )
@@ -31,9 +30,9 @@ def _check_keras_version():
 
 def _can_compute_flops() -> bool:
     """FLOPS computation is restricted to TF 2.x as it requires tf.compat.v1."""
-    from wandb.util import parse_version
+    from packaging.version import parse
 
-    if parse_version(tf.__version__) >= parse_version("2.0.0"):
+    if parse(tf.__version__) >= parse("2.0.0"):
         return True
 
     return False
@@ -75,15 +74,10 @@ def is_generator_like(data):
 
 
 def patch_tf_keras():  # noqa: C901
+    from packaging.version import parse
     from tensorflow.python.eager import context
 
-    from wandb.util import parse_version
-
-    if (
-        parse_version("2.6.0")
-        <= parse_version(tf.__version__)
-        < parse_version("2.13.0")
-    ):
+    if parse("2.6.0") <= parse(tf.__version__) < parse("2.13.0"):
         keras_engine = "keras.engine"
         try:
             from keras.engine import training
@@ -238,9 +232,9 @@ patch_tf_keras()
 
 
 def _get_custom_optimizer_parent_class():
-    from wandb.util import parse_version
+    from packaging.version import parse
 
-    if parse_version(tf.__version__) >= parse_version("2.9.0"):
+    if parse(tf.__version__) >= parse("2.9.0"):
         custom_optimizer_parent_class = tf.keras.optimizers.legacy.Optimizer
     else:
         custom_optimizer_parent_class = tf.keras.optimizers.Optimizer

--- a/wandb/integration/kfp/kfp_patch.py
+++ b/wandb/integration/kfp/kfp_patch.py
@@ -10,12 +10,11 @@ try:
     from kfp.components import structures
     from kfp.components._components import _create_task_factory_from_component_spec
     from kfp.components._python_op import _func_to_component_spec
-
-    from wandb.util import parse_version
+    from packaging.version import parse
 
     MIN_KFP_VERSION = "1.6.1"
 
-    if parse_version(kfp_version) < parse_version(MIN_KFP_VERSION):
+    if parse(kfp_version) < parse(MIN_KFP_VERSION):
         wandb.termwarn(
             f"Your version of kfp {kfp_version} may not work.  This integration requires kfp>={MIN_KFP_VERSION}"
         )

--- a/wandb/integration/openai/fine_tuning.py
+++ b/wandb/integration/openai/fine_tuning.py
@@ -8,12 +8,13 @@ import tempfile
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from packaging.version import parse
+
 import wandb
 from wandb import util
 from wandb.data_types import Table
 from wandb.sdk.lib import telemetry
 from wandb.sdk.wandb_run import Run
-from wandb.util import parse_version
 
 openai = util.get_module(
     name="openai",
@@ -21,7 +22,7 @@ openai = util.get_module(
     lazy=False,
 )
 
-if parse_version(openai.__version__) < parse_version("1.12.0"):
+if parse(openai.__version__) < parse("1.12.0"):
     raise wandb.Error(
         f"This integration requires openai version 1.12.0 and above. Your current version is {openai.__version__} "
         "To fix, please `pip install -U openai`"

--- a/wandb/sdk/data_types/base_types/wb_value.py
+++ b/wandb/sdk/data_types/base_types/wb_value.py
@@ -37,7 +37,7 @@ def _is_maybe_offline() -> bool:
 
 
 def _server_accepts_client_ids() -> bool:
-    from wandb.util import parse_version
+    from packaging.version import parse
 
     # There are versions of W&B Server that cannot accept client IDs. Those versions of
     # the backend have a max_cli_version of less than "0.11.0." If the backend cannot
@@ -63,7 +63,7 @@ def _server_accepts_client_ids() -> bool:
     max_cli_version = util._get_max_cli_version()
     if max_cli_version is None:
         return False
-    accepts_client_ids: bool = parse_version("0.11.0") <= parse_version(max_cli_version)
+    accepts_client_ids: bool = parse(max_cli_version) >= parse("0.11.0")
     return accepts_client_ids
 
 

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -6,6 +6,8 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Type, Union, cast
 from urllib import parse
 
+from packaging.version import parse as parse_version
+
 import wandb
 from wandb import util
 from wandb.sdk.lib import hashutil, runid
@@ -44,10 +46,9 @@ def _server_accepts_image_filenames(run: "LocalRun") -> bool:
     max_cli_version = util._get_max_cli_version()
     if max_cli_version is None:
         return False
-    from wandb.util import parse_version
 
-    accepts_image_filenames: bool = parse_version("0.12.10") <= parse_version(
-        max_cli_version
+    accepts_image_filenames: bool = parse_version(max_cli_version) >= parse_version(
+        "0.12.10"
     )
     return accepts_image_filenames
 
@@ -60,7 +61,7 @@ def _server_accepts_artifact_path(run: "LocalRun") -> bool:
     if max_cli_version is None:
         return False
 
-    return util.parse_version("0.12.14") <= util.parse_version(max_cli_version)
+    return parse_version(max_cli_version) >= parse_version("0.12.14")
 
 
 class Image(BatchableMedia):

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -35,14 +35,14 @@ if TYPE_CHECKING:  # pragma: no cover
 def write_gif_with_image_io(
     clip: Any, filename: str, fps: Optional[int] = None
 ) -> None:
-    from wandb.util import parse_version
+    from packaging.version import parse
 
     imageio = util.get_module(
         "imageio",
         required='wandb.Video requires imageio when passing raw data. Install with "pip install wandb[media]"',
     )
 
-    if parse_version(imageio.__version__) < parse_version("2.28.1"):
+    if parse(imageio.__version__) < parse("2.28.1"):
         raise ValueError(
             "imageio version 2.28.1 or higher is required to encode gifs. "
             "Please upgrade imageio with `pip install imageio>=2.28.1`"

--- a/wandb/sdk/internal/profiler.py
+++ b/wandb/sdk/internal/profiler.py
@@ -54,12 +54,12 @@ def torch_trace_handler():
             prof.step()
     ```
     """
-    from wandb.util import parse_version
+    from packaging.version import parse
 
     torch = wandb.util.get_module(PYTORCH_MODULE, required=True)
     torch_profiler = wandb.util.get_module(PYTORCH_PROFILER_MODULE, required=True)
 
-    if parse_version(torch.__version__) < parse_version("1.9.0"):
+    if parse(torch.__version__) < parse("1.9.0"):
         raise Error(
             f"torch version must be at least 1.9 in order to use the PyTorch Profiler API.\
             \nVersion of torch currently installed: {torch.__version__}"

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1502,7 +1502,7 @@ class SendManager:
     def _send_artifact(
         self, artifact: "ArtifactRecord", history_step: Optional[int] = None
     ) -> Optional[Dict]:
-        from wandb.util import parse_version
+        from packaging.version import parse
 
         assert self._pusher
         saver = ArtifactSaver(
@@ -1515,9 +1515,7 @@ class SendManager:
 
         if artifact.distributed_id:
             max_cli_version = self._max_cli_version()
-            if max_cli_version is None or parse_version(
-                max_cli_version
-            ) < parse_version("0.10.16"):
+            if max_cli_version is None or parse(max_cli_version) < parse("0.10.16"):
                 logger.warning(
                     "This W&B Server doesn't support distributed artifacts, "
                     "have your administrator install wandb/local >= 0.9.37"
@@ -1553,13 +1551,11 @@ class SendManager:
         return res
 
     def send_alert(self, record: "Record") -> None:
-        from wandb.util import parse_version
+        from packaging.version import parse
 
         alert = record.alert
         max_cli_version = self._max_cli_version()
-        if max_cli_version is None or parse_version(max_cli_version) < parse_version(
-            "0.10.9"
-        ):
+        if max_cli_version is None or parse(max_cli_version) < parse("0.10.9"):
             logger.warning(
                 "This W&B server doesn't support alerts, "
                 "have your administrator install wandb/local >= 0.9.31"

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -503,9 +503,11 @@ class LaunchProject:
                         req = Requirement(line)
                         name = req.name.lower()
                         include_only.add(shlex_quote(name))
-                    except InvalidRequirement as e:
+                    except InvalidRequirement:
                         _logger.warning(
-                            f"Unable to parse line {line} in requirements.txt: {e}"
+                            "Unable to parse line %s in requirements.txt",
+                            line,
+                            exc_info=True,
                         )
                         continue
 

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -487,30 +487,21 @@ class LaunchProject:
         return env_vars
 
     def parse_existing_requirements(self) -> str:
-        import pkg_resources
+        from packaging.requirements import Requirement
 
         requirements_line = ""
         assert self.project_dir is not None
         base_requirements = os.path.join(self.project_dir, "requirements.txt")
         if os.path.exists(base_requirements):
             include_only = set()
-            with open(base_requirements) as f:
-                iter = pkg_resources.parse_requirements(f)
-                while True:
-                    try:
-                        pkg = next(iter)
-                        if hasattr(pkg, "name"):
-                            name = pkg.name.lower()
-                        else:
-                            name = str(pkg)
-                        include_only.add(shlex_quote(name))
-                    except StopIteration:
-                        break
-                    # Different versions of pkg_resources throw different errors
-                    # just catch them all and ignore packages we can't parse
-                    except Exception as e:
-                        _logger.warning(f"Unable to parse requirements.txt: {e}")
+            with open(base_requirements) as f2:
+                for line in f2:
+                    if line.strip() == "":
                         continue
+
+                    req = Requirement(line)
+                    name = req.name.lower()
+                    include_only.add(shlex_quote(name))
             requirements_line += "WANDB_ONLY_INCLUDE={} ".format(",".join(include_only))
             if "wandb" not in requirements_line:
                 wandb.termwarn(f"{LOG_PREFIX}wandb is not present in requirements.txt.")

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -474,11 +474,12 @@ def check_wandb_version(api: Api) -> None:
     min_cli_version = server_info.get("cliVersionInfo", {}).get(
         "min_cli_version", "0.0.1"
     )
-    from wandb.util import parse_version
 
-    if parse_version(wandb.__version__) < parse_version(min_cli_version):
+    from packaging.version import parse
+
+    if parse(wandb.__version__) < parse(min_cli_version):
         fail_string = f"wandb version out of date, please run pip install --upgrade wandb=={max_cli_version}"
-    elif parse_version(wandb.__version__) > parse_version(max_cli_version):
+    elif parse(wandb.__version__) > parse(max_cli_version):
         fail_string = (
             "wandb version is not supported by your local installation. This could "
             "cause some issues. If you're having problems try: please run `pip "

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -67,8 +67,6 @@ from wandb.sdk.lib.json_util import dump, dumps
 from wandb.sdk.lib.paths import FilePathStr, StrPath
 
 if TYPE_CHECKING:
-    import packaging.version  # type: ignore[import-not-found]
-
     import wandb.sdk.internal.settings_static
     import wandb.sdk.wandb_settings
     from wandb.sdk.artifacts.artifact import Artifact
@@ -1932,21 +1930,6 @@ def working_set() -> Iterable[InstalledDistribution]:
             yield InstalledDistribution(key=d.metadata["Name"], version=d.version)
         except (KeyError, UnicodeDecodeError):
             pass
-
-
-def parse_version(version: str) -> "packaging.version.Version":
-    """Parse a version string into a version object.
-
-    This function is a wrapper around the `packaging.version.parse` function, which
-    is used to parse version strings into version objects. If the `packaging` library
-    is not installed, it falls back to the `pkg_resources` library.
-    """
-    try:
-        from packaging.version import parse as parse_version  # type: ignore
-    except ImportError:
-        from pkg_resources import parse_version  # type: ignore[assignment]
-
-    return parse_version(version)
 
 
 def get_core_path() -> str:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-25032

What does the PR do? Include a concise description of the PR contents.

This PR removes the dependency on `pkg_resources`.
`pkg_resources` is deprecated and should be moved to the various other files recommended [here](https://setuptools.pypa.io/en/latest/pkg_resources.html). 
Specifically most of our code relied on using version parsing, which has moved to the `packaging` package.

The bulk of this change is removing the `wandb.util::parse_version` wrapper used in many places, and replacing with `packaging.version::parse`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
