### PR TITLE
fix: handle deprecated mode parameter of PIL.Image.fromarray in wandb.Image

### DIFF
--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -285,11 +285,8 @@ const AnimationFrame = AnimationDuration / AnimationSteps
 
 // Help screen styles.
 var (
-	helpKeyStyle = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).Width(20)
-
-	helpDescStyle = lipgloss.NewStyle().Foreground(colorText)
-
+	helpKeyStyle     = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).Width(20)
+	helpDescStyle    = lipgloss.NewStyle().Foreground(colorText)
 	helpSectionStyle = lipgloss.NewStyle().Bold(true).Foreground(colorHeading)
-
 	helpContentStyle = lipgloss.NewStyle().MarginLeft(2).MarginTop(1)
 )


### PR DESCRIPTION
## Description
- Fixes WB-28838
- Fixes #10786

This PR addresses compatibility issues with PIL 11.3.0+ where the `mode` parameter in `PIL.Image.fromarray()` [was deprecated](https://pillow.readthedocs.io/en/stable/deprecations.html#image-fromarray-mode-parameter).

Under certain conditions, initializing a wandb image from data would print PIL's deprecation warnings (`DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)`).

Pillow 11.3.0 was released in July 2025, so I don't think it's a good idea to require a more recent version and simply drop that parameter from our internal calls, so I added that version check ugliness.