### PR TITLE
refactor: use Unix domain sockets to connect to wandb-core

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 This version removes the legacy implementaion of the `service` process. This is a breaking change.
 
+### Changed
+
+- `wandb` now attempts to use Unix sockets for IPC instead of listening on localhost, making it work in environments with more restrictive permissions (such as Databricks) (@timoffex in https://github.com/wandb/wandb/pull/9995)
+
 ### Removed
 
 - Removed the legacy python implementation of the `service` process. The `legacy-service` option of `wandb.require` as well as the `x_require_legacy_service` and `x_disable_setproctitle` settings with the corresponding environment variables have been removed and will now raise an error if used (@dmitryduev in https://github.com/wandb/wandb/pull/9965)

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -38,6 +38,10 @@ func mainWithExitCode() int {
 		"Enables automatic server shutdown when the external process identified by the PID terminates.")
 	enableDCGMProfiling := flag.Bool("enable-dcgm-profiling", false,
 		"Enables collection of profiling metrics for Nvidia GPUs using DCGM. Requires a running `nvidia-dcgm` service.")
+	listenOnLocalhost := flag.Bool("listen-on-localhost", false,
+		"Whether to listen on a localhost socket. This is less secure than"+
+			" Unix sockets, but some clients do not support them"+
+			" (in particular, Python on Windows).")
 
 	// Custom usage function to add a header, version, and commit info
 	flag.Usage = func() {
@@ -110,6 +114,7 @@ func mainWithExitCode() int {
 		server.ServerParams{
 			Commit:              commit,
 			EnableDCGMProfiling: *enableDCGMProfiling,
+			ListenOnLocalhost:   *listenOnLocalhost,
 			LoggerPath:          loggerPath,
 			LogLevel:            slog.Level(*logLevel),
 			ParentPID:           *pid,

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -32,6 +32,8 @@ type ConnectionParams struct {
 	StreamMux          *stream.StreamMux
 	GPUResourceManager *monitor.GPUResourceManager
 
+	ID string
+
 	Conn         net.Conn
 	SentryClient *sentry_ext.Client
 	Commit       string
@@ -102,7 +104,7 @@ func NewConnection(
 		gpuResourceManager: params.GPUResourceManager,
 		conn:               params.Conn,
 		commit:             params.Commit,
-		id:                 params.Conn.RemoteAddr().String(), // TODO: check if this is properly unique
+		id:                 params.ID,
 		inChan:             make(chan *spb.ServerRequest, BufferSize),
 		outChan:            make(chan *spb.ServerResponse, BufferSize),
 		closed:             &atomic.Bool{},

--- a/core/pkg/server/listeners/listeners.go
+++ b/core/pkg/server/listeners/listeners.go
@@ -1,0 +1,62 @@
+// Package listeners opens listening sockets for IPC.
+package listeners
+
+import (
+	"errors"
+	"log/slog"
+	"net"
+)
+
+// Config contains the parameters for MakeListeners().
+type Config struct {
+	// ParentPID is the PID of our parent process, used for naming Unix sockets.
+	ParentPID int
+
+	// ListenOnLocalhost ensures that we open a localhost socket
+	// in addition to any other IPC mechanisms that work.
+	//
+	// These sockets are less secure than Unix sockets: Unix sockets use
+	// the file permission system, so that only processes running as the same
+	// user can connect to the socket, but anyone can connect to a localhost
+	// socket.
+	//
+	// Unfortunately, not all clients support Unix sockets.
+	ListenOnLocalhost bool
+}
+
+// MakeListeners creates listeners for interprocess communication.
+func (c Config) MakeListeners() ([]net.Listener, PortInfo, error) {
+	var listeners []net.Listener
+	var portInfo PortInfo
+	var errs []error
+
+	unixListener, err := makeUnixListener(c.ParentPID, &portInfo)
+	if err != nil {
+		errs = append(errs, err)
+	} else {
+		listeners = append(listeners, unixListener)
+	}
+
+	if c.ListenOnLocalhost || unixListener == nil {
+		tcpListener, err := makeTCPListener(&portInfo)
+
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			listeners = append(listeners, tcpListener)
+		}
+	}
+
+	if len(listeners) == 0 {
+		return nil, portInfo, errors.Join(errs...)
+	}
+
+	if len(errs) > 0 {
+		slog.Warn(
+			"server/listeners: failed to make some listeners",
+			"error", errors.Join(errs...),
+		)
+	}
+
+	return listeners, portInfo, nil
+}

--- a/core/pkg/server/listeners/portinfo.go
+++ b/core/pkg/server/listeners/portinfo.go
@@ -1,4 +1,4 @@
-package server
+package listeners
 
 import (
 	"fmt"
@@ -6,6 +6,12 @@ import (
 )
 
 type PortInfo struct {
+	// UnixPath is the path of a Unix domain socket for connecting to
+	// the server.
+	//
+	// An empty string means a Unix domain socket cannot be used to connect.
+	UnixPath string
+
 	// LocalhostPort is the port for connecting to the server via localhost.
 	//
 	// The zero value means localhost cannot be used to connect.
@@ -24,7 +30,7 @@ func (info PortInfo) WriteToFile(path string) error {
 	}
 
 	if err := os.Rename(tempFile, path); err != nil {
-		return fmt.Errorf("server: rename port file: %v", err)
+		return fmt.Errorf("server/listeners: rename port file: %v", err)
 	}
 
 	return nil
@@ -34,24 +40,30 @@ func (info PortInfo) WriteToFile(path string) error {
 func (info PortInfo) writeToNewFile(path string) (err error) {
 	f, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("server: create port file: %v", err)
+		return fmt.Errorf("server/listeners: create port file: %v", err)
 	}
 
 	defer func() {
 		closeErr := f.Close()
 		if err == nil && closeErr != nil {
-			err = fmt.Errorf("server: close port file: %v", closeErr)
+			err = fmt.Errorf("server/listeners: close port file: %v", closeErr)
 		}
 	}()
 
+	if info.UnixPath != "" {
+		if _, err = fmt.Fprintf(f, "unix=%s\n", info.UnixPath); err != nil {
+			return fmt.Errorf(
+				"server/listeners: write Unix path to port file: %v", err)
+		}
+	}
 	if info.LocalhostPort != 0 {
 		if _, err = fmt.Fprintf(f, "sock=%d\n", info.LocalhostPort); err != nil {
-			return fmt.Errorf("server: write port to port file: %v", err)
+			return fmt.Errorf("server/listeners: write port to port file: %v", err)
 		}
 	}
 
 	if _, err = f.WriteString("EOF"); err != nil {
-		return fmt.Errorf("server: write EOF to port file: %v", err)
+		return fmt.Errorf("server/listeners: write EOF to port file: %v", err)
 	}
 
 	return nil

--- a/core/pkg/server/listeners/tcplistener.go
+++ b/core/pkg/server/listeners/tcplistener.go
@@ -1,0 +1,18 @@
+package listeners
+
+import (
+	"fmt"
+	"net"
+)
+
+// makeTCPListener starts listening on a localhost socket.
+func makeTCPListener(portInfo *PortInfo) (net.Listener, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf(
+			"server/listeners: failed to listen on localhost: %v", err)
+	}
+
+	portInfo.LocalhostPort = listener.Addr().(*net.TCPAddr).Port
+	return listener, nil
+}

--- a/core/pkg/server/listeners/unixlistener_common.go
+++ b/core/pkg/server/listeners/unixlistener_common.go
@@ -1,0 +1,55 @@
+package listeners
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// listenInTempDir attempts to listen on a path constructed from os.TempDir().
+//
+// This is preferred over /tmp on macOS, but it may not work if the temporary
+// directory is very long because Unix sockets are generally limited to 92-108
+// characters.
+func listenInTempDir(
+	namePattern string,
+	portInfo *PortInfo,
+) (net.Listener, error) {
+	sockDir, err := makeUniqueDir(os.TempDir(), namePattern)
+
+	if err != nil {
+		return nil, fmt.Errorf(
+			"server/listeners: failed to make tempdir for Unix socket: %v", err)
+	}
+
+	return listenUnix(filepath.Join(sockDir, "socket"), portInfo)
+}
+
+// makeUniqueDir creates a unique directory as os.MkdirTemp().
+//
+// This is necessary to avoid conflicts with other processes. We couldn't just
+// use "/tmp/wandb-<pid>" as the socket name, for instance, because another
+// process (maybe another W&B product) could rely on a "/tmp/wandb-<number>"
+// file.
+//
+// The directory's default permissions (0o700) mean the socket will be
+// accessible only by programs running as the same user. wandb-core runs as
+// the user of the Python process that started it.
+func makeUniqueDir(dir string, namePattern string) (string, error) {
+	return os.MkdirTemp(dir, namePattern)
+}
+
+// listenUnix attempts to listen on a Unix socket with the given path.
+func listenUnix(path string, portInfo *PortInfo) (net.Listener, error) {
+	listener, err := net.Listen("unix", path)
+
+	if err != nil {
+		return nil, fmt.Errorf(
+			"server/listeners: failed to open Unix socket on %q: %v",
+			path, err)
+	}
+
+	portInfo.UnixPath = path
+	return listener, nil
+}

--- a/core/pkg/server/listeners/unixlistener_unix.go
+++ b/core/pkg/server/listeners/unixlistener_unix.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package listeners
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// makeUnixListener starts listening on a Unix domain socket.
+//
+// This tries os.TempDir() and /tmp on Unix-like systems. We don't try
+// /var/run because it usually requires root permissions.
+func makeUnixListener(parentPID int, portInfo *PortInfo) (net.Listener, error) {
+	namePattern := fmt.Sprintf("wandb-%d-%d-*", parentPID, os.Getpid())
+
+	listener, err := listenInTempDir(namePattern, portInfo)
+	if err == nil {
+		return listener, nil
+	}
+	slog.Warn(
+		"server/listeners: couldn't open Unix socket in os.TempDir()",
+		"error", err,
+	)
+
+	return listenInTmp(namePattern, portInfo)
+}
+
+// listenInTmp attemps to listen on a path under /tmp.
+//
+// On macOS, os.TempDir() points to a per-user temporary folder under
+// /var/folders (with more secure permissions than /tmp) but the path may be too
+// long.
+func listenInTmp(namePattern string, portInfo *PortInfo) (net.Listener, error) {
+	sockDir, err := makeUniqueDir("/tmp", namePattern)
+
+	if err != nil {
+		return nil, fmt.Errorf(
+			"server/listeners: failed to make folder in /tmp for Unix socket: %v",
+			err,
+		)
+	}
+
+	return listenUnix(filepath.Join(sockDir, "socket"), portInfo)
+}

--- a/core/pkg/server/listeners/unixlistener_windows.go
+++ b/core/pkg/server/listeners/unixlistener_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package listeners
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// makeUnixListener starts listening on a Unix domain socket.
+func makeUnixListener(parentPID int, portInfo *PortInfo) (net.Listener, error) {
+	namePattern := fmt.Sprintf("wandb-%d-%d-*", parentPID, os.Getpid())
+	return listenInTempDir(namePattern, portInfo)
+}

--- a/tests/unit_tests/test_lib/test_service_token.py
+++ b/tests/unit_tests/test_lib/test_service_token.py
@@ -3,7 +3,7 @@ import pathlib
 import socket
 
 import pytest
-from wandb.sdk.lib.service import service_token
+from wandb.sdk.lib.service import ipc_support, service_token
 
 
 @pytest.fixture
@@ -17,6 +17,10 @@ def chdir_to_tmp_path(tmp_path):
         os.chdir(cwd)
 
 
+@pytest.mark.skipif(
+    not ipc_support.SUPPORTS_UNIX,
+    reason="AF_UNIX sockets not supported",
+)
 def test_unix_token(chdir_to_tmp_path):
     # Unix socket paths are limited to ~100 characters, and tmp_path can be
     # too long on some systems. So instead, we cd into it and use a relative

--- a/wandb/sdk/lib/service/ipc_support.py
+++ b/wandb/sdk/lib/service/ipc_support.py
@@ -1,0 +1,13 @@
+"""Constants determining what IPC methods are supported."""
+
+import socket
+
+SUPPORTS_UNIX = hasattr(socket, "AF_UNIX")
+"""Whether Unix sockets are supported.
+
+AF_UNIX is not supported on Windows:
+https://github.com/python/cpython/issues/77589
+
+Windows has supported Unix sockets since ~2017, but support in Python is
+missing as of 2025.
+"""

--- a/wandb/sdk/lib/service/service_process.py
+++ b/wandb/sdk/lib/service/service_process.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from wandb import _sentry
 from wandb.env import core_debug, dcgm_profiling_enabled, error_reporting_enabled
 from wandb.errors import WandbCoreNotAvailableError
+from wandb.sdk.lib.service import ipc_support
 from wandb.util import get_core_path
 
 from . import service_port_file, service_token
@@ -87,12 +88,11 @@ def _launch_server(settings: Settings) -> ServiceProcess:
         if dcgm_profiling_enabled():
             service_args.append("--enable-dcgm-profiling")
 
-        service_args += [
-            "--port-filename",
-            str(port_file),
-            "--pid",
-            pid,
-        ]
+        service_args.extend(["--port-filename", str(port_file)])
+        service_args.extend(["--pid", pid])
+
+        if not ipc_support.SUPPORTS_UNIX:
+            service_args.append("--listen-on-localhost")
 
         proc = subprocess.Popen(
             service_args,

--- a/wandb/sdk/lib/service/service_token.py
+++ b/wandb/sdk/lib/service/service_token.py
@@ -8,6 +8,7 @@ import socket
 from typing_extensions import final, override
 
 from wandb import env
+from wandb.sdk.lib.service import ipc_support
 from wandb.sdk.lib.sock_client import SockClient
 
 _CURRENT_VERSION = "3"
@@ -81,6 +82,9 @@ class UnixServiceToken(ServiceToken):
 
     @override
     def connect(self) -> SockClient:
+        if not ipc_support.SUPPORTS_UNIX:
+            raise WandbServiceConnectionError("AF_UNIX socket not supported")
+
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
         try:


### PR DESCRIPTION
Fixes WB-25232, WB-25245, WB-25138, WB-11895

Makes `wandb-core` listen on a Unix domain socket if possible and fall back to a localhost socket if not.

~After confirming that Unix domain sockets work in all environments we support, we should drop the localhost fallback as it could be a security issue (or check the peer's UID and refuse connections from mismatched UIDs)~ (UPDATE: Python on Windows does not support Unix sockets, so localhost sockets will remain). The reason is that it bypasses the permission model, letting processes running as different users send messages to the server. This creates a potential pathway for such processes to affect the user's script. This is probably why connections to localhost sockets are blocked in some Databricks environments.

Unix domain sockets should work on Linux, macOS ~and updated Windows versions (after \~2017)~ (they work on Windows, but not supported in Python). Reasons this code could fail include:

* If we don't have read/write permissions for `os.TempDir()` or `/tmp`
* If the socket's path is too long (apparently, on some systems the limit [may be 92 bytes](https://man7.org/linux/man-pages/man7/unix.7.html))
    * On my macOS, the `os.TempDir()` is "/var/folders/v0/mtcq4gwj13q7lzyj4fsq5hz40000gp/T/", resulting in an 85-character path
    * The fallback to `/tmp` on Unix-like systems should help
