### PR TITLE
fix: api.history scans retries were being multiplied with the clients retries

### DIFF
--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -52,8 +52,6 @@ class HistoryScan:
             max_step: The maximum step to scan up to.
             page_size: Number of history rows to fetch per page.
                 Default page_size is 1000.
-
-        <!-- lazydoc-ignore-class: internal -->
         """
         self.client = client
         self.run = run
@@ -144,8 +142,6 @@ class SampledHistoryScan:
             max_step: The maximum step to sample up to.
             page_size: Number of sampled history rows to fetch per page.
                 Default page_size is 1000.
-
-        <!-- lazydoc-ignore-class: internal -->
         """
         self.client = client
         self.run = run


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes #8381
- Fixes WB-21179

What does the PR do? Include a concise description of the PR contents.

This PR removes a redunant decorator from the `_load_next` functions in the `apis.public.History` classes. Which was already being retried from the retrying client provided to the History scan objects.

When doing a full or sampled history scan, the public API is passing a `RetryingClient` which itself retries on exceptions. Additonally, the `_load_next` functions are also wrapped with the decorator `@retry.retriable` which retries when an exception is raised. 

The load next internally is calling `.execute` on the retrying client provided during initialization which will retry until 20 seconds have elapsed, at which point the exception will be raised. Because the load next does not provide timeout or max retry count that will retry for the default amount of time (365 days) or until the max retries is exceeded (100,000).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- Test script, patched the `_load_next` function to always raise a retry-able exception.
```python
import wandb

api = wandb.Api()
run = api.run("jacob-romero/test/2kd61az8")

history = run.scan_history()
for row in history:
    print(row)
```
verified that the history scan would fail after the default (20 second) timeout from the Api's retrying client.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
