### PR TITLE
fix: warn on OSError on reading netrc file

### DIFF
--- a/tests/unit_tests/test_lib/test_auth_netrc.py
+++ b/tests/unit_tests/test_lib/test_auth_netrc.py
@@ -53,6 +53,18 @@ def test_read_parse_error(
     mock_wandb_log.assert_warned("Failed to read netrc file")
 
 
+def test_read_unreadable(
+    fake_netrc_path: pathlib.Path,
+    mock_wandb_log: MockWandbLog,
+):
+    fake_netrc_path.mkdir()
+
+    result = wbnetrc.read_netrc_auth(host="https://test-host")
+
+    assert result is None
+    mock_wandb_log.assert_warned("Failed to read netrc file")
+
+
 def test_write(fake_netrc_path: pathlib.Path):
     fake_netrc_path.write_text(
         textwrap.dedent("""\

--- a/wandb/sdk/lib/auth/wbnetrc.py
+++ b/wandb/sdk/lib/auth/wbnetrc.py
@@ -30,14 +30,14 @@ def read_netrc_auth(*, host: str) -> str | None:
         netrc_file = netrc.netrc(path)
     except FileNotFoundError:
         return None
-    except netrc.NetrcParseError as e:
-        if e.lineno is None:
-            term.termwarn(f"Failed to read netrc file at {path}: {e.msg}")
-        else:
+    except (netrc.NetrcParseError, OSError) as e:
+        if isinstance(e, netrc.NetrcParseError) and e.lineno is not None:
             term.termwarn(
                 f"Failed to read netrc file at {path},"
                 + f" error on line {e.lineno}: {e.msg}"
             )
+        else:
+            term.termwarn(f"Failed to read netrc file at {path}: {e}")
 
         return None
 


### PR DESCRIPTION
Makes the new `read_netrc_auth()` correctly handle permission and other errors reading the .netrc file.