### PR TITLE
fix: put _has_internet back into wandb.util

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -20,6 +20,7 @@ import random
 import re
 import secrets
 import shlex
+import socket
 import string
 import sys
 import tarfile
@@ -1610,6 +1611,21 @@ def _is_kaggle() -> bool:
         os.getenv("KAGGLE_KERNEL_RUN_TYPE") is not None
         or "kaggle_environments" in sys.modules
     )
+
+
+def _has_internet() -> bool:
+    """Returns whether we have internet access.
+
+    Checks for internet access by attempting to open a DNS connection to
+    Google's root servers.
+    """
+    try:
+        s = socket.create_connection(("8.8.8.8", 53), 0.5)
+        s.close()
+    except OSError:
+        return False
+
+    return True
 
 
 def _is_likely_kaggle() -> bool:


### PR DESCRIPTION
## Description

Fixes WB-29138 and #10872.

Puts back a util func accidentally deleted in https://github.com/wandb/wandb/pull/10791.

Found in Sentry: https://weights-biases.sentry.io/issues/7018134607/?project=4504800232407040