### PR TITLE
fix: mismatch attributes for single vs multiple project queries

### DIFF
--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -488,17 +488,22 @@ def test_projects(user, wandb_backend_spy):
 
 
 def test_project_get_id(user, wandb_backend_spy):
-    body = {
-        "data": {
-            "project": {
-                "id": "123",
-            },
-        },
-    }
     gql = wandb_backend_spy.gql
     wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="ProjectID"),
-        gql.Constant(content=body),
+        gql.Matcher(operation="Project"),
+        gql.once(
+            content={
+                "data": {
+                    "project": {
+                        "id": "123",
+                        "name": "test",
+                        "entityName": "test-entity",
+                        "createdAt": "2021-01-01T00:00:00Z",
+                        "isBenchmark": False,
+                    },
+                },
+            }
+        ),
     )
 
     project = Api().project(user, "test")
@@ -507,15 +512,22 @@ def test_project_get_id(user, wandb_backend_spy):
 
 
 def test_project_get_id_project_does_not_exist__raises_error(user, wandb_backend_spy):
-    body = {
-        "data": {
-            "project": None,
-        },
-    }
     gql = wandb_backend_spy.gql
     wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="ProjectID"),
-        gql.Constant(content=body),
+        gql.Matcher(operation="Project"),
+        gql.once(
+            content={
+                "data": {
+                    "project": {
+                        # "id": "123",
+                        "name": "test",
+                        "entityName": "test-entity",
+                        "createdAt": "2021-01-01T00:00:00Z",
+                        "isBenchmark": False,
+                    },
+                },
+            }
+        ),
     )
 
     with pytest.raises(ValueError):

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -519,7 +519,6 @@ def test_project_get_id_project_does_not_exist__raises_error(user, wandb_backend
             content={
                 "data": {
                     "project": {
-                        # "id": "123",
                         "name": "test",
                         "entityName": "test-entity",
                         "createdAt": "2021-01-01T00:00:00Z",

--- a/tests/unit_tests/test_public_api.py
+++ b/tests/unit_tests/test_public_api.py
@@ -265,6 +265,7 @@ def test_initialize_api_does_not_prompt_for_api_key__when_using_env_var(monkeypa
 
 @pytest.mark.usefixtures("patch_apikey", "patch_prompt")
 def test_project_id_lazy_load(monkeypatch):
+    api = wandb.Api()
     mock_execute = MagicMock(
         return_value={
             "project": {
@@ -276,7 +277,7 @@ def test_project_id_lazy_load(monkeypatch):
     )
     monkeypatch.setattr(wandb.apis.public.api.RetryingClient, "execute", mock_execute)
     project = wandb.apis.public.Project(
-        client=wandb.Api().client,
+        client=api.client,
         entity="test-entity",
         project="test-project",
         attrs={},
@@ -291,12 +292,11 @@ def test_project_id_lazy_load(monkeypatch):
 
 @pytest.mark.usefixtures("patch_apikey", "patch_prompt")
 def test_project_load__raises_error(monkeypatch):
-    mock_execute = MagicMock(
-        side_effect=HTTPError(response=MagicMock(status_code=404))
-    )
+    api = wandb.Api()
+    mock_execute = MagicMock(side_effect=HTTPError(response=MagicMock(status_code=404)))
     monkeypatch.setattr(wandb.apis.public.api.RetryingClient, "execute", mock_execute)
     project = wandb.apis.public.Project(
-        client=wandb.Api().client,
+        client=api.client,
         entity="test-entity",
         project="test-project",
         attrs={},

--- a/tests/unit_tests/test_public_api.py
+++ b/tests/unit_tests/test_public_api.py
@@ -260,3 +260,29 @@ def test_initialize_api_does_not_prompt_for_api_key__when_using_env_var(monkeypa
     assert "key" in mock_login.call_args[1]
     assert mock_login.call_args[1]["key"] == "X" * 40
     assert api.api_key == "X" * 40
+    
+
+@pytest.mark.usefixtures("patch_apikey", "patch_prompt")
+def test_project_id_lazy_load(monkeypatch):
+    mock_execute = MagicMock(
+        return_value={
+            "project": {
+                "id": "123",
+                "createdAt": "2021-01-01T00:00:00Z",
+                "isBenchmark": False,
+            }
+        }
+    )
+    monkeypatch.setattr(wandb.apis.public.api.RetryingClient, "execute", mock_execute)
+    project = wandb.apis.public.Project(
+        client=wandb.Api().client,
+        entity="test-entity",
+        project="test-project",
+        attrs={},
+    )
+
+    assert project.id == "123"
+    assert project.created_at == "2021-01-01T00:00:00Z"
+    assert project.is_benchmark is False
+
+    mock_execute.assert_called_once()

--- a/tests/unit_tests/test_public_api.py
+++ b/tests/unit_tests/test_public_api.py
@@ -4,8 +4,8 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
-from requests import HTTPError
 import wandb
+from requests import HTTPError
 from wandb import Api
 from wandb.apis import internal
 from wandb.sdk import wandb_login
@@ -261,9 +261,9 @@ def test_initialize_api_does_not_prompt_for_api_key__when_using_env_var(monkeypa
     assert "key" in mock_login.call_args[1]
     assert mock_login.call_args[1]["key"] == "X" * 40
     assert api.api_key == "X" * 40
-    
 
-@pytest.mark.usefixtures("patch_apikey", "patch_prompt")
+
+@pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
 def test_project_id_lazy_load(monkeypatch):
     api = wandb.Api()
     mock_execute = MagicMock(
@@ -290,7 +290,7 @@ def test_project_id_lazy_load(monkeypatch):
     mock_execute.assert_called_once()
 
 
-@pytest.mark.usefixtures("patch_apikey", "patch_prompt")
+@pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
 def test_project_load__raises_error(monkeypatch):
     api = wandb.Api()
     mock_execute = MagicMock(side_effect=HTTPError(response=MagicMock(status_code=404)))

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -197,7 +197,7 @@ class Project(Attrs):
             attrs: The attributes of the project.
         """
         super().__init__(dict(attrs))
-        self._is_loaded = False if not attrs else True
+        self._is_loaded = bool(attrs)
         self.client = client
         self.name = project
         self.entity = entity
@@ -206,11 +206,10 @@ class Project(Attrs):
         variable_values = {"project": self.name, "entity": self.entity}
         try:
             response = self.client.execute(self.QUERY, variable_values)
-            project = response["project"]
         except HTTPError as e:
             raise ValueError(f"Unable to fetch project ID: {variable_values!r}") from e
 
-        self._attrs = project
+        self._attrs = response["project"]
         self._is_loaded = True
 
     @property


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-15364

What does the PR do? Include a concise description of the PR contents.

This pr fixes a mismatch of attributes provided when querying a single project (`Api().project(...)`) or multiple projects (`Api().projects(...)`).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
