### PR TITLE
fix: adaptive colors for light/dark mode support in leet

### DIFF
--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -65,8 +65,7 @@ func NewEpochLineChart(width, height int, title string) *EpochLineChart {
 	graphColors := GraphColors()
 
 	// Temporarily use a default style - it will be updated during sorting.
-	graphStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(graphColors[0]))
+	graphStyle := lipgloss.NewStyle().Foreground(graphColors[0])
 
 	chart := &EpochLineChart{
 		Model: linechart.New(width, height, 0, defaultMaxX, 0, defaultMaxY,

--- a/core/internal/leet/metricsgrid.go
+++ b/core/internal/leet/metricsgrid.go
@@ -44,7 +44,7 @@ type MetricsGrid struct {
 	filter FilterState
 
 	// Stable color assignment.
-	colorOfTitle map[string]string
+	colorOfTitle map[string]lipgloss.AdaptiveColor
 	nextColorIdx int
 }
 
@@ -63,7 +63,7 @@ func NewMetricsGrid(
 		currentPage:  make([][]*EpochLineChart, gridRows),
 		focus:        focus,
 		logger:       logger,
-		colorOfTitle: make(map[string]string),
+		colorOfTitle: make(map[string]lipgloss.AdaptiveColor),
 	}
 
 	for r := range gridRows {
@@ -176,7 +176,7 @@ func (mg *MetricsGrid) effectiveChartCountNoLock() int {
 }
 
 // colorForNoLock returns a stable color for a given metric title.
-func (mg *MetricsGrid) colorForNoLock(title string) string {
+func (mg *MetricsGrid) colorForNoLock(title string) lipgloss.AdaptiveColor {
 	if c, ok := mg.colorOfTitle[title]; ok {
 		return c
 	}
@@ -201,8 +201,7 @@ func (mg *MetricsGrid) sortChartsNoLock() {
 
 		// Stable color per title (no reshuffling when new charts arrive).
 		col := mg.colorForNoLock(chart.Title())
-		chart.graphStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(col))
+		chart.graphStyle = lipgloss.NewStyle().Foreground(col)
 	}
 
 	// Ensure filtered mirrors all when filter is empty.

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -79,10 +79,12 @@ var teal450 = lipgloss.AdaptiveColor{
 }
 
 // Functional colors not specific to any visual component.
-// Ideally these should be adaptive!
 var (
 	// Color for main items such as chart titles.
-	colorAccent = lipgloss.Color("250")
+	colorAccent = lipgloss.AdaptiveColor{
+		Light: "#6c6c6c",
+		Dark:  "#bcbcbc",
+	}
 
 	// Main text color that appears the most frequently on the screen.
 	colorText = lipgloss.Color("245")
@@ -92,7 +94,10 @@ var (
 	colorSubtle = lipgloss.Color("240")
 
 	// Color for layout elements, like borders and separator lines.
-	colorLayout = lipgloss.Color("238")
+	colorLayout = lipgloss.AdaptiveColor{
+		Light: "#949494",
+		Dark:  "#444444",
+	}
 
 	// Color for layout elements when they're highlighted or focused.
 	colorLayoutHighlight = teal450
@@ -103,12 +108,21 @@ var (
 
 	// Color for lower-level headings; more frequent than headings.
 	// Help page keys, metrics grid header.
-	colorSubheading = lipgloss.Color("230")
+	colorSubheading = lipgloss.AdaptiveColor{
+		Light: "#3a3a3a",
+		Dark:  "#eeeeee",
+	}
 
 	// Colors for key-value pairs such as run summary or config items.
 	colorItemKey   = lipgloss.Color("243")
-	colorItemValue = lipgloss.Color("252")
-	colorSelected  = lipgloss.Color("238")
+	colorItemValue = lipgloss.AdaptiveColor{
+		Light: "#262626",
+		Dark:  "#d0d0d0",
+	}
+	colorSelected = lipgloss.AdaptiveColor{
+		Light: "#c6c6c6",
+		Dark:  "#444444",
+	}
 )
 
 // ASCII art for the loading screen and the help page.
@@ -134,57 +148,57 @@ const leetArt = `
 // Each scheme consists of an ordered list of colors,
 // where each new graph, and/or a line on a multi-line graph takes the next color.
 // Colors get reused in a cyclic manner.
-var colorSchemes = map[string][]string{
+var colorSchemes = map[string][]lipgloss.AdaptiveColor{
 	"sunset-glow": { // Golden-pink gradient
-		"#E281FE",
-		"#E78DE3",
-		"#E993D5",
-		"#ED9FBB",
-		"#F0A5AD",
-		"#F2AB9F",
-		"#F6B784",
-		"#F8BD78",
-		"#FBC36B",
-		"#FFCF4F",
+		lipgloss.AdaptiveColor{Light: "#B84FD4", Dark: "#E281FE"},
+		lipgloss.AdaptiveColor{Light: "#BD5AB9", Dark: "#E78DE3"},
+		lipgloss.AdaptiveColor{Light: "#BF60AB", Dark: "#E993D5"},
+		lipgloss.AdaptiveColor{Light: "#C36C91", Dark: "#ED9FBB"},
+		lipgloss.AdaptiveColor{Light: "#C67283", Dark: "#F0A5AD"},
+		lipgloss.AdaptiveColor{Light: "#C87875", Dark: "#F2AB9F"},
+		lipgloss.AdaptiveColor{Light: "#CC8451", Dark: "#F6B784"},
+		lipgloss.AdaptiveColor{Light: "#CE8A45", Dark: "#F8BD78"},
+		lipgloss.AdaptiveColor{Light: "#D19038", Dark: "#FBC36B"},
+		lipgloss.AdaptiveColor{Light: "#D59C1C", Dark: "#FFCF4F"},
 	},
 	"wandb-vibe-10": {
-		"#B1B4B9",
-		"#58D3DB",
-		"#5ED6A4",
-		"#FCA36F",
-		"#FF7A88",
-		"#7DB1FA",
-		"#BBE06B",
-		"#FFCF4D",
-		"#E180FF",
-		"#B199FF",
+		lipgloss.AdaptiveColor{Light: "#B1B4B9", Dark: "#B1B4B9"},
+		lipgloss.AdaptiveColor{Light: "#58D3DB", Dark: "#58D3DB"},
+		lipgloss.AdaptiveColor{Light: "#5ED6A4", Dark: "#5ED6A4"},
+		lipgloss.AdaptiveColor{Light: "#FCA36F", Dark: "#FCA36F"},
+		lipgloss.AdaptiveColor{Light: "#FF7A88", Dark: "#FF7A88"},
+		lipgloss.AdaptiveColor{Light: "#7DB1FA", Dark: "#7DB1FA"},
+		lipgloss.AdaptiveColor{Light: "#BBE06B", Dark: "#BBE06B"},
+		lipgloss.AdaptiveColor{Light: "#FFCF4D", Dark: "#FFCF4D"},
+		lipgloss.AdaptiveColor{Light: "#E180FF", Dark: "#E180FF"},
+		lipgloss.AdaptiveColor{Light: "#B199FF", Dark: "#B199FF"},
 	},
 	"wandb-vibe-20": {
-		"#D4D5D9",
-		"#565C66",
-		"#A9EDF2",
-		"#038194",
-		"#A1F0CB",
-		"#00875A",
-		"#FFCFB2",
-		"#C2562F",
-		"#FFC7CA",
-		"#CC2944",
-		"#BDD9FF",
-		"#1F59C4",
-		"#D0ED9D",
-		"#5F8A2D",
-		"#FFE49E",
-		"#B8740F",
-		"#EFC2FC",
-		"#9E36C2",
-		"#D6C9FF",
-		"#6645D1",
+		lipgloss.AdaptiveColor{Light: "#D4D5D9", Dark: "#D4D5D9"},
+		lipgloss.AdaptiveColor{Light: "#565C66", Dark: "#565C66"},
+		lipgloss.AdaptiveColor{Light: "#A9EDF2", Dark: "#A9EDF2"},
+		lipgloss.AdaptiveColor{Light: "#038194", Dark: "#038194"},
+		lipgloss.AdaptiveColor{Light: "#A1F0CB", Dark: "#A1F0CB"},
+		lipgloss.AdaptiveColor{Light: "#00875A", Dark: "#00875A"},
+		lipgloss.AdaptiveColor{Light: "#FFCFB2", Dark: "#FFCFB2"},
+		lipgloss.AdaptiveColor{Light: "#C2562F", Dark: "#C2562F"},
+		lipgloss.AdaptiveColor{Light: "#FFC7CA", Dark: "#FFC7CA"},
+		lipgloss.AdaptiveColor{Light: "#CC2944", Dark: "#CC2944"},
+		lipgloss.AdaptiveColor{Light: "#BDD9FF", Dark: "#BDD9FF"},
+		lipgloss.AdaptiveColor{Light: "#1F59C4", Dark: "#1F59C4"},
+		lipgloss.AdaptiveColor{Light: "#D0ED9D", Dark: "#D0ED9D"},
+		lipgloss.AdaptiveColor{Light: "#5F8A2D", Dark: "#5F8A2D"},
+		lipgloss.AdaptiveColor{Light: "#FFE49E", Dark: "#FFE49E"},
+		lipgloss.AdaptiveColor{Light: "#B8740F", Dark: "#B8740F"},
+		lipgloss.AdaptiveColor{Light: "#EFC2FC", Dark: "#EFC2FC"},
+		lipgloss.AdaptiveColor{Light: "#9E36C2", Dark: "#9E36C2"},
+		lipgloss.AdaptiveColor{Light: "#D6C9FF", Dark: "#D6C9FF"},
+		lipgloss.AdaptiveColor{Light: "#6645D1", Dark: "#6645D1"},
 	},
 }
 
 // GraphColors returns the colors for the current color scheme.
-func GraphColors() []string {
+func GraphColors() []lipgloss.AdaptiveColor {
 	return colorSchemes[DefaultColorScheme]
 }
 

--- a/core/internal/leet/systemmetricsgrid.go
+++ b/core/internal/leet/systemmetricsgrid.go
@@ -94,7 +94,7 @@ func (g *SystemMetricsGrid) effectiveGridSize() GridSize {
 }
 
 // nextColorHex returns the next color from the palette.
-func (g *SystemMetricsGrid) nextColorHex() string {
+func (g *SystemMetricsGrid) nextColorHex() lipgloss.AdaptiveColor {
 	colors := colorSchemes[g.config.SystemColorScheme()]
 	color := colors[g.nextColor%len(colors)]
 	g.nextColor++
@@ -106,10 +106,10 @@ func (g *SystemMetricsGrid) nextColorHex() string {
 //
 // The first call returns the color *after* the base color,
 // so the base can be used for the first series.
-func (g *SystemMetricsGrid) anchoredSeriesColorProvider(baseIdx int) func() string {
+func (g *SystemMetricsGrid) anchoredSeriesColorProvider(baseIdx int) func() lipgloss.AdaptiveColor {
 	colors := colorSchemes[g.config.SystemColorScheme()]
 	idx := baseIdx + 1
-	return func() string {
+	return func() lipgloss.AdaptiveColor {
 		c := colors[idx%len(colors)]
 		idx++
 		return c
@@ -128,7 +128,7 @@ func (g *SystemMetricsGrid) createMetricChart(def *MetricDef) *TimeSeriesLineCha
 
 	// Base color by color mode.
 	var (
-		baseColor string
+		baseColor lipgloss.AdaptiveColor
 		baseIdx   int
 	)
 	colorMode := g.config.SystemColorMode()

--- a/core/internal/leet/timeserieslinechart.go
+++ b/core/internal/leet/timeserieslinechart.go
@@ -20,7 +20,7 @@ type TimeSeriesLineChart struct {
 
 	// colorProvider yields the next color for additional series on this chart.
 	// It is anchored to the chart's base color so multi-series colors are stable per chart.
-	colorProvider func() string
+	colorProvider func() lipgloss.AdaptiveColor
 
 	lastUpdate         time.Time
 	minValue, maxValue float64
@@ -29,13 +29,13 @@ type TimeSeriesLineChart struct {
 type TimeSeriesLineChartParams struct {
 	Width, Height int
 	Def           *MetricDef
-	BaseColor     string
-	ColorProvider func() string
+	BaseColor     lipgloss.AdaptiveColor
+	ColorProvider func() lipgloss.AdaptiveColor
 	Now           time.Time
 }
 
 func NewTimeSeriesLineChart(params TimeSeriesLineChartParams) *TimeSeriesLineChart {
-	graphStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(params.BaseColor))
+	graphStyle := lipgloss.NewStyle().Foreground(params.BaseColor)
 
 	// Show the most recent 10 minutes (slight look-back).
 	// TODO: make this configurable.
@@ -92,7 +92,7 @@ func (c *TimeSeriesLineChart) ensureSeries(seriesName string) {
 	// Additional datasets advance the palette via the chart-local provider,
 	// which is anchored to the base color.
 	if len(c.series) > 0 {
-		seriesStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(c.colorProvider()))
+		seriesStyle := lipgloss.NewStyle().Foreground(c.colorProvider())
 		c.chart.SetDataSetStyle(seriesName, seriesStyle)
 	}
 

--- a/core/internal/leet/timeserieslinechart_test.go
+++ b/core/internal/leet/timeserieslinechart_test.go
@@ -5,20 +5,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/leet"
 )
 
 // stubColorProvider returns deterministic colors for series creation order.
-func stubColorProvider(colors ...string) func() string {
+func stubColorProvider(colors ...string) func() lipgloss.AdaptiveColor {
 	i := 0
-	return func() string {
+	return func() lipgloss.AdaptiveColor {
 		if len(colors) == 0 {
-			return ""
+			return lipgloss.AdaptiveColor{}
 		}
 		c := colors[i%len(colors)]
 		i++
-		return c
+		return lipgloss.AdaptiveColor{Light: c, Dark: c}
 	}
 }
 
@@ -36,8 +37,8 @@ func TestNewTimeSeriesLineChart_ConstructsAndInitializes(t *testing.T) {
 	ch := leet.NewTimeSeriesLineChart(leet.TimeSeriesLineChartParams{
 		80, 20,
 		def,
-		"#FF00FF",                    // base color
-		stubColorProvider("#00FF00"), // provider for subsequent series
+		lipgloss.AdaptiveColor{Light: "#FF00FF", Dark: "#FF00FF"}, // base color
+		stubColorProvider("#00FF00"),                              // provider for subsequent series
 		now,
 	})
 
@@ -60,7 +61,7 @@ func TestAddDataPoint_DefaultSeries_BookKeeping(t *testing.T) {
 	}
 	now := time.Unix(1_700_000_000, 0)
 	ch := leet.NewTimeSeriesLineChart(leet.TimeSeriesLineChartParams{
-		80, 20, def, "#ABCDEF", stubColorProvider(), now})
+		80, 20, def, lipgloss.AdaptiveColor{Light: "#ABCDEF", Dark: "#ABCDEF"}, stubColorProvider(), now})
 
 	// First point
 	ts1 := now.Add(-5 * time.Minute).Unix()
@@ -103,7 +104,7 @@ func TestAddDataPoint_NamedSeries_CreatesSeriesOnDemand(t *testing.T) {
 	}
 	now := time.Unix(1_700_000_000, 0)
 	ch := leet.NewTimeSeriesLineChart(leet.TimeSeriesLineChartParams{
-		80, 20, def, "#FF00FF", stubColorProvider("#00FF00", "#0000FF"), now})
+		80, 20, def, lipgloss.AdaptiveColor{Light: "#FF00FF", Dark: "#FF00FF"}, stubColorProvider("#00FF00", "#0000FF"), now})
 
 	ts := now.Unix()
 	ch.AddDataPoint("cpu0", ts, 30)


### PR DESCRIPTION
## Description
Converts color definitions in the LEET UI to use `lipgloss.AdaptiveColor` instead of fixed color strings & Updates graph colors to support both light and dark modes with appropriate contrast.

Great tool BTW: https://hexdocs.pm/color_palette/color_table.html.

## Testing
Dark mode:
<img width="1726" height="1023" alt="image" src="https://github.com/user-attachments/assets/0acebd9f-23bf-4e54-b4c0-dc83e5d66170" />

Light mode:
<img width="1728" height="1023" alt="image" src="https://github.com/user-attachments/assets/4a0d5a49-8700-4907-847b-6e1f52747b8a" />


- [x] I updated CHANGELOG.unreleased.md, or it's not applicable