### PR TITLE
fix: don't print empty status lines when output device is not a terminal

### DIFF
--- a/tests/unit_tests/test_lib/test_progress.py
+++ b/tests/unit_tests/test_lib/test_progress.py
@@ -74,6 +74,25 @@ def test_minimal_operations_static(mock_wandb_log, static_progress_printer):
     assert mock_wandb_log.logged("op 1; op 2; op 3; op 4; op 5 (+ 95 more)")
 
 
+def test_does_not_print_empty_lines(capsys, static_progress_printer):
+    stats1 = pb.OperationStats(
+        total_operations=1,
+        operations=[pb.Operation(desc="op 1", runtime_seconds=123)],
+    )
+    static_progress_printer.update(stats1)
+
+    # Normally, this prints a new line whenever the status changes.
+    # But since the new status is empty, it should just be ignored.
+    static_progress_printer.update(pb.OperationStats(total_operations=0))
+    # The new status is different from the previous one (empty),
+    # but it's the same as the last *printed* one, so it should be skipped.
+    static_progress_printer.update(stats1)
+
+    assert capsys.readouterr().err.splitlines() == [
+        "wandb: op 1",
+    ]
+
+
 def test_operation_progress_and_error(
     emulated_terminal,
     dynamic_progress_printer,

--- a/wandb/sdk/lib/progress.py
+++ b/wandb/sdk/lib/progress.py
@@ -145,10 +145,9 @@ class ProgressPrinter:
             if extra_operations > 0:
                 line += f" (+ {extra_operations} more)"
 
-            if line != self._last_printed_line:
+            if line and line != self._last_printed_line:
                 self._printer.display(line)
-
-            self._last_printed_line = line
+                self._last_printed_line = line
 
     def _update_single_run(
         self,


### PR DESCRIPTION
When `wandb` is used in a script whose output is redirected to a file or a so-called "dumb" terminal, the progress updates it prints during `wandb.init()`, `run.finish()` and some other functions are simplified to avoid dynamic text with ANSI cursor motions and to instead print a single line each time the combined status message changes.

The code was incorrectly printing a blank line when the status was blank (meaning wandb-core didn't report any ongoing operations). This was noticed because it caused a test to flake in `test_offline_sync_beta.py`.