### PR TITLE
fix(artifacts): reduce repeat instantiation of InternalApi in wandb.Api methods

### DIFF
--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -107,7 +107,8 @@ class UserOrg:
 
 @pytest.fixture
 def user_in_orgs_factory(
-    mocker: pytest.MonkeyPatch, backend_fixture_factory: BackendFixtureFactory
+    backend_fixture_factory: BackendFixtureFactory,
+    user: str,
 ) -> Iterator[Callable[[int], UserOrg]]:
     """Fixture that provides a factory function to create a user and associated orgs.
 
@@ -119,13 +120,6 @@ def user_in_orgs_factory(
             # Get a user with the default (1) organization
             user_org_data_default = user_in_orgs_factory()
     """
-    username = backend_fixture_factory.make_user()
-    envvars = {
-        "WANDB_API_KEY": username,
-        "WANDB_ENTITY": username,
-        "WANDB_USERNAME": username,
-    }
-    mocker.patch.dict(os.environ, envvars)
 
     def _factory(number_of_orgs: int = 1) -> UserOrg:
         """Creates organizations for the pre-defined user."""
@@ -133,7 +127,7 @@ def user_in_orgs_factory(
             raise ValueError("Number of organizations have to be positive.")
         try:
             orgs = [
-                backend_fixture_factory.make_org(username=username)
+                backend_fixture_factory.make_org(username=user)
                 for _ in range(number_of_orgs)
             ]
         except Exception as e:
@@ -143,7 +137,7 @@ def user_in_orgs_factory(
                 f"Error: {e}",
             )
 
-        return UserOrg(username=username, organization_names=orgs)
+        return UserOrg(username=user, organization_names=orgs)
 
     yield _factory
 

--- a/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
+++ b/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
@@ -15,7 +15,7 @@ from wandb.sdk.artifacts._generated import (
     ArtifactMembershipByName,
     ArtifactMembershipFragment,
 )
-from wandb.sdk.internal.internal_api import Api as InternalApi
+from wandb.sdk.artifacts._gqlutils import server_supports
 
 
 @fixture
@@ -105,8 +105,8 @@ def test_fetch_migrated_registry_artifact(
     mock_artifact_rsp_data: dict[str, Any],
     mock_membership_rsp_data: dict[str, Any],
 ):
-    server_supports_artifact_via_membership = InternalApi()._server_supports(
-        ServerFeature.PROJECT_ARTIFACT_COLLECTION_MEMBERSHIP
+    server_supports_artifact_via_membership = server_supports(
+        api.client, ServerFeature.PROJECT_ARTIFACT_COLLECTION_MEMBERSHIP
     )
 
     mocker.patch("wandb.sdk.artifacts.artifact.Artifact._from_attrs")

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -30,7 +30,7 @@ from wandb._strutils import nameof
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import Paginator, SizedPaginator
 from wandb.errors.term import termlog, termwarn
-from wandb.proto.wandb_internal_pb2 import ServerFeature
+from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
 from wandb.sdk.artifacts._gqlutils import omit_artifact_fields
 from wandb.sdk.artifacts._models import ArtifactCollectionData
@@ -985,10 +985,10 @@ class ArtifactFiles(SizedPaginator["public.File"]):
         )
         from wandb.sdk.artifacts._gqlutils import server_supports
 
-        self.artifact = artifact
         self.query_via_membership = server_supports(
-            client, ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES
+            client, pb.ARTIFACT_COLLECTION_MEMBERSHIP_FILES
         )
+        self.artifact = artifact
 
         if self.query_via_membership:
             query_str = ARTIFACT_COLLECTION_MEMBERSHIP_FILES_GQL
@@ -1016,7 +1016,7 @@ class ArtifactFiles(SizedPaginator["public.File"]):
         if not client.version_supported("0.12.21"):
             omit_fields.add("storagePath")
 
-        if not server_supports(client, ServerFeature.TOTAL_COUNT_IN_FILE_CONNECTION):
+        if not server_supports(client, pb.TOTAL_COUNT_IN_FILE_CONNECTION):
             omit_fields.add("totalCount")
 
         self.QUERY = gql_compat(

--- a/wandb/old/settings.py
+++ b/wandb/old/settings.py
@@ -97,9 +97,7 @@ class Settings:
                 self._local_settings, Settings._local_path(self.root_dir), persist
             )
 
-    def items(self, section=None):
-        section = section if section is not None else Settings.DEFAULT_SECTION
-
+    def items(self, section: str = DEFAULT_SECTION):
         result = {"section": section}
 
         try:

--- a/wandb/sdk/artifacts/_gqlutils.py
+++ b/wandb/sdk/artifacts/_gqlutils.py
@@ -82,8 +82,11 @@ def server_supports(client: RetryingClient, feature: str | int) -> bool:
     # as the keys here, since:
     # - the server identifies features by their name, rather than (client-side) enum value
     # - the defined list of client-side flags may be behind the server-side list of flags
-    feature_name = ServerFeature.Name(feature) if isinstance(feature, int) else feature
-    return server_features(client).get(feature_name) or False
+    try:
+        name = ServerFeature.Name(feature) if isinstance(feature, int) else feature
+    except ValueError:
+        return False  # Invalid int-like value, assume unsupported
+    return server_features(client).get(name) or False
 
 
 def supports_enable_tracking_var(client: RetryingClient) -> bool:
@@ -120,7 +123,7 @@ class OrgInfo:
 
 def resolve_org_entity_name(
     client: RetryingClient,
-    non_org_entity: str,
+    non_org_entity: str | None,
     org_or_entity: str | None = None,
 ) -> str:
     # Resolve the portfolio's org entity name.

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -26,6 +26,7 @@ from typing import (
     Sequence,
     TextIO,
     Union,
+    overload,
 )
 
 import click
@@ -470,7 +471,14 @@ class Api:
     def default_entity(self) -> str:
         return self.viewer().get("entity")  # type: ignore
 
-    def settings(self, key: str | None = None, section: str | None = None) -> Any:
+    @overload
+    def settings(self, key: str = ..., section: str = ...) -> Any: ...
+    @overload
+    def settings(self, key: None = None, section: str = ...) -> dict[str, Any]: ...
+
+    def settings(
+        self, key: str | None = None, section: str = Settings.DEFAULT_SECTION
+    ) -> Any:
         """The settings overridden from the wandb/settings file.
 
         Args:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes https://wandb.atlassian.net/browse/WB-28777

Re-instantiating `InternalApi()`, especially just to make certain one-off GraphQL requests is pretty expensive.

We can reduce (avoidable) runtime overhead in a lot of places by avoiding this pattern, preferring instead:
- reuse of an existing, open client, if available in the same scope
- caching results, or relying on existing helpers that are already cached, where appropriate

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
PR does not intentionally make any functional, user-facing changes.  Existing tests must continue to pass.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
