### PR TITLE
refactor: don't crash in sender if exitRecord.Control is nil

### DIFF
--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -389,7 +389,8 @@ func (s *Sender) respondResponse(record *spb.Record, response *spb.Response) {
 
 // respondExit responds to an exit record
 func (s *Sender) respondExit(record *spb.Record, exit *spb.RunExitResult) {
-	if !s.exitRecord.Control.ReqResp && s.exitRecord.Control.MailboxSlot == "" {
+	if !s.exitRecord.GetControl().GetReqResp() &&
+		s.exitRecord.GetControl().GetMailboxSlot() == "" {
 		return
 	}
 	result := &spb.Result{


### PR DESCRIPTION
Encountered such a record when syncing an old run. Not entirely sure why it doesn't have `Control` set, but either way we shouldn't assume that it is always set.