### PR TITLE
fix: console capture infinite loop

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,3 +31,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Artifact collection aliases are now fetched lazily on accessing `ArtifactCollection.aliases` instead of on instantiating `ArtifactCollection`, improving performance of `Api.artifact_collections()`, `Api.registries().collections()`, etc. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10731)
 - Use explicitly provided API key in `wandb.init(settings=wandb.Settings(api_key="..."))` for login. Use the key from run when logging artifacts via `run.log_artifact` (@pingleiwandb in https://github.com/wandb/wandb/pull/10914)
 - W&B LEET TUI correctly displays negative Y axis tick values and base/display units of certain system metrics (@dmitryduev in https://github.com/wandb/wandb/pull/10905)
+- Fixed a rare infinite loop in `console_capture.py` (@timoffex in https://github.com/wandb/wandb/pull/10955)

--- a/tests/system_tests/test_functional/console_capture/infinite_loop.py
+++ b/tests/system_tests/test_functional/console_capture/infinite_loop.py
@@ -1,0 +1,68 @@
+"""Fails if tasks started by console callbacks invoke more callbacks."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from wandb.sdk.lib import asyncio_manager, console_capture
+
+
+def _info(msg: str) -> None:
+    sys.stderr.write(msg + "\n")
+
+
+class _Tester:
+    def __init__(self) -> None:
+        self._asyncer = asyncio_manager.AsyncioManager()
+        self._scheduled_message: asyncio.Event
+        self._outside_of_callback: asyncio.Event
+        self._callback_count = 0
+
+    def run(self) -> None:
+        self._asyncer.start()
+        self._asyncer.run(self._run)
+        self._asyncer.join()
+
+    async def _run(self) -> None:
+        self._scheduled_message = asyncio.Event()
+        self._outside_of_callback = asyncio.Event()
+
+        # The callback should be invoked before write() returns.
+        # This is a precondition for the test to make sense.
+        sys.stdout.write("Initial message.\n")
+        if self._callback_count != 1:
+            _info(f"FAIL: Precondition not satisfied ({self._callback_count=})")
+            sys.exit(1)
+
+        # Allow the scheduled task to print. Its message should not be captured
+        # even though we're not inside the write() anymore.
+        self._outside_of_callback.set()
+        await self._scheduled_message.wait()
+        if self._callback_count != 1:
+            _info(f"FAIL: Unexpected callback count ({self._callback_count=})")
+            sys.exit(1)
+
+    def callback(self, data: bytes | str, written: int) -> None:
+        _ = data
+        _ = written
+
+        self._callback_count += 1
+        self._asyncer.run_soon(self._print_more_later)
+
+    async def _print_more_later(self) -> None:
+        await self._outside_of_callback.wait()
+        sys.stdout.write("Scheduled message.\n")
+        self._scheduled_message.set()
+
+
+def main() -> None:
+    tester = _Tester()
+
+    reset = console_capture.capture_stdout(tester.callback)
+    tester.run()
+    reset()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/system_tests/test_functional/console_capture/test_console_capture.py
+++ b/tests/system_tests/test_functional/console_capture/test_console_capture.py
@@ -7,6 +7,11 @@ def test_deadlocks():
     subprocess.check_call(["python", str(script)], timeout=5)
 
 
+def test_infinite_loop():
+    script = pathlib.Path(__file__).parent / "infinite_loop.py"
+    subprocess.check_call(["python", str(script)], timeout=5)
+
+
 def test_patch_stdout_and_stderr():
     script = pathlib.Path(__file__).parent / "patch_stdout_and_stderr.py"
 


### PR DESCRIPTION
Fixes #10811 and WB-29304.

Follow-up to #10683.

Prevents a particular type of infinite loop when capturing console output: a callback schedules an asynchronous task that prints, which invokes the callback and schedules the same task again, repeating forever.

This fixes an infinite loop in our current usage, but it's impossible to completely prevent all infinite loops. For example, this infinite loop cannot be avoided:

```python
import queue
import time
import threading

from wandb.sdk.lib import console_capture


def print_queue(messages: queue.Queue[str]) -> None:
    while not messages.empty():
        print(messages.get())
        time.sleep(1)


def main() -> None:
    messages = queue.Queue[str]()
    messages.put("Initial message.")

    def add_message_to_queue(*args, **kwargs) -> None:
        messages.put("Scheduled message.")

    console_capture.capture_stdout(add_message_to_queue)

    thread = threading.Thread(target=print_queue, args=(messages,))
    thread.start()
    thread.join()


if __name__ == "__main__":
    main()
```

This is fundamentally unavoidable if we want to patch `stdout` / `stderr`. One tempting mitigation is to skip invoking callbacks when they happen too rapidly, but this would also fail to capture rapid console output.