### PR TITLE
chore: live store abstraction on top of live leveldb log reader

### DIFF
--- a/core/internal/leet/livestore.go
+++ b/core/internal/leet/livestore.go
@@ -1,0 +1,83 @@
+package leet
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/wandb/wandb/core/pkg/leveldb"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+	"google.golang.org/protobuf/proto"
+)
+
+const wandbStoreVersion = 0
+
+// LiveStore is the persistent store for a stream that may be actively
+// written to by another process.
+type LiveStore struct {
+	// db is the underlying database.
+	db *os.File
+	// reader is a LiveReader that reads records from a W&B LevelDB-style log
+	// that may be actively written.
+	reader *leveldb.LiveReader
+}
+
+func NewLiveStore(filename string) (*LiveStore, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("livestore: failed opening file: %w", err)
+	}
+	reader := leveldb.NewLiveReader(f, leveldb.CRCAlgoIEEE)
+
+	// Validate W&B header once; it's OK if it's not fully there yet (io.EOF).
+	if err := reader.VerifyWandbHeader(wandbStoreVersion); err != nil && !errors.Is(err, io.EOF) {
+		_ = f.Close()
+		return nil, fmt.Errorf("livestore: header verify: %w", err)
+	}
+	return &LiveStore{f, reader}, nil
+}
+
+// Reads the next record from the database.
+func (lr *LiveStore) Read() (*spb.Record, error) {
+	if lr.db == nil {
+		return nil, fmt.Errorf("livestore: db is closed")
+	}
+	rdr, err := lr.reader.Next()
+	if err != nil {
+		return nil, err // include io.EOF (soft)
+	}
+
+	buf, err := io.ReadAll(rdr)
+	if err != nil {
+		return nil, fmt.Errorf("livestore: read record body: %w", err)
+	}
+
+	msg := &spb.Record{}
+	if err := proto.Unmarshal(buf, msg); err != nil {
+		// Helpful debug: print first bytes of the payload
+		head := buf
+		if len(head) > 32 {
+			head = head[:32]
+		}
+		return nil, fmt.Errorf("livestore: unmarshal: %w (payload[0:32]=%s)", err, hex.EncodeToString(head))
+	}
+	return msg, nil
+}
+
+// Close closes the database.
+func (ls *LiveStore) Close() error {
+	if ls.db == nil {
+		return nil
+	}
+
+	db := ls.db
+	ls.db = nil
+
+	if err := db.Close(); err != nil {
+		return fmt.Errorf("livestore: failed closing file: %v", err)
+	}
+
+	return nil
+}

--- a/core/internal/leet/livestore_test.go
+++ b/core/internal/leet/livestore_test.go
@@ -1,0 +1,465 @@
+package leet_test
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wandb/wandb/core/internal/leet"
+	"github.com/wandb/wandb/core/internal/transactionlog"
+	"github.com/wandb/wandb/core/pkg/leveldb"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestNewLiveStore_ValidFile tests creating a LiveStore with a valid file
+func TestNewLiveStore_ValidFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "valid-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmpFile.Close()
+	// transactionlog.Writer doesn't want the file to exist
+	_ = os.Remove(tmpFile.Name())
+
+	// Write a valid header to a tranaction log.
+	w, err := transactionlog.OpenWriter(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open transaction log for writing: %v", err)
+	}
+	w.Close()
+
+	// Now open with LiveStore
+	ls, err := leet.NewLiveStore(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore failed: %v", err)
+	}
+	defer ls.Close()
+
+	// Should be able to read (will get EOF since no records)
+	_, err = ls.Read()
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("Expected EOF, got: %v", err)
+	}
+}
+
+// TestNewLiveStore_NonExistentFile tests error handling for missing files
+func TestNewLiveStore_NonExistentFile(t *testing.T) {
+	_, err := leet.NewLiveStore("/nonexistent/path/file.wandb")
+	if err == nil {
+		t.Fatal("Expected error for non-existent file")
+	}
+}
+
+// TestNewLiveStore_InvalidHeader tests handling of files with invalid headers
+func TestNewLiveStore_InvalidHeader(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "invalid-header-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Write invalid header data
+	if _, err := tmpFile.Write([]byte("INVALID_HEADER_DATA")); err != nil {
+		t.Fatalf("Failed to write invalid header: %v", err)
+	}
+	tmpFile.Close()
+
+	_, err = leet.NewLiveStore(tmpFile.Name())
+	if err == nil {
+		t.Fatal("Expected error for invalid header")
+	}
+}
+
+// TestLiveStore_ReadValidRecords tests reading valid records
+func TestLiveStore_ReadValidRecords(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "records-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmpFile.Close()
+	// transactionlog.Writer doesn't want the file to exist
+	_ = os.Remove(tmpFile.Name())
+
+	// Write records using regular Store
+	// Write a valid header to a tranaction log.
+	w, err := transactionlog.OpenWriter(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open transaction log for writing: %v", err)
+	}
+
+	records := []*spb.Record{
+		{Num: 1, Uuid: "uuid-1"},
+		{Num: 2, Uuid: "uuid-2"},
+		{Num: 3, Uuid: "uuid-3"},
+	}
+
+	for _, rec := range records {
+		if err := w.Write(rec); err != nil {
+			t.Fatalf("Failed to write record: %v", err)
+		}
+	}
+	w.Close()
+
+	// Read with LiveStore
+	ls, err := leet.NewLiveStore(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore failed: %v", err)
+	}
+	defer ls.Close()
+
+	// Read all records
+	for i, expected := range records {
+		rec, err := ls.Read()
+		if err != nil {
+			t.Fatalf("Failed to read record %d: %v", i, err)
+		}
+		if rec.Num != expected.Num || rec.Uuid != expected.Uuid {
+			t.Errorf("Record %d mismatch: got {Num:%d, Uuid:%s}, want {Num:%d, Uuid:%s}",
+				i, rec.Num, rec.Uuid, expected.Num, expected.Uuid)
+		}
+	}
+
+	// Next read should return EOF
+	_, err = ls.Read()
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("Expected EOF, got: %v", err)
+	}
+}
+
+// TestLiveStore_CloseIdempotent tests that Close can be called multiple times
+func TestLiveStore_CloseIdempotent(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "close-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmpFile.Close()
+	_ = os.Remove(tmpFile.Name())
+
+	// Write a valid header to a tranaction log.
+	w, err := transactionlog.OpenWriter(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open transaction log for writing: %v", err)
+	}
+	w.Close()
+
+	ls, err := leet.NewLiveStore(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore failed: %v", err)
+	}
+
+	// Close multiple times
+	if err := ls.Close(); err != nil {
+		t.Fatalf("First Close() failed: %v", err)
+	}
+	if err := ls.Close(); err != nil {
+		t.Fatalf("Second Close() failed: %v", err)
+	}
+	if err := ls.Close(); err != nil {
+		t.Fatalf("Third Close() failed: %v", err)
+	}
+}
+
+// TestLiveStore_ReadAfterClose tests that reading after close returns an error
+func TestLiveStore_ReadAfterClose(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "read-after-close-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmpFile.Close()
+	_ = os.Remove(tmpFile.Name())
+
+	// Create valid file with a record.
+	w, err := transactionlog.OpenWriter(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open transaction log for writing: %v", err)
+	}
+	_ = w.Write(&spb.Record{Num: 1, Uuid: "test"})
+	w.Close()
+
+	ls, err := leet.NewLiveStore(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore failed: %v", err)
+	}
+
+	// Close the LiveStore
+	ls.Close()
+
+	// Try to read after close
+	_, err = ls.Read()
+	if err == nil {
+		t.Fatal("Expected error when reading from closed LiveStore")
+	}
+	if !errors.Is(err, os.ErrClosed) && err.Error() != "livestore: db is closed" {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// TestLiveStore_LiveRead_ConcurrentWriterFlushes writes records in one goroutine
+// using the low-level LevelDB writer (so we can Flush) and reads them from another.
+// It ensures we see newly flushed records in order, and only get io.EOF between flushes.
+func TestLiveStore_LiveRead_ConcurrentWriterFlushes(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "live-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	_ = tmp.Close()
+
+	const total = 50
+
+	// Writer goroutine.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(path string) {
+		defer wg.Done()
+
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			t.Errorf("open for write: %v", err)
+			return
+		}
+		defer f.Close()
+
+		// Match LiveStore (CRCAlgoIEEE, version 0).
+		w := leveldb.NewWriterExt(f, leveldb.CRCAlgoIEEE, 0)
+
+		for i := range total {
+			rec := &spb.Record{
+				Num:  int64(i),
+				Uuid: fmt.Sprintf("uuid-%d", i),
+			}
+			payload, err := proto.Marshal(rec)
+			if err != nil {
+				t.Errorf("marshal: %v", err)
+				return
+			}
+
+			chunk, err := w.Next()
+			if err != nil {
+				t.Errorf("writer.Next: %v", err)
+				return
+			}
+			if _, err := chunk.Write(payload); err != nil {
+				t.Errorf("writer.Write: %v", err)
+				return
+			}
+			if err := w.Flush(); err != nil {
+				t.Errorf("writer.Flush: %v", err)
+				return
+			}
+
+			// Small delay to exercise reader's EOF path between records.
+			time.Sleep(2 * time.Millisecond)
+		}
+		// Finish cleanly.
+		if err := w.Close(); err != nil {
+			t.Errorf("writer.Close: %v", err)
+		}
+	}(tmp.Name())
+
+	// Reader on the same file.
+	ls, err := leet.NewLiveStore(tmp.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore: %v", err)
+	}
+	defer ls.Close()
+
+	deadline := time.After(5 * time.Second)
+	for i := 0; i < total; {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for record %d/%d", i, total)
+		default:
+			rec, err := ls.Read()
+			if err == io.EOF {
+				// No complete record yet; try again shortly.
+				time.Sleep(1 * time.Millisecond)
+				continue
+			}
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if rec.Num != int64(i) || rec.Uuid != fmt.Sprintf("uuid-%d", i) {
+				t.Fatalf("out of order: got Num=%d Uuid=%q; want Num=%d Uuid=%q", rec.Num, rec.Uuid, i, fmt.Sprintf("uuid-%d", i))
+			}
+			i++
+		}
+	}
+	wg.Wait()
+}
+
+func TestLiveStore_LiveRead_OpenedBeforeWriter(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "live-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	_ = tmp.Close()
+
+	// Start reader first: header may not exist yet; allowed by NewLiveStore.
+	ls, err := leet.NewLiveStore(tmp.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore: %v", err)
+	}
+	defer ls.Close()
+
+	// Now start the writer.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(path string) {
+		defer wg.Done()
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			t.Errorf("open for write: %v", err)
+			return
+		}
+		defer f.Close()
+		w := leveldb.NewWriterExt(f, leveldb.CRCAlgoIEEE, 0)
+
+		rec := &spb.Record{Num: 1, Uuid: "first"}
+		payload, err := proto.Marshal(rec)
+		if err != nil {
+			t.Errorf("marshal: %v", err)
+			return
+		}
+		chunk, err := w.Next()
+		if err != nil {
+			t.Errorf("writer.Next: %v", err)
+			return
+		}
+		if _, err := chunk.Write(payload); err != nil {
+			t.Errorf("writer.Write: %v", err)
+			return
+		}
+		if err := w.Flush(); err != nil {
+			t.Errorf("writer.Flush: %v", err)
+			return
+		}
+		_ = w.Close()
+	}(tmp.Name())
+
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for first record")
+		default:
+			rec, err := ls.Read()
+			if err == io.EOF {
+				time.Sleep(1 * time.Millisecond)
+				continue
+			}
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if rec.Num != 1 || rec.Uuid != "first" {
+				t.Fatalf("unexpected record: %+v", rec)
+			}
+			wg.Wait()
+			return
+		}
+	}
+}
+
+// TestLiveStore_LargeRecord tests handling of large records
+func TestLiveStore_LargeRecord(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "large-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmpFile.Close()
+	_ = os.Remove(tmpFile.Name())
+
+	w, err := transactionlog.OpenWriter(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open transaction log for writing: %v", err)
+	}
+
+	// Create a large record
+	largeData := make([]byte, 1024*1024) // 1MB
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	largeRecord := &spb.Record{
+		Num:  1,
+		Uuid: hex.EncodeToString(largeData[:16]), // Use first 16 bytes as UUID
+	}
+
+	if err := w.Write(largeRecord); err != nil {
+		t.Fatalf("Failed to write large record: %v", err)
+	}
+	w.Close()
+
+	// Read with LiveStore
+	ls, err := leet.NewLiveStore(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore failed: %v", err)
+	}
+	defer ls.Close()
+
+	rec, err := ls.Read()
+	if err != nil {
+		t.Fatalf("Failed to read large record: %v", err)
+	}
+	if rec.Num != largeRecord.Num || rec.Uuid != largeRecord.Uuid {
+		t.Errorf("Large record mismatch")
+	}
+}
+
+// TestLiveStore_PartialWrite tests handling of partial writes
+func TestLiveStore_PartialWrite(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "partial-*.wandb")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	// transactionlog.Writer doesn't want the file to exist
+	_ = os.Remove(tmpFile.Name())
+
+	// Write header
+	w, err := transactionlog.OpenWriter(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open transaction log for writing: %v", err)
+	}
+
+	// Write one complete record
+	if err := w.Write(&spb.Record{Num: 1, Uuid: "complete"}); err != nil {
+		t.Fatalf("Failed to write record: %v", err)
+	}
+	w.Close()
+
+	// Append partial record data (simulate interrupted write)
+	f, err := os.OpenFile(tmpFile.Name(), os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open for append: %v", err)
+	}
+	// Write incomplete record header
+	_, _ = f.Write([]byte{0x00, 0x00}) // Partial record that will cause read error
+	f.Close()
+
+	// Try to read
+	ls, err := leet.NewLiveStore(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("NewLiveStore failed: %v", err)
+	}
+	defer ls.Close()
+
+	// First record should be readable
+	rec, err := ls.Read()
+	if err != nil {
+		t.Fatalf("Failed to read complete record: %v", err)
+	}
+	if rec.Num != 1 {
+		t.Errorf("Expected Num=1, got %d", rec.Num)
+	}
+
+	// Second read should fail or return EOF
+	_, err = ls.Read()
+	if err == nil {
+		t.Fatal("Expected error for partial record")
+	}
+}

--- a/core/internal/leet/livestore_test.go
+++ b/core/internal/leet/livestore_test.go
@@ -1,16 +1,17 @@
 package leet_test
 
 import (
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/leet"
+	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/transactionlog"
 	"github.com/wandb/wandb/core/pkg/leveldb"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -19,182 +20,102 @@ import (
 
 // TestNewLiveStore_ValidFile tests creating a LiveStore with a valid file
 func TestNewLiveStore_ValidFile(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "valid-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	tmpFile.Close()
-	// transactionlog.Writer doesn't want the file to exist
-	_ = os.Remove(tmpFile.Name())
+	path := filepath.Join(t.TempDir(), "valid.wandb")
 
 	// Write a valid header to a tranaction log.
-	w, err := transactionlog.OpenWriter(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open transaction log for writing: %v", err)
-	}
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
 	w.Close()
 
 	// Now open with LiveStore
-	ls, err := leet.NewLiveStore(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore failed: %v", err)
-	}
+	ls, err := leet.NewLiveStore(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
 	defer ls.Close()
 
 	// Should be able to read (will get EOF since no records)
 	_, err = ls.Read()
-	if !errors.Is(err, io.EOF) {
-		t.Fatalf("Expected EOF, got: %v", err)
-	}
+	require.ErrorIs(t, err, io.EOF)
 }
 
 // TestNewLiveStore_NonExistentFile tests error handling for missing files
 func TestNewLiveStore_NonExistentFile(t *testing.T) {
-	_, err := leet.NewLiveStore("/nonexistent/path/file.wandb")
-	if err == nil {
-		t.Fatal("Expected error for non-existent file")
-	}
+	path := filepath.Join(t.TempDir(), "nonexistent.wandb")
+	_, err := leet.NewLiveStore(path, observability.NewNoOpLogger())
+	require.Error(t, err)
 }
 
 // TestNewLiveStore_InvalidHeader tests handling of files with invalid headers
 func TestNewLiveStore_InvalidHeader(t *testing.T) {
 	tmpFile, err := os.CreateTemp(t.TempDir(), "invalid-header-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
+	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 
 	// Write invalid header data
-	if _, err := tmpFile.Write([]byte("INVALID_HEADER_DATA")); err != nil {
-		t.Fatalf("Failed to write invalid header: %v", err)
-	}
+	_, err = tmpFile.Write([]byte("INVALID_HEADER_DATA"))
+	require.NoError(t, err)
 	tmpFile.Close()
 
-	_, err = leet.NewLiveStore(tmpFile.Name())
-	if err == nil {
-		t.Fatal("Expected error for invalid header")
-	}
+	_, err = leet.NewLiveStore(tmpFile.Name(), observability.NewNoOpLogger())
+	require.Error(t, err)
 }
 
 // TestLiveStore_ReadValidRecords tests reading valid records
 func TestLiveStore_ReadValidRecords(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "records-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	tmpFile.Close()
-	// transactionlog.Writer doesn't want the file to exist
-	_ = os.Remove(tmpFile.Name())
+	path := filepath.Join(t.TempDir(), "records.wandb")
 
 	// Write records using regular Store
 	// Write a valid header to a tranaction log.
-	w, err := transactionlog.OpenWriter(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open transaction log for writing: %v", err)
-	}
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
 
 	records := []*spb.Record{
-		{Num: 1, Uuid: "uuid-1"},
-		{Num: 2, Uuid: "uuid-2"},
-		{Num: 3, Uuid: "uuid-3"},
+		{Num: 1},
+		{Num: 2},
+		{Num: 3},
 	}
 
 	for _, rec := range records {
-		if err := w.Write(rec); err != nil {
-			t.Fatalf("Failed to write record: %v", err)
-		}
+		err := w.Write(rec)
+		require.NoError(t, err)
 	}
 	w.Close()
 
 	// Read with LiveStore
-	ls, err := leet.NewLiveStore(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore failed: %v", err)
-	}
+	ls, err := leet.NewLiveStore(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
 	defer ls.Close()
 
 	// Read all records
-	for i, expected := range records {
+	for _, expected := range records {
 		rec, err := ls.Read()
-		if err != nil {
-			t.Fatalf("Failed to read record %d: %v", i, err)
-		}
-		if rec.Num != expected.Num || rec.Uuid != expected.Uuid {
-			t.Errorf("Record %d mismatch: got {Num:%d, Uuid:%s}, want {Num:%d, Uuid:%s}",
-				i, rec.Num, rec.Uuid, expected.Num, expected.Uuid)
-		}
+		require.NoError(t, err)
+		require.Equal(t, rec.Num, expected.Num)
 	}
 
 	// Next read should return EOF
 	_, err = ls.Read()
-	if !errors.Is(err, io.EOF) {
-		t.Fatalf("Expected EOF, got: %v", err)
-	}
-}
-
-// TestLiveStore_CloseIdempotent tests that Close can be called multiple times
-func TestLiveStore_CloseIdempotent(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "close-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	tmpFile.Close()
-	_ = os.Remove(tmpFile.Name())
-
-	// Write a valid header to a tranaction log.
-	w, err := transactionlog.OpenWriter(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open transaction log for writing: %v", err)
-	}
-	w.Close()
-
-	ls, err := leet.NewLiveStore(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore failed: %v", err)
-	}
-
-	// Close multiple times
-	if err := ls.Close(); err != nil {
-		t.Fatalf("First Close() failed: %v", err)
-	}
-	if err := ls.Close(); err != nil {
-		t.Fatalf("Second Close() failed: %v", err)
-	}
-	if err := ls.Close(); err != nil {
-		t.Fatalf("Third Close() failed: %v", err)
-	}
+	require.ErrorIs(t, err, io.EOF)
 }
 
 // TestLiveStore_ReadAfterClose tests that reading after close returns an error
 func TestLiveStore_ReadAfterClose(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "read-after-close-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	tmpFile.Close()
-	_ = os.Remove(tmpFile.Name())
+	path := filepath.Join(t.TempDir(), "read-after-close.wandb")
 
 	// Create valid file with a record.
-	w, err := transactionlog.OpenWriter(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open transaction log for writing: %v", err)
-	}
-	_ = w.Write(&spb.Record{Num: 1, Uuid: "test"})
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
+	_ = w.Write(&spb.Record{Num: 1})
 	w.Close()
 
-	ls, err := leet.NewLiveStore(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore failed: %v", err)
-	}
+	ls, err := leet.NewLiveStore(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
 
 	// Close the LiveStore
 	ls.Close()
 
 	// Try to read after close
 	_, err = ls.Read()
-	if err == nil {
-		t.Fatal("Expected error when reading from closed LiveStore")
-	}
+	require.Error(t, err)
 	if !errors.Is(err, os.ErrClosed) && err.Error() != "livestore: db is closed" {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -205,9 +126,7 @@ func TestLiveStore_ReadAfterClose(t *testing.T) {
 // It ensures we see newly flushed records in order, and only get io.EOF between flushes.
 func TestLiveStore_LiveRead_ConcurrentWriterFlushes(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "live-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
+	require.NoError(t, err)
 	_ = tmp.Close()
 
 	const total = 50
@@ -229,10 +148,7 @@ func TestLiveStore_LiveRead_ConcurrentWriterFlushes(t *testing.T) {
 		w := leveldb.NewWriterExt(f, leveldb.CRCAlgoIEEE, 0)
 
 		for i := range total {
-			rec := &spb.Record{
-				Num:  int64(i),
-				Uuid: fmt.Sprintf("uuid-%d", i),
-			}
+			rec := &spb.Record{Num: int64(i)}
 			payload, err := proto.Marshal(rec)
 			if err != nil {
 				t.Errorf("marshal: %v", err)
@@ -263,10 +179,8 @@ func TestLiveStore_LiveRead_ConcurrentWriterFlushes(t *testing.T) {
 	}(tmp.Name())
 
 	// Reader on the same file.
-	ls, err := leet.NewLiveStore(tmp.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore: %v", err)
-	}
+	ls, err := leet.NewLiveStore(tmp.Name(), observability.NewNoOpLogger())
+	require.NoError(t, err)
 	defer ls.Close()
 
 	deadline := time.After(5 * time.Second)
@@ -281,12 +195,8 @@ func TestLiveStore_LiveRead_ConcurrentWriterFlushes(t *testing.T) {
 				time.Sleep(1 * time.Millisecond)
 				continue
 			}
-			if err != nil {
-				t.Fatalf("Read: %v", err)
-			}
-			if rec.Num != int64(i) || rec.Uuid != fmt.Sprintf("uuid-%d", i) {
-				t.Fatalf("out of order: got Num=%d Uuid=%q; want Num=%d Uuid=%q", rec.Num, rec.Uuid, i, fmt.Sprintf("uuid-%d", i))
-			}
+			require.NoError(t, err)
+			require.Equal(t, rec.Num, int64(i))
 			i++
 		}
 	}
@@ -295,16 +205,12 @@ func TestLiveStore_LiveRead_ConcurrentWriterFlushes(t *testing.T) {
 
 func TestLiveStore_LiveRead_OpenedBeforeWriter(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "live-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
+	require.NoError(t, err)
 	_ = tmp.Close()
 
 	// Start reader first: header may not exist yet; allowed by NewLiveStore.
-	ls, err := leet.NewLiveStore(tmp.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore: %v", err)
-	}
+	ls, err := leet.NewLiveStore(tmp.Name(), observability.NewNoOpLogger())
+	require.NoError(t, err)
 	defer ls.Close()
 
 	// Now start the writer.
@@ -320,7 +226,7 @@ func TestLiveStore_LiveRead_OpenedBeforeWriter(t *testing.T) {
 		defer f.Close()
 		w := leveldb.NewWriterExt(f, leveldb.CRCAlgoIEEE, 0)
 
-		rec := &spb.Record{Num: 1, Uuid: "first"}
+		rec := &spb.Record{Num: 1}
 		payload, err := proto.Marshal(rec)
 		if err != nil {
 			t.Errorf("marshal: %v", err)
@@ -356,9 +262,7 @@ func TestLiveStore_LiveRead_OpenedBeforeWriter(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Read: %v", err)
 			}
-			if rec.Num != 1 || rec.Uuid != "first" {
-				t.Fatalf("unexpected record: %+v", rec)
-			}
+			require.Equal(t, rec.Num, int64(1))
 			wg.Wait()
 			return
 		}
@@ -367,17 +271,10 @@ func TestLiveStore_LiveRead_OpenedBeforeWriter(t *testing.T) {
 
 // TestLiveStore_LargeRecord tests handling of large records
 func TestLiveStore_LargeRecord(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "large-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	tmpFile.Close()
-	_ = os.Remove(tmpFile.Name())
+	path := filepath.Join(t.TempDir(), "large.wandb")
 
-	w, err := transactionlog.OpenWriter(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open transaction log for writing: %v", err)
-	}
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
 
 	// Create a large record
 	largeData := make([]byte, 1024*1024) // 1MB
@@ -385,81 +282,53 @@ func TestLiveStore_LargeRecord(t *testing.T) {
 		largeData[i] = byte(i % 256)
 	}
 
-	largeRecord := &spb.Record{
-		Num:  1,
-		Uuid: hex.EncodeToString(largeData[:16]), // Use first 16 bytes as UUID
-	}
+	largeRecord := &spb.Record{Num: 1}
 
-	if err := w.Write(largeRecord); err != nil {
-		t.Fatalf("Failed to write large record: %v", err)
-	}
+	err = w.Write(largeRecord)
+	require.NoError(t, err)
 	w.Close()
 
 	// Read with LiveStore
-	ls, err := leet.NewLiveStore(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore failed: %v", err)
-	}
+	ls, err := leet.NewLiveStore(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
 	defer ls.Close()
 
 	rec, err := ls.Read()
-	if err != nil {
-		t.Fatalf("Failed to read large record: %v", err)
-	}
-	if rec.Num != largeRecord.Num || rec.Uuid != largeRecord.Uuid {
-		t.Errorf("Large record mismatch")
-	}
+	require.NoError(t, err)
+	require.Equal(t, rec.Num, largeRecord.Num)
 }
 
 // TestLiveStore_PartialWrite tests handling of partial writes
 func TestLiveStore_PartialWrite(t *testing.T) {
-	tmpFile, err := os.CreateTemp(t.TempDir(), "partial-*.wandb")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	// transactionlog.Writer doesn't want the file to exist
-	_ = os.Remove(tmpFile.Name())
+	path := filepath.Join(t.TempDir(), "partial.wandb")
 
 	// Write header
-	w, err := transactionlog.OpenWriter(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open transaction log for writing: %v", err)
-	}
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
 
 	// Write one complete record
-	if err := w.Write(&spb.Record{Num: 1, Uuid: "complete"}); err != nil {
-		t.Fatalf("Failed to write record: %v", err)
-	}
+	err = w.Write(&spb.Record{Num: 1})
+	require.NoError(t, err)
 	w.Close()
 
 	// Append partial record data (simulate interrupted write)
-	f, err := os.OpenFile(tmpFile.Name(), os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		t.Fatalf("Failed to open for append: %v", err)
-	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	require.NoError(t, err)
 	// Write incomplete record header
 	_, _ = f.Write([]byte{0x00, 0x00}) // Partial record that will cause read error
 	f.Close()
 
 	// Try to read
-	ls, err := leet.NewLiveStore(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("NewLiveStore failed: %v", err)
-	}
+	ls, err := leet.NewLiveStore(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
 	defer ls.Close()
 
 	// First record should be readable
 	rec, err := ls.Read()
-	if err != nil {
-		t.Fatalf("Failed to read complete record: %v", err)
-	}
-	if rec.Num != 1 {
-		t.Errorf("Expected Num=1, got %d", rec.Num)
-	}
+	require.NoError(t, err)
+	require.Equal(t, rec.Num, int64(1))
 
 	// Second read should fail or return EOF
 	_, err = ls.Read()
-	if err == nil {
-		t.Fatal("Expected error for partial record")
-	}
+	require.Error(t, err)
 }


### PR DESCRIPTION
Description
-----------
This PR implements a `LiveStore` abstraction (on top of the LiveReader live leveldb reader) that represents a persistent run data store that may be actively written to by another process.
