### PR TITLE
chore: fix another race in handler_test.go

### DIFF
--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -179,9 +179,9 @@ func (h *Handler) Do(allWork <-chan runwork.Work) {
 }
 
 func (h *Handler) Close() {
+	h.logger.Info("handler: closed", "stream_id", h.settings.GetRunID())
 	close(h.outChan)
 	close(h.fwdChan)
-	h.logger.Info("handler: closed", "stream_id", h.settings.GetRunID())
 }
 
 // respond sends a response to the client


### PR DESCRIPTION
Log before closing channels, so that `handler_test.go` doesn't end the test until the log statement executes.

`handler_test.go` consumes the `outChan` to detect when `Handler` is done with all its work.