### PR TITLE
refactor: support Unix domain sockets on the client-side

### DIFF
--- a/tests/unit_tests/test_lib/test_service_token.py
+++ b/tests/unit_tests/test_lib/test_service_token.py
@@ -1,0 +1,47 @@
+import os
+import pathlib
+import socket
+
+import pytest
+from wandb.sdk.lib.service import service_token
+
+
+@pytest.fixture
+def chdir_to_tmp_path(tmp_path):
+    cwd = pathlib.Path.cwd()
+
+    os.chdir(tmp_path)
+    try:
+        yield
+    finally:
+        os.chdir(cwd)
+
+
+def test_unix_token(chdir_to_tmp_path):
+    # Unix socket paths are limited to ~100 characters, and tmp_path can be
+    # too long on some systems. So instead, we cd into it and use a relative
+    # path as the socket name.
+    _ = chdir_to_tmp_path
+
+    unix_listener = socket.socket(socket.AF_UNIX)
+    unix_listener.bind("socket")
+    unix_listener.listen(1)
+    with unix_listener:
+        token = service_token.UnixServiceToken(parent_pid=123, path="socket")
+
+        # Connection should succeed.
+        client = token.connect()
+        client.close()
+
+
+def test_tcp_token():
+    tcp_listener = socket.socket(socket.AF_INET)
+    tcp_listener.bind(("127.0.0.1", 0))
+    tcp_listener.listen(1)
+    with tcp_listener:
+        _, port = tcp_listener.getsockname()
+        token = service_token.TCPServiceToken(parent_pid=123, port=port)
+
+        # Connection should succeed.
+        client = token.connect()
+        client.close()

--- a/wandb/sdk/lib/sock_client.py
+++ b/wandb/sdk/lib/sock_client.py
@@ -79,17 +79,17 @@ class SockBuffer:
 
 
 class SockClient:
-    _sock: socket.socket
-    _sockid: str
-    _retry_delay: float
-    _lock: "threading.Lock"
-    _bufsize: int
-    _buffer: SockBuffer
-
     # current header is magic byte "W" followed by 4 byte length of the message
     HEADLEN = 1 + 4
 
-    def __init__(self) -> None:
+    def __init__(self, sock: socket.socket) -> None:
+        """Create a SockClient.
+
+        Args:
+            sock: A connected socket.
+        """
+        self._sock = sock
+
         # TODO: use safe uuid's (python3.7+) or emulate this
         self._sockid = uuid.uuid4().hex
         self._retry_delay = 0.1
@@ -97,10 +97,6 @@ class SockClient:
         self._bufsize = 4096
         self._buffer = SockBuffer()
 
-    def connect(self, port: int) -> None:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.connect(("localhost", port))
-        self._sock = s
         self._detect_bufsize()
 
     def _detect_bufsize(self) -> None:


### PR DESCRIPTION
Adds support for Unix domain sockets in Python. Since the server does not emit such sockets yet, this code never runs (except in unit tests!)