### PR TITLE
chore(artifacts): move SerializedToJson annotation to automations

### DIFF
--- a/tools/graphql_codegen/plugin.py
+++ b/tools/graphql_codegen/plugin.py
@@ -38,7 +38,6 @@ DEFAULT_BASE_MODEL_NAME = "BaseModel"  #: The name of the default pydantic base 
 CUSTOM_GQL_BASE_MODEL_NAME = "GQLBase"  #: Custom base class for GraphQL types
 CUSTOM_BASE_MODEL_NAME = "Base"  #: Custom base class for other pydantic types
 TYPENAME_TYPE = "Typename"  #: Custom Typename type for field annotations
-JSON_TYPE = "SerializedToJson"  #: Custom SerializedToJson type for field annotations
 GQLID_TYPE = "GQLId"  #: Custom GraphQL ID type for field annotations
 
 CUSTOM_BASE_IMPORT_NAMES = [

--- a/wandb/_pydantic/__init__.py
+++ b/wandb/_pydantic/__init__.py
@@ -1,7 +1,7 @@
 """Internal utilities for working with pydantic."""
 
 from .base import CompatBaseModel, GQLBase
-from .field_types import GQLId, SerializedToJson, Typename, ensure_json
+from .field_types import GQLId, Typename
 from .utils import IS_PYDANTIC_V2, from_json, gql_typename, pydantic_isinstance, to_json
 from .v1_compat import (
     AliasChoices,
@@ -17,7 +17,6 @@ __all__ = [
     "GQLBase",
     "Typename",
     "GQLId",
-    "SerializedToJson",
     "AliasChoices",
     "computed_field",
     "field_validator",
@@ -26,6 +25,5 @@ __all__ = [
     "to_camel",
     "to_json",
     "from_json",
-    "ensure_json",
     "gql_typename",
 ]

--- a/wandb/_pydantic/field_types.py
+++ b/wandb/_pydantic/field_types.py
@@ -2,24 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
-from pydantic import Field, Json, StrictStr
+from pydantic import Field, StrictStr
 from typing_extensions import Annotated
 
-from .utils import IS_PYDANTIC_V2, to_json
+from .utils import IS_PYDANTIC_V2
 
 T = TypeVar("T")
-
-
-def ensure_json(v: Any) -> Any:
-    """In case the incoming value isn't serialized JSON, reserialize it.
-
-    This lets us use `Json[...]` fields with values that are already deserialized.
-    """
-    # NOTE: Assumes that the deserialized type is not itself a string.
-    # Revisit this if we need to support deserialized types that are str/bytes.
-    return v if isinstance(v, (str, bytes)) else to_json(v)
 
 
 #: GraphQL `__typename` fields
@@ -27,14 +17,7 @@ Typename = Annotated[T, Field(repr=False, frozen=True, alias="__typename")]
 
 
 if IS_PYDANTIC_V2 or TYPE_CHECKING:
-    from pydantic import BeforeValidator, PlainSerializer
-
     GQLId = Annotated[StrictStr, Field(repr=False, frozen=True)]
-
-    # Allow lenient instantiation/validation: incoming data may already be deserialized.
-    SerializedToJson = Annotated[
-        Json[T], BeforeValidator(ensure_json), PlainSerializer(to_json)
-    ]
 
 else:
     # FIXME: Find a way to fix this for pydantic v1, which doesn't like when
@@ -44,6 +27,3 @@ else:
     #   class MyModel(GQLBase):
     #       my_id: GQLId = Field(alias="myID")
     GQLId = StrictStr  # type: ignore[misc]
-
-    # FIXME: Restore, modify, or replace this later after ensuring pydantic v1 compatibility.
-    SerializedToJson = Json[T]  # type: ignore[misc]

--- a/wandb/automations/actions.py
+++ b/wandb/automations/actions.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, Optional, Union
 from pydantic import BeforeValidator, Field
 from typing_extensions import Annotated, Self, get_args
 
-from wandb._pydantic import GQLBase, GQLId, SerializedToJson, Typename
+from wandb._pydantic import GQLBase, GQLId, Typename
 from wandb._strutils import nameof
 
 from ._generated import (
@@ -22,6 +22,7 @@ from ._generated import (
 )
 from ._validators import (
     LenientStrEnum,
+    SerializedToJson,
     default_if_none,
     to_input_action,
     to_saved_action,

--- a/wandb/automations/events.py
+++ b/wandb/automations/events.py
@@ -9,8 +9,6 @@ from typing_extensions import Annotated, Self, get_args
 
 from wandb._pydantic import (
     GQLBase,
-    SerializedToJson,
-    ensure_json,
     field_validator,
     model_validator,
     pydantic_isinstance,
@@ -21,7 +19,7 @@ from ._filters import And, MongoLikeFilter, Or
 from ._filters.expressions import FilterableField
 from ._filters.run_metrics import MetricChangeFilter, MetricThresholdFilter, MetricVal
 from ._generated import FilterEventFields
-from ._validators import LenientStrEnum, simplify_op
+from ._validators import LenientStrEnum, SerializedToJson, ensure_json, simplify_op
 from .actions import InputAction, InputActionTypes, SavedActionTypes
 from .scopes import ArtifactCollectionScope, AutomationScope, ProjectScope
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Moves the `SerializedToJson` field annotation (and the validator function `ensure_json()`) from `wandb._pydantic` into `wandb.automations._validators`, since it's only used there and need pydantic v2 to work properly anyway.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
