### PR TITLE
fix: do not throw error when updating a run created from the api

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -422,6 +422,9 @@ class Run(Attrs):
                     }
                     id
                     name
+                    displayName
+                    group
+                    jobType
                 }
                 inserted
             }
@@ -450,6 +453,9 @@ class Run(Attrs):
                 "description": None,
                 "notes": None,
                 "state": state,
+                "displayName": res["displayName"],
+                "group": res["group"],
+                "jobType": res["jobType"],
             },
         )
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-1705
- Fixes #846

What does the PR do? Include a concise description of the PR contents.

When creating a run from the public API, and then subsequently trying to update the same run, a user would get the error `AttributeError: '<Run entity/project/run (running)>' object has no attribute 'display_name'`.
This occurred because not enough data was pulled back during the creation of the run from the mutation call to actually make the update call later. Specifically we need the `displayName`, `group`, and `jobType`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- TODO: add system tests
- Sample script
```python
import wandb

api = wandb.Api()
run = api.create_run(entity="wandb", project="jpr-test")
run.tags = ["foobar"]
run.update()
```

#### after this change
<img width="287" alt="image" src="https://github.com/user-attachments/assets/a4ef35d9-a3b8-4edc-a005-ca11f07d2e70" />

#### before this change
<img width="650" alt="image" src="https://github.com/user-attachments/assets/dbe47497-5d2f-4aad-a91b-852cee145a2c" />



<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
