### PR TITLE
chore(artifacts): starter system tests for registry search queries

### DIFF
--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -1,8 +1,9 @@
 from typing import Iterator
 from unittest.mock import patch
 
+import wandb
 from pytest import fixture, mark, raises, skip
-from wandb import Api
+from wandb import Api, Artifact
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 from wandb.sdk.internal.internal_api import Api as InternalApi
@@ -328,3 +329,81 @@ def test_edit_registry_name(mock_termlog, default_organization, api: Api):
     assert new_name_registry.description == "This is the initial description"
     # Assert that the rename termlog was called as we never created a new registry
     mock_termlog.assert_not_called()
+
+
+@mark.usefixtures(skip_if_server_does_not_support_create_registry.__name__)
+def test_fetch_registries(team: str, org: str, api: Api):
+    num_registries = 3
+
+    for registry_idx in range(num_registries):
+        api.create_registry(
+            organization=org,
+            name=f"test-{registry_idx}",
+            visibility="organization",
+        )
+
+    registries = list(api.registries(organization=org))
+
+    assert len(registries) == num_registries
+
+
+@mark.usefixtures(skip_if_server_does_not_support_create_registry.__name__)
+def test_registries_collections(team: str, org: str, api: Api):
+    registry_name = "test-registry"
+    registry = api.create_registry(
+        organization=org,
+        name=registry_name,
+        visibility="organization",
+    )
+
+    num_versions = 3
+
+    # Each version linked to a different registry collection
+    with wandb.init(entity=team) as run:
+        for i in range(num_versions):
+            artifact = Artifact(name=f"test-artifact-{i}", type="test-type")
+            run.log_artifact(artifact)
+
+            target_path = f"{org}/{registry.full_name}/reg-collection-{i}"
+            artifact.link(target_path)
+
+    registries = api.registries(organization=org)
+
+    collections = sorted(registries.collections(), key=lambda c: c.name)
+    assert len(collections) == num_versions
+
+    # Check that we have the correct registry collections
+    for i, collection in enumerate(collections):
+        assert collection.name == f"reg-collection-{i}"
+        assert collection.type == "test-type"
+
+
+@mark.usefixtures(skip_if_server_does_not_support_create_registry.__name__)
+def test_registries_versions(team: str, org: str, api: Api):
+    registry_name = "test-registry"
+    registry = api.create_registry(
+        organization=org,
+        name=registry_name,
+        visibility="organization",
+    )
+
+    num_versions = 3
+
+    # Each version linked to the same registry collection
+    with wandb.init(entity=team) as run:
+        for i in range(num_versions):
+            artifact = Artifact(name=f"test-artifact-{i}", type="test-type")
+            run.log_artifact(artifact)
+
+            target_path = f"{org}/{registry.full_name}/reg-collection"
+            artifact.link(target_path)
+
+    registries = api.registries(organization=org)
+
+    versions = sorted(registries.versions(), key=lambda v: v.name)
+    assert len(versions) == num_versions
+
+    # Check that the versions are linked to the correct registry collection
+    for i, registry_version in enumerate(versions):
+        assert registry_version.source_name == f"test-artifact-{i}:v0"
+        assert registry_version.name == f"reg-collection:v{i}"


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- https://wandb.atlassian.net/browse/WB-26973

Adds starter system tests for registry API search queries.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->