### PR TITLE
refactor: don't require legacy-service in CLI

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -21,6 +21,7 @@ import wandb
 from wandb.apis import InternalApi
 from wandb.errors import term
 from wandb.errors.links import url_registry
+from wandb.sdk import wandb_setup
 from wandb.util import _is_databricks, isatty, prompt_choices
 
 if TYPE_CHECKING:
@@ -316,7 +317,7 @@ def write_key(
 
 def api_key(settings: Settings | None = None) -> str | None:
     if settings is None:
-        settings = wandb.setup().settings
+        settings = wandb_setup._setup(start_service=False).settings
     if settings.api_key:
         return settings.api_key
 

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -13,6 +13,7 @@ from requests.exceptions import ConnectionError
 import wandb
 from wandb.errors import AuthenticationError, UsageError
 from wandb.old.settings import Settings as OldSettings
+from wandb.sdk import wandb_setup
 
 from ..apis import InternalApi
 from .internal.internal_api import Api
@@ -115,7 +116,7 @@ class _WandbLogin:
         }
         self.is_anonymous = anonymous == "must"
 
-        self._wandb_setup = wandb.setup()
+        self._wandb_setup = wandb_setup._setup(start_service=False)
         self._wandb_setup.settings.update_from_dict(login_settings)
         self._settings = self._wandb_setup.settings
 


### PR DESCRIPTION
Removes `wandb.require("legacy-service")` in `cli.py` and uses `wandb_setup._setup(settings=..., start_service=False)` instead of `wandb.setup(settings=...)` to modify global settings.

This was causing an erroneous warning

> wandb: WARNING Using legacy-service, which is deprecated. If this is unintentional, you can fix it by ensuring you do not call `wandb.require('legacy-service')` and do not set the WANDB_X_REQUIRE_LEGACY_SERVICE environment variable.

The `require` was originally added out of caution in case any users were running on machines that didn't support `wandb-core` before making it the default. If `wandb.require("legacy-service")` isn't used and `wandb-core` isn't supported, then `wandb.setup()` fails when trying to start up the service process. In a normal script, a user is expected to add the `require` to their code; but in the CLI, there would have been no workaround.

In `cli.py` and the login code, `wandb.setup()` is only used for global settings, and the service process isn't needed. The internal `wandb_setup._setup(start_service=False)` function was added a couple months ago for this purpose during a refactor of `wandb.init()`.

In general, we should not call `wandb.setup()` from within the SDK. After this PR, the only remaining call is in `wandb/cli/beta.py` which seems valid, and two innocuous ones in `wandb/sdk/artifacts/artifact.py` and `wandb/sdk/wandb_init.py` which I will remove separately.


## Testing

Use `pip install -e <wandb>`, then delete `wandb/bin/wandb-core` and attempt to use the CLI:

* `wandb login`
* `wandb projects` is good enough to test the `_get_cling_api()` path