### PR TITLE
fix: colon and space after api key prompt

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -136,9 +136,14 @@ def prompt_api_key(
         result = prompt_choices(choices, input_timeout=settings.login_timeout)
 
     key: str | None = None
-    api_ask = "Paste an API key from your profile and hit enter"
+
     if not jupyter:
-        api_ask += ", or press ctrl+c to quit"
+        api_ask = (
+            "Paste an API key from your profile and hit enter,"
+            " or press ctrl+c to quit: "
+        )
+    else:
+        api_ask = "Paste an API key from your profile and hit enter: "
 
     if result == LOGIN_CHOICE_ANON:
         key = api.create_anonymous_api_key()


### PR DESCRIPTION
Adds a colon and a space to the API key prompt.

PR #10834 changed this from using input() to click.prompt() via terminput(), but on terminput() I documented that the prompt should end with a colon and a space. That PR didn't change anything, and I didn't notice this when testing because the Terminal on macOS has a special display for hidden input, but I don't know for sure about other systems and terminals.
