### PR TITLE
refactor: remove unused "deduped bytes" printing code

### DIFF
--- a/core/internal/filetransfer/file_transfer_stats.go
+++ b/core/internal/filetransfer/file_transfer_stats.go
@@ -34,7 +34,6 @@ type fileTransferStats struct {
 
 	uploadedBytes *atomic.Int64
 	totalBytes    *atomic.Int64
-	dedupedBytes  *atomic.Int64
 
 	wandbCount    *atomic.Int32
 	mediaCount    *atomic.Int32
@@ -50,7 +49,6 @@ func NewFileTransferStats() FileTransferStats {
 
 		uploadedBytes: &atomic.Int64{},
 		totalBytes:    &atomic.Int64{},
-		dedupedBytes:  &atomic.Int64{},
 
 		wandbCount:    &atomic.Int32{},
 		mediaCount:    &atomic.Int32{},
@@ -65,7 +63,6 @@ func (fts *fileTransferStats) GetFilesStats() *spb.FilePusherStats {
 	return &spb.FilePusherStats{
 		UploadedBytes: fts.uploadedBytes.Load(),
 		TotalBytes:    fts.totalBytes.Load(),
-		DedupedBytes:  fts.dedupedBytes.Load(),
 	}
 }
 

--- a/wandb/sdk/lib/progress.py
+++ b/wandb/sdk/lib/progress.py
@@ -14,25 +14,6 @@ from wandb.sdk.lib import asyncio_compat
 from . import printer as p
 
 
-def print_sync_dedupe_stats(
-    printer: p.Printer,
-    final_result: pb.PollExitResponse,
-) -> None:
-    """Print how much W&B sync reduced the amount of uploaded data.
-
-    Args:
-        final_result: The final PollExit result.
-    """
-    deduped_bytes = final_result.pusher_stats.deduped_bytes
-    total_bytes = final_result.pusher_stats.total_bytes
-
-    if total_bytes <= 0 or deduped_bytes <= 0:
-        return
-
-    frac = deduped_bytes / total_bytes
-    printer.display(f"W&B sync reduced upload amount by {frac:.1%}")
-
-
 async def loop_printing_operation_stats(
     progress: ProgressPrinter,
     interface: interface.InterfaceBase,

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2729,15 +2729,10 @@ class Run:
                 ),
             )
 
-        # Print some final statistics.
         poll_exit_handle = self._backend.interface.deliver_poll_exit()
         result = poll_exit_handle.wait_or(timeout=None)
-        progress.print_sync_dedupe_stats(
-            self._printer,
-            result.response.poll_exit_response,
-        )
-
         self._poll_exit_response = result.response.poll_exit_response
+
         internal_messages_handle = self._backend.interface.deliver_internal_messages()
         result = internal_messages_handle.wait_or(timeout=None)
         self._internal_messages_response = result.response.internal_messages_response


### PR DESCRIPTION
Removes unused "deduped bytes" code, as we don't track this in wandb-core.