### PR TITLE
fix(sweeps): In API mode, ensure exceptions in the run function are logged to server.

### DIFF
--- a/tests/system_tests/test_sweep/test_wandb_agent_full.py
+++ b/tests/system_tests/test_sweep/test_wandb_agent_full.py
@@ -3,7 +3,6 @@
 import contextlib
 import io
 import os
-import sys
 import unittest.mock
 
 import wandb


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-25813

When running a sweeps agent in API mode, we previously finished the run before printing any exceptions that the run throws, so those exceptions never got reported to the server.

Now we print the exception to stderr to match CLI mode behavior.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
