### PR TITLE
refactor: report Writer.Flush error in FlowControl

### DIFF
--- a/core/internal/stream/writer.go
+++ b/core/internal/stream/writer.go
@@ -136,15 +136,13 @@ func (w *Writer) write(record *spb.Record) (int64, error) {
 }
 
 // Flush ensures all Work the Writer has output has been written to disk.
-func (w *Writer) Flush() {
+func (w *Writer) Flush() error {
 	w.writerMu.Lock()
 	defer w.writerMu.Unlock()
 
 	if w.finished {
-		return
+		return nil
 	}
 
-	if err := w.writer.Flush(); err != nil {
-		w.logger.CaptureError(fmt.Errorf("writer: failed to flush: %v", err))
-	}
+	return w.writer.Flush()
 }


### PR DESCRIPTION
Makes `Writer.Flush` return an error if it failed to flush, and makes `FlowControl` detect the error and stop instead of likely running into another, more confusing error like "failed to seek: EOF".

See [this trace](https://weights-biases.sentry.io/issues/trace/59ed8bd07e02a6e86440887df980f9c6/?groupId=6912553190&node=error-ec4c618f2038484b818e140fe564e49b&pageEnd=2025-10-01T18%3A09%3A37.618&pageStart=2025-09-30T18%3A09%3A37.618&project=4505513612214272&query=release%3A%5B0.22.1%2C0.22.0%5D&referrer=issue-stream&source=issue_details&timestamp=1759298977) where that happened because the machine ran out of disk space.