### PR TITLE
refactor: rename operation "creating run" to "setting up run {id}"

### DIFF
--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -162,7 +162,8 @@ func InitRun(
 		environment: environment,
 	}
 
-	operation := upserter.operations.New("creating run")
+	operation := upserter.operations.New(
+		fmt.Sprintf("setting up run %s", runParams.RunID))
 	defer operation.Finish()
 	ctx := operation.Context(upserter.beforeRunEndCtx)
 


### PR DESCRIPTION
Changes the status text shown during `wandb.init()` from "creating run" to "setting up run {ID}" so that it makes sense when resuming or syncing (using `wandb beta sync`​). This also helps disambiguate status updates for different runs when syncing multiple .wandb files at once.