### PR TITLE
fix(artifacts): allow artifact.add_dir to overwrite

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,19 +22,15 @@ This version removes the ability to disable the `service` process. This is a bre
 
 ### Added
 
+- Added `merge` parameter to `Artifact.add_dir` to allow overwrite of previously-added artifact files (@pingleiwandb in https://github.com/wandb/wandb/pull/9907)
 - Support for pytorch.tensor for `masks` and `boxes` parameters when creating a `wandb.Image` object. (jacobromero in https://github.com/wandb/wandb/pull/9802)
 - `sync_tensorboard` now supports syncing tfevents files stored in S3, GCS and Azure (@timoffex in https://github.com/wandb/wandb/pull/9849)
-    - GCS paths use the format `gs://bucket/path/to/log/dir` and rely on application-default credentials, which can be configured using `gcloud auth application-default login`
-    - S3 paths use the format `s3://bucket/path/to/log/dir` and rely on the default credentials set through `aws configure`
-    - Azure paths use the format `az://account/container/path/to/log/dir` and the `az login` credentials, but also require the `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables to be set. Some other environment variables are supported as well, see [here](https://pkg.go.dev/gocloud.dev@v0.41.0/blob/azureblob#hdr-URLs).
+  - GCS paths use the format `gs://bucket/path/to/log/dir` and rely on application-default credentials, which can be configured using `gcloud auth application-default login`
+  - S3 paths use the format `s3://bucket/path/to/log/dir` and rely on the default credentials set through `aws configure`
+  - Azure paths use the format `az://account/container/path/to/log/dir` and the `az login` credentials, but also require the `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables to be set. Some other environment variables are supported as well, see [here](https://pkg.go.dev/gocloud.dev@v0.41.0/blob/azureblob#hdr-URLs).
 - Added support for initializing some Media objects with `pathlib.Path` (@jacobromero in https://github.com/wandb/wandb/pull/9692)
-- New setting `x_skip_transaction_log` that allows to skip the transaction log. Note: Should be used with caution, as it removes the gurantees about
-    recoverability. (@kptkin in https://github.com/wandb/wandb/pull/9064)
+- New setting `x_skip_transaction_log` that allows to skip the transaction log. Note: Should be used with caution, as it removes the gurantees about recoverability. (@kptkin in https://github.com/wandb/wandb/pull/9064)
 - `normalize` parameter to `wandb.Image` initialization to normalize pixel values for Images initialized with a numpy array or pytorch tensor. (@jacobromero in https://github.com/wandb/wandb/pull/9883)
-
-### Changed
-
-- Various APIs now raise `TypeError` instead of `ValueError` or other generic errors when given an argument of the wrong type. (@timoffex in https://github.com/wandb/wandb/pull/9902)
 
 ### Changed
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1437,6 +1437,7 @@ class Artifact:
         name: str | None = None,
         skip_cache: bool | None = False,
         policy: Literal["mutable", "immutable"] | None = "mutable",
+        merge: bool = False,
     ) -> None:
         """Add a local directory to the artifact.
 
@@ -1449,6 +1450,10 @@ class Artifact:
             policy: "mutable" | "immutable". By default, "mutable"
                 "mutable": Create a temporary copy of the file to prevent corruption during upload.
                 "immutable": Disable protection, rely on the user not to delete or change the file.
+            merge: If `False` (default), throws ValueError if a file was already added in a previous add_dir call
+                and its content has changed. If `True`, overwrites existing files with changed content.
+                Always adds new files and never removes files. To replace an entire directory, pass a name when adding the directory
+                using `add_dir(local_path, name=my_prefix)` and call `remove(my_prefix)` to remove the directory, then add it again.
 
         Raises:
             ArtifactFinalizedError: You cannot make changes to the current artifact
@@ -1482,6 +1487,7 @@ class Artifact:
                 path=physical_path,
                 skip_cache=skip_cache,
                 policy=policy,
+                overwrite=merge,
             )
 
         num_threads = 8


### PR DESCRIPTION
Description
-----------

- Fixes WB-25135

Allow `Artifact.add_dir` to'overwrite' using `merge` flag similar to `add` and `add_file` from https://github.com/wandb/wandb/pull/8553/files

For the flag name, we use `merge` instead of `overwrite` because we are not replacing entire directory.
Calling `add_dir` leads to add and update, but no delete.  When `merge` is true and some files are deleted locally after first `add_dir` call, second `add_dir` won't remove those deleted file from artifact manifest.
These deleted files can still be uploaded because the default `mutable` policy copy the files to a staging folder and upload files using the copy.

If user want to replace entire directory, they can call `remove(dir_prefix_in_artifact)` and add the dir again.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- system test