### PR TITLE
fix: panic in LongestCommonPrefix

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,3 +29,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Suffixes on sanitized `InternalArtifact` names have been shortened to 6 alphanumeric characters (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10102)
 - `wandb.Video` will not print a progress spinner while encoding video when `WANDB_SILENT`/`WANDB_QUIET` environment variables are set (@jacobromero in https://github.com/wandb/wandb/pull/10064)
 - Fixed registries fetched using `api.registries()` from having an extra `wandb-registry-` prefix in the name and full_name fields (@estellazx in https://github.com/wandb/wandb/pull/10187)
+- Fixed a crash that could happen when using `sync_tensorboard` (@timoffex in https://github.com/wandb/wandb/pull/10199)

--- a/core/internal/paths/longestcommonprefix.go
+++ b/core/internal/paths/longestcommonprefix.go
@@ -53,7 +53,7 @@ func LongestCommonPrefixStr(paths iter.Seq[string], separator string) string {
 		}
 
 		for i, part := range longestPrefix {
-			if part != pathParts[i] {
+			if i >= len(pathParts) || part != pathParts[i] {
 				longestPrefix = longestPrefix[:i]
 				break
 			}

--- a/core/internal/paths/longestcommonprefix_test.go
+++ b/core/internal/paths/longestcommonprefix_test.go
@@ -18,8 +18,8 @@ func absPath(t *testing.T, path string) paths.AbsolutePath {
 func TestLongestCommonPrefix(t *testing.T) {
 	prefix, err := paths.LongestCommonPrefix(
 		[]paths.AbsolutePath{
-			absPath(t, "/one/two"),
 			absPath(t, "/one/two/three"),
+			absPath(t, "/one/two"),
 			absPath(t, "/one/ten"),
 		},
 	)


### PR DESCRIPTION
Fixes WB-25912.

Fixes a panic that could be triggered when using `sync_tensorboard` depending on the logging directories.

In the test file, reordering data in a test case is enough to cover this.