### PR TITLE
refactor: use refactored auth methods in Api._load_api_key

### DIFF
--- a/tests/system_tests/test_core/test_wandb_login.py
+++ b/tests/system_tests/test_core/test_wandb_login.py
@@ -26,4 +26,3 @@ def test_login_invalid_key_length(user):
     with mock.patch.dict("os.environ", {"WANDB_API_KEY": ""}):
         with pytest.raises(wandb.errors.AuthenticationError):
             wandb.login(verify=True, key="I")
-        assert wandb.api.api_key is None

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -106,6 +106,7 @@ def test_login_invalid_key_arg(runner, dummy_api_key):
         assert "API key must have 40+ characters, has 35." in result.output
 
 
+@pytest.mark.usefixtures("patch_apikey")
 def test_sync_gc(runner):
     with runner.isolated_filesystem():
         if not os.path.isdir("wandb"):

--- a/tests/unit_tests/test_job_builder.py
+++ b/tests/unit_tests/test_job_builder.py
@@ -13,6 +13,7 @@ def str_of_length(n):
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=n))
 
 
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_repo_job(runner, api):
     remote_name = str_of_length(129)
     metadata = {
@@ -56,6 +57,7 @@ def test_build_repo_job(runner, api):
             assert source_json["build_context"] == "blah/"
 
 
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_repo_notebook_job(runner, tmp_path, api, mocker):
     remote_name = str_of_length(129)
     metadata = {
@@ -101,6 +103,7 @@ def test_build_repo_notebook_job(runner, tmp_path, api, mocker):
         assert job_builder._is_notebook_run is True
 
 
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_artifact_job(runner, api):
     metadata = {
         "codePath": "blah/test.py",
@@ -133,6 +136,7 @@ def test_build_artifact_job(runner, api):
         assert artifact._manifest.entries["requirements.frozen.txt"]
 
 
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_artifact_notebook_job(runner, tmp_path, mocker, api):
     metadata = {
         "program": "blah/test.ipynb",
@@ -177,6 +181,7 @@ def test_build_artifact_notebook_job(runner, tmp_path, mocker, api):
 
 
 @pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_artifact_notebook_job_no_program(
     mocker,
     runner,
@@ -224,6 +229,7 @@ def test_build_artifact_notebook_job_no_program(
 
 
 @pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_artifact_notebook_job_no_metadata(
     mocker,
     runner,
@@ -264,6 +270,7 @@ def test_build_artifact_notebook_job_no_metadata(
 
 
 @pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_artifact_notebook_job_no_program_metadata(
     mocker,
     runner,
@@ -308,6 +315,7 @@ def test_build_artifact_notebook_job_no_program_metadata(
             assert _msg not in out
 
 
+@pytest.mark.usefixtures("patch_apikey")
 def test_build_image_job(runner, api):
     image_name = str_of_length(129)
     metadata = {
@@ -348,7 +356,8 @@ def test_set_disabled():
     assert job_builder.disable == "testtest"
 
 
-def test_no_metadata_file(runner, api):
+@pytest.mark.usefixtures("patch_apikey")
+def test_no_metadata_file(api):
     settings = SettingsStatic(
         {
             "disable_job_creation": False,

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -11,6 +11,7 @@ from wandb.apis import internal
 from wandb.sdk import wandb_login
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
+from wandb.sdk.lib import auth
 
 
 def test_api_auto_login_no_tty():
@@ -64,13 +65,10 @@ def test_base_url_sanitization():
 )
 @pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
 def test_parse_path(path):
-    with mock.patch.object(
-        wandb_login, "_login", mock.MagicMock(return_value=(True, None))
-    ):
-        user, project, run = Api()._parse_path(path)
-        assert user == "user"
-        assert project == "proj"
-        assert run == "run"
+    user, project, run = Api()._parse_path(path)
+    assert user == "user"
+    assert project == "proj"
+    assert run == "run"
 
 
 @pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
@@ -155,17 +153,6 @@ def test_report_to_html():
     assert "<button" in report_html
 
 
-@pytest.mark.usefixtures("skip_verify_login")
-def test_override_base_url_passed_to_login():
-    base_url = "https://wandb.space"
-    with mock.patch.object(
-        wandb_login, "_login", mock.MagicMock(return_value=(True, None))
-    ) as mock_login:
-        api = wandb.Api(api_key=None, overrides={"base_url": base_url})
-        assert mock_login.call_args[1]["host"] == base_url
-        assert api.settings["base_url"] == base_url
-
-
 def test_artifact_download_logger():
     now = 0
     termlog = mock.Mock()
@@ -233,59 +220,75 @@ def test_create_custom_chart(monkeypatch):
     )
 
 
-def test_initialize_api_prompts_for_api_key():
-    with mock.patch.object(
-        wandb_login, "_verify_login", mock.MagicMock(return_value=True)
-    ) as mock_verify_login, mock.patch.object(
-        wandb_login, "_login", mock.MagicMock(return_value=(True, None))
-    ):
-        Api()
-
-        assert mock_verify_login.call_count == 1
-        assert "key" in mock_verify_login.call_args[1]
-        assert mock_verify_login.call_args[1]["key"] is None
-
-
-def test_initialize_api_does_not_prompt_for_api_key__when_api_key_is_provided():
-    api_key = "X" * 40
-    with mock.patch.object(
-        wandb_login, "_verify_login", mock.MagicMock(return_value=True)
-    ) as mock_verify_login:
-        api = Api(api_key=api_key)
-
-        assert mock_verify_login.call_count == 1
-        assert "key" in mock_verify_login.call_args[1]
-        assert mock_verify_login.call_args[1]["key"] == api_key
-        assert api.api_key == api_key
-
-
 @pytest.mark.usefixtures("skip_verify_login")
-def test_initialize_api_does_not_prompt_for_api_key__when_using_thread_local_settings():
-    with mock.patch.object(
-        wandb_login, "_verify_login", mock.MagicMock(return_value=True)
-    ) as mock_verify_login:
-        _thread_local_api_settings.api_key = "X" * 40
+def test_initialize_api_prompts_for_api_key(monkeypatch: pytest.MonkeyPatch):
+    mock_prompt_api_key = MagicMock()
+    mock_prompt_api_key.return_value = "test-api-key"
+    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
 
-        api = Api()
+    Api()
 
-        assert mock_verify_login.call_count == 1
-        assert "key" in mock_verify_login.call_args[1]
-        assert mock_verify_login.call_args[1]["key"] == "X" * 40
-        assert api.api_key == "X" * 40
+    mock_prompt_api_key.assert_called_once()
 
 
-def test_initialize_api_does_not_prompt_for_api_key__when_using_env_var(monkeypatch):
-    api_key = "X" * 40
-    mock_verify_login = mock.MagicMock(return_value=True)
+def test_initialize_api_does_not_prompt_for_api_key__when_api_key_is_provided(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mock_prompt_api_key = MagicMock()
+    mock_verify_login = MagicMock()
+    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
     monkeypatch.setattr(wandb_login, "_verify_login", mock_verify_login)
-    monkeypatch.setattr("os.environ", {"WANDB_API_KEY": api_key})
 
-    api = Api(overrides={"api_key": api_key})
+    api = Api(api_key="test-api-key", overrides={"base_url": "https://test-url"})
 
-    assert mock_verify_login.call_count == 1
-    assert "key" in mock_verify_login.call_args[1]
-    assert mock_verify_login.call_args[1]["key"] == api_key
-    assert api.api_key == api_key
+    mock_prompt_api_key.assert_not_called()
+    mock_verify_login.assert_called_once_with(
+        key="test-api-key",
+        base_url="https://test-url",
+    )
+    assert api.api_key == "test-api-key"
+
+
+def test_initialize_api_does_not_prompt_for_api_key__when_using_thread_local_settings(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mock_prompt_api_key = MagicMock()
+    mock_verify_login = MagicMock()
+    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
+    monkeypatch.setattr(wandb_login, "_verify_login", mock_verify_login)
+    monkeypatch.setattr(
+        _thread_local_api_settings,
+        "api_key",
+        "test-thread-local-api-key",
+    )
+
+    api = Api(overrides={"base_url": "https://test-url"})
+
+    mock_prompt_api_key.assert_not_called()
+    mock_verify_login.assert_called_once_with(
+        key="test-thread-local-api-key",
+        base_url="https://test-url",
+    )
+    assert api.api_key == "test-thread-local-api-key"
+
+
+def test_initialize_api_does_not_prompt_for_api_key__when_using_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mock_prompt_api_key = MagicMock()
+    mock_verify_login = MagicMock()
+    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
+    monkeypatch.setattr(wandb_login, "_verify_login", mock_verify_login)
+    monkeypatch.setenv("WANDB_API_KEY", "test-api-key-from-env")
+
+    api = Api(overrides={"base_url": "https://test-url"})
+
+    mock_prompt_api_key.assert_not_called()
+    mock_verify_login.assert_called_once_with(
+        key="test-api-key-from-env",
+        base_url="https://test-url",
+    )
+    assert api.api_key == "test-api-key-from-env"
 
 
 @pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -110,16 +110,15 @@ def test_login_sets_api_base_url(
     assert wandb_setup.singleton().settings.base_url == base_url
 
 
-def test_login_invalid_key():
-    with mock.patch(
+def test_login_invalid_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
         "wandb.apis.internal.Api.validate_api_key",
-        return_value=False,
-    ):
-        wandb.ensure_configured()
-        with pytest.raises(wandb.errors.AuthenticationError):
-            wandb.login(key="X" * 40, verify=True)
+        lambda self: False,
+    )
+    wandb.ensure_configured()
 
-        assert wandb.api.api_key is None
+    with pytest.raises(wandb.errors.AuthenticationError):
+        wandb.login(key="X" * 40, verify=True)
 
 
 # TODO: Make this a system test that runs agains the local-testcontainer?

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -41,14 +41,15 @@ from wandb.apis.public.utils import (
     gql_compat,
     parse_org_from_registry_path,
 )
+from wandb.errors import AuthenticationError, UsageError, term
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
-from wandb.sdk import wandb_login
+from wandb.sdk import wandb_login, wandb_setup
 from wandb.sdk.artifacts._gqlutils import resolve_org_entity_name, server_supports
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.internal.thread_local_settings import _thread_local_api_settings
 from wandb.sdk.launch.utils import LAUNCH_DEFAULT_PROJECT
-from wandb.sdk.lib import retry, runid
+from wandb.sdk.lib import auth, retry, runid
 from wandb.sdk.lib.deprecation import warn_and_record_deprecation
 from wandb.sdk.lib.gql_request import GraphQLSession
 
@@ -373,39 +374,49 @@ class Api:
         The API key is loaded in the following order:
             1. User explicitly provided api key
             2. Thread local api key
-            3. Environment variable
-            4. Netrc file
-            5. Prompt for api key using wandb.login
+            3. The session api key
+            4. Environment variable
+            5. Netrc file
+            6. Interactive prompt (if possible)
         """
-        import requests
-
         # Use explicit key before thread local.
         # This allow user switching keys without picking up the wrong key from thread local.
         if init_api_key is not None:
             return init_api_key
         if _thread_local_api_settings.api_key:
             return _thread_local_api_settings.api_key
-        if os.getenv("WANDB_API_KEY"):
-            return os.environ["WANDB_API_KEY"]
 
-        auth = requests.utils.get_netrc_auth(base_url)
-        if auth:
-            return auth[-1]
+        if (  #
+            (settings := wandb_setup.singleton().settings_if_loaded)
+            and (api_key := settings.api_key)
+        ):
+            return api_key
 
-        _, prompted_key = wandb_login._login(
-            host=base_url,
-            key=None,
-            # We will explicitly verify the key later
-            verify=False,
-            _silent=(
-                self.settings.get("silent", False) or self.settings.get("quiet", False)
-            ),
-            update_api_key=False,
-            _disable_warning=True,
-        )
-        return prompted_key
+        if api_key := os.getenv(env.API_KEY):
+            return api_key
+
+        if api_key := auth.read_netrc_auth(host=base_url):
+            return api_key
+
+        is_silent = self.settings.get("silent", False)
+        is_quiet = self.settings.get("quiet", False)
+        if not is_silent and not is_quiet:
+            try:
+                if api_key := auth.prompt_api_key(
+                    host=base_url,
+                    no_offline=True,
+                ):
+                    return api_key
+            except term.NotATerminalError:
+                message = "No API key configured. Use `wandb login` to log in."
+                raise UsageError(message) from None
+
+        raise AuthenticationError("No API key.")
 
     def _configure_sentry(self) -> None:
+        if not env.error_reporting_enabled():
+            return
+
         import requests
 
         try:


### PR DESCRIPTION
Instead of calling `_login()` to indirectly trigger an interactive prompt, uses `auth.prompt_api_key()`. Instead of using `requests.util` to read from .netrc, uses `auth.read_netrc_auth()`.

This also serves as a fix for the API key loading order: previously, `Api()` was reading the `WANDB_API_KEY` environment variable and .netrc file *before* checking the session API key configured through `wandb.setup()` or a previous call to `wandb.login()`. So something like this:

```python
wandb.setup(settings=wandb.Settings(api_key="my-api-key"))
wandb.Api()  # will read the .netrc file
```

This was probably not noticed before because `wandb.login()` updates the `.netrc` file by default, so `wandb.login(); wandb.Api()` would work as expected. Even though that behavior is fixed, having detailed auth logic in `Api` is very problematic.

Horrifyingly, we have similar but slightly different code in `internal_api.py`, which I also updated.

I'll send out further refactors later; for now, this will aid in refactoring `_login`.