### PR TITLE
refactor: create observabilitytest.NewTestLogger

### DIFF
--- a/core/internal/api/api_test.go
+++ b/core/internal/api/api_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/apitest"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	wbsettings "github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -120,7 +120,7 @@ func newClient(
 
 	credentialProvider, err := api.NewCredentialProvider(
 		settings,
-		observability.NewNoOpLogger().Logger,
+		observabilitytest.NewTestLogger(t).Logger,
 	)
 	require.NoError(t, err)
 
@@ -146,12 +146,15 @@ func TestNewClientWithProxy(t *testing.T) {
 	settings := wbsettings.From(&spb.Settings{
 		ApiKey: &wrapperspb.StringValue{Value: "test_api_key"},
 	})
-	credentialProvider, err := api.NewCredentialProvider(settings, observability.NewNoOpLogger().Logger)
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
 	require.NoError(t, err)
 
 	backend := api.New(api.BackendOptions{
 		BaseURL:            &url.URL{Scheme: "http", Host: "api.example.com"},
-		Logger:             observability.NewNoOpLogger().Logger,
+		Logger:             observabilitytest.NewTestLogger(t).Logger,
 		CredentialProvider: credentialProvider,
 	})
 

--- a/core/internal/api/credentials_test.go
+++ b/core/internal/api/credentials_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/apitest"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	wbsettings "github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"golang.org/x/sync/errgroup"
@@ -22,7 +22,10 @@ func TestNewAPIKeyCredentialProvider(t *testing.T) {
 	settings := wbsettings.From(&spb.Settings{
 		ApiKey: &wrapperspb.StringValue{Value: "test-api-key"},
 	})
-	credentialProvider, err := api.NewCredentialProvider(settings, observability.NewNoOpLogger().Logger)
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
@@ -35,7 +38,10 @@ func TestNewAPIKeyCredentialProvider(t *testing.T) {
 
 func TestNewAPIKeyCredentialProvider_NoAPIKey(t *testing.T) {
 	settings := wbsettings.From(&spb.Settings{})
-	_, err := api.NewCredentialProvider(settings, observability.NewNoOpLogger().Logger)
+	_, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
 	assert.Error(t, err)
 }
 
@@ -87,7 +93,10 @@ func TestNewOAuth2CredentialProvider(t *testing.T) {
 		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile.Name()},
 		CredentialsFile:   &wrapperspb.StringValue{Value: credentialsFile},
 	})
-	credentialProvider, err := api.NewCredentialProvider(settings, observability.NewNoOpLogger().Logger)
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
@@ -155,7 +164,10 @@ func TestNewOAuth2CredentialProvider_RefreshesToken(t *testing.T) {
 		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile.Name()},
 		CredentialsFile:   &wrapperspb.StringValue{Value: credsFile.Name()},
 	})
-	credentialProvider, err := api.NewCredentialProvider(settings, observability.NewNoOpLogger().Logger)
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
@@ -222,7 +234,10 @@ func TestNewOAuth2CredentialProvider_RefreshesTokenOnce(t *testing.T) {
 		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile.Name()},
 		CredentialsFile:   &wrapperspb.StringValue{Value: credsFile.Name()},
 	})
-	credentialProvider, err := api.NewCredentialProvider(settings, observability.NewNoOpLogger().Logger)
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
 	require.NoError(t, err)
 
 	// issue 2 requests
@@ -291,7 +306,10 @@ func TestNewOAuth2CredentialProvider_CreatesNewTokenForNewBaseURL(t *testing.T) 
 		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile.Name()},
 		CredentialsFile:   &wrapperspb.StringValue{Value: credsFile.Name()},
 	})
-	credentialProvider, err := api.NewCredentialProvider(settings, observability.NewNoOpLogger().Logger)
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)

--- a/core/internal/debounce/debounce_test.go
+++ b/core/internal/debounce/debounce_test.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/debounce"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"golang.org/x/time/rate"
 )
 
 func TestNewDebouncer(t *testing.T) {
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	debouncer := debounce.NewDebouncer(rate.Every(time.Second), 1, logger)
 	assert.NotNil(t, debouncer)
 }
 
 func TestDebouncer(t *testing.T) {
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	debouncer := debounce.NewDebouncer(rate.Every(time.Millisecond*50), 1, logger)
 
 	count := 0

--- a/core/internal/featurechecker/features_test.go
+++ b/core/internal/featurechecker/features_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/featurechecker"
 	"github.com/wandb/wandb/core/internal/gqlmock"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -38,7 +38,7 @@ func TestServerFeaturesInitialization(t *testing.T) {
 	stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
 		mockGQL,
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	// Assert - features are not loaded until Get is called
@@ -60,7 +60,7 @@ func TestGetFeature(t *testing.T) {
 	stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
 		mockGQL,
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	// Act
@@ -85,7 +85,7 @@ func TestGetFeature_MissingWithDefaultValue(t *testing.T) {
 	stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
 		mockGQL,
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	// Act
@@ -103,7 +103,7 @@ func TestCreateFeaturesCache_WithNullGraphQLClient(t *testing.T) {
 	// Arrange
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
 		nil,
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	// Act
@@ -127,7 +127,7 @@ func TestGetFeature_GraphQLError(t *testing.T) {
 	// stubServerFeaturesQuery(mockGQL)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
 		mockGQL,
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	feature := serverFeaturesCache.GetFeature(

--- a/core/internal/filetransfer/file_transfer_azure_test.go
+++ b/core/internal/filetransfer/file_transfer_azure_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/filetransfer"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
 // the mockAzureClients mock the azure client with the following containers/blobs:
@@ -143,7 +143,7 @@ func TestAzureFileTransfer_Download(t *testing.T) {
 			AccountClients: accountClients,
 			BlobClient:     &mockAzureBlobClient{azureFile1Latest},
 		},
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -152,7 +152,7 @@ func TestAzureFileTransfer_Download(t *testing.T) {
 			AccountClients: accountClients,
 			BlobClient:     &mockAzureBlobClient{azureFile1v0},
 		},
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -161,7 +161,7 @@ func TestAzureFileTransfer_Download(t *testing.T) {
 			AccountClients: accountClients,
 			BlobClient:     &mockAzureBlobClient{azureFile2},
 		},
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -313,7 +313,7 @@ func TestAzureFileTransfer_Upload(t *testing.T) {
 		&filetransfer.AzureClientOverrides{
 			BlockBlobClient: &mockAzureBlockBlobClient,
 		},
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -349,7 +349,7 @@ func TestAzureFileTransfer_UploadOffsetChunkOverlong(t *testing.T) {
 		&filetransfer.AzureClientOverrides{
 			BlockBlobClient: &mockAzureBlockBlobClient{},
 		},
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -392,7 +392,7 @@ func TestAzureFileTransfer_UploadClientError(t *testing.T) {
 		&filetransfer.AzureClientOverrides{
 			BlockBlobClient: &mockAzureBlockBlobClient,
 		},
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 

--- a/core/internal/filetransfer/file_transfer_default_test.go
+++ b/core/internal/filetransfer/file_transfer_default_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/filetransfer"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
 func TestDefaultFileTransfer_Download(t *testing.T) {
@@ -36,7 +36,7 @@ func TestDefaultFileTransfer_Download(t *testing.T) {
 	// Creating a file transfer
 	ft := filetransfer.NewDefaultFileTransfer(
 		retryablehttp.NewClient(),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -98,7 +98,7 @@ func TestDefaultFileTransfer_Upload(t *testing.T) {
 	// Creating a file transfer
 	ft := filetransfer.NewDefaultFileTransfer(
 		retryablehttp.NewClient(),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -136,7 +136,7 @@ func TestDefaultFileTransfer_UploadOffsetChunk(t *testing.T) {
 
 	ft := filetransfer.NewDefaultFileTransfer(
 		impatientClient(),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -169,7 +169,7 @@ func TestDefaultFileTransfer_UploadOffsetChunkOverlong(t *testing.T) {
 
 	ft := filetransfer.NewDefaultFileTransfer(
 		impatientClient(),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -229,7 +229,7 @@ func TestDefaultFileTransfer_UploadContextCancelled(t *testing.T) {
 	}))
 	ft := filetransfer.NewDefaultFileTransfer(
 		impatientClient(),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -255,7 +255,7 @@ func TestDefaultFileTransfer_UploadNoServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	ft := filetransfer.NewDefaultFileTransfer(
 		impatientClient(),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 
@@ -288,7 +288,7 @@ func uploadToServerWithHandler(
 	defer server.Close()
 	ft := filetransfer.NewDefaultFileTransfer(
 		impatientClient(),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 

--- a/core/internal/filetransfer/file_transfer_gcs_test.go
+++ b/core/internal/filetransfer/file_transfer_gcs_test.go
@@ -5,7 +5,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/wandb/wandb/core/internal/filetransfer"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
 type mockGCSClient struct {
@@ -63,7 +63,7 @@ func TestGCSFileTransfer_Download(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ft := filetransfer.NewGCSFileTransfer(
 				mockGCSClient,
-				observability.NewNoOpLogger(),
+				observabilitytest.NewTestLogger(t),
 				filetransfer.NewFileTransferStats(),
 			)
 			err := ft.Download(tt.task)

--- a/core/internal/filetransfer/file_transfer_s3_test.go
+++ b/core/internal/filetransfer/file_transfer_s3_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/filetransfer"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
 // mockS3Client mocks the s3 client with the following buckets/objects:
@@ -240,7 +240,7 @@ func TestS3FileTransfer_Download(t *testing.T) {
 
 	ft := filetransfer.NewS3FileTransfer(
 		mockS3Client,
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		filetransfer.NewFileTransferStats(),
 	)
 

--- a/core/internal/gitops/git_test.go
+++ b/core/internal/gitops/git_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/gitops"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
 func setupTestRepo() (string, func(), error) {
@@ -62,7 +62,7 @@ func TestIsAvailable(t *testing.T) {
 	}
 	defer cleanup()
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	git := gitops.New(repoPath, logger)
 	available := git.IsAvailable()
 	assert.True(t, available)
@@ -75,7 +75,7 @@ func TestLatestCommit(t *testing.T) {
 	}
 	defer cleanup()
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	git := gitops.New(repoPath, logger)
 	latest, err := git.LatestCommit("HEAD")
 	assert.NoError(t, err)
@@ -105,7 +105,7 @@ func TestSavePatch(t *testing.T) {
 	}()
 	outputPath := filepath.Join(tempDir, "diff.patch")
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	git := gitops.New(repoPath, logger)
 	err = git.SavePatch("HEAD", outputPath)
 	assert.NoError(t, err)

--- a/core/internal/monitor/cwmetadata_test.go
+++ b/core/internal/monitor/cwmetadata_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wandb/wandb/core/internal/gqlmock"
 	"github.com/wandb/wandb/core/internal/monitor"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -179,7 +180,7 @@ func TestCoreWeaveMetadataProbe(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := observability.NewNoOpLogger()
+			logger := observabilitytest.NewTestLogger(t)
 			mockGQLClient := gqlmock.NewMockClient()
 			if tc.setupGQLMock != nil {
 				tc.setupGQLMock(mockGQLClient)

--- a/core/internal/monitor/dcgm_exporter_test.go
+++ b/core/internal/monitor/dcgm_exporter_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/monitor"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -72,7 +72,7 @@ func TestParsePromQLURL(t *testing.T) {
 }
 
 func TestNewDCGMExporter(t *testing.T) {
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 
 	tests := []struct {
 		name        string
@@ -147,7 +147,7 @@ func TestSample(t *testing.T) {
 	}))
 	defer server.Close()
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	client := retryablehttp.NewClient()
 	client.HTTPClient.Timeout = time.Second * 5
 
@@ -214,7 +214,7 @@ func TestProbe(t *testing.T) {
 	defer server.Close()
 
 	// Create exporter with test configuration
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	client := retryablehttp.NewClient()
 	client.HTTPClient.Timeout = time.Second * 5
 
@@ -329,7 +329,7 @@ func TestDCGMExporterAuth(t *testing.T) {
 	}))
 	defer server.Close()
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	headers := map[string]string{
 		"Authorization": "Bearer test-token-123",
 	}

--- a/core/internal/monitor/monitor_test.go
+++ b/core/internal/monitor/monitor_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/monitor"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -14,9 +14,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func newTestSystemMonitor() *monitor.SystemMonitor {
+func newTestSystemMonitor(t *testing.T) *monitor.SystemMonitor {
+	t.Helper()
 	factory := &monitor.SystemMonitorFactory{
-		Logger:             observability.NewNoOpLogger(),
+		Logger:             observabilitytest.NewTestLogger(t),
 		Settings:           settings.From(&spb.Settings{}),
 		GpuResourceManager: monitor.NewGPUResourceManager(false),
 	}
@@ -24,7 +25,7 @@ func newTestSystemMonitor() *monitor.SystemMonitor {
 }
 
 func TestSystemMonitor_BasicStateTransitions(t *testing.T) {
-	sm := newTestSystemMonitor()
+	sm := newTestSystemMonitor(t)
 
 	assert.Equal(t, monitor.StateStopped, sm.GetState())
 
@@ -42,7 +43,7 @@ func TestSystemMonitor_BasicStateTransitions(t *testing.T) {
 }
 
 func TestSystemMonitor_RepeatedCalls(t *testing.T) {
-	sm := newTestSystemMonitor()
+	sm := newTestSystemMonitor(t)
 
 	// Multiple starts
 	sm.Start(nil)
@@ -66,7 +67,7 @@ func TestSystemMonitor_RepeatedCalls(t *testing.T) {
 }
 
 func TestSystemMonitor_UnexpectedTransitions(t *testing.T) {
-	sm := newTestSystemMonitor()
+	sm := newTestSystemMonitor(t)
 
 	// Resume when stopped
 	sm.Resume()
@@ -106,7 +107,7 @@ func TestSystemMonitor_UnexpectedTransitions(t *testing.T) {
 }
 
 func TestSystemMonitor_FullCycle(t *testing.T) {
-	sm := newTestSystemMonitor()
+	sm := newTestSystemMonitor(t)
 
 	// Full cycle of operations
 	sm.Start(nil)

--- a/core/internal/monitor/openmetrics_test.go
+++ b/core/internal/monitor/openmetrics_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/monitor"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
 func randomInRange(vmin, vmax float64) float64 {
@@ -71,7 +71,7 @@ func TestDCGMNotAvailable(t *testing.T) {
 			}))
 			defer server.Close()
 
-			logger := observability.NewNoOpLogger()
+			logger := observabilitytest.NewTestLogger(t)
 			retryClient := newRetryableHTTPClient()
 			_ = monitor.NewOpenMetrics(logger, "test", server.URL, nil /* filters */, nil /* headers */, retryClient)
 		})
@@ -86,7 +86,7 @@ func TestDCGM(t *testing.T) {
 	}))
 	defer server.Close()
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	om := monitor.NewOpenMetrics(logger, "dcgm", server.URL, nil /* filters */, nil /* headers */, nil /* client */)
 
 	result, err := om.Sample()
@@ -203,7 +203,7 @@ func TestMetricFilters(t *testing.T) {
 		},
 	}
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
 			om := monitor.NewOpenMetrics(logger, tc.endpointName, "http://localhost:9400", nil /* filters */, nil /* headers */, nil /* client */)
@@ -230,7 +230,7 @@ func TestIntermittentFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	retryClient := newRetryableHTTPClient()
 	retryClient.RetryMax = 1
 	om := monitor.NewOpenMetrics(logger, "intermittent", server.URL, nil /* filters */, nil /* headers */, retryClient)
@@ -251,7 +251,7 @@ func TestIntermittentFailure(t *testing.T) {
 }
 
 func TestCache(t *testing.T) {
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	om := monitor.NewOpenMetrics(logger, "dcgm", "http://localhost:9400", nil /* filters */, nil /* headers */, nil /* client */)
 
 	filters := []monitor.Filter{
@@ -291,7 +291,7 @@ func TestOpenMetricsHeaders(t *testing.T) {
 	}))
 	defer server.Close()
 
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	headers := map[string]string{
 		"Authorization": "Bearer test-token-123",
 	}

--- a/core/internal/observabilitytest/logging.go
+++ b/core/internal/observabilitytest/logging.go
@@ -1,0 +1,20 @@
+package observabilitytest
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+// NewTestLogger returns a logger that's captured by the testing framework.
+//
+// Messages from this logger at or above INFO level are displayed in the test
+// output on failure which can be helpful for debugging.
+func NewTestLogger(t *testing.T) *observability.CoreLogger {
+	t.Helper()
+	return observability.NewCoreLogger(
+		slog.New(slog.NewJSONHandler(t.Output(), &slog.HandlerOptions{})),
+		&observability.CoreLoggerParams{},
+	)
+}

--- a/core/internal/runconsolelogs/runconsolelogs_test.go
+++ b/core/internal/runconsolelogs/runconsolelogs_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/filestreamtest"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/paths"
 	. "github.com/wandb/wandb/core/internal/runconsolelogs"
 	"github.com/wandb/wandb/core/internal/runfilestest"
@@ -29,7 +29,7 @@ func TestFileStreamUpdates(t *testing.T) {
 		ConsoleOutputFile: *outputFile,
 		FilesDir:          settings.GetFilesDir(),
 		EnableCapture:     true,
-		Logger:            observability.NewNoOpLogger(),
+		Logger:            observabilitytest.NewTestLogger(t),
 		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(
 			runfilestest.Params{},
 		),
@@ -68,7 +68,7 @@ func TestFileStreamUpdatesDisabled(t *testing.T) {
 		ConsoleOutputFile: *outputFile,
 		FilesDir:          settings.GetFilesDir(),
 		EnableCapture:     false,
-		Logger:            observability.NewNoOpLogger(),
+		Logger:            observabilitytest.NewTestLogger(t),
 		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(
 			runfilestest.Params{},
 		),

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runsync"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/runworktest"
@@ -39,7 +39,7 @@ func setup(t *testing.T) testFixtures {
 	mockRecordParser := streamtest.NewMockRecordParser(mockCtrl)
 
 	factory := runsync.RunReaderFactory{
-		Logger: observability.NewNoOpLogger(),
+		Logger: observabilitytest.NewTestLogger(t),
 	}
 
 	return testFixtures{

--- a/core/internal/runwork/runwork_test.go
+++ b/core/internal/runwork/runwork_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runwork"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
 func TestAddWorkConcurrent(t *testing.T) {
 	count := 0
-	rw := runwork.New(0, observability.NewNoOpLogger())
+	rw := runwork.New(0, observabilitytest.NewTestLogger(t))
 	wgConsumer := &sync.WaitGroup{}
 	wgConsumer.Add(1)
 	go func() {
@@ -74,7 +75,7 @@ func TestCloseDuringAddWork(t *testing.T) {
 }
 
 func TestCloseAfterClose(t *testing.T) {
-	rw := runwork.New(0, observability.NewNoOpLogger())
+	rw := runwork.New(0, observabilitytest.NewTestLogger(t))
 
 	rw.SetDone()
 	rw.SetDone()
@@ -86,7 +87,7 @@ func TestCloseAfterClose(t *testing.T) {
 
 func TestRaceAddWorkClose(t *testing.T) {
 	for range 50 {
-		rw := runwork.New(0, observability.NewNoOpLogger())
+		rw := runwork.New(0, observabilitytest.NewTestLogger(t))
 
 		go func() {
 			rw.SetDone()
@@ -98,7 +99,7 @@ func TestRaceAddWorkClose(t *testing.T) {
 }
 
 func TestCloseCancelsContext(t *testing.T) {
-	rw := runwork.New(0, observability.NewNoOpLogger())
+	rw := runwork.New(0, observabilitytest.NewTestLogger(t))
 
 	go func() {
 		rw.SetDone()
@@ -110,7 +111,7 @@ func TestCloseCancelsContext(t *testing.T) {
 }
 
 func TestCloseBlocksUntilDone(t *testing.T) {
-	rw := runwork.New(0, observability.NewNoOpLogger())
+	rw := runwork.New(0, observabilitytest.NewTestLogger(t))
 	wg := &sync.WaitGroup{}
 	count := 0
 

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wandb/wandb/core/internal/gqlmock"
 	"github.com/wandb/wandb/core/internal/mailbox"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runfiles"
 	"github.com/wandb/wandb/core/internal/runworktest"
 	wbsettings "github.com/wandb/wandb/core/internal/settings"
@@ -27,9 +28,10 @@ const validLinkArtifactResponse = `{
 	"linkArtifact": { "versionIndex": 0 }
 }`
 
-func makeSender(client graphql.Client) *stream.Sender {
+func makeSender(t *testing.T, client graphql.Client) *stream.Sender {
+	t.Helper()
 	runWork := runworktest.New()
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 	settings := wbsettings.From(&spb.Settings{
 		RunId:   &wrapperspb.StringValue{Value: "run1"},
 		Console: &wrapperspb.StringValue{Value: "off"},
@@ -71,7 +73,7 @@ func makeSender(client graphql.Client) *stream.Sender {
 // Verify that arguments are properly passed through to graphql
 func TestSendLinkArtifact(t *testing.T) {
 	mockGQL := gqlmock.NewMockClient()
-	sender := makeSender(mockGQL)
+	sender := makeSender(t, mockGQL)
 
 	// 1. When both clientId and serverId are sent, serverId is used
 	linkArtifact := &spb.Record{
@@ -181,7 +183,7 @@ func TestSendLinkArtifact(t *testing.T) {
 
 func TestSendUseArtifact(t *testing.T) {
 	mockGQL := gqlmock.NewMockClient()
-	sender := makeSender(mockGQL)
+	sender := makeSender(t, mockGQL)
 
 	useArtifact := &spb.Record{
 		RecordType: &spb.Record_UseArtifact{

--- a/core/internal/tensorboard/rootdirguesser_test.go
+++ b/core/internal/tensorboard/rootdirguesser_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/tensorboard"
 )
 
 func TestInfer_FewerThan2Directories_Fails(t *testing.T) {
-	guesser := tensorboard.NewRootDirGuesser(observability.NewNoOpLogger())
+	guesser := tensorboard.NewRootDirGuesser(observabilitytest.NewTestLogger(t))
 	path, err := tensorboard.ParseTBPath("/log/dir")
 	require.NoError(t, err)
 
@@ -21,7 +21,7 @@ func TestInfer_FewerThan2Directories_Fails(t *testing.T) {
 }
 
 func TestInfer(t *testing.T) {
-	guesser := tensorboard.NewRootDirGuesser(observability.NewNoOpLogger())
+	guesser := tensorboard.NewRootDirGuesser(observabilitytest.NewTestLogger(t))
 
 	localPath1, err := tensorboard.ParseTBPath("/tblogs/train")
 	require.NoError(t, err)

--- a/core/internal/tensorboard/tensorboard_test.go
+++ b/core/internal/tensorboard/tensorboard_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/tensorboard"
@@ -53,7 +53,7 @@ func setupTest(t *testing.T, opts testOptions) testContext {
 	settings := settings.From(settingsProto)
 
 	factory := tensorboard.TBHandlerFactory{
-		Logger:   observability.NewNoOpLogger(),
+		Logger:   observabilitytest.NewTestLogger(t),
 		Settings: settings,
 	}
 	handler := factory.New(runWork, fileReadDelay)

--- a/core/internal/tensorboard/tfeventconverter_test.go
+++ b/core/internal/tensorboard/tfeventconverter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/tensorboard"
 	"github.com/wandb/wandb/core/internal/tensorboard/tbproto"
@@ -245,7 +246,7 @@ func TestConvertStepAndTimestamp(t *testing.T) {
 		summaryEvent(
 			123, 0.345,
 			scalarValue("epoch_loss", "scalars", 0.5)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -269,19 +270,19 @@ func TestConvertScalar(t *testing.T) {
 		emitter,
 		summaryEvent(123, 0.345,
 			scalarValue("epoch_loss", "scalars", 0.5)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 	converter.ConvertNext(
 		emitter,
 		summaryEvent(123, 0.345,
 			scalarValue("epoch_loss", "scalars", float32(math.Inf(1)))),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 	converter.ConvertNext(
 		emitter,
 		summaryEvent(123, 0.345,
 			tensorValue("epoch_loss", "scalars", []int{0}, 2.5)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 	converter.ConvertNext(
 		emitter,
@@ -291,7 +292,7 @@ func TestConvertScalar(t *testing.T) {
 				"scalars",
 				tbproto.DataType_DT_DOUBLE,
 				doubleTenPointFiveBytes.Bytes())),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -324,7 +325,7 @@ func TestConvertHistogram(t *testing.T) {
 				1.0, 1.5, 10,
 				1.5, 2.0, 11,
 				2.0, 2.5, 4)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -359,7 +360,7 @@ func TestConvertHistogramProto(t *testing.T) {
 					},
 				},
 			}),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -390,7 +391,7 @@ func TestConvertHistogramRebin(t *testing.T) {
 		summaryEvent(123, 0.345,
 			tensorValue("my_hist", "histograms",
 				[]int{1000, 3}, inputTensor...)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	var result map[string]any
@@ -416,7 +417,7 @@ func TestConvertImageNoPluginName(t *testing.T) {
 		summaryEvent(123, 0.345,
 			tensorValueImage("my_img", "",
 				2, 4, testPNG2x4)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -443,7 +444,7 @@ func TestConvertImage(t *testing.T) {
 		summaryEvent(123, 0.345,
 			tensorValueStrings("my_img", "images",
 				"2", "4", testPNG2x4)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -477,7 +478,7 @@ func TestConvertBatchImages(t *testing.T) {
 		summaryEvent(123, 0.345,
 			tensorValueStrings("my_img", "images",
 				"2", "4", testPNG2x4, testPNG2x4)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -502,7 +503,7 @@ func TestConvertGif(t *testing.T) {
 		summaryEvent(123, 0.345,
 			tensorValueStrings("test_gif", "images",
 				"1", "1", testGif1x1)),
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,
@@ -584,7 +585,7 @@ func TestConvertPRCurve(t *testing.T) {
 				[]int{2, 3},
 				1, 2, 3, // precision
 				4, 5, 6)), // recall
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 
 	assert.Equal(t,

--- a/core/internal/tensorboard/tfeventreader_test.go
+++ b/core/internal/tensorboard/tfeventreader_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/paths"
 	"github.com/wandb/wandb/core/internal/tensorboard"
 	"github.com/wandb/wandb/core/internal/tensorboard/tbproto"
@@ -61,7 +61,7 @@ func TestReadsSequenceOfFiles(t *testing.T) {
 	reader := tensorboard.NewTFEventReader(
 		tmpdirAsPath,
 		tensorboard.TFEventsFileFilter{},
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 	)
 	backgroundCtx := context.Background()
 	noopOnFile := func(path *tensorboard.LocalOrCloudPath) {}

--- a/core/pkg/artifacts/multipart_test.go
+++ b/core/pkg/artifacts/multipart_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
 func TestCreateMultiPartRequest_EmptyFile(t *testing.T) {
@@ -19,7 +19,10 @@ func TestCreateMultiPartRequest_EmptyFile(t *testing.T) {
 	defer tempFile.Close()
 
 	// Returns nil, nil for empty file (and any file that is smaller than 2GB)
-	parts, err := createMultiPartRequest(observability.NewNoOpLogger(), tempFile.Name())
+	parts, err := createMultiPartRequest(
+		observabilitytest.NewTestLogger(t),
+		tempFile.Name(),
+	)
 	require.NoError(t, err)
 	assert.Nil(t, parts)
 }
@@ -74,7 +77,7 @@ func TestComputeMultipartHashes(t *testing.T) {
 	require.NoError(t, err)
 
 	p := tempFile.Name()
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 
 	// Invalid chunk size, larger than file, e.g. 22MB
 	_, err = computeMultipartHashes(logger, p, fileSize, fileSize+1, 1)
@@ -115,7 +118,7 @@ func TestComputeMultipartHashes(t *testing.T) {
 }
 
 func TestComputeMultipartHashesInvalidFile(t *testing.T) {
-	logger := observability.NewNoOpLogger()
+	logger := observabilitytest.NewTestLogger(t)
 
 	// Test with a non-existent file path
 	invalidPath := t.TempDir() + "/must_be_404.txt"

--- a/core/pkg/artifacts/saver_test.go
+++ b/core/pkg/artifacts/saver_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/filetransfertest"
 	"github.com/wandb/wandb/core/internal/gqlmock"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"go.uber.org/mock/gomock"
 )
@@ -48,7 +48,7 @@ func TestSaveGraphQLRequest(t *testing.T) {
 	ftm := filetransfertest.NewFakeFileTransferManager()
 	ftm.ShouldCompleteImmediately = true
 	saver := NewArtifactSaveManager(
-		observability.NewNoOpLogger(),
+		observabilitytest.NewTestLogger(t),
 		mockGQL,
 		ftm,
 		true,

--- a/core/pkg/launch/job_builder_test.go
+++ b/core/pkg/launch/job_builder_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/gqlmock"
-	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	. "github.com/wandb/wandb/core/pkg/launch"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -100,7 +100,7 @@ func TestJobBuilderRepo(t *testing.T) {
 			RunId:    toWrapperPb("testRunId").(*wrapperspb.StringValue),
 			FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifact, err := jobBuilder.Build(ctx, gql, nil, nil)
 		assert.Nil(t, err)
 		assert.Equal(t, "job-example.com__path_to_train.py", artifact.Name)
@@ -167,7 +167,7 @@ func TestJobBuilderRepo(t *testing.T) {
 			XJupyter:     toWrapperPb(true).(*wrapperspb.BoolValue),
 			XJupyterRoot: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifact, err := jobBuilder.Build(ctx, gql, nil, nil)
 		assert.Nil(t, err)
 		assert.Equal(t, "job-example.com_Untitled.ipynb", artifact.Name)
@@ -220,7 +220,7 @@ func TestJobBuilderArtifact(t *testing.T) {
 			RunId:    toWrapperPb("testRunId").(*wrapperspb.StringValue),
 			FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifactRecord := &spb.ArtifactRecord{
 			Name: "testArtifact",
 			Type: "code",
@@ -288,7 +288,7 @@ func TestJobBuilderArtifact(t *testing.T) {
 			XJupyter:     toWrapperPb(true).(*wrapperspb.BoolValue),
 			XJupyterRoot: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifactRecord := &spb.ArtifactRecord{
 			Name: "testArtifact",
 			Type: "code",
@@ -346,7 +346,7 @@ func TestJobBuilderImage(t *testing.T) {
 			RunId:    toWrapperPb("testRunId").(*wrapperspb.StringValue),
 			FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifact, err := jobBuilder.Build(ctx, gql, nil, nil)
 		assert.Nil(t, err)
 		assert.Equal(t, "job-testImage", artifact.Name)
@@ -386,7 +386,7 @@ func TestJobBuilderDisabledOrMissingFiles(t *testing.T) {
 				Value: true,
 			},
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifact, err := jobBuilder.Build(ctx, gql, nil, nil)
 		assert.Nil(t, err)
 		assert.Nil(t, artifact)
@@ -399,7 +399,7 @@ func TestJobBuilderDisabledOrMissingFiles(t *testing.T) {
 		settings := &spb.Settings{
 			FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifact, err := jobBuilder.Build(ctx, gql, nil, nil)
 		assert.Nil(t, artifact)
 		assert.Nil(t, err)
@@ -417,7 +417,7 @@ func TestJobBuilderDisabledOrMissingFiles(t *testing.T) {
 			FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
 
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifact, err := jobBuilder.Build(ctx, gql, nil, nil)
 		assert.Nil(t, artifact)
 		assert.NotNil(t, err)
@@ -441,7 +441,7 @@ func TestJobBuilderDisabledOrMissingFiles(t *testing.T) {
 		settings := &spb.Settings{
 			FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		artifact, err := jobBuilder.Build(ctx, gql, nil, nil)
 		assert.Nil(t, artifact)
 		assert.Nil(t, err)
@@ -482,7 +482,7 @@ func TestJobBuilderHandleUseArtifactRecord(t *testing.T) {
 			},
 		}
 
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		jobBuilder.HandleUseArtifactRecord(artifactRecord)
 		assert.Equal(t, "testID", *jobBuilder.PartialJobID)
 	})
@@ -499,7 +499,7 @@ func TestJobBuilderHandleUseArtifactRecord(t *testing.T) {
 				},
 			},
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		jobBuilder.HandleUseArtifactRecord(artifactRecord)
 		assert.True(t, jobBuilder.Disable)
 
@@ -528,7 +528,7 @@ func TestJobBuilderHandleUseArtifactRecord(t *testing.T) {
 				},
 			},
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		jobBuilder.HandleUseArtifactRecord(artifactRecord)
 		assert.True(t, jobBuilder.Disable)
 	})
@@ -567,7 +567,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 				expectedError:      &noRepoIngredientsError,
 			},
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		for _, testCase := range testCases {
 			res, err := jobBuilder.GetSourceType(testCase.metadata)
 			if testCase.expectedSourceType != nil {
@@ -611,7 +611,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 		}
 
 		for index, testCase := range testCases {
-			jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+			jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 			if index == 0 {
 				jobBuilder.SetRunCodeArtifact("testID", "testName")
 			}
@@ -658,7 +658,7 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 				expectedError:      &noImageIngredientsError,
 			},
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		for _, testCase := range testCases {
 
 			res, err := jobBuilder.GetSourceType(testCase.metadata)
@@ -688,7 +688,7 @@ func TestUtilFunctions(t *testing.T) {
 		settings := &spb.Settings{
 			XJupyterRoot: toWrapperPb("/path/to/jupyterRoot").(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		path, err := jobBuilder.HandlePathsAboveRoot("gitRoot/a/notebook.ipynb", "/path/to/jupyterRoot/gitRoot")
 		assert.Nil(t, err)
 		assert.Equal(t, "a/notebook.ipynb", path)
@@ -697,7 +697,7 @@ func TestUtilFunctions(t *testing.T) {
 		settings := &spb.Settings{
 			XJupyterRoot: toWrapperPb("/path/to/gitRoot/jupyterRoot").(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		path, err := jobBuilder.HandlePathsAboveRoot("a/notebook.ipynb", "/path/to/gitRoot")
 		assert.Nil(t, err)
 		assert.Equal(t, "jupyterRoot/a/notebook.ipynb", path)
@@ -707,7 +707,7 @@ func TestUtilFunctions(t *testing.T) {
 		settings := &spb.Settings{
 			XJupyterRoot: toWrapperPb("/path/to/gitRoot").(*wrapperspb.StringValue),
 		}
-		jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+		jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 		path, err := jobBuilder.HandlePathsAboveRoot("a/notebook.ipynb", "/path/to/gitRoot")
 		assert.Nil(t, err)
 		assert.Equal(t, "a/notebook.ipynb", path)
@@ -746,7 +746,7 @@ func TestWandbConfigParameters(t *testing.T) {
 		RunId:    toWrapperPb("testRunId").(*wrapperspb.StringValue),
 		FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 	}
-	jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+	jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 	runConfig := map[string]interface{}{
 		"key1": "value1",
 		"key2": "value2",
@@ -833,7 +833,7 @@ func TestWandbConfigParametersWithInputSchema(t *testing.T) {
 		RunId:    toWrapperPb("testRunId").(*wrapperspb.StringValue),
 		FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 	}
-	jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+	jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 	runConfig := map[string]interface{}{
 		"key1": "value1",
 		"key2": "value2",
@@ -930,7 +930,7 @@ func TestConfigFileParameters(t *testing.T) {
 		RunId:    toWrapperPb("testRunId").(*wrapperspb.StringValue),
 		FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 	}
-	jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+	jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 
 	jobBuilder.HandleJobInputRequest(&spb.JobInputRequest{
 		InputSource: &spb.JobInputSource{
@@ -1009,7 +1009,7 @@ func TestConfigFileParametersWithInputSchema(t *testing.T) {
 		RunId:    toWrapperPb("testRunId").(*wrapperspb.StringValue),
 		FilesDir: toWrapperPb(fdir).(*wrapperspb.StringValue),
 	}
-	jobBuilder := NewJobBuilder(settings, observability.NewNoOpLogger(), true)
+	jobBuilder := NewJobBuilder(settings, observabilitytest.NewTestLogger(t), true)
 
 	inputSchema, _ := json.Marshal(map[string]interface{}{
 		"type": "object",


### PR DESCRIPTION
Unlike `NewNoOpLogger()`, this creates a logger whose logged messages show up in test output on failure.

Updated most uses of `NewNoOpLogger()` in tests so that `NewTestLogger()` is the preferred convention.