### PR TITLE
chore(launch): expose wandb config to auxiliary resources

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -577,8 +577,10 @@ class KubernetesRunner(AbstractRunner):
         env_vars = launch_project.get_env_vars_dict(
             self._api, MAX_ENV_LENGTHS[self.__class__.__name__]
         )
-
-        add_wandb_env(config, env_vars.get("WANDB_CONFIG", {}))
+        wandb_config_env = {
+            "WANDB_CONFIG": env_vars.get("WANDB_CONFIG", "{}"),
+        }
+        add_wandb_env(config, wandb_config_env)
 
         await kubernetes_asyncio.utils.create_from_dict(
             api_client, config, namespace=namespace


### PR DESCRIPTION
## Description

Adds `WANDB_CONFIG` to auxiliary resources. To test, I created an additional resource in my [queue config](https://wandb.ai/wandb/launch/UnVuUXVldWU6NTk0NzI5MQ==/config) that runs the following code and verified that the config is accessible
```
echo "=== All Environment Variables ==="
env | sort
echo ""
echo "=== WANDB_CONFIG specifically ==="
echo "WANDB_CONFIG: $WANDB_CONFIG"
echo ""
echo "=== WANDB Variables ==="
env | grep WANDB | sort
echo "=== Test Complete ==="
```

Recording verifying the above:

https://github.com/user-attachments/assets/e9547f57-8ae3-46f2-9b18-e416e1095cba

--- 

Additionally, here's the resource spec that I added:
```
kind: Job
spec:
  template:
    spec:
      containers:
        - args:
            - -c
            - |
              echo "=== All Environment Variables ==="
              env | sort
              echo ""
              echo "=== WANDB_CONFIG specifically ==="
              echo "WANDB_CONFIG: $WANDB_CONFIG"
              echo ""
              echo "=== WANDB Variables ==="
              env | grep WANDB | sort
              echo "=== Test Complete ==="
          name: env-printer
          image: busybox:1.35
          command:
            - /bin/sh
      restartPolicy: Never
  backoffLimit: 4
metadata:
  name: test-wandb-config
  labels:
    app: wandb-config-test
apiVersion: batch/v1
```


