### PR TITLE
chore: add live wandb file watcher manager to leet

### DIFF
--- a/core/internal/leet/watchermanager.go
+++ b/core/internal/leet/watchermanager.go
@@ -1,0 +1,84 @@
+package leet
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/watcher"
+)
+
+// WatcherManager manages file watching for live runs.
+type WatcherManager struct {
+	watcher watcher.Watcher
+	started bool
+	wcChan  chan tea.Msg
+	logger  *observability.CoreLogger
+}
+
+// NewWatcherManager creates a new watcher manager.
+func NewWatcherManager(
+	wcChan chan tea.Msg,
+	logger *observability.CoreLogger,
+) *WatcherManager {
+	return &WatcherManager{
+		watcher: watcher.New(watcher.Params{Logger: logger}),
+		wcChan:  wcChan,
+		logger:  logger,
+	}
+}
+
+// Start starts watching the specified file.
+func (wm *WatcherManager) Start(runPath string) error {
+	if wm.started {
+		return nil
+	}
+
+	wm.logger.Debug(fmt.Sprintf("watcher: starting for path: %s", runPath))
+
+	err := wm.watcher.Watch(runPath, func() {
+		wm.logger.Debug(fmt.Sprintf("watcher: file changed: %s", runPath))
+
+		select {
+		case wm.wcChan <- FileChangedMsg{}:
+			wm.logger.Debug("watcher: FileChangedMsg sent")
+		default:
+			wm.logger.CaptureWarn("watcher: wcChan full, dropping FileChangedMsg")
+		}
+	})
+
+	if err != nil {
+		wm.logger.CaptureError(fmt.Errorf("watcher: error starting: %v", err))
+		return err
+	}
+
+	wm.started = true
+	wm.logger.Debug("watcher: started successfully")
+	return nil
+}
+
+// Finish stops the watcher.
+func (wm *WatcherManager) Finish() {
+	if !wm.started {
+		return
+	}
+
+	wm.logger.Debug("watcher: finishing")
+	wm.watcher.Finish()
+	wm.started = false
+}
+
+// IsStarted returns whether the watcher is started.
+func (wm *WatcherManager) IsStarted() bool {
+	return wm.started
+}
+
+// WaitForMsg waits for watcher messages.
+func (wm *WatcherManager) WaitForMsg() tea.Msg {
+	wm.logger.Debug("watcher: waiting for message...")
+	msg := <-wm.wcChan
+	if msg != nil {
+		wm.logger.Debug(fmt.Sprintf("watcher: received message: %T", msg))
+	}
+	return msg
+}

--- a/core/internal/leet/watchermanager_test.go
+++ b/core/internal/leet/watchermanager_test.go
@@ -1,0 +1,52 @@
+package leet_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/internal/leet"
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/transactionlog"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestWatcherManager_FileChangeDetection(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	wcChan := make(chan tea.Msg, 10)
+	wm := leet.NewWatcherManager(wcChan, logger)
+	require.False(t, wm.IsStarted())
+
+	path := filepath.Join(t.TempDir(), "test.wandb")
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
+
+	err = wm.Start(path)
+	require.NoError(t, err)
+	require.True(t, wm.IsStarted())
+
+	for i := range 3 {
+		require.NoError(t, w.Write(&spb.Record{
+			RecordType: &spb.Record_History{
+				History: &spb.HistoryRecord{
+					Item: []*spb.HistoryItem{
+						{NestedKey: []string{"_step"}, ValueJson: fmt.Sprintf("%d", i)},
+					},
+				},
+			},
+		}))
+		time.Sleep(10 * time.Millisecond)
+		require.NoError(t, w.Flush())
+	}
+	require.NoError(t, w.Close())
+
+	msg := wm.WaitForMsg()
+	_, ok := msg.(leet.FileChangedMsg)
+	require.True(t, ok, "expected FileChangedMsg, got %T", msg)
+
+	wm.Finish()
+	require.False(t, wm.IsStarted())
+}


### PR DESCRIPTION
Description
-----------
Adds a wrapper around `wm.watcher.Watch` for leet to convert file change events into bubbletea messages to drive data loading from a live .wandb file.