### PR TITLE
refactor: always save API key to .netrc after an interactive prompt

### DIFF
--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -224,7 +224,7 @@ def test_create_custom_chart(monkeypatch):
 def test_initialize_api_prompts_for_api_key(monkeypatch: pytest.MonkeyPatch):
     mock_prompt_api_key = MagicMock()
     mock_prompt_api_key.return_value = "test-api-key"
-    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
+    monkeypatch.setattr(auth, "prompt_and_save_api_key", mock_prompt_api_key)
 
     Api()
 
@@ -236,7 +236,7 @@ def test_initialize_api_does_not_prompt_for_api_key__when_api_key_is_provided(
 ):
     mock_prompt_api_key = MagicMock()
     mock_verify_login = MagicMock()
-    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
+    monkeypatch.setattr(auth, "prompt_and_save_api_key", mock_prompt_api_key)
     monkeypatch.setattr(wandb_login, "_verify_login", mock_verify_login)
 
     api = Api(api_key="test-api-key", overrides={"base_url": "https://test-url"})
@@ -254,7 +254,7 @@ def test_initialize_api_does_not_prompt_for_api_key__when_using_thread_local_set
 ):
     mock_prompt_api_key = MagicMock()
     mock_verify_login = MagicMock()
-    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
+    monkeypatch.setattr(auth, "prompt_and_save_api_key", mock_prompt_api_key)
     monkeypatch.setattr(wandb_login, "_verify_login", mock_verify_login)
     monkeypatch.setattr(
         _thread_local_api_settings,
@@ -277,7 +277,7 @@ def test_initialize_api_does_not_prompt_for_api_key__when_using_env_var(
 ):
     mock_prompt_api_key = MagicMock()
     mock_verify_login = MagicMock()
-    monkeypatch.setattr(auth, "prompt_api_key", mock_prompt_api_key)
+    monkeypatch.setattr(auth, "prompt_and_save_api_key", mock_prompt_api_key)
     monkeypatch.setattr(wandb_login, "_verify_login", mock_verify_login)
     monkeypatch.setenv("WANDB_API_KEY", "test-api-key-from-env")
 

--- a/wandb/sdk/lib/auth/__init__.py
+++ b/wandb/sdk/lib/auth/__init__.py
@@ -1,11 +1,11 @@
 __all__ = (
     "check_api_key",
-    "prompt_api_key",
+    "prompt_and_save_api_key",
     "read_netrc_auth",
     "write_netrc_auth",
     "WriteNetrcError",
 )
 
-from .prompt import prompt_api_key
+from .prompt import prompt_and_save_api_key
 from .validation import check_api_key
 from .wbnetrc import WriteNetrcError, read_netrc_auth, write_netrc_auth


### PR DESCRIPTION
Changes `auth.prompt_api_key()` to automatically save the input key to .netrc and restructures `_login()` to better accommodate this.

`_login()` was previously saving the value of the `WANDB_API_KEY` environment variable to `.netrc`, which was dubious. It was also not saving a prompted API key to `.netrc` when given `update_api_key=False`, like in `wandb.Api()`.