### PR TITLE
refactor(artifacts): cleanup storage policy session-init logic

### DIFF
--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -530,13 +530,12 @@ class MockOpener:
 
 
 def test_artifact_multipart_download_network_error():
-    policy = WandbStoragePolicy()
     # Disable retries and backoff to avoid timeout in test
     session = requests.Session()
     adapter = requests.adapters.HTTPAdapter(max_retries=0)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
-    policy._session = session
+    policy = WandbStoragePolicy(session=session)
 
     class CountOnlyFile(IO):
         def __init__(self):
@@ -563,8 +562,6 @@ def test_artifact_multipart_download_network_error():
 
 
 def test_artifact_multipart_download_disk_error():
-    policy = WandbStoragePolicy()
-
     class ThrowFile(IO):
         def seek(self, offset: int, whence: int = 0) -> int:
             raise ValueError("I/O operation on closed file")
@@ -585,7 +582,7 @@ def test_artifact_multipart_download_disk_error():
             return MockResponse()
 
     session = MockSession()
-    policy._session = session
+    policy = WandbStoragePolicy(session=session)
 
     file = ThrowFile()
     opener = MockOpener(file)

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -65,7 +65,7 @@ class GCSHandler(StorageHandler):
         path, hit, cache_open = self._cache.check_etag_obj_path(
             url=URIStr(manifest_entry.ref),
             etag=ETag(manifest_entry.digest),
-            size=manifest_entry.size if manifest_entry.size is not None else 0,
+            size=manifest_entry.size or 0,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_handlers/http_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/http_handler.py
@@ -43,7 +43,7 @@ class HTTPHandler(StorageHandler):
         path, hit, cache_open = self._cache.check_etag_obj_path(
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),
-            manifest_entry.size if manifest_entry.size is not None else 0,
+            manifest_entry.size or 0,
         )
         if hit:
             return path
@@ -54,7 +54,6 @@ class HTTPHandler(StorageHandler):
             cookies=_thread_local_api_settings.cookies,
             headers=_thread_local_api_settings.headers,
         )
-        response.raise_for_status()
 
         digest: ETag | FilePathStr | URIStr | None
         digest, size, extra = self._entry_from_headers(response.headers)
@@ -87,7 +86,6 @@ class HTTPHandler(StorageHandler):
             cookies=_thread_local_api_settings.cookies,
             headers=_thread_local_api_settings.headers,
         ) as response:
-            response.raise_for_status()
             digest: ETag | FilePathStr | URIStr | None
             digest, size, extra = self._entry_from_headers(response.headers)
             digest = digest or path

--- a/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
@@ -51,7 +51,7 @@ class LocalFileHandler(StorageHandler):
 
         path, hit, cache_open = self._cache.check_md5_obj_path(
             B64MD5(manifest_entry.digest),  # TODO(spencerpearson): unsafe cast
-            manifest_entry.size if manifest_entry.size is not None else 0,
+            manifest_entry.size or 0,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -96,7 +96,7 @@ class S3Handler(StorageHandler):
         path, hit, cache_open = self._cache.check_etag_obj_path(
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),
-            manifest_entry.size if manifest_entry.size is not None else 0,
+            manifest_entry.size or 0,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_policies/_factories.py
+++ b/wandb/sdk/artifacts/storage_policies/_factories.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Final
+
+from requests import Response, Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from ..storage_handler import StorageHandler
+from ..storage_handlers.azure_handler import AzureHandler
+from ..storage_handlers.gcs_handler import GCSHandler
+from ..storage_handlers.http_handler import HTTPHandler
+from ..storage_handlers.local_file_handler import LocalFileHandler
+from ..storage_handlers.s3_handler import S3Handler
+from ..storage_handlers.wb_artifact_handler import WBArtifactHandler
+from ..storage_handlers.wb_local_artifact_handler import WBLocalArtifactHandler
+
+# Sleep length: 0, 2, 4, 8, 16, 32, 64, 120, 120, 120, 120, 120, 120, 120, 120, 120
+# seconds, i.e. a total of 20min 6s.
+HTTP_RETRY_STRATEGY: Final[Retry] = Retry(
+    backoff_factor=1,
+    total=16,
+    status_forcelist=(308, 408, 409, 429, 500, 502, 503, 504),
+)
+HTTP_POOL_CONNECTIONS: Final[int] = 64
+HTTP_POOL_MAXSIZE: Final[int] = 64
+
+
+def raise_for_status(response: Response, *_, **__) -> None:
+    """A `requests.Session` hook to raise for status on all requests."""
+    response.raise_for_status()
+
+
+def make_http_session() -> Session:
+    """A factory that returns a `requests.Session` for use with artifact storage handlers."""
+    session = Session()
+
+    # Explicitly configure the retry strategy for http/https adapters.
+    adapter = HTTPAdapter(
+        max_retries=HTTP_RETRY_STRATEGY,
+        pool_connections=HTTP_POOL_CONNECTIONS,
+        pool_maxsize=HTTP_POOL_MAXSIZE,
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    # Always raise on HTTP status errors.
+    session.hooks["response"].append(raise_for_status)
+    return session
+
+
+def make_storage_handlers(session: Session) -> list[StorageHandler]:
+    """A factory that returns the default artifact storage handlers."""
+    return [
+        S3Handler(),  # s3
+        GCSHandler(),  # gcs
+        AzureHandler(),  # azure
+        HTTPHandler(session, scheme="http"),  # http
+        HTTPHandler(session, scheme="https"),  # https
+        WBArtifactHandler(),  # artifact
+        WBLocalArtifactHandler(),  # local_artifact
+        LocalFileHandler(),  # file_handler
+    ]


### PR DESCRIPTION
## Description

PR refactors / cleans up / modernizes some existing code for artifacts storage policies / storage handlers.  Timeboxed.
- Defines internal, private factory functions for creating HTTP sessions and default storage handlers
- Reduces unnecessarily verbose patterns in various places, e.g. `manifest_entry.size if manifest_entry.size is not None else 0` --> `manifest_entry.size or 0`
- Registers a hook on creating a `Session` to automatically `raise_for_status()`.  Reduces verbosity and ensures consistent expectations across requests _without_ requiring repeated, manual invocation of `response.raise_for_status()`.
- Refactors existing authentication logic for clarity (i.e. prefer bearer token, cookies, or basic auth in that order)
- Simplifies URL construction in `_file_url` method

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable