### PR TITLE
fix: object is not serializable for dataclasses containing real classes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,3 +25,6 @@ This version raises errors that would previously have been suppressed during cal
 
 - Errors encountered while linking an artifact are no longer suppressed/silenced, and `Artifact.link()` and `Run.link_artifact()` no longer return `None` (@tonyyli-wandb in https://github.com/wandb/wandb/pull/9968)
 - The "Run history" and "Run summary" printed at the end of a run are now limited to 10 metrics each (@timoffex in https://github.com/wandb/wandb/pull/10351)
+
+### Fixed
+- Dataclasses in a run's `config` no long raise `Object of type ... is not JSON serializable` when containing real classes as fields to the dataclass (@jacobromero in https://github.com/wandb/wandb/pull/10371)

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -219,7 +219,6 @@ def test_nested_dataclasses_containing_real_class():
     class TestDataClassHolder:
         test_real_class: TestRealClass
 
-
     real_class = TestRealClass(True)
     nested_dataclass = TestDataClassHolder(real_class)
     converted = util.json_friendly_val(nested_dataclass)

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -7,6 +7,7 @@ import sys
 import tarfile
 import tempfile
 import time
+from dataclasses import dataclass
 from unittest import mock
 
 import matplotlib.pyplot as plt
@@ -179,8 +180,6 @@ def test_bfloat16_to_float():
 
 
 def test_dataclass():
-    from dataclasses import dataclass
-
     @dataclass
     class TestDataClass:
         test: bool
@@ -191,8 +190,6 @@ def test_dataclass():
 
 
 def test_nested_dataclasses():
-    from dataclasses import dataclass
-
     @dataclass
     class TestDataClass:
         test: bool
@@ -209,22 +206,25 @@ def test_nested_dataclasses():
 
 
 def test_nested_dataclasses_containing_real_class():
-    from dataclasses import dataclass
-
     class TestRealClass:
         test: bool
 
         def __init__(self, test: bool):
             self.test = test
 
+        def __str__(self):
+            return f"TestRealClass(test={self.test})"
+
     @dataclass
     class TestDataClassHolder:
         test_real_class: TestRealClass
 
-    nested_dataclass = TestDataClassHolder(TestRealClass(True))
+
+    real_class = TestRealClass(True)
+    nested_dataclass = TestDataClassHolder(real_class)
     converted = util.json_friendly_val(nested_dataclass)
     assert isinstance(converted, dict)
-    assert isinstance(converted["test_real_class"], str)
+    assert converted["test_real_class"] == str(real_class)
 
 
 ###############################################################################

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -208,6 +208,25 @@ def test_nested_dataclasses():
     assert converted["nested_dataclass"]["test_dataclass"]["test"] is False
 
 
+def test_nested_dataclasses_containing_real_class():
+    from dataclasses import dataclass
+
+    class TestRealClass:
+        test: bool
+
+        def __init__(self, test: bool):
+            self.test = test
+
+    @dataclass
+    class TestDataClassHolder:
+        test_real_class: TestRealClass
+
+    nested_dataclass = TestDataClassHolder(TestRealClass(True))
+    converted = util.json_friendly_val(nested_dataclass)
+    assert isinstance(converted, dict)
+    assert isinstance(converted["test_real_class"], str)
+
+
 ###############################################################################
 # Test util.make_json_if_not_number
 ###############################################################################

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -223,7 +223,7 @@ def test_nested_dataclasses_containing_real_class():
     nested_dataclass = TestDataClassHolder(real_class)
     converted = util.json_friendly_val(nested_dataclass)
     assert isinstance(converted, dict)
-    assert converted["test_real_class"] == str(real_class)
+    assert converted == {"test_real_class": "TestRealClass(test=True)"}
 
 
 ###############################################################################

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -702,7 +702,7 @@ def json_friendly_val(val: Any) -> Any:
         return converted
     if is_dataclass(val) and not isinstance(val, type):
         converted = asdict(val)
-        return converted
+        return json_friendly_val(converted)
     else:
         if val.__class__.__module__ not in ("builtins", "__builtin__"):
             val = str(val)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-21766

What does the PR do? Include a concise description of the PR contents.
This PR fixes a bug when attempting to serialize the run config to JSON. This happens when attempting to make complex data types (e.g. dataclasses, real classes) json friendly.
Data classes are converted to dictionaries for serialization, but when a dataclass contains a real class those values were not being converted recursively to json friendly values.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
- unit test added
- repro from WB-21766 passes

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
