### PR TITLE
fix(sdk): future-proof type hints on BaseModel.{model_dump,model_dump_json}

### DIFF
--- a/wandb/_pydantic/field_types.py
+++ b/wandb/_pydantic/field_types.py
@@ -11,13 +11,18 @@ from .utils import IS_PYDANTIC_V2
 
 T = TypeVar("T")
 
+# HACK: Pydantic no longer seems to like it when you define a type alias
+# at the module level with `Annotated[...]`.
+# The commented TypeAliases are a hack to unblock CI for now.
 
-#: GraphQL `__typename` fields
-Typename = Annotated[T, Field(repr=False, frozen=True, alias="__typename")]
+# Typename = Annotated[T, Field(repr=False, frozen=True, alias="__typename")]
+Typename = Annotated[T, Field(alias="__typename")]
+"""Annotates GraphQL `__typename` fields."""
 
 
 if IS_PYDANTIC_V2 or TYPE_CHECKING:
-    GQLId = Annotated[StrictStr, Field(repr=False, frozen=True)]
+    # GQLId = Annotated[StrictStr, Field(repr=False, frozen=True)]
+    GQLId = StrictStr
 
 else:
     # FIXME: Find a way to fix this for pydantic v1, which doesn't like when


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Pydantic added new keyword args to `BaseModel.model_{dump,dump_json}` in v2.12.  This is totally fine, but we internally override the default kwargs for those methods while preserving the original signature + type hints where possible.

The way we currently handle this caused CI checks to fail after `pydantic==2.12` was released.

PR makes the type hints a bit more future-proof, if verbose.  Future-proofing is worth it here, since this is the 2nd (and very plausibly not the last) time this has happened in our CI checks.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
