### PR TITLE
refactor: replace StreamParams by direct params

### DIFF
--- a/core/internal/stream/streaminject.go
+++ b/core/internal/stream/streaminject.go
@@ -4,6 +4,7 @@ package stream
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/google/wire"
 	"github.com/wandb/wandb/core/internal/api"
@@ -13,6 +14,8 @@ import (
 	"github.com/wandb/wandb/core/internal/monitor"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runwork"
+	"github.com/wandb/wandb/core/internal/sentry_ext"
+	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sharedmode"
 	"github.com/wandb/wandb/core/internal/tensorboard"
 	"github.com/wandb/wandb/core/internal/watcher"
@@ -20,21 +23,20 @@ import (
 )
 
 // InjectStream returns a new Stream.
-func InjectStream(params StreamParams) *Stream {
+func InjectStream(
+	commit GitCommitHash,
+	gpuResourceManager *monitor.GPUResourceManager,
+	debugCorePath DebugCorePath,
+	logLevel slog.Level,
+	sentry *sentry_ext.Client,
+	settings *settings.Settings,
+) *Stream {
 	wire.Build(streamProviders)
 	return &Stream{}
 }
 
 var streamProviders = wire.NewSet(
 	NewStream,
-	wire.FieldsOf(
-		new(StreamParams),
-		"Commit",
-		"GPUResourceManager",
-		"Settings",
-		"Sentry",
-		"LogLevel",
-	),
 	wire.Bind(new(runwork.ExtraWork), new(runwork.RunWork)),
 	wire.Bind(new(api.Peeker), new(*observability.Peeker)),
 	wire.Struct(new(observability.Peeker)),

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -352,14 +352,12 @@ func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
 	}
 
 	strm := stream.InjectStream(
-		stream.StreamParams{
-			Settings:           settings,
-			Commit:             stream.GitCommitHash(nc.commit),
-			LogLevel:           nc.logLevel,
-			Sentry:             sentryClient,
-			LoggerPath:         nc.loggerPath,
-			GPUResourceManager: nc.gpuResourceManager,
-		},
+		stream.GitCommitHash(nc.commit),
+		nc.gpuResourceManager,
+		stream.DebugCorePath(nc.loggerPath),
+		nc.logLevel,
+		nc.sentryClient,
+		settings,
 	)
 	strm.AddResponders(stream.ResponderEntry{Responder: nc, ID: nc.id})
 	strm.Start()


### PR DESCRIPTION
When using `wire`, `Params` structs aren't helpful since everything is wired up by type and all parameter types are different.