### PR TITLE
chore: add cleanup to handler_test.go

### DIFF
--- a/core/internal/stream/handler_test.go
+++ b/core/internal/stream/handler_test.go
@@ -37,6 +37,13 @@ func makeHandler(
 
 	go h.Do(inChan)
 
+	// Wait for the Handler goroutine to finish at the end of each test.
+	t.Cleanup(func() {
+		close(inChan)
+		for range h.OutChan() {
+		}
+	})
+
 	return h
 }
 


### PR DESCRIPTION
Without the cleanup, the Handler's `Do()` goroutine keeps running after the test, incorrectly writing to the finished test's logger in some cases.