### PR TITLE
chore(sdk): replace/update codeowners from (deprecated) mlw-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,16 +48,22 @@
 /.github @wandb/sdk-team
 
 
-# Artifacts, Automations, and Launch teams
-/core/pkg/artifacts/                  @wandb/mlw-team @wandb/sdk-team
-/wandb/sdk/artifacts/                 @wandb/mlw-team @wandb/sdk-team
+# Artifacts, Registries, Automations
+/core/pkg/artifacts/                  @wandb/art-reg-team @wandb/sdk-team
+/wandb/sdk/artifacts/                 @wandb/art-reg-team @wandb/sdk-team
+/wandb/automations/                   @wandb/art-reg-team @wandb/sdk-team
+/wandb/apis/public/registries/        @wandb/art-reg-team @wandb/sdk-team
+/wandb/apis/public/artifacts.py       @wandb/art-reg-team @wandb/sdk-team
+/wandb/apis/public/automations.py     @wandb/art-reg-team @wandb/sdk-team
+/wandb/apis/public/integrations.py    @wandb/art-reg-team @wandb/sdk-team
+/tests/system_tests/test_artifacts/   @wandb/art-reg-team @wandb/sdk-team
+/tests/system_tests/test_registries/  @wandb/art-reg-team @wandb/sdk-team
+/tests/system_tests/test_automations/ @wandb/art-reg-team @wandb/sdk-team
+/tests/unit_tests/test_artifacts/     @wandb/art-reg-team @wandb/sdk-team
+/tests/unit_tests/test_registries/    @wandb/art-reg-team @wandb/sdk-team
+/tests/unit_tests/test_automations/   @wandb/art-reg-team @wandb/sdk-team
+
+# Launch
 /wandb/sdk/launch/                    @wandb/sweeps-launch-team @wandb/sdk-team
-/wandb/automations/                   @wandb/mlw-team @wandb/sdk-team
-/tests/system_tests/test_artifacts/   @wandb/mlw-team @wandb/sdk-team
-/tests/system_tests/test_registries/  @wandb/mlw-team @wandb/sdk-team
-/tests/system_tests/test_automations/ @wandb/mlw-team @wandb/sdk-team
 /tests/system_tests/test_launch/      @wandb/sweeps-launch-team @wandb/sdk-team
-/tests/unit_tests/test_artifacts/     @wandb/mlw-team @wandb/sdk-team
-/tests/unit_tests/test_registries/    @wandb/mlw-team @wandb/sdk-team
-/tests/unit_tests/test_automations/   @wandb/mlw-team @wandb/sdk-team
 /tests/unit_tests/test_launch/        @wandb/sweeps-launch-team @wandb/sdk-team


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Updates CODEOWNERS by:
- replacing `@mlw-team` with one of `@art-reg-team` or `@sweeps-launch-team` as appropriate
- adding additional paths related to artifacts/registries/automations to `@art-reg-team` ownership.
  - Note that `@sdk-team` retains co-ownership of these files as well, in keeping with existing patterns & processes.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
