### PR TITLE
feat(launch): implement k8s resource cleanup

### DIFF
--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -3,9 +3,11 @@ import base64
 import json
 import platform
 import uuid
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import kubernetes_asyncio
 import pytest
 import wandb
 import wandb.sdk.launch.runner.kubernetes_runner
@@ -412,6 +414,14 @@ def mock_kube_context_and_api_client(monkeypatch):
     )
     monkeypatch.setattr(
         "wandb.sdk.launch.runner.kubernetes_monitor.get_kube_context_and_api_client",
+        _mock_get_kube_context_and_api_client,
+    )
+    monkeypatch.setattr(
+        "wandb.sdk.launch.runner.kubernetes_cleanup.get_kube_context_and_api_client",
+        _mock_get_kube_context_and_api_client,
+    )
+    monkeypatch.setattr(
+        "wandb.sdk.launch.utils.get_kube_context_and_api_client",
         _mock_get_kube_context_and_api_client,
     )
 
@@ -995,9 +1005,8 @@ async def test_launch_kube_api_secret_failed(
     )
     mock_la = MagicMock()
     mock_la.initialized = MagicMock(return_value=True)
-    monkeypatch.setattr(
-        "wandb.sdk.launch.runner.kubernetes_runner.LaunchAgent", mock_la
-    )
+
+    monkeypatch.setattr("wandb.sdk.launch.agent.agent.LaunchAgent", mock_la)
 
     async def mock_create_namespaced_secret(*args, **kwargs):
         raise Exception("Test exception")
@@ -2610,6 +2619,11 @@ async def test_resource_role_labels_on_job_and_auxiliary_resources(
     assert job_labels["wandb.ai/resource-role"] == "primary"
     assert "wandb.ai/auxiliary-resource" not in job_labels
 
+    # job's pod template should also have resource-role: primary
+    job_pod_labels = job_manifest["spec"]["template"]["metadata"]["labels"]
+    assert "wandb.ai/resource-role" in job_pod_labels
+    assert job_pod_labels["wandb.ai/resource-role"] == "primary"
+
     # service should have resource-role: auxiliary and auxiliary-resource UUID
     assert "wandb.ai/resource-role" in service_labels
     assert service_labels["wandb.ai/resource-role"] == "auxiliary"
@@ -2622,7 +2636,6 @@ async def test_resource_role_labels_on_job_and_auxiliary_resources(
 
 def test_cleanup_manager_initialization():
     """Test that cleanup manager initializes with correct configuration."""
-
     # Test with defaults
     cleanup = KubernetesResourceCleanup()
     assert cleanup._minimum_age == 900
@@ -2639,7 +2652,6 @@ def test_cleanup_manager_initialization():
 
 def test_cleanup_manager_namespace_parsing():
     """Test that namespace configuration is parsed correctly."""
-
     # Test whitespace handling
     cleanup = KubernetesResourceCleanup(monitored_namespaces=" ns1 , ns2 ,  ns3  ")
     assert cleanup._monitored_namespaces == {"ns1", "ns2", "ns3"}
@@ -2655,8 +2667,618 @@ def test_cleanup_manager_namespace_parsing():
 
 def test_cleanup_manager_environment_variable(monkeypatch):
     """Test that cleanup manager reads from environment variable."""
-
     monkeypatch.setenv("WANDB_LAUNCH_MONITORED_NAMESPACES", "env-ns1,env-ns2")
 
     cleanup = KubernetesResourceCleanup()
     assert cleanup._monitored_namespaces == {"env-ns1", "env-ns2"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_get_active_job_run_ids():
+    """Test getting active job run-ids from Kubernetes."""
+    # Create mock batch API with jobs
+    mock_batch_api = MagicMock()
+
+    # Create mock jobs with run-id labels
+    mock_job1 = MagicMock()
+    mock_job1.metadata.labels = {
+        "wandb.ai/run-id": "run-123",
+        "wandb.ai/resource-role": "primary",
+    }
+
+    mock_job2 = MagicMock()
+    mock_job2.metadata.labels = {
+        "wandb.ai/run-id": "run-456",
+        "wandb.ai/resource-role": "primary",
+    }
+
+    mock_job3 = MagicMock()
+    mock_job3.metadata.labels = {
+        "wandb.ai/resource-role": "primary"
+        # No run-id label
+    }
+
+    mock_list = MagicMock()
+    mock_list.items = [mock_job1, mock_job2, mock_job3]
+    mock_batch_api.list_namespaced_job = AsyncMock(return_value=mock_list)
+
+    cleanup = KubernetesResourceCleanup()
+    active_run_ids = await cleanup._get_active_job_run_ids(mock_batch_api, "default")
+
+    assert active_run_ids == {"run-123", "run-456"}
+    mock_batch_api.list_namespaced_job.assert_called_once_with(
+        namespace="default", label_selector="wandb.ai/resource-role=primary"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_get_active_job_run_ids_with_agent_tracker(monkeypatch):
+    """Test dual-source detection: Kubernetes + agent job tracker."""
+    # Mock Kubernetes Jobs
+    mock_batch_api = MagicMock()
+    mock_job = MagicMock()
+    mock_job.metadata.labels = {"wandb.ai/run-id": "run-from-k8s"}
+    mock_list = MagicMock()
+    mock_list.items = [mock_job]
+    mock_batch_api.list_namespaced_job = AsyncMock(return_value=mock_list)
+
+    # Mock agent returning additional run-ids (e.g., job being launched)
+    mock_agent_class = MagicMock()
+    mock_agent_class.initialized.return_value = True
+    mock_agent_class.get_active_run_ids.return_value = {
+        "run-from-agent",
+        "run-launching",
+    }
+
+    monkeypatch.setattr(
+        "wandb.sdk.launch.agent.agent.LaunchAgent.initialized",
+        mock_agent_class.initialized,
+    )
+    monkeypatch.setattr(
+        "wandb.sdk.launch.agent.agent.LaunchAgent.get_active_run_ids",
+        mock_agent_class.get_active_run_ids,
+    )
+
+    cleanup = KubernetesResourceCleanup()
+    active_run_ids = await cleanup._get_active_job_run_ids(mock_batch_api, "default")
+
+    # Should have run-ids from BOTH sources
+    assert active_run_ids == {"run-from-k8s", "run-from-agent", "run-launching"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_aux_resources_when_job_launching(monkeypatch):
+    """Test the scenario: aux resources exist, no K8s Job yet, but agent tracker has it.
+
+    This tests the race condition window where:
+    1. Agent starts launching job (in tracker)
+    2. Auxiliary resources created
+    3. K8s Job not yet created ← cleanup runs HERE
+
+    Result: Should NOT delete aux resources because agent tracker has the run-id.
+    """
+    cleanup = KubernetesResourceCleanup(minimum_resource_age_seconds=900)
+
+    # Mock Kubernetes APIs
+    mock_batch_api = MagicMock()
+    mock_core_api = MagicMock()
+    mock_apps_api = MagicMock()
+    mock_network_api = MagicMock()
+
+    # NO Kubernetes Job exists yet (launching window)
+    mock_batch_api.list_namespaced_job = AsyncMock(
+        return_value=MagicMock(items=[])  # Empty - no Job yet!
+    )
+
+    # But agent tracker HAS this run-id (job is launching)
+    mock_agent_class = MagicMock()
+    mock_agent_class.initialized.return_value = True
+    mock_agent_class.get_active_run_ids.return_value = {"run-launching"}
+
+    monkeypatch.setattr(
+        "wandb.sdk.launch.agent.agent.LaunchAgent.initialized",
+        mock_agent_class.initialized,
+    )
+    monkeypatch.setattr(
+        "wandb.sdk.launch.agent.agent.LaunchAgent.get_active_run_ids",
+        mock_agent_class.get_active_run_ids,
+    )
+
+    # Auxiliary resources exist (old enough to clean)
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=1000)
+    mock_aux_service = MagicMock()
+    mock_aux_service.metadata.labels = {
+        "wandb.ai/run-id": "run-launching",  # Matches agent tracker!
+        "wandb.ai/auxiliary-resource": "uuid-launching",
+    }
+    mock_aux_service.metadata.creation_timestamp = old_time
+    mock_aux_service.metadata.name = "launching-service"
+
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(
+        return_value=MagicMock(items=[mock_aux_service])
+    )
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    # Get active run-ids (should include agent tracker)
+    active_run_ids = await cleanup._get_active_job_run_ids(mock_batch_api, "default")
+    assert active_run_ids == {"run-launching"}  # From agent tracker
+
+    # Find orphaned UUIDs
+    orphaned = await cleanup._find_orphaned_uuids(
+        mock_core_api,
+        mock_apps_api,
+        mock_network_api,
+        mock_batch_api,
+        "default",
+        active_run_ids,
+    )
+
+    # CRITICAL: Should be EMPTY - resource is NOT orphaned because agent tracker has it!
+    assert orphaned == set()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_aux_resources_when_no_job_and_no_tracker(monkeypatch):
+    """Test that aux resources ARE deleted when NEITHER K8s Job NOR agent tracker has the run-id.
+
+    This is the opposite case - truly orphaned resources.
+    """
+    cleanup = KubernetesResourceCleanup(minimum_resource_age_seconds=900)
+
+    # Mock Kubernetes APIs
+    mock_batch_api = MagicMock()
+    mock_core_api = MagicMock()
+    mock_apps_api = MagicMock()
+    mock_network_api = MagicMock()
+
+    # NO Kubernetes Job exists
+    mock_batch_api.list_namespaced_job = AsyncMock(return_value=MagicMock(items=[]))
+
+    # Agent tracker does NOT have this run-id
+    mock_agent_class = MagicMock()
+    mock_agent_class.initialized.return_value = True
+    mock_agent_class.get_active_run_ids.return_value = set()  # Empty!
+
+    monkeypatch.setattr(
+        "wandb.sdk.launch.agent.agent.LaunchAgent.initialized",
+        mock_agent_class.initialized,
+    )
+    monkeypatch.setattr(
+        "wandb.sdk.launch.agent.agent.LaunchAgent.get_active_run_ids",
+        mock_agent_class.get_active_run_ids,
+    )
+
+    # Orphaned auxiliary resources exist
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=1000)
+    mock_aux_service = MagicMock()
+    mock_aux_service.metadata.labels = {
+        "wandb.ai/run-id": "run-orphaned",
+        "wandb.ai/auxiliary-resource": "uuid-orphaned",
+    }
+    mock_aux_service.metadata.creation_timestamp = old_time
+    mock_aux_service.metadata.name = "orphaned-service"
+
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(
+        return_value=MagicMock(items=[mock_aux_service])
+    )
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    # Get active run-ids (should be empty)
+    active_run_ids = await cleanup._get_active_job_run_ids(mock_batch_api, "default")
+    assert active_run_ids == set()  # No active jobs!
+
+    # Find orphaned UUIDs
+    orphaned = await cleanup._find_orphaned_uuids(
+        mock_core_api,
+        mock_apps_api,
+        mock_network_api,
+        mock_batch_api,
+        "default",
+        active_run_ids,
+    )
+
+    assert orphaned == {"uuid-orphaned"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_get_active_job_run_ids_api_failure():
+    """Test that API failure returns None (safety mechanism)."""
+    mock_batch_api = MagicMock()
+    mock_batch_api.list_namespaced_job = AsyncMock(
+        side_effect=ApiException(status=403, reason="Forbidden")
+    )
+
+    cleanup = KubernetesResourceCleanup()
+    active_run_ids = await cleanup._get_active_job_run_ids(mock_batch_api, "default")
+
+    assert active_run_ids is None  # Returns None on failure
+
+
+@pytest.mark.asyncio
+async def test_cleanup_find_orphaned_uuids_basic():
+    """Test finding orphaned UUIDs - basic case."""
+    cleanup = KubernetesResourceCleanup(minimum_resource_age_seconds=900)
+
+    # Create mock APIs
+    mock_core_api = MagicMock()
+    mock_apps_api = MagicMock()
+    mock_network_api = MagicMock()
+
+    # Mock service with orphaned UUID (old enough)
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=1000)
+    mock_service = MagicMock()
+    mock_service.metadata.labels = {
+        "wandb.ai/run-id": "run-orphaned",
+        "wandb.ai/auxiliary-resource": "uuid-orphaned",
+        "wandb.ai/resource-role": "auxiliary",
+    }
+    mock_service.metadata.creation_timestamp = old_time
+    mock_service.metadata.name = "test-service"
+
+    mock_list = MagicMock()
+    mock_list.items = [mock_service]
+
+    # Setup mock responses
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(return_value=mock_list)
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    active_run_ids = {"run-active-1", "run-active-2"}  # run-orphaned not in here
+
+    orphaned = await cleanup._find_orphaned_uuids(
+        mock_core_api,
+        mock_apps_api,
+        mock_network_api,
+        mock_batch_api,
+        "default",
+        active_run_ids,
+    )
+
+    assert orphaned == {"uuid-orphaned"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_find_orphaned_uuids_skips_active():
+    """Test that resources with active Jobs are NOT marked as orphaned."""
+    cleanup = KubernetesResourceCleanup(minimum_resource_age_seconds=900)
+
+    mock_core_api = MagicMock()
+    mock_apps_api = MagicMock()
+    mock_network_api = MagicMock()
+
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=1000)
+    mock_service = MagicMock()
+    mock_service.metadata.labels = {
+        "wandb.ai/run-id": "run-active",  # This is active
+        "wandb.ai/auxiliary-resource": "uuid-123",
+        "wandb.ai/resource-role": "auxiliary",
+    }
+    mock_service.metadata.creation_timestamp = old_time
+
+    mock_list = MagicMock()
+    mock_list.items = [mock_service]
+
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(return_value=mock_list)
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    active_run_ids = {"run-active"}  # run-active is active
+
+    orphaned = await cleanup._find_orphaned_uuids(
+        mock_core_api,
+        mock_apps_api,
+        mock_network_api,
+        mock_batch_api,
+        "default",
+        active_run_ids,
+    )
+
+    assert orphaned == set()  # Nothing orphaned - all active
+
+
+@pytest.mark.asyncio
+async def test_cleanup_find_orphaned_uuids_skips_recent():
+    """Test that recent resources are NOT marked as orphaned (safety mechanism)."""
+    cleanup = KubernetesResourceCleanup(minimum_resource_age_seconds=900)
+
+    mock_core_api = MagicMock()
+    mock_apps_api = MagicMock()
+    mock_network_api = MagicMock()
+
+    # Resource created 5 minutes ago (too recent - need 15 min)
+    recent_time = datetime.now(timezone.utc) - timedelta(seconds=300)
+    mock_service = MagicMock()
+    mock_service.metadata.labels = {
+        "wandb.ai/run-id": "run-orphaned",
+        "wandb.ai/auxiliary-resource": "uuid-123",
+        "wandb.ai/resource-role": "auxiliary",
+    }
+    mock_service.metadata.creation_timestamp = recent_time
+    mock_service.metadata.name = "test-service"
+
+    mock_list = MagicMock()
+    mock_list.items = [mock_service]
+
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(return_value=mock_list)
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    active_run_ids = set()  # No active runs
+
+    orphaned = await cleanup._find_orphaned_uuids(
+        mock_core_api,
+        mock_apps_api,
+        mock_network_api,
+        mock_batch_api,
+        "default",
+        active_run_ids,
+    )
+
+    assert orphaned == set()  # Nothing orphaned - too recent
+
+
+@pytest.mark.asyncio
+async def test_cleanup_find_orphaned_uuids_multiple_resources_same_uuid():
+    """Test that multiple resources with same UUID are grouped correctly."""
+    cleanup = KubernetesResourceCleanup(minimum_resource_age_seconds=900)
+
+    mock_core_api = MagicMock()
+    mock_apps_api = MagicMock()
+    mock_network_api = MagicMock()
+    mock_batch_api = MagicMock()
+
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=1000)
+
+    # Create multiple resources with same UUID
+    mock_service = MagicMock()
+    mock_service.metadata.labels = {
+        "wandb.ai/run-id": "run-orphaned",
+        "wandb.ai/auxiliary-resource": "uuid-shared",
+    }
+    mock_service.metadata.creation_timestamp = old_time
+    mock_service.metadata.name = "test-service"
+
+    mock_deployment = MagicMock()
+    mock_deployment.metadata.labels = {
+        "wandb.ai/run-id": "run-orphaned",
+        "wandb.ai/auxiliary-resource": "uuid-shared",  # Same UUID
+    }
+    mock_deployment.metadata.creation_timestamp = old_time
+    mock_deployment.metadata.name = "test-deployment"
+
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(
+        return_value=MagicMock(items=[mock_service])
+    )
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[mock_deployment])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    active_run_ids = set()
+
+    orphaned = await cleanup._find_orphaned_uuids(
+        mock_core_api,
+        mock_apps_api,
+        mock_network_api,
+        mock_batch_api,
+        "default",
+        active_run_ids,
+    )
+
+    # Both resources have same UUID, so only one UUID in set
+    assert orphaned == {"uuid-shared"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_find_orphaned_uuids_missing_run_id():
+    """Test that resources without run-id label are skipped."""
+    cleanup = KubernetesResourceCleanup(minimum_resource_age_seconds=900)
+
+    mock_core_api = MagicMock()
+    mock_apps_api = MagicMock()
+    mock_network_api = MagicMock()
+    mock_batch_api = MagicMock()
+
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=1000)
+    mock_service = MagicMock()
+    mock_service.metadata.labels = {
+        # No run-id label
+    }
+    mock_service.metadata.creation_timestamp = old_time
+    mock_service.metadata.name = "test-service"
+
+    mock_list = MagicMock()
+    mock_list.items = [mock_service]
+
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(return_value=mock_list)
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    active_run_ids = set()
+
+    orphaned = await cleanup._find_orphaned_uuids(
+        mock_core_api,
+        mock_apps_api,
+        mock_network_api,
+        mock_batch_api,
+        "default",
+        active_run_ids,
+    )
+
+    # Resource skipped due to missing run-id
+    assert orphaned == set()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_namespace_end_to_end(
+    monkeypatch,
+    mock_batch_api,
+    mock_core_api,
+    mock_apps_api,
+    mock_network_api,
+    mock_kube_context_and_api_client,
+):
+    """Test complete cleanup flow through _cleanup_namespace including deletion."""
+
+    # Create the mock delete function with diagnostic logging
+    async def _mock_delete(*args, **kwargs):
+        return None
+
+    mock_delete = AsyncMock(side_effect=_mock_delete)
+
+    # Patch the function at the runner module where it's accessed from
+    monkeypatch.setattr(
+        "wandb.sdk.launch.runner.kubernetes_runner.delete_auxiliary_resources_by_label",
+        mock_delete,
+    )
+
+    monkeypatch.setattr(
+        kubernetes_asyncio.client,
+        "BatchV1Api",
+        lambda *args, **kwargs: mock_batch_api,
+    )
+    monkeypatch.setattr(
+        kubernetes_asyncio.client,
+        "CoreV1Api",
+        lambda *args, **kwargs: mock_core_api,
+    )
+    monkeypatch.setattr(
+        kubernetes_asyncio.client,
+        "AppsV1Api",
+        lambda *args, **kwargs: mock_apps_api,
+    )
+    monkeypatch.setattr(
+        kubernetes_asyncio.client,
+        "NetworkingV1Api",
+        lambda *args, **kwargs: mock_network_api,
+    )
+
+    # Mock active job for _get_active_job_run_ids call
+    mock_job = MagicMock()
+    mock_job.metadata.labels = {"wandb.ai/run-id": "run-active"}
+
+    # Set up list_namespaced_job to handle different label selectors
+    async def mock_list_jobs(namespace, label_selector=None):
+        if label_selector == "wandb.ai/resource-role=primary":
+            return MagicMock(items=[mock_job])
+        elif label_selector == "wandb.ai/auxiliary-resource":
+            return MagicMock(items=[])
+        return MagicMock(items=[])
+
+    mock_batch_api.list_namespaced_job = AsyncMock(side_effect=mock_list_jobs)
+
+    # Mock orphaned resource
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=1000)
+    mock_orphaned_service = MagicMock()
+    mock_orphaned_service.metadata.labels = {
+        "wandb.ai/run-id": "run-orphaned",
+        "wandb.ai/auxiliary-resource": "uuid-orphaned",
+    }
+    mock_orphaned_service.metadata.creation_timestamp = old_time
+    mock_orphaned_service.metadata.name = "orphaned-service"
+
+    mock_core_api.list_namespaced_secret = AsyncMock(return_value=MagicMock(items=[]))
+    mock_core_api.list_namespaced_service = AsyncMock(
+        return_value=MagicMock(items=[mock_orphaned_service])
+    )
+    mock_core_api.list_namespaced_pod = AsyncMock(return_value=MagicMock(items=[]))
+    mock_apps_api.list_namespaced_deployment = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+    mock_network_api.list_namespaced_network_policy = AsyncMock(
+        return_value=MagicMock(items=[])
+    )
+
+    # Create cleanup instance
+    cleanup = KubernetesResourceCleanup(
+        minimum_resource_age_seconds=900, monitored_namespaces="test-ns"
+    )
+
+    # Run end-to-end cleanup
+    await cleanup._cleanup_namespace("test-ns")
+
+    # Verify delete was called for orphaned UUID
+    assert mock_delete.called, (
+        "delete_auxiliary_resources_by_label should have been called"
+    )
+    mock_delete.assert_called_once()
+    args = mock_delete.call_args[0]
+    assert args[0] == mock_apps_api
+    assert args[1] == mock_core_api
+    assert args[2] == mock_network_api
+    assert args[3] == mock_batch_api
+    assert args[4] == "test-ns"
+    assert args[5] == "uuid-orphaned"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cycle_multiple_namespaces(monkeypatch):
+    """Test that cleanup cycle processes all namespaces."""
+    cleanup = KubernetesResourceCleanup(monitored_namespaces="ns1,ns2,ns3")
+
+    cleanup_calls = []
+
+    async def mock_cleanup_namespace(namespace):
+        cleanup_calls.append(namespace)
+
+    cleanup._cleanup_namespace = mock_cleanup_namespace
+
+    await cleanup.run_cleanup_cycle()
+
+    assert set(cleanup_calls) == {"ns1", "ns2", "ns3"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cycle_continues_on_namespace_error(monkeypatch):
+    """Test that error in one namespace doesn't stop others."""
+    cleanup = KubernetesResourceCleanup(monitored_namespaces="ns1,ns2,ns3")
+
+    cleanup_calls = []
+
+    async def mock_cleanup_namespace(namespace):
+        cleanup_calls.append(namespace)
+        if namespace == "ns2":
+            raise Exception("Test error in ns2")
+
+    cleanup._cleanup_namespace = mock_cleanup_namespace
+
+    # Should not raise - error is caught
+    await cleanup.run_cleanup_cycle()
+
+    # All three namespaces should be attempted
+    assert set(cleanup_calls) == {"ns1", "ns2", "ns3"}

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -10,7 +10,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from multiprocessing import Event
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import yaml
 
@@ -194,6 +194,27 @@ class LaunchAgent:
     def initialized(cls) -> bool:
         """Return whether the agent is initialized."""
         return cls._instance is not None
+
+    @classmethod
+    def get_active_run_ids(cls) -> Set[str]:
+        """Return set of active run-ids from the agent's job tracker.
+
+        This includes jobs that are in the process of being launched
+        (e.g., auxiliary resources created but Job not yet created).
+
+        Returns:
+            Set of run-ids for all tracked jobs
+        """
+        if cls._instance is None:
+            return set()
+
+        active_run_ids = set()
+        with cls._instance._jobs_lock:
+            for job_tracker in cls._instance._jobs.values():
+                if job_tracker.run_id:
+                    active_run_ids.add(job_tracker.run_id)
+
+        return active_run_ids
 
     def __init__(self, api: Api, config: Dict[str, Any]):
         """Initialize a launch agent.

--- a/wandb/sdk/launch/runner/kubernetes_cleanup.py
+++ b/wandb/sdk/launch/runner/kubernetes_cleanup.py
@@ -4,9 +4,18 @@ This module handles periodic cleanup of auxiliary resources (services, deploymen
 network policies, etc.) that may be left behind after an agent restart or crash.
 """
 
+import asyncio
 import logging
 import os
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Optional, Set
+
+import kubernetes_asyncio
+from kubernetes_asyncio.client import ApiException
+
+import wandb
+from wandb.sdk.launch.runner import kubernetes_runner
+from wandb.sdk.launch.utils import LOG_PREFIX, get_kube_context_and_api_client
 
 _logger = logging.getLogger(__name__)
 
@@ -44,12 +53,12 @@ class KubernetesResourceCleanup:
                 "WANDB_LAUNCH_MONITORED_NAMESPACES", "default,wandb"
             )
 
-        self._monitored_namespaces: set[str] = set(
+        self._monitored_namespaces: Set[str] = set(
             ns.strip() for ns in monitored_namespaces.split(",") if ns.strip()
         )
 
-        _logger.info(
-            f"Initialized resource cleanup with min_age={minimum_resource_age_seconds}s, "
+        wandb.termlog(
+            f"{LOG_PREFIX}Initialized resource cleanup with min_age={minimum_resource_age_seconds}s, "
             f"namespaces={sorted(self._monitored_namespaces)}"
         )
 
@@ -57,15 +66,277 @@ class KubernetesResourceCleanup:
         """Execute one cleanup cycle across all monitored namespaces.
 
         This method is called periodically by the agent's main loop.
-        todo: impl this.
         """
         if not self._monitored_namespaces:
             _logger.debug("No namespaces to clean, skipping cycle")
             return
 
-        _logger.info(
-            f"Starting cleanup cycle for {len(self._monitored_namespaces)} namespace(s): "
+        wandb.termlog(
+            f"{LOG_PREFIX}Starting cleanup cycle for {len(self._monitored_namespaces)} namespace(s): "
             f"{', '.join(sorted(self._monitored_namespaces))}"
         )
 
-        pass
+        for namespace in self._monitored_namespaces:
+            try:
+                await self._cleanup_namespace(namespace)
+            except Exception as e:
+                _logger.warning(
+                    f"Failed to clean namespace {namespace}: {e}", exc_info=True
+                )
+
+        wandb.termlog(f"{LOG_PREFIX}Cleanup cycle completed")
+
+    async def _cleanup_namespace(self, namespace: str) -> None:
+        """Clean orphaned resources in a single namespace.
+
+        Args:
+            namespace: Kubernetes namespace to clean
+        """
+        # Initialize Kubernetes clients
+        try:
+            _, api_client = await get_kube_context_and_api_client(
+                kubernetes_asyncio, {}
+            )
+        except Exception as e:
+            _logger.warning(f"Failed to get Kubernetes API client: {e}")
+            return
+
+        batch_api = kubernetes_asyncio.client.BatchV1Api(api_client)
+        core_api = kubernetes_asyncio.client.CoreV1Api(api_client)
+        apps_api = kubernetes_asyncio.client.AppsV1Api(api_client)
+        network_api = kubernetes_asyncio.client.NetworkingV1Api(api_client)
+
+        # Get all active primary Jobs (those with run-id labels)
+        active_run_ids = await self._get_active_job_run_ids(batch_api, namespace)
+        if active_run_ids is None:
+            # Failed to get active jobs - skip this namespace for safety
+            _logger.warning(
+                f"Unable to retrieve active jobs from {namespace}, "
+                "skipping cleanup to avoid deleting active resources"
+            )
+            return
+
+        if active_run_ids:
+            _logger.debug(
+                f"Found {len(active_run_ids)} active job(s) in {namespace}: "
+                f"{', '.join(sorted(active_run_ids))}"
+            )
+        else:
+            _logger.debug(f"No active jobs found in {namespace}")
+
+        # Find all orphaned auxiliary resources
+        orphaned_uuids = await self._find_orphaned_uuids(
+            core_api,
+            apps_api,
+            network_api,
+            batch_api,
+            namespace,
+            active_run_ids,
+        )
+
+        if not orphaned_uuids:
+            _logger.debug(f"No orphaned resources found in {namespace}")
+            return
+
+        wandb.termlog(
+            f"{LOG_PREFIX}Found {len(orphaned_uuids)} orphaned resource group(s) in {namespace}"
+        )
+
+        # Delete all resources for each orphaned UUID concurrently
+        async def delete_uuid(uuid_val: str) -> None:
+            """Delete resources for a single UUID."""
+            try:
+                await kubernetes_runner.delete_auxiliary_resources_by_label(
+                    apps_api,
+                    core_api,
+                    network_api,
+                    batch_api,
+                    namespace,
+                    uuid_val,
+                )
+                wandb.termlog(
+                    f"{LOG_PREFIX}Cleaned up orphaned resources with UUID {uuid_val} in {namespace}"
+                )
+            except Exception as e:
+                _logger.warning(
+                    f"Failed to cleanup UUID {uuid_val} in {namespace}: {e}"
+                )
+
+        # execute deletions concurrently
+        await asyncio.gather(*[delete_uuid(uuid_val) for uuid_val in orphaned_uuids])
+
+    async def _get_active_job_run_ids(
+        self, batch_api: "kubernetes_asyncio.client.BatchV1Api", namespace: str
+    ) -> Optional[Set[str]]:
+        """Get run-ids of all active primary Jobs in a namespace.
+
+        Uses dual-source detection:
+        1. Kubernetes Jobs (authoritative source - what's actually running)
+        2. Agent's job tracker (includes jobs being launched but not yet in K8s)
+
+        Args:
+            batch_api: Kubernetes Batch API client
+            namespace: Kubernetes namespace
+
+        Returns:
+            Set of active run-ids, or None if Kubernetes query failed
+        """
+        active_run_ids = set()
+
+        # Source 1: Query Kubernetes for active Jobs
+        try:
+            jobs = await batch_api.list_namespaced_job(
+                namespace=namespace,
+                label_selector="wandb.ai/resource-role=primary",
+            )
+
+            for job in jobs.items:
+                run_id = job.metadata.labels.get("wandb.ai/run-id")
+                if run_id:
+                    active_run_ids.add(run_id)
+
+        except ApiException as e:
+            _logger.warning(
+                f"Failed to list jobs in {namespace}: {e}. "
+                "Skipping cleanup for this namespace for safety."
+            )
+            return None
+        except Exception as e:
+            _logger.warning(
+                f"Unexpected error listing jobs in {namespace}: {e}", exc_info=True
+            )
+            return None
+
+        # Source 2: Get run-ids from agent's job tracker (for launching jobs)
+        # This catches the window where auxiliary resources exist but Job doesn't yet
+        try:
+            from wandb.sdk.launch.agent.agent import LaunchAgent
+
+            if LaunchAgent.initialized():
+                agent_run_ids = LaunchAgent.get_active_run_ids()
+                if agent_run_ids:
+                    active_run_ids.update(agent_run_ids)
+                    _logger.debug(
+                        f"Added {len(agent_run_ids)} run-ids from agent job tracker"
+                    )
+        except Exception as e:
+            # Agent job tracker is optional - don't fail if unavailable
+            _logger.debug(f"Could not get agent job tracker run-ids: {e}")
+
+        return active_run_ids
+
+    async def _scan_resource_type(
+        self,
+        api_client,
+        resource_type: str,
+        namespace: str,
+        active_run_ids: Set[str],
+    ) -> Set[str]:
+        """Scan a single resource type for orphaned UUIDs.
+
+        Args:
+            api_client: Kubernetes API client
+            resource_type: Type of resource to scan
+            namespace: Kubernetes namespace to scan
+            active_run_ids: Set of run-ids with active primary Jobs
+
+        Returns:
+            Set of orphaned UUIDs found in this resource type
+        """
+        found_orphaned = set()
+        try:
+            list_method = getattr(api_client, f"list_namespaced_{resource_type}")
+            resources = await list_method(
+                namespace=namespace,
+                label_selector="wandb.ai/auxiliary-resource",
+            )
+
+            for resource in resources.items:
+                uuid_val = resource.metadata.labels.get("wandb.ai/auxiliary-resource")
+                if not uuid_val:
+                    continue
+
+                # Check if the run-id for this resource has an active Job
+                run_id = resource.metadata.labels.get("wandb.ai/run-id")
+                if not run_id:
+                    # Resource has no run-id label - shouldn't happen, but skip for safety
+                    _logger.warning(
+                        f"Resource {resource_type} {resource.metadata.name} "
+                        f"has auxiliary-resource label but no run-id label"
+                    )
+                    continue
+
+                # Skip if has active primary Job
+                if run_id in active_run_ids:
+                    continue
+
+                # Check age (safety buffer)
+                creation_time = resource.metadata.creation_timestamp
+                if creation_time:
+                    age = (datetime.now(timezone.utc) - creation_time).total_seconds()
+                    if age < self._minimum_age:
+                        _logger.debug(
+                            f"Skipping {resource_type} {resource.metadata.name} "
+                            f"(age: {age:.0f}s < {self._minimum_age}s)"
+                        )
+                        continue
+
+                # This UUID is orphaned
+                found_orphaned.add(uuid_val)
+
+        except (AttributeError, ApiException) as e:
+            _logger.warning(f"Failed to scan {resource_type} in {namespace}: {e}")
+        except Exception as e:
+            _logger.warning(
+                f"Unexpected error scanning {resource_type} in {namespace}: {e}",
+                exc_info=True,
+            )
+
+        return found_orphaned
+
+    async def _find_orphaned_uuids(
+        self,
+        core_api: "kubernetes_asyncio.client.CoreV1Api",
+        apps_api: "kubernetes_asyncio.client.AppsV1Api",
+        network_api: "kubernetes_asyncio.client.NetworkingV1Api",
+        batch_api: "kubernetes_asyncio.client.BatchV1Api",
+        namespace: str,
+        active_run_ids: Set[str],
+    ) -> Set[str]:
+        """Find UUIDs of orphaned auxiliary resources.
+
+        Args:
+            core_api: Kubernetes Core API client
+            apps_api: Kubernetes Apps API client
+            network_api: Kubernetes Networking API client
+            batch_api: Kubernetes Batch API client
+            namespace: Kubernetes namespace
+            active_run_ids: Set of run-ids with active primary Jobs
+
+        Returns:
+            Set of orphaned UUIDs
+        """
+        resource_types = [
+            (core_api, "service"),
+            (batch_api, "job"),
+            (core_api, "pod"),
+            (core_api, "secret"),
+            (apps_api, "deployment"),
+            (network_api, "network_policy"),
+        ]
+
+        # scan all resource types concurrently
+        results = await asyncio.gather(
+            *[
+                self._scan_resource_type(
+                    api_client, resource_type, namespace, active_run_ids
+                )
+                for api_client, resource_type in resource_types
+            ]
+        )
+
+        orphaned_uuids = set()
+        for uuid_set in results:
+            orphaned_uuids.update(uuid_set)
+
+        return orphaned_uuids

--- a/wandb/sdk/launch/runner/kubernetes_monitor.py
+++ b/wandb/sdk/launch/runner/kubernetes_monitor.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import traceback
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import kubernetes_asyncio  # type: ignore
 import urllib3
@@ -18,10 +18,12 @@ from kubernetes_asyncio.client import (  # type: ignore
 )
 
 import wandb
-from wandb.sdk.launch.agent import LaunchAgent
 from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.runner.abstract import State, Status
 from wandb.sdk.launch.utils import get_kube_context_and_api_client
+
+if TYPE_CHECKING:
+    from wandb.sdk.launch.agent import LaunchAgent  # noqa: F401
 
 WANDB_K8S_LABEL_NAMESPACE = "wandb.ai"
 WANDB_K8S_RUN_ID = f"{WANDB_K8S_LABEL_NAMESPACE}/run-id"
@@ -236,6 +238,9 @@ class LaunchKubernetesMonitor:
             batch_api = BatchV1Api(api_client)
             custom_api = CustomObjectsApi(api_client)
             label_selector = f"{WANDB_K8S_LABEL_MONITOR}=true"
+            # Import LaunchAgent lazily to avoid circular import
+            from wandb.sdk.launch.agent import LaunchAgent
+
             if LaunchAgent.initialized():
                 label_selector += f",{WANDB_K8S_LABEL_AGENT}={LaunchAgent.name()}"
             cls(

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -8,12 +8,11 @@ import logging
 import os
 import time
 import uuid
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import wandb
 import yaml
 from wandb.apis.internal import Api
-from wandb.sdk.launch.agent.agent import LaunchAgent
 from wandb.sdk.launch.environment.abstract import AbstractEnvironment
 from wandb.sdk.launch.registry.abstract import AbstractRegistry
 from wandb.sdk.launch.registry.azure_container_registry import AzureContainerRegistry
@@ -47,6 +46,9 @@ from ..utils import (
     make_k8s_label_safe,
     make_name_dns_safe,
 )
+
+if TYPE_CHECKING:
+    from wandb.sdk.launch.agent.agent import LaunchAgent  # noqa: F401
 from .abstract import AbstractRun, AbstractRunner
 
 get_module(
@@ -492,6 +494,9 @@ class KubernetesRunner(AbstractRunner):
         job_metadata["labels"][WANDB_K8S_RUN_ID] = launch_project.run_id
         job_metadata["labels"][WANDB_K8S_LABEL_MONITOR] = "true"
         job_metadata["labels"][WANDB_K8S_LABEL_RESOURCE_ROLE] = "primary"
+        # Import LaunchAgent lazily to avoid circular import
+        from wandb.sdk.launch.agent.agent import LaunchAgent
+
         if LaunchAgent.initialized():
             job_metadata["labels"][WANDB_K8S_LABEL_AGENT] = LaunchAgent.name()
 
@@ -562,6 +567,9 @@ class KubernetesRunner(AbstractRunner):
         )
         api_key_secret = None
         wandb_team_secrets_secret = None
+
+        # Import LaunchAgent lazily to avoid circular import
+        from wandb.sdk.launch.agent.agent import LaunchAgent
 
         for cont in containers:
             # Add our env vars to user supplied env vars
@@ -1028,6 +1036,9 @@ class KubernetesRunner(AbstractRunner):
             )
 
             # Add wandb.ai/agent: current agent label on all pods
+            # Import LaunchAgent lazily to avoid circular import
+            from wandb.sdk.launch.agent.agent import LaunchAgent
+
             if LaunchAgent.initialized():
                 add_label_to_pods(
                     resource_args,


### PR DESCRIPTION
Description
-----------
- Fixes WB-NNNNN

Implements the k8s auxiliary resource cleanup that prevents premature deletion of auxiliary resources during job launch. The implementation adds:

1. A method to get active run IDs from the agent's job tracker
2. Orphaned UUID detection
3. Age-based safety checks to prevent cleanup of recently created resources
4. Proper labeling of job pod templates with resource roles
5. Error handling for API failures

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Added comprehensive unit tests covering:
- Active job run ID detection from both Kubernetes and agent tracker
- End-to-end namespace cleanup flow
- Error handling during API failures
- Multiple namespace processing

Performed manual testing on Test Public Queue:
1. Confirmed that if a job is running with additional resources during agent restart, then when the job completes, it gets cleaned up
2. Confirmed that the cleanup loop cleans up resources when the job isn't active anymore

```
wandb: launch: agent 7vf73wf6 polling on queues Test Public Queue, running 0 out of a maximum of 10 jobs
wandb: launch: Starting cleanup cycle for 2 namespace(s): default, wandb
wandb: launch: Cleanup cycle completed
wandb: launch: Starting cleanup cycle for 2 namespace(s): default, wandb
wandb: launch: Cleanup cycle completed
wandb: launch: Starting cleanup cycle for 2 namespace(s): default, wandb
wandb: launch: Cleanup cycle completed
wandb: launch: Starting cleanup cycle for 2 namespace(s): default, wandb
wandb: launch: Found 1 orphaned resource group(s) in wandb
wandb: launch: Cleaned up service: evals-g5ozawnk-test-jobs-wandb
wandb: launch: Cleaned up pod: deploy-g5ozawnk-test-jobs-wandb-6568d497d6-5shrg
wandb: launch: Cleaned up deployment: deploy-g5ozawnk-test-jobs-wandb
wandb: launch: Cleaned up network_policy: job-policy-g5ozawnk-test-jobs-wandb
wandb: launch: Cleaned up network_policy: resource-policy-g5ozawnk-test-jobs-wandb
wandb: launch: Cleaned up orphaned resources with UUID faf159fe-9e92-44b1-b5dd-6f2d5398926a in wandb
wandb: launch: Cleanup cycle completed
```