### PR TITLE
refactor: process summary updates in FileStream without debouncing in Sender

### DIFF
--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -30,6 +30,10 @@ const (
 	// See https://github.com/wandb/core/pull/7339 for history.
 	defaultMaxFileLineBytes = (10 << 20) - (100 << 10)
 
+	// defaultMaxRequestSizeBytes is a default approximate maximum size in bytes
+	// for a FileStream request.
+	defaultMaxRequestSizeBytes = 10 << 20
+
 	// Retry filestream requests for 7 days before dropping chunk
 	// retry_count = seconds_in_7_days / max_retry_time + num_retries_until_max_60_sec
 	//             = 7 * 86400 / 60 + ceil(log2(60/2))

--- a/core/internal/filestream/filestreamrequest.go
+++ b/core/internal/filestream/filestreamrequest.go
@@ -3,6 +3,7 @@ package filestream
 import (
 	"maps"
 
+	"github.com/wandb/wandb/core/internal/runsummary"
 	"github.com/wandb/wandb/core/internal/sparselist"
 )
 
@@ -21,8 +22,8 @@ type FileStreamRequest struct {
 	// Each line is a JSON object mapping metric names to values.
 	EventsLines []string
 
-	// LatestSummary is the run's most recent summary, JSON-encoded.
-	LatestSummary string
+	// SummaryUpdates contains changes to the run's summary.
+	SummaryUpdates *runsummary.Updates
 
 	// ConsoleLines is updates to make to the run's output logs.
 	//
@@ -62,8 +63,10 @@ func (r *FileStreamRequest) Merge(next *FileStreamRequest) {
 	r.HistoryLines = append(r.HistoryLines, next.HistoryLines...)
 	r.EventsLines = append(r.EventsLines, next.EventsLines...)
 
-	if next.LatestSummary != "" {
-		r.LatestSummary = next.LatestSummary
+	if r.SummaryUpdates == nil {
+		r.SummaryUpdates = next.SummaryUpdates
+	} else {
+		r.SummaryUpdates.Merge(next.SummaryUpdates)
 	}
 
 	r.ConsoleLines.Update(next.ConsoleLines)

--- a/core/internal/filestream/filestreamstate.go
+++ b/core/internal/filestream/filestreamstate.go
@@ -1,15 +1,27 @@
 package filestream
 
 import (
+	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/wandb/wandb/core/internal/nullify"
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runsummary"
 )
 
 // FileStreamState turns a [FileStreamRequest] into sequence
 // of [FileStreamRequestJSON].
 type FileStreamState struct {
+	// MaxRequestSizeBytes is an approximate maximum FileStream request size
+	// in bytes.
+	MaxRequestSizeBytes int
+
+	// MaxFileLineSize is an approximate maximum per-line size in bytes for
+	// the "Files" uploaded in FileStream.
+	MaxFileLineSize int
+
 	// HistoryLineNum is the line number where to append history.
 	HistoryLineNum int
 
@@ -24,6 +36,21 @@ type FileStreamState struct {
 	// to properly resume such a run we must update the last line.
 	SummaryLineNum int
 
+	// RunSummary is the run's full summary.
+	//
+	// It may be nil if the run has no summary.
+	RunSummary *runsummary.RunSummary
+
+	// UnsentSummary is the serialized RunSummary if it did not fit in
+	// a previous request.
+	UnsentSummary string
+
+	// LastRunSummarySize is the size in bytes of the RunSummary's
+	// last successfully serialized JSON value.
+	//
+	// If there is a non-empty UnsentSummary, this is its length.
+	LastRunSummarySize int
+
 	// ConsoleLineOffset is an offset to add to all console updates.
 	//
 	// This is used when resuming a run, in which case we want the new
@@ -33,34 +60,36 @@ type FileStreamState struct {
 
 // IsAtSizeLimit returns true if the next JSON chunk of the request could
 // contain more than around maxBytes of data.
-func (s *FileStreamState) IsAtSizeLimit(
-	request *FileStreamRequest,
-	maxBytes int,
-) bool {
+func (s *FileStreamState) IsAtSizeLimit(request *FileStreamRequest) bool {
 	approxSize := 0
 
 	for _, line := range request.HistoryLines {
 		approxSize += len(line)
-		if approxSize >= maxBytes {
+		if approxSize >= s.MaxRequestSizeBytes {
 			return true
 		}
 	}
 
 	for _, line := range request.EventsLines {
 		approxSize += len(line)
-		if approxSize >= maxBytes {
+		if approxSize >= s.MaxRequestSizeBytes {
 			return true
 		}
 	}
 
-	approxSize += len(request.LatestSummary)
-	if approxSize >= maxBytes {
-		return true
+	// Use the last summary size to approximate the next.
+	// It is too expensive to serialize the summary every time and too complex
+	// to track its size incrementally.
+	if !request.SummaryUpdates.IsEmpty() || len(s.UnsentSummary) > 0 {
+		approxSize += s.LastRunSummarySize
+		if approxSize >= s.MaxRequestSizeBytes {
+			return true
+		}
 	}
 
 	for line := range request.ConsoleLines.FirstRunValues() {
 		approxSize += len(line)
-		if approxSize >= maxBytes {
+		if approxSize >= s.MaxRequestSizeBytes {
 			return true
 		}
 	}
@@ -69,19 +98,20 @@ func (s *FileStreamState) IsAtSizeLimit(
 }
 
 // Pop extracts a chunk of data from the request, limiting its JSON
-// representation to approximately maxBytes.
+// representation to approximately the maximum size.
 //
 // The second return value is true if there remains unsent data in the request.
 func (s *FileStreamState) Pop(
 	request *FileStreamRequest,
-	maxBytes int,
+	logger *observability.CoreLogger,
+	printer *observability.Printer,
 ) (*FileStreamRequestJSON, bool) {
 	builder := &requestJSONBuilder{}
-	builder.MaxSizeBytes = maxBytes
+	builder.MaxSizeBytes = s.MaxRequestSizeBytes
 
 	s.popHistory(builder, request)
 	s.popEvents(builder, request)
-	s.popSummary(builder, request)
+	s.popSummary(builder, request, logger, printer)
 	s.popConsoleLines(builder, request)
 
 	s.popUploadedFiles(builder, request)
@@ -156,19 +186,68 @@ func (s *FileStreamState) popEvents(
 func (s *FileStreamState) popSummary(
 	builder *requestJSONBuilder,
 	request *FileStreamRequest,
+	logger *observability.CoreLogger,
+	printer *observability.Printer,
 ) {
-	if len(request.LatestSummary) == 0 {
+	if !request.SummaryUpdates.IsEmpty() {
+		if s.RunSummary == nil {
+			s.RunSummary = runsummary.New()
+		}
+
+		err := request.SummaryUpdates.Apply(s.RunSummary)
+		request.SummaryUpdates = nil
+
+		if err != nil {
+			// A partial success is possible, so we log and continue.
+			logger.CaptureError(
+				fmt.Errorf("filestream: error applying summary updates: %v", err))
+		}
+
+		summaryJSON, err := s.RunSummary.Serialize()
+		if err != nil {
+			// On error, we don't modify UnsentSummary so that we still upload
+			// a previous successfully-serialized value.
+			logger.CaptureError(
+				fmt.Errorf("filestream: failed to serialize summary: %v", err))
+		} else {
+			s.UnsentSummary = string(summaryJSON)
+			s.LastRunSummarySize = len(summaryJSON)
+		}
+	}
+
+	if len(s.UnsentSummary) == 0 {
 		return
 	}
 
-	if !builder.TryAddSize(len(request.LatestSummary)) {
+	if len(s.UnsentSummary) > s.MaxFileLineSize {
+		logger.Warn(
+			"filestream: run summary line too long, skipping",
+			"len", len(s.UnsentSummary),
+			"max", s.MaxFileLineSize,
+		)
+		printer.
+			AtMostEvery(time.Minute).
+			Writef(
+				"Skipped uploading summary data that exceeded"+
+					" size limit (%d > %d bytes).",
+				len(s.UnsentSummary),
+				s.MaxFileLineSize,
+			)
+
+		// Clear the unsent value; we will not attempt to send it unless
+		// it is modified, in which case it'll be serialized again.
+		s.UnsentSummary = ""
+		return
+	}
+
+	if !builder.TryAddSize(len(s.UnsentSummary)) {
 		builder.HasMore = true
 		return
 	}
 
 	builder.SummaryChunk.Offset = s.SummaryLineNum
-	builder.SummaryChunk.Content = []string{request.LatestSummary}
-	request.LatestSummary = ""
+	builder.SummaryChunk.Content = []string{s.UnsentSummary}
+	s.UnsentSummary = ""
 }
 
 func (s *FileStreamState) popConsoleLines(

--- a/core/internal/filestream/updatesummary.go
+++ b/core/internal/filestream/updatesummary.go
@@ -1,39 +1,15 @@
 package filestream
 
-import "time"
+import (
+	"github.com/wandb/wandb/core/internal/runsummary"
+)
 
-// SummaryUpdate contains a run's most recent summary.
+// SummaryUpdate contains updates to a run's summary.
 type SummaryUpdate struct {
-	SummaryJSON string
+	Updates *runsummary.Updates
 }
 
 func (u *SummaryUpdate) Apply(ctx UpdateContext) error {
-	// Override the default max line length if the user has set a custom value.
-	maxLineBytes := ctx.Settings.GetFileStreamMaxLineBytes()
-	if maxLineBytes == 0 {
-		maxLineBytes = defaultMaxFileLineBytes
-	}
-
-	if len(u.SummaryJSON) > int(maxLineBytes) {
-		// Failing to upload the summary is non-blocking.
-		ctx.Logger.CaptureWarn(
-			"filestream: run summary line too long, skipping",
-			"len", len(u.SummaryJSON),
-			"max", maxLineBytes,
-		)
-		ctx.Printer.
-			AtMostEvery(time.Minute).
-			Writef(
-				"Skipped uploading summary data that exceeded"+
-					" size limit (%d > %d).",
-				len(u.SummaryJSON),
-				maxLineBytes,
-			)
-	} else {
-		ctx.MakeRequest(&FileStreamRequest{
-			LatestSummary: u.SummaryJSON,
-		})
-	}
-
+	ctx.MakeRequest(&FileStreamRequest{SummaryUpdates: u.Updates})
 	return nil
 }


### PR DESCRIPTION
Completes WB-27347.

Makes `FileStream` accept incremental summary updates and removes the 30-second summary rate limit in `Sender`. `FileStream` serializes the full summary just before making an HTTP request, which is subject to a default 15-second batching delay.