### PR TITLE
chore: use orjson by default for json serialization/deserialization

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,8 +15,12 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Notable Changes
 
-This version raises errors that would previously have been suppressed during calls to `Artifact.link()` or `Run.link_artifact()`. While this prevents undetected failures in those methods, it is also a breaking change.
 
+- This version raises errors that would previously have been suppressed during calls to `Artifact.link()` or `Run.link_artifact()`. While this prevents undetected failures in those methods, it is also a breaking change.
+
+- This release uses [orjson](https://github.com/ijl/orjson) by default for serializing/deserializing JSON objects. This may cause some issues in edge cases with `NaN`, `+Infinity`, `-Infinity` values.
+    - You can use `_WANDB_USE_JSON` environment variable to revert back to using the previous JSON serialization library.
 ### Changed
 
 - Errors encountered while linking an artifact are no longer suppressed/silenced, and `Artifact.link()` and `Run.link_artifact()` no longer return `None` (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9968)
+-  `orjson` is now used by default for serializing/deserializing JSON objects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic<3",
     "eval_type_backport; python_version < '3.10'",
     "packaging",
+    "orjson",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -106,7 +107,6 @@ launch = [
     "tornado>=6.5.0;python_version>='3.9'",
 ]
 models = ["cloudpickle"]
-perf = ["orjson"]
 importers = ["polars<=1.2.1", "rich", "filelock", "mlflow", "tenacity"]
 workspaces = ["wandb-workspaces"]
 

--- a/tests/system_tests/test_core/test_metric_full.py
+++ b/tests/system_tests/test_core/test_metric_full.py
@@ -219,6 +219,18 @@ def test_metric_nan_mean(wandb_backend_spy):
         assert math.isnan(summary["val"]["mean"])
 
 
+def test_metric_inf_mean(wandb_backend_spy):
+    with wandb.init() as run:
+        run.define_metric("val", summary="mean")
+        run.log(dict(mystep=1, val=2))
+        run.log(dict(mystep=1, val=float("inf")))
+        run.log(dict(mystep=1, val=4))
+
+    with wandb_backend_spy.freeze() as snapshot:
+        summary = snapshot.summary(run_id=run.id)
+        assert math.isinf(summary["val"]["mean"])
+
+
 def test_metric_nan_min_norm(wandb_backend_spy):
     with wandb.init() as run:
         run.define_metric("val", summary="min")

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -218,10 +218,10 @@ def test_make_json_if_not_number():
     assert util.make_json_if_not_number(1.0) == 1.0
     assert util.make_json_if_not_number("1") == '"1"'
     assert util.make_json_if_not_number("1.0") == '"1.0"'
-    assert util.make_json_if_not_number({"a": 1}) == '{"a": 1}'
-    assert util.make_json_if_not_number({"a": 1.0}) == '{"a": 1.0}'
-    assert util.make_json_if_not_number({"a": "1"}) == '{"a": "1"}'
-    assert util.make_json_if_not_number({"a": "1.0"}) == '{"a": "1.0"}'
+    assert util.make_json_if_not_number({"a": 1}) == '{"a":1}'
+    assert util.make_json_if_not_number({"a": 1.0}) == '{"a":1.0}'
+    assert util.make_json_if_not_number({"a": "1"}) == '{"a":"1"}'
+    assert util.make_json_if_not_number({"a": "1.0"}) == '{"a":"1.0"}'
 
 
 ###############################################################################

--- a/wandb/sdk/lib/json_util.py
+++ b/wandb/sdk/lib/json_util.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from typing import Any, Union
 
 logger = logging.getLogger(__name__)
@@ -13,63 +12,57 @@ try:
     #  NaN, Infinity, and -Infinity. Should be fixed in the future.
 
     # additional safeguard for now
-    if os.environ.get("_WANDB_ORJSON"):
+    def dumps(obj: Any, **kwargs: Any) -> str:
+        """Wrapper for <json|orjson>.dumps."""
+        cls = kwargs.pop("cls", None)
+        try:
+            _kwargs = kwargs.copy()
+            if cls:
+                _kwargs["default"] = cls.default
+            encoded = orjson.dumps(
+                obj, option=orjson.OPT_NON_STR_KEYS, **_kwargs
+            ).decode()
+        except Exception:
+            logger.exception("Error using orjson.dumps")
+            if cls:
+                kwargs["cls"] = cls
+            encoded = json.dumps(obj, **kwargs)
 
-        def dumps(obj: Any, **kwargs: Any) -> str:
-            """Wrapper for <json|orjson>.dumps."""
-            cls = kwargs.pop("cls", None)
-            try:
-                _kwargs = kwargs.copy()
-                if cls:
-                    _kwargs["default"] = cls.default
-                encoded = orjson.dumps(
-                    obj, option=orjson.OPT_NON_STR_KEYS, **_kwargs
-                ).decode()
-            except Exception:
-                logger.exception("Error using orjson.dumps")
-                if cls:
-                    kwargs["cls"] = cls
-                encoded = json.dumps(obj, **kwargs)
+        return encoded  # type: ignore[no-any-return]
 
-            return encoded  # type: ignore[no-any-return]
+    def dump(obj: Any, fp: Any, **kwargs: Any) -> None:
+        """Wrapper for <json|orjson>.dump."""
+        cls = kwargs.pop("cls", None)
+        try:
+            _kwargs = kwargs.copy()
+            if cls:
+                _kwargs["default"] = cls.default
+            encoded = orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS, **_kwargs)
+            fp.write(encoded)
+        except Exception:
+            logger.exception("Error using orjson.dump")
+            if cls:
+                kwargs["cls"] = cls
+            json.dump(obj, fp, **kwargs)
 
-        def dump(obj: Any, fp: Any, **kwargs: Any) -> None:
-            """Wrapper for <json|orjson>.dump."""
-            cls = kwargs.pop("cls", None)
-            try:
-                _kwargs = kwargs.copy()
-                if cls:
-                    _kwargs["default"] = cls.default
-                encoded = orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS, **_kwargs)
-                fp.write(encoded)
-            except Exception:
-                logger.exception("Error using orjson.dump")
-                if cls:
-                    kwargs["cls"] = cls
-                json.dump(obj, fp, **kwargs)
+    def loads(obj: Union[str, bytes]) -> Any:
+        """Wrapper for orjson.loads."""
+        try:
+            decoded = orjson.loads(obj)
+        except Exception:
+            logger.exception("Error using orjson.loads")
+            decoded = json.loads(obj)
 
-        def loads(obj: Union[str, bytes]) -> Any:
-            """Wrapper for orjson.loads."""
-            try:
-                decoded = orjson.loads(obj)
-            except Exception:
-                logger.exception("Error using orjson.loads")
-                decoded = json.loads(obj)
+        return decoded
 
-            return decoded
+    def load(fp: Any) -> Any:
+        """Wrapper for orjson.load."""
+        try:
+            decoded = orjson.loads(fp.read())
+        except Exception:
+            logger.exception("Error using orjson.load")
+            decoded = json.load(fp)
 
-        def load(fp: Any) -> Any:
-            """Wrapper for orjson.load."""
-            try:
-                decoded = orjson.loads(fp.read())
-            except Exception:
-                logger.exception("Error using orjson.load")
-                decoded = json.load(fp)
-
-            return decoded
-
-    else:
-        from json import dump, dumps, load, loads  # type: ignore[assignment]
-
+        return decoded
 except ImportError:
     from json import dump, dumps, load, loads  # type: ignore[assignment] # noqa: F401

--- a/wandb/sdk/lib/json_util.py
+++ b/wandb/sdk/lib/json_util.py
@@ -6,6 +6,26 @@ from typing import Any, Union
 logger = logging.getLogger(__name__)
 
 
+def _create_orjson_fragments(obj: Any) -> Any:
+    """Create orjson fragments for non-serializable objects.
+
+    Orjson fragments are not serialized by orjson.
+    So this allows us to still support non-standard json types. (inf, -inf, nan)
+    """
+    if isinstance(obj, float) and (math.isnan(obj) or math.isinf(obj)):
+        return orjson.Fragment(json.dumps(obj))
+    return obj
+
+
+def _walk_and_create_fragments(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: _walk_and_create_fragments(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_walk_and_create_fragments(v) for v in obj]
+    else:
+        return _create_orjson_fragments(obj)
+
+
 try:
     import orjson  # type: ignore
 
@@ -17,18 +37,15 @@ try:
         """Wrapper for <json|orjson>.dumps."""
         cls = kwargs.pop("cls", None)
         try:
-            if isinstance(obj, float) and obj == float("inf"):
-                return "Infinity"
-            elif isinstance(obj, float) and obj == float("-inf"):
-                return "-Infinity"
-            elif isinstance(obj, float) and math.isnan(obj):
-                return "NaN"
+            obj = _walk_and_create_fragments(obj)
 
             _kwargs = kwargs.copy()
             if cls:
                 _kwargs["default"] = cls.default
             encoded = orjson.dumps(
-                obj, option=orjson.OPT_NON_STR_KEYS, **_kwargs
+                obj,
+                option=orjson.OPT_NON_STR_KEYS,
+                **_kwargs,
             ).decode()
         except Exception:
             logger.exception("Error using orjson.dumps")

--- a/wandb/sdk/lib/json_util.py
+++ b/wandb/sdk/lib/json_util.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 from typing import Any, Union
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,13 @@ try:
         """Wrapper for <json|orjson>.dumps."""
         cls = kwargs.pop("cls", None)
         try:
+            if isinstance(obj, float) and obj == float("inf"):
+                return "Infinity"
+            elif isinstance(obj, float) and obj == float("-inf"):
+                return "-Infinity"
+            elif isinstance(obj, float) and math.isnan(obj):
+                return "NaN"
+
             _kwargs = kwargs.copy()
             if cls:
                 _kwargs["default"] = cls.default


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

This PR changes `json_util.py` to use [orjson](https://github.com/ijl/orjson) by default.
Additionally as part of this change we still need to support json serialization of `NaN`, `+Infinity`, `-Infinity`. To achieve this we walk lists, and dictionaries and manually set the value in those cases to use `orjson.Fragment`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
