### PR TITLE
refactor: improve mock_wandb_log assertion messages

### DIFF
--- a/tests/fixtures/mock_wandb_log.py
+++ b/tests/fixtures/mock_wandb_log.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+import textwrap
 import unittest.mock
-from typing import Iterable, Iterator
+from typing import Iterable
 
 import pytest
 
 
 @pytest.fixture
-def mock_wandb_log() -> Iterator[MockWandbLog]:
+def mock_wandb_log(monkeypatch: pytest.MonkeyPatch) -> MockWandbLog:
     """Mocks the wandb.term*() methods for a test.
 
     This patches the termlog() / termwarn() / termerror() methods and returns
@@ -17,19 +18,25 @@ def mock_wandb_log() -> Iterator[MockWandbLog]:
     them unsuitable for tests. Use this fixture to assert that a message
     was logged.
     """
-    # NOTE: This only stubs out calls like "wandb.termlog()", NOT
-    # "from wandb.errors.term import termlog; termlog()".
-    with unittest.mock.patch.multiple(
-        "wandb",
-        termlog=unittest.mock.DEFAULT,
-        termwarn=unittest.mock.DEFAULT,
-        termerror=unittest.mock.DEFAULT,
-    ) as patched:
-        yield MockWandbLog(
-            patched["termlog"],
-            patched["termwarn"],
-            patched["termerror"],
-        )
+    # Only calls like this are stubbed:
+    #   import wandb; wandb.termlog()
+    #   from wandb.errors import term; term.termlog()
+    #
+    # Calls like this are NOT stubbed:
+    #   from wandb.errors.term import termlog; termlog()
+
+    termlog = unittest.mock.MagicMock()
+    termwarn = unittest.mock.MagicMock()
+    termerror = unittest.mock.MagicMock()
+
+    monkeypatch.setattr("wandb.termlog", termlog)
+    monkeypatch.setattr("wandb.termwarn", termwarn)
+    monkeypatch.setattr("wandb.termerror", termerror)
+    monkeypatch.setattr("wandb.errors.term.termlog", termlog)
+    monkeypatch.setattr("wandb.errors.term.termwarn", termwarn)
+    monkeypatch.setattr("wandb.errors.term.termerror", termerror)
+
+    return MockWandbLog(termlog, termwarn, termerror)
 
 
 class MockWandbLog:
@@ -48,20 +55,31 @@ class MockWandbLog:
         self._termwarn = termwarn
         self._termerror = termerror
 
-    def logged(self, msg: str) -> bool:
-        """Returns whether the message was included in a termlog()."""
-        return self._logged(self._termlog, msg)
+    def assert_logged(self, msg: str) -> None:
+        """Raise if no message passed to termlog() contains msg_re."""
+        self._assert_logged(self._termlog, msg)
 
-    def warned(self, msg: str) -> bool:
-        """Returns whether the message was included in a termwarn()."""
-        return self._logged(self._termwarn, msg)
+    def assert_warned(self, msg: str) -> None:
+        """Raise if no message passed to termwarn() contains msg_re."""
+        self._assert_logged(self._termwarn, msg)
 
-    def errored(self, msg: str) -> bool:
-        """Returns whether the message was included in a termerror()."""
-        return self._logged(self._termerror, msg)
+    def assert_errored(self, msg: str) -> None:
+        """Raise if no message passed to termerror() contains msg_re."""
+        self._assert_logged(self._termerror, msg)
 
-    def _logged(self, termfunc: unittest.mock.MagicMock, msg: str) -> bool:
-        return any(msg in logged for logged in self._logs(termfunc))
+    def _assert_logged(
+        self,
+        termfunc: unittest.mock.MagicMock,
+        expected_msg: str,
+    ) -> None:
+        messages = list(self._logs(termfunc))
+
+        for msg in messages:
+            if expected_msg in msg:
+                return
+        else:
+            messages_pretty = textwrap.indent("\n".join(messages), ">    ")
+            raise AssertionError(f"{expected_msg!r} not in any of\n{messages_pretty}")
 
     def _logs(self, termfunc: unittest.mock.MagicMock) -> Iterable[str]:
         # All the term*() functions have a similar API: the message is the

--- a/tests/system_tests/test_core/test_data_types_full.py
+++ b/tests/system_tests/test_core/test_data_types_full.py
@@ -162,7 +162,7 @@ def test_image_array_old_wandb(
         wb_image = [wandb.Image(np.zeros((28, 28))) for i in range(5)]
         run.log({"logged_images": wb_image})
 
-    assert mock_wandb_log.warned("Unable to log image array filenames.")
+    mock_wandb_log.assert_warned("Unable to log image array filenames.")
 
     with wandb_backend_spy.freeze() as snapshot:
         summary = snapshot.summary(run_id=run.id)
@@ -181,7 +181,7 @@ def test_image_array_old_wandb_mp_warning(
         run._init_pid += 1
         run.log({"logged_images": wb_image})
 
-    assert mock_wandb_log.warned(
+    mock_wandb_log.assert_warned(
         "Attempting to log a sequence of Image objects from multiple processes"
         " might result in data loss. Please upgrade your wandb server"
     )

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -244,16 +244,16 @@ def test_run_history_keys_bad_arg(stub_run_gql_once, mock_wandb_log):
     run = Api().run("test/test/test")
 
     run.history(keys="acc", pandas=False)
-    mock_wandb_log.errored("keys must be specified in a list")
+    mock_wandb_log.assert_errored("keys must be specified in a list")
 
     run.history(keys=[["acc"]], pandas=False)
-    mock_wandb_log.errored("keys argument must be a list of strings")
+    mock_wandb_log.assert_errored("keys argument must be a list of strings")
 
     run.scan_history(keys="acc")
-    mock_wandb_log.errored("keys must be specified in a list")
+    mock_wandb_log.assert_errored("keys must be specified in a list")
 
     run.scan_history(keys=[["acc"]])
-    mock_wandb_log.errored("keys argument must be a list of strings")
+    mock_wandb_log.assert_errored("keys argument must be a list of strings")
 
 
 def test_run_summary(wandb_backend_spy):

--- a/tests/system_tests/test_core/test_resume.py
+++ b/tests/system_tests/test_core/test_resume.py
@@ -52,7 +52,7 @@ def test_resume__offline__warns(resume, mock_wandb_log):
     with wandb.init(mode="offline", resume=resume):
         pass
 
-    assert mock_wandb_log.warned(
+    mock_wandb_log.assert_warned(
         "`resume` will be ignored since W&B syncing is set to `offline`"
     )
 

--- a/tests/system_tests/test_core/test_resume_auto.py
+++ b/tests/system_tests/test_core/test_resume_auto.py
@@ -38,7 +38,7 @@ def test_explicit_id_overrides_autoresume(mock_wandb_log):
         pass
 
     assert run2.id == "explicit"
-    assert mock_wandb_log.warned(
+    mock_wandb_log.assert_warned(
         "Ignoring ID auto-id loaded due to resume='auto'"
         " because the run ID is set to explicit."
     )

--- a/tests/system_tests/test_functional/test_tensorboard/test_tf_summary.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_tf_summary.py
@@ -260,7 +260,7 @@ def test_tb_sync_with_explicit_step_and_log(
         run.log({"y_scalar": 1337}, step=42)
 
     with wandb_backend_spy.freeze() as snapshot:
-        assert mock_wandb_log.warned(
+        mock_wandb_log.assert_warned(
             "Step cannot be set when using tensorboard syncing"
         )
         history = snapshot.history(run_id=run.id)

--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -403,7 +403,7 @@ def test_cache_add_gives_useful_error_when_out_of_space(
         with opener():
             pass
 
-    assert mock_wandb_log.warned("Cache size exceeded. Attempting to reclaim space...")
+    mock_wandb_log.assert_warned("Cache size exceeded. Attempting to reclaim space...")
 
 
 # todo: fix this test

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -1676,7 +1676,7 @@ def test_log_uint8_image():
 def test_init_image_jpeg_removes_transparency(data, file_type, mock_wandb_log):
     wandb_img = wandb.Image(data, file_type=file_type)
 
-    assert mock_wandb_log.warned(
+    mock_wandb_log.assert_warned(
         "JPEG format does not support transparency. Ignoring alpha channel.",
     )
     assert wandb_img.format == file_type

--- a/tests/unit_tests/test_lib/test_apikey.py
+++ b/tests/unit_tests/test_lib/test_apikey.py
@@ -10,7 +10,7 @@ from wandb.sdk.lib.apikey import _api_key_prompt_str
 @pytest.mark.parametrize("api_key", ["X" * 40, "X" * 86])
 def test_write_netrc(mock_wandb_log, api_key):
     wandb_lib.apikey.write_netrc("http://localhost", "vanpelt", api_key)
-    assert mock_wandb_log.logged("No netrc file found, creating one.")
+    mock_wandb_log.assert_logged("No netrc file found, creating one.")
     with open(wandb_lib.apikey.get_netrc_file_path()) as f:
         assert f.read() == (
             f"machine localhost\n  login vanpelt\n  password {api_key}\n"
@@ -152,7 +152,7 @@ def test_read_apikey_no_netrc_access(tmp_path, monkeypatch, mock_wandb_log):
     ):
         api_key = wandb_lib.apikey.api_key(settings)
         assert api_key is None
-        assert mock_wandb_log.warned(f"Cannot access {netrc_path}.")
+        mock_wandb_log.assert_warned(f"Cannot access {netrc_path}.")
 
 
 def test_apikey_prompt_str():

--- a/tests/unit_tests/test_lib/test_progress.py
+++ b/tests/unit_tests/test_lib/test_progress.py
@@ -140,7 +140,7 @@ def test_minimal_operations_static(mock_wandb_log, static_progress_printer):
         ),
     )
 
-    assert mock_wandb_log.logged("op 1; op 2; op 3; op 4; op 5 (+ 195 more)")
+    mock_wandb_log.assert_logged("op 1; op 2; op 3; op 4; op 5 (+ 195 more)")
 
 
 def test_grouped_operations_static(
@@ -174,7 +174,7 @@ def test_grouped_operations_static(
         }
     )
 
-    assert mock_wandb_log.logged("[run1] op 1; op 2; [run3] op 3 (+ 121 more)")
+    mock_wandb_log.assert_logged("[run1] op 1; op 2; [run3] op 3 (+ 121 more)")
 
 
 def test_does_not_print_empty_lines(capsys, static_progress_printer):

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -348,7 +348,7 @@ def test_table_logging_mode_incremental_warnings(mock_wandb_log):
 
     t.add_data("test", "test")
 
-    assert mock_wandb_log.warned(
+    mock_wandb_log.assert_warned(
         "You have exceeded 100 increments for this table. "
         "Only the latest 100 increments will be visualized in the run workspace."
     )

--- a/tests/unit_tests/test_torch.py
+++ b/tests/unit_tests/test_torch.py
@@ -76,7 +76,7 @@ def test_watch_parameters_torch_jit(mock_run, log_type, mock_wandb_log):
     net = torch.jit.script(nn.Linear(10, 2))
     run.watch(net, log=log_type)
 
-    assert mock_wandb_log.warned("skipping parameter tracking")
+    mock_wandb_log.assert_warned("skipping parameter tracking")
 
 
 def test_watch_graph_torch_jit(mock_run, mock_wandb_log):
@@ -93,7 +93,7 @@ def test_watch_graph_torch_jit(mock_run, mock_wandb_log):
     net = torch.jit.script(Net())
     run.watch(net, log_graph=True)
 
-    assert mock_wandb_log.warned("skipping graph tracking")
+    mock_wandb_log.assert_warned("skipping graph tracking")
 
 
 def test_watch_bad_argument(mock_run):

--- a/tests/unit_tests/test_weave.py
+++ b/tests/unit_tests/test_weave.py
@@ -2,49 +2,60 @@ from __future__ import annotations
 
 import sys
 import types
-from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 import wandb
 
-
-def _reset_import(monkeypatch, module: str):
-    if module in sys.modules:
-        monkeypatch.delitem(sys.modules, module, raising=False)
-
-
-def _inject_fake_weave(monkeypatch):
-    m = cast(Any, types.ModuleType("weave"))
-
-    def init(project):
-        # no-op stub for weave.init
-        return None
-
-    m.init = init
-    monkeypatch.setitem(sys.modules, "weave", m)
+from tests.fixtures.mock_wandb_log import MockWandbLog
 
 
 @pytest.fixture()
-def setup_env(monkeypatch, tmp_path):
-    monkeypatch.delenv("WANDB_DISABLE_WEAVE", raising=False)
-    monkeypatch.setenv("WANDB_MODE", "offline")
-
-    _reset_import(monkeypatch, "weave")
-
-
-def test_import_nothing(setup_env, mock_wandb_log):
-    wandb.init(project="test-project")
-    assert not mock_wandb_log.logged("Initializing weave")
+def fake_weave_init(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    fake_init = MagicMock()
+    monkeypatch.setattr("wandb.integration.weave.weave._weave_init", fake_init)
+    return fake_init
 
 
-def test_import_weave(setup_env, mock_wandb_log, monkeypatch):
-    _inject_fake_weave(monkeypatch)
-    wandb.init(project="test-project")
-    assert mock_wandb_log.logged("Initializing weave")
+@pytest.fixture()
+def weave_imported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "weave", types.ModuleType("weave"))
 
 
-def test_import_weave_disabled(setup_env, mock_wandb_log, monkeypatch):
+@pytest.fixture()
+def weave_not_imported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "weave", raising=False)
+
+
+def test_not_imported(weave_not_imported, fake_weave_init: MagicMock):
+    _ = weave_not_imported
+
+    wandb.init(project="test-project", mode="offline")
+
+    fake_weave_init.assert_not_called()
+
+
+def test_import_weave(
+    weave_imported,
+    fake_weave_init: MagicMock,
+    mock_wandb_log: MockWandbLog,
+):
+    _ = weave_imported
+
+    wandb.init(project="test-project", mode="offline")
+
+    fake_weave_init.assert_called_once()
+    mock_wandb_log.assert_logged("Initializing weave")
+
+
+def test_import_weave_disabled(
+    weave_imported,
+    fake_weave_init: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _ = weave_imported
     monkeypatch.setenv("WANDB_DISABLE_WEAVE", "1")
-    _inject_fake_weave(monkeypatch)
-    wandb.init(project="test-project")
-    assert not mock_wandb_log.logged("Initializing weave")
+
+    wandb.init(project="test-project", mode="offline")
+
+    fake_weave_init.assert_not_called()


### PR DESCRIPTION
Replaces `assert mock_wandb_log.logged("message")` by `mock_wandb_log.assert_logged("message")`.

The new assertion methods print the logged messages when they don't contain the expected message.

There's no way to write `assert not mock_wandb_log.logged(...)` anymore, but that was a bad idea since it can't test that a different, similar message was not logged. The only example of this was in the weave integration tests, which I updated.