### PR TITLE
refactor: disambiguate `wandb beta sync` when syncing multiple runs

### DIFF
--- a/core/internal/runsync/runinfo.go
+++ b/core/internal/runsync/runinfo.go
@@ -1,7 +1,38 @@
 package runsync
 
+import (
+	"strings"
+)
+
 // RunInfo is basic information about a run that can be extracted from
 // its transaction log.
 type RunInfo struct {
-	RunID string
+	// Components of the run's path.
+	//
+	// Entity and Project may be empty to indicate that the user's defaults
+	// should be used.
+	Entity, Project, RunID string
+}
+
+// Path returns the run's full path in the form entity/project/id
+// with empty values omitted.
+func (info *RunInfo) Path() string {
+	parts := make([]string, 0, 3)
+
+	if len(info.Entity) > 0 {
+		parts = append(parts, info.Entity)
+	}
+	if len(info.Project) > 0 {
+		parts = append(parts, info.Project)
+	}
+
+	if len(info.RunID) > 0 {
+		parts = append(parts, info.RunID)
+	} else {
+		// Not normally valid, but useful for debugging.
+		parts = append(parts, "<no ID>")
+	}
+
+	// NOTE: The components never contain forward slashes.
+	return strings.Join(parts, "/")
 }

--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -66,7 +66,11 @@ func (r *RunReader) ExtractRunInfo() (*RunInfo, error) {
 		}
 
 		if run := record.GetRun(); run != nil {
-			return &RunInfo{RunID: run.RunId}, nil
+			return &RunInfo{
+				Entity:  run.Entity,
+				Project: run.Project,
+				RunID:   run.RunId,
+			}, nil
 		}
 	}
 }

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -136,14 +136,20 @@ func Test_Extract_FindsRunRecord(t *testing.T) {
 		x.TransactionLog,
 		&spb.Record{RecordType: &spb.Record_Run{
 			Run: &spb.RunRecord{
-				RunId: "test run ID",
+				Entity:  "test entity",
+				Project: "test project",
+				RunId:   "test run ID",
 			},
 		}})
 
 	runInfo, err := x.RunReader.ExtractRunInfo()
 	require.NoError(t, err)
 
-	assert.Equal(t, &runsync.RunInfo{RunID: "test run ID"}, runInfo)
+	assert.Equal(t, &runsync.RunInfo{
+		Entity:  "test entity",
+		Project: "test project",
+		RunID:   "test run ID",
+	}, runInfo)
 }
 
 func Test_Extract_ErrorIfNoRunRecord(t *testing.T) {

--- a/core/internal/runsync/runsyncer.go
+++ b/core/internal/runsync/runsyncer.go
@@ -104,12 +104,12 @@ func (rs *RunSyncer) Sync() {
 		// TODO: Emit error.
 		logSyncFailure(rs.logger, err)
 	} else {
-		rs.printer.Write("Finished syncing run.")
+		rs.printer.Writef("Finished syncing %s", rs.path)
 	}
 }
 
 // AddStats inserts the sync operation's status info into the map
-// keyed by the run's ID.
+// keyed by the run's path.
 func (rs *RunSyncer) AddStats(status map[string]*spb.OperationStats) {
 	rs.mu.Lock()
 	runInfo := rs.runInfo
@@ -118,7 +118,7 @@ func (rs *RunSyncer) AddStats(status map[string]*spb.OperationStats) {
 		return
 	}
 
-	status[runInfo.RunID] = rs.operations.ToProto()
+	status[runInfo.Path()] = rs.operations.ToProto()
 }
 
 // PopMessages returns any new messages for the sync operation.
@@ -136,7 +136,7 @@ func (rs *RunSyncer) PopMessages() []*spb.ServerSyncMessage {
 			&spb.ServerSyncMessage{
 				// TODO: Existing code assumes printer messages are warnings.
 				Severity: spb.ServerSyncMessage_SEVERITY_INFO,
-				Content:  fmt.Sprintf("[%s] %s", runInfo.RunID, msg),
+				Content:  fmt.Sprintf("[%s] %s", runInfo.Path(), msg),
 			})
 	}
 	return messages

--- a/core/pkg/service_go_proto/wandb_sync.pb.go
+++ b/core/pkg/service_go_proto/wandb_sync.pb.go
@@ -350,7 +350,7 @@ type ServerSyncStatusResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The status of any ongoing work (such as network requests),
-	// keyed by the run ID.
+	// keyed by the run path (entity/project/id).
 	Stats map[string]*OperationStats `protobuf:"bytes,1,rep,name=stats,proto3" json:"stats,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// New messages since the last status request.
 	NewMessages []*ServerSyncMessage `protobuf:"bytes,2,rep,name=new_messages,json=newMessages,proto3" json:"new_messages,omitempty"`

--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -183,7 +183,7 @@ def test_syncs_run(tmp_path, wandb_backend_spy, runner: CliRunner):
     assert lines[0] == "Syncing 1 file(s):"
     assert lines[1].endswith(f"run-{run.id}.wandb")
     # More lines possible depending on status updates. Not deterministic.
-    assert lines[-1] == f"wandb: [{run.id}] Finished syncing run."
+    assert lines[-1] == f"wandb: [{run.path}] Finished syncing {run.settings.sync_file}"
 
     with wandb_backend_spy.freeze() as snapshot:
         history = snapshot.history(run_id=run.id)

--- a/wandb/proto/v3/wandb_sync_pb2.pyi
+++ b/wandb/proto/v3/wandb_sync_pb2.pyi
@@ -165,7 +165,7 @@ class ServerSyncStatusResponse(google.protobuf.message.Message):
     @property
     def stats(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, wandb.proto.wandb_internal_pb2.OperationStats]:
         """The status of any ongoing work (such as network requests),
-        keyed by the run ID.
+        keyed by the run path (entity/project/id).
         """
     @property
     def new_messages(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___ServerSyncMessage]:

--- a/wandb/proto/v4/wandb_sync_pb2.pyi
+++ b/wandb/proto/v4/wandb_sync_pb2.pyi
@@ -165,7 +165,7 @@ class ServerSyncStatusResponse(google.protobuf.message.Message):
     @property
     def stats(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, wandb.proto.wandb_internal_pb2.OperationStats]:
         """The status of any ongoing work (such as network requests),
-        keyed by the run ID.
+        keyed by the run path (entity/project/id).
         """
     @property
     def new_messages(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___ServerSyncMessage]:

--- a/wandb/proto/v5/wandb_sync_pb2.pyi
+++ b/wandb/proto/v5/wandb_sync_pb2.pyi
@@ -169,7 +169,7 @@ class ServerSyncStatusResponse(google.protobuf.message.Message):
     @property
     def stats(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, wandb.proto.wandb_internal_pb2.OperationStats]:
         """The status of any ongoing work (such as network requests),
-        keyed by the run ID.
+        keyed by the run path (entity/project/id).
         """
 
     @property

--- a/wandb/proto/v6/wandb_sync_pb2.pyi
+++ b/wandb/proto/v6/wandb_sync_pb2.pyi
@@ -169,7 +169,7 @@ class ServerSyncStatusResponse(google.protobuf.message.Message):
     @property
     def stats(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, wandb.proto.wandb_internal_pb2.OperationStats]:
         """The status of any ongoing work (such as network requests),
-        keyed by the run ID.
+        keyed by the run path (entity/project/id).
         """
 
     @property

--- a/wandb/proto/wandb_sync.proto
+++ b/wandb/proto/wandb_sync.proto
@@ -56,7 +56,7 @@ message ServerSyncStatusRequest {
 // The status of a sync operation.
 message ServerSyncStatusResponse {
   // The status of any ongoing work (such as network requests),
-  // keyed by the run ID.
+  // keyed by the run path (entity/project/id).
   map<string, OperationStats> stats = 1;
 
   // New messages since the last status request.


### PR DESCRIPTION
Makes messages printed by `wandb beta sync` unambiguous when:

* Syncing multiple resumed instances of the same run all having the same run ID
* Syncing multiple runs with the same ID but to different projects or entities

The run's full path (entity/project/ID) is assumed to be unambiguous. I changed the "Finished syncing run" message to also include the path of the .wandb file to better support resumed runs.