### PR TITLE
refactor: remove sender summary debouncing

### DIFF
--- a/core/internal/filestream/collectloop.go
+++ b/core/internal/filestream/collectloop.go
@@ -37,7 +37,7 @@ func (cl CollectLoop) Start(
 
 		for !isDone {
 			reader, _ := NewRequestReader(buffer, cl.MaxRequestSizeBytes)
-			output.Push(reader.GetJSON(state))
+			output.Push(reader.GetJSON(state, cl.Logger))
 			buffer, isDone = reader.Next()
 		}
 
@@ -99,19 +99,19 @@ func (cl CollectLoop) transmit(
 		// If we're at max size, stop adding to the buffer.
 		if isTruncated {
 			cl.Logger.Info("filestream: waiting to send request of max size")
-			output.Push(reader.GetJSON(state))
+			output.Push(reader.GetJSON(state, cl.Logger))
 			return reader.Next()
 		}
 
 		// Otherwise, either send the buffer or add to it.
 		select {
 		case pushChan := <-output.PreparePush():
-			pushChan <- reader.GetJSON(state)
+			pushChan <- reader.GetJSON(state, cl.Logger)
 			return reader.Next()
 
 		case request, ok := <-requests:
 			if !ok {
-				output.Push(reader.GetJSON(state))
+				output.Push(reader.GetJSON(state, cl.Logger))
 				return reader.Next()
 			}
 

--- a/core/internal/filestream/collectloop_test.go
+++ b/core/internal/filestream/collectloop_test.go
@@ -24,7 +24,7 @@ func TestCollectLoop_BatchesWhileWaiting(t *testing.T) {
 		return map[string]struct{}{s: {}}
 	}
 
-	transmissions := loop.Start(&FileStreamState{}, requests)
+	transmissions := loop.Start(NewFileStreamState(), requests)
 	requests <- &FileStreamRequest{UploadedFiles: set("one")}
 	requests <- &FileStreamRequest{UploadedFiles: set("two")}
 	requests <- &FileStreamRequest{UploadedFiles: set("three")}
@@ -47,7 +47,7 @@ func TestCollectLoop_SendsLastRequestImmediately(t *testing.T) {
 		MaxRequestSizeBytes: 99999,
 	}
 
-	transmissions := loop.Start(&FileStreamState{}, requests)
+	transmissions := loop.Start(NewFileStreamState(), requests)
 	close(requests)
 	request1, ok1 := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
 	request2, ok2 := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
@@ -66,7 +66,7 @@ func TestCollectLoop_BlocksOnceAtMaxSize(t *testing.T) {
 		MaxRequestSizeBytes: 5,
 	}
 
-	transmissions := loop.Start(&FileStreamState{}, requests)
+	transmissions := loop.Start(NewFileStreamState(), requests)
 	requests <- &FileStreamRequest{HistoryLines: []string{`{"x": "12345"}`}}
 
 	// Verify that the loop blocks since the above request is above max size.

--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -69,7 +69,7 @@ func (fs *fileStream) startTransmitting(
 		maxRequestSizeBytes = 10 << 20 // 10 MB
 	}
 
-	state := &FileStreamState{}
+	state := NewFileStreamState()
 	if initialOffsets != nil {
 		state.HistoryLineNum = initialOffsets[HistoryChunk]
 		state.EventsLineNum = initialOffsets[EventsChunk]

--- a/core/internal/filestream/filestreamrequest.go
+++ b/core/internal/filestream/filestreamrequest.go
@@ -3,6 +3,7 @@ package filestream
 import (
 	"maps"
 
+	"github.com/wandb/wandb/core/internal/runsummary"
 	"github.com/wandb/wandb/core/internal/sparselist"
 )
 
@@ -21,8 +22,8 @@ type FileStreamRequest struct {
 	// Each line is a JSON object mapping metric names to values.
 	EventsLines []string
 
-	// LatestSummary is the run's most recent summary, JSON-encoded.
-	LatestSummary string
+	// SummaryUpdates contains changes to the run's summary.
+	SummaryUpdates *runsummary.Updates
 
 	// ConsoleLines is updates to make to the run's output logs.
 	//
@@ -62,8 +63,12 @@ func (r *FileStreamRequest) Merge(next *FileStreamRequest) {
 	r.HistoryLines = append(r.HistoryLines, next.HistoryLines...)
 	r.EventsLines = append(r.EventsLines, next.EventsLines...)
 
-	if next.LatestSummary != "" {
-		r.LatestSummary = next.LatestSummary
+	if next.SummaryUpdates != nil {
+		if r.SummaryUpdates == nil {
+			r.SummaryUpdates = next.SummaryUpdates
+		} else {
+			r.SummaryUpdates.Merge(next.SummaryUpdates)
+		}
 	}
 
 	r.ConsoleLines.Update(next.ConsoleLines)

--- a/core/internal/filestream/filestreamrequestreader_test.go
+++ b/core/internal/filestream/filestreamrequestreader_test.go
@@ -5,7 +5,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	. "github.com/wandb/wandb/core/internal/filestream"
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
+	"github.com/wandb/wandb/core/internal/pathtree"
+	"github.com/wandb/wandb/core/internal/runsummary"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+func testLogger(t *testing.T) *observability.CoreLogger {
+	t.Helper()
+	return observabilitytest.NewTestLogger(t)
+}
 
 func TestSizeLimit_HugeLine_SentAlone(t *testing.T) {
 	reader, isTruncated := NewRequestReader(
@@ -13,7 +23,7 @@ func TestSizeLimit_HugeLine_SentAlone(t *testing.T) {
 		0,
 	)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 	next, done := reader.Next()
 
 	// Even though "too large" is above the size limit (0) we do want
@@ -32,7 +42,7 @@ func TestSizeLimit_AboveMaxSize(t *testing.T) {
 		5,
 	)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 
 	assert.True(t, isTruncated)
 	assert.Equal(t, []string{"one"}, json.Files[HistoryFileName].Content)
@@ -44,7 +54,7 @@ func TestSizeLimit_BelowMaxSize(t *testing.T) {
 		10, // both lines will fit
 	)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 
 	assert.False(t, isTruncated)
 	assert.Equal(t, []string{"one", "two"}, json.Files[HistoryFileName].Content)
@@ -55,7 +65,7 @@ func TestHistory_ReadFull(t *testing.T) {
 		&FileStreamRequest{HistoryLines: []string{"one", "two"}}, 999)
 	state := &FileStreamState{HistoryLineNum: 5}
 
-	json := reader.GetJSON(state)
+	json := reader.GetJSON(state, testLogger(t))
 	next, done := reader.Next()
 
 	assert.Equal(t, 7, state.HistoryLineNum)
@@ -70,7 +80,7 @@ func TestHistory_ReadPartial(t *testing.T) {
 		&FileStreamRequest{HistoryLines: []string{"one", "two"}}, 3)
 	state := &FileStreamState{HistoryLineNum: 5}
 
-	json := reader.GetJSON(state)
+	json := reader.GetJSON(state, testLogger(t))
 	next, done := reader.Next()
 
 	assert.Equal(t, 6, state.HistoryLineNum)
@@ -85,7 +95,7 @@ func TestEvents_ReadFull(t *testing.T) {
 		&FileStreamRequest{EventsLines: []string{"one", "two"}}, 999)
 	state := &FileStreamState{EventsLineNum: 5}
 
-	json := reader.GetJSON(state)
+	json := reader.GetJSON(state, testLogger(t))
 	next, done := reader.Next()
 
 	assert.Equal(t, 7, state.EventsLineNum)
@@ -100,7 +110,7 @@ func TestEvents_ReadPartial(t *testing.T) {
 		&FileStreamRequest{EventsLines: []string{"one", "two"}}, 3)
 	state := &FileStreamState{EventsLineNum: 5}
 
-	json := reader.GetJSON(state)
+	json := reader.GetJSON(state, testLogger(t))
 	next, done := reader.Next()
 
 	assert.Equal(t, 6, state.EventsLineNum)
@@ -110,17 +120,47 @@ func TestEvents_ReadPartial(t *testing.T) {
 	assert.False(t, done)
 }
 
-func TestSummary_Read(t *testing.T) {
-	reader, _ := NewRequestReader(&FileStreamRequest{LatestSummary: "summary"}, 99)
-	state := &FileStreamState{SummaryLineNum: 9}
+func TestSummary_ReadNil(t *testing.T) {
+	reader, _ := NewRequestReader(&FileStreamRequest{}, 99)
+	state := NewFileStreamState()
+	state.SummaryLineNum = 9
 
-	json := reader.GetJSON(state)
+	json := reader.GetJSON(state, testLogger(t))
 	next, _ := reader.Next()
 
 	assert.Equal(t, 9, state.SummaryLineNum) // unchanged!
+	assert.Empty(t, state.RunSummary.ToNestedMaps())
+	assert.NotContains(t, json.Files, SummaryFileName)
+	assert.Nil(t, next.SummaryUpdates)
+}
+
+func TestSummary_Read(t *testing.T) {
+	reader, _ := NewRequestReader(&FileStreamRequest{
+		SummaryUpdates: runsummary.FromProto(&spb.SummaryRecord{
+			Update: []*spb.SummaryItem{
+				{Key: "test", ValueJson: `1`},
+			},
+		}),
+	}, 99)
+	state := NewFileStreamState()
+	state.RunSummary = runsummary.New()
+	state.RunSummary.Set(pathtree.PathOf("initial"), "value")
+	state.SummaryLineNum = 9
+
+	json := reader.GetJSON(state, testLogger(t))
+	next, _ := reader.Next()
+
+	assert.Equal(t, 9, state.SummaryLineNum) // unchanged!
+	assert.Equal(t, map[string]any{
+		"initial": "value",
+		"test":    int64(1),
+	}, state.RunSummary.ToNestedMaps())
 	assert.Equal(t, 9, json.Files[SummaryFileName].Offset)
-	assert.Equal(t, []string{"summary"}, json.Files[SummaryFileName].Content)
-	assert.Empty(t, next.LatestSummary)
+	assert.Len(t, json.Files[SummaryFileName].Content, 1)
+	assert.JSONEq(t,
+		`{"initial":"value","test":1}`,
+		json.Files[SummaryFileName].Content[0])
+	assert.Nil(t, next.SummaryUpdates)
 }
 
 func TestConsole_ReadFull(t *testing.T) {
@@ -130,7 +170,7 @@ func TestConsole_ReadFull(t *testing.T) {
 	reader, _ := NewRequestReader(req, 999)
 	state := &FileStreamState{ConsoleLineOffset: 1}
 
-	json := reader.GetJSON(state)
+	json := reader.GetJSON(state, testLogger(t))
 	next, done := reader.Next()
 
 	assert.Equal(t, 1, state.ConsoleLineOffset) // unchanged!
@@ -148,7 +188,7 @@ func TestConsole_ReadPartial_OneLineBlock(t *testing.T) {
 	req.ConsoleLines.Put(1, "line 1")
 	reader, _ := NewRequestReader(req, 6)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 	next, done := reader.Next()
 
 	assert.Equal(t, []string{"line 0"}, json.Files[OutputFileName].Content)
@@ -163,7 +203,7 @@ func TestConsole_ReadPartial_ManyLineBlocks(t *testing.T) {
 	req.ConsoleLines.Put(99, "line 99")
 	reader, _ := NewRequestReader(req, 6)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 	next, done := reader.Next()
 
 	assert.Equal(t, []string{"line 0"}, json.Files[OutputFileName].Content)
@@ -180,7 +220,7 @@ func TestUploadedFiles_Read(t *testing.T) {
 		},
 	}, 999)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 	next, _ := reader.Next()
 
 	assert.Len(t, json.Uploaded, 2)
@@ -193,7 +233,7 @@ func TestExitCode_Read_Done(t *testing.T) {
 	reader, _ := NewRequestReader(
 		&FileStreamRequest{Complete: true, ExitCode: 5}, 99)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 
 	assert.True(t, *json.Complete)
 	assert.EqualValues(t, 5, *json.ExitCode)
@@ -206,7 +246,7 @@ func TestExitCode_Read_NotDone(t *testing.T) {
 	req.ConsoleLines.Put(9, "line 9")
 	reader, _ := NewRequestReader(req, 99)
 
-	json := reader.GetJSON(&FileStreamState{})
+	json := reader.GetJSON(&FileStreamState{}, testLogger(t))
 
 	assert.Nil(t, json.Complete)
 	assert.Nil(t, json.ExitCode)

--- a/core/internal/filestream/updatesummary.go
+++ b/core/internal/filestream/updatesummary.go
@@ -1,39 +1,15 @@
 package filestream
 
-import "time"
+import (
+	"github.com/wandb/wandb/core/internal/runsummary"
+)
 
-// SummaryUpdate contains a run's most recent summary.
+// SummaryUpdate contains updates to a run's summary.
 type SummaryUpdate struct {
-	SummaryJSON string
+	Updates *runsummary.Updates
 }
 
 func (u *SummaryUpdate) Apply(ctx UpdateContext) error {
-	// Override the default max line length if the user has set a custom value.
-	maxLineBytes := ctx.Settings.GetFileStreamMaxLineBytes()
-	if maxLineBytes == 0 {
-		maxLineBytes = defaultMaxFileLineBytes
-	}
-
-	if len(u.SummaryJSON) > int(maxLineBytes) {
-		// Failing to upload the summary is non-blocking.
-		ctx.Logger.CaptureWarn(
-			"filestream: run summary line too long, skipping",
-			"len", len(u.SummaryJSON),
-			"max", maxLineBytes,
-		)
-		ctx.Printer.
-			AtMostEvery(time.Minute).
-			Writef(
-				"Skipped uploading summary data that exceeded"+
-					" size limit (%d > %d).",
-				len(u.SummaryJSON),
-				maxLineBytes,
-			)
-	} else {
-		ctx.MakeRequest(&FileStreamRequest{
-			LatestSummary: u.SummaryJSON,
-		})
-	}
-
+	ctx.MakeRequest(&FileStreamRequest{SummaryUpdates: u.Updates})
 	return nil
 }


### PR DESCRIPTION
Removes the 30-second summary debouncing in Sender, building up the summary in FileStream instead.

The debouncing initially existed to avoid sending the summary (which may be large) too frequently. Once FileStream was fully implemented with proper batching and rate limiting, that became redundant, but the Sender debouncing was kept to avoid serializing the summary to JSON every time it changed (which normally happens on every history update). Now, Sender just passes small `runsummary.Updates` chunks to FileStream and the debouncing is completely unnecessary. FileStream serializes the summary to JSON immediately before making an HTTP request.