### PR TITLE
Handle None metadata in InstalledDistribution yield

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1992,7 +1992,8 @@ def working_set() -> Iterable[InstalledDistribution]:
             # From Sentry events we observed that UnicodeDecodeError can occur when
             # trying to decode the metadata of a distribution. To handle this, we catch
             # the exception and skip those distributions.
-            yield InstalledDistribution(key=d.metadata["Name"], version=d.version)
+            if d.metadata is not None: # Sometimes metadata is None
+                yield InstalledDistribution(key=d.metadata["Name"], version=d.version)
         except (KeyError, UnicodeDecodeError):
             pass
 


### PR DESCRIPTION
Add check for None metadata before yielding InstalledDistribution.

Description
-----------
Handle the case  when package metadata is None.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
Not tested.
