### PR TITLE
fix: add nowait param to publish_output() for asyncio safety

### DIFF
--- a/wandb/sdk/interface/interface_queue.py
+++ b/wandb/sdk/interface/interface_queue.py
@@ -1,12 +1,8 @@
-"""InterfaceQueue - Derived from InterfaceShared using queues to send to internal thread.
-
-See interface.py for how interface classes relate to each other.
-
-"""
+from __future__ import annotations
 
 import logging
 from multiprocessing.process import BaseProcess
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from typing_extensions import override
 
@@ -23,11 +19,21 @@ logger = logging.getLogger("wandb")
 
 
 class InterfaceQueue(InterfaceShared):
+    """Legacy implementation of InterfaceShared.
+
+    This was used by legacy-service to pass messages back to itself before
+    the existence of wandb-core. It may be removed once legacy-service is
+    completely removed (including its use in `wandb sync`).
+
+    Since it was used by the internal service, it does not implement
+    the "deliver" methods, which are only used in the client.
+    """
+
     def __init__(
         self,
-        record_q: Optional["Queue[pb.Record]"] = None,
-        result_q: Optional["Queue[pb.Result]"] = None,
-        process: Optional[BaseProcess] = None,
+        record_q: Queue[pb.Record] | None = None,
+        result_q: Queue[pb.Result] | None = None,
+        process: BaseProcess | None = None,
     ) -> None:
         self.record_q = record_q
         self.result_q = result_q
@@ -35,16 +41,19 @@ class InterfaceQueue(InterfaceShared):
         super().__init__()
 
     @override
-    async def deliver_async(
-        self,
-        record: "pb.Record",
-    ) -> "MailboxHandle[pb.Result]":
-        raise NotImplementedError
-
-    def _publish(self, record: "pb.Record", local: Optional[bool] = None) -> None:
+    def _publish(self, record: pb.Record, *, nowait: bool = False) -> None:
         if self._process and not self._process.is_alive():
             raise Exception("The wandb backend process has shutdown")
-        if local:
-            record.control.local = local
         if self.record_q:
             self.record_q.put(record)
+
+    @override
+    async def deliver_async(
+        self,
+        record: pb.Record,
+    ) -> MailboxHandle[pb.Result]:
+        raise NotImplementedError
+
+    @override
+    def _deliver(self, record: pb.Record) -> MailboxHandle[pb.Result]:
+        raise NotImplementedError

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1572,15 +1572,13 @@ class Run:
 
     @_log_to_run
     def _console_callback(self, name: str, data: str) -> None:
-        # logger.info("console callback: %s, %s", name, data)
         if self._backend and self._backend.interface:
-            self._backend.interface.publish_output(name, data)
+            # nowait=True so that this can be called from an asyncio context.
+            self._backend.interface.publish_output(name, data, nowait=True)
 
     @_log_to_run
     @_raise_if_finished
     def _console_raw_callback(self, name: str, data: str) -> None:
-        # logger.info("console callback: %s, %s", name, data)
-
         # NOTE: console output is only allowed on the process which installed the callback
         # this will prevent potential corruption in the socket to the service.  Other methods
         # are protected by the _attach run decorator, but this callback was installed on the
@@ -1590,7 +1588,8 @@ class Run:
             return
 
         if self._backend and self._backend.interface:
-            self._backend.interface.publish_output_raw(name, data)
+            # nowait=True so that this can be called from an asyncio context.
+            self._backend.interface.publish_output_raw(name, data, nowait=True)
 
     @_log_to_run
     def _tensorboard_callback(


### PR DESCRIPTION
Adds a `nowait` parameter to `publish_output` and `publish_output_raw` to allow them to be called from the asyncio thread. When set to true, `AsyncioManager`'s `run_soon()` method is used instead of `run()` to submit the task to send the record over the socket, which makes it non-blocking even if the socket buffer is full.

This PR also improves the very outdated documentation for the `InterfaceBase` class hierarchy.

Before this PR, console output from wandb async functions (running in the AsyncioManager) was not captured and raised an exception that is logged and suppressed. One example is when the `asyncio` Socket code logs the message `socket.send() raised an exception.` if the underlying socket disconnects unexpectedly (like if `wandb-core` dies).
