### PR TITLE
feat(leet): chart data inspection

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,9 +15,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Added
 
+- Regex support in metrics and run overview filters in W&B LEET TUI (@dmitryduev in https://github.com/wandb/wandb/pull/10919)
+- Chart inspection in W&B LEET TUI: right-click and drag to show (x, y) at the nearest data point; hold Alt for synchronized inspection across all visible charts (@dmitryduev in https://github.com/wandb/wandb/pull/10989)
 - The automations API now supports creating and editing automations that trigger on run states (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10848)
 - The automations API now support basic zscore automation events (@matthoare117-wandb in https://github.com/wandb/wandb/pull/10931)
-- Regex support in metrics and run overview filters in W&B LEET TUI (@dmitryduev in https://github.com/wandb/wandb/pull/10919)
 - Simplified the syntax for creating z-score metric automation triggers in the automations API (@matthoare117-wandb in https://github.com/wandb/wandb/pull/10953)
 
 ### Changed

--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -1,6 +1,7 @@
 package leet
 
 import (
+	"fmt"
 	"math"
 	"slices"
 	"sort"
@@ -61,6 +62,9 @@ type EpochLineChart struct {
 
 	// yMin/yMax are the observed Y bounds used to compute padded Y axes.
 	yMin, yMax float64
+
+	// inspection holds the chart overlay state.
+	inspection ChartInspection
 }
 
 func NewEpochLineChart(width, height int, title string) *EpochLineChart {
@@ -159,6 +163,11 @@ func (c *EpochLineChart) updateRanges() {
 	}
 
 	c.SetXYRange(c.MinX(), c.MaxX(), newYMin, newYMax)
+
+	// Keep inspection overlay consistent if the view/domain changed.
+	if c.inspection.Active {
+		c.refreshInspectionAfterViewChange()
+	}
 }
 
 // calculatePadding determines appropriate padding for the Y axis
@@ -330,7 +339,67 @@ func (c *EpochLineChart) Draw() {
 		patterns,
 		style)
 
+	// Overlay: vertical crosshair + legend.
+	c.drawInspectionOverlay(startX)
+
 	c.dirty = false
+}
+
+// drawInspectionOverlay renders the vertical crosshair line and the (x, y)
+// legend beside it when inspection mode is active.
+func (c *EpochLineChart) drawInspectionOverlay(graphStartX int) {
+	if !c.inspection.Active || c.GraphWidth() <= 0 || c.GraphHeight() <= 0 {
+		return
+	}
+	canvasX := graphStartX + c.inspection.MouseX
+
+	// Vertical hairline across the graph area.
+	for y := 0; y < c.GraphHeight(); y++ {
+		c.Canvas.SetCell(
+			canvas.Point{X: canvasX, Y: y},
+			canvas.NewCellWithStyle(boxLightVertical, inspectionLineStyle),
+		)
+	}
+
+	// Legend: "X: Y" near the hairline (middle row), placed to the side that fits.
+	label := fmt.Sprintf("%v: %v", c.inspection.DataX, formatSigFigs(c.inspection.DataY, 4))
+	labelRunes := []rune(label)
+
+	legendY := c.GraphHeight() / 2
+	rightBound := graphStartX + c.GraphWidth()
+
+	legendX := canvasX + 1
+	if legendX+len(labelRunes) >= rightBound {
+		legendX = canvasX - 1 - len(labelRunes)
+	}
+	if legendX < graphStartX {
+		legendX = graphStartX
+	}
+
+	for i, ch := range labelRunes {
+		c.Canvas.SetCell(
+			canvas.Point{X: legendX + i, Y: legendY},
+			canvas.NewCellWithStyle(ch, inspectionLegendStyle),
+		)
+	}
+}
+
+// Binary-search utility over monotonic xData.
+func (c *EpochLineChart) findNearestDataPoint(mouseX int) (dataX, dataY float64, idx int, ok bool) {
+	if len(c.xData) == 0 || c.GraphWidth() <= 0 {
+		return 0, 0, -1, false
+	}
+	xRange := c.ViewMaxX() - c.ViewMinX()
+	if xRange <= 0 {
+		return 0, 0, -1, false
+	}
+	targetX := c.ViewMinX() + (float64(mouseX)/float64(c.GraphWidth()))*xRange
+
+	bestIdx := nearestIndexForX(c.xData, targetX)
+	if bestIdx < 0 {
+		return 0, 0, -1, false
+	}
+	return c.xData[bestIdx], c.yData[bestIdx], bestIdx, true
 }
 
 // pixelEpsX returns ~1 horizontal pixel in X units for the current graph.
@@ -464,4 +533,131 @@ func TruncateTitle(title string, maxWidth int) string {
 // SetGraphStyle swaps the style used for drawing.
 func (c *EpochLineChart) SetGraphStyle(s lipgloss.Style) {
 	c.graphStyle.Store(s)
+}
+
+// ChartInspection holds state for the crosshair overlay displayed during
+// right-click inspection.
+type ChartInspection struct {
+	// Active indicates whether inspection mode is on.
+	Active bool
+	// MouseX is the vertical crosshair position in graph-local pixels.
+	MouseX int
+	// DataX, DataY are coordinates of the nearest data sample.
+	DataX, DataY float64
+}
+
+// nearestIndexForX returns the index of the sample in xs that is closest to targetX.
+// xs must be non-decreasing.
+//
+// Returns -1 if input slice is empty
+func nearestIndexForX(xs []float64, targetX float64) int {
+	if len(xs) == 0 {
+		return -1
+	}
+	j := sort.SearchFloat64s(xs, targetX)
+
+	// Inspect the nearest values to find the best match.
+	bestIdx := -1
+	bestDist := math.Inf(1)
+	for _, i := range []int{j - 1, j, j + 1} {
+		if i < 0 || i >= len(xs) {
+			continue
+		}
+		if d := math.Abs(xs[i] - targetX); d < bestDist {
+			bestDist, bestIdx = d, i
+		}
+	}
+	return bestIdx
+}
+
+// snapInspectionToDataX finds the nearest sample to targetX, updates the
+// inspection (DataX, DataY) and snaps the hairline MouseX to the sample's
+// exact x-position in the current view.
+func (c *EpochLineChart) snapInspectionToDataX(targetX float64) {
+	if !c.inspection.Active || c.GraphWidth() <= 0 || len(c.xData) == 0 {
+		return
+	}
+
+	xRange := c.ViewMaxX() - c.ViewMinX()
+	if xRange <= 0 {
+		return
+	}
+
+	idx := nearestIndexForX(c.xData, targetX)
+	if idx < 0 {
+		return
+	}
+
+	c.inspection.DataX = c.xData[idx]
+	c.inspection.DataY = c.yData[idx]
+
+	// Pixel snap to the exact dataX under current view.
+	mouseXFrac := (c.inspection.DataX - c.ViewMinX()) / xRange
+	mouseX := int(math.Round(mouseXFrac * float64(c.GraphWidth())))
+	c.inspection.MouseX = max(0, min(c.GraphWidth()-1, mouseX))
+
+	// Need a redraw.
+	c.dirty = true
+}
+
+// InspectAtDataX turns inspection on and positions the crosshair/legend
+// at the sample nearest to targetX (in data coordinates), snapping the
+// hairline to the sample's exact X.
+func (c *EpochLineChart) InspectAtDataX(targetX float64) {
+	if len(c.xData) == 0 || c.GraphWidth() <= 0 {
+		return
+	}
+	c.inspection.Active = true
+	c.snapInspectionToDataX(targetX)
+}
+
+// refreshInspectionAfterViewChange keeps the hairline aligned with the same DataX
+// after the X view/domain changed (e.g., new data expands the domain).
+func (c *EpochLineChart) refreshInspectionAfterViewChange() {
+	if !c.inspection.Active {
+		return
+	}
+	c.snapInspectionToDataX(c.inspection.DataX)
+}
+
+// StartInspection begins inspection mode at the given graph-local mouse X.
+func (c *EpochLineChart) StartInspection(mouseX int) {
+	if len(c.xData) == 0 || c.GraphWidth() <= 0 {
+		return
+	}
+	c.inspection.Active = true
+	c.UpdateInspection(mouseX)
+}
+
+// UpdateInspection updates the crosshair position and snaps to the nearest
+// data point based on the current mouse X position.
+func (c *EpochLineChart) UpdateInspection(mouseX int) {
+	if !c.inspection.Active || c.GraphWidth() <= 0 {
+		return
+	}
+	// Clamp to the drawable graph area.
+	c.inspection.MouseX = max(0, min(c.GraphWidth()-1, mouseX))
+
+	// Resolve the data point under the mouse, then reuse the unified snap logic.
+	if dataX, _, _, ok := c.findNearestDataPoint(mouseX); ok {
+		c.snapInspectionToDataX(dataX)
+	}
+	c.dirty = true
+}
+
+// EndInspection exits inspection mode.
+func (c *EpochLineChart) EndInspection() {
+	c.inspection = ChartInspection{}
+	c.dirty = true
+}
+
+// IsInspecting reports whether inspection is active for this chart.
+func (c *EpochLineChart) IsInspecting() bool { return c.inspection.Active }
+
+// InspectionData returns the coordinates of the currently inspected point
+// and whether inspection is active.
+//
+// Used for cross-chart synchronization.
+func (c *EpochLineChart) InspectionData() (x, y float64, active bool) {
+	return c.inspection.DataX, c.inspection.DataY, c.inspection.Active
 }

--- a/core/internal/leet/epochlinechart_overlay_test.go
+++ b/core/internal/leet/epochlinechart_overlay_test.go
@@ -1,0 +1,166 @@
+package leet_test
+
+import (
+	"math"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/internal/leet"
+)
+
+// stripANSI removes ANSI color/style sequences so we can assert on plain text.
+func stripANSI(s string) string {
+	re := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	return re.ReplaceAllString(s, "")
+}
+
+func seedXY(n int) leet.MetricData {
+	xs := make([]float64, n)
+	ys := make([]float64, n)
+	for i := range n {
+		xs[i] = float64(i)
+		ys[i] = float64(i + 1)
+	}
+	return leet.MetricData{X: xs, Y: ys}
+}
+
+func TestEpochLineChart_DrawInspectionOverlay_RendersHairlineAndLegend_RightSide(t *testing.T) {
+	c := leet.NewEpochLineChart(80, 12, "acc")
+	c.AddData(seedXY(30))
+	c.Draw()
+
+	// Inspect near X=5 -> expect legend to the right of the vertical hairline.
+	wantX := 5.0
+	px := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	c.StartInspection(px)
+	c.Draw()
+
+	view := stripANSI(c.View())
+	lines := strings.Split(view, "\n")
+
+	label := "5: 6" // y = x+1
+	found := false
+	for _, line := range lines {
+		// When placed on the right: hairline '│' immediately followed by label.
+		if strings.Contains(line, "│"+label) {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected hairline followed by legend on the right in the same row")
+}
+
+func TestInspectAtDataX_SnapsToNearestAndPixel(t *testing.T) {
+	c := leet.NewEpochLineChart(80, 12, "loss")
+
+	// Non-uniform X to exercise nearest selection.
+	data := leet.MetricData{
+		X: []float64{0, 2, 5, 9},
+		Y: []float64{10, 20, 50, 90},
+	}
+	c.AddData(data)
+
+	// Domain becomes [0,20] (niceMax), view = [0,20] initially.
+	c.Draw()
+
+	// Target X=4 should snap to X=5 (nearest), then hairline snaps to exact pixel for X=5.
+	c.InspectAtDataX(4.0)
+
+	x, y, active := c.InspectionData()
+	require.True(t, active)
+	require.InDelta(t, 5.0, x, 1e-9)
+	require.InDelta(t, 50.0, y, 1e-9)
+
+	px, ok := c.TestInspectionMouseX()
+	require.True(t, ok)
+
+	// Expected pixel for X=5
+	expectPX := int(math.Round((5.0 - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	require.Equal(t, expectPX, px, "hairline should pixel-snap to the exact sample X")
+}
+
+func TestInspectAtDataX_NoData_NoActivate(t *testing.T) {
+	c := leet.NewEpochLineChart(80, 12, "acc")
+	// No data; should no-op
+	c.InspectAtDataX(1.0)
+	_, _, active := c.InspectionData()
+	require.False(t, active)
+}
+
+// When new data expands the X domain (e.g., [0,20] -> [0,30]), the overlay
+// should keep pointing at the same data X and move to the correct pixel.
+func TestInspection_RepositionsOnXDomainExpansion(t *testing.T) {
+	c := leet.NewEpochLineChart(120, 12, "loss")
+
+	// Seed 0..19 so nice X domain is [0,20].
+	xs := make([]float64, 20)
+	ys := make([]float64, 20)
+	for i := range xs {
+		xs[i] = float64(i)
+	}
+	c.AddData(leet.MetricData{X: xs, Y: ys})
+	require.InDelta(t, 20.0, c.ViewMaxX(), 1e-9)
+
+	// Start inspecting at X=10 (middle of initial view).
+	wantX := 10.0
+	startPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	c.StartInspection(startPX)
+
+	// Sanity: active and anchored to ~X=10.
+	x0, _, active0 := c.InspectionData()
+	require.True(t, active0)
+	require.InDelta(t, wantX, x0, 1e-9)
+	oldPX, _ := c.TestInspectionMouseX()
+
+	// Append 20..29 -> nice view should expand to [0,30].
+	c.AddData(leet.MetricData{
+		X: []float64{20, 21, 22, 23, 24, 25, 26, 27, 28, 29},
+		Y: []float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	})
+	require.InDelta(t, 30.0, c.ViewMaxX(), 1e-9)
+
+	// The overlay remains at the same DataX but moves to the new pixel.
+	newPX, active1 := c.TestInspectionMouseX()
+	require.True(t, active1)
+	x1, _, active1B := c.InspectionData()
+	require.True(t, active1B)
+	require.InDelta(t, wantX, x1, 1e-9)
+
+	expectPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	require.Equal(t, expectPX, newPX)
+	require.Less(t, newPX, oldPX, "overlay should move left as view widens from 20 to 30")
+}
+
+// Resizing the chart should also keep the overlay anchored to the same DataX.
+func TestInspection_RepositionsOnResize(t *testing.T) {
+	c := leet.NewEpochLineChart(80, 12, "acc")
+
+	// Seed 0..29 so nice X domain is [0,30].
+	xs := make([]float64, 30)
+	ys := make([]float64, 30)
+	for i := range xs {
+		xs[i] = float64(i)
+	}
+	c.AddData(leet.MetricData{X: xs, Y: ys})
+	require.InDelta(t, 30.0, c.ViewMaxX(), 1e-9)
+
+	wantX := 15.0
+	startPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	c.StartInspection(startPX)
+	oldPX, _ := c.TestInspectionMouseX()
+
+	// Wider chart -> overlay should move proportionally to new width.
+	c.Resize(160, 12)
+
+	newPX, active := c.TestInspectionMouseX()
+	require.True(t, active)
+	x, _, a := c.InspectionData()
+	require.True(t, a)
+	require.InDelta(t, wantX, x, 1e-9)
+
+	expectPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	require.Equal(t, expectPX, newPX)
+	require.Greater(t, newPX, oldPX, "overlay should move right when width doubles")
+}

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -159,11 +159,19 @@ func KeyBindings() []BindingCategory {
 			Name: "Mouse",
 			Bindings: []KeyBinding{
 				{
-					Keys:        []string{"mouse wheel"},
+					Keys:        []string{"wheel"},
 					Description: "Zoom in/out on focused chart",
 				},
 				{
-					Keys:        []string{"shift+mouse select"},
+					Keys:        []string{"right-click+drag"},
+					Description: "Inspect: show (x, y) at nearest point on a chart",
+				},
+				{
+					Keys:        []string{"alt+right-click+drag"},
+					Description: "Inspect all visible charts in sync",
+				},
+				{
+					Keys:        []string{"shift+drag"},
 					Description: "Select text",
 				},
 			},

--- a/core/internal/leet/metricsgrid.go
+++ b/core/internal/leet/metricsgrid.go
@@ -46,6 +46,9 @@ type MetricsGrid struct {
 	// Stable color assignment.
 	colorOfTitle map[string]lipgloss.AdaptiveColor
 	nextColorIdx int
+
+	// synchronized inspection session state (active only between press/release)
+	syncInspectActive bool
 }
 
 func NewMetricsGrid(
@@ -527,43 +530,23 @@ func (mg *MetricsGrid) HandleWheel(
 	dims GridDims,
 	wheelUp bool,
 ) {
-	size := mg.effectiveGridSize()
-
-	// Inspect under read lock.
-	mg.mu.RLock()
-	if row < 0 || row >= size.Rows || col < 0 || col >= size.Cols ||
-		row >= len(mg.currentPage) || col >= len(mg.currentPage[row]) ||
-		mg.currentPage[row][col] == nil {
-		mg.mu.RUnlock()
+	chart, relX, needFocus, ok := mg.hitChartAndRelX(adjustedX, row, col, dims)
+	if !ok || chart == nil {
 		return
 	}
-	chart := mg.currentPage[row][col]
-
-	chartStartX := col * dims.CellWWithPadding
-	graphStartX := chartStartX + 1
-	if chart.YStep() > 0 {
-		graphStartX += chart.Origin().X + 1
-	}
-	relativeMouseX := adjustedX - graphStartX
-	needFocus := mg.focus.Type != FocusMainChart ||
-		mg.focus.Row != row || mg.focus.Col != col
-	mg.mu.RUnlock()
-
-	if relativeMouseX < 0 || relativeMouseX >= chart.GraphWidth() {
+	if relX < 0 || relX >= chart.GraphWidth() {
 		return
 	}
-
-	// Focus the chart when zooming (if not already focused).
 	if needFocus {
 		mg.clearFocus()
 		mg.setFocus(row, col)
 	}
 
-	direction := "out"
+	dir := "out"
 	if wheelUp {
-		direction = "in"
+		dir = "in"
 	}
-	chart.HandleZoom(direction, relativeMouseX)
+	chart.HandleZoom(dir, relX)
 	chart.DrawIfNeeded()
 }
 
@@ -580,4 +563,148 @@ func (mg *MetricsGrid) IsFiltering() bool {
 // FilterQuery returns the current filter pattern.
 func (mg *MetricsGrid) FilterQuery() string {
 	return mg.filter.Query()
+}
+
+// hitChartAndRelX returns the chart under (row, col) on the grid
+// with relative graph-local X.
+//
+// needFocus is true if this chart differs from current focus.
+// ok is false if row/col doesn't map to a visible chart.
+func (mg *MetricsGrid) hitChartAndRelX(
+	adjustedX, row, col int,
+	dims GridDims,
+) (chart *EpochLineChart, relX int, needFocus, ok bool) {
+	size := mg.effectiveGridSize()
+
+	mg.mu.RLock()
+	defer mg.mu.RUnlock()
+
+	if row < 0 || row >= size.Rows || col < 0 || col >= size.Cols ||
+		row >= len(mg.currentPage) || col >= len(mg.currentPage[row]) {
+		return nil, 0, false, false
+	}
+	chart = mg.currentPage[row][col]
+	if chart == nil {
+		return nil, 0, false, false
+	}
+
+	chartStartX := col * dims.CellWWithPadding
+	graphStartX := chartStartX + 1
+	if chart.YStep() > 0 {
+		graphStartX += chart.Origin().X + 1
+	}
+	relX = adjustedX - graphStartX
+
+	needFocus = mg.focus.Type != FocusMainChart || mg.focus.Row != row || mg.focus.Col != col
+	return chart, relX, needFocus, true
+}
+
+// StartInspection focuses the chart and begins inspection if inside the graph.
+//
+// If synced==true (Alt+right-press), a synchronized inspection session starts:
+// the anchor X from the focused chart is broadcast to all visible charts.
+func (mg *MetricsGrid) StartInspection(adjustedX, row, col int, dims GridDims, synced bool) {
+	chart, relX, needFocus, ok := mg.hitChartAndRelX(adjustedX, row, col, dims)
+	if !ok || chart == nil {
+		return
+	}
+
+	// Clamp to graph bounds at the chart level, but ignore wildly out-of-bounds here.
+	if relX < -2 || relX > chart.GraphWidth()+1 {
+		return
+	}
+
+	if needFocus {
+		mg.clearFocus()
+		mg.setFocus(row, col)
+	}
+
+	chart.StartInspection(relX)
+	chart.DrawIfNeeded()
+
+	if synced {
+		mg.syncInspectActive = true
+		if x, _, active := chart.InspectionData(); active {
+			mg.broadcastInspectAtDataX(x)
+		}
+	}
+}
+
+// UpdateInspection updates the crosshair position on the focused chart.
+//
+// If a synchronized inspection session is active, broadcasts the position
+// to all visible charts on the current page.
+func (mg *MetricsGrid) UpdateInspection(adjustedX, row, col int, dims GridDims) {
+	chart, relX, _, ok := mg.hitChartAndRelX(adjustedX, row, col, dims)
+	if !ok || chart == nil || !chart.IsInspecting() {
+		return
+	}
+
+	chart.StartInspection(relX)
+	chart.DrawIfNeeded()
+
+	if mg.syncInspectActive {
+		if x, _, active := chart.InspectionData(); active {
+			mg.broadcastInspectAtDataX(x)
+		}
+	}
+}
+
+// EndInspection clears inspection mode.
+//
+// If a synchronized session is active, clears inspection on all visible charts;
+// otherwise clears only the focused chart.
+func (mg *MetricsGrid) EndInspection() {
+	if mg.syncInspectActive {
+		mg.broadcastEndInspection()
+		mg.syncInspectActive = false
+		return
+	}
+
+	if mg.focus.Type != FocusMainChart || mg.focus.Row < 0 || mg.focus.Col < 0 {
+		return
+	}
+	mg.mu.RLock()
+	var chart *EpochLineChart
+	if mg.focus.Row < len(mg.currentPage) &&
+		mg.focus.Col < len(mg.currentPage[mg.focus.Row]) {
+		chart = mg.currentPage[mg.focus.Row][mg.focus.Col]
+	}
+	mg.mu.RUnlock()
+	if chart != nil {
+		chart.EndInspection()
+		chart.DrawIfNeeded()
+	}
+}
+
+// broadcastInspectAtDataX applies InspectAtDataX to all visible charts on the current page.
+func (mg *MetricsGrid) broadcastInspectAtDataX(anchorX float64) {
+	mg.mu.RLock()
+	page := mg.currentPage
+	mg.mu.RUnlock()
+
+	for r := range page {
+		for c := range page[r] {
+			if ch := page[r][c]; ch != nil {
+				ch.InspectAtDataX(anchorX)
+				ch.DrawIfNeeded()
+			}
+		}
+	}
+}
+
+// broadcastEndInspection clears inspection on all visible charts on the current page.
+func (mg *MetricsGrid) broadcastEndInspection() {
+	mg.mu.RLock()
+	page := mg.currentPage
+	mg.mu.RUnlock()
+
+	for r := range page {
+		for c := range page[r] {
+			if ch := page[r][c]; ch != nil && ch.IsInspecting() {
+				ch.EndInspection()
+				ch.DrawIfNeeded()
+			}
+		}
+	}
 }

--- a/core/internal/leet/metricsgrid_test.go
+++ b/core/internal/leet/metricsgrid_test.go
@@ -1,6 +1,7 @@
 package leet_test
 
 import (
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ func newMetricsGrid(t *testing.T, rows, cols, width, height int, focus *leet.Foc
 	require.NoError(t, cfg.SetMetricsCols(cols))
 
 	if focus == nil {
-		focus = &leet.Focus{}
+		focus = leet.NewFocus()
 	}
 
 	grid := leet.NewMetricsGrid(cfg, focus, logger)
@@ -146,4 +147,121 @@ func TestMetricsGrid_PreservesFocusAcrossHistoryUpdates(t *testing.T) {
 	}
 	grid.ProcessHistory(d)
 	require.Equal(t, "alpha", f.Title, "expected focus restored to previous title")
+}
+
+// computeAdjustedX builds a grid-absolute X such that relX within the chart equals wantRelX.
+func computeAdjustedX(
+	t *testing.T,
+	chart *leet.EpochLineChart,
+	cellWWithPad int,
+	col, wantRelX int,
+) int {
+	t.Helper()
+	chartStartX := col * cellWWithPad
+	graphStartX := chartStartX + 1
+	if chart.YStep() > 0 {
+		graphStartX += chart.Origin().X + 1
+	}
+	return graphStartX + wantRelX
+}
+
+func TestMetricsGrid_Inspection_FocusedOnly(t *testing.T) {
+	w, h := 240, 60
+	grid := newMetricsGrid(t, 1, 2, w, h, nil)
+
+	// Two charts: both share the same view initially.
+	hist := map[string]leet.MetricData{
+		"alpha": {X: []float64{0, 1, 2, 3, 4, 5}, Y: []float64{10, 20, 30, 40, 50, 60}},
+		"beta":  {X: []float64{0, 1, 2, 3, 4, 5}, Y: []float64{100, 200, 300, 400, 500, 600}},
+	}
+	created := grid.ProcessHistory(hist)
+	require.True(t, created)
+	grid.UpdateDimensions(w, h)
+
+	// Get dimensions + target chart to compute adjustedX.
+	dims := grid.CalculateChartDimensions(w, h)
+	ch0 := grid.TestChartAt(0, 0)
+	require.NotNil(t, ch0)
+
+	// Choose anchor X=3 -> rel pixel.
+	relPX := int(math.Round((3.0 - ch0.ViewMinX()) / (ch0.ViewMaxX() - ch0.ViewMinX()) * float64(ch0.GraphWidth())))
+	adjX := computeAdjustedX(t, ch0, dims.CellWWithPadding, 0, relPX)
+
+	// Start non-synced inspection on (row=0,col=0).
+	grid.StartInspection(adjX, 0, 0, dims, false /*synced*/)
+	require.True(t, ch0.IsInspecting())
+	require.False(t, grid.TestChartAt(0, 1).IsInspecting(), "other chart should not be inspecting")
+
+	// Move to X=5; only the focused chart updates.
+	relPX = int(math.Round((5.0 - ch0.ViewMinX()) / (ch0.ViewMaxX() - ch0.ViewMinX()) * float64(ch0.GraphWidth())))
+	adjX = computeAdjustedX(t, ch0, dims.CellWWithPadding, 0, relPX)
+	grid.UpdateInspection(adjX, 0, 0, dims)
+
+	x0, _, active := ch0.InspectionData()
+	require.True(t, active)
+	require.InDelta(t, 5.0, x0, 1e-6)
+	require.False(t, grid.TestChartAt(0, 1).IsInspecting())
+
+	// End clears only the focused one.
+	grid.EndInspection()
+	require.False(t, ch0.IsInspecting())
+}
+
+func TestMetricsGrid_Inspection_Synchronized_BroadcastAndEnd(t *testing.T) {
+	w, h := 240, 60
+	grid := newMetricsGrid(t, 1, 2, w, h, nil)
+
+	// alpha has dense steps, beta has sparse to exercise nearestIndex tie-breaks.
+	hist := map[string]leet.MetricData{
+		"alpha": {
+			X: []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			Y: []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		"beta": {
+			X: []float64{0, 2, 4, 6, 8},
+			Y: []float64{20, 40, 60, 80, 100},
+		},
+	}
+	require.True(t, grid.ProcessHistory(hist))
+	grid.UpdateDimensions(w, h)
+
+	dims := grid.CalculateChartDimensions(w, h)
+
+	chA := grid.TestChartAt(0, 0)
+	chB := grid.TestChartAt(0, 1)
+	require.NotNil(t, chA)
+	require.NotNil(t, chB)
+
+	// Start synchronized at X=3 on alpha.
+	relPX := int(math.Round((3.0 - chA.ViewMinX()) / (chA.ViewMaxX() - chA.ViewMinX()) * float64(chA.GraphWidth())))
+	adjX := computeAdjustedX(t, chA, dims.CellWWithPadding, 0, relPX)
+	grid.StartInspection(adjX, 0, 0, dims /*synced*/, true)
+	require.True(t, grid.TestSyncInspectActive())
+
+	// Both charts should now be inspecting near the anchor X.
+	xA, _, aActive := chA.InspectionData()
+	xB, _, bActive := chB.InspectionData()
+	require.True(t, aActive)
+	require.True(t, bActive)
+	require.InDelta(t, 3.0, xA, 1e-6) // alpha matches anchor exactly
+
+	// For beta (X: {0,2,4,6,8}), nearest to 3 is a tie (2 and 4). Implementation picks the lower (2).
+	require.InDelta(t, 2.0, xB, 1e-6)
+
+	// Move synchronized anchor to ~X=7.
+	relPX = int(math.Round((7.0 - chA.ViewMinX()) / (chA.ViewMaxX() - chA.ViewMinX()) * float64(chA.GraphWidth())))
+	adjX = computeAdjustedX(t, chA, dims.CellWWithPadding, 0, relPX)
+	grid.UpdateInspection(adjX, 0, 0, dims)
+
+	xA, _, _ = chA.InspectionData()
+	xB, _, _ = chB.InspectionData()
+	require.InDelta(t, 7.0, xA, 1e-6)
+	// For beta, nearest to 7 is 6 (tie 6/8 -> lower).
+	require.InDelta(t, 6.0, xB, 1e-6)
+
+	// End synchronized session should clear both.
+	grid.EndInspection()
+	require.False(t, grid.TestSyncInspectActive())
+	require.False(t, chA.IsInspecting())
+	require.False(t, chB.IsInspecting())
 }

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -231,29 +231,22 @@ func (m *Model) handleHelp(msg tea.Msg) (bool, tea.Cmd) {
 func (m *Model) dispatch(msg tea.Msg) []tea.Cmd {
 	switch t := msg.(type) {
 	case InitMsg:
-		return m.onInit(t)
+		return m.handleInit(t)
 	case ChunkedBatchMsg:
-		return m.onChunkedBatch(t)
+		return m.handleChunkedBatch(t)
 	case BatchedRecordsMsg:
-		return m.onBatched(t)
+		return m.handleBatched(t)
 	case HeartbeatMsg:
-		return m.onHeartbeat()
+		return m.handleHeartbeat()
 	case FileChangedMsg:
-		return m.onFileChange()
-	case tea.KeyMsg:
-		_, cmd := m.handleKeyMsg(t)
-		if cmd != nil {
-			return []tea.Cmd{cmd}
-		}
-	case tea.MouseMsg, tea.WindowSizeMsg, LeftSidebarAnimationMsg, RightSidebarAnimationMsg:
-		_, cmd := m.handleOther(msg)
-		if cmd != nil {
-			return []tea.Cmd{cmd}
-		}
+		return m.handleFileChange()
+	case tea.WindowSizeMsg:
+		m.handleWindowResize(t)
+	case LeftSidebarAnimationMsg, RightSidebarAnimationMsg:
+		return m.handleSidebarAnimation(msg)
 	default:
 		// History/Run/Summary/Stats/SystemInfo/FileComplete/Error
-		_, cmd := m.processRecordMsg(msg)
-		if cmd != nil {
+		if _, cmd := m.handleRecordMsg(msg); cmd != nil {
 			return []tea.Cmd{cmd}
 		}
 	}

--- a/core/internal/leet/model_update_test.go
+++ b/core/internal/leet/model_update_test.go
@@ -24,7 +24,7 @@ func TestProcessRecordMsg_Run_Summary_System_FileComplete(t *testing.T) {
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 50})
 
 	model := m.(*leet.Model)
-	model.TestProcessRecordMsg(leet.RunMsg{
+	model.TestHandleRecordMsg(leet.RunMsg{
 		ID:          "run_123",
 		DisplayName: "cool-run",
 		Project:     "proj",
@@ -33,15 +33,15 @@ func TestProcessRecordMsg_Run_Summary_System_FileComplete(t *testing.T) {
 	require.Equal(t, "cool-run", model.TestRunDisplayName())
 	require.Equal(t, "proj", model.TestRunProject())
 
-	model.TestProcessRecordMsg(leet.SystemInfoMsg{
+	model.TestHandleRecordMsg(leet.SystemInfoMsg{
 		Record: &spb.EnvironmentRecord{},
 	})
 
-	model.TestProcessRecordMsg(leet.SummaryMsg{
+	model.TestHandleRecordMsg(leet.SummaryMsg{
 		Summary: []*spb.SummaryRecord{{}},
 	})
 
-	model.TestProcessRecordMsg(leet.FileCompleteMsg{ExitCode: 0})
+	model.TestHandleRecordMsg(leet.FileCompleteMsg{ExitCode: 0})
 	require.Equal(t, leet.RunStateFinished, model.TestRunState())
 }
 

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -229,6 +229,12 @@ var (
 	axisStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 
 	labelStyle = lipgloss.NewStyle().Foreground(colorText)
+
+	inspectionLineStyle = lipgloss.NewStyle().Foreground(colorSubtle)
+
+	inspectionLegendStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.AdaptiveColor{Light: "#111111", Dark: "#EEEEEE"}).
+				Background(lipgloss.AdaptiveColor{Light: "#EEEEEE", Dark: "#333333"})
 )
 
 // Status bar styles.
@@ -288,7 +294,7 @@ const AnimationFrame = AnimationDuration / AnimationSteps
 
 // Help screen styles.
 var (
-	helpKeyStyle = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).Width(20)
+	helpKeyStyle = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).Width(24)
 
 	helpDescStyle = lipgloss.NewStyle().Foreground(colorText)
 

--- a/core/internal/leet/systemmetricsgrid_test.go
+++ b/core/internal/leet/systemmetricsgrid_test.go
@@ -99,7 +99,7 @@ func TestSystemMetricsGrid_NavigateWithPowerMetrics(t *testing.T) {
 	require.Equal(t, 4, grid.ChartCount())
 
 	// Test navigation forward
-	initialCharts := grid.CurrentPage()
+	initialCharts := grid.TestCurrentPage()
 	var firstPageChart *leet.TimeSeriesLineChart
 	if initialCharts[0][0] != nil {
 		firstPageChart = initialCharts[0][0]
@@ -108,7 +108,7 @@ func TestSystemMetricsGrid_NavigateWithPowerMetrics(t *testing.T) {
 	grid.Navigate(1) // Move to page 2
 	grid.LoadCurrentPage()
 
-	secondPageCharts := grid.CurrentPage()
+	secondPageCharts := grid.TestCurrentPage()
 	var secondPageChart *leet.TimeSeriesLineChart
 	if secondPageCharts[0][0] != nil {
 		secondPageChart = secondPageCharts[0][0]

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -50,9 +50,9 @@ func (m *Model) TestGetLeftSidebar() *LeftSidebar {
 	return m.leftSidebar
 }
 
-// TestProcessRecordMsg processes a record message
-func (m *Model) TestProcessRecordMsg(msg tea.Msg) (*Model, tea.Cmd) {
-	return m.processRecordMsg(msg)
+// TestHandleRecordMsg processes a record message
+func (m *Model) TestHandleRecordMsg(msg tea.Msg) (*Model, tea.Cmd) {
+	return m.handleRecordMsg(msg)
 }
 
 // TestHandleChartGridClick handles a click on the main chart grid
@@ -82,7 +82,29 @@ func (c *TimeSeriesLineChart) TestSeriesCount() int {
 	return len(c.series)
 }
 
-// CurrentPage returns the current grid of charts.
-func (g *SystemMetricsGrid) CurrentPage() [][]*TimeSeriesLineChart {
+// TestCurrentPage returns the current grid of charts.
+func (g *SystemMetricsGrid) TestCurrentPage() [][]*TimeSeriesLineChart {
 	return g.currentPage
+}
+
+// TestInspectionMouseX exposes the current overlay pixel X for tests.
+// This keeps production APIs clean while allowing focused assertions.
+func (c *EpochLineChart) TestInspectionMouseX() (int, bool) {
+	return c.inspection.MouseX, c.inspection.Active
+}
+
+// TestChartAt returns the chart at (row, col) on the current page (or nil).
+func (mg *MetricsGrid) TestChartAt(row, col int) *EpochLineChart {
+	mg.mu.RLock()
+	defer mg.mu.RUnlock()
+	if row < 0 || row >= len(mg.currentPage) ||
+		col < 0 || col >= len(mg.currentPage[row]) {
+		return nil
+	}
+	return mg.currentPage[row][col]
+}
+
+// TestSyncInspectActive exposes the synchronized inspection flag for tests.
+func (mg *MetricsGrid) TestSyncInspectActive() bool {
+	return mg.syncInspectActive
 }


### PR DESCRIPTION
## Description

Implements a chart inspection feature that shows a crosshair and displays the exact X/Y values when right-clicking on charts.

<img width="516" height="290" alt="image" src="https://github.com/user-attachments/assets/3596eb2a-8dfe-434f-9a27-ef0987680af8" />

If right mouse button is pressed while holding the Alt key, a sync inspection across the charts on the current page is activated:

<img width="1527" height="903" alt="image" src="https://github.com/user-attachments/assets/e8bf3570-063b-41ae-8cc8-dac46b19a155" />

UX Qs for the reviewer:
- Should the Alt + Right button behavior be the only available option (without Alt)? I'm only trying to cut on potentially unnecessary CPU cycles for binary searches and redraws of all the charts on the page, but that is the behavior in our web UI (on mouse over):
<img width="1644" height="629" alt="image" src="https://github.com/user-attachments/assets/189c4d4d-ca7d-406b-afe5-d75da904fbd9" />

- In synchronized mode, if an X value is outside of the current view (when zoomed in), it would be displayed (either on the left or right). If the X value is absent for a chart or it is outside the X domain, the closest value will be picked and displayed. I like it this way, but looking for validation.
