### PR TITLE
fix: respect verbosity settings when printing service warnings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,4 +33,4 @@ This version removes the legacy implementaion of the `service` process. This is 
 
 - Allow s3 style CoreWeave URIs for reference artifacts. (@estellazx in https://github.com/wandb/wandb/pull/9979)
 - Fixed rare bug that made Ctrl+C ineffective after logging large amounts of data (@timoffex in https://github.com/wandb/wandb/pull/10071)
-- Respect `silent`, `quiet`, and `show_warnings` settings passed to a `Run` instance for warning emitted by the service process (@kptkin in https://github.com/wandb/wandb/pull/10077)
+- Respect `silent`, `quiet`, and `show_warnings` settings passed to a `Run` instance for warnings emitted by the service process (@kptkin in https://github.com/wandb/wandb/pull/10077)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,3 +33,4 @@ This version removes the legacy implementaion of the `service` process. This is 
 
 - Allow s3 style CoreWeave URIs for reference artifacts. (@estellazx in https://github.com/wandb/wandb/pull/9979)
 - Fixed rare bug that made Ctrl+C ineffective after logging large amounts of data (@timoffex in https://github.com/wandb/wandb/pull/10071)
+- Respect `silent`, `quiet`, and `show_warnings` settings passed to a `Run` instance for warning emitted by the service process (@kptkin in https://github.com/wandb/wandb/pull/10077)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-25536

What does the PR do? Include a concise description of the PR contents.

respect different settings of verbosity when printing warning messages provided from the service process. 
in this case the relevant settings are: 
- quiet
- silent
- show_warnings

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
