### PR TITLE
refactor: improve mailbox handle traceback on wandb-core crash

### DIFF
--- a/wandb/sdk/lib/asyncio_compat.py
+++ b/wandb/sdk/lib/asyncio_compat.py
@@ -157,11 +157,9 @@ class TaskGroup:
         )
 
         for task in done:
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 if exc := task.exception():
                     raise exc
-            except asyncio.CancelledError:
-                pass
 
     def _cancel_all(self) -> None:
         """Cancel all tasks."""
@@ -199,15 +197,16 @@ async def open_task_group() -> AsyncIterator[TaskGroup]:
 def cancel_on_exit(coro: Coroutine[Any, Any, Any]) -> Iterator[None]:
     """Schedule a task, cancelling it when exiting the context manager.
 
-    If the given coroutine raises an exception, that exception is raised
-    when exiting the context manager.
+    If the context manager exits successfully but the given coroutine raises
+    an exception, that exception is reraised. The exception is suppressed
+    if the context manager raises an exception.
     """
     task = asyncio.create_task(coro)
 
     try:
         yield
-    finally:
+
         if task.done() and (exception := task.exception()):
             raise exception
-
+    finally:
         task.cancel()


### PR DESCRIPTION
Prevents `asyncio_compat.cancel_on_exit()` from raising its task's exception if the code inside the context manager raised an exception, because the traceback for the latter is generally more important.

This matters when `wandb-core` panics during something like `progress.loop_printing_operation_stats()` in `wandb.init()`. The printed traceback looked like this before:

```
    @contextlib.contextmanager
    def cancel_on_exit(coro: Coroutine[Any, Any, Any]) -> Iterator[None]:
        """Schedule a task, cancelling it when exiting the context manager.
    
        If the given coroutine raises an exception, that exception is raised
        when exiting the context manager.
        """
        task = asyncio.create_task(coro)
    
        try:
>           yield

.../wandb/sdk/lib/asyncio_compat.py:209: 
-------
.../wandb/sdk/mailbox/wait_with_progress.py:72: in progress_loop_with_timeout
    return await _wait_handles_async(
.../wandb/sdk/mailbox/wait_with_progress.py:95: in _wait_handles_async
    async with asyncio_compat.open_task_group() as task_group:
.../python3.10/contextlib.py:206: in __aexit__
    await anext(self.gen)
.../wandb/sdk/lib/asyncio_compat.py:194: in open_task_group
    await task_group._wait_all()
.../wandb/sdk/lib/asyncio_compat.py:163: in _wait_all
    raise exc
.../wandb/sdk/mailbox/wait_with_progress.py:93: in wait_single
    results[index] = await handle.wait_async(timeout=timeout)
.../wandb/sdk/mailbox/mailbox_handle.py:131: in wait_async
    response = await self._handle.wait_async(timeout=timeout)
------
    @override
    async def wait_async(self, *, timeout: float | None) -> spb.ServerResponse:
        if timeout is not None and not math.isfinite(timeout):
            raise ValueError("Timeout must be finite or None.")
    
        if not self._done_event:
            self._done_event = asyncio.Event()
    
        try:
            await asyncio.wait_for(self._done_event.wait(), timeout=timeout)
    
        except (asyncio.TimeoutError, TimeoutError) as e:
            if self._response:
                return self._response
            elif self._abandoned:
                raise HandleAbandonedError()
            else:
                raise TimeoutError(
                    f"Timed out waiting for response on {self._address}"
                ) from e
    
        else:
            if self._response:
                return self._response
    
            assert self._abandoned
>           raise HandleAbandonedError()
E           wandb.sdk.mailbox.mailbox_handle.HandleAbandonedError

.../wandb/sdk/mailbox/response_handle.py:99: HandleAbandonedError

During handling of the above exception, another exception occurred:

    def test_get_artifact_obj_by_name(
        user,
        api,
        image_pair,
        table,
        anon_storage_handlers,
    ):
        """Test the ability to instantiate a wandb Media object from the name of the object.
    
        This is the logical inverse of Artifact.add(name).
        """
        artifact_name = "A2"
        artifact_type = "database"
    
        image_1, image_2 = image_pair
    
        # TODO: test more robustly for every Media type, nested objects (eg. Table -> Image), and references.
>       with wandb.init() as run:

.../tests/system_tests/test_artifacts/test_object_references.py:617: 
-----
[...]
-----
    @override
    async def wait_async(self, *, timeout: float | None) -> spb.ServerResponse:
        if timeout is not None and not math.isfinite(timeout):
            raise ValueError("Timeout must be finite or None.")
    
        if not self._done_event:
            self._done_event = asyncio.Event()
    
        try:
            await asyncio.wait_for(self._done_event.wait(), timeout=timeout)
    
        except (asyncio.TimeoutError, TimeoutError) as e:
            if self._response:
                return self._response
            elif self._abandoned:
                raise HandleAbandonedError()
            else:
                raise TimeoutError(
                    f"Timed out waiting for response on {self._address}"
                ) from e
    
        else:
            if self._response:
                return self._response
    
            assert self._abandoned
>           raise HandleAbandonedError()
E           wandb.sdk.mailbox.mailbox_handle.HandleAbandonedError

.../wandb/sdk/mailbox/response_handle.py:99: HandleAbandonedError
```

The "During handling of the above exception, another exception occurred" message is confusing, especially because the following exception is the more useful one as it shows the triggering `wandb.init()` call. I saw this when a test failed in CI.

This was happening because `cancel_on_exit()` raised its exception during `finally`. This PR causes the inner exception to be preferred.