### PR TITLE
fix: clear console capture callbacks on error

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,3 +28,4 @@ This version removes the legacy implementaion of the `service` process. This is 
 ### Fixed
 
 - Allow s3 style CoreWeave URIs for reference artifacts. (@estellazx in https://github.com/wandb/wandb/pull/9979)
+- Fixed rare bug that made Ctrl+C ineffective after logging large amounts of data (@timoffex in https://github.com/wandb/wandb/pull/10071)

--- a/tests/system_tests/test_functional/console_capture/removes_callback_on_error.py
+++ b/tests/system_tests/test_functional/console_capture/removes_callback_on_error.py
@@ -1,0 +1,38 @@
+"""Exits with code 0 if callbacks are removed after raising an exception."""
+
+import sys
+
+from wandb.sdk.lib import console_capture
+
+num_calls = 0
+
+
+def count_and_interrupt(*unused) -> None:
+    global num_calls
+    num_calls += 1
+
+    raise KeyboardInterrupt
+
+
+if __name__ == "__main__":
+    console_capture.capture_stdout(count_and_interrupt)
+
+    try:
+        # print() makes a separate write() call for the implicit \n,
+        # making the output a little less nice.
+        sys.stdout.write("First call -- should count.\n")
+    except KeyboardInterrupt:
+        # The callback must not suppress BaseExceptions.
+        print("Got KeyboardInterrupt!")
+    else:
+        print("FAIL: No KeyboardInterrupt")
+        sys.exit(1)
+
+    print("Second call -- should not invoke callback.")
+
+    if num_calls == 1:
+        print("PASS: Only 1 call.")
+        sys.exit(0)
+    else:
+        print(f"FAIL: Got {num_calls} calls, but expected 1.")
+        sys.exit(1)

--- a/tests/system_tests/test_functional/console_capture/test_console_capture.py
+++ b/tests/system_tests/test_functional/console_capture/test_console_capture.py
@@ -12,6 +12,7 @@ def test_patch_stdout_and_stderr():
     )
 
     exit_code = proc.wait()  # on error, stderr may have useful details
+    assert proc.stderr and proc.stdout
     assert proc.stderr.read() == b"I AM STDERR\n"
     assert proc.stdout.read() == b"I AM STDOUT\n"
     assert exit_code == 0
@@ -19,6 +20,12 @@ def test_patch_stdout_and_stderr():
 
 def test_patching_exception():
     script = pathlib.Path(__file__).parent / "patching_exception.py"
+
+    subprocess.check_call(["python", str(script)])
+
+
+def test_removes_callback_on_error():
+    script = pathlib.Path(__file__).parent / "removes_callback_on_error.py"
 
     subprocess.check_call(["python", str(script)])
 


### PR DESCRIPTION
Makes `console_capture.py` clear all callbacks if a callback raises an error.

Since callbacks are invoked when stdout or stderr is being written to, and since errors are likely to be printed to the console, this can trigger an infinite loop. This is especially problematic for `KeyboardInterrupt` as it makes it difficult to stop the program using Ctrl+C if a callback is permanently stuck (imagine a callback that does `time.sleep(600)`).

Also updates `console_capture.py` to log and suppress regular Exceptions thrown by callbacks, since these will almost always be W&B bugs that shouldn't propagate to the user's `print()` statements.