### PR TITLE
fix(artifacts): `Api.artifact_exists` and `Api.artifact_collection_exists` should raise on timeout errors

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,3 +18,8 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Optimize artifacts downloads re-verification with checksum caching (@thanos-wandb in https://github.com/wandb/wandb/pull/10157)
 - Lazy loading support for `Api().runs()` to improve performance when listing runs. The new `lazy=True` parameter (default) loads only essential metadata initially, with automatic on-demand loading of heavy fields like config and summary when accessed (@thanos-wandb in https://github.com/wandb/wandb/pull/10034)
 - Add `storage_region` option when creating artifacts. Users can use [CoreWeave AI Object Storage](https://docs.coreweave.com/docs/products/storage/object-storage) by specifying `wandb.Artifact(storage_region="coreweave-us")` when using wandb.ai for faster artifact upload/download on CoreWeave's infrastructure. (@pingleiwandb in https://github.com/wandb/wandb/pull/10533)
+
+
+### Fixed
+
+- `Api.artifact_exists()` and `Api.artifact_collection_exists()` now raise on encountering timeout errors, rather than (potentially erroneously) returning `False`.  (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10591)

--- a/tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -182,10 +182,6 @@ def test_artifact_collection_exists_raises_on_timeout(mocker, user, api, sample_
         api.artifact_collection_exists("mnist-fake", "dataset")
     assert isinstance(exc_info.value.exc, requests.Timeout)
 
-    with pytest.raises(CommError) as exc_info:
-        api.artifact_collection_exists("mnist-fake", "dataset")
-    assert isinstance(exc_info.value.exc, requests.Timeout)
-
 
 def test_artifact_delete(user, api, sample_data):
     art = api.artifact("mnist:v0", type="dataset")

--- a/tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -3,8 +3,10 @@ import platform
 from contextlib import nullcontext
 
 import pytest
+import requests
 import wandb
 from wandb._strutils import nameof
+from wandb.errors.errors import CommError
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk.artifacts._generated import ArtifactByName, ArtifactViaMembershipByName
 from wandb.sdk.artifacts.exceptions import ArtifactFinalizedError
@@ -127,14 +129,62 @@ def test_artifact_download(user, api, sample_data):
 
 
 def test_artifact_exists(user, api, sample_data):
-    assert api.artifact_exists("mnist:v0")
-    assert not api.artifact_exists("mnist:v2")
-    assert not api.artifact_exists("mnist-fake:v0")
+    assert api.artifact_exists("mnist:v0") is True
+    assert api.artifact_exists("mnist:v2") is False
+    assert api.artifact_exists("mnist-fake:v0") is False
 
 
 def test_artifact_collection_exists(user, api, sample_data):
-    assert api.artifact_collection_exists("mnist", "dataset")
-    assert not api.artifact_collection_exists("mnist-fake", "dataset")
+    assert api.artifact_collection_exists("mnist", "dataset") is True
+    assert api.artifact_collection_exists("mnist-fake", "dataset") is False
+
+
+def test_artifact_exists_raises_on_timeout(mocker, user, api, sample_data):
+    # FIXME: We should really be mocking the GraphQL HTTP requests/responses, NOT the
+    # actual python methods, but this is complicated by the fact that we need to instantiate
+    # a new Api with a shorter timeout, and that Api makes immediate requests on _instantiation_.
+    #
+    # Mocking every single one of them makes test setup quite brittle and error prone.
+    # Moreover, the interaction between @normalize_exceptions and our home-grown retry
+    # logic isn't readily configurable, so this test can easily become flaky and/or timeout.
+    # The following will have to do for now.
+    mocker.patch.object(api, "_artifact", side_effect=requests.Timeout())
+
+    with pytest.raises(CommError) as exc_info:
+        api.artifact_exists("mnist:v0")
+    assert isinstance(exc_info.value.exc, requests.Timeout)
+
+    with pytest.raises(CommError) as exc_info:
+        api.artifact_exists("mnist-fake:v0")
+    assert isinstance(exc_info.value.exc, requests.Timeout)
+
+    with pytest.raises(CommError):
+        api.artifact_exists("mnist-fake:v0")
+    assert isinstance(exc_info.value.exc, requests.Timeout)
+
+
+def test_artifact_collection_exists_raises_on_timeout(mocker, user, api, sample_data):
+    # FIXME: We should really be mocking the GraphQL HTTP requests/responses, NOT the
+    # actual python methods, but this is complicated by the fact that we need to instantiate
+    # a new Api with a shorter timeout, and that Api makes immediate requests on _instantiation_.
+    #
+    # Mocking every single one of them makes test setup quite brittle and error prone.
+    # Moreover, the interaction between @normalize_exceptions and our home-grown retry
+    # logic isn't readily configurable, so this test can easily become flaky and/or timeout.
+    # The following will have to do for now.
+    mocker.patch.object(api, "artifact_collection", side_effect=requests.Timeout())
+
+    with pytest.raises(CommError) as exc_info:
+        api.artifact_collection_exists("mnist", "dataset")
+    assert isinstance(exc_info.value.exc, requests.Timeout)
+
+    with pytest.raises(CommError) as exc_info:
+        api.artifact_collection_exists("mnist-fake", "dataset")
+    assert isinstance(exc_info.value.exc, requests.Timeout)
+
+    with pytest.raises(CommError) as exc_info:
+        api.artifact_collection_exists("mnist-fake", "dataset")
+    assert isinstance(exc_info.value.exc, requests.Timeout)
 
 
 def test_artifact_delete(user, api, sample_data):

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1725,9 +1725,10 @@ class Api:
         """
         try:
             self._artifact(name, type)
-        except wandb.errors.CommError:
+        except wandb.errors.CommError as e:
+            if isinstance(e.exc, requests.Timeout):
+                raise
             return False
-
         return True
 
     @normalize_exceptions
@@ -1758,9 +1759,10 @@ class Api:
         """
         try:
             self.artifact_collection(type, name)
-        except wandb.errors.CommError:
+        except wandb.errors.CommError as e:
+            if isinstance(e.exc, requests.Timeout):
+                raise
             return False
-
         return True
 
     @tracked

--- a/wandb/errors/errors.py
+++ b/wandb/errors/errors.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 
 class Error(Exception):
@@ -7,7 +7,7 @@ class Error(Exception):
     <!-- lazydoc-ignore-class: internal -->
     """
 
-    def __init__(self, message, context: Optional[dict] = None) -> None:
+    def __init__(self, message: str, context: dict | None = None) -> None:
         super().__init__(message)
         self.message = message
         # sentry context capture
@@ -18,7 +18,7 @@ class Error(Exception):
 class CommError(Error):
     """Error communicating with W&B servers."""
 
-    def __init__(self, msg, exc=None) -> None:
+    def __init__(self, msg: str, exc: Exception | None = None) -> None:
         self.exc = exc
         self.message = msg
         super().__init__(self.message)

--- a/wandb/sdk/data_types/bokeh.py
+++ b/wandb/sdk/data_types/bokeh.py
@@ -5,6 +5,7 @@ import pathlib
 from typing import TYPE_CHECKING, Union
 
 from wandb import util
+from wandb._strutils import nameof
 from wandb.sdk.lib import runid
 
 from . import _dtypes
@@ -34,7 +35,10 @@ class Bokeh(Media):
         ],
     ):
         super().__init__()
-        bokeh = util.get_module("bokeh", required=True)
+        bokeh = util.get_module(
+            "bokeh",
+            required=f"{nameof(Bokeh)!r} requires the bokeh package.  Please install it with `pip install bokeh`.",
+        )
         if isinstance(data_or_path, (str, pathlib.Path)) and os.path.exists(
             data_or_path
         ):

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -229,7 +229,7 @@ def import_module_lazy(name: str) -> types.ModuleType:
 
 def get_module(
     name: str,
-    required: Optional[Union[str, bool]] = None,
+    required: Optional[str] = None,
     lazy: bool = True,
 ) -> Any:
     """Return module or None. Absolute import is required.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- https://wandb.atlassian.net/browse/WB-27854

`Api.artifact_exists()` and `Api.artifact_collection_exists()` should raise on timeout errors, rather than (potentially erroneously) returning `False`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
