### PR TITLE
chore: read and process records from transaction log in leet

### DIFF
--- a/core/internal/leet/messages.go
+++ b/core/internal/leet/messages.go
@@ -48,10 +48,6 @@ type ErrorMsg struct {
 	Err error
 }
 
-func (e ErrorMsg) Error() string {
-	return e.Err.Error()
-}
-
 // InitMsg contains the initialized reader.
 type InitMsg struct {
 	Reader *WandbReader


### PR DESCRIPTION
Description
-----------
This PR introduces:
- The `WandbReader` struct that handles reading records from a (potentially live) W&B LevelDB-style transaction log (.wandb file).
- Messages (of type `tea.Msg`) that the LEET application uses to communicate data & state + conversions from W&B protobuf messages thereto.
