### PR TITLE
feat: add sentry telemetry for beta_scan_history events

### DIFF
--- a/core/internal/runhistoryreader/reader.go
+++ b/core/internal/runhistoryreader/reader.go
@@ -71,6 +71,18 @@ func New(
 	return historyReader, nil
 }
 
+func (h *HistoryReader) GetEntity() string {
+	return h.entity
+}
+
+func (h *HistoryReader) GetProject() string {
+	return h.project
+}
+
+func (h *HistoryReader) GetRunId() string {
+	return h.runId
+}
+
 // GetHistorySteps gets all history rows for HistoryReader's keys
 // that fall between minStep and maxStep.
 // Returns a list of KVMapLists, where each item in the list is a history row.

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -2,14 +2,17 @@ package wbapi
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/simplejsonext"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runhistoryreader"
+	"github.com/wandb/wandb/core/internal/sentry_ext"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/stream"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -20,6 +23,7 @@ import (
 type RunHistoryAPIHandler struct {
 	graphqlClient graphql.Client
 	httpClient    *retryablehttp.Client
+	sentryClient  *sentry_ext.Client
 
 	// currentRequestId is the id of the last scan init request made.
 	//
@@ -34,7 +38,10 @@ type RunHistoryAPIHandler struct {
 	scanHistoryReaders map[int32]*runhistoryreader.HistoryReader
 }
 
-func NewRunHistoryAPIHandler(settings *settings.Settings) *RunHistoryAPIHandler {
+func NewRunHistoryAPIHandler(
+	settings *settings.Settings,
+	sentryClient *sentry_ext.Client,
+) *RunHistoryAPIHandler {
 	backend := stream.NewBackend(observability.NewNoOpLogger(), settings)
 	graphqlClient := stream.NewGraphQLClient(
 		backend,
@@ -54,6 +61,7 @@ func NewRunHistoryAPIHandler(settings *settings.Settings) *RunHistoryAPIHandler 
 		httpClient:         httpClient,
 		currentRequestId:   atomic.Int32{},
 		scanHistoryReaders: make(map[int32]*runhistoryreader.HistoryReader),
+		sentryClient:       sentryClient,
 	}
 }
 
@@ -82,6 +90,16 @@ func (f *RunHistoryAPIHandler) HandleRequest(
 func (f *RunHistoryAPIHandler) handleScanRunHistoryInit(
 	request *spb.ScanRunHistoryInit,
 ) *spb.ApiResponse {
+	f.sentryClient.CaptureMessage(
+		"handleScanRunHistoryInit",
+		map[string]string{
+			"entity":  request.Entity,
+			"project": request.Project,
+			"runId":   request.RunId,
+		},
+	)
+	defer f.sentryClient.Flush(2)
+
 	requestId := f.currentRequestId.Add(1)
 	requestKeys := request.GetKeys()
 
@@ -141,6 +159,7 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryRead(
 	minStep := request.MinStep
 	maxStep := request.MaxStep
 
+	getHistoryStepsStart := time.Now()
 	historySteps, err := historyReader.GetHistorySteps(
 		context.Background(),
 		minStep,
@@ -155,6 +174,19 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryRead(
 			},
 		}
 	}
+	getHistoryStepsEnd := time.Now()
+	f.sentryClient.CaptureMessage(
+		fmt.Sprintf(
+			"handleScanRunHistoryRead: getHistorySteps time: %dms",
+			getHistoryStepsEnd.Sub(getHistoryStepsStart).Milliseconds(),
+		),
+		map[string]string{
+			"entity":  historyReader.GetEntity(),
+			"project": historyReader.GetProject(),
+			"runId":   historyReader.GetRunId(),
+		},
+	)
+	defer f.sentryClient.Flush(2)
 
 	historyRows := make([]*spb.HistoryRow, 0, len(historySteps))
 	for _, historyStep := range historySteps {

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -4,6 +4,7 @@
 package wbapi
 
 import (
+	"github.com/wandb/wandb/core/internal/sentry_ext"
 	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -23,13 +24,19 @@ type WandbAPI struct {
 	settings *settings.Settings
 
 	runHistoryApiHandler *RunHistoryAPIHandler
+
+	sentryClient *sentry_ext.Client
 }
 
-func NewWandbAPI(settings *settings.Settings) *WandbAPI {
+func NewWandbAPI(
+	settings *settings.Settings,
+	sentryClient *sentry_ext.Client,
+) *WandbAPI {
 	return &WandbAPI{
 		semaphore:            make(chan struct{}, maxConcurrency),
 		settings:             settings,
-		runHistoryApiHandler: NewRunHistoryAPIHandler(settings),
+		runHistoryApiHandler: NewRunHistoryAPIHandler(settings, sentryClient),
+		sentryClient:         sentryClient,
 	}
 }
 

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -607,7 +607,7 @@ func (nc *Connection) handleSyncStatus(
 
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	settings := settings.From(request.GetSettings())
-	nc.wbapi = wbapi.NewWandbAPI(settings)
+	nc.wbapi = wbapi.NewWandbAPI(settings, nc.sentryClient)
 	nc.Respond(&spb.ServerResponse{
 		RequestId: id,
 		ServerResponseType: &spb.ServerResponse_ApiInitResponse{


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Add sentry messages when initializing a beta_history_scan. Allows us to measure adoption of the new scan feature.
Also adds message with the latency of GetRunHistory call to monitor for anomalous latency spikes.
