### PR TITLE
refactor: define Auth type and core functions

### DIFF
--- a/tests/unit_tests/test_lib/test_auth.py
+++ b/tests/unit_tests/test_lib/test_auth.py
@@ -1,0 +1,146 @@
+import pathlib
+import textwrap
+from typing import Iterator
+
+import pytest
+from wandb.errors import AuthenticationError
+from wandb.sdk.lib.auth import (
+    AuthApiKey,
+    AuthIdentityTokenFile,
+    authenticate_session,
+    session_credentials,
+    unauthenticate_session,
+    use_explicit_auth,
+)
+
+from tests.fixtures.mock_wandb_log import MockWandbLog
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_for_tests() -> Iterator[None]:
+    auth = unauthenticate_session()
+    try:
+        yield
+    finally:
+        if auth:
+            use_explicit_auth(auth, source=__name__)
+
+
+def test_auth_repr_no_secrets():
+    auth = AuthApiKey(host="https://test", api_key="test" * 10)
+
+    assert repr(auth) == "<AuthApiKey host='https://test'>"
+
+
+def test_auth_validates_key():
+    with pytest.raises(
+        AuthenticationError,
+        match=r"API key must have 40\+ characters",
+    ):
+        AuthApiKey(host="https://test", api_key="too_short")
+
+
+def test_use_explicit_auth(mock_wandb_log: MockWandbLog):
+    auth = AuthApiKey(host="https://test", api_key="test" * 10)
+
+    use_explicit_auth(auth, source="test")
+
+    assert session_credentials(host="https://test") is auth
+    mock_wandb_log.assert_logged(
+        "[test] Using explicit session credentials for https://test."
+    )
+
+
+def test_warns_if_changing_auth(mock_wandb_log: MockWandbLog):
+    auth1 = AuthApiKey(host="https://test1", api_key="auth_one" * 5)
+    auth2 = AuthApiKey(host="https://test2", api_key="auth_two" * 5)
+
+    use_explicit_auth(auth1, source="test")
+    use_explicit_auth(auth2, source="test")
+
+    assert session_credentials(host="https://test2") is auth2
+    mock_wandb_log.assert_warned(
+        "[test] Changing session credentials to explicit value for https://test2."
+    )
+
+
+def test_error_if_multiple_credentials_in_env(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("WANDB_API_KEY", "from_env" * 5)
+    monkeypatch.setenv("WANDB_IDENTITY_TOKEN_FILE", "file.jwt")
+
+    with pytest.raises(
+        AuthenticationError,
+        match="Both WANDB_API_KEY and WANDB_IDENTITY_TOKEN_FILE are set",
+    ):
+        authenticate_session(host="https://fake-url", source="test")
+
+
+def test_loads_api_key_from_environment_variable(
+    mock_wandb_log: MockWandbLog,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("WANDB_API_KEY", "from_env" * 5)
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthApiKey)
+    assert result.host.is_same_url("https://fake-url")
+    assert result.api_key == "from_env" * 5
+    mock_wandb_log.assert_logged(
+        "[test] Loaded credentials for https://fake-url from WANDB_API_KEY."
+    )
+
+
+def test_invalid_env_api_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WANDB_API_KEY", "invalid")
+
+    with pytest.raises(
+        AuthenticationError,
+        match=r"WANDB_API_KEY invalid: API key must have 40\+ characters",
+    ):
+        authenticate_session(host="https://fake-url", source="test")
+
+
+def test_loads_oidc_from_environment_variable(
+    mock_wandb_log: MockWandbLog,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("WANDB_IDENTITY_TOKEN_FILE", "file.jwt")
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthIdentityTokenFile)
+    assert result.host.is_same_url("https://fake-url")
+    assert result.path == pathlib.Path("file.jwt")
+    mock_wandb_log.assert_logged(
+        "[test] Loaded credentials for https://fake-url from"
+        + " WANDB_IDENTITY_TOKEN_FILE."
+    )
+
+
+def test_reads_netrc(
+    mock_wandb_log: MockWandbLog,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    netrc = tmp_path / "test_netrc"
+    password = "netrc" * 8
+    netrc.write_text(
+        textwrap.dedent(f"""\
+            machine example.com
+                login user
+                password {password}
+        """)
+    )
+    monkeypatch.setenv("NETRC", str(netrc))
+
+    result = authenticate_session(host="https://example.com", source="test")
+
+    assert isinstance(result, AuthApiKey)
+    assert result.host.is_same_url("https://example.com")
+    assert result.api_key == password
+    mock_wandb_log.assert_logged(
+        f"[test] Loaded credentials for https://example.com from {netrc}"
+    )

--- a/tests/unit_tests/test_lib/test_auth_host_url.py
+++ b/tests/unit_tests/test_lib/test_auth_host_url.py
@@ -1,0 +1,26 @@
+import pytest
+from wandb.sdk.lib.auth.host_url import HostUrl
+
+
+def test_validates_url():
+    with pytest.raises(ValueError):
+        HostUrl("invalid")
+
+
+@pytest.mark.parametrize(
+    "raw_url",
+    (
+        "https://api.wandb.ai",
+        "https://api.wandb.ai/",
+        "https://api.wandb.ai//",
+    ),
+)
+def test_normalizes_url(raw_url: str):
+    url = HostUrl(raw_url)
+
+    assert url.is_same_url(raw_url)
+    assert not url.url.endswith("/")
+
+
+def test_repr():
+    assert repr(HostUrl("https://some-url")) == "HostUrl('https://some-url')"

--- a/tests/unit_tests/test_lib/test_auth_netrc.py
+++ b/tests/unit_tests/test_lib/test_auth_netrc.py
@@ -18,11 +18,12 @@ def fake_netrc_path(
 
 
 def test_read(fake_netrc_path: pathlib.Path):
-    fake_netrc_path.write_text("machine test login user password pass")
+    key = "test" * 10
+    fake_netrc_path.write_text(f"machine test login user password {key}")
 
     result = wbnetrc.read_netrc_auth(host="https://test")
 
-    assert result == "pass"
+    assert result == key
 
 
 def test_read_host_not_found(fake_netrc_path: pathlib.Path):

--- a/wandb/sdk/lib/auth/__init__.py
+++ b/wandb/sdk/lib/auth/__init__.py
@@ -1,4 +1,11 @@
 __all__ = (
+    "Auth",
+    "AuthApiKey",
+    "AuthIdentityTokenFile",
+    "session_credentials",
+    "authenticate_session",
+    "unauthenticate_session",
+    "use_explicit_auth",
     "check_api_key",
     "prompt_and_save_api_key",
     "read_netrc_auth",
@@ -6,6 +13,13 @@ __all__ = (
     "WriteNetrcError",
 )
 
+from .auth import Auth, AuthApiKey, AuthIdentityTokenFile
+from .authenticate import (
+    authenticate_session,
+    session_credentials,
+    unauthenticate_session,
+    use_explicit_auth,
+)
 from .prompt import prompt_and_save_api_key
 from .validation import check_api_key
 from .wbnetrc import WriteNetrcError, read_netrc_auth, write_netrc_auth

--- a/wandb/sdk/lib/auth/auth.py
+++ b/wandb/sdk/lib/auth/auth.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import abc
+import dataclasses
+import pathlib
+
+from typing_extensions import final, override
+
+from wandb.errors import AuthenticationError
+
+from . import validation
+from .host_url import HostUrl
+
+
+# We use an abstract base class instead of a union because
+#   (1) All Auth subtypes have a 'host' property and a safe repr
+#   (2) Auth should be treated as an open union, meaning typecheckers should
+#       not consider any list of isinstance() checks exhaustive and should
+#       always require a fallback case
+class Auth(abc.ABC):
+    """Credentials that give access to a W&B server."""
+
+    @abc.abstractmethod
+    def __init__(self, *, host: str | HostUrl) -> None:
+        if isinstance(host, str):
+            host = HostUrl(host)
+        self._host = host
+
+    @property
+    def host(self) -> HostUrl:
+        """The W&B server for which the credentials are valid."""
+        return self._host
+
+    @final
+    @override
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} host={self.host.url!r}>"
+
+    @final
+    @override
+    def __str__(self) -> str:
+        return repr(self)
+
+
+@final
+class AuthApiKey(Auth):
+    """An API key for connecting to a W&B server."""
+
+    @override
+    def __init__(self, *, host: str | HostUrl, api_key: str) -> None:
+        """Initialize AuthApiKey.
+
+        Args:
+            host: The W&B server URL.
+            api_key: The API key.
+
+        Raises:
+            ValueError: If the host is invalid.
+            AuthenticationError: If the API key is in an invalid format.
+        """
+        super().__init__(host=host)
+
+        if problems := validation.check_api_key(api_key):
+            raise AuthenticationError(problems)
+
+        self._api_key = api_key
+
+    @property
+    def api_key(self) -> str:
+        """The API key."""
+        return self._api_key
+
+
+@final
+class AuthIdentityTokenFile(Auth):
+    """A path to a file storing a JWT with OIDC credentials."""
+
+    @override
+    def __init__(self, *, host: str | HostUrl, path: str) -> None:
+        super().__init__(host=host)
+        self._identity_token_file = pathlib.Path(path)
+
+    @property
+    def path(self) -> pathlib.Path:
+        """Path to a file storing a JWT identity token."""
+        return self._identity_token_file
+
+
+@dataclasses.dataclass(frozen=True)
+class AuthWithSource:
+    """Credentials with information about where they came from."""
+
+    auth: Auth
+
+    source: str
+    """A file path or environment variable."""

--- a/wandb/sdk/lib/auth/authenticate.py
+++ b/wandb/sdk/lib/auth/authenticate.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+
+from wandb import env
+from wandb.errors import AuthenticationError, term
+from wandb.sdk import wandb_setup
+
+from . import prompt, wbnetrc
+from .auth import Auth, AuthApiKey, AuthIdentityTokenFile, AuthWithSource
+
+_session_auth_lock = threading.Lock()
+_session_auth: Auth | None = None
+
+
+def session_credentials(*, host: str) -> Auth | None:
+    """Returns the configured session credentials.
+
+    Returns None if session credentials are configured for a different host.
+    """
+    with _session_auth_lock:
+        if _session_auth and _session_auth.host.is_same_url(host):
+            return _session_auth
+        else:
+            return None
+
+
+def _locked_set_session_auth(auth: Auth | None) -> None:
+    """Update session credentials.
+
+    Updates the global _session_auth variable and the global settings.
+    This is a refactoring step to transition away from storing auth in settings.
+    """
+    global _session_auth
+
+    settings = wandb_setup.singleton().settings
+
+    if auth is None:
+        settings.api_key = None
+        settings.identity_token_file = None
+
+    elif isinstance(auth, AuthApiKey):
+        settings.api_key = auth.api_key
+        settings.identity_token_file = None
+        settings.base_url = str(auth.host)
+
+    elif isinstance(auth, AuthIdentityTokenFile):
+        settings.api_key = None
+        settings.identity_token_file = str(auth.path)
+        settings.base_url = str(auth.host)
+
+    else:
+        raise NotImplementedError(str(auth))
+
+    _session_auth = auth
+
+
+def unauthenticate_session() -> Auth | None:
+    """Clear the session credentials.
+
+    Returns:
+        The previous credentials, if any.
+    """
+    with _session_auth_lock:
+        auth = _session_auth
+        _locked_set_session_auth(None)
+        return auth
+
+
+def authenticate_session(
+    *,
+    host: str,
+    source: str,
+    no_offline: bool = False,
+    no_create: bool = False,
+    input_timeout: float | None = None,
+    referrer: str = "models",
+    relogin: bool = False,
+) -> Auth | None:
+    """Returns or configures the session credentials.
+
+    If the session credentials are already configured for the given host,
+    returns them. Otherwise, uses system credentials or prompts interactively.
+
+    Args:
+        host: The W&B server URL.
+        source: The source to include in printed messages,
+            like "wandb.init()".
+        no_offline: Whether to show an offline option in interactive prompts.
+        no_create: Whether to show a new account option in interactive prompts.
+        input_timeout: A timeout for interactive prompts to avoid hanging
+            the process if we incorrectly identify it as interactive.
+        referrer: Referrer parameter to add to printed URLs for analytics.
+        relogin: If true, forces an interactive prompt.
+
+    Raises:
+        TimeoutError: If an interactive prompt is shown and input_timeout expires.
+        AuthenticationError: If credentials are found but have an invalid format.
+    """
+    if not relogin and (auth := session_credentials(host=host)):
+        return auth
+
+    if not relogin and (auth := _use_system_auth(host=host, source=source)):
+        return auth
+
+    with contextlib.suppress(term.NotATerminalError):
+        return _use_prompted_auth(
+            host=host,
+            no_offline=no_offline,
+            no_create=no_create,
+            referrer=referrer,
+            input_timeout=input_timeout,
+        )
+
+    return None
+
+
+def use_explicit_auth(auth: Auth, *, source: str) -> None:
+    """Use explicitly given credentials in the session.
+
+    Args:
+        auth: Credentials to use.
+        source: The source to include in the printed message,
+            like "wandb.init()".
+    """
+    with _session_auth_lock:
+        if _session_auth == auth:
+            return
+
+        if _session_auth:
+            term.termwarn(
+                f"[{source}] Changing session credentials to explicit value"
+                + f" for {auth.host}."
+            )
+        else:
+            term.termlog(
+                f"[{source}] Using explicit session credentials for {auth.host}."
+            )
+
+        _locked_set_session_auth(auth)
+
+
+def _use_system_auth(*, host: str, source: str) -> Auth | None:
+    """Load (or reload) session credentials from external sources.
+
+    Loads credentials from environment variables or the .netrc file.
+    If no credentials are found, the session credentials are unchanged.
+
+    Args:
+        host: The W&B server URL.
+        source: The source to include in the printed message,
+            like "wandb.init()".
+
+    Raises:
+        AuthenticationError: If a source of credentials is found but has an
+            invalid format.
+
+    Returns:
+        The new credentials, if any.
+    """
+    auth = (
+        _try_env_auth(host=host)  #
+        or wbnetrc.read_netrc_auth_with_source(host=host)
+    )
+
+    with _session_auth_lock:
+        if auth:
+            term.termlog(
+                f"[{source}] Loaded credentials for {auth.auth.host}"
+                + f" from {auth.source}."
+            )
+            _locked_set_session_auth(auth.auth)
+
+        return _session_auth
+
+
+def _try_env_auth(*, host: str) -> AuthWithSource | None:
+    """Returns credentials from environment variables, if set.
+
+    Raises an authentication error if an invalid combination of environment
+    variables is set.
+    """
+    api_key = os.getenv(env.API_KEY)
+    identity_token_file = os.getenv(env.IDENTITY_TOKEN_FILE)
+
+    if api_key and identity_token_file:
+        raise AuthenticationError(
+            f"Both {env.API_KEY} and {env.IDENTITY_TOKEN_FILE} are set,"
+            + " which is not allowed."
+        )
+
+    if api_key:
+        try:
+            return AuthWithSource(
+                auth=AuthApiKey(host=host, api_key=api_key),
+                source=env.API_KEY,
+            )
+        except AuthenticationError as e:
+            raise AuthenticationError(f"{env.API_KEY} invalid: {e}") from None
+
+    elif identity_token_file:
+        return AuthWithSource(
+            auth=AuthIdentityTokenFile(host=host, path=identity_token_file),
+            source=env.IDENTITY_TOKEN_FILE,
+        )
+
+    return None
+
+
+def _use_prompted_auth(
+    *,
+    host: str,
+    no_offline: bool,
+    no_create: bool,
+    referrer: str,
+    input_timeout: float | None = None,
+) -> Auth | None:
+    """Prompt interactively to set session credentials.
+
+    May clear session credentials if the user selects offline mode.
+
+    Args:
+        host: The W&B server URL.
+        no_offline: If true, do not show an option to skip logging in.
+        no_create: If true, do not show an option to create a new account.
+        referrer: Referrer parameter to include in printed URLs for analytics.
+        input_timeout: How long to wait for user input before timing out.
+
+    Raises:
+        NotATerminalError: If interactive prompting is not possible.
+        TimeoutError: If input_timeout expires.
+    """
+    api_key = prompt.prompt_and_save_api_key(
+        host=host,
+        no_offline=no_offline,
+        no_create=no_create,
+        referrer=referrer,
+        input_timeout=input_timeout,
+    )
+
+    with _session_auth_lock:
+        if api_key:
+            _locked_set_session_auth(AuthApiKey(host=host, api_key=api_key))
+        else:
+            # Offline mode selected.
+            _locked_set_session_auth(None)
+
+        return _session_auth

--- a/wandb/sdk/lib/auth/host_url.py
+++ b/wandb/sdk/lib/auth/host_url.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing_extensions import final, override
+
+from wandb.sdk.lib import urls
+
+
+@final
+class HostUrl:
+    """A validated and normalized W&B server URL.
+
+    For convenient formatting, the __str__ representation is the URL itself.
+    """
+
+    def __init__(self, url: str) -> None:
+        urls.validate_url(url)
+        self._url = url.rstrip("/")
+
+    def is_same_url(self, value: str | HostUrl, /) -> bool:
+        """Compare normalized URLs.
+
+        Returns true if the value is an equivalent HostUrl or a string
+        that normalizes to this URL.
+        """
+        if isinstance(value, HostUrl):
+            return self._url == value._url
+        else:
+            return self._url == value.rstrip("/")
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @override
+    def __str__(self) -> str:
+        return self._url
+
+    @override
+    def __repr__(self) -> str:
+        return f"HostUrl({self._url!r})"


### PR DESCRIPTION
Defines the `Auth` type, the `AuthApiKey` implementation, and the core session credential management functions.

Also defines the `AuthIdentityTokenFile` type, although I am not certain about the public interface for it. It's only needed as a bridge between `auth` and `settings` for now; the actual logic around JWTs is still elsewhere.

This PR does not export the new types from `wandb` and does not update old code to use the new functions yet.