### PR TITLE
refactor: use new auth functions

### DIFF
--- a/tests/unit_tests/test_lib/test_auth.py
+++ b/tests/unit_tests/test_lib/test_auth.py
@@ -1,6 +1,5 @@
 import pathlib
 import textwrap
-from typing import Iterator
 
 import pytest
 from wandb.errors import AuthenticationError
@@ -9,21 +8,10 @@ from wandb.sdk.lib.auth import (
     AuthIdentityTokenFile,
     authenticate_session,
     session_credentials,
-    unauthenticate_session,
     use_explicit_auth,
 )
 
 from tests.fixtures.mock_wandb_log import MockWandbLog
-
-
-@pytest.fixture(autouse=True)
-def clear_auth_for_tests() -> Iterator[None]:
-    auth = unauthenticate_session()
-    try:
-        yield
-    finally:
-        if auth:
-            use_explicit_auth(auth, source=__name__)
 
 
 def test_auth_repr_no_secrets():

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -2,6 +2,22 @@ from unittest import mock
 
 import pytest
 import wandb
+from wandb.apis.public import runs
+
+
+@pytest.fixture(autouse=True)
+def patch_server_features(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent unit tests from attempting to contact the real server."""
+    monkeypatch.setattr(
+        runs,
+        "_server_provides_project_id_for_run",
+        lambda *args, **kwargs: False,
+    )
+    monkeypatch.setattr(
+        runs,
+        "_server_provides_internal_id_for_project",
+        lambda *args, **kwargs: False,
+    )
 
 
 @pytest.mark.parametrize(
@@ -13,7 +29,7 @@ import wandb
     ],
     ids=["config", "summaryMetrics", "systemMetrics"],
 )
-@pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_create_run_with_string_attrs(field, value, expected):
     run = wandb.apis.public.Run(
         client=wandb.Api().client,
@@ -34,7 +50,7 @@ def test_create_run_with_string_attrs(field, value, expected):
     ],
     ids=["config", "summaryMetrics", "systemMetrics"],
 )
-@pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_create_run_with_dictionary_attrs_already_parsed(field, value):
     with mock.patch.object(wandb, "login", mock.MagicMock()):
         run = wandb.apis.public.Run(
@@ -56,7 +72,7 @@ def test_create_run_with_dictionary_attrs_already_parsed(field, value):
     ],
     ids=["config", "summaryMetrics", "systemMetrics"],
 )
-@pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_create_run_with_dictionary__throws_type_error(field, value):
     with mock.patch.object(wandb, "login", mock.MagicMock()):
         with pytest.raises(wandb.errors.CommError):
@@ -80,7 +96,7 @@ def test_create_run_with_dictionary__throws_type_error(field, value):
     ],
     ids=["config", "summaryMetrics", "systemMetrics"],
 )
-@pytest.mark.usefixtures("patch_apikey", "patch_prompt", "skip_verify_login")
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_create_run_with_control_characters(field, value, expected):
     with mock.patch.object(wandb, "login", mock.MagicMock()):
         run = wandb.apis.public.Run(

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -89,20 +89,17 @@ def test_login(test_settings):
 def test_login_sets_api_base_url(monkeypatch: pytest.MonkeyPatch):
     # HACK: Prevent the test from attempting to connect to the fake URLs.
     monkeypatch.setattr(
-        wandb_login._WandbLogin,
+        wandb_login,
         "_print_logged_in_message",
-        lambda self: None,
+        lambda *args, **kwargs: None,
     )
 
-    wandb_setup.singleton().settings.api_key = "test" * 10
     base_url = "https://api.test.host.ai"
-    wandb.login(host=base_url)
-
+    wandb.login(key="test" * 10, host=base_url)
     assert wandb_setup.singleton().settings.base_url == base_url
 
     base_url = "https://api.wandb.ai"
-    wandb.login(host=base_url)
-
+    wandb.login(key="test" * 10, host=base_url)
     assert wandb_setup.singleton().settings.base_url == base_url
 
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -421,17 +421,17 @@ class Api:
 
     @property
     def api_key(self) -> str | None:
-        if (  #
-            (settings := wandb_setup.singleton().settings_if_loaded)
-            and (api_key := settings.api_key)
-        ):
-            return api_key
+        from wandb.sdk.lib import auth as wbauth
 
-        from wandb.sdk.lib import auth
+        if (  #
+            (auth := wbauth.session_credentials(host=self.api_url))
+            and isinstance(auth, wbauth.AuthApiKey)
+        ):
+            return auth.api_key
 
         return (
             os.getenv(env.API_KEY)
-            or auth.read_netrc_auth(host=self.api_url)
+            or wbauth.read_netrc_auth(host=self.api_url)
             or parse_sm_secrets().get(env.API_KEY)
             or self.default_settings.get("api_key")
         )

--- a/wandb/sdk/lib/auth/__init__.py
+++ b/wandb/sdk/lib/auth/__init__.py
@@ -2,6 +2,7 @@ __all__ = (
     "Auth",
     "AuthApiKey",
     "AuthIdentityTokenFile",
+    "HostUrl",
     "session_credentials",
     "authenticate_session",
     "unauthenticate_session",
@@ -20,6 +21,7 @@ from .authenticate import (
     unauthenticate_session,
     use_explicit_auth,
 )
+from .host_url import HostUrl
 from .prompt import prompt_and_save_api_key
 from .validation import check_api_key
 from .wbnetrc import WriteNetrcError, read_netrc_auth, write_netrc_auth

--- a/wandb/sdk/lib/auth/host_url.py
+++ b/wandb/sdk/lib/auth/host_url.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from typing_extensions import final, override
 
 from wandb.sdk.lib import urls
@@ -14,6 +16,18 @@ class HostUrl:
 
     def __init__(self, url: str) -> None:
         urls.validate_url(url)
+
+        # Checks for wandb.ai.
+        if re.match(r".*wandb\.ai[^\.]*$", url):
+            if "api." not in url:
+                # A user might guess that app.wandb.ai is the default cloud server.
+                raise ValueError(
+                    f"{url!r} is not a valid server address,"
+                    + " did you mean https://api.wandb.ai?"
+                )
+            elif not url.startswith("https"):
+                raise ValueError("http is not secure, please use https://api.wandb.ai")
+
         self._url = url.rstrip("/")
 
     def is_same_url(self, value: str | HostUrl, /) -> bool:

--- a/wandb/sdk/lib/auth/wbnetrc.py
+++ b/wandb/sdk/lib/auth/wbnetrc.py
@@ -10,13 +10,14 @@ from urllib.parse import urlsplit
 from wandb.errors import term
 
 from .auth import AuthApiKey, AuthWithSource
+from .host_url import HostUrl
 
 
 class WriteNetrcError(Exception):
     """Could not write to the netrc file."""
 
 
-def read_netrc_auth(*, host: str) -> str | None:
+def read_netrc_auth(*, host: str | HostUrl) -> str | None:
     """Read a W&B API key from the .netrc file.
 
     Args:
@@ -30,6 +31,9 @@ def read_netrc_auth(*, host: str) -> str | None:
         AuthenticationError: If an API key is found but is not in
             a valid format.
     """
+    if not isinstance(host, HostUrl):
+        host = HostUrl(host)
+
     if not (auth := read_netrc_auth_with_source(host=host)):
         return None
 
@@ -37,7 +41,7 @@ def read_netrc_auth(*, host: str) -> str | None:
     return auth.auth.api_key
 
 
-def read_netrc_auth_with_source(*, host: str) -> AuthWithSource | None:
+def read_netrc_auth_with_source(*, host: HostUrl) -> AuthWithSource | None:
     """Read a W&B API key from the .netrc file.
 
     Args:
@@ -69,7 +73,7 @@ def read_netrc_auth_with_source(*, host: str) -> AuthWithSource | None:
 
         return None
 
-    if not (netloc := urlsplit(host).netloc):
+    if not (netloc := urlsplit(host.url).netloc):
         return None
     if not (creds := netrc_file.authenticators(netloc)):
         return None

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -189,13 +189,16 @@ class _WandbInit:
         if run_settings._noop or run_settings._offline:
             return
 
+        # Only pass an explicit key when the key was provided directly
+        # to ensure correct messaging in _login().
+        explicit_key = init_settings.api_key
+
         wandb_login._login(
             host=run_settings.base_url,
             force=run_settings.force,
-            key=run_settings.api_key,
-            # Do not save an explicitly provided API key to .netrc.
-            update_api_key=run_settings.api_key is None,
             _silent=run_settings.quiet or run_settings.silent,
+            key=explicit_key,
+            update_api_key=explicit_key is None,
         )
 
     def warn_env_vars_change_after_setup(self) -> _PrinterCallback:

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -5,21 +5,16 @@ This authenticates your machine to log data to your account.
 
 from __future__ import annotations
 
-import enum
-
 import click
 
 import wandb
-from wandb.errors import AuthenticationError, UsageError, term
+from wandb.errors import AuthenticationError, term
 from wandb.sdk import wandb_setup
-from wandb.sdk.lib import auth, settings_file
+from wandb.sdk.lib import auth as wbauth
+from wandb.sdk.lib import settings_file
 from wandb.sdk.lib.deprecation import UNSET, DoNotSet
 
 from ..apis import InternalApi
-
-
-class OidcError(Exception):
-    """OIDC is configured but not allowed."""
 
 
 def login(
@@ -111,7 +106,7 @@ def login(
         force=force,
         timeout=timeout,
         verify=verify,
-        referrer=referrer,
+        referrer=referrer or "models",
     )
     return logged_in
 
@@ -137,180 +132,42 @@ def _update_system_settings(
         wandb.termwarn(str(e))
 
 
-class ApiKeyStatus(enum.Enum):
-    VALID = 1
-    NOTTY = 2
-    OFFLINE = 3
-    DISABLED = 4
-
-
-class _WandbLogin:
-    def __init__(
-        self,
-        force: bool | None = None,
-        host: str | None = None,
-        key: str | None = None,
-        relogin: bool | None = None,
-        timeout: int | None = None,
-    ):
-        self._relogin = relogin
-
-        login_settings = {
-            "api_key": key,
-            "base_url": host,
-            "force": force,
-            "login_timeout": timeout,
-        }
-
-        self._wandb_setup = wandb_setup.singleton()
-        self._wandb_setup.settings.update_from_dict(login_settings)
-        self._settings = self._wandb_setup.settings
-
-    def _print_logged_in_message(self) -> None:
-        """Prints a message telling the user they are logged in."""
-        username = self._wandb_setup._get_username()
-
-        if username:
-            host_str = (
-                f" to {click.style(self._settings.base_url, fg='green')}"
-                if self._settings.base_url
-                else ""
-            )
-
-            # check to see if we got an entity from the setup call or from the user
-            entity = self._settings.entity or self._wandb_setup._get_entity()
-
-            entity_str = ""
-            # check if entity exist, valid (is part of a certain team) and different from the username
-            if (
-                entity
-                and entity in self._wandb_setup._get_teams()
-                and entity != username
-            ):
-                entity_str = f" ({click.style(entity, fg='yellow')})"
-
-            login_state_str = f"Currently logged in as: {click.style(username, fg='yellow')}{entity_str}{host_str}"
-        else:
-            login_state_str = "W&B API key is configured"
-
-        login_info_str = (
-            f"Use {click.style('`wandb login --relogin`', bold=True)} to force relogin"
-        )
-        wandb.termlog(
-            f"{login_state_str}. {login_info_str}",
-            repeat=False,
-        )
-
-    def try_save_api_key(self, key: str) -> None:
-        """Saves the API key to disk for future use."""
-        if self._settings._notebook and not self._settings.silent:
-            wandb.termwarn(
-                "If you're specifying your api key in code, ensure this"
-                + " code is not shared publicly."
-                + "\nConsider setting the WANDB_API_KEY environment variable,"
-                + " or running `wandb login` from the command line."
-            )
-
-        try:
-            auth.write_netrc_auth(host=self._settings.base_url, api_key=key)
-        except auth.WriteNetrcError as e:
-            wandb.termwarn(str(e))
-
-    def update_session(
-        self,
-        key: str | None,
-        status: ApiKeyStatus = ApiKeyStatus.VALID,
-    ) -> None:
-        """Updates mode and API key settings on the global setup object.
-
-        If we're online, this also pulls in user settings from the server.
-        """
-        login_settings = dict()
-        if status == ApiKeyStatus.OFFLINE:
-            login_settings = dict(mode="offline")
-        elif status == ApiKeyStatus.DISABLED:
-            login_settings = dict(mode="disabled")
-        elif key:
-            login_settings = dict(api_key=key)
-        self._wandb_setup.settings.update_from_dict(login_settings)
-        # Whenever the key changes, make sure to pull in user settings
-        # from server.
-        if not self._wandb_setup.settings._offline:
-            self._wandb_setup.update_user_settings()
-
-    def prompt_api_key(self, referrer: str) -> tuple[str | None, ApiKeyStatus]:
-        """Prompt the user for an API key.
-
-        Returns:
-            (key, VALID) if a key was provided.
-            (None, OFFLINE) if the user selected offline mode.
-            (None, DISABLED) if a timeout occurred.
-
-        Raises:
-            UsageError: If interactive prompting is unavailable.
-        """
-        try:
-            key = auth.prompt_and_save_api_key(
-                host=self._settings.base_url,
-                no_offline=self._settings.force,
-                no_create=self._settings.force,
-                referrer=referrer,
-                input_timeout=self._settings.login_timeout,
-            )
-
-        except TimeoutError:
-            wandb.termlog("W&B disabled due to login timeout.")
-            return None, ApiKeyStatus.DISABLED
-
-        except term.NotATerminalError:
-            message = "No API key configured. Use `wandb login` to log in."
-            raise UsageError(message) from None
-
-        if not key:
-            return None, ApiKeyStatus.OFFLINE
-
-        return key, ApiKeyStatus.VALID
-
-
 def _login(
     *,
     key: str | None = None,
     relogin: bool | None = None,
     host: str | None = None,
     force: bool | None = None,
-    timeout: int | None = None,
+    timeout: float | None = None,
     verify: bool = False,
     referrer: str = "models",
     update_api_key: bool = True,
-    no_oidc: bool = False,
     _silent: bool | None = None,
 ) -> tuple[bool, str | None]:
-    """Logs in to W&B.
+    """Log in to W&B.
 
-    This is the internal implementation of wandb.login(),
-    with many of the same arguments as wandb.login().
-    Additional arguments are documented below.
+    Arguments are the same as for wandb.login() with the following additions:
 
     Args:
-        update_api_key: If true, the api key will be saved or updated
-            in the users .netrc file.
-        no_oidc: If true, raise an OidcError instead of returning early if OIDC
-            credentials are configured.
+        update_api_key: If true and an explicit API key is given, it will be
+            saved to the .netrc file.
         _silent: If true, will not print any messages to the console.
 
     Returns:
-        bool: If the login was successful
-            or the user is assumed to be already be logged in.
-        str: The API key used to log in,
-            or None if the api key was not verified during the login process.
+        A pair (is_successful, key).
     """
-    wlogin = _WandbLogin(
-        force=force,
-        host=host,
-        key=key,
-        relogin=relogin,
-        timeout=timeout,
-    )
+    settings = wandb_setup.singleton().settings
+
+    if host is None:
+        host = settings.base_url
+    if relogin is None:
+        relogin = settings.relogin
+    if force is None:
+        force = settings.force
+    if timeout is None:
+        timeout = settings.login_timeout
+    if _silent is None:
+        _silent = settings.silent
 
     if wandb.util._is_kaggle() and not wandb.util._has_internet():
         term.termerror(
@@ -319,55 +176,113 @@ def _login(
         )
         return False, None
 
-    if wlogin._settings.identity_token_file:
-        if no_oidc:
-            raise OidcError
+    if key:
+        auth = _use_explicit_key(
+            key,
+            host=host,
+            settings=settings,
+            update_api_key=update_api_key,
+            silent=_silent,
+        )
+    else:
+        auth = _find_or_prompt_for_key(
+            settings,
+            host=host,
+            force=force,
+            relogin=relogin,
+            referrer=referrer,
+            input_timeout=timeout,
+        )
 
+    if verify and isinstance(auth, wbauth.AuthApiKey):
+        _verify_login(key=auth.api_key, base_url=auth.host.url)
+
+    wandb_setup.singleton().update_user_settings()
+    if not _silent:
+        _print_logged_in_message(settings, host=host)
+
+    if auth is None:
+        return False, None
+    elif isinstance(auth, wbauth.AuthApiKey):
+        return True, auth.api_key
+    else:
         return True, None
 
-    if key:
-        if problems := auth.check_api_key(key):
-            raise AuthenticationError(problems)
 
-        if verify:
-            _verify_login(key, wlogin._settings.base_url)
+def _use_explicit_key(
+    key: str,
+    settings: wandb.Settings,
+    *,
+    host: str,
+    update_api_key: bool,
+    silent: bool,
+) -> wbauth.Auth:
+    """Log in with an explicit key.
 
-        if update_api_key:
-            wlogin.try_save_api_key(key)
+    Same arguments as `_login()`.
+    """
+    if settings._notebook and not silent:
+        term.termwarn(
+            "If you're specifying your api key in code, ensure this"
+            + " code is not shared publicly."
+            + "\nConsider setting the WANDB_API_KEY environment variable,"
+            + " or running `wandb login` from the command line."
+        )
 
-        wlogin.update_session(key, status=ApiKeyStatus.VALID)
+    auth = wbauth.AuthApiKey(host=host, api_key=key)
+    wbauth.use_explicit_auth(auth, source="wandb.login()")
 
-        if not _silent:
-            wlogin._print_logged_in_message()
+    if update_api_key:
+        try:
+            wbauth.write_netrc_auth(
+                host=auth.host.url,
+                api_key=auth.api_key,
+            )
+        except wbauth.WriteNetrcError as e:
+            wandb.termwarn(str(e))
 
-        return True, key
+    return auth
 
-    # See if there already is a key in settings. This is true if WANDB_API_KEY
-    # was set or login() already happened.
-    if not relogin and (settings_key := wlogin._settings.api_key):
-        key = settings_key
-        key_status = ApiKeyStatus.VALID
 
-    # Otherwise, try the .netrc file.
-    elif not relogin and (
-        netrc_key := auth.read_netrc_auth(host=wlogin._settings.base_url)
-    ):
-        key = netrc_key
-        key_status = ApiKeyStatus.VALID
+def _find_or_prompt_for_key(
+    settings: wandb.Settings,
+    *,
+    host: str,
+    force: bool,
+    relogin: bool,
+    referrer: str,
+    input_timeout: float | None,
+) -> wbauth.Auth | None:
+    """Log in without an explicit key.
 
-    # Finally (or necessarily, if relogin was set), prompt interactively.
-    else:
-        key, key_status = wlogin.prompt_api_key(referrer=referrer)
+    Same arguments as `_login()`.
+    """
+    timed_out = False
+    auth: wbauth.Auth | None = None
 
-    # The key may be None if offline mode was selected interactively.
+    try:
+        auth = wbauth.authenticate_session(
+            host=host,
+            source="wandb.login()",
+            no_offline=force,
+            no_create=force,
+            referrer=referrer,
+            input_timeout=input_timeout,
+            relogin=relogin,
+        )
 
-    if key and verify:
-        _verify_login(key, wlogin._settings.base_url)
-    wlogin.update_session(key, status=key_status)
-    if key and not _silent:
-        wlogin._print_logged_in_message()
+    except TimeoutError:
+        timed_out = True
 
-    return key is not None, key
+    if not auth:
+        if timed_out:
+            term.termwarn("W&B disabled due to login timeout.")
+            settings.mode = "disabled"
+        else:
+            term.termlog("Using W&B in offline mode.")
+            settings.mode = "offline"
+
+    return auth
 
 
 def _verify_login(key: str, base_url: str) -> None:
@@ -392,5 +307,34 @@ def _verify_login(key: str, base_url: str) -> None:
     if not is_api_key_valid:
         raise AuthenticationError(
             f"API key verification failed for host {base_url}."
-            " Make sure your API key is valid."
+            + " Make sure your API key is valid."
         )
+
+
+def _print_logged_in_message(settings: wandb.Settings, *, host: str) -> None:
+    """Print a message telling the user they are logged in."""
+    singleton = wandb_setup.singleton()
+    username = singleton._get_username()
+
+    if username:
+        host_str = f" to {click.style(host, fg='green')}" if host else ""
+
+        # check to see if we got an entity from the setup call or from the user
+        entity = settings.entity or singleton._get_entity()
+
+        entity_str = ""
+        # check if entity exist, valid (is part of a certain team) and different from the username
+        if entity and entity in singleton._get_teams() and entity != username:
+            entity_str = f" ({click.style(entity, fg='yellow')})"
+
+        login_state_str = f"Currently logged in as: {click.style(username, fg='yellow')}{entity_str}{host_str}"
+    else:
+        login_state_str = "W&B API key is configured"
+
+    login_info_str = (
+        f"Use {click.style('`wandb login --relogin`', bold=True)} to force relogin"
+    )
+    term.termlog(
+        f"{login_state_str}. {login_info_str}",
+        repeat=False,
+    )


### PR DESCRIPTION
Completely rewrites `wandb._login()` in terms of the new auth functions, and also slightly updates `Api._load_api_key` and `InternalApi.api_key`.

There are several things to consider:

## wandb.init()

`wandb.init()` can accept an explicit API key through the `settings` parameter. This needed a small update because it was not distinguishing between an explicit API key and one loaded from the global settings.

```python
# Implicit login:
wandb.init()
# wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai
# from /Users/timoffex/.netrc.

# Explicit login (in the same file):
wandb.init(settings=wandb.Settings(api_key="test"*10))
# wandb: WARNING [wandb.login()] Changing session credentials to
# explicit value for https://api.wandb.ai.
```

## Global settings vs `auth`

The `auth` package updates global settings whenever the session credentials change.

This PR also makes `wandb.setup(settings=...)` pass new credentials to `auth.use_explicit_auth()`.

Other changes to the global Settings object are not synchronized: it's assumed that none of our code elsewhere mutates `wandb.singleton().settings.api_key` (I didn't find any use-cases, and it would probably not have worked well). Only `wandb.setup()` is part of the public interface.

The first time the singleton settings are instantiated, they may load credentials from environment variables (e.g. WANDB_API_KEY is a setting), but this is also not synchronized with `auth`. I checked that `wandb.init()`, `wandb.Api()` and `InternalApi()` don't directly read api_key / identity_token_file from `wandb.singleton().settings` without a preceding `authenticate_session` call.

## Identity token file

`auth` tracks the identity token file credential, and it is passed to `wandb-core` via settings. This can be configured with the `WANDB_IDENTITY_TOKEN_FILE` environment variable _or_ a `wandb.setup(settings=wandb.Settings(identity_token_file=...))` call.

On the Python side, `InternalApi` _directly_ checks the `WANDB_IDENTITY_TOKEN_FILE` environment variable, so it is unaffected by `wandb.setup()` and `authenticate_session()` calls. This is unchanged from before; my upcoming refactors will fix this.