### PR TITLE
refactor: create settings/derived.go (WIP)

### DIFF
--- a/core/internal/runconsolelogs/runconsolelogs.go
+++ b/core/internal/runconsolelogs/runconsolelogs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/paths"
 	"github.com/wandb/wandb/core/internal/runfiles"
+	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sparselist"
 	"github.com/wandb/wandb/core/internal/terminalemulator"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -53,9 +54,8 @@ type Params struct {
 	// console messages.
 	ConsoleOutputFile paths.RelativePath
 
-	// FilesDir is the directory in which to write the console output file.
-	// Note this is actually the root directory for all run files.
-	FilesDir string
+	// FilesDir is the directory in which to store the run's files.
+	FilesDir settings.FilesDir
 
 	// EnableCapture indicates whether to capture console output.
 	EnableCapture bool
@@ -101,7 +101,7 @@ func New(params Params) *Sender {
 		var err error
 		fileWriter, err = NewOutputFileWriter(
 			filepath.Join(
-				params.FilesDir,
+				string(params.FilesDir),
 				string(params.ConsoleOutputFile),
 			),
 			params.Logger,

--- a/core/internal/runconsolelogs/runconsolelogs_test.go
+++ b/core/internal/runconsolelogs/runconsolelogs_test.go
@@ -15,19 +15,15 @@ import (
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sparselist"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestFileStreamUpdates(t *testing.T) {
-	settings := settings.From(&spb.Settings{
-		FilesDir: wrapperspb.String(t.TempDir()),
-	})
 	fileStream := filestreamtest.NewFakeFileStream()
 	outputFile, _ := paths.Relative("output.log")
 
 	sender := New(Params{
 		ConsoleOutputFile: *outputFile,
-		FilesDir:          settings.GetFilesDir(),
+		FilesDir:          settings.FilesDir(t.TempDir()),
 		EnableCapture:     true,
 		Logger:            observabilitytest.NewTestLogger(t),
 		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(t,
@@ -44,7 +40,7 @@ func TestFileStreamUpdates(t *testing.T) {
 	sender.StreamLogs(&spb.OutputRawRecord{Line: "\x1b[Aline2 - modified\n"})
 	sender.Finish()
 
-	request := fileStream.GetRequest(settings)
+	request := fileStream.GetRequest(settings.New())
 	assert.Equal(t,
 		[]sparselist.Run[string]{
 			{Start: 0, Items: []string{
@@ -56,17 +52,14 @@ func TestFileStreamUpdates(t *testing.T) {
 }
 
 func TestFileStreamUpdatesDisabled(t *testing.T) {
-
 	// Test that the filestream is not updated when capture is disabled.
-	settings := settings.From(&spb.Settings{
-		FilesDir: wrapperspb.String(t.TempDir()),
-	})
+	filesDir := settings.FilesDir(t.TempDir())
 	fileStream := filestreamtest.NewFakeFileStream()
 	outputFile, _ := paths.Relative("output.log")
 
 	sender := New(Params{
 		ConsoleOutputFile: *outputFile,
-		FilesDir:          settings.GetFilesDir(),
+		FilesDir:          filesDir,
 		EnableCapture:     false,
 		Logger:            observabilitytest.NewTestLogger(t),
 		RunfilesUploaderOrNil: runfilestest.WithTestDefaults(t,
@@ -83,10 +76,10 @@ func TestFileStreamUpdatesDisabled(t *testing.T) {
 	sender.StreamLogs(&spb.OutputRawRecord{Line: "\x1b[Aline2 - modified\n"})
 	sender.Finish()
 
-	outputFilePath := filepath.Join(settings.GetFilesDir(), string(*outputFile))
+	outputFilePath := filepath.Join(string(filesDir), string(*outputFile))
 	_, err := os.Stat(outputFilePath)
 	assert.True(t, os.IsNotExist(err))
 
-	request := fileStream.GetRequest(settings)
+	request := fileStream.GetRequest(settings.New())
 	assert.Equal(t, []sparselist.Run[string]{}, request.ConsoleLines.ToRuns())
 }

--- a/core/internal/runfiles/runfiles.go
+++ b/core/internal/runfiles/runfiles.go
@@ -62,6 +62,7 @@ type UploaderTesting interface {
 
 // UploaderFactory constructs Uploader instances.
 type UploaderFactory struct {
+	FilesDir     settings.FilesDir
 	FileTransfer filetransfer.FileTransferManager
 	FileWatcher  watcher.Watcher
 	GraphQL      graphql.Client

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -113,11 +113,11 @@ func TestUploader(t *testing.T) {
 		uploader = runfilestest.WithTestDefaults(t,
 			runfilestest.Params{
 				GraphQL:      mockGQLClient,
+				FilesDir:     settings.FilesDir(filesDir),
 				FileStream:   fakeFileStream,
 				FileTransfer: fakeFileTransfer,
 				FileWatcher:  fakeFileWatcher,
 				Settings: settings.From(&spb.Settings{
-					FilesDir:    &wrapperspb.StringValue{Value: filesDir},
 					IgnoreGlobs: &spb.ListStringValue{Value: ignoreGlobs},
 					XOffline:    &wrapperspb.BoolValue{Value: isOffline},
 					XSync:       &wrapperspb.BoolValue{Value: isSync},

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -27,6 +27,7 @@ import (
 // uploader is the implementation of the Uploader interface.
 type uploader struct {
 	extraWork  runwork.ExtraWork
+	filesDir   settings.FilesDir
 	fs         filestream.FileStream
 	ftm        filetransfer.FileTransferManager
 	graphQL    graphql.Client
@@ -81,6 +82,7 @@ func newUploader(
 
 	uploader := &uploader{
 		extraWork:  extraWork,
+		filesDir:   f.FilesDir,
 		fs:         fileStream,
 		ftm:        f.FileTransfer,
 		graphQL:    f.GraphQL,
@@ -177,7 +179,7 @@ func (u *uploader) toRealPath(path string) string {
 		return path
 	}
 
-	return filepath.Join(u.settings.GetFilesDir(), path)
+	return filepath.Join(string(u.filesDir), path)
 }
 
 func (u *uploader) UploadNow(

--- a/core/internal/runfilestest/runfilestest.go
+++ b/core/internal/runfilestest/runfilestest.go
@@ -26,6 +26,7 @@ import (
 
 // Params for constructing a runfiles.Uploader for testing.
 type Params struct {
+	FilesDir     settings.FilesDir
 	FileTransfer filetransfer.FileTransferManager
 	FileWatcher  watcher.Watcher
 	GraphQL      graphql.Client
@@ -51,6 +52,10 @@ func WithTestDefaults(t *testing.T, params Params) runfiles.Uploader {
 
 	if params.Logger == nil {
 		params.Logger = observability.NewNoOpLogger()
+	}
+
+	if params.FilesDir == "" {
+		params.FilesDir = settings.FilesDir(t.TempDir())
 	}
 
 	if params.Settings == nil {
@@ -80,6 +85,7 @@ func WithTestDefaults(t *testing.T, params Params) runfiles.Uploader {
 	}
 
 	factory := &runfiles.UploaderFactory{
+		FilesDir:     params.FilesDir,
 		FileTransfer: params.FileTransfer,
 		FileWatcher:  params.FileWatcher,
 		GraphQL:      params.GraphQL,

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -1,6 +1,8 @@
 package runsync
 
 import (
+	"path/filepath"
+
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/wboperation"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -21,7 +23,7 @@ type RunSyncOperation struct {
 
 func (f *RunSyncOperationFactory) New(
 	paths []string,
-	settings *settings.Settings,
+	wandbSettings *settings.Settings,
 ) *RunSyncOperation {
 	op := &RunSyncOperation{}
 
@@ -29,7 +31,11 @@ func (f *RunSyncOperationFactory) New(
 
 	// TODO: Since settings are mutable, we need to create copies!
 	for _, path := range paths {
-		factory := InjectRunSyncerFactory(op.operations, settings)
+		factory := InjectRunSyncerFactory(
+			op.operations,
+			wandbSettings,
+			settings.SyncDir(filepath.Dir(path)),
+		)
 		op.syncers = append(op.syncers, factory.New(path))
 	}
 

--- a/core/internal/runsync/wire.go
+++ b/core/internal/runsync/wire.go
@@ -25,6 +25,7 @@ import (
 func InjectRunSyncerFactory(
 	operations *wboperation.WandbOperations,
 	settings *settings.Settings,
+	syncDir settings.SyncDir,
 ) *RunSyncerFactory {
 	wire.Build(runSyncerFactoryBindings)
 	return &RunSyncerFactory{}
@@ -43,6 +44,7 @@ var runSyncerFactoryBindings = wire.NewSet(
 	runhandle.New,
 	runReaderProviders,
 	runSyncerProviders,
+	settings.DerivedSettingsProviders,
 	sharedmode.RandomClientID,
 	stream.NewBackend,
 	stream.NewFileTransferManager,

--- a/core/internal/settings/derived.go
+++ b/core/internal/settings/derived.go
@@ -1,0 +1,33 @@
+package settings
+
+import (
+	"path/filepath"
+
+	"github.com/google/wire"
+)
+
+// This file contains settings that can affect how a run is logged.
+//
+// Since settings are not stored in the transaction log, we must be able to
+// re-derive these when syncing.
+//
+// Arguably, these should not be settings at all. This file creates types
+// to make it easier to pass these values as constructor parameters to
+// components that rely on them. All types should be passed by value.
+
+// DerivedSettingsProviders provides all derived settings.
+var DerivedSettingsProviders = wire.NewSet(InferFilesDir)
+
+// SyncDir is the path to the run's sync directory.
+//
+// For example, ".../run-20250913-123456-abcdefgh/".
+type SyncDir string
+
+// FilesDir is where a run's files are stored, including the user's files
+// saved with `run.save()` in Python and generated files like `output.log`.
+type FilesDir string
+
+func InferFilesDir(syncDir SyncDir) FilesDir {
+	// Must match the logic of wandb.Settings.files_dir
+	return FilesDir(filepath.Join(string(syncDir), "files"))
+}

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -177,19 +177,9 @@ func (s *Settings) GetInternalLogFile() string {
 	return s.Proto.LogInternal.GetValue()
 }
 
-// Absolute path to the local directory where this run's files are stored.
-func (s *Settings) GetFilesDir() string {
-	return s.Proto.FilesDir.GetValue()
-}
-
 // Unix glob patterns relative to `files_dir` to not upload.
 func (s *Settings) GetIgnoreGlobs() []string {
 	return s.Proto.IgnoreGlobs.GetValue()
-}
-
-// The directory for syncing the run from the transaction log.
-func (s *Settings) GetSyncDir() string {
-	return s.Proto.SyncDir.GetValue()
 }
 
 // The URL for the W&B backend.

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -60,6 +60,7 @@ type Stream struct {
 
 	// settings is the settings for the stream
 	settings *settings.Settings
+	syncDir  settings.SyncDir
 
 	// RecordParser turns Records into Work.
 	recordParser RecordParser
@@ -100,6 +101,7 @@ func NewStream(
 	senderFactory *SenderFactory,
 	sentry *sentry_ext.Client,
 	settings *settings.Settings,
+	syncDir settings.SyncDir,
 	runHandle *runhandle.RunHandle,
 	tbHandlerFactory *tensorboard.TBHandlerFactory,
 	writerFactory *WriterFactory,
@@ -122,6 +124,7 @@ func NewStream(
 		logger:             logger,
 		loggerFile:         loggerFile,
 		settings:           settings,
+		syncDir:            syncDir,
 		recordParser:       recordParser,
 		handler:            handlerFactory.New(runWork),
 		sender:             senderFactory.New(runWork),
@@ -244,10 +247,13 @@ func (s *Stream) FinishAndClose(exitCode int32) {
 
 	s.Close()
 
-	printFooter(s.settings)
+	printFooter(s.settings, s.syncDir)
 }
 
-func printFooter(settings *settings.Settings) {
+func printFooter(
+	settings *settings.Settings,
+	syncDir settings.SyncDir,
+) {
 	// Silent mode disables any footer output
 	if settings.IsSilent() {
 		return
@@ -262,7 +268,7 @@ func printFooter(settings *settings.Settings) {
 		formatter.Println("You can sync this run to the cloud by running:")
 		formatter.Println(
 			pfxout.WithStyle(
-				fmt.Sprintf("wandb sync %v", settings.GetSyncDir()),
+				fmt.Sprintf("wandb sync %v", string(syncDir)),
 				pfxout.Bold,
 			),
 		)

--- a/core/internal/stream/streaminject.go
+++ b/core/internal/stream/streaminject.go
@@ -31,6 +31,7 @@ func InjectStream(
 	logLevel slog.Level,
 	sentry *sentry_ext.Client,
 	settings *settings.Settings,
+	syncDir settings.SyncDir,
 ) *Stream {
 	wire.Build(streamProviders)
 	return &Stream{}
@@ -55,6 +56,7 @@ var streamProviders = wire.NewSet(
 	runfiles.UploaderProviders,
 	runhandle.New,
 	SenderProviders,
+	settings.DerivedSettingsProviders,
 	sharedmode.RandomClientID,
 	streamLoggerProviders,
 	tensorboard.TBHandlerProviders,

--- a/core/internal/tensorboard/emitter.go
+++ b/core/internal/tensorboard/emitter.go
@@ -60,11 +60,11 @@ type tfEmitter struct {
 	hasWallTime bool
 	tfWallTime  float64
 
-	settings *settings.Settings
+	filesDir settings.FilesDir
 }
 
-func NewTFEmitter(settings *settings.Settings) *tfEmitter {
-	return &tfEmitter{settings: settings}
+func NewTFEmitter(filesDir settings.FilesDir) *tfEmitter {
+	return &tfEmitter{filesDir: filesDir}
 }
 
 // Emit sends accumulated data to the run.
@@ -230,7 +230,7 @@ func (e *tfEmitter) EmitTable(
 		return err
 	}
 	runRelativePath := *maybeRunFilePath
-	fsPath := filepath.Join(e.settings.GetFilesDir(), string(runRelativePath))
+	fsPath := filepath.Join(string(e.filesDir), string(runRelativePath))
 
 	if err := e.writeDataToPath(fsPath, content); err != nil {
 		return err
@@ -274,7 +274,7 @@ func (e *tfEmitter) EmitImages(
 		}
 
 		runRelativePath := *maybeRunFilePath
-		fsPath := filepath.Join(e.settings.GetFilesDir(), string(runRelativePath))
+		fsPath := filepath.Join(string(e.filesDir), string(runRelativePath))
 
 		if err := e.writeDataToPath(fsPath, img.EncodedData); err != nil {
 			return err

--- a/core/internal/tensorboard/emitter_test.go
+++ b/core/internal/tensorboard/emitter_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/wandb/wandb/core/internal/wbvalue"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func localFlushPartialHistory(items []*spb.HistoryItem) *spb.Record {
@@ -52,7 +51,7 @@ func assertProtoEqual(t *testing.T, expected proto.Message, actual proto.Message
 }
 
 func TestAccumulatesHistory(t *testing.T) {
-	emitter := tensorboard.NewTFEmitter(settings.From(&spb.Settings{}))
+	emitter := tensorboard.NewTFEmitter(settings.FilesDir(""))
 
 	emitter.EmitHistory(pathtree.PathOf("x", "y"), "0.5")
 	emitter.EmitHistory(pathtree.PathOf("z"), `"abc"`)
@@ -70,7 +69,7 @@ func TestAccumulatesHistory(t *testing.T) {
 }
 
 func TestStepAndWallTime(t *testing.T) {
-	emitter := tensorboard.NewTFEmitter(settings.From(&spb.Settings{}))
+	emitter := tensorboard.NewTFEmitter(settings.FilesDir(""))
 
 	emitter.SetTFStep(pathtree.PathOf("train", "global_step"), 9)
 	emitter.SetTFWallTime(2.5)
@@ -90,7 +89,7 @@ func TestStepAndWallTime(t *testing.T) {
 }
 
 func TestChartModifiesConfig(t *testing.T) {
-	emitter := tensorboard.NewTFEmitter(settings.From(&spb.Settings{}))
+	emitter := tensorboard.NewTFEmitter(settings.FilesDir(""))
 	chart := wbvalue.Chart{Title: "test-title"}
 	expectedConfigJSON, err := chart.ConfigValueJSON()
 	require.NoError(t, err)
@@ -113,11 +112,7 @@ func TestChartModifiesConfig(t *testing.T) {
 
 func TestTableWritesToFile(t *testing.T) {
 	tmpdir := t.TempDir()
-	emitter := tensorboard.NewTFEmitter(
-		settings.From(&spb.Settings{
-			FilesDir: wrapperspb.String(tmpdir),
-		}),
-	)
+	emitter := tensorboard.NewTFEmitter(settings.FilesDir(tmpdir))
 	table := wbvalue.Table{
 		ColumnLabels: []string{"a", "b"},
 		Rows:         [][]any{{1, 2}, {3, 4}},
@@ -140,11 +135,7 @@ func TestTableWritesToFile(t *testing.T) {
 }
 
 func TestTableUpdatesHistory(t *testing.T) {
-	emitter := tensorboard.NewTFEmitter(
-		settings.From(&spb.Settings{
-			FilesDir: wrapperspb.String(t.TempDir()),
-		}),
-	)
+	emitter := tensorboard.NewTFEmitter(settings.FilesDir(t.TempDir()))
 	table := wbvalue.Table{
 		ColumnLabels: []string{"a", "b"},
 		Rows:         [][]any{{1, 2}, {3, 4}},
@@ -165,11 +156,7 @@ func TestTableUpdatesHistory(t *testing.T) {
 
 func TestEmitImages(t *testing.T) {
 	tmpdir := t.TempDir()
-	emitter := tensorboard.NewTFEmitter(
-		settings.From(&spb.Settings{
-			FilesDir: wrapperspb.String(tmpdir),
-		}),
-	)
+	emitter := tensorboard.NewTFEmitter(settings.FilesDir(tmpdir))
 	require.NoError(t,
 		emitter.EmitImages(
 			pathtree.PathOf("my", "image"),

--- a/core/internal/tensorboard/tensorboard_test.go
+++ b/core/internal/tensorboard/tensorboard_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/wandb/wandb/core/internal/tensorboard"
 	"github.com/wandb/wandb/core/internal/waitingtest"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // testOptions is data used to configure a test.
@@ -46,15 +45,15 @@ func setupTest(t *testing.T, opts testOptions) testContext {
 		return filepath.Join(tmpdir, filepath.FromSlash(slashPath))
 	}
 
-	settingsProto := &spb.Settings{}
+	var filesDir settings.FilesDir
 	if opts.SlashFilesDir != "" {
-		settingsProto.FilesDir = wrapperspb.String(toPath(opts.SlashFilesDir))
+		filesDir = settings.FilesDir(toPath(opts.SlashFilesDir))
 	}
-	settings := settings.From(settingsProto)
 
 	factory := tensorboard.TBHandlerFactory{
+		FilesDir: filesDir,
 		Logger:   observabilitytest.NewTestLogger(t),
-		Settings: settings,
+		Settings: settings.New(),
 	}
 	handler := factory.New(runWork, fileReadDelay)
 

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -353,6 +353,7 @@ func (nc *Connection) handleIncomingRequests() {
 // from the client. It creates a new stream, associates it with the connection.
 // Also starts the stream and adds the connection as a responder to the stream.
 func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
+	syncDir := settings.SyncDir(msg.GetSettings().GetSyncDir().GetValue())
 	settings := settings.From(msg.GetSettings())
 
 	streamId := msg.GetXInfo().GetStreamId()
@@ -373,6 +374,7 @@ func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
 		nc.logLevel,
 		nc.sentryClient,
 		settings,
+		syncDir,
 	)
 	strm.AddResponders(stream.ResponderEntry{Responder: nc, ID: nc.id})
 	strm.Start()


### PR DESCRIPTION
Creates `settings/derived.go`​ for settings that affect how a run is logged, for now just `sync_dir`​ and `files_dir`​. These are different from most other settings, which are optional and can be different when syncing.

Settings are not saved in the transaction log, so we have to be able to re-derive them when syncing. `files_dir`​ is important because `FilesRecord`​ paths are relative to it, so we can't find the files without knowing it.