### PR TITLE
chore(launch): allow list/sets in input schemas

### DIFF
--- a/tests/unit_tests/test_launch/test_inputs/test_internal.py
+++ b/tests/unit_tests/test_launch/test_inputs/test_internal.py
@@ -124,31 +124,17 @@ def test_validate_schema_pydantic_lists():
         epochs: int = Field(ge=1)
 
     class GenericLists(BaseModel):
-        tags: list[str] = Field(min_length=0, max_length=10)
-        probs: list[float] = Field(min_length=1)
-        items: list[Item] = Field(min_length=1)
-        dicts: list[dict[str, str]] = Field(min_length=1)
+        # TODO: Only list of enums are supported for now
+        # tags: list[str] = Field(min_length=0, max_length=10)
+        # probs: list[float] = Field(min_length=1)
+        # items: list[Item] = Field(min_length=1)
+        # dicts: list[dict[str, str]] = Field(min_length=1)
         enums: list[DatasetEnum] = Field(min_length=1)
         enums_no_bounds: list[DatasetEnum] = Field()
 
     prepared_schema = _prepare_schema(GenericLists)
 
     props = prepared_schema["properties"]
-    assert props["tags"]["type"] == "array"
-    assert props["tags"]["items"]["type"] == "string"
-    assert props["tags"]["maxItems"] == 10
-
-    assert props["probs"]["type"] == "array"
-    assert props["probs"]["minItems"] == 1
-    assert props["probs"]["items"]["type"] == "number"
-
-    assert props["items"]["type"] == "array"
-    assert props["items"]["minItems"] == 1
-    assert props["items"]["items"]["type"] == "object"
-
-    assert props["dicts"]["type"] == "array"
-    assert props["dicts"]["items"]["type"] == "object"
-
     assert props["enums"]["type"] == "array"
     assert props["enums"]["items"]["type"] == "string"
 
@@ -166,31 +152,17 @@ def test_validate_schema_pydantic_sets():
         epochs: int = Field(ge=1)
 
     class GenericSets(BaseModel):
-        tags: set[str] = Field(min_length=0, max_length=10)
-        probs: set[float] = Field(min_length=1)
-        items: set[Item] = Field(min_length=1)
-        dicts: set[dict[str, str]] = Field(min_length=1)
+        # TODO: Only set of enums are supported for now
+        # tags: set[str] = Field(min_length=0, max_length=10)
+        # probs: set[float] = Field(min_length=1)
+        # items: set[Item] = Field(min_length=1)
+        # dicts: set[dict[str, str]] = Field(min_length=1)
         enums: set[DatasetEnum] = Field(min_length=1)
         enums_no_bounds: set[DatasetEnum] = Field()
 
     prepared_schema = _prepare_schema(GenericSets)
 
     props = prepared_schema["properties"]
-    assert props["tags"]["type"] == "array"
-    assert props["tags"]["items"]["type"] == "string"
-    assert props["tags"]["maxItems"] == 10
-
-    assert props["probs"]["type"] == "array"
-    assert props["probs"]["minItems"] == 1
-    assert props["probs"]["items"]["type"] == "number"
-
-    assert props["items"]["type"] == "array"
-    assert props["items"]["minItems"] == 1
-    assert props["items"]["items"]["type"] == "object"
-
-    assert props["dicts"]["type"] == "array"
-    assert props["dicts"]["items"]["type"] == "object"
-
     assert props["enums"]["type"] == "array"
     assert props["enums"]["items"]["type"] == "string"
 
@@ -568,70 +540,6 @@ def test_handle_run_config_input_staged(mocker, reset_staged_inputs):
                 },
             },
             ["1.5 is not of type 'integer'"],
-        ),
-        # --- Generic array passing cases ---
-        # Generic string list with bounds
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "tags": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "minItems": 0,
-                        "maxItems": 10,
-                    }
-                },
-            },
-            [],
-        ),
-        # Generic number list with per-item bounds and minItems
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "probs": {
-                        "type": "array",
-                        "items": {"type": "number", "minimum": 0, "maximum": 1},
-                        "minItems": 1,
-                    }
-                },
-            },
-            [],
-        ),
-        # Generic integer list with uniqueness
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "ids": {
-                        "type": "array",
-                        "items": {"type": "integer"},
-                        "uniqueItems": True,
-                    }
-                },
-            },
-            [],
-        ),
-        # List of objects
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "epochs": {"type": "integer", "minimum": 1},
-                            },
-                        },
-                        "minItems": 1,
-                    }
-                },
-            },
-            [],
         ),
     ],
 )

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1985,7 +1985,7 @@ def create(
         base_image=base_image,
         dockerfile=dockerfile,
         services=services,
-        schema=schema_dict,
+        schema=schema_dict if schema else None,
     )
     if not artifact:
         wandb.termerror("Job creation failed")

--- a/wandb/sdk/launch/inputs/internal.py
+++ b/wandb/sdk/launch/inputs/internal.py
@@ -171,7 +171,7 @@ def _replace_refs_and_allofs(schema: dict, defs: Optional[dict]) -> dict:
     return ret
 
 
-def _prepare_schema(schema: dict) -> dict:
+def _prepare_schema(schema: Any) -> dict:
     """Prepare a schema for validation.
 
     This function prepares a schema for validation by:

--- a/wandb/sdk/launch/inputs/schema.py
+++ b/wandb/sdk/launch/inputs/schema.py
@@ -43,12 +43,26 @@ META_SCHEMA = {
         {
             "if": {"properties": {"type": {"const": "array"}}},
             "then": {
+                "required": ["items"],
                 "properties": {
-                    "items": {"$ref": "#"},
+                    "items": {
+                        "properties": {
+                            "type": {"enum": ["integer", "number", "string"]},
+                            "enum": {
+                                "type": "array",
+                                "items": {"type": ["integer", "number", "string"]},
+                            },
+                            "title": {"type": "string"},
+                            "description": {"type": "string"},
+                            "format": {"type": "string"},
+                        },
+                        "required": ["type", "enum"],
+                        "unevaluatedProperties": False,
+                    },
                     "uniqueItems": {"type": "boolean"},
                     "minItems": {"type": "integer", "minimum": 0},
                     "maxItems": {"type": "integer", "minimum": 0},
-                }
+                },
             },
         },
     ],

--- a/wandb/sdk/launch/inputs/schema.py
+++ b/wandb/sdk/launch/inputs/schema.py
@@ -3,7 +3,7 @@ META_SCHEMA = {
     "properties": {
         "type": {
             "type": "string",
-            "enum": ["boolean", "integer", "number", "string", "object"],
+            "enum": ["boolean", "integer", "number", "string", "object", "array"],
         },
         "title": {"type": "string"},
         "description": {"type": "string"},
@@ -11,6 +11,11 @@ META_SCHEMA = {
         "enum": {"type": "array", "items": {"type": ["integer", "number", "string"]}},
         "properties": {"type": "object", "patternProperties": {".*": {"$ref": "#"}}},
         "allOf": {"type": "array", "items": {"$ref": "#"}},
+        # Array-specific properties
+        "items": {"$ref": "#"},
+        "uniqueItems": {"type": "boolean"},
+        "minItems": {"type": "integer", "minimum": 0},
+        "maxItems": {"type": "integer", "minimum": 0},
     },
     "allOf": [
         {
@@ -32,6 +37,17 @@ META_SCHEMA = {
                     "maximum": {"type": "integer"},
                     "exclusiveMinimum": {"type": "integer"},
                     "exclusiveMaximum": {"type": "integer"},
+                }
+            },
+        },
+        {
+            "if": {"properties": {"type": {"const": "array"}}},
+            "then": {
+                "properties": {
+                    "items": {"$ref": "#"},
+                    "uniqueItems": {"type": "boolean"},
+                    "minItems": {"type": "integer", "minimum": 0},
+                    "maxItems": {"type": "integer", "minimum": 0},
                 }
             },
         },


### PR DESCRIPTION
Description
-----------
Extends our schema validation to allow for arrays (from python lists or sets) of integer, number or string enums. This is the first pass to enable list types in input schemas and we are purposely only allowing enums so that the FE remains structured. The user will be able to select more than one option from the existing dropdown that is present on enum types.

The following cases are more complex and not yet supported:
- Enums of "complex types" or dicts 
- Generic lists and lists of other types

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
- Added unit tests
- Created a job with updated schema: https://wandb.ai/wandb/launch-tutorial/artifacts/job/test-simple-schema-npun/v5/metadata