### PR TITLE
fix(artifacts): prune unused fragments from rewritten GQL requests

### DIFF
--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -742,12 +742,9 @@ class Artifacts(SizedPaginator["Artifact"]):
         else:
             rename_fields = {"artifactCollection": "artifactSequence"}
 
-        omit_fields = omit_artifact_fields(client)
-        omit_fragments = {"TagFragment"} if ("tags" in omit_fields) else set()
         self.QUERY = gql_compat(
             PROJECT_ARTIFACTS_GQL,
-            omit_fields=omit_fields,
-            omit_fragments=omit_fragments,
+            omit_fields=omit_artifact_fields(client),
             rename_fields=rename_fields,
         )
 
@@ -848,11 +845,7 @@ class RunArtifacts(SizedPaginator["Artifact"]):
         except LookupError:
             raise ValueError("mode must be logged or used")
         else:
-            omit_fields = omit_artifact_fields(client)
-            omit_fragments = {"TagFragment"} if ("tags" in omit_fields) else set()
-            self.QUERY = gql_compat(
-                query_str, omit_fields=omit_fields, omit_fragments=omit_fragments
-            )
+            self.QUERY = gql_compat(query_str, omit_fields=omit_artifact_fields(client))
 
         variable_values = {
             "entity": run.entity,

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -269,12 +269,7 @@ class Versions(Paginator["Artifact"]):
         self.artifact_filter = artifact_filter or {}
 
         omit_fields = omit_artifact_fields(client)
-        omit_fragments = {"TagFragment"} if ("tags" in omit_fields) else set()
-        self.QUERY = gql_compat(
-            REGISTRY_VERSIONS_GQL,
-            omit_fields=omit_fields,
-            omit_fragments=omit_fragments,
-        )
+        self.QUERY = gql_compat(REGISTRY_VERSIONS_GQL, omit_fields=omit_fields)
 
         variables = {
             "registryFilter": json.dumps(f) if (f := registry_filter) else None,

--- a/wandb/apis/public/utils.py
+++ b/wandb/apis/public/utils.py
@@ -6,7 +6,9 @@ from typing import Any, Iterable, Mapping
 from urllib.parse import urlparse
 
 from wandb_gql import gql
+from wandb_graphql import TypeInfo
 from wandb_graphql.language import ast, visitor
+from wandb_graphql.validation.validation import ValidationContext
 
 from wandb._iterutils import one
 from wandb.sdk.artifacts._validators import is_artifact_registry_project
@@ -112,11 +114,6 @@ def fetch_org_from_settings_or_entity(
 class _GQLCompatRewriter(visitor.Visitor):
     """GraphQL AST visitor to rewrite queries/mutations to be compatible with older server versions."""
 
-    omit_variables: set[str]
-    omit_fragments: set[str]
-    omit_fields: set[str]
-    rename_fields: dict[str, str]
-
     def __init__(
         self,
         omit_variables: Iterable[str] | None = None,
@@ -129,25 +126,52 @@ class _GQLCompatRewriter(visitor.Visitor):
         self.omit_fields = set(omit_fields or ())
         self.rename_fields = dict(rename_fields or {})
 
-    def enter_VariableDefinition(self, node: ast.VariableDefinition, *_, **__) -> Any:  # noqa: N802
-        if node.variable.name.value in self.omit_variables:
+    def leave_Document(self, node: ast.Document, *_, **__) -> Any:  # noqa: N802
+        # After rewriting the GQL document, prune "orphan" (unused) fragment definitions.
+        # Note: The ValidationContext doesn't require a schema here, as we only use it to check for reachable fragments.
+        ctx = ValidationContext(schema=None, ast=node, type_info=TypeInfo(schema=None))
+        operation_defns = {
+            dfn for dfn in node.definitions if isinstance(dfn, ast.OperationDefinition)
+        }
+        used_fragment_defns = {
+            frag
+            for op in operation_defns
+            for frag in ctx.get_recursively_referenced_fragments(op)
+        }
+        # Preserve original defintion order
+        allowed_defns = operation_defns | used_fragment_defns
+        node.definitions = [dfn for dfn in node.definitions if (dfn in allowed_defns)]
+
+    def enter_Variable(self, node: ast.Variable, *_, **__) -> Any:  # noqa: N802
+        if node.name.value in self.omit_variables:
             return visitor.REMOVE
 
-    def enter_ObjectField(self, node: ast.ObjectField, *_, **__) -> Any:  # noqa: N802
-        # For context, note that e.g.:
+    def leave_VariableDefinition(self, node: ast.VariableDefinition, *_, **__) -> Any:  # noqa: N802
+        # For context, consider the `$varName: String` variable definition below:
+        #   (..., $varName: String, ...)
         #
-        #   {description: $description
-        #   ...}
+        # On ENTERING, the AST looks like:
+        #     VariableDefinition(variable=Variable(name=Name(value='varName')), ...)
         #
-        # Is parsed as:
+        # On LEAVING, if `$varName` was removed, the AST looks like:
+        #     VariableDefinition(variable=REMOVE, ...)
+        if node.variable is visitor.REMOVE:
+            return visitor.REMOVE
+
+    def leave_ObjectField(self, node: ast.ObjectField, *_, **__) -> Any:  # noqa: N802
+        # For context, consider `argName: $varName` in the input args below:
+        #   input: {..., argName: $varName, ...}
         #
-        #   ObjectValue(fields=[
-        #     ObjectField(name=Name(value='description'), value=Variable(name=Name(value='description'))),
-        #   ...])
-        if (
-            isinstance(var := node.value, ast.Variable)
-            and var.name.value in self.omit_variables
-        ):
+        # On ENTERING, the AST for `argName: $varName` looks like:
+        #     ObjectField(
+        #       name=Name(value='argName'), value=Variable(name=Name(value='varName')),
+        #     )
+        #
+        # On LEAVING, if `$varName` was removed, the AST looks like:
+        #     ObjectField(
+        #       name=Name(value='argName'), value=REMOVE,
+        #     )
+        if node.value is visitor.REMOVE:
             return visitor.REMOVE
 
     def enter_Argument(self, node: ast.Argument, *_, **__) -> Any:  # noqa: N802
@@ -167,7 +191,6 @@ class _GQLCompatRewriter(visitor.Visitor):
             return visitor.REMOVE
         if new_name := self.rename_fields.get(node.name.value):
             node.name.value = new_name
-            return node
 
     def leave_Field(self, node: ast.Field, *_, **__) -> Any:  # noqa: N802
         # If the field had a selection set, but now it's empty, remove the field entirely


### PR DESCRIPTION
## Description

- Fixes https://wandb.atlassian.net/browse/WB-28498

PR ensures the internal `gql_compat()` helper -- which is used to rewrite GQL queries/mutations for compatibility with older servers -- correctly removes _all_ unused fragment definitions from the GraphQL query/mutation before sending it in a request.

- In particular, queries for artifacts include multiple fields that have been added to the GraphQL schema in different server releases. 
- Including a newer field in GraphQL requests to an older server will cause the request to error out (rather than e.g. returning a null value).
- To clarify, this fix **is agnostic to whether the calling code uses (prev) GQL introspection or (current) ServerFeature flags** to determine server compatibility.

This PR ensures that `gql_compat()` recursively prunes "orphan" fragment definitions that become unreachable after rewriting a GQL request for older servers. Previously, such orphan fragments would remain in the rewritten GQL query/mutation, leading to either:
- Brittle workarounds to remove them (to pass existing tests in CI), or
- Unnecessary GQL request errors at runtime (if uncaught by tests)

-----

- [x] ~I updated CHANGELOG.unreleased.md, or~ it's not applicable

## Testing

The PR includes updated unit tests for `gql_compat()` with more complex fragment relationships, including nested fragments and orphaned fragments, to verify the correct pruning behavior.

The test is probably the easiest way of seeing what the added logic is meant to do.  See: https://github.com/wandb/wandb/pull/10611/files#diff-c8869437d0c764bced8404510a26f41029d8fa405097233c0abf10920ff81f15