### PR TITLE
chore(sdk): fix changelog entry for sweep.name change

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Changed
 - `Sweep.name` property will now return user-edited display name if available (falling back to
-  original name from sweep config, then sweep ID as before). (@kelu-wandb in https://github.com/wandb/wandb/pull/10144)
+  original name from sweep config, then sweep ID as before) (@kelu-wandb in https://github.com/wandb/wandb/pull/10144)
 
 ### Added
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Changed
 - `Sweep.name` property will now return user-edited display name if available (falling back to
-  original name from sweep config, then sweep ID as before).
+  original name from sweep config, then sweep ID as before). (@kelu-wandb in https://github.com/wandb/wandb/pull/10144)
 
 ### Added
 


### PR DESCRIPTION
Description
-----------
Adds user and PR to changelog entry for sweeps.name change

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

n/a

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
