### PR TITLE
refactor: improve asyncio_compat.open_task_group()

### DIFF
--- a/tests/unit_tests/test_asyncio_compat.py
+++ b/tests/unit_tests/test_asyncio_compat.py
@@ -117,7 +117,7 @@ def test_compat_run_in_asyncio_context():
 async def test_cancel_on_exit_normal():
     cd = _CancellationDetector()
 
-    with asyncio_compat.cancel_on_exit(cd.expect_cancelled()):
+    async with asyncio_compat.cancel_on_exit(cd.expect_cancelled()):
         await _yield()
 
     await cd.assert_cancelled()
@@ -128,7 +128,7 @@ async def test_cancel_on_exit_error_in_body():
     cd = _CancellationDetector()
 
     with pytest.raises(_TestError):
-        with asyncio_compat.cancel_on_exit(cd.expect_cancelled()):
+        async with asyncio_compat.cancel_on_exit(cd.expect_cancelled()):
             await _yield()
             raise _TestError()
 
@@ -142,7 +142,7 @@ async def test_cancel_on_exit_error_in_task():
         raise _TestError()
 
     with pytest.raises(_TestError):
-        with asyncio_compat.cancel_on_exit(fail()):
+        async with asyncio_compat.cancel_on_exit(fail()):
             await _yield()
             await _yield()
 
@@ -153,7 +153,7 @@ async def test_cancel_on_exit_errors_everywhere():
         raise _TestError(msg)
 
     with pytest.raises(_TestError, match="inner") as exc:
-        with asyncio_compat.cancel_on_exit(fail("outer")):
+        async with asyncio_compat.cancel_on_exit(fail("outer")):
             # Ensure the outer task has already failed before raising
             # an error. We want to make sure that the inner error still
             # takes priority.
@@ -223,5 +223,100 @@ async def test_task_group_cancels_on_subtask_error():
 @pytest.mark.asyncio
 async def test_task_group_exit_timeout():
     with pytest.raises(TimeoutError):
-        async with asyncio_compat.open_task_group(exit_timeout=0):
-            pass
+        async with asyncio_compat.open_task_group(exit_timeout=0) as group:
+            group.start_soon(asyncio.sleep(5))
+
+
+@pytest.mark.asyncio
+async def test_task_group_empty_ok():
+    async with asyncio_compat.open_task_group():
+        pass
+
+
+@pytest.mark.asyncio
+async def test_race_cancels_unfinished_tasks():
+    completion_order = []
+    event = asyncio.Event()
+
+    async def wait_for_event():
+        await event.wait()
+        completion_order.append("finished first")
+
+    async def set_event_then_wait_forever():
+        event.set()
+
+        try:
+            await asyncio.sleep(99)
+        except asyncio.CancelledError:
+            completion_order.append("cancelled second")
+            raise
+
+    await asyncio_compat.race(
+        wait_for_event(),
+        set_event_then_wait_forever(),
+    )
+
+    assert completion_order == ["finished first", "cancelled second"]
+
+
+@pytest.mark.asyncio
+async def test_race_raises_first_error():
+    event = asyncio.Event()
+
+    async def raise_first():
+        event.set()
+        raise _TestError("first")
+
+    async def return_first():
+        pass
+
+    async def raise_second():
+        await event.wait()
+        return _TestError("second")
+
+    with pytest.raises(_TestError, match="first"):
+        await asyncio_compat.race(
+            return_first(),  # The error always takes precedence.
+            raise_first(),
+            raise_second(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_race_raises_error_during_cancellation():
+    async def return_normally():
+        pass
+
+    async def raise_if_cancelled():
+        try:
+            await asyncio.sleep(99)
+        except asyncio.CancelledError:
+            raise _TestError
+
+    with pytest.raises(_TestError):
+        await asyncio_compat.race(return_normally(), raise_if_cancelled())
+
+
+@pytest.mark.asyncio
+async def test_race_cancels_subtasks_if_cancelled():
+    started = asyncio.Event()
+    cancelled = False
+
+    async def detect_cancelled():
+        nonlocal cancelled
+        try:
+            started.set()
+            await asyncio.sleep(99)
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+
+    async def do_race():
+        await asyncio_compat.race(detect_cancelled())
+
+    task = asyncio.create_task(do_race())
+    await started.wait()
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert cancelled

--- a/tests/unit_tests/test_asyncio_compat.py
+++ b/tests/unit_tests/test_asyncio_compat.py
@@ -218,3 +218,10 @@ async def test_task_group_cancels_on_subtask_error():
     await tester.assert_exits()
     await cd1.assert_cancelled()
     await cd2.assert_cancelled()
+
+
+@pytest.mark.asyncio
+async def test_task_group_exit_timeout():
+    with pytest.raises(TimeoutError):
+        async with asyncio_compat.open_task_group(exit_timeout=0):
+            pass

--- a/wandb/sdk/lib/asyncio_compat.py
+++ b/wandb/sdk/lib/asyncio_compat.py
@@ -7,7 +7,7 @@ import concurrent
 import concurrent.futures
 import contextlib
 import threading
-from typing import Any, AsyncIterator, Callable, Coroutine, Iterator, TypeVar
+from typing import Any, AsyncIterator, Callable, Coroutine, TypeVar
 
 _T = TypeVar("_T")
 
@@ -143,36 +143,70 @@ class TaskGroup:
         """
         self._tasks.append(asyncio.create_task(coro))
 
-    async def _wait_all(self) -> None:
-        """Block until all tasks complete.
+    async def _wait_all(self, *, race: bool, timeout: float | None) -> None:
+        """Block until tasks complete.
+
+        Args:
+            race: If true, blocks until the first task completes and then
+                cancels the rest. Otherwise, waits for all tasks or until
+                the first exception.
+            timeout: How long to wait.
 
         Raises:
+            TimeoutError: If the timeout expires.
             Exception: If one or more tasks raises an exception, one of these
                 is raised arbitrarily.
         """
-        done, _ = await asyncio.wait(
+        if not self._tasks:
+            return
+
+        if race:
+            return_when = asyncio.FIRST_COMPLETED
+        else:
+            return_when = asyncio.FIRST_EXCEPTION
+
+        done, pending = await asyncio.wait(
             self._tasks,
-            # NOTE: Cancelling a task counts as a normal exit,
-            #   not an exception.
-            return_when=concurrent.futures.FIRST_EXCEPTION,
+            timeout=timeout,
+            return_when=return_when,
         )
 
-        for task in done:
-            with contextlib.suppress(asyncio.CancelledError):
-                if exc := task.exception():
-                    raise exc
+        if not done:
+            raise TimeoutError(f"Timed out after {timeout} seconds.")
 
-    def _cancel_all(self) -> None:
-        """Cancel all tasks."""
+        # If any of the finished tasks raised an exception, pick the first one.
+        for task in done:
+            if exc := task.exception():
+                raise exc
+
+        # Wait for remaining tasks to clean up, then re-raise any exceptions
+        # that arise. Note that pending is only non-empty when race=True.
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        for task in pending:
+            if task.cancelled():
+                continue
+            if exc := task.exception():
+                raise exc
+
+    async def _cancel_all(self) -> None:
+        """Cancel all tasks.
+
+        Blocks until cancelled tasks complete to allow them to clean up.
+        Ignores exceptions.
+        """
         for task in self._tasks:
             # NOTE: It is safe to cancel tasks that have already completed.
             task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
 
 
 @contextlib.asynccontextmanager
 async def open_task_group(
     *,
     exit_timeout: float | None = None,
+    race: bool = False,
 ) -> AsyncIterator[TaskGroup]:
     """Create a task group.
 
@@ -192,6 +226,8 @@ async def open_task_group(
         exit_timeout: An optional timeout in seconds. When exiting the
             context manager, if tasks don't complete in this time,
             they are cancelled and a TimeoutError is raised.
+        race: If true, all pending tasks are cancelled once any task
+            in the group completes. Prefer to use the race() function instead.
 
     Raises:
         TimeoutError: if exit_timeout is specified and tasks don't finish
@@ -201,27 +237,42 @@ async def open_task_group(
 
     try:
         yield task_group
-        await asyncio.wait_for(task_group._wait_all(), exit_timeout)
-    except asyncio.TimeoutError as e:
-        raise TimeoutError from e  # Wrap in a standard TimeoutError.
+        await task_group._wait_all(race=race, timeout=exit_timeout)
     finally:
-        task_group._cancel_all()
+        await task_group._cancel_all()
 
 
-@contextlib.contextmanager
-def cancel_on_exit(coro: Coroutine[Any, Any, Any]) -> Iterator[None]:
+@contextlib.asynccontextmanager
+async def cancel_on_exit(coro: Coroutine[Any, Any, Any]) -> AsyncIterator[None]:
     """Schedule a task, cancelling it when exiting the context manager.
 
     If the context manager exits successfully but the given coroutine raises
     an exception, that exception is reraised. The exception is suppressed
     if the context manager raises an exception.
     """
-    task = asyncio.create_task(coro)
 
-    try:
+    async def stop_immediately():
+        pass
+
+    async with open_task_group(race=True) as group:
+        group.start_soon(stop_immediately())
+        group.start_soon(coro)
         yield
 
-        if task.done() and (exception := task.exception()):
-            raise exception
-    finally:
-        task.cancel()
+
+async def race(*coros: Coroutine[Any, Any, Any]) -> None:
+    """Wait until the first completed task.
+
+    After any coroutine completes, all others are cancelled.
+    If the current task is cancelled, all coroutines are cancelled too.
+
+    If coroutines complete simultaneously and any one of them raises
+    an exception, an arbitrary one is propagated. Similarly, if any coroutines
+    raise exceptions during cancellation, one of them propagates.
+
+    Args:
+        coros: Coroutines to race.
+    """
+    async with open_task_group(race=True) as tg:
+        for coro in coros:
+            tg.start_soon(coro)

--- a/wandb/sdk/mailbox/wait_with_progress.py
+++ b/wandb/sdk/mailbox/wait_with_progress.py
@@ -62,7 +62,7 @@ def wait_all_with_progress(
     start_time = time.monotonic()
 
     async def progress_loop_with_timeout() -> list[_T]:
-        with asyncio_compat.cancel_on_exit(display_progress()):
+        async with asyncio_compat.cancel_on_exit(display_progress()):
             if timeout is not None:
                 elapsed_time = time.monotonic() - start_time
                 remaining_timeout = timeout - elapsed_time


### PR DESCRIPTION
Adds an optional timeout to `open_task_group()`​ (useful in a test in PR #10441), and a `race()`​ function.

Improves cancellation handling: it’s important to await tasks after calling `cancel()`​ to allow them to run their `finally`​ blocks. Otherwise, the `finally`​ blocks run sometime later, which could be unexpected, for example:

```
event = asyncio.Event()
cleaned_up = False

async def failing_task():
    await event.wait()
    raise ValueError

async def task_with_cleanup():
    try:
        event.set()  # allow failing_task() to fail
        ...          # do work
    finally:
        cleaned_up = True

async with asyncio_compat.open_task_group() as group:
    group.start_soon(failing_task())
    group.start_soon(task_with_cleanup())

# cleaned_up would have been False here before this PR
# until an await statement.
```

