### PR TITLE
chore(sdk): add nox session for python GraphQL codegen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,7 +337,9 @@ If there is a schema change on the Server side that affects your GraphQL API,
 follow the instructions:
 
 - For `wandb-core` (Go): [here](core/api/graphql/schemas/README.md)
-- For `wandb` (Python): [here](tools/graphql_codegen/README.md)
+- For `wandb` (Python):
+  - Update the commit hash in `./core/api/graphql/schemas/commit.hash.txt`
+  - (Re-)run `nox -s gql-codegen`
 
 ## Testing
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -448,6 +448,12 @@ def local_testcontainer_registry(session: nox.Session) -> None:
     session.log(f"Successfully copied image {target_image}")
 
 
+@nox.session(name="gql-codegen", tags=["graphql"], python="3.10")
+def gql_codegen(session: nox.Session) -> None:
+    """Generate Python bindings for graphql queries/mutations/fragments."""
+    session.run("tools/graphql_codegen/generate-graphql.sh", external=True)
+
+
 @nox.session(python=False, name="proto-rust", tags=["proto"])
 def proto_rust(session: nox.Session) -> None:
     """Generate Rust bindings for protobufs."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -450,7 +450,7 @@ def local_testcontainer_registry(session: nox.Session) -> None:
 
 @nox.session(name="gql-codegen", tags=["graphql"], python="3.10")
 def gql_codegen(session: nox.Session) -> None:
-    """Generate Python bindings for graphql queries/mutations/fragments."""
+    """Generate client-side Python code from GraphQL query, mutation, and fragment definitions."""
     session.run("tools/graphql_codegen/generate-graphql.sh", external=True)
 
 

--- a/tools/graphql_codegen/README.md
+++ b/tools/graphql_codegen/README.md
@@ -1,7 +1,3 @@
 # GraphQL Schema
 
 This directory contains GraphQL-to-Python code generation tools for the W&B API.
-
-## To update the schema:
-1. Update the commit hash in `./core/api/graphql/schemas/commit.hash.txt`
-2. Re-run `./tools/graphql_codegen/generate-graphql.sh`


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- https://wandb.atlassian.net/browse/WB-27987

PR:
- Adds a new `nox` session, `nox -s gql-codegen`, to run codegen for Python GraphQL types.  This improves ease of use -- and discoverability -- for the command.
- Updates relevant repo docs to reflect this

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] ~I updated CHANGELOG.unreleased.md, or~ it's not applicable


Testing
-------
N/A.  Changes do not touch any runtime code or tests.

Have confirmed that:
- After running `nox -s gql-codegen` locally, all `_generated/**/*.py` remain unchanged.
- After removing all generated files, _then_ rerunning `nox -s gql-codegen`, all previous `_generated/**/*.py` files are regenerated without changes.

Both of these are expected behavior at this time.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
