### PR TITLE
chore: remove legacy-service parts from release action

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -335,7 +335,7 @@ jobs:
 
   verify-test-pypi:
     needs: test-pypi-publish
-    name: Smoke-test on ${{ matrix.os }} ${{ matrix.use_legacy_service && '' || 'with core' }}
+    name: Smoke-test on ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
@@ -347,7 +347,6 @@ jobs:
           - ubuntu-22.04
           - windows-2022
           - macos-14
-        use_legacy_service: [false, true]
 
     steps:
       - name: Setup Python
@@ -365,7 +364,6 @@ jobs:
       - name: Smoke-test wandb
         shell: bash
         run: |
-          WANDB_X_REQUIRE_LEGACY_SERVICE=${{ matrix.use_legacy_service }} \
           WANDB_MODE=offline \
           python -c "import wandb; run = wandb.init(); run.finish()"
 
@@ -375,10 +373,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        use_legacy_service: [false, true]
 
     steps:
       - name: Set up Python
@@ -396,10 +390,9 @@ jobs:
             --extra-index-url https://test.pypi.org/simple/ \
             wandb==${{ github.event.inputs.version }}
 
-      - name: Smoke-test wandb ${{ matrix.use_legacy_service && '' || 'with core' }}
+      - name: Smoke-test wandb
         shell: bash
         run: |
-          WANDB_X_REQUIRE_LEGACY_SERVICE=${{ matrix.use_legacy_service }} \
           WANDB_MODE=offline \
           python -c "import wandb; run = wandb.init(); run.finish()"
 


### PR DESCRIPTION
The `legacy-service` was removed in 0.21.0.