### PR TITLE
chore: don't use -v in the go unit tests pre-commit hook

### DIFF
--- a/core/scripts/pre-commit-hooks/run-go-unit-tests.sh
+++ b/core/scripts/pre-commit-hooks/run-go-unit-tests.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
-# From: https://github.com/dnephin/pre-commit-golang/blob/master/run-go-unit-tests.sh
 
 set -e
 
-fail() {
-  echo "unit tests failed"
-  exit 1
-}
-
-# Change to the root of the repository
-cd "$(dirname $(dirname $(dirname "$0")))" || fail
-
-# Get the list of files to test
-FILES=$(go list ./... | grep -v /vendor/) || fail
-
-# Run the unit tests
-go test -tags=unit -timeout 30s -short -v ${FILES} || fail
+cd core
+go test -timeout 30s ./...


### PR DESCRIPTION
Changes the go-unit-tests hook to not use `-v`, which produces uselessly verbose output in which it is difficult to spot a failure.

Some extra cleanup:

- Removes the `dirname` stuff beacuse pre-commit hooks always run from the repo root
- Removes the `|| fail`​ because that's what `set -e`​ is for
- Removes the `-tags=unit`​ flag; we set build tags on our tests as far as I can tell

I'm not sure about the `-short` option. It's documented as:

```
Tell long-running tests to shorten their run time.
It is off by default but set during all.bash so that installing
the Go tree can run a sanity check but not spend time running
exhaustive tests.
```

and I do not understand what this means.