### PR TITLE
refactor: enable and fix TRY201 (verbose-raise)

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,10 @@ This version removes the ability to disable the `service` process. This is a bre
 
 - Various APIs now raise `TypeError` instead of `ValueError` or other generic errors when given an argument of the wrong type. (@timoffex in https://github.com/wandb/wandb/pull/9902)
 
+### Changed
+
+- Various APIs now raise `TypeError` instead of `ValueError` or other generic errors when given an argument of the wrong type. (@timoffex in https://github.com/wandb/wandb/pull/9902)
+
 ### Removed
 
 - Removed support for disabling the `service` process. The `x_disable_service`/`_disable_service` setting and the `WANDB_DISABLE_SERVICE`/`WANDB_X_DISABLE_SERVICE` environment variable have been deprecated and will now raise an error if used (@kptkin in https://github.com/wandb/wandb/pull/9829)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ select = [
 
     # tryceratops
     "TRY004", # type-check-without-type-error
+    "TRY201", # verbose-raise
 ]
 ignore = [
     "B904",

--- a/tools/inspect_tool.py
+++ b/tools/inspect_tool.py
@@ -37,7 +37,7 @@ def inspect_wandb_transaction_log(wandb_file: str, pause: bool = False) -> None:
                 )
                 return None
             else:
-                raise e
+                raise
 
     ds = datastore.DataStore()
     try:

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -268,13 +268,13 @@ class Agent:
                     wandb.termlog("Ctrl + C detected. Stopping sweep.")
                     self._exit()
                     return
-                except Exception as e:
+                except Exception:
                     if self._exit_flag:
                         logger.debug("Exiting main loop due to exit flag.")
                         wandb.termlog("Sweep Agent: Killed.")
                         return
                     else:
-                        raise e
+                        raise
         finally:
             _INSTANCES -= 1
 
@@ -301,8 +301,8 @@ class Agent:
 
             self._function()
             wandb.finish()
-        except KeyboardInterrupt as ki:
-            raise ki
+        except KeyboardInterrupt:
+            raise
         except Exception as e:
             wandb.finish(exit_code=1)
             if self._run_status[run_id] == RunStatus.RUNNING:

--- a/wandb/apis/importers/internals/util.py
+++ b/wandb/apis/importers/internals/util.py
@@ -55,7 +55,7 @@ def parallelize(
                 f"Exception: {func=} {args=} {kwargs=} {e=} {filename=} {lineno=}. {traceback_details=}"
             )
             if raise_on_error:
-                raise e
+                raise
 
     results = []
     with ThreadPoolExecutor(max_workers) as exc:

--- a/wandb/apis/importers/wandb.py
+++ b/wandb/apis/importers/wandb.py
@@ -568,7 +568,7 @@ class WandbImporter:
                 if "cannot delete system managed artifact" in str(e):
                     logger.warning("Cannot delete system managed artifact")
                 else:
-                    raise e
+                    raise
 
     def _get_dst_art(
         self, src_art: Run, entity: Optional[str] = None, project: Optional[str] = None
@@ -1475,7 +1475,7 @@ def _read_ndjson(fname: str) -> Optional[pl.DataFrame]:
             return None
         if "error parsing ndjson" in str(e):
             return None
-        raise e
+        raise
 
     return df
 

--- a/wandb/apis/normalize.py
+++ b/wandb/apis/normalize.py
@@ -61,8 +61,8 @@ def normalize_exceptions(func: _F) -> _F:
                 raise CommError(message, err.last_exception).with_traceback(
                     sys.exc_info()[2]
                 )
-        except Error as err:
-            raise err
+        except Error:
+            raise
         except Exception as err:
             # gql raises server errors with dict's as strings...
             if len(err.args) > 0:

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -2145,7 +2145,7 @@ class Api:
 
             # Not a (known) recoverable HTTP error
             wandb.termerror(f"Got response status {status!r}: {e.response.text!r}")
-            raise e
+            raise
 
         try:
             result = UpdateAutomation.model_validate(data).result

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1551,7 +1551,7 @@ def launch(
 
         except Exception as e:
             wandb._sentry.exception(e)
-            raise e
+            raise
 
 
 @cli.command(
@@ -1642,7 +1642,7 @@ def launch_agent(
         _launch.create_and_run_agent(api, agent_config)
     except Exception as e:
         wandb._sentry.exception(e)
-        raise e
+        raise
 
 
 @cli.command(context_settings=CONTEXT, help="Run the W&B agent")
@@ -1720,7 +1720,7 @@ def scheduler(
         _scheduler.start()
     except Exception as e:
         wandb._sentry.exception(e)
-        raise e
+        raise
 
 
 @cli.group(help="Commands for managing and viewing W&B jobs")

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1369,7 +1369,7 @@ class Artifact:
                 f"Failed to open the provided file ({type(e).__name__}: {e}). Please "
                 f"provide the proper encoding."
             )
-            raise e
+            raise
 
         self.add_file(
             path, name=name, policy="immutable", skip_cache=True, overwrite=overwrite

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -254,7 +254,7 @@ class WandbStoragePolicy(StoragePolicy):
                     if env.is_debug():
                         logger.debug(f"Error writing chunk to file: {e}")
                     download_has_error.set()
-                    raise e
+                    raise
             else:
                 raise ValueError(f"Unknown queue item type: {type(item)}")
 
@@ -340,7 +340,7 @@ class WandbStoragePolicy(StoragePolicy):
                 if env.is_debug():
                     logger.debug(f"Error downloading file: {e}")
                 download_has_error.set()
-                raise e
+                raise
             finally:
                 # Always signal the writer to stop
                 q.put(_CHUNK_QUEUE_SENTINEL)

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -199,9 +199,9 @@ class Media(WBValue):
         else:
             try:
                 shutil.copy(self._path, new_path)
-            except shutil.SameFileError as e:
+            except shutil.SameFileError:
                 if not ignore_copy_err:
-                    raise e
+                    raise
             self._path = new_path
             run._publish_file(media_path)
 

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -860,7 +860,7 @@ class Table(Media):
 
         try:
             self.cast(name, _dtypes.UnknownType(), optional=optional)
-        except TypeError as err:
+        except TypeError:
             # Undo the changes
             if is_first_col:
                 self.data = []
@@ -869,7 +869,7 @@ class Table(Media):
                 for ndx in range(len(self.data)):
                     self.data[ndx] = self.data[ndx][:-1]
                 self.columns = self.columns[:-1]
-            raise err
+            raise
 
     def get_column(self, name, convert_to=None):
         """Retrieves a column from the table and optionally converts it to a NumPy object.

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -489,12 +489,12 @@ class FileStreamApi:
         # TODO: Consolidate with internal_util.ExceptionThread
         try:
             self._thread_body()
-        except Exception as e:
+        except Exception:
             exc_info = sys.exc_info()
             self._exc_info = exc_info
             logger.exception("generic exception in filestream thread")
             wandb._sentry.exception(exc_info)
-            raise e
+            raise
 
     def _handle_response(self, response: Union[Exception, "requests.Response"]) -> None:
         """Log dropped chunks and updates dynamic settings."""

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3376,8 +3376,8 @@ class Api:
                     variable_values=variables,
                     check_retry_fn=util.no_retry_4xx,
                 )
-            except UsageError as e:
-                raise e
+            except UsageError:
+                raise
             except Exception as e:
                 # graphql schema exception is generic
                 err = e

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -288,9 +288,9 @@ class TBDirWatcher:
     def _thread_except_body(self) -> None:
         try:
             self._thread_body()
-        except Exception as e:
+        except Exception:
             logger.exception("generic exception in TBDirWatcher thread")
-            raise e
+            raise
 
     def _thread_body(self) -> None:
         """Check for new events every second."""
@@ -394,9 +394,9 @@ class TBEventConsumer:
     def _thread_except_body(self) -> None:
         try:
             self._thread_body()
-        except Exception as e:
+        except Exception:
             logger.exception("generic exception in TBEventConsumer thread")
-            raise e
+            raise
 
     def _thread_body(self) -> None:
         while True:

--- a/wandb/sdk/launch/builder/kaniko_builder.py
+++ b/wandb/sdk/launch/builder/kaniko_builder.py
@@ -358,7 +358,7 @@ class KanikoBuilder(AbstractBuilder):
             wandb.termerror(
                 f"{LOG_PREFIX}Exception when creating Kubernetes resources: {e}\n"
             )
-            raise e
+            raise
         finally:
             wandb.termlog(f"{LOG_PREFIX}Cleaning up resources")
             try:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -354,7 +354,7 @@ class Scheduler(ABC):
             wandb.termlog(f"{LOG_PREFIX}Scheduler failed with exception {e}")
             self.state = SchedulerState.FAILED
             self.exit()
-            raise e
+            raise
         else:
             # scheduler succeeds if at runcap
             if self.state == SchedulerState.FLUSH_RUNS and self.at_runcap:

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -627,9 +627,9 @@ def docker_image_exists(docker_image: str, should_raise: bool = False) -> bool:
     try:
         docker.run(["docker", "image", "inspect", docker_image])
         return True
-    except (docker.DockerError, ValueError) as e:
+    except (docker.DockerError, ValueError):
         if should_raise:
-            raise e
+            raise
         _logger.info("Base image not found. Generating new base image")
         return False
 

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -421,8 +421,8 @@ class StreamMux:
     def loop(self) -> None:
         try:
             self._loop()
-        except Exception as e:
-            raise e
+        except Exception:
+            raise
 
     def cleanup(self) -> None:
         pass

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -241,7 +241,7 @@ class SyncThread(threading.Thread):
                 )
                 return None
             else:
-                raise e
+                raise
 
     def run(self):
         if self._log_path is not None:


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/verbose-raise/. Instead of

```python
except Exception as e:
    raise e
```

do

```python
except Exception:
    raise
```

The fix was applied automatically, but it is marked unsafe because it sometimes doesn't work well with shadowed error variables. I manually checked all changes---we don't do this type of shadowing anywhere.