### PR TITLE
chore: fix test_xgboost failure

### DIFF
--- a/tests/system_tests/test_functional/xgboost/classification.py
+++ b/tests/system_tests/test_functional/xgboost/classification.py
@@ -11,7 +11,6 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_
 run = wandb.init(project="wine-xgboost")
 
 model = XGBClassifier(
-    use_label_encoder=False,
     eval_metric=["mlogloss", "auc"],
     seed=42,
     n_estimators=50,

--- a/tests/system_tests/test_functional/xgboost/test_xgboost.py
+++ b/tests/system_tests/test_functional/xgboost/test_xgboost.py
@@ -14,10 +14,14 @@ def test_classification(wandb_backend_spy, execute_script):
         assert config["learner"]["value"]["gradient_booster"]["name"] == "gbtree"
         assert config["learner"]["value"]["objective"]["name"] == "multi:softprob"
 
+        # NOTE: The values below depend on the Wine dataset.
+        #
+        # This is a bad test that needs rewriting.
+        # If it breaks, check if there was an xgboost release.
         summary = snapshot.summary(run_id=run_id)
         assert summary["Feature Importance_table"]["_type"] == "table-file"
         assert summary["Feature Importance_table"]["ncols"] == 2
-        assert summary["Feature Importance_table"]["nrows"] == 11
+        assert summary["Feature Importance_table"]["nrows"] == 13
         assert summary["best_score"] == 1.0
         assert summary["epoch"] == 49
         assert summary["validation_0-auc"]["max"] == 1


### PR DESCRIPTION
Fixes `test_xgboost.py` which is failing because of the recent `xgboost` release (3.1.0) which appears to have changed the number of features it loads from the Wine dataset from 11 to 13.

This test is poorly written, but really fixing it would take a lot of time and possibly require refactoring the integration as well.

I removed `use_label_encoder=False` because it was emitting a warning about being an unused argument.