### PR TITLE
refactor: featurechecker context parameter

### DIFF
--- a/core/internal/featurechecker/features_test.go
+++ b/core/internal/featurechecker/features_test.go
@@ -37,7 +37,6 @@ func TestServerFeaturesInitialization(t *testing.T) {
 	mockGQL := gqlmock.NewMockClient()
 	stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		context.Background(),
 		mockGQL,
 		observability.NewNoOpLogger(),
 	)
@@ -46,7 +45,10 @@ func TestServerFeaturesInitialization(t *testing.T) {
 	assert.Equal(t, 0, len(mockGQL.AllRequests()))
 
 	// Act
-	serverFeaturesCache.GetFeature(spb.ServerFeature_LARGE_FILENAMES)
+	serverFeaturesCache.GetFeature(
+		context.Background(),
+		spb.ServerFeature_LARGE_FILENAMES,
+	)
 
 	// Assert - Features are loaded after Get is called
 	assert.Equal(t, 1, len(mockGQL.AllRequests()))
@@ -57,14 +59,19 @@ func TestGetFeature(t *testing.T) {
 	mockGQL := gqlmock.NewMockClient()
 	stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		context.Background(),
 		mockGQL,
 		observability.NewNoOpLogger(),
 	)
 
 	// Act
-	enabledFeatureValue := serverFeaturesCache.GetFeature(spb.ServerFeature_LARGE_FILENAMES)
-	disabledFeatureValue := serverFeaturesCache.GetFeature(spb.ServerFeature_ARTIFACT_TAGS)
+	enabledFeatureValue := serverFeaturesCache.GetFeature(
+		context.Background(),
+		spb.ServerFeature_LARGE_FILENAMES,
+	)
+	disabledFeatureValue := serverFeaturesCache.GetFeature(
+		context.Background(),
+		spb.ServerFeature_ARTIFACT_TAGS,
+	)
 
 	// Assert
 	assert.True(t, enabledFeatureValue.Enabled)
@@ -77,13 +84,15 @@ func TestGetFeature_MissingWithDefaultValue(t *testing.T) {
 	mockGQL := gqlmock.NewMockClient()
 	stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		context.Background(),
 		mockGQL,
 		observability.NewNoOpLogger(),
 	)
 
 	// Act
-	missingFeatureValue := serverFeaturesCache.GetFeature(spb.ServerFeature_ARTIFACT_TAGS)
+	missingFeatureValue := serverFeaturesCache.GetFeature(
+		context.Background(),
+		spb.ServerFeature_ARTIFACT_TAGS,
+	)
 
 	// Assert
 	assert.False(t, missingFeatureValue.Enabled)
@@ -93,13 +102,15 @@ func TestGetFeature_MissingWithDefaultValue(t *testing.T) {
 func TestCreateFeaturesCache_WithNullGraphQLClient(t *testing.T) {
 	// Arrange
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		context.Background(),
 		nil,
 		observability.NewNoOpLogger(),
 	)
 
 	// Act
-	feature := serverFeaturesCache.GetFeature(spb.ServerFeature_LARGE_FILENAMES)
+	feature := serverFeaturesCache.GetFeature(
+		context.Background(),
+		spb.ServerFeature_LARGE_FILENAMES,
+	)
 
 	// Assert
 	assert.False(t, feature.Enabled)
@@ -115,12 +126,14 @@ func TestGetFeature_GraphQLError(t *testing.T) {
 
 	// stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		context.Background(),
 		mockGQL,
 		observability.NewNoOpLogger(),
 	)
 
-	feature := serverFeaturesCache.GetFeature(spb.ServerFeature_LARGE_FILENAMES)
+	feature := serverFeaturesCache.GetFeature(
+		context.Background(),
+		spb.ServerFeature_LARGE_FILENAMES,
+	)
 
 	// Assert
 	assert.False(t, feature.Enabled)

--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -129,6 +129,7 @@ func InitRun(
 	// Initialize the run metrics.
 	enableServerExpandedMetrics := params.Settings.IsEnableServerSideExpandGlobMetrics()
 	if enableServerExpandedMetrics && !params.FeatureProvider.GetFeature(
+		params.BeforeRunEndCtx,
 		spb.ServerFeature_EXPAND_DEFINED_METRIC_GLOBS,
 	).Enabled {
 		params.Logger.Warn(

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -216,6 +217,7 @@ func (f *SenderFactory) New() *Sender {
 		Label:                 f.Settings.GetLabel(),
 		RunfilesUploaderOrNil: runfilesUploader,
 		Structured: f.FeatureProvider.GetFeature(
+			context.Background(),
 			spb.ServerFeature_STRUCTURED_CONSOLE_LOGS,
 		).Enabled,
 	}
@@ -235,6 +237,7 @@ func (f *SenderFactory) New() *Sender {
 			f.GraphqlClient,
 			f.FileTransferManager,
 			f.FeatureProvider.GetFeature(
+				context.Background(),
 				spb.ServerFeature_USE_ARTIFACT_WITH_ENTITY_AND_PROJECT_INFORMATION,
 			).Enabled,
 		),

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -65,11 +65,7 @@ func makeSender(client graphql.Client) *stream.Sender {
 		Mailbox:                 mailbox.New(),
 		GraphqlClient:           client,
 		RunWork:                 runWork,
-		FeatureProvider: featurechecker.NewServerFeaturesCache(
-			runWork.BeforeEndCtx(),
-			nil,
-			logger,
-		),
+		FeatureProvider:         featurechecker.NewServerFeaturesCache(nil, logger),
 	}
 	return senderFactory.New()
 }

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -34,15 +34,15 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 	clientID := sharedmode.RandomClientID()
 	streamStreamLoggerFile := openStreamLoggerFile(settings2)
 	coreLogger := streamLogger(streamStreamLoggerFile, settings2, sentry, logLevel)
-	runWork := provideStreamRunWork(coreLogger)
-	context := provideRunContext(runWork)
 	backend := NewBackend(coreLogger, settings2)
 	peeker := &observability.Peeker{}
 	client := NewGraphQLClient(backend, settings2, peeker, clientID)
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(context, client, coreLogger)
+	serverFeaturesCache := featurechecker.NewServerFeaturesCache(client, coreLogger)
 	fileTransferStats := filetransfer.NewFileTransferStats()
 	mailboxMailbox := mailbox.New()
 	wandbOperations := wboperation.NewOperations()
+	runWork := provideStreamRunWork(coreLogger)
+	context := provideRunContext(runWork)
 	systemMonitorParams := monitor.SystemMonitorParams{
 		Ctx:                context,
 		Logger:             coreLogger,


### PR DESCRIPTION
Makes `Context` a function parameter rather than a struct field in `ServerFeaturesCache` so that each caller can provide its own context.

There's one `ServerFeaturesCache` per `Stream`, but `context.Background()` is the only reasonable context at that level. Right now we use `ExtraWork.BeforeRunEndCtx()`, but that should be passed by callers directly to `GetFeature()` instead. The `BeforeRunEndCtx` will soon not be injectable because `RunWork` needs lifecycle management and should be explicitly constructed.