### PR TITLE
chore: add heartbeat manager to leet

### DIFF
--- a/core/internal/leet/heartbeat.go
+++ b/core/internal/leet/heartbeat.go
@@ -1,0 +1,113 @@
+// heartbeat.go
+package leet
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+// HeartbeatManager manages periodic heartbeat messages for live runs.
+type HeartbeatManager struct {
+	mu         sync.Mutex // guards timer lifecycle (start/stop/replace)
+	timer      *time.Timer
+	interval   time.Duration
+	logger     *observability.CoreLogger
+	outChan    chan tea.Msg
+	generation atomic.Uint64 // increments on each (re)arm/stop; stale callbacks bail out
+}
+
+func NewHeartbeatManager(
+	interval time.Duration,
+	outChan chan tea.Msg,
+	logger *observability.CoreLogger,
+) *HeartbeatManager {
+	return &HeartbeatManager{
+		interval: interval,
+		outChan:  outChan,
+		logger:   logger,
+	}
+}
+
+// arm arms the timer for the current interval using the provided generation.
+//
+// The caller must hold hm.mu.
+func (hm *HeartbeatManager) arm(gen uint64, isRunning func() bool) {
+	hm.timer = time.AfterFunc(hm.interval, func() {
+		// Discard stale callbacks (racing AfterFunc from a previous reset/start/stop).
+		if hm.generation.Load() != gen || !isRunning() {
+			return
+		}
+
+		select {
+		case hm.outChan <- HeartbeatMsg{}:
+			hm.logger.Debug("heartbeat: triggered")
+		default:
+			hm.logger.Warn("heartbeat: outChan full, dropping message")
+		}
+	})
+}
+
+// Start starts the heartbeat timer.
+func (hm *HeartbeatManager) Start(isRunning func() bool) {
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	// Invalidate all in-flight callbacks *before* stopping/arming.
+	gen := hm.generation.Add(1)
+
+	// Stop any existing timer (best effort).
+	if hm.timer != nil {
+		hm.timer.Stop()
+	}
+
+	if !isRunning() {
+		hm.logger.Debug("heartbeat: not starting - run not active")
+		return
+	}
+
+	hm.logger.Debug(fmt.Sprintf("heartbeat: starting with interval %v", hm.interval))
+	hm.arm(gen, isRunning)
+}
+
+// Reset resets the heartbeat timer.
+func (hm *HeartbeatManager) Reset(isRunning func() bool) {
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	// Invalidate callbacks from the prior arming.
+	gen := hm.generation.Add(1)
+
+	// Stop the previous timer (best effort).
+	if hm.timer != nil {
+		hm.timer.Stop()
+	}
+
+	if !isRunning() {
+		return
+	}
+
+	hm.logger.Debug("heartbeat: resetting timer")
+	hm.arm(gen, isRunning)
+}
+
+// Stop stops the heartbeat timer.
+func (hm *HeartbeatManager) Stop() {
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	// Invalidate all in-flight callbacks before stopping the timer.
+	hm.generation.Add(1)
+
+	if hm.timer != nil {
+		hm.timer.Stop()
+		hm.timer = nil
+		hm.logger.Debug("heartbeat: stopped")
+	} else {
+		hm.logger.Debug("heartbeat: stopped (no timer)")
+	}
+}

--- a/core/internal/leet/heartbeat_test.go
+++ b/core/internal/leet/heartbeat_test.go
@@ -1,0 +1,160 @@
+package leet_test
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/internal/leet"
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+func TestHeartbeatManager_StartsAndSendsMessages(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	outChan := make(chan tea.Msg, 10)
+
+	hm := leet.NewHeartbeatManager(100*time.Millisecond, outChan, logger)
+
+	isRunning := func() bool { return true }
+	hm.Start(isRunning)
+
+	select {
+	case msg := <-outChan:
+		_, ok := msg.(leet.HeartbeatMsg)
+		require.True(t, ok, "expected HeartbeatMsg")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("heartbeat not received within timeout")
+	}
+
+	hm.Stop()
+}
+
+func TestHeartbeatManager_DoesNotStartWhenNotRunning(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	outChan := make(chan tea.Msg, 10)
+
+	hm := leet.NewHeartbeatManager(50*time.Millisecond, outChan, logger)
+
+	isRunning := func() bool { return false }
+	hm.Start(isRunning)
+
+	select {
+	case <-outChan:
+		t.Fatal("heartbeat sent when run not active")
+	case <-time.After(150 * time.Millisecond):
+		// Expected - no heartbeat
+	}
+}
+
+func TestHeartbeatManager_StopsProperly(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	outChan := make(chan tea.Msg, 10)
+
+	hm := leet.NewHeartbeatManager(100*time.Millisecond, outChan, logger)
+
+	isRunning := func() bool { return true }
+	hm.Start(isRunning)
+	hm.Stop()
+
+	select {
+	case <-outChan:
+		t.Fatal("heartbeat sent after Stop")
+	case <-time.After(200 * time.Millisecond):
+		// Expected - no heartbeat after stop
+	}
+}
+
+func TestHeartbeatManager_ResetRestartsTimer(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	outChan := make(chan tea.Msg, 10)
+
+	const interval = 100 * time.Millisecond
+	hm := leet.NewHeartbeatManager(interval, outChan, logger)
+
+	isRunning := func() bool { return true }
+	hm.Start(isRunning)
+
+	// Wait for a bit, but not too close to the interval boundary.
+	time.Sleep(interval / 2)
+	hm.Reset(isRunning)
+
+	// Original heartbeat shouldn't fire shortly after reset.
+	time.Sleep(interval / 3)
+	select {
+	case <-outChan:
+		t.Fatal("original heartbeat fired after reset")
+	default:
+		// Expected
+	}
+
+	// New heartbeat should fire after the full interval from reset.
+	select {
+	case msg := <-outChan:
+		_, ok := msg.(leet.HeartbeatMsg)
+		require.True(t, ok)
+	case <-time.After(interval):
+		t.Fatal("heartbeat not received after reset")
+	}
+
+	hm.Stop()
+}
+
+func TestHeartbeatManager_ChecksIsRunningBeforeSending(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	outChan := make(chan tea.Msg, 10)
+
+	hm := leet.NewHeartbeatManager(100*time.Millisecond, outChan, logger)
+
+	var running atomic.Bool
+	running.Store(true)
+
+	hm.Start(running.Load)
+
+	// Stop the run before heartbeat fires.
+	time.Sleep(50 * time.Millisecond)
+	running.Store(false)
+
+	// Wait for when heartbeat would fire.
+	time.Sleep(100 * time.Millisecond)
+
+	// Should not receive heartbeat.
+	select {
+	case <-outChan:
+		t.Fatal("heartbeat sent after run stopped")
+	default:
+		// Expected
+	}
+
+	hm.Stop()
+}
+
+func TestHeartbeatManager_MultipleStartsAndResets(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	outChan := make(chan tea.Msg, 10)
+
+	hm := leet.NewHeartbeatManager(50*time.Millisecond, outChan, logger)
+
+	isRunning := func() bool { return true }
+
+	hm.Start(isRunning)
+	hm.Reset(isRunning)
+	hm.Start(isRunning)
+	hm.Reset(isRunning)
+
+	// Should get exactly one heartbeat after the interval.
+	timeout := time.After(150 * time.Millisecond)
+	msgCount := 0
+
+	for {
+		select {
+		case <-outChan:
+			msgCount++
+		case <-timeout:
+			require.Equal(t, 1, msgCount, "expected exactly one heartbeat")
+			hm.Stop()
+			return
+		}
+	}
+}


### PR DESCRIPTION
Description
-----------
This PR adds a HeartbeatManager to LEET to manage periodic heartbeat messages for live runs. Useful if the filewatcher misses an update made to a live .wandb file, especially at the end of an experiment.

This is a continuation of this PR stack: https://github.com/wandb/wandb/pull/10571.