### PR TITLE
chore: reorganize/pull out helper logic from artifacts/registries/automations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,11 @@
 # GitHub configuration
 /.github @wandb/sdk-team
 
+# Internal helpers: used by multiple teams, any here can approve
+/wandb/_iterutils.py @wandb/sdk-team @wandb/art-reg-team
+/wandb/_strutils.py @wandb/sdk-team @wandb/art-reg-team
+/wandb/_pydantic/ @wandb/sdk-team @wandb/art-reg-team
+
 
 # Artifacts, Registries, Automations
 /core/pkg/artifacts/                  @wandb/art-reg-team @wandb/sdk-team

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -1670,7 +1670,7 @@ def test_change_artifact_collection_type_to_internal_type(user):
         artifact = Artifact("image_data", "data")
         run.log_artifact(artifact).wait()
 
-    internal_type = RESERVED_ARTIFACT_TYPE_PREFIX + "invalid"
+    internal_type = f"{RESERVED_ARTIFACT_TYPE_PREFIX}invalid"
     collection = artifact.collection
     with wandb.init() as run:
         # test deprecated change_type errors for changing to internal type
@@ -1684,7 +1684,7 @@ def test_change_artifact_collection_type_to_internal_type(user):
 
 
 def test_change_type_of_internal_artifact_collection(user):
-    internal_type = RESERVED_ARTIFACT_TYPE_PREFIX + "invalid"
+    internal_type = f"{RESERVED_ARTIFACT_TYPE_PREFIX}invalid"
     with wandb.init() as run:
         artifact = InternalArtifact("test-internal", internal_type)
         run.log_artifact(artifact).wait()

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -782,7 +782,7 @@ def test_used_artifacts_preserve_original_project(user, api, logged_artifact):
 
 
 def test_internal_artifacts(user):
-    internal_type = RESERVED_ARTIFACT_TYPE_PREFIX + "invalid"
+    internal_type = f"{RESERVED_ARTIFACT_TYPE_PREFIX}invalid"
     with wandb.init() as run:
         with pytest.raises(ValueError, match="is reserved for internal use"):
             artifact = wandb.Artifact(name="test-artifact", type=internal_type)

--- a/wandb/_iterutils.py
+++ b/wandb/_iterutils.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, Iterable, TypeVar, Union, overload
 
 if TYPE_CHECKING:
     T = TypeVar("T")
+    HashableT = TypeVar("HashableT", bound=Hashable)
     ClassInfo = Union[type[T], tuple[type[T], ...]]
 
 
@@ -20,6 +22,12 @@ def always_list(obj: Any, base_type: Any = (str, bytes)) -> list[T]:
     https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.always_iterable
     """
     return [obj] if isinstance(obj, base_type) else list(obj)
+
+
+def unique_list(iterable: Iterable[HashableT]) -> list[HashableT]:
+    """Return a deduplicated list of items from the given iterable, preserving order."""
+    # Trick for O(1) uniqueness check that maintains order
+    return list(dict.fromkeys(iterable))
 
 
 def one(

--- a/wandb/_strutils.py
+++ b/wandb/_strutils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 

--- a/wandb/_strutils.py
+++ b/wandb/_strutils.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+
+def removeprefix(s: str, prefix: str) -> str:
+    """Removes a prefix from a string.
+
+    This roughly backports the built-in `str.removeprefix` function from Python 3.9+.
+    Once Python 3.8 support is dropped, just replace this with `str.removeprefix`.
+    """
+    return s[len(prefix) :] if s.startswith(prefix) else s
+
+
+def removesuffix(s: str, suffix: str) -> str:
+    """Removes a suffix from a string.
+
+    This roughly backports the built-in `str.removesuffix` function from Python 3.9+.
+    Once Python 3.8 support is dropped, just replace this with `str.removesuffix`.
+    """
+    return s[: -len(suffix)] if s.endswith(suffix) else s
+
+
+def ensureprefix(s: str, prefix: str) -> str:
+    """Ensures the string has the given prefix prepended."""
+    return s if s.startswith(prefix) else f"{prefix}{s}"
+
+
+def ensuresuffix(s: str, suffix: str) -> str:
+    """Ensures the string has the given suffix appended."""
+    return s if s.endswith(suffix) else f"{s}{suffix}"
+
+
+def nameof(obj: Any, full: bool = True) -> str:
+    """Internal convenience helper that returns the object's `__name__` or `__qualname__`.
+
+    If `full` is True, attempt to return the object's `__qualname__` attribute,
+    falling back on the `__name__` attribute.
+    """
+    return getattr(obj, "__qualname__", obj.__name__) if full else obj.__name__

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -37,6 +37,7 @@ from wandb_gql.client import RetryError
 import wandb
 from wandb import env, util
 from wandb._iterutils import one
+from wandb._strutils import nameof
 from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public.const import RETRY_TIMEDELTA
@@ -2079,10 +2080,10 @@ class Api:
         # Note: we can't currently define this as a constant outside the method
         # and still keep it nearby in this module, because it relies on pydantic v2-only imports
         fragment_names: dict[ActionType, str] = {
-            ActionType.NO_OP: NoOpActionFields.__name__,
-            ActionType.QUEUE_JOB: QueueJobActionFields.__name__,
-            ActionType.NOTIFICATION: NotificationActionFields.__name__,
-            ActionType.GENERIC_WEBHOOK: GenericWebhookActionFields.__name__,
+            ActionType.NO_OP: nameof(NoOpActionFields),
+            ActionType.QUEUE_JOB: nameof(QueueJobActionFields),
+            ActionType.NOTIFICATION: nameof(NotificationActionFields),
+            ActionType.GENERIC_WEBHOOK: nameof(GenericWebhookActionFields),
         }
 
         return set(

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -15,6 +15,7 @@ from typing_extensions import override
 from wandb_gql import Client, gql
 
 import wandb
+from wandb._strutils import nameof
 from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import Paginator, SizedPaginator
@@ -104,7 +105,7 @@ class ArtifactTypes(Paginator["ArtifactType"]):
 
         # Extract the inner `*Connection` result for faster/easier access.
         if not ((proj := result.project) and (conn := proj.artifact_types)):
-            raise ValueError(f"Unable to parse {type(self).__name__!r} response data")
+            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
 
         self.last_response = ArtifactTypesFragment.model_validate(conn)
 
@@ -305,7 +306,7 @@ class ArtifactCollections(SizedPaginator["ArtifactCollection"]):
             and (type_ := proj.artifact_type)
             and (conn := type_.artifact_collections)
         ):
-            raise ValueError(f"Unable to parse {type(self).__name__!r} response data")
+            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
 
         self.last_response = ArtifactCollectionsFragment.model_validate(conn)
 
@@ -732,7 +733,7 @@ class Artifacts(SizedPaginator["Artifact"]):
             and (collection := type_.artifact_collection)
             and (conn := collection.artifacts)
         ):
-            raise ValueError(f"Unable to parse {type(self).__name__!r} response data")
+            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
 
         self.last_response = ArtifactsFragment.model_validate(conn)
 
@@ -959,7 +960,7 @@ class ArtifactFiles(SizedPaginator["public.File"]):
             conn = result.project.artifact_type.artifact.files
 
         if conn is None:
-            raise ValueError(f"Unable to parse {type(self).__name__!r} response data")
+            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
 
         self.last_response = FilesFragment.model_validate(conn)
 

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from typing_extensions import override
 from wandb_graphql.language.ast import Document
 
+from wandb._strutils import nameof
 from wandb.apis.paginator import Paginator, _Client
 
 if TYPE_CHECKING:
@@ -34,7 +35,7 @@ class Automations(Paginator["Automation"]):
     ):
         super().__init__(client, variables, per_page=per_page)
         if _query is None:
-            raise RuntimeError(f"Query required for {type(self).__qualname__}")
+            raise RuntimeError(f"Query required for {nameof(type(self))}")
         self._query = _query
 
     @property

--- a/wandb/apis/public/registries/_freezable_list.py
+++ b/wandb/apis/public/registries/_freezable_list.py
@@ -13,6 +13,8 @@ from typing import (
     overload,
 )
 
+from wandb._strutils import nameof
+
 T = TypeVar("T")
 
 
@@ -84,9 +86,7 @@ class FreezableList(MutableSequence[T]):
     ) -> None:
         if isinstance(index, slice):
             # Setting slices might affect saved items, disallow for simplicity
-            raise TypeError(
-                f"{type(self).__name__!r} does not support slice assignment"
-            )
+            raise TypeError(f"{nameof(type(self))!r} does not support slice assignment")
         else:
             if value in self._frozen or value in self._draft:
                 return
@@ -111,7 +111,7 @@ class FreezableList(MutableSequence[T]):
 
     def __delitem__(self, index: Union[int, slice]) -> None:
         if isinstance(index, slice):
-            raise TypeError(f"{type(self).__name__!r} does not support slice deletion")
+            raise TypeError(f"{nameof(type(self))!r} does not support slice deletion")
         else:
             # The frozen items are sequentially first and protected from changes
             len_frozen = len(self._frozen)
@@ -158,7 +158,7 @@ class FreezableList(MutableSequence[T]):
         return self._draft.insert(draft_index, value)
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(frozen={list(self._frozen)!r}, draft={list(self._draft)!r})"
+        return f"{nameof(type(self))}(frozen={list(self._frozen)!r}, draft={list(self._draft)!r})"
 
     @property
     def draft(self) -> Tuple[T, ...]:
@@ -176,4 +176,4 @@ class AddOnlyArtifactTypesList(FreezableList[str]):
             )
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(saved={list(self._frozen)!r}, draft={list(self._draft)!r})"
+        return f"{nameof(type(self))}(saved={list(self._frozen)!r}, draft={list(self._draft)!r})"

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -4,6 +4,7 @@ from enum import Enum
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Sequence
 
+from wandb._strutils import ensureprefix
 from wandb.sdk.artifacts._validators import (
     REGISTRY_PREFIX,
     validate_artifact_types_list,
@@ -81,7 +82,7 @@ def ensure_registry_prefix_on_names(query: Any, in_name: bool = False) -> Any:
     """
     if isinstance((txt := query), str):
         if in_name:
-            return txt if txt.startswith(REGISTRY_PREFIX) else f"{REGISTRY_PREFIX}{txt}"
+            return ensureprefix(txt, REGISTRY_PREFIX)
         return txt
     if isinstance((dct := query), Mapping):
         new_dict = {}

--- a/wandb/automations/_filters/expressions.py
+++ b/wandb/automations/_filters/expressions.py
@@ -9,6 +9,7 @@ from pydantic import ConfigDict, model_serializer
 from typing_extensions import Self, TypeAlias, get_args
 
 from wandb._pydantic import CompatBaseModel, model_validator
+from wandb._strutils import nameof
 
 from .operators import (
     Contains,
@@ -59,7 +60,7 @@ class FilterableField:
         return self._name
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self._name!r})"
+        return f"{nameof(type(self))}({self._name!r})"
 
     # Methods to define filter expressions through chaining
     def matches_regex(self, pattern: str) -> FilterExpr:
@@ -145,7 +146,7 @@ class FilterExpr(CompatBaseModel, SupportsLogicalOpSyntax):
     op: Op
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.field!s}: {self.op!r})"
+        return f"{nameof(type(self))}({self.field!s}: {self.op!r})"
 
     def __rich_repr__(self) -> RichReprResult:
         # https://rich.readthedocs.io/en/stable/pretty.html

--- a/wandb/automations/_filters/operators.py
+++ b/wandb/automations/_filters/operators.py
@@ -8,6 +8,7 @@ from pydantic import ConfigDict, Field, StrictBool, StrictFloat, StrictInt, Stri
 from typing_extensions import TypeAlias, get_args
 
 from wandb._pydantic import GQLBase
+from wandb._strutils import nameof
 
 # for type annotations
 Scalar = Union[StrictStr, StrictInt, StrictFloat, StrictBool]
@@ -62,7 +63,7 @@ class BaseOp(GQLBase, SupportsLogicalOpSyntax):
     def __repr__(self) -> str:
         # Display operand as a positional arg
         values_repr = ", ".join(map(repr, self.model_dump().values()))
-        return f"{type(self).__name__}({values_repr})"
+        return f"{nameof(type(self))}({values_repr})"
 
     def __rich_repr__(self) -> RichReprResult:
         # Display field values as positional args:

--- a/wandb/automations/actions.py
+++ b/wandb/automations/actions.py
@@ -8,6 +8,7 @@ from pydantic import BeforeValidator, Field
 from typing_extensions import Annotated, Self, get_args
 
 from wandb._pydantic import GQLBase, GQLId, SerializedToJson, Typename
+from wandb._strutils import nameof
 
 from ._generated import (
     AlertSeverity,
@@ -214,5 +215,5 @@ InputActionTypes: tuple[type, ...] = get_args(InputAction.__origin__)  # type: i
 
 __all__ = [
     "ActionType",
-    *(cls.__name__ for cls in InputActionTypes),
+    *(nameof(cls) for cls in InputActionTypes),
 ]

--- a/wandb/automations/events.py
+++ b/wandb/automations/events.py
@@ -15,6 +15,7 @@ from wandb._pydantic import (
     model_validator,
     pydantic_isinstance,
 )
+from wandb._strutils import nameof
 
 from ._filters import And, MongoLikeFilter, Or
 from ._filters.expressions import FilterableField
@@ -156,7 +157,7 @@ class _BaseEventInput(GQLBase):
         if isinstance(action, (InputActionTypes, SavedActionTypes)):
             return NewAutomation(event=self, action=action)
 
-        raise TypeError(f"Expected a valid action, got: {type(action).__qualname__!r}")
+        raise TypeError(f"Expected a valid action, got: {nameof(type(action))!r}")
 
     def __rshift__(self, other: InputAction) -> NewAutomation:
         """Implements `event >> action` to define an Automation with this event and action."""
@@ -277,7 +278,7 @@ OnRunMetric.model_rebuild()
 
 __all__ = [
     "EventType",
-    *(cls.__name__ for cls in InputEventTypes),
+    *(nameof(cls) for cls in InputEventTypes),
     "RunEvent",
     "ArtifactEvent",
     "MetricThresholdFilter",

--- a/wandb/sdk/artifacts/exceptions.py
+++ b/wandb/sdk/artifacts/exceptions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeVar
 
 from wandb import errors
+from wandb._strutils import nameof
 
 if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
@@ -39,7 +40,7 @@ class ArtifactNotLoggedError(ArtifactStatusError):
         *_, name = fullname.split(".")
         msg = (
             f"{fullname!r} used prior to logging artifact or while in offline mode. "
-            f"Call {type(obj).wait.__qualname__}() before accessing logged artifact properties."
+            f"Call {nameof(obj.wait)}() before accessing logged artifact properties."
         )
         super().__init__(msg=msg, name=name, obj=obj)
 

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Sequence
 from urllib.parse import parse_qsl, urlparse
 
 from wandb import util
+from wandb._strutils import ensureprefix
 from wandb.errors import CommError
 from wandb.errors.term import termlog
 from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
@@ -328,7 +329,7 @@ class S3Handler(StorageHandler):
             return True
 
         # Enforce HTTPS otherwise
-        https_url = url if url.startswith("https://") else f"https://{url}"
+        https_url = ensureprefix(url, "https://")
         netloc = urlparse(https_url).netloc
         return bool(
             # Match for https://cwobject.com


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes https://wandb.atlassian.net/browse/WB-27171

Extract generic, repeated helper logic from artifacts/registries/automations code into private modules for reuse anywhere in the SDK.  Updates relevant call sites in artifacts/registries/automations code.

- Added: wandb/_strutils.py
- Updated: wandb/_iterutils.py

Also updates CODEOWNERS so that multiple teams can approve changes to these modules.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
No functional changes intended, relying on existing tests/CI.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
