### PR TITLE
feat(sdk): add --replace-tags option to wandb sync command

### DIFF
--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -54,6 +54,7 @@ class SyncThread(threading.Thread):
         log_path=None,
         append=None,
         skip_console=None,
+        replace_tags=None,
     ):
         threading.Thread.__init__(self)
         # mark this process as internal
@@ -71,6 +72,7 @@ class SyncThread(threading.Thread):
         self._log_path = log_path
         self._append = append
         self._skip_console = skip_console
+        self._replace_tags = replace_tags or {}
 
         self._tmp_dir = tempfile.TemporaryDirectory()
         atexit.register(self._tmp_dir.cleanup)
@@ -94,6 +96,16 @@ class SyncThread(threading.Thread):
                 pb.run.entity = self._entity
             if self._job_type:
                 pb.run.job_type = self._job_type
+            # Replace tags if specified
+            if self._replace_tags:
+                new_tags = []
+                for tag in pb.run.tags:
+                    if tag in self._replace_tags:
+                        new_tags.append(self._replace_tags[tag])
+                    else:
+                        new_tags.append(tag)
+                pb.run.ClearField("tags")
+                pb.run.tags.extend(new_tags)
             pb.control.req_resp = True
         elif record_type in ("output", "output_raw") and self._skip_console:
             return pb, exit_pb, True
@@ -338,6 +350,7 @@ class SyncManager:
         log_path=None,
         append=None,
         skip_console=None,
+        replace_tags=None,
     ):
         self._sync_list = []
         self._thread = None
@@ -353,6 +366,7 @@ class SyncManager:
         self._log_path = log_path
         self._append = append
         self._skip_console = skip_console
+        self._replace_tags = replace_tags or {}
 
     def status(self):
         pass
@@ -376,6 +390,7 @@ class SyncManager:
             log_path=self._log_path,
             append=self._append,
             skip_console=self._skip_console,
+            replace_tags=self._replace_tags,
         )
         self._thread.start()
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-18861](https://wandb.atlassian.net/browse/WB-18861)

### Problem
Users can get blocked when syncing offline runs that contain tags longer than 64 characters. The W&B API rejects these tags with a 400 error, preventing the entire run from syncing successfully.

### Solution
Added a new `--replace-tags` option to the `wandb sync` command that allows users to replace problematic tags during the sync process. This enables users to:
- Fix tags that exceed the 64-character limit
- Rename tags to follow new naming conventions
- Clean up tag names without re-running experiments

### Usage
```bash
wandb sync <path> --replace-tags "old_tag1=new_tag1,old_tag2=new_tag2"
```

### Example Use Case
**Test code that creates a run with a long tag:**
```python
import wandb

run = wandb.init(project="test_replace_tags", mode="offline", tags=["tag1", "tag2", "a"*65, "tag3"])
for step in range(10):
    run.log({"metric": step})
run.finish()
```

**Before this change - sync fails:**
````
wandb sync /Users/luisbergua/Desktop/dev-env/wandb/wandb/offline-run-20250709_175702-q4qvr0kb
Find logs at: /Users/luisbergua/Desktop/dev-env/wandb/wandb/debug-cli.luisbergua.log
wandb: ERROR Error while calling W&B API: invalid tag 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'. must be between 1 and 64 characters (<Response [400]>)
Syncing: https://wandb.ai//test_replace_tags/runs/q4qvr0kb ... done.
````
**After this change - sync succeeds:**
````
wandb sync /Users/luisbergua/Desktop/dev-env/wandb/wandb/offline-run-20250709_175702-q4qvr0kb --replace-tags 'tag1=new_tag,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=short_tag'
Find logs at: /Users/luisbergua/Desktop/dev-env/wandb/wandb/debug-cli.luisbergua.log
Syncing: https://wandb.ai/luis_team_test/test_replace_tags/runs/q4qvr0kb ... done.
````
![image](https://github.com/user-attachments/assets/d6eeb33d-eb71-4378-a6ee-119cac686076)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [X] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested? Example code above

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
