### PR TITLE
chore: skip metaflow 2.16.0 in CI

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -52,7 +52,7 @@ ray[air,tune]
 # Latest version of plum-dispatch tested is 2.5.7
 plum-dispatch>=2.0.0,<3.0.0
 pyarrow
-metaflow
+metaflow~=2.15,!=2.16.0  # https://github.com/Netflix/metaflow/issues/2489
 xgboost
 lightgbm
 mlflow


### PR DESCRIPTION
https://github.com/Netflix/metaflow/issues/2489 causes tests/system_tests/test_functional/metaflow/test_metaflow.py to fail.