### PR TITLE
refactor: add terminput to emulated_terminal fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,8 @@ from typing import Any, Callable, Generator, Iterable, Iterator
 
 import pyte
 import pyte.modes
-from pytest_mock import MockerFixture
 from wandb.errors import term
+from wandb.sdk import wandb_login
 
 # Don't write to Sentry in wandb.
 os.environ["WANDB_ERROR_REPORTING"] = "false"
@@ -181,9 +181,10 @@ class EmulatedTerminal:
         self._screen = pyte.Screen(80, 24)
         self._screen.set_mode(pyte.modes.LNM)  # \n implies \r
         self._stream = pyte.Stream(self._screen)
+        self._inputs: list[str] = []
 
     def reset_capsys(self) -> None:
-        """Resets pytest's captured stderr and stdout buffers."""
+        """Reset pytest's captured stderr and stdout buffers."""
         self._capsys.readouterr()
 
     def read_stderr(self) -> list[str]:
@@ -197,7 +198,7 @@ class EmulatedTerminal:
         NOTE: This resets pytest's stderr and stdout buffers. You should not
         use this with anything else that uses capsys.
         """
-        self._stream.feed(self._capsys.readouterr().err)
+        self._process_captured_text()
 
         lines = [line.rstrip() for line in self._screen.display]
 
@@ -206,27 +207,71 @@ class EmulatedTerminal:
         n_empty_at_end = sum(1 for _ in takewhile(lambda line: not line, lines[::-1]))
         return lines[n_empty_at_start:-n_empty_at_end]
 
+    def queue_input(self, text: str) -> None:
+        """Queue the next terminput return value."""
+        self._inputs.append(text)
+
+    def terminput(
+        self,
+        prefixed_prompt: str,
+        *,
+        timeout: float | None = None,
+        hide: bool = False,
+    ) -> str:
+        """A fake implementation of term._terminput().
+
+        Raises an assertion error if no inputs are queued.
+        """
+        # Simulate printing the prompt.
+        self._process_captured_text()
+        self._stream.feed(prefixed_prompt)
+
+        if not self._inputs:
+            if timeout is not None:
+                raise TimeoutError
+            else:
+                raise AssertionError("terminput() used, but no inputs queued.")
+
+        input = self._inputs.pop(0)
+
+        # Simulate printing the input and the return key press.
+        if not hide:
+            self._stream.feed(f"{input}\n")
+        else:
+            self._stream.feed("\n")
+
+        return input
+
+    def _process_captured_text(self) -> None:
+        """Read capsys and update the terminal state."""
+        self._stream.feed(self._capsys.readouterr().err)
+
 
 @pytest.fixture()
 def emulated_terminal(monkeypatch, capsys) -> EmulatedTerminal:
     """Emulates a terminal for the duration of a test.
 
     This makes functions in the `wandb.errors.term` module act as if
-    stderr is a terminal.
+    we're connected to a terminal.
 
     NOTE: This resets pytest's stderr and stdout buffers. You should not
     use this with anything else that uses capsys.
     """
+    terminal = EmulatedTerminal(capsys)
 
+    # Allow dynamic_text().
     monkeypatch.setenv("TERM", "xterm")
-
     monkeypatch.setattr(term, "_sys_stderr_isatty", lambda: True)
+
+    # Allow terminput().
+    monkeypatch.setattr(term, "can_use_terminput", lambda: True)
+    monkeypatch.setattr(term, "_terminput", terminal.terminput)
 
     # Make click pretend we're a TTY, so it doesn't strip ANSI sequences.
     # This is fragile and could break when click is updated.
     monkeypatch.setattr("click._compat.isatty", lambda *args, **kwargs: True)
 
-    return EmulatedTerminal(capsys)
+    return terminal
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -283,11 +328,14 @@ def dummy_api_key() -> str:
 
 
 @pytest.fixture
-def patch_apikey(mocker: MockerFixture, dummy_api_key: str):
-    mocker.patch.object(
-        wandb.sdk.lib.apikey,
+def patch_apikey(monkeypatch: pytest.MonkeyPatch, dummy_api_key: str) -> None:
+    monkeypatch.setattr(
+        wandb_login._WandbLogin,
         "prompt_api_key",
-        return_value=dummy_api_key,
+        lambda *args, **kwargs: (
+            dummy_api_key,
+            wandb_login.ApiKeyStatus.VALID,
+        ),
     )
 
 

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -1,128 +1,69 @@
 import json
-import os
-import platform
-import queue
-import sys
-import tempfile
-import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest import mock
 
 import pytest
 import wandb
+from wandb.sdk import wandb_login, wandb_setup
 from wandb.sdk.lib.credentials import _expires_at_fmt
 
 
-@pytest.fixture
-def mock_tty(monkeypatch):
-    class WriteThread(threading.Thread):
-        def __init__(self, fname):
-            threading.Thread.__init__(self)
-            self._fname = fname
-            self._q = queue.Queue()
+def test_login_timeout(emulated_terminal):
+    emulated_terminal.queue_input("junk")
+    emulated_terminal.queue_input("more")
 
-        def run(self):
-            with open(self._fname, "w") as fp:
-                while True:
-                    data = self._q.get()
-                    if data == "_DONE_":
-                        break
-                    fp.write(data)
-                    fp.flush()
-
-        def add(self, input_str):
-            self._q.put(input_str)
-
-        def stop(self):
-            self.add("_DONE_")
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        fds = dict()
-
-        def setup_fn(input_str):
-            fname = os.path.join(tmpdir, "file.txt")
-            if platform.system() != "Windows":
-                os.mkfifo(fname, 0o600)
-                writer = WriteThread(fname)
-                writer.start()
-                writer.add(input_str)
-                fds["writer"] = writer
-                monkeypatch.setattr("termios.tcflush", lambda x, y: None)
-            else:
-                # windows doesn't support named pipes, just write it
-                # TODO: emulate msvcrt to support input on windows
-                with open(fname, "w") as fp:
-                    fp.write(input_str)
-            fds["stdin"] = open(fname)
-            monkeypatch.setattr("sys.stdin", fds["stdin"])
-            sys.stdin.isatty = lambda: True
-            sys.stderr.isatty = lambda: True
-
-        yield setup_fn
-
-        writer = fds.get("writer")
-        if writer:
-            writer.stop()
-            writer.join()
-        stdin = fds.get("stdin")
-        if stdin:
-            stdin.close()
-
-    del sys.stdin.isatty
-    del sys.stderr.isatty
-
-
-def test_login_timeout(mock_tty):
-    mock_tty("junk\nmore\n")
     logged_in = wandb.login(timeout=4)
+
     assert logged_in is False
     assert wandb.api.api_key is None
     assert wandb.setup().settings.mode == "disabled"
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows",
-    reason="mock_tty does not support windows input yet",
-)
-def test_login_timeout_choose(mock_tty):
-    mock_tty("3\n")
+def test_login_timeout_choose(emulated_terminal):
+    emulated_terminal.queue_input("3")
+
     logged_in = wandb.login(timeout=8)
+
     assert logged_in is False
     assert wandb.api.api_key is None
     assert wandb.setup().settings.mode == "offline"
 
 
-def test_login_timeout_env_blank(mock_tty):
-    mock_tty("\n\n\n")
-    with mock.patch.dict(os.environ, {"WANDB_LOGIN_TIMEOUT": "4"}):
-        logged_in = wandb.login()
-        assert logged_in is False
-        assert wandb.api.api_key is None
-        assert wandb.setup().settings.mode == "disabled"
+def test_login_timeout_env_blank(emulated_terminal, monkeypatch):
+    _ = emulated_terminal
+    monkeypatch.setenv("WANDB_LOGIN_TIMEOUT", "4")
 
-
-def test_login_timeout_env_invalid(mock_tty):
-    mock_tty("")
-    with mock.patch.dict(os.environ, {"WANDB_LOGIN_TIMEOUT": "junk"}):
-        with pytest.raises(ValueError):
-            wandb.login()
-
-
-def test_relogin_timeout(dummy_api_key):
-    logged_in = wandb.login(relogin=True, key=dummy_api_key)
-    assert logged_in is True
     logged_in = wandb.login()
-    assert logged_in is True
+
+    assert logged_in is False
+    assert wandb.api.api_key is None
+    assert wandb.setup().settings.mode == "disabled"
 
 
-def test_login_key(capsys):
+def test_login_timeout_env_invalid(emulated_terminal, monkeypatch):
+    _ = emulated_terminal
+    monkeypatch.setenv("WANDB_LOGIN_TIMEOUT", "junk")
+
+    with pytest.raises(ValueError):
+        wandb.login()
+
+
+def test_relogin_timeout(emulated_terminal, dummy_api_key):
+    assert wandb.login(relogin=True, key=dummy_api_key)
+    terminal_state1 = emulated_terminal.read_stderr()
+
+    assert wandb.login()
+    terminal_state2 = emulated_terminal.read_stderr()
+
+    # The second login should succeed immediately without printing.
+    assert terminal_state1 == terminal_state2
+
+
+def test_login_key(emulated_terminal):
     wandb.login(key="A" * 40)
-    # TODO: this was a bug when tests were leaking out to the global config
-    # wandb.api.set_setting("base_url", "http://localhost:8080")
-    _, err = capsys.readouterr()
-    assert "Appending key" in err
-    #  WTF is happening?
+
+    assert "Appending key" in "\n".join(emulated_terminal.read_stderr())
     assert wandb.api.api_key == "A" * 40
 
 
@@ -133,23 +74,40 @@ def test_login(test_settings):
     wandb.finish()
 
 
-def test_login_anonymous():
-    with mock.patch.dict("os.environ", WANDB_API_KEY="ANONYMOOSE" * 4):
-        wandb.login(anonymous="must")
-        assert wandb.api.api_key == "ANONYMOOSE" * 4
-        assert wandb.setup().settings.anonymous == "must"
+def test_login_anonymous(monkeypatch):
+    monkeypatch.setenv("WANDB_API_KEY", "ANONYMOOSE" * 4)
+
+    wandb.login(anonymous="must")
+
+    assert wandb.api.api_key == "ANONYMOOSE" * 4
+    assert wandb.setup().settings.anonymous == "must"
 
 
-def test_login_sets_api_base_url(local_settings, skip_verify_login):
-    with mock.patch.dict("os.environ", WANDB_API_KEY="ANONYMOOSE" * 4):
-        base_url = "https://api.test.host.ai"
-        wandb.login(anonymous="must", host=base_url)
-        api = wandb.Api()
-        assert api.settings["base_url"] == base_url
-        base_url = "https://api.wandb.ai"
-        wandb.login(anonymous="must", host=base_url)
-        api = wandb.Api()
-        assert api.settings["base_url"] == base_url
+def test_login_sets_api_base_url(
+    emulated_terminal,
+    monkeypatch,
+    local_settings,
+    skip_verify_login,
+):
+    _ = emulated_terminal
+
+    # HACK: Prevent the test from attempting to connect to the fake URLs.
+    monkeypatch.setattr(
+        wandb_login._WandbLogin,
+        "_print_logged_in_message",
+        lambda self: None,
+    )
+
+    monkeypatch.setenv("WANDB_API_KEY", "ANONYMOOSE" * 4)
+    base_url = "https://api.test.host.ai"
+    wandb.login(anonymous="must", host=base_url)
+
+    assert wandb_setup.singleton().settings.base_url == base_url
+
+    base_url = "https://api.wandb.ai"
+    wandb.login(anonymous="must", host=base_url)
+
+    assert wandb_setup.singleton().settings.base_url == base_url
 
 
 def test_login_invalid_key():
@@ -164,6 +122,8 @@ def test_login_invalid_key():
         assert wandb.api.api_key is None
 
 
+# TODO: Make this a system test that runs agains the local-testcontainer?
+@pytest.mark.skip(reason="Test has network calls")
 def test_login_with_token_file(tmp_path: Path):
     token_file = str(tmp_path / "jwt.txt")
     credentials_file = str(tmp_path / "credentials.json")

--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -289,14 +289,23 @@ def terminput(
             set, or wandb is configured in 'silent' mode.
         KeyboardInterrupt: If the user pressed Ctrl+C during the prompt.
     """
+    prefixed_prompt = f"{LOG_STRING}: {prompt}"
+    return _terminput(prefixed_prompt, timeout=timeout, hide=hide)
+
+
+def _terminput(
+    prefixed_prompt: str,
+    *,
+    timeout: float | None = None,
+    hide: bool = False,
+) -> str:
+    """Implements terminput() and can be patched by tests."""
     if not can_use_terminput():
         raise NotATerminalError
 
     if hide and timeout is not None:
         # Only click.prompt() can hide, and only timed_input can time out.
         raise NotImplementedError
-
-    prefixed_prompt = f"{LOG_STRING}: {prompt}"
 
     if timeout is not None:
         # Lazy import to avoid circular imports.


### PR DESCRIPTION
Makes `terminput` usage testable!

I updated `test_wandb_login.py` which is the main place this was useful. The login tests definitely need some cleanup: these are supposed to be "unit" tests, but they're performing network operations.