### PR TITLE
refactor: move Metaflow integration PyTorch support to its own file

### DIFF
--- a/wandb/integration/metaflow/data_pytorch.py
+++ b/wandb/integration/metaflow/data_pytorch.py
@@ -1,0 +1,75 @@
+"""Support for PyTorch datatypes.
+
+May raise MissingDependencyError on import.
+"""
+
+from __future__ import annotations
+
+from typing_extensions import Any, TypeIs
+
+import wandb
+
+from . import errors
+
+try:
+    import torch
+    import torch.nn as nn
+except ImportError as e:
+    warning = (
+        "`torch` (PyTorch) not installed >>"
+        " @wandb_log(models=True) may not auto log your model!"
+    )
+    raise errors.MissingDependencyError(warning=warning) from e
+
+
+def is_nn_module(data: Any) -> TypeIs[nn.Module]:
+    """Returns whether the data is a PyTorch nn.Module."""
+    return isinstance(data, nn.Module)
+
+
+def use_nn_module(
+    name: str,
+    run: wandb.Run | None,
+    testing: bool = False,
+) -> str | None:
+    """Log a dependency on a PyTorch model input.
+
+    Args:
+        name: Name of the input.
+        run: The run to update.
+        testing: True in unit tests.
+    """
+    if testing:
+        return "models"
+    assert run
+
+    wandb.termlog(f"Using artifact: {name} (PyTorch nn.Module)")
+    run.use_artifact(f"{name}:latest")
+    return None
+
+
+def track_nn_module(
+    name: str,
+    data: nn.Module,
+    run: wandb.Run | None,
+    testing: bool = False,
+) -> str | None:
+    """Log a PyTorch model output as an artifact.
+
+    Args:
+        name: The output's name.
+        data: The output's value.
+        run: The run to update.
+        testing: True in unit tests.
+    """
+    if testing:
+        return "nn.Module"
+    assert run
+
+    artifact = wandb.Artifact(name, type="model")
+    with artifact.new_file(f"{name}.pkl", "wb") as f:
+        torch.save(data, f)
+
+    wandb.termlog(f"Logging artifact: {name} (PyTorch nn.Module)")
+    run.log_artifact(artifact)
+    return None

--- a/wandb/integration/metaflow/metaflow.py
+++ b/wandb/integration/metaflow/metaflow.py
@@ -19,7 +19,6 @@ except ImportError as e:
 
 
 # Classes for isinstance() checks.
-_NN_MODULE = None
 _BASE_ESTIMATOR = None
 
 try:
@@ -29,44 +28,10 @@ except errors.MissingDependencyError as e:
     data_pandas = None
 
 try:
-    import torch
-    import torch.nn as nn
-
-    _NN_MODULE = nn.Module
-
-    def _use_torch_module(
-        name: str,
-        data: nn.Module,
-        run,
-        testing: bool = False,
-    ) -> Optional[str]:
-        if testing:
-            return "models"
-
-        run.use_artifact(f"{name}:latest")
-        wandb.termlog(f"Using artifact: {name} ({type(data)})")
-        return None
-
-    def _track_torch_module(
-        name: str,
-        data: nn.Module,
-        run,
-        testing: bool = False,
-    ) -> Optional[str]:
-        if testing:
-            return "nn.Module"
-
-        artifact = wandb.Artifact(name, type="model")
-        with artifact.new_file(f"{name}.pkl", "wb") as f:
-            torch.save(data, f)
-        run.log_artifact(artifact)
-        wandb.termlog(f"Logging artifact: {name} ({type(data)})")
-        return None
-
-except ImportError:
-    wandb.termwarn(
-        "`pytorch` not installed >> @wandb_log(models=True) may not auto log your model!"
-    )
+    from . import data_pytorch
+except errors.MissingDependencyError as e:
+    e.warn()
+    data_pytorch = None
 
 try:
     from sklearn.base import BaseEstimator
@@ -195,8 +160,8 @@ def wandb_track(
         return data_pandas.track_dataframe(name, data, run, testing)
 
     # Check for PyTorch Module
-    if _NN_MODULE and isinstance(data, _NN_MODULE) and models:
-        return _track_torch_module(name, data, run, testing)
+    if data_pytorch and data_pytorch.is_nn_module(data) and models:
+        return data_pytorch.track_nn_module(name, data, run, testing)
 
     # Check for scikit-learn BaseEstimator
     if _BASE_ESTIMATOR and isinstance(data, _BASE_ESTIMATOR) and models:
@@ -238,8 +203,8 @@ def wandb_use(
             return data_pandas.use_dataframe(name, run, testing)
 
         # Check for PyTorch Module
-        elif _NN_MODULE and isinstance(data, _NN_MODULE) and models:
-            return _use_torch_module(name, data, run, testing)
+        elif data_pytorch and data_pytorch.is_nn_module(data) and models:
+            return data_pytorch.use_nn_module(name, run, testing)
 
         # Check for scikit-learn BaseEstimator
         elif _BASE_ESTIMATOR and isinstance(data, _BASE_ESTIMATOR) and models:


### PR DESCRIPTION
Factors out PyTorch code in `metaflow.py` into its own file and improves docstrings and type annotations.