### PR TITLE
refactor: rename Work.Save() to ToRecord()

### DIFF
--- a/core/internal/runupserter/runupdatework.go
+++ b/core/internal/runupserter/runupdatework.go
@@ -58,9 +58,9 @@ func (w *RunUpdateWork) Accept(_ func(*spb.Record)) bool {
 	return true
 }
 
-// Save implements Work.Save.
-func (w *RunUpdateWork) Save(write func(*spb.Record)) {
-	write(w.Record)
+// ToRecord implements Work.ToRecord.
+func (w *RunUpdateWork) ToRecord() *spb.Record {
+	return w.Record
 }
 
 // Process implements Work.Process.

--- a/core/internal/runwork/work.go
+++ b/core/internal/runwork/work.go
@@ -7,12 +7,6 @@ import (
 )
 
 // Work is a task in the Handler->Sender pipeline.
-//
-// Most work is in the form of Record protos from the client.
-// Occasionally, it is useful to inject additional work that must
-// happen in order with Record processing. There are some Records
-// that exist only for this purpose, but it is not an appropriate
-// use of protos, and it is very limiting.
 type Work interface {
 	// Schedule inserts work into the pipeline.
 	//
@@ -37,10 +31,11 @@ type Work interface {
 	// If this is a Record proto, the given function is called.
 	Accept(func(*spb.Record)) bool
 
-	// Save writes the work to the transaction log.
+	// ToRecord returns the serialized representation of this Work.
 	//
-	// If this is a Record proto, the given function is called.
-	Save(func(*spb.Record))
+	// The returned value's number may be modified in the Writer goroutine.
+	// Otherwise, the value must not be modified.
+	ToRecord() *spb.Record
 
 	// BypassOfflineMode reports whether Process needs to happen
 	// even if we're offline.

--- a/core/internal/runwork/workrecord.go
+++ b/core/internal/runwork/workrecord.go
@@ -56,8 +56,9 @@ func (wr WorkRecord) Accept(fn func(*spb.Record)) bool {
 	return true
 }
 
-func (wr WorkRecord) Save(fn func(*spb.Record)) {
-	fn(wr.Record)
+// ToRecord implements Work.ToRecord.
+func (wr WorkRecord) ToRecord() *spb.Record {
+	return wr.Record
 }
 
 func (wr WorkRecord) BypassOfflineMode() bool {

--- a/core/internal/tensorboard/tbwork.go
+++ b/core/internal/tensorboard/tbwork.go
@@ -38,10 +38,8 @@ func (w *TBWork) Schedule(wg *sync.WaitGroup, process func()) {
 	process()
 }
 
-// Save implements Work.Save.
-func (w *TBWork) Save(write func(*spb.Record)) {
-	write(w.Record)
-}
+// ToRecord implements Work.ToRecord.
+func (w *TBWork) ToRecord() *spb.Record { return w.Record }
 
 // DebugInfo implements Work.DebugInfo
 func (w *TBWork) DebugInfo() string {


### PR DESCRIPTION
Replaces `Work.Save()` by `Work.ToRecord()`.

The `Save()` method made it difficult for the `Writer` to know whether the `Work` was written to disk or not.