### PR TITLE
fix: race in FakeStopwatch testing utility

### DIFF
--- a/core/internal/waitingtest/fakestopwatch.go
+++ b/core/internal/waitingtest/fakestopwatch.go
@@ -59,12 +59,12 @@ func (fs *FakeStopwatch) Reset() {
 }
 
 func (fs *FakeStopwatch) Wait() (<-chan struct{}, func()) {
-	if fs.IsDone() {
-		return completedDelay(), func() {}
-	}
-
 	fs.Lock()
 	defer fs.Unlock()
+
+	if fs.done || fs.doneForever {
+		return completedDelay(), func() {}
+	}
 
 	if fs.waitChan == nil {
 		fs.waitChan = make(chan struct{})


### PR DESCRIPTION
Fixes a race between `SetDone` and `Wait`.

`Wait` unlocked the mutex between checking `done` and setting up `waitChan`, on rare occasions leading to nondeterminism if `SetDone` and `Wait` are called simultaneously in a test.