### PR TITLE
feat(automations): support registry-scoped automations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Added a `--term-timeout` flag to `wandb agent` (@nathancy-wandb in https://github.com/wandb/wandb/pull/12246)
 - Added `run.sync_dir` (@timoffex in https://github.com/wandb/wandb/pull/12319)
 - The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
+- The automations API now supports creating and editing automations whose scope is a `Registry` object (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10867)
 
 ## Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Added
 
 - The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
+- The automations API now supports creating and editing automations whose scope is a `Registry` object (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10867)
 
 ### Changed
 

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -10,7 +10,7 @@ import wandb
 from pytest import FixtureRequest, fixture, skip
 from wandb import Artifact
 from wandb._filters import FilterExpr
-from wandb.apis.public import ArtifactCollection, Organization, Project, Team
+from wandb.apis.public import ArtifactCollection, Organization, Project, Registry, Team
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -51,7 +51,9 @@ if TYPE_CHECKING:
         TeamAndOrgNames,
     )
 
-ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
+ScopableWandbType: TypeAlias = (
+    ArtifactCollection | Project | Registry | Team | Organization
+)
 
 
 def random_string(chars: str = ascii_lowercase + digits, n: int = 12) -> str:
@@ -140,6 +142,20 @@ def project(
     return project
 
 
+@fixture
+def registry(
+    team_and_org: TeamAndOrgNames,
+    module_api: wandb.Api,
+    make_name: Callable[[str], str],
+) -> Registry:
+    """A registry in the same organization as the other automation scopes."""
+    return module_api.create_registry(
+        name=make_name("test-registry"),
+        visibility="organization",
+        organization=team_and_org.org,
+    )
+
+
 @fixture(scope="module")
 def artifact(team: Team, project: Project, make_name) -> Artifact:
     name = make_name("test-artifact")
@@ -178,14 +194,16 @@ def make_webhook_integration(
         gql_input = CreateGenericWebhookIntegrationInput(
             name=name, entity_name=entity, url_endpoint=url
         )
-        gql_op = CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL
-        gql_vars = {"input": gql_input.model_dump()}
-        api = make_module_api()
-        data = api._service_api.execute_graphql(gql_op, variables=gql_vars)
-
-        result = CreateGenericWebhookIntegration(**data)
-        integration = result.create_generic_webhook_integration.integration
-        return WebhookIntegration.model_validate(integration)
+        result = (
+            make_module_api()
+            ._service_api.execute_graphql(
+                CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL,
+                variables={"input": gql_input.model_dump()},
+                parse=CreateGenericWebhookIntegration.model_validate_json,
+            )
+            .result
+        )
+        return WebhookIntegration.model_validate(result.integration)
 
     return _make_webhook
 

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -10,7 +10,7 @@ import wandb
 from pytest import FixtureRequest, fixture, skip
 from wandb import Artifact
 from wandb._filters import FilterExpr
-from wandb.apis.public import ArtifactCollection, Organization, Project, Team
+from wandb.apis.public import ArtifactCollection, Organization, Project, Registry, Team
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -46,7 +46,9 @@ if TYPE_CHECKING:
         TeamAndOrgNames,
     )
 
-ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
+ScopableWandbType: TypeAlias = (
+    ArtifactCollection | Project | Registry | Team | Organization
+)
 
 
 def random_string(chars: str = ascii_lowercase + digits, n: int = 12) -> str:
@@ -147,6 +149,20 @@ def project(
     return project
 
 
+@fixture
+def registry(
+    team_and_org: TeamAndOrgNames,
+    module_api: wandb.Api,
+    make_name: Callable[[str], str],
+) -> Registry:
+    """A registry in the same organization as the other automation scopes."""
+    return module_api.create_registry(
+        name=make_name("test-registry"),
+        visibility="organization",
+        organization=team_and_org.org,
+    )
+
+
 @fixture(scope="module")
 def artifact(team: Team, project: Project, make_name) -> Artifact:
     name = make_name("test-artifact")
@@ -185,14 +201,16 @@ def make_webhook_integration(
         gql_input = CreateGenericWebhookIntegrationInput(
             name=name, entity_name=entity, url_endpoint=url
         )
-        gql_op = CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL
-        gql_vars = {"input": gql_input.model_dump()}
-        api = make_module_api()
-        data = api._service_api.execute_graphql(gql_op, variables=gql_vars)
-
-        result = CreateGenericWebhookIntegration(**data)
-        integration = result.create_generic_webhook_integration.integration
-        return WebhookIntegration.model_validate(integration)
+        result = (
+            make_module_api()
+            ._service_api.execute_graphql(
+                CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL,
+                variables={"input": gql_input.model_dump()},
+                parse=CreateGenericWebhookIntegration.model_validate_json,
+            )
+            .result
+        )
+        return WebhookIntegration.model_validate(result.integration)
 
     return _make_webhook
 

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import wandb
 from pytest import FixtureRequest, fixture, mark, raises, skip
-from wandb.apis.public import ArtifactCollection, Project
+from wandb.apis.public import ArtifactCollection, Project, Registry
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -24,6 +24,7 @@ from wandb.automations import (
     OnRunMetric,
     OnRunState,
     ProjectScope,
+    RegistryScope,
     RunEvent,
     ScopeType,
     SendWebhook,
@@ -689,8 +690,26 @@ class TestUpdateAutomation:
         updated_scope = new_automation.scope
 
         assert isinstance(updated_scope, ProjectScope)
+        assert updated_scope.is_registry is False
         assert updated_scope.id == project.id
         assert updated_scope.name == project.name
+
+    def test_update_scope_to_registry(
+        self,
+        module_api: wandb.Api,
+        old_automation: Automation,
+        registry: Registry,
+    ):
+        old_automation.scope = registry
+
+        new_automation = module_api.update_automation(old_automation)
+        updated_scope = new_automation.scope
+
+        assert isinstance(updated_scope, RegistryScope)
+        assert updated_scope.is_registry is True
+        assert updated_scope.id == registry.id
+        assert updated_scope.name == registry.full_name
+        assert updated_scope.name.startswith("wandb-registry-")
 
     # Each mutation event, started on a scope it supports. CREATE_ARTIFACT only
     # supports collection scope, so it starts and stays there. The rest start on

--- a/tests/unit_tests/test_automations/conftest.py
+++ b/tests/unit_tests/test_automations/conftest.py
@@ -10,7 +10,7 @@ from hypothesis import settings
 from pytest import FixtureRequest, fixture, skip
 from pytest_mock import MockerFixture
 from wandb._strutils import b64encode_ascii
-from wandb.apis.public import ArtifactCollection, Organization, Project, Team
+from wandb.apis.public import ArtifactCollection, Organization, Project, Registry, Team
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -40,14 +40,16 @@ from wandb.automations.actions import (
 )
 from wandb.automations.automations import Automation
 from wandb.automations.events import InputEvent, OnRunState, SavedEvent
-from wandb.sdk.artifacts._generated import ArtifactCollectionFragment
+from wandb.sdk.artifacts._generated import ArtifactCollectionFragment, RegistryFragment
 
 # default Hypothesis settings
 settings.register_profile("default", max_examples=100)
 settings.load_profile("default")
 
 
-ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
+ScopableWandbType: TypeAlias = (
+    ArtifactCollection | Project | Registry | Team | Organization
+)
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +146,35 @@ def project(mock_client: Mock) -> Project:
         attrs={
             "id": make_graphql_id(prefix="Project"),
         },
+    )
+
+
+@fixture(scope="session")
+def registry(mock_client: Mock) -> Registry:
+    """A simulated `Registry` that could be returned by `wandb.Api`.
+
+    For unit-testing purposes, this has been heavily mocked.
+    Tests relying on real `wandb.Api` calls should live in system tests.
+    """
+    name = "test-registry"
+    organization = "test-organization"
+    entity = "test-entity"
+    return Registry(
+        service_api=mock_client,
+        name=name,
+        entity=entity,
+        organization=organization,
+        attrs=RegistryFragment(
+            id=make_graphql_id(prefix="Project"),
+            name=f"wandb-registry-{name}",
+            description="This is a fake registry.",
+            created_at="2021-01-01T00:00:00Z",
+            updated_at=None,
+            access="organization",
+            allow_all_artifact_types=True,
+            artifact_types={"edges": []},
+            entity={"name": entity, "organization": {"name": organization}},
+        ),
     )
 
 

--- a/tests/unit_tests/test_automations/conftest.py
+++ b/tests/unit_tests/test_automations/conftest.py
@@ -10,7 +10,7 @@ from hypothesis import settings
 from pytest import FixtureRequest, fixture, skip
 from pytest_mock import MockerFixture
 from wandb._strutils import b64encode_ascii
-from wandb.apis.public import ArtifactCollection, Organization, Project, Team
+from wandb.apis.public import ArtifactCollection, Organization, Project, Registry, Team
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -40,14 +40,16 @@ from wandb.automations.actions import (
 )
 from wandb.automations.automations import Automation
 from wandb.automations.events import InputEvent, OnRunState, SavedEvent
-from wandb.sdk.artifacts._generated import ArtifactCollectionFragment
+from wandb.sdk.artifacts._generated import ArtifactCollectionFragment, RegistryFragment
 
 # default Hypothesis settings
 settings.register_profile("default", max_examples=100)
 settings.load_profile("default")
 
 
-ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
+ScopableWandbType: TypeAlias = (
+    ArtifactCollection | Project | Registry | Team | Organization
+)
 
 
 # ---------------------------------------------------------------------------
@@ -146,6 +148,36 @@ def project(mock_client: Mock) -> Project:
         attrs={
             "id": make_graphql_id(prefix="Project"),
         },
+    )
+
+
+@fixture(scope="session")
+def registry(mock_client: Mock) -> Registry:
+    """A simulated `Registry` that could be returned by `wandb.Api`.
+
+    For unit-testing purposes, this has been heavily mocked.
+    Tests relying on real `wandb.Api` calls should live in system tests.
+    """
+    name = "test-registry"
+    organization = "test-organization"
+    entity = "test-entity"
+    return Registry(
+        service_api=mock_client,
+        name=name,
+        entity=entity,
+        organization=organization,
+        attrs=RegistryFragment(
+            id=make_graphql_id(prefix="Project"),
+            internal_id=make_graphql_id(prefix="ProjectInternalId"),
+            name=f"wandb-registry-{name}",
+            description="This is a fake registry.",
+            created_at="2021-01-01T00:00:00Z",
+            updated_at=None,
+            access="organization",
+            allow_all_artifact_types=True,
+            artifact_types={"edges": []},
+            entity={"name": entity, "organization": {"name": organization}},
+        ),
     )
 
 

--- a/tests/unit_tests/test_automations/test_automations.py
+++ b/tests/unit_tests/test_automations/test_automations.py
@@ -19,7 +19,9 @@ from wandb.automations import (
     OnRemoveCollectionTag,
     OnRunMetric,
     OnUnlinkArtifact,
+    RegistryScope,
     RunEvent,
+    ScopeType,
 )
 from wandb.automations._utils import (
     INVALID_INPUT_ACTIONS,
@@ -79,6 +81,20 @@ class TestPrepareToCreate:
         gql_input_via_obj_and_kwargs = prepare_to_create(orig_obj, **attrs)
 
         assert expected_gql_input == gql_input_via_obj_and_kwargs
+
+    def test_registry_scoped_artifact_event(self, registry, do_nothing):
+        event = OnLinkArtifact(
+            scope=registry,
+            filter=ArtifactEvent.alias == "prod",
+        )
+
+        assert isinstance(event.scope, RegistryScope)
+        assert event.scope.is_registry is True
+
+        prepared = prepare_to_create(event >> do_nothing, name="test-automation")
+        prepared_vars = prepared.model_dump()
+        assert prepared_vars["scopeType"] == ScopeType.PROJECT.value
+        assert prepared_vars["scopeID"] == registry.id
 
     @mark.parametrize("invalid_event_type", INVALID_INPUT_EVENTS)
     def test_prepare_to_create_rejects_excluded_event_types(

--- a/tests/unit_tests/test_automations/test_automations.py
+++ b/tests/unit_tests/test_automations/test_automations.py
@@ -19,7 +19,9 @@ from wandb.automations import (
     OnRemoveCollectionTag,
     OnRunMetric,
     OnUnlinkArtifact,
+    RegistryScope,
     RunEvent,
+    ScopeType,
 )
 from wandb.automations._inputs import (
     INVALID_INPUT_ACTIONS,
@@ -79,6 +81,20 @@ class TestPrepareToCreate:
         gql_input_via_obj_and_kwargs = prepare_to_create(orig_obj, **attrs)
 
         assert expected_gql_input == gql_input_via_obj_and_kwargs
+
+    def test_registry_scoped_artifact_event(self, registry, do_nothing):
+        event = OnLinkArtifact(
+            scope=registry,
+            filter=ArtifactEvent.alias == "prod",
+        )
+
+        assert isinstance(event.scope, RegistryScope)
+        assert event.scope.is_registry is True
+
+        prepared = prepare_to_create(event >> do_nothing, name="test-automation")
+        prepared_vars = prepared.model_dump()
+        assert prepared_vars["scopeType"] == ScopeType.PROJECT.value
+        assert prepared_vars["scopeID"] == registry.id
 
     @mark.parametrize("invalid_event_type", INVALID_INPUT_EVENTS)
     def test_prepare_to_create_rejects_excluded_event_types(

--- a/tests/unit_tests/test_automations/test_scopes.py
+++ b/tests/unit_tests/test_automations/test_scopes.py
@@ -9,15 +9,23 @@ from wandb.automations import (
     ArtifactCollectionScope,
     EntityScope,
     ProjectScope,
+    RegistryScope,
     ScopeType,
 )
-from wandb.automations._generated import TriggerScopeType
+from wandb.automations._generated import ProjectScopeFields, TriggerScopeType
 from wandb.automations.scopes import AutomationScope
+from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 
 if TYPE_CHECKING:
     from unittest.mock import Mock
 
-    from wandb.apis.public import ArtifactCollection, Organization, Project, Team
+    from wandb.apis.public import (
+        ArtifactCollection,
+        Organization,
+        Project,
+        Registry,
+        Team,
+    )
 
 
 class HasScope(BaseModel):
@@ -30,6 +38,10 @@ class HasCollectionScope(HasScope):
 
 class HasProjectScope(HasScope):
     scope: ProjectScope
+
+
+class HasRegistryScope(HasScope):
+    scope: RegistryScope
 
 
 class HasEntityScope(HasScope):
@@ -69,8 +81,44 @@ def test_scope_can_validate_from_wandb_project(
 
     validated = model_cls(scope=project)
     assert validated.scope.scope_type is ScopeType.PROJECT
+    assert validated.scope.is_registry is False
     assert validated.scope.id == project.id
     assert validated.scope.name == project.name
+
+
+@mark.parametrize("model_cls", (HasRegistryScope, HasScope), ids=nameof)
+def test_scope_can_validate_from_wandb_registry(
+    registry: Registry, model_cls: type[HasScope]
+):
+    """Check that we can parse an automation scope from a pre-existing `Registry` type."""
+
+    validated = model_cls(scope=registry)
+    assert validated.scope.scope_type is ScopeType.PROJECT
+    assert validated.scope.is_registry is True
+    assert validated.scope.id == registry.id
+    assert validated.scope.name == registry.full_name
+
+
+@mark.parametrize(
+    ("name", "expected_type", "expected_is_registry"),
+    (
+        ("test-project", ProjectScope, False),
+        (REGISTRY_PREFIX, ProjectScope, False),
+        (f"{REGISTRY_PREFIX}test", RegistryScope, True),
+    ),
+    ids=("project", "bare-prefix", "registry"),
+)
+def test_project_scope_fragment_sets_registry_discriminator(
+    project: Project,
+    name: str,
+    expected_type: type[ProjectScope],
+    expected_is_registry: bool,
+):
+    fragment = ProjectScopeFields(id=project.id, name=name)
+
+    validated = HasScope(scope=fragment)
+    assert type(validated.scope) is expected_type
+    assert validated.scope.is_registry is expected_is_registry
 
 
 @mark.parametrize("model_cls", (HasEntityScope, HasScope), ids=nameof)

--- a/tools/graphql_codegen/automations/automations.graphql
+++ b/tools/graphql_codegen/automations/automations.graphql
@@ -218,7 +218,7 @@ query IntegrationsByEntity($entity: String!, $cursor: String, $perPage: Int) {
 }
 
 mutation CreateGenericWebhookIntegration($input: CreateGenericWebhookIntegrationInput!) {
-  createGenericWebhookIntegration(input: $input) {
+  result: createGenericWebhookIntegration(input: $input) {
     integration {
       ...WebhookIntegrationFields
     }

--- a/wandb/automations/__init__.py
+++ b/wandb/automations/__init__.py
@@ -25,6 +25,7 @@ from .scopes import (
     EntityScope,
     OrgScope,
     ProjectScope,
+    RegistryScope,
     ScopeType,
     TeamScope,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "ScopeType",  # doc:exclude
     "ArtifactCollectionScope",  # doc:exclude
     "ProjectScope",  # doc:exclude
+    "RegistryScope",  # doc:exclude
     "OrgScope",  # doc:exclude
     "TeamScope",  # doc:exclude
     "EntityScope",  # doc:exclude

--- a/wandb/automations/_generated/create_generic_webhook_integration.py
+++ b/wandb/automations/_generated/create_generic_webhook_integration.py
@@ -13,25 +13,21 @@ from .fragments import WebhookIntegrationFields
 
 
 class CreateGenericWebhookIntegration(GQLResult):
-    create_generic_webhook_integration: (
-        CreateGenericWebhookIntegrationCreateGenericWebhookIntegration | None
-    ) = Field(alias="createGenericWebhookIntegration")
+    result: CreateGenericWebhookIntegrationResult | None
 
 
-class CreateGenericWebhookIntegrationCreateGenericWebhookIntegration(GQLResult):
+class CreateGenericWebhookIntegrationResult(GQLResult):
     integration: (
-        CreateGenericWebhookIntegrationCreateGenericWebhookIntegrationIntegrationIntegration
+        CreateGenericWebhookIntegrationResultIntegrationIntegration
         | WebhookIntegrationFields
     ) = Field(discriminator="typename__")
 
 
-class CreateGenericWebhookIntegrationCreateGenericWebhookIntegrationIntegrationIntegration(
-    GQLResult
-):
+class CreateGenericWebhookIntegrationResultIntegrationIntegration(GQLResult):
     typename__: Typename[
         Literal["GitHubOAuthIntegration", "Integration", "SlackIntegration"]
     ]
 
 
 CreateGenericWebhookIntegration.model_rebuild()
-CreateGenericWebhookIntegrationCreateGenericWebhookIntegration.model_rebuild()
+CreateGenericWebhookIntegrationResult.model_rebuild()

--- a/wandb/automations/_generated/operations.py
+++ b/wandb/automations/_generated/operations.py
@@ -795,7 +795,7 @@ fragment WebhookIntegrationFields on GenericWebhookIntegration {
 
 CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL = """
 mutation CreateGenericWebhookIntegration($input: CreateGenericWebhookIntegrationInput!) {
-  createGenericWebhookIntegration(input: $input) {
+  result: createGenericWebhookIntegration(input: $input) {
     integration {
       __typename
       ...WebhookIntegrationFields

--- a/wandb/automations/_validators.py
+++ b/wandb/automations/_validators.py
@@ -69,17 +69,39 @@ def upper_if_str(v: Any) -> Any:
 # ----------------------------------------------------------------------------
 def parse_scope(v: Any) -> Any:
     """Convert eligible objects (including wandb types) to an automation scope."""
-    from wandb.apis.public import ArtifactCollection, Organization, Project, Team
+    from wandb.apis.public import (
+        ArtifactCollection,
+        Organization,
+        Project,
+        Registry,
+        Team,
+    )
+    from wandb.sdk.artifacts._validators import is_artifact_registry_project
 
+    from ._generated import ProjectScopeFields
     from .scopes import (
         OrgScope,
         ProjectScope,
+        RegistryScope,
         TeamScope,
         _ArtifactPortfolioScope,
         _ArtifactSequenceScope,
+        _BaseScope,
     )
 
     match v:
+        # Already parsed as an automation scope
+        case _BaseScope():
+            return v
+
+        # GraphQL fragments
+        case ProjectScopeFields(name=name) if is_artifact_registry_project(name):
+            return RegistryScope.model_validate(v)
+        case ProjectScopeFields():
+            return ProjectScope.model_validate(v)
+
+        case Registry():
+            return RegistryScope.model_validate(v)
         case Project():
             return ProjectScope.model_validate(v)
 

--- a/wandb/automations/_validators.py
+++ b/wandb/automations/_validators.py
@@ -58,17 +58,39 @@ def upper_if_str(v: Any) -> Any:
 # ----------------------------------------------------------------------------
 def parse_scope(v: Any) -> Any:
     """Convert eligible objects (including wandb types) to an automation scope."""
-    from wandb.apis.public import ArtifactCollection, Organization, Project, Team
+    from wandb.apis.public import (
+        ArtifactCollection,
+        Organization,
+        Project,
+        Registry,
+        Team,
+    )
+    from wandb.sdk.artifacts._validators import is_artifact_registry_project
 
+    from ._generated import ProjectScopeFields
     from .scopes import (
         OrgScope,
         ProjectScope,
+        RegistryScope,
         TeamScope,
         _ArtifactPortfolioScope,
         _ArtifactSequenceScope,
+        _BaseScope,
     )
 
     match v:
+        # Already parsed as an automation scope
+        case _BaseScope():
+            return v
+
+        # GraphQL fragments
+        case ProjectScopeFields(name=name) if is_artifact_registry_project(name):
+            return RegistryScope.model_validate(v)
+        case ProjectScopeFields():
+            return ProjectScope.model_validate(v)
+
+        case Registry():
+            return RegistryScope.model_validate(v)
         case Project():
             return ProjectScope.model_validate(v)
 

--- a/wandb/automations/events.py
+++ b/wandb/automations/events.py
@@ -53,11 +53,13 @@ class EventType(LenientStrEnum):
     # Note: "LINK_MODEL" is the (legacy) value expected by the backend, but we
     # name it "LINK_ARTIFACT" here in the public API for clarity and consistency.
     LINK_ARTIFACT = "LINK_MODEL"
+    LINK_MODEL = LINK_ARTIFACT
     UNLINK_ARTIFACT = "UNLINK_ARTIFACT"
 
     # ---------------------------------------------------------------------------
     # Events triggered by run conditions
     RUN_METRIC_THRESHOLD = "RUN_METRIC"
+    RUN_METRIC = RUN_METRIC_THRESHOLD
     RUN_METRIC_CHANGE = "RUN_METRIC_CHANGE"
     RUN_METRIC_ZSCORE = "RUN_METRIC_ZSCORE"
     RUN_STATE = "RUN_STATE"

--- a/wandb/automations/scopes.py
+++ b/wandb/automations/scopes.py
@@ -26,18 +26,18 @@ class ScopeType(LenientStrEnum):
     ENTITY = "ENTITY"
 
 
-class _BaseScope(GQLBase):
+class _BaseScope(GQLBase, extra="ignore"):
     scope_type: Annotated[ScopeType, Field(frozen=True)]
 
 
 class _ArtifactSequenceScope(_BaseScope, ArtifactSequenceScopeFields):
-    """A scope defined by an `ArtifactSequence`."""
+    """A scope defined by an ArtifactSequence."""
 
     scope_type: Literal[ScopeType.ARTIFACT_COLLECTION] = ScopeType.ARTIFACT_COLLECTION
 
 
 class _ArtifactPortfolioScope(_BaseScope, ArtifactPortfolioScopeFields):
-    """A scope defined by an `ArtifactPortfolio`, usually a registry collection."""
+    """A scope defined by an ArtifactPortfolio, usually a registry collection."""
 
     scope_type: Literal[ScopeType.ARTIFACT_COLLECTION] = ScopeType.ARTIFACT_COLLECTION
 
@@ -48,27 +48,45 @@ ArtifactCollectionScope = Annotated[
     BeforeValidator(parse_scope),
     Discriminator("typename__"),
 ]
-"""Type hint for a scope defined by an `ArtifactCollection`."""
+"""Type hint for a scope defined by an ArtifactCollection."""
 
 # for runtime type checks
 ArtifactCollectionScopeTypes = ArtifactCollectionScope.__origin__  # type: ignore[attr-defined]
 
 
 class ProjectScope(_BaseScope, ProjectScopeFields):
-    """A scope defined by a `Project`."""
+    """A scope defined by a Project."""
 
     scope_type: Literal[ScopeType.PROJECT] = ScopeType.PROJECT
+    is_registry: Literal[False] = False
+
+
+class RegistryScope(_BaseScope, ProjectScopeFields):
+    """A scope defined by a Registry."""
+
+    # Registries are represented as projects server-side.
+    scope_type: Literal[ScopeType.PROJECT] = ScopeType.PROJECT
+    is_registry: Literal[True] = True
+    name: Annotated[str, Field(validation_alias="full_name")]
+
+
+_RegistryOrProjectScope = Annotated[
+    RegistryScope | ProjectScope,
+    BeforeValidator(parse_scope),
+    Discriminator("is_registry"),
+]
+"""Type hint for a scope defined by a registry or project."""
 
 
 class TeamScope(_BaseScope, EntityScopeFields):
-    """A scope defined by a team `Entity`."""
+    """A scope defined by a team Entity."""
 
     scope_type: Literal[ScopeType.ENTITY] = ScopeType.ENTITY
     entity_type: Literal["team"] = "team"
 
 
 class OrgScope(_BaseScope, EntityScopeFields):
-    """A scope defined by an org `Entity`."""
+    """A scope defined by an org Entity."""
 
     scope_type: Literal[ScopeType.ENTITY] = ScopeType.ENTITY
     entity_type: Literal["organization"] = "organization"
@@ -79,11 +97,11 @@ EntityScope = Annotated[
     BeforeValidator(parse_scope),
     Discriminator("entity_type"),
 ]
-"""Type hint for a scope defined by a team or org `Entity`."""
+"""Type hint for a scope defined by a team or org Entity."""
 
 
 AutomationScope = Annotated[
-    _ArtifactSequenceScope | _ArtifactPortfolioScope | ProjectScope | EntityScope,
+    ArtifactCollectionScope | _RegistryOrProjectScope | EntityScope,
     BeforeValidator(parse_scope),
     Discriminator("typename__"),
 ]
@@ -96,6 +114,7 @@ __all__ = [
     "ScopeType",
     "ArtifactCollectionScope",
     "ProjectScope",
+    "RegistryScope",
     "TeamScope",
     "OrgScope",
     "EntityScope",

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -305,7 +305,7 @@ def ensure_not_finalized(method: MethodT[ArtifactT, P, R]) -> MethodT[ArtifactT,
 
 
 def is_artifact_registry_project(project: str) -> bool:
-    return project.startswith(REGISTRY_PREFIX)
+    return project.startswith(REGISTRY_PREFIX) and project != REGISTRY_PREFIX
 
 
 def remove_registry_prefix(project: str) -> str:

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -298,7 +298,7 @@ def ensure_not_finalized(method: MethodT[ArtifactT, P, R]) -> MethodT[ArtifactT,
 
 
 def is_artifact_registry_project(project: str) -> bool:
-    return project.startswith(REGISTRY_PREFIX)
+    return project.startswith(REGISTRY_PREFIX) and project != REGISTRY_PREFIX
 
 
 def remove_registry_prefix(project: str) -> str:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [https://wandb.atlassian.net/browse/WB-24815](https://wandb.atlassian.net/browse/WB-24815)

Supports programmatically creating and updating Registry-scoped automations by accepting `Registry` objects from the native registries API as an allowed scope. For example:

```python
from wandb import Api
from wandb.automations import ArtifactEvent, OnLinkArtifact, SendWebhook

api = Api()

registry = api.registry(name="my-registry", organization="my-org")

event = OnLinkArtifact(
    scope=registry,
    filter=ArtifactEvent.alias.eq("prod"),
)

action = SendWebhook(integration_id="...")

api.create_automation(
    event >> action,
    name="registry-automation",
    description="...",
)
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

Unit tests cover converting registries into scopes, preparing mutation inputs, and distinguishing project and registry scopes when parsing responses. A system test covers updating an existing automation to a registry scope and parsing the saved response back as `RegistryScope`.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
