### PR TITLE
chore: make wandb.Settings.api_key a pydantic.SecretStr

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -315,7 +315,7 @@ def api_key(settings: Settings | None = None) -> str | None:
     if settings is None:
         settings = wandb_setup.singleton().settings
     if settings.api_key:
-        return settings.api_key
+        return settings.api_key.get_secret_value()
 
     netrc_access = check_netrc_access(get_netrc_file_path())
     if netrc_access.exists and not netrc_access.read_access:


### PR DESCRIPTION
Description
-----------
Fixes WB-27468.

Convert `wandb.Settings.api_key` from string to `pydantic.SecretStr` to make sure it's redacted in reprs.

![image.png](https://app.graphite.dev/user-attachments/assets/e7996a7b-8108-489f-9ab2-39dfe9ac3bd5.png)

