### PR TITLE
refactor: remove unnecessary summary encoding/decoding in filestream

### DIFF
--- a/core/internal/filestream/updatesummary.go
+++ b/core/internal/filestream/updatesummary.go
@@ -1,57 +1,24 @@
 package filestream
 
-import (
-	"fmt"
-	"time"
-
-	"github.com/wandb/wandb/core/internal/runsummary"
-	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
-)
+import "time"
 
 // SummaryUpdate contains a run's most recent summary.
 type SummaryUpdate struct {
-	Record *spb.SummaryRecord
+	SummaryJSON string
 }
 
 func (u *SummaryUpdate) Apply(ctx UpdateContext) error {
-	rs := runsummary.New()
-
-	for _, update := range u.Record.Update {
-		if err := rs.SetFromRecord(update); err != nil {
-			ctx.Logger.CaptureError(
-				fmt.Errorf(
-					"filestream: failed to apply summary record: %v",
-					err,
-				),
-				"key", update.Key,
-				"nested_key", update.NestedKey,
-			)
-		}
-	}
-
-	for _, remove := range u.Record.Remove {
-		rs.RemoveFromRecord(remove)
-	}
-
-	line, err := rs.Serialize()
-	if err != nil {
-		return fmt.Errorf(
-			"filestream: json unmarshal error in SummaryUpdate: %v",
-			err,
-		)
-	}
-
 	// Override the default max line length if the user has set a custom value.
 	maxLineBytes := ctx.Settings.GetFileStreamMaxLineBytes()
 	if maxLineBytes == 0 {
 		maxLineBytes = defaultMaxFileLineBytes
 	}
 
-	if len(line) > int(maxLineBytes) {
+	if len(u.SummaryJSON) > int(maxLineBytes) {
 		// Failing to upload the summary is non-blocking.
 		ctx.Logger.CaptureWarn(
 			"filestream: run summary line too long, skipping",
-			"len", len(line),
+			"len", len(u.SummaryJSON),
 			"max", maxLineBytes,
 		)
 		ctx.Printer.
@@ -59,12 +26,12 @@ func (u *SummaryUpdate) Apply(ctx UpdateContext) error {
 			Writef(
 				"Skipped uploading summary data that exceeded"+
 					" size limit (%d > %d).",
-				len(line),
+				len(u.SummaryJSON),
 				maxLineBytes,
 			)
 	} else {
 		ctx.MakeRequest(&FileStreamRequest{
-			LatestSummary: string(line),
+			LatestSummary: u.SummaryJSON,
 		})
 	}
 

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -872,16 +872,16 @@ func (s *Sender) streamSummary() {
 		return
 	}
 
-	update, err := s.runSummary.ToRecords()
+	summaryJSON, err := s.runSummary.Serialize()
 
-	// `update` may be non-empty even on error.
 	if err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: error flattening summary: %v", err))
+			fmt.Errorf("sender: error serializing summary: %v", err))
+		return
 	}
 
 	s.fileStream.StreamUpdate(&fs.SummaryUpdate{
-		Record: &spb.SummaryRecord{Update: update},
+		SummaryJSON: string(summaryJSON),
 	})
 }
 


### PR DESCRIPTION
Instead of converting a `RunSummary` to a list of records, then rebuilding it from the records and converting it to JSON, just convert it to JSON.