### PR TITLE
refactor: clean up `retry.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,6 @@ ignore-decorators = [
 "wandb/sdk/launch/runner/kubernetes_runner.py" = ["TRY300"]
 "wandb/sdk/launch/sweeps/scheduler.py" = ["TRY300"]
 "wandb/sdk/launch/utils.py" = ["TRY300"]
-"wandb/sdk/lib/retry.py" = ["TRY300"]
 "wandb/sklearn/**" = ["B010", "B011", "N803", "N806", "UP031"]
 "wandb/wandb_controller.py" = ["N806"]
 "wandb/wandb_torch.py" = ["C901", "D", "E741", "F841"]


### PR DESCRIPTION
Simplifies the implementation of `Retry.__call__` by extracting the stateful part into a `_RetryLoop` object and other parts into helper methods. This fixes the `C901` (complexity) and `TRY300` (large try-except scope) lint findings. I also documented the keyword parameters on `__call__` and replaced the strange `kwargs.pop()` pattern by actual keyword parameters.