### PR TITLE
chore: increase backend fixture timeout

### DIFF
--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -157,8 +157,8 @@ class BackendFixtureFactory:
     def __post_init__(self, service_url: str):
         self._client = httpx.Client(
             base_url=service_url,
-            # event_hooks={"response": [httpx.Response.raise_for_status]},
-            # timeout=None,
+            # The default 5s timeout is sometimes too short in CI.
+            timeout=30,
         )
 
     def __enter__(self):


### PR DESCRIPTION
Increase timeout for backend fixtures (like creating a test user) from 5s to 30s to avoid the occasional timeout errors such as https://app.circleci.com/pipelines/github/wandb/wandb/49425/workflows/7b5850d0-19f8-457b-b4cd-ce50f5c30240/jobs/1428146/tests