### PR TITLE
fix(artifacts): ensure Artifact.link() logs draft artifacts first

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 - `Artifact.files()` now has a correct `len()` when filtering by the `names` parameter (@matthoare117-wandb in https://github.com/wandb/wandb/pull/10796)
 - The numerator for file upload progress no longer occasionally exceeds the total file size (@timoffex in https://github.com/wandb/wandb/pull/10812)
+- `Artifact.link()` now logs unsaved artifacts instead of raising an error, consistent with the behavior of `Run.link_artifact()` (@tonyyli-wandb in https://github.com/wandb/wandb/10822)
 
 ### Added
 - The registry API now supports programmatic management of user and team members of individual registries. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10542)

--- a/tests/system_tests/test_artifacts/test_link_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_link_artifacts.py
@@ -50,10 +50,34 @@ def test_link_artifact_from_run_logs_draft_artifacts_first(user):
         assert artifact.is_draft() is True
 
         linked_artifact = run.link_artifact(artifact, "test-collection")
+
+        # Check that neither the artifact nor the linked artifact are drafts
         assert artifact.is_draft() is False
+        assert linked_artifact.is_draft() is False
+        assert linked_artifact.source_artifact.is_draft() is False
 
         assert linked_artifact.id == artifact.id
-        assert linked_artifact.source_artifact.is_draft() is False
+        assert linked_artifact.is_link is True
+        assert linked_artifact.qualified_name != artifact.qualified_name
+        assert linked_artifact.source_qualified_name == artifact.qualified_name
+
+
+def test_link_artifact_without_run_logs_draft_artifacts_first(user):
+    artifact = wandb.Artifact("test-artifact", "test-type")
+
+    assert artifact.is_draft() is True
+
+    linked_artifact = artifact.link("test-collection")
+
+    # Check that neither the artifact nor the linked artifact are drafts
+    assert artifact.is_draft() is False
+    assert linked_artifact.is_draft() is False
+    assert linked_artifact.source_artifact.is_draft() is False
+
+    assert linked_artifact.id == artifact.id
+    assert linked_artifact.is_link is True
+    assert linked_artifact.qualified_name != artifact.qualified_name
+    assert linked_artifact.source_qualified_name == artifact.qualified_name
 
 
 def test_link_artifact_from_run_infers_target_path_from_run(user):

--- a/tools/graphql_codegen/artifacts/artifacts.graphql
+++ b/tools/graphql_codegen/artifacts/artifacts.graphql
@@ -267,8 +267,8 @@ query ArtifactCreatedBy($id: ID!) {
   }
 }
 
-query ArtifactType($entityName: String, $projectName: String, $name: String!) {
-  project(name: $projectName, entityName: $entityName) {
+query ArtifactType($entity: String, $project: String, $name: String!) {
+  project(name: $project, entityName: $entity) {
     artifact(name: $name) {
       artifactType {
         name
@@ -279,18 +279,18 @@ query ArtifactType($entityName: String, $projectName: String, $name: String!) {
 
 # ---------------------------------------------------------------------------
 mutation AddAliases($input: AddAliasesInput!) {
-  addAliases(input: $input) {
+  result: addAliases(input: $input) {
     success
   }
 }
 mutation DeleteAliases($input: DeleteAliasesInput!) {
-  deleteAliases(input: $input) {
+  result: deleteAliases(input: $input) {
     success
   }
 }
 
 mutation UpdateArtifact($input: UpdateArtifactInput!, $includeAliases: Boolean = true) {
-  updateArtifact(input: $input) {
+  result: updateArtifact(input: $input) {
     artifact {
       ...ArtifactFragment
     }
@@ -298,7 +298,7 @@ mutation UpdateArtifact($input: UpdateArtifactInput!, $includeAliases: Boolean =
 }
 
 mutation DeleteArtifact($input: DeleteArtifactInput!) {
-  deleteArtifact(input: $input) {
+  result: deleteArtifact(input: $input) {
     artifact {
       id
     }
@@ -306,7 +306,7 @@ mutation DeleteArtifact($input: DeleteArtifactInput!) {
 }
 
 mutation LinkArtifact($input: LinkArtifactInput!, $includeAliases: Boolean = true) {
-  linkArtifact(input: $input) {
+  result: linkArtifact(input: $input) {
     versionIndex
     artifactMembership @include(if: true) {
       # Workaround: ensures generated pydantic field defaults to `None`
@@ -316,7 +316,7 @@ mutation LinkArtifact($input: LinkArtifactInput!, $includeAliases: Boolean = tru
 }
 
 mutation UnlinkArtifact($input: UnlinkArtifactInput!) {
-  unlinkArtifact(input: $input) {
+  result: unlinkArtifact(input: $input) {
     success
   }
 }

--- a/wandb/sdk/artifacts/_generated/add_aliases.py
+++ b/wandb/sdk/artifacts/_generated/add_aliases.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
-
 from wandb._pydantic import GQLResult
 
 
 class AddAliases(GQLResult):
-    add_aliases: Optional[AddAliasesAddAliases] = Field(alias="addAliases")
+    result: Optional[AddAliasesResult]
 
 
-class AddAliasesAddAliases(GQLResult):
+class AddAliasesResult(GQLResult):
     success: bool
 
 

--- a/wandb/sdk/artifacts/_generated/delete_aliases.py
+++ b/wandb/sdk/artifacts/_generated/delete_aliases.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
-
 from wandb._pydantic import GQLResult
 
 
 class DeleteAliases(GQLResult):
-    delete_aliases: Optional[DeleteAliasesDeleteAliases] = Field(alias="deleteAliases")
+    result: Optional[DeleteAliasesResult]
 
 
-class DeleteAliasesDeleteAliases(GQLResult):
+class DeleteAliasesResult(GQLResult):
     success: bool
 
 

--- a/wandb/sdk/artifacts/_generated/delete_artifact.py
+++ b/wandb/sdk/artifacts/_generated/delete_artifact.py
@@ -5,24 +5,20 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
-
 from wandb._pydantic import GQLId, GQLResult
 
 
 class DeleteArtifact(GQLResult):
-    delete_artifact: Optional[DeleteArtifactDeleteArtifact] = Field(
-        alias="deleteArtifact"
-    )
+    result: Optional[DeleteArtifactResult]
 
 
-class DeleteArtifactDeleteArtifact(GQLResult):
-    artifact: DeleteArtifactDeleteArtifactArtifact
+class DeleteArtifactResult(GQLResult):
+    artifact: DeleteArtifactResultArtifact
 
 
-class DeleteArtifactDeleteArtifactArtifact(GQLResult):
+class DeleteArtifactResultArtifact(GQLResult):
     id: GQLId
 
 
 DeleteArtifact.model_rebuild()
-DeleteArtifactDeleteArtifact.model_rebuild()
+DeleteArtifactResult.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/link_artifact.py
+++ b/wandb/sdk/artifacts/_generated/link_artifact.py
@@ -13,10 +13,10 @@ from .fragments import ArtifactMembershipFragment
 
 
 class LinkArtifact(GQLResult):
-    link_artifact: Optional[LinkArtifactLinkArtifact] = Field(alias="linkArtifact")
+    result: Optional[LinkArtifactResult]
 
 
-class LinkArtifactLinkArtifact(GQLResult):
+class LinkArtifactResult(GQLResult):
     version_index: Optional[int] = Field(alias="versionIndex")
     artifact_membership: Optional[ArtifactMembershipFragment] = Field(
         alias="artifactMembership", default=None
@@ -24,4 +24,4 @@ class LinkArtifactLinkArtifact(GQLResult):
 
 
 LinkArtifact.model_rebuild()
-LinkArtifactLinkArtifact.model_rebuild()
+LinkArtifactResult.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/operations.py
+++ b/wandb/sdk/artifacts/_generated/operations.py
@@ -1148,8 +1148,8 @@ fragment RunInfoFragment on Run {
 """
 
 ARTIFACT_TYPE_GQL = """
-query ArtifactType($entityName: String, $projectName: String, $name: String!) {
-  project(name: $projectName, entityName: $entityName) {
+query ArtifactType($entity: String, $project: String, $name: String!) {
+  project(name: $project, entityName: $entity) {
     artifact(name: $name) {
       artifactType {
         name
@@ -1161,7 +1161,7 @@ query ArtifactType($entityName: String, $projectName: String, $name: String!) {
 
 ADD_ALIASES_GQL = """
 mutation AddAliases($input: AddAliasesInput!) {
-  addAliases(input: $input) {
+  result: addAliases(input: $input) {
     success
   }
 }
@@ -1169,7 +1169,7 @@ mutation AddAliases($input: AddAliasesInput!) {
 
 DELETE_ALIASES_GQL = """
 mutation DeleteAliases($input: DeleteAliasesInput!) {
-  deleteAliases(input: $input) {
+  result: deleteAliases(input: $input) {
     success
   }
 }
@@ -1177,7 +1177,7 @@ mutation DeleteAliases($input: DeleteAliasesInput!) {
 
 UPDATE_ARTIFACT_GQL = """
 mutation UpdateArtifact($input: UpdateArtifactInput!, $includeAliases: Boolean = true) {
-  updateArtifact(input: $input) {
+  result: updateArtifact(input: $input) {
     artifact {
       ...ArtifactFragment
     }
@@ -1255,7 +1255,7 @@ fragment TagFragment on Tag {
 
 DELETE_ARTIFACT_GQL = """
 mutation DeleteArtifact($input: DeleteArtifactInput!) {
-  deleteArtifact(input: $input) {
+  result: deleteArtifact(input: $input) {
     artifact {
       id
     }
@@ -1265,7 +1265,7 @@ mutation DeleteArtifact($input: DeleteArtifactInput!) {
 
 LINK_ARTIFACT_GQL = """
 mutation LinkArtifact($input: LinkArtifactInput!, $includeAliases: Boolean = true) {
-  linkArtifact(input: $input) {
+  result: linkArtifact(input: $input) {
     versionIndex
     artifactMembership @include(if: true) {
       ...ArtifactMembershipFragment
@@ -1359,7 +1359,7 @@ fragment TagFragment on Tag {
 
 UNLINK_ARTIFACT_GQL = """
 mutation UnlinkArtifact($input: UnlinkArtifactInput!) {
-  unlinkArtifact(input: $input) {
+  result: unlinkArtifact(input: $input) {
     success
   }
 }

--- a/wandb/sdk/artifacts/_generated/unlink_artifact.py
+++ b/wandb/sdk/artifacts/_generated/unlink_artifact.py
@@ -5,18 +5,14 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
-
 from wandb._pydantic import GQLResult
 
 
 class UnlinkArtifact(GQLResult):
-    unlink_artifact: Optional[UnlinkArtifactUnlinkArtifact] = Field(
-        alias="unlinkArtifact"
-    )
+    result: Optional[UnlinkArtifactResult]
 
 
-class UnlinkArtifactUnlinkArtifact(GQLResult):
+class UnlinkArtifactResult(GQLResult):
     success: bool
 
 

--- a/wandb/sdk/artifacts/_generated/update_artifact.py
+++ b/wandb/sdk/artifacts/_generated/update_artifact.py
@@ -5,22 +5,18 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
-
 from wandb._pydantic import GQLResult
 
 from .fragments import ArtifactFragment
 
 
 class UpdateArtifact(GQLResult):
-    update_artifact: Optional[UpdateArtifactUpdateArtifact] = Field(
-        alias="updateArtifact"
-    )
+    result: Optional[UpdateArtifactResult]
 
 
-class UpdateArtifactUpdateArtifact(GQLResult):
+class UpdateArtifactResult(GQLResult):
     artifact: ArtifactFragment
 
 
 UpdateArtifact.model_rebuild()
-UpdateArtifactUpdateArtifact.model_rebuild()
+UpdateArtifactResult.model_rebuild()

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -6,17 +6,7 @@ import json
 import re
 from dataclasses import dataclass, field, replace
 from functools import wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Literal,
-    Optional,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional, TypeVar, cast
 
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from typing_extensions import Concatenate, ParamSpec, Self
@@ -29,7 +19,7 @@ from wandb.util import json_friendly_val
 from .exceptions import ArtifactFinalizedError, ArtifactNotLoggedError
 
 if TYPE_CHECKING:
-    from typing import Collection, Final
+    from typing import Final, Iterable
 
     from wandb.sdk.artifacts.artifact import Artifact
 
@@ -49,7 +39,7 @@ ARTIFACT_SEP_CHARS: Final[frozenset[str]] = frozenset("/:")
 
 
 @dataclass
-class _LinkArtifactFields:
+class LinkArtifactFields:
     """Keep this list updated with fields where linked and source artifacts differ."""
 
     entity_name: str
@@ -125,7 +115,7 @@ def validate_project_name(name: str) -> str:
     return name
 
 
-def validate_aliases(aliases: Collection[str] | str) -> list[str]:
+def validate_aliases(aliases: Iterable[str] | str) -> list[str]:
     """Validate the artifact aliases and return them as a list.
 
     Raises:
@@ -140,7 +130,7 @@ def validate_aliases(aliases: Collection[str] | str) -> list[str]:
     return aliases_list
 
 
-def validate_artifact_types(types: Collection[str] | str) -> list[str]:
+def validate_artifact_types(types: Iterable[str] | str) -> list[str]:
     """Validate the artifact type names and return them as a list."""
     types_list = always_list(types)
     if any(ARTIFACT_SEP_CHARS.intersection(name) for name in types_list):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes https://wandb.atlassian.net/browse/WB-28037

PR ensures that when `Artifact.link()` is called on a draft artifact, the artifact is logged first.

Due to a bug/regression, this is currently failing with an error that looks like:
```python
...
File ~/.../wandb/sdk/artifacts/artifact.py:2411, in Artifact.link(self, target_path, aliases)
   2406     wandb.termwarn(
   2407         "Linking to a link artifact will result in directly linking to the source artifact of that link artifact."
   2408     )
   2410 if self._client is None:
-> 2411     raise ValueError("Client not initialized for artifact mutations")
   2413 # Save the artifact first if necessary
   2414 if self.is_draft():

CommError: Client not initialized for artifact mutations
```

The fix ensures the behavior of `Artifact.link()` is aligned with the current, tested behavior of `run.link_artifact()`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Added/extended existing tests in `tests/system_tests/test_artifacts/test_link_artifacts.py`.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
