### PR TITLE
chore(deps): require Click>=8.0.1 to avoid numeric color error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "package_readme.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
 dependencies = [
-    "Click>=7.1,!=8.0.0",
+    "Click>=8.0.1",
     "GitPython>=1.0.0,!=3.1.29",
     "requests>=2.0.0,<3",
     "sentry-sdk>=2.0.0",


### PR DESCRIPTION
Require Click>=8.0.1 to ensure numeric 256-color indices (e.g., 178) are accepted by click.style. This avoids TypeError: Unknown color '178' seen in init spinner. Fixes https://github.com/wandb/wandb/issues/10396.