### PR TITLE
feat(launch): create network policies for job and resource pods

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -17,10 +17,6 @@ from functools import wraps
 from typing import Any, Dict, Optional
 
 import click
-import wandb
-import wandb.env
-import wandb.errors
-import wandb.sdk.verify.verify as wandb_verify
 import yaml
 from click.exceptions import ClickException
 

--- a/wandb/sdk/launch/_launch.py
+++ b/wandb/sdk/launch/_launch.py
@@ -4,8 +4,9 @@ import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
-import wandb
 import yaml
+
+import wandb
 from wandb.apis.internal import Api
 
 from . import loader

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -11,8 +11,9 @@ from dataclasses import dataclass
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import wandb
 import yaml
+
+import wandb
 from wandb.apis.internal import Api
 from wandb.errors import CommError
 from wandb.sdk.launch._launch_add import launch_add

--- a/wandb/sdk/launch/runner/kubernetes_monitor.py
+++ b/wandb/sdk/launch/runner/kubernetes_monitor.py
@@ -6,6 +6,7 @@ import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import kubernetes_asyncio  # type: ignore
+import urllib3
 from kubernetes_asyncio import watch
 from kubernetes_asyncio.client import (  # type: ignore
     ApiException,
@@ -16,7 +17,6 @@ from kubernetes_asyncio.client import (  # type: ignore
     V1PodStatus,
 )
 
-import urllib3
 import wandb
 from wandb.sdk.launch.agent import LaunchAgent
 from wandb.sdk.launch.errors import LaunchError


### PR DESCRIPTION
Description
-----------
- https://linear.app/wandb/issue/ENG-47/security-handling-between-jobspods

This PR limits the networking of job and resource pods created by the launch agent by using kubernetes `NetworkPolicy` manifests.

By default, a job pod created by the launch agent will have a NetworkPolicy created for it that allows:
* Egress for DNS lookups
* Egress for external web

If the launch agent creates an auxiliary resource of kind `Deployment`, then a `NetworkPolicy` will be created so that:
* Ingress only from the job pod for the same run
* Egress for DNS lookups
* Egress for external web

We will always create a NetworkPolicy for the job pod so that a default deny all network policy can be set up if desired. This is to prevent job pods from making requests to other vllm pods not belonging to the same run.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
