### PR TITLE
fix: excessive data uploads when calling `run.save()` repeatedly on unchanged files

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,3 +16,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Possibly fixed some cases where the `output.log` file was not being uploaded (@timoffex in https://github.com/wandb/wandb/pull/10620)
+- Fixed excessive data uploads when calling `run.save()` repeatedly on unchanged files (@dmitryduev in https://github.com/wandb/wandb/pull/10639)

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -525,44 +525,46 @@ func TestUploader(t *testing.T) {
 		},
 	)
 
-	// runTest("Process reuploads when bytes change but size is the same",
-	// 	func() { /* no batchDelay */ },
-	// 	func(t *testing.T) {
-	// 		fakeFileTransfer.ShouldCompleteImmediately = false
+	runTest("Process reuploads when bytes change but size is the same",
+		func() { /* no batchDelay */ },
+		func(t *testing.T) {
+			fakeFileTransfer.ShouldCompleteImmediately = false
 
-	// 		testRel := "same_size_change.txt"
-	// 		testAbs := filepath.Join(filesDir, testRel)
+			testRel := "same_size_change.txt"
+			testAbs := filepath.Join(filesDir, testRel)
+			writeEmptyFile(t, testAbs)
+			require.NoError(t, os.Chmod(testAbs, os.FileMode(0644)))
 
-	// 		// Write 4 bytes, make file writable.
-	// 		require.NoError(t, os.WriteFile(testAbs, []byte("AAAA"), 0644))
+			// Write 4 bytes, make file writable.
+			require.NoError(t, os.WriteFile(testAbs, []byte("AAAA"), 0644))
 
-	// 		// First upload.
-	// 		stubCreateRunFilesOneFile(mockGQLClient, testRel)
-	// 		uploader.Process(&spb.FilesRecord{
-	// 			Files: []*spb.FilesItem{{Path: testRel, Policy: spb.FilesItem_NOW}},
-	// 		})
-	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
-	// 		require.Len(t, fakeFileTransfer.Tasks(), 1)
-	// 		fakeFileTransfer.Tasks()[0].Complete(nil)
-	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
+			// First upload.
+			stubCreateRunFilesOneFile(mockGQLClient, testRel)
+			uploader.Process(&spb.FilesRecord{
+				Files: []*spb.FilesItem{{Path: testRel, Policy: spb.FilesItem_NOW}},
+			})
+			uploader.(UploaderTesting).FlushSchedulingForTest()
+			require.Len(t, fakeFileTransfer.Tasks(), 1)
+			fakeFileTransfer.Tasks()[0].Complete(nil)
+			uploader.(UploaderTesting).FlushSchedulingForTest()
 
-	// 		// Overwrite with same size but different bytes.
-	// 		require.NoError(t, os.WriteFile(testAbs, []byte("BBBB"), 0644))
+			// Overwrite with same size but different bytes.
+			require.NoError(t, os.WriteFile(testAbs, []byte("BBBB"), 0644))
 
-	// 		// Second Process should schedule reupload (hash differs).
-	// 		stubCreateRunFilesOneFile(mockGQLClient, testRel)
-	// 		uploader.Process(&spb.FilesRecord{
-	// 			Files: []*spb.FilesItem{{Path: testRel, Policy: spb.FilesItem_NOW}},
-	// 		})
-	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
+			// Second Process should schedule reupload (hash differs).
+			stubCreateRunFilesOneFile(mockGQLClient, testRel)
+			uploader.Process(&spb.FilesRecord{
+				Files: []*spb.FilesItem{{Path: testRel, Policy: spb.FilesItem_NOW}},
+			})
+			uploader.(UploaderTesting).FlushSchedulingForTest()
 
-	// 		assert.Len(t, fakeFileTransfer.Tasks(), 2,
-	// 			"same-size content change must schedule reupload")
+			assert.Len(t, fakeFileTransfer.Tasks(), 2,
+				"same-size content change must schedule reupload")
 
-	// 		// Finish cleanly.
-	// 		fakeFileTransfer.Tasks()[1].Complete(nil)
-	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
-	// 		uploader.Finish()
-	// 	},
-	// )
+			// Finish cleanly.
+			fakeFileTransfer.Tasks()[1].Complete(nil)
+			uploader.(UploaderTesting).FlushSchedulingForTest()
+			uploader.Finish()
+		},
+	)
 }

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -475,4 +475,49 @@ func TestUploader(t *testing.T) {
 		},
 	)
 
+	runTest("Process reuploads when file modified between calls",
+		func() { /* no batchDelay => immediate batching */ },
+		func(t *testing.T) {
+			fakeFileTransfer.ShouldCompleteImmediately = false
+
+			testRel := "test_reupload_on_change.txt"
+			testAbs := filepath.Join(filesDir, testRel)
+			writeEmptyFile(t, testAbs)
+
+			// 1) First Process -> schedules a single upload task.
+			stubCreateRunFilesOneFile(mockGQLClient, testRel)
+			uploader.Process(&spb.FilesRecord{
+				Files: []*spb.FilesItem{
+					{Path: testRel, Policy: spb.FilesItem_NOW},
+				},
+			})
+			uploader.(UploaderTesting).FlushSchedulingForTest()
+			require.Len(t, fakeFileTransfer.Tasks(), 1, "first upload should schedule exactly one task")
+
+			// Complete the first upload.
+			fakeFileTransfer.Tasks()[0].Complete(nil)
+			uploader.(UploaderTesting).FlushSchedulingForTest()
+
+			// Modify the file (size changes).
+			require.NoError(t, os.Chmod(testAbs, os.FileMode(0644)))
+			require.NoError(t, os.WriteFile(testAbs, []byte("changed"), 0644))
+
+			// 2) Second Process after modification -> should schedule a new task.
+			stubCreateRunFilesOneFile(mockGQLClient, testRel)
+			uploader.Process(&spb.FilesRecord{
+				Files: []*spb.FilesItem{
+					{Path: testRel, Policy: spb.FilesItem_NOW},
+				},
+			})
+			uploader.(UploaderTesting).FlushSchedulingForTest()
+
+			assert.Len(t, fakeFileTransfer.Tasks(), 2,
+				"modified file should schedule a new upload task")
+
+			// Complete the second upload and finish to avoid dangling goroutines.
+			fakeFileTransfer.Tasks()[1].Complete(nil)
+			uploader.(UploaderTesting).FlushSchedulingForTest()
+			uploader.Finish()
+		},
+	)
 }

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -443,6 +443,8 @@ func TestUploader(t *testing.T) {
 			testAbs := filepath.Join(filesDir, testRel)
 			writeEmptyFile(t, testAbs)
 
+			require.NoError(t, os.Chmod(testAbs, os.FileMode(0644)))
+
 			// 1) First Process -> schedules a single upload task.
 			stubCreateRunFilesOneFile(mockGQLClient, testRel)
 			uploader.Process(&spb.FilesRecord{
@@ -484,6 +486,8 @@ func TestUploader(t *testing.T) {
 			testAbs := filepath.Join(filesDir, testRel)
 			writeEmptyFile(t, testAbs)
 
+			require.NoError(t, os.Chmod(testAbs, os.FileMode(0644)))
+
 			// 1) First Process -> schedules a single upload task.
 			stubCreateRunFilesOneFile(mockGQLClient, testRel)
 			uploader.Process(&spb.FilesRecord{
@@ -520,4 +524,45 @@ func TestUploader(t *testing.T) {
 			uploader.Finish()
 		},
 	)
+
+	// runTest("Process reuploads when bytes change but size is the same",
+	// 	func() { /* no batchDelay */ },
+	// 	func(t *testing.T) {
+	// 		fakeFileTransfer.ShouldCompleteImmediately = false
+
+	// 		testRel := "same_size_change.txt"
+	// 		testAbs := filepath.Join(filesDir, testRel)
+
+	// 		// Write 4 bytes, make file writable.
+	// 		require.NoError(t, os.WriteFile(testAbs, []byte("AAAA"), 0644))
+
+	// 		// First upload.
+	// 		stubCreateRunFilesOneFile(mockGQLClient, testRel)
+	// 		uploader.Process(&spb.FilesRecord{
+	// 			Files: []*spb.FilesItem{{Path: testRel, Policy: spb.FilesItem_NOW}},
+	// 		})
+	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
+	// 		require.Len(t, fakeFileTransfer.Tasks(), 1)
+	// 		fakeFileTransfer.Tasks()[0].Complete(nil)
+	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
+
+	// 		// Overwrite with same size but different bytes.
+	// 		require.NoError(t, os.WriteFile(testAbs, []byte("BBBB"), 0644))
+
+	// 		// Second Process should schedule reupload (hash differs).
+	// 		stubCreateRunFilesOneFile(mockGQLClient, testRel)
+	// 		uploader.Process(&spb.FilesRecord{
+	// 			Files: []*spb.FilesItem{{Path: testRel, Policy: spb.FilesItem_NOW}},
+	// 		})
+	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
+
+	// 		assert.Len(t, fakeFileTransfer.Tasks(), 2,
+	// 			"same-size content change must schedule reupload")
+
+	// 		// Finish cleanly.
+	// 		fakeFileTransfer.Tasks()[1].Complete(nil)
+	// 		uploader.(UploaderTesting).FlushSchedulingForTest()
+	// 		uploader.Finish()
+	// 	},
+	// )
 }

--- a/core/internal/runfiles/saved_file.go
+++ b/core/internal/runfiles/saved_file.go
@@ -88,7 +88,7 @@ func (f *savedFile) SetCategory(category filetransfer.RunFileKind) {
 // Upload schedules an upload of savedFile.
 //
 // If there is an ongoing upload operation for the file, the new upload
-// is scheduled to happen after the previous one completes.
+// is scheduled to happen after the previous one completes, and the file has changed..
 func (f *savedFile) Upload(url string, headers []string) {
 	f.Lock()
 	if f.shouldDeferUpload(url, headers) {

--- a/core/internal/runfiles/saved_file.go
+++ b/core/internal/runfiles/saved_file.go
@@ -118,6 +118,7 @@ func (f *savedFile) doUpload(uploadURL string, uploadHeaders []string) {
 	currentB64MD5, isUnchanged := f.checkContentB64MD5()
 	if isUnchanged {
 		f.maybeReupload()
+		return
 	}
 
 	op := f.operations.New(fmt.Sprintf("uploading %s", string(f.runPath)))
@@ -147,14 +148,14 @@ func (f *savedFile) doUpload(uploadURL string, uploadHeaders []string) {
 // with the hash at the last successful upload.
 //
 // It must be called while holding the lock, which it temporarily releases.
-func (f *savedFile) checkContentB64MD5() (currentB64MD5 string, isUnchanged bool) {
+func (f *savedFile) checkContentB64MD5() (string, bool) {
 	f.Unlock()
 	currentB64MD5, err := hashencode.ComputeFileB64MD5(f.realPath)
 	if err != nil {
 		currentB64MD5 = "" // treat file as "changed" below
 	}
 	f.Lock()
-	isUnchanged = currentB64MD5 != "" && f.lastUploadedB64MD5 == currentB64MD5
+	isUnchanged := currentB64MD5 != "" && f.lastUploadedB64MD5 == currentB64MD5
 
 	return currentB64MD5, isUnchanged
 }

--- a/core/internal/runfiles/saved_file.go
+++ b/core/internal/runfiles/saved_file.go
@@ -52,7 +52,7 @@ type savedFile struct {
 	// `reuploadScheduled`.
 	reuploadHeaders []string
 
-	// The size the file when it was last uploaded.
+	// The size of the file when it was last uploaded.
 	//
 	// Used to avoid re-uploading files that haven't changed.
 	lastUploadedSize int64

--- a/core/internal/runfiles/saved_file.go
+++ b/core/internal/runfiles/saved_file.go
@@ -180,6 +180,7 @@ func (f *savedFile) onFinishUpload(task *filetransfer.DefaultUploadTask) {
 	f.Lock()
 	defer f.Unlock()
 
+	// Record what we believe the server now has.
 	if task.Err == nil {
 		if f.uploadingB64MD5 != "" {
 			f.lastUploadedB64MD5 = f.uploadingB64MD5

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -754,6 +754,9 @@ def save(
     When given an absolute path or glob and no `base_path`, one
     directory level is preserved as in the example above.
 
+    Files are automatically deduplicated: calling `save()` multiple times
+    on the same file without modifications will not re-upload it.
+
     Args:
         glob_str: A relative or absolute path or Unix glob.
         base_path: A path to use to infer a directory structure; see examples.

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -778,10 +778,10 @@ def save(
     run.save("these/are/myfiles/*", base_path="these")
     # => Saves files in an "are/myfiles/" folder in the run.
 
-    run.save("/User/username/Documents/run123/*.txt")
+    run.save("/Users/username/Documents/run123/*.txt")
     # => Saves files in a "run123/" folder in the run. See note below.
 
-    run.save("/User/username/Documents/run123/*.txt", base_path="/User")
+    run.save("/Users/username/Documents/run123/*.txt", base_path="/Users")
     # => Saves files in a "username/Documents/run123/" folder in the run.
 
     run.save("files/*/saveme.txt")

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2075,10 +2075,10 @@ class Run:
         run.save("these/are/myfiles/*", base_path="these")
         # => Saves files in an "are/myfiles/" folder in the run.
 
-        run.save("/User/username/Documents/run123/*.txt")
+        run.save("/Users/username/Documents/run123/*.txt")
         # => Saves files in a "run123/" folder in the run. See note below.
 
-        run.save("/User/username/Documents/run123/*.txt", base_path="/User")
+        run.save("/Users/username/Documents/run123/*.txt", base_path="/Users")
         # => Saves files in a "username/Documents/run123/" folder in the run.
 
         run.save("files/*/saveme.txt")

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2051,6 +2051,9 @@ class Run:
         When given an absolute path or glob and no `base_path`, one
         directory level is preserved as in the example above.
 
+        Files are automatically deduplicated: calling `save()` multiple times
+        on the same file without modifications will not re-upload it.
+
         Args:
             glob_str: A relative or absolute path or Unix glob.
             base_path: A path to use to infer a directory structure; see examples.


### PR DESCRIPTION
Description
-----------
Older versions (pre 0.18.0) of the SDK had deduplication logic for saving files absent in `wandb-core`: tracking file sizes and modification dates for successfully uploaded files to prevent re-upload. This PR adds this logic to `wandb-core`.

<details>
  <summary>The script used for testing:</summary>

```python
import pathlib
from time import sleep

import torch

import wandb

num_bytes = 1 * 1024 * 1024
num_floats = num_bytes // 4
num_steps = 50
save_interval = 5
num_files = 0

with wandb.init(project="file-sync-test") as run:
    for i in range(num_steps):
        if (i + 1) % save_interval == 0:
            num_files += 1
            print(pathlib.Path(__file__).parent / f"data_{i + 1}.save")
            torch.save(
                torch.rand(num_floats, dtype=torch.float32),
                f"{wandb.run.dir}/data_{i + 1}.save",
                # pathlib.Path(__file__).parent / f"data_{i + 1}.save",
            )
            print(f"{i + 1}/{num_steps} -> Saved file")
        else:
            print(f"{i + 1}/{num_steps}")
        run.save("*.save")  # sync any new files of interest
        sleep(2.0)


print(f"Total traffic should be: ~{num_files * num_bytes / 1024 / 1024} MB")
print(f"Total saved files: {num_files}")

```

</details>

See https://wandb.ai/trustmebro/file-sync-test/.

<img width="665" height="314" alt="image" src="https://github.com/user-attachments/assets/37e96d64-ca06-4bf7-afa6-d6bdc42d494f" />

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Added unit tests.