### PR TITLE
fix(artifacts): respect per_page in ArtifactCollections and ArtifactTypes paginators

### DIFF
--- a/tools/graphql_codegen/artifacts/artifact_collections.graphql
+++ b/tools/graphql_codegen/artifacts/artifact_collections.graphql
@@ -73,10 +73,16 @@ mutation DeleteArtifactCollectionTags($input: DeleteArtifactCollectionTagAssignm
   }
 }
 
-query ProjectArtifactCollections($entity: String!, $project: String!, $artifactType: String!, $cursor: String) {
+query ProjectArtifactCollections(
+  $entity: String!
+  $project: String!
+  $artifactType: String!
+  $cursor: String
+  $perPage: Int
+) {
   project(name: $project, entityName: $entity) {
     artifactType(name: $artifactType) {
-      artifactCollections(after: $cursor) {
+      artifactCollections(after: $cursor, first: $perPage) {
         totalCount
         pageInfo {
           ...PageInfoFragment

--- a/tools/graphql_codegen/artifacts/artifact_types.graphql
+++ b/tools/graphql_codegen/artifacts/artifact_types.graphql
@@ -6,9 +6,9 @@ fragment ArtifactTypeFragment on ArtifactType {
   createdAt
 }
 
-query ProjectArtifactTypes($entity: String!, $project: String!, $cursor: String) {
+query ProjectArtifactTypes($entity: String!, $project: String!, $cursor: String, $perPage: Int) {
   project(name: $project, entityName: $entity) {
-    artifactTypes(after: $cursor) {
+    artifactTypes(after: $cursor, first: $perPage) {
       edges {
         node {
           ...ArtifactTypeFragment

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -157,14 +157,6 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
 
         self.last_response = ArtifactTypeConnection.model_validate(conn)
 
-    @override
-    def update_variables(self) -> None:
-        """Update the cursor variable for pagination.
-
-        <!-- lazydoc-ignore: internal -->
-        """
-        self.variables.update({"cursor": self.cursor})
-
     def _convert(self, node: ArtifactTypeFragment) -> ArtifactType:
         return ArtifactType(
             client=self.client,
@@ -331,14 +323,6 @@ class ArtifactCollections(
             raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
 
         self.last_response = ArtifactCollectionConnection.model_validate(conn)
-
-    @override
-    def update_variables(self) -> None:
-        """Update the cursor variable for pagination.
-
-        <!-- lazydoc-ignore: internal -->
-        """
-        self.variables.update({"cursor": self.cursor})
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:

--- a/wandb/sdk/artifacts/_generated/operations.py
+++ b/wandb/sdk/artifacts/_generated/operations.py
@@ -234,10 +234,10 @@ mutation DeleteArtifactCollectionTags($input: DeleteArtifactCollectionTagAssignm
 """
 
 PROJECT_ARTIFACT_COLLECTIONS_GQL = """
-query ProjectArtifactCollections($entity: String!, $project: String!, $artifactType: String!, $cursor: String) {
+query ProjectArtifactCollections($entity: String!, $project: String!, $artifactType: String!, $cursor: String, $perPage: Int) {
   project(name: $project, entityName: $entity) {
     artifactType(name: $artifactType) {
-      artifactCollections(after: $cursor) {
+      artifactCollections(after: $cursor, first: $perPage) {
         totalCount
         pageInfo {
           ...PageInfoFragment
@@ -520,9 +520,9 @@ fragment PageInfoFragment on PageInfo {
 """
 
 PROJECT_ARTIFACT_TYPES_GQL = """
-query ProjectArtifactTypes($entity: String!, $project: String!, $cursor: String) {
+query ProjectArtifactTypes($entity: String!, $project: String!, $cursor: String, $perPage: Int) {
   project(name: $project, entityName: $entity) {
-    artifactTypes(after: $cursor) {
+    artifactTypes(after: $cursor, first: $perPage) {
       edges {
         node {
           ...ArtifactTypeFragment


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes https://wandb.atlassian.net/browse/WB-29404

AFAICT, the `ArtifactCollections` and `ArtifactTypes` paginated iterators have never actually accepted a `perPage` GraphQL argument.  This is probably fine most of the time, but it almost certainly won't be forever.

PR fixes the paginated GraphQL query so that it accepts -- and respects -- the `per_page` value (whether it's the SDK default or a custom value provided by the user).

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Existing tests must continue to pass.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
