### PR TITLE
refactor: improve types for InternalApi.settings and clean up

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -307,17 +307,8 @@ class Api:
                 or configured in the environment.
         """
         self.settings = InternalApi().settings()
-
-        _overrides = overrides or {}
-        self.settings.update(_overrides)
+        self.settings.update(overrides or {})
         self.settings["base_url"] = self.settings["base_url"].rstrip("/")
-        if "organization" in _overrides:
-            self.settings["organization"] = _overrides["organization"]
-        if "username" in _overrides and "entity" not in _overrides:
-            wandb.termwarn(
-                'Passing "username" to Api is deprecated. please use "entity" instead.'
-            )
-            self.settings["entity"] = _overrides["username"]
 
         use_api_key = api_key is not None or _thread_local_api_settings.cookies is None
 


### PR DESCRIPTION
A little bit of cleanup around `InternalApi.settings`:

* Removed redundant logic in `Api.__init__()`
  * Dropped support for passing "username" via the overrides argument (deprecated for 2 years)
  * Removed the underscore prefix for the local variable, letting it shadow the param instead
* Fixed up the `@overload` definitions for `settings`
  * The `...` in `key: str = ...` meant "key is optional", so type checkers couldn't distinguish between `key: None = None` and `key: str = ...` when `key` wasn't passed
  * Putting the more common overload first seems like a good rule of thumb; at least basedpyright [defaults to the first overload](https://docs.basedpyright.com/v1.31.4/usage/type-concepts-advanced/#overloads) if multiple match
* Fixed up types for `internal_api.py::DefaultSettings`
  * A `TypedDict` expects to have all its keys by default; the `total=False` argument makes them optional
  * A `TypedDict` expects no other keys, so calling `update()` with an arbitrary dict doesn't type-check

Replacing the `update()` call in the `default_settings` initialization is a little risky: before this PR, if a Settings object was passed to `InternalApi()`, then `default_settings` contained _all_ settings keys and `InternalApi.settings()` could have returned them. I searched for `\.settings\(` and verified that all calls only access `DefaultSettings` keys.