### PR TITLE
chore: skip flaky tests for OpenAI fine tuning, Keras and DSPy

### DIFF
--- a/tests/system_tests/test_functional/dspy/test_dspy.py
+++ b/tests/system_tests/test_functional/dspy/test_dspy.py
@@ -61,6 +61,7 @@ def run_and_snapshot(wandb_backend_spy):
     return _runner
 
 
+@pytest.mark.skip(reason="flaky")
 def test_dspy_callback_end_to_end(run_and_snapshot):
     # Capture artifact-related GraphQL operations before running the script
     def _setup(spy):

--- a/tests/system_tests/test_functional/keras/test_keras.py
+++ b/tests/system_tests/test_functional/keras/test_keras.py
@@ -1,6 +1,8 @@
 import pathlib
 import subprocess
 
+import pytest
+
 
 def test_eval_tables_builder(wandb_backend_spy):
     script_path = pathlib.Path(__file__).parent / "keras_eval_tables_builder.py"
@@ -68,6 +70,7 @@ def test_model_checkpoint(wandb_backend_spy):
         assert 39 in telemetry["3"]  # feature=keras_wandb_model_checkpoint
 
 
+@pytest.mark.skip(reason="flaky")
 def test_deprecated_keras_callback(wandb_backend_spy):
     script_path = pathlib.Path(__file__).parent / "keras_deprecated.py"
     subprocess.check_call(["python", str(script_path)])

--- a/tests/system_tests/test_functional/openai/test_finetuning.py
+++ b/tests/system_tests/test_functional/openai/test_finetuning.py
@@ -1,9 +1,11 @@
 import os
 
+import pytest
 from openai import OpenAI
 from wandb.integration.openai.fine_tuning import WandbLogger
 
 
+@pytest.mark.skip(reason="flaky")
 def test_finetuning(wandb_backend_spy):
     # TODO: this does not test much, it should be improved
     client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])


### PR DESCRIPTION
Skips flaky tests.

- test_dspy_callback_end_to_end [flake](https://app.circleci.com/pipelines/github/wandb/wandb/51744/workflows/226a6c67-0b9b-4b08-91c3-b0a06e64aba2/jobs/1466179/tests)
- test_deprecated_keras_callback [flake](https://app.circleci.com/pipelines/github/wandb/wandb/51700/workflows/513cc3c5-7202-46f1-9388-e9863a56d2df/jobs/1465462/tests)
- test_finetuning [flake](https://app.circleci.com/pipelines/github/wandb/wandb/51643/workflows/bfb36f7e-e46b-4d9e-8b97-6624fb5685db/jobs/1464525/tests)

If not fixed within 1-2 months, we should remove these.