### PR TITLE
chore: add left sidebar component to leet to display run metadata

### DIFF
--- a/core/internal/leet/leftsidebar.go
+++ b/core/internal/leet/leftsidebar.go
@@ -1,0 +1,455 @@
+package leet
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+const (
+	leftSidebarHeader = "Run Overview"
+
+	// Sidebar header lines (title + state + ID + name + project + blank line).
+	// TODO: replace with len(LeftSidebar.buildHeaderLines())
+	sidebarHeaderLines = 7
+)
+
+// SectionView represents a paginated section in the overview.
+type SectionView struct {
+	Title         string
+	Items         []KeyValuePair
+	FilteredItems []KeyValuePair
+	CurrentPage   int
+	ItemsPerPage  int
+	CursorPos     int // Position within current page
+	Height        int // Total allocated height for this section (including title)
+	Active        bool
+	FilterMatches int
+}
+
+// LeftSidebar stores and displays run metadata.
+//
+// It handles presentation concerns: sections, filtering, navigation, layout, and rendering.
+// All data processing is delegated to the RunOverview model.
+type LeftSidebar struct {
+	animState   *AnimationState
+	runOverview *RunOverview
+
+	// UI state: sections, filtering, navigation.
+	sections      []SectionView
+	activeSection int
+
+	// Filter state.
+	filter FilterState
+
+	// Dimensions.
+	height int
+}
+
+func NewLeftSidebar(config *ConfigManager) *LeftSidebar {
+	animState := NewAnimationState(config.LeftSidebarVisible(), SidebarMinWidth)
+
+	return &LeftSidebar{
+		animState:   animState,
+		runOverview: NewRunOverview(),
+		sections: []SectionView{
+			{Title: "Environment", ItemsPerPage: 10, Active: true},
+			{Title: "Config", ItemsPerPage: 15},
+			{Title: "Summary", ItemsPerPage: 20},
+		},
+		activeSection: 0,
+	}
+}
+
+// Toggle toggles the sidebar between expanded and collapsed states.
+func (s *LeftSidebar) Toggle() {
+	s.animState.Toggle()
+
+	if s.animState.IsExpanding() {
+		s.selectFirstAvailableItem()
+	}
+}
+
+// Update handles animation and input updates for the sidebar.
+func (s *LeftSidebar) Update(msg tea.Msg) (*LeftSidebar, tea.Cmd) {
+	// Handle key input only when expanded.
+	// TODO: hook up with keybindings.
+	if s.animState.IsExpanded() {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.Type {
+			case tea.KeyUp:
+				s.navigateUp()
+			case tea.KeyDown:
+				s.navigateDown()
+			case tea.KeyTab:
+				s.navigateSection(1)
+			case tea.KeyShiftTab:
+				s.navigateSection(-1)
+			case tea.KeyLeft:
+				s.navigatePage(-1)
+			case tea.KeyRight:
+				s.navigatePage(1)
+			}
+		}
+	}
+
+	// Handle animation.
+	if s.animState.IsAnimating() {
+		complete := s.animState.Update(time.Now())
+		if !complete {
+			return s, s.animationCmd()
+		}
+	}
+
+	return s, nil
+}
+
+// View renders the sidebar.
+func (s *LeftSidebar) View(height int) string {
+	if s.animState.Width() <= 0 {
+		return ""
+	}
+
+	s.height = height
+	s.calculateSectionHeights()
+
+	headerLines := s.buildHeaderLines()
+
+	contentWidth := s.animState.Width() - leftSidebarContentPadding
+	sectionLines := s.buildSectionLines(contentWidth)
+
+	allLines := slices.Concat(headerLines, sectionLines)
+	content := strings.Join(allLines, "\n")
+
+	styledContent := sidebarStyle.
+		Width(s.animState.Width() - 1).
+		Height(height).
+		MaxWidth(s.animState.Width() - 1).
+		MaxHeight(height).
+		Render(content)
+
+	return sidebarBorderStyle.
+		Width(s.animState.Width()).
+		Height(height).
+		MaxWidth(s.animState.Width()).
+		MaxHeight(height).
+		Render(styledContent)
+}
+
+// ProcessRunMsg delegates to the data model and updates UI.
+func (s *LeftSidebar) ProcessRunMsg(msg RunMsg) {
+	s.runOverview.ProcessRunMsg(msg)
+	s.updateSections()
+}
+
+// ProcessSystemInfoMsg delegates to the data model and updates UI.
+func (s *LeftSidebar) ProcessSystemInfoMsg(record *spb.EnvironmentRecord) {
+	s.runOverview.ProcessSystemInfoMsg(record)
+	s.updateSections()
+}
+
+// ProcessSummaryMsg delegates to the data model and updates UI.
+func (s *LeftSidebar) ProcessSummaryMsg(summary *spb.SummaryRecord) {
+	s.runOverview.ProcessSummaryMsg(summary)
+	s.updateSections()
+}
+
+// SetRunState delegates to the data model.
+func (s *LeftSidebar) SetRunState(state RunState) {
+	s.runOverview.SetRunState(state)
+}
+
+// UpdateDimensions updates the sidebar dimensions based on terminal width
+// and the visibility of the right sidebar.
+func (s *LeftSidebar) UpdateDimensions(terminalWidth int, rightSidebarVisible bool) {
+	var calculatedWidth int
+
+	if rightSidebarVisible {
+		calculatedWidth = int(float64(terminalWidth) * SidebarWidthRatioBoth)
+	} else {
+		calculatedWidth = int(float64(terminalWidth) * SidebarWidthRatio)
+	}
+
+	expandedWidth := clamp(calculatedWidth, SidebarMinWidth, SidebarMaxWidth)
+	s.animState.SetExpandedWidth(expandedWidth)
+}
+
+// Width returns the current width of the sidebar.
+func (s *LeftSidebar) Width() int {
+	return s.animState.Width()
+}
+
+// IsVisible returns true if the sidebar is visible.
+func (s *LeftSidebar) IsVisible() bool {
+	return s.animState.IsVisible()
+}
+
+// IsAnimating returns true if the sidebar is currently animating.
+func (s *LeftSidebar) IsAnimating() bool {
+	return s.animState.IsAnimating()
+}
+
+// SelectedItem returns the currently selected key-value pair.
+func (s *LeftSidebar) SelectedItem() (key, value string) {
+	if s.activeSection < 0 || s.activeSection >= len(s.sections) {
+		return "", ""
+	}
+
+	section := &s.sections[s.activeSection]
+	if len(section.FilteredItems) == 0 {
+		return "", ""
+	}
+
+	startIdx := section.CurrentPage * section.ItemsPerPage
+	itemIdx := startIdx + section.CursorPos
+
+	if itemIdx >= 0 && itemIdx < len(section.FilteredItems) {
+		item := section.FilteredItems[itemIdx]
+		return item.Key, item.Value
+	}
+
+	return "", ""
+}
+
+// updateSections pulls data from the model and updates UI sections.
+func (s *LeftSidebar) updateSections() {
+	var currentKey, currentValue string
+	if s.activeSection >= 0 && s.activeSection < len(s.sections) {
+		currentKey, currentValue = s.SelectedItem()
+	}
+
+	s.sections[0].Items = s.runOverview.EnvironmentItems()
+	s.sections[1].Items = s.runOverview.ConfigItems()
+	s.sections[2].Items = s.runOverview.SummaryItems()
+
+	if s.filter.active || s.filter.applied != "" {
+		s.applyFilter()
+	} else {
+		for i := range s.sections {
+			s.sections[i].FilteredItems = s.sections[i].Items
+		}
+	}
+
+	s.calculateSectionHeights()
+
+	if currentKey == "" {
+		s.selectFirstAvailableItem()
+	} else {
+		s.restoreSelection(currentKey, currentValue)
+	}
+}
+
+// animationCmd returns a command to continue the animation on section toggle.
+func (s *LeftSidebar) animationCmd() tea.Cmd {
+	return tea.Tick(time.Millisecond*16, func(t time.Time) tea.Msg {
+		return LeftSidebarAnimationMsg{}
+	})
+}
+
+// truncateValue truncates long values for display.
+func truncateValue(value string, maxWidth int) string {
+	if lipgloss.Width(value) <= maxWidth {
+		return value
+	}
+	if maxWidth <= 3 {
+		return "..."
+	}
+	return value[:maxWidth-3] + "..."
+}
+
+// buildHeaderLines builds the header section from the data model.
+func (s *LeftSidebar) buildHeaderLines() []string {
+	lines := make([]string, 0, sidebarHeaderLines)
+
+	// Title.
+	lines = append(lines, sidebarHeaderStyle.Render(leftSidebarHeader))
+
+	// Run state from data model.
+	stateLabel := "State: "
+	stateValue := s.runStateString()
+	lines = append(lines,
+		sidebarKeyStyle.Render(stateLabel)+sidebarValueStyle.Render(stateValue))
+
+	// Optional metadata from data model (only if present).
+	if id := s.runOverview.ID(); id != "" {
+		lines = append(lines,
+			sidebarKeyStyle.Render("ID: ")+sidebarValueStyle.Render(id))
+	}
+	if name := s.runOverview.DisplayName(); name != "" {
+		lines = append(lines,
+			sidebarKeyStyle.Render("Name: ")+sidebarValueStyle.Render(name))
+	}
+	if project := s.runOverview.Project(); project != "" {
+		lines = append(lines,
+			sidebarKeyStyle.Render("Project: ")+sidebarValueStyle.Render(project))
+	}
+
+	// Blank separator line.
+	lines = append(lines, "")
+
+	return lines
+}
+
+// buildSectionLines builds all section content lines.
+func (s *LeftSidebar) buildSectionLines(contentWidth int) []string {
+	var lines []string
+
+	for i := range s.sections {
+		if s.sections[i].Height == 0 {
+			continue
+		}
+
+		sectionContent := s.renderSection(i, contentWidth)
+		if sectionContent != "" {
+			lines = append(lines, sectionContent)
+
+			// Add spacing between sections if there's a next section.
+			if s.hasNextVisibleSection(i) {
+				lines = append(lines, "")
+			}
+		}
+	}
+
+	return lines
+}
+
+// renderSection renders a single section.
+func (s *LeftSidebar) renderSection(idx int, width int) string {
+	section := &s.sections[idx]
+
+	if len(section.FilteredItems) == 0 || section.Height == 0 {
+		return ""
+	}
+
+	var lines []string
+
+	// Render section header.
+	lines = append(lines, s.renderSectionHeader(section))
+
+	// Render section items.
+	itemLines := s.renderSectionItems(section, width)
+	lines = append(lines, itemLines...)
+
+	return strings.Join(lines, "\n")
+}
+
+// renderSectionHeader renders the section title with pagination info.
+func (s *LeftSidebar) renderSectionHeader(section *SectionView) string {
+	titleStyle := sidebarSectionStyle
+	if section.Active {
+		titleStyle = sidebarSectionHeaderStyle
+	}
+
+	totalItems := len(section.Items)
+	filteredItems := len(section.FilteredItems)
+
+	startIdx := section.CurrentPage * section.ItemsPerPage
+	endIdx := min(startIdx+section.ItemsPerPage, filteredItems)
+
+	titleText := section.Title
+	infoText := s.buildSectionInfo(section, totalItems, filteredItems, startIdx, endIdx)
+
+	return titleStyle.Render(titleText) + navInfoStyle.Render(infoText)
+}
+
+// buildSectionInfo builds the pagination/count info string for a section.
+func (s *LeftSidebar) buildSectionInfo(
+	section *SectionView,
+	totalItems, filteredItems, startIdx, endIdx int,
+) string {
+	switch {
+	case (s.filter.active || s.filter.applied != "") && filteredItems != totalItems:
+		// Filtered view with pagination.
+		return fmt.Sprintf(" [%d-%d of %d filtered from %d]",
+			startIdx+1, endIdx, filteredItems, totalItems)
+	case filteredItems > section.ItemsPerPage:
+		// Paginated view.
+		return fmt.Sprintf(" [%d-%d of %d]", startIdx+1, endIdx, filteredItems)
+	case filteredItems > 0:
+		// All items fit on one page.
+		return fmt.Sprintf(" [%d items]", filteredItems)
+	default:
+		return ""
+	}
+}
+
+// renderSectionItems renders the items for a section.
+func (s *LeftSidebar) renderSectionItems(section *SectionView, width int) []string {
+	maxKeyWidth := int(float64(width) * leftSidebarKeyWidthRatio)
+	maxValueWidth := width - maxKeyWidth - 1
+
+	startIdx := section.CurrentPage * section.ItemsPerPage
+	endIdx := min(startIdx+section.ItemsPerPage, len(section.FilteredItems))
+	actualItemsToShow := endIdx - startIdx
+
+	itemsToRender := min(actualItemsToShow, section.ItemsPerPage)
+
+	lines := make([]string, 0, itemsToRender)
+	for i := range itemsToRender {
+		itemIdx := startIdx + i
+		if itemIdx >= len(section.FilteredItems) {
+			break
+		}
+
+		item := section.FilteredItems[itemIdx]
+		line := s.renderItem(item, i, section, maxKeyWidth, maxValueWidth)
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// renderItem renders a single key-value item.
+func (s *LeftSidebar) renderItem(
+	item KeyValuePair,
+	posInPage int,
+	section *SectionView,
+	maxKeyWidth, maxValueWidth int,
+) string {
+	keyStyle := sidebarKeyStyle
+	valueStyle := sidebarValueStyle
+
+	// Highlight selected item.
+	if section.Active && posInPage == section.CursorPos {
+		keyStyle = keyStyle.Background(colorSelected)
+		valueStyle = valueStyle.Background(colorSelected)
+	}
+
+	key := truncateValue(item.Key, maxKeyWidth)
+	value := truncateValue(item.Value, maxValueWidth)
+
+	return fmt.Sprintf("%s %s",
+		keyStyle.Width(maxKeyWidth).Render(key),
+		valueStyle.Render(value))
+}
+
+// runStateString returns a string representation from the data model.
+func (s *LeftSidebar) runStateString() string {
+	switch s.runOverview.State() {
+	case RunStateRunning:
+		return "Running"
+	case RunStateFinished:
+		return "Finished"
+	case RunStateFailed:
+		return "Failed"
+	case RunStateCrashed:
+		return "Error"
+	default:
+		return "Unknown"
+	}
+}
+
+// hasNextVisibleSection returns true if there's another visible section after idx.
+func (s *LeftSidebar) hasNextVisibleSection(idx int) bool {
+	for j := idx + 1; j < len(s.sections); j++ {
+		if s.sections[j].Height > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/core/internal/leet/leftsidebar_test.go
+++ b/core/internal/leet/leftsidebar_test.go
@@ -1,0 +1,281 @@
+package leet_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	leet "github.com/wandb/wandb/core/internal/leet"
+	"github.com/wandb/wandb/core/internal/observability"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestSidebarFilter_WithPrefixes(t *testing.T) {
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	s := leet.NewLeftSidebar(cfg)
+
+	s.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"trainer", "epochs"}, ValueJson: "10"},
+			},
+		},
+	})
+
+	s.ProcessSummaryMsg(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{NestedKey: []string{"acc"}, ValueJson: "0.9"},
+		},
+	})
+
+	s.ProcessSystemInfoMsg(&spb.EnvironmentRecord{
+		WriterId: "writer-1",
+		Os:       "linux",
+	})
+
+	s.StartFilter()
+	s.UpdateFilter("@c train") // live preview
+	if info := s.FilterInfo(); info == "" {
+		t.Fatal("expected filter info for config section")
+	}
+	s.ConfirmFilter() // locks it in
+}
+
+func TestSidebar_SelectsFirstNonEmptySection(t *testing.T) {
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	s := leet.NewLeftSidebar(cfg)
+
+	s.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"trainer", "epochs"}, ValueJson: "10"},
+			},
+		},
+	})
+
+	key, val := s.SelectedItem()
+	if key != "trainer.epochs" || val != "10" {
+		t.Fatalf("selected item = {%q,%q}; want {\"trainer.epochs\",\"10\"}", key, val)
+	}
+}
+
+func TestSidebar_ConfirmSummaryFilterSelectsSummary(t *testing.T) {
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	s := leet.NewLeftSidebar(cfg)
+
+	s.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"trainer", "epochs"}, ValueJson: "10"},
+			},
+		},
+	})
+
+	s.ProcessSummaryMsg(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{NestedKey: []string{"acc"}, ValueJson: "0.9"},
+			{NestedKey: []string{"loss"}, ValueJson: "0.5"},
+		},
+	})
+
+	// Live preview on summary, then apply it.
+	s.StartFilter()
+	s.UpdateFilter("@s acc")
+	s.ConfirmFilter()
+
+	key, _ := s.SelectedItem()
+	if key != "acc" {
+		t.Fatalf("after summary filter, selected key=%q; want \"acc\"", key)
+	}
+}
+
+func expandSidebar(t *testing.T, s *leet.LeftSidebar, termWidth int, rightVisible bool) {
+	t.Helper()
+	s.UpdateDimensions(termWidth, rightVisible)
+	s.Toggle()
+	time.Sleep(leet.AnimationDuration + 20*time.Millisecond)
+	// Drive animation to completion.
+	s.Update(leet.LeftSidebarAnimationMsg{})
+}
+
+func TestSidebar_CalculateSectionHeights_PaginationAndAllItems(t *testing.T) {
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	s := leet.NewLeftSidebar(cfg)
+	expandSidebar(t, s, 120, false)
+
+	s.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"alpha", "a"}, ValueJson: "1"},
+				{NestedKey: []string{"alpha", "b"}, ValueJson: "2"},
+				{NestedKey: []string{"alpha", "c"}, ValueJson: "3"},
+				{NestedKey: []string{"beta", "d"}, ValueJson: "4"},
+				{NestedKey: []string{"beta", "e"}, ValueJson: "5"},
+			},
+		},
+	})
+
+	s.ProcessSummaryMsg(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{NestedKey: []string{"acc"}, ValueJson: "0.91"},
+			{NestedKey: []string{"val", "acc"}, ValueJson: "0.88"},
+		},
+	})
+
+	s.ProcessSystemInfoMsg(&spb.EnvironmentRecord{
+		WriterId: "writer-1",
+		Os:       "linux",
+	})
+
+	// Small height -> ItemsPerPage=1 -> expect "[1-1 of N]" pagination per section.
+	view := s.View(15)
+	if !strings.Contains(view, "Config") || !strings.Contains(view, "Summary") || !strings.Contains(view, "Environment") {
+		t.Fatalf("expected all section headers in view; got:\n%s", view)
+	}
+	if !strings.Contains(view, "Config [1-2 of 5]") {
+		t.Fatalf("expected paginated config header; got:\n%s", view)
+	}
+	if !strings.Contains(view, "Summary [1-1 of 2]") {
+		t.Fatalf("expected paginated summary header; got:\n%s", view)
+	}
+
+	// Larger height -> enough space -> expect "[N items]" (non-paginated).
+	view = s.View(40)
+	if !strings.Contains(view, "Config [5 items]") || !strings.Contains(view, "Summary [2 items]") {
+		t.Fatalf("expected non-paginated headers with item counts; got:\n%s", view)
+	}
+
+	s.Toggle()
+}
+
+func TestSidebar_Navigation_SectionPageUpDown(t *testing.T) {
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	s := leet.NewLeftSidebar(cfg)
+	expandSidebar(t, s, 120, false)
+
+	s.ProcessSystemInfoMsg(&spb.EnvironmentRecord{
+		WriterId: "writer-1",
+		Os:       "linux",
+	})
+
+	s.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"alpha", "a"}, ValueJson: "1"},
+				{NestedKey: []string{"alpha", "z"}, ValueJson: "2"},
+				{NestedKey: []string{"beta", "b"}, ValueJson: "3"},
+			},
+		},
+	})
+
+	s.ProcessSummaryMsg(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{NestedKey: []string{"acc"}, ValueJson: "0.9"},
+			{NestedKey: []string{"loss"}, ValueJson: "0.1"},
+		},
+	})
+
+	// Start in Environment; Tab to Config (navigateSection).
+	s.Update(tea.KeyMsg{Type: tea.KeyTab})
+	key, _ := s.SelectedItem()
+	if !strings.HasPrefix(key, "alpha.") && !strings.HasPrefix(key, "beta.") {
+		t.Fatalf("expected to be in Config after Tab, got key=%q", key)
+	}
+
+	// Height=15 -> 1 item/page; Down moves to next page/next item (navigateDown + navigatePage).
+	_ = s.View(15)
+	s.Update(tea.KeyMsg{Type: tea.KeyDown})
+	key2, _ := s.SelectedItem()
+	if key2 == key {
+		t.Fatalf("expected selection to move with Down; still at %q", key2)
+	}
+
+	// Page right, then left, then Up; remain in Config.
+	s.Update(tea.KeyMsg{Type: tea.KeyRight})
+	s.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	s.Update(tea.KeyMsg{Type: tea.KeyUp})
+	key3, _ := s.SelectedItem()
+	if !strings.HasPrefix(key3, "alpha.") && !strings.HasPrefix(key3, "beta.") {
+		t.Fatalf("expected to stay in Config after paging; got key=%q", key3)
+	}
+
+	// Shift-Tab back to previous section (Environment).
+	s.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	key4, _ := s.SelectedItem()
+	if strings.HasPrefix(key4, "alpha.") || strings.HasPrefix(key4, "beta.") {
+		t.Fatalf("expected to be back in Environment; got key=%q", key4)
+	}
+}
+
+func TestSidebar_ClearFilter_PublicPath(t *testing.T) {
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	s := leet.NewLeftSidebar(cfg)
+	expandSidebar(t, s, 120, false)
+
+	s.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"alpha", "a"}, ValueJson: "1"},
+				{NestedKey: []string{"alpha", "b"}, ValueJson: "2"},
+			},
+		},
+	})
+
+	s.ProcessSummaryMsg(&spb.SummaryRecord{
+		Update: []*spb.SummaryItem{
+			{NestedKey: []string{"acc"}, ValueJson: "0.91"},
+		},
+	})
+
+	s.ProcessSystemInfoMsg(&spb.EnvironmentRecord{
+		WriterId: "writer-1",
+		Os:       "linux",
+	})
+
+	// Apply a filter and verify info shows.
+	s.StartFilter()
+	s.UpdateFilter("acc")
+	s.ConfirmFilter()
+	if info := s.FilterInfo(); info == "" {
+		t.Fatal("expected filter info after applying filter")
+	}
+
+	// Clearing via an empty confirmed query hides the info and restores all items.
+	s.StartFilter()
+	s.UpdateFilter("")
+	s.ConfirmFilter()
+	if info := s.FilterInfo(); info != "" {
+		t.Fatalf("expected empty filter info after clearing; got %q", info)
+	}
+	if view := s.View(40); !strings.Contains(view, "Config [2 items]") {
+		t.Fatalf("expected full config section after clearing filter; got:\n%s", view)
+	}
+}
+
+func TestSidebar_TruncateValue(t *testing.T) {
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	s := leet.NewLeftSidebar(cfg)
+	expandSidebar(t, s, 40, false) // clamps to SidebarMinWidth
+
+	long := strings.Repeat("x", 200)
+
+	s.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"a", "k"}, ValueJson: `"` + long + `"`},
+			},
+		},
+	})
+
+	s.ProcessSystemInfoMsg(&spb.EnvironmentRecord{
+		WriterId: "writer-1",
+		Os:       "linux",
+	})
+
+	view := s.View(12)
+	if !strings.Contains(view, "a.k") || !strings.Contains(view, "...") {
+		t.Fatalf("expected truncated value in view; got:\n%s", view)
+	}
+}

--- a/core/internal/leet/leftsidebarfilter.go
+++ b/core/internal/leet/leftsidebarfilter.go
@@ -1,0 +1,203 @@
+package leet
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StartFilter activates filter mode.
+func (s *LeftSidebar) StartFilter() {
+	s.filter.active = true
+	if s.filter.applied != "" {
+		s.filter.draft = s.filter.applied
+	} else {
+		s.filter.draft = ""
+	}
+}
+
+// UpdateFilter updates the filter query (for live preview).
+func (s *LeftSidebar) UpdateFilter(query string) {
+	s.filter.draft = query
+	s.applyFilter()
+	s.calculateSectionHeights()
+}
+
+// ConfirmFilter applies the filter (on Enter).
+func (s *LeftSidebar) ConfirmFilter() {
+	s.filter.applied = s.filter.draft
+	s.filter.active = false
+	s.applyFilter()
+	s.calculateSectionHeights()
+}
+
+// CancelFilter cancels the current filter input and restores the previous state.
+func (s *LeftSidebar) CancelFilter() {
+	s.filter.active = false
+	s.filter.draft = ""
+	if s.filter.applied != "" {
+		s.filter.draft = s.filter.applied
+		s.applyFilter()
+		s.calculateSectionHeights()
+	} else {
+		s.filter.draft = ""
+		s.applyFilter()
+		s.calculateSectionHeights()
+	}
+}
+
+// IsFilterMode returns true if the sidebar is currently in filter input mode.
+func (s *LeftSidebar) IsFilterMode() bool {
+	return s.filter.active
+}
+
+// FilterDraft returns the current filter input being typed.
+func (s *LeftSidebar) FilterDraft() string {
+	return s.filter.draft
+}
+
+// IsFiltering returns true if the sidebar has an applied filter.
+func (s *LeftSidebar) IsFiltering() bool {
+	return s.filter.applied != ""
+}
+
+// FilterQuery returns the current or applied filter query.
+func (s *LeftSidebar) FilterQuery() string {
+	if s.filter.applied != "" {
+		return s.filter.applied
+	}
+	return s.filter.draft
+}
+
+// FilterInfo returns formatted filter information for status bar.
+func (s *LeftSidebar) FilterInfo() string {
+	if (!s.filter.active && s.filter.applied == "") || (s.filter.draft == "" && s.filter.applied == "") {
+		return ""
+	}
+
+	totalMatches := 0
+	var matchInfo []string
+
+	for _, section := range s.sections {
+		if section.FilterMatches > 0 {
+			totalMatches += section.FilterMatches
+			matchInfo = append(matchInfo,
+				fmt.Sprintf("@%s: %d", strings.ToLower(section.Title)[:1], section.FilterMatches))
+		}
+	}
+
+	if len(matchInfo) == 0 {
+		return "no matches"
+	}
+
+	return strings.Join(matchInfo, ", ")
+}
+
+// clearFilter clears the active filter.
+// func (s *LeftSidebar) clearFilter() {
+// 	s.filter.active = false
+// 	s.filter.draft = ""
+// 	s.filter.applied = ""
+
+// 	for i := range s.sections {
+// 		s.sections[i].FilteredItems = s.sections[i].Items
+// 		s.sections[i].CurrentPage = 0
+// 		s.sections[i].CursorPos = 0
+// 		s.sections[i].FilterMatches = 0
+// 	}
+
+// 	s.calculateSectionHeights()
+// }
+
+// applyFilter filters items based on current filter query.
+func (s *LeftSidebar) applyFilter() {
+	query := s.filterQuery()
+	sectionFilter := s.extractSectionFilter(&query)
+	query = strings.ToLower(query)
+
+	for i := range s.sections {
+		s.filterSection(i, sectionFilter, query)
+	}
+
+	// Auto-focus section with most matches.
+	if query != "" {
+		s.focusBestMatchSection()
+	}
+}
+
+// filterQuery returns the current active filter query.
+func (s *LeftSidebar) filterQuery() string {
+	query := strings.TrimSpace(s.filter.draft)
+	if s.filter.applied != "" {
+		query = strings.TrimSpace(s.filter.applied)
+	}
+	return query
+}
+
+// extractSectionFilter extracts and removes section prefix from query.
+func (s *LeftSidebar) extractSectionFilter(query *string) string {
+	sectionFilter := ""
+	switch {
+	case strings.HasPrefix(*query, "@e "):
+		sectionFilter = "environment"
+		*query = strings.TrimPrefix(*query, "@e ")
+	case strings.HasPrefix(*query, "@c "):
+		sectionFilter = "config"
+		*query = strings.TrimPrefix(*query, "@c ")
+	case strings.HasPrefix(*query, "@s "):
+		sectionFilter = "summary"
+		*query = strings.TrimPrefix(*query, "@s ")
+	}
+	return sectionFilter
+}
+
+// filterSection filters a single section based on the query and section filter.
+func (s *LeftSidebar) filterSection(idx int, sectionFilter, query string) {
+	section := &s.sections[idx]
+
+	// Skip section if section filter doesn't match.
+	if sectionFilter != "" {
+		sectionName := strings.ToLower(section.Title)
+		if !strings.HasPrefix(sectionName, sectionFilter) {
+			section.FilteredItems = []KeyValuePair{}
+			section.FilterMatches = 0
+			section.CurrentPage = 0
+			section.CursorPos = 0
+			return
+		}
+	}
+
+	// Filter items based on query.
+	filtered := make([]KeyValuePair, 0)
+	for _, item := range section.Items {
+		if query == "" ||
+			strings.Contains(strings.ToLower(item.Key), query) ||
+			strings.Contains(strings.ToLower(item.Value), query) {
+			filtered = append(filtered, item)
+		}
+	}
+
+	section.FilteredItems = filtered
+	section.FilterMatches = len(filtered)
+	section.CurrentPage = 0
+	section.CursorPos = 0
+}
+
+// focusBestMatchSection focuses the section with the most filter matches.
+func (s *LeftSidebar) focusBestMatchSection() {
+	maxMatches := 0
+	bestSection := s.activeSection
+
+	for i, section := range s.sections {
+		if section.FilterMatches > maxMatches {
+			maxMatches = section.FilterMatches
+			bestSection = i
+		}
+	}
+
+	if maxMatches > 0 {
+		s.activeSection = bestSection
+		for i := range s.sections {
+			s.sections[i].Active = i == s.activeSection
+		}
+	}
+}

--- a/core/internal/leet/leftsidebarnav.go
+++ b/core/internal/leet/leftsidebarnav.go
@@ -1,0 +1,376 @@
+package leet
+
+const (
+	// Maximum heights for each section type.
+	// TODO: dynamically upscale if more space is available.
+	sectionMaxHeightEnvironment = 12
+	sectionMaxHeightConfig      = 20
+	sectionMaxHeightSummary     = 25
+
+	// Minimum section height when visible (title + 1 item).
+	sectionMinHeight = 2
+)
+
+// calculateSectionHeights dynamically allocates heights to sections.
+func (s *LeftSidebar) calculateSectionHeights() {
+	if s.height == 0 {
+		return
+	}
+
+	totalAvailable := s.calculateAvailableHeight()
+	if totalAvailable <= 0 {
+		return
+	}
+
+	desired := s.calculateDesiredHeights()
+	totalDesired := s.sumDesiredHeights(desired)
+
+	if totalDesired > totalAvailable {
+		s.scaleHeightsProportionally(desired, totalAvailable)
+	} else {
+		s.allocateDesiredHeights(desired)
+		s.distributeExtraSpace(totalAvailable, totalDesired)
+	}
+
+	s.updateItemsPerPage()
+}
+
+// calculateAvailableHeight returns the height available for sections.
+func (s *LeftSidebar) calculateAvailableHeight() int {
+	availableHeight := s.height - sidebarHeaderLines
+
+	activeSections := s.countActiveSections()
+	if activeSections == 0 {
+		return 0
+	}
+
+	// Account for spacing between sections.
+	spacingBetweenSections := 0
+	if activeSections > 1 {
+		spacingBetweenSections = activeSections - 1
+	}
+
+	// Ensure minimum space for all active sections.
+	minRequired := activeSections * sectionMinHeight
+	return max(availableHeight-spacingBetweenSections, minRequired)
+}
+
+// countActiveSections returns the number of sections with items.
+func (s *LeftSidebar) countActiveSections() int {
+	count := 0
+	for i := range s.sections {
+		if len(s.sections[i].FilteredItems) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// calculateDesiredHeights calculates the desired height for each section.
+func (s *LeftSidebar) calculateDesiredHeights() []int {
+	maxHeights := []int{
+		sectionMaxHeightEnvironment,
+		sectionMaxHeightConfig,
+		sectionMaxHeightSummary,
+	}
+
+	desired := make([]int, len(s.sections))
+
+	for i := range s.sections {
+		itemCount := len(s.sections[i].FilteredItems)
+		if itemCount == 0 {
+			s.sections[i].Height = 0
+			desired[i] = 0
+			continue
+		}
+
+		// Desired height is item count + 1 (for title), capped at max.
+		maxHeight := maxHeights[i]
+		desired[i] = max(min(itemCount+1, maxHeight), sectionMinHeight)
+	}
+
+	return desired
+}
+
+// sumDesiredHeights returns the sum of all desired heights.
+func (s *LeftSidebar) sumDesiredHeights(desired []int) int {
+	total := 0
+	for _, h := range desired {
+		total += h
+	}
+	return total
+}
+
+// scaleHeightsProportionally scales section heights when total exceeds available.
+func (s *LeftSidebar) scaleHeightsProportionally(desired []int, totalAvailable int) {
+	totalDesired := s.sumDesiredHeights(desired)
+	scaleFactor := float64(totalAvailable) / float64(totalDesired)
+
+	allocated := 0
+	for i := range s.sections {
+		if desired[i] > 0 {
+			scaled := int(float64(desired[i]) * scaleFactor)
+			// Enforce minimum height for visible sections.
+			if scaled < sectionMinHeight && len(s.sections[i].FilteredItems) > 0 {
+				scaled = sectionMinHeight
+			}
+			s.sections[i].Height = scaled
+			allocated += scaled
+		} else {
+			s.sections[i].Height = 0
+		}
+	}
+
+	// Distribute remainder to last section with items.
+	if allocated < totalAvailable {
+		remainder := totalAvailable - allocated
+		s.allocateRemainder(remainder)
+	}
+}
+
+// allocateDesiredHeights sets each section to its desired height.
+func (s *LeftSidebar) allocateDesiredHeights(desired []int) {
+	for i := range s.sections {
+		s.sections[i].Height = desired[i]
+	}
+}
+
+// distributeExtraSpace distributes unused space to sections that can use it.
+func (s *LeftSidebar) distributeExtraSpace(totalAvailable, totalDesired int) {
+	maxHeights := []int{
+		sectionMaxHeightEnvironment,
+		sectionMaxHeightConfig,
+		sectionMaxHeightSummary,
+	}
+
+	extraSpace := totalAvailable - totalDesired
+
+	// Try to expand sections from bottom to top (summary, config, env).
+	for i := 2; i >= 0 && extraSpace > 0; i-- {
+		section := &s.sections[i]
+		if section.Height == 0 {
+			continue
+		}
+
+		itemCount := len(section.FilteredItems)
+		currentItems := section.Height - 1 // Subtract title line
+
+		// Only expand if we have more items to show.
+		if currentItems < itemCount {
+			maxIncrease := min(maxHeights[i]-section.Height, itemCount+1-section.Height)
+			increase := min(maxIncrease, extraSpace)
+
+			section.Height += increase
+			extraSpace -= increase
+		}
+	}
+}
+
+// allocateRemainder distributes remaining space to the last section with items.
+func (s *LeftSidebar) allocateRemainder(remainder int) {
+	// Try sections from bottom to top.
+	for i := 2; i >= 0; i-- {
+		if len(s.sections[i].FilteredItems) > 0 && s.sections[i].Height > 0 {
+			s.sections[i].Height += remainder
+			return
+		}
+	}
+}
+
+// updateItemsPerPage updates the items per page for each section.
+func (s *LeftSidebar) updateItemsPerPage() {
+	for i := range s.sections {
+		if s.sections[i].Height > 0 {
+			// Height includes title line, so items per page is height - 1.
+			s.sections[i].ItemsPerPage = max(s.sections[i].Height-1, 1)
+		} else {
+			s.sections[i].ItemsPerPage = 0
+		}
+	}
+}
+
+// navigateUp moves cursor up within the active section.
+func (s *LeftSidebar) navigateUp() {
+	if !s.isValidActiveSection() {
+		return
+	}
+
+	section := &s.sections[s.activeSection]
+	if section.CursorPos > 0 {
+		section.CursorPos--
+	} else if section.CurrentPage > 0 {
+		// Move to previous page, last item.
+		section.CurrentPage--
+		section.CursorPos = section.ItemsPerPage - 1
+	}
+}
+
+// navigateDown moves cursor down within the active section.
+func (s *LeftSidebar) navigateDown() {
+	if !s.isValidActiveSection() {
+		return
+	}
+
+	section := &s.sections[s.activeSection]
+	startIdx := section.CurrentPage * section.ItemsPerPage
+	endIdx := min(startIdx+section.ItemsPerPage, len(section.FilteredItems))
+	itemsOnPage := endIdx - startIdx
+
+	if section.CursorPos < itemsOnPage-1 {
+		section.CursorPos++
+	} else if endIdx < len(section.FilteredItems) {
+		// Move to next page, first item.
+		section.CurrentPage++
+		section.CursorPos = 0
+	}
+}
+
+// navigateSection jumps between sections, skipping empty ones.
+func (s *LeftSidebar) navigateSection(direction int) {
+	if len(s.sections) == 0 {
+		return
+	}
+
+	prev := s.activeSection
+	idx := prev
+
+	// Try each section in the given direction.
+	for i := 0; i < len(s.sections); i++ {
+		idx += direction
+		if idx < 0 {
+			idx = len(s.sections) - 1
+		} else if idx >= len(s.sections) {
+			idx = 0
+		}
+
+		// Select first non-empty section.
+		if len(s.sections[idx].FilteredItems) > 0 {
+			s.setActiveSection(idx)
+			return
+		}
+
+		// Wrapped around to starting section.
+		if idx == prev {
+			break
+		}
+	}
+
+	// No non-empty section found, keep current active.
+	s.sections[prev].Active = true
+}
+
+// navigatePage changes page within active section.
+func (s *LeftSidebar) navigatePage(direction int) {
+	if !s.isValidActiveSection() {
+		return
+	}
+
+	section := &s.sections[s.activeSection]
+	if section.ItemsPerPage == 0 {
+		return
+	}
+
+	totalPages := (len(section.FilteredItems) + section.ItemsPerPage - 1) / section.ItemsPerPage
+
+	if totalPages <= 1 {
+		return
+	}
+
+	section.CurrentPage += direction
+	if section.CurrentPage < 0 {
+		section.CurrentPage = totalPages - 1
+	} else if section.CurrentPage >= totalPages {
+		section.CurrentPage = 0
+	}
+
+	section.CursorPos = 0
+}
+
+// selectFirstAvailableItem selects the first item in the first non-empty section.
+func (s *LeftSidebar) selectFirstAvailableItem() {
+	// Find first non-empty section.
+	for i := range s.sections {
+		if len(s.sections[i].FilteredItems) > 0 && s.sections[i].ItemsPerPage > 0 {
+			s.setActiveSection(i)
+			return
+		}
+	}
+
+	// No non-empty section found, default to first section.
+	s.setActiveSection(0)
+}
+
+// restoreSelection attempts to restore the previously selected item.
+func (s *LeftSidebar) restoreSelection(previousKey, previousValue string) {
+	// Try to find exact key+value match in current active section.
+	if s.tryRestoreInSection(s.activeSection, previousKey, previousValue, true) {
+		return
+	}
+
+	// Try to find key-only match in current active section.
+	if s.tryRestoreInSection(s.activeSection, previousKey, previousValue, false) {
+		return
+	}
+
+	// Try to find in any section (key-only match).
+	for sectionIdx := range s.sections {
+		if s.tryRestoreInSection(sectionIdx, previousKey, "", false) {
+			s.setActiveSection(sectionIdx)
+			return
+		}
+	}
+
+	// Could not restore, select first available.
+	s.selectFirstAvailableItem()
+}
+
+// tryRestoreInSection attempts to restore selection in a specific section.
+//
+// Returns true if successful.
+func (s *LeftSidebar) tryRestoreInSection(sectionIdx int, key, value string, matchValue bool) bool {
+	if sectionIdx < 0 || sectionIdx >= len(s.sections) {
+		return false
+	}
+
+	section := &s.sections[sectionIdx]
+	if section.ItemsPerPage == 0 {
+		return false
+	}
+
+	for i, item := range section.FilteredItems {
+		keyMatch := item.Key == key
+		valueMatch := !matchValue || item.Value == value
+
+		if keyMatch && valueMatch {
+			page := i / section.ItemsPerPage
+			posInPage := i % section.ItemsPerPage
+
+			section.CurrentPage = page
+			section.CursorPos = posInPage
+			return true
+		}
+	}
+
+	return false
+}
+
+// setActiveSection changes the active section and resets navigation state.
+func (s *LeftSidebar) setActiveSection(idx int) {
+	// Deactivate all sections.
+	for i := range s.sections {
+		s.sections[i].Active = false
+	}
+
+	// Activate target section.
+	s.activeSection = idx
+	if idx >= 0 && idx < len(s.sections) {
+		s.sections[idx].Active = true
+		s.sections[idx].CurrentPage = 0
+		s.sections[idx].CursorPos = 0
+	}
+}
+
+// isValidActiveSection returns true if the active section index is valid.
+func (s *LeftSidebar) isValidActiveSection() bool {
+	return s.activeSection >= 0 && s.activeSection < len(s.sections)
+}

--- a/core/internal/leet/messages.go
+++ b/core/internal/leet/messages.go
@@ -70,5 +70,8 @@ type ChunkedBatchMsg struct {
 // HeartbeatMsg is sent periodically for live runs to ensure we don't miss data.
 type HeartbeatMsg struct{}
 
+// LeftSidebarAnimationMsg is sent during left sidebar animations.
+type LeftSidebarAnimationMsg struct{}
+
 // RightSidebarAnimationMsg is sent during right sidebar animations.
 type RightSidebarAnimationMsg struct{}

--- a/core/internal/leet/metricsfilter.go
+++ b/core/internal/leet/metricsfilter.go
@@ -1,0 +1,8 @@
+package leet
+
+// FilterState tracks the filter state (for run overview or metric charts).
+type FilterState struct {
+	active  bool   // filter input mode: whether the user is typing
+	draft   string // what the user is typing
+	applied string // committed pattern
+}

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -34,6 +34,12 @@ const (
 	SidebarMinWidth       = 40
 	SidebarMaxWidth       = 120
 
+	// Sidebar internal content padding (accounts for borders).
+	leftSidebarContentPadding = 4
+
+	// Key/value column width ratio.
+	leftSidebarKeyWidthRatio = 0.4 // 40% of available width for keys
+
 	// Sidebar content padding (accounts for borders and internal spacing).
 	rightSidebarContentPadding = 3
 
@@ -42,6 +48,18 @@ const (
 
 	// Mouse click coordinate adjustments for border/padding.
 	rightSidebarMouseClickPaddingOffset = 1
+)
+
+// Rune constants for UI drawing.
+const (
+	// verticalLine is ASCII vertical bar U+007C.
+	verticalLine rune = '\u007C' // |
+
+	// BoxLightVertical is U+2502 and is "taller" than verticalLine.
+	boxLightVertical rune = '\u2502' // │
+
+	// unicodeSpace is the regular whitespace.
+	unicodeSpace rune = '\u0020'
 )
 
 // WANDB brand colors.
@@ -83,6 +101,11 @@ var (
 	// Color for lower-level headings; more frequent than headings.
 	// Help page keys, metrics grid header.
 	colorSubheading = lipgloss.Color("230")
+
+	// Colors for key-value pairs such as run summary or config items.
+	colorItemKey   = lipgloss.Color("243")
+	colorItemValue = lipgloss.Color("252")
+	colorSelected  = lipgloss.Color("238")
 )
 
 // ASCII art for the loading screen and the help page.
@@ -187,20 +210,41 @@ var (
 	statusBarStyle = lipgloss.NewStyle().Foreground(moon900).Background(colorLayoutHighlight)
 )
 
+// Left sidebar styles.
+var (
+	sidebarStyle              = lipgloss.NewStyle().Padding(0, 1)
+	sidebarBorderStyle        = lipgloss.NewStyle().Border(lipgloss.Border{Right: "│"}).BorderForeground(colorLayout)
+	sidebarHeaderStyle        = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).MarginBottom(1)
+	sidebarSectionHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading)
+	sidebarSectionStyle       = lipgloss.NewStyle().Foreground(colorText).Bold(true)
+	sidebarKeyStyle           = lipgloss.NewStyle().Foreground(colorItemKey)
+	sidebarValueStyle         = lipgloss.NewStyle().Foreground(colorItemValue)
+	RightBorder               = lipgloss.Border{
+		Top:         string(unicodeSpace),
+		Bottom:      string(unicodeSpace),
+		Left:        "",
+		Right:       string(verticalLine),
+		TopLeft:     string(unicodeSpace),
+		TopRight:    string(verticalLine),
+		BottomLeft:  string(unicodeSpace),
+		BottomRight: string(verticalLine),
+	}
+)
+
 // Right sidebar styles.
 var (
 	rightSidebarStyle       = lipgloss.NewStyle().Padding(0, 1)
 	rightSidebarBorderStyle = lipgloss.NewStyle().Border(lipgloss.Border{Left: "│"}).BorderForeground(colorLayout)
 	rightSidebarHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).MarginLeft(1)
 	LeftBorder              = lipgloss.Border{
-		Top:         " ",
-		Bottom:      " ",
-		Left:        "│",
+		Top:         string(unicodeSpace),
+		Bottom:      string(unicodeSpace),
+		Left:        string(boxLightVertical),
 		Right:       "",
-		TopLeft:     "|",
-		TopRight:    " ",
-		BottomLeft:  "|",
-		BottomRight: " ",
+		TopLeft:     string(verticalLine),
+		TopRight:    string(unicodeSpace),
+		BottomLeft:  string(verticalLine),
+		BottomRight: string(unicodeSpace),
 	}
 )
 


### PR DESCRIPTION
Description
-----------
Adds the left sidebar component to LEET to display run metadata -- run state, project, id/name, config, summary, and environment info.

This is the jankiest PR on the stack, but it kind of works for now. I solemnly swear to revisit and clean it up :)