### PR TITLE
chore: add warning when SDK is unable to create global settings.

### DIFF
--- a/wandb/old/settings.py
+++ b/wandb/old/settings.py
@@ -152,6 +152,12 @@ class Settings:
                 return os.path.join(os.getenv(env.CONFIG_DIR), "settings")
 
             if not try_create_dir(home_config_dir):
+                wandb.termwarn(
+                    f"Failed to create global config settings in: {home_config_dir}."
+                    " Settings will not be persisted.",
+                    repeat=False,
+                )
+
                 temp_config_dir = os.path.join(
                     tempfile.gettempdir(), ".config", "wandb"
                 )
@@ -164,11 +170,6 @@ class Settings:
                     try_create_dir(config_dir)
                 else:
                     config_dir = temp_config_dir
-                wandb.termwarn(
-                    f"Error creating global config settings in: {home_config_dir}."
-                    " Settings will not be persisted.",
-                    repeat=False,
-                )
             else:
                 config_dir = home_config_dir
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-28046

What does the PR do? Include a concise description of the PR contents.

When trying to get the global settings file (`~/.config/wandb/settings`) if for any reason we fall back to a temporary directory we do not let the user know. This can lead to confusion where a user is able to successfully do `wandb login --host=...` then when running a script without `wandb.login` it will default to `api.wandb.ai`.

This PR adds a warning that settings will not be persisted, since we do not check the temporary directory during init/api/other operations, effectively the settings were not saved.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
