### PR TITLE
refactor: use TypeIs instead of TypeGuard in metaflow/data_pandas.py

### DIFF
--- a/wandb/integration/metaflow/data_pandas.py
+++ b/wandb/integration/metaflow/data_pandas.py
@@ -5,7 +5,7 @@ May raise MissingDependencyError on import.
 
 from __future__ import annotations
 
-from typing_extensions import Any, TypeGuard
+from typing_extensions import Any, TypeIs
 
 import wandb
 
@@ -21,7 +21,7 @@ except ImportError as e:
     raise errors.MissingDependencyError(warning=warning) from e
 
 
-def is_dataframe(data: Any) -> TypeGuard[pd.DataFrame]:
+def is_dataframe(data: Any) -> TypeIs[pd.DataFrame]:
     """Returns whether the data is a Pandas DataFrame."""
     return isinstance(data, pd.DataFrame)
 


### PR DESCRIPTION
`TypeIs[X]` means "the type is X if and only if this returns True" whereas `TypeGuard[X]` only implies "the type is X if this returns True". `TypeIs` is more correct, and even though it doesn't really matter here at the moment, it's a better habit.