### PR TITLE
refactor: replace wandb_setup._setup()

### DIFF
--- a/wandb/beta/workflows.py
+++ b/wandb/beta/workflows.py
@@ -87,7 +87,7 @@ def _log_artifact_version(
         Artifact
 
     """
-    run = wandb_setup._setup(start_service=False).most_recent_active_run
+    run = wandb_setup.singleton().most_recent_active_run
     if not run:
         run = wandb.init(
             project=project,
@@ -218,7 +218,7 @@ def use_model(aliased_path: str, unsafe: bool = False) -> "_SavedModel":
         )
 
     # Returns a _SavedModel instance
-    if run := wandb_setup._setup(start_service=False).most_recent_active_run:
+    if run := wandb_setup.singleton().most_recent_active_run:
         artifact = run.use_artifact(aliased_path)
         sm = artifact.get("index")
 
@@ -263,7 +263,7 @@ def link_model(
     """
     aliases = wandb.util._resolve_aliases(aliases)
 
-    if run := wandb_setup._setup(start_service=False).most_recent_active_run:
+    if run := wandb_setup.singleton().most_recent_active_run:
         # _artifact_source, if it exists, points to a Public Artifact.
         # Its existence means that _SavedModel was deserialized from a logged artifact, most likely from `use_model`.
         if model._artifact_source:

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -126,10 +126,7 @@ def _get_cling_api(reset=None):
     if _api is None:
         # TODO(jhr): make a settings object that is better for non runs.
         # only override the necessary setting
-        wandb_setup._setup(
-            settings=wandb.Settings(x_cli_only_mode=True),
-            start_service=False,
-        )
+        wandb_setup.singleton().settings.x_cli_only_mode = True
         _api = InternalApi()
     return _api
 
@@ -240,13 +237,9 @@ def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):
     key = key[0] if key is not None and len(key) > 0 else None
     relogin = True if key or relogin else False
 
-    wandb_setup._setup(
-        settings=wandb.Settings(
-            x_cli_only_mode=True,
-            x_disable_viewer=relogin and not verify,
-        ),
-        start_service=False,
-    )
+    global_settings = wandb_setup.singleton().settings
+    global_settings.x_cli_only_mode = True
+    global_settings.x_disable_viewer = relogin and not verify
 
     wandb.login(
         anonymous=anon_mode,

--- a/wandb/integration/sagemaker/auth.py
+++ b/wandb/integration/sagemaker/auth.py
@@ -2,6 +2,7 @@ import os
 
 import wandb
 from wandb import env
+from wandb.sdk import wandb_setup
 
 
 def sagemaker_auth(overrides=None, path=".", api_key=None):
@@ -12,7 +13,7 @@ def sagemaker_auth(overrides=None, path=".", api_key=None):
                                     to secrets.env
         path (str, optional): The path to write the secrets file.
     """
-    settings = wandb.setup().settings
+    settings = wandb_setup.singleton().settings
     current_api_key = wandb.wandb_lib.apikey.api_key(settings=settings)
 
     overrides = overrides or dict()

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -148,7 +148,7 @@ class WandBMagics(Magics):
         if path:
             _display_by_wandb_path(path, height=height)
             displayed = True
-        elif run := wandb_setup._setup(start_service=False).most_recent_active_run:
+        elif run := wandb_setup.singleton().most_recent_active_run:
             _display_wandb_run(run, height=height)
             displayed = True
         else:

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1089,9 +1089,7 @@ class Artifact:
             with telemetry.context() as tel:
                 tel.feature.artifact_incremental = True
 
-        singleton = wandb_setup._setup(start_service=False)
-
-        if run := singleton.most_recent_active_run:
+        if run := wandb_setup.singleton().most_recent_active_run:
             # TODO: Deprecate and encourage explicit log_artifact().
             run.log_artifact(self)
         else:
@@ -1910,7 +1908,7 @@ class Artifact:
 
         # TODO: Create a special stream instead of relying on an existing run.
         if wandb.run is None:
-            wl = wandb.setup()
+            wl = wandb_setup.singleton()
 
             stream_id = generate_id()
 
@@ -2349,9 +2347,7 @@ class Artifact:
                 "Linking to a link artifact will result in directly linking to the source artifact of that link artifact."
             )
 
-        singleton = wandb_setup._setup(start_service=False)
-
-        if run := singleton.most_recent_active_run:
+        if run := wandb_setup.singleton().most_recent_active_run:
             # TODO: Deprecate and encourage explicit link_artifact().
             return run.link_artifact(self, target_path, aliases)
 

--- a/wandb/sdk/data_types/base_types/wb_value.py
+++ b/wandb/sdk/data_types/base_types/wb_value.py
@@ -22,7 +22,7 @@ def _is_maybe_offline() -> bool:
     Returns:
         Whether the user likely configured wandb to be offline.
     """
-    singleton = wandb_setup._setup(start_service=False)
+    singleton = wandb_setup.singleton()
 
     # First check: if there's a run, check if it is offline.
     #
@@ -51,7 +51,7 @@ def _server_accepts_client_ids() -> bool:
     # client IDs.
 
     if _is_maybe_offline():
-        singleton = wandb_setup._setup(start_service=False)
+        singleton = wandb_setup.singleton()
 
         if run := singleton.most_recent_active_run:
             return run._settings.allow_offline_artifacts

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -317,7 +317,7 @@ def write_key(
 
 def api_key(settings: Settings | None = None) -> str | None:
     if settings is None:
-        settings = wandb_setup._setup(start_service=False).settings
+        settings = wandb_setup.singleton().settings
     if settings.api_key:
         return settings.api_key
 

--- a/wandb/sdk/lib/printer.py
+++ b/wandb/sdk/lib/printer.py
@@ -102,7 +102,7 @@ def new_printer(settings: wandb.Settings | None = None) -> Printer:
             has been called, then global settings are used. Otherwise,
             settings (such as silent mode) are ignored.
     """
-    if not settings and (singleton := wandb_setup.singleton()):
+    if not settings and (singleton := wandb_setup.singleton_if_setup()):
         settings = singleton.settings
 
     if ipython.in_jupyter():

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -202,15 +202,11 @@ class _WandbInit:
         Returns:
             A callback to print any generated warnings.
         """
-        singleton = wandb_setup.singleton()
-        if singleton is None:
-            return _noop_printer_callback()
-
         exclude_env_vars = {"WANDB_SERVICE", "WANDB_KUBEFLOW_URL"}
         # check if environment variables have changed
         singleton_env = {
             k: v
-            for k, v in singleton._environ.items()
+            for k, v in wandb_setup.singleton()._environ.items()
             if k.startswith("WANDB_") and k not in exclude_env_vars
         }
         os_env = {
@@ -1109,7 +1105,7 @@ def _attach(
         )
     wandb._assert_is_user_process()  # type: ignore
 
-    _wl = wandb.setup()
+    _wl = wandb_setup.singleton()
     logger = _wl._get_logger()
 
     service = _wl.ensure_service()
@@ -1548,7 +1544,7 @@ def init(  # noqa: C901
     wl: wandb_setup._WandbSetup | None = None
 
     try:
-        wl = wandb_setup._setup(start_service=False)
+        wl = wandb_setup.singleton()
 
         wi = _WandbInit(wl, init_telemetry)
 

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -116,7 +116,7 @@ class _WandbLogin:
         }
         self.is_anonymous = anonymous == "must"
 
-        self._wandb_setup = wandb_setup._setup(start_service=False)
+        self._wandb_setup = wandb_setup.singleton()
         self._wandb_setup.settings.update_from_dict(login_settings)
         self._settings = self._wandb_setup.settings
 

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -344,10 +344,25 @@ The value is invalid and must not be used if `os.getpid() != _singleton._pid`.
 """
 
 
-def singleton() -> _WandbSetup | None:
-    """Returns the W&B singleton if it exists for the current process.
+def singleton() -> _WandbSetup:
+    """The W&B singleton for the current process.
 
-    Unlike setup(), this does not create the singleton if it doesn't exist.
+    The first call to this in this process (which may be a fork of another
+    process) creates the singleton, and all subsequent calls return it
+    until teardown(). This does not start the service process.
+    """
+    return _setup(start_service=False)
+
+
+def singleton_if_setup() -> _WandbSetup | None:
+    """The W&B singleton for the current process or None if it isn't set up.
+
+    Always prefer singleton() over this function.
+
+    Unlike singleton(), this never creates the singleton and therefore never
+    initializes global settings from the environment. This is useful only
+    during tests, which may modify the environment after having imported wandb
+    and called certain functions.
     """
     if _singleton and _singleton._pid == os.getpid():
         return _singleton


### PR DESCRIPTION
Updates `wandb_setup.singleton()` to call `wandb_setup._setup(start_service=False)` and replaces all usages of the latter.

The original implementation is renamed to `wandb_setup.singleton_if_setup()` and is used only in `printer.py` to avoid locking in environment-derived settings when a printer is initialized in tests because test fixtures currently use environment variables to configure global settings.

This PR also removes all remaining calls to `wandb.setup()` within the SDK. Internally, it is always preferred to use `wandb.singleton()` instead.