### PR TITLE
chore: claim python 3.14 compatibility

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ import nox
 
 nox.options.default_venv_backend = "uv"
 
-_SUPPORTED_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+_SUPPORTED_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 # Directories in which to create temporary per-session directories
 # containing test results and pytest/Go coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Go",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
Description
-----------
I verified that it works, and we even already have 3.14 support in conda, see https://github.com/conda-forge/wandb-feedstock/pull/163.
