### PR TITLE
chore: unix domain socket support for wandb-core/gpu_stats gRPC communication

### DIFF
--- a/core/pkg/monitor/gpuresourcemanager.go
+++ b/core/pkg/monitor/gpuresourcemanager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -131,9 +132,11 @@ func (m *GPUResourceManager) startGPUCollector() error {
 		"--portfile", pf.path,
 		"--ppid", strconv.Itoa(os.Getpid()),
 	)
-
 	if m.enableDCGMProfiling {
 		cmd.Args = append(cmd.Args, "--enable-dcgm-profiling")
+	}
+	if !supportsUDS() {
+		cmd.Args = append(cmd.Args, "--listen-on-localhost")
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -142,14 +145,14 @@ func (m *GPUResourceManager) startGPUCollector() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	port, err := pf.Read(ctx)
+	targetURI, err := pf.Read(ctx)
 	if err != nil {
 		_ = cmd.Process.Kill()
 		return fmt.Errorf("monitor: could not get GPU binary port: %v", err)
 	}
 
 	conn, err := grpc.NewClient(
-		fmt.Sprintf("127.0.0.1:%d", port),
+		targetURI,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 
@@ -184,4 +187,32 @@ func getGPUCollectorCmdPath() (string, error) {
 		return "", err
 	}
 	return exPath, nil
+}
+
+// supportUDS performs a runtime check for Unix Domain Socket support.
+//
+// On non-Windows systems supported by W&B, it assumes that UDS is supported.
+// On Windows, it attempts to create a temporary UDS listener to verify support.
+func supportsUDS() bool {
+	if runtime.GOOS != "windows" {
+		return true
+	}
+
+	tempDir, err := os.MkdirTemp("", "uds-support-check-*")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(tempDir)
+
+	socketPath := filepath.Join(tempDir, "test.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return false
+	}
+	if err = listener.Close(); err != nil {
+		return false
+	}
+
+	return true
 }

--- a/core/pkg/monitor/gpuresourcemanager.go
+++ b/core/pkg/monitor/gpuresourcemanager.go
@@ -202,7 +202,9 @@ func supportsUDS() bool {
 	if err != nil {
 		return false
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 

--- a/core/pkg/monitor/gpuresourcemanager.go
+++ b/core/pkg/monitor/gpuresourcemanager.go
@@ -129,7 +129,7 @@ func (m *GPUResourceManager) startGPUCollector() error {
 
 	cmd := exec.Command(
 		cmdPath,
-		"--portfile", pf.path,
+		"--portfile", pf.Path,
 		"--ppid", strconv.Itoa(os.Getpid()),
 	)
 	if m.enableDCGMProfiling {

--- a/core/pkg/monitor/gpuresourcemanager.go
+++ b/core/pkg/monitor/gpuresourcemanager.go
@@ -130,7 +130,7 @@ func (m *GPUResourceManager) startGPUCollector() error {
 	cmd := exec.Command(
 		cmdPath,
 		"--portfile", pf.Path,
-		"--ppid", strconv.Itoa(os.Getpid()),
+		"--parent-pid", strconv.Itoa(os.Getpid()),
 	)
 	if m.enableDCGMProfiling {
 		cmd.Args = append(cmd.Args, "--enable-dcgm-profiling")

--- a/core/pkg/monitor/portfile.go
+++ b/core/pkg/monitor/portfile.go
@@ -49,7 +49,9 @@ func (p *portfile) ReadFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	scanner := bufio.NewScanner(file)
 	if !scanner.Scan() {

--- a/core/pkg/monitor/portfile.go
+++ b/core/pkg/monitor/portfile.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// portfile is used to communicate the port number of the gRPC service
+// portfile is used to communicate the token of the gRPC service
 // started by the gpu_stats binary to the wandb-core process.
 type portfile struct {
 	Path string

--- a/core/pkg/monitor/portfile.go
+++ b/core/pkg/monitor/portfile.go
@@ -13,7 +13,7 @@ import (
 // portfile is used to communicate the port number of the gRPC service
 // started by the gpu_stats binary to the wandb-core process.
 type portfile struct {
-	path string
+	Path string
 }
 
 func NewPortfile() *portfile {
@@ -22,7 +22,7 @@ func NewPortfile() *portfile {
 		return nil
 	}
 	_ = file.Close()
-	return &portfile{path: file.Name()}
+	return &portfile{Path: file.Name()}
 }
 
 // Read reads the port number from the portfile.
@@ -30,9 +30,9 @@ func (p *portfile) Read(ctx context.Context) (string, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("timeout reading portfile %s", p.path)
+			return "", fmt.Errorf("timeout reading portfile %s", p.Path)
 		default:
-			target, err := p.readFile()
+			target, err := p.ReadFile()
 			if err != nil {
 				time.Sleep(100 * time.Millisecond)
 				continue
@@ -44,8 +44,8 @@ func (p *portfile) Read(ctx context.Context) (string, error) {
 
 // readFile reads a portfile to find a TCP port or a Unix socket path,
 // then returns a gRPC-compatible target URI string.
-func (p *portfile) readFile() (string, error) {
-	file, err := os.Open(p.path)
+func (p *portfile) ReadFile() (string, error) {
+	file, err := os.Open(p.Path)
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +56,7 @@ func (p *portfile) readFile() (string, error) {
 		if err := scanner.Err(); err != nil {
 			return "", fmt.Errorf("error reading portfile: %v", err)
 		}
-		return "", fmt.Errorf("portfile is empty: %s", p.path)
+		return "", fmt.Errorf("portfile is empty: %s", p.Path)
 	}
 
 	line := scanner.Text()
@@ -73,9 +73,9 @@ func (p *portfile) readFile() (string, error) {
 		return fmt.Sprintf("127.0.0.1:%d", port), nil
 	}
 
-	return "", fmt.Errorf("unknown format in portfile: %s", p.path)
+	return "", fmt.Errorf("unknown format in portfile: %s", p.Path)
 }
 
 func (p *portfile) Delete() error {
-	return os.Remove(p.path)
+	return os.Remove(p.Path)
 }

--- a/core/pkg/monitor/portfile.go
+++ b/core/pkg/monitor/portfile.go
@@ -25,7 +25,7 @@ func NewPortfile() *portfile {
 	return &portfile{Path: file.Name()}
 }
 
-// Read reads the port number from the portfile.
+// Read reads the target URI from the portfile.
 func (p *portfile) Read(ctx context.Context) (string, error) {
 	for {
 		select {

--- a/core/pkg/monitor/portfile_test.go
+++ b/core/pkg/monitor/portfile_test.go
@@ -1,0 +1,141 @@
+package monitor_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wandb/wandb/core/pkg/monitor"
+)
+
+func writeToTempFile(t *testing.T, path, content string) {
+	t.Helper()
+	err := os.WriteFile(path, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+}
+
+func TestReadFile(t *testing.T) {
+	testCases := []struct {
+		name           string
+		fileContent    string
+		expected       string
+		expectErr      bool
+		expectedErrMsg string
+	}{
+		{
+			name:        "Valid TCP Port",
+			fileContent: "sock=12345\n",
+			expected:    "127.0.0.1:12345",
+			expectErr:   false,
+		},
+		{
+			name:        "Valid Unix Socket",
+			fileContent: "unix=/tmp/test.sock",
+			expected:    "unix:/tmp/test.sock",
+			expectErr:   false,
+		},
+		{
+			name:        "Valid Unix Socket with Windows Path",
+			fileContent: `unix=C:\Users\test\wandb.sock`,
+			expected:    `unix:C:\Users\test\wandb.sock`,
+			expectErr:   false,
+		},
+		{
+			name:           "Empty File",
+			fileContent:    "",
+			expectErr:      true,
+			expectedErrMsg: "portfile is empty",
+		},
+		{
+			name:           "Unknown Format",
+			fileContent:    "invalid_format=999",
+			expectErr:      true,
+			expectedErrMsg: "unknown format in portfile",
+		},
+		{
+			name:           "Malformed TCP Port",
+			fileContent:    "sock=not-a-number",
+			expectErr:      true,
+			expectedErrMsg: "invalid port in portfile",
+		},
+		{
+			name:           "File with only newline",
+			fileContent:    "\n",
+			expectErr:      true,
+			expectedErrMsg: "unknown format in portfile",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pf := monitor.NewPortfile()
+			writeToTempFile(t, pf.Path, tc.fileContent)
+
+			target, err := pf.ReadFile()
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("Expected an error, but got nil")
+				}
+				if !strings.Contains(err.Error(), tc.expectedErrMsg) {
+					t.Errorf("Expected error message to contain %q, but got %q", tc.expectedErrMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, but got: %v", err)
+				}
+				if target != tc.expected {
+					t.Errorf("Expected target %q, but got %q", tc.expected, target)
+				}
+			}
+		})
+	}
+
+	t.Run("File Does Not Exist", func(t *testing.T) {
+		pf := monitor.NewPortfile()
+		pf.Path = filepath.Join(t.TempDir(), "nonexistent.file")
+		_, err := pf.ReadFile()
+		if err == nil {
+			t.Fatal("Expected an error for a non-existent file, but got nil")
+		}
+		if !os.IsNotExist(err) {
+			t.Errorf("Expected a file-not-exist error, but got a different error: %v", err)
+		}
+	})
+}
+
+func TestRead_SuccessWithPolling(t *testing.T) {
+	pf := monitor.NewPortfile()
+	defer pf.Delete()
+
+	expectedTarget := "127.0.0.1:54321"
+	fileContent := "sock=54321"
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		err := os.WriteFile(pf.Path, []byte(fileContent), 0644)
+		if err != nil {
+			// Use t.Error in a goroutine as t.Fatal will not stop the test.
+			t.Errorf("Failed to write to portfile in goroutine: %v", err)
+		}
+	}()
+
+	// Use a context with a timeout that is longer than the write delay.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// This should block, poll, and eventually succeed.
+	target, err := pf.Read(ctx)
+
+	if err != nil {
+		t.Fatalf("Read() failed: %v", err)
+	}
+
+	if target != expectedTarget {
+		t.Errorf("Expected target %q, got %q", expectedTarget, target)
+	}
+}

--- a/core/pkg/monitor/portfile_test.go
+++ b/core/pkg/monitor/portfile_test.go
@@ -111,7 +111,7 @@ func TestReadFile(t *testing.T) {
 
 func TestRead_SuccessWithPolling(t *testing.T) {
 	pf := monitor.NewPortfile()
-	defer pf.Delete()
+	defer func() { _ = pf.Delete() }()
 
 	expectedTarget := "127.0.0.1:54321"
 	fileContent := "sock=54321"

--- a/gpu_stats/Cargo.lock
+++ b/gpu_stats/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gpu_stats"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "clap",

--- a/gpu_stats/Cargo.toml
+++ b/gpu_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu_stats"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Description
-----------
Fixes WB-25245.

This PR adds support for using Unix Domain Sockets for the `wandb-core` <> `gpu_stats` gRPC communication.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Added Go unit tests, tests manually in different environments.
