### PR TITLE
fix(artifacts): filter by artifact type before assert length

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     default: "us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer"
   server_image_tag:
     type: string
-    default: "96f3ecb397dbeff1a36909f19039d913b30e791c"
+    default: "master"
 
 executors:
   macos:


### PR DESCRIPTION
Description
-----------

No JIRA ticket

When checking logged artifacts of different types, we should filter on expected type instead of comparing length directly. Server can generate artifacts such as parquet export automatically.

Rever server docker image pin in https://github.com/wandb/wandb/pull/10665

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable. NA


Testing
-------
How was this PR tested?

```bash
python tools/local_wandb_server.py start
pytest -s -vv tests/system_tests/test_artifacts/test_data_types.py
```