### PR TITLE
feat(sdk): pass extra http headers to presigned url requests

### DIFF
--- a/core/internal/filetransfer/file_transfers.go
+++ b/core/internal/filetransfer/file_transfers.go
@@ -35,8 +35,10 @@ func NewFileTransfers(
 	client *retryablehttp.Client,
 	logger *observability.CoreLogger,
 	fileTransferStats FileTransferStats,
+	extraHeaders map[string]string,
 ) *FileTransfers {
-	defaultFileTransfer := NewDefaultFileTransfer(client, logger, fileTransferStats)
+	defaultFileTransfer := NewDefaultFileTransfer(client, logger, fileTransferStats, extraHeaders)
+	// NOTE: Cloud specific handlers are reference artifacts so we do NOT pass the extra headers to them (for now)
 	gcsFileTransfer := NewGCSFileTransfer(nil, logger, fileTransferStats)
 	s3FileTransfer := NewS3FileTransfer(nil, logger, fileTransferStats)
 	azureFileTransfer := NewAzureFileTransfer(nil, logger, fileTransferStats)

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -220,6 +220,9 @@ func NewFileTransferManager(
 		return nil
 	}
 
+	extraHeaders := map[string]string{}
+	maps.Copy(extraHeaders, settings.GetExtraHTTPHeaders())
+
 	fileTransferRetryClient := retryablehttp.NewClient()
 	fileTransferRetryClient.Logger = logger
 	fileTransferRetryClient.CheckRetry = filetransfer.FileTransferRetryPolicy
@@ -232,6 +235,7 @@ func NewFileTransferManager(
 		fileTransferRetryClient,
 		logger,
 		fileTransferStats,
+		extraHeaders,
 	)
 
 	// Set the Proxy function on the HTTP client.
@@ -248,7 +252,8 @@ func NewFileTransferManager(
 
 	// Set the "Proxy-Authorization" header for the CONNECT requests
 	// to the proxy server if the header is present in the extra headers.
-	if header, ok := settings.GetExtraHTTPHeaders()["Proxy-Authorization"]; ok {
+	// NOTE: [NewGraphQLClient] and [NewFileStream] does this in backend.NewClient
+	if header, ok := extraHeaders["Proxy-Authorization"]; ok {
 		transport.ProxyConnectHeader = http.Header{
 			"Proxy-Authorization": []string{header},
 		}

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -195,6 +195,7 @@ func (m *Manifest) GetManifestEntryFromArtifactFilePath(path string) (ManifestEn
 }
 
 func loadManifestFromURL(url string) (Manifest, error) {
+	// FIXME: inject header and use proper logger ... should use file transfers
 	client := retryablehttp.NewClient()
 	client.Logger = observability.NewNoOpLogger()
 	resp, err := client.Get(url)

--- a/wandb/apis/importers/wandb.py
+++ b/wandb/apis/importers/wandb.py
@@ -608,9 +608,7 @@ class WandbImporter:
 
         dst_f = dst_run.file(fname)
         try:
-            contents = wandb.util.download_file_into_memory(
-                dst_f.url, self.dst_api.api_key
-            )
+            contents = self.dst_api._download_file_into_memory(dst_f.url)
         except urllib3.exceptions.ReadTimeoutError:
             return {"Error checking": "Timeout"}
         except requests.HTTPError as e:

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -322,6 +322,8 @@ class File(Attrs):
             `ValueError` if file already exists, `replace=False` and
             `exist_ok=False`.
         """
+        # TODO: When user get file from API, each download call creates a new wandb.Api
+        # Which would verify login by making another API request...
         if api is None:
             api = wandb.Api()
 
@@ -334,7 +336,7 @@ class File(Attrs):
                     "File already exists, pass replace=True to overwrite or exist_ok=True to leave it as is and don't error."
                 )
 
-        util.download_file_from_url(path, self.url, api.api_key)
+        api._download_file_from_url(path, self.url)
         return open(path)
 
     @normalize_exceptions

--- a/wandb/sdk/artifacts/artifact_manifest.py
+++ b/wandb/sdk/artifacts/artifact_manifest.py
@@ -32,14 +32,17 @@ class ArtifactManifest(ArtifactsBase, ABC):
     @classmethod
     @abstractmethod
     def from_manifest_json(
-        cls, manifest_json: dict[str, Any], api: InternalApi | None = None
+        cls,
+        manifest_json: dict[str, Any],
+        api: InternalApi | None = None,
+        extra_http_headers: dict[str, str] | None = None,
     ) -> ArtifactManifest:
         if (version := manifest_json.get("version")) is None:
             raise ValueError("Invalid manifest format. Must contain version field.")
 
         for sub in cls.__subclasses__():
             if sub.version() == version:
-                return sub.from_manifest_json(manifest_json, api=api)
+                return sub.from_manifest_json(manifest_json, api=api, extra_http_headers=extra_http_headers)
         raise ValueError("Invalid manifest version.")
 
     def __len__(self) -> int:

--- a/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
+++ b/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
@@ -32,13 +32,16 @@ class ArtifactManifestV1(ArtifactManifest):
 
     @classmethod
     def from_manifest_json(
-        cls, manifest_json: dict[str, Any], api: InternalApi | None = None
+        cls,
+        manifest_json: dict[str, Any],
+        api: InternalApi | None = None,
+        extra_http_headers: dict[str, str] | None = None,
     ) -> ArtifactManifestV1:
         data = ArtifactManifestV1Data(**manifest_json)
 
         policy_name = data.storage_policy
         policy_cfg = data.storage_policy_config
-        policy = StoragePolicy.lookup_by_name(policy_name).from_config(policy_cfg, api)
+        policy = StoragePolicy.lookup_by_name(policy_name).from_config(policy_cfg, api, extra_http_headers)
         return cls(
             manifest_version=data.version, entries=data.contents, storage_policy=policy
         )

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -57,15 +57,19 @@ class WandbStoragePolicy(StoragePolicy):
 
     @classmethod
     def from_config(
-        cls, config: dict[str, Any], api: InternalApi | None = None
+        cls,
+        config: dict[str, Any],
+        api: InternalApi | None = None,
+        extra_http_headers: dict[str, str] | None = None,
     ) -> WandbStoragePolicy:
-        return cls(config=config, api=api)
+        return cls(config=config, api=api, extra_http_headers=extra_http_headers)
 
     def __init__(
         self,
         config: dict[str, Any] | None = None,
         cache: ArtifactFileCache | None = None,
         api: InternalApi | None = None,
+        extra_http_headers: dict[str, str] | None = None,
         session: requests.Session | None = None,
     ) -> None:
         self._config = config or {}
@@ -73,6 +77,10 @@ class WandbStoragePolicy(StoragePolicy):
             self._validate_storage_region(storage_region)
         self._cache = cache or get_artifact_file_cache()
         self._session = session or make_http_session()
+        logger.debug("WandbStoragePolicy extra_http_headers: %s", extra_http_headers)
+        self._session.headers = extra_http_headers or {}
+        # TODO: Creating InternalApi() directly would ignore the settings from
+        # top level run or public wandb.Api
         self._api = api or InternalApi()
         self._handler = MultiHandler(
             handlers=make_storage_handlers(self._session),

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -38,7 +38,10 @@ class StoragePolicy(ABC):
     @classmethod
     @abstractmethod
     def from_config(
-        cls, config: dict[str, Any], api: InternalApi | None = None
+        cls,
+        config: dict[str, Any],
+        api: InternalApi | None = None,
+        extra_http_headers: dict[str, str] | None = None,
     ) -> StoragePolicy:
         raise NotImplementedError
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -278,10 +278,12 @@ class Api:
 
         # todo: remove these hacky hacks after settings refactor is complete
         #  keeping this code here to limit scope and so that it is easy to remove later
+        # TODO: https://github.com/wandb/wandb/pull/8986 already broke this adding x_ for settings environment variable?
         self._extra_http_headers = self.settings("_extra_http_headers") or json.loads(
             self._environ.get("WANDB__EXTRA_HTTP_HEADERS", "{}")
         )
         self._extra_http_headers.update(_thread_local_api_settings.headers or {})
+        logger.debug("InternalApi._extra_http_headers: %s", self._extra_http_headers)
 
         auth = None
         api_key = api_key or self.default_settings.get("api_key")
@@ -540,6 +542,9 @@ class Api:
                 ),
             }
         )
+        # Set x_extra_http_headers for public API
+        if hasattr(self, "_extra_http_headers") and self._extra_http_headers:
+            result["x_extra_http_headers"] = self._extra_http_headers
 
         return result if key is None else result[key]  # type: ignore
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -47,6 +47,8 @@ from .wandb_helper import parse_config
 from .wandb_run import Run, TeardownHook, TeardownStage
 from .wandb_settings import Settings
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     import wandb.jupyter
 
@@ -277,6 +279,7 @@ class _WandbInit:
 
         # Inherit global settings.
         settings = self._wl.settings.model_copy()
+        logger.debug("settings.x_extra_http_headers: %s", settings.x_extra_http_headers)
 
         # Apply settings from wandb.init() call.
         settings.update_from_settings(init_settings)
@@ -1465,6 +1468,7 @@ def init(  # noqa: C901
         init_settings = Settings(**settings)
     elif isinstance(settings, Settings):
         init_settings = settings
+    logger.debug("init_settings.x_extra_http_headers: %s", init_settings.x_extra_http_headers)
 
     # Explicit function arguments take precedence over settings
     if job_type is not None:
@@ -1519,6 +1523,7 @@ def init(  # noqa: C901
 
         wi.maybe_login(init_settings)
         run_settings, show_warnings = wi.make_run_settings(init_settings)
+        logger.debug("run_settings.x_extra_http_headers: %s", run_settings.x_extra_http_headers)
 
         if isinstance(run_settings.reinit, bool):
             wi.deprecated_features_used["run__reinit_bool"] = (

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1390,46 +1390,6 @@ def guess_data_type(shape: Sequence[int], risky: bool = False) -> Optional[str]:
             return "segmentation_mask"
     return None
 
-
-def download_file_from_url(
-    dest_path: str, source_url: str, api_key: Optional[str] = None
-) -> None:
-    auth = None
-    if not _thread_local_api_settings.cookies:
-        auth = ("api", api_key or "")
-    response = requests.get(
-        source_url,
-        auth=auth,
-        headers=_thread_local_api_settings.headers,
-        cookies=_thread_local_api_settings.cookies,
-        stream=True,
-        timeout=5,
-    )
-    response.raise_for_status()
-
-    if os.sep in dest_path:
-        filesystem.mkdir_exists_ok(os.path.dirname(dest_path))
-    with fsync_open(dest_path, "wb") as file:
-        for data in response.iter_content(chunk_size=1024):
-            file.write(data)
-
-
-def download_file_into_memory(source_url: str, api_key: Optional[str] = None) -> bytes:
-    auth = None
-    if not _thread_local_api_settings.cookies:
-        auth = ("api", api_key or "")
-    response = requests.get(
-        source_url,
-        auth=auth,
-        headers=_thread_local_api_settings.headers,
-        cookies=_thread_local_api_settings.cookies,
-        stream=True,
-        timeout=5,
-    )
-    response.raise_for_status()
-    return response.content
-
-
 def isatty(ob: IO) -> bool:
     return hasattr(ob, "isatty") and ob.isatty()
 


### PR DESCRIPTION
**WIP**

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

From https://github.com/wandb/wandb/pull/10719 a bit cleaner commit to do a test release.

Existing `WANDB__EXTRA_HTTP_HEADERS` is only used for graphql and filestream requests. 
Apply these headers to file upload/download requests that uses presigned urls as well.

- Artifact manifest, file
- Run file

There is existing issues with how settings get propagated when using Artifact/Api so using environment variable is the 'best' way for setting the headers ...

Problems discovered along the way

## public and internal Api

- The magical `WANDB__` converts to `x_` is not working in internal api, it only get the headers from env. `_extra_http_headers` should be `x_extra_http_headers` https://github.com/wandb/wandb/pull/8986

```python
        # TODO: https://github.com/wandb/wandb/pull/8986 already broke this adding x_ for settings environment variable?
        self._extra_http_headers = self.settings("") or json.loads(
            self._environ.get("WANDB__EXTRA_HTTP_HEADERS", "{}")
        )
```

- public api, i.e. `wandb.Api` is not taking the extra http headers

Too many places creating new Api without passing settings from run/api down

- `run._public_apis` creates new public api for each call, used by `run.log_artifact` etc.
- run file's `File.download` creates a new public api each file when using `api.runs() > run.files() > file.download`

## artifacts

- many places create Artifact by passing a `RetryClient` so I just attach the headers to the retry client to avoid updating all the callers e.g. `api.artifact`, `api.artifacts`, `run.logged_artifacts()`, run.used_artifacts()`...
- The storage policy requires a lot of plumbing due to the abstraction and the policy (i.e. the download implementation) is attached on the manifest and used by both `Artifact` and `ArtifactEntry`
- The good news is after logging a artifact, you cannot call `download` thanks to `@ensure_logged`, when you call `artifact.wait()` it will reset `self._manifest` and creates a new manifest with right header

## Performance issues

-  public api always do verify login when created unless there is cookie from thread local, which is never the case for `run._public_apis` and `file.download` 

## Go side is much better

Artifact and run files use same file transfer and the settings for a stream has the headers.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
