### PR TITLE
fix(integrations): avoid blank histograms for 1-D tensors in torch watch (WB-24349)

### DIFF
--- a/wandb/integration/torch/wandb_torch.py
+++ b/wandb/integration/torch/wandb_torch.py
@@ -74,7 +74,7 @@ class TorchHistory:
         global torch
         torch = wandb.util.get_module("torch", "Could not import torch")
         self._hook_handles = {}
-        self._num_bins = 64 
+        self._num_bins = 64
         self._is_cuda_histc_supported = None
         self.hook_torch = TorchGraph.hook_torch
 


### PR DESCRIPTION
Fix blank histogram panels when wandb.watch logs 1‑element tensors (e.g., biases). Current logic produced degenerate bins (min == max), which the UI can’t render.
`eps` will keep the bin width non-zero.
`eps_abs` holds the smallest representable number such that` 1.0 + eps != 1.0` .
`eps_rel` will create bin-width proportional to tmin magnitude.
previous:
<img width="1196" height="355" alt="image" src="https://github.com/user-attachments/assets/5dc8bb2d-7da2-4170-b2d6-9d9f94ad9d5c" />
now:
<img width="1221" height="319" alt="image" src="https://github.com/user-attachments/assets/d87fb6e2-9c18-424d-802e-735c24eae979" />
