### PR TITLE
chore: add env variable to enable CGO

### DIFF
--- a/core/hatch.py
+++ b/core/hatch.py
@@ -90,6 +90,10 @@ def _go_env(
     env["GOOS"] = target_system
     env["GOARCH"] = target_arch
 
+    # CGO can be enabled if, for example, FIPS compliance is required, as it
+    # relies on being able to load SSL libraries dynamically - and therefore
+    # building with CGO_ENABLED=1.
+    # See https://github.com/wandb/wandb/issues/10131.
     env["CGO_ENABLED"] = "1" if with_cgo else "0"
 
     if with_race_detection:

--- a/core/hatch.py
+++ b/core/hatch.py
@@ -11,6 +11,7 @@ def build_wandb_core(
     output_path: pathlib.PurePath,
     with_code_coverage: bool,
     with_race_detection: bool,
+    with_cgo: bool,
     wandb_commit_sha: Optional[str],
     target_system,
     target_arch,
@@ -25,6 +26,7 @@ def build_wandb_core(
             support, using `go build -cover`.
         with_race_detection: Whether to build the binary with race detection
             enabled, using `go build -race`.
+        with_cgo: Whether to build the binary with CGO enabled.
         wandb_commit_sha: The Git commit hash we're building from, if this
             is the https://github.com/wandb/wandb repository. Otherwise, an
             empty string.
@@ -56,6 +58,7 @@ def build_wandb_core(
         ],
         cwd="./core",
         env=_go_env(
+            with_cgo=with_cgo,
             with_race_detection=with_race_detection,
             target_system=target_system,
             target_arch=target_arch,
@@ -77,6 +80,7 @@ def _go_linker_flags(wandb_commit_sha: Optional[str]) -> str:
 
 
 def _go_env(
+    with_cgo: bool,
     with_race_detection: bool,
     target_system: str,
     target_arch: str,
@@ -87,6 +91,9 @@ def _go_env(
     env["GOARCH"] = target_arch
 
     env["CGO_ENABLED"] = "0"
+    if with_cgo:
+        env["CGO_ENABLED"] = "1"
+
     if with_race_detection:
         # Crash if a race is detected. The default behavior is to print
         # to stderr and continue.

--- a/core/hatch.py
+++ b/core/hatch.py
@@ -90,9 +90,7 @@ def _go_env(
     env["GOOS"] = target_system
     env["GOARCH"] = target_arch
 
-    env["CGO_ENABLED"] = "0"
-    if with_cgo:
-        env["CGO_ENABLED"] = "1"
+    env["CGO_ENABLED"] = "1" if with_cgo else "0"
 
     if with_race_detection:
         # Crash if a race is detected. The default behavior is to print

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -26,6 +26,7 @@ _WANDB_BUILD_GORACEDETECT = "WANDB_BUILD_GORACEDETECT"
 # Other build options.
 _WANDB_BUILD_UNIVERSAL = "WANDB_BUILD_UNIVERSAL"
 _WANDB_BUILD_SKIP_GPU_STATS = "WANDB_BUILD_SKIP_GPU_STATS"
+_WANDB_ENABLE_CGO = "WANDB_ENABLE_CGO"
 
 
 class CustomBuildHook(BuildHookInterface):
@@ -134,6 +135,7 @@ class CustomBuildHook(BuildHookInterface):
 
         with_coverage = _get_env_bool(_WANDB_BUILD_COVERAGE, default=False)
         with_race_detection = _get_env_bool(_WANDB_BUILD_GORACEDETECT, default=False)
+        with_cgo = _get_env_bool(_WANDB_ENABLE_CGO, default=False)
 
         plat = self._target_platform()
 
@@ -143,6 +145,7 @@ class CustomBuildHook(BuildHookInterface):
             output_path=output,
             with_code_coverage=with_coverage,
             with_race_detection=with_race_detection,
+            with_cgo=with_cgo,
             wandb_commit_sha=os.getenv(_WANDB_RELEASE_COMMIT) or self._git_commit_sha(),
             target_system=plat.goos,
             target_arch=plat.goarch,


### PR DESCRIPTION
Description
-----------
Fixes #10131
Fixes: WB-26048

Add env var `WANDB_ENABLE_CGO` to force `CGO_ENABLED=1` when building `wandb-core`.
