### PR TITLE
fix: flaky test in test_keras.py

### DIFF
--- a/tests/system_tests/test_functional/keras/test_keras.py
+++ b/tests/system_tests/test_functional/keras/test_keras.py
@@ -1,9 +1,10 @@
 import pathlib
+import subprocess
 
 
-def test_eval_tables_builder(wandb_backend_spy, execute_script):
+def test_eval_tables_builder(wandb_backend_spy):
     script_path = pathlib.Path(__file__).parent / "keras_eval_tables_builder.py"
-    execute_script(script_path)
+    subprocess.check_call(["python", str(script_path)])
 
     with wandb_backend_spy.freeze() as snapshot:
         run_ids = snapshot.run_ids()
@@ -14,9 +15,9 @@ def test_eval_tables_builder(wandb_backend_spy, execute_script):
         assert 40 in telemetry["3"]  # feature=keras_wandb_eval_callback
 
 
-def test_metrics_logger_epochwise(wandb_backend_spy, execute_script):
+def test_metrics_logger_epochwise(wandb_backend_spy):
     script_path = pathlib.Path(__file__).parent / "keras_metrics_logger_epochwise.py"
-    execute_script(script_path)
+    subprocess.check_call(["python", str(script_path)])
 
     with wandb_backend_spy.freeze() as snapshot:
         run_ids = snapshot.run_ids()
@@ -33,9 +34,9 @@ def test_metrics_logger_epochwise(wandb_backend_spy, execute_script):
         assert "epoch/learning_rate" in summary
 
 
-def test_metrics_logger(wandb_backend_spy, execute_script):
+def test_metrics_logger(wandb_backend_spy):
     script_path = pathlib.Path(__file__).parent / "keras_metrics_logger.py"
-    execute_script(script_path)
+    subprocess.check_call(["python", str(script_path)])
 
     with wandb_backend_spy.freeze() as snapshot:
         run_ids = snapshot.run_ids()
@@ -54,9 +55,9 @@ def test_metrics_logger(wandb_backend_spy, execute_script):
         assert "batch/learning_rate" in summary
 
 
-def test_model_checkpoint(wandb_backend_spy, execute_script):
+def test_model_checkpoint(wandb_backend_spy):
     script_path = pathlib.Path(__file__).parent / "keras_model_checkpoint.py"
-    execute_script(script_path)
+    subprocess.check_call(["python", str(script_path)])
 
     with wandb_backend_spy.freeze() as snapshot:
         run_ids = snapshot.run_ids()
@@ -67,13 +68,9 @@ def test_model_checkpoint(wandb_backend_spy, execute_script):
         assert 39 in telemetry["3"]  # feature=keras_wandb_model_checkpoint
 
 
-def test_deprecated_keras_callback(
-    wandb_backend_spy,
-    execute_script,
-    mock_wandb_log,
-):
+def test_deprecated_keras_callback(wandb_backend_spy):
     script_path = pathlib.Path(__file__).parent / "keras_deprecated.py"
-    execute_script(script_path)
+    subprocess.check_call(["python", str(script_path)])
 
     with wandb_backend_spy.freeze() as snapshot:
         run_ids = snapshot.run_ids()
@@ -89,7 +86,3 @@ def test_deprecated_keras_callback(
 
         telemetry = snapshot.telemetry(run_id=run_id)
         assert 8 in telemetry["3"]  # feature=keras
-
-        assert mock_wandb_log.warned(
-            "WandbCallback is deprecated and will be removed in a future release."
-        )


### PR DESCRIPTION
Makes `test_keras.py` use the subprocess module instead of `runpy` to fix a flaky test.

Example of a flake: https://app.circleci.com/pipelines/github/wandb/wandb/49366/workflows/55c71ca7-bb87-4b4b-b022-1aa2dfca8626/jobs/1427172/tests

The flake was likely happening because of a race condition: `execute_script` would return after all `run.summary[...] = ...` statements in `WandbCallback` were executed but not necessarily processed by `wandb-core`. By executing the script using `subprocess`, it triggers `wandb.teardown()` at the end and blocks until `wandb-core` finishes all of its work.