### PR TITLE
chore: bump go version to 1.25.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 parameters:
   go_version:
     type: string
-    default: "1.25.2"
+    default: "1.25.3"
   server_image:
     type: string
     default: "us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ pip install -U nox uv
 
 ### Setting up Go
 
-Install Go version `1.25.2` following the instructions [here](https://go.dev/doc/install) or using your package manager, for example:
+Install Go version `1.25.3` following the instructions [here](https://go.dev/doc/install) or using your package manager, for example:
 
 ```shell
 brew install go@1.25

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/wandb/wandb/core
 
-go 1.25.2
+go 1.25.3
 
 require (
 	cloud.google.com/go/storage v1.57.0


### PR DESCRIPTION
Description
-----------
Go 1.25.3 includes some security updates and bugfixes: https://go.dev/doc/devel/release#go1.25.minor