### PR TITLE
refactor: remove RunStoppedStatus GQL query

### DIFF
--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -112,12 +112,7 @@ func (fs *fileStream) startProcessingFeedback(
 		for res := range feedback {
 			if v, ok := res["stopped"]; ok {
 				if b, ok := v.(bool); ok {
-					if b {
-						fs.state.Store(uint32(StopTrue))
-					} else if StopState(fs.state.Load()) == StopUnknown {
-						// Only set false if we haven't observed any value yet.
-						fs.state.Store(uint32(StopFalse))
-					}
+					fs.stopState.CompareAndSwap(false, b)
 				}
 			}
 		}

--- a/core/internal/filestream/filestreamimpl_test.go
+++ b/core/internal/filestream/filestreamimpl_test.go
@@ -9,16 +9,14 @@ func TestStopState_FeedbackTable(t *testing.T) {
 	tests := []struct {
 		name     string
 		feedback []any
-		want     StopState
+		want     bool
 	}{
-		{"default unknown", nil, StopUnknown},
-		{"false only -> false", []any{false}, StopFalse},
-		{"true only -> true", []any{true}, StopTrue},
-		{"false then true -> true", []any{false, true}, StopTrue},
-		{"true then false -> true", []any{true, false}, StopTrue},
-		{"non-bool ignored -> unknown", []any{"nope", 1}, StopUnknown},
-		{"non-bool then false -> false", []any{"nope", false}, StopFalse},
-		{"non-bool then true -> true", []any{0, true}, StopTrue},
+		{"default false", nil, false},
+		{"false only -> false", []any{false}, false},
+		{"true only -> true", []any{true}, true},
+		{"false, non-bool, true -> true", []any{false, true}, true},
+		{"true, non-bool, false -> true", []any{true, false}, true},
+		{"non-bool ignored", []any{"nope", 1}, false},
 	}
 
 	for _, tc := range tests {
@@ -34,7 +32,7 @@ func TestStopState_FeedbackTable(t *testing.T) {
 			close(ch)
 			wg.Wait()
 
-			if got := fs.StopState(); got != tc.want {
+			if got := fs.IsStopped(); got != tc.want {
 				t.Fatalf("StopState = %v, want %v", got, tc.want)
 			}
 		})

--- a/core/internal/filestreamtest/filestreamtest.go
+++ b/core/internal/filestreamtest/filestreamtest.go
@@ -70,6 +70,6 @@ func (fs *FakeFileStream) StreamUpdate(update filestream.Update) {
 	fs.updates = append(fs.updates, update)
 }
 
-func (fs *FakeFileStream) StopState() filestream.StopState {
-	return filestream.StopUnknown
+func (fs *FakeFileStream) IsStopped() bool {
+	return false
 }

--- a/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
+++ b/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
@@ -1,25 +1,31 @@
 """Starts a W&B run and exits with code 1 if it's not interrupted."""
 
+from __future__ import annotations
+
 import sys
 import time
 
 import wandb
 
 if __name__ == "__main__":
-    with wandb.init():
-        try:
+    # The stop status is delivered via a FileStream response.
+    settings = wandb.Settings(x_file_stream_transmit_interval=0.1)
+    start_time: float | None = None
+
+    try:
+        with wandb.init(settings=settings):
             start_time = time.monotonic()
             time.sleep(30)
-        except KeyboardInterrupt:
-            # Something like _thread.interrupt_main() would raise a
-            # KeyboardInterrupt exception at the end of the sleep, instead of
-            # interrupting the sleep.
-            if time.monotonic() - start_time >= 29:
-                print("FAIL: Got KeyboardInterrupt too late!", file=sys.stderr)
-                sys.exit(1)
+    except KeyboardInterrupt:
+        # Something like _thread.interrupt_main() would raise a
+        # KeyboardInterrupt exception at the end of the sleep, instead of
+        # interrupting the sleep.
+        if start_time is not None and time.monotonic() - start_time >= 29:
+            print("FAIL: Got KeyboardInterrupt too late!", file=sys.stderr)
+            sys.exit(1)
 
-            print("PASS: KeyboardInterrupt detected!", file=sys.stderr)
-            sys.exit(0)
+        print("PASS: KeyboardInterrupt detected!", file=sys.stderr)
+        sys.exit(0)
 
     print("FAIL: No KeyboardInterrupt detected!", file=sys.stderr)
     sys.exit(1)

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -1,24 +1,13 @@
 import pathlib
 import subprocess
-from typing import Any
+
+from tests.fixtures.wandb_backend_spy import WandbBackendSpy
 
 
-def _run_stopped_response(stopped: bool) -> dict[str, Any]:
-    return {"data": {"project": {"run": {"stopped": stopped}}}}
-
-
-def test_run_stops_if_asked(wandb_backend_spy):
-    gql = wandb_backend_spy.gql
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="RunStoppedStatus"),
-        gql.Sequence(
-            [
-                # Respond False to the first check so that the True response
-                # is more likely to be observed during time.sleep().
-                gql.Constant(content=_run_stopped_response(False)),
-                gql.Constant(content=_run_stopped_response(True)),
-            ]
-        ),
+def test_run_stops_if_asked(wandb_backend_spy: WandbBackendSpy):
+    wandb_backend_spy.stub_filestream(
+        {"stopped": True},
+        status=200,
     )
 
     script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"


### PR DESCRIPTION
Fixes WB-22171.

Stops making RunStoppedStatus GQL queries, relying entirely on FileStream responses.

The SDK has used the stop status from FileStream responses since 0.22.0. The backend has been returning the stop status via FileStream since about 1-1.5 years ago.

Judging by Sentry, some users still hit the RunStoppedStatus fallback which can get stuck for 10+ minutes. Those users are running against `api.wandb.ai`, so the GQL query is completely useless to them; even adding a shorter timeout would be pointless.