### PR TITLE
chore(launch): bump launch agent go version from 1.24.5 to 1.25.1

### DIFF
--- a/tools/launch_release/build/Dockerfile
+++ b/tools/launch_release/build/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 # Download and install Go bootstrap
-# Go 1.24 ships with a package containing a critical security vulnerability.
+# Go 1.25 ships with a package containing a critical security vulnerability.
 # We will use a bootstrap version of Go to build a patched version.
-COPY --from=golang:1.24-alpine /usr/local/go/ /usr/local/go-bootstrap
+COPY --from=golang:1.25-alpine /usr/local/go/ /usr/local/go-bootstrap
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Set up Go environment for bootstrap


### PR DESCRIPTION
Fixes https://github.com/wandb/wandb/actions/runs/17930687755/job/50987127411, which fails due to:

```
go: go.mod requires go >= 1.25.1 (running go 1.24.5; GOTOOLCHAIN=local)
```

Successful build: https://github.com/wandb/wandb/actions/runs/17961957204/job/51086927759