### PR TITLE
fix: update test_tune_with_callback to work with ray 2.51.0

### DIFF
--- a/tests/system_tests/test_functional/raytune/tune_with_callback.py
+++ b/tests/system_tests/test_functional/raytune/tune_with_callback.py
@@ -1,10 +1,10 @@
-from ray import train, tune
+from ray import tune
 from ray.air.integrations.wandb import WandbLoggerCallback
 
 
 def train_fc(config):
     for i in range(10):
-        train.report({"mean_accuracy": (i + config["alpha"]) / 10})
+        tune.report({"mean_accuracy": (i + config["alpha"]) / 10})
 
 
 search_space = {


### PR DESCRIPTION
## Description

Fixes a deprecated API usage in Ray Tune test.

This PR updates the Ray Tune test to use the correct API. It replaces the deprecated `train.report()` with `tune.report()` and removes an unused import of `train` from the Ray package. See https://pypi.org/project/ray/2.51.0/#history.