### PR TITLE
chore: add race detection to go test flags in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,9 @@
     "./experimental/rust-sdk/examples/basic/Cargo.toml"
   ],
   "python.analysis.autoImportCompletions": false,
-  "python.analysis.typeCheckingMode": "off"
+  "python.analysis.typeCheckingMode": "off",
+  "go.testFlags": [
+      "-race",
+      "-covermode=atomic"
+  ]
 }


### PR DESCRIPTION
Description
-----------
I use the go test tooling in vscode a lot and find it convenient. This PR adds the race detection flags that we use in CI to the vscode config.

