### PR TITLE
[DNM] Disable http keep alive and hash entire file in parallel in python 

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `Sweep.name` property will now return user-edited display name if available (falling back to original name from sweep config, then sweep ID as before) (@kelu-wandb in https://github.com/wandb/wandb/pull/10144)
 
+### Changed
+
+- Hash multipart upload parts in parallel. (@pingleiwandb in https://github.com/wandb/wandb/pull/10136)
+
 ### Fixed
 
 - Correct the artifact url for organization registry artifacts to be independent of the artifact type (@ibindlish in https://github.com/wandb/wandb/pull/10049)

--- a/core/internal/hashencode/hash.go
+++ b/core/internal/hashencode/hash.go
@@ -44,6 +44,18 @@ func ComputeFileB64MD5(path string) (string, error) {
 	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
 }
 
+// ComputeReaderHexMD5 computes the MD5 hash of the data from the given io.Reader
+// and returns the result as a hexadecimal string.
+//
+// Returns an error if the reader cannot be read.
+func ComputeReaderHexMD5(reader io.Reader) (string, error) {
+	hasher := md5.New()
+	if _, err := io.Copy(hasher, reader); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
 // VerifyFileB64MD5 checks if the file at the given path matches the provided
 // base64-encoded MD5 hash.
 //

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -310,7 +311,7 @@ func (as *ArtifactSaver) uploadFiles(
 		if entry.LocalPath == nil {
 			continue
 		}
-		parts, err := multiPartRequest(*entry.LocalPath)
+		parts, err := multiPartRequest(as.logger, *entry.LocalPath)
 		if err != nil {
 			return err
 		}
@@ -497,7 +498,7 @@ const (
 	S3MaxParts           = 10000
 )
 
-func multiPartRequest(path string) ([]gql.UploadPartsInput, error) {
+func multiPartRequest(logger *observability.CoreLogger, path string) ([]gql.UploadPartsInput, error) {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file size for path %s: %w", path, err)
@@ -512,31 +513,108 @@ func multiPartRequest(path string) ([]gql.UploadPartsInput, error) {
 		return nil, fmt.Errorf("file size exceeds maximum S3 object size: %v", fileSize)
 	}
 
-	file, err := os.Open(path)
+	chunkSize := getChunkSize(fileSize)
+	startTime := time.Now()
+	numWorkers := runtime.NumCPU()
+	parts, err := computeMultipartHashes(path, chunkSize, numWorkers)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = file.Close()
-	}()
+	elapsed := time.Since(startTime)
+	logger.Debug("Computed multipart hashes",
+		"hashTimeMs", elapsed.Milliseconds(),
+		"numWorkers", numWorkers,
+		"numParts", len(parts),
+		"fileSize", fileSize,
+		"chunkSize", chunkSize,
+	)
+	return parts, nil
+}
 
-	partsInfo := []gql.UploadPartsInput{}
-	partNumber := int64(1)
-	buffer := make([]byte, getChunkSize(fileSize))
-	for {
-		bytesRead, err := file.Read(buffer)
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-		if bytesRead == 0 {
-			break
-		}
-		partsInfo = append(partsInfo, gql.UploadPartsInput{
-			PartNumber: partNumber,
-			HexMD5:     hashencode.ComputeHexMD5(buffer[:bytesRead]),
-		})
-		partNumber++
+func computeMultipartHashes(path string, chunkSize int64, numWorkers int) ([]gql.UploadPartsInput, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file size for path %s: %w", path, err)
 	}
+	fileSize := fileInfo.Size()
+
+	numParts := int(fileSize / chunkSize)
+	if fileSize%chunkSize != 0 {
+		numParts++
+	}
+	numWorkers = min(numWorkers, numParts)
+
+	partsPerWorker := numParts / numWorkers
+	remainingParts := numParts % numWorkers
+
+	workerTasks := make([]struct {
+		startPart int // inclusive
+		endPart   int // exclusive
+	}, numWorkers)
+	// NOTE: We start from 0, and only switch to 1-indexed when assiging the partNumber for server request
+	startPart := 0
+	for i := 0; i < numWorkers; i++ {
+		endPart := startPart + partsPerWorker
+		// Split the remaining parts evenly among the workers instead of doubling the work for the last worker.
+		if remainingParts > 0 {
+			endPart++
+			remainingParts--
+		}
+		workerTasks[i].startPart = startPart
+		workerTasks[i].endPart = endPart
+		startPart = endPart
+	}
+
+	partsInfo := make([]gql.UploadPartsInput, numParts)
+
+	var wg sync.WaitGroup
+	errChan := make(chan error, numWorkers)
+	wg.Add(numWorkers)
+	for worker, workerTask := range workerTasks {
+		go func(worker, startPart, endPart int) {
+			defer wg.Done()
+
+			// One open file per worker so they seek in sequential order within its own file handler
+			// instead of jumping around by different workers. Might make file system's life easier (not benchmarked).
+			file, err := os.Open(path)
+			if err != nil {
+				errChan <- fmt.Errorf("worker %d failed to open file: %w", worker, err)
+				return
+			}
+			//nolint:errcheck
+			defer file.Close()
+
+			for part := startPart; part < endPart; part++ {
+				offset := int64(part) * chunkSize
+
+				partSize := chunkSize
+				if offset+partSize > fileSize {
+					partSize = fileSize - offset
+				}
+
+				hexMD5, err := hashencode.ComputeReaderHexMD5(io.NewSectionReader(file, offset, partSize))
+				if err != nil {
+					errChan <- fmt.Errorf("worker %d failed to compute hash for part %d: %w", worker, part, err)
+					return
+				}
+
+				partsInfo[part] = gql.UploadPartsInput{
+					// Server request uses 1-indexed part numbers.
+					// https://cloud.google.com/storage/docs/xml-api/put-object-multipart#query_string_parameters
+					// https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#:~:text=You%20can%20choose%20any%20part%20number%20between%201%20and%2010%2C000
+					PartNumber: int64(part + 1),
+					HexMD5:     hexMD5,
+				}
+			}
+		}(worker, workerTask.startPart, workerTask.endPart)
+	}
+
+	wg.Wait()
+	close(errChan)
+	for err := range errChan {
+		return nil, err
+	}
+
 	return partsInfo, nil
 }
 
@@ -561,6 +639,9 @@ func (as *ArtifactSaver) uploadMultipart(
 	// TODO: add mid-upload cancel.
 
 	contentType := getContentType(fileInfo.uploadHeaders)
+
+	// Record start time for network upload phase
+	uploadStartTime := time.Now()
 
 	partInfo := fileInfo.multipartUploadInfo
 	for i, part := range partInfo {
@@ -636,6 +717,19 @@ func (as *ArtifactSaver) uploadMultipart(
 		as.ctx, as.graphqlClient, gql.CompleteMultipartActionComplete, partEtags,
 		fileInfo.birthArtifactID, *fileInfo.storagePath, fileInfo.uploadID,
 	)
+
+	// Log network upload time
+	uploadTime := time.Since(uploadStartTime)
+	uploadSpeedMBps := float64(statInfo.Size()) / (1024 * 1024) / uploadTime.Seconds()
+	as.logger.Debug("Completed multipart upload",
+		"fileName", fileInfo.name,
+		"uploadTimeMs", uploadTime.Milliseconds(),
+		"uploadSpeedMBps", uploadSpeedMBps,
+		"numParts", len(partData),
+		"fileSize", statInfo.Size(),
+		"chunkSize", chunkSize,
+	)
+
 	return uploadResult{name: fileInfo.name, err: err}
 }
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1823,12 +1823,17 @@ class Artifact:
             )
         upload_path = path
         if policy == "mutable":
+            start_time = time.monotonic()
             with tempfile.NamedTemporaryFile(dir=get_staging_dir(), delete=False) as f:
                 staging_path = f.name
                 shutil.copyfile(path, staging_path)
                 # Set as read-only to prevent changes to the file during upload process
                 os.chmod(staging_path, stat.S_IRUSR)
                 upload_path = staging_path
+            end_time = time.monotonic()
+            logger.debug(
+                f"Artifact.add_file: mutable policy copyTimeMs={int((end_time - start_time) * 1000)}"
+            )
 
         entry = ArtifactManifestEntry(
             path=name,

--- a/wandb/sdk/lib/hashutil.py
+++ b/wandb/sdk/lib/hashutil.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import base64
+import concurrent.futures
 import hashlib
 import logging
 import mmap
+import os
 import sys
 import time
 from typing import TYPE_CHECKING, NewType
@@ -63,8 +65,69 @@ def md5_file_hex(*paths: StrPath) -> HexMD5:
 
 
 _KB: int = 1_024
+_MB: int = 1_024 * _KB
+_GB: int = 1_024 * _MB
 _CHUNKSIZE: int = 128 * _KB
+_PART_SIZE: int = 100 * _MB  # 100MiB part size
+_LARGE_FILE_THRESHOLD: int = 2 * _GB  # 2GiB threshold for parallel hashing
 """Chunk size (in bytes) for iteratively reading from file, if needed."""
+
+
+def _hash_file_part(path: str, start_offset: int, part_size: int) -> bytes:
+    """Hash a specific part of a file."""
+    md5_hash = _md5()
+
+    with open(path, "rb") as f:
+        f.seek(start_offset)
+        remaining = part_size
+
+        while remaining > 0:
+            chunk_size = min(_CHUNKSIZE, remaining)
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            md5_hash.update(chunk)
+            remaining -= len(chunk)
+
+    return md5_hash.digest()
+
+
+def _compute_multipart_hash(path: str, file_size: int) -> _hashlib.HASH:
+    """Compute hash using multipart approach similar to AWS S3.
+
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#ChecksumTypes
+    """
+    # Calculate number of parts
+    num_parts = (file_size + _PART_SIZE - 1) // _PART_SIZE
+
+    # Hash each part in parallel
+    part_hashes = []
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = []
+        for part_num in range(num_parts):
+            start_offset = part_num * _PART_SIZE
+            actual_part_size = min(_PART_SIZE, file_size - start_offset)
+
+            future = executor.submit(
+                _hash_file_part, path, start_offset, actual_part_size
+            )
+            futures.append(future)
+
+        # Collect results
+        for future in concurrent.futures.as_completed(futures):
+            part_hashes.append(future.result())
+
+    # Sort part hashes to ensure consistent ordering
+    part_hashes.sort()
+
+    # Concatenate all part hashes and hash the result
+    concatenated_hashes = b"".join(part_hashes)
+    final_hash = _md5(concatenated_hashes)
+
+    # Add dash and number of parts (AWS S3 style)
+    final_hash.update(f"-{num_parts}".encode())
+
+    return final_hash
 
 
 def _md5_file_hasher(*paths: StrPath) -> _hashlib.HASH:
@@ -72,6 +135,18 @@ def _md5_file_hasher(*paths: StrPath) -> _hashlib.HASH:
 
     # Note: We use str paths (instead of pathlib.Path objs) for minor perf improvements.
     for path in sorted(map(str, paths)):
+        # Check if file is large enough and multipart hashing is enabled via env var
+        try:
+            if os.getenv("WANDB_ENABLE_MULTIPART_HASHING") == "true":
+                file_size = os.path.getsize(path)
+                if file_size >= _LARGE_FILE_THRESHOLD:
+                    # Use multipart hashing for large files
+                    return _compute_multipart_hash(path, file_size)
+        except OSError:
+            # If we can't get file size, fall back to original method
+            pass
+
+        # Original hashing method for smaller files or when file size can't be determined
         with open(path, "rb") as f:
             try:
                 with mmap.mmap(f.fileno(), length=0, access=mmap.ACCESS_READ) as mview:

--- a/wandb/sdk/lib/hashutil.py
+++ b/wandb/sdk/lib/hashutil.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import logging
 import mmap
 import sys
+import time
 from typing import TYPE_CHECKING, NewType
 
 from wandb.sdk.lib.paths import StrPath
@@ -14,6 +16,8 @@ if TYPE_CHECKING:
 ETag = NewType("ETag", str)
 HexMD5 = NewType("HexMD5", str)
 B64MD5 = NewType("B64MD5", str)
+
+logger = logging.getLogger(__name__)
 
 
 def _md5(data: bytes = b"") -> _hashlib.HASH:
@@ -44,7 +48,14 @@ def hex_to_b64_id(encoded_string: str | bytes) -> B64MD5:
 
 
 def md5_file_b64(*paths: StrPath) -> B64MD5:
-    return _b64_from_hasher(_md5_file_hasher(*paths))
+    start_time = time.monotonic()
+    digest = _b64_from_hasher(_md5_file_hasher(*paths))
+    hash_time_seconds = time.monotonic() - start_time
+    if hash_time_seconds > 1.0:
+        logger.debug(
+            f"Computed MD5 hash for file. paths={paths}, hashTimeMs={int(hash_time_seconds * 1000)}"
+        )
+    return digest
 
 
 def md5_file_hex(*paths: StrPath) -> HexMD5:


### PR DESCRIPTION
Quick test base on https://github.com/wandb/wandb/pull/10145

- Disabled http keep alive for upload, only works for GCS
- Hash large file in parallel in python (NOTE: it can cause compatibility issue in current incomplete implementation)