### PR TITLE
fix(launch): Prevent Kubernetes job tracker from getting stuck with stale watch connections

### DIFF
--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -10,8 +10,9 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
-import wandb
 import yaml
+
+import wandb
 from wandb.apis.internal import Api
 from wandb.sdk.launch.environment.abstract import AbstractEnvironment
 from wandb.sdk.launch.registry.abstract import AbstractRegistry


### PR DESCRIPTION
Description
-----------

This PR adds additional mitigation to prevent completed launch jobs from getting stuck. In the graph below, we can see an uptick in watch connection activity once the agent is restarted at 1:39pm pt. This means that our watcher silently failed.


https://grafana.int.coreweave.com/d/launch-watch-timeout-filtered/5ceacdb?orgId=1&from=now-12h&to=now&timezone=browser

<img width="2456" height="669" alt="image" src="https://github.com/user-attachments/assets/15c51b1f-6475-4471-b12f-49fd508c9572" />

> In case of a network outage, the server side timeout value will have no effect & the client will hang indefinitely without raising any exception. Note, that this is the case provided when there is no other client-side timeout (i.e., _request_timeout) value specified.

☝️ I believe this is what happened to our watcher and why jobs piled up. https://github.com/kubernetes-client/python/blob/master/examples/watch/timeout-settings.md#client-side-timeout-kwargs_request_timeout--n


To solve this, we can update clientside (`_request_timeout`) and serverside (`timeout_seconds`) settings of the watch to:
1. increase the timeout on the stream so we reduce the odds of us reconnecting during a network blip
2. force the client to drop and reestablish the connection if there's no network activity after a period of time

The updated settings:
* Increased watch `timeout_seconds` from 30 s to 300s so the API server reconnects less often.
* Add a 120 s client-side `_request_timeout` so if the watch socket hangs we force a reconnect and keep the agent from getting stuck
