### PR TITLE
refactor: remove legacy progress-printing code

### DIFF
--- a/tests/unit_tests/test_lib/test_progress.py
+++ b/tests/unit_tests/test_lib/test_progress.py
@@ -33,19 +33,15 @@ def static_progress_printer() -> Iterator[progress.ProgressPrinter]:
 
 def test_minimal_operations_dynamic(emulated_terminal, dynamic_progress_printer):
     dynamic_progress_printer.update(
-        [
-            pb.PollExitResponse(
-                operation_stats=pb.OperationStats(
-                    total_operations=4,
-                    operations=[
-                        pb.Operation(desc="op 1", runtime_seconds=45.315),
-                        pb.Operation(desc="op 2", runtime_seconds=9.123),
-                        pb.Operation(desc="op 3", runtime_seconds=123.45),
-                        pb.Operation(desc="op 4", runtime_seconds=5000),
-                    ],
-                ),
-            )
-        ]
+        pb.OperationStats(
+            total_operations=4,
+            operations=[
+                pb.Operation(desc="op 1", runtime_seconds=45.315),
+                pb.Operation(desc="op 2", runtime_seconds=9.123),
+                pb.Operation(desc="op 3", runtime_seconds=123.45),
+                pb.Operation(desc="op 4", runtime_seconds=5000),
+            ],
+        ),
     )
 
     assert emulated_terminal.read_stderr() == [
@@ -58,17 +54,13 @@ def test_minimal_operations_dynamic(emulated_terminal, dynamic_progress_printer)
 
 def test_minimal_operations_static(mock_wandb_log, static_progress_printer):
     static_progress_printer.update(
-        [
-            pb.PollExitResponse(
-                operation_stats=pb.OperationStats(
-                    total_operations=4,
-                    operations=[
-                        pb.Operation(desc=f"op {i}", runtime_seconds=45.315)
-                        for i in range(1, 101)
-                    ],
-                ),
-            )
-        ]
+        pb.OperationStats(
+            total_operations=4,
+            operations=[
+                pb.Operation(desc=f"op {i}", runtime_seconds=45.315)
+                for i in range(1, 101)
+            ],
+        ),
     )
 
     assert mock_wandb_log.logged("op 1; op 2; op 3; op 4; op 5 (+ 95 more)")
@@ -98,21 +90,17 @@ def test_operation_progress_and_error(
     dynamic_progress_printer,
 ):
     dynamic_progress_printer.update(
-        [
-            pb.PollExitResponse(
-                operation_stats=pb.OperationStats(
-                    total_operations=1,
-                    operations=[
-                        pb.Operation(
-                            desc="op 1",
-                            runtime_seconds=45.315,
-                            progress="4/9",
-                            error_status="retrying HTTP 419",
-                        ),
-                    ],
+        pb.OperationStats(
+            total_operations=1,
+            operations=[
+                pb.Operation(
+                    desc="op 1",
+                    runtime_seconds=45.315,
+                    progress="4/9",
+                    error_status="retrying HTTP 419",
                 ),
-            )
-        ]
+            ],
+        ),
     )
 
     assert emulated_terminal.read_stderr() == [
@@ -137,20 +125,16 @@ def test_operation_subtasks(emulated_terminal, dynamic_progress_printer):
     )
 
     dynamic_progress_printer.update(
-        [
-            pb.PollExitResponse(
-                operation_stats=pb.OperationStats(
-                    total_operations=1,
-                    operations=[
-                        pb.Operation(
-                            desc="op 1",
-                            runtime_seconds=45.315,
-                            subtasks=[subtask],
-                        ),
-                    ],
+        pb.OperationStats(
+            total_operations=1,
+            operations=[
+                pb.Operation(
+                    desc="op 1",
+                    runtime_seconds=45.315,
+                    subtasks=[subtask],
                 ),
-            )
-        ]
+            ],
+        ),
     )
 
     assert emulated_terminal.read_stderr() == [
@@ -164,16 +148,12 @@ def test_operation_subtasks(emulated_terminal, dynamic_progress_printer):
 
 def test_remaining_operations(emulated_terminal, dynamic_progress_printer):
     dynamic_progress_printer.update(
-        [
-            pb.PollExitResponse(
-                operation_stats=pb.OperationStats(
-                    total_operations=20,
-                    operations=[
-                        pb.Operation(desc="op 1"),
-                    ],
-                ),
-            )
-        ]
+        pb.OperationStats(
+            total_operations=20,
+            operations=[
+                pb.Operation(desc="op 1"),
+            ],
+        ),
     )
 
     assert emulated_terminal.read_stderr() == [
@@ -183,6 +163,6 @@ def test_remaining_operations(emulated_terminal, dynamic_progress_printer):
 
 
 def test_no_operations_text(emulated_terminal, dynamic_progress_printer):
-    dynamic_progress_printer.update([pb.PollExitResponse()])
+    dynamic_progress_printer.update(pb.OperationStats())
 
     assert emulated_terminal.read_stderr() == ["wandb: ⢿ DEFAULT TEXT"]

--- a/wandb/sdk/lib/progress.py
+++ b/wandb/sdk/lib/progress.py
@@ -101,19 +101,10 @@ class ProgressPrinter:
 
     def update(
         self,
-        progress: list[pb.PollExitResponse] | pb.OperationStats,
+        progress: pb.OperationStats,
     ) -> None:
         """Update the displayed information."""
-        if not progress:
-            return
-
-        if isinstance(progress, pb.OperationStats):
-            self._update_operation_stats([progress])
-        else:
-            self._update_operation_stats(
-                list(response.operation_stats for response in progress)
-            )
-
+        self._update_operation_stats([progress])
         self._tick += 1
 
     def _update_operation_stats(self, stats_list: list[pb.OperationStats]) -> None:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import functools
 import glob
 import json
@@ -33,7 +32,6 @@ from wandb.errors import CommError, UsageError
 from wandb.errors.links import url_registry
 from wandb.integration.torch import wandb_torch
 from wandb.plot import CustomChart, Visualize
-from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_deprecated import Deprecated
 from wandb.proto.wandb_internal_pb2 import (
     MetricRecord,
@@ -44,7 +42,7 @@ from wandb.proto.wandb_internal_pb2 import (
 from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.internal import job_builder
-from wandb.sdk.lib import asyncio_compat, wb_logging
+from wandb.sdk.lib import wb_logging
 from wandb.sdk.lib.import_hooks import (
     register_post_import_hook,
     unregister_post_import_hook,
@@ -2682,41 +2680,6 @@ class Run:
         else:
             return artifact
 
-    async def _display_finish_stats(
-        self,
-        progress_printer: progress.ProgressPrinter,
-    ) -> None:
-        last_result: Result | None = None
-
-        async def loop_update_printer() -> None:
-            while True:
-                if last_result:
-                    progress_printer.update(
-                        [last_result.response.poll_exit_response],
-                    )
-                await asyncio.sleep(0.1)
-
-        async def loop_poll_exit() -> None:
-            nonlocal last_result
-            assert self._backend and self._backend.interface
-
-            while True:
-                handle = await self._backend.interface.deliver_async(
-                    pb.Record(request=pb.Request(poll_exit=pb.PollExitRequest()))
-                )
-
-                time_start = time.monotonic()
-                last_result = await handle.wait_async(timeout=None)
-
-                # Update at most once a second.
-                time_elapsed = time.monotonic() - time_start
-                if time_elapsed < 1:
-                    await asyncio.sleep(1 - time_elapsed)
-
-        async with asyncio_compat.open_task_group() as task_group:
-            task_group.start_soon(loop_update_printer())
-            task_group.start_soon(loop_poll_exit())
-
     def _on_finish(self) -> None:
         trigger.call("on_finished")
 
@@ -2741,8 +2704,9 @@ class Run:
                 exit_handle,
                 timeout=None,
                 display_progress=functools.partial(
-                    self._display_finish_stats,
+                    progress.loop_printing_operation_stats,
                     progress_printer,
+                    self._backend.interface,
                 ),
             )
 


### PR DESCRIPTION
- Removes `list[PollExitResponse]` from the `ProgressPrinter.update()` parameter type options
- Uses `loop_printing_operation_stats` in `run.finish()` instead of a bespoke helper method (the only difference was that it used the `list[PollExitResponse]` form of `update()` which used to have a different behavior in legacy mode)
- Removes an inline progress-printing function in `wandb.init()` so that it's consistent with the pattern in `run.finish()`