### PR TITLE
chore(leet): use medium shade block as cursor for input

### DIFF
--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -442,9 +442,10 @@ func (m *Model) buildOverviewFilterStatus() string {
 		filterInfo = "no matches"
 	}
 	return fmt.Sprintf(
-		"Overview filter (%s): %s_ [%s] (Enter to apply • Tab to toggle mode)",
+		"Overview filter (%s): %s%s [%s] (Enter to apply • Tab to toggle mode)",
 		m.leftSidebar.FilterMode().String(),
 		m.leftSidebar.FilterQuery(),
+		string(mediumShadeBlock),
 		filterInfo,
 	)
 }
@@ -454,9 +455,10 @@ func (m *Model) buildOverviewFilterStatus() string {
 // Should be guarded by the caller's check that filter input is active.
 func (m *Model) buildMetricsFilterStatus() string {
 	return fmt.Sprintf(
-		"Filter (%s): %s_ [%d/%d] (Enter to apply • Tab to toggle mode)",
+		"Filter (%s): %s%s [%d/%d] (Enter to apply • Tab to toggle mode)",
 		m.metricsGrid.FilterMode().String(),
 		m.metricsGrid.FilterQuery(),
+		string(mediumShadeBlock),
 		m.metricsGrid.FilteredChartCount(), m.metricsGrid.ChartCount())
 }
 

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -63,6 +63,9 @@ const (
 
 	// unicodeSpace is the regular whitespace.
 	unicodeSpace rune = '\u0020'
+
+	// mediumShadeBlock is a medium-shaded block.
+	mediumShadeBlock rune = '\u2592' // ▒
 )
 
 // WANDB brand colors.


### PR DESCRIPTION
Description
-----------
Replaces the underscore cursor with a medium-shaded block character (▒) in filter input in the status bar.

Looks better IMO:
<img width="716" height="143" alt="image" src="https://github.com/user-attachments/assets/86712cdf-2bdb-49f9-836b-41be52ca9aae" />
