### PR TITLE
refactor: don't use `x_files_dir` for JobBuilder

### DIFF
--- a/tests/unit_tests/test_job_builder.py
+++ b/tests/unit_tests/test_job_builder.py
@@ -30,11 +30,10 @@ def test_build_repo_job(runner, api):
 
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
             }
         )
-        job_builder = JobBuilder(settings)
+        job_builder = JobBuilder(settings, files_dir="./")
         artifact = job_builder.build(
             api,
             dockerfile="Dockerfile",
@@ -86,12 +85,11 @@ def test_build_repo_notebook_job(runner, tmp_path, api, mocker):
 
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
                 "x_jupyter_root": str(tmp_path),
             }
         )
-        job_builder = JobBuilder(settings, True)
+        job_builder = JobBuilder(settings, True, files_dir="./")
         artifact = job_builder.build(api)
         assert artifact is not None
         assert artifact.name == make_artifact_name_safe(
@@ -119,11 +117,10 @@ def test_build_artifact_job(runner, api):
 
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
             }
         )
-        job_builder = JobBuilder(settings)
+        job_builder = JobBuilder(settings, files_dir="./")
         job_builder._logged_code_artifact = {
             "id": "testtest",
             "name": artifact_name,
@@ -161,12 +158,11 @@ def test_build_artifact_notebook_job(runner, tmp_path, mocker, api):
             f.write(json.dumps(metadata))
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
                 "x_jupyter_root": str(tmp_path),
             }
         )
-        job_builder = JobBuilder(settings)
+        job_builder = JobBuilder(settings, files_dir="./")
         job_builder._logged_code_artifact = {
             "id": "testtest",
             "name": artifact_name,
@@ -207,12 +203,11 @@ def test_build_artifact_notebook_job_no_program(
             f.write(json.dumps(metadata))
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
                 "x_jupyter_root": str(tmp_path),
             }
         )
-        job_builder = JobBuilder(settings, verbose)
+        job_builder = JobBuilder(settings, verbose, files_dir="./")
         job_builder._logged_code_artifact = {
             "id": "testtest",
             "name": artifact_name,
@@ -248,12 +243,11 @@ def test_build_artifact_notebook_job_no_metadata(
 
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
                 "x_jupyter_root": str(tmp_path),
             }
         )
-        job_builder = JobBuilder(settings, verbose)
+        job_builder = JobBuilder(settings, verbose, files_dir="./")
         job_builder._logged_code_artifact = {
             "id": "testtest",
             "name": artifact_name,
@@ -294,12 +288,11 @@ def test_build_artifact_notebook_job_no_program_metadata(
             f.write(json.dumps(metadata))
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
                 "x_jupyter_root": str(tmp_path),
             }
         )
-        job_builder = JobBuilder(settings, verbose)
+        job_builder = JobBuilder(settings, verbose, files_dir="./")
         job_builder._logged_code_artifact = {
             "id": "testtest",
             "name": artifact_name,
@@ -331,11 +324,10 @@ def test_build_image_job(runner, api):
             f.write(json.dumps(metadata))
         settings = SettingsStatic(
             {
-                "x_files_dir": "./",
                 "disable_job_creation": False,
             }
         )
-        job_builder = JobBuilder(settings)
+        job_builder = JobBuilder(settings, files_dir="./")
         artifact = job_builder.build(api)
         assert artifact is not None
         assert artifact.name == make_artifact_name_safe(f"job-{image_name}")
@@ -347,12 +339,11 @@ def test_build_image_job(runner, api):
 def test_set_disabled():
     settings = SettingsStatic(
         {
-            "x_files_dir": "./",
             "disable_job_creation": False,
         }
     )
 
-    job_builder = JobBuilder(settings)
+    job_builder = JobBuilder(settings, files_dir="./")
     job_builder.disable = "testtest"
     assert job_builder.disable == "testtest"
 
@@ -360,10 +351,9 @@ def test_set_disabled():
 def test_no_metadata_file(runner, api):
     settings = SettingsStatic(
         {
-            "x_files_dir": "./",
             "disable_job_creation": False,
         }
     )
-    job_builder = JobBuilder(settings)
+    job_builder = JobBuilder(settings, files_dir="./")
     artifact = job_builder.build(api)
     assert artifact is None

--- a/tests/unit_tests/test_launch/test_create_job.py
+++ b/tests/unit_tests/test_launch/test_create_job.py
@@ -75,7 +75,7 @@ def test_configure_job_builder_for_partial():
     assert isinstance(builder, JobBuilder)
     assert builder._config == {}
     assert builder._summary == {}
-    assert builder._settings.files_dir == dir
+    assert builder._files_dir == dir
     assert builder._settings.job_source == job_source
 
 

--- a/tests/unit_tests/test_launch/test_job.py
+++ b/tests/unit_tests/test_launch/test_job.py
@@ -111,13 +111,13 @@ def test_configure_notebook_artifact_job(mocker, tmp_path):
 
 
 def test_make_job_name(test_settings):
-    builder = JobBuilder(settings=test_settings())
+    builder = JobBuilder(settings=test_settings(), files_dir="")
     name = builder._make_job_name("testing*123")
 
     assert name == "job-testing_123"
 
     settings = test_settings({"job_name": "custom-name"})
-    builder = JobBuilder(settings=settings)
+    builder = JobBuilder(settings=settings, files_dir="")
     name = builder._make_job_name("testing*123")
 
     assert name == "custom-name"

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -311,7 +311,10 @@ class SendManager:
         self._output_raw_file = None
 
         # job builder
-        self._job_builder = JobBuilder(settings)
+        self._job_builder = JobBuilder(
+            settings,
+            files_dir=settings.files_dir,
+        )
 
         time_now = time.monotonic()
         self._debounce_config_time = time_now

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -417,10 +417,11 @@ def _configure_job_builder_for_partial(tmpdir: str, job_source: str) -> JobBuild
     if job_source == "code":
         job_source = "artifact"
 
-    settings = wandb.Settings(x_files_dir=tmpdir, job_source=job_source)
+    settings = wandb.Settings(job_source=job_source)
     job_builder = JobBuilder(
         settings=settings,  # type: ignore
         verbose=True,
+        files_dir=tmpdir,
     )
     job_builder._partial = True
     # never allow notebook runs


### PR DESCRIPTION
Makes `files_dir` an explicit parameter to `JobBuilder` instead of reading it from `settings` to get rid of the hack of setting `x_files_dir`.

Setting the `files_dir` setting was always an antipattern, and when it was made immutable, `x_files_dir` was added to aid the refactor.