### PR TITLE
refactor: move FileStream state into collector goroutine

### DIFF
--- a/core/internal/filestream/collectloop_test.go
+++ b/core/internal/filestream/collectloop_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	. "github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/waiting"
 	"golang.org/x/time/rate"
 )
 
@@ -23,21 +24,18 @@ func TestCollectLoop_BatchesWhileWaiting(t *testing.T) {
 		return map[string]struct{}{s: {}}
 	}
 
-	transmissions := loop.Start(requests)
+	transmissions := loop.Start(&FileStreamState{}, requests)
 	requests <- &FileStreamRequest{UploadedFiles: set("one")}
 	requests <- &FileStreamRequest{UploadedFiles: set("two")}
 	requests <- &FileStreamRequest{UploadedFiles: set("three")}
 
-	select {
-	case result := <-transmissions:
-		req := result.GetJSON(&FileStreamState{})
-		assert.Len(t, req.Uploaded, 3)
-		assert.Contains(t, req.Uploaded, "one")
-		assert.Contains(t, req.Uploaded, "two")
-		assert.Contains(t, req.Uploaded, "three")
-	case <-time.After(time.Second):
-		t.Error("timeout after 1 second")
-	}
+	req, _ := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
+	transmissions.IgnoreFutureRequests()
+
+	assert.Len(t, req.Uploaded, 3)
+	assert.Contains(t, req.Uploaded, "one")
+	assert.Contains(t, req.Uploaded, "two")
+	assert.Contains(t, req.Uploaded, "three")
 }
 
 func TestCollectLoop_SendsLastRequestImmediately(t *testing.T) {
@@ -49,14 +47,15 @@ func TestCollectLoop_SendsLastRequestImmediately(t *testing.T) {
 		MaxRequestSizeBytes: 99999,
 	}
 
-	transmissions := loop.Start(requests)
+	transmissions := loop.Start(&FileStreamState{}, requests)
 	close(requests)
+	request1, ok1 := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
+	request2, ok2 := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
 
-	select {
-	case <-transmissions:
-	case <-time.After(time.Second):
-		t.Error("timeout after 1 second")
-	}
+	assert.True(t, ok1)
+	assert.NotNil(t, request1)
+	assert.False(t, ok2)
+	assert.Nil(t, request2)
 }
 
 func TestCollectLoop_BlocksOnceAtMaxSize(t *testing.T) {
@@ -67,7 +66,7 @@ func TestCollectLoop_BlocksOnceAtMaxSize(t *testing.T) {
 		MaxRequestSizeBytes: 5,
 	}
 
-	transmissions := loop.Start(requests)
+	transmissions := loop.Start(&FileStreamState{}, requests)
 	requests <- &FileStreamRequest{HistoryLines: []string{`{"x": "12345"}`}}
 
 	// Verify that the loop blocks since the above request is above max size.
@@ -78,10 +77,5 @@ func TestCollectLoop_BlocksOnceAtMaxSize(t *testing.T) {
 	}
 
 	close(requests)
-
-	select {
-	case <-transmissions:
-	case <-time.After(time.Second):
-		t.Error("timeout after 1 second")
-	}
+	transmissions.IgnoreFutureRequests()
 }

--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -69,17 +69,25 @@ func (fs *fileStream) startTransmitting(
 		maxRequestSizeBytes = 10 << 20 // 10 MB
 	}
 
+	state := &FileStreamState{}
+	if initialOffsets != nil {
+		state.HistoryLineNum = initialOffsets[HistoryChunk]
+		state.EventsLineNum = initialOffsets[EventsChunk]
+		state.SummaryLineNum = initialOffsets[SummaryChunk]
+		state.ConsoleLineOffset = initialOffsets[OutputChunk]
+	}
+
 	transmissions := CollectLoop{
 		Logger:              fs.logger,
 		TransmitRateLimit:   fs.transmitRateLimit,
 		MaxRequestSizeBytes: int(maxRequestSizeBytes),
-	}.Start(requests)
+	}.Start(state, requests)
 
 	feedback := TransmitLoop{
 		HeartbeatStopwatch:     fs.heartbeatStopwatch,
 		Send:                   fs.send,
 		LogFatalAndStopWorking: fs.logFatalAndStopWorking,
-	}.Start(transmissions, initialOffsets)
+	}.Start(transmissions)
 
 	return feedback
 }

--- a/core/internal/filestream/transmitchan.go
+++ b/core/internal/filestream/transmitchan.go
@@ -1,0 +1,109 @@
+package filestream
+
+import (
+	"time"
+
+	"github.com/wandb/wandb/core/internal/waiting"
+)
+
+// TransmitChan is a channel of FileStreamRequestJSON values.
+//
+// It is designed to be read by one goroutine and written to by another.
+//
+// The key difference from a regular channel is that the writing goroutine
+// can detect if a value would be accepted before creating it. This is important
+// because creating the FileStreamRequestJSON object is expensive.
+type TransmitChan struct {
+	// requests is a 1-buffered channel of added requests.
+	//
+	// It is 1-buffered to maintain the non-blocking guarantee of `ready`.
+	// See the logic in NextRequest.
+	requests chan *FileStreamRequestJSON
+
+	// ready is a 1-buffered channel that indicates when a single
+	// request can be pushed without blocking.
+	//
+	// When `requests` can accept a value without blocking, it is added
+	// to the `ready` channel.
+	ready chan chan<- *FileStreamRequestJSON
+}
+
+func NewTransmitChan() *TransmitChan {
+	return &TransmitChan{
+		requests: make(chan *FileStreamRequestJSON, 1),
+		ready:    make(chan chan<- *FileStreamRequestJSON, 1),
+	}
+}
+
+// NextRequest returns the next request to make or a heartbeat
+// if enough time has passed.
+//
+// If the channel is closed, returns (nil, false).
+// Otherwise, returns a non-nil value and true.
+func (tc *TransmitChan) NextRequest(heartbeat waiting.Stopwatch) (
+	*FileStreamRequestJSON,
+	bool,
+) {
+	// Mark ready if not marked yet.
+	//
+	// If tc.requests has a buffered item, we're about to pop it and empty
+	// a buffer slot. If it does not, then it already has an empty buffer slot.
+	select {
+	case tc.ready <- tc.requests:
+	default:
+	}
+
+	// Return a request if one is already available.
+	select {
+	case x, ok := <-tc.requests:
+		return x, ok
+	default:
+	}
+
+	// Otherwise, wait for a request or a heartbeat.
+	heartbeatCh, heartbeatCancel := heartbeat.Wait()
+	select {
+	case x, ok := <-tc.requests:
+		heartbeatCancel()
+		return x, ok
+
+	case <-heartbeatCh:
+		return &FileStreamRequestJSON{}, true
+	}
+}
+
+// PreparePush returns a channel to which to push the next request.
+//
+// Exactly one value must be pushed into the returned channel.
+// Pushing to the request channel is guaranteed not to block.
+func (tc *TransmitChan) PreparePush() <-chan (chan<- *FileStreamRequestJSON) {
+	return tc.ready
+}
+
+// Push blocks until it can push a request.
+//
+// It is shorthand for using PreparePush and adding to the returned channel.
+func (tc *TransmitChan) Push(request *FileStreamRequestJSON) {
+	pushChan := <-tc.PreparePush()
+	pushChan <- request
+}
+
+// IgnoreFutureRequests causes all new requests to be ignored.
+//
+// It effectively closes the read-side of the channel.
+func (tc *TransmitChan) IgnoreFutureRequests() {
+	// This goroutine gets garbage collected after Close() is called.
+	go func() {
+		for {
+			_, ok := tc.NextRequest(waiting.NewStopwatch(time.Hour))
+			if !ok {
+				return
+			}
+		}
+	}()
+}
+
+// Close indicates no more requests will be pushed.
+func (tc *TransmitChan) Close() {
+	close(tc.requests)
+}

--- a/core/internal/filestream/transmitchan_test.go
+++ b/core/internal/filestream/transmitchan_test.go
@@ -1,0 +1,80 @@
+package filestream_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wandb/wandb/core/internal/filestream"
+	"github.com/wandb/wandb/core/internal/waiting"
+)
+
+// nonEmptyRequest makes a non-empty FileStream JSON request for testing.
+func nonEmptyRequest() *filestream.FileStreamRequestJSON {
+	exitCode := int32(123)
+	return &filestream.FileStreamRequestJSON{
+		ExitCode: &exitCode,
+	}
+}
+
+func TestTransmitChan(t *testing.T) {
+	ch := filestream.NewTransmitChan()
+	requestIn := nonEmptyRequest()
+
+	go ch.Push(requestIn)
+	requestOut, ok := ch.NextRequest(waiting.NewStopwatch(time.Second))
+
+	assert.True(t, ok)
+	assert.Equal(t, requestIn, requestOut)
+}
+
+func TestTransmitChan_Heartbeat(t *testing.T) {
+	ch := filestream.NewTransmitChan()
+
+	requestOut, ok := ch.NextRequest(waiting.NewStopwatch(0))
+
+	assert.True(t, ok)
+	assert.Equal(t, &filestream.FileStreamRequestJSON{}, requestOut)
+}
+
+func TestTransmitChan_PreparePush_ReturnsNonBlockingChannel(t *testing.T) {
+	ch := filestream.NewTransmitChan()
+	defer ch.Close()
+
+	// Read in a loop until the end of the test.
+	go func() {
+		for {
+			_, ok := ch.NextRequest(waiting.NewStopwatch(time.Second))
+			if !ok {
+				break
+			}
+		}
+	}()
+
+	// Test several times to cover different types of race conditions.
+	for range 100 {
+		pushChan := <-ch.PreparePush()
+
+		select {
+		case pushChan <- nonEmptyRequest():
+		default:
+			t.Fatal("pushChan blocked")
+		}
+	}
+}
+
+func TestTransmitChan_IgnoreFutureRequests(t *testing.T) {
+	ch := filestream.NewTransmitChan()
+	defer ch.Close()
+
+	ch.IgnoreFutureRequests()
+
+	for range 100 {
+		select {
+		case pushChan := <-ch.PreparePush():
+			pushChan <- nonEmptyRequest()
+		case <-time.After(time.Second):
+			t.Fatal("preparePush blocked")
+		}
+	}
+}

--- a/core/internal/filestream/transmitloop.go
+++ b/core/internal/filestream/transmitloop.go
@@ -15,31 +15,18 @@ type TransmitLoop struct {
 //
 // It ingests a channel of requests and outputs a channel of API responses.
 func (tr TransmitLoop) Start(
-	data <-chan *FileStreamRequestReader,
-	offsets FileStreamOffsetMap,
+	data *TransmitChan,
 ) <-chan map[string]any {
 	feedback := make(chan map[string]any)
 
 	go func() {
 		defer func() {
-			// Flush the input channel.
-			for range data {
-			}
-
-			// Close the output channel.
+			data.IgnoreFutureRequests()
 			close(feedback)
 		}()
 
-		state := &FileStreamState{}
-		if offsets != nil {
-			state.HistoryLineNum = offsets[HistoryChunk]
-			state.EventsLineNum = offsets[EventsChunk]
-			state.SummaryLineNum = offsets[SummaryChunk]
-			state.ConsoleLineOffset = offsets[OutputChunk]
-		}
-
 		for {
-			x, ok := readWithHeartbeat(state, data, tr.HeartbeatStopwatch)
+			x, ok := data.NextRequest(tr.HeartbeatStopwatch)
 			if !ok {
 				break
 			}
@@ -55,43 +42,4 @@ func (tr TransmitLoop) Start(
 	}()
 
 	return feedback
-}
-
-// readWithHeartbeat waits for data or a heartbeat.
-//
-// A heartbeat is an empty request that is sent if no data is sent
-// for too long. It indicates to the server that we're still alive.
-func readWithHeartbeat(
-	state *FileStreamState,
-	data <-chan *FileStreamRequestReader,
-	heartbeat waiting.Stopwatch,
-) (*FileStreamRequestJSON, bool) {
-	select {
-	// If data is available now, send it.
-	case x, ok := <-data:
-		if !ok {
-			return nil, false
-		}
-		return x.GetJSON(state), true
-
-	// Otherwise, wait for data to arrive or a heartbeat to happen.
-	//
-	// We need this in a separate 'default' case because Go selects a random
-	// available case, so if data is available and the stopwatch is finished,
-	// Go might send a heartbeat instead of the data. This could be a problem
-	// on slow internet connections with a long roundtrip time.
-	default:
-		heartbeatCh, heartbeatCancel := heartbeat.Wait()
-		select {
-		case x, ok := <-data:
-			heartbeatCancel()
-			if !ok {
-				return nil, false
-			}
-			return x.GetJSON(state), true
-
-		case <-heartbeatCh:
-			return &FileStreamRequestJSON{}, true
-		}
-	}
 }


### PR DESCRIPTION
Moves FileStream state from the TransmitLoop goroutine to the CollectLoop goroutine.

The CollectLoop goroutine needs to estimate the size of the next request, and since the state is necessary for constructing a request, it needs to live in CollectLoop. This was unnecessary before because the state did not affect the size of a request (it just contained line offsets), but we'll need it to put the run summary into the state.

To avoid serializing the full JSON request every time the CollectLoop receives an update like

```go
for {
	select {
	// Running GetJSON on every iteration is expensive!
	case transmissions <- reader.GetJSON(state):
		... // start a new buffer
	case request := <-requests:
		... // incorporate into the buffer
	}
}
```

the new `TransmitChan` enables a semaphore-like pattern:

```go
for {
	select {
	// Here, GetJSON only runs if the TransmitLoop is ready.
	case transmissions := <-output.PreparePush():
		transmissions <- reader.GetJSON(state)
		...
	case request := <-requests:
		...
	}
}
```