### PR TITLE
chore(artifacts): show error messages from server in artifacts and automations api

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,7 +35,7 @@ This version removes the ability to disable the `service` process. This is a bre
 ### Changed
 
 - Various APIs now raise `TypeError` instead of `ValueError` or other generic errors when given an argument of the wrong type. (@timoffex in https://github.com/wandb/wandb/pull/9902)
-- Various Artifacts and Automations APIs now raise `CommError` instead of `ValueErrors` upon encountering server errors, so as to surface the server error message. (@ibindlish in https://github.com/wandb/wandb/pull/9933)
+- Various Artifacts and Automations APIs now raise `CommError` instead of `ValueError` upon encountering server errors, so as to surface the server error message. (@ibindlish in https://github.com/wandb/wandb/pull/9933)
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@ This version removes the ability to disable the `service` process. This is a bre
 ### Changed
 
 - Various APIs now raise `TypeError` instead of `ValueError` or other generic errors when given an argument of the wrong type. (@timoffex in https://github.com/wandb/wandb/pull/9902)
+- Various Artifacts and Automations APIs now raise `CommError` instead of `ValueErrors` upon encountering server errors, so as to surface the server error message. (@ibindlish in https://github.com/wandb/wandb/pull/9933)
 
 ### Changed
 

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -15,9 +15,9 @@ import requests
 import responses
 import wandb
 import wandb.data_types as data_types
-from wandb.errors.errors import CommError
 import wandb.sdk.artifacts.artifact_file_cache as artifact_file_cache
 from wandb import Artifact, util
+from wandb.errors.errors import CommError
 from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 from wandb.sdk.artifacts._validators import (
     ARTIFACT_NAME_MAXLEN,

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -15,6 +15,7 @@ import requests
 import responses
 import wandb
 import wandb.data_types as data_types
+from wandb.errors.errors import CommError
 import wandb.sdk.artifacts.artifact_file_cache as artifact_file_cache
 from wandb import Artifact, util
 from wandb.sdk.artifacts._internal_artifact import InternalArtifact
@@ -1646,11 +1647,11 @@ def test_change_artifact_collection_type_to_internal_type(user):
     collection = artifact.collection
     with wandb.init() as run:
         # test deprecated change_type errors for changing to internal type
-        with pytest.raises(ValueError, match="is reserved for internal use"):
+        with pytest.raises(CommError, match="is reserved for internal use"):
             collection.change_type(internal_type)
 
         # test .save()
-        with pytest.raises(ValueError, match="is reserved for internal use"):
+        with pytest.raises(CommError, match="is reserved for internal use"):
             collection.type = internal_type
             collection.save()
 
@@ -1665,13 +1666,13 @@ def test_change_type_of_internal_artifact_collection(user):
     with wandb.init() as run:
         # test deprecated change_type
         with pytest.raises(
-            ValueError, match="is an internal type and cannot be changed"
+            CommError, match="is an internal type and cannot be changed"
         ):
             collection.change_type("model")
 
         # test .save()
         with pytest.raises(
-            ValueError, match="is an internal type and cannot be changed"
+            CommError, match="is an internal type and cannot be changed"
         ):
             collection.type = "model"
             collection.save()

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -4,7 +4,6 @@ import math
 from collections import deque
 from typing import Any, Callable
 
-import requests
 import wandb
 from pytest import FixtureRequest, fixture, mark, raises, skip
 from wandb.apis.public import ArtifactCollection, Project

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -25,6 +25,7 @@ from wandb.automations import (
 from wandb.automations.actions import SavedNoOpAction, SavedWebhookAction
 from wandb.automations.events import RunMetricFilter
 from wandb.automations.scopes import ArtifactCollectionScopeTypes
+from wandb.errors.errors import CommError
 
 
 @fixture
@@ -145,7 +146,7 @@ def test_create_existing_automation_raises_by_default_if_existing(
         (event >> action),
         name=automation_name,
     )
-    with raises(ValueError):
+    with raises(CommError):
         api.create_automation((event >> action), name=created.name)
 
     # Fetching the automation by name should return the original automation,
@@ -296,7 +297,7 @@ def test_create_automation_for_run_metric_change_event(
     server_supports_event = api._supports_automation(event=event.event_type)
 
     if not server_supports_event:
-        with raises(ValueError):
+        with raises(CommError):
             api.create_automation(
                 (event >> action), name=automation_name, description="test description"
             )
@@ -364,15 +365,15 @@ def test_automation_cannot_be_deleted_again(
         api.automation(name=automation_name)
 
     # Deleting the automation again (by object or ID) should raise the same error
-    with raises(requests.HTTPError):
+    with raises(CommError):
         api.delete_automation(created_automation)
-    with raises(requests.HTTPError):
+    with raises(CommError):
         api.delete_automation(created_automation.id)
 
 
 @mark.usefixtures(reset_automations.__name__)
 def test_delete_automation_raises_on_invalid_id(api: wandb.Api):
-    with raises(requests.HTTPError):
+    with raises(CommError):
         api.delete_automation("invalid-automation-id")
 
 
@@ -543,7 +544,7 @@ class TestUpdateAutomation:
         """Updating automation scope to an artifact collection fails if the event type doesn't support it."""
         assert old_automation.event.event_type == event_type  # Consistency check
 
-        with raises(requests.HTTPError):
+        with raises(CommError):
             old_automation.scope = artifact_collection
             api.update_automation(old_automation)
 

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -237,7 +237,7 @@ def test_create_automation_for_run_metric_threshold_event(
     server_supports_event = api._supports_automation(event=event.event_type)
 
     if not server_supports_event:
-        with raises(ValueError):
+        with raises(CommError):
             api.create_automation(
                 (event >> action), name=automation_name, description="test description"
             )

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1934,6 +1934,7 @@ class Api:
             iterator = filter(lambda x: x.name == name, iterator)
         yield from iterator
 
+    @normalize_exceptions
     def create_automation(
         self,
         obj: "NewAutomation",
@@ -2040,6 +2041,7 @@ class Api:
 
         return Automation.model_validate(result.trigger)
 
+    @normalize_exceptions
     def update_automation(
         self,
         obj: "Automation",
@@ -2161,6 +2163,7 @@ class Api:
 
         return Automation.model_validate(result.trigger)
 
+    @normalize_exceptions
     def delete_automation(self, obj: Union["Automation", str]) -> Literal[True]:
         """Delete an automation.
 

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -373,6 +373,7 @@ class ArtifactCollection:
             self._attrs = collection.model_dump(exclude_unset=True)
         return self._attrs
 
+    @normalize_exceptions
     def change_type(self, new_type: str) -> None:
         """Deprecated, change type directly with `save` instead."""
         deprecate.deprecate(
@@ -513,6 +514,7 @@ class ArtifactCollection:
             },
         )
 
+    @normalize_exceptions
     def save(self) -> None:
         """Persist any changes made to the artifact collection."""
         if self._saved_type != self.type:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3043,6 +3043,7 @@ class Run:
         response = result.response.link_artifact_response
         if response.error_message:
             wandb.termerror(response.error_message)
+            return None
         if response.version_index is None:
             wandb.termerror(
                 "Error fetching the linked artifact's version index after linking"


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

  - Adds the `@normalize_exceptions` decorator to some automations and artifacts api methods so that server errors are printed when errors are raised
  - Doesn't query for the linked version upon encountering an error from the server

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
