### PR TITLE
chore: upgrade MacOS execution environment in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ parameters:
 executors:
   macos:
     macos:
-      xcode: 15.1.0
-    resource_class: macos.m1.medium.gen1
+      xcode: 15.4.0
+    resource_class: m4pro.medium
 
   linux-python:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
 executors:
   macos:
     macos:
-      xcode: 15.4.0
+      xcode: 16.4.0
     resource_class: m4pro.medium
 
   linux-python:


### PR DESCRIPTION
Description
-----------
Our MacOS tests have been taking a long time:
https://app.circleci.com/insights/github/wandb/wandb/workflows/main/jobs?branch=main
<img width="1448" height="92" alt="image" src="https://github.com/user-attachments/assets/17f13d5e-a4e1-4d33-8794-06c8c301a348" />

And
<img width="1471" height="65" alt="image" src="https://github.com/user-attachments/assets/b6f7a87f-e7a0-44f9-805f-3649d1d4f6c3" />

So let's upgrade to m4pro.medium, which seems like the best deal. These are more expensive:
<img width="1394" height="747" alt="image" src="https://github.com/user-attachments/assets/db801ec8-1cd7-44cf-8c05-93e157db6f1c" />

But I think the saved exec time will compensate for that.