### PR TITLE
fix(artifacts): sanitize names of all internal artifacts

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -56,4 +56,5 @@ This version removes the ability to disable the `service` process. This is a bre
 - Log exception as string when raising exception in Job wait_until_running method (@KyleGoyette in https://github.com/wandb/wandb/pull/9607)
 - `wandb.Image` initialized with tensorflow data would be normalized differently than when initialized with a numpy array (@jacobromero in https://github.com/wandb/wandb/pull/9883)
 - Using `wandb login` no longer prints a warning about `wandb.require("legacy-service")` (@timoffex in https://github.com/wandb/wandb/pull/9912)
+- Logging a `Table` (or other objects that create internal artifacts) no longer raises `ValueError` when logged from a run whose ID contains special characters.  (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9943)
 - `wandb.Api` initialized with the `base_url` now respects the provided url, rather than the last login url (@jacobromero in https://github.com/wandb/wandb/pull/9942)

--- a/tests/system_tests/test_artifacts/test_data_types.py
+++ b/tests/system_tests/test_artifacts/test_data_types.py
@@ -66,6 +66,22 @@ def test_log_dataframe(user, test_settings):
     assert len(run.logged_artifacts()) == 1
 
 
+@pytest.mark.parametrize("log_mode", ["IMMUTABLE", "MUTABLE", "INCREMENTAL"])
+def test_table_logged_from_run_with_special_characters_in_name(
+    user, test_settings, log_mode
+):
+    name_and_id = "random-run-id-=1234567-seed-0"  # Contains special characters
+
+    with wandb.init(name=name_and_id, id=name_and_id) as run:
+        table = wandb.Table(
+            ["col1", "col2", "col3"],
+            [[1, 4.6, "hello"], [5, 4.5, "world"]],
+            allow_mixed_types=True,
+            log_mode=log_mode,
+        )
+        run.log({"my-table": table}, step=1)
+
+
 @pytest.mark.parametrize("max_cli_version", ["0.10.33", "0.11.0"])
 def test_reference_table_logging(
     user, test_settings, wandb_backend_spy, max_cli_version

--- a/wandb/sdk/artifacts/_internal_artifact.py
+++ b/wandb/sdk/artifacts/_internal_artifact.py
@@ -1,8 +1,22 @@
+import re
 from typing import Any, Dict, Final, Optional
 
 from wandb.sdk.artifacts.artifact import Artifact
 
 PLACEHOLDER: Final[str] = "PLACEHOLDER"
+
+
+def sanitize_artifact_name(name: str) -> str:
+    """Sanitize the string to satisfy constraints on artifact names."""
+    from wandb.sdk.lib.hashutil import _md5
+
+    # If the name is already sanitized, don't change it.
+    if (sanitized := re.sub(r"[^a-zA-Z0-9_\-.]+", "", name)) == name:
+        return name
+
+    # Append an alphanumeric suffix to maintain uniqueness of the name.
+    suffix = _md5(name.encode("utf-8")).hexdigest()
+    return f"{sanitized}-{suffix}"
 
 
 class InternalArtifact(Artifact):
@@ -22,5 +36,8 @@ class InternalArtifact(Artifact):
         incremental: bool = False,
         use_as: Optional[str] = None,
     ) -> None:
-        super().__init__(name, PLACEHOLDER, description, metadata, incremental, use_as)
+        sanitized_name = sanitize_artifact_name(name)
+        super().__init__(
+            sanitized_name, PLACEHOLDER, description, metadata, incremental, use_as
+        )
         self._type = type

--- a/wandb/sdk/data_types/utils.py
+++ b/wandb/sdk/data_types/utils.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import os
-import re
 from decimal import Decimal
 from typing import TYPE_CHECKING, Optional, Sequence, Union, cast
 
@@ -184,9 +183,6 @@ def _log_table_artifact(val: "Media", key: str, run: "LocalRun") -> None:
     """
     from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 
-    # Sanitize the key to meet the constraints of artifact names.
-    sanitized_key = re.sub(r"[^a-zA-Z0-9_\-.]+", "", key)
-
     if isinstance(val, wandb.Table) and val.log_mode == "INCREMENTAL":
         if (
             run.resumed
@@ -196,10 +192,10 @@ def _log_table_artifact(val: "Media", key: str, run: "LocalRun") -> None:
             val._load_incremental_table_state_from_resumed_run(run, key)
         else:
             val._set_incremental_table_run_target(run)
-        art = incremental_table_util.init_artifact(run, sanitized_key)
+        art = incremental_table_util.init_artifact(run, key)
         entry_name = incremental_table_util.get_entry_name(val, key)
     else:
-        art = InternalArtifact(f"run-{run.id}-{sanitized_key}", "run_table")
+        art = InternalArtifact(f"run-{run.id}-{key}", "run_table")
         entry_name = key
 
     art.add(val, entry_name)

--- a/wandb/sdk/internal/incremental_table_util.py
+++ b/wandb/sdk/internal/incremental_table_util.py
@@ -12,8 +12,10 @@ if TYPE_CHECKING:
 ART_TYPE = "wandb-run-incremental-table"
 
 
-def _get_artifact_name(run: LocalRun, sanitized_key: str) -> str:
-    return f"run-{run.id}-incr-{sanitized_key}"
+def _get_artifact_name(run: LocalRun, key: str) -> str:
+    from wandb.sdk.artifacts._internal_artifact import sanitize_artifact_name
+
+    return sanitize_artifact_name(f"run-{run.id}-incr-{key}")
 
 
 def init_artifact(run: LocalRun, sanitized_key: str) -> Artifact:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-25173](https://wandb.atlassian.net/browse/WB-25173), [WB-25176](https://wandb.atlassian.net/browse/WB-25176)

Ensures all instances of `InternalArtifact` have their names sanitized on instantiation.

Sanitized names are suffixed with an alphanumeric hash of the original name in order to maintain uniqueness / avoid collisions.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-25173]: https://wandb.atlassian.net/browse/WB-25173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WB-25176]: https://wandb.atlassian.net/browse/WB-25176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ