### PR TITLE
chore: fix data race in runwork_test.go

### DIFF
--- a/core/internal/runwork/runwork_test.go
+++ b/core/internal/runwork/runwork_test.go
@@ -87,7 +87,9 @@ func TestCloseAfterClose(t *testing.T) {
 
 func TestRaceAddWorkClose(t *testing.T) {
 	for range 50 {
-		rw := runwork.New(0, observabilitytest.NewTestLogger(t))
+		// Don't use a test logger since AddWork() can emit a warning
+		// and this test doesn't wait for goroutines to exit.
+		rw := runwork.New(0, observability.NewNoOpLogger())
 
 		go func() {
 			rw.SetDone()


### PR DESCRIPTION
Fixes a data race introduced by changing to a test logger. This particular test's goroutines can emit warnings, and since the test doesn't wait for the goroutines to complete, a goroutine can try to emit a warning after the test finishes which is invalid.

I decided against using an `errgroup.Group` or a `sync.WaitGroup` as they add too much noise without a lot of value. It's fine for the goroutines to complete after the test if they don't log.