### PR TITLE
fix: error when calling upload_file for path outside of the root_dir path

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -839,8 +839,9 @@ class Run(Attrs):
         api.set_current_run_id(self.id)
         root = os.path.abspath(root)
         name = os.path.relpath(path, root)
+        upload_path = util.make_file_path_upload_safe(name)
         with open(os.path.join(root, name), "rb") as f:
-            api.push({LogicalPath(name): f})
+            api.push({LogicalPath(upload_path): f})
         return public.Files(self.client, self, [name])[0]
 
     @normalize_exceptions

--- a/wandb/sdk/data_types/base_types/media.py
+++ b/wandb/sdk/data_types/base_types/media.py
@@ -45,10 +45,6 @@ def _wb_filename(
 ) -> str:
     r"""Generates a safe filename/path for storing media files, using the provided key, step, and id.
 
-    The filename is made safe by:
-    1. Removing any leading slashes to prevent writing to absolute paths
-    2. Replacing '.' and '..' with underscores to prevent directory traversal attacks
-
     If the key contains slashes (e.g. 'images/cats/fluffy.jpg'), subdirectories will be created:
         media/
           images/
@@ -73,23 +69,7 @@ def _wb_filename(
             f'Media {key} is invalid. Please remove invalid filename characters (\\, :, *, ?, ", <, >, |)'
         )
 
-    # On Windows, convert forward slashes to backslashes.
-    # This ensures that the key is a valid filename on Windows.
-    if SYS_PLATFORM == "Windows":
-        key = str(key).replace("/", os.sep)
-
-    # Avoid writing to absolute paths by striping any leading slashes.
-    # The key has already been validated for windows operating systems in util.check_windows_valid_filename
-    # This ensures the key does not contain invalid characters for windows, such as '\' or ':'.
-    # So we can check only for '/' in the key.
-    key = str(key).lstrip(os.sep)
-
-    # Avoid directory traversal by replacing dots with underscores.
-    keys = key.split(os.sep)
-    keys = [k.replace(".", "_") if k in (os.curdir, os.pardir) else k for k in keys]
-
-    # Recombine the key into a relative path.
-    key = os.sep.join(keys)
+    key = util.make_file_path_upload_safe(str(key))
 
     return f"{str(key)}_{str(step)}_{str(id)}{extension}"
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -340,6 +340,32 @@ def get_local_path_or_none(path_or_uri: str) -> Optional[str]:
     else:
         return None
 
+def make_file_path_upload_safe(path: str) -> str:
+    """Makes the provide path safe for file upload.
+
+    The filename is made safe by:
+    1. Removing any leading slashes to prevent writing to absolute paths
+    2. Replacing '.' and '..' with underscores to prevent directory traversal attacks
+    """
+    # On Windows, convert forward slashes to backslashes.
+    # This ensures that the key is a valid filename on Windows.
+    if platform.system() == "Windows":
+        path = str(path).replace("/", os.sep)
+
+    # Avoid writing to absolute paths by striping any leading slashes.
+    # The key has already been validated for windows operating systems in util.check_windows_valid_filename
+    # This ensures the key does not contain invalid characters for windows, such as '\' or ':'.
+    # So we can check only for '/' in the key.
+    path = path.lstrip(os.sep)
+
+    # Avoid directory traversal by replacing dots with underscores.
+    paths = path.split(os.sep)
+    safe_paths = [p.replace(".", "_") if p in (os.curdir, os.pardir) else p for p in paths]
+
+    # Recombine the key into a relative path.
+    safe_paths = [p.replace(".", "_") if p in (os.curdir, os.pardir) else p for p in paths]
+    return os.sep.join(safe_paths)
+
 
 def make_tarfile(
     output_filename: str,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-6709

What does the PR do? Include a concise description of the PR contents.

This PR fixes an error that is thrown when a user attempts to upload a file to a run using the public API when the provided file path is relative and outside the root dir (default to current directory)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- Test script
```python
import wandb

api = wandb.Api()
run = api.run("jacobromerotest/jpr-api-test/qdhihoql")
run.upload_file("../test2.txt")
```

#### After this change
<img width="437" height="122" alt="image" src="https://github.com/user-attachments/assets/234c7a1f-b5d5-4c9d-9423-43a582cc0d40" />

#### Before this change
<img width="1334" height="500" alt="image" src="https://github.com/user-attachments/assets/e02c2921-d715-40ba-91ce-07b8b701024a" />


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
