### PR TITLE
[DNM] Hash entire file in parallel in python

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,8 +14,14 @@ Section headings should be at level 3 (e.g. `### Added`).
 ## Unreleased
 
 ### Added
+
 - Support `first` summary option in `define_metric` (@kptkin in https://github.com/wandb/wandb/pull/10121)
 
+### Changed
+
+- Hash multipart upload parts in parallel. (@pingleiwandb in https://github.com/wandb/wandb/pull/10136)
+
 ### Fixed
-- Correct the artifact url for organization registry artifacts to be independent of the artifact type (@ibindlish in https://github.com/wandb/wandb/pull/10049)
-- Suffixes on sanitized `InternalArtifact` names have been shortened to 6 alphanumeric characters (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10102)
+
+- Correct the artifact url for organization registry artifacts to be independent of the artifact type. (@ibindlish in https://github.com/wandb/wandb/pull/10049)
+- Suffixes on sanitized `InternalArtifact` names have been shortened to 6 alphanumeric characters. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10102)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Changed
 
 - Hash multipart upload parts in parallel. (@pingleiwandb in https://github.com/wandb/wandb/pull/10136)
+- Added parallel multipart hashing for large files (>2GiB) with 100MiB part sizes, similar to AWS S3 approach. (@pingleiwandb in https://github.com/wandb/wandb/pull/10136)
 
 ### Fixed
 

--- a/core/internal/filetransfer/file_transfer_default.go
+++ b/core/internal/filetransfer/file_transfer_default.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/wandb/core/internal/observability"
-	"github.com/wandb/wandb/core/internal/wboperation"
 )
 
 // DefaultFileTransfer uploads or downloads files to/from the server
@@ -196,30 +195,31 @@ func getUploadRequestBody(
 		if task.Size > math.MaxInt {
 			return nil, fmt.Errorf("file transfer: file too large (%d bytes)", task.Size)
 		}
+		requestBody = io.NewSectionReader(file, task.Offset, task.Size)
 
-		progress, err := wboperation.Get(task.Context).NewProgress()
-		if err != nil {
-			logger.CaptureError(fmt.Errorf("file transfer: %v", err))
-		}
+		// progress, err := wboperation.Get(task.Context).NewProgress()
+		// if err != nil {
+		// 	logger.CaptureError(fmt.Errorf("file transfer: %v", err))
+		// }
 
-		requestBody = NewProgressReader(
-			io.NewSectionReader(file, task.Offset, task.Size),
-			int(task.Size),
-			func(processed int, total int) {
-				if task.ProgressCallback != nil {
-					task.ProgressCallback(processed, total)
-				}
+		// requestBody = NewProgressReader(
+		// 	io.NewSectionReader(file, task.Offset, task.Size),
+		// 	int(task.Size),
+		// 	func(processed int, total int) {
+		// 		if task.ProgressCallback != nil {
+		// 			task.ProgressCallback(processed, total)
+		// 		}
 
-				progress.SetBytesOfTotal(processed, total)
+		// 		progress.SetBytesOfTotal(processed, total)
 
-				fileTransferStats.UpdateUploadStats(FileUploadInfo{
-					FileKind:      task.FileKind,
-					Path:          task.Path,
-					UploadedBytes: int64(processed),
-					TotalBytes:    int64(total),
-				})
-			},
-		)
+		// 		fileTransferStats.UpdateUploadStats(FileUploadInfo{
+		// 			FileKind:      task.FileKind,
+		// 			Path:          task.Path,
+		// 			UploadedBytes: int64(processed),
+		// 			TotalBytes:    int64(total),
+		// 		})
+		// 	},
+		// )
 	}
 	return requestBody, nil
 }

--- a/core/internal/hashencode/hash.go
+++ b/core/internal/hashencode/hash.go
@@ -44,6 +44,18 @@ func ComputeFileB64MD5(path string) (string, error) {
 	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
 }
 
+// ComputeReaderHexMD5 computes the MD5 hash of the data from the given io.Reader
+// and returns the result as a hexadecimal string.
+//
+// Returns an error if the reader cannot be read.
+func ComputeReaderHexMD5(reader io.Reader) (string, error) {
+	hasher := md5.New()
+	if _, err := io.Copy(hasher, reader); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
 // VerifyFileB64MD5 checks if the file at the given path matches the provided
 // base64-encoded MD5 hash.
 //

--- a/core/pkg/artifacts/saver_test.go
+++ b/core/pkg/artifacts/saver_test.go
@@ -2,7 +2,9 @@ package artifacts
 
 import (
 	"context"
+	"crypto/rand"
 	"math"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -105,4 +107,62 @@ func TestSaveGraphQLRequest(t *testing.T) {
 	gqlmock.AssertVariables(t,
 		createArtifactRequest,
 		gqlmock.GQLVar("input.entityName", gomock.Eq("test-entity")))
+}
+
+func TestComputeMultipartHashes(t *testing.T) {
+	// Create a temporary file with 21MB of random data
+	tempFile, err := os.CreateTemp("", "test_multipart_*")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
+	// Write 21MB of random data
+	fileSize := int64(21 * 1024 * 1024) // 21MB
+	data := make([]byte, fileSize)
+	_, err = rand.Read(data)
+	assert.NoError(t, err)
+
+	_, err = tempFile.Write(data)
+	assert.NoError(t, err)
+	err = tempFile.Close()
+	assert.NoError(t, err)
+
+	// Test with 2MB chunk size
+	chunkSize := int64(2 * 1024 * 1024) // 2MB
+	numWorkers := 4
+
+	parts, err := computeMultipartHashes(tempFile.Name(), chunkSize, numWorkers)
+	assert.NoError(t, err)
+
+	// Should have 11 parts, last part is 1MB
+	assert.Len(t, parts, 11)
+
+	// Verify each part has correct part number and non-empty hash
+	for i, part := range parts {
+		assert.Equal(t, int64(i+1), part.PartNumber)
+		assert.NotEmpty(t, part.HexMD5)
+		assert.Len(t, part.HexMD5, 32) // MD5 hex string is 32 characters
+	}
+
+	// Verify part numbers are sequential
+	for i := 0; i < len(parts)-1; i++ {
+		assert.Equal(t, parts[i].PartNumber+1, parts[i+1].PartNumber)
+	}
+}
+
+func TestComputeMultipartHashesInvalidPath(t *testing.T) {
+	// Test with a non-existent file path
+	invalidPath := t.TempDir() + "/must_be_404.txt"
+	chunkSize := int64(1024 * 1024) // 1MB
+	numWorkers := 4
+
+	parts, err := computeMultipartHashes(invalidPath, chunkSize, numWorkers)
+
+	// Should return an error and nil parts
+	assert.Error(t, err)
+	assert.Nil(t, parts)
+
+	// Verify the error message contains the expected information
+	assert.ErrorContains(t, err, "failed to get file size for path")
+	assert.ErrorContains(t, err, invalidPath)
 }

--- a/wandb/sdk/lib/hashutil.py
+++ b/wandb/sdk/lib/hashutil.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import logging
 import mmap
 import sys
+import time
 from typing import TYPE_CHECKING, NewType
 
 from wandb.sdk.lib.paths import StrPath
@@ -14,6 +16,8 @@ if TYPE_CHECKING:
 ETag = NewType("ETag", str)
 HexMD5 = NewType("HexMD5", str)
 B64MD5 = NewType("B64MD5", str)
+
+logger = logging.getLogger(__name__)
 
 
 def _md5(data: bytes = b"") -> _hashlib.HASH:
@@ -44,7 +48,14 @@ def hex_to_b64_id(encoded_string: str | bytes) -> B64MD5:
 
 
 def md5_file_b64(*paths: StrPath) -> B64MD5:
-    return _b64_from_hasher(_md5_file_hasher(*paths))
+    start_time = time.monotonic()
+    digest = _b64_from_hasher(_md5_file_hasher(*paths))
+    hash_time_seconds = time.monotonic() - start_time
+    if hash_time_seconds > 1.0:
+        logger.debug(
+            f"Computed MD5 hash for file. paths={paths}, hashTimeMs={int(hash_time_seconds * 1000)}"
+        )
+    return digest
 
 
 def md5_file_hex(*paths: StrPath) -> HexMD5:


### PR DESCRIPTION
This a quick test base on #10136 but it use parallel hash for both go and python.
This is breaking change, but it works without any work on server side.

Verified existing dedupe logic works for new file. It should break existing file for sure due to the hash change.

Log from uploading file that already exists, 5207MB/s .... previously the speed is 600MB/s when the file already exists.

```text
2025-07-09 22:07:18,450 - wandb.wandb_agent - INFO - About to run command: /usr/bin/env python mega.py --action=upload --cloud=gcp --sdk=wandb --size=20
wandb: Currently logged in as: pinglei (reg-team-2) to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
wandb: Tracking run with wandb version 0.21.1.dev1
wandb: Run data is saved locally in /home/pinglei_guo/scripts/wandb/run-20250709_220719-y9f9rzb4
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run 07092207_upload_20gb_wandb
wandb: ⭐️ View project at https://wandb.ai/reg-team-2/pinglei-wbench-gcs-upload-from-gcp-v20250709-v1-pr-python-parallel-entire-file
wandb: 🧹 View sweep at https://wandb.ai/reg-team-2/pinglei-wbench-gcs-upload-from-gcp-v20250709-v1-pr-python-parallel-entire-file/sweeps/fk7lem1j
wandb: 🚀 View run at https://wandb.ai/reg-team-2/pinglei-wbench-gcs-upload-from-gcp-v20250709-v1-pr-python-parallel-entire-file/runs/y9f9rzb4
2025-07-09 22:07:23,459 - wandb.wandb_agent - INFO - Running runs: ['y9f9rzb4']
Using wandb to upload 20gb in 3.9325852394104004 seconds, speed: 5207.77mb/s
wandb:
```