### PR TITLE
fix: fall back to hardlinks/copying in Run.save

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,3 +21,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `wandb.Image()` no longer prints a deprecation warning (@jacobromero in https://github.com/wandb/wandb/pull/10880)
 - `Registry.description` and `ArtifactCollection.description` no longer reject empty strings (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10891)
+- `wandb.Run.save()` now falls back to hardlinks and, if needed, copying (downgrading the 'live' file policy to 'now', if applicable) when symlinks are disabled or unavailable (e.g., cross‑volume or no Developer Mode on Windows) (@dmitryduev in https://github.com/wandb/wandb/pull/10894)

--- a/tests/unit_tests/test_dir_watcher.py
+++ b/tests/unit_tests/test_dir_watcher.py
@@ -13,7 +13,7 @@ from wandb.filesync.dir_watcher import DirWatcher, PolicyEnd, PolicyLive, Policy
 from wandb.sdk.internal.file_pusher import FilePusher
 
 if TYPE_CHECKING:
-    from wandb.sdk.interface.interface import PolicyName
+    from wandb.sdk.lib.filesystem import PolicyName
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_lib/test_filesystem.py
+++ b/tests/unit_tests/test_lib/test_filesystem.py
@@ -15,6 +15,7 @@ import pytest
 # from pyfakefs.fake_filesystem import OSType
 from wandb.sdk.lib import filesystem
 from wandb.sdk.lib.filesystem import (
+    are_paths_on_same_drive,
     check_exists,
     copy_or_overwrite_changed,
     mkdir_allow_fallback,
@@ -592,3 +593,18 @@ def test_mkdir_allow_fallback_with_warning(wandb_caplog, tmp_path):
     new_name = tmp_path / "direct-ry"
     assert mkdir_allow_fallback(dir_name) == new_name
     assert f"Creating '{new_name}' instead of '{dir_name}'" in wandb_caplog.text
+
+
+@pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="Drive letters are only relevant on Windows",
+)
+@pytest.mark.parametrize(
+    "path1,path2,expected",
+    [
+        ("C:\\foo", "C:\\bar", True),
+        ("C:\\foo", "D:\\bar", False),
+    ],
+)
+def test_are_windows_paths_on_same_drive(path1, path2, expected):
+    assert are_paths_on_same_drive(path1, path2) == expected

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -823,21 +823,6 @@ def test_json_dump_uncompressed_with_numpy_datatypes():
     assert iostr.getvalue() == '{"a": [1, 2.0, 3]}'
 
 
-@pytest.mark.skipif(
-    platform.system() != "Windows",
-    reason="Drive letters are only relevant on Windows",
-)
-@pytest.mark.parametrize(
-    "path1,path2,expected",
-    [
-        ("C:\\foo", "C:\\bar", True),
-        ("C:\\foo", "D:\\bar", False),
-    ],
-)
-def test_are_windows_paths_on_same_drive(path1, path2, expected):
-    assert util.are_paths_on_same_drive(path1, path2) == expected
-
-
 @pytest.mark.parametrize(
     "internet_state",
     [

--- a/tests/unit_tests/test_wandb_save.py
+++ b/tests/unit_tests/test_wandb_save.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 
 import pytest
@@ -201,3 +202,73 @@ def test_save_s3_path_warns(mock_run, capsys):
     mock_run().save("s3://file.txt")
 
     assert "cloud storage url, can't save" in capsys.readouterr().err
+
+
+def test_save_hardlink_fallback_when_symlink_fails(
+    monkeypatch,
+    mock_run,
+    parse_records,
+    record_q,
+    capsys,
+):
+    run = mock_run()
+
+    base_dir = pathlib.Path(run.dir).parent / "hl_src"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    (base_dir / "a.hl").write_text("a")
+    (base_dir / "b.hl").write_text("b")
+
+    # Force symlink creation to fail so the code falls back to hardlinks.
+    def _raise_symlink(*_args, **_kwargs):
+        raise OSError("symlink not permitted")
+
+    monkeypatch.setattr(pathlib.Path, "symlink_to", _raise_symlink)
+
+    run.save(str(base_dir / "*.hl"), base_path=str(base_dir), policy="now")
+
+    _, err = capsys.readouterr()
+    assert "Linked 2 files into the W&B run directory (hardlinks)" in err
+    assert (pathlib.Path(run.dir) / "a.hl").exists()
+    assert (pathlib.Path(run.dir) / "b.hl").exists()
+
+    parsed = parse_records(record_q)
+    paths = {f.path for f in parsed.files[0].files}
+    assert paths == {"a.hl", "b.hl"}
+
+
+def test_save_copy_fallback_when_links_unavailable(
+    monkeypatch,
+    mock_run,
+    parse_records,
+    record_q,
+    capsys,
+):
+    run = mock_run()
+
+    base_dir = pathlib.Path(run.dir).parent / "cp_src"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    (base_dir / "a.cpy").write_text("a")
+    (base_dir / "b.cpy").write_text("b")
+
+    # Force both symlink *and* hardlink creation to fail to trigger copy.
+    def _raise_symlink(*_args, **_kwargs):
+        raise OSError("symlink not permitted")
+
+    monkeypatch.setattr(pathlib.Path, "symlink_to", _raise_symlink)
+
+    def _raise_link(*_args, **_kwargs):
+        raise OSError("hardlink not permitted")
+
+    monkeypatch.setattr(os, "link", _raise_link)
+
+    # Exercise internal downgrade logic when copying.
+    run.save(str(base_dir / "*.cpy"), base_path=str(base_dir), policy="live")
+
+    _, err = capsys.readouterr()
+    assert "Copied 2 files" in err
+    assert (pathlib.Path(run.dir) / "a.cpy").exists()
+    assert (pathlib.Path(run.dir) / "b.cpy").exists()
+
+    parsed = parse_records(record_q)
+    paths = {f.path for f in parsed.files[0].files}
+    assert paths == {"a.cpy", "b.cpy"}

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -94,7 +94,7 @@ from wandb.errors import Error
 from wandb.errors.term import termerror, termlog, termsetup, termwarn
 from wandb.sdk import Artifact, Settings, wandb_config, wandb_metric, wandb_summary
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
-from wandb.sdk.interface.interface import PolicyName
+from wandb.sdk.lib.filesystem import PolicyName
 from wandb.sdk.lib.paths import FilePathStr, StrPath
 from wandb.sdk.wandb_run import Run
 from wandb.sdk.wandb_setup import _WandbSetup

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -94,7 +94,7 @@ from wandb.errors import Error
 from wandb.errors.term import termerror, termlog, termsetup, termwarn
 from wandb.sdk import Artifact, Settings, wandb_config, wandb_metric, wandb_summary
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
-from wandb.sdk.interface.interface import PolicyName
+from wandb.sdk.lib.filesystem import PolicyName
 from wandb.sdk.lib.paths import FilePathStr, StrPath
 from wandb.sdk.wandb_run import Run
 from wandb.sdk.wandb_setup import _WandbSetup

--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -8,16 +8,16 @@ import time
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, MutableSet, Optional
 
 from wandb import util
-from wandb.sdk.interface.interface import GlobStr
+from wandb.sdk.lib.filesystem import GlobStr
 from wandb.sdk.lib.paths import LogicalPath
 
 if TYPE_CHECKING:
     import wandb.vendor.watchdog_0_9_0.observers.api as wd_api
     import wandb.vendor.watchdog_0_9_0.observers.polling as wd_polling
     import wandb.vendor.watchdog_0_9_0.watchdog.events as wd_events
-    from wandb.sdk.interface.interface import PolicyName
     from wandb.sdk.internal.file_pusher import FilePusher
     from wandb.sdk.internal.settings_static import SettingsStatic
+    from wandb.sdk.lib.filesystem import PolicyName
 else:
     wd_polling = util.vendor_import("wandb_watchdog.observers.polling")
     wd_events = util.vendor_import("wandb_watchdog.events")

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -6,12 +6,13 @@ import logging
 import time
 from pathlib import Path
 from secrets import token_hex
-from typing import TYPE_CHECKING, Any, Iterable, Literal, NewType, TypedDict
+from typing import TYPE_CHECKING, Any, Iterable
 
 from wandb import termwarn
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_telemetry_pb2 as tpb
 from wandb.sdk.lib import json_util as json
+from wandb.sdk.lib.filesystem import FilesDict, PolicyName
 from wandb.sdk.mailbox import HandleAbandonedError, MailboxHandle
 from wandb.util import (
     WandBJSONEncoderOld,
@@ -27,16 +28,6 @@ from ..data_types.utils import history_dict_to_json, val_to_json
 from . import summary_record as sr
 
 MANIFEST_FILE_SIZE_THRESHOLD = 100_000
-
-GlobStr = NewType("GlobStr", str)
-
-
-PolicyName = Literal["now", "live", "end"]
-
-
-class FilesDict(TypedDict):
-    files: Iterable[tuple[GlobStr, PolicyName]]
-
 
 if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -1172,7 +1172,7 @@ class SendManager:
         summary_path = os.path.join(self._settings.files_dir, filenames.SUMMARY_FNAME)
         with open(summary_path, "w") as f:
             f.write(json_summary)
-        self._save_file(interface.GlobStr(filenames.SUMMARY_FNAME))
+        self._save_file(filesystem.GlobStr(filenames.SUMMARY_FNAME))
 
     def send_stats(self, record: "Record") -> None:
         stats = record.stats
@@ -1399,7 +1399,7 @@ class SendManager:
         self._update_telemetry_record(record.request.telemetry_record.telemetry)
 
     def _save_file(
-        self, fname: interface.GlobStr, policy: "interface.PolicyName" = "end"
+        self, fname: filesystem.GlobStr, policy: "filesystem.PolicyName" = "end"
     ) -> None:
         logger.info("saving file %s with policy %s", fname, policy)
         if self._dir_watcher:
@@ -1410,7 +1410,7 @@ class SendManager:
         for k in files.files:
             # TODO(jhr): fix paths with directories
             self._save_file(
-                interface.GlobStr(glob.escape(k.path)),
+                filesystem.GlobStr(glob.escape(k.path)),
                 interface.file_enum_to_policy(k.policy),
             )
 
@@ -1439,7 +1439,7 @@ class SendManager:
         ) as f:
             f.write(environment_json)
 
-        self._save_file(interface.GlobStr(filenames.METADATA_FNAME), policy="now")
+        self._save_file(filesystem.GlobStr(filenames.METADATA_FNAME), policy="now")
 
     def send_request_link_artifact(self, record: "Record") -> None:
         if not (record.control.req_resp or record.control.mailbox_slot):

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import wandb
 from wandb import util
 from wandb.plot import CustomChart
-from wandb.sdk.interface.interface import GlobStr
 from wandb.sdk.lib import filesystem
 
 from . import run as internal_run
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
     from tensorboard.compat.proto.event_pb2 import ProtoEvent
 
     from wandb.proto.wandb_internal_pb2 import RunRecord
-    from wandb.sdk.interface.interface import FilesDict
+    from wandb.sdk.lib.filesystem import FilesDict
 
     from ..interface.interface_queue import InterfaceQueue
     from .settings_static import SettingsStatic
@@ -55,7 +54,9 @@ def _link_and_save_file(
     elif not os.path.exists(wandb_path):
         os.symlink(abs_path, wandb_path)
     # TODO(jhr): need to figure out policy, live/throttled?
-    interface.publish_files(dict(files=[(GlobStr(glob.escape(file_name)), "live")]))
+    interface.publish_files(
+        dict(files=[(filesystem.GlobStr(glob.escape(file_name)), "live")])
+    )
 
 
 def is_tfevents_file_created_by(
@@ -365,7 +366,7 @@ class TBEventConsumer:
         # This is a bit of a hack to get file saving to work as it does in the user
         # process. Since we don't have a real run object, we have to define the
         # datatypes callback ourselves.
-        def datatypes_cb(fname: GlobStr) -> None:
+        def datatypes_cb(fname: filesystem.GlobStr) -> None:
             files: FilesDict = dict(files=[(fname, "now")])
             self._tbwatcher._interface.publish_files(files)
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -35,7 +35,7 @@ from wandb._pydantic import (
 from wandb.errors import UsageError
 from wandb.proto import wandb_settings_pb2
 
-from .lib import credentials, ipython
+from .lib import credentials, filesystem, ipython
 from .lib.run_moment import RunMoment
 
 validate_url: Callable[[str], None]
@@ -2107,9 +2107,11 @@ class Settings(BaseModel, validate_assignment=True):
         if not root:
             return None
 
-        # For windows if the root and program are on different drives,
+        # For windows, if the root and program are on different drives,
         # os.path.relpath will raise a ValueError.
-        if not util.are_paths_on_same_drive(root, program):
+        if not filesystem.are_paths_on_same_drive(
+            pathlib.Path(root), pathlib.Path(program)
+        ):
             return None
 
         full_path_to_program = os.path.join(

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1481,25 +1481,6 @@ def auto_project_name(program: str | None) -> str:
     return str(project.replace(os.sep, "_"))
 
 
-def are_paths_on_same_drive(path1: str, path2: str) -> bool:
-    """Check if two paths are on the same drive.
-
-    This check is only relevant on Windows,
-    since the concept of drives only exists on Windows.
-    """
-    if platform.system() != "Windows":
-        return True
-
-    try:
-        path1_drive = pathlib.Path(path1).resolve().drive
-        path2_drive = pathlib.Path(path2).resolve().drive
-    except OSError:
-        # If either path is not a valid Windows path, an OSError is raised.
-        return False
-
-    return path1_drive == path2_drive
-
-
 # TODO(hugh): Deprecate version here and use wandb/sdk/lib/paths.py
 def to_forward_slash_path(path: str) -> str:
     if platform.system() == "Windows":


### PR DESCRIPTION
## Description

Fixes WB-29101.

Improves the `_save` method in `wandb_run.py` to use a more robust approach for file linking that tries symlinks first, then hardlinks, and finally copies with appropriate policy downgrades when necessary. + Some adjacent clean up.

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable.

## Testing

Tested with unit tests to ensure file linking operations work correctly across different platforms.