### PR TITLE
refactor: remove unreachable statement

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1619,4 +1619,3 @@ def init(  # noqa: C901
         # Need to build delay into this sentry capture because our exit hooks
         # mess with sentry's ability to send out errors before the program ends.
         wandb._sentry.reraise(e)
-        raise AssertionError()  # should never get here


### PR DESCRIPTION
Removes a `raise AssertionError` that was added to satisfy type checkers. It is no longer needed, as `reraise()`'s return type was updated to `Never`.

Note that `assert False` is [the more idiomatic way](https://typing.python.org/en/latest/guides/unreachable.html) (if we needed it).