### PR TITLE
refactor: create terminput to consolidate input(), click.prompt() and timed_input() usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,9 +284,11 @@ def dummy_api_key() -> str:
 
 @pytest.fixture
 def patch_apikey(mocker: MockerFixture, dummy_api_key: str):
-    mocker.patch.object(wandb.sdk.lib.apikey, "isatty", return_value=True)
-    mocker.patch.object(wandb.sdk.lib.apikey, "input", return_value=1)
-    mocker.patch.object(wandb.sdk.lib.apikey, "getpass", return_value=dummy_api_key)
+    mocker.patch.object(
+        wandb.sdk.lib.apikey,
+        "prompt_api_key",
+        return_value=dummy_api_key,
+    )
 
 
 @pytest.fixture
@@ -305,12 +307,12 @@ def skip_verify_login(monkeypatch):
 @pytest.fixture
 def patch_prompt(monkeypatch):
     monkeypatch.setattr(
-        wandb.util, "prompt_choices", lambda x, input_timeout=None, jupyter=False: x[0]
+        wandb.util, "prompt_choices", lambda x, input_timeout=None: x[0]
     )
     monkeypatch.setattr(
         wandb.wandb_lib.apikey,
         "prompt_choices",
-        lambda x, input_timeout=None, jupyter=False: x[0],
+        lambda x, input_timeout=None: x[0],
     )
 
 

--- a/tests/system_tests/test_core/test_cli_full.py
+++ b/tests/system_tests/test_core/test_cli_full.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 import wandb
+import wandb.errors.term
 from click.testing import CliRunner
 from wandb.cli import cli
 from wandb.sdk.lib.apikey import get_netrc_file_path
@@ -205,7 +206,7 @@ def test_login_key_arg(runner):
 
 
 def test_login_key_prompt(monkeypatch):
-    monkeypatch.setattr(wandb.sdk.lib.apikey, "isatty", lambda _: True)
+    monkeypatch.setattr(wandb.errors.term, "can_use_terminput", lambda: True)
     monkeypatch.delenv("WANDB_API_KEY", raising=False)
     runner = CliRunner()
 

--- a/tests/system_tests/test_functional/terminput/terminput_tester.py
+++ b/tests/system_tests/test_functional/terminput/terminput_tester.py
@@ -1,0 +1,34 @@
+import argparse
+import fcntl
+import os
+import sys
+import termios
+
+from wandb.errors.term import terminput
+
+if __name__ == "__main__":
+    # Tell the pseudoterminal to which stdin is attached to control
+    # this process, so that it can implement Ctrl+C and so on.
+    os.setsid()
+    fcntl.ioctl(sys.stdin, termios.TIOCSCTTY)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hide", action="store_true")
+    parser.add_argument("--timeout")
+    args = parser.parse_args()
+
+    hide = bool(args.hide)
+    if timeout_str := args.timeout:
+        timeout = float(timeout_str)
+    else:
+        timeout = None
+
+    try:
+        result = terminput("PROMPT: ", hide=hide, timeout=timeout)
+    except TimeoutError:
+        sys.stderr.write("TIMEOUT!\n")
+    except KeyboardInterrupt:
+        sys.stderr.write("INTERRUPT!\n")
+    else:
+        sys.stderr.write(f"Got result: {result}\n")
+        sys.stderr.write("DONE\n")

--- a/tests/system_tests/test_functional/terminput/test_terminput.py
+++ b/tests/system_tests/test_functional/terminput/test_terminput.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import time
+from typing import Sequence
+
+import click
+import pytest
+
+# Will skip on Windows.
+pytest.importorskip("pty")
+import pty  # Import using normal syntax for IDE support.
+
+_TESTER_SCRIPT = pathlib.Path(__file__).parent / "terminput_tester.py"
+
+
+class _TtyTester:
+    """Helps test a subprocess's tty usage.
+
+    This requires some low level control:
+
+    * We use openpty() to get file descriptors for a "pseudoterminal" which
+      implements nice functionality like "turn the Ctrl+C character into a
+      SIGINT"
+    * The child script has to make the pseudoterminal its controlling
+      terminal (so that it knows where to send the SIGINT in the above
+      example)
+
+    The low level os.read() and os.write() are necessary to implement timeouts.
+    """
+
+    def __init__(
+        self,
+        script: pathlib.Path,
+        args: Sequence[str] | None = None,
+        timeout: float = 1,
+    ) -> None:
+        """Start the script as a Python subprocess connected to a pty.
+
+        Args:
+            script: Path to the script to start.
+            timeout: Timeout in seconds for most operations.
+        """
+        self._script = script
+        self._timeout = timeout
+        self._timer = 0
+        self._buffer = bytearray()
+
+        # Create a pseudoterminal.
+        #
+        # This returns two file descriptors: a "parent" and a "child".
+        # They're connected to the pseudoterminal like this:
+        #
+        #   parent  <->  pty  <->  child
+        #
+        # The parent side is us. We can read from it to get the "displayed"
+        # bytes. Any bytes we write to it are sent to the child
+        # and possibly echoed back to us (like in a real terminal).
+        #
+        # The child side is for the subprocess. The subprocess can read it
+        # to receive bytes written on the parent side and can write to it
+        # to output bytes to the parent side.
+        self._parent_fd, child_fd = pty.openpty()
+        self._proc = subprocess.Popen(
+            ("python", self._script, *(args or [])),
+            stdin=child_fd,
+            stderr=child_fd,
+            stdout=child_fd,
+        )
+
+        # Close our copy of the child FD as we no longer need it.
+        os.close(child_fd)
+
+        # We must use low-level operations to read the parent FD.
+        # We need non-blocking reads to implement timeouts.
+        os.set_blocking(self._parent_fd, False)
+
+    def __enter__(self) -> _TtyTester:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self._reset_timer()
+
+        try:
+            self._read_and_wait_for_proc()
+        except TimeoutError:
+            self._proc.kill()
+        finally:
+            os.close(self._parent_fd)
+
+    def unstyled_output(self) -> list[str]:
+        """Returns all text read so far without ANSI sequences."""
+        return click.unstyle(self.all_output().decode()).splitlines()
+
+    def all_output(self) -> bytes:
+        """Returns all bytes output by the subprocess so far.
+
+        Can be used after exiting the context manager.
+        """
+        return bytes(self._buffer)
+
+    def wait_for_text(self, text: bytes) -> None:
+        """Block until the given text has been output by the subprocess."""
+        self._reset_timer()
+        while text not in self._buffer:
+            self._read_more()
+            self._check_timeout()
+
+    def send_input(self, text: bytes) -> None:
+        """Write text to the process's stdin."""
+        self._reset_timer()
+        total_written = 0
+        while total_written < len(text):
+            total_written += os.write(self._parent_fd, text[total_written:])
+            self._check_timeout()
+
+    def _read_and_wait_for_proc(self) -> None:
+        """Read the process's output until it terminates, or time out."""
+
+        while True:
+            data = self._read_chunk()
+
+            if data:
+                self._buffer.extend(data)
+            elif self._proc.poll() is not None:
+                break
+
+            time.sleep(0.01)
+            self._check_timeout()
+
+    def _read_more(self) -> None:
+        """Block until at least one more byte is read, or time out."""
+        while not (data := self._read_chunk()):
+            time.sleep(0.01)
+            self._check_timeout()
+        self._buffer.extend(data)
+
+    def _read_chunk(self) -> bytes | None:
+        """Read a chunk of data if any is available."""
+        try:
+            return os.read(self._parent_fd, 1024)
+        except OSError:
+            # On macOS, only a BlockingIOError is possible.
+            # On Linux, this can also be an OSError after the child process
+            # shuts down.
+            return None
+
+    def _reset_timer(self) -> None:
+        """Reset the timeout timer."""
+        self._timer = time.monotonic()
+
+    def _check_timeout(self) -> None:
+        """Raise if too much time has passed since _reset_timer()."""
+        time_passed = time.monotonic() - self._timer
+        if time_passed > self._timeout:
+            message = (
+                f"Timed out after {time_passed:.2g}s."
+                f" Text so far: {self._buffer.decode()}"
+            )
+            raise TimeoutError(message)
+
+
+def test_basic_prompt():
+    with _TtyTester(_TESTER_SCRIPT, timeout=1) as tester:
+        tester.wait_for_text(b"PROMPT: ")
+        tester.send_input(b"the prompt\n")
+
+    assert tester.unstyled_output() == [
+        "wandb: PROMPT: the prompt",
+        "Got result: the prompt",
+        "DONE",
+    ]
+
+
+def test_abort():
+    with _TtyTester(_TESTER_SCRIPT, timeout=1) as tester:
+        tester.wait_for_text(b"PROMPT: ")
+
+        tester.send_input(b"this may be ignored")
+        # 3 is the ASCII code for Ctrl+C, understood by the pty.
+        tester.send_input(b"\x03")
+
+    lines = tester.unstyled_output()
+    assert lines[0] in (
+        # On macOS:
+        "wandb: PROMPT: ^C",
+        # On Linux:
+        "wandb: PROMPT: this may be ignored^C",
+    )
+    assert lines[1:] == [
+        "INTERRUPT!",
+    ]
+
+
+def test_abort_timeout():
+    with _TtyTester(
+        _TESTER_SCRIPT,
+        args=["--timeout", "10"],
+        timeout=1,
+    ) as tester:
+        tester.wait_for_text(b"PROMPT: ")
+
+        tester.send_input(b"this may be ignored")
+        # 3 is the ASCII code for Ctrl+C, understood by the pty.
+        tester.send_input(b"\x03")
+
+    lines = tester.unstyled_output()
+    assert lines[0] in (
+        # On macOS:
+        "wandb: PROMPT: (10 second timeout) ^C",
+        # On Linux:
+        "wandb: PROMPT: (10 second timeout) this may be ignored^C",
+    )
+    assert lines[1:] == [
+        "INTERRUPT!",
+    ]
+
+
+def test_hidden_prompt():
+    with _TtyTester(_TESTER_SCRIPT, args=["--hide"], timeout=1) as tester:
+        tester.wait_for_text(b"PROMPT: ")
+        tester.send_input(b"the prompt\n")
+
+    assert tester.unstyled_output() == [
+        "wandb: PROMPT: ",
+        "Got result: the prompt",
+        "DONE",
+    ]
+
+
+def test_timeout():
+    with _TtyTester(
+        _TESTER_SCRIPT,
+        args=["--timeout", "0.1"],
+        timeout=1,
+    ) as tester:
+        # Don't send any input, just let it time out.
+        pass
+
+    assert tester.unstyled_output() == [
+        "wandb: PROMPT: (0 second timeout) ",
+        "TIMEOUT!",
+    ]

--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -9,18 +9,9 @@ from unittest import mock
 import pytest
 import wandb
 import wandb.sdk.lib.apikey
-import wandb.util
 
 
-def test_login_timeout(notebook, monkeypatch):
-    monkeypatch.setattr(
-        wandb.util, "prompt_choices", lambda x, input_timeout=None, jupyter=True: x[0]
-    )
-    monkeypatch.setattr(
-        wandb.wandb_lib.apikey,
-        "prompt_choices",
-        lambda x, input_timeout=None, jupyter=True: x[0],
-    )
+def test_login_timeout(notebook):
     with notebook("login_timeout.ipynb", skip_api_key_env=True) as nb:
         nb.execute_all()
         output = nb.cell_output_text(1)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -210,22 +210,6 @@ def test_sync_gc(runner):
         assert not os.path.exists(run1_dir)
 
 
-def test_cli_login_reprompts_when_no_key_specified(runner, mocker, dummy_api_key):
-    with runner.isolated_filesystem():
-        mocker.patch("wandb.wandb_lib.apikey.getpass", input)
-        # this first gives login an empty API key, which should cause
-        # it to re-prompt.  this is what we are testing.  we then give
-        # it a valid API key (the dummy API key with a different final
-        # letter to check that our monkeypatch input is working as
-        # expected) to terminate the prompt finally we grep for the
-        # Error: No API key specified to assert that the re-prompt
-        # happened
-        result = runner.invoke(cli.login, input=f"\n{dummy_api_key[:-1]}q\n")
-        with open(get_netrc_file_path()) as f:
-            print(f.read())
-        assert "ERROR No API key specified." in result.output
-
-
 def test_docker_run_digest(runner, docker, monkeypatch):
     result = runner.invoke(
         cli.docker_run,

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -57,7 +57,7 @@ def mock_tty(monkeypatch):
             fds["stdin"] = open(fname)
             monkeypatch.setattr("sys.stdin", fds["stdin"])
             sys.stdin.isatty = lambda: True
-            sys.stdout.isatty = lambda: True
+            sys.stderr.isatty = lambda: True
 
         yield setup_fn
 
@@ -70,7 +70,7 @@ def mock_tty(monkeypatch):
             stdin.close()
 
     del sys.stdin.isatty
-    del sys.stdout.isatty
+    del sys.stderr.isatty
 
 
 def test_login_timeout(mock_tty):

--- a/wandb/sdk/lib/timed_input.py
+++ b/wandb/sdk/lib/timed_input.py
@@ -14,13 +14,14 @@ LF = "\n"
 CRLF = CR + LF
 
 
-def _echo(prompt: str) -> None:
-    sys.stdout.write(prompt)
-    sys.stdout.flush()
+def _echo(prompt: str, *, err: bool) -> None:
+    stream = sys.stderr if err else sys.stdout
+    stream.write(prompt)
+    stream.flush()
 
 
-def _posix_timed_input(prompt: str, timeout: float) -> str:
-    _echo(prompt)
+def _posix_timed_input(prompt: str, timeout: float, err: bool) -> str:
+    _echo(prompt, err=err)
     sel = selectors.DefaultSelector()
     sel.register(sys.stdin, selectors.EVENT_READ, data=sys.stdin.readline)
     events = sel.select(timeout=timeout)
@@ -32,15 +33,15 @@ def _posix_timed_input(prompt: str, timeout: float) -> str:
             raise TimeoutError
         return input_data.rstrip(LF)
 
-    _echo(LF)
+    _echo(LF, err=err)
     termios.tcflush(sys.stdin, termios.TCIFLUSH)
     raise TimeoutError
 
 
-def _windows_timed_input(prompt: str, timeout: float) -> str:
+def _windows_timed_input(prompt: str, timeout: float, err: bool) -> str:
     interval = 0.1
 
-    _echo(prompt)
+    _echo(prompt, err=err)
     begin = time.monotonic()
     end = begin + timeout
     line = ""
@@ -49,23 +50,23 @@ def _windows_timed_input(prompt: str, timeout: float) -> str:
         if msvcrt.kbhit():  # type: ignore[attr-defined]
             c = msvcrt.getwche()  # type: ignore[attr-defined]
             if c in (CR, LF):
-                _echo(CRLF)
+                _echo(CRLF, err=err)
                 return line
             if c == "\003":
                 raise KeyboardInterrupt
             if c == "\b":
                 line = line[:-1]
                 cover = SP * len(prompt + line + SP)
-                _echo("".join([CR, cover, CR, prompt, line]))
+                _echo("".join([CR, cover, CR, prompt, line]), err=err)
             else:
                 line += c
         time.sleep(interval)
 
-    _echo(CRLF)
+    _echo(CRLF, err=err)
     raise TimeoutError
 
 
-def _jupyter_timed_input(prompt: str, timeout: float) -> str:
+def _jupyter_timed_input(prompt: str, timeout: float, err: bool) -> str:
     clear = True
     try:
         from IPython.core.display import clear_output  # type: ignore
@@ -75,7 +76,7 @@ def _jupyter_timed_input(prompt: str, timeout: float) -> str:
             "Unable to clear output, can't import clear_output from ipython.core"
         )
 
-    _echo(prompt)
+    _echo(prompt, err=err)
 
     user_inp = None
     event = threading.Event()
@@ -99,25 +100,31 @@ def _jupyter_timed_input(prompt: str, timeout: float) -> str:
 
 
 def timed_input(
-    prompt: str, timeout: float, show_timeout: bool = True, jupyter: bool = False
+    prompt: str,
+    timeout: float,
+    show_timeout: bool = True,
+    jupyter: bool = False,
+    err: bool = False,
 ) -> str:
     """Behaves like builtin `input()` but adds timeout.
 
     Args:
-        prompt (str): Prompt to output to stdout.
-        timeout (float): Timeout to wait for input.
-        show_timeout (bool): Show timeout in prompt
-        jupyter (bool): If True, use jupyter specific code.
+        prompt: Prompt to output to stdout.
+        timeout: Timeout to wait for input.
+        show_timeout: Show timeout in prompt
+        jupyter: If True, use jupyter specific code.
+        err: If True, use stderr instead of stdout.
 
     Raises:
-        TimeoutError: exception raised if timeout occurred.
+        TimeoutError: If a timeout occurred.
+        KeyboardInterrupt: If the user aborted by pressing Ctrl+C.
     """
     if show_timeout:
         prompt = f"{prompt}({timeout:.0f} second timeout) "
     if jupyter:
-        return _jupyter_timed_input(prompt=prompt, timeout=timeout)
+        return _jupyter_timed_input(prompt=prompt, timeout=timeout, err=err)
 
-    return _timed_input(prompt=prompt, timeout=timeout)
+    return _timed_input(prompt=prompt, timeout=timeout, err=err)
 
 
 try:


### PR DESCRIPTION
Creates `terminput()` alongside `termlog()` for user input.

We had two ways of reading user input: `click.prompt()` and `timed_input()`. Both needed extra code to add the blue `wandb:` prefix, which was janky. They didn't respect `silent` mode or `TERM=dumb` and were printing to both `stdout` and `stderr`.

Known bug: `terminput` does unfortunately print a single space to `stdout` because that's what `click.prompt()` does even with `err=True`. It appears to be a bug in `click`. If you do something like

```
WANDB_BASE_URL="https://fake-url" python -c "import wandb; wandb.login()" > output.txt
```

then there will be a missing space after the prompt.

## Testing

The `test_terminput.py` test uses a pseudoterminal to realistically check usage of `click.prompt()` and the `timed_input` function.

I tested all printing modes on Windows, macOS and in Jupyter notebooks by running `wandb.login(host="https://fake-url")` with and without the `timeout` argument.

I tested that redirecting stderr with `... 2> output.txt`, piping stdin through `echo something | ...`, or setting `TERM=dumb` prevents an interactive prompt from being shown.

I updated a few tests that patched prompting internals to make `wandb.login()` do something. For most, I just updated the monkeypatches, but I removed `tests/unit_tests/test_cli.py::test_cli_login_reprompts_when_no_key_specified` because it's too hacky for testing a relatively unimportant functionality (it allows the user to try again if they accidentally pressed enter without typing anything).