### PR TITLE
chore: clean up release-sdk gh actions job

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -89,11 +89,6 @@ jobs:
           package-dir: .
           output-dir: dist
         env:
-          # In cp36-*, the wheel name sometimes includes additional dashes that
-          # make it invalid, breaking the job.
-          #
-          # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_SKIP: cp36-* cp37-*
           CIBW_ARCHS_LINUX: aarch64
           CIBW_BEFORE_ALL_LINUX: >
             export DOWNLOAD_GOVERSION=$( grep '^go' core/go.mod | cut -d' ' -f2 ) &&
@@ -146,11 +141,6 @@ jobs:
           package-dir: .
           output-dir: dist
         env:
-          # In cp36-*, the wheel name sometimes includes additional dashes that
-          # make it invalid, breaking the job.
-          #
-          # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_SKIP: cp36-* cp37-*
           CIBW_ARCHS_LINUX: x86_64 #aarch64 is handled by build-linux-arm64-wheels
           CIBW_ARCHS_MACOS: x86_64 arm64 # arm64 == aarch64
 


### PR DESCRIPTION
Description
-----------
v3 of cibuildwheel [deprecated](https://iscinumpy.dev/post/cibuildwheel-3-0-0/) python <3.8, so this removes the now unnecessary skip tags. See also https://github.com/wandb/wandb/pull/10685.
