### PR TITLE
chore: reduce library import time

### DIFF
--- a/tests/unit_tests/test_artifacts/test_saved_model.py
+++ b/tests/unit_tests/test_artifacts/test_saved_model.py
@@ -31,11 +31,6 @@ def test_saved_model_pytorch(mocker):
     )
 
 
-# TODO: uncomment this once the test is fixed
-# @pytest.mark.skipif(
-#     platform.system() == "Windows",
-#     reason="TODO: Windows is legitimately busted",
-# )
 @pytest.mark.skip(reason="New keras release broke this test")
 def test_saved_model_keras(mocker):
     saved_model_test(mocker, keras_model())
@@ -63,11 +58,6 @@ def test_pytorch_saved_model():
     )
 
 
-# TODO: uncomment this once the test is fixed
-# @pytest.mark.skipif(
-#     platform.system() == "Windows",
-#     reason="TODO: Windows is legitimately busted",
-# )
 @pytest.mark.skip(reason="New keras release broke this test")
 def test_tensorflow_keras_saved_model():
     subclass_test(
@@ -85,13 +75,6 @@ def test_tensorflow_keras_saved_model():
         "save_fn",
     ),
     [
-        # TODO: Uncomment once _TensorflowKerasSavedModel._serialize is fixed.
-        # (
-        #     keras_model,
-        #     saved_model._TensorflowKerasSavedModel,
-        #     "keras",
-        #     lambda model, path: model.save(path),
-        # ),
         (
             sklearn_model,
             saved_model._SklearnSavedModel,

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -60,8 +60,6 @@ _cleanup_media_tmp_dir()
 from wandb.data_types import Graph
 from wandb.data_types import Image
 from wandb.data_types import Plotly
-
-# from wandb.data_types import Bokeh # keeping out of top level for now since Bokeh plots have poor UI
 from wandb.data_types import Video
 from wandb.data_types import Audio
 from wandb.data_types import Table

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -446,14 +446,14 @@ def finish(
     ...
 
 def login(
-    anonymous: Optional[Literal["must", "allow", "never"]] = None,
-    key: Optional[str] = None,
-    relogin: Optional[bool] = None,
-    host: Optional[str] = None,
-    force: Optional[bool] = None,
-    timeout: Optional[int] = None,
+    anonymous: Literal["must", "allow", "never"] | None = None,
+    key: str | None = None,
+    relogin: bool | None = None,
+    host: str | None = None,
+    force: bool | None = None,
+    timeout: int | None = None,
     verify: bool = False,
-    referrer: Optional[str] = None,
+    referrer: str | None = None,
 ) -> bool:
     """Set up W&B login credentials.
 

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -180,14 +180,14 @@ def finish(
     ...
 
 def login(
-    anonymous: Optional[Literal["must", "allow", "never"]] = None,
-    key: Optional[str] = None,
-    relogin: Optional[bool] = None,
-    host: Optional[str] = None,
-    force: Optional[bool] = None,
-    timeout: Optional[int] = None,
+    anonymous: Literal["must", "allow", "never"] | None = None,
+    key: str | None = None,
+    relogin: bool | None = None,
+    host: str | None = None,
+    force: bool | None = None,
+    timeout: int | None = None,
     verify: bool = False,
-    referrer: Optional[str] = None,
+    referrer: str | None = None,
 ) -> bool:
     """<sdk/wandb_login.py::login>"""
     ...

--- a/wandb/_pydantic/utils.py
+++ b/wandb/_pydantic/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from contextlib import suppress
+from functools import lru_cache
 from typing import Any, Type
 
 import pydantic
@@ -20,6 +21,7 @@ IS_PYDANTIC_V2: bool = int(pydantic_major) >= 2
 BaseModelType: TypeAlias = Type[BaseModel]
 
 
+@lru_cache
 def gql_typename(cls: type[BaseModel]) -> str:
     """Get the GraphQL typename for a Pydantic model."""
     if (field := cls.model_fields.get("typename__")) and (typename := field.default):

--- a/wandb/apis/__init__.py
+++ b/wandb/apis/__init__.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import Callable
 
-import requests
-from urllib3.exceptions import InsecureRequestWarning
-
 import wandb
 from wandb import env, util
 
 
 def _disable_ssl() -> Callable[[], None]:
+    import requests
+    from urllib3.exceptions import InsecureRequestWarning
+
     # Because third party libraries may also use requests, we monkey patch it globally
     # and turn off urllib3 warnings instead printing a global warning to the user.
     wandb.termwarn(

--- a/wandb/apis/normalize.py
+++ b/wandb/apis/normalize.py
@@ -7,7 +7,6 @@ import sys
 from functools import wraps
 from typing import Callable, TypeVar
 
-import requests
 from wandb_gql.client import RetryError
 
 from wandb import env
@@ -22,6 +21,8 @@ def normalize_exceptions(func: _F) -> _F:
 
     @wraps(func)
     def wrapper(*args, **kwargs):
+        import requests
+
         message = "Whoa, you found a bug."
         try:
             return func(*args, **kwargs)

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -41,7 +41,7 @@ __all__ = (
 )
 
 
-from wandb.apis.public.api import Api, RetryingClient, requests
+from wandb.apis.public.api import Api, RetryingClient
 from wandb.apis.public.artifacts import (
     ArtifactCollection,
     ArtifactCollections,

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -8,73 +8,32 @@ from __future__ import annotations
 
 import json
 from copy import copy
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
-    ClassVar,
     Collection,
     Iterable,
     List,
     Literal,
     Mapping,
     Sequence,
+    TypeVar,
 )
 
 from typing_extensions import override
 from wandb_gql import gql
 
-import wandb
 from wandb._iterutils import always_list
 from wandb._pydantic import ConnectionWithTotal, Edge
 from wandb._strutils import nameof
-from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import Paginator, SizedPaginator
-from wandb.errors.term import termlog
+from wandb.errors.term import termlog, termwarn
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
-from wandb.sdk.artifacts._generated import (
-    ADD_ARTIFACT_COLLECTION_TAGS_GQL,
-    ARTIFACT_COLLECTION_MEMBERSHIP_FILES_GQL,
-    ARTIFACT_VERSION_FILES_GQL,
-    DELETE_ARTIFACT_COLLECTION_TAGS_GQL,
-    DELETE_ARTIFACT_PORTFOLIO_GQL,
-    DELETE_ARTIFACT_SEQUENCE_GQL,
-    PROJECT_ARTIFACT_COLLECTION_GQL,
-    PROJECT_ARTIFACT_COLLECTIONS_GQL,
-    PROJECT_ARTIFACT_TYPE_GQL,
-    PROJECT_ARTIFACT_TYPES_GQL,
-    PROJECT_ARTIFACTS_GQL,
-    RUN_INPUT_ARTIFACTS_GQL,
-    RUN_OUTPUT_ARTIFACTS_GQL,
-    UPDATE_ARTIFACT_COLLECTION_TYPE_GQL,
-    UPDATE_ARTIFACT_PORTFOLIO_GQL,
-    UPDATE_ARTIFACT_SEQUENCE_GQL,
-    ArtifactCollectionFragment,
-    ArtifactCollectionMembershipFiles,
-    ArtifactFragment,
-    ArtifactTypeFragment,
-    ArtifactVersionFiles,
-    CreateArtifactCollectionTagAssignmentsInput,
-    DeleteArtifactCollectionTagAssignmentsInput,
-    MoveArtifactSequenceInput,
-    ProjectArtifactCollection,
-    ProjectArtifactCollections,
-    ProjectArtifacts,
-    ProjectArtifactType,
-    ProjectArtifactTypes,
-    UpdateArtifactPortfolioInput,
-    UpdateArtifactSequenceInput,
-)
-from wandb.sdk.artifacts._gqlutils import omit_artifact_fields, server_supports
+from wandb.sdk.artifacts._gqlutils import omit_artifact_fields
 from wandb.sdk.artifacts._models import ArtifactCollectionData
-from wandb.sdk.artifacts._models.pagination import (
-    ArtifactCollectionConnection,
-    ArtifactFileConnection,
-    ArtifactTypeConnection,
-    RunArtifactConnection,
-)
-from wandb.sdk.artifacts._validators import FullArtifactPath, validate_artifact_type
 from wandb.sdk.lib.deprecation import warn_and_record_deprecation
 
 from .utils import gql_compat
@@ -82,9 +41,38 @@ from .utils import gql_compat
 if TYPE_CHECKING:
     from wandb_gql import Client
 
+    from wandb.apis import public
+    from wandb.sdk.artifacts._generated import (
+        ArtifactCollectionFragment,
+        ArtifactTypeFragment,
+    )
+    from wandb.sdk.artifacts._models.pagination import (
+        ArtifactCollectionConnection,
+        ArtifactFileConnection,
+        ArtifactTypeConnection,
+        RunArtifactConnection,
+    )
     from wandb.sdk.artifacts.artifact import Artifact
 
     from . import RetryingClient, Run
+
+
+TNode = TypeVar("TNode")
+
+
+@lru_cache(maxsize=1)
+def _run_artifacts_mode_to_gql() -> dict[Literal["logged", "used"], str]:
+    """Lazily import and cache the run artifact GQL query strings.
+
+    This keeps import-time light and only loads the generated GQL
+    when RunArtifacts is actually used.
+    """
+    from wandb.sdk.artifacts._generated import (
+        RUN_INPUT_ARTIFACTS_GQL,
+        RUN_OUTPUT_ARTIFACTS_GQL,
+    )
+
+    return {"logged": RUN_OUTPUT_ARTIFACTS_GQL, "used": RUN_INPUT_ARTIFACTS_GQL}
 
 
 class ArtifactTypes(Paginator["ArtifactType"]):
@@ -93,9 +81,17 @@ class ArtifactTypes(Paginator["ArtifactType"]):
     <!-- lazydoc-ignore-init: internal -->
     """
 
-    QUERY = gql(PROJECT_ARTIFACT_TYPES_GQL)
-
     last_response: ArtifactTypeConnection | None
+
+    _QUERY = None
+
+    @property
+    def QUERY(self):  # noqa: N802
+        if self._QUERY is None:
+            from wandb.sdk.artifacts._generated import PROJECT_ARTIFACT_TYPES_GQL
+
+            type(self)._QUERY = gql(PROJECT_ARTIFACT_TYPES_GQL)
+        return self._QUERY
 
     def __init__(
         self,
@@ -116,6 +112,9 @@ class ArtifactTypes(Paginator["ArtifactType"]):
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
+        from wandb.sdk.artifacts._generated import ProjectArtifactTypes
+        from wandb.sdk.artifacts._models.pagination import ArtifactTypeConnection
+
         data = self.client.execute(self.QUERY, variable_values=self.variables)
         result = ProjectArtifactTypes.model_validate(data)
 
@@ -202,6 +201,8 @@ class ArtifactType:
         type_name: str,
         attrs: ArtifactTypeFragment | None = None,
     ):
+        from wandb.sdk.artifacts._generated import ArtifactTypeFragment
+
         self.client = client
         self.entity = entity
         self.project = project
@@ -215,6 +216,12 @@ class ArtifactType:
 
         <!-- lazydoc-ignore: internal -->
         """
+        from wandb.sdk.artifacts._generated import (
+            PROJECT_ARTIFACT_TYPE_GQL,
+            ArtifactTypeFragment,
+            ProjectArtifactType,
+        )
+
         gql_op = gql(PROJECT_ARTIFACT_TYPE_GQL)
         gql_vars = {
             "entityName": self.entity,
@@ -293,6 +300,8 @@ class ArtifactCollections(SizedPaginator["ArtifactCollection"]):
         type_name: str,
         per_page: int = 50,
     ):
+        from wandb.sdk.artifacts._generated import PROJECT_ARTIFACT_COLLECTIONS_GQL
+
         self.entity = entity
         self.project = project
         self.type_name = type_name
@@ -313,6 +322,9 @@ class ArtifactCollections(SizedPaginator["ArtifactCollection"]):
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
+        from wandb.sdk.artifacts._generated import ProjectArtifactCollections
+        from wandb.sdk.artifacts._models.pagination import ArtifactCollectionConnection
+
         data = self.client.execute(self.QUERY, variable_values=self.variables)
         result = ProjectArtifactCollections.model_validate(data)
 
@@ -471,6 +483,11 @@ class ArtifactCollection:
 
         <!-- lazydoc-ignore: internal -->
         """
+        from wandb.sdk.artifacts._generated import (
+            PROJECT_ARTIFACT_COLLECTION_GQL,
+            ProjectArtifactCollection,
+        )
+
         if server_supports_artifact_collections_gql_edges(self.client):
             rename_fields = None
         else:
@@ -499,6 +516,12 @@ class ArtifactCollection:
     @normalize_exceptions
     def change_type(self, new_type: str) -> None:
         """Deprecated, change type directly with `save` instead."""
+        from wandb.sdk.artifacts._generated import (
+            UPDATE_ARTIFACT_COLLECTION_TYPE_GQL,
+            MoveArtifactSequenceInput,
+        )
+        from wandb.sdk.artifacts._validators import validate_artifact_type
+
         warn_and_record_deprecation(
             feature=Deprecated(artifact_collection__change_type=True),
             message="ArtifactCollection.change_type(type) is deprecated, use ArtifactCollection.save() instead.",
@@ -536,6 +559,11 @@ class ArtifactCollection:
     @normalize_exceptions
     def delete(self) -> None:
         """Delete the entire artifact collection."""
+        from wandb.sdk.artifacts._generated import (
+            DELETE_ARTIFACT_PORTFOLIO_GQL,
+            DELETE_ARTIFACT_SEQUENCE_GQL,
+        )
+
         gql_op = gql(
             DELETE_ARTIFACT_SEQUENCE_GQL
             if self.is_sequence()
@@ -588,6 +616,13 @@ class ArtifactCollection:
         self._current.type = type
 
     def _update_collection(self) -> None:
+        from wandb.sdk.artifacts._generated import (
+            UPDATE_ARTIFACT_PORTFOLIO_GQL,
+            UPDATE_ARTIFACT_SEQUENCE_GQL,
+            UpdateArtifactPortfolioInput,
+            UpdateArtifactSequenceInput,
+        )
+
         if self.is_sequence():
             gql_op = gql(UPDATE_ARTIFACT_SEQUENCE_GQL)
             gql_input = UpdateArtifactSequenceInput(
@@ -606,6 +641,11 @@ class ArtifactCollection:
         self._saved.name = self._current.name
 
     def _update_collection_type(self) -> None:
+        from wandb.sdk.artifacts._generated import (
+            UPDATE_ARTIFACT_COLLECTION_TYPE_GQL,
+            MoveArtifactSequenceInput,
+        )
+
         gql_op = gql(UPDATE_ARTIFACT_COLLECTION_TYPE_GQL)
         gql_input = MoveArtifactSequenceInput(
             artifact_sequence_id=self.id,
@@ -615,6 +655,11 @@ class ArtifactCollection:
         self._saved.type = self._current.type
 
     def _add_tags(self, tag_names: Iterable[str]) -> None:
+        from wandb.sdk.artifacts._generated import (
+            ADD_ARTIFACT_COLLECTION_TAGS_GQL,
+            CreateArtifactCollectionTagAssignmentsInput,
+        )
+
         gql_op = gql(ADD_ARTIFACT_COLLECTION_TAGS_GQL)
         gql_input = CreateArtifactCollectionTagAssignmentsInput(
             entity_name=self.entity,
@@ -625,6 +670,11 @@ class ArtifactCollection:
         self.client.execute(gql_op, variable_values={"input": gql_input.model_dump()})
 
     def _delete_tags(self, tag_names: Iterable[str]) -> None:
+        from wandb.sdk.artifacts._generated import (
+            DELETE_ARTIFACT_COLLECTION_TAGS_GQL,
+            DeleteArtifactCollectionTagAssignmentsInput,
+        )
+
         gql_op = gql(DELETE_ARTIFACT_COLLECTION_TAGS_GQL)
         gql_input = DeleteArtifactCollectionTagAssignmentsInput(
             entity_name=self.entity,
@@ -637,6 +687,8 @@ class ArtifactCollection:
     @normalize_exceptions
     def save(self) -> None:
         """Persist any changes made to the artifact collection."""
+        from wandb.sdk.artifacts._validators import validate_artifact_type
+
         if (old_type := self._saved.type) != (new_type := self.type):
             try:
                 validate_artifact_type(new_type, self.name)
@@ -670,12 +722,12 @@ class ArtifactCollection:
         return f"<ArtifactCollection {self.name} ({self.type})>"
 
 
-class _ArtifactEdge(Edge[ArtifactFragment]):
+class _ArtifactEdgeGeneric(Edge[TNode]):
     version: str  # Extra field defined only on VersionedArtifactEdge
 
 
-class _ArtifactConnection(ConnectionWithTotal[ArtifactFragment]):
-    edges: List[_ArtifactEdge]  # noqa: UP006
+class _ArtifactConnectionGeneric(ConnectionWithTotal[TNode]):
+    edges: List[_ArtifactEdgeGeneric]  # noqa: UP006
 
 
 class Artifacts(SizedPaginator["Artifact"]):
@@ -698,7 +750,8 @@ class Artifacts(SizedPaginator["Artifact"]):
     <!-- lazydoc-ignore-init: internal -->
     """
 
-    last_response: _ArtifactConnection | None
+    # Loosely-annotated to avoid importing heavy types at module import time.
+    last_response: _ArtifactConnectionGeneric | None
 
     def __init__(
         self,
@@ -712,6 +765,8 @@ class Artifacts(SizedPaginator["Artifact"]):
         per_page: int = 50,
         tags: str | list[str] | None = None,
     ):
+        from wandb.sdk.artifacts._generated import PROJECT_ARTIFACTS_GQL
+
         self.entity = entity
         self.collection_name = collection_name
         self.type = type
@@ -743,6 +798,8 @@ class Artifacts(SizedPaginator["Artifact"]):
 
     @override
     def _update_response(self) -> None:
+        from wandb.sdk.artifacts._generated import ArtifactFragment, ProjectArtifacts
+
         data = self.client.execute(self.QUERY, variable_values=self.variables)
         result = ProjectArtifacts.model_validate(data)
 
@@ -755,7 +812,9 @@ class Artifacts(SizedPaginator["Artifact"]):
         ):
             raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
 
-        self.last_response = _ArtifactConnection.model_validate(conn)
+        self.last_response = _ArtifactConnectionGeneric[
+            ArtifactFragment
+        ].model_validate(conn)
 
     @property
     def _length(self) -> int:
@@ -788,12 +847,15 @@ class Artifacts(SizedPaginator["Artifact"]):
 
         <!-- lazydoc-ignore: internal -->
         """
+        from wandb.sdk.artifacts._validators import FullArtifactPath
+        from wandb.sdk.artifacts.artifact import Artifact
+
         if self.last_response is None:
             return []
 
         artifact_edges = (edge for edge in self.last_response.edges if edge.node)
         artifacts = (
-            wandb.Artifact._from_attrs(
+            Artifact._from_attrs(
                 path=FullArtifactPath(
                     prefix=self.entity,
                     project=self.project,
@@ -816,12 +878,6 @@ class RunArtifacts(SizedPaginator["Artifact"]):
 
     last_response: RunArtifactConnection | None
 
-    _mode2gqlstr: ClassVar[dict[Literal["logged", "used"], str]] = {
-        "logged": RUN_OUTPUT_ARTIFACTS_GQL,
-        "used": RUN_INPUT_ARTIFACTS_GQL,
-    }
-    """Maps the mode ("logged" or "used") to the corresponding GraphQL query string."""
-
     def __init__(
         self,
         client: Client,
@@ -832,7 +888,7 @@ class RunArtifacts(SizedPaginator["Artifact"]):
         self.run = run
 
         try:
-            query_str = self._mode2gqlstr[mode]
+            query_str = _run_artifacts_mode_to_gql()[mode]
         except LookupError:
             raise ValueError("mode must be logged or used")
         else:
@@ -847,6 +903,8 @@ class RunArtifacts(SizedPaginator["Artifact"]):
 
     @override
     def _update_response(self) -> None:
+        from wandb.sdk.artifacts._models.pagination import RunArtifactConnection
+
         data = self.client.execute(self.QUERY, variable_values=self.variables)
 
         # Extract the inner `*Connection` result for faster/easier access.
@@ -884,11 +942,14 @@ class RunArtifacts(SizedPaginator["Artifact"]):
 
         <!-- lazydoc-ignore: internal -->
         """
+        from wandb.sdk.artifacts._validators import FullArtifactPath
+        from wandb.sdk.artifacts.artifact import Artifact
+
         if self.last_response is None:
             return []
 
         return [
-            wandb.Artifact._from_attrs(
+            Artifact._from_attrs(
                 path=FullArtifactPath(
                     prefix=proj.entity.name,
                     project=proj.name,
@@ -918,6 +979,12 @@ class ArtifactFiles(SizedPaginator["public.File"]):
         names: Sequence[str] | None = None,
         per_page: int = 50,
     ):
+        from wandb.sdk.artifacts._generated import (
+            ARTIFACT_COLLECTION_MEMBERSHIP_FILES_GQL,
+            ARTIFACT_VERSION_FILES_GQL,
+        )
+        from wandb.sdk.artifacts._gqlutils import server_supports
+
         self.artifact = artifact
         self.query_via_membership = server_supports(
             client, ServerFeature.ARTIFACT_COLLECTION_MEMBERSHIP_FILES
@@ -961,6 +1028,12 @@ class ArtifactFiles(SizedPaginator["public.File"]):
 
     @override
     def _update_response(self) -> None:
+        from wandb.sdk.artifacts._generated import (
+            ArtifactCollectionMembershipFiles,
+            ArtifactVersionFiles,
+        )
+        from wandb.sdk.artifacts._models.pagination import ArtifactFileConnection
+
         data = self.client.execute(self.QUERY, variable_values=self.variables)
 
         # Extract the inner `*Connection` result for faster/easier access.
@@ -1016,6 +1089,8 @@ class ArtifactFiles(SizedPaginator["public.File"]):
 
         <!-- lazydoc-ignore: internal -->
         """
+        from wandb.apis import public
+
         if self.last_response is None:
             return []
 
@@ -1052,7 +1127,8 @@ def server_supports_artifact_collections_gql_edges(
     supported = client.version_supported("0.12.11")  # edges were merged on
     if not supported and warn:
         # First local release to include the above is 0.9.50: https://github.com/wandb/local/releases/tag/0.9.50
-        wandb.termwarn(
-            "W&B Local Server version does not support ArtifactCollection gql edges; falling back to using legacy ArtifactSequence. Please update server to at least version 0.9.50."
+        termwarn(
+            "W&B Local Server version does not support ArtifactCollection gql edges; "
+            "falling back to using legacy ArtifactSequence. Please update server to at least version 0.9.50."
         )
     return supported

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -33,7 +33,6 @@ Note:
 
 from __future__ import annotations
 
-from requests import HTTPError
 from wandb_gql import gql
 
 from wandb.apis import public
@@ -205,6 +204,8 @@ class Project(Attrs):
         self.entity = entity
 
     def _load(self):
+        from requests import HTTPError
+
         variable_values = {"project": self.name, "entity": self.entity}
         try:
             response = self.client.execute(self.QUERY, variable_values)

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Collection
 from wandb_gql import gql
 
 from wandb._strutils import ensureprefix
-from wandb.sdk.artifacts._validators import REGISTRY_PREFIX, validate_artifact_types
 
 if TYPE_CHECKING:
     from wandb_gql import Client
@@ -58,6 +57,8 @@ def prepare_artifact_types_input(
     Returns:
         The artifact types for the GQL input.
     """
+    from wandb.sdk.artifacts._validators import validate_artifact_types
+
     if artifact_types:
         return [{"name": typ} for typ in validate_artifact_types(artifact_types)]
     return None
@@ -70,6 +71,8 @@ def ensure_registry_prefix_on_names(query: Any, in_name: bool = False) -> Any:
 
     EX: {"name": "model"} -> {"name": "wandb-registry-model"}
     """
+    from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
+
     if isinstance((txt := query), str):
         return ensureprefix(txt, REGISTRY_PREFIX) if in_name else txt
     if isinstance((dct := query), dict):

--- a/wandb/apis/public/teams.py
+++ b/wandb/apis/public/teams.py
@@ -10,7 +10,6 @@ Note:
 
 from __future__ import annotations
 
-import requests
 from wandb_gql import gql
 
 from wandb.apis.attrs import Attrs
@@ -46,6 +45,8 @@ class Member(Attrs):
         Returns:
             Boolean indicating success
         """
+        import requests
+
         try:
             return self._client.execute(
                 self.DELETE_MEMBER_MUTATION, {"id": self.id, "entityName": self.team}
@@ -168,6 +169,8 @@ class Team(Attrs):
         Returns:
             A `Team` object
         """
+        import requests
+
         try:
             api.client.execute(
                 cls.CREATE_TEAM_MUTATION,
@@ -189,6 +192,8 @@ class Team(Attrs):
         Returns:
             `True` on success, `False` if user was already invited or didn't exist.
         """
+        import requests
+
         variables = {"entityName": self.name, "admin": admin}
         if "@" in username_or_email:
             variables["email"] = username_or_email
@@ -209,6 +214,8 @@ class Team(Attrs):
         Returns:
             The service account `Member` object, or None on failure
         """
+        import requests
+
         try:
             self._client.execute(
                 self.CREATE_SERVICE_ACCOUNT_MUTATION,

--- a/wandb/apis/public/users.py
+++ b/wandb/apis/public/users.py
@@ -9,7 +9,6 @@ Note:
 
 from __future__ import annotations
 
-import requests
 from wandb_gql import gql
 
 import wandb
@@ -136,6 +135,8 @@ class User(Attrs):
         Raises:
             ValueError if the api_key couldn't be found
         """
+        import requests
+
         idx = self.api_keys.index(api_key)
         try:
             self._client.execute(
@@ -156,6 +157,8 @@ class User(Attrs):
         Returns:
             The new api key, or None on failure
         """
+        import requests
+
         try:
             # We must make this call using credentials from the original user
             key = self.user_api.client.execute(

--- a/wandb/apis/public/utils.py
+++ b/wandb/apis/public/utils.py
@@ -11,7 +11,6 @@ from wandb_graphql.language import ast, visitor
 from wandb_graphql.validation.validation import ValidationContext
 
 from wandb._iterutils import one
-from wandb.sdk.artifacts._validators import is_artifact_registry_project
 from wandb.sdk.internal.internal_api import Api as InternalApi
 
 
@@ -68,6 +67,8 @@ def parse_org_from_registry_path(path: str, path_type: PathType) -> str:
         artifact path like <entity>/<project>/<artifact> or <project>/<artifact> or <artifact>
         path_type (PathType): The type of path to parse.
     """
+    from wandb.sdk.artifacts._validators import is_artifact_registry_project
+
     parts = path.split("/")
     expected_parts = 3 if path_type == PathType.ARTIFACT else 2
 

--- a/wandb/sdk/artifacts/_gqlutils.py
+++ b/wandb/sdk/artifacts/_gqlutils.py
@@ -10,21 +10,14 @@ from wandb_gql import gql
 from wandb._iterutils import one
 from wandb.errors import UnsupportedError
 from wandb.proto.wandb_internal_pb2 import ServerFeature
-from wandb.sdk.artifacts._generated.fetch_org_info_from_entity import (
-    FetchOrgInfoFromEntityEntity,
-)
 from wandb.sdk.internal._generated import SERVER_FEATURES_QUERY_GQL, ServerFeaturesQuery
-
-from ._generated import (
-    FETCH_ORG_INFO_FROM_ENTITY_GQL,
-    TYPE_INFO_GQL,
-    FetchOrgInfoFromEntity,
-    TypeInfo,
-    TypeInfoFragment,
-)
 
 if TYPE_CHECKING:
     from wandb.apis.public import RetryingClient
+    from wandb.sdk.artifacts._generated import TypeInfoFragment
+    from wandb.sdk.artifacts._generated.fetch_org_info_from_entity import (
+        FetchOrgInfoFromEntityEntity,
+    )
 
 OMITTABLE_ARTIFACT_FIELDS = frozenset(
     {
@@ -40,6 +33,8 @@ OMITTABLE_ARTIFACT_FIELDS = frozenset(
 @lru_cache(maxsize=16)
 def type_info(client: RetryingClient, typename: str) -> TypeInfoFragment | None:
     """Returns the type info for a given GraphQL type."""
+    from ._generated import TYPE_INFO_GQL, TypeInfo
+
     data = client.execute(gql(TYPE_INFO_GQL), variable_values={"name": typename})
     return TypeInfo.model_validate(data).type
 
@@ -49,6 +44,8 @@ def org_info_from_entity(
     client: RetryingClient, entity: str
 ) -> FetchOrgInfoFromEntityEntity | None:
     """Returns the organization info for a given entity."""
+    from ._generated import FETCH_ORG_INFO_FROM_ENTITY_GQL, FetchOrgInfoFromEntity
+
     gql_op = gql(FETCH_ORG_INFO_FROM_ENTITY_GQL)
     data = client.execute(gql_op, variable_values={"entity": entity})
     return FetchOrgInfoFromEntity.model_validate(data).entity

--- a/wandb/sdk/artifacts/_models/registry.py
+++ b/wandb/sdk/artifacts/_models/registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import ConfigDict, Field
 from typing_extensions import Self
@@ -9,11 +9,11 @@ from wandb._pydantic import GQLId, field_validator
 from wandb._strutils import nameof
 from wandb.apis.public.registries._freezable_list import AddOnlyArtifactTypesList
 from wandb.apis.public.registries._utils import Visibility
-from wandb.sdk.artifacts._generated import RegistryFragment
-from wandb.sdk.artifacts._generated.fragments import RegistryFragmentArtifactTypes
-from wandb.sdk.artifacts._validators import REGISTRY_PREFIX, remove_registry_prefix
 
 from .base_model import ArtifactsBase
+
+if TYPE_CHECKING:
+    from wandb.sdk.artifacts._generated import RegistryFragment
 
 
 class RegistryData(ArtifactsBase):
@@ -69,11 +69,17 @@ class RegistryData(ArtifactsBase):
     @property
     def full_name(self) -> str:
         """The project name with the expected `wandb-registry-` prefix."""
+        from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
+
         return f"{REGISTRY_PREFIX}{self.name}"
 
     @field_validator("artifact_types", mode="plain")
     def _validate_artifact_types(cls, v: Any) -> AddOnlyArtifactTypesList:
         """Coerce `artifact_types` to an AddOnlyArtifactTypesList."""
+        from wandb.sdk.artifacts._generated.fragments import (
+            RegistryFragmentArtifactTypes,
+        )
+
         if isinstance(v, RegistryFragmentArtifactTypes):
             # This is a GQL connection object, so we need to extract the node names
             return AddOnlyArtifactTypesList(e.node.name for e in v.edges if e.node)
@@ -83,6 +89,8 @@ class RegistryData(ArtifactsBase):
 
     @classmethod
     def from_fragment(cls, obj: RegistryFragment) -> Self:
+        from wandb.sdk.artifacts._validators import remove_registry_prefix
+
         if not obj.entity.organization:
             raise ValueError(
                 f"Unable to parse registry organization from {nameof(type(obj))!r} object"

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -22,11 +22,10 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 from typing_extensions import Concatenate, ParamSpec, Self
 
 from wandb._iterutils import always_list, unique_list
-from wandb._pydantic import from_json, gql_typename
+from wandb._pydantic import from_json
 from wandb._strutils import nameof, removeprefix
 from wandb.util import json_friendly_val
 
-from ._generated import ArtifactPortfolioTypeFields, ArtifactSequenceTypeFields
 from .exceptions import ArtifactFinalizedError, ArtifactNotLoggedError
 
 if TYPE_CHECKING:
@@ -47,9 +46,6 @@ NAME_MAXLEN: Final[int] = 128
 INVALID_ARTIFACT_NAME_CHARS: Final[frozenset[str]] = frozenset("/")
 INVALID_URL_CHARS: Final[frozenset[str]] = frozenset("/\\#?%:\r\n")
 ARTIFACT_SEP_CHARS: Final[frozenset[str]] = frozenset("/:")
-
-LINKED_COLLECTION_TYPENAME: Final[str] = gql_typename(ArtifactPortfolioTypeFields)
-SOURCE_COLLECTION_TYPENAME: Final[str] = gql_typename(ArtifactSequenceTypeFields)
 
 
 @dataclass

--- a/wandb/sdk/artifacts/storage_policies/_factories.py
+++ b/wandb/sdk/artifacts/storage_policies/_factories.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from typing import Final
-
-from requests import Response, Session
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+from typing import TYPE_CHECKING, Final
 
 from ..storage_handler import StorageHandler
 from ..storage_handlers.azure_handler import AzureHandler
@@ -15,13 +11,10 @@ from ..storage_handlers.s3_handler import S3Handler
 from ..storage_handlers.wb_artifact_handler import WBArtifactHandler
 from ..storage_handlers.wb_local_artifact_handler import WBLocalArtifactHandler
 
-# Sleep length: 0, 2, 4, 8, 16, 32, 64, 120, 120, 120, 120, 120, 120, 120, 120, 120
-# seconds, i.e. a total of 20min 6s.
-HTTP_RETRY_STRATEGY: Final[Retry] = Retry(
-    backoff_factor=1,
-    total=16,
-    status_forcelist=(308, 408, 409, 429, 500, 502, 503, 504),
-)
+if TYPE_CHECKING:
+    from requests import Response, Session
+
+
 HTTP_POOL_CONNECTIONS: Final[int] = 64
 HTTP_POOL_MAXSIZE: Final[int] = 64
 
@@ -33,6 +26,18 @@ def raise_for_status(response: Response, *_, **__) -> None:
 
 def make_http_session() -> Session:
     """Return a `requests.Session` configured for artifact storage handlers."""
+    from requests import Session
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+    # Sleep length: 0, 2, 4, 8, 16, 32, 64, 120, 120, 120, 120, 120, 120, 120, 120, 120
+    # seconds, i.e. a total of 20min 6s.
+    HTTP_RETRY_STRATEGY: Final[Retry] = Retry(  # noqa: N806
+        backoff_factor=1,
+        total=16,
+        status_forcelist=(308, 408, 409, 429, 500, 502, 503, 504),
+    )
+
     session = Session()
 
     # Explicitly configure the retry strategy for http/https adapters.

--- a/wandb/sdk/artifacts/storage_policies/_multipart.py
+++ b/wandb/sdk/artifacts/storage_policies/_multipart.py
@@ -8,13 +8,15 @@ import threading
 from concurrent.futures import FIRST_EXCEPTION, Executor, wait
 from dataclasses import dataclass, field
 from queue import Queue
-from typing import Any, Final, Iterator, Union
+from typing import TYPE_CHECKING, Any, Final, Iterator, Union
 
-from requests import Session
 from typing_extensions import TypeAlias, TypeIs, final
 
 from wandb import env
 from wandb.sdk.artifacts.artifact_file_cache import Opener
+
+if TYPE_CHECKING:
+    from requests import Session
 
 logger = logging.getLogger(__name__)
 

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -12,7 +12,6 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
-import requests
 from typing_extensions import assert_never
 
 from wandb.errors.term import termwarn
@@ -45,6 +44,8 @@ from wandb.sdk.lib.paths import FilePathStr, URIStr
 from ._factories import make_http_session, make_storage_handlers
 
 if TYPE_CHECKING:
+    import requests
+
     from wandb.filesync.step_prepare import StepPrepare
     from wandb.sdk.artifacts.artifact import Artifact
     from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry

--- a/wandb/sdk/backend/backend.py
+++ b/wandb/sdk/backend/backend.py
@@ -4,31 +4,33 @@ Manage backend.
 
 """
 
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from wandb.sdk.interface.interface import InterfaceBase
-from wandb.sdk.wandb_settings import Settings
 
 if TYPE_CHECKING:
     from wandb.sdk.lib.service import service_connection
+    from wandb.sdk.wandb_settings import Settings
 
 logger = logging.getLogger("wandb")
 
 
 class Backend:
-    interface: Optional[InterfaceBase]
+    interface: InterfaceBase | None
 
     _settings: Settings
 
     _done: bool
 
-    _service: Optional["service_connection.ServiceConnection"]
+    _service: service_connection.ServiceConnection | None
 
     def __init__(
         self,
         settings: Settings,
-        service: Optional["service_connection.ServiceConnection"] = None,
+        service: service_connection.ServiceConnection | None = None,
     ) -> None:
         self._done = False
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import datetime
 import functools
@@ -16,23 +18,17 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Iterable,
-    List,
     Literal,
     Mapping,
     MutableMapping,
     NamedTuple,
-    Optional,
     Sequence,
     TextIO,
-    Tuple,
     Union,
 )
 
 import click
-import requests
-import yaml
 from wandb_gql import Client, gql
 from wandb_gql.client import RetryError
 from wandb_graphql.language.ast import Document
@@ -44,7 +40,6 @@ from wandb.errors import AuthenticationError, CommError, UnsupportedError, Usage
 from wandb.integration.sagemaker import parse_sm_secrets
 from wandb.old.settings import Settings
 from wandb.proto.wandb_internal_pb2 import ServerFeature
-from wandb.sdk.artifacts._validators import is_artifact_registry_project
 from wandb.sdk.internal._generated import SERVER_FEATURES_QUERY_GQL, ServerFeaturesQuery
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.lib.gql_request import GraphQLSession
@@ -62,6 +57,8 @@ LAUNCH_DEFAULT_PROJECT = "model-registry"
 if TYPE_CHECKING:
     from typing import Literal, TypedDict
 
+    import requests
+
     from .progress import ProgressFn
 
     class CreateArtifactFileSpecInput(TypedDict, total=False):
@@ -70,25 +67,25 @@ if TYPE_CHECKING:
         artifactID: str
         name: str
         md5: str
-        mimetype: Optional[str]
-        artifactManifestID: Optional[str]
-        uploadPartsInput: Optional[List[Dict[str, object]]]
+        mimetype: str | None
+        artifactManifestID: str | None
+        uploadPartsInput: list[dict[str, object]] | None
 
     class CreateArtifactFilesResponseFile(TypedDict):
         id: str
         name: str
         displayName: str
-        uploadUrl: Optional[str]
+        uploadUrl: str | None
         uploadHeaders: Sequence[str]
-        uploadMultipartUrls: "UploadPartsResponse"
+        uploadMultipartUrls: UploadPartsResponse
         storagePath: str
-        artifact: "CreateArtifactFilesResponseFileNode"
+        artifact: CreateArtifactFilesResponseFileNode
 
     class CreateArtifactFilesResponseFileNode(TypedDict):
         id: str
 
     class UploadPartsResponse(TypedDict):
-        uploadUrlParts: List["UploadUrlParts"]
+        uploadUrlParts: list[UploadUrlParts]
         uploadID: str
 
     class UploadUrlParts(TypedDict):
@@ -99,7 +96,7 @@ if TYPE_CHECKING:
         """Corresponds to `type CompleteMultipartUploadArtifactInput` in schema.graphql."""
 
         completeMultipartAction: str
-        completedParts: Dict[int, str]
+        completedParts: dict[int, str]
         artifactID: str
         storagePath: str
         uploadID: str
@@ -111,24 +108,19 @@ if TYPE_CHECKING:
     class DefaultSettings(TypedDict):
         section: str
         git_remote: str
-        ignore_globs: Optional[List[str]]
-        base_url: Optional[str]
-        root_dir: Optional[str]
-        api_key: Optional[str]
-        entity: Optional[str]
-        organization: Optional[str]
-        project: Optional[str]
-        _extra_http_headers: Optional[Mapping[str, str]]
-        _proxies: Optional[Mapping[str, str]]
+        ignore_globs: list[str] | None
+        base_url: str | None
+        root_dir: str | None
+        api_key: str | None
+        entity: str | None
+        organization: str | None
+        project: str | None
+        _extra_http_headers: Mapping[str, str] | None
+        _proxies: Mapping[str, str] | None
 
     _Response = MutableMapping
     SweepState = Literal["RUNNING", "PAUSED", "CANCELED", "FINISHED"]
     Number = Union[int, float]
-
-# class _MappingSupportsCopy(Protocol):
-#     def copy(self) -> "_MappingSupportsCopy": ...
-#     def keys(self) -> Iterable: ...
-#     def __getitem__(self, name: str) -> Any: ...
 
 httpclient_logger = logging.getLogger("http.client")
 if os.environ.get("WANDB_DEBUG"):
@@ -159,7 +151,7 @@ def check_httpclient_logger_handler() -> None:
 
 
 class _ThreadLocalData(threading.local):
-    context: Optional[context.Context]
+    context: context.Context | None
 
     def __init__(self) -> None:
         self.context = None
@@ -177,7 +169,7 @@ def _match_org_with_fetched_org_entities(
 
     Args:
         organization: The organization name to match
-        orgs: List of tuples containing (org_entity_name, org_display_name)
+        orgs: list of tuples containing (org_entity_name, org_display_name)
 
     Returns:
         str: The matched org entity name
@@ -226,22 +218,21 @@ class Api:
 
     def __init__(
         self,
-        default_settings: Optional[
-            Union[
-                "wandb.sdk.wandb_settings.Settings",
-                "wandb.sdk.internal.settings_static.SettingsStatic",
-                Settings,
-                dict,
-            ]
-        ] = None,
+        default_settings: wandb.sdk.wandb_settings.Settings
+        | wandb.sdk.internal.settings_static.SettingsStatic
+        | Settings
+        | dict
+        | None = None,
         load_settings: bool = True,
         retry_timedelta: datetime.timedelta = datetime.timedelta(  # okay because it's immutable
             days=7
         ),
         environ: MutableMapping = os.environ,
-        retry_callback: Optional[Callable[[int, str], Any]] = None,
-        api_key: Optional[str] = None,
+        retry_callback: Callable[[int, str], Any] | None = None,
+        api_key: str | None = None,
     ) -> None:
+        import requests
+
         self._environ = environ
         self._global_context = context.Context()
         self._local_data = _ThreadLocalData()
@@ -321,7 +312,7 @@ class Api:
             retryable_exceptions=(RetryError, requests.RequestException),
             retry_callback=retry_callback,
         )
-        self._current_run_id: Optional[str] = None
+        self._current_run_id: str | None = None
         self._file_stream_api = None
         self._upload_file_session = requests.Session()
         if self.FILE_PUSHER_TIMEOUT:
@@ -341,28 +332,28 @@ class Api:
                 self.upload_multipart_file_chunk
             )
         )
-        self._client_id_mapping: Dict[str, str] = {}
+        self._client_id_mapping: dict[str, str] = {}
         # Large file uploads to azure can optionally use their SDK
         self._azure_blob_module = util.get_module("azure.storage.blob")
 
-        self.query_types: Optional[List[str]] = None
-        self.mutation_types: Optional[List[str]] = None
-        self.server_info_types: Optional[List[str]] = None
-        self.server_use_artifact_input_info: Optional[List[str]] = None
-        self.server_create_artifact_input_info: Optional[List[str]] = None
-        self.server_artifact_fields_info: Optional[List[str]] = None
-        self.server_organization_type_fields_info: Optional[List[str]] = None
-        self.server_supports_enabling_artifact_usage_tracking: Optional[bool] = None
-        self._max_cli_version: Optional[str] = None
-        self._server_settings_type: Optional[List[str]] = None
-        self.fail_run_queue_item_input_info: Optional[List[str]] = None
-        self.create_launch_agent_input_info: Optional[List[str]] = None
-        self.server_create_run_queue_supports_drc: Optional[bool] = None
-        self.server_create_run_queue_supports_priority: Optional[bool] = None
-        self.server_supports_template_variables: Optional[bool] = None
-        self.server_push_to_run_queue_supports_priority: Optional[bool] = None
+        self.query_types: list[str] | None = None
+        self.mutation_types: list[str] | None = None
+        self.server_info_types: list[str] | None = None
+        self.server_use_artifact_input_info: list[str] | None = None
+        self.server_create_artifact_input_info: list[str] | None = None
+        self.server_artifact_fields_info: list[str] | None = None
+        self.server_organization_type_fields_info: list[str] | None = None
+        self.server_supports_enabling_artifact_usage_tracking: bool | None = None
+        self._max_cli_version: str | None = None
+        self._server_settings_type: list[str] | None = None
+        self.fail_run_queue_item_input_info: list[str] | None = None
+        self.create_launch_agent_input_info: list[str] | None = None
+        self.server_create_run_queue_supports_drc: bool | None = None
+        self.server_create_run_queue_supports_priority: bool | None = None
+        self.server_supports_template_variables: bool | None = None
+        self.server_push_to_run_queue_supports_priority: bool | None = None
 
-        self._server_features_cache: Optional[Dict[str, bool]] = None
+        self._server_features_cache: dict[str, bool] | None = None
 
     def gql(self, *args: Any, **kwargs: Any) -> Any:
         ret = self._retry_gql(
@@ -372,7 +363,7 @@ class Api:
         )
         return ret
 
-    def set_local_context(self, api_context: Optional[context.Context]) -> None:
+    def set_local_context(self, api_context: context.Context | None) -> None:
         self._local_data.context = api_context
 
     def clear_local_context(self) -> None:
@@ -390,8 +381,10 @@ class Api:
         """Ensure the current api points to the right server."""
         self.client.transport.url = "{}/graphql".format(self.settings("base_url"))
 
-    def execute(self, *args: Any, **kwargs: Any) -> "_Response":
+    def execute(self, *args: Any, **kwargs: Any) -> _Response:
         """Wrapper around execute that logs in cases of failure."""
+        import requests
+
         try:
             return self.client.execute(*args, **kwargs)  # type: ignore
         except requests.exceptions.HTTPError as err:
@@ -411,7 +404,7 @@ class Api:
         self._current_run_id = run_id
 
     @property
-    def current_run_id(self) -> Optional[str]:
+    def current_run_id(self) -> str | None:
         return self._current_run_id
 
     @property
@@ -419,7 +412,9 @@ class Api:
         return f"W&B Internal Client {wandb.__version__}"
 
     @property
-    def api_key(self) -> Optional[str]:
+    def api_key(self) -> str | None:
+        import requests
+
         if _thread_local_api_settings.api_key:
             return _thread_local_api_settings.api_key
         auth = requests.utils.get_netrc_auth(self.api_url)
@@ -428,13 +423,13 @@ class Api:
             key = auth[-1]
 
         # Environment should take precedence
-        env_key: Optional[str] = self._environ.get(env.API_KEY)
-        sagemaker_key: Optional[str] = parse_sm_secrets().get(env.API_KEY)
-        default_key: Optional[str] = self.default_settings.get("api_key")
+        env_key: str | None = self._environ.get(env.API_KEY)
+        sagemaker_key: str | None = parse_sm_secrets().get(env.API_KEY)
+        default_key: str | None = self.default_settings.get("api_key")
         return env_key or key or sagemaker_key or default_key
 
     @property
-    def access_token(self) -> Optional[str]:
+    def access_token(self) -> str | None:
         """Retrieves an access token for authentication.
 
         This function attempts to exchange an identity token for a temporary
@@ -443,7 +438,7 @@ class Api:
         variables. If the environment variable is not set, it returns None.
 
         Returns:
-            Optional[str]: The access token if available, otherwise None if
+            str | None: The access token if available, otherwise None if
             no identity token is supplied.
         Raises:
             AuthenticationError: If the path to the identity token is not found.
@@ -474,7 +469,7 @@ class Api:
     def default_entity(self) -> str:
         return self.viewer().get("entity")  # type: ignore
 
-    def settings(self, key: Optional[str] = None, section: Optional[str] = None) -> Any:
+    def settings(self, key: str | None = None, section: str | None = None) -> Any:
         """The settings overridden from the wandb/settings file.
 
         Args:
@@ -562,8 +557,8 @@ class Api:
             self.relocate()
 
     def parse_slug(
-        self, slug: str, project: Optional[str] = None, run: Optional[str] = None
-    ) -> Tuple[str, str]:
+        self, slug: str, project: str | None = None, run: str | None = None
+    ) -> tuple[str, str]:
         """Parse a slug into a project and run.
 
         Args:
@@ -589,7 +584,7 @@ class Api:
         return project, run
 
     @normalize_exceptions
-    def server_info_introspection(self) -> Tuple[List[str], List[str], List[str]]:
+    def server_info_introspection(self) -> tuple[list[str], list[str], list[str]]:
         query_string = """
            query ProbeServerCapabilities {
                QueryType: __type(name: "Query") {
@@ -658,7 +653,7 @@ class Api:
                 else []
             )
 
-    def server_use_artifact_input_introspection(self) -> List:
+    def server_use_artifact_input_introspection(self) -> list:
         query_string = """
            query ProbeServerUseArtifactInput {
                UseArtifactInputInfoType: __type(name: "UseArtifactInput") {
@@ -682,7 +677,7 @@ class Api:
         return self.server_use_artifact_input_info
 
     @normalize_exceptions
-    def launch_agent_introspection(self) -> Optional[str]:
+    def launch_agent_introspection(self) -> str | None:
         query = gql(
             """
             query LaunchAgentIntrospection {
@@ -697,7 +692,7 @@ class Api:
         return res.get("LaunchAgentType") or None
 
     @normalize_exceptions
-    def create_run_queue_introspection(self) -> Tuple[bool, bool, bool]:
+    def create_run_queue_introspection(self) -> tuple[bool, bool, bool]:
         _, _, mutations = self.server_info_introspection()
         query_string = """
            query ProbeCreateRunQueueInput {
@@ -741,7 +736,7 @@ class Api:
         return "upsertRunQueue" in mutations
 
     @normalize_exceptions
-    def push_to_run_queue_introspection(self) -> Tuple[bool, bool]:
+    def push_to_run_queue_introspection(self) -> tuple[bool, bool]:
         query_string = """
             query ProbePushToRunQueueInput {
                 PushToRunQueueInputType: __type(name: "PushToRunQueueInput") {
@@ -788,7 +783,7 @@ class Api:
         return "failRunQueueItem" in mutations
 
     @normalize_exceptions
-    def fail_run_queue_item_fields_introspection(self) -> List:
+    def fail_run_queue_item_fields_introspection(self) -> list:
         if self.fail_run_queue_item_input_info:
             return self.fail_run_queue_item_input_info
         query_string = """
@@ -818,11 +813,11 @@ class Api:
         run_queue_item_id: str,
         message: str,
         stage: str,
-        file_paths: Optional[List[str]] = None,
+        file_paths: list[str] | None = None,
     ) -> bool:
         if not self.fail_run_queue_item_introspection():
             return False
-        variable_values: Dict[str, Union[str, Optional[List[str]]]] = {
+        variable_values: dict[str, str | (list[str] | None)] = {
             "runQueueItemId": run_queue_item_id,
         }
         if "message" in self.fail_run_queue_item_fields_introspection():
@@ -866,7 +861,7 @@ class Api:
         _, _, mutations = self.server_info_introspection()
         return "updateRunQueueItemWarning" in mutations
 
-    def _server_features(self) -> Dict[str, bool]:
+    def _server_features(self) -> dict[str, bool]:
         # NOTE: Avoid caching via `@cached_property`, due to undocumented
         # locking behavior before Python 3.12.
         # See: https://github.com/python/cpython/issues/87634
@@ -888,7 +883,7 @@ class Api:
                 self._server_features_cache = {}
         return self._server_features_cache
 
-    def _server_supports(self, feature: Union[int, str]) -> bool:
+    def _server_supports(self, feature: int | str) -> bool:
         """Return whether the current server supports the given feature.
 
         This also caches the underlying lookup of server feature flags,
@@ -910,7 +905,7 @@ class Api:
         run_queue_item_id: str,
         message: str,
         stage: str,
-        file_paths: Optional[List[str]] = None,
+        file_paths: list[str] | None = None,
     ) -> bool:
         if not self.update_run_queue_item_warning_introspection():
             return False
@@ -943,7 +938,7 @@ class Api:
         return result
 
     @normalize_exceptions
-    def viewer(self) -> Dict[str, Any]:
+    def viewer(self) -> dict[str, Any]:
         query = gql(
             """
         query Viewer{
@@ -967,7 +962,7 @@ class Api:
         return res.get("viewer") or {}
 
     @normalize_exceptions
-    def max_cli_version(self) -> Optional[str]:
+    def max_cli_version(self) -> str | None:
         if self._max_cli_version is not None:
             return self._max_cli_version
 
@@ -985,7 +980,7 @@ class Api:
         return self._max_cli_version
 
     @normalize_exceptions
-    def viewer_server_info(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def viewer_server_info(self) -> tuple[dict[str, Any], dict[str, Any]]:
         local_query = """
             latestLocalVersionInfo {
                 outOfDate
@@ -1040,7 +1035,7 @@ class Api:
         return res.get("viewer") or {}, res.get("serverInfo") or {}
 
     @normalize_exceptions
-    def list_projects(self, entity: Optional[str] = None) -> List[Dict[str, str]]:
+    def list_projects(self, entity: str | None = None) -> list[dict[str, str]]:
         """List projects in W&B scoped by entity.
 
         Args:
@@ -1064,7 +1059,7 @@ class Api:
         }
         """
         )
-        project_list: List[Dict[str, str]] = self._flatten_edges(
+        project_list: list[dict[str, str]] = self._flatten_edges(
             self.gql(
                 query, variable_values={"entity": entity or self.settings("entity")}
             )["models"]
@@ -1072,7 +1067,7 @@ class Api:
         return project_list
 
     @normalize_exceptions
-    def project(self, project: str, entity: Optional[str] = None) -> "_Response":
+    def project(self, project: str, entity: str | None = None) -> _Response:
         """Retrieve project.
 
         Args:
@@ -1105,9 +1100,9 @@ class Api:
         self,
         sweep: str,
         specs: str,
-        project: Optional[str] = None,
-        entity: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        project: str | None = None,
+        entity: str | None = None,
+    ) -> dict[str, Any]:
         """Retrieve sweep.
 
         Args:
@@ -1172,15 +1167,15 @@ class Api:
         )
         if response["project"] is None or response["project"]["sweep"] is None:
             raise ValueError(f"Sweep {entity}/{project}/{sweep} not found")
-        data: Dict[str, Any] = response["project"]["sweep"]
+        data: dict[str, Any] = response["project"]["sweep"]
         if data:
             data["runs"] = self._flatten_edges(data["runs"])
         return data
 
     @normalize_exceptions
     def list_runs(
-        self, project: str, entity: Optional[str] = None
-    ) -> List[Dict[str, str]]:
+        self, project: str, entity: str | None = None
+    ) -> list[dict[str, str]]:
         """List runs in W&B scoped by project.
 
         Args:
@@ -1220,8 +1215,8 @@ class Api:
 
     @normalize_exceptions
     def run_config(
-        self, project: str, run: Optional[str] = None, entity: Optional[str] = None
-    ) -> Tuple[str, Dict[str, Any], Optional[str], Dict[str, Any]]:
+        self, project: str, run: str | None = None, entity: str | None = None
+    ) -> tuple[str, dict[str, Any], str | None, dict[str, Any]]:
         """Get the relevant configs for a run.
 
         Args:
@@ -1229,6 +1224,8 @@ class Api:
             run (str, optional): The run to download
             entity (str, optional): The entity to scope this project to.
         """
+        import requests
+
         check_httpclient_logger_handler()
 
         query = gql(
@@ -1270,9 +1267,9 @@ class Api:
         }
 
         commit: str = ""
-        config: Dict[str, Any] = {}
-        patch: Optional[str] = None
-        metadata: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
+        patch: str | None = None
+        metadata: dict[str, Any] = {}
 
         # If we use the `names` parameter on the `files` node, then the server
         # will helpfully give us and 'open' file handle to the files that don't
@@ -1288,7 +1285,7 @@ class Api:
             response = self.gql(query, variable_values=variable_values)
             if response["model"] is None:
                 raise CommError(f"Run {entity}/{project}/{run} not found")
-            run_obj: Dict = response["model"]["bucket"]
+            run_obj: dict = response["model"]["bucket"]
             # we only need to fetch this config once
             if variable_values["includeConfig"]:
                 commit = run_obj["commit"]
@@ -1310,7 +1307,7 @@ class Api:
     @normalize_exceptions
     def run_resume_status(
         self, entity: str, project_name: str, name: str
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Check if a run exists and get resume information.
 
         Args:
@@ -1366,7 +1363,7 @@ class Api:
         if "entity" in project:
             self.set_setting("entity", project["entity"]["name"])
 
-        result: Dict[str, Any] = project["bucket"]
+        result: dict[str, Any] = project["bucket"]
 
         return result
 
@@ -1412,10 +1409,10 @@ class Api:
     def upsert_project(
         self,
         project: str,
-        id: Optional[str] = None,
-        description: Optional[str] = None,
-        entity: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        id: str | None = None,
+        description: str | None = None,
+        entity: str | None = None,
+    ) -> dict[str, Any]:
         """Create a new project.
 
         Args:
@@ -1444,7 +1441,7 @@ class Api:
                 "id": id,
             },
         )
-        result: Dict[str, Any] = response["upsertModel"]["model"]
+        result: dict[str, Any] = response["upsertModel"]["model"]
         return result
 
     @normalize_exceptions
@@ -1474,7 +1471,7 @@ class Api:
         return is_team
 
     @normalize_exceptions
-    def get_project_run_queues(self, entity: str, project: str) -> List[Dict[str, str]]:
+    def get_project_run_queues(self, entity: str, project: str) -> list[dict[str, str]]:
         query = gql(
             """
         query ProjectRunQueues($entity: String!, $projectName: String!){
@@ -1510,7 +1507,7 @@ class Api:
 
             raise Exception(msg)
 
-        project_run_queues: List[Dict[str, str]] = res["project"]["runQueues"]
+        project_run_queues: list[dict[str, str]] = res["project"]["runQueues"]
         return project_run_queues
 
     @normalize_exceptions
@@ -1519,8 +1516,8 @@ class Api:
         entity: str,
         resource: str,
         config: str,
-        template_variables: Optional[Dict[str, Union[float, int, str]]],
-    ) -> Optional[Dict[str, Any]]:
+        template_variables: dict[str, float | int | str] | None,
+    ) -> dict[str, Any] | None:
         if not self.create_default_resource_config_introspection():
             raise Exception()
         supports_template_vars, _ = self.push_to_run_queue_introspection()
@@ -1573,7 +1570,7 @@ class Api:
         """
         )
 
-        result: Optional[Dict[str, Any]] = self.gql(query, variable_values)[
+        result: dict[str, Any] | None = self.gql(query, variable_values)[
             "createDefaultResourceConfig"
         ]
         return result
@@ -1585,9 +1582,9 @@ class Api:
         project: str,
         queue_name: str,
         access: str,
-        prioritization_mode: Optional[str] = None,
-        config_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+        prioritization_mode: str | None = None,
+        config_id: str | None = None,
+    ) -> dict[str, Any] | None:
         (
             create_run_queue,
             supports_drc,
@@ -1677,7 +1674,7 @@ class Api:
                 "defaultResourceConfigID": config_id,
             }
 
-        result: Optional[Dict[str, Any]] = self.gql(query, variable_values)[
+        result: dict[str, Any] | None = self.gql(query, variable_values)[
             "createRunQueue"
         ]
         return result
@@ -1690,10 +1687,10 @@ class Api:
         resource_type: str,
         resource_config: dict,
         project: str = LAUNCH_DEFAULT_PROJECT,
-        prioritization_mode: Optional[str] = None,
-        template_variables: Optional[dict] = None,
-        external_links: Optional[dict] = None,
-    ) -> Optional[Dict[str, Any]]:
+        prioritization_mode: str | None = None,
+        template_variables: dict | None = None,
+        external_links: dict | None = None,
+    ) -> dict[str, Any] | None:
         if not self.upsert_run_queue_introspection():
             raise UnsupportedError(
                 "upserting run queues is not supported by this version of "
@@ -1743,7 +1740,7 @@ class Api:
             "prioritizationMode": prioritization_mode,
             "externalLinks": json.dumps(external_links) if external_links else None,
         }
-        result: Dict[str, Any] = self.gql(query, variable_values)
+        result: dict[str, Any] = self.gql(query, variable_values)
         return result["upsertRunQueue"]
 
     @normalize_exceptions
@@ -1753,9 +1750,9 @@ class Api:
         project: str,
         queue_name: str,
         run_spec: str,
-        template_variables: Optional[Dict[str, Union[int, float, str]]],
-        priority: Optional[int] = None,
-    ) -> Optional[Dict[str, Any]]:
+        template_variables: dict[str, int | float | str] | None,
+        priority: int | None = None,
+    ) -> dict[str, Any] | None:
         self.push_to_run_queue_introspection()
         """Queryless mutation, should be used before legacy fallback method."""
 
@@ -1773,7 +1770,7 @@ class Api:
             runSpec: $runSpec
         """
 
-        variables: Dict[str, Any] = {
+        variables: dict[str, Any] = {
             "entityName": entity,
             "projectName": project,
             "queueName": queue_name,
@@ -1821,7 +1818,7 @@ class Api:
         )
 
         try:
-            result: Optional[Dict[str, Any]] = self.gql(
+            result: dict[str, Any] | None = self.gql(
                 mutation, variables, check_retry_fn=util.no_retry_4xx
             ).get("pushToRunQueueByName")
             if not result:
@@ -1874,11 +1871,11 @@ class Api:
     def push_to_run_queue(
         self,
         queue_name: str,
-        launch_spec: Dict[str, str],
-        template_variables: Optional[dict],
+        launch_spec: dict[str, str],
+        template_variables: dict | None,
         project_queue: str,
-        priority: Optional[int] = None,
-    ) -> Optional[Dict[str, Any]]:
+        priority: int | None = None,
+    ) -> dict[str, Any] | None:
         self.push_to_run_queue_introspection()
         entity = launch_spec.get("queue_entity") or launch_spec["entity"]
         run_spec = json.dumps(launch_spec)
@@ -1983,17 +1980,17 @@ class Api:
         if not response.get("pushToRunQueue"):
             raise CommError(f"Error pushing run queue item to queue {queue_name}.")
 
-        result: Optional[Dict[str, Any]] = response["pushToRunQueue"]
+        result: dict[str, Any] | None = response["pushToRunQueue"]
         return result
 
     @normalize_exceptions
     def pop_from_run_queue(
         self,
         queue_name: str,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
-        agent_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+        entity: str | None = None,
+        project: str | None = None,
+        agent_id: str | None = None,
+    ) -> dict[str, Any] | None:
         mutation = gql(
             """
         mutation popFromRunQueue($entity: String!, $project: String!, $queueName: String!, $launchAgentId: ID)  {
@@ -2018,11 +2015,11 @@ class Api:
                 "launchAgentId": agent_id,
             },
         )
-        result: Optional[Dict[str, Any]] = response["popFromRunQueue"]
+        result: dict[str, Any] | None = response["popFromRunQueue"]
         return result
 
     @normalize_exceptions
-    def ack_run_queue_item(self, item_id: str, run_id: Optional[str] = None) -> bool:
+    def ack_run_queue_item(self, item_id: str, run_id: str | None = None) -> bool:
         mutation = gql(
             """
         mutation ackRunQueueItem($itemId: ID!, $runId: String!)  {
@@ -2043,7 +2040,7 @@ class Api:
         return result
 
     @normalize_exceptions
-    def create_launch_agent_fields_introspection(self) -> List:
+    def create_launch_agent_fields_introspection(self) -> list:
         if self.create_launch_agent_input_info:
             return self.create_launch_agent_input_info
         query_string = """
@@ -2072,8 +2069,8 @@ class Api:
         self,
         entity: str,
         project: str,
-        queues: List[str],
-        agent_config: Dict[str, Any],
+        queues: list[str],
+        agent_config: dict[str, Any],
         version: str,
         gorilla_agent_support: bool,
     ) -> dict:
@@ -2220,26 +2217,26 @@ class Api:
     @normalize_exceptions
     def upsert_run(
         self,
-        id: Optional[str] = None,
-        name: Optional[str] = None,
-        project: Optional[str] = None,
-        host: Optional[str] = None,
-        group: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-        config: Optional[dict] = None,
-        description: Optional[str] = None,
-        entity: Optional[str] = None,
-        state: Optional[str] = None,
-        display_name: Optional[str] = None,
-        notes: Optional[str] = None,
-        repo: Optional[str] = None,
-        job_type: Optional[str] = None,
-        program_path: Optional[str] = None,
-        commit: Optional[str] = None,
-        sweep_name: Optional[str] = None,
-        summary_metrics: Optional[str] = None,
-        num_retries: Optional[int] = None,
-    ) -> Tuple[dict, bool, Optional[List]]:
+        id: str | None = None,
+        name: str | None = None,
+        project: str | None = None,
+        host: str | None = None,
+        group: str | None = None,
+        tags: list[str] | None = None,
+        config: dict | None = None,
+        description: str | None = None,
+        entity: str | None = None,
+        state: str | None = None,
+        display_name: str | None = None,
+        notes: str | None = None,
+        repo: str | None = None,
+        job_type: str | None = None,
+        program_path: str | None = None,
+        commit: str | None = None,
+        sweep_name: str | None = None,
+        summary_metrics: str | None = None,
+        num_retries: int | None = None,
+    ) -> tuple[dict, bool, list | None]:
         """Update a run.
 
         Args:
@@ -2394,10 +2391,10 @@ class Api:
             **kwargs,
         )
 
-        run_obj: Dict[str, Dict[str, Dict[str, str]]] = response["upsertBucket"][
+        run_obj: dict[str, dict[str, dict[str, str]]] = response["upsertBucket"][
             "bucket"
         ]
-        project_obj: Dict[str, Dict[str, str]] = run_obj.get("project", {})
+        project_obj: dict[str, dict[str, str]] = run_obj.get("project", {})
         if project_obj:
             self.set_setting("project", project_obj["name"])
             entity_obj = project_obj.get("entity", {})
@@ -2424,10 +2421,10 @@ class Api:
         run_name: str,
         metric_name: str,
         metric_value: float,
-        program_path: Optional[str] = None,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
-        num_retries: Optional[int] = None,
+        program_path: str | None = None,
+        entity: str | None = None,
+        project: str | None = None,
+        num_retries: int | None = None,
     ) -> dict:
         """Rewinds a run to a previous state.
 
@@ -2513,10 +2510,10 @@ class Api:
             **kwargs,
         )
 
-        run_obj: Dict[str, Dict[str, Dict[str, str]]] = response.get(
+        run_obj: dict[str, dict[str, dict[str, str]]] = response.get(
             "rewindRun", {}
         ).get("rewoundRun", {})
-        project_obj: Dict[str, Dict[str, str]] = run_obj.get("project", {})
+        project_obj: dict[str, dict[str, str]] = run_obj.get("project", {})
         if project_obj:
             self.set_setting("project", project_obj["name"])
             entity_obj = project_obj.get("entity", {})
@@ -2607,11 +2604,11 @@ class Api:
     def upload_urls(
         self,
         project: str,
-        files: Union[List[str], Dict[str, IO]],
-        run: Optional[str] = None,
-        entity: Optional[str] = None,
-        description: Optional[str] = None,
-    ) -> Tuple[str, List[str], Dict[str, Dict[str, Any]]]:
+        files: list[str] | dict[str, IO],
+        run: str | None = None,
+        entity: str | None = None,
+        description: str | None = None,
+    ) -> tuple[str, list[str], dict[str, dict[str, Any]]]:
         """Generate temporary resumable upload urls.
 
         Args:
@@ -2681,11 +2678,11 @@ class Api:
     def legacy_upload_urls(
         self,
         project: str,
-        files: Union[List[str], Dict[str, IO]],
-        run: Optional[str] = None,
-        entity: Optional[str] = None,
-        description: Optional[str] = None,
-    ) -> Tuple[str, List[str], Dict[str, Dict[str, Any]]]:
+        files: list[str] | dict[str, IO],
+        run: str | None = None,
+        entity: str | None = None,
+        description: str | None = None,
+    ) -> tuple[str, list[str], dict[str, dict[str, Any]]]:
         """Generate temporary resumable upload urls.
 
         A new mutation createRunFiles was introduced after 0.15.4.
@@ -2746,9 +2743,9 @@ class Api:
     def download_urls(
         self,
         project: str,
-        run: Optional[str] = None,
-        entity: Optional[str] = None,
-    ) -> Dict[str, Dict[str, str]]:
+        run: str | None = None,
+        entity: str | None = None,
+    ) -> dict[str, dict[str, str]]:
         """Generate download urls.
 
         Args:
@@ -2805,9 +2802,9 @@ class Api:
         self,
         project: str,
         file_name: str,
-        run: Optional[str] = None,
-        entity: Optional[str] = None,
-    ) -> Optional[Dict[str, str]]:
+        run: str | None = None,
+        entity: str | None = None,
+    ) -> dict[str, str] | None:
         """Generate download urls.
 
         Args:
@@ -2860,7 +2857,7 @@ class Api:
             return None
 
     @normalize_exceptions
-    def download_file(self, url: str) -> Tuple[int, requests.Response]:
+    def download_file(self, url: str) -> tuple[int, requests.Response]:
         """Initiate a streaming download.
 
         Args:
@@ -2869,6 +2866,8 @@ class Api:
         Returns:
             A tuple of the content length and the streaming response
         """
+        import requests
+
         check_httpclient_logger_handler()
 
         http_headers = _thread_local_api_settings.headers or {}
@@ -2892,9 +2891,9 @@ class Api:
     @normalize_exceptions
     def download_write_file(
         self,
-        metadata: Dict[str, str],
-        out_dir: Optional[str] = None,
-    ) -> Tuple[str, Optional[requests.Response]]:
+        metadata: dict[str, str],
+        out_dir: str | None = None,
+    ) -> tuple[str, requests.Response | None]:
         """Download a file from a run and write it to wandb/.
 
         Args:
@@ -2919,9 +2918,10 @@ class Api:
         return path, response
 
     def upload_file_azure(
-        self, url: str, file: Any, extra_headers: Dict[str, str]
+        self, url: str, file: Any, extra_headers: dict[str, str]
     ) -> None:
         """Upload a file to azure."""
+        import requests
         from azure.core.exceptions import AzureError  # type: ignore
 
         # Configure the client without retries so our existing logic can handle them
@@ -2930,7 +2930,7 @@ class Api:
         )
         try:
             if extra_headers.get("Content-MD5") is not None:
-                md5: Optional[bytes] = base64.b64decode(extra_headers["Content-MD5"])
+                md5: bytes | None = base64.b64decode(extra_headers["Content-MD5"])
             else:
                 md5 = None
             content_settings = self._azure_blob_module.ContentSettings(
@@ -2957,8 +2957,8 @@ class Api:
         self,
         url: str,
         upload_chunk: bytes,
-        extra_headers: Optional[Dict[str, str]] = None,
-    ) -> Optional[requests.Response]:
+        extra_headers: dict[str, str] | None = None,
+    ) -> requests.Response | None:
         """Upload a file chunk to S3 with failure resumption.
 
         Args:
@@ -2969,6 +2969,8 @@ class Api:
         Returns:
             The `requests` library response object
         """
+        import requests
+
         check_httpclient_logger_handler()
         try:
             if env.is_debug(env=self._environ):
@@ -3006,9 +3008,9 @@ class Api:
         self,
         url: str,
         file: IO[bytes],
-        callback: Optional["ProgressFn"] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-    ) -> Optional[requests.Response]:
+        callback: ProgressFn | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> requests.Response | None:
         """Upload a file to W&B with failure resumption.
 
         Args:
@@ -3021,9 +3023,11 @@ class Api:
         Returns:
             The `requests` library response object
         """
+        import requests
+
         check_httpclient_logger_handler()
         extra_headers = extra_headers.copy() if extra_headers else {}
-        response: Optional[requests.Response] = None
+        response: requests.Response | None = None
         progress = Progress(file, callback=callback)
         try:
             if "x-ms-blob-type" in extra_headers and self._azure_blob_module:
@@ -3074,9 +3078,9 @@ class Api:
     def register_agent(
         self,
         host: str,
-        sweep_id: Optional[str] = None,
-        project_name: Optional[str] = None,
-        entity: Optional[str] = None,
+        sweep_id: str | None = None,
+        project_name: str | None = None,
+        entity: str | None = None,
     ) -> dict:
         """Register a new agent.
 
@@ -3127,7 +3131,7 @@ class Api:
 
     def agent_heartbeat(
         self, agent_id: str, metrics: dict, run_states: dict
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Notify server about agent state, receive commands.
 
         Args:
@@ -3135,7 +3139,7 @@ class Api:
             metrics (dict): system metrics
             run_states (dict): run_id: state mapping
         Returns:
-            List of commands to execute.
+            list of commands to execute.
         """
         mutation = gql(
             """
@@ -3175,7 +3179,7 @@ class Api:
             logger.exception("Error communicating with W&B.")
             return []
         else:
-            result: List[Dict[str, Any]] = json.loads(
+            result: list[dict[str, Any]] = json.loads(
                 response["agentHeartbeat"]["commands"]
             )
             return result
@@ -3223,17 +3227,17 @@ class Api:
     def upsert_sweep(
         self,
         config: dict,
-        controller: Optional[str] = None,
-        launch_scheduler: Optional[str] = None,
-        scheduler: Optional[str] = None,
-        obj_id: Optional[str] = None,
-        project: Optional[str] = None,
-        entity: Optional[str] = None,
-        state: Optional[str] = None,
-        prior_runs: Optional[List[str]] = None,
-        display_name: Optional[str] = None,
-        template_variable_values: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[str, List[str]]:
+        controller: str | None = None,
+        launch_scheduler: str | None = None,
+        scheduler: str | None = None,
+        obj_id: str | None = None,
+        project: str | None = None,
+        entity: str | None = None,
+        state: str | None = None,
+        prior_runs: list[str] | None = None,
+        display_name: str | None = None,
+        template_variable_values: dict[str, Any] | None = None,
+    ) -> tuple[str, list[str]]:
         """Upsert a sweep object.
 
         Args:
@@ -3249,6 +3253,8 @@ class Api:
             display_name (str): display name for the sweep
             template_variable_values (dict): template variable values
         """
+        import yaml
+
         project_query = """
             project {
                 id
@@ -3336,16 +3342,28 @@ class Api:
 
         config = self._validate_config_and_fill_distribution(config)
 
-        # Silly, but attr-dicts like EasyDicts don't serialize correctly to yaml.
+        # Silly, but attr-dicts like Easydicts don't serialize correctly to yaml.
         # This sanitizes them with a round trip pass through json to get a regular dict.
+        class NonOctalStringDumper(yaml.Dumper):
+            """Prevents strings containing non-octal values like "008" and "009" from being converted to numbers in in the yaml string saved as the sweep config."""
+
+            def represent_scalar(self, tag, value, style=None):
+                if (
+                    tag == "tag:yaml.org,2002:str"
+                    and value.startswith("0")
+                    and len(value) > 1
+                ):
+                    return super().represent_scalar(tag, value, style="'")
+                return super().represent_scalar(tag, value, style)
+
         config_str = yaml.dump(
-            json.loads(json.dumps(config)), Dumper=util.NonOctalStringDumper
+            json.loads(json.dumps(config)), Dumper=NonOctalStringDumper
         )
         filters = None
         if prior_runs:
             filters = json.dumps({"$or": [{"name": r} for r in prior_runs]})
 
-        err: Optional[Exception] = None
+        err: Exception | None = None
         for mutation in mutations:
             try:
                 variables = {
@@ -3380,8 +3398,8 @@ class Api:
         if err:
             raise err
 
-        sweep: Dict[str, Dict[str, Dict]] = response["upsertSweep"]["sweep"]
-        project_obj: Dict[str, Dict] = sweep.get("project", {})
+        sweep: dict[str, dict[str, dict]] = response["upsertSweep"]["sweep"]
+        project_obj: dict[str, dict] = sweep.get("project", {})
         if project_obj:
             self.set_setting("project", project_obj["name"])
             entity_obj: dict = project_obj.get("entity", {})
@@ -3417,8 +3435,8 @@ class Api:
 
     @normalize_exceptions
     def pull(
-        self, project: str, run: Optional[str] = None, entity: Optional[str] = None
-    ) -> "List[requests.Response]":
+        self, project: str, run: str | None = None, entity: str | None = None
+    ) -> list[requests.Response]:
         """Download files from W&B.
 
         Args:
@@ -3446,14 +3464,14 @@ class Api:
     @normalize_exceptions
     def push(
         self,
-        files: Union[List[str], Dict[str, IO]],
-        run: Optional[str] = None,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
-        description: Optional[str] = None,
+        files: list[str] | dict[str, IO],
+        run: str | None = None,
+        entity: str | None = None,
+        project: str | None = None,
+        description: str | None = None,
         force: bool = True,
-        progress: Union[TextIO, Literal[False]] = False,
-    ) -> "List[Optional[requests.Response]]":
+        progress: TextIO | Literal[False] = False,
+    ) -> list[requests.Response | None]:
         """Uploads multiple files to W&B.
 
         Args:
@@ -3551,7 +3569,9 @@ class Api:
         project: str,
         aliases: Sequence[str],
         organization: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
+        from wandb.sdk.artifacts._validators import is_artifact_registry_project
+
         template = """
                 mutation LinkArtifact(
                     $artifactPortfolioName: String!,
@@ -3607,7 +3627,7 @@ class Api:
 
         mutation = gql(template)
         response = self.gql(mutation, variable_values=variable_values)
-        link_artifact: Dict[str, Any] = response["linkArtifact"]
+        link_artifact: dict[str, Any] = response["linkArtifact"]
         return link_artifact
 
     def _resolve_org_entity_name(self, entity: str, organization: str = "") -> str:
@@ -3650,14 +3670,14 @@ class Api:
             )
         return orgs_from_entity[0].entity_name
 
-    def _fetch_orgs_and_org_entities_from_entity(self, entity: str) -> List[_OrgNames]:
+    def _fetch_orgs_and_org_entities_from_entity(self, entity: str) -> list[_OrgNames]:
         """Fetches organization entity names and display names for a given entity.
 
         Args:
             entity (str): Entity name to lookup. Can be either a personal or team entity.
 
         Returns:
-            List[_OrgNames]: List of _OrgNames tuples. (_OrgNames(entity_name, display_name))
+            list[_OrgNames]: list of _OrgNames tuples. (_OrgNames(entity_name, display_name))
 
         Raises:
         ValueError: If entity is not found, has no organizations, or other validation errors.
@@ -3728,13 +3748,13 @@ class Api:
     def _construct_use_artifact_query(
         self,
         artifact_id: str,
-        entity_name: Optional[str] = None,
-        project_name: Optional[str] = None,
-        run_name: Optional[str] = None,
-        use_as: Optional[str] = None,
-        artifact_entity_name: Optional[str] = None,
-        artifact_project_name: Optional[str] = None,
-    ) -> Tuple[Document, Dict[str, Any]]:
+        entity_name: str | None = None,
+        project_name: str | None = None,
+        run_name: str | None = None,
+        use_as: str | None = None,
+        artifact_entity_name: str | None = None,
+        artifact_project_name: str | None = None,
+    ) -> tuple[Document, dict[str, Any]]:
         query_vars = [
             "$entityName: String!",
             "$projectName: String!",
@@ -3757,7 +3777,7 @@ class Api:
         project_name = project_name or self.settings("project")
         run_name = run_name or self.current_run_id
 
-        variable_values: Dict[str, Any] = {
+        variable_values: dict[str, Any] = {
             "entityName": entity_name,
             "projectName": project_name,
             "runName": run_name,
@@ -3808,13 +3828,13 @@ class Api:
     def use_artifact(
         self,
         artifact_id: str,
-        entity_name: Optional[str] = None,
-        project_name: Optional[str] = None,
-        run_name: Optional[str] = None,
-        artifact_entity_name: Optional[str] = None,
-        artifact_project_name: Optional[str] = None,
-        use_as: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+        entity_name: str | None = None,
+        project_name: str | None = None,
+        run_name: str | None = None,
+        artifact_entity_name: str | None = None,
+        artifact_project_name: str | None = None,
+        use_as: str | None = None,
+    ) -> dict[str, Any] | None:
         query, variable_values = self._construct_use_artifact_query(
             artifact_id,
             entity_name,
@@ -3827,12 +3847,12 @@ class Api:
         response = self.gql(query, variable_values)
 
         if response["useArtifact"]["artifact"]:
-            artifact: Dict[str, Any] = response["useArtifact"]["artifact"]
+            artifact: dict[str, Any] = response["useArtifact"]["artifact"]
             return artifact
         return None
 
     # Fetch fields available in backend of Organization type
-    def server_organization_type_introspection(self) -> List[str]:
+    def server_organization_type_introspection(self) -> list[str]:
         query_string = """
             query ProbeServerOrganization {
                 OrganizationInfoType: __type(name:"Organization") {
@@ -3874,7 +3894,7 @@ class Api:
         query = gql(query_string)
         res = self.gql(query)
         input_fields = res.get("ProjectInfoType", {}).get("fields", [{}])
-        artifact_args: List[Dict[str, str]] = next(
+        artifact_args: list[dict[str, str]] = next(
             (
                 field.get("args", [])
                 for field in input_fields
@@ -3891,10 +3911,10 @@ class Api:
     def create_artifact_type(
         self,
         artifact_type_name: str,
-        entity_name: Optional[str] = None,
-        project_name: Optional[str] = None,
-        description: Optional[str] = None,
-    ) -> Optional[str]:
+        entity_name: str | None = None,
+        project_name: str | None = None,
+        description: str | None = None,
+    ) -> str | None:
         mutation = gql(
             """
         mutation CreateArtifactType(
@@ -3927,10 +3947,10 @@ class Api:
                 "description": description,
             },
         )
-        _id: Optional[str] = response["createArtifactType"]["artifactType"]["id"]
+        _id: str | None = response["createArtifactType"]["artifactType"]["id"]
         return _id
 
-    def server_artifact_introspection(self) -> List[str]:
+    def server_artifact_introspection(self) -> list[str]:
         query_string = """
             query ProbeServerArtifact {
                 ArtifactInfoType: __type(name:"Artifact") {
@@ -3951,7 +3971,7 @@ class Api:
 
         return self.server_artifact_fields_info
 
-    def server_create_artifact_introspection(self) -> List[str]:
+    def server_create_artifact_introspection(self) -> list[str]:
         query_string = """
             query ProbeServerCreateArtifactInput {
                 CreateArtifactInputInfoType: __type(name:"CreateArtifactInput") {
@@ -3976,9 +3996,9 @@ class Api:
 
     def _get_create_artifact_mutation(
         self,
-        fields: List,
-        history_step: Optional[int],
-        distributed_id: Optional[str],
+        fields: list,
+        history_step: int | None,
+        distributed_id: str | None,
     ) -> str:
         types = ""
         values = ""
@@ -4060,20 +4080,20 @@ class Api:
         artifact_type_name: str,
         artifact_collection_name: str,
         digest: str,
-        client_id: Optional[str] = None,
-        sequence_client_id: Optional[str] = None,
-        entity_name: Optional[str] = None,
-        project_name: Optional[str] = None,
-        run_name: Optional[str] = None,
-        description: Optional[str] = None,
-        metadata: Optional[Dict] = None,
-        ttl_duration_seconds: Optional[int] = None,
-        aliases: Optional[List[Dict[str, str]]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-        distributed_id: Optional[str] = None,
-        is_user_created: Optional[bool] = False,
-        history_step: Optional[int] = None,
-    ) -> Tuple[Dict, Dict]:
+        client_id: str | None = None,
+        sequence_client_id: str | None = None,
+        entity_name: str | None = None,
+        project_name: str | None = None,
+        run_name: str | None = None,
+        description: str | None = None,
+        metadata: dict | None = None,
+        ttl_duration_seconds: int | None = None,
+        aliases: list[dict[str, str]] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        distributed_id: str | None = None,
+        is_user_created: bool | None = False,
+        history_step: int | None = None,
+    ) -> tuple[dict, dict]:
         fields = self.server_create_artifact_introspection()
         artifact_fields = self.server_artifact_introspection()
         if ("ttlIsInherited" not in artifact_fields) and ttl_duration_seconds:
@@ -4126,7 +4146,7 @@ class Api:
         )
         return av, latest
 
-    def commit_artifact(self, artifact_id: str) -> "_Response":
+    def commit_artifact(self, artifact_id: str) -> _Response:
         mutation = gql(
             """
         mutation CommitArtifact(
@@ -4155,10 +4175,10 @@ class Api:
         self,
         artifact_id: str,
         storage_path: str,
-        completed_parts: List[Dict[str, Any]],
-        upload_id: Optional[str],
+        completed_parts: list[dict[str, Any]],
+        upload_id: str | None,
         complete_multipart_action: str = "Complete",
-    ) -> Optional[str]:
+    ) -> str | None:
         mutation = gql(
             """
         mutation CompleteMultipartUploadArtifact(
@@ -4192,21 +4212,21 @@ class Api:
                 "uploadID": upload_id,
             },
         )
-        digest: Optional[str] = response["completeMultipartUploadArtifact"]["digest"]
+        digest: str | None = response["completeMultipartUploadArtifact"]["digest"]
         return digest
 
     def create_artifact_manifest(
         self,
         name: str,
         digest: str,
-        artifact_id: Optional[str],
-        base_artifact_id: Optional[str] = None,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
-        run: Optional[str] = None,
+        artifact_id: str | None,
+        base_artifact_id: str | None = None,
+        entity: str | None = None,
+        project: str | None = None,
+        run: str | None = None,
         include_upload: bool = True,
         type: str = "FULL",
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> tuple[str, dict[str, Any]]:
         mutation = gql(
             """
         mutation CreateArtifactManifest(
@@ -4274,10 +4294,10 @@ class Api:
     def update_artifact_manifest(
         self,
         artifact_manifest_id: str,
-        base_artifact_id: Optional[str] = None,
-        digest: Optional[str] = None,
-        include_upload: Optional[bool] = True,
-    ) -> Tuple[str, Dict[str, Any]]:
+        base_artifact_id: str | None = None,
+        digest: str | None = None,
+        include_upload: bool | None = True,
+    ) -> tuple[str, dict[str, Any]]:
         mutation = gql(
             """
         mutation UpdateArtifactManifest(
@@ -4322,8 +4342,8 @@ class Api:
         )
 
     def update_artifact_metadata(
-        self, artifact_id: str, metadata: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, artifact_id: str, metadata: dict[str, Any]
+    ) -> dict[str, Any]:
         """Set the metadata of the given artifact version."""
         mutation = gql(
             """
@@ -4354,7 +4374,7 @@ class Api:
     def _resolve_client_id(
         self,
         client_id: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         if client_id in self._client_id_mapping:
             return self._client_id_mapping[client_id]
 
@@ -4382,7 +4402,7 @@ class Api:
                     self._client_id_mapping[client_id] = server_id
         return server_id
 
-    def server_create_artifact_file_spec_input_introspection(self) -> List:
+    def server_create_artifact_file_spec_input_introspection(self) -> list:
         query_string = """
            query ProbeServerCreateArtifactFileSpecInput {
                 CreateArtifactFileSpecInputInfoType: __type(name:"CreateArtifactFileSpecInput") {
@@ -4405,8 +4425,8 @@ class Api:
 
     @normalize_exceptions
     def create_artifact_files(
-        self, artifact_files: Iterable["CreateArtifactFileSpecInput"]
-    ) -> Mapping[str, "CreateArtifactFilesResponseFile"]:
+        self, artifact_files: Iterable[CreateArtifactFileSpecInput]
+    ) -> Mapping[str, CreateArtifactFilesResponseFile]:
         query_template = """
         mutation CreateArtifactFiles(
             $storageLayout: ArtifactStorageLayout!
@@ -4482,8 +4502,8 @@ class Api:
         self,
         title: str,
         text: str,
-        level: Optional[str] = None,
-        wait_duration: Optional["Number"] = None,
+        level: str | None = None,
+        wait_duration: Number | None = None,
     ) -> bool:
         mutation = gql(
             """
@@ -4527,8 +4547,8 @@ class Api:
         return success
 
     def get_sweep_state(
-        self, sweep: str, entity: Optional[str] = None, project: Optional[str] = None
-    ) -> "SweepState":
+        self, sweep: str, entity: str | None = None, project: str | None = None
+    ) -> SweepState:
         state: SweepState = self.sweep(
             sweep=sweep, entity=entity, project=project, specs="{}"
         )["state"]
@@ -4537,9 +4557,9 @@ class Api:
     def set_sweep_state(
         self,
         sweep: str,
-        state: "SweepState",
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
+        state: SweepState,
+        entity: str | None = None,
+        project: str | None = None,
     ) -> None:
         assert state in ("RUNNING", "PAUSED", "CANCELED", "FINISHED")
         s = self.sweep(sweep=sweep, entity=entity, project=project, specs="{}")
@@ -4583,8 +4603,8 @@ class Api:
     def stop_sweep(
         self,
         sweep: str,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
+        entity: str | None = None,
+        project: str | None = None,
     ) -> None:
         """Finish the sweep to stop running new runs and let currently running runs finish."""
         self.set_sweep_state(
@@ -4594,8 +4614,8 @@ class Api:
     def cancel_sweep(
         self,
         sweep: str,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
+        entity: str | None = None,
+        project: str | None = None,
     ) -> None:
         """Cancel the sweep to kill all running runs and stop running new runs."""
         self.set_sweep_state(
@@ -4605,8 +4625,8 @@ class Api:
     def pause_sweep(
         self,
         sweep: str,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
+        entity: str | None = None,
+        project: str | None = None,
     ) -> None:
         """Pause the sweep to temporarily stop running new runs."""
         self.set_sweep_state(
@@ -4616,8 +4636,8 @@ class Api:
     def resume_sweep(
         self,
         sweep: str,
-        entity: Optional[str] = None,
-        project: Optional[str] = None,
+        entity: str | None = None,
+        project: str | None = None,
     ) -> None:
         """Resume the sweep to continue running new runs."""
         self.set_sweep_state(
@@ -4626,13 +4646,15 @@ class Api:
 
     def _status_request(self, url: str, length: int) -> requests.Response:
         """Ask google how much we've uploaded."""
+        import requests
+
         check_httpclient_logger_handler()
         return requests.put(
             url=url,
             headers={"Content-Length": "0", "Content-Range": f"bytes */{length}"},
         )
 
-    def _flatten_edges(self, response: "_Response") -> List[Dict]:
+    def _flatten_edges(self, response: _Response) -> list[dict]:
         """Return an array from the nested graphql relay structure."""
         return [node["node"] for node in response["edges"]]
 
@@ -4673,8 +4695,8 @@ class Api:
         display_name: str,
         spec_type: str,
         access: str,
-        spec: Union[str, Mapping[str, Any]],
-    ) -> Optional[Dict[str, Any]]:
+        spec: str | Mapping[str, Any],
+    ) -> dict[str, Any] | None:
         if not isinstance(spec, str):
             spec = json.dumps(spec)
 
@@ -4713,7 +4735,7 @@ class Api:
             "spec": spec,
         }
 
-        result: Optional[Dict[str, Any]] = self.gql(mutation, variable_values)[
+        result: dict[str, Any] | None = self.gql(mutation, variable_values)[
             "createCustomChart"
         ]
         return result

--- a/wandb/sdk/launch/_launch.py
+++ b/wandb/sdk/launch/_launch.py
@@ -4,8 +4,6 @@ import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
-import yaml
-
 import wandb
 from wandb.apis.internal import Api
 
@@ -75,6 +73,8 @@ def resolve_agent_config(
     Returns:
         Tuple[Dict[str, Any], Api]: The resolved config and api.
     """
+    import yaml
+
     defaults = {
         "max_jobs": 1,
         "max_schedulers": 1,

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -12,8 +12,6 @@ from dataclasses import dataclass
 from multiprocessing import Event
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import yaml
-
 import wandb
 from wandb.apis.internal import Api
 from wandb.errors import CommError
@@ -141,6 +139,8 @@ def construct_agent_configs(
     launch_config: Optional[Dict] = None,
     build_config: Optional[Dict] = None,
 ) -> Tuple[Optional[Dict[str, Any]], Dict[str, Any], Dict[str, Any]]:
+    import yaml
+
     registry_config = None
     environment_config = None
     if launch_config is not None:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -15,7 +15,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import click
-import yaml
 
 import wandb
 from wandb.errors import CommError
@@ -116,6 +115,8 @@ class Scheduler(ABC):
         num_workers: Optional[Union[int, str]] = None,
         **kwargs: Optional[Any],
     ):
+        import yaml
+
         from wandb.apis.public import Api as PublicApi
 
         self._api = api

--- a/wandb/sdk/launch/sweeps/utils.py
+++ b/wandb/sdk/launch/sweeps/utils.py
@@ -3,8 +3,6 @@ import os
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-import yaml
-
 import wandb
 from wandb import util
 from wandb.sdk.launch.errors import LaunchError
@@ -95,6 +93,8 @@ def handle_sweep_config_violations(warnings: List[str]) -> None:
 
 def load_sweep_config(sweep_config_path: str) -> Optional[Dict[str, Any]]:
     """Load a sweep yaml from path."""
+    import yaml
+
     try:
         yaml_file = open(sweep_config_path)
     except OSError:

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -9,13 +9,10 @@ import stat
 import sys
 import textwrap
 from functools import partial
-
-# import Literal
 from typing import TYPE_CHECKING, Callable, Literal
 from urllib.parse import urlparse
 
 import click
-from requests.utils import NETRC_FILES, get_netrc_auth
 
 import wandb
 from wandb.apis import InternalApi
@@ -67,7 +64,8 @@ def _fixup_anon_mode(default: Mode | None) -> Mode | None:
 
 def get_netrc_file_path() -> str:
     """Return the path to the netrc file."""
-    # if the NETRC environment variable is set, use that
+    from requests.utils import NETRC_FILES
+
     netrc_file = os.environ.get("NETRC")
     if netrc_file:
         return os.path.expanduser(netrc_file)
@@ -312,6 +310,8 @@ def write_key(
 
 
 def api_key(settings: Settings | None = None) -> str | None:
+    from requests.utils import get_netrc_auth
+
     if settings is None:
         settings = wandb_setup.singleton().settings
     if settings.api_key:

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -3,8 +3,6 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
-import yaml
-
 import wandb
 from wandb.errors import Error
 from wandb.util import load_yaml
@@ -45,6 +43,8 @@ def dict_no_value_from_proto_list(obj_list):
 
 # TODO(jhr): these functions should go away once we merge jobspec PR
 def save_config_file_from_dict(config_filename, config_dict):
+    import yaml
+
     s = b"wandb_version: 1"
     if config_dict:  # adding an empty dictionary here causes a parse error
         s += b"\n\n" + yaml.dump(
@@ -64,6 +64,8 @@ def save_config_file_from_dict(config_filename, config_dict):
 def dict_from_config_file(
     filename: str, must_exist: bool = False
 ) -> Optional[Dict[str, Any]]:
+    import yaml
+
     if not os.path.exists(filename):
         if must_exist:
             raise ConfigError(f"config file {filename} doesn't exist")

--- a/wandb/sdk/lib/credentials.py
+++ b/wandb/sdk/lib/credentials.py
@@ -3,8 +3,6 @@ import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import requests.utils
-
 from wandb.errors import AuthenticationError
 
 DEFAULT_WANDB_CREDENTIALS_FILE = Path(
@@ -109,6 +107,8 @@ def _create_access_token(base_url: str, token_file: Path) -> dict:
         OSError: If there is an issue reading the token file.
         AuthenticationError: If the server fails to provide an access token.
     """
+    import requests
+
     try:
         with open(token_file) as file:
             token = file.read().strip()

--- a/wandb/sdk/lib/gql_request.py
+++ b/wandb/sdk/lib/gql_request.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-import requests
 from wandb_gql.transport.http import HTTPTransport
 from wandb_graphql.execution import ExecutionResult
 from wandb_graphql.language import ast
@@ -35,6 +34,8 @@ class GraphQLSession(HTTPTransport):
             use_json (bool): Send request body as JSON instead of form-urlencoded
             timeout (int, float): Specifies a default timeout for requests (Default: None)
         """
+        import requests
+
         super().__init__(url, **kwargs)
         self.session = requests.Session()
         if proxies:

--- a/wandb/sdk/lib/retry.py
+++ b/wandb/sdk/lib/retry.py
@@ -9,8 +9,6 @@ import threading
 import time
 from typing import Any, Awaitable, Callable, Generic, Optional, Tuple, Type, TypeVar
 
-from requests import HTTPError
-
 import wandb
 import wandb.errors
 from wandb.util import CheckRetryFnType
@@ -183,6 +181,8 @@ class Retry(Generic[_R]):
         Args:
             exception: The most recent exception we will retry.
         """
+        from requests import HTTPError
+
         if (
             isinstance(exception, HTTPError)
             and exception.response is not None

--- a/wandb/sdk/lib/server.py
+++ b/wandb/sdk/lib/server.py
@@ -6,7 +6,6 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from wandb import util
-from wandb.apis import InternalApi
 
 if TYPE_CHECKING:
     from wandb.sdk.wandb_settings import Settings
@@ -17,6 +16,8 @@ class Server:
         self,
         settings: Settings,
     ) -> None:
+        from wandb.apis import InternalApi
+
         self._api = InternalApi(default_settings=settings)
         self._viewer: dict[str, Any] = {}
         self._flags: dict[str, Any] = {}

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -35,7 +35,7 @@ from wandb._pydantic import (
 from wandb.errors import UsageError
 from wandb.proto import wandb_settings_pb2
 
-from .lib import apikey, credentials, ipython
+from .lib import credentials, ipython
 from .lib.run_moment import RunMoment
 
 validate_url: Callable[[str], None]
@@ -2150,9 +2150,11 @@ class Settings(BaseModel, validate_assignment=True):
 
     def _get_url_query_string(self) -> str:
         """Construct the query string for project, run, and sweep URLs."""
-        # TODO: remove dependency on Api()
         if self.anonymous not in ["allow", "must"]:
             return ""
+
+        # TODO: remove dependency on Api()
+        from .lib import apikey
 
         api_key = apikey.api_key(settings=self)
 

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -36,7 +36,6 @@ import wandb.integration.sagemaker as sagemaker
 from wandb.env import CONFIG_DIR
 from wandb.sdk.lib import asyncio_manager, import_hooks, wb_logging
 
-from . import wandb_settings
 from .lib import config_util, server
 
 if TYPE_CHECKING:
@@ -204,7 +203,9 @@ class _WandbSetup:
                 SageMaker.
             overrides: Additional settings to apply to the global settings.
         """
-        self._settings = wandb_settings.Settings()
+        from wandb.sdk.wandb_settings import Settings
+
+        self._settings = Settings()
 
         # the pid of the process to monitor for system stats
         pid = os.getpid()
@@ -297,7 +298,7 @@ class _WandbSetup:
         return self._logger
 
     @property
-    def settings(self) -> wandb_settings.Settings:
+    def settings(self) -> Settings:
         """The global wandb settings.
 
         Initializes settings if they have not yet been loaded.
@@ -312,7 +313,7 @@ class _WandbSetup:
         return self._settings
 
     @property
-    def settings_if_loaded(self) -> wandb_settings.Settings | None:
+    def settings_if_loaded(self) -> Settings | None:
         """The global wandb settings, or None if not yet loaded."""
         return self._settings
 

--- a/wandb/sdk/wandb_sweep.py
+++ b/wandb/sdk/wandb_sweep.py
@@ -3,8 +3,6 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import wandb
 from wandb import env
-from wandb.apis import InternalApi
-from wandb.sdk.launch.sweeps.utils import handle_sweep_config_violations
 
 from . import wandb_login
 
@@ -67,6 +65,9 @@ def sweep(
     Returns:
       str: A unique identifier for the sweep.
     """
+    from wandb.apis import InternalApi
+    from wandb.sdk.launch.sweeps.utils import handle_sweep_config_violations
+
     if callable(sweep):
         sweep = sweep()
     """Sweep create for controller api and jupyter (eventually for cli)."""

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import colorsys
 import contextlib
 import dataclasses
@@ -19,7 +21,6 @@ import random
 import re
 import secrets
 import shlex
-import socket
 import string
 import sys
 import tarfile
@@ -37,19 +38,13 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Callable,
-    Dict,
     Iterable,
-    List,
     Mapping,
-    Optional,
     Sequence,
     TextIO,
-    Tuple,
     Union,
 )
 
-import requests
-import yaml
 from typing_extensions import Any, Generator, TypeGuard, TypeVar
 
 import wandb
@@ -67,8 +62,8 @@ from wandb.sdk.lib.json_util import dump, dumps
 from wandb.sdk.lib.paths import FilePathStr, StrPath
 
 if TYPE_CHECKING:
-    import wandb.sdk.internal.settings_static
-    import wandb.sdk.wandb_settings
+    from requests import Response
+
     from wandb.sdk.artifacts.artifact import Artifact
 
 CheckRetryFnType = Callable[[Exception], Union[bool, timedelta]]
@@ -229,7 +224,7 @@ def import_module_lazy(name: str) -> types.ModuleType:
 
 def get_module(
     name: str,
-    required: Optional[str] = None,
+    required: str | None = None,
     lazy: bool = True,
 ) -> Any:
     """Return module or None. Absolute import is required.
@@ -254,7 +249,7 @@ def get_module(
         raise wandb.Error(required)
 
 
-def get_optional_module(name) -> Optional["importlib.ModuleInterface"]:  # type: ignore
+def get_optional_module(name) -> importlib.ModuleInterface | None:  # type: ignore
     return get_module(name)
 
 
@@ -324,7 +319,7 @@ def local_file_uri_to_path(uri: str) -> str:
     return urllib.request.url2pathname(path)
 
 
-def get_local_path_or_none(path_or_uri: str) -> Optional[str]:
+def get_local_path_or_none(path_or_uri: str) -> str | None:
     """Return path if local, None otherwise.
 
     Return None if the argument is a local path (not a scheme or file:///). Otherwise
@@ -341,7 +336,7 @@ def get_local_path_or_none(path_or_uri: str) -> Optional[str]:
         return None
 
 
-def check_windows_valid_filename(path: Union[int, str]) -> bool:
+def check_windows_valid_filename(path: int | str) -> bool:
     r"""Verify that the given path does not contain any invalid characters for a Windows filename.
 
     Windows filenames cannot contain the following characters:
@@ -402,10 +397,10 @@ def make_tarfile(
     output_filename: str,
     source_dir: str,
     archive_name: str,
-    custom_filter: Optional[Callable] = None,
+    custom_filter: Callable | None = None,
 ) -> None:
     # Helper for filtering out modification timestamps
-    def _filter_timestamps(tar_info: "tarfile.TarInfo") -> Optional["tarfile.TarInfo"]:
+    def _filter_timestamps(tar_info: tarfile.TarInfo) -> tarfile.TarInfo | None:
         tar_info.mtime = 0
         return tar_info if custom_filter is None else custom_filter(tar_info)
 
@@ -456,7 +451,7 @@ def is_jax_tensor_typename(typename: str) -> bool:
     return typename.startswith("jaxlib.") and "Array" in typename
 
 
-def get_jax_tensor(obj: Any) -> Optional[Any]:
+def get_jax_tensor(obj: Any) -> Any:
     import jax  # type: ignore
 
     return jax.device_get(obj)
@@ -577,9 +572,9 @@ def _numpy_generic_convert(obj: Any) -> Any:
 
 
 def _sanitize_numpy_keys(
-    d: Dict,
-    visited: Optional[Dict[int, Dict]] = None,
-) -> Tuple[Dict, bool]:
+    d: dict,
+    visited: dict[int, dict] | None = None,
+) -> tuple[dict, bool]:
     """Returns a dictionary where all NumPy keys are converted.
 
     Args:
@@ -589,7 +584,7 @@ def _sanitize_numpy_keys(
         A sanitized dictionary, and a boolean indicating whether anything was
         changed.
     """
-    out: Dict[Any, Any] = dict()
+    out: dict[Any, Any] = dict()
     converted = False
 
     # Work with recursive dictionaries: if a dictionary has already been
@@ -615,7 +610,7 @@ def _sanitize_numpy_keys(
 
 def json_friendly(  # noqa: C901
     obj: Any,
-) -> Union[Tuple[Any, bool], Tuple[Union[None, str, float], bool]]:
+) -> tuple[Any, bool] | tuple[None | str | float, bool]:
     """Convert an object into something that's more becoming of JSON."""
     converted = True
     typename = get_full_typename(obj)
@@ -683,7 +678,7 @@ def json_friendly(  # noqa: C901
 
 def json_friendly_val(val: Any) -> Any:
     """Make any value (including dict, slice, sequence, dataclass) JSON friendly."""
-    converted: Union[dict, list]
+    converted: dict | list
     if isinstance(val, dict):
         converted = {}
         for key, value in val.items():
@@ -730,14 +725,14 @@ def convert_plots(obj: Any) -> Any:
         return obj
 
 
-def maybe_compress_history(obj: Any) -> Tuple[Any, bool]:
+def maybe_compress_history(obj: Any) -> tuple[Any, bool]:
     if np and isinstance(obj, np.ndarray) and obj.size > 32:
         return wandb.Histogram(obj, num_bins=32).to_json(), True
     else:
         return obj, False
 
 
-def maybe_compress_summary(obj: Any, h5_typename: str) -> Tuple[Any, bool]:
+def maybe_compress_summary(obj: Any, h5_typename: str) -> tuple[Any, bool]:
     if np and isinstance(obj, np.ndarray) and obj.size > 32:
         return (
             {
@@ -875,8 +870,8 @@ def json_dumps_safer_history(obj: Any, **kwargs: Any) -> str:
 
 
 def make_json_if_not_number(
-    v: Union[int, float, str, Mapping, Sequence],
-) -> Union[int, float, str]:
+    v: int | float | str | Mapping | Sequence,
+) -> int | float | str:
     """If v is not a basic type convert it to json."""
     if isinstance(v, (float, int)):
         return v
@@ -904,7 +899,9 @@ def make_safe_for_json(obj: Any) -> Any:
 
 
 def no_retry_4xx(e: Exception) -> bool:
-    if not isinstance(e, requests.HTTPError):
+    from requests import HTTPError
+
+    if not isinstance(e, HTTPError):
         return True
     assert e.response is not None
     if not (400 <= e.response.status_code < 500) or e.response.status_code == 429:
@@ -913,7 +910,7 @@ def no_retry_4xx(e: Exception) -> bool:
     raise UsageError(body["errors"][0]["message"])
 
 
-def parse_backend_error_messages(response: requests.Response) -> List[str]:
+def parse_backend_error_messages(response: Response) -> list[str]:
     """Returns error messages stored in a backend response.
 
     If the response is not in an expected format, an empty list is returned.
@@ -921,9 +918,11 @@ def parse_backend_error_messages(response: requests.Response) -> List[str]:
     Args:
         response: A response to an HTTP request to the W&B server.
     """
+    from requests import JSONDecodeError
+
     try:
         data = response.json()
-    except requests.JSONDecodeError:
+    except JSONDecodeError:
         return []
 
     if not isinstance(data, dict):
@@ -932,7 +931,7 @@ def parse_backend_error_messages(response: requests.Response) -> List[str]:
     # Backend error values are returned in one of two ways:
     # - A string containing the error message
     # - A JSON object with a "message" field that is a string
-    def get_message(error: Any) -> Optional[str]:
+    def get_message(error: Any) -> str | None:
         if isinstance(error, str):
             return error
         elif (
@@ -951,7 +950,7 @@ def parse_backend_error_messages(response: requests.Response) -> List[str]:
         return [message] if message else []
 
     elif (errors := data.get("errors")) and isinstance(errors, list):
-        messages: List[str] = []
+        messages: list[str] = []
         for error in errors:
             message = get_message(error)
             if message:
@@ -963,9 +962,11 @@ def parse_backend_error_messages(response: requests.Response) -> List[str]:
 
 
 def no_retry_auth(e: Any) -> bool:
+    from requests import HTTPError
+
     if hasattr(e, "exception"):
         e = e.exception
-    if not isinstance(e, requests.HTTPError):
+    if not isinstance(e, HTTPError):
         return True
     if e.response is None:
         return True
@@ -1012,7 +1013,7 @@ def no_retry_auth(e: Any) -> bool:
     return False
 
 
-def check_retry_conflict(e: Any) -> Optional[bool]:
+def check_retry_conflict(e: Any) -> bool | None:
     """Check if the exception is a conflict type so it can be retried.
 
     Returns:
@@ -1020,15 +1021,17 @@ def check_retry_conflict(e: Any) -> Optional[bool]:
         False - Should not retry this operation
         None - No decision, let someone else decide
     """
+    from requests import HTTPError
+
     if hasattr(e, "exception"):
         e = e.exception
-    if isinstance(e, requests.HTTPError) and e.response is not None:
+    if isinstance(e, HTTPError) and e.response is not None:
         if e.response.status_code == 409:
             return True
     return None
 
 
-def check_retry_conflict_or_gone(e: Any) -> Optional[bool]:
+def check_retry_conflict_or_gone(e: Any) -> bool | None:
     """Check if the exception is a conflict or gone type, so it can be retried or not.
 
     Returns:
@@ -1036,9 +1039,11 @@ def check_retry_conflict_or_gone(e: Any) -> Optional[bool]:
         False - Should not retry this operation
         None - No decision, let someone else decide
     """
+    from requests import HTTPError
+
     if hasattr(e, "exception"):
         e = e.exception
-    if isinstance(e, requests.HTTPError) and e.response is not None:
+    if isinstance(e, HTTPError) and e.response is not None:
         if e.response.status_code == 409:
             return True
         if e.response.status_code == 410:
@@ -1048,8 +1053,8 @@ def check_retry_conflict_or_gone(e: Any) -> Optional[bool]:
 
 def make_check_retry_fn(
     fallback_retry_fn: CheckRetryFnType,
-    check_fn: Callable[[Exception], Optional[bool]],
-    check_timedelta: Optional[timedelta] = None,
+    check_fn: Callable[[Exception], bool | None],
+    check_timedelta: timedelta | None = None,
 ) -> CheckRetryFnType:
     """Return a check_retry_fn which can be used by lib.Retry().
 
@@ -1059,7 +1064,7 @@ def make_check_retry_fn(
         check_timedelta: Optional retry timeout if we check_fn matches the exception
     """
 
-    def check_retry_fn(e: Exception) -> Union[bool, timedelta]:
+    def check_retry_fn(e: Exception) -> bool | timedelta:
         check = check_fn(e)
         if check is None:
             return fallback_retry_fn(e)
@@ -1072,7 +1077,7 @@ def make_check_retry_fn(
     return check_retry_fn
 
 
-def find_runner(program: str) -> Union[None, list, List[str]]:
+def find_runner(program: str) -> None | list | list[str]:
     """Return a command that will run program.
 
     Args:
@@ -1128,7 +1133,7 @@ def docker_image_regex(image: str) -> Any:
     return None
 
 
-def image_from_docker_args(args: List[str]) -> Optional[str]:
+def image_from_docker_args(args: list[str]) -> str | None:
     """Scan docker run args and attempt to find the most likely docker image argument.
 
     It excludes any arguments that start with a dash, and the argument after it if it
@@ -1182,10 +1187,12 @@ def image_from_docker_args(args: List[str]) -> Optional[str]:
 
 
 def load_yaml(file: Any) -> Any:
+    import yaml
+
     return yaml.safe_load(file)
 
 
-def image_id_from_k8s() -> Optional[str]:
+def image_id_from_k8s() -> str | None:
     """Ping the k8s metadata service for the image id.
 
     Specify the KUBERNETES_NAMESPACE environment variable if your pods are not in the
@@ -1220,6 +1227,8 @@ def image_id_from_k8s() -> Optional[str]:
     if not token:
         return None
 
+    import requests
+
     k8s_server = "https://{}:{}/api/v1/namespaces/{}/pods/{}".format(
         os.getenv("KUBERNETES_SERVICE_HOST"),
         os.getenv("KUBERNETES_PORT_443_TCP_PORT"),
@@ -1245,9 +1254,7 @@ def image_id_from_k8s() -> Optional[str]:
         return None
 
 
-def async_call(
-    target: Callable, timeout: Optional[Union[int, float]] = None
-) -> Callable:
+def async_call(target: Callable, timeout: int | float | None = None) -> Callable:
     """Wrap a method to run in the background with an optional timeout.
 
     Returns a new method that will call the original with any args, waiting for upto
@@ -1258,7 +1265,7 @@ def async_call(
     """
     q: queue.Queue = queue.Queue()
 
-    def wrapped_target(q: "queue.Queue", *args: Any, **kwargs: Any) -> Any:
+    def wrapped_target(q: queue.Queue, *args: Any, **kwargs: Any) -> Any:
         try:
             q.put(target(*args, **kwargs))
         except Exception as e:
@@ -1266,7 +1273,7 @@ def async_call(
 
     def wrapper(
         *args: Any, **kwargs: Any
-    ) -> Union[Tuple[Exception, "threading.Thread"], Tuple[None, "threading.Thread"]]:
+    ) -> tuple[Exception, threading.Thread] | tuple[None, threading.Thread]:
         thread = threading.Thread(
             target=wrapped_target, args=(q,) + args, kwargs=kwargs
         )
@@ -1286,7 +1293,7 @@ def async_call(
 
 
 def read_many_from_queue(
-    q: "queue.Queue", max_items: int, queue_timeout: Union[int, float]
+    q: queue.Queue, max_items: int, queue_timeout: int | float
 ) -> list:
     try:
         item = q.get(True, queue_timeout)
@@ -1310,7 +1317,7 @@ def stopwatch_now() -> float:
     return time.monotonic()
 
 
-def class_colors(class_count: int) -> List[List[int]]:
+def class_colors(class_count: int) -> list[list[int]]:
     # make class 0 black, and the rest equally spaced fully saturated hues
     return [[0, 0, 0]] + [
         colorsys.hsv_to_rgb(i / (class_count - 1.0), 1.0, 1.0)  # type: ignore
@@ -1319,7 +1326,7 @@ def class_colors(class_count: int) -> List[List[int]]:
 
 
 def _prompt_choice(
-    input_timeout: Union[int, float, None] = None,
+    input_timeout: int | float | None = None,
     jupyter: bool = False,
 ) -> str:
     input_fn: Callable = input
@@ -1343,7 +1350,7 @@ def _prompt_choice(
 
 def prompt_choices(
     choices: Sequence[str],
-    input_timeout: Union[int, float, None] = None,
+    input_timeout: int | float | None = None,
     jupyter: bool = False,
 ) -> str:
     """Allow a user to choose from a list of options."""
@@ -1367,7 +1374,7 @@ def prompt_choices(
     return result
 
 
-def guess_data_type(shape: Sequence[int], risky: bool = False) -> Optional[str]:
+def guess_data_type(shape: Sequence[int], risky: bool = False) -> str | None:
     """Infer the type of data based on the shape of the tensors.
 
     Args:
@@ -1392,8 +1399,10 @@ def guess_data_type(shape: Sequence[int], risky: bool = False) -> Optional[str]:
 
 
 def download_file_from_url(
-    dest_path: str, source_url: str, api_key: Optional[str] = None
+    dest_path: str, source_url: str, api_key: str | None = None
 ) -> None:
+    import requests
+
     auth = None
     if not _thread_local_api_settings.cookies:
         auth = ("api", api_key or "")
@@ -1414,7 +1423,9 @@ def download_file_from_url(
             file.write(data)
 
 
-def download_file_into_memory(source_url: str, api_key: Optional[str] = None) -> bytes:
+def download_file_into_memory(source_url: str, api_key: str | None = None) -> bytes:
+    import requests
+
     auth = None
     if not _thread_local_api_settings.cookies:
         auth = ("api", api_key or "")
@@ -1434,7 +1445,7 @@ def isatty(ob: IO) -> bool:
     return hasattr(ob, "isatty") and ob.isatty()
 
 
-def to_human_size(size: int, units: Optional[List[Tuple[str, Any]]] = None) -> str:
+def to_human_size(size: int, units: list[tuple[str, Any]] | None = None) -> str:
     units = units or POW_10_BYTES
     unit, value = units[0]
     factor = round(float(size) / value, 1)
@@ -1445,7 +1456,7 @@ def to_human_size(size: int, units: Optional[List[Tuple[str, Any]]] = None) -> s
     )
 
 
-def from_human_size(size: str, units: Optional[List[Tuple[str, Any]]] = None) -> int:
+def from_human_size(size: str, units: list[tuple[str, Any]] | None = None) -> int:
     units = units or POW_10_BYTES
     units_dict = {unit.upper(): value for (unit, value) in units}
     regex = re.compile(
@@ -1461,7 +1472,7 @@ def from_human_size(size: str, units: Optional[List[Tuple[str, Any]]] = None) ->
     return int(factor * unit)
 
 
-def auto_project_name(program: Optional[str]) -> str:
+def auto_project_name(program: str | None) -> str:
     # if we're in git, set project name to git repo name + relative path within repo
     from wandb.sdk.lib.gitlib import GitRepo
 
@@ -1517,7 +1528,7 @@ def to_native_slash_path(path: str) -> FilePathStr:
     return FilePathStr(path.replace("/", os.sep))
 
 
-def check_and_warn_old(files: List[str]) -> bool:
+def check_and_warn_old(files: list[str]) -> bool:
     if "wandb-metadata.json" in files:
         wandb.termwarn("These runs were logged with a previous version of wandb.")
         wandb.termwarn(
@@ -1529,8 +1540,8 @@ def check_and_warn_old(files: List[str]) -> bool:
 
 class ImportMetaHook:
     def __init__(self) -> None:
-        self.modules: Dict[str, ModuleType] = dict()
-        self.on_import: Dict[str, list] = dict()
+        self.modules: dict[str, ModuleType] = dict()
+        self.on_import: dict[str, list] = dict()
 
     def add(self, fullname: str, on_import: Callable) -> None:
         self.on_import.setdefault(fullname, []).append(on_import)
@@ -1542,8 +1553,8 @@ class ImportMetaHook:
         sys.meta_path.remove(self)  # type: ignore
 
     def find_module(
-        self, fullname: str, path: Optional[str] = None
-    ) -> Optional["ImportMetaHook"]:
+        self, fullname: str, path: str | None = None
+    ) -> ImportMetaHook | None:
         if fullname in self.on_import:
             return self
         return None
@@ -1559,14 +1570,14 @@ class ImportMetaHook:
                 f()
         return mod
 
-    def get_modules(self) -> Tuple[str, ...]:
+    def get_modules(self) -> tuple[str, ...]:
         return tuple(self.modules)
 
     def get_module(self, module: str) -> ModuleType:
         return self.modules[module]
 
 
-_import_hook: Optional[ImportMetaHook] = None
+_import_hook: ImportMetaHook | None = None
 
 
 def add_import_hook(fullname: str, on_import: Callable) -> None:
@@ -1577,13 +1588,13 @@ def add_import_hook(fullname: str, on_import: Callable) -> None:
     _import_hook.add(fullname, on_import)
 
 
-def host_from_path(path: Optional[str]) -> str:
+def host_from_path(path: str | None) -> str:
     """Return the host of the path."""
     url = urllib.parse.urlparse(path)
     return str(url.netloc)
 
 
-def uri_from_path(path: Optional[str]) -> str:
+def uri_from_path(path: str | None) -> str:
     """Return the URI of the path."""
     url = urllib.parse.urlparse(path)
     uri = url.path if url.path[0] != "/" else url.path[1:]
@@ -1596,23 +1607,8 @@ def is_unicode_safe(stream: TextIO) -> bool:
     return encoding.lower() in {"utf-8", "utf_8"} if encoding else False
 
 
-def _has_internet() -> bool:
-    """Returns whether we have internet access.
-
-    Checks for internet access by attempting to open a DNS connection to
-    Google's root servers.
-    """
-    try:
-        s = socket.create_connection(("8.8.8.8", 53), 0.5)
-        s.close()
-    except OSError:
-        return False
-
-    return True
-
-
 def rand_alphanumeric(
-    length: int = 8, rand: Optional[Union[ModuleType, random.Random]] = None
+    length: int = 8, rand: ModuleType | random.Random | None = None
 ) -> str:
     wandb.termerror("rand_alphanumeric is deprecated, use 'secrets.token_hex'")
     rand = rand or random
@@ -1621,7 +1617,7 @@ def rand_alphanumeric(
 
 @contextlib.contextmanager
 def fsync_open(
-    path: StrPath, mode: str = "w", encoding: Optional[str] = None
+    path: StrPath, mode: str = "w", encoding: str | None = None
 ) -> Generator[IO[Any], None, None]:
     """Open a path for I/O and guarantee that the file is flushed and synced."""
     with open(path, mode, encoding=encoding) as f:
@@ -1674,7 +1670,7 @@ def _is_py_requirements_or_dockerfile(path: str) -> bool:
     )
 
 
-def artifact_to_json(artifact: "Artifact") -> Dict[str, Any]:
+def artifact_to_json(artifact: Artifact) -> dict[str, Any]:
     return {
         "_type": "artifactVersion",
         "_version": "v0",
@@ -1697,6 +1693,8 @@ def check_dict_contains_nested_artifact(d: dict, nested: bool = False) -> bool:
 
 
 def load_json_yaml_dict(config: str) -> Any:
+    import yaml
+
     ext = os.path.splitext(config)[-1]
     if ext == ".json":
         with open(config) as f:
@@ -1737,17 +1735,17 @@ def _parse_entity_project_item(path: str) -> tuple:
     return tuple(reversed(padded_words))
 
 
-def _resolve_aliases(aliases: Optional[Union[str, Iterable[str]]]) -> List[str]:
+def _resolve_aliases(aliases: str | Iterable[str] | None) -> list[str]:
     """Add the 'latest' alias and ensure that all aliases are unique.
 
-    Takes in `aliases` which can be None, str, or List[str] and returns List[str].
+    Takes in `aliases` which can be None, str, or List[str] and returns list[str].
     Ensures that "latest" is always present in the returned list.
 
     Args:
-        aliases: `Optional[Union[str, List[str]]]`
+        aliases: `aliases: str | Iterable[str] | None`
 
     Returns:
-        List[str], with "latest" always present.
+        list[str], with "latest" always present.
 
     Usage:
 
@@ -1770,15 +1768,15 @@ def _resolve_aliases(aliases: Optional[Union[str, Iterable[str]]]) -> List[str]:
         raise ValueError("`aliases` must be Iterable or None") from exc
 
 
-def _is_artifact_object(v: Any) -> "TypeGuard[wandb.Artifact]":
+def _is_artifact_object(v: Any) -> TypeGuard[wandb.Artifact]:
     return isinstance(v, wandb.Artifact)
 
 
-def _is_artifact_string(v: Any) -> "TypeGuard[str]":
+def _is_artifact_string(v: Any) -> TypeGuard[str]:
     return isinstance(v, str) and v.startswith("wandb-artifact://")
 
 
-def _is_artifact_version_weave_dict(v: Any) -> "TypeGuard[dict]":
+def _is_artifact_version_weave_dict(v: Any) -> TypeGuard[dict]:
     return isinstance(v, dict) and v.get("_type") == "artifactVersion"
 
 
@@ -1790,7 +1788,7 @@ def _is_artifact_representation(v: Any) -> bool:
     )
 
 
-def parse_artifact_string(v: str) -> Tuple[str, Optional[str], bool]:
+def parse_artifact_string(v: str) -> tuple[str, str | None, bool]:
     if not v.startswith("wandb-artifact://"):
         raise ValueError(f"Invalid artifact string: {v}")
     parsed_v = v[len("wandb-artifact://") :]
@@ -1817,13 +1815,13 @@ def parse_artifact_string(v: str) -> Tuple[str, Optional[str], bool]:
     return f"{entity}/{project}/{name_and_alias_or_version}", base_uri, False
 
 
-def _get_max_cli_version() -> Union[str, None]:
+def _get_max_cli_version() -> str | None:
     max_cli_version = wandb.api.max_cli_version()
     return str(max_cli_version) if max_cli_version is not None else None
 
 
 def ensure_text(
-    string: Union[str, bytes], encoding: str = "utf-8", errors: str = "strict"
+    string: str | bytes, encoding: str = "utf-8", errors: str = "strict"
 ) -> str:
     """Coerce s to str."""
     if isinstance(string, bytes):
@@ -1854,9 +1852,9 @@ def make_docker_image_name_safe(name: str) -> str:
 
 
 def merge_dicts(
-    source: Dict[str, Any],
-    destination: Dict[str, Any],
-) -> Dict[str, Any]:
+    source: dict[str, Any],
+    destination: dict[str, Any],
+) -> dict[str, Any]:
     """Recursively merge two dictionaries.
 
     This mutates the destination and its nested dictionaries and lists.
@@ -1897,7 +1895,7 @@ def coalesce(*arg: Any) -> Any:
     return next((a for a in arg if a is not None), None)
 
 
-def recursive_cast_dictlike_to_dict(d: Dict[str, Any]) -> Dict[str, Any]:
+def recursive_cast_dictlike_to_dict(d: dict[str, Any]) -> dict[str, Any]:
     for k, v in d.items():
         if isinstance(v, dict):
             recursive_cast_dictlike_to_dict(v)
@@ -1907,9 +1905,7 @@ def recursive_cast_dictlike_to_dict(d: Dict[str, Any]) -> Dict[str, Any]:
     return d
 
 
-def remove_keys_with_none_values(
-    d: Union[Dict[str, Any], Any],
-) -> Union[Dict[str, Any], Any]:
+def remove_keys_with_none_values(d: dict[str, Any] | Any) -> dict[str, Any] | Any:
     # otherwise iterrows will create a bunch of ugly charts
     if not isinstance(d, dict):
         return d
@@ -1923,7 +1919,7 @@ def remove_keys_with_none_values(
         return new_dict if new_dict else None
 
 
-def batched(n: int, iterable: Iterable[T]) -> Generator[List[T], None, None]:
+def batched(n: int, iterable: Iterable[T]) -> Generator[list[T], None, None]:
     i = iter(iterable)
     batch = list(itertools.islice(i, n))
     while batch:
@@ -1943,11 +1939,11 @@ def random_string(length: int = 12) -> str:
 
 
 def sample_with_exponential_decay_weights(
-    xs: Union[Iterable, Iterable[Iterable]],
+    xs: Iterable | Iterable[Iterable],
     ys: Iterable[Iterable],
-    keys: Optional[Iterable] = None,
+    keys: Iterable | None = None,
     sample_size: int = 1500,
-) -> Tuple[List, List, Optional[List]]:
+) -> tuple[list, list, list | None]:
     """Sample from a list of lists with weights that decay exponentially.
 
     May be used with the wandb.plot.line_series function.
@@ -2029,12 +2025,3 @@ def get_core_path() -> str:
         )
 
     return str(bin_path)
-
-
-class NonOctalStringDumper(yaml.Dumper):
-    """Prevents strings containing non-octal values like "008" and "009" from being converted to numbers in in the yaml string saved as the sweep config."""
-
-    def represent_scalar(self, tag, value, style=None):
-        if tag == "tag:yaml.org,2002:str" and value.startswith("0") and len(value) > 1:
-            return super().represent_scalar(tag, value, style="'")
-        return super().represent_scalar(tag, value, style)

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -12,13 +12,8 @@ import time
 import traceback
 from typing import Any, Callable, Dict, List, Optional
 
-import yaml
-
 import wandb
 from wandb import util, wandb_lib, wandb_sdk
-from wandb.agents.pyagent import pyagent
-from wandb.apis import InternalApi
-from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.lib import ipython
 
 logger = logging.getLogger(__name__)
@@ -218,6 +213,8 @@ class Agent:
 
     def run(self):  # noqa: C901
         # TODO: catch exceptions, handle errors, show validation warnings, and make more generic
+        import yaml
+
         sweep_obj = self._api.sweep(self._sweep_id, "{}")
         if sweep_obj:
             sweep_yaml = sweep_obj.get("config")
@@ -374,6 +371,8 @@ class Agent:
         return response
 
     def _command_run(self, command):
+        from wandb.sdk.launch.sweeps import utils as sweep_utils
+
         logger.info(
             "Agent starting run with config:\n"
             + "\n".join(
@@ -512,6 +511,9 @@ class AgentApi:
 def run_agent(
     sweep_id, function=None, in_jupyter=None, entity=None, project=None, count=None
 ):
+    from wandb.apis import InternalApi
+    from wandb.sdk.launch.sweeps import utils as sweep_utils
+
     parts = dict(entity=entity, project=project, name=sweep_id)
     err = sweep_utils.parse_sweep_id(parts)
     if err:
@@ -585,6 +587,8 @@ def agent(
             run is sent to a project labeled "Uncategorized".
         count: The number of sweep config trials to try.
     """
+    from wandb.agents.pyagent import pyagent
+
     global _INSTANCES
     _INSTANCES += 1
     try:


### PR DESCRIPTION
Description
-----------
Together with #10823, addresses WB-28619 and WB-14883. Partially addresses #5440.

We load a lot of stuff at `import wandb`. This PR tries to improve this by making slow imports lazy. Surprisingly, suppressing initializing pydantic models and validators at import could yield an even bigger win than shown below.

This is me trying to chase the imports:

![giphy](https://github.com/user-attachments/assets/2d2eff23-a11b-4510-81c5-5506c26f6114)


On my M1 Pro:

```python
pyinstrument -r html -c "import wandb"
```

Before:
<img width="1728" height="988" alt="image" src="https://github.com/user-attachments/assets/75230f0f-6a76-46cb-8095-e85daeee8ed5" />

And sometimes even:

<img width="1724" height="991" alt="image" src="https://github.com/user-attachments/assets/8d8bcbc7-c08a-4a4d-beb4-a20948e2cdf5" />

After:
<img width="1728" height="986" alt="image" src="https://github.com/user-attachments/assets/9d5aaacf-6e40-4e99-b3ef-8e8aac4e9e89" />

Typical before: 0.8s - 2(!)s.
Typical after: 0.5s.

This almost passes as "subjectively instantaneous" in the python REPL.

Note: I'll make sentry initialization lazy in a follow-up PR, which will save another ~80ms.