### PR TITLE
refactor: runsummary Updates object

### DIFF
--- a/core/internal/runsummary/updates.go
+++ b/core/internal/runsummary/updates.go
@@ -1,0 +1,139 @@
+package runsummary
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/wandb/simplejsonext"
+	"github.com/wandb/wandb/core/internal/pathtree"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// Updates is a collection of updates to a run's summary.
+//
+// A nil value acts like no updates but cannot be mutated with Merge.
+type Updates struct {
+	// update contains values to add to or change in the summary.
+	//
+	// Leaves in the tree are JSON-encoded values (supporting +-Infinity
+	// and NaN).
+	update *pathtree.PathTree[string]
+
+	// remove contains paths to remove from the summary.
+	//
+	// None of the paths appear in 'update'.
+	remove *pathtree.PathTree[struct{}]
+}
+
+// IsEmpty returns whether the Updates instance contains any changes.
+//
+// Returns true given nil.
+func (u *Updates) IsEmpty() bool {
+	return u == nil || (u.update.IsEmpty() && u.remove.IsEmpty())
+}
+
+// NoUpdates returns a mutable Updates instance that makes no changes.
+func NoUpdates() *Updates {
+	return &Updates{
+		update: pathtree.New[string](),
+		remove: pathtree.New[struct{}](),
+	}
+}
+
+// FromProto makes Updates from a SummaryRecord.
+func FromProto(record *spb.SummaryRecord) *Updates {
+	u := NoUpdates()
+
+	for _, item := range record.GetUpdate() {
+		path := keyPath(item)
+		u.update.Set(path, item.GetValueJson())
+	}
+
+	for _, item := range record.GetRemove() {
+		path := keyPath(item)
+		u.remove.Set(path, struct{}{})
+		u.update.Remove(path)
+	}
+
+	return u
+}
+
+// Merge merges the given Updates into this Updates instance,
+// so that `u1.Apply(rs); u2.Apply(rs)` has the same effect on `rs` as
+// `u1.Merge(u2); u1.Apply(rs)`.
+func (u *Updates) Merge(newUpdates *Updates) {
+	newUpdates.update.ForEachLeaf(
+		func(path pathtree.TreePath, valueJSON string) bool {
+			u.remove.Remove(path)
+			u.update.Set(path, valueJSON)
+			return true
+		})
+
+	newUpdates.remove.ForEachLeaf(
+		func(path pathtree.TreePath, _ struct{}) bool {
+			u.remove.Set(path, struct{}{})
+			u.update.Remove(path)
+			return true
+		})
+}
+
+// Apply modifies the summary with these updates.
+//
+// A partial success is possible if some values' JSON strings cannot be
+// unmarshaled.
+func (u *Updates) Apply(rs *RunSummary) error {
+	var errs []error
+
+	u.update.ForEachLeaf(
+		func(path pathtree.TreePath, valueJSON string) bool {
+			value, err := simplejsonext.UnmarshalString(valueJSON)
+
+			if err != nil {
+				errs = append(errs,
+					fmt.Errorf("error in path %s: %v", toDottedPath(path), err))
+			} else {
+				rs.Set(path, value)
+			}
+
+			return true
+		})
+
+	u.remove.ForEachLeaf(
+		func(path pathtree.TreePath, _ struct{}) bool {
+			rs.Remove(path)
+			return true
+		})
+
+	if len(errs) > 0 {
+		return fmt.Errorf(
+			"runsummary: failed to update some keys: %v",
+			errors.Join(errs...))
+	}
+
+	return nil
+}
+
+// toDottedPath escapes dots in the path components and concatenates them
+// using dots.
+func toDottedPath(path pathtree.TreePath) string {
+	var escapedLabels []string
+
+	for _, label := range path.Labels() {
+		escapedLabels = append(escapedLabels,
+			strings.ReplaceAll(label, ".", "\\."))
+	}
+
+	return strings.Join(escapedLabels, ".")
+}
+
+// keyPath returns the key on the summary item as a path.
+func keyPath(item *spb.SummaryItem) pathtree.TreePath {
+	if len(item.GetNestedKey()) > 0 {
+		return pathtree.PathOf(
+			item.GetNestedKey()[0],
+			item.GetNestedKey()[1:]...,
+		)
+	}
+	return pathtree.PathOf(item.GetKey())
+}

--- a/core/internal/runsummary/updates_test.go
+++ b/core/internal/runsummary/updates_test.go
@@ -1,0 +1,131 @@
+package runsummary_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/internal/pathtree"
+	"github.com/wandb/wandb/core/internal/runsummary"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestUpdates_Apply_InsertsRemovesAndCollectsErrors(t *testing.T) {
+	rs := runsummary.New()
+	rs.Set(pathtree.PathOf("x"), 1)
+	rs.Set(pathtree.PathOf("y"), 2)
+
+	err := runsummary.FromProto(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{Key: "x", ValueJson: `3.5`},
+			{Key: "z", ValueJson: `"this is z"`},
+			{Key: "oops", ValueJson: `<not valid JSON>`},
+		},
+		Remove: []*spb.SummaryItem{
+			{Key: "y"},
+		},
+	}).Apply(rs)
+
+	assert.Equal(t,
+		map[string]any{
+			"x": float64(3.5),
+			"z": "this is z",
+		},
+		rs.ToNestedMaps())
+	assert.ErrorContains(t, err, "failed to update some keys")
+	assert.ErrorContains(t, err, "oops")
+}
+
+func TestUpdates_Merge(t *testing.T) {
+	u1 := runsummary.FromProto(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{Key: "update-then-remove", ValueJson: `"test"`},
+		},
+		Remove: []*spb.SummaryItem{
+			{Key: "remove-then-update"},
+		},
+	})
+	u2 := runsummary.FromProto(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{Key: "remove-then-update", ValueJson: `7`},
+		},
+		Remove: []*spb.SummaryItem{
+			{Key: "update-then-remove"},
+		},
+	})
+	rs := runsummary.New()
+	rs.Set(pathtree.PathOf("not-changed-at-all"), "not changed")
+	rs.Set(pathtree.PathOf("update-then-remove"), "initial")
+	rs.Set(pathtree.PathOf("remove-then-update"), "initial")
+
+	u1.Merge(u2)
+	err := u1.Apply(rs)
+
+	assert.NoError(t, err)
+	assert.Equal(t,
+		map[string]any{
+			"not-changed-at-all": "not changed",
+			"remove-then-update": int64(7),
+		},
+		rs.ToNestedMaps())
+}
+
+func TestUpdates_FromProto(t *testing.T) {
+	rs := runsummary.New()
+
+	err := runsummary.FromProto(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{Key: "invalid-but-removed", ValueJson: "<not valid JSON>"},
+			{NestedKey: []string{"good", "key"}, ValueJson: "123"},
+		},
+		Remove: []*spb.SummaryItem{
+			{Key: "invalid-but-removed"},
+		},
+	}).Apply(rs)
+
+	assert.NoError(t, err)
+	assert.Equal(t,
+		map[string]any{
+			"good": map[string]any{
+				"key": int64(123),
+			},
+		},
+		rs.ToNestedMaps())
+}
+
+func TestUpdates_IsEmpty(t *testing.T) {
+	testCases := []struct {
+		name    string
+		updates *runsummary.Updates
+		isEmpty bool
+	}{
+		{
+			name:    "nil is empty",
+			updates: nil,
+			isEmpty: true,
+		},
+		{
+			name:    "NoUpdates is empty",
+			updates: runsummary.NoUpdates(),
+			isEmpty: true,
+		},
+		{
+			name:    "updates from empty proto is empty",
+			updates: runsummary.FromProto(&spb.SummaryRecord{}),
+			isEmpty: true,
+		},
+		{
+			name: "non-empty updates is not empty",
+			updates: runsummary.FromProto(&spb.SummaryRecord{
+				Remove: []*spb.SummaryItem{{Key: "x"}},
+			}),
+			isEmpty: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.isEmpty, tc.updates.IsEmpty())
+		})
+	}
+}

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -788,16 +788,9 @@ func (h *Handler) handleRequestJobInput(record *spb.Record) {
 //   - Records from the transaction log when syncing
 //   - `updateRunTiming`
 func (h *Handler) handleSummary(summary *spb.SummaryRecord) {
-	for _, update := range summary.Update {
-		err := h.runSummary.SetFromRecord(update)
-		if err != nil {
-			h.logger.CaptureError(
-				fmt.Errorf("handler: error processing summary: %v", err))
-		}
-	}
-
-	for _, remove := range summary.Remove {
-		h.runSummary.RemoveFromRecord(remove)
+	if err := runsummary.FromProto(summary).Apply(h.runSummary); err != nil {
+		h.logger.CaptureError(
+			fmt.Errorf("handler: error processing summary: %v", err))
 	}
 }
 

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -851,15 +851,10 @@ func (s *Sender) sendSummary(_ *spb.Record, summary *spb.SummaryRecord) {
 		return
 	}
 
-	for _, update := range summary.Update {
-		if err := s.runSummary.SetFromRecord(update); err != nil {
-			s.logger.CaptureError(
-				fmt.Errorf("sender: error updating summary: %v", err))
-		}
-	}
-
-	for _, remove := range summary.Remove {
-		s.runSummary.RemoveFromRecord(remove)
+	updates := runsummary.FromProto(summary)
+	if err := updates.Apply(s.runSummary); err != nil {
+		s.logger.CaptureError(
+			fmt.Errorf("sender: error updating summary: %v", err))
 	}
 
 	s.summaryDebouncer.SetNeedsDebounce()


### PR DESCRIPTION
Creates `runsummary.Updates` as the Go counterpart to `SummaryRecord`, splitting out this logic from `runsummary.RunSummary`.

This will allow passing updates instead of the full serialized summary to FileStream, which we're doing to remove the summary debouncing logic in `sender.go`.

I kept the `SummaryItem` proto in the return values of `UpdateSummaries` and `ToRecords` since that's what `handler.go` needs. It wouldn't make sense to convert to `Updates` and then back to `SummaryItem`.