### PR TITLE
refactor: enable and fix TRY300 (try-consider-else)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ select = [
     "TRY004", # type-check-without-type-error
     "TRY201", # verbose-raise
     "TRY203", # useless-try-except
+    "TRY300", # try-consider-else
     "TRY301", # raise-within-try
     "TRY400", # error-instead-of-exception
     "TRY401", # verbose-log-message
@@ -277,7 +278,21 @@ ignore-decorators = [
 "wandb/integration/metaflow/metaflow.py" = ["F811"]
 "wandb/old/**" = ["B006", "B020", "D", "F822"]
 "wandb/plot/**" = ["D", "B007", "F401", "N812", "F841", "UP031"]
+"wandb/sdk/internal/file_stream.py" = ["TRY300"]
+"wandb/sdk/internal/internal_api.py" = ["TRY300"]
+"wandb/sdk/internal/system/assets/gpu.py" = ["TRY300"]
+"wandb/sdk/internal/system/assets/trainium.py" = ["TRY300"]
 "wandb/sdk/launch/**" = ["T20"]
+"wandb/sdk/launch/agent/agent.py" = ["TRY300"]
+"wandb/sdk/launch/builder/templates/_wandb_bootstrap.py" = ["TRY300"]
+"wandb/sdk/launch/environment/aws_environment.py" = ["TRY300"]
+"wandb/sdk/launch/environment/gcp_environment.py" = ["TRY300"]
+"wandb/sdk/launch/registry/azure_container_registry.py" = ["TRY300"]
+"wandb/sdk/launch/runner/abstract.py" = ["TRY300"]
+"wandb/sdk/launch/runner/kubernetes_runner.py" = ["TRY300"]
+"wandb/sdk/launch/sweeps/scheduler.py" = ["TRY300"]
+"wandb/sdk/launch/utils.py" = ["TRY300"]
+"wandb/sdk/lib/retry.py" = ["TRY300"]
 "wandb/sklearn/**" = ["B010", "B011", "N803", "N806", "UP031"]
 "wandb/wandb_controller.py" = ["N806"]
 "wandb/wandb_torch.py" = ["C901", "D", "E741", "F841"]

--- a/wandb/apis/public/jobs.py
+++ b/wandb/apis/public/jobs.py
@@ -405,9 +405,10 @@ class QueuedRun:
                         None,
                     )
                     self._run_id = item["associatedRunId"]
-                    return self._run
                 except ValueError as e:
                     wandb.termwarn(str(e))
+                else:
+                    return self._run
             elif item:
                 wandb.termlog("Waiting for run to start")
 

--- a/wandb/integration/diffusers/resolvers/multimodal.py
+++ b/wandb/integration/diffusers/resolvers/multimodal.py
@@ -669,8 +669,7 @@ class DiffusersMultiModalPipelineResolver:
                 )
 
             # Return the WandB loggable dict
-            loggable_dict = self.prepare_loggable_dict(pipeline, response, kwargs)
-            return loggable_dict
+            return self.prepare_loggable_dict(pipeline, response, kwargs)
         except Exception as e:
             logger.warning(e)
         return None

--- a/wandb/integration/sklearn/utils.py
+++ b/wandb/integration/sklearn/utils.py
@@ -114,10 +114,11 @@ def test_fitted(model):
                 ],
                 all_or_any=any,
             )
-            return True
         except sklearn.exceptions.NotFittedError:
             wandb.termerror("Please fit the model before passing it in.")
             return False
+        else:
+            return True
     except Exception:
         # Assume it's fitted, since ``NotFittedError`` wasn't raised
         return True

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -246,12 +246,11 @@ def notebook_metadata(silent: bool) -> dict[str, str]:
 
         if jupyter_metadata:
             return jupyter_metadata
-        wandb.termerror(error_message)
-        return {}
     except Exception:
-        wandb.termerror(error_message)
         logger.exception(error_message)
-        return {}
+
+    wandb.termerror(error_message)
+    return {}
 
 
 def jupyter_servers_and_kernel_id():
@@ -273,9 +272,10 @@ def jupyter_servers_and_kernel_id():
             servers.extend(list(serverapp.list_running_servers()))
         if notebookapp is not None:
             servers.extend(list(notebookapp.list_running_servers()))
-        return servers, kernel_id
     except (AttributeError, ValueError, ImportError):
         return [], None
+
+    return servers, kernel_id
 
 
 def attempt_colab_load_ipynb():
@@ -289,17 +289,20 @@ def attempt_colab_load_ipynb():
 
 def attempt_kaggle_load_ipynb():
     kaggle = wandb.util.get_module("kaggle_session")
-    if kaggle:
-        try:
-            client = kaggle.UserSessionClient()
-            parsed = json.loads(client.get_exportable_ipynb()["source"])
-            # TODO: couldn't find a way to get the name of the notebook...
-            parsed["metadata"]["name"] = "kaggle.ipynb"
-            return parsed
-        except Exception:
-            wandb.termerror("Unable to load kaggle notebook.")
-            logger.exception("Unable to load kaggle notebook.")
-            return None
+    if not kaggle:
+        return None
+
+    try:
+        client = kaggle.UserSessionClient()
+        parsed = json.loads(client.get_exportable_ipynb()["source"])
+        # TODO: couldn't find a way to get the name of the notebook...
+        parsed["metadata"]["name"] = "kaggle.ipynb"
+    except Exception:
+        wandb.termerror("Unable to load kaggle notebook.")
+        logger.exception("Unable to load kaggle notebook.")
+        return None
+
+    return parsed
 
 
 def attempt_colab_login(

--- a/wandb/plot/utils.py
+++ b/wandb/plot/utils.py
@@ -98,10 +98,11 @@ def test_fitted(model):
                 ],
                 all_or_any=any,
             )
-            return True
         except scikit_exceptions.NotFittedError:
             wandb.termerror("Please fit the model before passing it in.")
             return False
+        else:
+            return True
     except Exception:
         # Assume it's fitted, since ``NotFittedError`` wasn't raised
         return True

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -1363,7 +1363,6 @@ def _get_data_from_increments(
             increment_num = int(increment_parts[0])
             # If there's a timestamp part, use it for secondary sorting
             timestamp = int(increment_parts[1]) if len(increment_parts) > 1 else 0
-            return (increment_num, timestamp)
         except (ValueError, IndexError):
             wandb.termwarn(
                 (
@@ -1375,6 +1374,8 @@ def _get_data_from_increments(
                 repeat=False,
             )
             return (0, 0)
+
+        return (increment_num, timestamp)
 
     sorted_increment_keys = []
     for entry_key in source_artifact.manifest.entries:

--- a/wandb/sdk/lib/gitlib.py
+++ b/wandb/sdk/lib/gitlib.py
@@ -214,11 +214,12 @@ class GitRepo:
                         most_recent_ancestor = ancestor
                     elif self.repo.is_ancestor(most_recent_ancestor, ancestor):  # type: ignore
                         most_recent_ancestor = ancestor
-            return most_recent_ancestor
         except GitCommandError as e:
             logger.debug("git remote upstream fork point could not be found")
             logger.debug(str(e))
             return None
+
+        return most_recent_ancestor
 
     def tag(self, name: str, message: Optional[str]) -> Any:
         if not self.repo:

--- a/wandb/sdk/lib/service_connection.py
+++ b/wandb/sdk/lib/service_connection.py
@@ -167,7 +167,6 @@ class ServiceConnection:
             handle = self._mailbox.require_response(request)
             self._client.send_server_request(request)
             response = handle.wait_or(timeout=10)
-            return response.inform_attach_response.settings
 
         except (MailboxClosedError, HandleAbandonedError, SockClientClosedError):
             raise WandbAttachFailedError(
@@ -180,6 +179,9 @@ class ServiceConnection:
                 " the current service process, or because the service"
                 " process is busy (unlikely)."
             ) from None
+
+        else:
+            return response.inform_attach_response.settings
 
     def inform_start(
         self,

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1338,13 +1338,12 @@ class Run:
 
         try:
             from IPython import display
-
-            display.display(display.HTML(self.to_html(height, hidden)))
-            return True
-
         except ImportError:
             wandb.termwarn(".display() only works in jupyter environments")
             return False
+
+        display.display(display.HTML(self.to_html(height, hidden)))
+        return True
 
     @_log_to_run
     @_attach
@@ -3814,20 +3813,15 @@ class Run:
             logger.exception("Timeout getting run metadata.")
             return None
 
-        try:
-            response = result.response.get_system_metadata_response
+        response = result.response.get_system_metadata_response
 
-            # Temporarily disable the callback to prevent triggering
-            # an update call to wandb-core with the callback.
-            with self.__metadata.disable_callback():
-                # Values stored in the metadata object take precedence.
-                self.__metadata.update_from_proto(response.metadata, skip_existing=True)
+        # Temporarily disable the callback to prevent triggering
+        # an update call to wandb-core with the callback.
+        with self.__metadata.disable_callback():
+            # Values stored in the metadata object take precedence.
+            self.__metadata.update_from_proto(response.metadata, skip_existing=True)
 
-            return self.__metadata
-        except Exception:
-            logger.exception("Error getting run metadata.")
-
-        return None
+        return self.__metadata
 
     @_log_to_run
     @_raise_if_finished

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1215,13 +1215,15 @@ def async_call(
         )
         thread.daemon = True
         thread.start()
+
         try:
             result = q.get(True, timeout)
-            if isinstance(result, Exception):
-                raise result.with_traceback(sys.exc_info()[2])
-            return result, thread
         except queue.Empty:
             return None, thread
+
+        if isinstance(result, Exception):
+            raise result.with_traceback(sys.exc_info()[2])
+        return result, thread
 
     return wrapper
 
@@ -1439,10 +1441,11 @@ def are_paths_on_same_drive(path1: str, path2: str) -> bool:
     try:
         path1_drive = pathlib.Path(path1).resolve().drive
         path2_drive = pathlib.Path(path2).resolve().drive
-        return path1_drive == path2_drive
-    # If either path is not a valid windows path, an OSError is raised.
     except OSError:
+        # If either path is not a valid Windows path, an OSError is raised.
         return False
+
+    return path1_drive == path2_drive
 
 
 # TODO(hugh): Deprecate version here and use wandb/sdk/lib/paths.py
@@ -1537,13 +1540,18 @@ def is_unicode_safe(stream: TextIO) -> bool:
 
 
 def _has_internet() -> bool:
-    """Attempt to open a DNS connection to Googles root servers."""
+    """Returns whether we have internet access.
+
+    Checks for internet access by attempting to open a DNS connection to
+    Google's root servers.
+    """
     try:
         s = socket.create_connection(("8.8.8.8", 53), 0.5)
         s.close()
-        return True
     except OSError:
         return False
+
+    return True
 
 
 def rand_alphanumeric(


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/try-consider-else/

The lint is a little misleading: it's not about preferring an `else` clause in `try-except` blocks, but about narrowing the scope of a `try-except`. So, for instance:

```python
try:
    result = do_something()
    do_something_else()
    return result
except DoSomethingError:
    return something_else
```

should really be written as

```python
try:
    result = do_something()
except DoSomethingError:
    return something_else

do_something_else()
return result
```

An `else` clause would be appropriate if the `except DoSomethingError` clause didn't return, or if it helps with readability by improving vertical alignment or flow of logic.

I fixed a few cases, and added ignores for the remaining violations. This at least prevents this kind of code in new files.