### PR TITLE
feat: enforce order between related runs in `wandb beta sync`

### DIFF
--- a/core/internal/runsync/errors.go
+++ b/core/internal/runsync/errors.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/wandb/wandb/core/internal/observability"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
 // SyncError is a failure that prevents syncing a run.
 type SyncError struct {
-	Err     error  // wrapped error
+	Err     error  // wrapped error, which may be nil
 	Message string // Go-style error message (not including Err)
 
 	// UserText is text to show to the user to explain the problem.
@@ -20,15 +21,10 @@ type SyncError struct {
 
 // Error implements error.Error.
 func (e *SyncError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Message, e.Err.Error())
-}
-
-// LogOrCapture logs the error, capturing it if UserText is unset.
-func (e *SyncError) LogOrCapture(logger *observability.CoreLogger) {
-	if e.UserText == "" {
-		logger.CaptureError(e)
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.Err.Error())
 	} else {
-		logger.Error(e.Error())
+		return e.Message
 	}
 }
 
@@ -45,5 +41,24 @@ func logSyncFailure(logger *observability.CoreLogger, err error) {
 		// the error happens and wrap it in a SyncError with
 		// proper UserText. Or fix it so it can't happen.
 		logger.CaptureError(err)
+	}
+}
+
+// ToUserText returns user-facing text for the error, which may be a SyncError.
+func ToUserText(err error) string {
+	syncErr, ok := err.(*SyncError)
+	if !ok || syncErr.UserText == "" {
+		return fmt.Sprintf("Internal error: %v", err)
+	} else {
+		return syncErr.UserText
+	}
+}
+
+// ToSyncErrorMessage converts the error, which may be a SyncError,
+// into a ServerSyncMessage to display to the user.
+func ToSyncErrorMessage(err error) *spb.ServerSyncMessage {
+	return &spb.ServerSyncMessage{
+		Severity: spb.ServerSyncMessage_SEVERITY_ERROR,
+		Content:  ToUserText(err),
 	}
 }

--- a/core/internal/runsync/errors_test.go
+++ b/core/internal/runsync/errors_test.go
@@ -1,0 +1,36 @@
+package runsync_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	. "github.com/wandb/wandb/core/internal/runsync"
+)
+
+func TestToUserText_SyncError(t *testing.T) {
+	err := &SyncError{
+		Message:  "internal text",
+		UserText: "A problem happened.",
+	}
+
+	userText := ToUserText(err)
+
+	assert.Equal(t, "A problem happened.", userText)
+}
+
+func TestToUserText_SyncErrorWithoutUserText(t *testing.T) {
+	err := &SyncError{Message: "internal text"}
+
+	userText := ToUserText(err)
+
+	assert.Equal(t, "Internal error: internal text", userText)
+}
+
+func TestToUserText_UnknownError(t *testing.T) {
+	err := fmt.Errorf("test error")
+
+	userText := ToUserText(err)
+
+	assert.Equal(t, "Internal error: test error", userText)
+}

--- a/core/internal/runsync/runinfo.go
+++ b/core/internal/runsync/runinfo.go
@@ -2,6 +2,7 @@ package runsync
 
 import (
 	"strings"
+	"time"
 )
 
 // RunInfo is basic information about a run that can be extracted from
@@ -12,6 +13,9 @@ type RunInfo struct {
 	// Entity and Project may be empty to indicate that the user's defaults
 	// should be used.
 	Entity, Project, RunID string
+
+	// StartTime is the time this run instance was initialized.
+	StartTime time.Time
 }
 
 // Path returns the run's full path in the form entity/project/id

--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -62,14 +62,19 @@ func (r *RunReader) ExtractRunInfo() (*RunInfo, error) {
 	for {
 		record, err := store.Read()
 		if err != nil {
-			return nil, fmt.Errorf("runsync: didn't find run info: %v", err)
+			return nil, &SyncError{
+				Err:      err,
+				Message:  "didn't find run info",
+				UserText: fmt.Sprintf("Failed to read %q: %v", r.path, err),
+			}
 		}
 
 		if run := record.GetRun(); run != nil {
 			return &RunInfo{
-				Entity:  run.Entity,
-				Project: run.Project,
-				RunID:   run.RunId,
+				Entity:    run.Entity,
+				Project:   run.Project,
+				RunID:     run.RunId,
+				StartTime: run.StartTime.AsTime(),
 			}, nil
 		}
 	}

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,7 @@ import (
 	"github.com/wandb/wandb/core/internal/transactionlog"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type testFixtures struct {
@@ -132,13 +134,15 @@ func isExitRecord(code int32) gomock.Matcher {
 
 func Test_Extract_FindsRunRecord(t *testing.T) {
 	x := setup(t)
+	startTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	wandbFileWithRecords(t,
 		x.TransactionLog,
 		&spb.Record{RecordType: &spb.Record_Run{
 			Run: &spb.RunRecord{
-				Entity:  "test entity",
-				Project: "test project",
-				RunId:   "test run ID",
+				Entity:    "test entity",
+				Project:   "test project",
+				RunId:     "test run ID",
+				StartTime: timestamppb.New(startTime),
 			},
 		}})
 
@@ -146,9 +150,10 @@ func Test_Extract_FindsRunRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, &runsync.RunInfo{
-		Entity:  "test entity",
-		Project: "test project",
-		RunID:   "test run ID",
+		Entity:    "test entity",
+		Project:   "test project",
+		RunID:     "test run ID",
+		StartTime: startTime,
 	}, runInfo)
 }
 

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -1,6 +1,10 @@
 package runsync
 
 import (
+	"slices"
+	"time"
+
+	"github.com/wandb/wandb/core/internal/observability"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"golang.org/x/sync/errgroup"
 )
@@ -14,13 +18,16 @@ type RunSyncOperationFactory struct{}
 // This is needed because the server can sync multiple paths simultaneously.
 type RunSyncOperation struct {
 	syncers []*RunSyncer
+	printer *observability.Printer
 }
 
 func (f *RunSyncOperationFactory) New(
 	paths []string,
 	globalSettings *spb.Settings,
 ) *RunSyncOperation {
-	op := &RunSyncOperation{}
+	op := &RunSyncOperation{
+		printer: observability.NewPrinter(),
+	}
 
 	for _, path := range paths {
 		settings := MakeSyncSettings(globalSettings, path)
@@ -33,12 +40,29 @@ func (f *RunSyncOperationFactory) New(
 
 // Do starts syncing and blocks until all sync work completes.
 func (op *RunSyncOperation) Do(parallelism int) *spb.ServerSyncResponse {
+	plan, err := op.initAndPlan()
+
+	if err != nil {
+		// TODO: Log the error.
+		return &spb.ServerSyncResponse{
+			Messages: []*spb.ServerSyncMessage{ToSyncErrorMessage(err)},
+		}
+	}
+
 	group := &errgroup.Group{}
 	group.SetLimit(parallelism)
 
-	for _, syncer := range op.syncers {
+	for _, syncers := range plan {
 		group.Go(func() error {
-			syncer.Sync()
+			for _, syncer := range syncers {
+				err := syncer.Sync()
+
+				if err != nil {
+					// TODO: Print this at ERROR level, not INFO.
+					op.printer.Write(ToUserText(err))
+					break
+				}
+			}
 			return nil
 		})
 	}
@@ -48,6 +72,50 @@ func (op *RunSyncOperation) Do(parallelism int) *spb.ServerSyncResponse {
 	return &spb.ServerSyncResponse{
 		Messages: op.popMessages(),
 	}
+}
+
+// initAndPlan inits all syncers and returns the order in which to run them.
+//
+// The return value is a map from run paths to lists of syncers.
+// Different paths can be synced independently, but all syncers for the same
+// path must run in order. This happens when syncing multiple resumed
+// instances of the same run.
+func (op *RunSyncOperation) initAndPlan() (map[string][]*RunSyncer, error) {
+	type syncerAndTime struct {
+		syncer    *RunSyncer
+		startTime time.Time
+	}
+
+	syncerByRun := make(map[string][]syncerAndTime)
+	for _, syncer := range op.syncers {
+		info, err := syncer.Init()
+		if err != nil {
+			return nil, err
+		}
+
+		runPath := info.Path()
+		syncerByRun[runPath] = append(syncerByRun[runPath], syncerAndTime{
+			syncer:    syncer,
+			startTime: info.StartTime,
+		})
+	}
+
+	groupedOrderedSyncers := make(map[string][]*RunSyncer)
+	for path, syncersAndTimes := range syncerByRun {
+		// Sort by ascending start time.
+		slices.SortFunc(syncersAndTimes, func(a, b syncerAndTime) int {
+			return a.startTime.Compare(b.startTime)
+		})
+
+		syncers := make([]*RunSyncer, len(syncersAndTimes))
+		for i := range syncersAndTimes {
+			syncers[i] = syncersAndTimes[i].syncer
+		}
+
+		groupedOrderedSyncers[path] = syncers
+	}
+
+	return groupedOrderedSyncers, nil
 }
 
 // Status returns the operation's status.
@@ -65,6 +133,14 @@ func (op *RunSyncOperation) Status() *spb.ServerSyncStatusResponse {
 
 func (op *RunSyncOperation) popMessages() []*spb.ServerSyncMessage {
 	var messages []*spb.ServerSyncMessage
+
+	for _, message := range op.printer.Read() {
+		messages = append(messages, &spb.ServerSyncMessage{
+			Severity: spb.ServerSyncMessage_SEVERITY_INFO,
+			Content:  message,
+		})
+	}
+
 	for _, syncer := range op.syncers {
 		messages = append(messages, syncer.PopMessages()...)
 	}

--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -72,7 +72,12 @@ def leet(path: str | None = None) -> None:
 @click.option(
     "-n",
     default=5,
-    help="Max number of runs to sync at a time.",
+    help="""Max number of runs to sync at a time.
+
+    When syncing multiple files that are part of the same run,
+    the files are synced sequentially in order of start time
+    regardless of this setting.
+    """,
 )
 def sync(
     paths: tuple[str, ...],


### PR DESCRIPTION
Sync multiple instances of the same run (such as resumed runs) sequentially and in order of start time.