### PR TITLE
chore: fix repeated login warning

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -314,6 +314,7 @@ class Api:
                     or self.settings.get("quiet", False)
                 ),
                 update_api_key=False,
+                _disable_warning=True,
             )
 
         self._viewer = None


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Due to this change: https://github.com/wandb/wandb/pull/10099/files#diff-0ebdc60ebc3b59c136358ecb9adcfd65747135332c029b28d23719f2d4bb9f3dR307 a warning on the futility of a wandb.login after a wandb.init is shown in many more situations, essentially most of the times an Api object is created. Since it's almost a no-op in this case, I suggest to simply disable the warning (but we'd keep the benefits of #10099).

Testing
-------
Tried in Jupyter (since it calls log_code, which calls saving artifacts, which creates an Api object)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
