### PR TITLE
refactor: construct RunWork explicitly instead of injecting

### DIFF
--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -84,16 +84,11 @@ type SystemMonitor struct {
 
 // SystemMonitorFactory constructs a SystemMonitor.
 type SystemMonitorFactory struct {
-	Ctx context.Context
-
 	// A logger for internal debug logging.
 	Logger *observability.CoreLogger
 
 	// Stream settings.
 	Settings *settings.Settings
-
-	// Extrawork accepts outgoing messages for the run.
-	ExtraWork runwork.ExtraWork
 
 	// GpuResourceManager manages costly resources used for GPU metrics.
 	GpuResourceManager *GPUResourceManager
@@ -108,18 +103,15 @@ type SystemMonitorFactory struct {
 // New initializes and returns a new SystemMonitor instance.
 //
 // It sets up resources based on provided settings and configures the metrics buffer.
-func (f *SystemMonitorFactory) New() *SystemMonitor {
-	if f.Ctx == nil {
-		f.Ctx = context.Background()
-	}
-	ctx, cancel := context.WithCancel(f.Ctx)
+func (f *SystemMonitorFactory) New(extraWork runwork.ExtraWork) *SystemMonitor {
+	ctx, cancel := context.WithCancel(extraWork.BeforeEndCtx())
 	sm := &SystemMonitor{
 		ctx:              ctx,
 		cancel:           cancel,
 		wg:               sync.WaitGroup{},
 		settings:         f.Settings,
 		logger:           f.Logger,
-		extraWork:        f.ExtraWork,
+		extraWork:        extraWork,
 		samplingInterval: defaultSamplingInterval,
 		graphqlClient:    f.GraphqlClient,
 		writerID:         f.WriterID,

--- a/core/internal/monitor/monitor_test.go
+++ b/core/internal/monitor/monitor_test.go
@@ -15,10 +15,9 @@ func newTestSystemMonitor() *monitor.SystemMonitor {
 	factory := &monitor.SystemMonitorFactory{
 		Logger:             observability.NewNoOpLogger(),
 		Settings:           settings.From(&spb.Settings{}),
-		ExtraWork:          runworktest.New(),
 		GpuResourceManager: monitor.NewGPUResourceManager(false),
 	}
-	return factory.New()
+	return factory.New(runworktest.New())
 }
 
 func TestSystemMonitor_BasicStateTransitions(t *testing.T) {

--- a/core/internal/runfiles/runfiles.go
+++ b/core/internal/runfiles/runfiles.go
@@ -61,7 +61,6 @@ type UploaderTesting interface {
 
 // UploaderFactory constructs Uploader instances.
 type UploaderFactory struct {
-	ExtraWork    runwork.ExtraWork
 	FileTransfer filetransfer.FileTransferManager
 	FileWatcher  watcher.Watcher
 	GraphQL      graphql.Client
@@ -76,7 +75,8 @@ type UploaderFactory struct {
 // within this duration of each other are combined into a single GraphQL call.
 func (f *UploaderFactory) New(
 	batchDelay waiting.Delay,
+	extraWork runwork.ExtraWork,
 	fileStream filestream.FileStream,
 ) Uploader {
-	return newUploader(f, batchDelay, fileStream)
+	return newUploader(f, batchDelay, extraWork, fileStream)
 }

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -56,10 +56,11 @@ type uploader struct {
 func newUploader(
 	f *UploaderFactory,
 	batchDelay waiting.Delay,
+	extraWork runwork.ExtraWork,
 	fileStream filestream.FileStream,
 ) *uploader {
 	switch {
-	case f.ExtraWork == nil:
+	case extraWork == nil:
 		panic("runfiles: ExtraWork is nil")
 	case f.Logger == nil:
 		panic("runfiles: Logger is nil")
@@ -76,7 +77,7 @@ func newUploader(
 	}
 
 	uploader := &uploader{
-		extraWork:  f.ExtraWork,
+		extraWork:  extraWork,
 		logger:     f.Logger,
 		operations: f.Operations,
 		fs:         fileStream,

--- a/core/internal/runfilestest/runfilestest.go
+++ b/core/internal/runfilestest/runfilestest.go
@@ -21,7 +21,6 @@ import (
 
 // Params for constructing a runfiles.Uploader for testing.
 type Params struct {
-	ExtraWork    runwork.ExtraWork
 	FileTransfer filetransfer.FileTransferManager
 	FileWatcher  watcher.Watcher
 	GraphQL      graphql.Client
@@ -30,6 +29,7 @@ type Params struct {
 	Settings     *settings.Settings
 
 	BatchDelay waiting.Delay
+	ExtraWork  runwork.ExtraWork
 	FileStream filestream.FileStream
 }
 
@@ -66,7 +66,6 @@ func WithTestDefaults(params Params) runfiles.Uploader {
 	}
 
 	factory := &runfiles.UploaderFactory{
-		ExtraWork:    params.ExtraWork,
 		FileTransfer: params.FileTransfer,
 		FileWatcher:  params.FileWatcher,
 		GraphQL:      params.GraphQL,
@@ -75,5 +74,5 @@ func WithTestDefaults(params Params) runfiles.Uploader {
 		Settings:     params.Settings,
 	}
 
-	return factory.New(params.BatchDelay, params.FileStream)
+	return factory.New(params.BatchDelay, params.ExtraWork, params.FileStream)
 }

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -123,10 +123,10 @@ type Handler struct {
 }
 
 // New returns a new Handler.
-func (f *HandlerFactory) New() *Handler {
+func (f *HandlerFactory) New(extraWork runwork.ExtraWork) *Handler {
 	var systemMonitor *monitor.SystemMonitor
 	if f.SystemMonitorFactory != nil { // nil in tests only
-		systemMonitor = f.SystemMonitorFactory.New()
+		systemMonitor = f.SystemMonitorFactory.New(extraWork)
 	}
 
 	return &Handler{

--- a/core/internal/stream/handler_test.go
+++ b/core/internal/stream/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runwork"
+	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/stream"
 	"github.com/wandb/wandb/core/internal/version"
@@ -28,7 +29,7 @@ func makeHandler(
 		TerminalPrinter: observability.NewPrinter(),
 		Commit:          stream.GitCommitHash(commit),
 	}
-	h := handlerFactory.New()
+	h := handlerFactory.New(runworktest.New())
 
 	go h.Do(inChan)
 

--- a/core/internal/stream/recordparser.go
+++ b/core/internal/stream/recordparser.go
@@ -32,7 +32,6 @@ type RecordParser interface {
 
 // RecordParserFactory constructs the real RecordParser.
 type RecordParserFactory struct {
-	BeforeRunEndCtx    context.Context
 	FeatureProvider    *featurechecker.ServerFeaturesCache
 	GraphqlClientOrNil graphql.Client
 	Logger             *observability.CoreLogger
@@ -45,16 +44,18 @@ type RecordParserFactory struct {
 
 // New returns a new RecordParser.
 func (f *RecordParserFactory) New(
+	beforeRunEndCtx context.Context,
 	tbHandler *tensorboard.TBHandler,
 ) *recordParser {
-	return &recordParser{*f, tbHandler}
+	return &recordParser{*f, beforeRunEndCtx, tbHandler}
 }
 
 // recordParser is the real implementation of RecordParser.
 type recordParser struct {
 	RecordParserFactory // injected fields
 
-	tbHandler *tensorboard.TBHandler
+	beforeRunEndCtx context.Context
+	tbHandler       *tensorboard.TBHandler
 }
 
 // Ensure recordParser implements RecordParser.
@@ -70,7 +71,7 @@ func (p *recordParser) Parse(record *spb.Record) runwork.Work {
 			StreamRunUpserter: p.Run,
 
 			Settings:           p.Settings,
-			BeforeRunEndCtx:    p.BeforeRunEndCtx,
+			BeforeRunEndCtx:    p.beforeRunEndCtx,
 			Operations:         p.Operations,
 			FeatureProvider:    p.FeatureProvider,
 			GraphqlClientOrNil: p.GraphqlClientOrNil,

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -66,7 +66,6 @@ type SenderFactory struct {
 	Peeker                  *observability.Peeker
 	StreamRun               *StreamRun
 	Mailbox                 *mailbox.Mailbox
-	RunWork                 runwork.RunWork
 }
 
 // Sender performs blocking operations to process Work, such as uploading data.
@@ -148,7 +147,7 @@ type Sender struct {
 }
 
 // New returns a new Sender.
-func (f *SenderFactory) New() *Sender {
+func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 	// Guaranteed not to fail.
 	maybeOutputFileName, _ := paths.Relative(ConsoleFileName)
 	outputFileName := *maybeOutputFileName
@@ -204,6 +203,7 @@ func (f *SenderFactory) New() *Sender {
 	if !f.Settings.IsOffline() {
 		runfilesUploader = f.RunfilesUploaderFactory.New(
 			/*batchDelay=*/ waiting.NewDelay(50*time.Millisecond),
+			runWork,
 			fileStream,
 		)
 	}
@@ -223,7 +223,7 @@ func (f *SenderFactory) New() *Sender {
 	}
 
 	s := &Sender{
-		runWork:             f.RunWork,
+		runWork:             runWork,
 		logger:              f.Logger,
 		operations:          f.Operations,
 		settings:            f.Settings,

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -47,7 +47,6 @@ func makeSender(client graphql.Client) *stream.Sender {
 		settings,
 	)
 	runfilesUploaderFactory := &runfiles.UploaderFactory{
-		ExtraWork:    runWork,
 		FileTransfer: fileTransferManager,
 		FileWatcher:  watchertest.NewFakeWatcher(),
 		GraphQL:      client,
@@ -64,10 +63,9 @@ func makeSender(client graphql.Client) *stream.Sender {
 		RunfilesUploaderFactory: runfilesUploaderFactory,
 		Mailbox:                 mailbox.New(),
 		GraphqlClient:           client,
-		RunWork:                 runWork,
 		FeatureProvider:         featurechecker.NewServerFeaturesCache(nil, logger),
 	}
-	return senderFactory.New()
+	return senderFactory.New(runWork)
 }
 
 // Verify that arguments are properly passed through to graphql

--- a/core/internal/stream/streaminject.go
+++ b/core/internal/stream/streaminject.go
@@ -3,7 +3,6 @@
 package stream
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/google/wire"
@@ -15,7 +14,6 @@ import (
 	"github.com/wandb/wandb/core/internal/monitor"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runfiles"
-	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/sentry_ext"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sharedmode"
@@ -39,7 +37,6 @@ func InjectStream(
 
 var streamProviders = wire.NewSet(
 	NewStream,
-	wire.Bind(new(runwork.ExtraWork), new(runwork.RunWork)),
 	wire.Bind(new(api.Peeker), new(*observability.Peeker)),
 	wire.Struct(new(observability.Peeker)),
 	featurechecker.NewServerFeaturesCache,
@@ -54,8 +51,6 @@ var streamProviders = wire.NewSet(
 	NewStreamRun,
 	observability.NewPrinter,
 	provideFileWatcher,
-	provideRunContext,
-	provideStreamRunWork,
 	RecordParserProviders,
 	runfiles.UploaderProviders,
 	senderProviders,
@@ -68,12 +63,4 @@ var streamProviders = wire.NewSet(
 
 func provideFileWatcher(logger *observability.CoreLogger) watcher.Watcher {
 	return watcher.New(watcher.Params{Logger: logger})
-}
-
-func provideRunContext(extraWork runwork.ExtraWork) context.Context {
-	return extraWork.BeforeEndCtx()
-}
-
-func provideStreamRunWork(logger *observability.CoreLogger) runwork.RunWork {
-	return runwork.New(BufferSize, logger)
 }

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -7,7 +7,6 @@
 package stream
 
 import (
-	"context"
 	"github.com/google/wire"
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/featurechecker"
@@ -17,7 +16,6 @@ import (
 	"github.com/wandb/wandb/core/internal/monitor"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runfiles"
-	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/sentry_ext"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sharedmode"
@@ -41,13 +39,9 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 	fileTransferStats := filetransfer.NewFileTransferStats()
 	mailboxMailbox := mailbox.New()
 	wandbOperations := wboperation.NewOperations()
-	runWork := provideStreamRunWork(coreLogger)
-	context := provideRunContext(runWork)
 	systemMonitorFactory := &monitor.SystemMonitorFactory{
-		Ctx:                context,
 		Logger:             coreLogger,
 		Settings:           settings2,
-		ExtraWork:          runWork,
 		GpuResourceManager: gpuResourceManager,
 		GraphqlClient:      client,
 		WriterID:           clientID,
@@ -65,7 +59,6 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 	}
 	streamRun := NewStreamRun()
 	recordParserFactory := &RecordParserFactory{
-		BeforeRunEndCtx:    context,
 		FeatureProvider:    serverFeaturesCache,
 		GraphqlClientOrNil: client,
 		Logger:             coreLogger,
@@ -83,7 +76,6 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 	fileTransferManager := NewFileTransferManager(fileTransferStats, coreLogger, settings2)
 	watcher := provideFileWatcher(coreLogger)
 	uploaderFactory := &runfiles.UploaderFactory{
-		ExtraWork:    runWork,
 		FileTransfer: fileTransferManager,
 		FileWatcher:  watcher,
 		GraphQL:      client,
@@ -107,41 +99,29 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 		Peeker:                  peeker,
 		StreamRun:               streamRun,
 		Mailbox:                 mailboxMailbox,
-		RunWork:                 runWork,
 	}
 	tbHandlerFactory := &tensorboard.TBHandlerFactory{
-		ExtraWork: runWork,
-		Logger:    coreLogger,
-		Settings:  settings2,
+		Logger:   coreLogger,
+		Settings: settings2,
 	}
 	writerFactory := &WriterFactory{
 		Logger:   coreLogger,
 		Settings: settings2,
 	}
-	stream := NewStream(clientID, debugCorePath, serverFeaturesCache, client, handlerFactory, streamStreamLoggerFile, coreLogger, wandbOperations, recordParserFactory, runWork, senderFactory, sentry, settings2, streamRun, tbHandlerFactory, writerFactory)
+	stream := NewStream(clientID, debugCorePath, serverFeaturesCache, client, handlerFactory, streamStreamLoggerFile, coreLogger, wandbOperations, recordParserFactory, senderFactory, sentry, settings2, streamRun, tbHandlerFactory, writerFactory)
 	return stream
 }
 
 // streaminject.go:
 
 var streamProviders = wire.NewSet(
-	NewStream, wire.Bind(new(runwork.ExtraWork), new(runwork.RunWork)), wire.Bind(new(api.Peeker), new(*observability.Peeker)), wire.Struct(new(observability.Peeker)), featurechecker.NewServerFeaturesCache, filestream.FileStreamProviders, filetransfer.NewFileTransferStats, handlerProviders, mailbox.New, monitor.SystemMonitorProviders, NewBackend,
+	NewStream, wire.Bind(new(api.Peeker), new(*observability.Peeker)), wire.Struct(new(observability.Peeker)), featurechecker.NewServerFeaturesCache, filestream.FileStreamProviders, filetransfer.NewFileTransferStats, handlerProviders, mailbox.New, monitor.SystemMonitorProviders, NewBackend,
 	NewFileTransferManager,
 	NewGraphQLClient,
 	NewStreamRun, observability.NewPrinter, provideFileWatcher,
-	provideRunContext,
-	provideStreamRunWork,
 	RecordParserProviders, runfiles.UploaderProviders, senderProviders, sharedmode.RandomClientID, streamLoggerProviders, tensorboard.TBHandlerProviders, wboperation.NewOperations, writerProviders,
 )
 
 func provideFileWatcher(logger *observability.CoreLogger) watcher.Watcher {
 	return watcher.New(watcher.Params{Logger: logger})
-}
-
-func provideRunContext(extraWork runwork.ExtraWork) context.Context {
-	return extraWork.BeforeEndCtx()
-}
-
-func provideStreamRunWork(logger *observability.CoreLogger) runwork.RunWork {
-	return runwork.New(BufferSize, logger)
 }

--- a/core/internal/tensorboard/tensorboard.go
+++ b/core/internal/tensorboard/tensorboard.go
@@ -60,15 +60,17 @@ type TBHandler struct {
 
 // TBHandlerFactory constructs a TBHandler.
 type TBHandlerFactory struct {
-	ExtraWork runwork.ExtraWork
-	Logger    *observability.CoreLogger
-	Settings  *settings.Settings
+	Logger   *observability.CoreLogger
+	Settings *settings.Settings
 }
 
-func (f *TBHandlerFactory) New(fileReadDelay waiting.Delay) *TBHandler {
+func (f *TBHandlerFactory) New(
+	extraWork runwork.ExtraWork,
+	fileReadDelay waiting.Delay,
+) *TBHandler {
 	tb := &TBHandler{
 		rootDirGuesser: NewRootDirGuesser(f.Logger),
-		extraWork:      f.ExtraWork,
+		extraWork:      extraWork,
 		logger:         f.Logger,
 		settings:       f.Settings,
 		fileReadDelay:  fileReadDelay,

--- a/core/internal/tensorboard/tensorboard_test.go
+++ b/core/internal/tensorboard/tensorboard_test.go
@@ -53,11 +53,10 @@ func setupTest(t *testing.T, opts testOptions) testContext {
 	settings := settings.From(settingsProto)
 
 	factory := tensorboard.TBHandlerFactory{
-		ExtraWork: runWork,
-		Logger:    observability.NewNoOpLogger(),
-		Settings:  settings,
+		Logger:   observability.NewNoOpLogger(),
+		Settings: settings,
 	}
-	handler := factory.New(fileReadDelay)
+	handler := factory.New(runWork, fileReadDelay)
 
 	return testContext{
 		Handler: handler,


### PR DESCRIPTION
Now that all objects that depend on it are also constructed explicitly, `RunWork` can be removed from the injection set. This is done because `RunWork` needs ownership to be explicit because of its `Close()` method, which is like closing a channel.