### PR TITLE
chore: disable CGO when building for MacOS x86_64

### DIFF
--- a/core/hatch.py
+++ b/core/hatch.py
@@ -109,13 +109,4 @@ def _go_env(
         # -race requires cgo.
         env["CGO_ENABLED"] = "1"
 
-    if target_system == "darwin" and target_arch == "amd64":
-        # When CGO is disabled, the Go compiler's internal linker does not respect
-        # the MACOSX_DEPLOYMENT_TARGET value to lower the minimum OS version, which we rely on
-        # for building wheels for MacOS 10.x in CI. Instead, it embeds a minimum target
-        # based on the SDK in the CI runner, which as of 2025-02-20 is 11.0.
-        # To work around this, we enable CGO and force the Go compiler to use
-        # the system linker, which respects MACOSX_DEPLOYMENT_TARGET.
-        env["CGO_ENABLED"] = "1"
-
     return env


### PR DESCRIPTION
Description
-----------
#10529 removed MacOS 10 support, so CGO is no longer required when targeting x86_64 macs.