### PR TITLE
feat: add flag to include inference server on job create via wandb launch

### DIFF
--- a/core/pkg/launch/job_builder.go
+++ b/core/pkg/launch/job_builder.go
@@ -151,11 +151,12 @@ type JobSourceMetadata struct {
 	// this field is used by launch to determine the flow for launching the job
 	// see public.py.Job for more info
 
-	SourceType  SourceType                    `json:"source_type"`
-	InputTypes  data_types.TypeRepresentation `json:"input_types"`
-	OutputTypes data_types.TypeRepresentation `json:"output_types"`
-	Runtime     *string                       `json:"runtime,omitempty"`
-	Partial     *string                       `json:"_partial,omitempty"`
+	SourceType              SourceType                    `json:"source_type"`
+	InputTypes              data_types.TypeRepresentation `json:"input_types"`
+	OutputTypes             data_types.TypeRepresentation `json:"output_types"`
+	Runtime                 *string                       `json:"runtime,omitempty"`
+	Partial                 *string                       `json:"_partial,omitempty"`
+	RequiresInferenceServer bool                          `json:"requires_inference_server,omitempty"`
 }
 
 type ArtifactInfoForJob struct {
@@ -634,6 +635,8 @@ func (j *JobBuilder) Build(
 		metadataString = ""
 		sourceInfo.InputTypes = data_types.ResolveTypes(runConfig)
 	}
+
+	_, sourceInfo.RequiresInferenceServer = os.LookupEnv("WANDB_REQUIRES_INFERENCE_SERVER")
 
 	baseArtifact := &spb.ArtifactRecord{
 		Entity:           j.settings.GetEntity().GetValue(),

--- a/wandb/apis/public/jobs.py
+++ b/wandb/apis/public/jobs.py
@@ -69,6 +69,9 @@ class Job:
         self._output_types = TypeRegistry.type_from_dict(
             self._job_info.get("output_types")
         )
+        self._requires_inference_server = self._job_info.get(
+            "requires_inference_server", False
+        )
         if self._job_info.get("source_type") == "artifact":
             self._set_configure_launch_project(self._configure_launch_project_artifact)
         if self._job_info.get("source_type") == "repo":

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -17,16 +17,15 @@ from functools import wraps
 from typing import Any, Dict, Optional
 
 import click
+import wandb
+import wandb.env
+import wandb.errors
+import wandb.sdk.verify.verify as wandb_verify
 import yaml
 from click.exceptions import ClickException
 
 # pycreds has a find_executable that works in windows
 from dockerpycreds.utils import find_executable
-
-import wandb
-import wandb.env
-import wandb.errors
-import wandb.sdk.verify.verify as wandb_verify
 from wandb import Config, Error, env, util, wandb_agent, wandb_sdk
 from wandb.apis import InternalApi, PublicApi
 from wandb.apis.public import RunQueue
@@ -1336,6 +1335,12 @@ def launch_sweep(
     help="""When --queue is passed, set the priority of the job. Launch jobs with higher priority
     are served first.  The order, from highest to lowest priority, is: critical, high, medium, low""",
 )
+@click.option(
+    "--requires-inference-server",
+    is_flag=True,
+    hidden=True,
+    help="Run the job with an inference server",
+)
 @display_error
 def launch(
     uri,
@@ -1360,6 +1365,7 @@ def launch(
     dockerfile,
     priority,
     job_name,
+    requires_inference_server,
 ):
     """Start a W&B run from the given URI.
 
@@ -1449,6 +1455,7 @@ def launch(
             build_context=build_context,
             dockerfile=dockerfile,
             entity=entity,
+            requires_inference_server=requires_inference_server,
         )
         if artifact is None:
             raise LaunchError(f"Failed to create job from uri: {uri}")

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1507,6 +1507,7 @@ def launch(
                     synchronous=(not run_async),
                     run_id=run_id,
                     repository=repository,
+                    requires_inference_server=requires_inference_server,
                 )
             )
             if asyncio.run(run.get_status()).state in [

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -426,6 +426,7 @@ class JobBuilder:
         build_context: Optional[str] = None,
         dockerfile: Optional[str] = None,
         base_image: Optional[str] = None,
+        requires_inference_server: bool = False,
     ) -> Optional[Artifact]:
         """Build a job artifact from the current run.
 
@@ -437,6 +438,7 @@ class JobBuilder:
             dockerfile (Optional[str]): Path within the build context the
                 Dockerfile. Saved as part of the job for future builds.
             base_image (Optional[str]): The base image used to run the job code.
+            requires_inference_server (bool): Whether the job requires an inference server.
 
         Returns:
             Optional[Artifact]: The job artifact if it was successfully built,
@@ -542,6 +544,7 @@ class JobBuilder:
             "input_types": input_types,
             "output_types": output_types,
             "runtime": runtime,
+            "requires_inference_server": requires_inference_server,
         }
 
         assert source_info is not None

--- a/wandb/sdk/internal/job_builder.py
+++ b/wandb/sdk/internal/job_builder.py
@@ -109,6 +109,7 @@ class JobSourceDict(TypedDict, total=False):
     input_types: Dict[str, Any]
     output_types: Dict[str, Any]
     runtime: Optional[str]
+    requires_inference_server: Optional[bool]
 
 
 class ArtifactInfoForJob(TypedDict):

--- a/wandb/sdk/launch/_launch.py
+++ b/wandb/sdk/launch/_launch.py
@@ -185,6 +185,7 @@ async def _launch(
     synchronous: Optional[bool] = None,
     run_id: Optional[str] = None,
     repository: Optional[str] = None,
+    requires_inference_server: Optional[bool] = None,
 ) -> AbstractRun:
     """Helper that delegates to the project-running method corresponding to the passed-in backend."""
     if launch_config is None:
@@ -211,6 +212,7 @@ async def _launch(
     validate_launch_spec_source(launch_spec)
     launch_project = LaunchProject.from_spec(launch_spec, api)
     launch_project.fetch_and_validate_project()
+    launch_project._requires_inference_server = requires_inference_server
     entrypoint = launch_project.get_job_entry_point()
     image_uri = (
         launch_project.docker_image or launch_project.job_base_image

--- a/wandb/sdk/launch/_launch.py
+++ b/wandb/sdk/launch/_launch.py
@@ -4,9 +4,8 @@ import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
-import yaml
-
 import wandb
+import yaml
 from wandb.apis.internal import Api
 
 from . import loader

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -437,6 +437,7 @@ class LaunchProject:
             )
         job.configure_launch_project(self)  # Why is this a method of the job?
         self._job_artifact = job._job_artifact
+        self._requires_inference_server = job._requires_inference_server
 
     def get_env_vars_dict(self, api: Api, max_env_length: int) -> Dict[str, str]:
         """Generate environment variables for the project.

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -123,9 +123,9 @@ class LaunchProject:
             "docker_image"
         ) or launch_spec.get("image_uri")  # type: ignore [assignment]
         self.docker_user_id = docker_config.get("user_id", 1000)
-        self._entry_point: Optional[
-            EntryPoint
-        ] = None  # todo: keep multiple entrypoint support?
+        self._entry_point: Optional[EntryPoint] = (
+            None  # todo: keep multiple entrypoint support?
+        )
         self.init_overrides(overrides)
         self.init_source()
         self.init_git(git_info)

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -123,9 +123,9 @@ class LaunchProject:
             "docker_image"
         ) or launch_spec.get("image_uri")  # type: ignore [assignment]
         self.docker_user_id = docker_config.get("user_id", 1000)
-        self._entry_point: Optional[EntryPoint] = (
-            None  # todo: keep multiple entrypoint support?
-        )
+        self._entry_point: Optional[
+            EntryPoint
+        ] = None  # todo: keep multiple entrypoint support?
         self.init_overrides(overrides)
         self.init_source()
         self.init_git(git_info)
@@ -473,6 +473,8 @@ class LaunchProject:
             env_vars[wandb.env.LAUNCH_QUEUE_ENTITY] = self.queue_entity
         if self.run_queue_item_id:
             env_vars[wandb.env.LAUNCH_TRACE_ID] = self.run_queue_item_id
+        if self._requires_inference_server:
+            env_vars["WANDB_REQUIRES_INFERENCE_SERVER"] = "True"
 
         _inject_wandb_config_env_vars(self.override_config, env_vars, max_env_length)
         _inject_file_overrides_env_vars(self.override_files, env_vars, max_env_length)

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -135,6 +135,7 @@ class LaunchProject:
         self._queue_name: Optional[str] = None
         self._queue_entity: Optional[str] = None
         self._run_queue_item_id: Optional[str] = None
+        self._requires_inference_server: Optional[bool] = None
 
     def init_source(self) -> None:
         if self.docker_image is not None:

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -11,9 +11,8 @@ from dataclasses import dataclass
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import yaml
-
 import wandb
+import yaml
 from wandb.apis.internal import Api
 from wandb.errors import CommError
 from wandb.sdk.launch._launch_add import launch_add
@@ -706,6 +705,12 @@ class LaunchAgent:
         job_tracker.update_run_info(project)
         self._internal_logger.info("Fetching and validating project...")
         project.fetch_and_validate_project()
+        wandb.termlog(
+            f"Job requires_inference_server: {project._requires_inference_server}"
+        )
+        wandb.termlog(
+            f"Launch spec requires_inference_server config: {launch_spec.get('inferenceServerConfig', None)}"
+        )
         self._internal_logger.info("Fetching resource...")
         resource = launch_spec.get("resource") or "local-container"
         backend_config: Dict[str, Any] = {

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -11,8 +11,9 @@ from dataclasses import dataclass
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import wandb
 import yaml
+
+import wandb
 from wandb.apis.internal import Api
 from wandb.errors import CommError
 from wandb.sdk.launch._launch_add import launch_add
@@ -705,12 +706,6 @@ class LaunchAgent:
         job_tracker.update_run_info(project)
         self._internal_logger.info("Fetching and validating project...")
         project.fetch_and_validate_project()
-        wandb.termlog(
-            f"Job requires_inference_server: {project._requires_inference_server}"
-        )
-        wandb.termlog(
-            f"Launch spec requires_inference_server config: {launch_spec.get('inferenceServerConfig', None)}"
-        )
         self._internal_logger.info("Fetching resource...")
         resource = launch_spec.get("resource") or "local-container"
         backend_config: Dict[str, Any] = {

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -115,6 +115,7 @@ def _create_job(
     build_context: Optional[str] = None,
     dockerfile: Optional[str] = None,
     base_image: Optional[str] = None,
+    requires_inference_server: bool = False,
 ) -> Tuple[Optional[Artifact], str, List[str]]:
     wandb.termlog(f"Creating launch job of type: {job_type}...")
 
@@ -191,6 +192,7 @@ def _create_job(
         dockerfile=dockerfile,
         build_context=build_context,
         base_image=base_image,
+        requires_inference_server=requires_inference_server,
     )
     if not artifact:
         wandb.termerror("JobBuilder failed to build a job")


### PR DESCRIPTION
https://linear.app/wandb/issue/ENG-15/separate-handling-of-evals-and-vllm-api-jobs

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
