### PR TITLE
fix(artifacts): ensure `artifact.link` can fetch the linked artifact regardless of user's default entity

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1307,9 +1307,6 @@ class Api:
             settings_entity = self.settings["entity"] or self.default_entity
             # Registry artifacts are under the org entity. Because we offer a shorthand and alias for this path,
             # we need to fetch the org entity to for the user behind the scenes.
-            wandb.termlog(
-                f"Resolving org entity in Api._artifact: {settings_entity=}, {organization=}"
-            )
             entity = InternalApi()._resolve_org_entity_name(
                 entity=settings_entity, organization=organization
             )

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1307,6 +1307,9 @@ class Api:
             settings_entity = self.settings["entity"] or self.default_entity
             # Registry artifacts are under the org entity. Because we offer a shorthand and alias for this path,
             # we need to fetch the org entity to for the user behind the scenes.
+            wandb.termlog(
+                f"Resolving org entity in Api._artifact: {settings_entity=}, {organization=}"
+            )
             entity = InternalApi()._resolve_org_entity_name(
                 entity=settings_entity, organization=organization
             )

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2483,38 +2483,16 @@ class Artifact:
 
         # Parse the entity (first part of the path) appropriately,
         # depending on whether we're linking to a registry
-
-        # if (project := target.project) and (
-        #     is_registry_target := is_artifact_registry_project(project)
-        # ):
-
-        organization = ""
         if target.project and is_artifact_registry_project(target.project):
             # In a Registry linking, the entity is used to fetch the organization of the artifact
             # therefore the source artifact's entity is passed to the backend
             organization = target.prefix or api.settings.get("organization") or ""
 
-            # target_entity = InternalApi()._resolve_org_entity_name(
-            #     self.source_entity, organization
-            # )
-
-            org_entity = InternalApi()._resolve_org_entity_name(
+            target.prefix = InternalApi()._resolve_org_entity_name(
                 self.source_entity, organization
             )
-            wandb.termlog(
-                f"Org entity resolved: {organization=}, {org_entity=}, {target=}"
-            )
-
-            target.prefix = org_entity
         else:
-            target = target.with_defaults(
-                prefix=api.settings.get("entity") or api.default_entity,
-            )
-
-            # organization = ""
-
-            # target_entity = self.source_entity
-            target.prefix = self.source_entity
+            target = target.with_defaults(prefix=self.source_entity)
 
         # Prepare the validated GQL input, send it
         alias_inputs = [
@@ -2524,7 +2502,6 @@ class Artifact:
         gql_input = LinkArtifactInput(
             artifact_id=self.id,
             artifact_portfolio_name=target.name,
-            # entity_name=target_entity,
             entity_name=target.prefix,
             project_name=target.project,
             aliases=alias_inputs,
@@ -2538,24 +2515,12 @@ class Artifact:
             raise ValueError("Unable to parse linked artifact version from response")
 
         # Fetch the linked artifact to return it
-        linked_path = f"{target.project}/{target.name}:v{version_idx}"
-
-        # If appropriate, prepend the org or entity to the fetched path
-        linked_path = f"{target.prefix}/{linked_path}"
-
-        # if is_registry_target and organization:
-        #     linked_path = f"{organization}/{linked_path}"
-        # elif not is_registry_target:
-        #     linked_path = f"{target.prefix}/{linked_path}"
-        # else:
-        #     linked_path = f"{target_entity}/{linked_path}"
+        linked_path = f"{target.to_str()}:v{version_idx}"
 
         try:
             return api._artifact(linked_path)
         except Exception as e:
-            wandb.termerror(
-                f"Error fetching link artifact after linking: {e} -- {target_path=}, {target=}, {linked_path=}"
-            )
+            wandb.termerror(f"Error fetching link artifact after linking: {e}")
             return None
 
     @ensure_logged


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fixes `artifact.link()` so that the linked artifact is fetched successfully, even if the user's current default entity is in a different org.


Testing
-------
Updated `test_artifact_link_to_registry_collection` to run with the user's default entity set to different teams.

Note that the updated test does indeed fail without the changes in this PR, so it should be guarding against regressions on this bug going forward.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
