### PR TITLE
refactor(artifacts): decouple transport-free ArtifactCollection attributes into validated ArtifactCollectionData type

### DIFF
--- a/wandb/sdk/artifacts/_models/__init__.py
+++ b/wandb/sdk/artifacts/_models/__init__.py
@@ -6,7 +6,8 @@ Excludes GraphQL-generated classes.
 __all__ = [
     "ArtifactsBase",
     "RegistryData",
+    "ArtifactCollectionData",
 ]
-
+from .artifact_collection import ArtifactCollectionData
 from .base_model import ArtifactsBase
 from .registry import RegistryData

--- a/wandb/sdk/artifacts/_models/artifact_collection.py
+++ b/wandb/sdk/artifacts/_models/artifact_collection.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple
+
+from pydantic import ConfigDict, Field
+from typing_extensions import Self
+
+from wandb._pydantic import field_validator
+from wandb.sdk.artifacts._generated import ArtifactCollectionFragment
+from wandb.sdk.artifacts._validators import (
+    SOURCE_COLLECTION_TYPENAME,
+    validate_artifact_name,
+    validate_tags,
+)
+
+from .base_model import ArtifactsBase
+
+
+class ArtifactCollectionData(ArtifactsBase):
+    """Transport-free model for local `ArtifactCollection` data.
+
+    For now, this is separated from the public `ArtifactCollection` model
+    to more easily ensure continuity in the public `ArtifactCollection` API.
+
+    Note:
+        In a future change, consider making _this_ the public `ArtifactCollection` instead, i.e.:
+        - Replace the _existing_ `ArtifactCollection` class with this one
+        - Rename _this_ class to `ArtifactCollection`
+        Note that this would be a breaking change.
+    """
+
+    model_config = ConfigDict(
+        str_min_length=1,  # Strings cannot be empty
+    )
+
+    typename__: str = Field(alias="__typename", frozen=True, repr=False)
+    """The GraphQL `__typename` for this object."""
+
+    id: str = Field(frozen=True, repr=False)
+    """The encoded GraphQL ID for this object."""
+
+    name: str
+    """The name of this collection."""
+
+    type: str
+    """The artifact type of this collection."""
+
+    description: Optional[str] = None
+    """The description, if any, for this collection."""
+
+    created_at: str = Field(frozen=True)
+    """When this collection was created."""
+
+    project: str = Field(frozen=True)
+    """The name of this collection's project."""
+
+    entity: str = Field(frozen=True)
+    """The name of the entity that owns this collection's project."""
+
+    aliases: Optional[Tuple[str, ...]] = Field(default=None, frozen=True)
+    """All aliases assigned to artifact versions within this collection.
+
+    Note:
+        `None` should signal that aliases haven't been (or couldn't be) fetched and parsed yet,
+        for any reason, NOT the actual absence of aliases in this collection.
+    """
+
+    tags: List[str] = Field(default_factory=list)
+    """The tags assigned to this collection.
+
+    Note that this is distinct from any tags assigned to individual artifact versions within this collection.
+    """
+
+    @field_validator("name", mode="plain")
+    def _validate_name(cls, v: str) -> str:
+        return validate_artifact_name(v)
+
+    @field_validator("tags", mode="plain")
+    def _validate_tags(cls, v: Any) -> list[str]:
+        """Ensure tags is a validated, deduped list of (str) tag names."""
+        return validate_tags(v)
+
+    @property
+    def is_sequence(self) -> bool:
+        """Returns True if the artifact collection is an ArtifactSequence (source collection)."""
+        return self.typename__ == SOURCE_COLLECTION_TYPENAME
+
+    @classmethod
+    def from_fragment(cls, obj: ArtifactCollectionFragment) -> Self:
+        """Instantiate this type from a GraphQL fragment."""
+        if obj.project is None:
+            raise ValueError(f"Missing project info in {type(obj)!r} data")
+
+        return cls(
+            typename__=obj.typename__,
+            id=obj.id,
+            name=obj.name,
+            type=obj.type.name,
+            description=obj.description,
+            created_at=obj.created_at,
+            project=obj.project.name,
+            entity=obj.project.entity.name,
+            tags=[e.node.name for e in obj.tags.edges if e.node],
+            aliases=(
+                [e.node.alias for e in obj.aliases.edges if e.node]
+                if obj.aliases
+                else []
+            ),
+        )

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -6,7 +6,17 @@ import json
 import re
 from dataclasses import dataclass, field, replace
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Literal,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from typing_extensions import Concatenate, ParamSpec, Self
@@ -164,7 +174,7 @@ TAG_REGEX: re.Pattern[str] = re.compile(r"^[-\w]+( +[-\w]+)*$")
 """Regex pattern for valid tag names."""
 
 
-def validate_tags(tags: Collection[str] | str) -> list[str]:
+def validate_tags(tags: Iterable[str] | str) -> list[str]:
     """Validate the artifact tag names and return them as a deduped list.
 
     In the case of duplicates, only keep the first tag, and otherwise maintain the order of appearance.


### PR DESCRIPTION
## Description

PR: 
- Refactors `ArtifactCollection` to use a dedicated data model
- Introduces an `ArtifactCollectionData` type as the "transport-free" data model for parsed, local artifact collection objects.
- Refactors `ArtifactCollection` to hold separate `_saved` vs `_current` instances of `ArtifactCollectionData`.  This is intended to provide a more extensible, less brittle mechanism for keeping track of the collection's:
  - saved state, vs 
  - local unsaved changes/edits
- Updates GraphQL `ArtifactCollectionFragment` to include relevant fields including `project`, `defaultArtifactType`
- Improves internal data handling + type safety via runtime model validation

This PR refactors the `ArtifactCollection` class to use a dedicated data model that properly separates the saved state (as fetched from the server) from the current, editable state. It introduces a new `ArtifactCollectionData` class that handles validation and provides a cleaner interface for working with artifact collection data.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable