### PR TITLE
refactor(artifacts): decouple transport-free Registry attributes into RegistryData type

### DIFF
--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -66,10 +66,10 @@ def test_artifact_error_for_invalid_aliases(user):
     for aliases in error_aliases:
         with pytest.raises(ValueError) as e_info:
             run.log_artifact(artifact, aliases=aliases)
-            assert (
-                str(e_info.value)
-                == "Aliases must not contain any of the following characters: /, :"
-            )
+        assert (
+            str(e_info.value)
+            == "Aliases must not contain any of the following characters: '/', ':'"
+        )
 
     for aliases in [["latest", "boom_test-q"]]:
         run.log_artifact(artifact, aliases=aliases)

--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -52,7 +52,7 @@ def test_registry_create_edit(default_organization, api: Api):
     assert registry.organization == default_organization
     assert registry.description == initial_description
     assert registry.visibility == "organization"
-    assert registry.allow_all_artifact_types
+    assert registry.allow_all_artifact_types is True
     assert len(registry.artifact_types) == 0
 
     # This doesn't do anything but want to make sure it doesn't raise unexpected errors
@@ -61,7 +61,7 @@ def test_registry_create_edit(default_organization, api: Api):
     assert registry.name == registry_name
     assert registry.description == initial_description
     assert registry.visibility == "organization"
-    assert registry.allow_all_artifact_types
+    assert registry.allow_all_artifact_types is True
 
     # === Edit ===
     registry.description = updated_description
@@ -116,7 +116,7 @@ def test_registry_create_edit_artifact_types(default_organization, api: Api):
         artifact_types=None,  # Test default: allow all
     )
     assert registry
-    assert registry.allow_all_artifact_types
+    assert registry.allow_all_artifact_types is True
     assert registry.artifact_types == []
 
     # Test restriction: Cannot add types if allow_all is True
@@ -128,6 +128,7 @@ def test_registry_create_edit_artifact_types(default_organization, api: Api):
         registry.save()
     # Reset for valid save
     registry.allow_all_artifact_types = False
+    assert registry.allow_all_artifact_types is False
     registry.save()
     assert registry.artifact_types == [artifact_type_1]
     assert registry.artifact_types.draft == ()
@@ -315,12 +316,16 @@ def test_edit_registry_name(mock_termlog, default_organization, api: Api):
         description="This is the initial description",
     )
 
+    assert registry.name == registry_name
+
     new_registry_name = "new-name"
+
     registry.name = new_registry_name
-    assert registry._saved_name == registry_name
-    registry.save()
     assert registry.name == new_registry_name
-    assert registry._saved_name == new_registry_name
+
+    registry.save()
+
+    assert registry.name == new_registry_name
     assert registry.description == "This is the initial description"
 
     # Double check we didn't create a new registry instead of renaming the old one

--- a/tests/unit_tests/test_automations/conftest.py
+++ b/tests/unit_tests/test_automations/conftest.py
@@ -108,7 +108,7 @@ def artifact_collection(mock_client: Mock) -> ArtifactCollection:
                     "name": entity_name,
                 },
             },
-            default_artifact_type={"name": collection_type},
+            type={"name": collection_type},
             description="This is a fake artifact collection.",
             aliases={"edges": []},
             createdAt="2021-01-01T00:00:00Z",

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from wandb.apis.public.registries._utils import (
     ensure_registry_prefix_on_names,
-    format_gql_artifact_types_input,
+    prepare_artifact_types_input,
 )
 from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 
@@ -16,13 +16,13 @@ from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
             [{"name": "apple"}, {"name": "banana"}, {"name": "cherry"}],
         ),
         # None/empty input
-        (None, []),
-        ([], []),
+        (None, None),
+        ([], None),
     ],
 )
 def test_format_gql_artifact_types_input_valid(artifact_types, expected_output):
     """Test artifact type name validation and formatting for valid inputs."""
-    result = format_gql_artifact_types_input(artifact_types=artifact_types)
+    result = prepare_artifact_types_input(artifact_types=artifact_types)
     assert result == expected_output
 
 
@@ -40,7 +40,7 @@ def test_format_gql_artifact_types_input_valid(artifact_types, expected_output):
 def test_format_gql_artifact_types_input_error(artifact_types):
     """Test artifact type name validation raises errors for invalid inputs."""
     with pytest.raises(ValueError):
-        format_gql_artifact_types_input(artifact_types=artifact_types)
+        prepare_artifact_types_input(artifact_types=artifact_types)
 
 
 def test_simple_name_transform():

--- a/tools/graphql_codegen/artifacts/artifact_collections.graphql
+++ b/tools/graphql_codegen/artifacts/artifact_collections.graphql
@@ -7,7 +7,7 @@ fragment ArtifactCollectionFragment on ArtifactCollection {
   project {
     ...ProjectInfoFragment
   }
-  defaultArtifactType {
+  type: defaultArtifactType {
     name
   }
   tags {

--- a/tools/graphql_codegen/artifacts/registries.graphql
+++ b/tools/graphql_codegen/artifacts/registries.graphql
@@ -70,7 +70,7 @@ fragment RegistryCollectionFragment on ArtifactCollection {
   project {
     ...ProjectInfoFragment
   }
-  defaultArtifactType {
+  type: defaultArtifactType {
     name
   }
   tags {
@@ -133,7 +133,7 @@ fragment RegistryFragment on Project {
   createdAt
   updatedAt
   access
-  allowAllArtifactTypesInRegistry
+  allowAllArtifactTypes: allowAllArtifactTypesInRegistry
   artifactTypes(includeAll: true) {
     edges {
       node {

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -377,7 +377,7 @@ class ArtifactCollections(SizedPaginator["ArtifactCollection"]):
                 entity=node.project.entity.name,
                 project=node.project.name,
                 name=node.name,
-                type=node.default_artifact_type.name,
+                type=node.type.name,
                 attrs=node,
             )
             for node in self.last_response.nodes()

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -232,7 +232,7 @@ class Collections(Paginator[ArtifactCollection]):
                 entity=node.project.entity.name,
                 project=node.project.name,
                 name=node.name,
-                type=node.default_artifact_type.name,
+                type=node.type.name,
                 organization=self.organization,
                 attrs=node,
             )

--- a/wandb/sdk/artifacts/_generated/fragments.py
+++ b/wandb/sdk/artifacts/_generated/fragments.py
@@ -25,9 +25,7 @@ class ArtifactCollectionFragment(GQLResult):
     description: Optional[str]
     created_at: str = Field(alias="createdAt")
     project: Optional[ProjectInfoFragment]
-    default_artifact_type: ArtifactCollectionFragmentDefaultArtifactType = Field(
-        alias="defaultArtifactType"
-    )
+    type: ArtifactCollectionFragmentType
     tags: ArtifactCollectionFragmentTags
     aliases: Optional[ArtifactCollectionFragmentAliases] = None
 
@@ -40,16 +38,16 @@ class ArtifactCollectionFragmentAliasesEdges(GQLResult):
     node: Optional[ArtifactAliasFragment]
 
 
-class ArtifactCollectionFragmentDefaultArtifactType(GQLResult):
-    name: str
-
-
 class ArtifactCollectionFragmentTags(GQLResult):
     edges: List[ArtifactCollectionFragmentTagsEdges]
 
 
 class ArtifactCollectionFragmentTagsEdges(GQLResult):
     node: TagFragment
+
+
+class ArtifactCollectionFragmentType(GQLResult):
+    name: str
 
 
 class ArtifactCollectionSummary(GQLResult):
@@ -188,9 +186,7 @@ class RegistryCollectionFragment(GQLResult):
     description: Optional[str]
     created_at: str = Field(alias="createdAt")
     project: Optional[ProjectInfoFragment]
-    default_artifact_type: RegistryCollectionFragmentDefaultArtifactType = Field(
-        alias="defaultArtifactType"
-    )
+    type: RegistryCollectionFragmentType
     tags: RegistryCollectionFragmentTags
     aliases: RegistryCollectionFragmentAliases
 
@@ -203,16 +199,16 @@ class RegistryCollectionFragmentAliasesEdges(GQLResult):
     node: Optional[ArtifactAliasFragment]
 
 
-class RegistryCollectionFragmentDefaultArtifactType(GQLResult):
-    name: str
-
-
 class RegistryCollectionFragmentTags(GQLResult):
     edges: List[RegistryCollectionFragmentTagsEdges]
 
 
 class RegistryCollectionFragmentTagsEdges(GQLResult):
     node: TagFragment
+
+
+class RegistryCollectionFragmentType(GQLResult):
+    name: str
 
 
 class RegistryFragment(GQLResult):
@@ -224,9 +220,7 @@ class RegistryFragment(GQLResult):
     created_at: str = Field(alias="createdAt")
     updated_at: Optional[str] = Field(alias="updatedAt")
     access: Optional[str]
-    allow_all_artifact_types_in_registry: bool = Field(
-        alias="allowAllArtifactTypesInRegistry"
-    )
+    allow_all_artifact_types: bool = Field(alias="allowAllArtifactTypes")
     artifact_types: RegistryFragmentArtifactTypes = Field(alias="artifactTypes")
 
 
@@ -336,9 +330,9 @@ ArtifactAliasFragment.model_rebuild()
 ArtifactCollectionFragment.model_rebuild()
 ArtifactCollectionFragmentAliases.model_rebuild()
 ArtifactCollectionFragmentAliasesEdges.model_rebuild()
-ArtifactCollectionFragmentDefaultArtifactType.model_rebuild()
 ArtifactCollectionFragmentTags.model_rebuild()
 ArtifactCollectionFragmentTagsEdges.model_rebuild()
+ArtifactCollectionFragmentType.model_rebuild()
 ArtifactCollectionSummary.model_rebuild()
 ArtifactFragmentWithoutAliases.model_rebuild()
 ArtifactFragmentWithoutAliasesArtifactType.model_rebuild()
@@ -359,9 +353,9 @@ ProjectInfoFragmentEntity.model_rebuild()
 RegistryCollectionFragment.model_rebuild()
 RegistryCollectionFragmentAliases.model_rebuild()
 RegistryCollectionFragmentAliasesEdges.model_rebuild()
-RegistryCollectionFragmentDefaultArtifactType.model_rebuild()
 RegistryCollectionFragmentTags.model_rebuild()
 RegistryCollectionFragmentTagsEdges.model_rebuild()
+RegistryCollectionFragmentType.model_rebuild()
 RegistryFragment.model_rebuild()
 RegistryFragmentArtifactTypes.model_rebuild()
 RegistryFragmentArtifactTypesEdges.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/operations.py
+++ b/wandb/sdk/artifacts/_generated/operations.py
@@ -183,7 +183,7 @@ fragment ArtifactCollectionFragment on ArtifactCollection {
   project {
     ...ProjectInfoFragment
   }
-  defaultArtifactType {
+  type: defaultArtifactType {
     name
   }
   tags {
@@ -249,7 +249,7 @@ fragment ArtifactCollectionFragment on ArtifactCollection {
   project {
     ...ProjectInfoFragment
   }
-  defaultArtifactType {
+  type: defaultArtifactType {
     name
   }
   tags {
@@ -1597,7 +1597,7 @@ fragment RegistryCollectionFragment on ArtifactCollection {
   project {
     ...ProjectInfoFragment
   }
-  defaultArtifactType {
+  type: defaultArtifactType {
     name
   }
   tags {
@@ -1646,7 +1646,7 @@ fragment RegistryFragment on Project {
   createdAt
   updatedAt
   access
-  allowAllArtifactTypesInRegistry
+  allowAllArtifactTypes: allowAllArtifactTypesInRegistry
   artifactTypes(includeAll: true) {
     edges {
       node {
@@ -1695,7 +1695,7 @@ fragment RegistryFragment on Project {
   createdAt
   updatedAt
   access
-  allowAllArtifactTypesInRegistry
+  allowAllArtifactTypes: allowAllArtifactTypesInRegistry
   artifactTypes(includeAll: true) {
     edges {
       node {
@@ -1730,7 +1730,7 @@ fragment RegistryFragment on Project {
   createdAt
   updatedAt
   access
-  allowAllArtifactTypesInRegistry
+  allowAllArtifactTypes: allowAllArtifactTypesInRegistry
   artifactTypes(includeAll: true) {
     edges {
       node {
@@ -1765,7 +1765,7 @@ fragment RegistryFragment on Project {
   createdAt
   updatedAt
   access
-  allowAllArtifactTypesInRegistry
+  allowAllArtifactTypes: allowAllArtifactTypesInRegistry
   artifactTypes(includeAll: true) {
     edges {
       node {

--- a/wandb/sdk/artifacts/_models/__init__.py
+++ b/wandb/sdk/artifacts/_models/__init__.py
@@ -2,3 +2,11 @@
 
 Excludes GraphQL-generated classes.
 """
+
+__all__ = [
+    "ArtifactsBase",
+    "RegistryData",
+]
+
+from .base_model import ArtifactsBase
+from .registry import RegistryData

--- a/wandb/sdk/artifacts/_models/registry.py
+++ b/wandb/sdk/artifacts/_models/registry.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import ConfigDict, Field
+from typing_extensions import Self
+
+from wandb._pydantic import GQLId, field_validator
+from wandb._strutils import nameof
+from wandb.apis.public.registries._freezable_list import AddOnlyArtifactTypesList
+from wandb.apis.public.registries._utils import Visibility
+from wandb.sdk.artifacts._generated import RegistryFragment
+from wandb.sdk.artifacts._generated.fragments import RegistryFragmentArtifactTypes
+from wandb.sdk.artifacts._validators import REGISTRY_PREFIX, remove_registry_prefix
+
+from .base_model import ArtifactsBase
+
+
+class RegistryData(ArtifactsBase):
+    """Transport-free model for local `Registry` data.
+
+    For now, this is separated from the public `Registry` class
+    to more easily ensure continuity in the public `Registry` API.
+    """
+
+    model_config = ConfigDict(
+        str_min_length=1,  # Strings cannot be empty
+    )
+
+    id: GQLId = Field(frozen=True)
+    """The unique, encoded ID for this registry."""
+
+    created_at: str = Field(frozen=True)
+    """When this registry was created."""
+
+    updated_at: Optional[str] = Field(frozen=True)
+    """When this registry was last updated."""
+
+    organization: str = Field(frozen=True)
+    """The organization of the registry."""
+
+    entity: str = Field(frozen=True)
+    """The organization entity of the registry."""
+
+    name: str
+    """The name of the registry without the `wandb-registry-` project prefix."""
+
+    description: Optional[str] = None
+    """The description, if any, of the registry."""
+
+    allow_all_artifact_types: bool
+    """Whether all artifact types are allowed in the registry."""
+
+    artifact_types: AddOnlyArtifactTypesList = Field(
+        default_factory=AddOnlyArtifactTypesList
+    )
+    """The artifact types allowed in the registry.
+
+    The meaning of this list depends on the value of `allow_all_artifact_types`:
+    - If True: `artifact_types` are the previously-saved or currently-used types in the registry.
+    - If False: `artifact_types` are the only allowed artifact types in the registry.
+    """
+
+    visibility: Visibility = Field(alias="access")
+    """The visibility of the registry."""
+
+    @property
+    def full_name(self) -> str:
+        """The full project name of the registry, including the expected `wandb-registry-` prefix."""
+        return f"{REGISTRY_PREFIX}{self.name}"
+
+    @field_validator("artifact_types", mode="plain")
+    def _validate_artifact_types(cls, v: Any) -> AddOnlyArtifactTypesList:
+        """Coerce `artifact_types` to an AddOnlyArtifactTypesList."""
+        if isinstance(v, RegistryFragmentArtifactTypes):
+            # This is a GQL connection object, so we need to extract the node names
+            return AddOnlyArtifactTypesList(e.node.name for e in v.edges if e.node)
+
+        # By default, assume we were passed an iterable of strings
+        return AddOnlyArtifactTypesList(v)
+
+    @classmethod
+    def from_fragment(cls, obj: RegistryFragment) -> Self:
+        if not obj.entity.organization:
+            raise ValueError(
+                f"Unable to parse registry organization from {nameof(type(obj))!r} object"
+            )
+
+        return cls(
+            id=obj.id,
+            created_at=obj.created_at,
+            updated_at=obj.updated_at,
+            organization=obj.entity.organization.name,
+            entity=obj.entity.name,
+            name=remove_registry_prefix(obj.name),
+            description=obj.description,
+            allow_all_artifact_types=obj.allow_all_artifact_types,
+            artifact_types=obj.artifact_types,
+            visibility=obj.access,
+        )


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

PR: 
- Decouples transport-free Registry state into a typed model (`RegistryData`) and makes existing `Registry` class a thin wrapper around it.
  - This helps move us toward better separation between the (transport-free) local data model and parsing/validation logic vs actual GQL client request logic.  This is necessary whether we handle client logic in Python or core -- it's arguably more necessary if client operations must pass through the (non-Python) core process

- Introduces `RegistryData` (Pydantic) and dual snapshots in `Registry` (`_saved`/`_current`) so that edit operations are easier to manage locally (and extend for new features).
- Absorbs more Registry-specific parsing/validation logic into `RegistryData`.
- Absorbs helpers for converting GQL <-> python Visibility values into the `Visibility` enum class itself, via `Visibility.from_{gql,python}`.  Values passed to/from public registry API methods remain `"organization", "restricted"` strings for continuity.

No intentional functional changes to the public API.

Related:
- Similar refactor of `ArtifactCollection` data model: https://github.com/wandb/wandb/pull/10613
- Further context on why this PR defines a new/separate/internal `RegistryData` type (instead of _directly_ replacing the existing `Registry` class with a pydantic type of the same name): [discussion](https://github.com/wandb/wandb/pull/10723#discussion_r2457782480)

Some minor, incidental cleanup is also included in this PR.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
No intended functional changes, existing tests must continue to pass.  Some existing registry API tests have been expanded for extra assurance.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
