### PR TITLE
fix: allow nil runsummary.Updates for Apply

### DIFF
--- a/core/internal/runsummary/updates.go
+++ b/core/internal/runsummary/updates.go
@@ -83,6 +83,10 @@ func (u *Updates) Merge(newUpdates *Updates) {
 // A partial success is possible if some values' JSON strings cannot be
 // unmarshaled.
 func (u *Updates) Apply(rs *RunSummary) error {
+	if u == nil {
+		return nil
+	}
+
 	var errs []error
 
 	u.update.ForEachLeaf(

--- a/core/internal/runsummary/updates_test.go
+++ b/core/internal/runsummary/updates_test.go
@@ -36,6 +36,15 @@ func TestUpdates_Apply_InsertsRemovesAndCollectsErrors(t *testing.T) {
 	assert.ErrorContains(t, err, "oops")
 }
 
+func TestUpdates_Apply_NilMakesNoChanges(t *testing.T) {
+	rs := runsummary.New()
+
+	var nilUpdates *runsummary.Updates
+	err := nilUpdates.Apply(rs)
+
+	assert.NoError(t, err)
+}
+
 func TestUpdates_Merge(t *testing.T) {
 	u1 := runsummary.FromProto(&spb.SummaryRecord{
 		Update: []*spb.SummaryItem{


### PR DESCRIPTION
A nil `runsummary.Updates` is meant to represent "no updates" (`IsEmpty` checks for nil), so `Apply` should succeed and have no effect.