### PR TITLE
fix(sdk): use explict api key before thread local

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,3 +12,7 @@ Add here any changes made in a PR that are relevant to end users. Allowed sectio
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- `wandb.Api(api_key=...)` now prioritizes the explicitly provided API key over thread-local cached credentials (@pingleiwandb in https://github.com/wandb/wandb/pull/10657)

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -19,23 +19,32 @@ def test_api_auto_login_no_tty():
             Api()
 
 
-def test_thread_local_cookies():
-    try:
-        _thread_local_api_settings.cookies = {"foo": "bar"}
-        api = Api()
-        assert api._base_client.transport.cookies == {"foo": "bar"}
-    finally:
-        _thread_local_api_settings.cookies = None
+def test_thread_local_cookies(monkeypatch):
+    monkeypatch.setattr(_thread_local_api_settings, "cookies", {"foo": "bar"})
+    api = Api()
+    assert api._base_client.transport.cookies == {"foo": "bar"}
 
 
 @pytest.mark.usefixtures("skip_verify_login")
-def test_thread_local_api_key():
-    try:
-        _thread_local_api_settings.api_key = "X" * 40
-        api = Api()
-        assert api.api_key == "X" * 40
-    finally:
-        _thread_local_api_settings.api_key = None
+def test_thread_local_api_key(monkeypatch):
+    monkeypatch.setattr(_thread_local_api_settings, "api_key", "X" * 40)
+    api = Api()
+    assert api.api_key == "X" * 40
+
+
+@pytest.mark.usefixtures("skip_verify_login")
+def test_thread_local_api_key_with_explicit_api_key(monkeypatch):
+    monkeypatch.setattr(_thread_local_api_settings, "api_key", "X" * 40)
+    api = Api(api_key="Y" * 40)
+    assert api.api_key == "Y" * 40
+
+
+@pytest.mark.usefixtures("skip_verify_login")
+def test_thread_local_cookies_with_explicit_api_key(monkeypatch):
+    monkeypatch.setattr(_thread_local_api_settings, "cookies", {"foo": "bar"})
+    monkeypatch.setattr(_thread_local_api_settings, "api_key", "X" * 40)
+    api = Api(api_key="Y" * 40)
+    assert api.api_key == "Y" * 40
 
 
 @pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")


### PR DESCRIPTION
Description
-----------

No JIRA

User explicitly pass api key in `wandb.Api(api_key=...)` was picking up wrong key from thread local when switching between different keys.
The API key resolve logic should prefer the explicit key over the implicit thread local values.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

- [x] unit test

Manual test

```python
# Update thread local manually to trigger the error
def download_with_manual_thread_local():
    cleanup()

    key1 = read_key("u1.key.txt")
    key2 = read_key("u2.key.txt")

    from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
    _thread_local_api_settings.cookie = {"wandb": "invalid-cookie-value"}
    _thread_local_api_settings.api_key = key1

    a2_name = f"{U2_ENTITY}/{P2}/10mb_test_switch_user_reg-team-2:latest"
    api2 = wandb.Api(api_key=key2) # key1 is used instead of key2
    artifact2 = api2.artifact(a2_name)
    artifact2.download(skip_cache=True)
```