### PR TITLE
refactor: wandb login interactive prompt

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,10 +188,7 @@ def skip_verify_login(monkeypatch):
 @pytest.fixture
 def patch_prompt(monkeypatch):
     monkeypatch.setattr(
-        wandb.util, "prompt_choices", lambda x, input_timeout=None: x[0]
-    )
-    monkeypatch.setattr(
-        wandb.wandb_lib.apikey,
+        wandb.util,
         "prompt_choices",
         lambda x, input_timeout=None: x[0],
     )

--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 import wandb
-import wandb.sdk.lib.apikey
+import wandb.util
 
 
 def test_login_timeout(notebook):
@@ -151,16 +151,13 @@ def test_notebook_not_exists(mocked_ipython, user, capsys):
         run.finish()
 
 
-def test_databricks_notebook_doesnt_hang_on_wandb_login(mocked_module):
+def test_databricks_notebook_doesnt_hang_on_wandb_login(monkeypatch):
     # test for WB-5264
     # when we try to call wandb.login(), should fail with no-tty
-    with mock.patch.object(
-        wandb.sdk.lib.apikey,
-        "_is_databricks",
-        return_value=True,
-    ):
-        with pytest.raises(wandb.UsageError, match="tty"):
-            wandb.login()
+    monkeypatch.setattr(wandb.util, "_is_databricks", lambda: True)
+
+    with pytest.raises(wandb.UsageError, match="No API key configured"):
+        wandb.login()
 
 
 def test_mocked_notebook_html_default(user, run_id, mocked_ipython):

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -149,7 +149,7 @@ def test_login_invalid_key_arg(runner, dummy_api_key):
     with runner.isolated_filesystem():
         invalid_key = "test-" + dummy_api_key[:-5]
         result = runner.invoke(cli.login, [invalid_key])
-        assert "API key must be at least 40 characters long, yours was" in str(result)
+        assert "API key must have 40+ characters, has 35." in str(result)
         assert result.exit_code == 1
 
 

--- a/tests/unit_tests/test_lib/test_apikey.py
+++ b/tests/unit_tests/test_lib/test_apikey.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 import pytest
 from wandb import wandb, wandb_lib
-from wandb.sdk.lib.apikey import _api_key_prompt_str
 
 
 @pytest.mark.parametrize("api_key", ["X" * 40, "X" * 86])
@@ -153,11 +152,3 @@ def test_read_apikey_no_netrc_access(tmp_path, monkeypatch, mock_wandb_log):
         api_key = wandb_lib.apikey.api_key(settings)
         assert api_key is None
         mock_wandb_log.assert_warned(f"Cannot access {netrc_path}.")
-
-
-def test_apikey_prompt_str():
-    app_url = "http://localhost"
-    auth_base = f"{app_url}/authorize"
-    prompt_str = f"You can find your API key in your browser here: {auth_base}"
-    assert _api_key_prompt_str(app_url) == prompt_str
-    assert _api_key_prompt_str(app_url, "weave") == f"{prompt_str}?ref=weave"

--- a/tests/unit_tests/test_lib/test_auth_prompt.py
+++ b/tests/unit_tests/test_lib/test_auth_prompt.py
@@ -1,0 +1,234 @@
+import pytest
+from wandb.errors import links, term
+from wandb.sdk.lib.auth import anon, prompt, saas
+
+from tests.fixtures.emulated_terminal import EmulatedTerminal
+
+
+def test_authorize_url_uses_app_url():
+    result = prompt._authorize_url(
+        "https://api.wandb.ai",
+        signup=False,
+        referrer="",
+    )
+
+    # There's special logic to map several API URL formats to "app" URLs.
+    # This just tests that we're not using the API URL directly.
+    assert result == "https://wandb.ai/authorize"
+
+
+def test_timeout(emulated_terminal: EmulatedTerminal):
+    _ = emulated_terminal  # select nothing, allow a timeout
+
+    with pytest.raises(TimeoutError):
+        prompt.prompt_api_key(host="https://test-host", input_timeout=1)
+
+
+def test_not_a_terminal():
+    with pytest.raises(term.NotATerminalError):
+        prompt.prompt_api_key(host="https://test-host")
+
+
+def test_no_anonymous(emulated_terminal: EmulatedTerminal):
+    _ = emulated_terminal  # select nothing, allow a timeout
+
+    with pytest.raises(TimeoutError):
+        prompt.prompt_api_key(
+            host="https://test-host",
+            no_anonymous=True,
+            input_timeout=1,
+        )
+
+    assert emulated_terminal.read_stderr() == [
+        "wandb: (1) Create a W&B account",
+        "wandb: (2) Use an existing W&B account",
+        "wandb: (3) Don't visualize my results",
+        "wandb: Enter your choice:",
+    ]
+
+
+def test_no_offline(emulated_terminal: EmulatedTerminal):
+    _ = emulated_terminal  # select nothing, allow a timeout
+
+    with pytest.raises(TimeoutError):
+        prompt.prompt_api_key(
+            host="https://test-host",
+            no_offline=True,
+            input_timeout=1,
+        )
+
+    assert emulated_terminal.read_stderr() == [
+        "wandb: (1) Private W&B dashboard, no account required",
+        "wandb: (2) Create a W&B account",
+        "wandb: (3) Use an existing W&B account",
+        "wandb: Enter your choice:",
+    ]
+
+
+def test_no_create(emulated_terminal: EmulatedTerminal):
+    _ = emulated_terminal  # select nothing, allow a timeout
+
+    with pytest.raises(TimeoutError):
+        prompt.prompt_api_key(
+            host="https://test-host",
+            no_create=True,
+            input_timeout=1,
+        )
+
+    assert emulated_terminal.read_stderr() == [
+        "wandb: (1) Private W&B dashboard, no account required",
+        "wandb: (2) Use an existing W&B account",
+        "wandb: (3) Don't visualize my results",
+        "wandb: Enter your choice:",
+    ]
+
+
+def test_choice_anonymous(
+    emulated_terminal: EmulatedTerminal,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_key = "ANONYMOOSE" * 4
+    monkeypatch.setattr(
+        anon,
+        "make_anonymous_api_key",
+        lambda *args, **kwargs: fake_key,
+    )
+
+    emulated_terminal.queue_input("1")  # select anonymous mode in prompt
+    result = prompt.prompt_api_key(host="https://test-host")
+
+    assert result == fake_key
+
+
+def test_choice_anonymous_error_retries(
+    emulated_terminal: EmulatedTerminal,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def raise_error(*args, **kwargs):
+        raise Exception("Test error")
+
+    monkeypatch.setattr(anon, "make_anonymous_api_key", raise_error)
+
+    emulated_terminal.queue_input("1")  # select anonymous mode in prompt
+    emulated_terminal.queue_input("3")  # select "use an existing account"
+    emulated_terminal.queue_input("test" * 10)  # input a fake API key
+    result = prompt.prompt_api_key(host="https://test-host")
+
+    assert result == "test" * 10
+    assert (
+        "wandb: ERROR Error creating an anonymous API key: Test error"
+        in emulated_terminal.read_stderr()
+    )
+
+
+@pytest.mark.parametrize("referrer", ("", "test"))
+def test_choice_new(referrer: str, emulated_terminal: EmulatedTerminal):
+    emulated_terminal.queue_input("2")  # select "create a new account"
+    emulated_terminal.queue_input("test" * 10)  # input a fake API key
+    result = prompt.prompt_api_key(
+        host="https://test-host",
+        referrer=referrer,
+    )
+
+    if referrer:
+        expected_auth_url = f"https://test-host/authorize?signup=true&ref={referrer}"
+    else:
+        expected_auth_url = "https://test-host/authorize?signup=true"
+
+    assert result == "test" * 10
+    assert emulated_terminal.read_stderr() == [
+        "wandb: (1) Private W&B dashboard, no account required",
+        "wandb: (2) Create a W&B account",
+        "wandb: (3) Use an existing W&B account",
+        "wandb: (4) Don't visualize my results",
+        "wandb: Enter your choice: 2",
+        "wandb: You chose 'Create a W&B account'",
+        f"wandb: Create an account here: {expected_auth_url}",
+        "wandb: Paste an API key from your profile and hit enter:",
+    ]
+
+
+def test_choice_new_invalid(emulated_terminal: EmulatedTerminal):
+    emulated_terminal.queue_input("2")  # select "create a new account"
+    emulated_terminal.queue_input("")  # press enter without typing anything
+    emulated_terminal.queue_input("3")  # select "create an existing account"
+    emulated_terminal.queue_input("test" * 10)  # enter a valid key
+    result = prompt.prompt_api_key(host="https://test-host", input_timeout=1)
+
+    assert result == "test" * 10
+    assert (
+        "wandb: ERROR Invalid API key: API key is empty."
+        in emulated_terminal.read_stderr()
+    )
+
+
+@pytest.mark.parametrize("referrer", (None, "test-referrer"))
+@pytest.mark.parametrize("is_wandb_domain", (False, True))
+def test_choice_existing(
+    referrer: str,
+    is_wandb_domain: bool,
+    emulated_terminal: EmulatedTerminal,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        saas,
+        "is_wandb_domain",
+        lambda *args: is_wandb_domain,
+    )
+
+    emulated_terminal.queue_input("3")  # select "use an existing account"
+    emulated_terminal.queue_input("test" * 10)  # input a fake API key
+    result = prompt.prompt_api_key(
+        host="https://test-host",
+        referrer=referrer,
+    )
+
+    if referrer:
+        expected_auth_url = f"https://test-host/authorize?ref={referrer}"
+    else:
+        expected_auth_url = "https://test-host/authorize"
+
+    if is_wandb_domain:
+        help_url = links.url_registry.url("wandb-server")
+        maybe_local_server_hint = [
+            # Lines are wrapped at 80 characters in the test terminal.
+            "wandb: Logging into https://test-host."
+            + " (Learn how to deploy a W&B server locally",
+            f": {help_url})",
+        ]
+    else:
+        maybe_local_server_hint = []
+
+    assert result == "test" * 10
+    assert emulated_terminal.read_stderr() == [
+        "wandb: (1) Private W&B dashboard, no account required",
+        "wandb: (2) Create a W&B account",
+        "wandb: (3) Use an existing W&B account",
+        "wandb: (4) Don't visualize my results",
+        "wandb: Enter your choice: 3",
+        "wandb: You chose 'Use an existing W&B account'",
+    ] + maybe_local_server_hint + [
+        f"wandb: Find your API key here: {expected_auth_url}",
+        "wandb: Paste an API key from your profile and hit enter:",
+    ]
+
+
+def test_choice_existing_invalid(emulated_terminal: EmulatedTerminal):
+    emulated_terminal.queue_input("3")  # select "use an existing account"
+    emulated_terminal.queue_input("")  # press enter without typing anything
+    emulated_terminal.queue_input("2")  # select "create a new account"
+    emulated_terminal.queue_input("test" * 10)  # enter a valid key
+    result = prompt.prompt_api_key(host="https://test-host", input_timeout=1)
+
+    assert result == "test" * 10
+    assert (
+        "wandb: ERROR Invalid API key: API key is empty."
+        in emulated_terminal.read_stderr()
+    )
+
+
+def test_choice_offline(emulated_terminal: EmulatedTerminal):
+    emulated_terminal.queue_input("4")  # select offline mode in prompt
+    result = prompt.prompt_api_key(host="https://test-host")
+
+    assert result is None

--- a/tests/unit_tests/test_lib/test_auth_validation.py
+++ b/tests/unit_tests/test_lib/test_auth_validation.py
@@ -1,0 +1,21 @@
+import pytest
+from wandb.sdk.lib.auth import validation
+
+
+@pytest.mark.parametrize(
+    "key, problems",
+    (
+        ("", "API key is empty."),
+        ("some-prefix-" + "A" * 39, "API key must have 40+ characters, has 39."),
+        ("some-prefix-" + "A" * 40, None),
+        ("some-prefix-" + "A" * 60, None),
+        ("*", "API key may only contain"),
+    ),
+)
+def test_check_api_key(key, problems):
+    result = validation.check_api_key(key)
+
+    if problems is None:
+        assert result is None
+    else:
+        assert problems in result

--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -277,6 +277,13 @@ def can_use_terminput() -> bool:
     if _silent or not _show_info or _is_term_dumb():
         return False
 
+    from wandb import util
+
+    # TODO: Verify the databricks check is still necessary.
+    # Originally added to fix WB-5264.
+    if util._is_databricks():
+        return False
+
     # isatty() returns false in Jupyter, but it's OK to output ANSI color
     # sequences and to read from stdin.
     return _in_jupyter() or (_sys_stderr_isatty() and _sys_stdin_isatty())

--- a/wandb/sdk/lib/auth/__init__.py
+++ b/wandb/sdk/lib/auth/__init__.py
@@ -1,0 +1,9 @@
+__all__ = (
+    "check_api_key",
+    "prompt_api_key",
+    "make_anonymous_api_key",
+)
+
+from .anon import make_anonymous_api_key
+from .prompt import prompt_api_key
+from .validation import check_api_key

--- a/wandb/sdk/lib/auth/anon.py
+++ b/wandb/sdk/lib/auth/anon.py
@@ -1,0 +1,26 @@
+"""The 'anonymous' mode allows using W&B without an account."""
+
+from wandb.apis import InternalApi
+from wandb.sdk import wandb_setup
+
+
+def make_anonymous_api_key(*, host: str) -> str:
+    """Create a new API key for an anonymous user.
+
+    Args:
+        host: The URL to the W&B server.
+
+    Returns:
+        A new API key.
+
+    Raises:
+        Exception: If there was a network error, the backend returned
+            an error response, or a programming error occurred.
+    """
+    settings_for_host = wandb_setup.singleton().settings.model_copy()
+    settings_for_host.base_url = host  # raises if host format is wrong
+
+    api = InternalApi(settings_for_host)
+
+    # TODO: Move implementation here and provide better exception guarantees.
+    return api.create_anonymous_api_key()

--- a/wandb/sdk/lib/auth/prompt.py
+++ b/wandb/sdk/lib/auth/prompt.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlsplit, urlunsplit
+
+from wandb import util
+from wandb.errors import links, term
+
+from . import anon, saas, validation
+
+_logger = logging.getLogger(__name__)
+
+_LOGIN_CHOICE_ANON = "Private W&B dashboard, no account required"
+_LOGIN_CHOICE_NEW = "Create a W&B account"
+_LOGIN_CHOICE_EXISTS = "Use an existing W&B account"
+_LOGIN_CHOICE_OFFLINE = "Don't visualize my results"
+_LOGIN_CHOICES = [
+    _LOGIN_CHOICE_ANON,
+    _LOGIN_CHOICE_NEW,
+    _LOGIN_CHOICE_EXISTS,
+    _LOGIN_CHOICE_OFFLINE,
+]
+
+
+def prompt_api_key(
+    *,
+    host: str,
+    no_anonymous: bool = False,
+    no_offline: bool = False,
+    no_create: bool = False,
+    referrer: str = "",
+    input_timeout: float | None = None,
+) -> str | None:
+    """Prompt for an API key.
+
+    Args:
+        host: The URL to the W&B server, like 'https://api.wandb.ai'.
+        no_anonymous: If true, do not show an anonymous login option.
+        no_offline: If true, do not show an option to skip logging in.
+        no_create: If true, do not show an option to create a new account.
+        referrer: A referrer string to tack on as a query parameter to
+            the printed URL for analytics.
+        input_timeout: How long to wait for user input before timing out.
+
+    Returns:
+        Either the resulting API key or None if the user selected offline mode.
+
+    Raises:
+        NotATerminalError: If a terminal is not available.
+        TimeoutError: If the specified timeout expired.
+    """
+    if not term.can_use_terminput():
+        raise term.NotATerminalError
+
+    choices = list(_LOGIN_CHOICES)
+    if no_anonymous:
+        choices.remove(_LOGIN_CHOICE_ANON)
+    if no_offline:
+        choices.remove(_LOGIN_CHOICE_OFFLINE)
+    if no_create:
+        choices.remove(_LOGIN_CHOICE_NEW)
+
+    while True:
+        choice = util.prompt_choices(choices, input_timeout=input_timeout)
+
+        if choice == _LOGIN_CHOICE_ANON:
+            try:
+                return anon.make_anonymous_api_key(host=host)
+            except Exception as e:
+                term.termerror(f"Error creating an anonymous API key: {e}")
+                term.termerror("Please try again or select another option.")
+
+        elif choice == _LOGIN_CHOICE_NEW:
+            key = _create_new_account(host=host, referrer=referrer)
+            if problems := validation.check_api_key(key):
+                term.termerror(f"Invalid API key: {problems}")
+            else:
+                return key
+
+        elif choice == _LOGIN_CHOICE_EXISTS:
+            key = _use_existing_account(host=host, referrer=referrer)
+            if problems := validation.check_api_key(key):
+                term.termerror(f"Invalid API key: {problems}")
+            else:
+                return key
+
+        elif choice == _LOGIN_CHOICE_OFFLINE:
+            return None
+
+        else:
+            term.termerror("Not implemented. Please select another choice.")
+
+
+def _use_existing_account(host: str, referrer: str) -> str:
+    """Prompt the user to paste an API key from an existing W&B account.
+
+    Args:
+        host: The W&B server URL.
+        referrer: The referrer to add to the printed URL, if any.
+
+    Returns:
+        The API key entered by the user.
+    """
+    if saas.is_wandb_domain(host):
+        help_url = links.url_registry.url("wandb-server")
+        term.termlog(
+            f"Logging into {host}. "
+            + f"(Learn how to deploy a W&B server locally: {help_url})"
+        )
+
+    auth_url = _authorize_url(host, signup=False, referrer=referrer)
+    term.termlog(f"Find your API key here: {auth_url}")
+    return term.terminput(
+        "Paste an API key from your profile and hit enter: ",
+        hide=True,
+    )
+
+
+def _create_new_account(host: str, referrer: str) -> str:
+    """Prompt the user to create a new W&B account.
+
+    Args:
+        host: The W&B server URL.
+        referrer: The referrer to add to the printed URL, if any.
+
+    Returns:
+        The API key entered by the user.
+    """
+    url = _authorize_url(host, signup=True, referrer=referrer)
+    term.termlog(f"Create an account here: {url}")
+    return term.terminput(
+        "Paste an API key from your profile and hit enter: ",
+        hide=True,
+    )
+
+
+def _authorize_url(host: str, *, signup: bool, referrer: str) -> str:
+    """Returns the URL for the web page showing the user's API key.
+
+    Args:
+        host: The W&B server URL.
+        signup: If true, shows a signup page.
+        referrer: The referrer to add to the URL, if any.
+    """
+    app_url = util.app_url(host)
+    scheme, netloc, _, _, _ = urlsplit(app_url, scheme="https")
+
+    query_parts: list[str] = []
+    if signup:
+        query_parts.append("signup=true")
+    if referrer:
+        query_parts.append(f"ref={referrer}")
+    query = "&".join(query_parts)
+
+    return urlunsplit((scheme, netloc, "authorize", query, ""))

--- a/wandb/sdk/lib/auth/saas.py
+++ b/wandb/sdk/lib/auth/saas.py
@@ -1,0 +1,7 @@
+from urllib.parse import urlsplit
+
+
+def is_wandb_domain(url: str) -> bool:
+    """Returns whether the URL points to an official W&B server."""
+    _, netloc, _, _, _ = urlsplit(url)
+    return netloc.endswith("wandb.ai")

--- a/wandb/sdk/lib/auth/validation.py
+++ b/wandb/sdk/lib/auth/validation.py
@@ -1,0 +1,34 @@
+"""Validation for API keys."""
+
+from __future__ import annotations
+
+import re
+
+
+def check_api_key(key: str) -> str | None:
+    """Returns text describing problems with the API key, or None.
+
+    If the key is in a valid format, returns None. Otherwise, returns
+    a string formatted as a complete sentence (capitalized, punctuated)
+    explaining the problem with the key.
+
+    Args:
+        key: The API key to check.
+    """
+    if not key:
+        return "API key is empty."
+
+    # On-prem API keys have a variable-length prefix followed by a dash.
+    parts = key.rsplit("-", 1)
+    if len(parts) == 1:
+        secret = parts[0]
+    else:
+        _, secret = parts
+
+    if not re.fullmatch(r"\w+", secret):
+        return "API key may only contain the letters A-Z, digits and underscores."
+
+    if (secret_len := len(secret)) < 40:
+        return f"API key must have 40+ characters, has {secret_len}."
+
+    return None

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1325,11 +1325,16 @@ def prompt_choices(
 ) -> str:
     """Prompt the user to choose from a list of options.
 
+    If exactly one choice is given, it is returned immediately.
+
     Raises:
         TimeoutError: if input_timeout is specified and expires.
         NotATerminalError: if the output device is not capable.
         KeyboardInterrupt: if the user aborts by pressing Ctrl+C.
     """
+    if len(choices) == 1:
+        return choices[0]
+
     for i, choice_str in enumerate(choices):
         wandb.termlog(f"({i + 1}) {choice_str}")
 


### PR DESCRIPTION
Completely rewrites the `wandb login` / `wandb.login()` interactive prompt code.

I put this in the new `wandb/sdk/lib/auth/` directory which will later consolidate other auth logic. The new code is thoroughly tested unlike the old code, and it is a lot more readable in my opinion. For instance, the previous `prompt_api_key`'s return value was `str | Literal[False] | None`.

I made some small changes:

* The old code checked if we're in Jupyter and if not, added "or press ctrl+c to quit" to the input prompts. I think this was kind of nice, but I'm not sure it's worth the 3-4 extra lines of code (and additional test). We don't add this hint in other places, like `prompt_choices()`.
* The old code used `settings.is_local` which compared the base_url exactly to the string "https://api.wandb.ai"; the new code looks for any URL where the domain ends with "wandb.ai"
* I shortened "You can find your API key in your browser here" to "Find your API key here"
* The new code validates the entered API key

The function `check_api_key()` is slightly different from the validation logic in `apikey.py::write_key`. It uses `rsplit` instead of `split` to split out the on-prem prefix (using `split() is a bug in `write_key()`). It also enforces alphanumeric characters in the API key (confirmed with the team this is future-proof).


## Testing

This is only used by `wandb login` and `wandb.login()`, so manual tests just need to invoke those.

The CLI commands call `login()` with `force=True`, setting `no_offline` / `no_create`.

```bash
wandb login --host=https://fake-url --relogin

# Skips prompting, uses anonymous mode:
wandb login --anonymously --relogin
```

In the prompts, I tried entering invalid choices and pressing Ctrl+C.

For the other options:

```bash
# Without anonymous mode:
python -c 'import wandb; wandb.login(host="https://fake-url", relogin=True)'

# With anonymous mode:
python -c 'import wandb; wandb.login(host="https://fake-url", relogin=True, anonymous="allow")'

# Timeouts:
python -c 'import wandb; wandb.login(host="https://fake-url", relogin=True, timeout=3)'
```

Anonymous mode with WiFi turned off gets stuck on "wandb: Network error (ConnectionError), entering retry loop." Presumably it eventually succeeds, but to test that true failures reprompt the user, I just modified it locally to raise an exception:

```
wandb: (1) Private W&B dashboard, no account required
wandb: (2) Create a W&B account
wandb: (3) Use an existing W&B account
wandb: (4) Don't visualize my results
wandb: Enter your choice: 1
wandb: You chose 'Private W&B dashboard, no account required'
wandb: ERROR Error creating an anonymous API key: oops
wandb: ERROR Please try again or select another option.
```

(the "oops" is the message of my test exception; I'm relying on network errors having good `str()` representations)