### PR TITLE
feat: allow passing multiple paths to `wandb beta sync`

### DIFF
--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -33,7 +33,7 @@ def beta():
 
 
 @beta.command()
-@click.argument("path", type=click.Path(exists=True))
+@click.argument("paths", type=click.Path(exists=True), nargs=-1)
 @click.option(
     "--skip-synced/--no-skip-synced",
     is_flag=True,
@@ -47,15 +47,14 @@ def beta():
     help="Print what would happen without uploading anything.",
 )
 def sync(
-    path: str,
+    paths: tuple[str, ...],
     skip_synced: bool,
     dry_run: bool,
 ) -> None:
-    """Upload .wandb files in PATH.
+    """Upload .wandb files specified by PATHS.
 
-    PATH can be a path to a .wandb file, a path to a run's directory containing
-    its .wandb file, or a path to a "wandb" directory containing run
-    directories.
+    PATHS can include .wandb files, run directories containing .wandb files,
+    and "wandb" directories containing run directories.
 
     For example, to sync all runs in a directory:
 
@@ -72,7 +71,7 @@ def sync(
     from . import beta_sync
 
     beta_sync.sync(
-        pathlib.Path(path),
+        [pathlib.Path(path) for path in paths],
         dry_run=dry_run,
         skip_synced=skip_synced,
     )


### PR DESCRIPTION
Since it's possible to sync an entire `wandb` directory using `wandb beta sync ./wandb`, it makes sense to also be able to sync specific runs using `wandb beta sync ./wandb/run-1 ./wandb/run-2`.

This PR also makes it resolve symlinks, since the `wandb/` directory often includes a `latest-run/` symlink, and we wouldn't want to start two `sync` operations simultaneously.