### PR TITLE
refactor: enable Ruff UP032 lint (use f-strings instead of format())

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,13 +182,12 @@ ignore = [
     "B904",
     "E501",
     # pydocstyle rules: https://docs.astral.sh/ruff/rules/#pydocstyle-d
-    "D100",  # Allow missing docstrings in modules.
-    "D101",  # Allow missing docstrings in classes.
-    "D104",  # Allow missing docstrings in packages.
-    "D105",  # Allow missing docstrings in magic (dunder) methods, e.g. __str__().
-    "D106",  # Allow missing docstrings in nested classes.
-    "D107",  # Allow missing docstrings in __init__ methods.
-    "UP032", # Allow using format instead of f-string.
+    "D100", # Allow missing docstrings in modules.
+    "D101", # Allow missing docstrings in classes.
+    "D104", # Allow missing docstrings in packages.
+    "D105", # Allow missing docstrings in magic (dunder) methods, e.g. __str__().
+    "D106", # Allow missing docstrings in nested classes.
+    "D107", # Allow missing docstrings in __init__ methods.
 ]
 
 [tool.ruff.format]
@@ -244,6 +243,7 @@ ignore-decorators = [
 "wandb/__init__.py" = ["I001"]
 "wandb/__init__.pyi" = ["UP006", "UP007"]
 "wandb/__init__.template.pyi" = ["UP006", "UP007", "D415", "N999"]
+"wandb/apis/public/**" = ["UP032"]
 "wandb/cli/cli.py" = ["C901"]
 "wandb/sklearn/**" = ["B010", "B011", "N803", "N806", "UP031"]
 "wandb/wandb_torch.py" = ["C901", "D", "E741", "F841"]

--- a/tests/system_tests/test_artifacts/test_artifact_cli.py
+++ b/tests/system_tests/test_artifacts/test_artifact_cli.py
@@ -31,7 +31,7 @@ def test_artifact(runner, user):
     if platform.system() == "Windows":
         head, tail = os.path.splitdrive(path)
         path = head + tail.replace(":", "-")
-    assert "Artifact downloaded to {}".format(os.path.abspath(path)) in result.output
+    assert f"Artifact downloaded to {os.path.abspath(path)}" in result.output
     assert os.path.exists(path)
 
 

--- a/tests/system_tests/test_core/test_wandb_integration.py
+++ b/tests/system_tests/test_core/test_wandb_integration.py
@@ -88,9 +88,9 @@ def test_dir_on_import():
     with mock.patch.dict(os.environ, {"WANDB_DIR": custom_env_path}):
         _remove_dir_if_exists(default_path)
         reload_fn(wandb)
-        assert not os.path.isdir(default_path), "Unexpected directory at {}".format(
+        assert not os.path.isdir(
             default_path
-        )
+        ), f"Unexpected directory at {default_path}"
         assert not os.path.isdir(
             custom_env_path
         ), f"Unexpected directory at {custom_env_path}"
@@ -125,22 +125,22 @@ def test_dir_on_init_env(user):
         _remove_dir_if_exists(default_path)
         run = wandb.init()
         run.finish()
-        assert not os.path.isdir(default_path), "Unexpected directory at {}".format(
+        assert not os.path.isdir(
             default_path
-        )
-        assert os.path.isdir(custom_env_path), "Expected directory at {}".format(
+        ), f"Unexpected directory at {default_path}"
+        assert os.path.isdir(
             custom_env_path
-        )
+        ), f"Expected directory at {custom_env_path}"
         # And for the duplicate-run case
         _remove_dir_if_exists(default_path)
         run = wandb.init()
         run.finish()
-        assert not os.path.isdir(default_path), "Unexpected directory at {}".format(
+        assert not os.path.isdir(
             default_path
-        )
-        assert os.path.isdir(custom_env_path), "Expected directory at {}".format(
+        ), f"Unexpected directory at {default_path}"
+        assert os.path.isdir(
             custom_env_path
-        )
+        ), f"Expected directory at {custom_env_path}"
 
 
 def test_dir_on_init_dir(user):

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -237,10 +237,10 @@ def test_docker_run_digest(runner, docker, monkeypatch):
             "-e",
             "WANDB_API_KEY=test",
             "-e",
-            "WANDB_DOCKER={}".format(DOCKER_SHA),
+            f"WANDB_DOCKER={DOCKER_SHA}",
             "--runtime",
             "nvidia",
-            "{}".format(DOCKER_SHA),
+            f"{DOCKER_SHA}",
         ]
     )
 
@@ -549,7 +549,7 @@ def test_local_default(runner, docker, local_settings):
                 "--name",
                 "wandb-local",
                 "-e",
-                "LOCAL_USERNAME={}".format(user),
+                f"LOCAL_USERNAME={user}",
                 "-d",
                 "wandb/local",
             ]
@@ -574,7 +574,7 @@ def test_local_custom_port(runner, docker, local_settings):
             "--name",
             "wandb-local",
             "-e",
-            "LOCAL_USERNAME={}".format(user),
+            f"LOCAL_USERNAME={user}",
             "-d",
             "wandb/local",
         ]
@@ -599,7 +599,7 @@ def test_local_custom_env(runner, docker, local_settings):
             "--name",
             "wandb-local",
             "-e",
-            "LOCAL_USERNAME={}".format(user),
+            f"LOCAL_USERNAME={user}",
             "-e",
             "FOO=bar",
             "-d",

--- a/tests/unit_tests/test_file_stream.py
+++ b/tests/unit_tests/test_file_stream.py
@@ -39,7 +39,7 @@ def test_split_files():
     num_files = 10
     chunk_size = 0.1  # MB
     files = {
-        "file_{}.txt".format(i): {
+        f"file_{i}.txt": {
             "content": rand_string_list(int(file_size * 1024 * 1024)),
             "offset": 0,
         }

--- a/tests/unit_tests/test_lib/test_apikey.py
+++ b/tests/unit_tests/test_lib/test_apikey.py
@@ -13,7 +13,7 @@ def test_write_netrc(mock_wandb_log):
     assert mock_wandb_log.logged("No netrc file found, creating one.")
     with open(wandb_lib.apikey.get_netrc_file_path()) as f:
         assert f.read() == (
-            "machine localhost\n  login vanpelt\n  password {}\n".format(api_key)
+            f"machine localhost\n  login vanpelt\n  password {api_key}\n"
         )
 
 
@@ -38,9 +38,7 @@ def test_write_netrc_update_existing(tmp_path):
     with open(netrc_path) as f:
         assert f.read() == (
             "machine otherhost\n  login other-user\n  password password123\n"
-            "machine localhost\n  login random-user\n  password {}\n".format(
-                new_api_key
-            )
+            f"machine localhost\n  login random-user\n  password {new_api_key}\n"
         )
 
 

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -63,7 +63,7 @@ def assert_deep_lists_equal(a, b, indices=None):
                 raise
             finally:
                 if top and indices:
-                    print("Diff at index: {}".format(list(reversed(indices))))  # noqa: T201
+                    print(f"Diff at index: {list(reversed(indices))}")  # noqa: T201
 
 
 def json_friendly_test(orig_data, obj):

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -239,9 +239,7 @@ class Agent:
                         elif (
                             time.time() - self._start_time < self.FLAPPING_MAX_SECONDS
                         ) and (len(self._exceptions) >= self.FLAPPING_MAX_FAILURES):
-                            msg = "Detected {} failed runs in the first {} seconds, killing sweep.".format(
-                                self.FLAPPING_MAX_FAILURES, self.FLAPPING_MAX_SECONDS
-                            )
+                            msg = f"Detected {self.FLAPPING_MAX_FAILURES} failed runs in the first {self.FLAPPING_MAX_SECONDS} seconds, killing sweep."
                             logger.error(msg)
                             wandb.termerror(msg)
                             wandb.termlog(
@@ -253,9 +251,7 @@ class Agent:
                             self._max_initial_failures < len(self._exceptions)
                             and len(self._exceptions) >= count
                         ):
-                            msg = "Detected {} failed runs in a row at start, killing sweep.".format(
-                                self._max_initial_failures
-                            )
+                            msg = f"Detected {self._max_initial_failures} failed runs in a row at start, killing sweep."
                             logger.error(msg)
                             wandb.termerror(msg)
                             wandb.termlog(
@@ -320,9 +316,7 @@ class Agent:
 
     def run(self):
         logger.info(
-            "Starting sweep agent: entity={}, project={}, count={}".format(
-                self._entity, self._project, self._count
-            )
+            f"Starting sweep agent: entity={self._entity}, project={self._project}, count={self._count}"
         )
         self._setup()
         # self._main_thread = threading.Thread(target=self._run_jobs_from_queue)

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -203,7 +203,7 @@ def default_image(gpu: bool = False) -> str:
     tag = "all"
     if not gpu:
         tag += "-cpu"
-    return "wandb/deepo:{}".format(tag)
+    return f"wandb/deepo:{tag}"
 
 
 def parse_repository_tag(repo_name: str) -> Tuple[str, Optional[str]]:

--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -176,7 +176,7 @@ class StepUpload:
                 self._artifacts[event.artifact_id]["pending_count"] += 1
             self._start_upload_job(event)
         else:
-            raise Exception("Programming error: unhandled event: {}".format(str(event)))
+            raise Exception(f"Programming error: unhandled event: {str(event)}")
 
     def _start_upload_job(self, event: RequestUpload) -> None:
         # Operations on a single backend file must be serialized. if

--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -176,7 +176,7 @@ class StepUpload:
                 self._artifacts[event.artifact_id]["pending_count"] += 1
             self._start_upload_job(event)
         else:
-            raise Exception(f"Programming error: unhandled event: {str(event)}")
+            raise Exception(f"Programming error: unhandled event: {event!s}")
 
     def _start_upload_job(self, event: RequestUpload) -> None:
         # Operations on a single backend file must be serialized. if

--- a/wandb/integration/gym/__init__.py
+++ b/wandb/integration/gym/__init__.py
@@ -9,8 +9,7 @@ _gym_version_lt_0_26: Optional[bool] = None
 _gymnasium_version_lt_1_0_0: Optional[bool] = None
 
 _required_error_msg = (
-    "Couldn't import the gymnasium python package, "
-    "install with `pip install gymnasium`"
+    "Couldn't import the gymnasium python package, install with `pip install gymnasium`"
 )
 GymLib = Literal["gym", "gymnasium"]
 

--- a/wandb/integration/tensorboard/log.py
+++ b/wandb/integration/tensorboard/log.py
@@ -167,11 +167,8 @@ def tf_summary_to_dict(  # noqa: C901
                         )
                     except ValueError:
                         wandb.termwarn(
-                            'Not logging key "{}". '
-                            "Histograms must have fewer than {} bins".format(
-                                namespaced_tag(value.tag, namespace),
-                                wandb.Histogram.MAX_LENGTH,
-                            ),
+                            f'Not logging key "{namespaced_tag(value.tag, namespace)}". '
+                            f"Histograms must have fewer than {wandb.Histogram.MAX_LENGTH} bins",
                             repeat=False,
                         )
             elif plugin_name == "pr_curves":

--- a/wandb/plot/confusion_matrix.py
+++ b/wandb/plot/confusion_matrix.py
@@ -150,7 +150,7 @@ def confusion_matrix(
     else:
         class_idx = set(preds).union(set(y_true))
         n_classes = len(class_idx)
-        class_names = [f"Class_{i+1}" for i in range(n_classes)]
+        class_names = [f"Class_{i + 1}" for i in range(n_classes)]
 
     # Create a mapping from class name to index
     class_mapping = {val: i for i, val in enumerate(sorted(list(class_idx)))}

--- a/wandb/plot/utils.py
+++ b/wandb/plot/utils.py
@@ -13,7 +13,7 @@ def test_missing(**kwargs):
     for k, v in kwargs.items():
         # Missing/empty params/datapoint arrays
         if v is None:
-            wandb.termerror("{} is None. Please try again.".format(k))
+            wandb.termerror(f"{k} is None. Please try again.")
             test_passed = False
         if (k == "X") or (k == "X_test"):
             if isinstance(v, scipy.sparse.csr.csr_matrix):
@@ -159,25 +159,25 @@ def test_types(**kwargs):
                     list,
                 ),
             ):
-                wandb.termerror("{} is not an array. Please try again.".format(k))
+                wandb.termerror(f"{k} is not an array. Please try again.")
                 test_passed = False
         # check for classifier types
         if k == "model":
             if (not base.is_classifier(v)) and (not base.is_regressor(v)):
                 wandb.termerror(
-                    "{} is not a classifier or regressor. Please try again.".format(k)
+                    f"{k} is not a classifier or regressor. Please try again."
                 )
                 test_passed = False
         elif k == "clf" or k == "binary_clf":
             if not (base.is_classifier(v)):
-                wandb.termerror("{} is not a classifier. Please try again.".format(k))
+                wandb.termerror(f"{k} is not a classifier. Please try again.")
                 test_passed = False
         elif k == "regressor":
             if not base.is_regressor(v):
-                wandb.termerror("{} is not a regressor. Please try again.".format(k))
+                wandb.termerror(f"{k} is not a regressor. Please try again.")
                 test_passed = False
         elif k == "clusterer":
             if not (getattr(v, "_estimator_type", None) == "clusterer"):
-                wandb.termerror("{} is not a clusterer. Please try again.".format(k))
+                wandb.termerror(f"{k} is not a clusterer. Please try again.")
                 test_passed = False
     return test_passed

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1454,7 +1454,7 @@ class Artifact:
             ValueError: Policy must be "mutable" or "immutable"
         """
         if not os.path.isdir(local_path):
-            raise ValueError("Path is not a directory: {}".format(local_path))
+            raise ValueError(f"Path is not a directory: {local_path}")
 
         termlog(
             "Adding directory to artifact ({})... ".format(
@@ -1755,7 +1755,7 @@ class Artifact:
         name = LogicalPath(name)
         entry = self.manifest.entries.get(name) or self._get_obj_entry(name)[0]
         if entry is None:
-            raise KeyError("Path not contained in artifact: {}".format(name))
+            raise KeyError(f"Path not contained in artifact: {name}")
         entry._parent_artifact = self
         return entry
 
@@ -1971,9 +1971,7 @@ class Artifact:
         if nfiles > 5000 or size > 50 * 1024 * 1024:
             log = True
             termlog(
-                "Downloading large artifact {}, {:.2f}MB. {} files... ".format(
-                    self.name, size / (1024 * 1024), nfiles
-                ),
+                f"Downloading large artifact {self.name}, {size / (1024 * 1024):.2f}MB. {nfiles} files... ",
             )
             start_time = datetime.now()
         download_logger = ArtifactDownloadLogger(nfiles=nfiles)
@@ -2189,16 +2187,14 @@ class Artifact:
                     self.get_entry(artifact_path)
                 except KeyError:
                     raise ValueError(
-                        "Found file {} which is not a member of artifact {}".format(
-                            full_path, self.name
-                        )
+                        f"Found file {full_path} which is not a member of artifact {self.name}"
                     )
 
         ref_count = 0
         for entry in self.manifest.entries.values():
             if entry.ref is None:
                 if md5_file_b64(os.path.join(root, entry.path)) != entry.digest:
-                    raise ValueError("Digest mismatch for file: {}".format(entry.path))
+                    raise ValueError(f"Digest mismatch for file: {entry.path}")
             else:
                 ref_count += 1
         if ref_count > 0:

--- a/wandb/sdk/artifacts/artifact_saver.py
+++ b/wandb/sdk/artifacts/artifact_saver.py
@@ -273,7 +273,5 @@ class ArtifactSaver:
                     if artifact_id is None:
                         raise RuntimeError(f"Could not resolve client id {client_id}")
                     entry.ref = URIStr(
-                        "wandb-artifact://{}/{}".format(
-                            b64_to_hex_id(B64MD5(artifact_id)), artifact_file_path
-                        )
+                        f"wandb-artifact://{b64_to_hex_id(B64MD5(artifact_id))}/{artifact_file_path}"
                     )

--- a/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
@@ -46,9 +46,7 @@ class LocalFileHandler(StorageHandler):
         local_path = util.local_file_uri_to_path(str(manifest_entry.ref))
         if not os.path.exists(local_path):
             raise ValueError(
-                "Local file reference: Failed to find file at path {}".format(
-                    local_path
-                )
+                f"Local file reference: Failed to find file at path {local_path}"
             )
 
         path, hit, cache_open = self._cache.check_md5_obj_path(
@@ -140,7 +138,5 @@ class LocalFileHandler(StorageHandler):
             entries.append(entry)
         else:
             # TODO: update error message if we don't allow directories.
-            raise ValueError(
-                'Path "{}" must be a valid file or directory path'.format(path)
-            )
+            raise ValueError(f'Path "{path}" must be a valid file or directory path')
         return entries

--- a/wandb/sdk/artifacts/storage_handlers/multi_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/multi_handler.py
@@ -31,7 +31,7 @@ class MultiHandler(StorageHandler):
                 return handler
         if self._default_handler is not None:
             return self._default_handler
-        raise ValueError('No storage handler registered for url "{}"'.format(str(url)))
+        raise ValueError(f'No storage handler registered for url "{str(url)}"')
 
     def load_path(
         self,

--- a/wandb/sdk/artifacts/storage_handlers/multi_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/multi_handler.py
@@ -31,7 +31,7 @@ class MultiHandler(StorageHandler):
                 return handler
         if self._default_handler is not None:
             return self._default_handler
-        raise ValueError(f'No storage handler registered for url "{str(url)}"')
+        raise ValueError(f'No storage handler registered for url "{url!s}"')
 
     def load_path(
         self,

--- a/wandb/sdk/artifacts/storage_handlers/tracking_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/tracking_handler.py
@@ -59,14 +59,10 @@ class TrackingHandler(StorageHandler):
         url = urlparse(path)
         if name is None:
             raise ValueError(
-                'You must pass name="<entry_name>" when tracking references with unknown schemes. ref: {}'.format(
-                    path
-                )
+                f'You must pass name="<entry_name>" when tracking references with unknown schemes. ref: {path}'
             )
         termwarn(
-            "Artifact references with unsupported schemes cannot be checksummed: {}".format(
-                path
-            )
+            f"Artifact references with unsupported schemes cannot be checksummed: {path}"
         )
         name = name or url.path[1:]  # strip leading slash
         return [ArtifactManifestEntry(path=name, ref=path, digest=path)]

--- a/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
@@ -116,11 +116,7 @@ class WBArtifactHandler(StorageHandler):
         assert target_artifact is not None
         assert target_artifact.id is not None
         path = URIStr(
-            "{}://{}/{}".format(
-                self._scheme,
-                b64_to_hex_id(B64MD5(target_artifact.id)),
-                artifact_file_path,
-            )
+            f"{self._scheme}://{b64_to_hex_id(B64MD5(target_artifact.id))}/{artifact_file_path}"
         )
 
         # Return the new entry

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -686,9 +686,7 @@ class ListType(Type):
             for ndx, obj in enumerate(list(other)):
                 _new_element_type = new_element_type.assign(obj)
                 if isinstance(_new_element_type, InvalidType):
-                    exp += "\n{}Index {}:\n{}".format(
-                        gap, ndx, new_element_type.explain(obj, depth + 1)
-                    )
+                    exp += f"\n{gap}Index {ndx}:\n{new_element_type.explain(obj, depth + 1)}"
                     break
                 new_element_type = _new_element_type
         return exp
@@ -727,9 +725,7 @@ class NDArrayType(Type):
             return cls(shape)
         else:
             raise TypeError(
-                "NDArrayType.from_obj expects py_obj to be ndarray or list, found {}".format(
-                    py_obj.__class__
-                )
+                f"NDArrayType.from_obj expects py_obj to be ndarray or list, found {py_obj.__class__}"
             )
 
     def assign_type(self, wb_type: "Type") -> t.Union["NDArrayType", InvalidType]:

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -247,9 +247,7 @@ class Media(WBValue):
                 json_obj["_latest_artifact_path"] = artifact_entry_latest_url
 
             if artifact_entry_url is None or self.is_bound():
-                assert self.is_bound(), "Value of type {} must be bound to a run with bind_to_run() before being serialized to JSON.".format(
-                    type(self).__name__
-                )
+                assert self.is_bound(), f"Value of type {type(self).__name__} must be bound to a run with bind_to_run() before being serialized to JSON."
 
                 assert (
                     self._run is run

--- a/wandb/sdk/data_types/base_types/wb_value.py
+++ b/wandb/sdk/data_types/base_types/wb_value.py
@@ -220,9 +220,7 @@ class WBValue:
     ) -> None:
         assert (
             self._artifact_source is None
-        ), "Cannot update artifact_source. Existing source: {}/{}".format(
-            self._artifact_source.artifact, self._artifact_source.name
-        )
+        ), f"Cannot update artifact_source. Existing source: {self._artifact_source.artifact}/{self._artifact_source.name}"
         self._artifact_source = _WBValueArtifactSource(artifact, name)
 
     def _set_artifact_target(
@@ -230,9 +228,7 @@ class WBValue:
     ) -> None:
         assert (
             self._artifact_target is None
-        ), "Cannot update artifact_target. Existing target: {}/{}".format(
-            self._artifact_target.artifact, self._artifact_target.name
-        )
+        ), f"Cannot update artifact_target. Existing target: {self._artifact_target.artifact}/{self._artifact_target.name}"
         self._artifact_target = _WBValueArtifactTarget(artifact, name)
 
     def _get_artifact_entry_ref_url(self) -> Optional[str]:
@@ -250,10 +246,7 @@ class WBValue:
             and self._artifact_target.artifact._final
             and _server_accepts_client_ids()
         ):
-            return "wandb-client-artifact://{}/{}".format(
-                self._artifact_target.artifact._client_id,
-                type(self).with_suffix(self._artifact_target.name),
-            )
+            return f"wandb-client-artifact://{self._artifact_target.artifact._client_id}/{type(self).with_suffix(self._artifact_target.name)}"
         # Else if we do not support client IDs, but online, then block on upload
         # Note: this is old behavior just to stay backwards compatible
         # with older server versions. This code path should be removed
@@ -281,10 +274,7 @@ class WBValue:
             and self._artifact_target.artifact._final
             and _server_accepts_client_ids()
         ):
-            return "wandb-client-artifact://{}:latest/{}".format(
-                self._artifact_target.artifact._sequence_client_id,
-                type(self).with_suffix(self._artifact_target.name),
-            )
+            return f"wandb-client-artifact://{self._artifact_target.artifact._sequence_client_id}:latest/{type(self).with_suffix(self._artifact_target.name)}"
         # Else if we do not support client IDs, then block on upload
         # Note: this is old behavior just to stay backwards compatible
         # with older server versions. This code path should be removed

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -504,7 +504,7 @@ class Image(BatchableMedia):
                 return "RGBA"
         else:
             raise ValueError(
-                "Un-supported shape for image conversion {}".format(list(data.shape))
+                f"Un-supported shape for image conversion {list(data.shape)}"
             )
 
     @classmethod

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -336,11 +336,7 @@ class Table(Media):
             result_type = wbtype.assign(row[col_ndx])
             if isinstance(result_type, _dtypes.InvalidType):
                 raise TypeError(
-                    "Existing data {}, of type {} cannot be cast to {}".format(
-                        row[col_ndx],
-                        _dtypes.TypeRegistry.type_of(row[col_ndx]),
-                        wbtype,
-                    )
+                    f"Existing data {row[col_ndx]}, of type {_dtypes.TypeRegistry.type_of(row[col_ndx])} cannot be cast to {wbtype}"
                 )
             wbtype = result_type
 
@@ -359,9 +355,7 @@ class Table(Media):
         if is_pk:
             assert (
                 self._pk_col is None
-            ), "Cannot have multiple primary keys - {} is already set as the primary key.".format(
-                self._pk_col
-            )
+            ), f"Cannot have multiple primary keys - {self._pk_col} is already set as the primary key."
 
         # Update the column type
         self._column_types.params["type_map"][col_name] = wbtype
@@ -375,23 +369,21 @@ class Table(Media):
 
     def _eq_debug(self, other, should_assert=False):
         eq = isinstance(other, Table)
-        assert not should_assert or eq, "Found type {}, expected {}".format(
-            other.__class__, Table
-        )
+        assert (
+            not should_assert or eq
+        ), f"Found type {other.__class__}, expected {Table}"
         eq = eq and len(self.data) == len(other.data)
-        assert not should_assert or eq, "Found {} rows, expected {}".format(
-            len(other.data), len(self.data)
-        )
+        assert (
+            not should_assert or eq
+        ), f"Found {len(other.data)} rows, expected {len(self.data)}"
         eq = eq and self.columns == other.columns
-        assert not should_assert or eq, "Found columns {}, expected {}".format(
-            other.columns, self.columns
-        )
+        assert (
+            not should_assert or eq
+        ), f"Found columns {other.columns}, expected {self.columns}"
         eq = eq and self._column_types == other._column_types
         assert (
             not should_assert or eq
-        ), "Found column type {}, expected column type {}".format(
-            other._column_types, self._column_types
-        )
+        ), f"Found column type {other._column_types}, expected column type {self._column_types}"
         if eq:
             for row_ndx in range(len(self.data)):
                 for col_ndx in range(len(self.data[row_ndx])):
@@ -402,12 +394,7 @@ class Table(Media):
                     eq = eq and _eq
                     assert (
                         not should_assert or eq
-                    ), "Unequal data at row_ndx {} col_ndx {}: found {}, expected {}".format(
-                        row_ndx,
-                        col_ndx,
-                        other.data[row_ndx][col_ndx],
-                        self.data[row_ndx][col_ndx],
-                    )
+                    ), f"Unequal data at row_ndx {row_ndx} col_ndx {col_ndx}: found {other.data[row_ndx][col_ndx]}, expected {self.data[row_ndx][col_ndx]}"
                     if not eq:
                         return eq
         return eq
@@ -427,9 +414,7 @@ class Table(Media):
         """
         if len(data) != len(self.columns):
             raise ValueError(
-                "This table expects {} columns: {}, found {}".format(
-                    len(self.columns), self.columns, len(data)
-                )
+                f"This table expects {len(self.columns)} columns: {self.columns}, found {len(data)}"
             )
 
         # Special case to pre-emptively cast a column as a key.
@@ -468,9 +453,7 @@ class Table(Media):
         result_type = current_type.assign(incoming_row_dict)
         if isinstance(result_type, _dtypes.InvalidType):
             raise TypeError(
-                "Data row contained incompatible types:\n{}".format(
-                    current_type.explain(incoming_row_dict)
-                )
+                f"Data row contained incompatible types:\n{current_type.explain(incoming_row_dict)}"
             )
         return result_type
 
@@ -737,9 +720,7 @@ class Table(Media):
             # If there is a removed FK
             if len(self._fk_cols - _fk_cols) > 0:
                 raise AssertionError(
-                    "Cannot unset foreign key. Attempted to unset ({})".format(
-                        self._fk_cols - _fk_cols
-                    )
+                    f"Cannot unset foreign key. Attempted to unset ({self._fk_cols - _fk_cols})"
                 )
 
             self._pk_col = _pk_col
@@ -992,9 +973,7 @@ class PartitionedTable(Media):
                 columns = part.columns
             elif columns != part.columns:
                 raise ValueError(
-                    "Table parts have non-matching columns. {} != {}".format(
-                        columns, part.columns
-                    )
+                    f"Table parts have non-matching columns. {columns} != {part.columns}"
                 )
             for _, row in part.iterrows():
                 yield ndx, row
@@ -1137,13 +1116,13 @@ class JoinedTable(Media):
 
     def _eq_debug(self, other, should_assert=False):
         eq = isinstance(other, JoinedTable)
-        assert not should_assert or eq, "Found type {}, expected {}".format(
-            other.__class__, JoinedTable
-        )
+        assert (
+            not should_assert or eq
+        ), f"Found type {other.__class__}, expected {JoinedTable}"
         eq = eq and self._join_key == other._join_key
-        assert not should_assert or eq, "Found {} join key, expected {}".format(
-            other._join_key, self._join_key
-        )
+        assert (
+            not should_assert or eq
+        ), f"Found {other._join_key} join key, expected {self._join_key}"
         eq = eq and self._table1._eq_debug(other._table1, should_assert)
         eq = eq and self._table2._eq_debug(other._table2, should_assert)
         return eq

--- a/wandb/sdk/internal/datastore.py
+++ b/wandb/sdk/internal/datastore.py
@@ -126,9 +126,7 @@ class DataStore:
             return None
         assert (
             len(header) == LEVELDBLOG_HEADER_LEN
-        ), "record header is {} bytes instead of the expected {}".format(
-            len(header), LEVELDBLOG_HEADER_LEN
-        )
+        ), f"record header is {len(header)} bytes instead of the expected {LEVELDBLOG_HEADER_LEN}"
         fields = struct.unpack("<IHB", header)
         checksum, dlength, dtype = fields
         # check len, better fit in the block
@@ -195,9 +193,7 @@ class DataStore:
         header = self._fp.read(LEVELDBLOG_HEADER_LEN)
         assert (
             len(header) == LEVELDBLOG_HEADER_LEN
-        ), "header is {} bytes instead of the expected {}".format(
-            len(header), LEVELDBLOG_HEADER_LEN
-        )
+        ), f"header is {len(header)} bytes instead of the expected {LEVELDBLOG_HEADER_LEN}"
         ident, magic, version = struct.unpack("<4sHB", header)
         if ident != strtobytes(LEVELDBLOG_HEADER_IDENT):
             raise Exception("Invalid header")

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -98,11 +98,7 @@ class FilePusher:
             if not self.is_alive():
                 stop = True
             summary = self._stats.summary()
-            line = " {:.2f}MB of {:.2f}MB uploaded ({:.2f}MB deduped)\r".format(
-                summary.uploaded_bytes / 1048576.0,
-                summary.total_bytes / 1048576.0,
-                summary.deduped_bytes / 1048576.0,
-            )
+            line = f" {summary.uploaded_bytes / 1048576.0:.2f}MB of {summary.total_bytes / 1048576.0:.2f}MB uploaded ({summary.deduped_bytes / 1048576.0:.2f}MB deduped)\r"
             line = spinner_states[step % 4] + line
             step += 1
             wandb.termlog(line, newline=False, prefix=prefix)

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -75,7 +75,7 @@ class DefaultFilePolicy:
 
         # get key size and convert to MB
         key_sizes = [(k, len(json.dumps(v))) for k, v in loaded.items()]
-        key_msg = [f"{k}: {v/1048576:.5f} MB" for k, v in key_sizes]
+        key_msg = [f"{k}: {v / 1048576:.5f} MB" for k, v in key_sizes]
         wandb.termerror(f"Step: {loaded['_step']} | {key_msg}", repeat=False)
         self.has_debug_log = True
 
@@ -88,10 +88,7 @@ class JsonlFilePolicy(DefaultFilePolicy):
         chunk_data = []
         for chunk in chunks:
             if len(chunk.data) > util.MAX_LINE_BYTES:
-                msg = "Metric data exceeds maximum size of {} ({})".format(
-                    util.to_human_size(util.MAX_LINE_BYTES),
-                    util.to_human_size(len(chunk.data)),
-                )
+                msg = f"Metric data exceeds maximum size of {util.to_human_size(util.MAX_LINE_BYTES)} ({util.to_human_size(len(chunk.data))})"
                 wandb.termerror(msg, repeat=False)
                 wandb._sentry.message(msg, repeat=False)
                 self._debug_log(chunk.data)
@@ -108,9 +105,7 @@ class SummaryFilePolicy(DefaultFilePolicy):
     def process_chunks(self, chunks: List[Chunk]) -> Union[bool, "ProcessedChunk"]:
         data = chunks[-1].data
         if len(data) > util.MAX_LINE_BYTES:
-            msg = "Summary data exceeds maximum size of {}. Dropping it.".format(
-                util.to_human_size(util.MAX_LINE_BYTES)
-            )
+            msg = f"Summary data exceeds maximum size of {util.to_human_size(util.MAX_LINE_BYTES)}. Dropping it."
             wandb.termerror(msg, repeat=False)
             wandb._sentry.message(msg, repeat=False)
             self._debug_log(data)
@@ -507,7 +502,7 @@ class FileStreamApi:
             wandb.termerror(
                 "Dropped streaming file chunk (see wandb/debug-internal.log)"
             )
-            logger.exception("dropped chunk {}".format(response))
+            logger.exception(f"dropped chunk {response}")
             self._dropped_chunks += 1
         else:
             parsed: Optional[dict] = None
@@ -664,8 +659,7 @@ def request_with_retry(
                 e.response is not None and e.response.status_code == 429
             ):
                 err_str = (
-                    "Filestream rate limit exceeded, "
-                    f"retrying in {delay:.1f} seconds. "
+                    f"Filestream rate limit exceeded, retrying in {delay:.1f} seconds. "
                 )
                 if retry_callback:
                     retry_callback(e.response.status_code, err_str)

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2089,9 +2089,7 @@ class Api:
             )
             if default is None or default.get("queueID") is None:
                 raise CommError(
-                    "Unable to create default queue for {}/{}. No queues for agent to poll".format(
-                        entity, project
-                    )
+                    f"Unable to create default queue for {entity}/{project}. No queues for agent to poll"
                 )
             project_queues = [{"id": default["queueID"], "name": "default"}]
         polling_queue_ids = [
@@ -2568,15 +2566,11 @@ class Api:
         res = self.gql(query, variable_values)
         if res.get("project") is None:
             raise CommError(
-                "Error fetching run info for {}/{}/{}. Check that this project exists and you have access to this entity and project".format(
-                    entity, project, name
-                )
+                f"Error fetching run info for {entity}/{project}/{name}. Check that this project exists and you have access to this entity and project"
             )
         elif res["project"].get("run") is None:
             raise CommError(
-                "Error fetching run info for {}/{}/{}. Check that this run id exists".format(
-                    entity, project, name
-                )
+                f"Error fetching run info for {entity}/{project}/{name}. Check that this run id exists"
             )
         run_info: dict = res["project"]["run"]["runInfo"]
         return run_info
@@ -3232,10 +3226,8 @@ class Api:
                         parameter["distribution"] = "uniform"
                     else:
                         raise ValueError(
-                            "Parameter {} is ambiguous, please specify bounds as both floats (for a float_"
-                            "uniform distribution) or ints (for an int_uniform distribution).".format(
-                                parameter_name
-                            )
+                            f"Parameter {parameter_name} is ambiguous, please specify bounds as both floats (for a float_"
+                            "uniform distribution) or ints (for an int_uniform distribution)."
                         )
         return config
 
@@ -4560,9 +4552,9 @@ class Api:
         s = self.sweep(sweep=sweep, entity=entity, project=project, specs="{}")
         curr_state = s["state"].upper()
         if state == "PAUSED" and curr_state not in ("PAUSED", "RUNNING"):
-            raise Exception("Cannot pause {} sweep.".format(curr_state.lower()))
+            raise Exception(f"Cannot pause {curr_state.lower()} sweep.")
         elif state != "RUNNING" and curr_state not in ("RUNNING", "PAUSED", "PENDING"):
-            raise Exception("Sweep already {}.".format(curr_state.lower()))
+            raise Exception(f"Sweep already {curr_state.lower()}.")
         sweep_id = s["id"]
         mutation = gql(
             """

--- a/wandb/sdk/internal/progress.py
+++ b/wandb/sdk/internal/progress.py
@@ -43,9 +43,7 @@ class Progress:
             # files getting truncated while uploading seems like something
             # that shouldn't really be happening anyway.
             raise CommError(
-                "File {} size shrank from {} to {} while it was being uploaded.".format(
-                    self.file.name, self.len, self.bytes_read
-                )
+                f"File {self.file.name} size shrank from {self.len} to {self.bytes_read} while it was being uploaded."
             )
         # Growing files are also likely to be bad, but our code didn't break
         # on those in the past, so it's riskier to make that an error now.

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -754,9 +754,7 @@ class SendManager:
             if self._settings.resume == "must":
                 error = wandb_internal_pb2.ErrorInfo()
                 error.code = wandb_internal_pb2.ErrorInfo.ErrorCode.USAGE
-                error.message = "resume='must' but could not resume ({}) ".format(
-                    run.run_id
-                )
+                error.message = f"resume='must' but could not resume ({run.run_id}) "
                 return error
 
         # TODO: Do we need to restore config / summary?
@@ -772,7 +770,7 @@ class SendManager:
         self._resume_state.summary = summary
         self._resume_state.tags = tags
         self._resume_state.resumed = True
-        logger.info("configured resuming with: {}".format(self._resume_state))
+        logger.info(f"configured resuming with: {self._resume_state}")
         return None
 
     def _telemetry_get_framework(self) -> str:
@@ -816,9 +814,7 @@ class SendManager:
             self._interface.publish_config(
                 key=("_wandb", "spell_url"), val=env.get("SPELL_RUN_URL")
             )
-            url = "{}/{}/{}/runs/{}".format(
-                self._api.app_url, self._run.entity, self._run.project, self._run.run_id
-            )
+            url = f"{self._api.app_url}/{self._run.entity}/{self._run.project}/runs/{self._run.run_id}"
             requests.put(
                 env.get("SPELL_API_URL", "https://api.spell.run") + "/wandb_url",
                 json={"access_token": env.get("WANDB_ACCESS_TOKEN"), "url": url},
@@ -1500,9 +1496,7 @@ class SendManager:
             logger.info(f"sent artifact {artifact.name} - {res}")
         except Exception as e:
             logger.error(
-                'send_artifact: failed for artifact "{}/{}": {}'.format(
-                    artifact.type, artifact.name, e
-                )
+                f'send_artifact: failed for artifact "{artifact.type}/{artifact.name}": {e}'
             )
 
     def _send_artifact(

--- a/wandb/sdk/internal/system/assets/trainium.py
+++ b/wandb/sdk/internal/system/assets/trainium.py
@@ -127,7 +127,7 @@ class NeuronCoreStats:
                 process.kill()
                 process.wait()
         except Exception as e:
-            logger.error("neuron-monitor failed: {}".format(e))
+            logger.error(f"neuron-monitor failed: {e}")
 
     def __init__(
         self,
@@ -169,7 +169,7 @@ class NeuronCoreStats:
             assert self.neuron_monitor_thread is not None
             self.neuron_monitor_thread.join()
         except Exception as e:
-            logger.error("neuron-monitor thread failed to stop: {}".format(e))
+            logger.error(f"neuron-monitor thread failed to stop: {e}")
         finally:
             self.neuron_monitor_thread = None
 
@@ -389,5 +389,5 @@ class Trainium:
 
             return {self.name: neuron_hardware_info}
         except Exception as e:
-            logger.error("neuron-monitor failed: {}".format(e))
+            logger.error(f"neuron-monitor failed: {e}")
             return {}

--- a/wandb/sdk/internal/system/system_info.py
+++ b/wandb/sdk/internal/system/system_info.py
@@ -55,9 +55,7 @@ class SystemInfo:
         )
         program_absolute = os.path.join(root, program_relative)
         if not os.path.exists(program_absolute):
-            logger.warning(
-                "unable to save code -- can't find {}".format(program_absolute)
-            )
+            logger.warning(f"unable to save code -- can't find {program_absolute}")
             return None
         saved_program = os.path.join(self.settings.files_dir, "code", program_relative)
         self.saved_program = program_relative  # type: ignore
@@ -122,7 +120,7 @@ class SystemInfo:
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
         ) as e:
-            logger.error("Error generating diff: {}".format(e))
+            logger.error(f"Error generating diff: {e}")
         logger.debug("Saving git patches done")
 
     def _probe_git(self, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -490,9 +490,7 @@ class TBHistory:
                     dropped_keys.append(k)
                     del self._data[k]
             wandb.termwarn(
-                "Step {} exceeds max data limit, dropping {} of the largest keys:".format(
-                    self._step, len(dropped_keys)
-                )
+                f"Step {self._step} exceeds max data limit, dropping {len(dropped_keys)} of the largest keys:"
             )
             print("\t" + ("\n\t".join(dropped_keys)))  # noqa: T201
         self._data["_step"] = self._step

--- a/wandb/sdk/launch/environment/gcp_environment.py
+++ b/wandb/sdk/launch/environment/gcp_environment.py
@@ -94,8 +94,7 @@ class GcpEnvironment(AbstractEnvironment):
         region = config.get("region", None)
         if not region:
             raise LaunchError(
-                "Could not create GcpEnvironment from config. Missing 'region' "
-                "field."
+                "Could not create GcpEnvironment from config. Missing 'region' field."
             )
         return cls(region=region)
 

--- a/wandb/sdk/launch/runner/sagemaker_runner.py
+++ b/wandb/sdk/launch/runner/sagemaker_runner.py
@@ -69,7 +69,7 @@ class SagemakerSubmittedRun(AbstractRun):
             )
             assert "events" in res
             return "\n".join(
-                [f'{event["timestamp"]}:{event["message"]}' for event in res["events"]]
+                [f"{event['timestamp']}:{event['message']}" for event in res["events"]]
             )
         except self.log_client.exceptions.ResourceNotFoundException:
             wandb.termwarn(
@@ -398,9 +398,7 @@ async def launch_sagemaker_job(
     wandb.termlog(
         f"{LOG_PREFIX}Run job submitted with arn: {resp.get('TrainingJobArn')}"
     )
-    url = "https://{region}.console.aws.amazon.com/sagemaker/home?region={region}#/jobs/{job_name}".format(
-        region=sagemaker_client.meta.region_name, job_name=training_job_name
-    )
+    url = f"https://{sagemaker_client.meta.region_name}.console.aws.amazon.com/sagemaker/home?region={sagemaker_client.meta.region_name}#/jobs/{training_job_name}"
     wandb.termlog(f"{LOG_PREFIX}See training job status at: {url}")
     return run
 

--- a/wandb/sdk/launch/runner/vertex_runner.py
+++ b/wandb/sdk/launch/runner/vertex_runner.py
@@ -49,12 +49,7 @@ class VertexSubmittedRun(AbstractRun):
         return self._job.project  # type: ignore
 
     def get_page_link(self) -> str:
-        return "{console_uri}/vertex-ai/locations/{region}/training/{job_id}?project={project}".format(
-            console_uri=GCP_CONSOLE_URI,
-            region=self.gcp_region,
-            job_id=self.id,
-            project=self.gcp_project,
-        )
+        return f"{GCP_CONSOLE_URI}/vertex-ai/locations/{self.gcp_region}/training/{self.id}?project={self.gcp_project}"
 
     async def wait(self) -> bool:
         # TODO: run this in a separate thread.

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -699,7 +699,7 @@ class Scheduler(ABC):
         if entry_point:
             wandb.termwarn(
                 f"{LOG_PREFIX}Sweep command {entry_point} will override"
-                f' {"job" if _job else "image_uri"} entrypoint'
+                f" {'job' if _job else 'image_uri'} entrypoint"
             )
 
         # override resource and args of job

--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -199,7 +199,7 @@ def create_sweep_command(command: Optional[List] = None) -> List:
             for m in matches[::-1]:
                 # Default to just leaving as is if environment variable does not exist
                 _var: str = os.environ.get(m.group(1), m.group(1))
-                command[i] = f"{command[i][:m.start()]}{_var}{command[i][m.end():]}"
+                command[i] = f"{command[i][: m.start()]}{_var}{command[i][m.end() :]}"
     return command
 
 
@@ -211,7 +211,7 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
 
     """
     if "args" not in command:
-        raise ValueError('No "args" found in command: {}'.format(command))
+        raise ValueError(f'No "args" found in command: {command}')
     # four different formats of command args
     # (1) standard command line flags (e.g. --foo=bar)
     flags: List[str] = []
@@ -232,7 +232,7 @@ def create_sweep_command_args(command: Dict) -> Dict[str, Any]:
         try:
             _value: Any = config["value"]
         except KeyError:
-            raise ValueError('No "value" found for command["args"]["{}"]'.format(param))
+            raise ValueError(f'No "value" found for command["args"]["{param}"]')
 
         _flag: str = f"{param}={_value}"
         flags.append("--" + _flag)

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -323,8 +323,7 @@ def validate_launch_spec_source(launch_spec: Dict[str, Any]) -> None:
     docker_image = launch_spec.get("docker", {}).get("docker_image")
     if bool(job) == bool(docker_image):
         raise LaunchError(
-            "Exactly one of job or docker_image must be specified in the launch "
-            "spec."
+            "Exactly one of job or docker_image must be specified in the launch spec."
         )
 
 

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -237,9 +237,7 @@ def write_netrc(host: str, entity: str, key: str):
     _, key_suffix = key.split("-", 1) if "-" in key else ("", key)
     if len(key_suffix) != 40:
         raise ValueError(
-            "API-key must be exactly 40 characters long: {} ({} chars)".format(
-                key_suffix, len(key_suffix)
-            )
+            f"API-key must be exactly 40 characters long: {key_suffix} ({len(key_suffix)} chars)"
         )
 
     normalized_host = urlparse(host).netloc
@@ -276,7 +274,7 @@ def write_netrc(host: str, entity: str, key: str):
                     elif skip:
                         skip -= 1
                     else:
-                        f.write("{}\n".format(line))
+                        f.write(f"{line}\n")
 
             wandb.termlog(
                 f"Appending key for {normalized_host} to your netrc file: {netrc_path}"
@@ -311,9 +309,7 @@ def write_key(
     _, suffix = key.split("-", 1) if "-" in key else ("", key)
 
     if len(suffix) != 40:
-        raise ValueError(
-            "API key must be 40 characters long, yours was {}".format(len(key))
-        )
+        raise ValueError(f"API key must be 40 characters long, yours was {len(key)}")
 
     write_netrc(settings.base_url, "user", key)
 

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -66,13 +66,13 @@ def dict_from_config_file(
 ) -> Optional[Dict[str, Any]]:
     if not os.path.exists(filename):
         if must_exist:
-            raise ConfigError("config file {} doesn't exist".format(filename))
-        logger.debug("no default config file found in {}".format(filename))
+            raise ConfigError(f"config file {filename} doesn't exist")
+        logger.debug(f"no default config file found in {filename}")
         return None
     try:
         conf_file = open(filename)
     except OSError:
-        raise ConfigError("Couldn't read config file: {}".format(filename))
+        raise ConfigError(f"Couldn't read config file: {filename}")
     try:
         loaded = load_yaml(conf_file)
     except yaml.parser.ParserError:

--- a/wandb/sdk/lib/redirect.py
+++ b/wandb/sdk/lib/redirect.py
@@ -510,7 +510,7 @@ class RedirectBase:
 
     @property
     def src_stream(self):
-        return getattr(sys, "__{}__".format(self.src))
+        return getattr(sys, f"__{self.src}__")
 
     @property
     def src_fd(self):

--- a/wandb/sdk/lib/retry.py
+++ b/wandb/sdk/lib/retry.py
@@ -140,9 +140,7 @@ class Retry(Generic[_R]):
                     if self.retry_callback:
                         self.retry_callback(
                             200,
-                            "{} resolved after {}, resuming normal operation.".format(
-                                self._error_prefix, NOW_FN() - start_time
-                            ),
+                            f"{self._error_prefix} resolved after {NOW_FN() - start_time}, resuming normal operation.",
                         )
                 return result
             except self._retryable_exceptions as e:
@@ -184,9 +182,7 @@ class Retry(Generic[_R]):
                         # but some of these can be raised before the retry handler thread (RunStatusChecker) is
                         # spawned in wandb_init
                         wandb.termlog(
-                            "{} ({}), entering retry loop.".format(
-                                self._error_prefix, e.__class__.__name__
-                            )
+                            f"{self._error_prefix} ({e.__class__.__name__}), entering retry loop."
                         )
                 # if wandb.env.is_debug():
                 #     traceback.print_exc()

--- a/wandb/sdk/lib/service_token.py
+++ b/wandb/sdk/lib/service_token.py
@@ -31,8 +31,7 @@ def get_service_token() -> ServiceToken | None:
 
     if version != _CURRENT_VERSION:
         raise ValueError(
-            f"Expected version {_CURRENT_VERSION},"
-            f" but got {version} (token={token})"
+            f"Expected version {_CURRENT_VERSION}, but got {version} (token={token})"
         )
     if transport not in _SUPPORTED_TRANSPORTS:
         raise ValueError(

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -477,9 +477,7 @@ def check_wandb_version(api: Api) -> None:
     from wandb.util import parse_version
 
     if parse_version(wandb.__version__) < parse_version(min_cli_version):
-        fail_string = "wandb version out of date, please run pip install --upgrade wandb=={}".format(
-            max_cli_version
-        )
+        fail_string = f"wandb version out of date, please run pip install --upgrade wandb=={max_cli_version}"
     elif parse_version(wandb.__version__) > parse_version(max_cli_version):
         fail_string = (
             "wandb version is not supported by your local installation. This could "

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -273,9 +273,7 @@ class RunStatusChecker:
                     wandb.termlog(f"{hr.http_response_text}")
                 else:
                     wandb.termlog(
-                        "{} encountered ({}), retrying request".format(
-                            hr.http_status_code, hr.http_response_text.rstrip()
-                        )
+                        f"{hr.http_status_code} encountered ({hr.http_response_text.rstrip()}), retrying request"
                     )
 
         with wb_logging.log_to_run(self._run_id):
@@ -3118,9 +3116,7 @@ class Run:
             artifact = public_api._artifact(type=type, name=name)
             if type is not None and type != artifact.type:
                 raise ValueError(
-                    "Supplied type {} does not match type {} of artifact {}".format(
-                        type, artifact.type, artifact.name
-                    )
+                    f"Supplied type {type} does not match type {artifact.type} of artifact {artifact.name}"
                 )
             api.use_artifact(
                 artifact.id,

--- a/wandb/sdk/wandb_watch.py
+++ b/wandb/sdk/wandb_watch.py
@@ -139,7 +139,7 @@ def _unwatch(
             models = (models,)
         for model in models:
             if not hasattr(model, "_wandb_hook_names"):
-                wandb.termwarn("{} model has not been watched".format(model))
+                wandb.termwarn(f"{model} model has not been watched")
             else:
                 for name in model._wandb_hook_names:
                     run._torch.unhook(name)

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -157,13 +157,13 @@ class SyncThread(threading.Thread):
         proto_run.entity = self._entity
         proto_run.telemetry.feature.sync_tfevents = True
 
-        url = "{}/{}/{}/runs/{}".format(
-            self._app_url,
-            url_quote(proto_run.entity),
-            url_quote(proto_run.project),
-            url_quote(proto_run.run_id),
+        url = (
+            f"{self._app_url}"
+            f"/{url_quote(proto_run.entity)}"
+            f"/{url_quote(proto_run.project)}"
+            f"/runs/{url_quote(proto_run.run_id)}"
         )
-        print("Syncing: {} ...".format(url))  # noqa: T201
+        print(f"Syncing: {url} ...")  # noqa: T201
         sys.stdout.flush()
         # using a handler here automatically handles the step
         # logic, adds summaries to the run, and handles different
@@ -305,13 +305,13 @@ class SyncThread(threading.Thread):
                     if not shown and result_type == "run_result":
                         r = result.run_result.run
                         # TODO(jhr): hardcode until we have settings in sync
-                        url = "{}/{}/{}/runs/{}".format(
-                            self._app_url,
-                            url_quote(r.entity),
-                            url_quote(r.project),
-                            url_quote(r.run_id),
+                        url = (
+                            f"{self._app_url}"
+                            f"/{url_quote(r.entity)}"
+                            f"/{url_quote(r.project)}"
+                            f"/runs/{url_quote(r.run_id)}"
                         )
-                        print("Syncing: {} ... ".format(url), end="")  # noqa: T201
+                        print(f"Syncing: {url} ... ", end="")  # noqa: T201
                         sys.stdout.flush()
                         shown = True
             sm.finish()

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -621,9 +621,7 @@ def json_friendly(  # noqa: C901
         converted = False
     if getsizeof(obj) > VALUE_BYTES_LIMIT:
         wandb.termwarn(
-            "Serializing object of type {} that is {} bytes".format(
-                type(obj).__name__, getsizeof(obj)
-            )
+            f"Serializing object of type {type(obj).__name__} that is {getsizeof(obj)} bytes"
         )
     return obj, converted
 

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -332,7 +332,7 @@ class Agent:
             elif command_type == "resume":
                 result = self._command_run(command)
             else:
-                raise AgentError("No such command: {}".format(command_type))
+                raise AgentError(f"No such command: {command_type}")
             response["result"] = result
         except Exception:
             logger.exception("Exception while processing command: %s", command)
@@ -415,7 +415,7 @@ class Agent:
                     command_list += [c]
             logger.info(
                 "About to run command: {}".format(
-                    " ".join('"{}"'.format(c) if " " in c else c for c in command_list)
+                    " ".join(f'"{c}"' if " " in c else c for c in command_list)
                 )
             )
             proc = AgentProcess(command=command_list, env=env)
@@ -466,7 +466,7 @@ class AgentApi:
 
     def command(self, command):
         command["origin"] = "local"
-        command["id"] = "local-{}".format(self._command_id)
+        command["id"] = f"local-{self._command_id}"
         self._command_id += 1
         resp_queue = self._multiproc_manager.Queue()
         command["resp_queue"] = resp_queue


### PR DESCRIPTION
Removes `UP032` from the ignore list and applies automatic fixes to all files using `ruff check . --fix`.

As a result, some lines may be a bit overlong, but it's difficult to auto-fix, and enforcing the lint is worth it.

I ignore the lint for `wandb/apis/public/` because f-strings need to be formatted a little differently for `gql(...)` syntax highlighting to work.