### PR TITLE
chore: update Work.Schedule comment and fix a typo

### DIFF
--- a/core/internal/runwork/work.go
+++ b/core/internal/runwork/work.go
@@ -17,6 +17,8 @@ type Work interface {
 	// them.
 	//
 	// The WaitGroup is used to signal when proceed() has been invoked.
+	// To prevent deadlocks, it must not block on other work entering
+	// the pipeline.
 	Schedule(wg *sync.WaitGroup, proceed func())
 
 	// Accept indicates the work has entered the pipeline.

--- a/core/internal/tensorboard/tbwork.go
+++ b/core/internal/tensorboard/tbwork.go
@@ -30,12 +30,12 @@ type TBWork struct {
 // The right way to think about the TensorBoard integration is to pretend it
 // exists entirely in the client: the Schedule step can be viewed as something
 // that happens in the client itself.
-func (w *TBWork) Schedule(wg *sync.WaitGroup, process func()) {
+func (w *TBWork) Schedule(wg *sync.WaitGroup, proceed func()) {
 	err := w.TBHandler.Handle(w.Record.GetTbrecord())
 	if err != nil {
 		w.Logger.CaptureError(err)
 	}
-	process()
+	proceed()
 }
 
 // ToRecord implements Work.ToRecord.


### PR DESCRIPTION
* Mentions an important rule for implementing `Work.Schedule()` (becomes important with `wandb sync`, which will immediately call `wg.Wait()`)
* Changes `process` => `proceed` in the TB implementation of `Work.Schedule()` for consistency