### PR TITLE
chore(artifacts): remove now-unused internal gql helpers, other misc cleanup

### DIFF
--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -71,16 +71,16 @@ class Registries(Paginator):
 
     def collections(self, filter: dict[str, Any] | None = None) -> Collections:
         return Collections(
-            self.client,
-            self.organization,
+            client=self.client,
+            organization=self.organization,
             registry_filter=self.filter,
             collection_filter=filter,
         )
 
     def versions(self, filter: dict[str, Any] | None = None) -> Versions:
         return Versions(
-            self.client,
-            self.organization,
+            client=self.client,
+            organization=self.organization,
             registry_filter=self.filter,
             collection_filter=None,
             artifact_filter=filter,
@@ -129,7 +129,7 @@ class Registries(Paginator):
         nodes = (e.node for e in self.last_response.edges)
         return [
             Registry(
-                self.client,
+                client=self.client,
                 organization=self.organization,
                 entity=self._last_org_entity,
                 name=remove_registry_prefix(node.name),
@@ -162,7 +162,7 @@ class Collections(Paginator["ArtifactCollection"]):
         variables = {
             "registryFilter": json.dumps(f) if (f := registry_filter) else None,
             "collectionFilter": json.dumps(f) if (f := collection_filter) else None,
-            "organization": self.organization,
+            "organization": organization,
             "collectionTypes": [ArtifactCollectionType.PORTFOLIO],
             "perPage": per_page,
         }
@@ -179,8 +179,8 @@ class Collections(Paginator["ArtifactCollection"]):
 
     def versions(self, filter: dict[str, Any] | None = None) -> Versions:
         return Versions(
-            self.client,
-            self.organization,
+            client=self.client,
+            organization=self.organization,
             registry_filter=self.registry_filter,
             collection_filter=self.collection_filter,
             artifact_filter=filter,
@@ -231,13 +231,13 @@ class Collections(Paginator["ArtifactCollection"]):
         nodes = (e.node for e in self.last_response.edges)
         return [
             ArtifactCollection(
-                self.client,
-                project.entity.name,
-                project.name,
-                node.name,
-                node.default_artifact_type.name,
-                self.organization,
-                node.model_dump(),
+                client=self.client,
+                entity=project.entity.name,
+                project=project.name,
+                name=node.name,
+                type=node.default_artifact_type.name,
+                organization=self.organization,
+                attrs=node.model_dump(),
                 is_sequence=False,
             )
             for node in nodes
@@ -331,12 +331,12 @@ class Versions(Paginator["Artifact"]):
         nodes = (e.node for e in self.last_response.edges)
         return [
             Artifact._from_attrs(
-                project.entity.name,
-                project.name,
-                f"{collection.name}:v{node.version_index}",
-                artifact,
-                self.client,
-                [alias.alias for alias in node.aliases],
+                entity=project.entity.name,
+                project=project.name,
+                name=f"{collection.name}:v{node.version_index}",
+                attrs=artifact,
+                client=self.client,
+                aliases=[alias.alias for alias in node.aliases],
             )
             for node in nodes
             if (

--- a/wandb/sdk/artifacts/_graphql_fragments.py
+++ b/wandb/sdk/artifacts/_graphql_fragments.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from textwrap import dedent
-
-from wandb_graphql.language.printer import print_ast
-
-from wandb.apis.public.utils import gql_compat
 from wandb.sdk.internal.internal_api import Api as InternalApi
 
 OMITTABLE_ARTIFACT_FIELDS = frozenset(
@@ -22,81 +17,3 @@ def omit_artifact_fields(api: InternalApi | None = None) -> set[str]:
     """Return names of Artifact fields to remove from GraphQL requests (for server compatibility)."""
     allowed_fields = (api or InternalApi()).server_artifact_introspection()
     return set(OMITTABLE_ARTIFACT_FIELDS) - set(allowed_fields)
-
-
-def _gql_artifact_fragment(include_aliases: bool = True) -> str:
-    """Return a GraphQL query fragment with all parseable Artifact attributes."""
-    omit_fields = omit_artifact_fields(api=InternalApi())
-
-    # Respect the `include_aliases` flag
-    if not include_aliases:
-        omit_fields.add("aliases")
-
-    artifact_fragment_str = dedent(
-        """\
-        fragment ArtifactFragment on Artifact {
-            id
-            artifactSequence {
-                project {
-                    entityName
-                    name
-                }
-                name
-            }
-            versionIndex
-            artifactType {
-                name
-            }
-            description
-            metadata
-            ttlDurationSeconds
-            ttlIsInherited
-            aliases {
-                artifactCollection {
-                    project {
-                        entityName
-                        name
-                    }
-                    name
-                }
-                alias
-            }
-            tags {
-                name
-            }
-            historyStep
-            state
-            currentManifest {
-                file {
-                    directUrl
-                }
-            }
-            commitHash
-            fileCount
-            createdAt
-            updatedAt
-        }"""
-    )
-    compat_doc = gql_compat(artifact_fragment_str, omit_fields=omit_fields)
-    return print_ast(compat_doc)
-
-
-def _gql_registry_fragment() -> str:
-    return """
-        fragment RegistryFragment on Project {
-           id
-            allowAllArtifactTypesInRegistry
-            artifactTypes(includeAll: true) {
-                edges {
-                    node {
-                        name
-                    }
-                }
-            }
-            name
-            description
-            createdAt
-            updatedAt
-            access
-        }
-    """


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

Cleanup: removed now-unused `_gql_artifact_fragment()` and `_gql_registry_fragment()`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->