### PR TITLE
refactor: fix a few instances of TRY300

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -116,16 +116,16 @@ class CustomBuildHook(BuildHookInterface):
         return [output.as_posix()]
 
     def _git_commit_sha(self) -> str:
-        try:
-            import subprocess
+        import subprocess
 
-            src_dir = pathlib.Path(__file__).parent
-            commit = (
+        src_dir = pathlib.Path(__file__).parent
+
+        try:
+            return (
                 subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=src_dir)
                 .decode("utf-8")
                 .strip()
             )
-            return commit
         except Exception:
             return ""
 

--- a/wandb/apis/attrs.py
+++ b/wandb/apis/attrs.py
@@ -28,13 +28,12 @@ class Attrs:
 
         try:
             from IPython import display
-
-            display.display(display.HTML(html))
-            return True
-
         except ImportError:
             wandb.termwarn(".display() only works in jupyter environments")
             return False
+
+        display.display(display.HTML(html))
+        return True
 
     def to_html(self, *args, **kwargs):
         return None

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1463,9 +1463,10 @@ class Api:
         """
         try:
             self._artifact(name, type)
-            return True
         except wandb.errors.CommError:
             return False
+
+        return True
 
     @normalize_exceptions
     def artifact_collection_exists(self, name: str, type: str) -> bool:
@@ -1482,9 +1483,10 @@ class Api:
         """
         try:
             self.artifact_collection(type, name)
-            return True
         except wandb.errors.CommError:
             return False
+
+        return True
 
     def registries(
         self,


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/try-consider-else/

This one takes some manual work to really fix, and I don't enable this lint in this PR because its suggestion can be a little misleading. For instance, it will produce a diagnostic on this:

```python
try:
    result = computation()
    return result
except SomeError:
    return other
```

The lint message will make it seem that the solution is this:

```python
try:
    result = computation()
except SomeError:
    return other
else:
    return result
```

But an even better solution is

```python
try:
    return computation()
except SomeError:
    return other
```

In many cases in our codebase, the right fix is to narrow the scope of the `try-except` rather than to use `try-except-else`. It also sometimes makes sense to not use an `else` block at all, especially when the exception handler is an early return.