### PR TITLE
chore: update pydantic base model for mypy check

### DIFF
--- a/wandb/_pydantic/base.py
+++ b/wandb/_pydantic/base.py
@@ -24,6 +24,7 @@ class ModelDumpKwargs(TypedDict, total=False):
     exclude_unset: bool
     exclude_defaults: bool
     exclude_none: bool
+    exclude_computed_fields: bool
     round_trip: bool
     warnings: bool | Literal["none", "warn", "error"]
     fallback: Callable[[Any], Any] | None
@@ -93,10 +94,11 @@ class JsonableModel(CompatBaseModel, ABC):
         self,
         *,
         indent: int | None = None,
+        ensure_ascii: bool = True,
         **kwargs: Unpack[ModelDumpKwargs],
     ) -> str:
         kwargs = {**self.__DUMP_DEFAULTS, **kwargs}  # allows overrides, if needed
-        return super().model_dump_json(indent=indent, **kwargs)
+        return super().model_dump_json(indent=indent, ensure_ascii=ensure_ascii, **kwargs)
 
 
 # Base class for all GraphQL-generated types.


### PR DESCRIPTION
Description
-----------

Don't know why it is failing in https://github.com/wandb/wandb/pull/10648
Fix comes from claude code ...

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

The error from `nox -vs mypy-report` is:

```
Generated Cobertura report: /Users/pinglei.guo/go/src/github.com/wandb/wandb/mypy-results/cobertura.xml
Generated HTML report (via XSLT): /Users/pinglei.guo/go/src/github.com/wandb/wandb/mypy-results/index.html
wandb/_pydantic/base.py:82: error: Signature of "model_dump" incompatible with supertype "pydantic.main.BaseModel"  [override]
wandb/_pydantic/base.py:82: note:      Superclass:
wandb/_pydantic/base.py:82: note:          def model_dump(self, *, mode: Literal['json', 'python'] | str = ..., include: IncEx | None = ..., exclude: IncEx | None = ..., context: Any | None = ..., by_alias: bool | None = ..., exclude_unset: bool = ..., exclude_defaults: bool = ..., exclude_none: bool = ..., exclude_computed_fields: bool = ..., round_trip: bool = ..., warnings: Literal['none', 'warn', 'error'] | bool = ..., fallback: Callable[[Any], Any] | None = ..., serialize_as_any: bool = ...) -> dict[str, Any]
wandb/_pydantic/base.py:82: note:      Subclass:
wandb/_pydantic/base.py:82: note:          def model_dump(*, mode: Literal['json', 'python'] | str = ..., include: set[int] | set[str] | Mapping[int, IncEx | bool] | Mapping[str, IncEx | bool] | None = ..., exclude: set[int] | set[str] | Mapping[int, IncEx | bool] | Mapping[str, IncEx | bool] | None = ..., context: dict[str, Any] | None = ..., by_alias: bool | None = ..., exclude_unset: bool = ..., exclude_defaults: bool = ..., exclude_none: bool = ..., round_trip: bool = ..., warnings: Literal['none', 'warn', 'error'] | bool = ..., fallback: Callable[[Any], Any] | None = ..., serialize_as_any: bool = ...) -> dict[str, Any]
wandb/_pydantic/base.py:92: error: Signature of "model_dump_json" incompatible with supertype "pydantic.main.BaseModel"  [override]
wandb/_pydantic/base.py:92: note:      Superclass:
wandb/_pydantic/base.py:92: note:          def model_dump_json(self, *, indent: int | None = ..., ensure_ascii: bool = ..., include: IncEx | None = ..., exclude: IncEx | None = ..., context: Any | None = ..., by_alias: bool | None = ..., exclude_unset: bool = ..., exclude_defaults: bool = ..., exclude_none: bool = ..., exclude_computed_fields: bool = ..., round_trip: bool = ..., warnings: Literal['none', 'warn', 'error'] | bool = ..., fallback: Callable[[Any], Any] | None = ..., serialize_as_any: bool = ...) -> str
wandb/_pydantic/base.py:92: note:      Subclass:
wandb/_pydantic/base.py:92: note:          def model_dump_json(*, indent: int | None = ..., include: set[int] | set[str] | Mapping[int, IncEx | bool] | Mapping[str, IncEx | bool] | None = ..., exclude: set[int] | set[str] | Mapping[int, IncEx | bool] | Mapping[str, IncEx | bool] | None = ..., context: dict[str, Any] | None = ..., by_alias: bool | None = ..., exclude_unset: bool = ..., exclude_defaults: bool = ..., exclude_none: bool = ..., round_trip: bool = ..., warnings: Literal['none', 'warn', 'error'] | bool = ..., fallback: Callable[[Any], Any] | None = ..., serialize_as_any: bool = ...) -> str
Found 2 errors in 1 file (checked 548 source files)
nox > Command mypy --install-types --non-interactive --show-error-codes -p wandb --html-report mypy-results --cobertura-xml-report mypy-results --lineprecision-report mypy-results failed with exit code 1
nox > Session mypy-report failed.
```

Testing
-------
How was this PR tested?

```bash
nox -vs mypy-report
```
