### PR TITLE
refactor: factor out RecordParser for Record => Work parsing

### DIFF
--- a/core/internal/stream/recordparser.go
+++ b/core/internal/stream/recordparser.go
@@ -1,0 +1,55 @@
+package stream
+
+import (
+	"context"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/wandb/wandb/core/internal/featurechecker"
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runupserter"
+	"github.com/wandb/wandb/core/internal/runwork"
+	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/wboperation"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// RecordParser turns Records into Work.
+//
+// Records coming from the client via interprocess communication, or those
+// read from a transaction log, pass through here first.
+type RecordParser struct {
+	BeforeRunEndCtx    context.Context
+	FeatureProvider    *featurechecker.ServerFeaturesCache
+	GraphqlClientOrNil graphql.Client
+	Logger             *observability.CoreLogger
+	Operations         *wboperation.WandbOperations
+	Run                *StreamRun
+
+	Settings *settings.Settings
+}
+
+// Parse returns the Work corresponding to a Record.
+func (p *RecordParser) Parse(record *spb.Record) runwork.Work {
+	var work runwork.Work
+
+	if record.GetRun() != nil {
+		work = &runupserter.RunUpdateWork{
+			Record: record,
+
+			StreamRunUpserter: p.Run,
+
+			Settings:           p.Settings,
+			BeforeRunEndCtx:    p.BeforeRunEndCtx,
+			Operations:         p.Operations,
+			FeatureProvider:    p.FeatureProvider,
+			GraphqlClientOrNil: p.GraphqlClientOrNil,
+			Logger:             p.Logger,
+		}
+	} else {
+		// Legacy style for handling records where the code to process them
+		// lives in handler.go and sender.go directly.
+		work = runwork.WorkFromRecord(record)
+	}
+
+	return work
+}

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -19,7 +19,6 @@ import (
 	"github.com/wandb/wandb/core/internal/randomid"
 	"github.com/wandb/wandb/core/internal/runfiles"
 	"github.com/wandb/wandb/core/internal/runsummary"
-	"github.com/wandb/wandb/core/internal/runupserter"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/sentry_ext"
 	"github.com/wandb/wandb/core/internal/settings"
@@ -71,6 +70,9 @@ type Stream struct {
 
 	// reader is the reader for the stream
 	reader *Reader
+
+	// recordParser turns Records into Work.
+	recordParser *RecordParser
 
 	// handler is the handler for the stream
 	handler *Handler
@@ -267,6 +269,16 @@ func NewStream(
 		s.logger,
 	)
 
+	s.recordParser = &RecordParser{
+		BeforeRunEndCtx:    s.runWork.BeforeEndCtx(),
+		FeatureProvider:    s.featureProvider,
+		GraphqlClientOrNil: s.graphqlClientOrNil,
+		Logger:             s.logger,
+		Operations:         s.operations,
+		Run:                s.run,
+		Settings:           s.settings,
+	}
+
 	mailbox := mailbox.New()
 	switch {
 	case s.settings.IsSync():
@@ -432,32 +444,10 @@ func (s *Stream) Start() {
 	s.logger.Info("stream: started", "id", s.settings.GetRunID())
 }
 
-// HandleRecord handles the given record by sending it to the stream's handler.
+// HandleRecord ingests a record from the client.
 func (s *Stream) HandleRecord(record *spb.Record) {
 	s.logger.Debug("handling record", "record", record.GetRecordType())
-
-	var work runwork.Work
-
-	if record.GetRun() != nil {
-		work = &runupserter.RunUpdateWork{
-			Record: record,
-
-			StreamRunUpserter: s.run,
-
-			ClientID:           s.clientID,
-			Settings:           s.settings,
-			BeforeRunEndCtx:    s.runWork.BeforeEndCtx(),
-			Operations:         s.operations,
-			FeatureProvider:    s.featureProvider,
-			GraphqlClientOrNil: s.graphqlClientOrNil,
-			Logger:             s.logger,
-		}
-	} else {
-		// Legacy style for handling records where the code to process them
-		// lives in handler.go and sender.go directly.
-		work = runwork.WorkFromRecord(record)
-	}
-
+	work := s.recordParser.Parse(record)
 	s.runWork.AddWork(work)
 }
 


### PR DESCRIPTION
Factors out `RecordParser` to convert serialized `Record` values into `Work` domain objects; the logic was originally in `Stream` (which gets records from the client), but it will be reused for `wandb sync` (which gets records from the transaction log).