### PR TITLE
refactor: factor out url validation from wandb_settings.py

### DIFF
--- a/tests/unit_tests/test_lib/test_urls.py
+++ b/tests/unit_tests/test_lib/test_urls.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+from wandb._pydantic import IS_PYDANTIC_V2
+from wandb.sdk.lib import urls
+
+_TEST_CASES: tuple[tuple[str, str | None], ...] = (
+    ("https://api.wandb.ai", None),
+    ("http://123.123.123.123", None),
+    ("https://", "Invalid URL: 'https://'"),
+    ("https://wandb.ai\t", "URL cannot contain unsafe characters"),
+    ("https://wandb.ai\r", "URL cannot contain unsafe characters"),
+    ("https://wandb.ai\n", "URL cannot contain unsafe characters"),
+    ("file://wandb.ai", "URL must start with `http(s)://`"),
+    (
+        "https://wandb.ai\x00",
+        r"'https://wandb.ai\x00' is not a valid server address",
+    ),
+)
+
+
+@pytest.mark.parametrize("url, error", _TEST_CASES)
+def test_validate_url_custom(url: str, error: str | None):
+    if not error:
+        urls._validate_url_custom(url)
+    else:
+        with pytest.raises(ValueError, match=re.escape(error)):
+            urls._validate_url_custom(url)
+
+
+@pytest.mark.parametrize("url, error", _TEST_CASES)
+@pytest.mark.skipif(not IS_PYDANTIC_V2, reason="Requires Pydantic V2.")
+def test_validate_url_pydantic(url: str, error: str | None):
+    if not error:
+        urls._validate_url_pydantic(url)
+    else:
+        # We don't test the exact error messages for Pydantic since they
+        # depend on the Pydantic implementation, but we check that it agrees
+        # whether the URLs are valid.
+        with pytest.raises(ValueError):
+            urls._validate_url_pydantic(url)
+
+
+def test_uses_pydantic_if_available(monkeypatch: pytest.MonkeyPatch):
+    mock_validate = MagicMock()
+    monkeypatch.setattr(urls, "IS_PYDANTIC_V2", True)
+    monkeypatch.setattr(urls, "_validate_url_pydantic", mock_validate)
+
+    urls.validate_url("test URL")
+
+    mock_validate.assert_called_once_with("test URL")
+
+
+def test_uses_custom_validator(monkeypatch: pytest.MonkeyPatch):
+    mock_validate = MagicMock()
+    monkeypatch.setattr(urls, "IS_PYDANTIC_V2", False)
+    monkeypatch.setattr(urls, "_validate_url_custom", mock_validate)
+
+    urls.validate_url("test URL")
+
+    mock_validate.assert_called_once_with("test URL")

--- a/wandb/sdk/lib/urls.py
+++ b/wandb/sdk/lib/urls.py
@@ -1,0 +1,128 @@
+"""Validation for URLs."""
+
+import re
+
+from wandb._pydantic import IS_PYDANTIC_V2
+
+
+def validate_url(url: object) -> None:
+    """Validate a URL.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValueError: If the URL is invalid.
+        TypeError: If given something other than a string.
+    """
+    if not isinstance(url, str):
+        raise TypeError(f"Expected a string, got {type(url)}")
+
+    if IS_PYDANTIC_V2:
+        _validate_url_pydantic(url)
+    else:
+        _validate_url_custom(url)
+
+
+def _validate_url_pydantic(url: str) -> None:
+    """Validate a URL using Pydantic's validator."""
+    from pydantic_core import SchemaValidator, core_schema
+
+    SchemaValidator(
+        core_schema.url_schema(
+            allowed_schemes=["http", "https"],
+            strict=True,
+        )
+    ).validate_python(url)
+
+
+def _validate_url_custom(url: str) -> None:
+    """Validate a URL.
+
+    We will remove this once we can require Pydantic V2.
+
+    Based on the Django URLValidator, but with a few additional checks.
+
+    Copyright (c) Django Software Foundation and individual contributors.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification,
+    are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice,
+            this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright
+            notice, this list of conditions and the following disclaimer in the
+            documentation and/or other materials provided with the distribution.
+
+        3. Neither the name of Django nor the names of its contributors may be used
+            to endorse or promote products derived from this software without
+            specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    """
+    from urllib.parse import urlparse, urlsplit
+
+    ul = "\u00a1-\uffff"  # Unicode letters range (must not be a raw string).
+
+    # IP patterns
+    ipv4_re = (
+        r"(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)"
+        r"(?:\.(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)){3}"
+    )
+    ipv6_re = r"\[[0-9a-f:.]+\]"  # (simple regex, validated later)
+
+    # Host patterns
+    hostname_re = (
+        r"[a-z" + ul + r"0-9](?:[a-z" + ul + r"0-9-]{0,61}[a-z" + ul + r"0-9])?"
+    )
+    # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
+    domain_re = r"(?:\.(?!-)[a-z" + ul + r"0-9-]{1,63}(?<!-))*"
+    tld_re = (
+        r"\."  # dot
+        r"(?!-)"  # can't start with a dash
+        r"(?:[a-z" + ul + "-]{2,63}"  # domain label
+        r"|xn--[a-z0-9]{1,59})"  # or punycode label
+        r"(?<!-)"  # can't end with a dash
+        r"\.?"  # may have a trailing dot
+    )
+    # host_re = "(" + hostname_re + domain_re + tld_re + "|localhost)"
+    # todo?: allow hostname to be just a hostname (no tld)?
+    host_re = "(" + hostname_re + domain_re + f"({tld_re})?" + "|localhost)"
+
+    regex = re.compile(
+        r"^(?:[a-z0-9.+-]*)://"  # scheme is validated separately
+        r"(?:[^\s:@/]+(?::[^\s:@/]*)?@)?"  # user:pass authentication
+        r"(?:" + ipv4_re + "|" + ipv6_re + "|" + host_re + ")"
+        r"(?::[0-9]{1,5})?"  # port
+        r"(?:[/?#][^\s]*)?"  # resource path
+        r"\Z",
+        re.IGNORECASE,
+    )
+    schemes = {"http", "https"}
+    unsafe_chars = frozenset("\t\r\n")
+
+    scheme = url.split("://")[0].lower()
+    split_url = urlsplit(url)
+    parsed_url = urlparse(url)
+
+    if parsed_url.netloc == "":
+        raise ValueError(f"Invalid URL: {url!r}")
+    elif unsafe_chars.intersection(url):
+        raise ValueError("URL cannot contain unsafe characters")
+    elif scheme not in schemes:
+        raise ValueError("URL must start with `http(s)://`")
+    elif not regex.search(url):
+        raise ValueError(f"{url!r} is not a valid server address")
+    elif split_url.hostname is None or len(split_url.hostname) > 253:
+        raise ValueError("hostname is invalid")

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -16,7 +16,7 @@ from datetime import datetime
 # the latter is not supported in pydantic<2.6 and Python<3.10.
 # Dict, List, and Tuple are used for backwards compatibility
 # with pydantic v1 and Python<3.9.
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 from urllib.parse import quote, unquote
 
 from google.protobuf.wrappers_pb2 import BoolValue, DoubleValue, Int32Value, StringValue
@@ -34,121 +34,13 @@ from wandb._pydantic import (
 )
 from wandb.errors import UsageError
 from wandb.proto import wandb_settings_pb2
-from wandb.sdk.lib import deprecation
+from wandb.sdk.lib import deprecation, urls
 
 from .lib import credentials, filesystem, ipython
 from .lib.run_moment import RunMoment
 
-validate_url: Callable[[str], None]
-
-if IS_PYDANTIC_V2:
-    from pydantic_core import SchemaValidator, core_schema
-
-    def validate_url(url: str) -> None:
-        """Validate a URL string."""
-        url_validator = SchemaValidator(
-            core_schema.url_schema(
-                allowed_schemes=["http", "https"],
-                strict=True,
-            )
-        )
-        url_validator.validate_python(url)
-else:
+if not IS_PYDANTIC_V2:
     from pydantic import root_validator
-
-    def validate_url(url: str) -> None:
-        """Validate the base url of the wandb server.
-
-        param value: URL to validate
-
-        Based on the Django URLValidator, but with a few additional checks.
-
-        Copyright (c) Django Software Foundation and individual contributors.
-        All rights reserved.
-
-        Redistribution and use in source and binary forms, with or without modification,
-        are permitted provided that the following conditions are met:
-
-            1. Redistributions of source code must retain the above copyright notice,
-               this list of conditions and the following disclaimer.
-
-            2. Redistributions in binary form must reproduce the above copyright
-               notice, this list of conditions and the following disclaimer in the
-               documentation and/or other materials provided with the distribution.
-
-            3. Neither the name of Django nor the names of its contributors may be used
-               to endorse or promote products derived from this software without
-               specific prior written permission.
-
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-        ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-        ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-        """
-        from urllib.parse import urlparse, urlsplit
-
-        if url is None:
-            return
-
-        ul = "\u00a1-\uffff"  # Unicode letters range (must not be a raw string).
-
-        # IP patterns
-        ipv4_re = (
-            r"(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)"
-            r"(?:\.(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)){3}"
-        )
-        ipv6_re = r"\[[0-9a-f:.]+\]"  # (simple regex, validated later)
-
-        # Host patterns
-        hostname_re = (
-            r"[a-z" + ul + r"0-9](?:[a-z" + ul + r"0-9-]{0,61}[a-z" + ul + r"0-9])?"
-        )
-        # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
-        domain_re = r"(?:\.(?!-)[a-z" + ul + r"0-9-]{1,63}(?<!-))*"
-        tld_re = (
-            r"\."  # dot
-            r"(?!-)"  # can't start with a dash
-            r"(?:[a-z" + ul + "-]{2,63}"  # domain label
-            r"|xn--[a-z0-9]{1,59})"  # or punycode label
-            r"(?<!-)"  # can't end with a dash
-            r"\.?"  # may have a trailing dot
-        )
-        # host_re = "(" + hostname_re + domain_re + tld_re + "|localhost)"
-        # todo?: allow hostname to be just a hostname (no tld)?
-        host_re = "(" + hostname_re + domain_re + f"({tld_re})?" + "|localhost)"
-
-        regex = re.compile(
-            r"^(?:[a-z0-9.+-]*)://"  # scheme is validated separately
-            r"(?:[^\s:@/]+(?::[^\s:@/]*)?@)?"  # user:pass authentication
-            r"(?:" + ipv4_re + "|" + ipv6_re + "|" + host_re + ")"
-            r"(?::[0-9]{1,5})?"  # port
-            r"(?:[/?#][^\s]*)?"  # resource path
-            r"\Z",
-            re.IGNORECASE,
-        )
-        schemes = {"http", "https"}
-        unsafe_chars = frozenset("\t\r\n")
-
-        scheme = url.split("://")[0].lower()
-        split_url = urlsplit(url)
-        parsed_url = urlparse(url)
-
-        if parsed_url.netloc == "":
-            raise ValueError(f"Invalid URL: {url}")
-        elif unsafe_chars.intersection(url):
-            raise ValueError("URL cannot contain unsafe characters")
-        elif scheme not in schemes:
-            raise ValueError("URL must start with `http(s)://`")
-        elif not regex.search(url):
-            raise ValueError(f"{url} is not a valid server address")
-        elif split_url.hostname is None or len(split_url.hostname) > 253:
-            raise ValueError("hostname is invalid")
 
 
 def _path_convert(*args: str) -> str:
@@ -1087,7 +979,7 @@ class Settings(BaseModel, validate_assignment=True):
 
         <!-- lazydoc-ignore-classmethod: internal -->
         """
-        validate_url(value)
+        urls.validate_url(value)
         # wandb.ai-specific checks
         if re.match(r".*wandb\.ai[^\.]*$", value) and "api." not in value:
             # user might guess app.wandb.ai or wandb.ai is the default cloud server
@@ -1225,7 +1117,7 @@ class Settings(BaseModel, validate_assignment=True):
         """
         if value is None:
             return None
-        validate_url(value)
+        urls.validate_url(value)
         return value.rstrip("/")
 
     @field_validator("https_proxy", mode="after")
@@ -1237,7 +1129,7 @@ class Settings(BaseModel, validate_assignment=True):
         """
         if value is None:
             return None
-        validate_url(value)
+        urls.validate_url(value)
         return value.rstrip("/")
 
     @field_validator("ignore_globs", mode="after")
@@ -1424,7 +1316,7 @@ class Settings(BaseModel, validate_assignment=True):
     @field_validator("x_stats_coreweave_metadata_base_url", mode="after")
     @classmethod
     def validate_x_stats_coreweave_metadata_base_url(cls, value):
-        validate_url(value)
+        urls.validate_url(value)
         return value.rstrip("/")
 
     @field_validator("x_stats_gpu_device_ids", mode="before")


### PR DESCRIPTION
Moves `validate_url()` into `wandb/sdk/lib/urls.py` to make it reusable in `auth` code later.