### PR TITLE
refactor: subtask error message indent logic in progress.py

### DIFF
--- a/wandb/sdk/lib/progress.py
+++ b/wandb/sdk/lib/progress.py
@@ -292,14 +292,17 @@ class _OperationStatsPrinter:
         if not is_subtask:
             self._ops_shown += 1
 
+        status_indent_level = 0  # alignment for the status message, if any
         parts: list[str] = []
 
         # Subtask indicator.
         if is_subtask and self._printer.supports_unicode:
+            status_indent_level += 2  # +1 for space
             parts.append("↳")
 
         # Loading symbol.
         if self._loading_symbol:
+            status_indent_level += 2  # +1 for space
             parts.append(self._loading_symbol)
 
         # Task name.
@@ -317,9 +320,9 @@ class _OperationStatsPrinter:
         if op.error_status:
             error_word = self._printer.error("ERROR")
             error_desc = self._printer.secondary_text(op.error_status)
-            subtask_indent = "  " if is_subtask else ""
+            status_indent = " " * status_indent_level
             self._lines.append(
-                f"{indent}{subtask_indent}  {error_word} {error_desc}",
+                f"{indent}{status_indent}{error_word} {error_desc}",
             )
 
         # Subtasks.


### PR DESCRIPTION
I recently added an `_INDENT`​ constant to this file and was tempted to use it in the `op.error_status` block, but the "indent" there is for alignment and not the same thing as what `_INDENT` represents. I also noticed it would not align properly in terminals that don't support Unicode, so I refactored it slightly.