### PR TITLE
refactor: use runhandle in runfiles

### DIFF
--- a/core/internal/runconsolelogs/runconsolelogs_test.go
+++ b/core/internal/runconsolelogs/runconsolelogs_test.go
@@ -30,7 +30,7 @@ func TestFileStreamUpdates(t *testing.T) {
 		FilesDir:          settings.GetFilesDir(),
 		EnableCapture:     true,
 		Logger:            observabilitytest.NewTestLogger(t),
-		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(
+		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(t,
 			runfilestest.Params{},
 		),
 		FileStreamOrNil: fileStream,
@@ -69,7 +69,7 @@ func TestFileStreamUpdatesDisabled(t *testing.T) {
 		FilesDir:          settings.GetFilesDir(),
 		EnableCapture:     false,
 		Logger:            observabilitytest.NewTestLogger(t),
-		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(
+		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(t,
 			runfilestest.Params{},
 		),
 		FileStreamOrNil: fileStream,

--- a/core/internal/runfiles/runfiles.go
+++ b/core/internal/runfiles/runfiles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/paths"
+	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/waiting"
@@ -66,6 +67,7 @@ type UploaderFactory struct {
 	GraphQL      graphql.Client
 	Logger       *observability.CoreLogger
 	Operations   *wboperation.WandbOperations
+	RunHandle    *runhandle.RunHandle
 	Settings     *settings.Settings
 }
 

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -110,7 +110,7 @@ func TestUploader(t *testing.T) {
 
 		fakeFileWatcher = watchertest.NewFakeWatcher()
 
-		uploader = runfilestest.WithTestDefaults(
+		uploader = runfilestest.WithTestDefaults(t,
 			runfilestest.Params{
 				GraphQL:      mockGQLClient,
 				FileStream:   fakeFileStream,

--- a/core/internal/runsync/wire_gen.go
+++ b/core/internal/runsync/wire_gen.go
@@ -63,6 +63,7 @@ func InjectRunSyncerFactory(operations *wboperation.WandbOperations, settings2 *
 		GraphQL:      client,
 		Logger:       coreLogger,
 		Operations:   operations,
+		RunHandle:    runHandle,
 		Settings:     settings2,
 	}
 	mailboxMailbox := mailbox.New()

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -82,6 +82,7 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 		GraphQL:      client,
 		Logger:       coreLogger,
 		Operations:   wandbOperations,
+		RunHandle:    runHandle,
 		Settings:     settings2,
 	}
 	senderFactory := &SenderFactory{


### PR DESCRIPTION
Makes the dependency between `runfiles`​ and `RunRecord`​ more explicit by using `RunHandle`​ instead of relying on `Settings`​ having been mutated.