### PR TITLE
chore(launch): configure additional services before creation

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -576,6 +576,19 @@ class KubernetesRunner(AbstractRunner):
         )
         config["metadata"]["labels"]["wandb.ai/created-by"] = "launch-agent"
 
+        if config.get("kind") == "Service":
+            config.setdefault("metadata", {})
+            original_name = config["metadata"].get("name", "service")
+            safe_entity = make_name_dns_safe(launch_project.target_entity or "")
+            safe_project = make_name_dns_safe(launch_project.target_project or "")
+            safe_run_id = make_name_dns_safe(run_id or "")
+
+            new_name = f"{original_name}-{safe_entity}-{safe_project}-{safe_run_id}"
+            config["metadata"]["name"] = new_name
+            wandb.termlog(
+                f"{LOG_PREFIX}Modified service name from '{original_name}' to '{new_name}'"
+            )
+
         env_vars = launch_project.get_env_vars_dict(
             self._api, MAX_ENV_LENGTHS[self.__class__.__name__]
         )


### PR DESCRIPTION
Description
-----------

* Injects WANDB_API_KEY into containers of additional resources
* Modifies the service name to include project, entity and run ID so that service names across jobs don't clash

Testing
-------

Pending ...
