### PR TITLE
fix: restore original image normalization behavior

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,3 +20,7 @@ This version removes the legacy implementaion of the `service` process. This is 
 ### Removed
 
 - Removed the legacy python implementation of the `service` process. The `legacy-service` option of `wandb.require` as well as the `x_require_legacy_service` and `x_disable_setproctitle` settings with the corresponding environment variables have been removed and will now raise an error if used (@dmitryduev in https://github.com/wandb/wandb/pull/9965)
+
+### Fixed
+
+- `wandb.Image()` was broken in 0.20.0 when given NumPy arrays with values in the range [0, 1], now fixed (@timoffex in https://github.com/wandb/wandb/pull/9982)

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -419,6 +419,31 @@ def test_image_masks_with_pytorch_tensors():
     wandb.Image(image, masks={"predictions": {"mask_data": mask}})
 
 
+def test_image_normalize_neg1_to_1():
+    # Sometimes images are represented with values in range [-1, 1].
+    data = np.array([[-0.2, 0.6]])
+
+    transformed_data = wandb.Image(data).to_data_array()
+
+    assert transformed_data == [[102, 204]]
+
+
+def test_image_normalize_0_to_1():
+    data = np.array([[0.2, 0.3]])
+
+    transformed_data = wandb.Image(data).to_data_array()
+
+    assert transformed_data == [[51, 76]]
+
+
+def test_image_normalize_clips_bad_range():
+    data = np.array([[-9, 0.1, 100, 254.5, 270]])
+
+    transformed_data = wandb.Image(data).to_data_array()
+
+    assert transformed_data == [[0, 0, 100, 254, 255]]
+
+
 @pytest.mark.parametrize(
     "scale",
     [1e-8, 1e-5, 1e0, 1e1, -1e-8, -1e-5, -1e0, -1e1],


### PR DESCRIPTION
For comparison, the original code is [here](https://github.com/wandb/wandb/blob/fa9063d08d753434676e1cbe3206932faf839f23/wandb/sdk/data_types/image.py#L525-L533).

```python
        dmin = np.min(data)
        if dmin < 0:
            data = (data - np.min(data)) / np.ptp(data)
        if np.max(data) <= 1.0:
            data = (data * 255).astype(np.int32)

        return data.clip(0, 255).astype(np.uint8)
```

Note that this rescales [-1, 1] images to the _entire_ [0, 255] range mapping the image's minimum to 0 and its maximum to 255. For [0, 1] images, this simply multiplies them by 255.

After a refactor, PR #9883 changed the code to something almost similar, but with a bug:

```python
    if np.min(data) < 0:
        data = data - np.min(data)

    if np.ptp(data) != 0:
        data = data / np.ptp(data)

    if np.max(data) <= 1.0:
        data = (255 * data).astype(np.int32)

    return data.clip(0, 255)
```

For [0, 1] images this is broken: the first if statement gets skipped, but the second if statement usually matches. Take a grayscale 1x2 image `[[0.5, 0.6]]`: its `np.ptp` (peak-to-peak) value is 0.1, so dividing by it produces `[[5, 6]]` which is then returned, but the image's correct [0, 255] form is `[[127, 153]]`.

This PR restores the behavior for [0, 255] and [0, 1] images. I also took the liberty of changing the [-1, 1] behavior slightly: instead of mapping [min, max] to [0, 255], I map [-1, 1] to [0, 255]. I think this might have been the original intention; otherwise, images like `[[-0.1, 0.1]]` and `[[-0.8, 0.8]]` were both being converted to `[[0, 255]]`.

## Testing

```python
import numpy as np
import wandb

x = np.array([[0.68235186, 0.05382102],[0.22035987, 0.18437181]])
print(wandb.Image(x).to_data_array())
```

In wandb==0.20.0, this prints `[[1, 0], [0, 0]]`. With this PR, it correctly prints `[[173, 13], [56, 47]]`.