### PR TITLE
chore: fix coverage collection for tests that run subprocesses

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -149,7 +149,7 @@ def run_pytest(
 
     # (pytest-cov) Enable Python code coverage collection.
     # We set "--cov-report=" to suppress terminal output.
-    pytest_opts.extend(["--cov-report=", "--cov", "--no-cov-on-fail"])
+    pytest_opts.extend(["--cov-report=", "--no-cov-on-fail", "--cov=wandb"])
 
     pytest_env.update(python_coverage_env(session))
     pytest_env.update(go_coverage_env(session))


### PR DESCRIPTION
Best demonstrated with an example:

```bash
nox -s 'functional_tests-3.10' -- tests/system_tests/test_functional/asyncio_compat_run/test_asyncio_compat_run.py
coverage report --include=wandb/sdk/lib/asyncio_compat.py

# Output before this change:
#   wandb/sdk/lib/asyncio_compat.py      85     61    28%
# Output after this change:
#   wandb/sdk/lib/asyncio_compat.py      85     26    69%
```

The `--cov` option expects a value (it's not just a switch) in all documentation, so we appear to have been misusing it. **Why** does that break coverage in this way? I couldn't tell you. But I think it has to do with paths because I get the same 28% in a fresh venv doing this:

```bash
uv venv .venv-cov-bad
source .venv-cov-bad/bin/activate
uv pip install -r requirements_dev.txt
pytest --cov-report= --cov --no-cov-on-fail tests/system_tests/test_functional/asyncio_compat_run/test_asyncio_compat_run.py
```

but it becomes 69% if I make sure to use an editable install before the pytest command:

```bash
uv pip install -e .
```