### PR TITLE
refactor: expose `wandb.Run`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -429,15 +429,13 @@ def mock_run(test_settings, mocked_backend) -> Generator[Callable, None, None]:
     own unit-tested module instead.
     """
 
-    def mock_run_fn(use_magic_mock=False, **kwargs: Any) -> wandb.sdk.wandb_run.Run:
+    def mock_run_fn(use_magic_mock=False, **kwargs: Any) -> wandb.Run:
         kwargs_settings = kwargs.pop("settings", dict())
         kwargs_settings = {
             "run_id": runid.generate_id(),
             **dict(kwargs_settings),
         }
-        run = wandb.wandb_sdk.wandb_run.Run(
-            settings=test_settings(kwargs_settings), **kwargs
-        )
+        run = wandb.Run(settings=test_settings(kwargs_settings), **kwargs)
         run._set_backend(
             unittest.mock.MagicMock() if use_magic_mock else mocked_backend
         )

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -38,7 +38,6 @@ from wandb.sdk.artifacts.storage_handlers.http_handler import HTTPHandler
 from wandb.sdk.artifacts.storage_handlers.s3_handler import S3Handler
 from wandb.sdk.artifacts.storage_handlers.tracking_handler import TrackingHandler
 from wandb.sdk.lib.hashutil import md5_string
-from wandb.sdk.wandb_run import Run
 
 
 def mock_boto(artifact, path=False, content_type=None, version_id="1"):
@@ -493,7 +492,7 @@ def test_add_reference_local_file_no_checksum(tmp_path, artifact):
 
 class TestAddReferenceLocalFileNoChecksumTwice:
     @pytest.fixture
-    def run(self, user) -> Iterator[Run]:
+    def run(self, user) -> Iterator[wandb.Run]:
         with wandb.init() as run:
             yield run
 

--- a/tests/unit_tests/test_launch/test_agent/test_run_queue_item_saver.py
+++ b/tests/unit_tests/test_launch/test_agent/test_run_queue_item_saver.py
@@ -1,8 +1,8 @@
 import os
 from unittest.mock import MagicMock
 
+import wandb
 from wandb.sdk.launch.agent.run_queue_item_file_saver import RunQueueItemFileSaver
-from wandb.sdk.wandb_run import Run
 
 
 def test_no_run():
@@ -14,7 +14,7 @@ def test_run():
     rqi_id = "test_run_queue_item_id"
     settings = MagicMock()
     settings.files_dir = "blah"
-    run = MagicMock(spec=Run)
+    run = MagicMock(spec=wandb.Run)
     run._settings = settings
     run.project = "test-project"
     run.entity = "test-entity"

--- a/tests/unit_tests/test_library_public.py
+++ b/tests/unit_tests/test_library_public.py
@@ -30,6 +30,7 @@ SYMBOLS_ROOT_DATATYPES = {
 
 SYMBOLS_ROOT_SDK = {
     "ArtifactTTL",
+    "Run",
     "login",
     "init",
     "log",
@@ -233,8 +234,7 @@ SYMBOLS_RUN_OTHER = {
 
 
 def test_library_run():
-    Run = wandb.wandb_sdk.wandb_run.Run  # noqa: N806
-    symbol_list = dir(Run)
+    symbol_list = dir(wandb.Run)
     symbol_public_set = {s for s in symbol_list if not s.startswith("_")}
     symbol_unknown = (
         symbol_public_set

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -79,6 +79,7 @@ from wandb.wandb_agent import agent
 from wandb.plot import visualize, plot_table
 from wandb.integration.sagemaker import sagemaker_auth
 from wandb.sdk.internal import profiler
+from wandb.sdk.wandb_run import Run
 
 # Artifact import types
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
@@ -112,38 +113,38 @@ def _assert_is_user_process():
 # globals
 Api = PublicApi
 api = InternalApi()
-run: wandb_sdk.wandb_run.Run | None = None
+run: Run | None = None
 config = _preinit.PreInitObject("wandb.config", wandb_sdk.wandb_config.Config)
 summary = _preinit.PreInitObject("wandb.summary", wandb_sdk.wandb_summary.Summary)
-log = _preinit.PreInitCallable("wandb.log", wandb_sdk.wandb_run.Run.log)  # type: ignore
-watch = _preinit.PreInitCallable("wandb.watch", wandb_sdk.wandb_run.Run.watch)  # type: ignore
-unwatch = _preinit.PreInitCallable("wandb.unwatch", wandb_sdk.wandb_run.Run.unwatch)  # type: ignore
-save = _preinit.PreInitCallable("wandb.save", wandb_sdk.wandb_run.Run.save)  # type: ignore
+log = _preinit.PreInitCallable("wandb.log", Run.log)  # type: ignore
+watch = _preinit.PreInitCallable("wandb.watch", Run.watch)  # type: ignore
+unwatch = _preinit.PreInitCallable("wandb.unwatch", Run.unwatch)  # type: ignore
+save = _preinit.PreInitCallable("wandb.save", Run.save)  # type: ignore
 restore = wandb_sdk.wandb_run.restore
 use_artifact = _preinit.PreInitCallable(
-    "wandb.use_artifact", wandb_sdk.wandb_run.Run.use_artifact  # type: ignore
+    "wandb.use_artifact", Run.use_artifact  # type: ignore
 )
 log_artifact = _preinit.PreInitCallable(
-    "wandb.log_artifact", wandb_sdk.wandb_run.Run.log_artifact  # type: ignore
+    "wandb.log_artifact", Run.log_artifact  # type: ignore
 )
 log_model = _preinit.PreInitCallable(
-    "wandb.log_model", wandb_sdk.wandb_run.Run.log_model  # type: ignore
+    "wandb.log_model", Run.log_model  # type: ignore
 )
 use_model = _preinit.PreInitCallable(
-    "wandb.use_model", wandb_sdk.wandb_run.Run.use_model  # type: ignore
+    "wandb.use_model", Run.use_model  # type: ignore
 )
 link_model = _preinit.PreInitCallable(
-    "wandb.link_model", wandb_sdk.wandb_run.Run.link_model  # type: ignore
+    "wandb.link_model", Run.link_model  # type: ignore
 )
 define_metric = _preinit.PreInitCallable(
-    "wandb.define_metric", wandb_sdk.wandb_run.Run.define_metric  # type: ignore
+    "wandb.define_metric", Run.define_metric  # type: ignore
 )
 
 mark_preempting = _preinit.PreInitCallable(
-    "wandb.mark_preempting", wandb_sdk.wandb_run.Run.mark_preempting  # type: ignore
+    "wandb.mark_preempting", Run.mark_preempting  # type: ignore
 )
 
-alert = _preinit.PreInitCallable("wandb.alert", wandb_sdk.wandb_run.Run.alert)  # type: ignore
+alert = _preinit.PreInitCallable("wandb.alert", Run.alert)  # type: ignore
 
 # record of patched libraries
 patched = {"tensorboard": [], "keras": [], "gym": []}  # type: ignore
@@ -243,4 +244,5 @@ __all__ = (
     "watch",
     "unwatch",
     "plot_table",
+    "Run",
 )

--- a/wandb/integration/lightning/fabric/logger.py
+++ b/wandb/integration/lightning/fabric/logger.py
@@ -9,7 +9,6 @@ from typing_extensions import override
 import wandb
 from wandb import Artifact
 from wandb.sdk.lib import telemetry
-from wandb.sdk.wandb_run import Run
 
 try:
     import lightning
@@ -295,7 +294,7 @@ class WandbLogger(Logger):
         anonymous: Optional[bool] = None,
         project: Optional[str] = None,
         log_model: Union[Literal["all"], bool] = False,
-        experiment: Optional["Run"] = None,
+        experiment: Optional["wandb.Run"] = None,
         prefix: str = "",
         checkpoint_name: Optional[str] = None,
         log_checkpoint_on: Union[Literal["success"], Literal["all"]] = "success",
@@ -362,7 +361,7 @@ class WandbLogger(Logger):
 
     @property
     @rank_zero_experiment
-    def experiment(self) -> "Run":
+    def experiment(self) -> "wandb.Run":
         r"""Actual wandb object.
 
         To use wandb features in your :class:`~lightning.pytorch.core.LightningModule`, do the
@@ -395,7 +394,7 @@ class WandbLogger(Logger):
                 self._experiment = wandb.init(**self._wandb_init)
 
                 # define default x-axis
-                if isinstance(self._experiment, Run) and getattr(
+                if isinstance(self._experiment, wandb.Run) and getattr(
                     self._experiment, "define_metric", None
                 ):
                     self._experiment.define_metric("trainer/global_step")

--- a/wandb/integration/openai/fine_tuning.py
+++ b/wandb/integration/openai/fine_tuning.py
@@ -14,7 +14,6 @@ import wandb
 from wandb import util
 from wandb.data_types import Table
 from wandb.sdk.lib import telemetry
-from wandb.sdk.wandb_run import Run
 
 openai = util.get_module(
     name="openai",
@@ -54,7 +53,7 @@ class WandbLogger:
     _wandb_api: Optional[wandb.Api] = None
     _logged_in: bool = False
     openai_client: Optional[OpenAI] = None
-    _run: Optional[Run] = None
+    _run: Optional[wandb.Run] = None
 
     @classmethod
     def sync(

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -19,13 +19,13 @@ from requests.compat import urljoin
 
 import wandb
 import wandb.util
-from wandb.sdk import wandb_run, wandb_setup
+from wandb.sdk import wandb_setup
 from wandb.sdk.lib import filesystem
 
 logger = logging.getLogger(__name__)
 
 
-def display_if_magic_is_used(run: wandb_run.Run) -> bool:
+def display_if_magic_is_used(run: wandb.Run) -> bool:
     """Display a run's page if the cell has the %%wandb cell magic.
 
     Args:
@@ -53,7 +53,7 @@ class _WandbCellMagicState:
         self._height = height
         self._already_displayed = False
 
-    def display_if_allowed(self, run: wandb_run.Run) -> None:
+    def display_if_allowed(self, run: wandb.Run) -> None:
         """Display a run's iframe if one is not already displayed.
 
         Args:
@@ -93,7 +93,7 @@ def _display_by_wandb_path(path: str, *, height: int) -> None:
         )
 
 
-def _display_wandb_run(run: wandb_run.Run, *, height: int) -> None:
+def _display_wandb_run(run: wandb.Run, *, height: int) -> None:
     """Display a run (usually in an iframe).
 
     Args:
@@ -461,7 +461,7 @@ class Notebook:
 
         return False
 
-    def save_history(self, run: wandb_run.Run):
+    def save_history(self, run: wandb.Run):
         """This saves all cell executions in the current session as a new notebook."""
         try:
             from nbformat import v4, validator, write  # type: ignore

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -18,8 +18,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from wandb.sdk.artifacts.artifact import Artifact
 
-    from ...wandb_run import Run as LocalRun
-
 
 SYS_PLATFORM = platform.system()
 
@@ -104,7 +102,7 @@ class Media(WBValue):
     """
 
     _path: Optional[str]
-    _run: Optional["LocalRun"]
+    _run: Optional["wandb.Run"]
     _caption: Optional[str]
     _is_tmp: Optional[bool]
     _extension: Optional[str]
@@ -156,7 +154,7 @@ class Media(WBValue):
 
     def bind_to_run(
         self,
-        run: "LocalRun",
+        run: "wandb.Run",
         key: Union[int, str],
         step: Union[int, str],
         id_: Optional[Union[int, str]] = None,
@@ -205,7 +203,7 @@ class Media(WBValue):
             self._path = new_path
             run._publish_file(media_path)
 
-    def to_json(self, run: Union["LocalRun", "Artifact"]) -> dict:
+    def to_json(self, run: Union["wandb.Run", "Artifact"]) -> dict:
         """Serialize the object into a JSON blob.
 
         Uses run or artifact to store additional data. If `run_or_artifact` is a
@@ -223,14 +221,13 @@ class Media(WBValue):
         # into Media itself we should get rid of them
         from wandb import Image
         from wandb.data_types import Audio
-        from wandb.sdk.wandb_run import Run
 
         json_obj: Dict[str, Any] = {}
 
         if self._caption is not None:
             json_obj["caption"] = self._caption
 
-        if isinstance(run, Run):
+        if isinstance(run, wandb.Run):
             json_obj.update(
                 {
                     "_type": "file",  # TODO(adrian): This isn't (yet) a real media type we support on the frontend.
@@ -357,7 +354,7 @@ class BatchableMedia(Media):
     def seq_to_json(
         cls: Type["BatchableMedia"],
         seq: Sequence["BatchableMedia"],
-        run: "LocalRun",
+        run: "wandb.Run",
         key: str,
         step: Union[int, str],
     ) -> dict:

--- a/wandb/sdk/data_types/helper_types/bounding_boxes_2d.py
+++ b/wandb/sdk/data_types/helper_types/bounding_boxes_2d.py
@@ -310,9 +310,7 @@ class BoundingBoxes2D(JSONMetadata):
         return True
 
     def to_json(self, run_or_artifact: Union["LocalRun", "Artifact"]) -> dict:
-        from wandb.sdk.wandb_run import Run
-
-        if isinstance(run_or_artifact, Run):
+        if isinstance(run_or_artifact, wandb.Run):
             return super().to_json(run_or_artifact)
         elif isinstance(run_or_artifact, wandb.Artifact):
             # TODO (tim): I would like to log out a proper dictionary representing this object, but don't

--- a/wandb/sdk/data_types/helper_types/image_mask.py
+++ b/wandb/sdk/data_types/helper_types/image_mask.py
@@ -209,11 +209,9 @@ class ImageMask(Media):
         )
 
     def to_json(self, run_or_artifact: Union["LocalRun", "Artifact"]) -> dict:
-        from wandb.sdk.wandb_run import Run
-
         json_dict = super().to_json(run_or_artifact)
 
-        if isinstance(run_or_artifact, Run):
+        if isinstance(run_or_artifact, wandb.Run):
             json_dict["_type"] = self.type_name()
             return json_dict
         elif isinstance(run_or_artifact, wandb.Artifact):

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -28,8 +28,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from wandb.sdk.artifacts.artifact import Artifact
 
-    from ..wandb_run import Run as LocalRun
-
     ImageDataType = Union[
         "matplotlib.artist.Artist", "PILImage", "TorchTensorType", "np.ndarray"
     ]
@@ -101,7 +99,7 @@ def _convert_to_uint8(data: "np.ndarray") -> "np.ndarray":
     return data.astype(np.uint8)
 
 
-def _server_accepts_image_filenames(run: "LocalRun") -> bool:
+def _server_accepts_image_filenames(run: "wandb.Run") -> bool:
     if run.offline:
         return True
 
@@ -117,7 +115,7 @@ def _server_accepts_image_filenames(run: "LocalRun") -> bool:
     return accepts_image_filenames
 
 
-def _server_accepts_artifact_path(run: "LocalRun") -> bool:
+def _server_accepts_artifact_path(run: "wandb.Run") -> bool:
     if run.offline:
         return False
 
@@ -490,7 +488,7 @@ class Image(BatchableMedia):
 
     def bind_to_run(
         self,
-        run: "LocalRun",
+        run: "wandb.Run",
         key: Union[int, str],
         step: Union[int, str],
         id_: Optional[Union[int, str]] = None,
@@ -533,13 +531,11 @@ class Image(BatchableMedia):
                     run, key, step, id_, ignore_copy_err=ignore_copy_err
                 )
 
-    def to_json(self, run_or_artifact: Union["LocalRun", "Artifact"]) -> dict:
+    def to_json(self, run_or_artifact: Union["wandb.Run", "Artifact"]) -> dict:
         """Returns the JSON representation expected by the backend.
 
         <!-- lazydoc-ignore: internal -->
         """
-        from wandb.sdk.wandb_run import Run
-
         json_dict = super().to_json(run_or_artifact)
         json_dict["_type"] = Image._log_type
         json_dict["format"] = self.format
@@ -576,8 +572,8 @@ class Image(BatchableMedia):
                     "digest": classes_entry.digest,
                 }
 
-        elif not isinstance(run_or_artifact, Run):
-            raise TypeError("to_json accepts wandb_run.Run or wandb_artifact.Artifact")
+        elif not isinstance(run_or_artifact, wandb.Run):
+            raise TypeError("to_json accepts wandb.Run or wandb_artifact.Artifact")
 
         if self._boxes:
             json_dict["boxes"] = {
@@ -629,7 +625,7 @@ class Image(BatchableMedia):
     def seq_to_json(
         cls: Type["Image"],
         seq: Sequence["BatchableMedia"],
-        run: "LocalRun",
+        run: "wandb.Run",
         key: str,
         step: Union[int, str],
     ) -> dict:
@@ -706,7 +702,7 @@ class Image(BatchableMedia):
     def all_masks(
         cls: Type["Image"],
         images: Sequence["Image"],
-        run: "LocalRun",
+        run: "wandb.Run",
         run_key: str,
         step: Union[int, str],
     ) -> Union[List[Optional[dict]], bool]:
@@ -733,7 +729,7 @@ class Image(BatchableMedia):
     def all_boxes(
         cls: Type["Image"],
         images: Sequence["Image"],
-        run: "LocalRun",
+        run: "wandb.Run",
         run_key: str,
         step: Union[int, str],
     ) -> Union[List[Optional[dict]], bool]:

--- a/wandb/sdk/data_types/saved_model.py
+++ b/wandb/sdk/data_types/saved_model.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from wandb.sdk.artifacts.artifact import Artifact
-    from wandb.sdk.wandb_run import Run as LocalRun
 
 
 DEBUG_MODE = False
@@ -137,15 +136,14 @@ class _SavedModel(WBValue, Generic[SavedModelObjType]):
         # and specified adapter.
         return cls(dl_path)
 
-    def to_json(self, run_or_artifact: LocalRun | Artifact) -> dict:
+    def to_json(self, run_or_artifact: wandb.Run | Artifact) -> dict:
         # Unlike other data types, we do not allow adding to a Run directly. There is a
         # bit of tech debt in the other data types which requires the input to `to_json`
         # to accept a Run or Artifact. However, Run additions should be deprecated in the future.
         # This check helps ensure we do not add to the debt.
-        from wandb.sdk.wandb_run import Run
-
-        if isinstance(run_or_artifact, Run):
+        if isinstance(run_or_artifact, wandb.Run):
             raise TypeError("SavedModel cannot be added to run - must use artifact")
+
         artifact = run_or_artifact
         json_obj = {
             "type": self._log_type,
@@ -329,7 +327,7 @@ class _PicklingSavedModel(_SavedModel[SavedModelObjType]):
 
         return inst  # type: ignore
 
-    def to_json(self, run_or_artifact: LocalRun | Artifact) -> dict:
+    def to_json(self, run_or_artifact: wandb.Run | Artifact) -> dict:
         json_obj = super().to_json(run_or_artifact)
         assert isinstance(run_or_artifact, wandb.Artifact)
         if self._dep_py_files_path is not None:

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -727,7 +727,7 @@ class Table(Media):
                 }
             )
 
-        if isinstance(run_or_artifact, wandb.wandb_sdk.wandb_run.Run):
+        if isinstance(run_or_artifact, wandb.Run):
             if self.log_mode == "INCREMENTAL":
                 wbvalue_type = "incremental-table-file"
             else:
@@ -1107,7 +1107,7 @@ class PartitionedTable(Media):
         json_obj = {
             "_type": PartitionedTable._log_type,
         }
-        if isinstance(artifact_or_run, wandb.wandb_sdk.wandb_run.Run):
+        if isinstance(artifact_or_run, wandb.Run):
             artifact_entry_url = self._get_artifact_entry_ref_url()
             if artifact_entry_url is None:
                 raise ValueError(
@@ -1262,7 +1262,7 @@ class JoinedTable(Media):
         json_obj = {
             "_type": JoinedTable._log_type,
         }
-        if isinstance(artifact_or_run, wandb.wandb_sdk.wandb_run.Run):
+        if isinstance(artifact_or_run, wandb.Run):
             artifact_entry_url = self._get_artifact_entry_ref_url()
             if artifact_entry_url is None:
                 raise ValueError(

--- a/wandb/sdk/integration_utils/auto_logging.py
+++ b/wandb/sdk/integration_utils/auto_logging.py
@@ -71,7 +71,7 @@ class PatchAPI:
             )
         return self._api
 
-    def patch(self, run: "wandb.sdk.wandb_run.Run") -> None:
+    def patch(self, run: "wandb.Run") -> None:
         """Patches the API to log media or metrics to W&B."""
         for symbol in self.symbols:
             # split on dots, e.g. "Client.generate" -> ["Client", "generate"]
@@ -163,7 +163,7 @@ class AutologAPI:
             resolver=resolver,
         )
         self._name = self._patch_api.name
-        self._run: Optional[wandb.sdk.wandb_run.Run] = None
+        self._run: Optional[wandb.Run] = None
         self.__run_created_by_autolog: bool = False
 
     @property

--- a/wandb/sdk/launch/agent/run_queue_item_file_saver.py
+++ b/wandb/sdk/launch/agent/run_queue_item_file_saver.py
@@ -11,7 +11,7 @@ FileSubtypes = Literal["warning", "error"]
 class RunQueueItemFileSaver:
     def __init__(
         self,
-        agent_run: Optional["wandb.sdk.wandb_run.Run"],
+        agent_run: Optional["wandb.Run"],
         run_queue_item_id: str,
     ):
         self.run_queue_item_id = run_queue_item_id
@@ -20,7 +20,7 @@ class RunQueueItemFileSaver:
     def save_contents(
         self, contents: str, fname: str, file_sub_type: FileSubtypes
     ) -> Optional[List[str]]:
-        if not isinstance(self.run, wandb.sdk.wandb_run.Run):
+        if not isinstance(self.run, wandb.Run):
             wandb.termwarn("Not saving file contents because agent has no run")
             return None
         root_dir = self.run._settings.files_dir

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -421,7 +421,7 @@ def _configure_job_builder_for_partial(tmpdir: str, job_source: str) -> JobBuild
 def _make_code_artifact(
     api: Api,
     job_builder: JobBuilder,
-    run: "wandb.sdk.wandb_run.Run",
+    run: "wandb.Run",
     path: str,
     entrypoint: str,
     entity: Optional[str],

--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -17,7 +17,6 @@ import wandb
 import wandb.data_types
 from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.inputs.schema import META_SCHEMA
-from wandb.sdk.wandb_run import Run
 from wandb.util import get_module
 
 from .files import config_path_is_valid, override_file
@@ -93,7 +92,7 @@ class StagedLaunchInputs:
     ):
         self._staged_inputs.append(input_arguments)
 
-    def apply(self, run: Run):
+    def apply(self, run: wandb.Run):
         """Apply the staged inputs to the given run."""
         for input in self._staged_inputs:
             _publish_job_input(input, run)
@@ -101,13 +100,13 @@ class StagedLaunchInputs:
 
 def _publish_job_input(
     input: JobInputArguments,
-    run: Run,
+    run: wandb.Run,
 ) -> None:
     """Publish a job input to the backend interface of the given run.
 
     Arguments:
         input (JobInputArguments): The arguments for the job input.
-        run (Run): The run to publish the job input to.
+        run (wandb.Run): The run to publish the job input to.
     """
     assert run._backend is not None
     assert run._backend.interface is not None

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
     import wandb.apis.public as public
     from wandb.apis.internal import Api
     from wandb.apis.public import QueuedRun, Run
-    from wandb.sdk.wandb_run import Run as SdkRun
 
 
 _logger = logging.getLogger(__name__)
@@ -255,10 +254,10 @@ class Scheduler(ABC):
             _id: w for _id, w in self._workers.items() if _id not in self.busy_workers
         }
 
-    def _init_wandb_run(self) -> "SdkRun":
+    def _init_wandb_run(self) -> "wandb.Run":
         """Controls resume or init logic for a scheduler wandb run."""
         settings = wandb.Settings(disable_job_creation=True)
-        run: SdkRun = wandb.init(  # type: ignore
+        run: wandb.Run = wandb.init(  # type: ignore
             name=f"Scheduler.{self._sweep_id}",
             resume="allow",
             config=self._kwargs,  # when run as a job, this sets config

--- a/wandb/sdk/lib/deprecate.py
+++ b/wandb/sdk/lib/deprecate.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import wandb
 from wandb.proto.wandb_deprecated import DEPRECATED_FEATURES
 from wandb.sdk.lib import telemetry
-
-# Necessary to break import cycle.
-if TYPE_CHECKING:
-    from wandb import wandb_run
 
 
 def deprecate(
     field_name: DEPRECATED_FEATURES,
     warning_message: str,
-    run: wandb_run.Run | None = None,
+    run: wandb.Run | None = None,
 ) -> None:
     """Warn the user that a feature has been deprecated.
 

--- a/wandb/sdk/lib/disabled.py
+++ b/wandb/sdk/lib/disabled.py
@@ -26,5 +26,5 @@ class RunDisabled:
         deprecate.deprecate(
             field_name=Deprecated.run_disabled,
             warning_message="RunDisabled is deprecated and is a no-op. "
-            '`wandb.init(mode="disabled")` now returns and instance of `wandb.sdk.wandb_run.Run`.',
+            '`wandb.init(mode="disabled")` now returns an instance of `wandb.Run`.',
         )

--- a/wandb/sdk/lib/module.py
+++ b/wandb/sdk/lib/module.py
@@ -57,22 +57,16 @@ def unset_globals():
     wandb.run = None
     wandb.config = preinit.PreInitObject("wandb.config")
     wandb.summary = preinit.PreInitObject("wandb.summary")
-    wandb.log = preinit.PreInitCallable("wandb.log", wandb.wandb_sdk.wandb_run.Run.log)
-    wandb.watch = preinit.PreInitCallable(
-        "wandb.watch", wandb.wandb_sdk.wandb_run.Run.watch
-    )
-    wandb.unwatch = preinit.PreInitCallable(
-        "wandb.unwatch", wandb.wandb_sdk.wandb_run.Run.unwatch
-    )
-    wandb.save = preinit.PreInitCallable(
-        "wandb.save", wandb.wandb_sdk.wandb_run.Run.save
-    )
+    wandb.log = preinit.PreInitCallable("wandb.log", wandb.Run.log)
+    wandb.watch = preinit.PreInitCallable("wandb.watch", wandb.Run.watch)
+    wandb.unwatch = preinit.PreInitCallable("wandb.unwatch", wandb.Run.unwatch)
+    wandb.save = preinit.PreInitCallable("wandb.save", wandb.Run.save)
     wandb.use_artifact = preinit.PreInitCallable(
-        "wandb.use_artifact", wandb.wandb_sdk.wandb_run.Run.use_artifact
+        "wandb.use_artifact", wandb.Run.use_artifact
     )
     wandb.log_artifact = preinit.PreInitCallable(
-        "wandb.log_artifact", wandb.wandb_sdk.wandb_run.Run.log_artifact
+        "wandb.log_artifact", wandb.Run.log_artifact
     )
     wandb.define_metric = preinit.PreInitCallable(
-        "wandb.define_metric", wandb.wandb_sdk.wandb_run.Run.define_metric
+        "wandb.define_metric", wandb.Run.define_metric
     )

--- a/wandb/sdk/wandb_watch.py
+++ b/wandb/sdk/wandb_watch.py
@@ -17,15 +17,13 @@ from .lib import telemetry
 if TYPE_CHECKING:
     import torch  # type: ignore [import-not-found]
 
-    from wandb.sdk.wandb_run import Run
-
 logger = logging.getLogger("wandb")
 
 _global_watch_idx = 0
 
 
 def _watch(
-    run: Run,
+    run: wandb.Run,
     models: torch.nn.Module | Sequence[torch.nn.Module],
     criterion: torch.F | None = None,
     log: Literal["gradients", "parameters", "all"] | None = "gradients",
@@ -39,7 +37,7 @@ def _watch(
     extended to support arbitrary machine learning models in the future.
 
     Args:
-        run (wandb.sdk.wandb_run.Run): The run object to log to.
+        run (wandb.Run): The run object to log to.
         models (Union[torch.nn.Module, Sequence[torch.nn.Module]]):
             A single model or a sequence of models to be monitored.
         criterion (Optional[torch.F]):
@@ -122,12 +120,12 @@ def _watch(
 
 
 def _unwatch(
-    run: Run, models: torch.nn.Module | Sequence[torch.nn.Module] | None = None
+    run: wandb.Run, models: torch.nn.Module | Sequence[torch.nn.Module] | None = None
 ) -> None:
     """Remove pytorch model topology, gradient and parameter hooks.
 
     Args:
-        run (wandb.sdk.wandb_run.Run):
+        run (wandb.Run):
             The run object to log to.
         models (torch.nn.Module | Sequence[torch.nn.Module]):
             Optional list of pytorch models that have had watch called on them

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -1,7 +1,6 @@
 """Compatibility wandb_run module.
 
-In the future use:
-    from wandb.sdk.wandb_run import Run
+Please use `wandb.Run` instead.
 """
 
 from wandb.sdk.wandb_run import Run


### PR DESCRIPTION
We have it defined in `__init__.pyi` but not in `__init__.py`.

I updated a lot of code to use `wandb.Run` instead of `wandb.wandb_sdk.wandb_run.Run`, but there are still some spots left (like the many `LocalRun` definitions in `data_types`).

## Safety

The line

```python
# wandb/__init__.py
from wandb import sdk as wandb_sdk
```

triggers the line

```python
# wandb/sdk/__init__.py
from .wandb_run import finish
```

which executes `wandb/sdk/wandb_run.py`. So the new line,

```python
# wandb/__init__.py
from wandb.sdk.wandb_run import Run
```

does not perform an import, and its addition cannot introduce any new import cycles or change the import behavior in any way.