### PR TITLE
chore(sdk): extract base JsonableModel pydantic type

### DIFF
--- a/wandb/_pydantic/__init__.py
+++ b/wandb/_pydantic/__init__.py
@@ -1,6 +1,6 @@
 """Internal utilities for working with pydantic."""
 
-from .base import CompatBaseModel, GQLBase
+from .base import CompatBaseModel, GQLBase, JsonableModel
 from .field_types import GQLId, Typename
 from .utils import IS_PYDANTIC_V2, from_json, gql_typename, pydantic_isinstance, to_json
 from .v1_compat import (
@@ -14,6 +14,7 @@ from .v1_compat import (
 __all__ = [
     "IS_PYDANTIC_V2",
     "CompatBaseModel",
+    "JsonableModel",
     "GQLBase",
     "Typename",
     "GQLId",

--- a/wandb/_pydantic/base.py
+++ b/wandb/_pydantic/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict
 from typing_extensions import TypedDict, Unpack, override
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pydantic.main import IncEx
 
 
-class ModelDumpKwargs(TypedDict, total=False):
+class DumpKwargs(TypedDict, total=False):
     """Shared keyword arguments for `BaseModel.model_{dump,dump_json}`."""
 
     include: IncEx | None
@@ -29,50 +29,68 @@ class ModelDumpKwargs(TypedDict, total=False):
     serialize_as_any: bool
 
 
-#: Custom overrides of default kwargs for `BaseModel.model_{dump,dump_json}`.
-MODEL_DUMP_DEFAULTS = ModelDumpKwargs(
-    by_alias=True,  # Always serialize with aliases (e.g. camelCase names)
-    round_trip=True,  # Ensure serialized values remain valid inputs for deserialization
-)
+# ---------------------------------------------------------------------------
+# Base models and mixin classes.
+#
+# Extra info is provided for devs in inline comments, NOT docstrings.  This
+# prevents it from showing up in generated docs for subclasses.
 
 
-# v1-compatible base class for pydantic types.
+# FOR INTERNAL USE ONLY: v1-compatible drop-in replacement for `pydantic.BaseModel`.
+# If pydantic v2 is detected, this is just `pydantic.BaseModel`.
+#
+# Deliberately inherits ALL default configuration from `pydantic.BaseModel`.
 class CompatBaseModel(PydanticCompatMixin, BaseModel):
     __doc__ = None  # Prevent subclasses from inheriting the BaseModel docstring
 
 
-# Base class for all GraphQL-generated types.
-# Omitted from docstring to avoid inclusion in generated docs.
-class GQLBase(CompatBaseModel):
+class JsonableModel(CompatBaseModel):
+    # Base class with sensible default behavior for classes that need to convert to/from JSON.
+    #
+    # Automatically parse/serialize "raw" API data (e.g. automatically convert to/from camelCase keys):
+    # - `.model_{dump,dump_json}()` should return "JSON-ready" dicts or JSON strings
+    # - `.model_{validate,validate_json}()` should accept "JSON-ready" dicts or JSON strings
+    #
+    # Ensure round-trip serialization <-> deserialization between:
+    # - `model_dump()` <-> `model_validate()`
+    # - `model_dump_json()` <-> `model_validate_json()`
+    #
+    # These behaviors are useful for models that need to predictably handle e.g. GraphQL request/response data.
+
     model_config = ConfigDict(
-        populate_by_name=True,  # Discouraged in pydantic v2.11+, will be deprecated in v3
-        validate_by_name=True,  # Introduced in pydantic v2.11
-        validate_by_alias=True,  # Introduced in pydantic v2.11
-        serialize_by_alias=True,  # Introduced in pydantic v2.11
-        validate_assignment=True,
-        validate_default=True,
-        use_attribute_docstrings=True,
+        populate_by_name=True,  # Discouraged in v2.11+, deprecated in v3, kept for now for compatibility
+        validate_by_name=True,  # Introduced in v2.11, ignored in earlier versions
+        validate_by_alias=True,  # Introduced in v2.11, ignored in earlier versions
+        serialize_by_alias=True,  # Introduced in v2.11, ignored in earlier versions
         from_attributes=True,
-        revalidate_instances="always",
-        protected_namespaces=(),  # Some GraphQL fields may begin with "model_"
+        validate_assignment=True,
+        use_attribute_docstrings=True,
     )
+
+    # Custom defaults keyword args for `BaseModel.model_{dump,dump_json}`:
+    # - convert keys to JSON-ready names and objects to JSON-ready dicts
+    # - ensure round-trippable result
+    __DUMP_DEFAULTS: ClassVar[DumpKwargs] = DumpKwargs(by_alias=True, round_trip=True)
 
     @override
     def model_dump(
-        self,
-        *,
-        mode: Literal["json", "python"] | str = "json",  # NOTE: changed default
-        **kwargs: Unpack[ModelDumpKwargs],
+        self, *, mode: str = "json", **kwargs: Unpack[DumpKwargs]
     ) -> dict[str, Any]:
-        kwargs = {**MODEL_DUMP_DEFAULTS, **kwargs}
+        kwargs = {**self.__DUMP_DEFAULTS, **kwargs}  # allows overrides, if needed
         return super().model_dump(mode=mode, **kwargs)
 
     @override
     def model_dump_json(
-        self,
-        *,
-        indent: int | None = None,
-        **kwargs: Unpack[ModelDumpKwargs],
+        self, *, indent: int | None = None, **kwargs: Unpack[DumpKwargs]
     ) -> str:
-        kwargs = {**MODEL_DUMP_DEFAULTS, **kwargs}
+        kwargs = {**self.__DUMP_DEFAULTS, **kwargs}  # allows overrides, if needed
         return super().model_dump_json(indent=indent, **kwargs)
+
+
+# Base class for all GraphQL-generated types.
+class GQLBase(JsonableModel):
+    model_config = ConfigDict(
+        validate_default=True,
+        revalidate_instances="always",
+        protected_namespaces=(),  # Some GraphQL fields may begin with "model_"
+    )


### PR DESCRIPTION
Description
-----------

PR:
- Refactors internal pydantic class definitions by introducing a new `JsonableModel` base class
- Extracts configuration for general JSON serialization/deserialization behavior from `GQLBase` into `JsonableModel`, since it doesn't just apply to generated GQL types
- Makes `GQLBase` inherit from `JsonableModel` to maintain existing behavior
- (internal) Renames `ModelDumpKwargs` to `DumpKwargs` for brevity/clarity
- Improves inline explanatory comments

No intended functional changes.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable