### PR TITLE
chore: do not send benign system monitor resource sampling errors to Sentry

### DIFF
--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -418,7 +418,7 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 
 			metrics, err := resource.Sample()
 			if err != nil {
-				if shouldCaptureSamplingError(err) {
+				if ShouldCaptureSamplingError(err) {
 					sm.logger.CaptureError(fmt.Errorf("monitor: error sampling metrics: %v", err))
 				} else {
 					sm.logger.Debug(fmt.Sprintf("monitor: benign sampling error: %v", err))
@@ -455,10 +455,10 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 
 }
 
-// shouldCaptureSamplingError checks if a resource sampling error should be sent to Sentry.
+// ShouldCaptureSamplingError checks if a resource sampling error should be sent to Sentry.
 //
 // Use to filter out expected/transient failures. Keep this intentionally small and specific.
-func shouldCaptureSamplingError(err error) bool {
+func ShouldCaptureSamplingError(err error) bool {
 	// Transient gRPC connectivity to the gpu_stats sidecar.
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
 		return false

--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -3,7 +3,10 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -11,6 +14,8 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/google/wire"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/wandb/simplejsonext"
@@ -413,8 +418,11 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 
 			metrics, err := resource.Sample()
 			if err != nil {
-				sm.logger.CaptureError(fmt.Errorf("monitor: error sampling metrics: %v", err))
-				continue
+				if shouldCaptureSamplingError(err) {
+					sm.logger.CaptureError(fmt.Errorf("monitor: error sampling metrics: %v", err))
+				} else {
+					sm.logger.Debug(fmt.Sprintf("monitor: benign sampling error: %v", err))
+				}
 			}
 
 			if metrics == nil || len(metrics.Item) == 0 {
@@ -445,6 +453,39 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 		}
 	}
 
+}
+
+// shouldCaptureSamplingError checks if a resource sampling error should be sent to Sentry.
+//
+// Use to filter out expected/transient failures. Keep this intentionally small and specific.
+func shouldCaptureSamplingError(err error) bool {
+	// Transient gRPC connectivity to the gpu_stats sidecar.
+	if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "connection refused") {
+		return false
+	}
+	// Platforms without netstat (gopsutil may shell out on some OSes).
+	if errors.Is(err, exec.ErrNotFound) ||
+		(strings.Contains(msg, "executable file not found") && strings.Contains(msg, "netstat")) {
+		return false
+	}
+	// Windows sporadic low-level API failure wording.
+	if strings.Contains(msg, "Incorrect function.") {
+		return false
+	}
+	// Container/lean Linux builds without /proc/diskstats.
+	if strings.Contains(msg, "/proc/diskstats") && (strings.Contains(msg, "no such file") || strings.Contains(msg, "no such file or directory")) {
+		return false
+	}
+	// Some gopsutil APIs report "not implemented yet" for certain platforms.
+	if strings.Contains(msg, "not implemented yet") {
+		return false
+	}
+
+	return true
 }
 
 // GetBuffer returns the current buffer of collected metrics.


### PR DESCRIPTION
Description
-----------
Ignore benign sampling errors such as https://weights-biases.sentry.io/issues/6858581950/events/aeec454dd55d40bf989e0d35c3181b00/?project=4505513612214272, https://weights-biases.sentry.io/issues/6858581950/events/e68a977372e8466a99a5666531dc589a/?project=4505513612214272, or https://weights-biases.sentry.io/issues/6858581950/events/cf4144a77ad0441b92571ab719da6d60/?project=4505513612214272.