### PR TITLE
chore: small fix to run.log() step and commit documentation

### DIFF
--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -580,7 +580,7 @@ def log(
         run.log({"accuracy": 0.8}, step=current_step)
         current_step += 1
         run.log({"train-loss": 0.4}, step=current_step)
-        run.log({"accuracy": 0.9}, step=current_step)
+        run.log({"accuracy": 0.9}, step=current_step, commit=True)
     ```
 
     Args:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1859,7 +1859,7 @@ class Run:
             run.log({"accuracy": 0.8}, step=current_step)
             current_step += 1
             run.log({"train-loss": 0.4}, step=current_step)
-            run.log({"accuracy": 0.9}, step=current_step)
+            run.log({"accuracy": 0.9}, step=current_step, commit=True)
         ```
 
         Args:


### PR DESCRIPTION
The docstring said "all of the following are equivalent", which is true for the last example if the run ends after the final `log()`, but otherwise `commit=True` is needed for the last logged step to be finalized and uploaded.