### PR TITLE
chore: improve code in some pytest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,7 +308,6 @@ def patch_apikey(mocker: MockerFixture, dummy_api_key: str):
     mocker.patch.object(wandb.sdk.lib.apikey, "isatty", return_value=True)
     mocker.patch.object(wandb.sdk.lib.apikey, "input", return_value=1)
     mocker.patch.object(wandb.sdk.lib.apikey, "getpass", return_value=dummy_api_key)
-    yield
 
 
 @pytest.fixture
@@ -322,7 +321,6 @@ def skip_verify_login(monkeypatch):
         "_verify_login",
         unittest.mock.MagicMock(),
     )
-    yield
 
 
 @pytest.fixture
@@ -381,13 +379,13 @@ def clean_up():
 
 
 @pytest.fixture
-def api() -> wandb.PublicApi:
+def api() -> Api:
     with unittest.mock.patch.object(
         wandb.sdk.wandb_login,
         "_login",
         return_value=True,
     ):
-        yield Api()
+        return Api()
 
 
 # --------------------------------

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -1066,7 +1066,13 @@ def test_delete_api_key_failure(wandb_backend_spy, stub_search_users):
     assert not user.delete_api_key(api_key["name"])
 
 
-def test_generate_api_key_success(wandb_backend_spy, stub_search_users, api):
+def test_generate_api_key_success(
+    wandb_backend_spy,
+    stub_search_users,
+    api,
+    skip_verify_login,
+):
+    _ = skip_verify_login  # Don't verify user API keys.
     email = "test@test.com"
     api_key_1 = {"name": "X" * 40, "id": "QXBpS2V5OjE4MzA="}
     api_key_2 = {"name": "Y" * 40, "id": "QXBpS2V5OjE4MzE="}
@@ -1086,7 +1092,13 @@ def test_generate_api_key_success(wandb_backend_spy, stub_search_users, api):
     assert user.api_keys[-1] == new_key
 
 
-def test_generate_api_key_failure(wandb_backend_spy, stub_search_users, api):
+def test_generate_api_key_failure(
+    wandb_backend_spy,
+    stub_search_users,
+    api,
+    skip_verify_login,
+):
+    _ = skip_verify_login  # Don't verify user API keys.
     email = "test@test.com"
     api_key = {"name": "X" * 40, "id": "QXBpS2V5OjE4MzA="}
     stub_search_users(email=email, api_keys=[api_key], teams=[])


### PR DESCRIPTION
- A `yield` at the very end of a fixture is not necessary
- The `api` fixture was using `yield` instead of `return`, causing it to patch `_login` for all tests instead of just the duration of the `Api()` initializer