### PR TITLE
feat(launch): add support for required and placeholder fields on META_SCHEMA

### DIFF
--- a/tests/unit_tests/test_launch/test_inputs/test_internal.py
+++ b/tests/unit_tests/test_launch/test_inputs/test_internal.py
@@ -413,6 +413,134 @@ def test_handle_run_config_input_staged(mocker, reset_staged_inputs):
             },
             [],
         ),
+        # --- Placeholder field tests ---
+        # Test basic placeholder field
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string",
+                        "placeholder": "Enter your username",
+                        "title": "Username",
+                        "description": "Your account username",
+                    }
+                },
+            },
+            [],
+        ),
+        # --- Label field tests ---
+        # Test basic label field
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "api_key": {
+                        "type": "string",
+                        "label": "API Key",
+                        "placeholder": "sk-...",
+                        "required": True,
+                        "format": "secret",
+                    }
+                },
+            },
+            [],
+        ),
+        # Test nested object with label and placeholder fields
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "database": {
+                        "type": "object",
+                        "label": "Database Configuration",
+                        "properties": {
+                            "host": {
+                                "type": "string",
+                                "label": "Database Host",
+                                "placeholder": "localhost",
+                                "description": "Database host",
+                            },
+                            "port": {
+                                "type": "integer",
+                                "label": "Database Port",
+                                "placeholder": "5432",
+                                "minimum": 1,
+                            },
+                        },
+                    }
+                },
+            },
+            [],
+        ),
+        # --- Required field tests ---
+        # Test basic required field
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "api_key": {
+                        "type": "string",
+                        "required": True,
+                        "title": "API Key",
+                        "description": "Required API key",
+                    },
+                    "optional_field": {
+                        "type": "string",
+                        "required": False,
+                        "description": "Optional field",
+                    },
+                },
+            },
+            [],
+        ),
+        # Test required field with different types
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "required": True,
+                        "minimum": 1,
+                    },
+                    "threshold": {
+                        "type": "number",
+                        "required": True,
+                        "minimum": 0.0,
+                    },
+                    "active": {
+                        "type": "boolean",
+                        "required": False,
+                    },
+                },
+            },
+            [],
+        ),
+        # Test nested object with required fields
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "required": True,
+                                "description": "Configuration name",
+                            },
+                            "version": {
+                                "type": "string",
+                                "required": False,
+                                "placeholder": "1.0.0",
+                            },
+                        },
+                    }
+                },
+            },
+            [],
+        ),
         # --- Warning cases ---
         # Test using a float as a minimum for an integer
         (
@@ -437,6 +565,64 @@ def test_handle_run_config_input_staged(mocker, reset_staged_inputs):
                 "properties": {"key1": {"type": "integer", "default": 5}},
             },
             ["Unevaluated properties are not allowed ('default' was unexpected)"],
+        ),
+        # --- Placeholder field tests for all types ---
+        # Test placeholder on boolean field
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "field1": {
+                        "type": "boolean",
+                        "placeholder": "Enable this feature",
+                    }
+                },
+            },
+            [],
+        ),
+        # Test placeholder on array field
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "field1": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": ["a", "b", "c"],
+                        },
+                        "placeholder": "Select options...",
+                    }
+                },
+            },
+            [],
+        ),
+        # --- Invalid UI field tests ---
+        # Test placeholder with wrong type (must be string)
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "field1": {
+                        "type": "string",
+                        "placeholder": 123,  # Should be string
+                    }
+                },
+            },
+            ["123 is not of type 'string'"],
+        ),
+        # Test label with wrong type (must be string)
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "field1": {
+                        "type": "string",
+                        "label": 456,  # Should be string
+                    }
+                },
+            },
+            ["456 is not of type 'string'"],
         ),
         # --- Array passing cases ---
         # Array: string enum multi-select with bounds and uniqueness
@@ -493,6 +679,37 @@ def test_handle_run_config_input_staged(mocker, reset_staged_inputs):
                             }
                         },
                     }
+                },
+            },
+            [],
+        ),
+        # Array with label, placeholder and required fields
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": ["dev", "prod", "test"],
+                        },
+                        "label": "Environment Tags",
+                        "placeholder": "Select environment tags...",
+                        "required": True,
+                        "minItems": 1,
+                        "uniqueItems": True,
+                    },
+                    "optional_list": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "enum": [1, 2, 3, 4, 5],
+                        },
+                        "label": "Optional Numbers",
+                        "placeholder": "Choose numbers (optional)",
+                        "required": False,
+                    },
                 },
             },
             [],

--- a/wandb/sdk/launch/inputs/schema.py
+++ b/wandb/sdk/launch/inputs/schema.py
@@ -7,6 +7,9 @@ META_SCHEMA = {
         },
         "title": {"type": "string"},
         "description": {"type": "string"},
+        "label": {"type": "string"},
+        "placeholder": {"type": "string"},
+        "required": {"type": "boolean"},
         "format": {"type": "string"},
         "enum": {"type": "array", "items": {"type": ["integer", "number", "string"]}},
         "properties": {"type": "object", "patternProperties": {".*": {"$ref": "#"}}},
@@ -19,17 +22,6 @@ META_SCHEMA = {
     },
     "allOf": [
         {
-            "if": {"properties": {"type": {"const": "number"}}},
-            "then": {
-                "properties": {
-                    "minimum": {"type": ["integer", "number"]},
-                    "maximum": {"type": ["integer", "number"]},
-                    "exclusiveMinimum": {"type": ["integer", "number"]},
-                    "exclusiveMaximum": {"type": ["integer", "number"]},
-                }
-            },
-        },
-        {
             "if": {"properties": {"type": {"const": "integer"}}},
             "then": {
                 "properties": {
@@ -37,6 +29,17 @@ META_SCHEMA = {
                     "maximum": {"type": "integer"},
                     "exclusiveMinimum": {"type": "integer"},
                     "exclusiveMaximum": {"type": "integer"},
+                }
+            },
+        },
+        {
+            "if": {"properties": {"type": {"const": "number"}}},
+            "then": {
+                "properties": {
+                    "minimum": {"type": ["integer", "number"]},
+                    "maximum": {"type": ["integer", "number"]},
+                    "exclusiveMinimum": {"type": ["integer", "number"]},
+                    "exclusiveMaximum": {"type": ["integer", "number"]},
                 }
             },
         },


### PR DESCRIPTION
Description
-----------
Required for these JIRA tickets
- https://wandb.atlassian.net/browse/WB-28589
- https://wandb.atlassian.net/browse/WB-28581

This PR adds the `required`, `label`, and `placeholder` fields to our custom input schema to:
1. Mark properties are required so we can disable the launch button or throw an error on cli call
2. Use more specific labels to inputs. The description of a boolean often times differs from its label
3. Use more specific placeholders to inputs. Currently, we use generic placeholders in dropdowns.

Design has recommended UX changes that involve modifying the placeholder for different inputs, changing the labels on booleans, and disabling the launch button based on required fields.

Why `required` instead of `optional`? Launch has never validated config inputs before pushing to the queue, so using `optional` would be challenging from a backwards compatibility standpoint. With this change, all fields are still optional, unless the property has the `required` field set to true.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
* Added unit tests