### PR TITLE
chore: temporarily pin server image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     default: "us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer"
   server_image_tag:
     type: string
-    default: "49936c0c7ce4dabf49ba0695c4769d7ad4f9ceba"
+    default: "96f3ecb397dbeff1a36909f19039d913b30e791c"
 
 executors:
   macos:


### PR DESCRIPTION
Description
-----------
This PR: https://github.com/wandb/core/pull/35046 seems to cause the test failures in our CI (see e.g. https://app.circleci.com/pipelines/github/wandb/wandb/54519/workflows/357ac19f-2de2-4ddf-86ba-a738e704319d/jobs/1511237/tests).
Pinning the last working commit in core to unblock the CI.