### PR TITLE
refactor: use `shutil.which()` instead of find_executable() from dockerpycreds

### DIFF
--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -30,7 +30,8 @@ def docker(request, mocker, monkeypatch):
         "wandb.apis.InternalApi.api_key", new_callable=mocker.PropertyMock
     )
     api_key.return_value = "test"
-    monkeypatch.setattr(cli, "find_executable", lambda name: True)
+    monkeypatch.setattr(cli, "_HAS_NVIDIA_DOCKER", True)
+    monkeypatch.setattr(cli, "_HAS_DOCKER", True)
     old_call = subprocess.call
 
     def new_call(command, **kwargs):
@@ -262,7 +263,7 @@ def test_docker_run_bad_image(runner, docker, monkeypatch):
 
 
 def test_docker_run_no_nvidia(runner, docker, monkeypatch):
-    monkeypatch.setattr(cli, "find_executable", lambda name: False)
+    monkeypatch.setattr(cli, "_HAS_NVIDIA_DOCKER", False)
     result = runner.invoke(cli.docker_run, ["run", "-v", "cool:/cool", "rad"])
     assert result.exit_code == 0
     docker.assert_called_once_with(

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -20,9 +20,6 @@ import click
 import yaml
 from click.exceptions import ClickException
 
-# pycreds has a find_executable that works in windows
-from dockerpycreds.utils import find_executable
-
 import wandb
 import wandb.env
 import wandb.errors
@@ -67,6 +64,9 @@ logging.basicConfig(
 )
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("wandb")
+
+_HAS_DOCKER = bool(shutil.which("docker"))
+_HAS_NVIDIA_DOCKER = bool(shutil.which("nvidia-docker"))
 
 # Click Contexts
 CONTEXT = {"default_map": {}}
@@ -1970,9 +1970,7 @@ def docker_run(ctx, docker_run_args):
     args = list(docker_run_args)
     if len(args) > 0 and args[0] == "run":
         args.pop(0)
-    if len([a for a in args if a.startswith("--runtime")]) == 0 and find_executable(
-        "nvidia-docker"
-    ):
+    if len([a for a in args if a.startswith("--runtime")]) == 0 and _HAS_NVIDIA_DOCKER:
         args = ["--runtime", "nvidia"] + args
     #  TODO: image_from_docker_args uses heuristics to find the docker image arg, there are likely cases
     #  where this won't work
@@ -2001,7 +1999,7 @@ def docker_run(ctx, docker_run_args):
 @click.argument("docker_image", required=False)
 @click.option(
     "--nvidia/--no-nvidia",
-    default=find_executable("nvidia-docker") is not None,
+    default=_HAS_NVIDIA_DOCKER,
     help="Use the nvidia runtime, defaults to nvidia if nvidia-docker is present",
 )
 @click.option(
@@ -2058,7 +2056,7 @@ def docker(
     variable to an existing docker run command, see the wandb docker-run command.
     """
     api = InternalApi()
-    if not find_executable("docker"):
+    if not _HAS_DOCKER:
         raise ClickException("Docker not installed, install it from https://docker.com")
     args = list(docker_run_args)
     image = docker_image or ""
@@ -2185,7 +2183,7 @@ def server():
 @display_error
 def start(ctx, port, env, daemon, upgrade, edge):
     api = InternalApi()
-    if not find_executable("docker"):
+    if not _HAS_DOCKER:
         raise ClickException("Docker not installed, install it from https://docker.com")
     local_image_sha = wandb.docker.image_id("wandb/local").split("wandb/local")[-1]
     registry_image_sha = wandb.docker.image_id_from_registry("wandb/local").split(
@@ -2255,7 +2253,7 @@ def start(ctx, port, env, daemon, upgrade, edge):
 
 @server.command(context_settings=RUN_CONTEXT, help="Stop a local W&B server")
 def stop():
-    if not find_executable("docker"):
+    if not _HAS_DOCKER:
         raise ClickException("Docker not installed, install it from https://docker.com")
     subprocess.call(["docker", "stop", "wandb-local"])
 

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import os
+import shutil
 import subprocess
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
-from dockerpycreds.utils import find_executable  # type: ignore
 
 from wandb.docker import auth, www_authenticate
 from wandb.errors import Error
@@ -74,7 +74,7 @@ def is_buildx_installed() -> bool:
     global _buildx_installed
     if _buildx_installed is not None:
         return _buildx_installed  # type: ignore
-    if not find_executable("docker"):
+    if not shutil.which("docker"):
         _buildx_installed = False
     else:
         help_output = shell(["buildx", "--help"])

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -4,9 +4,8 @@ import logging
 import os
 import pathlib
 import shlex
+import shutil
 from typing import Any, Dict, List, Tuple
-
-from dockerpycreds.utils import find_executable  # type: ignore
 
 import wandb
 import wandb.env
@@ -38,7 +37,7 @@ _WANDB_DOCKERFILE_NAME = "Dockerfile.wandb"
 
 async def validate_docker_installation() -> None:
     """Verify if Docker is installed on host machine."""
-    find_exec = event_loop_thread_exec(find_executable)
+    find_exec = event_loop_thread_exec(shutil.which)
     if not await find_exec("docker"):
         raise ExecutionError(
             "Could not find Docker executable. "

--- a/wandb/sdk/launch/runner/abstract.py
+++ b/wandb/sdk/launch/runner/abstract.py
@@ -6,12 +6,11 @@ of runs launched in different environments (e.g. runs launched locally or in a c
 
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Literal, Optional, Union
-
-from dockerpycreds.utils import find_executable  # type: ignore
 
 import wandb
 from wandb.apis.internal import Api
@@ -145,10 +144,11 @@ class AbstractRunner(ABC):
         self._namespace = runid.generate_id()
 
     def find_executable(
-        self, cmd: str
-    ) -> Any:  # should return a string, but mypy doesn't trust find_executable
+        self,
+        cmd: str,
+    ) -> Union[str, None]:
         """Cross platform utility for checking if a program is available."""
-        return find_executable(cmd)
+        return shutil.which(cmd)
 
     @property
     def api_key(self) -> Any:


### PR DESCRIPTION
The `find_executable()` in `dockerpycreds` used to wrap `distutils.spawn.find_executable()` to additionally handle `PATH_EXT` on Windows, which is why we used it according to comments in the code. The replacement suggested by [PEP 0632](https://peps.python.org/pep-0632/#migration-advice) is `shutil.which()` which appears to have logic using `PATH_EXT` (at least in Python 3.10).
