### PR TITLE
fix(sdk): modernize type hints in `wandb.apis.public.*` modules (PEP 563/585/604)

### DIFF
--- a/wandb/apis/__init__.py
+++ b/wandb/apis/__init__.py
@@ -1,5 +1,7 @@
 """api."""
 
+from __future__ import annotations
+
 from typing import Callable
 
 import requests

--- a/wandb/apis/attrs.py
+++ b/wandb/apis/attrs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, MutableMapping
 
 import wandb

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from wandb.sdk.internal.internal_api import Api as InternalApi

--- a/wandb/apis/normalize.py
+++ b/wandb/apis/normalize.py
@@ -1,5 +1,7 @@
 """normalize."""
 
+from __future__ import annotations
+
 import ast
 import sys
 from functools import wraps

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -27,6 +27,7 @@ __all__ = (
     "Sweeps",
     "QueryGenerator",  # doc:exclude
     "Registry",
+    "Registries",  # doc:exclude
     "BetaReport",
     "PanelMetricsHelper",  # doc:exclude
     "PythonMongoishQueryGenerator",  # doc:exclude
@@ -64,7 +65,7 @@ from wandb.apis.public.jobs import (
 )
 from wandb.apis.public.projects import PROJECT_FRAGMENT, Project, Projects, Sweeps
 from wandb.apis.public.query_generator import QueryGenerator
-from wandb.apis.public.registries.registry import Registry
+from wandb.apis.public.registries import Registries, Registry
 from wandb.apis.public.reports import (
     BetaReport,
     PanelMetricsHelper,

--- a/wandb/apis/public/const.py
+++ b/wandb/apis/public/const.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 # Only retry requests for 20 seconds in the public api

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -9,6 +9,8 @@ Note:
     both complete and sampled access to metrics logged during training runs.
 """
 
+from __future__ import annotations
+
 import json
 
 from wandb_gql import gql

--- a/wandb/apis/public/jobs.py
+++ b/wandb/apis/public/jobs.py
@@ -4,11 +4,13 @@ This module provides classes for managing W&B jobs, queued runs, and run
 queues.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import shutil
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Literal, Mapping
 
 from wandb_gql import gql
 
@@ -37,11 +39,11 @@ class Job:
     _output_types: Type
     _entity: str
     _project: str
-    _entrypoint: List[str]
+    _entrypoint: list[str]
     _notebook_job: bool
     _partial: bool
 
-    def __init__(self, api: "Api", name, path: Optional[str] = None) -> None:
+    def __init__(self, api: Api, name, path: str | None = None) -> None:
         try:
             self._job_artifact = api._artifact(name, type="job")
         except CommError:
@@ -166,7 +168,7 @@ class Job:
         if self._entrypoint:
             launch_project.set_job_entry_point(self._entrypoint)
 
-    def set_entrypoint(self, entrypoint: List[str]):
+    def set_entrypoint(self, entrypoint: list[str]):
         """Set the entrypoint for the job."""
         self._entrypoint = entrypoint
 
@@ -307,7 +309,7 @@ class QueuedRun:
         )
 
     @normalize_exceptions
-    def _get_run_queue_item_legacy(self) -> Dict:
+    def _get_run_queue_item_legacy(self) -> dict:
         query = gql(
             """
             query GetRunQueueItem($projectName: String!, $entityName: String!, $runQueue: String!) {
@@ -490,13 +492,13 @@ class RunQueue:
 
     def __init__(
         self,
-        client: "RetryingClient",
+        client: RetryingClient,
         name: str,
         entity: str,
-        prioritization_mode: Optional[RunQueuePrioritizationMode] = None,
-        _access: Optional[RunQueueAccessType] = None,
-        _default_resource_config_id: Optional[int] = None,
-        _default_resource_config: Optional[dict] = None,
+        prioritization_mode: RunQueuePrioritizationMode | None = None,
+        _access: RunQueueAccessType | None = None,
+        _default_resource_config_id: int | None = None,
+        _default_resource_config: dict | None = None,
     ) -> None:
         self._name: str = name
         self._client = client
@@ -538,7 +540,7 @@ class RunQueue:
         return self._access
 
     @property
-    def external_links(self) -> Dict[str, str]:
+    def external_links(self) -> dict[str, str]:
         """External resource links for the queue."""
         if self._external_links is None:
             self._get_metadata()
@@ -579,7 +581,7 @@ class RunQueue:
         return self._id
 
     @property
-    def items(self) -> List[QueuedRun]:
+    def items(self) -> list[QueuedRun]:
         """Up to the first 100 queued runs. Modifying this list will not modify the queue or any enqueued items!"""
         # TODO(np): Add a paginated interface
         if self._items is None:
@@ -716,12 +718,12 @@ class RunQueue:
     def create(
         cls,
         name: str,
-        resource: "RunQueueResourceType",
-        entity: Optional[str] = None,
-        prioritization_mode: Optional["RunQueuePrioritizationMode"] = None,
-        config: Optional[dict] = None,
-        template_variables: Optional[dict] = None,
-    ) -> "RunQueue":
+        resource: RunQueueResourceType,
+        entity: str | None = None,
+        prioritization_mode: RunQueuePrioritizationMode | None = None,
+        config: dict | None = None,
+        template_variables: dict | None = None,
+    ) -> RunQueue:
         """Create a RunQueue.
 
         Args:

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -31,6 +31,8 @@ Note:
     with a new project name.
 """
 
+from __future__ import annotations
+
 from requests import HTTPError
 from wandb_gql import gql
 
@@ -100,7 +102,7 @@ class Projects(Paginator["Project"]):
         client: RetryingClient,
         entity: str,
         per_page: int = 50,
-    ) -> "Projects":
+    ) -> Projects:
         """An iterable collection of `Project` objects.
 
         Args:
@@ -187,7 +189,7 @@ class Project(Attrs):
         entity: str,
         project: str,
         attrs: dict,
-    ) -> "Project":
+    ) -> Project:
         """A single project associated with an entity.
 
         Args:

--- a/wandb/apis/public/query_generator.py
+++ b/wandb/apis/public/query_generator.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class QueryGenerator:
     """QueryGenerator is a helper object to write filters for runs.
 

--- a/wandb/apis/public/registries/__init__.py
+++ b/wandb/apis/public/registries/__init__.py
@@ -1,0 +1,7 @@
+__all__ = [
+    "Registry",  # doc:exclude
+    "Registries",  # doc:exclude
+]
+
+from .registries_search import Registries
+from .registry import Registry

--- a/wandb/apis/public/registries/_freezable_list.py
+++ b/wandb/apis/public/registries/_freezable_list.py
@@ -1,14 +1,13 @@
+from __future__ import annotations
+
 from itertools import chain
 from typing import (
     Any,
     Iterable,
     Iterator,
-    List,
     MutableSequence,
     Sequence,
-    Tuple,
     TypeVar,
-    Union,
     final,
     overload,
 )
@@ -29,9 +28,9 @@ class FreezableList(MutableSequence[T]):
     Any initial items passed to the constructor are saved.
     """
 
-    def __init__(self, iterable: Union[Iterable[T], None] = None, /) -> None:
-        self._frozen: Tuple[T, ...] = tuple(iterable or ())
-        self._draft: List[T] = []
+    def __init__(self, iterable: Iterable[T] | None = None, /) -> None:
+        self._frozen: tuple[T, ...] = tuple(iterable or ())
+        self._draft: list[T] = []
 
     def append(self, value: T) -> None:
         """Append an item to the draft list. No duplicates are allowed."""
@@ -72,7 +71,7 @@ class FreezableList(MutableSequence[T]):
     @overload
     def __getitem__(self, index: slice) -> Sequence[T]: ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Union[T, Sequence[T]]:
+    def __getitem__(self, index: int | slice) -> T | Sequence[T]:
         return [*self._frozen, *self._draft][index]
 
     @overload
@@ -81,9 +80,7 @@ class FreezableList(MutableSequence[T]):
     @overload
     def __setitem__(self, index: slice, value: Iterable[T]) -> None: ...
 
-    def __setitem__(
-        self, index: Union[int, slice], value: Union[T, Iterable[T]]
-    ) -> None:
+    def __setitem__(self, index: int | slice, value: T | Iterable[T]) -> None:
         if isinstance(index, slice):
             # Setting slices might affect saved items, disallow for simplicity
             raise TypeError(f"{nameof(type(self))!r} does not support slice assignment")
@@ -109,7 +106,7 @@ class FreezableList(MutableSequence[T]):
     @overload
     def __delitem__(self, index: slice) -> None: ...
 
-    def __delitem__(self, index: Union[int, slice]) -> None:
+    def __delitem__(self, index: int | slice) -> None:
         if isinstance(index, slice):
             raise TypeError(f"{nameof(type(self))!r} does not support slice deletion")
         else:
@@ -161,7 +158,7 @@ class FreezableList(MutableSequence[T]):
         return f"{nameof(type(self))}(frozen={list(self._frozen)!r}, draft={list(self._draft)!r})"
 
     @property
-    def draft(self) -> Tuple[T, ...]:
+    def draft(self) -> tuple[T, ...]:
         """A read-only, tuple copy of the current draft items."""
         return tuple(self._draft)
 

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
 
 from wandb_gql import gql
 
@@ -35,11 +37,11 @@ class Registry:
 
     def __init__(
         self,
-        client: "Client",
+        client: Client,
         organization: str,
         entity: str,
         name: str,
-        attrs: Optional[Dict[str, Any]] = None,
+        attrs: dict[str, Any] | None = None,
     ):
         self.client = client
         self._name = name
@@ -49,7 +51,7 @@ class Registry:
         if attrs is not None:
             self._update_attributes(attrs)
 
-    def _update_attributes(self, attrs: Dict[str, Any]) -> None:
+    def _update_attributes(self, attrs: dict[str, Any]) -> None:
         """Helper method to update instance attributes from a dictionary."""
         self._id = attrs.get("id", "")
         if self._id is None:
@@ -182,7 +184,7 @@ class Registry:
         self._visibility = value
 
     @tracked
-    def collections(self, filter: Optional[Dict[str, Any]] = None) -> Collections:
+    def collections(self, filter: dict[str, Any] | None = None) -> Collections:
         """Returns the collections belonging to the registry."""
         registry_filter = {
             "name": self.full_name,
@@ -190,7 +192,7 @@ class Registry:
         return Collections(self.client, self.organization, registry_filter, filter)
 
     @tracked
-    def versions(self, filter: Optional[Dict[str, Any]] = None) -> Versions:
+    def versions(self, filter: dict[str, Any] | None = None) -> Versions:
         """Returns the versions belonging to the registry."""
         registry_filter = {
             "name": self.full_name,
@@ -201,12 +203,12 @@ class Registry:
     @tracked
     def create(
         cls,
-        client: "Client",
+        client: Client,
         organization: str,
         name: str,
         visibility: Literal["organization", "restricted"],
-        description: Optional[str] = None,
-        artifact_types: Optional[List[str]] = None,
+        description: str | None = None,
+        artifact_types: list[str] | None = None,
     ):
         """Create a new registry.
 

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -4,6 +4,8 @@ This module provides classes for interacting with W&B reports and
 managing report-related data.
 """
 
+from __future__ import annotations
+
 import ast
 import json
 import re

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -27,8 +27,9 @@ Note:
     and wandb.agent() functions from the main wandb package.
 """
 
+from __future__ import annotations
+
 import urllib
-from typing import Optional
 
 from wandb_gql import gql
 
@@ -103,7 +104,7 @@ class Sweeps(SizedPaginator["Sweep"]):
         entity: str,
         project: str,
         per_page: int = 50,
-    ) -> "Sweeps":
+    ) -> Sweeps:
         """An iterable collection of `Sweep` objects.
 
         Args:
@@ -317,7 +318,7 @@ class Sweep(Attrs):
             return None
 
     @property
-    def expected_run_count(self) -> Optional[int]:
+    def expected_run_count(self) -> int | None:
         """Return the number of expected runs in the sweep or None for infinite runs."""
         return self._attrs.get("runCountExpected")
 
@@ -360,12 +361,12 @@ class Sweep(Attrs):
     @classmethod
     def get(
         cls,
-        client: "RetryingClient",
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
-        sid: Optional[str] = None,
-        order: Optional[str] = None,
-        query: Optional[str] = None,
+        client: RetryingClient,
+        entity: str | None = None,
+        project: str | None = None,
+        sid: str | None = None,
+        order: str | None = None,
+        query: str | None = None,
         **kwargs,
     ):
         """Execute a query against the cloud backend.

--- a/wandb/apis/public/teams.py
+++ b/wandb/apis/public/teams.py
@@ -8,6 +8,8 @@ Note:
     permissions.
 """
 
+from __future__ import annotations
+
 import requests
 from wandb_gql import gql
 

--- a/wandb/apis/public/users.py
+++ b/wandb/apis/public/users.py
@@ -7,6 +7,8 @@ Note:
     users and their authentication. Some operations require admin privileges.
 """
 
+from __future__ import annotations
+
 import requests
 from wandb_gql import gql
 

--- a/wandb/apis/public/utils.py
+++ b/wandb/apis/public/utils.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import re
 from enum import Enum
-from typing import Any, Dict, Iterable, Mapping, Optional, Set
+from typing import Any, Iterable, Mapping
 from urllib.parse import urlparse
 
 from wandb_gql import gql
@@ -75,7 +77,7 @@ def parse_org_from_registry_path(path: str, path_type: PathType) -> str:
 
 
 def fetch_org_from_settings_or_entity(
-    settings: dict, default_entity: Optional[str] = None
+    settings: dict, default_entity: str | None = None
 ) -> str:
     """Fetch the org from either the settings or deriving it from the entity.
 
@@ -110,17 +112,17 @@ def fetch_org_from_settings_or_entity(
 class _GQLCompatRewriter(visitor.Visitor):
     """GraphQL AST visitor to rewrite queries/mutations to be compatible with older server versions."""
 
-    omit_variables: Set[str]
-    omit_fragments: Set[str]
-    omit_fields: Set[str]
-    rename_fields: Dict[str, str]
+    omit_variables: set[str]
+    omit_fragments: set[str]
+    omit_fields: set[str]
+    rename_fields: dict[str, str]
 
     def __init__(
         self,
-        omit_variables: Optional[Iterable[str]] = None,
-        omit_fragments: Optional[Iterable[str]] = None,
-        omit_fields: Optional[Iterable[str]] = None,
-        rename_fields: Optional[Mapping[str, str]] = None,
+        omit_variables: Iterable[str] | None = None,
+        omit_fragments: Iterable[str] | None = None,
+        omit_fields: Iterable[str] | None = None,
+        rename_fields: Mapping[str, str] | None = None,
     ):
         self.omit_variables = set(omit_variables or ())
         self.omit_fragments = set(omit_fragments or ())
@@ -130,7 +132,6 @@ class _GQLCompatRewriter(visitor.Visitor):
     def enter_VariableDefinition(self, node: ast.VariableDefinition, *_, **__) -> Any:  # noqa: N802
         if node.variable.name.value in self.omit_variables:
             return visitor.REMOVE
-        # return node
 
     def enter_ObjectField(self, node: ast.ObjectField, *_, **__) -> Any:  # noqa: N802
         # For context, note that e.g.:
@@ -176,10 +177,10 @@ class _GQLCompatRewriter(visitor.Visitor):
 
 def gql_compat(
     request_string: str,
-    omit_variables: Optional[Iterable[str]] = None,
-    omit_fragments: Optional[Iterable[str]] = None,
-    omit_fields: Optional[Iterable[str]] = None,
-    rename_fields: Optional[Mapping[str, str]] = None,
+    omit_variables: Iterable[str] | None = None,
+    omit_fragments: Iterable[str] | None = None,
+    omit_fields: Iterable[str] | None = None,
+    rename_fields: Mapping[str, str] | None = None,
 ) -> ast.Document:
     """Rewrite a GraphQL request string to ensure compatibility with older server versions.
 


### PR DESCRIPTION
Description
-----------
Applies autofixes to modernize type annotations in the `wandb.apis.public.*` modules, following PEP 563/585/604, e.g.:
  - Adding `from __future__ import annotations` to enable forward references
  - Replacing `Optional[T]` with `T | None` syntax
  - Replacing `Union[T, U]` with `T | U` syntax
  - Replacing `typing` containers with generic collections, e.g. `List[T] -> list[T]`, etc
  - Removing redundant imports from typing module

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
No intended functional changes, relying on existing tests