### PR TITLE
fix: dashes in api keys in tests

### DIFF
--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -171,14 +171,7 @@ class BackendFixtureFactory:
 
     def make_user(self, name: str | None = None, admin: bool = False) -> str:
         """Create a new user and return their username."""
-        # Many tests use the username as the API key.
-        # However, the API key must be 40 characters long after the first hyphen.
-        # So we need to pad the username
-        # with the appropriate number of random characters.
-        name = name or (
-            f"user-{self.worker_id}-"
-            f"{random_string(length=(40 - len(self.worker_id) - 1))}"
-        )
+        name = name or (f"user-{self.worker_id}-{random_string(length=40)}")
 
         self.send_cmds(
             UserCmd("up", username=name, admin=admin),


### PR DESCRIPTION
Removes a workaround that tests used because API key validation code used to split on dashes using `split` instead of `rsplit`, which got fixed in PR #10879.