### PR TITLE
refactor(launch): refactor label constants and move up cleanup method

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_monitor.py
+++ b/wandb/sdk/launch/runner/kubernetes_monitor.py
@@ -20,17 +20,14 @@ from kubernetes_asyncio.client import (  # type: ignore
 import wandb
 from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.runner.abstract import State, Status
-from wandb.sdk.launch.utils import get_kube_context_and_api_client
+from wandb.sdk.launch.utils import (
+    WANDB_K8S_LABEL_AGENT,
+    WANDB_K8S_LABEL_MONITOR,
+    get_kube_context_and_api_client,
+)
 
 if TYPE_CHECKING:
     from wandb.sdk.launch.agent import LaunchAgent  # noqa: F401
-
-WANDB_K8S_LABEL_NAMESPACE = "wandb.ai"
-WANDB_K8S_RUN_ID = f"{WANDB_K8S_LABEL_NAMESPACE}/run-id"
-WANDB_K8S_LABEL_AGENT = f"{WANDB_K8S_LABEL_NAMESPACE}/agent"
-WANDB_K8S_LABEL_MONITOR = f"{WANDB_K8S_LABEL_NAMESPACE}/monitor"
-WANDB_K8S_LABEL_AUXILIARY_RESOURCE = f"{WANDB_K8S_LABEL_NAMESPACE}/auxiliary-resource"
-WANDB_K8S_LABEL_RESOURCE_ROLE = f"{WANDB_K8S_LABEL_NAMESPACE}/resource-role"
 
 
 class Resources:

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -19,15 +19,15 @@ from wandb.sdk.launch.registry.azure_container_registry import AzureContainerReg
 from wandb.sdk.launch.registry.local_registry import LocalRegistry
 from wandb.sdk.launch.runner.abstract import Status
 from wandb.sdk.launch.runner.kubernetes_monitor import (
+    CustomResource,
+    LaunchKubernetesMonitor,
+)
+from wandb.sdk.launch.utils import (
     WANDB_K8S_LABEL_AGENT,
     WANDB_K8S_LABEL_AUXILIARY_RESOURCE,
     WANDB_K8S_LABEL_MONITOR,
     WANDB_K8S_LABEL_RESOURCE_ROLE,
     WANDB_K8S_RUN_ID,
-    CustomResource,
-    LaunchKubernetesMonitor,
-)
-from wandb.sdk.launch.utils import (
     recursive_macro_sub,
     sanitize_identifiers_for_k8s,
     yield_containers,

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -99,6 +99,14 @@ MAX_ENV_LENGTHS["SageMakerRunner"] = 512
 
 CODE_MOUNT_DIR = "/mnt/wandb"
 
+# Kubernetes label constants
+WANDB_K8S_LABEL_NAMESPACE = "wandb.ai"
+WANDB_K8S_RUN_ID = f"{WANDB_K8S_LABEL_NAMESPACE}/run-id"
+WANDB_K8S_LABEL_AGENT = f"{WANDB_K8S_LABEL_NAMESPACE}/agent"
+WANDB_K8S_LABEL_MONITOR = f"{WANDB_K8S_LABEL_NAMESPACE}/monitor"
+WANDB_K8S_LABEL_AUXILIARY_RESOURCE = f"{WANDB_K8S_LABEL_NAMESPACE}/auxiliary-resource"
+WANDB_K8S_LABEL_RESOURCE_ROLE = f"{WANDB_K8S_LABEL_NAMESPACE}/resource-role"
+
 
 def load_wandb_config() -> Config:
     """Load wandb config from WANDB_CONFIG environment variable(s).


### PR DESCRIPTION
# Refactor Kubernetes label constants into a central location

- Moves Kubernetes label constants from `kubernetes_monitor.py` to `utils.py` to centralize these definitions
- Updates imports across all files to reference the constants from the new location
- Refactors the `_scan_resource_type` method in `kubernetes_cleanup.py` to be a class method instead of a nested function

This change improves code organization by centralizing the Kubernetes label constants in a single location, making them easier to maintain and ensuring consistency across the codebase.

## Testing
- Existing tests continue to pass with the updated imports
- No functional changes to the code behavior