### PR TITLE
feat(sdk): allow override of requests.Session

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Changed
+
+- `wandb.Api()` now supports an optional `session` argument which can be set to any object compatible with `requests.Session`. This allows advanced users to override HTTP client settings which are not otherwise/directly exposed through public interfaces.
+
 ### Fixed
 
 - `wandb.Api(api_key=...)` now prioritizes the explicitly provided API key over thread-local cached credentials (@pingleiwandb in https://github.com/wandb/wandb/pull/10657)

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -286,6 +286,7 @@ class Api:
         overrides: dict[str, Any] | None = None,
         timeout: int | None = None,
         api_key: str | None = None,
+        session: requests.Session | None = None,
     ) -> None:
         """Initialize the API.
 
@@ -299,6 +300,8 @@ class Api:
                 the API key from the current environment or configuration will be used.
                 Prompts for an API key if none is provided
                 or configured in the environment.
+            session: Requests session instance, in case your environment requires custom
+                setup for HTTP requests.
         """
         self.settings = InternalApi().settings()
 
@@ -353,6 +356,7 @@ class Api:
                 url="{}/graphql".format(self.settings["base_url"]),
                 cookies=_thread_local_api_settings.cookies,
                 proxies=proxies,
+                session=session,
             )
         )
         self._client = RetryingClient(self._base_client)

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -218,6 +218,9 @@ class Api:
         default_settings(dict, optional): If you aren't using a settings
         file, or you wish to override the section to use in the settings file
         Override the settings here.
+
+        session: Requests session instance, in case your environment requires custom
+        setup for HTTP requests.
     """
 
     HTTP_TIMEOUT = env.get_http_timeout(20)
@@ -240,8 +243,9 @@ class Api:
             days=7
         ),
         environ: MutableMapping = os.environ,
-        retry_callback: Optional[Callable[[int, str], Any]] = None,
-        api_key: Optional[str] = None,
+        retry_callback: Callable[[int, str], Any] | None = None,
+        api_key: str | None = None,
+        session: requests.Session | None = None,
     ) -> None:
         self._environ = environ
         self._global_context = context.Context()
@@ -312,6 +316,7 @@ class Api:
                 url=f"{self.settings('base_url')}/graphql",
                 cookies=_thread_local_api_settings.cookies,
                 proxies=proxies,
+                session=session,
             )
         )
 

--- a/wandb/sdk/lib/gql_request.py
+++ b/wandb/sdk/lib/gql_request.py
@@ -25,6 +25,7 @@ class GraphQLSession(HTTPTransport):
         use_json: bool = False,
         timeout: int | float | None = None,
         proxies: dict[str, str] | None = None,
+        session: requests.Session | None = None,
         **kwargs: Any,
     ) -> None:
         """Setup a session for sending GraphQL queries and mutations.
@@ -36,7 +37,7 @@ class GraphQLSession(HTTPTransport):
             timeout (int, float): Specifies a default timeout for requests (Default: None)
         """
         super().__init__(url, **kwargs)
-        self.session = requests.Session()
+        self.session = session or requests.Session()
         if proxies:
             self.session.proxies.update(proxies)
         self.session.auth = auth


### PR DESCRIPTION
Description
-----------
Allow injection of any object compatible with `requests.Session` to the API constructor.

This allows environments with highly specialized outbound HTTP paths to configure requests in an extensible manner, beyond what is explicitly exposed through settings (e.g. proxies).

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
mypy