### PR TITLE
refactor: enable and fix TRY400 (logger.exception() instead of logger.error())

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ select = [
     "TRY201", # verbose-raise
     "TRY203", # useless-try-except
     "TRY301", # raise-within-try
+    "TRY400", # error-instead-of-exception
 ]
 ignore = [
     "B904",

--- a/tools/perf/scripts/process_sar_helper.py
+++ b/tools/perf/scripts/process_sar_helper.py
@@ -130,11 +130,11 @@ def process_sar_files(log_dir: str) -> None:
         subprocess.run("killall sar", check=True, shell=True)
         logger.info("kill sar executed successfully.")
     except FileNotFoundError:
-        logger.error(
+        logger.exception(
             "Command not found. Make sure 'killall' is installed and in your PATH."
         )
-    except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
+    except Exception:
+        logger.exception("An unexpected error occurred.")
 
     log_files = ["cpu.log", "mem.log", "network.sock.log", "paging.log"]
 

--- a/wandb/apis/importers/validation.py
+++ b/wandb/apis/importers/validation.py
@@ -92,8 +92,8 @@ def _check_entry_is_downloable(entry):
 
     try:
         resp = requests.head(url, allow_redirects=True)
-    except Exception as e:
-        logger.error(f"Problem validating {entry=}, {e=}")
+    except Exception:
+        logger.exception(f"Problem validating {entry=}")
         return False
 
     if resp.status_code != 200:

--- a/wandb/apis/importers/wandb.py
+++ b/wandb/apis/importers/wandb.py
@@ -552,8 +552,8 @@ class WandbImporter:
                 f"{seq=} does not exist in dst.  Has it already been deleted?"
             )
             return
-        except TypeError as e:
-            logger.error(f"Problem getting dst versions (try again later) {e=}")
+        except TypeError:
+            logger.exception("Problem getting dst versions (try again later).")
             return
 
         for art in dst_arts:
@@ -705,7 +705,7 @@ class WandbImporter:
                 )
             except ValueError as e:
                 if "Could not find project" in str(e):
-                    logger.error("Could not find project, does it exist?")
+                    logger.exception("Could not find project, does it exist?")
                     continue
 
             for run in runs:
@@ -1173,8 +1173,8 @@ class WandbImporter:
             for art in seq:
                 try:
                     logged_by = _get_run_or_dummy_from_art(art, self.src_api)
-                except requests.HTTPError as e:
-                    logger.error(f"Failed to get run, skipping: {art=}, {e=}")
+                except requests.HTTPError:
+                    logger.exception(f"Failed to get run, skipping: {art=}")
                     continue
 
                 if art.type == "wandb-history" and isinstance(logged_by, _DummyRun):
@@ -1219,9 +1219,10 @@ class WandbImporter:
                     art = seq.artifacts[0]
                     try:
                         logged_by = _get_run_or_dummy_from_art(art, self.src_api)
-                    except requests.HTTPError as e:
-                        logger.error(
-                            f"Validate Artifact http error: {art.entity=}, {art.project=}, {art.name=}, {e=}"
+                    except requests.HTTPError:
+                        logger.exception(
+                            f"Validate Artifact http error: {art.entity=},"
+                            f" {art.project=}, {art.name=}"
                         )
                         continue
 
@@ -1351,8 +1352,8 @@ class WandbImporter:
                 types = []
                 try:
                     types = [t for t in api.artifact_types(ns.path)]
-                except Exception as e:
-                    logger.error(f"Failed to get artifact types {e=}")
+                except Exception:
+                    logger.exception("Failed to get artifact types.")
 
                 for t in types:
                     collections = []
@@ -1363,8 +1364,8 @@ class WandbImporter:
 
                     try:
                         collections = t.collections()
-                    except Exception as e:
-                        logger.error(f"Failed to get artifact collections {e=}")
+                    except Exception:
+                        logger.exception("Failed to get artifact collections.")
 
                     for c in collections:
                         if c.is_sequence():
@@ -1542,8 +1543,8 @@ def _download_art(art: Artifact, root: str) -> Optional[str]:
     try:
         with patch("click.echo"):
             return art.download(root=root, skip_cache=True)
-    except Exception as e:
-        logger.error(f"Error downloading artifact {art=}, {e=}")
+    except Exception:
+        logger.exception(f"Error downloading artifact {art=}")
 
 
 def _clone_art(art: Artifact, root: Optional[str] = None):

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -105,7 +105,7 @@ def display_error(func):
         except wandb.Error as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            logger.error("".join(lines))
+            logger.exception("".join(lines))
             wandb.termerror(f"Find detailed error logs at: {_wandb_log_path}")
             click_exc = ClickWandbException(e)
             click_exc.orig_type = exc_type
@@ -1510,11 +1510,11 @@ def launch(
                 wandb.termerror("Launched run exited with non-zero status")
                 sys.exit(1)
         except LaunchError as e:
-            logger.error("=== %s ===", e)
+            logger.exception("An error occurred.")
             wandb._sentry.exception(e)
             sys.exit(e)
         except ExecutionError as e:
-            logger.error("=== %s ===", e)
+            logger.exception("An error occurred.")
             wandb._sentry.exception(e)
             sys.exit(e)
         except asyncio.CancelledError:

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -284,7 +284,7 @@ def image_id_from_registry(image_name: str) -> Optional[str]:
         )
         res.raise_for_status()
     except requests.RequestException:
-        log.error(f"Received {res} when attempting to get digest for {image_name}")
+        log.exception(f"Received {res} when attempting to get digest for {image_name}")
         return None
     return "@".join([registry + "/" + repository, res.headers["Docker-Content-Digest"]])
 

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -682,8 +682,5 @@ def request_with_retry(
                 error_message = response.json()["error"]  # todo: clean this up
             except Exception:
                 pass
-            logger.error(f"requests_with_retry error: {error_message}")
-            logger.exception(
-                "requests_with_retry encountered unretryable exception: %s", e
-            )
+            logger.exception(f"requests_with_retry error: {error_message}")
             return e

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -704,8 +704,8 @@ class HandleManager:
         ):
             try:
                 self._metadata = Metadata(**self._system_monitor.probe(publish=True))
-            except Exception as e:
-                logger.error("Error probing system metadata: %s", e)
+            except Exception:
+                logger.exception("Error probing system metadata.")
 
         self._tb_watcher = tb_watcher.TBWatcher(
             self._settings, interface=self._interface, run_proto=run_start.run

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -749,8 +749,8 @@ class SendManager:
                 self._resume_state.wandb_runtime = new_runtime
             tags = resume_status.get("tags") or []
 
-        except (IndexError, ValueError) as e:
-            logger.error("unable to load resume tails", exc_info=e)
+        except (IndexError, ValueError):
+            logger.exception("unable to load resume tails")
             if self._settings.resume == "must":
                 error = wandb_internal_pb2.ErrorInfo()
                 error.code = wandb_internal_pb2.ErrorInfo.ErrorCode.USAGE
@@ -1182,7 +1182,7 @@ class SendManager:
             try:
                 d[item.key] = json.loads(item.value_json)
             except json.JSONDecodeError:
-                logger.error("error decoding stats json: %s", item.value_json)
+                logger.exception("error decoding stats json: %s", item.value_json)
         row: Dict[str, Any] = dict(system=d)
         self._flatten(row)
         row["_wandb"] = True
@@ -1494,9 +1494,9 @@ class SendManager:
         try:
             res = self._send_artifact(artifact)
             logger.info(f"sent artifact {artifact.name} - {res}")
-        except Exception as e:
-            logger.error(
-                f'send_artifact: failed for artifact "{artifact.type}/{artifact.name}": {e}'
+        except Exception:
+            logger.exception(
+                f'send_artifact: failed for artifact "{artifact.type}/{artifact.name}"'
             )
 
     def _send_artifact(
@@ -1568,8 +1568,8 @@ class SendManager:
                     level=alert.level,
                     wait_duration=alert.wait_duration,
                 )
-            except Exception as e:
-                logger.error(f"send_alert: failed for alert {alert.title!r}: {e}")
+            except Exception:
+                logger.exception(f"send_alert: failed for alert {alert.title!r}")
 
     def finish(self) -> None:
         logger.info("shutting down sender")

--- a/wandb/sdk/internal/system/assets/gpu.py
+++ b/wandb/sdk/internal/system/assets/gpu.py
@@ -377,8 +377,8 @@ class GPU:
             return True
         except pynvml.NVMLError_LibraryNotFound:  # type: ignore
             return False
-        except Exception as e:
-            logger.error(f"Error initializing NVML: {e}")
+        except Exception:
+            logger.exception("Error initializing NVML.")
             return False
 
     def start(self) -> None:
@@ -410,7 +410,7 @@ class GPU:
 
         except pynvml.NVMLError:
             pass
-        except Exception as e:
-            logger.error(f"Error Probing GPU: {e}")
+        except Exception:
+            logger.exception("Error Probing GPU.")
 
         return info

--- a/wandb/sdk/internal/system/assets/interfaces.py
+++ b/wandb/sdk/internal/system/assets/interfaces.py
@@ -136,8 +136,8 @@ class MetricsMonitor:
                         logger.info(f"Process {metric.name} has exited.")
                         self._shutdown_event.set()
                         break
-                    except Exception as e:
-                        logger.error(f"Failed to sample metric: {e}")
+                    except Exception:
+                        logger.exception("Failed to sample metric.")
                 self._shutdown_event.wait(self.sampling_interval)
                 if self._shutdown_event.is_set():
                     break
@@ -153,8 +153,8 @@ class MetricsMonitor:
                 # aggregated_metrics = wandb.util.merge_dicts(
                 #     aggregated_metrics, metric.serialize()
                 # )
-            except Exception as e:
-                logger.error(f"Failed to serialize metric: {e}")
+            except Exception:
+                logger.exception("Failed to serialize metric.")
         return aggregated_metrics
 
     def publish(self) -> None:
@@ -165,8 +165,8 @@ class MetricsMonitor:
                 self._interface.publish_stats(aggregated_metrics)
             for metric in self.metrics:
                 metric.clear()
-        except Exception as e:
-            logger.error(f"Failed to publish metrics: {e}")
+        except Exception:
+            logger.exception("Failed to publish metrics.")
 
     def start(self) -> None:
         if (self._process is not None) or self._shutdown_event.is_set():

--- a/wandb/sdk/internal/system/assets/trainium.py
+++ b/wandb/sdk/internal/system/assets/trainium.py
@@ -126,8 +126,8 @@ class NeuronCoreStats:
                         self.raw_samples.append(raw_data)
                 process.kill()
                 process.wait()
-        except Exception as e:
-            logger.error(f"neuron-monitor failed: {e}")
+        except Exception:
+            logger.exception("neuron-monitor failed")
 
     def __init__(
         self,
@@ -168,8 +168,8 @@ class NeuronCoreStats:
             self.shutdown_event.set()
             assert self.neuron_monitor_thread is not None
             self.neuron_monitor_thread.join()
-        except Exception as e:
-            logger.error(f"neuron-monitor thread failed to stop: {e}")
+        except Exception:
+            logger.exception("neuron-monitor thread failed to stop")
         finally:
             self.neuron_monitor_thread = None
 
@@ -388,6 +388,6 @@ class Trainium:
                 pass
 
             return {self.name: neuron_hardware_info}
-        except Exception as e:
-            logger.error(f"neuron-monitor failed: {e}")
+        except Exception:
+            logger.exception("neuron-monitor failed")
             return {}

--- a/wandb/sdk/internal/system/system_info.py
+++ b/wandb/sdk/internal/system/system_info.py
@@ -119,8 +119,8 @@ class SystemInfo:
             ValueError,
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
-        ) as e:
-            logger.error(f"Error generating diff: {e}")
+        ):
+            logger.exception("Error generating diff.")
         logger.debug("Saving git patches done")
 
     def _probe_git(self, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/wandb/sdk/internal/system/system_monitor.py
+++ b/wandb/sdk/internal/system/system_monitor.py
@@ -177,8 +177,8 @@ class SystemMonitor:
             # publish telemetry
             self.publish_telemetry()
             self.aggregate_and_publish_asset_metrics()
-        except Exception as e:
-            logger.error(f"Error publishing last batch of metrics: {e}")
+        except Exception:
+            logger.exception("Error publishing last batch of metrics.")
 
     def start(self) -> None:
         self._shutdown_event.clear()
@@ -199,8 +199,8 @@ class SystemMonitor:
             asset.finish()
         try:
             self._process.join()
-        except Exception as e:
-            logger.error(f"Error joining system monitor process: {e}")
+        except Exception:
+            logger.exception("Error joining system monitor process.")
         self._process = None
 
     def probe(self, publish: bool = True) -> dict:

--- a/wandb/sdk/launch/agent/job_status_tracker.py
+++ b/wandb/sdk/launch/agent/job_status_tracker.py
@@ -48,6 +48,6 @@ class JobAndRunStatusTracker:
         check_stop = event_loop_thread_exec(api.api.check_stop_requested)
         try:
             return bool(await check_stop(self.project, self.entity, self.run_id))
-        except CommError as e:
-            _logger.error(f"CommError when checking if wandb run stopped: {e}")
+        except CommError:
+            _logger.exception("CommError when checking if wandb run stopped")
         return False

--- a/wandb/sdk/lib/gitlib.py
+++ b/wandb/sdk/lib/gitlib.py
@@ -87,9 +87,9 @@ class GitRepo:
             return None
         try:
             return self.repo.git.rev_parse("--show-toplevel")
-        except GitCommandError as e:
+        except GitCommandError:
             # todo: collect telemetry on this
-            logger.error(f"git root error: {e}")
+            logger.exception("git root error")
             return None
 
     @property

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -360,7 +360,7 @@ class _WandbInit:
                 return None
 
             except KeyError:
-                self._logger.error(
+                self._logger.exception(
                     f"resume file at {resume_file} did not store a run_id"
                 )
                 return None

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2445,7 +2445,7 @@ class Run:
             logger.info("Redirects installed.")
         except Exception as e:
             wandb.termwarn(f"Failed to redirect: {e}")
-            logger.error("Failed to redirect.", exc_info=e)
+            logger.exception("Failed to redirect.")
         return
 
     def _restore(self) -> None:
@@ -2486,9 +2486,9 @@ class Run:
                 wandb.termerror("Control-C detected -- Run data was not synced")
             raise
 
-        except Exception as e:
+        except Exception:
             self._console_stop()
-            logger.error("Problem finishing run", exc_info=e)
+            logger.exception("Problem finishing run")
             wandb.termerror("Problem finishing run")
             raise
 
@@ -2586,8 +2586,8 @@ class Run:
 
         try:
             self._detect_and_apply_job_inputs()
-        except Exception as e:
-            logger.error("Problem applying launch job inputs", exc_info=e)
+        except Exception:
+            logger.exception("Problem applying launch job inputs")
 
         # object is about to be returned to the user, don't let them modify it
         self._freeze()
@@ -3784,8 +3784,8 @@ class Run:
             try:
                 response = result.response.get_system_metrics_response
                 return pb_to_dict(response) if response else {}
-            except Exception as e:
-                logger.error("Error getting system metrics: %s", e)
+            except Exception:
+                logger.exception("Error getting system metrics.")
                 return {}
 
     @property
@@ -3810,7 +3810,7 @@ class Run:
         try:
             result = handle.wait_or(timeout=1)
         except TimeoutError:
-            logger.error("Error getting run metadata: timeout")
+            logger.exception("Timeout getting run metadata.")
             return None
 
         try:
@@ -3823,8 +3823,8 @@ class Run:
                 self.__metadata.update_from_proto(response.metadata, skip_existing=True)
 
             return self.__metadata
-        except Exception as e:
-            logger.error("Error getting run metadata: %s", e)
+        except Exception:
+            logger.exception("Error getting run metadata.")
 
         return None
 


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/error-instead-of-exception/

All fixes are manual because in most cases I had to remove redundant string-interpolation of the error. In a few spots, `logger.exception()` would have been called multiple times in a row, so I condensed those into a single `logger.exception()` call. Also, in `internal_api.py`, I simplified some `logger.exception()` calls to not parse the underlying error; I am assuming all the needed info will appear in log files when the exception is formatted.

I think some of the stranger `logger.error()` invocations came from a time when we didn't consistently set up the `wandb` logger, causing their messages to sometimes get printed to the user's console. That's probably why `cli.py` had statements like `logger.error("=== %s ===", e)`.