### PR TITLE
chore: update macos target version for release

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -239,7 +239,7 @@ jobs:
               -w {dest_dir} \
               -v {wheel}
           CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=11
+            MACOSX_DEPLOYMENT_TARGET=12
 
           # Install Go and Rust for Linux amd64
           CIBW_BEFORE_ALL_LINUX: >


### PR DESCRIPTION
Description
-----------
The minimum target version is based on the SDK in the CI runner, which as of 2025-08-28 is 12.0.

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
