### PR TITLE
chore(launch): redact api key in runSpec

### DIFF
--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -1,5 +1,6 @@
 """Implementation of launch agent."""
 
+import copy
 import asyncio
 import logging
 import os
@@ -516,7 +517,11 @@ class LaunchAgent:
         Arguments:
             job: Job to run.
         """
-        _msg = f"{LOG_PREFIX}Launch agent received job:\n{pprint.pformat(job)}\n"
+        job_copy = copy.deepcopy(job)
+        if 'runSpec' in job_copy and '_wandb_api_key' in job_copy['runSpec']:
+            job_copy['runSpec']['_wandb_api_key'] = '<redacted>'
+
+        _msg = f"{LOG_PREFIX}Launch agent received job:\n{pprint.pformat(job_copy)}\n"
         wandb.termlog(_msg)
         _logger.info(_msg)
         # update agent status


### PR DESCRIPTION
Description
-----------
- https://linear.app/wandb/issue/ENG-79/obfuscate-api-token-in-launch-agent-logs

* When logging the job, `<redacted>` will show for the api key

Merges into the `cw-wandb-evals-project` dev branch

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
* unit test

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
