### PR TITLE
feat: add wiring for python beta read run history

### DIFF
--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -12,6 +12,7 @@ __all__ = (
     "Automations",
     "File",
     "Files",
+    "BetaHistoryScan",  # doc:exclude
     "HistoryScan",  # doc:exclude
     "SampledHistoryScan",  # doc:exclude
     "SlackIntegrations",  # doc:exclude
@@ -53,7 +54,7 @@ from wandb.apis.public.artifacts import (
 )
 from wandb.apis.public.automations import Automations
 from wandb.apis.public.files import FILE_FRAGMENT, File, Files
-from wandb.apis.public.history import HistoryScan, SampledHistoryScan
+from wandb.apis.public.history import BetaHistoryScan, HistoryScan, SampledHistoryScan
 from wandb.apis.public.integrations import SlackIntegrations, WebhookIntegrations
 from wandb.apis.public.jobs import (
     Job,

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -281,6 +281,7 @@ class Runs(SizedPaginator["Run"]):
         per_page: int = 50,
         include_sweeps: bool = True,
         lazy: bool = True,
+        backend: wandb.sdk.backend.backend.Backend | None = None,
     ):
         if not order:
             order = "+created_at"
@@ -299,6 +300,7 @@ class Runs(SizedPaginator["Run"]):
         self._sweeps = {}
         self._include_sweeps = include_sweeps
         self._lazy = lazy
+        self._backend = backend
         variables = {
             "project": self.project,
             "entity": self.entity,
@@ -358,6 +360,7 @@ class Runs(SizedPaginator["Run"]):
                 run_response["node"],
                 include_sweeps=self._include_sweeps,
                 lazy=self._lazy,
+                backend=self._backend,
             )
             objs.append(run)
 
@@ -561,6 +564,7 @@ class Run(Attrs):
         attrs: Mapping | None = None,
         include_sweeps: bool = True,
         lazy: bool = True,
+        backend: wandb.sdk.backend.backend.Backend | None = None,
     ):
         """Initialize a Run object.
 
@@ -590,6 +594,7 @@ class Run(Attrs):
         self.server_provides_internal_id_field: bool | None = None
         self._server_provides_project_id_field: bool | None = None
         self._is_loaded: bool = False
+        self._backend = backend
 
         self.load(force=not _attrs)
 
@@ -1436,3 +1441,50 @@ class Run(Attrs):
 
     def __repr__(self):
         return "<Run {} ({})>".format("/".join(self.path), self.state)
+
+    def _beta_scan_history(
+        self,
+        keys: list[str] | None = None,
+        page_size=1000,
+        min_step=0,
+        max_step=None,
+    ) -> public.BetaHistoryScan:
+        """Returns an iterable collection of all history records for a run.
+
+        This function uses wandb-core to read history from a run's exported
+        parquet history locally.
+        This function is still in development and should not be used yet.
+
+        Args:
+            keys: list of metrics to read from the run's history.
+                if no keys are provided then all metrics will be returned.
+            page_size: the number of history records to read at a time.
+            min_step: The minimum step to start reading history from (inclusive).
+            max_step: The maximum step to read history up to (exclusive).
+
+        Returns:
+            A BetaHistoryScan object,
+            which can be iterator over to get history records.
+        """
+        if self._backend is None:
+            raise ValueError(
+                "wandb-core was not initialized."
+                + " Please call wandb.Api(overrides={'beta_start_service': True})"
+                + " to initialize wandb-core."
+            )
+
+        if keys is None:
+            keys = []
+        if max_step is None:
+            max_step = self.lastHistoryStep + 1
+
+        beta_history_scan = public.BetaHistoryScan(
+            client=self.client,
+            backend=self._backend,
+            run=self,
+            min_step=min_step,
+            max_step=max_step,
+            keys=keys,
+            page_size=page_size,
+        )
+        return beta_history_scan

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 from wandb import termwarn
+from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_telemetry_pb2 as tpb
 from wandb.sdk.artifacts.artifact import Artifact
@@ -1089,5 +1090,11 @@ class InterfaceBase:
     @abstractmethod
     def _deliver_request_run_status(
         self, run_status: pb.RunStatusRequest
+    ) -> MailboxHandle[pb.Result]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _deliver_api_request(
+        self, get_run_history: apb.ReadRunHistoryApiRequest
     ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -8,6 +8,7 @@ import logging
 from abc import abstractmethod
 from typing import Any, Optional, cast
 
+from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_telemetry_pb2 as tpb
 from wandb.sdk.mailbox import MailboxHandle
@@ -470,4 +471,11 @@ class InterfaceShared(InterfaceBase):
         self, run_status: pb.RunStatusRequest
     ) -> MailboxHandle[pb.Result]:
         record = self._make_request(run_status=run_status)
+        return self._deliver(record)
+
+    def _deliver_api_request(
+        self, api_request: apb.ApiRequest
+    ) -> MailboxHandle[pb.Result]:
+        record = pb.Record()
+        record.api_request.CopyFrom(api_request)
         return self._deliver(record)

--- a/wandb/sdk/lib/service/service_connection.py
+++ b/wandb/sdk/lib/service/service_connection.py
@@ -197,6 +197,21 @@ class ServiceConnection:
         else:
             return response.inform_attach_response.settings
 
+    def inform_api_start(
+        self,
+        settings: wandb_settings_pb2.Settings,
+        stream_id: str,
+    ) -> None:
+        """Send an inform api request to start a new API stream."""
+        request = spb.ServerInformApiRequest()
+        request.settings.CopyFrom(settings)
+        request._info.stream_id = stream_id
+        self._asyncer.run(
+            lambda: self._client.publish(
+                spb.ServerRequest(inform_init_api=request),
+            )
+        )
+
     def teardown(self, exit_code: int) -> int | None:
         """Close the connection.
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

adds BetaScanHistory class to iterate over a runs history, and calls wandb-core (if initialized) to get run history.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

Modified `readrunhistorywork.go` to return some sample history rows
```go
HistoryRows: []*spb.HistoryRow{
    {
        HistoryItems: []*spb.ParquetHistoryItem{
            {Key: "step", ValueJson: "1"},
            {Key: "loss", ValueJson: "0.01"},
        },
    },
}
```

used this test script to verify
```python
import wandb

api = wandb.Api(overrides={"beta_start_service": True})
run = api.run("jacobromerotest/testreadhistory/bf3tgew2")
runs = api.runs("jacobromerotest/testreadhistory")
for run in runs:
    print(run.name)
    history = run._beta_scan_history(
        min_step=1,
        max_step=10,
    )

    for row in history:
        print(row)
```

and got the output
```bash
fallen-butterfly-1
{'step': 1, 'loss': 0.01}
curious-tree-2
{'step': 1, 'loss': 0.01}
quiet-frog-3
{'step': 1, 'loss': 0.01}
clean-grass-4
{'step': 1, 'loss': 0.01}

```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
