### PR TITLE
chore(sdk): hopefully fix error creating token to notify core

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -462,6 +462,9 @@ jobs:
         with:
           app-id: ${{ vars.WANDBOT_3000_APP_ID }}
           private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
+          owner: wandb
+          repositories: |
+            core
 
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
The default config would have tried to get a token with permissions for wandb/wandb, but that failed and I think it's because this (that) repo isn't configured for wandbot. But we actually just need to be able to interact with wandb/core, so maybe hopefully this'll do it.