### PR TITLE
refactor(artifacts): multipart upload/download - reduce coupling, minor perf fixes

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import atexit
-import concurrent.futures
 import contextlib
 import json
 import logging
@@ -15,10 +14,10 @@ import stat
 import tempfile
 import time
 from collections import deque
+from concurrent.futures import Executor, ThreadPoolExecutor, as_completed
 from copy import copy
 from dataclasses import asdict, dataclass, replace
 from datetime import timedelta
-from functools import partial
 from itertools import filterfalse
 from pathlib import Path, PurePosixPath
 from typing import (
@@ -50,6 +49,7 @@ from wandb.errors.term import termerror, termlog, termwarn
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_deprecated import Deprecated
 from wandb.sdk import wandb_setup
+from wandb.sdk.artifacts.storage_policies._multipart import should_multipart_download
 from wandb.sdk.data_types._dtypes import Type as WBType
 from wandb.sdk.data_types._dtypes import TypeRegistry
 from wandb.sdk.internal.internal_api import Api as InternalApi
@@ -2046,24 +2046,14 @@ class Artifact:
 
         download_logger = ArtifactDownloadLogger(nfiles=nfiles)
 
-        def _download_entry(
-            entry: ArtifactManifestEntry,
-            executor: concurrent.futures.Executor,
-            api_key: str | None,
-            cookies: dict | None,
-            headers: dict | None,
-        ) -> None:
-            _thread_local_api_settings.api_key = api_key
-            _thread_local_api_settings.cookies = cookies
-            _thread_local_api_settings.headers = headers
-
+        def _download_entry(entry: ArtifactManifestEntry, executor: Executor) -> None:
+            multipart_executor = (
+                executor
+                if should_multipart_download(entry.size, override=multipart)
+                else None
+            )
             try:
-                entry.download(
-                    root,
-                    skip_cache=skip_cache,
-                    executor=executor,
-                    multipart=multipart,
-                )
+                entry.download(root, skip_cache=skip_cache, executor=multipart_executor)
             except FileNotFoundError as e:
                 if allow_missing_references:
                     wandb.termwarn(str(e))
@@ -2074,15 +2064,23 @@ class Artifact:
                 return
             download_logger.notify_downloaded()
 
-        with concurrent.futures.ThreadPoolExecutor(64) as executor:
-            download_entry = partial(
-                _download_entry,
-                executor=executor,
-                api_key=_thread_local_api_settings.api_key,
-                cookies=_thread_local_api_settings.cookies,
-                headers=_thread_local_api_settings.headers,
-            )
+        def _init_thread(
+            api_key: str | None, cookies: dict | None, headers: dict | None
+        ) -> None:
+            """Initialize the thread-local API settings in the CURRENT thread."""
+            _thread_local_api_settings.api_key = api_key
+            _thread_local_api_settings.cookies = cookies
+            _thread_local_api_settings.headers = headers
 
+        with ThreadPoolExecutor(
+            max_workers=64,
+            initializer=_init_thread,
+            initargs=(
+                _thread_local_api_settings.api_key,
+                _thread_local_api_settings.cookies,
+                _thread_local_api_settings.headers,
+            ),
+        ) as executor:
             batch_size = env.get_artifact_fetch_file_url_batch_size()
 
             active_futures = set()
@@ -2103,7 +2101,9 @@ class Artifact:
                     #     continue
                     entry._download_url = node.direct_url
                     if (not path_prefix) or entry.path.startswith(str(path_prefix)):
-                        active_futures.add(executor.submit(download_entry, entry))
+                        active_futures.add(
+                            executor.submit(_download_entry, entry, executor=executor)
+                        )
 
                 # Wait for download threads to catch up.
                 #
@@ -2118,14 +2118,14 @@ class Artifact:
                 #   Consider this for a future change, or (depending on risk and risk tolerance)
                 #   managing this logic via asyncio instead, if viable.
                 if len(active_futures) > batch_size:
-                    for future in concurrent.futures.as_completed(active_futures):
+                    for future in as_completed(active_futures):
                         future.result()  # check for errors
                         active_futures.remove(future)
                         if len(active_futures) <= batch_size:
                             break
 
             # Check for errors.
-            for future in concurrent.futures.as_completed(active_futures):
+            for future in as_completed(active_futures):
                 future.result()
 
         if log:

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -182,7 +182,6 @@ class ArtifactManifestEntry:
         root: str | None = None,
         skip_cache: bool | None = None,
         executor: concurrent.futures.Executor | None = None,
-        multipart: bool | None = None,
     ) -> FilePathStr:
         """Download this artifact entry to the specified root path.
 
@@ -193,11 +192,10 @@ class ArtifactManifestEntry:
         Returns:
             (str): The path of the downloaded artifact entry.
         """
-        if self._parent_artifact is None:
-            raise NotImplementedError
+        artifact = self.parent_artifact()
 
-        root = root or self._parent_artifact._default_root()
-        self._parent_artifact._add_download_root(root)
+        root = root or artifact._default_root()
+        artifact._add_download_root(root)
         path = str(Path(self.path))
         dest_path = os.path.join(root, path)
 
@@ -225,16 +223,12 @@ class ArtifactManifestEntry:
                 return FilePathStr(dest_path)
 
         if self.ref is not None:
-            cache_path = self._parent_artifact.manifest.storage_policy.load_reference(
+            cache_path = artifact.manifest.storage_policy.load_reference(
                 self, local=True, dest_path=override_cache_path
             )
         else:
-            cache_path = self._parent_artifact.manifest.storage_policy.load_file(
-                self._parent_artifact,
-                self,
-                dest_path=override_cache_path,
-                executor=executor,
-                multipart=multipart,
+            cache_path = artifact.manifest.storage_policy.load_file(
+                artifact, self, dest_path=override_cache_path, executor=executor
             )
 
         # Determine the final path

--- a/wandb/sdk/artifacts/storage_policies/_multipart.py
+++ b/wandb/sdk/artifacts/storage_policies/_multipart.py
@@ -1,0 +1,187 @@
+"""Helpers and constants for multipart upload and download."""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+from concurrent.futures import FIRST_EXCEPTION, Executor, wait
+from dataclasses import dataclass, field
+from queue import Queue
+from typing import Any, Final, Iterator, Union
+
+from requests import Session
+from typing_extensions import TypeAlias, TypeIs, final
+
+from wandb import env
+from wandb.sdk.artifacts.artifact_file_cache import Opener
+
+logger = logging.getLogger(__name__)
+
+KiB: Final[int] = 1024
+MiB: Final[int] = 1024**2
+GiB: Final[int] = 1024**3
+TiB: Final[int] = 1024**4
+
+# AWS S3 max upload parts without having to make additional requests for extra parts
+MAX_PARTS = 1_000
+MIN_MULTI_UPLOAD_SIZE = 2 * GiB
+MAX_MULTI_UPLOAD_SIZE = 5 * TiB
+
+# Minimum size to switch to multipart download, same threshold as upload.
+MIN_MULTI_DOWNLOAD_SIZE = MIN_MULTI_UPLOAD_SIZE
+
+# Multipart download part size is same as multpart upload size, which is hard coded to 100MB.
+# https://github.com/wandb/wandb/blob/7b2a13cb8efcd553317167b823c8e52d8c3f7c4e/core/pkg/artifacts/saver.go#L496
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-guidelines.html#optimizing-performance-guidelines-get-range
+MULTI_DEFAULT_PART_SIZE = 100 * MiB
+
+# Chunk size for reading http response and writing to disk.
+RSP_CHUNK_SIZE = 1 * MiB
+
+
+@final
+class _ChunkSentinel:
+    """Signals the end of the multipart chunk queue.
+
+    Queue consumer(s) (file writer) should terminate on receiving an item of this type from the queue.
+    Do not instantiate this class directly, use the `END_CHUNK` constant as a pseudo-singleton instead.
+
+    NOTE: As implemented, this should only be used in multi-threaded (not multi-process) contexts, as
+    it's not currently guaranteed to be process-safe.
+    """
+
+    def __repr__(self) -> str:
+        return "ChunkSentinel"
+
+
+END_CHUNK: Final[_ChunkSentinel] = _ChunkSentinel()
+
+
+def is_end_chunk(obj: Any) -> TypeIs[_ChunkSentinel]:
+    """Returns True if the object is the terminal queue item for multipart downloads."""
+    # Needed for type checking, since _ChunkSentinel isn't formally a singleton.
+    return obj is END_CHUNK
+
+
+@dataclass(frozen=True)
+class ChunkContent:
+    __slots__ = ("offset", "data")  # slots=True only introduced in Python 3.10
+    offset: int
+    data: bytes
+
+
+QueuedChunk: TypeAlias = Union[ChunkContent, _ChunkSentinel]
+
+
+def should_multipart_download(size: int | None, override: bool | None = None) -> bool:
+    return ((size or 0) >= MIN_MULTI_DOWNLOAD_SIZE) if (override is None) else override
+
+
+def calc_part_size(file_size: int, min_part_size: int = MULTI_DEFAULT_PART_SIZE) -> int:
+    # Default to a chunk size of 100MiB. S3 has a cap of 10,000 upload parts.
+    return max(math.ceil(file_size / MAX_PARTS), min_part_size)
+
+
+def scan_chunks(path: str, chunk_size: int) -> Iterator[bytes]:
+    with open(path, "rb") as f:
+        while data := f.read(chunk_size):
+            yield data
+
+
+@dataclass
+class MultipartDownloadContext:
+    q: Queue[QueuedChunk]
+    cancel: threading.Event = field(default_factory=threading.Event)
+
+
+def multipart_download(
+    executor: Executor,
+    session: Session,
+    url: str,
+    size: int,
+    cached_open: Opener,
+    part_size: int = MULTI_DEFAULT_PART_SIZE,
+):
+    """Download file as multiple parts in parallel.
+
+    Only one thread for writing to file. Each part run one http request in one thread.
+    HTTP response chunk of a file part is sent to the writer thread via a queue.
+    """
+    # ------------------------------------------------------------------------------
+    # Shared between threads
+    ctx = MultipartDownloadContext(q=Queue(maxsize=500))
+
+    # Put cache_open at top so we remove the tmp file when there is network error.
+    with cached_open("wb") as f:
+
+        def download_chunk(start: int, end: int | None = None) -> None:
+            # Error from another thread, no need to start
+            if ctx.cancel.is_set():
+                return
+
+            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range
+            # Start and end are both inclusive, empty end means use the actual end of the file.
+            # e.g. "bytes=0-499"
+            bytes_range = f"{start}-" if (end is None) else f"{start}-{end}"
+            headers = {"Range": f"bytes={bytes_range}"}
+            with session.get(url=url, headers=headers, stream=True) as rsp:
+                offset = start
+                for chunk in rsp.iter_content(chunk_size=RSP_CHUNK_SIZE):
+                    if ctx.cancel.is_set():
+                        return
+                    ctx.q.put(ChunkContent(offset=offset, data=chunk))
+                    offset += len(chunk)
+
+        def write_chunks() -> None:
+            # If all chunks are written or there's an error in another thread, shutdown
+            while not (ctx.cancel.is_set() or is_end_chunk(chunk := ctx.q.get())):
+                try:
+                    # NOTE: Seek works without pre allocating the file on disk.
+                    # It automatically creates a sparse file, e.g. ls -hl would show
+                    # a bigger size compared to du -sh * because downloading different
+                    # chunks is not a sequential write.
+                    # See https://man7.org/linux/man-pages/man2/lseek.2.html
+                    f.seek(chunk.offset)
+                    f.write(chunk.data)
+
+                except Exception as e:
+                    if env.is_debug():
+                        logger.debug(f"Error writing chunk to file: {e}")
+                    ctx.cancel.set()
+                    raise
+
+        # Start writer thread first.
+        write_future = executor.submit(write_chunks)
+
+        # Start download threads for each chunk.
+        download_futures = set()
+        for start in range(0, size, part_size):
+            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range
+            # Start and end are both inclusive, empty end means use the actual end of the file.
+            # e.g. bytes=0-499
+            end = end if (end := (start + part_size - 1)) < size else None
+            download_futures.add(executor.submit(download_chunk, start=start, end=end))
+
+        # Wait for download
+        done, not_done = wait(download_futures, return_when=FIRST_EXCEPTION)
+        try:
+            for fut in done:
+                fut.result()
+        except Exception as e:
+            if env.is_debug():
+                logger.debug(f"Error downloading file: {e}")
+            ctx.cancel.set()
+
+            # Cancel any pending futures.  Note:
+            # - `Future.cancel()` does NOT stop the future if it's running, which is why
+            #   there's a separate `threading.Event` to ensure cooperative cancellation.
+            # - Once Python 3.8 support is dropped, replace these `fut.cancel()`
+            #   calls with `Executor.shutdown(cancel_futures=True)`.
+            for fut in not_done:
+                fut.cancel()
+            raise
+        finally:
+            # Always signal the writer to stop
+            ctx.q.put(END_CHUNK)
+            write_future.result()

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -3,32 +3,35 @@
 from __future__ import annotations
 
 import concurrent.futures
-import functools
 import hashlib
 import logging
-import math
 import os
-import queue
 import shutil
-import threading
 from collections import deque
-from typing import IO, TYPE_CHECKING, Any, NamedTuple
+from operator import itemgetter
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import requests
 
-from wandb import env
 from wandb.errors.term import termwarn
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk.artifacts.artifact_file_cache import (
     ArtifactFileCache,
-    Opener,
     get_artifact_file_cache,
 )
 from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.artifacts.storage_handlers.multi_handler import MultiHandler
 from wandb.sdk.artifacts.storage_handlers.tracking_handler import TrackingHandler
 from wandb.sdk.artifacts.storage_layout import StorageLayout
+from wandb.sdk.artifacts.storage_policies._multipart import (
+    MAX_MULTI_UPLOAD_SIZE,
+    MIN_MULTI_UPLOAD_SIZE,
+    KiB,
+    calc_part_size,
+    multipart_download,
+    scan_chunks,
+)
 from wandb.sdk.artifacts.storage_policies.register import WANDB_STORAGE_POLICY
 from wandb.sdk.artifacts.storage_policy import StoragePolicy
 from wandb.sdk.internal.internal_api import Api as InternalApi
@@ -44,32 +47,7 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
     from wandb.sdk.internal import progress
 
-
-# AWS S3 max upload parts without having to make additional requests for extra parts
-S3_MAX_PART_NUMBERS = 1000
-S3_MIN_MULTI_UPLOAD_SIZE = 2 * 1024**3
-S3_MAX_MULTI_UPLOAD_SIZE = 5 * 1024**4
-
-
-# Minimum size to switch to multipart download, same as upload, 2GB.
-_MULTIPART_DOWNLOAD_SIZE = S3_MIN_MULTI_UPLOAD_SIZE
-# Multipart download part size is same as multpart upload size, which is hard coded to 100MB.
-# https://github.com/wandb/wandb/blob/7b2a13cb8efcd553317167b823c8e52d8c3f7c4e/core/pkg/artifacts/saver.go#L496
-# https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-guidelines.html#optimizing-performance-guidelines-get-range
-_DOWNLOAD_PART_SIZE_BYTES = 100 * 1024 * 1024
-# Chunk size for reading http response and writing to disk. 1MB.
-_HTTP_RES_CHUNK_SIZE_BYTES = 1 * 1024 * 1024
-# Signal end of _ChunkQueue, consumer (file writer) should stop after getting this item.
-# NOTE: it should only be used for multithread executor, it does notwork for multiprocess executor.
-# multipart download is using the executor from artifact.download() which is a multithread executor.
-_CHUNK_QUEUE_SENTINEL = object()
-
 logger = logging.getLogger(__name__)
-
-
-class _ChunkContent(NamedTuple):
-    offset: int
-    data: bytes
 
 
 class WandbStoragePolicy(StoragePolicy):
@@ -117,8 +95,9 @@ class WandbStoragePolicy(StoragePolicy):
         artifact: Artifact,
         manifest_entry: ArtifactManifestEntry,
         dest_path: str | None = None,
+        # FIXME: We should avoid passing the executor into multiple inner functions,
+        # it leads to confusing code and opaque tracebacks/call stacks.
         executor: concurrent.futures.Executor | None = None,
-        multipart: bool | None = None,
     ) -> FilePathStr:
         """Use cache or download the file using signed url.
 
@@ -126,10 +105,8 @@ class WandbStoragePolicy(StoragePolicy):
             executor: Passed from caller, artifact has a thread pool for multi file download.
                 Reuse the thread pool for multi part download. The thread pool is closed when
                 artifact download is done.
-            multipart: If set to `None` (default), the artifact will be downloaded
-                in parallel using multipart download if individual file size is greater than
-                2GB. If set to `True` or `False`, the artifact will be downloaded in
-                parallel or serially regardless of the file size.
+
+                If this is None, download the file serially.
         """
         if dest_path is not None:
             self._cache._override_cache_path = dest_path
@@ -141,14 +118,10 @@ class WandbStoragePolicy(StoragePolicy):
         if hit:
             return path
 
-        if (url := manifest_entry._download_url) is not None:
+        if url := manifest_entry._download_url:
             # Use multipart parallel download for large file
-            if (
-                executor
-                and (size := manifest_entry.size)
-                and self._should_multipart_download(size, multipart)
-            ):
-                self._multipart_file_download(executor, url, size, cache_open)
+            if executor and (size := manifest_entry.size):
+                multipart_download(executor, self._session, url, size, cache_open)
                 return path
 
             # Serial download
@@ -171,141 +144,15 @@ class WandbStoragePolicy(StoragePolicy):
             else:
                 auth = ("api", self._api.api_key or "")
 
-            file_url = self._file_url(
-                self._api,
-                artifact.entity,
-                artifact.project,
-                artifact.name.split(":")[0],
-                manifest_entry,
-            )
+            file_url = self._file_url(self._api, artifact, manifest_entry)
             response = self._session.get(
                 file_url, auth=auth, cookies=cookies, headers=headers, stream=True
             )
 
         with cache_open(mode="wb") as file:
-            for data in response.iter_content(chunk_size=16 * 1024):
+            for data in response.iter_content(chunk_size=16 * KiB):
                 file.write(data)
         return path
-
-    def _should_multipart_download(
-        self,
-        file_size: int,
-        multipart: bool | None,
-    ) -> bool:
-        if multipart is not None:
-            return multipart
-        return file_size >= _MULTIPART_DOWNLOAD_SIZE
-
-    def _write_chunks_to_file(
-        self,
-        f: IO,
-        q: queue.Queue,
-        download_has_error: threading.Event,
-    ):
-        while not download_has_error.is_set():
-            item = q.get()
-            if item is _CHUNK_QUEUE_SENTINEL:
-                # Normal shutdown, all the chunks are written
-                return
-            elif isinstance(item, _ChunkContent):
-                try:
-                    # NOTE: Seek works without pre allocating the file on disk.
-                    # It automatically creates a sparse file, e.g. ls -hl would show
-                    # a bigger size compared to du -sh * because downloading different
-                    # chunks is not a sequential write.
-                    # See https://man7.org/linux/man-pages/man2/lseek.2.html
-                    f.seek(item.offset)
-                    f.write(item.data)
-                except Exception as e:
-                    if env.is_debug():
-                        logger.debug(f"Error writing chunk to file: {e}")
-                    download_has_error.set()
-                    raise
-            else:
-                raise ValueError(f"Unknown queue item type: {type(item)}")
-
-    def _download_part(
-        self,
-        download_url: str,
-        headers: dict,
-        start: int,
-        q: queue.Queue,
-        download_has_error: threading.Event,
-    ):
-        # Other threads has error, no need to start
-        if download_has_error.is_set():
-            return
-        response = self._session.get(url=download_url, headers=headers, stream=True)
-
-        file_offset = start
-        for content in response.iter_content(chunk_size=_HTTP_RES_CHUNK_SIZE_BYTES):
-            if download_has_error.is_set():
-                return
-            q.put(_ChunkContent(offset=file_offset, data=content))
-            file_offset += len(content)
-
-    def _multipart_file_download(
-        self,
-        executor: concurrent.futures.Executor,
-        download_url: str,
-        file_size_bytes: int,
-        cache_open: Opener,
-    ):
-        """Download file as multiple parts in parallel.
-
-        Only one thread for writing to file. Each part run one http request in one thread.
-        HTTP response chunk of a file part is sent to the writer thread via a queue.
-        """
-        q: queue.Queue[_ChunkContent | object] = queue.Queue(maxsize=500)
-        download_has_error = threading.Event()
-
-        # Put cache_open at top so we remove the tmp file when there is network error.
-        with cache_open("wb") as f:
-            # Start writer thread first.
-            write_handler = functools.partial(
-                self._write_chunks_to_file, f, q, download_has_error
-            )
-            write_future = executor.submit(write_handler)
-
-            # Start download threads for each part.
-            download_futures: deque[concurrent.futures.Future] = deque()
-            part_size = _DOWNLOAD_PART_SIZE_BYTES
-            num_parts = int(math.ceil(file_size_bytes / float(part_size)))
-            for i in range(num_parts):
-                # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range
-                # Start and end are both inclusive, empty end means use the actual end of the file.
-                start = i * part_size
-                bytes_range = f"bytes={start}-"
-                if i != (num_parts - 1):
-                    # bytes=0-499
-                    bytes_range += f"{start + part_size - 1}"
-                headers = {"Range": bytes_range}
-                download_handler = functools.partial(
-                    self._download_part,
-                    download_url,
-                    headers,
-                    start,
-                    q,
-                    download_has_error,
-                )
-                download_futures.append(executor.submit(download_handler))
-
-            # Wait for download
-            done, not_done = concurrent.futures.wait(
-                download_futures, return_when=concurrent.futures.FIRST_EXCEPTION
-            )
-            try:
-                for fut in done:
-                    fut.result()
-            except Exception as e:
-                if env.is_debug():
-                    logger.debug(f"Error downloading file: {e}")
-                download_has_error.set()
-                raise
-            finally:
-                # Always signal the writer to stop
-                q.put(_CHUNK_QUEUE_SENTINEL)
-                write_future.result()
 
     def store_reference(
         self,
@@ -334,13 +181,16 @@ class WandbStoragePolicy(StoragePolicy):
     def _file_url(
         self,
         api: InternalApi,
-        entity_name: str,
-        project_name: str,
-        artifact_name: str,
+        artifact: Artifact,
         entry: ArtifactManifestEntry,
     ) -> str:
         layout = self._config.get("storageLayout", StorageLayout.V1)
         region = self._config.get("storageRegion", "default")
+
+        entity_name = artifact.entity
+        project_name = artifact.project
+        artifact_name = artifact.name.split(":")[0]
+
         md5_hex = b64_to_hex_id(entry.digest)
 
         base_url: str = api.settings("base_url")
@@ -367,30 +217,21 @@ class WandbStoragePolicy(StoragePolicy):
         multipart_urls: dict[int, str],
         extra_headers: dict[str, str],
     ) -> list[dict[str, Any]]:
-        etags = []
-        part_number = 1
-
-        with open(file_path, "rb") as f:
-            while True:
-                data = f.read(chunk_size)
-                if not data:
-                    break
-                md5_b64_str = str(hex_to_b64_id(hex_digests[part_number]))
-                upload_resp = self._api.upload_multipart_file_chunk_retry(
-                    multipart_urls[part_number],
-                    data,
-                    extra_headers={
-                        "content-md5": md5_b64_str,
-                        "content-length": str(len(data)),
-                        "content-type": extra_headers.get("Content-Type", ""),
-                    },
-                )
-                assert upload_resp is not None
-                etags.append(
-                    {"partNumber": part_number, "hexMD5": upload_resp.headers["ETag"]}
-                )
-                part_number += 1
-        return etags
+        etags: deque[dict[str, Any]] = deque()
+        file_chunks = scan_chunks(file_path, chunk_size)
+        for num, data in enumerate(file_chunks, start=1):
+            rsp = self._api.upload_multipart_file_chunk_retry(
+                multipart_urls[num],
+                data,
+                extra_headers={
+                    "content-md5": hex_to_b64_id(hex_digests[num]),
+                    "content-length": str(len(data)),
+                    "content-type": extra_headers.get("Content-Type") or "",
+                },
+            )
+            assert rsp is not None
+            etags.append({"partNumber": num, "hexMD5": rsp.headers["ETag"]})
+        return list(etags)
 
     def default_file_upload(
         self,
@@ -403,19 +244,8 @@ class WandbStoragePolicy(StoragePolicy):
         with open(file_path, "rb") as file:
             # This fails if we don't send the first byte before the signed URL expires.
             self._api.upload_file_retry(
-                upload_url,
-                file,
-                progress_callback,
-                extra_headers=extra_headers,
+                upload_url, file, progress_callback, extra_headers=extra_headers
             )
-
-    def calc_chunk_size(self, file_size: int) -> int:
-        # Default to chunk size of 100MiB. S3 has cap of 10,000 upload parts.
-        # If file size exceeds the default chunk size, recalculate chunk size.
-        default_chunk_size = 100 * 1024**2
-        if default_chunk_size * S3_MAX_PART_NUMBERS < file_size:
-            return math.ceil(file_size / S3_MAX_PART_NUMBERS)
-        return default_chunk_size
 
     def store_file(
         self,
@@ -432,28 +262,20 @@ class WandbStoragePolicy(StoragePolicy):
             False if it needed to be uploaded or was a reference (nothing to dedupe).
         """
         file_size = entry.size or 0
-        chunk_size = self.calc_chunk_size(file_size)
-        upload_parts = []
-        hex_digests = {}
-        file_path = entry.local_path if entry.local_path is not None else ""
+        chunk_size = calc_part_size(file_size)
+        file_path = entry.local_path or ""
         # Logic for AWS s3 multipart upload.
         # Only chunk files if larger than 2 GiB. Currently can only support up to 5TiB.
-        if (
-            file_size >= S3_MIN_MULTI_UPLOAD_SIZE
-            and file_size <= S3_MAX_MULTI_UPLOAD_SIZE
-        ):
-            part_number = 1
-            with open(file_path, "rb") as f:
-                while True:
-                    data = f.read(chunk_size)
-                    if not data:
-                        break
-                    hex_digest = hashlib.md5(data).hexdigest()
-                    upload_parts.append(
-                        {"hexMD5": hex_digest, "partNumber": part_number}
-                    )
-                    hex_digests[part_number] = hex_digest
-                    part_number += 1
+        if MIN_MULTI_UPLOAD_SIZE <= file_size <= MAX_MULTI_UPLOAD_SIZE:
+            file_chunks = scan_chunks(file_path, chunk_size)
+            upload_parts = [
+                {"partNumber": num, "hexMD5": hashlib.md5(data).hexdigest()}
+                for num, data in enumerate(file_chunks, start=1)
+            ]
+            hex_digests = dict(map(itemgetter("partNumber", "hexMD5"), upload_parts))
+        else:
+            upload_parts = []
+            hex_digests = {}
 
         resp = preparer.prepare(
             {
@@ -467,24 +289,21 @@ class WandbStoragePolicy(StoragePolicy):
 
         entry.birth_artifact_id = resp.birth_artifact_id
 
-        multipart_urls = resp.multipart_upload_urls
         if resp.upload_url is None:
             return True
         if entry.local_path is None:
             return False
-        extra_headers = {
-            header.split(":", 1)[0]: header.split(":", 1)[1]
-            for header in (resp.upload_headers or {})
-        }
+
+        extra_headers = dict(hdr.split(":", 1) for hdr in (resp.upload_headers or []))
 
         # This multipart upload isn't available, do a regular single url upload
-        if multipart_urls is None and resp.upload_url:
+        if (multipart_urls := resp.multipart_upload_urls) is None and resp.upload_url:
             self.default_file_upload(
                 resp.upload_url, file_path, extra_headers, progress_callback
             )
+        elif multipart_urls is None:
+            raise ValueError(f"No multipart urls to upload for file: {file_path}")
         else:
-            if multipart_urls is None:
-                raise ValueError(f"No multipart urls to upload for file: {file_path}")
             # Upload files using s3 multipart upload urls
             etags = self.s3_multipart_file_upload(
                 file_path,
@@ -513,7 +332,7 @@ class WandbStoragePolicy(StoragePolicy):
 
         staging_dir = get_staging_dir()
         try:
-            if not entry.skip_cache and not hit:
+            if not (entry.skip_cache or hit):
                 with cache_open("wb") as f, open(entry.local_path, "rb") as src:
                     shutil.copyfileobj(src, f)
             if entry.local_path.startswith(staging_dir):

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -53,7 +53,6 @@ class StoragePolicy(ABC):
         manifest_entry: ArtifactManifestEntry,
         dest_path: str | None = None,
         executor: concurrent.futures.Executor | None = None,
-        multipart: bool | None = None,
     ) -> FilePathStr:
         raise NotImplementedError
 


### PR DESCRIPTION
## Description

PR:
- Refactors multipart download functionality into a dedicated, internal module (`wandb/sdk/artifacts/storage_policies/_multipart.py`)
  - Extracts multipart download logic from `WandbStoragePolicy` into `_multipart.py`
- Improves thread safety by properly initializing thread-local settings using `ThreadPoolExecutor`'s built-in `initializer`/`initargs` arguments
- Simplifies internal function signatures by removing unnecessary parameters
- Enhances code readability, clarity, idiomatic language usage

This PR reorganizes the artifact multipart download code to make it more maintainable and thread-safe. It moves the implementation details into a dedicated module while preserving the existing functionality and test coverage.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable