### PR TITLE
fix: console capture deadlock

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,3 +16,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - `wandb.Api(api_key=...)` now prioritizes the explicitly provided API key over thread-local cached credentials (@pingleiwandb in https://github.com/wandb/wandb/pull/10657)
+- Fixed a rare deadlock in `console_capture.py` (@timoffex in https://github.com/wandb/wandb/pull/10683)
+  - If you dump thread tracebacks during the deadlock and see the `wandb-AsyncioManager-main` thread stuck on a line in `console_capture.py`: this is now fixed.

--- a/tests/system_tests/test_functional/console_capture/deadlocks.py
+++ b/tests/system_tests/test_functional/console_capture/deadlocks.py
@@ -1,0 +1,40 @@
+"""Exits with code 0 if no deadlock occurs, and hangs otherwise."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import sys
+
+from wandb.sdk.lib import console_capture
+
+
+def _info(msg: str) -> None:
+    sys.stderr.write(msg + "\n")
+
+
+def _main() -> None:
+    reset = console_capture.capture_stdout(_check_reentrant)
+    _info("Testing _check_reentrant.")
+    sys.stdout.write("_check_reentrant\n")
+    _info("Success!")
+    reset()
+
+    reset = console_capture.capture_stdout(_check_block_on_other_thread)
+    _info("Testing _check_block_on_other_thread.")
+    sys.stdout.write("_check_block_on_other_thread\n")
+    _info("Success!")
+    reset()
+
+
+def _check_reentrant(data: bytes | str, written: int) -> None:
+    sys.stdout.write("This shouldn't deadlock or loop indefinitely.\n")
+
+
+def _check_block_on_other_thread(data: bytes | str, written: int) -> None:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(lambda: sys.stdout.write("This shouldn't deadlock.\n"))
+        future.result()
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/system_tests/test_functional/console_capture/test_console_capture.py
+++ b/tests/system_tests/test_functional/console_capture/test_console_capture.py
@@ -2,6 +2,11 @@ import pathlib
 import subprocess
 
 
+def test_deadlocks():
+    script = pathlib.Path(__file__).parent / "deadlocks.py"
+    subprocess.check_call(["python", str(script)], timeout=5)
+
+
 def test_patch_stdout_and_stderr():
     script = pathlib.Path(__file__).parent / "patch_stdout_and_stderr.py"
 
@@ -20,17 +25,14 @@ def test_patch_stdout_and_stderr():
 
 def test_patching_exception():
     script = pathlib.Path(__file__).parent / "patching_exception.py"
-
     subprocess.check_call(["python", str(script)])
 
 
 def test_removes_callback_on_error():
     script = pathlib.Path(__file__).parent / "removes_callback_on_error.py"
-
     subprocess.check_call(["python", str(script)])
 
 
 def test_uncapturing():
     script = pathlib.Path(__file__).parent / "uncapturing.py"
-
     subprocess.check_call(["python", str(script)])


### PR DESCRIPTION
Fixes a deadlock when capturing console output: if a thread prints and triggers a callback, and that callback blocks on a different thread that then attempts to print, a deadlock occurs. Our callbacks block on the asyncio thread, so prints in the asyncio thread can result in deadlocks.