### PR TITLE
chore(launch): set auxiliary label to None when there are no additional services

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -1124,7 +1124,7 @@ class KubernetesRunner(AbstractRunner):
             job_name,
             namespace,
             secret,
-            auxiliary_resource_label_value,
+            auxiliary_resource_label_value if additional_services else None,
             wandb_team_secrets_secret,
         )
         if self.backend_config[PROJECT_SYNCHRONOUS]:


### PR DESCRIPTION
### Description
https://weightsandbiases.slack.com/archives/C094CU1KZCG/p1759985975299729

For non-public queues, we want to return early on cleanup since there won't be any additional services. This is done by setting `auxiliary_resource_label_value` to be `None` on `KubernetesSubmittedRun` (see https://github.com/wandb/wandb/blob/cw-evals-project/wandb/sdk/launch/runner/kubernetes_runner.py#L240-L242). 


### Testing

Added two tests to verify that the k8s delete functions get called when the value is present and are not called when the value isn't there.
