### PR TITLE
chore(artifacts): fix artifacts test to match on updated error message

### DIFF
--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -681,7 +681,6 @@ def test_log_and_download_with_path_prefix(user, tmp_path):
     assert (download_dir / "other-thing.txt").is_file()
 
 
-@pytest.mark.skip(reason="This test is failing in CI")
 def test_retrieve_missing_artifact(logged_artifact):
     with pytest.raises(CommError, match="project 'bar' not found"):
         Api().artifact(f"foo/bar/{logged_artifact.name}")

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -688,10 +688,10 @@ def test_retrieve_missing_artifact(logged_artifact):
     with pytest.raises(CommError, match="project 'bar' not found"):
         Api().artifact(f"{logged_artifact.entity}/bar/{logged_artifact.name}")
 
-    with pytest.raises(CommError, match="must be specified as 'collection:alias'"):
+    with pytest.raises(CommError):
         Api().artifact(f"{logged_artifact.entity}/{logged_artifact.project}/baz")
 
-    with pytest.raises(CommError, match="artifact 'baz:v0' not found"):
+    with pytest.raises(CommError):
         Api().artifact(f"{logged_artifact.entity}/{logged_artifact.project}/baz:v0")
 
 

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -691,7 +691,7 @@ def test_retrieve_missing_artifact(logged_artifact):
     with pytest.raises(CommError, match="must be specified as 'collection:alias'"):
         Api().artifact(f"{logged_artifact.entity}/{logged_artifact.project}/baz")
 
-    with pytest.raises(CommError, match="failed to find artifact collection"):
+    with pytest.raises(CommError, match="artifact 'baz:v0' not found"):
         Api().artifact(f"{logged_artifact.entity}/{logged_artifact.project}/baz:v0")
 
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

We changed the result returned by the `Project -> Artifact` endpoint for a missing artifact, where instead of returning `collection not found`, we now return `null`. This changed the error raised by `api.artifact()`, since it now receives a null value for a non-existent artifact. 

This PR updates the test to just expect a `CommError` instead of matching on exact strings from the server.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
