### PR TITLE
refactor: create Factory structs for Handler, Writer, Sender

### DIFF
--- a/core/internal/stream/handler_test.go
+++ b/core/internal/stream/handler_test.go
@@ -22,14 +22,13 @@ func makeHandler(
 	s := settings.New()
 	s.UpdateServerSideDerivedSummary(skipDerivedSummary)
 
-	h := stream.NewHandler(
-		stream.HandlerParams{
-			Logger:          observability.NewNoOpLogger(),
-			Settings:        s,
-			TerminalPrinter: observability.NewPrinter(),
-			Commit:          stream.GitCommitHash(commit),
-		},
-	)
+	handlerFactory := stream.HandlerFactory{
+		Logger:          observability.NewNoOpLogger(),
+		Settings:        s,
+		TerminalPrinter: observability.NewPrinter(),
+		Commit:          stream.GitCommitHash(commit),
+	}
+	h := handlerFactory.New()
 
 	go h.Do(inChan)
 

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -43,11 +43,11 @@ const (
 )
 
 var senderProviders = wire.NewSet(
-	wire.Struct(new(SenderParams), "*"),
-	NewSender,
+	wire.Struct(new(SenderFactory), "*"),
 )
 
-type SenderParams struct {
+// SenderFactory constructs a Sender.
+type SenderFactory struct {
 	Logger              *observability.CoreLogger
 	Operations          *wboperation.WandbOperations
 	Settings            *settings.Settings
@@ -65,8 +65,7 @@ type SenderParams struct {
 	RunWork             runwork.RunWork
 }
 
-// Sender is the sender for a stream it handles the incoming messages and sends to the server
-// or/and to the dispatcher/handler
+// Sender performs blocking operations to process Work, such as uploading data.
 type Sender struct {
 	// mu is a coarse mutex for accessing non-threadsafe Sender state.
 	//
@@ -144,18 +143,14 @@ type Sender struct {
 	consoleLogsSender *runconsolelogs.Sender
 }
 
-// NewSender creates a new Sender with the given settings
-func NewSender(
-	params SenderParams,
-) *Sender {
-
-	var outputFileName paths.RelativePath
+// New returns a new Sender.
+func (f *SenderFactory) New() *Sender {
 	// Guaranteed not to fail.
-	path, _ := paths.Relative(ConsoleFileName)
-	outputFileName = *path
+	maybeOutputFileName, _ := paths.Relative(ConsoleFileName)
+	outputFileName := *maybeOutputFileName
 
-	if params.Settings.GetLabel() != "" {
-		sanitizedLabel := fileutil.SanitizeFilename(params.Settings.GetLabel())
+	if f.Settings.GetLabel() != "" {
+		sanitizedLabel := fileutil.SanitizeFilename(f.Settings.GetLabel())
 		// Guaranteed not to fail.
 		// split filename and extension
 		extension := filepath.Ext(string(outputFileName))
@@ -171,7 +166,7 @@ func NewSender(
 	}
 
 	// If console capture is enabled, we need to create a multipart console log file.
-	if params.Settings.IsConsoleMultipart() {
+	if f.Settings.IsConsoleMultipart() {
 		// This is guaranteed not to fail.
 		timestamp := time.Now()
 		extension := filepath.Ext(string(outputFileName))
@@ -192,50 +187,50 @@ func NewSender(
 
 	consoleLogsSenderParams := runconsolelogs.Params{
 		ConsoleOutputFile:     outputFileName,
-		FilesDir:              params.Settings.GetFilesDir(),
-		EnableCapture:         params.Settings.IsConsoleCaptureEnabled(),
-		Logger:                params.Logger,
-		FileStreamOrNil:       params.FileStream,
-		Label:                 params.Settings.GetLabel(),
-		RunfilesUploaderOrNil: params.RunfilesUploader,
-		Structured: params.FeatureProvider.GetFeature(
+		FilesDir:              f.Settings.GetFilesDir(),
+		EnableCapture:         f.Settings.IsConsoleCaptureEnabled(),
+		Logger:                f.Logger,
+		FileStreamOrNil:       f.FileStream,
+		Label:                 f.Settings.GetLabel(),
+		RunfilesUploaderOrNil: f.RunfilesUploader,
+		Structured: f.FeatureProvider.GetFeature(
 			spb.ServerFeature_STRUCTURED_CONSOLE_LOGS,
 		).Enabled,
 	}
 
 	s := &Sender{
-		runWork:             params.RunWork,
-		logger:              params.Logger,
-		operations:          params.Operations,
-		settings:            params.Settings,
-		fileStream:          params.FileStream,
-		fileTransferManager: params.FileTransferManager,
-		fileTransferStats:   params.FileTransferStats,
-		fileWatcher:         params.FileWatcher,
-		runfilesUploader:    params.RunfilesUploader,
+		runWork:             f.RunWork,
+		logger:              f.Logger,
+		operations:          f.Operations,
+		settings:            f.Settings,
+		fileStream:          f.FileStream,
+		fileTransferManager: f.FileTransferManager,
+		fileTransferStats:   f.FileTransferStats,
+		fileWatcher:         f.FileWatcher,
+		runfilesUploader:    f.RunfilesUploader,
 		artifactsSaver: artifacts.NewArtifactSaveManager(
-			params.Logger,
-			params.GraphqlClient,
-			params.FileTransferManager,
-			params.FeatureProvider.GetFeature(
+			f.Logger,
+			f.GraphqlClient,
+			f.FileTransferManager,
+			f.FeatureProvider.GetFeature(
 				spb.ServerFeature_USE_ARTIFACT_WITH_ENTITY_AND_PROJECT_INFORMATION,
 			).Enabled,
 		),
-		networkPeeker: params.Peeker,
-		graphqlClient: params.GraphqlClient,
-		mailbox:       params.Mailbox,
-		streamRun:     params.StreamRun,
+		networkPeeker: f.Peeker,
+		graphqlClient: f.GraphqlClient,
+		mailbox:       f.Mailbox,
+		streamRun:     f.StreamRun,
 		runSummary:    runsummary.New(),
 		outChan:       make(chan *spb.Result, BufferSize),
 		summaryDebouncer: debounce.NewDebouncer(
 			summaryDebouncerRateLimit,
 			summaryDebouncerBurstSize,
-			params.Logger,
+			f.Logger,
 		),
 		consoleLogsSender: runconsolelogs.New(consoleLogsSenderParams),
 	}
 
-	backendOrNil := params.Backend
+	backendOrNil := f.Backend
 	if !s.settings.IsOffline() && backendOrNil != nil && !s.settings.IsJobCreationDisabled() {
 		s.jobBuilder = launch.NewJobBuilder(s.settings.Proto, s.logger, false)
 	}

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -58,25 +58,24 @@ func makeSender(client graphql.Client) *stream.Sender {
 		watchertest.NewFakeWatcher(),
 		client,
 	)
-	sender := stream.NewSender(
-		stream.SenderParams{
-			Logger:              logger,
-			Settings:            settings,
-			Backend:             backend,
-			FileStream:          fileStream,
-			FileTransferManager: fileTransferManager,
-			RunfilesUploader:    runfilesUploader,
-			Mailbox:             mailbox.New(),
-			GraphqlClient:       client,
-			RunWork:             runWork,
-			FeatureProvider: featurechecker.NewServerFeaturesCache(
-				runWork.BeforeEndCtx(),
-				nil,
-				logger,
-			),
-		},
-	)
-	return sender
+
+	senderFactory := stream.SenderFactory{
+		Logger:              logger,
+		Settings:            settings,
+		Backend:             backend,
+		FileStream:          fileStream,
+		FileTransferManager: fileTransferManager,
+		RunfilesUploader:    runfilesUploader,
+		Mailbox:             mailbox.New(),
+		GraphqlClient:       client,
+		RunWork:             runWork,
+		FeatureProvider: featurechecker.NewServerFeaturesCache(
+			runWork.BeforeEndCtx(),
+			nil,
+			logger,
+		),
+	}
+	return senderFactory.New()
 }
 
 // Verify that arguments are properly passed through to graphql

--- a/core/internal/stream/streaminject.go
+++ b/core/internal/stream/streaminject.go
@@ -61,6 +61,7 @@ var streamProviders = wire.NewSet(
 	streamLoggerProviders,
 	tensorboard.TBHandlerProviders,
 	wboperation.NewOperations,
+	writerProviders,
 )
 
 func provideFileWatcher(logger *observability.CoreLogger) watcher.Watcher {

--- a/core/internal/stream/writer.go
+++ b/core/internal/stream/writer.go
@@ -4,16 +4,20 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/wire"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
-type WriterParams struct {
+var writerProviders = wire.NewSet(
+	wire.Struct(new(WriterFactory), "*"),
+)
+
+type WriterFactory struct {
 	Logger   *observability.CoreLogger
 	Settings *settings.Settings
-	FwdChan  chan runwork.Work
 }
 
 // Writer saves work to the transaction log.
@@ -34,12 +38,12 @@ type Writer struct {
 	recordNum int64
 }
 
-// NewWriter returns a new Writer.
-func NewWriter(params WriterParams) *Writer {
+// New returns a new Writer.
+func (f *WriterFactory) New(fwdChan chan runwork.Work) *Writer {
 	return &Writer{
-		logger:   params.Logger,
-		settings: params.Settings,
-		fwdChan:  params.FwdChan,
+		logger:   f.Logger,
+		settings: f.Settings,
+		fwdChan:  fwdChan,
 	}
 }
 


### PR DESCRIPTION
Creates `HandlerFactory`, `WriterFactory` and `SenderFactory` structs to be used instead of directly injecting `Handler`, `Writer` and `Sender`.

These allow separating injectable values from explicit parameters. `WriterFactory.New` is an example: the `fwdChan` is an explicit parameter, whereas `Logger` and `Settings` are provided implicitly through injection.

`wire` simplifies construction but in doing so hides object lifecycles and ownership. Objects with lifecycles (like `RunWork`, `TBHandler`, `FileStream`, etc.) are best constructed explicitly; shared objects without lifecycles (`observability.CoreLogger`, `Settings`, etc.) can continue to be injected.