### PR TITLE
refactor: stub implementation for wandb beta sync

### DIFF
--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -313,6 +313,27 @@ func (nc *Connection) handleIncomingRequests() {
 			nc.handleInformFinish(x.InformFinish)
 		case *spb.ServerRequest_InformTeardown:
 			nc.handleInformTeardown(x.InformTeardown)
+		case *spb.ServerRequest_InitSync:
+			nc.Respond(&spb.ServerResponse{
+				RequestId: msg.RequestId,
+				ServerResponseType: &spb.ServerResponse_InitSyncResponse{
+					InitSyncResponse: &spb.ServerInitSyncResponse{Id: "todo"},
+				},
+			})
+		case *spb.ServerRequest_Sync:
+			nc.Respond(&spb.ServerResponse{
+				RequestId: msg.RequestId,
+				ServerResponseType: &spb.ServerResponse_SyncResponse{
+					SyncResponse: &spb.ServerSyncResponse{
+						Errors: []string{"Internal error: not implemented"},
+					},
+				},
+			})
+		case *spb.ServerRequest_SyncStatus:
+			nc.Respond(&spb.ServerResponse{
+				RequestId:          msg.RequestId,
+				ServerResponseType: &spb.ServerResponse_SyncStatusResponse{},
+			})
 		case nil:
 			slog.Error("handleIncomingRequests: ServerRequestType is nil", "id", nc.id)
 			panic("ServerRequestType is nil")

--- a/tests/system_tests/test_core/test_offline_sync.py
+++ b/tests/system_tests/test_core/test_offline_sync.py
@@ -1,8 +1,6 @@
-import os
 import unittest.mock
 
 import pytest
-import wandb
 from wandb.cli import cli
 from wandb.sdk.lib.runid import generate_id
 
@@ -21,43 +19,3 @@ def test_sync_with_tensorboard(wandb_backend_spy, runner, copy_asset):
         history_runtime_values = [v["_runtime"] for k, v in history.items() if k > 0]
         for value in history_runtime_values:
             assert value > 0
-
-
-@pytest.mark.parametrize("mark_synced", [True, False])
-def test_beta_sync(user, runner, mark_synced):
-    _ = pytest.importorskip("wandb_core")
-
-    os.makedirs(".wandb", exist_ok=True)
-    run = wandb.init(settings={"mode": "offline"})
-    run.log(dict(a=1))
-    run.finish()
-
-    args = ["sync", ".wandb"]
-    if not mark_synced:
-        args.append("--no-mark-synced")
-    result = runner.invoke(cli.beta, args)
-    assert result.exit_code == 0
-    assert f"{run.id}" in result.output
-
-    if mark_synced:
-        # check that f"{run.settings.sync_file}.synced" exists
-        assert os.path.exists(f"{run.settings.sync_file}.synced")
-    else:
-        assert not os.path.exists(f"{run.settings.sync_file}.synced")
-
-
-def test_beta_sync_two_runs(user, test_settings, runner):
-    _ = pytest.importorskip("wandb_core")
-    os.makedirs(".wandb", exist_ok=True)
-    run = wandb.init(settings=test_settings({"mode": "offline"}))
-    run.log(dict(a=1))
-    run.finish()
-
-    run2 = wandb.init(settings=test_settings({"mode": "offline"}))
-    run2.log(dict(a=1))
-    run2.finish()
-
-    result = runner.invoke(cli.beta, ["sync", ".wandb"])
-    assert result.exit_code == 0
-    assert f"{run.id}" in result.output
-    assert f"{run2.id}" in result.output

--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import wandb
+from click.testing import CliRunner
+from wandb.cli import beta_sync, cli
+
+
+def test_makes_sync_request(runner: CliRunner):
+    with wandb.init(mode="offline") as run:
+        run.log({"test_sync": 321})
+
+    result = runner.invoke(cli.beta, f"sync {run.settings.sync_dir}")
+
+    lines = result.output.splitlines()
+    assert lines[0] == "Syncing 1 file(s):"
+    assert lines[1].endswith(f"run-{run.id}.wandb")
+    assert lines[2] == "wandb: ERROR Internal error: not implemented"
+
+
+@pytest.mark.parametrize("skip_synced", (True, False))
+def test_skip_synced(tmp_path, runner: CliRunner, skip_synced):
+    (tmp_path / "run-1.wandb").touch()
+    (tmp_path / "run-2.wandb").touch()
+    (tmp_path / "run-2.wandb.synced").touch()
+    (tmp_path / "run-3.wandb").touch()
+
+    skip = "--skip-synced" if skip_synced else "--no-skip-synced"
+    result = runner.invoke(cli.beta, f"sync --dry-run {skip} {tmp_path}")
+
+    assert "run-1.wandb" in result.output
+    assert "run-3.wandb" in result.output
+
+    if skip_synced:
+        assert "run-2.wandb" not in result.output
+    else:
+        assert "run-2.wandb" in result.output
+
+
+def test_sync_wandb_file(tmp_path, runner: CliRunner):
+    file = tmp_path / "run.wandb"
+    file.touch()
+
+    result = runner.invoke(cli.beta, f"sync --dry-run {file}")
+
+    lines = result.output.splitlines()
+    assert lines[0] == "Would sync 1 file(s):"
+    assert lines[1].endswith("run.wandb")
+
+
+def test_sync_run_directory(tmp_path, runner: CliRunner):
+    run_dir = tmp_path / "some-run"
+    run_dir.mkdir()
+    (run_dir / "run.wandb").touch()
+
+    result = runner.invoke(cli.beta, f"sync --dry-run {run_dir}")
+
+    lines = result.output.splitlines()
+    assert lines[0] == "Would sync 1 file(s):"
+    assert lines[1].endswith("run.wandb")
+
+
+def test_sync_wandb_directory(tmp_path, runner: CliRunner):
+    wandb_dir = tmp_path / "wandb-dir"
+    run1_dir = wandb_dir / "run-1"
+    run2_dir = wandb_dir / "run-2"
+
+    wandb_dir.mkdir()
+    run1_dir.mkdir()
+    run2_dir.mkdir()
+    (run1_dir / "run-1.wandb").touch()
+    (run2_dir / "run-2.wandb").touch()
+
+    result = runner.invoke(cli.beta, f"sync --dry-run {wandb_dir}")
+
+    lines = result.output.splitlines()
+    assert lines[0] == "Would sync 2 file(s):"
+    assert lines[1].endswith("run-1.wandb")
+    assert lines[2].endswith("run-2.wandb")
+
+
+def test_truncates_printed_paths(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+):
+    monkeypatch.setattr(beta_sync, "_MAX_LIST_LINES", 5)
+    files = list((tmp_path / f"run-{i}.wandb") for i in range(20))
+    for file in files:
+        file.touch()
+
+    result = runner.invoke(cli.beta, f"sync --dry-run {tmp_path}")
+
+    lines = result.output.splitlines()
+    assert lines[0] == "Would sync 20 file(s):"
+    for line in lines[1:6]:
+        assert re.fullmatch(r"  .+/run-\d+\.wandb", line)
+    assert lines[6] == "  +15 more"

--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -6,13 +6,10 @@ These commands are experimental and may change or be removed in future versions.
 from __future__ import annotations
 
 import pathlib
-import sys
 
 import click
 
-import wandb
 from wandb.errors import WandbCoreNotAvailableError
-from wandb.sdk.wandb_sync import _sync
 from wandb.util import get_core_path
 
 
@@ -35,141 +32,47 @@ def beta():
         )
 
 
-@beta.command(
-    name="sync",
-    context_settings={"default_map": {}},
-    help="Upload a training run to W&B",
-)
-@click.pass_context
-@click.argument("wandb_dir", nargs=1, type=click.Path(exists=True))
-@click.option("--id", "run_id", help="The run you want to upload to.")
-@click.option("--project", "-p", help="The project you want to upload to.")
-@click.option("--entity", "-e", help="The entity to scope to.")
-@click.option("--skip-console", is_flag=True, default=False, help="Skip console logs")
-@click.option("--append", is_flag=True, default=False, help="Append run")
-@click.option(
-    "--include",
-    "-i",
-    help="Glob to include. Can be used multiple times.",
-    multiple=True,
-)
-@click.option(
-    "--exclude",
-    "-e",
-    help="Glob to exclude. Can be used multiple times.",
-    multiple=True,
-)
-@click.option(
-    "--mark-synced/--no-mark-synced",
-    is_flag=True,
-    default=True,
-    help="Mark runs as synced",
-)
+@beta.command()
+@click.argument("path", type=click.Path(exists=True))
 @click.option(
     "--skip-synced/--no-skip-synced",
     is_flag=True,
     default=True,
-    help="Skip synced runs",
+    help="Skip runs that have already been synced with this command.",
 )
 @click.option(
-    "--dry-run", is_flag=True, help="Perform a dry run without uploading anything."
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print what would happen without uploading anything.",
 )
-def sync_beta(  # noqa: C901
-    ctx,
-    wandb_dir=None,
-    run_id: str | None = None,
-    project: str | None = None,
-    entity: str | None = None,
-    skip_console: bool = False,
-    append: bool = False,
-    include: str | None = None,
-    exclude: str | None = None,
-    skip_synced: bool = True,
-    mark_synced: bool = True,
-    dry_run: bool = False,
+def sync(
+    path: str,
+    skip_synced: bool,
+    dry_run: bool,
 ) -> None:
-    import concurrent.futures
-    from multiprocessing import cpu_count
+    """Upload .wandb files in PATH.
 
-    paths = set()
+    PATH can be a path to a .wandb file, a path to a run's directory containing
+    its .wandb file, or a path to a "wandb" directory containing run
+    directories.
 
-    # TODO: test file discovery logic
-    # include and exclude globs are evaluated relative to the provided base_path
-    if include:
-        for pattern in include:
-            matching_dirs = list(pathlib.Path(wandb_dir).glob(pattern))
-            for d in matching_dirs:
-                if not d.is_dir():
-                    continue
-                wandb_files = [p for p in d.glob("*.wandb") if p.is_file()]
-                if len(wandb_files) > 1:
-                    wandb.termwarn(
-                        f"Multiple wandb files found in directory {d}, skipping"
-                    )
-                elif len(wandb_files) == 1:
-                    paths.add(d)
-    else:
-        paths.update({p.parent for p in pathlib.Path(wandb_dir).glob("**/*.wandb")})
+    For example, to sync all runs in a directory:
 
-    for pattern in exclude:
-        matching_dirs = list(pathlib.Path(wandb_dir).glob(pattern))
-        for d in matching_dirs:
-            if not d.is_dir():
-                continue
-            if d in paths:
-                paths.remove(d)
+        wandb beta sync ./wandb
 
-    # remove paths that are already synced, if requested
-    if skip_synced:
-        synced_paths = set()
-        for path in paths:
-            wandb_synced_files = [p for p in path.glob("*.wandb.synced") if p.is_file()]
-            if len(wandb_synced_files) > 1:
-                wandb.termwarn(
-                    f"Multiple wandb.synced files found in directory {path}, skipping"
-                )
-            elif len(wandb_synced_files) == 1:
-                synced_paths.add(path)
-        paths -= synced_paths
+    To sync a specific run:
 
-    if run_id and len(paths) > 1:
-        # TODO: handle this more gracefully
-        click.echo("id can only be set for a single run.", err=True)
-        sys.exit(1)
+        wandb beta sync ./wandb/run-20250813_124246-n67z9ude
 
-    if not paths:
-        click.echo("No runs to sync.")
-        return
+    Or equivalently:
 
-    click.echo("Found runs:")
-    for path in paths:
-        click.echo(f"  {path}")
+        wandb beta sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb
+    """
+    from . import beta_sync
 
-    if dry_run:
-        return
-
-    wandb.setup()
-
-    # TODO: make it thread-safe in the Rust code
-    with concurrent.futures.ProcessPoolExecutor(
-        max_workers=min(len(paths), cpu_count())
-    ) as executor:
-        futures = []
-        for path in paths:
-            # we already know there is only one wandb file in the directory
-            wandb_file = [p for p in path.glob("*.wandb") if p.is_file()][0]
-            future = executor.submit(
-                _sync,
-                wandb_file,
-                run_id=run_id,
-                project=project,
-                entity=entity,
-                skip_console=skip_console,
-                append=append,
-                mark_synced=mark_synced,
-            )
-            futures.append(future)
-
-        # Wait for tasks to complete
-        for _ in concurrent.futures.as_completed(futures):
-            pass
+    beta_sync.sync(
+        pathlib.Path(path),
+        dry_run=dry_run,
+        skip_synced=skip_synced,
+    )

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -1,0 +1,110 @@
+"""Implements `wandb sync` using wandb-core."""
+
+from __future__ import annotations
+
+import pathlib
+from itertools import filterfalse
+from typing import Iterable
+
+import click
+from typing_extensions import Generator
+
+from wandb.sdk import wandb_setup
+from wandb.sdk.lib.printer import ERROR, new_printer
+
+_MAX_LIST_LINES = 20
+
+
+def sync(
+    path: pathlib.Path,
+    *,
+    dry_run: bool,
+    skip_synced: bool,
+) -> None:
+    """Replay one or more .wandb files.
+
+    Args:
+        path: A .wandb file, a run directory containing a .wandb file, or
+            a wandb directory containing run directories.
+        dry_run: If true, just prints what it would do and exits.
+        skip_synced: If true, skips files that have already been synced
+            as indicated by a .wandb.synced marker file in the same directory.
+    """
+    wandb_files = _find_wandb_files(path, skip_synced=skip_synced)
+
+    if not wandb_files:
+        click.echo("No files to sync.")
+        return
+
+    if dry_run:
+        click.echo(f"Would sync {len(wandb_files)} file(s):")
+        _print_sorted_paths(wandb_files)
+        return
+
+    click.echo(f"Syncing {len(wandb_files)} file(s):")
+    _print_sorted_paths(wandb_files)
+
+    singleton = wandb_setup.singleton()
+    service = singleton.ensure_service()
+    printer = new_printer()
+
+    init_handle = service.init_sync(wandb_files, singleton.settings)
+    sync_id = init_handle.wait_or(timeout=5).id
+    sync_result = service.sync(sync_id).wait_or(timeout=None)
+
+    if messages := list(sync_result.errors):
+        printer.display(messages, level=ERROR)
+
+
+def _find_wandb_files(
+    path: pathlib.Path,
+    *,
+    skip_synced: bool,
+) -> set[pathlib.Path]:
+    """Returns paths to the .wandb files to sync."""
+    if skip_synced:
+        return set(filterfalse(_is_synced, _expand_wandb_files(path)))
+    else:
+        return set(_expand_wandb_files(path))
+
+
+def _expand_wandb_files(
+    path: pathlib.Path,
+) -> Generator[pathlib.Path, None, None]:
+    """Iterate over .wandb files selected by the path."""
+    if path.suffix == ".wandb":
+        yield path
+        return
+
+    files_in_run_directory = path.glob("*.wandb")
+    try:
+        first_file = next(files_in_run_directory)
+    except StopIteration:
+        pass
+    else:
+        yield first_file
+        yield from files_in_run_directory
+        return
+
+    yield from path.glob("*/*.wandb")
+
+
+def _is_synced(path: pathlib.Path) -> bool:
+    """Returns whether the .wandb file is synced."""
+    return path.with_suffix(".wandb.synced").exists()
+
+
+def _print_sorted_paths(paths: Iterable[pathlib.Path]) -> None:
+    """Print file paths, sorting them and truncating the list if needed.
+
+    Args:
+        paths: Paths to print.
+    """
+    sorted_paths = sorted(str(path) for path in paths)
+
+    for i in range(min(len(sorted_paths), _MAX_LIST_LINES)):
+        click.echo(f"  {sorted_paths[i]}")
+
+    if len(sorted_paths) > _MAX_LIST_LINES:
+        remaining = len(sorted_paths) - _MAX_LIST_LINES
+        click.echo(f"  +{remaining:,d} more")


### PR DESCRIPTION
Tears out the old `wandb beta sync`​ implementation and replaces it with a new one.

The service process responds with errors and empty responses to sync requests. I add status messages in a separate PR because testing them is a bit more involved.