### PR TITLE
refactor(artifacts): make ArtifactManifest a pydantic class

### DIFF
--- a/wandb/sdk/artifacts/_models/manifest.py
+++ b/wandb/sdk/artifacts/_models/manifest.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict, Literal, final
+
+from wandb._pydantic import field_validator, to_camel
+from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
+
+from .base_model import ArtifactsBase
+
+
+@final
+class ArtifactManifestV1Data(ArtifactsBase, alias_generator=to_camel):
+    """Data model for the v1 artifact manifest."""
+
+    version: Literal[1]
+
+    contents: Dict[str, ArtifactManifestEntry]
+
+    storage_policy: str
+    storage_policy_config: Dict[str, Any]
+
+    @field_validator("contents", mode="before")
+    def _validate_entries(cls, v: Any) -> Any:
+        # The dict keys should be the `entry.path` values, but they've
+        # historically been dropped from the JSON objects. This restores
+        # them on instantiation.
+        # Pydantic will handle converting dicts -> ArtifactManifestEntries.
+        return {path: {**dict(entry), "path": path} for path, entry in v.items()}

--- a/wandb/sdk/artifacts/artifact_manifest.py
+++ b/wandb/sdk/artifacts/artifact_manifest.py
@@ -2,75 +2,76 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict
+
+from pydantic import Field
+from typing_extensions import Annotated
 
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.lib.hashutil import HexMD5
 
+from ._models.base_model import ArtifactsBase
+
 if TYPE_CHECKING:
-    from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-    from wandb.sdk.artifacts.storage_policy import StoragePolicy
+    from .artifact_manifest_entry import ArtifactManifestEntry
+    from .storage_policy import StoragePolicy
 
 
-class ArtifactManifest:
-    entries: dict[str, ArtifactManifestEntry]
+class ArtifactManifest(ArtifactsBase, ABC):
+    # Note: this can't be named "version" since it conflicts with the prior `version()` classmethod.
+    manifest_version: Annotated[Any, Field(repr=False)]
+    entries: Dict[str, ArtifactManifestEntry] = Field(default_factory=dict)  # noqa: UP006
+
+    storage_policy: Annotated[StoragePolicy, Field(exclude=True, repr=False)]
 
     @classmethod
+    def version(cls) -> int:
+        return cls.model_fields["manifest_version"].default
+
+    @classmethod
+    @abstractmethod
     def from_manifest_json(
-        cls, manifest_json: dict, api: InternalApi | None = None
+        cls, manifest_json: dict[str, Any], api: InternalApi | None = None
     ) -> ArtifactManifest:
-        if "version" not in manifest_json:
+        if (version := manifest_json.get("version")) is None:
             raise ValueError("Invalid manifest format. Must contain version field.")
-        version = manifest_json["version"]
+
         for sub in cls.__subclasses__():
             if sub.version() == version:
                 return sub.from_manifest_json(manifest_json, api=api)
         raise ValueError("Invalid manifest version.")
 
-    @classmethod
-    def version(cls) -> int:
-        raise NotImplementedError
-
-    def __init__(
-        self,
-        storage_policy: StoragePolicy,
-        entries: Mapping[str, ArtifactManifestEntry] | None = None,
-    ) -> None:
-        self.storage_policy = storage_policy
-        self.entries = dict(entries) if entries else {}
-
     def __len__(self) -> int:
         return len(self.entries)
 
-    def to_manifest_json(self) -> dict:
+    @abstractmethod
+    def to_manifest_json(self) -> dict[str, Any]:
         raise NotImplementedError
 
+    @abstractmethod
     def digest(self) -> HexMD5:
         raise NotImplementedError
 
     def add_entry(self, entry: ArtifactManifestEntry, overwrite: bool = False) -> None:
-        path = entry.path
         if (
             (not overwrite)
-            and (old_entry := self.entries.get(path))
+            and (old_entry := self.entries.get(entry.path))
             and (entry.digest != old_entry.digest)
         ):
-            raise ValueError(f"Cannot add the same path twice: {path!r}")
-        self.entries[path] = entry
+            raise ValueError(f"Cannot add the same path twice: {entry.path!r}")
+        self.entries[entry.path] = entry
 
     def remove_entry(self, entry: ArtifactManifestEntry) -> None:
         try:
             del self.entries[entry.path]
         except LookupError:
-            raise FileNotFoundError(f"Cannot remove missing entry: '{entry.path}'")
+            raise FileNotFoundError(f"Cannot remove missing entry: {entry.path!r}")
 
     def get_entry_by_path(self, path: str) -> ArtifactManifestEntry | None:
         return self.entries.get(path)
 
     def get_entries_in_directory(self, directory: str) -> list[ArtifactManifestEntry]:
-        return [
-            entry
-            for key, entry in self.entries.items()
-            # entry keys (paths) use forward slash even for windows
-            if key.startswith(f"{directory}/")
-        ]
+        # entry keys (paths) use forward slash even for windows
+        dir_prefix = f"{directory}/"
+        return [obj for key, obj in self.entries.items() if key.startswith(dir_prefix)]

--- a/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
+++ b/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
@@ -1,50 +1,47 @@
 """Artifact manifest v1."""
 
+# Older-style type annotations required for Pydantic v1 / python 3.8 compatibility.
+# ruff: noqa: UP006
+
 from __future__ import annotations
 
 from operator import itemgetter
-from typing import Mapping
+from typing import Any, Dict, Literal, final
 
-from wandb.sdk.artifacts.artifact_manifest import ArtifactManifest
-from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.storage_policy import StoragePolicy
+from pydantic import Field
+from typing_extensions import Annotated
+
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.lib.hashutil import HexMD5, _md5
 
+from .._factories import make_storage_policy
+from .._models.manifest import ArtifactManifestV1Data
+from ..artifact_manifest import ArtifactManifest
+from ..artifact_manifest_entry import ArtifactManifestEntry
+from ..storage_policy import StoragePolicy
 
+
+@final
 class ArtifactManifestV1(ArtifactManifest):
-    @classmethod
-    def version(cls) -> int:
-        return 1
+    manifest_version: Annotated[Literal[1], Field(repr=False)] = 1
+    entries: Dict[str, ArtifactManifestEntry] = Field(default_factory=dict)
+
+    storage_policy: StoragePolicy = Field(
+        default_factory=make_storage_policy, exclude=True, repr=False
+    )
 
     @classmethod
     def from_manifest_json(
-        cls, manifest_json: dict, api: InternalApi | None = None
+        cls, manifest_json: dict[str, Any], api: InternalApi | None = None
     ) -> ArtifactManifestV1:
-        if manifest_json["version"] != cls.version():
-            raise ValueError(
-                "Expected manifest version 1, got {}".format(manifest_json["version"])
-            )
+        data = ArtifactManifestV1Data(**manifest_json)
 
-        storage_policy_name = manifest_json["storagePolicy"]
-        storage_policy_config = manifest_json.get("storagePolicyConfig", {})
-        storage_policy_cls = StoragePolicy.lookup_by_name(storage_policy_name)
-
-        entries = {
-            path: ArtifactManifestEntry(**{**val, "path": path})
-            for path, val in manifest_json["contents"].items()
-        }
-
+        policy_name = data.storage_policy
+        policy_cfg = data.storage_policy_config
+        policy = StoragePolicy.lookup_by_name(policy_name).from_config(policy_cfg, api)
         return cls(
-            storage_policy_cls.from_config(storage_policy_config, api=api), entries
+            manifest_version=data.version, entries=data.contents, storage_policy=policy
         )
-
-    def __init__(
-        self,
-        storage_policy: StoragePolicy,
-        entries: Mapping[str, ArtifactManifestEntry] | None = None,
-    ) -> None:
-        super().__init__(storage_policy, entries=entries)
 
     def to_manifest_json(self) -> dict:
         """This is the JSON that's stored in wandb_manifest.json.
@@ -56,9 +53,9 @@ class ArtifactManifestV1(ArtifactManifest):
         """
         omit_entry_fields = {"path", "local_path", "skip_cache"}
         return {
-            "version": self.version(),
+            "version": self.manifest_version,
             "storagePolicy": self.storage_policy.name(),
-            "storagePolicyConfig": self.storage_policy.config() or {},
+            "storagePolicyConfig": self.storage_policy.config(),
             "contents": {
                 path: entry.model_dump(exclude=omit_entry_fields, exclude_defaults=True)
                 for path, entry in self.entries.items()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Makes `ArtifactManifest` a pydantic class.

No intended changes to the existing API for the class, save for standard pydantic methods inherited by all pydantic classes.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
