### PR TITLE
fix: inconsistent length values in `api.Runs` and `api.Files`

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -112,3 +112,8 @@ When preparing a release that can include breaking changes, consider applying ch
     - Owner: @kptkin
     - Deprecated in 0.19.10 (https://github.com/wandb/wandb/pull/8925)
     - Can do in >=0.21
+
+- Remove `wandb.apis.paginator.SizedPaginator::length`:
+    - Owner: @jacobromero
+    - Deprecated in 0.20.1
+    - can do in >= 0.21

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -115,5 +115,5 @@ When preparing a release that can include breaking changes, consider applying ch
 
 - Remove `wandb.apis.paginator.SizedPaginator::length`:
     - Owner: @jacobromero
-    - Deprecated in 0.20.2
-    - can do in >= 0.21
+    - Deprecated in 0.21.0
+    - can do in >= 0.22

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -115,5 +115,5 @@ When preparing a release that can include breaking changes, consider applying ch
 
 - Remove `wandb.apis.paginator.SizedPaginator::length`:
     - Owner: @jacobromero
-    - Deprecated in 0.20.1
+    - Deprecated in 0.20.2
     - can do in >= 0.21

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,3 +42,4 @@ This version removes the legacy implementaion of the `service` process. This is 
 - Respect `silent`, `quiet`, and `show_warnings` settings passed to a `Run` instance for warnings emitted by the service process (@kptkin in https://github.com/wandb/wandb/pull/10077)
 - `api.Runs` no longer makes an API call for each run loaded from W&B. (@jacobromero in https://github.com/wandb/wandb/pull/10087)
 - Correctly parse the `x_extra_http_headers` setting from the env variable (@dmitryduev in https://github.com/wandb/wandb/pull/10103)
+- `.length` calls the W&B backend to load the length of objects when no data has been loaded rather than returning `None` (@jacobromero in https://github.com/wandb/wandb/pull/10091)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@ This version removes the legacy implementaion of the `service` process. This is 
 - Calling `Artifact.link()` no longer instantiates a throwaway placeholder run. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9828)
 - `wandb` now attempts to use Unix sockets for IPC instead of listening on localhost, making it work in environments with more restrictive permissions (such as Databricks) (@timoffex in https://github.com/wandb/wandb/pull/9995)
 - `Api.artifact()` will now display a warning while fetching artifacts from migrated model registry collections. (@ibindlish in https://github.com/wandb/wandb/pull/10047)
+- The `.length` for objects queried from `wandb.Api` has been deprecated. Use `len(...)` instead.
 
 ### Removed
 

--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -13,6 +13,8 @@ from typing import (
     overload,
 )
 
+import wandb
+
 if TYPE_CHECKING:
     from wandb_graphql.language.ast import Document
 
@@ -112,14 +114,22 @@ class Paginator(Iterator[T]):
 class SizedPaginator(Paginator[T], Sized):
     """A Paginator for objects with a known total count."""
 
+    @property
+    def length(self) -> int | None:
+        wandb.termwarn(
+            "`.length` is deprecated and will be removed in a future version. Use SizedPaginator._length instead.",
+            repeat=False,
+        )
+        return len(self)
+
     def __len__(self) -> int:
-        if self.length is None:
+        if self._length is None:
             self._load_page()
-        if self.length is None:
+        if self._length is None:
             raise ValueError("Object doesn't provide length")
-        return self.length
+        return self._length
 
     @property
     @abstractmethod
-    def length(self) -> int | None:
+    def _length(self) -> int | None:
         raise NotImplementedError

--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -117,7 +117,10 @@ class SizedPaginator(Paginator[T], Sized):
     @property
     def length(self) -> int | None:
         wandb.termwarn(
-            "`.length` is deprecated and will be removed in a future version. Use SizedPaginator._length instead.",
+            (
+                "`.length` is deprecated and will be removed in a future version. "
+                "Use `len(...)` instead."
+            ),
             repeat=False,
         )
         return len(self)

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -240,7 +240,7 @@ class ArtifactCollections(SizedPaginator["ArtifactCollection"]):
         self.last_response = ArtifactCollectionsFragment.model_validate(conn)
 
     @property
-    def _length(self):
+    def _length(self) -> int:
         if self.last_response is None:
             self._load_page()
         return self.last_response.total_count
@@ -608,7 +608,7 @@ class Artifacts(SizedPaginator["Artifact"]):
         self.last_response = ArtifactsFragment.model_validate(conn)
 
     @property
-    def _length(self):
+    def _length(self) -> int:
         if self.last_response is None:
             self._load_page()
         return self.last_response.total_count
@@ -698,7 +698,7 @@ class RunArtifacts(SizedPaginator["Artifact"]):
         self.last_response = self._response_cls.model_validate(inner_data)
 
     @property
-    def _length(self):
+    def _length(self) -> int:
         if self.last_response is None:
             self._load_page()
         return self.last_response.total_count
@@ -799,7 +799,7 @@ class ArtifactFiles(SizedPaginator["public.File"]):
         return [self.artifact.entity, self.artifact.project, self.artifact.name]
 
     @property
-    def _length(self):
+    def _length(self) -> int:
         if self.last_response is None:
             self._load_page()
         return self.artifact.file_count

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -100,7 +100,7 @@ class ArtifactTypes(Paginator["ArtifactType"]):
         self.last_response = ArtifactTypesFragment.model_validate(conn)
 
     @property
-    def length(self) -> None:
+    def _length(self) -> None:
         # TODO
         return None
 
@@ -240,9 +240,9 @@ class ArtifactCollections(SizedPaginator["ArtifactCollection"]):
         self.last_response = ArtifactCollectionsFragment.model_validate(conn)
 
     @property
-    def length(self):
+    def _length(self):
         if self.last_response is None:
-            return None
+            self._load_page()
         return self.last_response.total_count
 
     @property
@@ -608,9 +608,9 @@ class Artifacts(SizedPaginator["Artifact"]):
         self.last_response = ArtifactsFragment.model_validate(conn)
 
     @property
-    def length(self) -> int | None:
+    def _length(self):
         if self.last_response is None:
-            return None
+            self._load_page()
         return self.last_response.total_count
 
     @property
@@ -698,9 +698,9 @@ class RunArtifacts(SizedPaginator["Artifact"]):
         self.last_response = self._response_cls.model_validate(inner_data)
 
     @property
-    def length(self) -> int | None:
+    def _length(self):
         if self.last_response is None:
-            return None
+            self._load_page()
         return self.last_response.total_count
 
     @property
@@ -799,7 +799,9 @@ class ArtifactFiles(SizedPaginator["public.File"]):
         return [self.artifact.entity, self.artifact.project, self.artifact.name]
 
     @property
-    def length(self) -> int:
+    def _length(self):
+        if self.last_response is None:
+            self._load_page()
         return self.artifact.file_count
 
     @property

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -73,10 +73,10 @@ class Files(SizedPaginator["File"]):
 
     @property
     def length(self):
-        if self.last_response:
-            return self.last_response["project"]["run"]["fileCount"]
-        else:
-            return None
+        if not self.last_response:
+            self._load_page()
+
+        return self.last_response["project"]["run"]["fileCount"]
 
     @property
     def more(self):

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -72,7 +72,7 @@ class Files(SizedPaginator["File"]):
         super().__init__(client, variables, per_page)
 
     @property
-    def length(self):
+    def _length(self):
         if not self.last_response:
             self._load_page()
 

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -63,7 +63,7 @@ class Reports(SizedPaginator["BetaReport"]):
         super().__init__(client, variables, per_page)
 
     @property
-    def length(self):
+    def _length(self):
         # TODO: Add the count the backend
         if self.last_response:
             return len(self.objects)

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -143,7 +143,7 @@ class Runs(SizedPaginator["Run"]):
         super().__init__(client, variables, per_page)
 
     @property
-    def length(self):
+    def _length(self):
         if not self.last_response:
             self._load_page()
         return self.last_response["project"]["runCount"]

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -144,10 +144,9 @@ class Runs(SizedPaginator["Run"]):
 
     @property
     def length(self):
-        if self.last_response:
-            return self.last_response["project"]["runCount"]
-        else:
-            return None
+        if not self.last_response:
+            self._load_page()
+        return self.last_response["project"]["runCount"]
 
     @property
     def more(self):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-16060

What does the PR do? Include a concise description of the PR contents.

When querying `api.Runs.length` before loading any data the value would return `None`. After data was loaded the actual value would be returned.
This would cause inconsistency when calling `len(Runs)` because the `__length__` function would force an api call to the backend, and would always return the number of runs in the queried project.
This behavior would also happen for `Files` associated with a specific run as well.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

```python
import wandb

api = wandb.Api()

runs = api.runs("wandb/api-run-query", per_page=1) # note: api-run-query has 100 runs

print(runs.length)
print(len(runs))
print(runs.length)

run = runs[0]
files = run.files()
print(files.length)
print(len(files))
print(files.length)
```

#### after this change

```bash
100
100
100
6
6
6
```

#### before this change

```bash
None
100
100
None
6
6
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
