### PR TITLE
fix: replace sagemaker_auth() usage of removed apikey module

### DIFF
--- a/wandb/integration/sagemaker/auth.py
+++ b/wandb/integration/sagemaker/auth.py
@@ -1,28 +1,39 @@
-import os
+from __future__ import annotations
 
-import wandb
+import os
+from typing import Any
+
 from wandb import env
 from wandb.sdk import wandb_setup
+from wandb.sdk.lib import auth as wbauth
 
 
-def sagemaker_auth(overrides=None, path=".", api_key=None):
+def sagemaker_auth(
+    overrides: dict[str, Any] | None = None,
+    path: str = ".",
+    api_key: str | None = None,
+) -> None:
     """Write a secrets.env file with the W&B ApiKey and any additional secrets passed.
 
     Args:
-        overrides (dict, optional): Additional environment variables to write
-                                    to secrets.env
-        path (str, optional): The path to write the secrets file.
+        overrides: Additional environment variables to write to secrets.env
+        path: The path to write the secrets file.
     """
-    settings = wandb_setup.singleton().settings
-    current_api_key = wandb.wandb_lib.apikey.api_key(settings=settings)
-
     overrides = overrides or dict()
-    api_key = overrides.get(env.API_KEY, api_key or current_api_key)
+
+    api_key = (
+        overrides.get(env.API_KEY, None)
+        or api_key
+        or wandb_setup.singleton().settings.api_key
+        or wbauth.read_netrc_auth(host=wandb_setup.singleton().settings.base_url)
+    )
+
     if api_key is None:
         raise ValueError(
-            "Can't find W&B ApiKey, set the WANDB_API_KEY env variable "
-            "or run `wandb login`"
+            "Can't find W&B API key, set the WANDB_API_KEY env variable"
+            + " or run `wandb login`"
         )
+
     overrides[env.API_KEY] = api_key
     with open(os.path.join(path, "secrets.env"), "w") as file:
         for k, v in overrides.items():


### PR DESCRIPTION
PR #10879 (not yet released) removed the `apikey` module and updated all callsites, except this one which used a very bad import pattern that I didn't `grep` for.