### PR TITLE
refactor: move test for databricks terminput behavior

### DIFF
--- a/tests/system_tests/test_notebooks/test_notebooks.py
+++ b/tests/system_tests/test_notebooks/test_notebooks.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from unittest import mock
 
-import pytest
 import wandb
 import wandb.util
 
@@ -149,15 +148,6 @@ def test_notebook_not_exists(mocked_ipython, user, capsys):
         _, err = capsys.readouterr()
         assert "WANDB_NOTEBOOK_NAME should be a path" in err
         run.finish()
-
-
-def test_databricks_notebook_doesnt_hang_on_wandb_login(monkeypatch):
-    # test for WB-5264
-    # when we try to call wandb.login(), should fail with no-tty
-    monkeypatch.setattr(wandb.util, "_is_databricks", lambda: True)
-
-    with pytest.raises(wandb.UsageError, match="No API key configured"):
-        wandb.login()
 
 
 def test_mocked_notebook_html_default(user, run_id, mocked_ipython):

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 import wandb
+from wandb.errors import UsageError
 from wandb.sdk import wandb_login, wandb_setup
 from wandb.sdk.lib.credentials import _expires_at_fmt
 
@@ -18,6 +19,12 @@ def test_login_timeout(emulated_terminal):
     assert logged_in is False
     assert wandb.api.api_key is None
     assert wandb.setup().settings.mode == "disabled"
+
+
+def test_login_no_terminput():
+    """Raise if key not configured and interactive prompt unavailable."""
+    with pytest.raises(UsageError, match="No API key configured"):
+        wandb.login()
 
 
 def test_login_timeout_choose(emulated_terminal):


### PR DESCRIPTION
Replaces the notebook test by a couple of more general unit tests.