### PR TITLE
chore(launch): change auxiliary resource label to be UUID

### DIFF
--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -2,8 +2,9 @@ import asyncio
 import base64
 import json
 import platform
+import uuid
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import wandb
@@ -1736,7 +1737,12 @@ async def test_kubernetes_submitted_run_cleanup_job_api_key_secret_delete_fails(
 
 
 @pytest.mark.asyncio
+@patch(
+    "wandb.sdk.launch.runner.kubernetes_runner.uuid.uuid4",
+    return_value=uuid.UUID("123e4567-e89b-12d3-a456-426614174000"),
+)
 async def test_launch_additional_services(
+    mock_uuid4,
     monkeypatch,
     mock_event_streams,
     mock_batch_api,
@@ -1754,7 +1760,6 @@ async def test_launch_additional_services(
     expected_deployment_name = "deploy-test-entity-test-project-test-run-id"
     expected_pod_name = "pod-test-entity-test-project-test-run-id"
     expected_label = "auxiliary-resource"
-    expected_auxiliary_resource_label = "aux-test-run-id-test-project-test-entity"
 
     additional_service = {
         "apiVersion": "apps/v1",
@@ -1834,5 +1839,6 @@ async def test_launch_additional_services(
     assert labels["wandb.ai/label"] == expected_label
     assert WANDB_K8S_LABEL_AUXILIARY_RESOURCE in labels
     assert (
-        labels[WANDB_K8S_LABEL_AUXILIARY_RESOURCE] == expected_auxiliary_resource_label
+        labels[WANDB_K8S_LABEL_AUXILIARY_RESOURCE]
+        == "123e4567-e89b-12d3-a456-426614174000"
     )

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import time
+import uuid
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import yaml
@@ -1064,9 +1065,7 @@ class KubernetesRunner(AbstractRunner):
         additional_services: List[Dict[str, Any]] = recursive_macro_sub(
             launch_project.launch_spec.get("additional_services", []), update_dict
         )
-        auxiliary_resource_label_value = make_k8s_label_safe(
-            f"aux-{launch_project.run_id}-{launch_project.target_project}-{launch_project.target_entity}"
-        )
+        auxiliary_resource_label_value = str(uuid.uuid4())
         if additional_services:
             wandb.termlog(
                 f"{LOG_PREFIX}Creating additional services: {additional_services}"


### PR DESCRIPTION
~~Swap the ordering of the auxiliary resource label from `<entity>-<project>-<run-id>` to `<run-id>-<project>-<entity>`. This prevents the same label from being applied when either of `entity` or `project` are long and surpass the 63 character limit for labels. The run ID will be unique within the `entity/project` pair.~~

~~(Note: the configs on the queue config will need to be updated to match this change once the agent containing this change is deployed)~~

The auxiliary resource label is used by the agent to keep track of what resources to cleanup and doesn't need to depend on the run ID, project name or entity name. A UUID will be unique and also k8s label names compliant.

Testing
-------
Updated unit test
