### PR TITLE
chore: remove hacky Colab login magic

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -136,12 +136,6 @@ def prompt_api_key(  # noqa: C901
     if (jupyter and not settings.login_timeout) or no_create:
         choices.remove(LOGIN_CHOICE_NEW)
 
-    if jupyter and "google.colab" in sys.modules:
-        log_string = term.LOG_STRING_NOCOLOR
-        key = wandb.jupyter.attempt_colab_login(app_url)  # type: ignore
-        if key is not None:
-            return key  # type: ignore
-
     if anon_mode == "must":
         result = LOGIN_CHOICE_ANON
     # If we're not in an interactive environment, default to dry-run.


### PR DESCRIPTION
Description
-----------
Potentially fixes WB-27895.

This was a cute hack to auto-login to Colab, but it hasn't been working for some time, and I don't think we should have this kind of hacks anyways.