### PR TITLE
chore: remove a misleading require warning

### DIFF
--- a/wandb/sdk/wandb_require.py
+++ b/wandb/sdk/wandb_require.py
@@ -60,7 +60,6 @@ class _Requires:
             func()
 
         if last_message:
-            wandb.termwarn("Supported requirements are: `legacy-service`, `service`.")
             raise UnsupportedError(last_message)
 
 


### PR DESCRIPTION
Description
-----------
Missed this warning in #9965 
