### PR TITLE
refactor: disallow OIDC with wandb.Api

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,11 @@ Section headings should be at level 3 (e.g. `### Added`).
 - The automations API now support basic zscore automation events (@matthoare117-wandb in https://github.com/wandb/wandb/pull/10931)
 - Regex support in metrics and run overview filters in W&B LEET TUI (@dmitryduev in https://github.com/wandb/wandb/pull/10919)
 
+### Changed
+
+- `wandb.Api()` now raises a `UsageError` if `WANDB_IDENTITY_TOKEN_FILE` is set and an explicit API key is not provided (@timoffex in https://app.graphite.com/github/pr/wandb/wandb/10970)
+  - `wandb.Api()` has only ever worked using an API key
+
 ### Deprecated
 
 - Anonymous mode, including the `anonymous` setting, the `WANDB_ANONYMOUS` environment variable, `wandb.init(anonymous=...)`, `wandb login --anonymously` and `wandb.login(anonymous=...)` is deprecated and will emit warnings (@timoffex in https://github.com/wandb/wandb/pull/10909)

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -20,6 +20,10 @@ from wandb.sdk.lib.deprecation import UNSET, DoNotSet
 from ..apis import InternalApi
 
 
+class OidcError(Exception):
+    """OIDC is configured but not allowed."""
+
+
 def _handle_host_wandb_setting(host: str | None, cloud: bool = False) -> None:
     """Write the host parameter to the global settings file.
 
@@ -283,6 +287,7 @@ def _login(
     verify: bool = False,
     referrer: str = "models",
     update_api_key: bool = True,
+    no_oidc: bool = False,
     _silent: bool | None = None,
 ) -> tuple[bool, str | None]:
     """Logs in to W&B.
@@ -294,6 +299,8 @@ def _login(
     Args:
         update_api_key: If true, the api key will be saved or updated
             in the users .netrc file.
+        no_oidc: If true, raise an OidcError instead of returning early if OIDC
+            credentials are configured.
         _silent: If true, will not print any messages to the console.
 
     Returns:
@@ -318,6 +325,9 @@ def _login(
         return False, None
 
     if wlogin._settings.identity_token_file:
+        if no_oidc:
+            raise OidcError
+
         return True, None
 
     if key:


### PR DESCRIPTION
Raise a UsageError when instantiating `wandb.Api` while `identity_token_file` is set. Passing an explicit API key still works.

Right now, it's possible to use [federated identities](https://docs.wandb.ai/platform/hosting/iam/identity_federation) (aka "OIDC" or "JWTs") together with an API key. OIDC is considered more secure, but an API key can do everything that OIDC can. Using both simultaneously is generally not useful and defeats the security advantages of OIDC.

One potential use-case is to use an API key for one identity and OIDC for another. This wasn't intentionally supported and probably had unpredictable behavior. I'm removing this capability to simplify the implicit credential management logic.

Using any combination of _explicit_ credentials will continue to be supported.