### PR TITLE
chore(launch): enable setting input schema on job create

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1906,6 +1906,12 @@ def describe(job):
     help="Service configurations in format serviceName=policy. Valid policies: always, never",
     hidden=True,
 )
+@click.option(
+    "--schema",
+    type=str,
+    help="Path to the schema file for the job.",
+    hidden=True,
+)
 @click.argument("path")
 def create(
     path,
@@ -1922,6 +1928,7 @@ def create(
     base_image,
     dockerfile,
     services,
+    schema,
 ):
     """Create a job from a source, without a wandb run.
 
@@ -1956,6 +1963,12 @@ def create(
         wandb.termerror("Cannot provide --base-image/-B for an `image` job")
         return
 
+    if schema:
+        schema_dict = util.load_json_yaml_dict(schema)
+        if schema_dict is None:
+            wandb.termerror(f"Invalid format for schema file: {schema}")
+            return
+
     artifact, action, aliases = _create_job(
         api=api,
         path=path,
@@ -1972,6 +1985,7 @@ def create(
         base_image=base_image,
         dockerfile=dockerfile,
         services=services,
+        schema=schema_dict,
     )
     if not artifact:
         wandb.termerror("Job creation failed")

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -11,6 +11,7 @@ from wandb.apis.internal import Api
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.internal.job_builder import JobBuilder
 from wandb.sdk.launch.git_reference import GitReference
+from wandb.sdk.launch.inputs.internal import _validate_schema
 from wandb.sdk.launch.utils import (
     _is_git_uri,
     get_current_python_version,
@@ -116,6 +117,7 @@ def _create_job(
     dockerfile: Optional[str] = None,
     base_image: Optional[str] = None,
     services: Optional[Dict[str, str]] = None,
+    schema: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Artifact], str, List[str]]:
     wandb.termlog(f"Creating launch job of type: {job_type}...")
 
@@ -206,6 +208,14 @@ def _create_job(
     if "latest" not in aliases:
         aliases += ["latest"]
 
+    if schema:
+        _validate_schema(schema)
+        schema = {
+            "input_schemas": {
+                "@wandb.config": schema,
+            }
+        }
+
     res, _ = api.create_artifact(
         artifact_type_name="job",
         artifact_collection_name=name,
@@ -216,7 +226,7 @@ def _create_job(
         project_name=project,
         run_name=run.id,  # type: ignore # run will be deleted after creation
         description=description,
-        metadata={"_partial": True},
+        metadata=schema if schema else {"_partial": True},
         is_user_created=True,
         aliases=[{"artifactCollectionName": name, "alias": a} for a in aliases],
     )

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -208,9 +208,10 @@ def _create_job(
     if "latest" not in aliases:
         aliases += ["latest"]
 
+    metadata = {"_partial": True}
     if schema:
         _validate_schema(schema)
-        schema = {
+        metadata = {
             "input_schemas": {
                 "@wandb.config": schema,
             }
@@ -226,7 +227,7 @@ def _create_job(
         project_name=project,
         run_name=run.id,  # type: ignore # run will be deleted after creation
         description=description,
-        metadata=schema if schema else {"_partial": True},
+        metadata=metadata,
         is_user_created=True,
         aliases=[{"artifactCollectionName": name, "alias": a} for a in aliases],
     )


### PR DESCRIPTION
Description
-----------
Expose a way for us to update the input schema for the evals jobs

Testing
-------
Verified that the metadata exists: https://app.wandb.test/wandb/launch-tutorial/artifacts/job/test-simple-schema-npun/v0/metadata

Verified that the job drawer shows the input overrides:
<img width="447" height="942" alt="Screenshot 2025-08-14 at 09 04 58" src="https://github.com/user-attachments/assets/c8b69605-0db5-46f7-9903-5d0af232b675" />

Run succeeds with the input:
https://app.wandb.test/wandb/launch-tutorial/runs/jfqkd4lk/logs

