### PR TITLE
fix(sdk): make project.internalId optional in gql query for runs

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -90,7 +90,31 @@ RUN_FRAGMENT = """fragment RunFragment on Run {
 def _server_provides_internal_id_for_project(client) -> bool:
     """Returns True if the server allows us to query the internalId field for a project.
 
-    This check is done by utilizing GraphQL introspection in the available fields on the Project type.
+    This check is done by utilizing GraphQL introspection in the available fields on the project type.
+    """
+    query_string = """
+       query ProbeProjectInput {
+            ProjectType: __type(name:"Project") {
+                fields {
+                    name
+                }
+            }
+        }
+    """
+
+    # Only perform the query once to avoid extra network calls
+    query = gql(query_string)
+    res = client.execute(query)
+    return "internalId" in [
+        x["name"] for x in (res.get("ProjectType", {}).get("fields", [{}]))
+    ]
+
+
+@normalize_exceptions
+def _server_provides_project_id_for_run(client) -> bool:
+    """Returns True if the server allows us to query the projectId field for a run.
+
+    This check is done by utilizing GraphQL introspection in the available fields on the run type.
     """
     query_string = """
        query ProbeRunInput {
@@ -209,13 +233,13 @@ class Runs(SizedPaginator["Run"]):
             f"""#graphql
             query Runs($project: String!, $entity: String!, $cursor: String, $perPage: Int = 50, $order: String, $filters: JSONString) {{
                 project(name: $project, entityName: $entity) {{
-                    internalId
+                    {"internalId" if _server_provides_internal_id_for_project(client) else ""}
                     runCount(filters: $filters)
                     readOnly
                     runs(filters: $filters, after: $cursor, first: $perPage, order: $order) {{
                         edges {{
                             node {{
-                                {"projectId" if _server_provides_internal_id_for_project(client) else ""}
+                                {"projectId" if _server_provides_project_id_for_run(client) else ""}
                                 ...RunFragment
                             }}
                             cursor
@@ -603,7 +627,7 @@ class Run(Attrs):
             query Run($project: String!, $entity: String!, $name: String!) {{
                 project(name: $project, entityName: $entity) {{
                     run(name: $name) {{
-                        {"projectId" if _server_provides_internal_id_for_project(self.client) else ""}
+                        {"projectId" if _server_provides_project_id_for_run(self.client) else ""}
                         ...RunFragment
                     }}
                 }}


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-25480

In the query for runs, only request `project.internalId` if it's available. This is because it's not available in the current server min version of `0.48.0`.

Renamed the existing `_server_provides_internal_id_for_project` to `_server_provides_project_id_for_run` because it was misnamed and actually checked for the `project_id` under `run`, and made `_server_provides_internal_id_for_project` actually check for `internal_id` under `project`.

This is a blocker for using `Api().runs()` against server `0.48.0`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
- [ ] Followup PR #10489 that uses `Api().runs()` now passes `system-tests-min-server-version-linux-3.12`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
