### PR TITLE
refactor: status updates in `wandb beta sync`

### DIFF
--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -1,12 +1,134 @@
 from __future__ import annotations
 
+import asyncio
 import pathlib
 import re
+from typing import Callable
 
 import pytest
 import wandb
 from click.testing import CliRunner
+from typing_extensions import Any, TypeVar
 from wandb.cli import beta_sync, cli
+from wandb.proto import wandb_server_pb2 as spb
+from wandb.proto import wandb_sync_pb2
+from wandb.sdk import wandb_setup
+from wandb.sdk.lib import asyncio_compat
+from wandb.sdk.lib.printer import new_printer
+from wandb.sdk.mailbox.mailbox import Mailbox
+from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
+
+_T = TypeVar("_T")
+
+
+class _Tester:
+    """A fake ServiceConnection for async testing."""
+
+    def __init__(self, mailbox: Mailbox) -> None:
+        self._mailbox = mailbox
+
+        self._cond = asyncio.Condition()
+        self._init_sync_addrs: list[str] = []
+        self._sync_addrs: list[str] = []
+        self._sync_status_addrs: list[str] = []
+
+    async def receive_init_sync(self) -> None:
+        """Wait until an init_sync request."""
+        await self._wait_for(self._init_sync_addrs)
+
+    async def receive_sync(self) -> None:
+        """Wait until a sync request."""
+        await self._wait_for(self._sync_addrs)
+
+    async def receive_sync_status(self) -> None:
+        """Wait until a sync_status request."""
+        await self._wait_for(self._sync_status_addrs)
+
+    async def _wait_for(self, addrs: list[str]) -> None:
+        async with self._cond:
+            await asyncio.wait_for(
+                self._cond.wait_for(lambda: bool(addrs)),
+                timeout=5,
+            )
+
+    async def respond_init_sync(self, id: str) -> None:
+        """Respond to an init_sync request."""
+        resp = wandb_sync_pb2.ServerInitSyncResponse(id=id)
+        await self._respond(self._init_sync_addrs, "init_sync_response", resp)
+
+    async def respond_sync(self, errors: list[str]) -> None:
+        """Respond to a sync request."""
+        resp = wandb_sync_pb2.ServerSyncResponse(errors=errors)
+        await self._respond(self._sync_addrs, "sync_response", resp)
+
+    async def respond_sync_status(self, new_errors: list[str]) -> None:
+        """Respond to a sync_status request."""
+        resp = wandb_sync_pb2.ServerSyncStatusResponse(new_errors=new_errors)
+        await self._respond(self._sync_status_addrs, "sync_status_response", resp)
+
+    async def _respond(self, addrs: list[str], field: str, resp: Any) -> None:
+        async with self._cond:
+            await asyncio.wait_for(
+                self._cond.wait_for(lambda: bool(addrs)),
+                timeout=5,
+            )
+            addr = addrs.pop(0)
+
+        server_response = spb.ServerResponse()
+        server_response.request_id = addr
+        getattr(server_response, field).CopyFrom(resp)
+
+        await self._mailbox.deliver(server_response)
+
+    def init_sync(
+        self,
+        paths: set[pathlib.Path],
+        settings: wandb.Settings,
+    ) -> MailboxHandle[wandb_sync_pb2.ServerInitSyncResponse]:
+        return self._make_handle(
+            self._init_sync_addrs,
+            lambda r: r.init_sync_response,
+        )
+
+    def sync(self, id: str) -> MailboxHandle[wandb_sync_pb2.ServerSyncResponse]:
+        return self._make_handle(
+            self._sync_addrs,
+            lambda r: r.sync_response,
+        )
+
+    def sync_status(
+        self,
+        id: str,
+    ) -> MailboxHandle[wandb_sync_pb2.ServerSyncStatusResponse]:
+        return self._make_handle(
+            self._sync_status_addrs,
+            lambda r: r.sync_status_response,
+        )
+
+    def _make_handle(
+        self,
+        addrs: list[str],
+        to_response: Callable[[spb.ServerResponse], _T],
+    ) -> MailboxHandle[_T]:
+        req = spb.ServerRequest()
+        handle = self._mailbox.require_response(req)
+
+        async def update_addrs():
+            async with self._cond:
+                addrs.append(req.request_id)
+                self._cond.notify_all()
+
+        _ = asyncio.create_task(update_addrs())
+
+        return handle.map(to_response)
+
+
+@pytest.fixture
+def skip_asyncio_sleep(monkeypatch):
+    async def do_nothing(duration):
+        pass
+
+    monkeypatch.setattr(beta_sync, "_SLEEP", do_nothing)
 
 
 def test_makes_sync_request(runner: CliRunner):
@@ -99,3 +221,46 @@ def test_truncates_printed_paths(
     for line in lines[1:6]:
         assert re.fullmatch(r"  .+/run-\d+\.wandb", line)
     assert lines[6] == "  +15 more"
+
+
+def test_prints_status_updates(skip_asyncio_sleep, tmp_path, emulated_terminal):
+    _ = skip_asyncio_sleep
+    wandb_file = tmp_path / "run-test-progress.wandb"
+    singleton = wandb_setup.singleton()
+    mailbox = Mailbox(singleton.asyncer)
+
+    async def simulate_service(tester: _Tester):
+        await tester.respond_init_sync(id="sync-test")
+        await tester.respond_sync_status(new_errors=["Err 1.", "Err 2."])
+        await tester.receive_sync_status()
+
+        assert emulated_terminal.read_stderr() == [
+            "wandb: ERROR Err 1.",
+            "wandb: ERROR Err 2.",
+            "wandb: ⢿ Syncing...",
+        ]
+
+        await tester.respond_sync(errors=["Final error."])
+        await tester.respond_sync_status(new_errors=[])
+
+    async def do_test():
+        tester = _Tester(mailbox=mailbox)
+
+        async with asyncio_compat.open_task_group(exit_timeout=5) as group:
+            group.start_soon(simulate_service(tester))
+            group.start_soon(
+                beta_sync._do_sync(
+                    set([wandb_file]),
+                    service=tester,  # type: ignore (we only mock used methods)
+                    settings=wandb.Settings(),
+                    printer=new_printer(),
+                )
+            )
+
+        assert emulated_terminal.read_stderr() == [
+            "wandb: ERROR Err 1.",
+            "wandb: ERROR Err 2.",
+            "wandb: ERROR Final error.",
+        ]
+
+    singleton.asyncer.run(do_test)

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import pathlib
+import time
 from itertools import filterfalse
 from typing import Iterable
 
 import click
 from typing_extensions import Generator
 
+import wandb
+from wandb.proto.wandb_sync_pb2 import ServerSyncResponse
 from wandb.sdk import wandb_setup
-from wandb.sdk.lib.printer import ERROR, new_printer
+from wandb.sdk.lib import asyncio_compat
+from wandb.sdk.lib.printer import ERROR, Printer, new_printer
+from wandb.sdk.lib.progress import progress_printer
+from wandb.sdk.lib.service.service_connection import ServiceConnection
+from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
 
 _MAX_LIST_LINES = 20
+_POLL_WAIT_SECONDS = 0.1
+_SLEEP = asyncio.sleep  # patched in tests
 
 
 def sync(
@@ -47,13 +57,99 @@ def sync(
     singleton = wandb_setup.singleton()
     service = singleton.ensure_service()
     printer = new_printer()
+    singleton.asyncer.run(
+        lambda: _do_sync(
+            wandb_files,
+            service=service,
+            settings=singleton.settings,
+            printer=printer,
+        )
+    )
 
-    init_handle = service.init_sync(wandb_files, singleton.settings)
-    sync_id = init_handle.wait_or(timeout=5).id
-    sync_result = service.sync(sync_id).wait_or(timeout=None)
 
-    if messages := list(sync_result.errors):
-        printer.display(messages, level=ERROR)
+async def _do_sync(
+    wandb_files: set[pathlib.Path],
+    *,
+    service: ServiceConnection,
+    settings: wandb.Settings,
+    printer: Printer,
+) -> None:
+    """Sync the specified files.
+
+    This is factored out to make the progress animation testable.
+    """
+    init_result = await service.init_sync(
+        wandb_files,
+        settings,
+    ).wait_async(timeout=5)
+
+    sync_handle = service.sync(init_result.id)
+
+    await _SyncStatusLoop(
+        init_result.id,
+        service,
+        printer,
+    ).wait_with_progress(sync_handle)
+
+
+class _SyncStatusLoop:
+    """Displays a sync operation's status until it completes."""
+
+    def __init__(
+        self,
+        id: str,
+        service: ServiceConnection,
+        printer: Printer,
+    ) -> None:
+        self._id = id
+        self._service = service
+        self._printer = printer
+
+        self._rate_limit_last_time: float | None = None
+        self._done = asyncio.Event()
+
+    async def wait_with_progress(
+        self,
+        handle: MailboxHandle[ServerSyncResponse],
+    ) -> None:
+        """Display status updates until the handle completes."""
+        async with asyncio_compat.open_task_group() as group:
+            group.start_soon(self._wait_then_mark_done(handle))
+            group.start_soon(self._show_progress_until_done())
+
+    async def _wait_then_mark_done(
+        self,
+        handle: MailboxHandle[ServerSyncResponse],
+    ) -> None:
+        response = await handle.wait_async(timeout=None)
+        if messages := list(response.errors):
+            self._printer.display(messages, level=ERROR)
+        self._done.set()
+
+    async def _show_progress_until_done(self) -> None:
+        """Show rate-limited status updates until _done is set."""
+        with progress_printer(self._printer, "Syncing...") as progress:
+            while not await self._rate_limit_check_done():
+                handle = self._service.sync_status(self._id)
+                response = await handle.wait_async(timeout=None)
+
+                if messages := list(response.new_errors):
+                    self._printer.display(messages, level=ERROR)
+                progress.update(response.stats)
+
+    async def _rate_limit_check_done(self) -> bool:
+        """Wait for rate limit and return whether _done is set."""
+        now = time.monotonic()
+        last_time = self._rate_limit_last_time
+        self._rate_limit_last_time = now
+
+        if last_time and (time_since_last := now - last_time) < _POLL_WAIT_SECONDS:
+            await asyncio_compat.race(
+                _SLEEP(_POLL_WAIT_SECONDS - time_since_last),
+                self._done.wait(),
+            )
+
+        return self._done.is_set()
 
 
 def _find_wandb_files(


### PR DESCRIPTION
Adds status update logic to `wandb beta sync`. This displays "operation stats" during syncing, just like `wandb.init()` and `run.finish()`.