### PR TITLE
fix: allow merging nil runsummary.Updates (into non-nil value)

### DIFF
--- a/core/internal/runsummary/updates.go
+++ b/core/internal/runsummary/updates.go
@@ -63,6 +63,10 @@ func FromProto(record *spb.SummaryRecord) *Updates {
 // so that `u1.Apply(rs); u2.Apply(rs)` has the same effect on `rs` as
 // `u1.Merge(u2); u1.Apply(rs)`.
 func (u *Updates) Merge(newUpdates *Updates) {
+	if newUpdates == nil {
+		return
+	}
+
 	newUpdates.update.ForEachLeaf(
 		func(path pathtree.TreePath, valueJSON string) bool {
 			u.remove.Remove(path)

--- a/core/internal/runsummary/updates_test.go
+++ b/core/internal/runsummary/updates_test.go
@@ -79,6 +79,14 @@ func TestUpdates_Merge(t *testing.T) {
 		rs.ToNestedMaps())
 }
 
+func TestUpdates_Merge_NilMakesNoChanges(t *testing.T) {
+	u := runsummary.NoUpdates()
+
+	u.Merge(nil)
+
+	assert.True(t, u.IsEmpty())
+}
+
 func TestUpdates_FromProto(t *testing.T) {
 	rs := runsummary.New()
 


### PR DESCRIPTION
Fixes another missed check: since `nil` should be treated as "no updates", merging it into an Updates instance should be valid and a no-op.