### PR TITLE
fix(sdk): pass api_key from init to login

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,3 +26,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - `Artifact.link()` now logs unsaved artifacts instead of raising an error, consistent with the behavior of `Run.link_artifact()` (@tonyyli-wandb in https://github.com/wandb/wandb/10822)
 - Automatic code saving now works when running ipython notebooks in VSCode's Jupyter notebook extension (@jacobromero in https://github.com/wandb/wandb/pull/10746)
 - Logging an artifact with infinite floats in `Artifact.metadata` now raises a `ValueError` early, instead of waiting on request retries to time out (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10845).
+- User-provided API key is now correctly passed through during initialization, preventing unnecessary login prompts

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -193,6 +193,7 @@ class _WandbInit:
             anonymous=run_settings.anonymous,
             host=run_settings.base_url,
             force=run_settings.force,
+            key=run_settings.api_key,
             _disable_warning=True,
             _silent=run_settings.quiet or run_settings.silent,
         )


### PR DESCRIPTION
Description
-----------
Pass run_settings.api_key into wandb_login._login(..) to prevent prompting the user for an interactive login when the api key is already provided.


- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Unit test added.