### PR TITLE
refactor: simplify Api._load_api_key

### DIFF
--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import secrets
-import unittest
 from functools import lru_cache
 from string import ascii_lowercase, digits
 from typing import Callable, Iterator, Union
@@ -84,12 +83,7 @@ def api(user: str) -> wandb.Api:
     since the default `api` fixture is function-scoped, meaning it does not
     play well with other module-scoped fixtures.
     """
-    with unittest.mock.patch.object(
-        wandb.sdk.wandb_login,
-        "_login",
-        return_value=(True, None),
-    ):
-        yield wandb.Api()
+    return wandb.Api(api_key=user)
 
 
 @fixture(scope="module")

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -445,20 +445,44 @@ def login(
     referrer: str | None = None,
     anonymous: DoNotSet = UNSET,
 ) -> bool:
-    """Set up W&B login credentials.
+    """Log into W&B.
 
-    By default, this will only store credentials locally without
-    verifying them with the W&B server. To verify credentials, pass
-    `verify=True`.
+    You generally don't have to use this because most W&B methods that need
+    authentication can log in implicitly. This is the programmatic counterpart
+    to the `wandb login` CLI.
+
+    This updates global credentials for the session (affecting all wandb usage
+    in the current Python process after this call) and possibly the .netrc file.
+
+    If the identity_token_file setting is set, like through the
+    WANDB_IDENTITY_TOKEN_FILE environment variable, then this is a no-op.
+
+    Otherwise, if an explicit API key is provided, it is used and written to
+    the system .netrc file. If no key is provided, but the session is already
+    authenticated, then the session key is used for verification (if verify
+    is True) and the .netrc file is not updated.
+
+    If none of the above is true, then this gets the API key from the first of:
+
+    - The WANDB_API_KEY environment variable
+    - The api_key setting in a system or workspace settings file
+    - The .netrc file (either ~/.netrc, ~/_netrc or the path specified by the
+      NETRC environment variable)
+    - An interactive prompt (if available)
 
     Args:
         key: The API key to use.
-        relogin: If true, will re-prompt for API key.
-        host: The host to connect to.
-        force: If true, will force a relogin.
-        timeout: Number of seconds to wait for user input.
-        verify: Verify the credentials with the W&B server.
-        referrer: The referrer to use in the URL login request.
+        relogin: If true, get the API key from an interactive prompt, skipping
+            reading .netrc, environment variables, etc.
+        host: The W&B server URL to connect to.
+        force: If true, disallows selecting offline mode in the interactive
+            prompt.
+        timeout: Number of seconds to wait for user input in the interactive
+            prompt. This can be used as a failsafe if an interactive prompt
+            is incorrectly shown in a non-interactive environment.
+        verify: Verify the credentials with the W&B server and raise an
+            AuthenticationError on failure.
+        referrer: The referrer to use in the URL login request for analytics.
 
     Returns:
         bool: If `key` is configured.

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -192,7 +192,6 @@ class _WandbInit:
         wandb_login._login(
             host=run_settings.base_url,
             force=run_settings.force,
-            _disable_warning=True,
             _silent=run_settings.quiet or run_settings.silent,
         )
 


### PR DESCRIPTION
Updates `_login` to make it usable in `Api._load_api_key` and fixes a bug in `_load_api_key`.

Pulls out the `_noop`, `_offline` and `wandb.run` checks into the higher level `wandb.login()` (which is also called by the `wandb login` CLI). The `_noop` and `_offline` checks are already present in `wandb.init()` and the `wandb.run` check is not relevant there. The fact that `Api._load_api_key` doesn't work if the `identity_token_file` setting is set is the same as it was before.

`_login` is called by `login()` (which is called by the `wandb login` CLI), `wandb.init()`, Sweeps, and now `Api._load_api_key()`. The changes above shouldn't matter for Sweeps.

I recently refactored `_load_api_key()` to use the new `auth` methods in PR #10893 but in doing so introduced a subtle bug: if `Api._load_api_key` prompts for a key, that key is not saved in the session, and later calls to `Api()` will prompt again. I will add an `auth` method for this soon, but due to other obstacles, using `_login` is the cleaner refactoring path.
