### PR TITLE
chore(artifacts): define path strings as TypeAliases, not NewTypes

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -54,8 +54,9 @@ from wandb.sdk.data_types._dtypes import Type as WBType
 from wandb.sdk.data_types._dtypes import TypeRegistry
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
-from wandb.sdk.lib import filesystem, retry, runid, telemetry
+from wandb.sdk.lib import retry, runid, telemetry
 from wandb.sdk.lib.deprecate import deprecate
+from wandb.sdk.lib.filesystem import check_exists, system_preferred_path
 from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
 from wandb.sdk.lib.runid import generate_id
@@ -1967,7 +1968,7 @@ class Artifact:
         Raises:
             ArtifactNotLoggedError: If the artifact is not logged.
         """
-        root = FilePathStr(str(root or self._default_root()))
+        root = FilePathStr(root or self._default_root())
         self._add_download_root(root)
 
         # TODO: download artifacts using core when implemented
@@ -2324,8 +2325,7 @@ class Artifact:
         # In case we're on a system where the artifact dir has a name corresponding to
         # an unexpected filesystem, we'll check for alternate roots. If one exists we'll
         # use that, otherwise we'll fall back to the system-preferred path.
-        path = filesystem.check_exists(root) or filesystem.system_preferred_path(root)
-        return FilePathStr(str(path))
+        return FilePathStr(check_exists(root) or system_preferred_path(root))
 
     def _add_download_root(self, dir_path: str) -> None:
         self._download_roots.add(os.path.abspath(dir_path))

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -87,7 +87,7 @@ class ArtifactFileCache:
     ) -> tuple[FilePathStr, bool, Opener]:
         opener = self._opener(path, size, skip_cache=skip_cache)
         hit = path.is_file() and path.stat().st_size == size
-        return FilePathStr(str(path)), hit, opener
+        return FilePathStr(path), hit, opener
 
     def cleanup(
         self,

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -11,8 +11,8 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from wandb.proto.wandb_deprecated import Deprecated
-from wandb.sdk.lib import filesystem
 from wandb.sdk.lib.deprecate import deprecate
+from wandb.sdk.lib.filesystem import copy_or_overwrite_changed
 from wandb.sdk.lib.hashutil import (
     B64MD5,
     ETag,
@@ -184,13 +184,11 @@ class ArtifactManifestEntry:
                 executor=executor,
                 multipart=multipart,
             )
-
-        if skip_cache:
-            return FilePathStr(dest_path)
-        else:
-            return FilePathStr(
-                str(filesystem.copy_or_overwrite_changed(cache_path, dest_path))
-            )
+        return FilePathStr(
+            dest_path
+            if skip_cache
+            else copy_or_overwrite_changed(cache_path, dest_path)
+        )
 
     def ref_target(self) -> FilePathStr | URIStr:
         """Get the reference URL that is targeted by this artifact entry.

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -198,7 +198,7 @@ class GCSHandler(StorageHandler):
             posix_ref = posix_path / relpath
         return ArtifactManifestEntry(
             path=posix_name,
-            ref=URIStr(f"{self._scheme}://{str(posix_ref)}"),
+            ref=URIStr(f"{self._scheme}://{posix_ref}"),
             digest=obj.etag,
             size=obj.size,
             extra={"versionID": obj.generation},

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2610,7 +2610,7 @@ class Run:
     ) -> Artifact:
         job_artifact = InternalArtifact(name, job_builder.JOB_ARTIFACT_TYPE)
         if patch_path and os.path.exists(patch_path):
-            job_artifact.add_file(FilePathStr(str(patch_path)), "diff.patch")
+            job_artifact.add_file(FilePathStr(patch_path), "diff.patch")
         with job_artifact.new_file("requirements.frozen.txt") as f:
             f.write("\n".join(installed_packages_list))
         with job_artifact.new_file("wandb-job.json") as f:


### PR DESCRIPTION
Copies (and supersedes) #10364, which somehow got merged to a temporary graphite branch without ever merging to `main`.

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes https://wandb.atlassian.net/browse/WB-27072

Note: Similar to https://github.com/wandb/wandb/pull/10356, which simplified type definitions for, internal `str` hash types (e.g. `ETag`, `HexMD5`, etc) mainly used in artifacts code.

### Summary
Replaces `NewType` definitions for path/URI string types (`FilePathStr`, `URIStr`) with simple `TypeAlias = str`, since they:
- provided no runtime validation
- incurred minor extra overhead from the runtime call

~Also defines a `URIOrFilePathStr = Union[URIStr, FilePathStr]` type alias, since these 2 often appear together in type hints across the artifacts codebase.  **Note that at runtime**, this evaluates to just `str`, since unions are deduplicated + flattened on evaluation, i.e. `Union[str, str] -> str`.  But it's kept for:~
- ~preserving + conveying intent~
- ~convenience~
- ~brevity~


Note:
- Explicit runtime casts are deliberately retained in this PR to continue to convey intent.
- No intended functional behavior changes.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
