### PR TITLE
refactor: initialize SettingsStatic with a dict instead of a proto

### DIFF
--- a/tests/unit_tests/test_handler.py
+++ b/tests/unit_tests/test_handler.py
@@ -11,7 +11,7 @@ def test_handle_bigint(test_settings):
     result_q = queue.Queue()
     settings = test_settings({})
     hm = handler.HandleManager(
-        settings=settings_static.SettingsStatic(settings.to_proto()),
+        settings=settings_static.SettingsStatic(dict(settings)),
         record_q=MagicMock(),
         result_q=result_q,
         stopped=MagicMock(),

--- a/tests/unit_tests/test_job_builder.py
+++ b/tests/unit_tests/test_job_builder.py
@@ -4,8 +4,6 @@ import random
 import string
 
 import pytest
-from google.protobuf.wrappers_pb2 import BoolValue, StringValue
-from wandb.proto import wandb_settings_pb2
 from wandb.sdk.internal.job_builder import JobBuilder
 from wandb.sdk.internal.settings_static import SettingsStatic
 from wandb.util import make_artifact_name_safe
@@ -13,16 +11,6 @@ from wandb.util import make_artifact_name_safe
 
 def str_of_length(n):
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=n))
-
-
-def make_proto_settings(**kwargs):
-    proto = wandb_settings_pb2.Settings()
-    for k, v in kwargs.items():
-        if isinstance(v, bool):
-            getattr(proto, k).CopyFrom(BoolValue(value=v))
-        elif isinstance(v, str):
-            getattr(proto, k).CopyFrom(StringValue(value=v))
-    return proto
 
 
 def test_build_repo_job(runner, api):
@@ -40,15 +28,11 @@ def test_build_repo_job(runner, api):
         with open("wandb-metadata.json", "w") as f:
             f.write(json.dumps(metadata))
 
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "_jupyter": False,
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+            }
         )
         job_builder = JobBuilder(settings)
         artifact = job_builder.build(
@@ -100,15 +84,12 @@ def test_build_repo_notebook_job(runner, tmp_path, api, mocker):
         with open("wandb-metadata.json", "w") as f:
             f.write(json.dumps(metadata))
 
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "x_jupyter_root": str(tmp_path),
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+                "x_jupyter_root": str(tmp_path),
+            }
         )
         job_builder = JobBuilder(settings, True)
         artifact = job_builder.build(api)
@@ -136,15 +117,11 @@ def test_build_artifact_job(runner, api):
         with open("wandb-metadata.json", "w") as f:
             f.write(json.dumps(metadata))
 
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "_jupyter": False,
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+            }
         )
         job_builder = JobBuilder(settings)
         job_builder._logged_code_artifact = {
@@ -182,15 +159,12 @@ def test_build_artifact_notebook_job(runner, tmp_path, mocker, api):
             f.write("wandb")
         with open("wandb-metadata.json", "w") as f:
             f.write(json.dumps(metadata))
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "x_jupyter_root": str(tmp_path),
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+                "x_jupyter_root": str(tmp_path),
+            }
         )
         job_builder = JobBuilder(settings)
         job_builder._logged_code_artifact = {
@@ -231,15 +205,12 @@ def test_build_artifact_notebook_job_no_program(
             f.write("wandb")
         with open("wandb-metadata.json", "w") as f:
             f.write(json.dumps(metadata))
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "x_jupyter_root": str(tmp_path),
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+                "x_jupyter_root": str(tmp_path),
+            }
         )
         job_builder = JobBuilder(settings, verbose)
         job_builder._logged_code_artifact = {
@@ -275,15 +246,12 @@ def test_build_artifact_notebook_job_no_metadata(
             f.write("numpy==1.19.0")
             f.write("wandb")
 
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "x_jupyter_root": str(tmp_path),
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+                "x_jupyter_root": str(tmp_path),
+            }
         )
         job_builder = JobBuilder(settings, verbose)
         job_builder._logged_code_artifact = {
@@ -324,15 +292,12 @@ def test_build_artifact_notebook_job_no_program_metadata(
             f.write("wandb")
         with open("wandb-metadata.json", "w") as f:
             f.write(json.dumps(metadata))
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "x_jupyter_root": str(tmp_path),
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+                "x_jupyter_root": str(tmp_path),
+            }
         )
         job_builder = JobBuilder(settings, verbose)
         job_builder._logged_code_artifact = {
@@ -364,15 +329,11 @@ def test_build_image_job(runner, api):
             f.write("wandb")
         with open("wandb-metadata.json", "w") as f:
             f.write(json.dumps(metadata))
-        kwargs = {
-            "x_files_dir": "./",
-            "disable_job_creation": False,
-            "_jupyter": False,
-        }
         settings = SettingsStatic(
-            make_proto_settings(
-                **kwargs,
-            )
+            {
+                "x_files_dir": "./",
+                "disable_job_creation": False,
+            }
         )
         job_builder = JobBuilder(settings)
         artifact = job_builder.build(api)
@@ -384,11 +345,12 @@ def test_build_image_job(runner, api):
 
 
 def test_set_disabled():
-    kwargs = {
-        "x_files_dir": "./",
-        "disable_job_creation": False,
-    }
-    settings = SettingsStatic(make_proto_settings(**kwargs))
+    settings = SettingsStatic(
+        {
+            "x_files_dir": "./",
+            "disable_job_creation": False,
+        }
+    )
 
     job_builder = JobBuilder(settings)
     job_builder.disable = "testtest"
@@ -396,11 +358,12 @@ def test_set_disabled():
 
 
 def test_no_metadata_file(runner, api):
-    kwargs = {
-        "x_files_dir": "./",
-        "disable_job_creation": False,
-    }
-    settings = SettingsStatic(make_proto_settings(**kwargs))
+    settings = SettingsStatic(
+        {
+            "x_files_dir": "./",
+            "disable_job_creation": False,
+        }
+    )
     job_builder = JobBuilder(settings)
     artifact = job_builder.build(api)
     assert artifact is None

--- a/tests/unit_tests/test_sender.py
+++ b/tests/unit_tests/test_sender.py
@@ -9,7 +9,7 @@ def test_config_save_preserve_order(tmp_path, test_settings):
     config_file = tmp_path / "config.yaml"
     settings = test_settings({"x_files_dir": str(tmp_path)})
     sender = SendManager(
-        settings=SettingsStatic(settings.to_proto()),
+        settings=SettingsStatic(dict(settings)),
         record_q=MagicMock(),
         result_q=MagicMock(),
         interface=MagicMock(),

--- a/tests/unit_tests/test_wandb_settings.py
+++ b/tests/unit_tests/test_wandb_settings.py
@@ -430,7 +430,7 @@ def test_log_internal():
 def test_settings_static():
     from wandb.sdk.internal.settings_static import SettingsStatic
 
-    static_settings = SettingsStatic(Settings().to_proto())
+    static_settings = SettingsStatic({})
     assert "base_url" in static_settings
     assert static_settings.base_url == "https://api.wandb.ai"
 

--- a/wandb/apis/importers/internals/internal.py
+++ b/wandb/apis/importers/internals/internal.py
@@ -8,12 +8,10 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
 import numpy as np
-from google.protobuf.json_format import ParseDict
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 from wandb import Artifact
 from wandb.proto import wandb_internal_pb2 as pb
-from wandb.proto import wandb_settings_pb2
 from wandb.proto import wandb_telemetry_pb2 as telem_pb
 from wandb.sdk.interface.interface import file_policy_to_enum
 from wandb.sdk.interface.interface_queue import InterfaceQueue
@@ -310,27 +308,22 @@ def _make_settings(
 ) -> SettingsStatic:
     _settings_override = coalesce(settings_override, {})
 
-    default_settings: Dict[str, Any] = {
-        "x_files_dir": os.path.join(root_dir, "files"),
-        "root_dir": root_dir,
-        "sync_file": os.path.join(root_dir, "txlog.wandb"),
-        "resume": "false",
-        "program": None,
-        "ignore_globs": [],
-        "disable_job_creation": True,
-        "x_start_time": 0,
-        "_offline": None,
-        "x_sync": True,
-        "x_live_policy_rate_limit": 15,  # matches dir_watcher
-        "x_live_policy_wait_time": 600,  # matches dir_watcher
-        "x_file_stream_timeout_seconds": 60,
-    }
-
-    combined_settings = {**default_settings, **_settings_override}
-    settings_message = wandb_settings_pb2.Settings()
-    ParseDict(combined_settings, settings_message)
-
-    return SettingsStatic(settings_message)
+    return SettingsStatic(
+        {
+            "x_files_dir": os.path.join(root_dir, "files"),
+            "root_dir": root_dir,
+            "resume": "never",
+            "program": None,
+            "ignore_globs": [],
+            "disable_job_creation": True,
+            "x_start_time": 0,
+            "x_sync": True,
+            "x_live_policy_rate_limit": 15,  # matches dir_watcher
+            "x_live_policy_wait_time": 600,  # matches dir_watcher
+            "x_file_stream_timeout_seconds": 60,
+            **_settings_override,
+        }
+    )
 
 
 def send_run(

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -343,7 +343,7 @@ class SendManager:
         publish_interface = InterfaceQueue(record_q=record_q)
         context_keeper = context.ContextKeeper()
         return SendManager(
-            settings=SettingsStatic(settings.to_proto()),
+            settings=SettingsStatic(dict(settings)),
             record_q=record_q,
             result_q=result_q,
             interface=publish_interface,

--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from wandb.proto import wandb_settings_pb2
-from wandb.sdk.lib import RunMoment
-from wandb.sdk.wandb_settings import CLIENT_ONLY_SETTINGS, Settings
+from wandb.sdk.wandb_settings import Settings
 
 
 class SettingsStatic(Settings):
@@ -14,86 +12,8 @@ class SettingsStatic(Settings):
     attributes or items.
     """
 
-    def __init__(self, proto: wandb_settings_pb2.Settings) -> None:
-        data = self._proto_to_dict(proto)
+    def __init__(self, data: dict[str, Any]) -> None:
         super().__init__(**data)
-
-    def _proto_to_dict(self, proto: wandb_settings_pb2.Settings) -> dict:
-        data = {}
-
-        exclude_fields = {
-            "model_config",
-            "model_fields",
-            "model_fields_set",
-            "__fields__",
-            "__model_fields_set",
-            "__pydantic_self__",
-            "__pydantic_initialised__",
-        }
-
-        fields = (
-            Settings.model_fields
-            if hasattr(Settings, "model_fields")
-            else Settings.__fields__
-        )  # type: ignore [attr-defined]
-
-        fields = {k: v for k, v in fields.items() if k not in exclude_fields}  # type: ignore [union-attr]
-
-        forks_specified: list[str] = []
-        for key in fields:
-            if key in CLIENT_ONLY_SETTINGS:
-                continue
-
-            value: Any = None
-
-            field_info = fields[key]
-            annotation = str(field_info.annotation)
-
-            if key == "_stats_open_metrics_filters":
-                # todo: it's an underscored field, refactor into
-                #  something more elegant?
-                # I'm really about this. It's ugly, but it works.
-                # Do not try to repeat this at home.
-                value_type = getattr(proto, key).WhichOneof("value")
-                if value_type == "sequence":
-                    value = list(getattr(proto, key).sequence.value)
-                elif value_type == "mapping":
-                    unpacked_mapping = {}
-                    for outer_key, outer_value in getattr(
-                        proto, key
-                    ).mapping.value.items():
-                        unpacked_inner = {}
-                        for inner_key, inner_value in outer_value.value.items():
-                            unpacked_inner[inner_key] = inner_value
-                        unpacked_mapping[outer_key] = unpacked_inner
-                    value = unpacked_mapping
-            elif key == "fork_from" or key == "resume_from":
-                value = getattr(proto, key)
-                if value.run:
-                    value = RunMoment(
-                        run=value.run, value=value.value, metric=value.metric
-                    )
-                    forks_specified.append(key)
-                else:
-                    value = None
-            else:
-                if proto.HasField(key):  # type: ignore [arg-type]
-                    value = getattr(proto, key).value
-                    # Convert to list if the field is a sequence
-                    if any(t in annotation for t in ("tuple", "Sequence", "list")):
-                        value = list(value)
-                else:
-                    value = None
-
-            if value is not None:
-                data[key] = value
-
-        if len(forks_specified) > 1:
-            raise ValueError(
-                "Only one of fork_from or resume_from can be specified, not both"
-            )
-
-        return data
 
     def __setattr__(self, name: str, value: object) -> None:
         raise AttributeError("Error: SettingsStatic is a readonly object")

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -193,7 +193,7 @@ class SyncThread(threading.Thread):
             x_start_time=time.time(),
         )
 
-        settings_static = SettingsStatic(settings.to_proto())
+        settings_static = SettingsStatic(dict(settings))
 
         handle_manager = handler.HandleManager(
             settings=settings_static,
@@ -207,7 +207,12 @@ class SyncThread(threading.Thread):
 
         filesystem.mkdir_exists_ok(settings.files_dir)
         send_manager.send_run(record, file_dir=settings.files_dir)
-        watcher = tb_watcher.TBWatcher(settings, proto_run, new_interface, True)
+        watcher = tb_watcher.TBWatcher(
+            settings_static,
+            proto_run,
+            new_interface,
+            True,
+        )
 
         for tb in tb_logdirs:
             watcher.add(tb, True, tb_root)


### PR DESCRIPTION
Instead of converting to a proto and then back to a dict, just pass a dict directly to `SettingsStatic`.

I will be removing `x_files_dir` from the proto but keeping it on the Python `Settings` object for legacy code.

Found all uses by searching for "SettingsStatic(". This class is not part of the public interface (it's not exported in `wandb/__init__.py`).

The `importers/internal.py::make_settings()`​function appears to not be tested, but I removed all fields that you aren't allowed to set explicitly on `Settings`​ (Pydantic raises an error). There were also some tests in `test_job_builder.py`​ that set `_jupyter`​ which isn't settable. The `SettingsStatic._proto_to_dict()`​ method used to silently ignore these fields.