### PR TITLE
fix: potential race conditions in Sender on exit

### DIFF
--- a/core/internal/runconsolelogs/debouncedwriter.go
+++ b/core/internal/runconsolelogs/debouncedwriter.go
@@ -75,6 +75,6 @@ func (b *debouncedWriter) loopFlushBuffer() {
 	}
 }
 
-func (b *debouncedWriter) Wait() {
+func (b *debouncedWriter) Finish() {
 	b.wg.Wait()
 }

--- a/core/internal/runconsolelogs/debouncedwriter_test.go
+++ b/core/internal/runconsolelogs/debouncedwriter_test.go
@@ -22,7 +22,7 @@ func TestInvokesCallback(t *testing.T) {
 	line := &RunLogsLine{}
 	line.Content = []rune("content")
 	writer.OnChanged(1, line)
-	writer.Wait()
+	writer.Finish()
 
 	select {
 	case lines := <-flushes:


### PR DESCRIPTION
Fixes potential race conditions in `Sender.finishRunSync()` by ensuring any objects not guarded by `Sender.mu` are concurrency-aware. The main problem is with `Finish()` methods, which often involve a `WaitGroup.Wait()` call. Calling `Wait()` and `Add()` simultaneously can cause a panic.

These race conditions can only occur if certain kinds of records are processed after `Exit`. I think there is a race condition in the Python client that can allow it to sometimes send `OutputRaw` records after `Exit`.