### PR TITLE
chore: fix error in unreleased changelog

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,4 +19,4 @@ This version removes the legacy implementaion of the `service` process. This is 
 
 ### Removed
 
-- Removed the legacy python implementation of the `service` process. The `legacy-service` option of `wandb.require` as well as the `x_require_legacy_service` and `x_disable_setproctitle` settings with the corresponding environment variable have been removed and will now raise an error if used (@dmitryduev in https://github.com/wandb/wandb/pull/9965)
+- Removed the legacy python implementation of the `service` process. The `legacy-service` option of `wandb.require` as well as the `x_require_legacy_service` and `x_disable_setproctitle` settings with the corresponding environment variables have been removed and will now raise an error if used (@dmitryduev in https://github.com/wandb/wandb/pull/9965)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,4 +19,4 @@ This version removes the legacy implementaion of the `service` process. This is 
 
 ### Removed
 
-- Removed the legacy python implementation of the `service` process. The `legacy-service`, `service` and `core` options of `wandb.require` as well as the `x_require_legacy_service` and `x_disable_setproctitle` settings with the corresponding environment variable have been removed and will now raise an error if used (@dmitryduev in https://github.com/wandb/wandb/pull/9965)
+- Removed the legacy python implementation of the `service` process. The `legacy-service` option of `wandb.require` as well as the `x_require_legacy_service` and `x_disable_setproctitle` settings with the corresponding environment variable have been removed and will now raise an error if used (@dmitryduev in https://github.com/wandb/wandb/pull/9965)


### PR DESCRIPTION
Description
-----------
I had to put the service and core options of wandb.require back in in #9965 for backwards compat, but didn't update the changelog.

