### PR TITLE
fix(artifacts): fix typing and inheritance issues in StorageHandler, StoragePolicy classes

### DIFF
--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -4,7 +4,6 @@ import random
 import tempfile
 from multiprocessing import Pool
 from pathlib import Path
-from urllib.parse import urlparse
 
 import pytest
 import wandb
@@ -13,7 +12,7 @@ from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.staging import get_staging_dir
-from wandb.sdk.artifacts.storage_handler import StorageHandler
+from wandb.sdk.artifacts.storage_handler import StorageHandler, _BaseStorageHandler
 from wandb.sdk.artifacts.storage_handlers.gcs_handler import GCSHandler
 from wandb.sdk.artifacts.storage_handlers.local_file_handler import LocalFileHandler
 from wandb.sdk.artifacts.storage_handlers.s3_handler import S3Handler
@@ -525,22 +524,23 @@ def test_storage_policy_incomplete():
     policy = StoragePolicy.lookup_by_name("UnfinishedStoragePolicy")
     assert policy is UnfinishedStoragePolicy
 
-    with pytest.raises(NotImplementedError, match="Failed to find storage policy"):
+    with pytest.raises(ValueError, match="Failed to find storage policy"):
         StoragePolicy.lookup_by_name("NotAStoragePolicy")
 
 
 def test_storage_handler_incomplete():
-    class UnfinishedStorageHandler(StorageHandler):
+    class UnfinishedStorageHandler(_BaseStorageHandler):
         pass
 
-    ush = UnfinishedStorageHandler()
+    # Instantiation should fail if the StorageHandler impl doesn't fully implement all abstract methods.
+    with pytest.raises(TypeError):
+        UnfinishedStorageHandler()
 
-    with pytest.raises(NotImplementedError):
-        ush.can_handle(parsed_url=urlparse("https://wandb.com"))
-    with pytest.raises(NotImplementedError):
-        ush.load_path(manifest_entry=None)
-    with pytest.raises(NotImplementedError):
-        ush.store_path(artifact=None, path="")
+    class UnfinishedSingleStorageHandler(StorageHandler):
+        pass
+
+    with pytest.raises(TypeError):
+        UnfinishedSingleStorageHandler()
 
 
 def test_unwritable_staging_dir(monkeypatch):

--- a/wandb/sdk/artifacts/storage_handler.py
+++ b/wandb/sdk/artifacts/storage_handler.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Final
 
 from wandb.sdk.lib.paths import FilePathStr, URIStr
 
@@ -12,18 +13,11 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
     from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 
-DEFAULT_MAX_OBJECTS = 10**7
+DEFAULT_MAX_OBJECTS: Final[int] = 10_000_000  # 10**7
 
 
-class StorageHandler:
-    def can_handle(self, parsed_url: ParseResult) -> bool:
-        """Checks whether this handler can handle the given url.
-
-        Returns:
-            Whether this handler can handle the given url.
-        """
-        raise NotImplementedError
-
+class _BaseStorageHandler(ABC):
+    @abstractmethod
     def load_path(
         self,
         manifest_entry: ArtifactManifestEntry,
@@ -40,6 +34,7 @@ class StorageHandler:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def store_path(
         self,
         artifact: Artifact,
@@ -47,7 +42,7 @@ class StorageHandler:
         name: str | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         """Store the file or directory at the given path to the specified artifact.
 
         Args:
@@ -58,5 +53,16 @@ class StorageHandler:
 
         Returns:
             A list of manifest entries to store within the artifact
+        """
+        raise NotImplementedError
+
+
+class StorageHandler(_BaseStorageHandler, ABC):  # Handles a single storage protocol
+    @abstractmethod
+    def can_handle(self, parsed_url: ParseResult) -> bool:
+        """Checks whether this handler can handle the given url.
+
+        Returns:
+            Whether this handler can handle the given url.
         """
         raise NotImplementedError

--- a/wandb/sdk/artifacts/storage_handlers/azure_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/azure_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import PurePosixPath
 from types import ModuleType
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 from urllib.parse import ParseResult, parse_qsl, urlparse
 
 import wandb
@@ -20,16 +20,21 @@ if TYPE_CHECKING:
     import azure.storage.blob  # type: ignore
 
     from wandb.sdk.artifacts.artifact import Artifact
+    from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
 
 
 class AzureHandler(StorageHandler):
+    _scheme: str
+    _cache: ArtifactFileCache
+
+    def __init__(self, scheme: str = "https") -> None:
+        self._scheme = scheme
+        self._cache = get_artifact_file_cache()
+
     def can_handle(self, parsed_url: ParseResult) -> bool:
-        return parsed_url.scheme == "https" and parsed_url.netloc.endswith(
+        return parsed_url.scheme == self._scheme and parsed_url.netloc.endswith(
             ".blob.core.windows.net"
         )
-
-    def __init__(self, scheme: str | None = None) -> None:
-        self._cache = get_artifact_file_cache()
 
     def load_path(
         self,
@@ -101,7 +106,7 @@ class AzureHandler(StorageHandler):
         name: StrPath | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         account_url, container_name, blob_name, query = self._parse_uri(path)
         path = URIStr(f"{account_url}/{container_name}/{blob_name}")
 

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 from urllib.parse import ParseResult, urlparse
 
 from wandb import util
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     import google.cloud.storage as gcs_module  # type: ignore
 
     from wandb.sdk.artifacts.artifact import Artifact
+    from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
 
 
 class _GCSIsADirectoryError(Exception):
@@ -26,10 +27,12 @@ class _GCSIsADirectoryError(Exception):
 
 
 class GCSHandler(StorageHandler):
+    _scheme: str
     _client: gcs_module.client.Client | None
+    _cache: ArtifactFileCache
 
-    def __init__(self, scheme: str | None = None) -> None:
-        self._scheme = scheme or "gs"
+    def __init__(self, scheme: str = "gs") -> None:
+        self._scheme = scheme
         self._client = None
         self._cache = get_artifact_file_cache()
 
@@ -111,7 +114,7 @@ class GCSHandler(StorageHandler):
         name: StrPath | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         self.init_gcs()
         assert self._client is not None  # mypy: unwraps optionality
 
@@ -131,7 +134,7 @@ class GCSHandler(StorageHandler):
             raise ValueError(f"Object does not exist: {path}#{version}")
         multi = obj is None
         if multi:
-            start_time = time.time()
+            start_time = time.monotonic()
             termlog(
                 f'Generating checksum for up to {max_objects} objects with prefix "{key}"... ',
                 newline=False,
@@ -148,7 +151,7 @@ class GCSHandler(StorageHandler):
             if not obj.name.endswith("/")
         ]
         if start_time is not None:
-            termlog("Done. %.1fs" % (time.time() - start_time), prefix=False)
+            termlog("Done. %.1fs" % (time.monotonic() - start_time), prefix=False)
         if len(entries) > max_objects:
             raise ValueError(
                 f"Exceeded {max_objects} objects tracked, pass max_objects to add_reference"

--- a/wandb/sdk/artifacts/storage_handlers/http_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/http_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 from urllib.parse import ParseResult
 
 from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
@@ -18,11 +18,16 @@ if TYPE_CHECKING:
     from requests.structures import CaseInsensitiveDict
 
     from wandb.sdk.artifacts.artifact import Artifact
+    from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
 
 
 class HTTPHandler(StorageHandler):
-    def __init__(self, session: requests.Session, scheme: str | None = None) -> None:
-        self._scheme = scheme or "http"
+    _scheme: str
+    _cache: ArtifactFileCache
+    _session: requests.Session
+
+    def __init__(self, session: requests.Session, scheme: str = "http") -> None:
+        self._scheme = scheme
         self._cache = get_artifact_file_cache()
         self._session = session
 
@@ -75,7 +80,7 @@ class HTTPHandler(StorageHandler):
         name: StrPath | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         name = name or os.path.basename(path)
         if not checksum:
             return [ArtifactManifestEntry(path=name, ref=path, digest=path)]

--- a/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 from urllib.parse import ParseResult
 
 from wandb import util
@@ -20,17 +20,21 @@ from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 
 if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
+    from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
 
 
 class LocalFileHandler(StorageHandler):
     """Handles file:// references."""
 
-    def __init__(self, scheme: str | None = None) -> None:
+    _scheme: str
+    _cache: ArtifactFileCache
+
+    def __init__(self, scheme: str = "file") -> None:
         """Track files or directories on a local filesystem.
 
         Expand directories to create an entry for each file contained.
         """
-        self._scheme = scheme or "file"
+        self._scheme = scheme
         self._cache = get_artifact_file_cache()
 
     def can_handle(self, parsed_url: ParseResult) -> bool:
@@ -75,7 +79,7 @@ class LocalFileHandler(StorageHandler):
         name: StrPath | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         local_path = util.local_file_uri_to_path(path)
         max_objects = max_objects or DEFAULT_MAX_OBJECTS
         # We have a single file or directory
@@ -95,7 +99,7 @@ class LocalFileHandler(StorageHandler):
 
         if os.path.isdir(local_path):
             i = 0
-            start_time = time.time()
+            start_time = time.monotonic()
             if checksum:
                 termlog(
                     f'Generating checksum for up to {max_objects} files in "{local_path}"... ',
@@ -126,7 +130,7 @@ class LocalFileHandler(StorageHandler):
                     )
                     entries.append(entry)
             if checksum:
-                termlog("Done. %.1fs" % (time.time() - start_time), prefix=False)
+                termlog("Done. %.1fs" % (time.monotonic() - start_time), prefix=False)
         elif os.path.isfile(local_path):
             name = name or os.path.basename(local_path)
             entry = ArtifactManifestEntry(

--- a/wandb/sdk/artifacts/storage_handlers/multi_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/multi_handler.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from wandb.sdk.artifacts.storage_handler import StorageHandler
+from wandb.sdk.artifacts.storage_handler import StorageHandler, _BaseStorageHandler
 from wandb.sdk.lib.paths import FilePathStr, URIStr
 
 if TYPE_CHECKING:
@@ -13,8 +13,9 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 
 
-class MultiHandler(StorageHandler):
+class MultiHandler(_BaseStorageHandler):
     _handlers: list[StorageHandler]
+    _default_handler: StorageHandler | None
 
     def __init__(
         self,
@@ -49,7 +50,7 @@ class MultiHandler(StorageHandler):
         name: str | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         handler = self._get_handler(path)
         return handler.store_path(
             artifact, path, name=name, checksum=checksum, max_objects=max_objects

--- a/wandb/sdk/artifacts/storage_handlers/tracking_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/tracking_handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from wandb.errors.term import termwarn
@@ -17,7 +17,9 @@ if TYPE_CHECKING:
 
 
 class TrackingHandler(StorageHandler):
-    def __init__(self, scheme: str | None = None) -> None:
+    _scheme: str
+
+    def __init__(self, scheme: str = "") -> None:
         """Track paths with no modification or special processing.
 
         Useful when paths being tracked are on file systems mounted at a standardized
@@ -26,7 +28,7 @@ class TrackingHandler(StorageHandler):
         For example, if the data to track is located on an NFS share mounted on
         `/data`, then it is sufficient to just track the paths.
         """
-        self._scheme = scheme or ""
+        self._scheme = scheme
 
     def can_handle(self, parsed_url: ParseResult) -> bool:
         return parsed_url.scheme == self._scheme
@@ -55,7 +57,7 @@ class TrackingHandler(StorageHandler):
         name: StrPath | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         url = urlparse(path)
         if name is None:
             raise ValueError(

--- a/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
@@ -3,27 +3,29 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse
 
-import wandb
-from wandb import util
+from wandb._strutils import removeprefix
 from wandb.apis import PublicApi
 from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.storage_handler import StorageHandler
-from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, hex_to_b64_id
+from wandb.sdk.lib.hashutil import b64_to_hex_id, hex_to_b64_id
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 
 if TYPE_CHECKING:
     from urllib.parse import ParseResult
 
     from wandb.sdk.artifacts.artifact import Artifact
+    from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
 
 
 class WBArtifactHandler(StorageHandler):
     """Handles loading and storing Artifact reference-type files."""
 
+    _scheme: Literal["wandb-artifact"]
+    _cache: ArtifactFileCache
     _client: PublicApi | None
 
     def __init__(self) -> None:
@@ -55,6 +57,8 @@ class WBArtifactHandler(StorageHandler):
         Returns:
             (os.PathLike): A path to the file represented by `index_entry`
         """
+        from wandb.sdk.artifacts.artifact import Artifact  # avoids circular import
+
         # We don't check for cache hits here. Since we have 0 for size (since this
         # is a cross-artifact reference which and we've made the choice to store 0
         # in the size field), we can't confirm if the file is complete. So we just
@@ -62,19 +66,17 @@ class WBArtifactHandler(StorageHandler):
         # check.
 
         # Parse the reference path and download the artifact if needed
-        artifact_id = util.host_from_path(manifest_entry.ref)
-        artifact_file_path = util.uri_from_path(manifest_entry.ref)
+        parsed = urlparse(manifest_entry.ref)
+        artifact_id = hex_to_b64_id(parsed.netloc)
+        artifact_file_path = removeprefix(str(parsed.path), "/")
 
-        dep_artifact = wandb.Artifact._from_id(
-            hex_to_b64_id(artifact_id), self.client.client
-        )
+        dep_artifact = Artifact._from_id(artifact_id, self.client.client)
         assert dep_artifact is not None
         link_target_path: URIStr | FilePathStr
         if local:
             link_target_path = dep_artifact.get_entry(artifact_file_path).download()
         else:
             link_target_path = dep_artifact.get_entry(artifact_file_path).ref_target()
-
         return link_target_path
 
     def store_path(
@@ -84,7 +86,7 @@ class WBArtifactHandler(StorageHandler):
         name: StrPath | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         """Store the file or directory at the given path into the specified artifact.
 
         Recursively resolves the reference until the result is a concrete asset.
@@ -97,26 +99,27 @@ class WBArtifactHandler(StorageHandler):
             (list[ArtifactManifestEntry]): A list of manifest entries to store within
             the artifact
         """
+        from wandb.sdk.artifacts.artifact import Artifact  # avoids circular import
+
         # Recursively resolve the reference until a concrete asset is found
         # TODO: Consider resolving server-side for performance improvements.
-        iter_path: URIStr | FilePathStr | None = path
-        while iter_path is not None and urlparse(iter_path).scheme == self._scheme:
-            artifact_id = util.host_from_path(iter_path)
-            artifact_file_path = util.uri_from_path(iter_path)
-            target_artifact = wandb.Artifact._from_id(
-                hex_to_b64_id(artifact_id), self.client.client
-            )
+        curr_path: URIStr | FilePathStr | None = path
+        while curr_path and (parsed := urlparse(curr_path)).scheme == self._scheme:
+            artifact_id = hex_to_b64_id(parsed.netloc)
+            artifact_file_path = removeprefix(parsed.path, "/")
+
+            target_artifact = Artifact._from_id(artifact_id, self.client.client)
             assert target_artifact is not None
 
             entry = target_artifact.manifest.get_entry_by_path(artifact_file_path)
             assert entry is not None
-            iter_path = entry.ref
+            curr_path = entry.ref
 
         # Create the path reference
         assert target_artifact is not None
         assert target_artifact.id is not None
-        path = URIStr(
-            f"{self._scheme}://{b64_to_hex_id(B64MD5(target_artifact.id))}/{artifact_file_path}"
+        path = (
+            f"{self._scheme}://{b64_to_hex_id(target_artifact.id)}/{artifact_file_path}"
         )
 
         # Return the new entry

--- a/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Literal
 
 import wandb
 from wandb import util
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
 class WBLocalArtifactHandler(StorageHandler):
     """Handles loading and storing Artifact reference-type files."""
+
+    _scheme: Literal["wandb-client-artifact"]
 
     def __init__(self) -> None:
         self._scheme = "wandb-client-artifact"
@@ -43,7 +45,7 @@ class WBLocalArtifactHandler(StorageHandler):
         name: StrPath | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         """Store the file or directory at the given path within the specified artifact.
 
         Args:

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -12,7 +12,7 @@ import queue
 import shutil
 import threading
 from collections import deque
-from typing import IO, TYPE_CHECKING, Any, NamedTuple, Sequence
+from typing import IO, TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import quote
 
 import requests
@@ -109,7 +109,7 @@ class WandbStoragePolicy(StoragePolicy):
         if not storage_region.strip():
             raise ValueError("storageRegion must be a non-empty string")
 
-    def config(self) -> dict:
+    def config(self) -> dict[str, Any]:
         return self._config
 
     def load_file(
@@ -314,7 +314,7 @@ class WandbStoragePolicy(StoragePolicy):
         name: str | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         return self._handler.store_path(
             artifact, path, name=name, checksum=checksum, max_objects=max_objects
         )

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import concurrent.futures
-from typing import TYPE_CHECKING, Sequence
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
 
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.lib.paths import FilePathStr, URIStr
@@ -15,27 +16,37 @@ if TYPE_CHECKING:
     from wandb.sdk.internal.progress import ProgressFn
 
 
-class StoragePolicy:
+_POLICY_REGISTRY: dict[str, type[StoragePolicy]] = {}
+
+
+class StoragePolicy(ABC):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        _POLICY_REGISTRY[cls.name()] = cls
+
     @classmethod
     def lookup_by_name(cls, name: str) -> type[StoragePolicy]:
-        import wandb.sdk.artifacts.storage_policies  # noqa: F401
-
-        for sub in cls.__subclasses__():
-            if sub.name() == name:
-                return sub
-        raise NotImplementedError(f"Failed to find storage policy '{name}'")
+        if policy := _POLICY_REGISTRY.get(name):
+            return policy
+        raise ValueError(f"Failed to find storage policy {name!r}")
 
     @classmethod
+    @abstractmethod
     def name(cls) -> str:
         raise NotImplementedError
 
     @classmethod
-    def from_config(cls, config: dict, api: InternalApi | None = None) -> StoragePolicy:
+    @abstractmethod
+    def from_config(
+        cls, config: dict[str, Any], api: InternalApi | None = None
+    ) -> StoragePolicy:
         raise NotImplementedError
 
-    def config(self) -> dict:
+    @abstractmethod
+    def config(self) -> dict[str, Any]:
         raise NotImplementedError
 
+    @abstractmethod
     def load_file(
         self,
         artifact: Artifact,
@@ -46,6 +57,7 @@ class StoragePolicy:
     ) -> FilePathStr:
         raise NotImplementedError
 
+    @abstractmethod
     def store_file(
         self,
         artifact_id: str,
@@ -56,6 +68,7 @@ class StoragePolicy:
     ) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
     def store_reference(
         self,
         artifact: Artifact,
@@ -63,9 +76,10 @@ class StoragePolicy:
         name: str | None = None,
         checksum: bool = True,
         max_objects: int | None = None,
-    ) -> Sequence[ArtifactManifestEntry]:
+    ) -> list[ArtifactManifestEntry]:
         raise NotImplementedError
 
+    @abstractmethod
     def load_reference(
         self,
         manifest_entry: ArtifactManifestEntry,


### PR DESCRIPTION
## Description

- Fixes https://wandb.atlassian.net/browse/WB-28038

PR:
- Fixes the definition of the `StorageHandler` base class, defining it as a proper [ABC](https://docs.python.org/3/library/abc.html#module-abc) and following expected patterns.
- Introduces `_BaseStorageHandler` as the underlying ABC for both:
  - `StorageHandler`, which handles a single storage protocol)
  - `MultiHandler`, which manages multiple storage handlers and previously 
- Fixes / narrows type annotations in StorageHandler method signatures
- Fixes raised error types: `NotImplementedError -> ValueError/TypeError` where appropriate.
  - Context: See [docs on NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError) for more details on when it's intended/not intended to be used
- Makes `StorageHandler` schemes non-optional with proper defaults, as well as `Literal[...]` annotations where appropriate for clarity and additional safety

- Fixes timing measurements in storage methods to use `time.monotonic()`, which is safer than `time.time()` in this context

## Testing
No intended functional changes. Existing tests must continue to pass.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable