### PR TITLE
chore: add leet as a valid PR scope

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -33,6 +33,7 @@ jobs:
             launch
             sdk
             sweeps
+            leet
           requireScope: false
           # Ensures the subject doesn't start with an uppercase character.
           subjectPattern: ^(?![A-Z]).+$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,7 @@ Which part of the codebase does this change impact? Only certain scopes are perm
 | artifacts    | Artifacts                | Changes related to Artifacts                   |
 | sweeps       | Sweeps                   | Changes related to Sweeps                      |
 | launch       | Launch                   | Changes related to Launch                      |
+| leet         | LEET                     | Changes related to W&B LEET TUI                |
 
 Sometimes a change may span multiple scopes. In this case, please choose the scope that would be most relevant to the user.
 


### PR DESCRIPTION
Description
-----------
- Add `leet` as a valid scope for PR titles in the GitHub workflow
- Update CONTRIBUTING.md to include LEET TUI as a valid scope for PR titles
