### PR TITLE
chore: disable golangci-lint errcheck on std error

### DIFF
--- a/core/.golangci.yaml
+++ b/core/.golangci.yaml
@@ -1,0 +1,7 @@
+# https://golangci-lint.run/usage/configuration/
+version: "2"
+linters:
+  exclusions:
+    # https://golangci-lint.run/usage/false-positives/#preset-std-error-handling
+    presets:
+      - std-error-handling


### PR DESCRIPTION
Description
-----------
No jira ticket, found the errcheck issue in https://github.com/wandb/wandb/pull/10136

We are using the default set of linters from golangci-lint. Default linters has `errcheck` and checks on `file.Close()`. This seems to be a new change in either golangci-lint or errcheck. Use the recommended preset to skip checking `file.Close()` and other common io closer, which is mostly used in test or defer. https://golangci-lint.run/usage/false-positives/#preset-std-error-handling

We should consider tweak the config to enable/disable other linters to align with internal repos golangci-lint config. Though this would likely requires some clean up of the code base on the new linter config


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

unit test, without the config, the updated test would fail (NOTE: the updated test are removed from the PR, but the config was verified to work locally)

```bash
(wandb-sdk-dev2) $ src/github.com/wandb/wandb/core golangci-lint run
0 issues.
(wandb-sdk-dev2) $ src/github.com/wandb/wandb/core mv .golangci.yaml notgolangci.yaml
(wandb-sdk-dev2) $ src/github.com/wandb/wandb/core golangci-lint run
internal/hashencode/hashencode_test.go:37:22: Error return value of `testFile.Close` is not checked (errcheck)
	defer testFile.Close()
	                    ^
internal/hashencode/hashencode_test.go:38:17: Error return value of `os.Remove` is not checked (errcheck)
	defer os.Remove(testFile.Name())
	               ^
2 issues:
* errcheck: 2
```
