### PR TITLE
fix: correctly parse x_extra_http_headers setting from env variable

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,3 +39,4 @@ This version removes the legacy implementaion of the `service` process. This is 
 - Fixed rare bug that made Ctrl+C ineffective after logging large amounts of data (@timoffex in https://github.com/wandb/wandb/pull/10071)
 - Respect `silent`, `quiet`, and `show_warnings` settings passed to a `Run` instance for warnings emitted by the service process (@kptkin in https://github.com/wandb/wandb/pull/10077)
 - `api.Runs` no longer makes an API call for each run loaded from W&B. (@jacobromero in https://github.com/wandb/wandb/pull/10087)
+- Correctly parse the `x_extra_http_headers` setting from the env variable (@dmitryduev in https://github.com/wandb/wandb/pull/10103)

--- a/tests/unit_tests/test_wandb_settings.py
+++ b/tests/unit_tests/test_wandb_settings.py
@@ -338,6 +338,10 @@ def test_preprocess_bool_settings(setting: str):
             "x_stats_open_metrics_filters",
             '{"DCGM_FI_DEV_POWER_USAGE": {"pod": "dcgm-*"}}',
         ),
+        (
+            "x_extra_http_headers",
+            '{"User-Agent": "foobar"}',
+        ),
     ],
 )
 def test_preprocess_dict_settings(setting: str, value: str):

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -924,6 +924,13 @@ class Settings(BaseModel, validate_assignment=True):
             return str(value)
         return value
 
+    @field_validator("x_extra_http_headers", mode="before")
+    @classmethod
+    def validate_x_extra_http_headers(cls, value):
+        if isinstance(value, str):
+            return json.loads(value)
+        return value
+
     @field_validator("x_file_stream_max_line_bytes", mode="after")
     @classmethod
     def validate_file_stream_max_line_bytes(cls, value):


### PR DESCRIPTION
Description
-----------
Fixes WB-25638.

I must have missed it when re-implementing Settings with `pydantic` in 0.19.0.

Testing
-------
Added a unit test.