### PR TITLE
docs(sdk): adds GH Action that updates SDK Extras in wandb/docs

### DIFF
--- a/.github/workflows/trigger-docs-sdk-extras.yml
+++ b/.github/workflows/trigger-docs-sdk-extras.yml
@@ -1,0 +1,27 @@
+name: Trigger Docs SDK Extras Update
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pyproject.toml'
+
+jobs:
+  trigger-docs-update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Trigger docs repository workflow
+      run: |
+        echo "🔔 Triggering SDK extras update in docs repository..."
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}" \
+          https://api.github.com/repos/wandb/docs/dispatches \
+          -d '{"event_type":"pyproject-updated"}'
+        echo "✅ Repository dispatch event sent successfully"
+
+    - name: Display notification
+      run: |
+        echo "::notice title=Docs Update Triggered::SDK extras documentation update has been triggered in the docs repository"


### PR DESCRIPTION
Description
-----------

When pyproject.toml is modified, triggers 

```python
python wandb/docs/scripts/generate_sdk_extras_table.py 
```

This updates the extras table in models/ref/python, see this link for a preview of what that looks like:
https://wb-21fd5541-sdk-optional-dependencies.mintlify.app/models/ref/python#supported-optional-dependencies

See accompanying PR: https://github.com/wandb/docs/pull/1906

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)

- Fixes WB-NNNNN
- Fixes #NNNN
-->
----

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
