### PR TITLE
chore: update error when failing to connect during api key verification

### DIFF
--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -385,10 +385,10 @@ def _verify_login(key: str, base_url: str) -> None:
 
     try:
         is_api_key_valid = api.validate_api_key()
-    except ConnectionError:
+    except ConnectionError as e:
         raise AuthenticationError(
-            "Unable to connect to server to verify API token."
-        ) from None
+            f"Unable to connect to {base_url} to verify API token."
+        ) from e
     except Exception as e:
         raise AuthenticationError(
             "An error occurred while verifying the API key."


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
What does the PR do? Include a concise description of the PR contents.

When a connection error occurs during API key validation, the exception message is not informative enough to understand the exact issue.
This PR maintains the stack trace for debugging.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

#### Before this change
```
wandb: Network error (ConnectionError), entering retry loop.
wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/test/connectiontest.py", line 3, in <module>
    api = wandb.Api(
          ^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/public/api.py", line 329, in __init__
    wandb_login._verify_login(
  File "/Users/jacob.romero/workspace/wandb/wandb/sdk/wandb_login.py", line 389, in _verify_login
    raise AuthenticationError(
wandb.errors.errors.AuthenticationError: Unable to connect to server to verify API token.
```

#### After this change

```
 File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/requests/adapters.py", line 700, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.wandb.ai', port=443): Max retries exceeded with url: /graphql (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x12cfd0080>: Failed to establish a new connection: [Errno 61] Connection refused'))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/test/connectiontest.py", line 3, in <module>
    api = wandb.Api(
          ^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/public/api.py", line 323, in __init__
    wandb_login._verify_login(
  File "/Users/jacob.romero/workspace/wandb/wandb/sdk/wandb_login.py", line 346, in _verify_login
    raise AuthenticationError(
wandb.errors.errors.AuthenticationError: Unable to connect to server (https://api.wandb.ai) to verify API token.
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
