### PR TITLE
chore: fix threasholds in size and import time checks with nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -797,7 +797,7 @@ def wandb_core_size_check(session: nox.Session) -> None:
     session.log(f"Difference:   {fmt_size(abs(diff))} ({pct:+.0%})")
     session.log("=" * 60)
 
-    if pct > 10:
+    if pct > 0.10:
         session.log(
             textwrap.dedent("""\
 
@@ -809,7 +809,7 @@ def wandb_core_size_check(session: nox.Session) -> None:
             """)
         )
         session.error(f"Binary size increased by {pct:.1f}% (>10% threshold)")
-    elif pct > 5:
+    elif pct > 0.05:
         session.warn(f"Binary size increased by {pct:.1f}%")
 
 
@@ -849,7 +849,7 @@ def wandb_import_time_check(session: nox.Session) -> None:
     session.log(f"Difference:   {abs(diff):.2g} ({pct:+.0%})")
     session.log("=" * 60)
 
-    if pct > 20:
+    if pct > 0.20:
         session.log(
             textwrap.dedent("""\
 
@@ -866,5 +866,5 @@ def wandb_import_time_check(session: nox.Session) -> None:
             """)
         )
         session.error(f"Import time increased by {pct:+.0%} (>20% threshold)")
-    elif pct > 10:
+    elif pct > 0.10:
         session.warn(f"Import time increased by {pct:+.0%}")


### PR DESCRIPTION
Description
-----------
Missed in a previous clean up when switched from % to fractions.