### PR TITLE
chore: enable golines formatter

### DIFF
--- a/core/.golangci.yaml
+++ b/core/.golangci.yaml
@@ -5,3 +5,8 @@ linters:
     # https://golangci-lint.run/usage/false-positives/#preset-std-error-handling
     presets:
       - std-error-handling
+
+formatters:
+  enable:
+    - gofmt
+    - golines

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -60,10 +60,16 @@ func serviceMain() int {
 		"Specifies the log level to use for logging. -4: debug, 0: info, 4: warn, 8: error.")
 	disableAnalytics := flag.Bool("no-observability", false,
 		"Disables observability features such as metrics and logging analytics.")
-	enableOsPidShutdown := flag.Bool("os-pid-shutdown", false,
-		"Enables automatic server shutdown when the external process identified by the PID terminates.")
-	enableDCGMProfiling := flag.Bool("enable-dcgm-profiling", false,
-		"Enables collection of profiling metrics for Nvidia GPUs using DCGM. Requires a running `nvidia-dcgm` service.")
+	enableOsPidShutdown := flag.Bool(
+		"os-pid-shutdown",
+		false,
+		"Enables automatic server shutdown when the external process identified by the PID terminates.",
+	)
+	enableDCGMProfiling := flag.Bool(
+		"enable-dcgm-profiling",
+		false,
+		"Enables collection of profiling metrics for Nvidia GPUs using DCGM. Requires a running `nvidia-dcgm` service.",
+	)
 	listenOnLocalhost := flag.Bool("listen-on-localhost", false,
 		"Whether to listen on a localhost socket. This is less secure than"+
 			" Unix sockets, but some clients do not support them"+
@@ -165,17 +171,21 @@ func leetMain(args []string) int {
 		"Disables observability features such as metrics and logging analytics.")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "wandb-core leet - Lightweight Experiment Exploration Tool\n\n")
-		fmt.Fprintf(os.Stderr, "A terminal UI for viewing your W&B runs locally.\n\n")
-		fmt.Fprintf(os.Stderr, "Usage:\n")
-		fmt.Fprintf(os.Stderr, "  wandb-core leet [flags] <wandb-file>\n")
-		fmt.Fprintf(os.Stderr, "Arguments:\n")
-		fmt.Fprintf(os.Stderr, "  <wandb-file>       Path to the .wandb file of a W&B run.\n")
-		fmt.Fprintf(os.Stderr, "                     Example: \n")
-		fmt.Fprintf(os.Stderr, "                       /path/to/.wandb/run-20250731_170606-iazb7i1k/run-iazb7i1k.wandb\n\n")
-		fmt.Fprintf(os.Stderr, "Options:\n")
-		fmt.Fprintf(os.Stderr, "  -h, --help         Show this help message\n\n")
-		fmt.Fprintf(os.Stderr, "Flags:\n")
+		fmt.Fprintf(os.Stderr, `wandb-core leet - Lightweight Experiment Exploration Tool
+A terminal UI for viewing your W&B runs locally.
+
+Usage:
+  wandb-core leet [flags] <wandb-file>
+Arguments:
+  <wandb-file>       Path to the .wandb file of a W&B run.
+                     Example:
+                       /path/to/.wandb/run-20250731_170606-iazb7i1k/run-iazb7i1k.wandb
+
+Options:
+  -h, --help         Show this help message
+
+Flags:
+`)
 		fs.PrintDefaults()
 	}
 
@@ -202,7 +212,11 @@ func leetMain(args []string) int {
 	logWriter := io.Discard
 	// TODO: Create a log file not only if debug logging is requested.
 	if *logLevel == -4 {
-		loggerFile, err := os.OpenFile("wandb-leet.debug.log", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		loggerFile, err := os.OpenFile(
+			"wandb-leet.debug.log",
+			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+			0644,
+		)
 		if err != nil {
 			fmt.Println("fatal:", err)
 			return exitCodeErrorInternal

--- a/core/internal/api/credentials.go
+++ b/core/internal/api/credentials.go
@@ -271,7 +271,10 @@ func (c *oauth2CredentialProvider) trySaveCredentialsToFile(credentials Credenti
 // in OAuth RFC 7523. The access token is then returned with its expiration time.
 func (c *oauth2CredentialProvider) fetchAccessToken() (accessTokenInfo, error) {
 	url := fmt.Sprintf("%s/oidc/token", c.baseURL)
-	data := fmt.Sprintf("grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=%s", c.identityToken)
+	data := fmt.Sprintf(
+		"grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=%s",
+		c.identityToken,
+	)
 	req, err := http.NewRequest("POST", url, strings.NewReader(data))
 	if err != nil {
 		return accessTokenInfo{}, err

--- a/core/internal/clients/backoff.go
+++ b/core/internal/clients/backoff.go
@@ -21,7 +21,11 @@ import (
 // A random jitter is added to the calculated duration, unless the calculated
 // duration is >= max.
 // The jitter is at most 25% of the calculated duration.
-func ExponentialBackoffWithJitter(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+func ExponentialBackoffWithJitter(
+	min, max time.Duration,
+	attemptNum int,
+	resp *http.Response,
+) time.Duration {
 	// based on go-retryablehttp's DefaultBackoff
 	addJitter := func(duration time.Duration) time.Duration {
 		jitter := SecondsToDuration(rand.Float64() * 0.25 * DurationToSeconds(duration))

--- a/core/internal/clients/backoff_test.go
+++ b/core/internal/clients/backoff_test.go
@@ -46,8 +46,18 @@ func TestExponentialBackoffWithJitter_HTTP429(t *testing.T) {
 	expectedMin := time.Duration(retryAfter) * time.Second
 	expectedMax := expectedMin + time.Duration(0.25*float64(expectedMin))
 
-	assert.GreaterOrEqual(t, backoff, expectedMin, "Backoff should be greater than or equal to Retry-After")
-	assert.LessOrEqual(t, backoff, expectedMax, "Backoff should be less than or equal to Retry-After plus jitter")
+	assert.GreaterOrEqual(
+		t,
+		backoff,
+		expectedMin,
+		"Backoff should be greater than or equal to Retry-After",
+	)
+	assert.LessOrEqual(
+		t,
+		backoff,
+		expectedMax,
+		"Backoff should be less than or equal to Retry-After plus jitter",
+	)
 }
 
 func TestExponentialBackoffWithJitter_MaxBackoffLimit(t *testing.T) {

--- a/core/internal/clients/retry_policy_test.go
+++ b/core/internal/clients/retry_policy_test.go
@@ -18,12 +18,42 @@ func TestDefaultRetryPolicy(t *testing.T) {
 		shouldRetry bool
 		errMsg      string
 	}{
-		{"BadRequest", http.StatusBadRequest, false, "the server responded with an error. (Error 400: Bad Request)"},
-		{"Conflict", http.StatusConflict, false, "the server responded with an error. (Error 409: Conflict)"},
-		{"Unauthorized", http.StatusUnauthorized, false, "the API key you provided is either invalid or missing. (Error 401: Unauthorized)"},
-		{"Forbidden", http.StatusForbidden, false, "you don't have permission to access this resource. (Error 403: Forbidden)"},
-		{"NotFound", http.StatusNotFound, false, "the resource you requested could not be found. (Error 404: Not Found)"},
-		{"Other4xxError", http.StatusTeapot, true, "the server responded with an error. (Error 418: I'm a teapot)"},
+		{
+			"BadRequest",
+			http.StatusBadRequest,
+			false,
+			"the server responded with an error. (Error 400: Bad Request)",
+		},
+		{
+			"Conflict",
+			http.StatusConflict,
+			false,
+			"the server responded with an error. (Error 409: Conflict)",
+		},
+		{
+			"Unauthorized",
+			http.StatusUnauthorized,
+			false,
+			"the API key you provided is either invalid or missing. (Error 401: Unauthorized)",
+		},
+		{
+			"Forbidden",
+			http.StatusForbidden,
+			false,
+			"you don't have permission to access this resource. (Error 403: Forbidden)",
+		},
+		{
+			"NotFound",
+			http.StatusNotFound,
+			false,
+			"the resource you requested could not be found. (Error 404: Not Found)",
+		},
+		{
+			"Other4xxError",
+			http.StatusTeapot,
+			true,
+			"the server responded with an error. (Error 418: I'm a teapot)",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/core/internal/data_types/data_types_test.go
+++ b/core/internal/data_types/data_types_test.go
@@ -65,8 +65,10 @@ func TestGenerateTypeRepresentation(t *testing.T) {
 						"b": {
 							Name: data_types.ListTypeName,
 							Params: &data_types.ListType{
-								ElementType: data_types.TypeRepresentation{Name: data_types.NumberTypeName},
-								Length:      3,
+								ElementType: data_types.TypeRepresentation{
+									Name: data_types.NumberTypeName,
+								},
+								Length: 3,
 							},
 						},
 					},
@@ -91,8 +93,10 @@ func TestGenerateTypeRepresentation(t *testing.T) {
 								ElementType: data_types.TypeRepresentation{
 									Name: data_types.ListTypeName,
 									Params: &data_types.ListType{
-										ElementType: data_types.TypeRepresentation{Name: data_types.NumberTypeName},
-										Length:      2,
+										ElementType: data_types.TypeRepresentation{
+											Name: data_types.NumberTypeName,
+										},
+										Length: 2,
 									},
 								},
 								Length: 2,

--- a/core/internal/filetransfer/file_transfer_azure.go
+++ b/core/internal/filetransfer/file_transfer_azure.go
@@ -32,18 +32,38 @@ const (
 )
 
 type AzureBlobClient interface {
-	DownloadFile(ctx context.Context, destination *os.File, options *blob.DownloadFileOptions) (int64, error)
-	GetProperties(ctx context.Context, options *blob.GetPropertiesOptions) (blob.GetPropertiesResponse, error)
+	DownloadFile(
+		ctx context.Context,
+		destination *os.File,
+		options *blob.DownloadFileOptions,
+	) (int64, error)
+	GetProperties(
+		ctx context.Context,
+		options *blob.GetPropertiesOptions,
+	) (blob.GetPropertiesResponse, error)
 	WithVersionID(versionId string) (*blob.Client, error)
 }
 
 type AzureAccountClient interface {
-	DownloadFile(ctx context.Context, containerName string, blobName string, destination *os.File, options *azblob.DownloadFileOptions) (int64, error)
-	NewListBlobsFlatPager(containerName string, options *azblob.ListBlobsFlatOptions) *runtime.Pager[azblob.ListBlobsFlatResponse]
+	DownloadFile(
+		ctx context.Context,
+		containerName string,
+		blobName string,
+		destination *os.File,
+		options *azblob.DownloadFileOptions,
+	) (int64, error)
+	NewListBlobsFlatPager(
+		containerName string,
+		options *azblob.ListBlobsFlatOptions,
+	) *runtime.Pager[azblob.ListBlobsFlatResponse]
 }
 
 type AzureBlockBlobClient interface {
-	UploadStream(ctx context.Context, body io.Reader, options *blockblob.UploadStreamOptions) (blockblob.UploadStreamResponse, error)
+	UploadStream(
+		ctx context.Context,
+		body io.Reader,
+		options *blockblob.UploadStreamOptions,
+	) (blockblob.UploadStreamResponse, error)
 }
 
 // AzureClientsMap is a map of account URLs/container names to client objects.
@@ -230,7 +250,10 @@ func (ft *AzureFileTransfer) Upload(task *DefaultUploadTask) error {
 }
 
 // uploadBlob uploads the given request body to a blob at task.Url.
-func (ft *AzureFileTransfer) uploadBlob(task *DefaultUploadTask, requestBody io.Reader) (*http.Response, error) {
+func (ft *AzureFileTransfer) uploadBlob(
+	task *DefaultUploadTask,
+	requestBody io.Reader,
+) (*http.Response, error) {
 	clientOptions := blockblob.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Retry: policy.RetryOptions{

--- a/core/internal/filetransfer/file_transfer_gcs.go
+++ b/core/internal/filetransfer/file_transfer_gcs.go
@@ -163,7 +163,8 @@ func (ft *GCSFileTransfer) downloadFiles(
 			if err != nil {
 				if errors.Is(err, ErrObjectIsDirectory) {
 					ft.logger.Debug(
-						"GCSFileTransfer: Download: skipping reference because it seems to be a folder",
+						"GCSFileTransfer: Download: skipping reference because"+
+							" it seems to be a folder",
 						"bucket", bucket.BucketName(),
 						"object", objectName,
 					)

--- a/core/internal/filetransfer/file_transfer_s3.go
+++ b/core/internal/filetransfer/file_transfer_s3.go
@@ -17,10 +17,26 @@ import (
 )
 
 type S3Client interface {
-	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
-	GetObjectAttributes(ctx context.Context, params *s3.GetObjectAttributesInput, optFns ...func(*s3.Options)) (*s3.GetObjectAttributesOutput, error)
-	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
-	ListObjectVersions(ctx context.Context, params *s3.ListObjectVersionsInput, optFns ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error)
+	GetObject(
+		ctx context.Context,
+		params *s3.GetObjectInput,
+		optFns ...func(*s3.Options),
+	) (*s3.GetObjectOutput, error)
+	GetObjectAttributes(
+		ctx context.Context,
+		params *s3.GetObjectAttributesInput,
+		optFns ...func(*s3.Options),
+	) (*s3.GetObjectAttributesOutput, error)
+	ListObjectsV2(
+		ctx context.Context,
+		params *s3.ListObjectsV2Input,
+		optFns ...func(*s3.Options),
+	) (*s3.ListObjectsV2Output, error)
+	ListObjectVersions(
+		ctx context.Context,
+		params *s3.ListObjectVersionsInput,
+		optFns ...func(*s3.Options),
+	) (*s3.ListObjectVersionsOutput, error)
 }
 
 const maxS3Workers int = 500

--- a/core/internal/fileutil/files_test.go
+++ b/core/internal/fileutil/files_test.go
@@ -11,15 +11,27 @@ func TestSanitizeLinuxFilename(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"valid-filename", "valid-filename"},                         // Valid filename
-		{"file/with/slash", "file_with_slash"},                       // Slash replaced with underscore
-		{"file\x00with\x00null", "file_with_null"},                   // Null characters replaced with underscore
-		{"file with leading space ", "file with leading space"},      // Leading space trimmed
-		{" file with trailing space ", "file with trailing space"},   // Leading and trailing space trimmed
-		{"file....", "file"},                                         // Trailing dots trimmed
-		{"control\x07chars", "controlchars"},                         // Control characters removed
-		{"", ""},                                                     // Empty string
-		{" . ..hidden file.", ". ..hidden file"},                     // Leading dot treated as valid
+		{"valid-filename", "valid-filename"}, // Valid filename
+		{
+			"file/with/slash",
+			"file_with_slash",
+		}, // Slash replaced with underscore
+		{
+			"file\x00with\x00null",
+			"file_with_null",
+		}, // Null characters replaced with underscore
+		{"file with leading space ", "file with leading space"}, // Leading space trimmed
+		{
+			" file with trailing space ",
+			"file with trailing space",
+		}, // Leading and trailing space trimmed
+		{"file....", "file"},                 // Trailing dots trimmed
+		{"control\x07chars", "controlchars"}, // Control characters removed
+		{"", ""},                             // Empty string
+		{
+			" . ..hidden file.",
+			". ..hidden file",
+		}, // Leading dot treated as valid
 		{"filename....with....dots....", "filename....with....dots"}, // Internal dots preserved
 	}
 
@@ -38,15 +50,33 @@ func TestSanitizeWindowsFilename(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"valid-filename.txt", "valid-filename.txt"},                       // Valid filename
-		{"invalid<file>name", "invalid_file_name"},                         // Forbidden characters replaced
-		{"trailing space ", "trailing space"},                              // Trailing space trimmed
-		{"trailing.dot.", "trailing.dot"},                                  // Trailing dot trimmed
-		{"<:>?|*\"\\filename", "________filename"},                         // Multiple forbidden characters
-		{"CON", "CON_safe"},                                                // Reserved name (case-sensitive)
-		{"nul", "nul_safe"},                                                // Reserved name (case-insensitive)
-		{"COM1", "COM1_safe"},                                              // Reserved name
-		{"filename with trailing dots....", "filename with trailing dots"}, // Multiple trailing dots
+		{"valid-filename.txt", "valid-filename.txt"}, // Valid filename
+		{
+			"invalid<file>name",
+			"invalid_file_name",
+		}, // Forbidden characters replaced
+		{
+			"trailing space ",
+			"trailing space",
+		}, // Trailing space trimmed
+		{"trailing.dot.", "trailing.dot"}, // Trailing dot trimmed
+		{
+			"<:>?|*\"\\filename",
+			"________filename",
+		}, // Multiple forbidden characters
+		{
+			"CON",
+			"CON_safe",
+		}, // Reserved name (case-sensitive)
+		{
+			"nul",
+			"nul_safe",
+		}, // Reserved name (case-insensitive)
+		{"COM1", "COM1_safe"}, // Reserved name
+		{
+			"filename with trailing dots....",
+			"filename with trailing dots",
+		}, // Multiple trailing dots
 		{" ", ""},              // Only space
 		{".", ""},              // Only dot
 		{"AUX.log", "AUX.log"}, // Reserved name but with extension
@@ -57,7 +87,12 @@ func TestSanitizeWindowsFilename(t *testing.T) {
 		t.Run(test.input, func(t *testing.T) {
 			result := fileutil.SanitizeWindowsFilename(test.input)
 			if result != test.expected {
-				t.Errorf("SanitizeWindowsFilename(%q) = %q; want %q", test.input, result, test.expected)
+				t.Errorf(
+					"SanitizeWindowsFilename(%q) = %q; want %q",
+					test.input,
+					result,
+					test.expected,
+				)
 			}
 		})
 	}

--- a/core/internal/hashencode/hash.go
+++ b/core/internal/hashencode/hash.go
@@ -13,7 +13,8 @@ import (
 // base64 encoded string.
 func ComputeB64MD5(data []byte) string {
 	hasher := md5.New()
-	_, _ = hasher.Write(data) // hasher.Write can't fail; the returned values are just to implement io.Writer
+	// hasher.Write can't fail; the returned values are just to implement io.Writer
+	_, _ = hasher.Write(data)
 	return base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 }
 

--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -93,8 +93,14 @@ func NewConfigManager(path string, logger *observability.CoreLogger) *ConfigMana
 	cm := &ConfigManager{
 		path: path,
 		config: Config{
-			MetricsGrid:         GridConfig{Rows: DefaultMetricsGridRows, Cols: DefaultMetricsGridCols},
-			SystemGrid:          GridConfig{Rows: DefaultSystemGridRows, Cols: DefaultSystemGridCols},
+			MetricsGrid: GridConfig{
+				Rows: DefaultMetricsGridRows,
+				Cols: DefaultMetricsGridCols,
+			},
+			SystemGrid: GridConfig{
+				Rows: DefaultSystemGridRows,
+				Cols: DefaultSystemGridCols,
+			},
 			ColorScheme:         DefaultColorScheme,
 			SystemColorScheme:   DefaultSystemColorScheme,
 			SystemColorMode:     DefaultSystemColorMode,

--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -286,7 +286,10 @@ func (c *EpochLineChart) Draw() {
 	lb := sort.Search(len(c.xData), func(i int) bool { return c.xData[i] >= c.ViewMinX() })
 	// Add a tiny epsilon so a point exactly at viewMax isn't dropped by rounding.
 	eps := c.pixelEpsX(c.ViewMaxX() - c.ViewMinX())
-	ub := sort.Search(len(c.xData), func(i int) bool { return c.xData[i] > c.ViewMaxX()+eps }) // exclusive
+	ub := sort.Search(
+		len(c.xData),
+		func(i int) bool { return c.xData[i] > c.ViewMaxX()+eps },
+	) // exclusive
 	if ub-lb <= 0 {
 		c.dirty = false
 		return

--- a/core/internal/leet/epochlinechart_overlay_test.go
+++ b/core/internal/leet/epochlinechart_overlay_test.go
@@ -33,7 +33,10 @@ func TestEpochLineChart_DrawInspectionOverlay_RendersHairlineAndLegend_RightSide
 
 	// Inspect near X=5 -> expect legend to the right of the vertical hairline.
 	wantX := 5.0
-	px := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	px := int(math.Round(
+		(wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) *
+			float64(c.GraphWidth()),
+	))
 	c.StartInspection(px)
 	c.Draw()
 
@@ -77,7 +80,10 @@ func TestInspectAtDataX_SnapsToNearestAndPixel(t *testing.T) {
 	require.True(t, ok)
 
 	// Expected pixel for X=5
-	expectPX := int(math.Round((5.0 - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	expectPX := int(math.Round(
+		(5.0 - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) *
+			float64(c.GraphWidth()),
+	))
 	require.Equal(t, expectPX, px, "hairline should pixel-snap to the exact sample X")
 }
 
@@ -105,7 +111,10 @@ func TestInspection_RepositionsOnXDomainExpansion(t *testing.T) {
 
 	// Start inspecting at X=10 (middle of initial view).
 	wantX := 10.0
-	startPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	startPX := int(math.Round(
+		(wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) *
+			float64(c.GraphWidth()),
+	))
 	c.StartInspection(startPX)
 
 	// Sanity: active and anchored to ~X=10.
@@ -128,7 +137,10 @@ func TestInspection_RepositionsOnXDomainExpansion(t *testing.T) {
 	require.True(t, active1B)
 	require.InDelta(t, wantX, x1, 1e-9)
 
-	expectPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	expectPX := int(math.Round(
+		(wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) *
+			float64(c.GraphWidth()),
+	))
 	require.Equal(t, expectPX, newPX)
 	require.Less(t, newPX, oldPX, "overlay should move left as view widens from 20 to 30")
 }
@@ -147,7 +159,10 @@ func TestInspection_RepositionsOnResize(t *testing.T) {
 	require.InDelta(t, 30.0, c.ViewMaxX(), 1e-9)
 
 	wantX := 15.0
-	startPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	startPX := int(math.Round(
+		(wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) *
+			float64(c.GraphWidth()),
+	))
 	c.StartInspection(startPX)
 	oldPX, _ := c.TestInspectionMouseX()
 
@@ -160,7 +175,10 @@ func TestInspection_RepositionsOnResize(t *testing.T) {
 	require.True(t, a)
 	require.InDelta(t, wantX, x, 1e-9)
 
-	expectPX := int(math.Round((wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) * float64(c.GraphWidth())))
+	expectPX := int(math.Round(
+		(wantX - c.ViewMinX()) / (c.ViewMaxX() - c.ViewMinX()) *
+			float64(c.GraphWidth()),
+	))
 	require.Equal(t, expectPX, newPX)
 	require.Greater(t, newPX, oldPX, "overlay should move right when width doubles")
 }

--- a/core/internal/leet/leftsidebar_test.go
+++ b/core/internal/leet/leftsidebar_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 func TestSidebarFilter_AppliesAndClears(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	s := leet.NewLeftSidebar(cfg)
 
 	s.ProcessRunMsg(leet.RunMsg{
@@ -39,7 +42,10 @@ func TestSidebarFilter_AppliesAndClears(t *testing.T) {
 }
 
 func TestSidebar_SelectsFirstNonEmptySection(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	s := leet.NewLeftSidebar(cfg)
 
 	s.ProcessRunMsg(leet.RunMsg{
@@ -56,7 +62,10 @@ func TestSidebar_SelectsFirstNonEmptySection(t *testing.T) {
 }
 
 func TestSidebar_ConfirmSummaryFilterSelectsSummary(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	s := leet.NewLeftSidebar(cfg)
 
 	s.ProcessRunMsg(leet.RunMsg{
@@ -93,7 +102,10 @@ func expandSidebar(t *testing.T, s *leet.LeftSidebar, termWidth int, rightVisibl
 }
 
 func TestSidebar_CalculateSectionHeights_PaginationAndAllItems(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	_, _ = cfg.SetLeftSidebarVisible(false), cfg.SetRightSidebarVisible(false)
 	s := leet.NewLeftSidebar(cfg)
 	expandSidebar(t, s, 120, false)
@@ -138,7 +150,10 @@ func TestSidebar_CalculateSectionHeights_PaginationAndAllItems(t *testing.T) {
 }
 
 func TestSidebar_Navigation_SectionPageUpDown(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	_, _ = cfg.SetLeftSidebarVisible(false), cfg.SetRightSidebarVisible(false)
 	s := leet.NewLeftSidebar(cfg)
 	expandSidebar(t, s, 120, false)
@@ -191,7 +206,10 @@ func TestSidebar_Navigation_SectionPageUpDown(t *testing.T) {
 }
 
 func TestSidebar_ClearFilter_PublicPath(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	_, _ = cfg.SetLeftSidebarVisible(false), cfg.SetRightSidebarVisible(false)
 	s := leet.NewLeftSidebar(cfg)
 	expandSidebar(t, s, 120, false)
@@ -230,7 +248,10 @@ func TestSidebar_ClearFilter_PublicPath(t *testing.T) {
 }
 
 func TestSidebar_TruncateValue(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	_, _ = cfg.SetLeftSidebarVisible(false), cfg.SetRightSidebarVisible(false)
 	s := leet.NewLeftSidebar(cfg)
 	expandSidebar(t, s, 40, false) // clamps to SidebarMinWidth
@@ -256,7 +277,10 @@ func TestSidebar_TruncateValue(t *testing.T) {
 }
 
 func TestSidebar_Filter_RegexAndGlob(t *testing.T) {
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), observability.NewNoOpLogger())
+	cfg := leet.NewConfigManager(
+		filepath.Join(t.TempDir(), "config.json"),
+		observability.NewNoOpLogger(),
+	)
 	s := leet.NewLeftSidebar(cfg)
 
 	s.ProcessRunMsg(leet.RunMsg{

--- a/core/internal/leet/livestore.go
+++ b/core/internal/leet/livestore.go
@@ -75,7 +75,11 @@ func (lr *LiveStore) Read() (*spb.Record, error) {
 		if len(head) > 32 {
 			head = head[:32]
 		}
-		return nil, fmt.Errorf("livestore: unmarshal: %w (payload[0:32]=%s)", err, hex.EncodeToString(head))
+		return nil, fmt.Errorf(
+			"livestore: unmarshal: %w (payload[0:32]=%s)",
+			err,
+			hex.EncodeToString(head),
+		)
 	}
 	return msg, nil
 }

--- a/core/internal/leet/metricsgrid.go
+++ b/core/internal/leet/metricsgrid.go
@@ -334,7 +334,8 @@ func (mg *MetricsGrid) renderGridCell(row, col int, dims GridDims) string {
 	mg.mu.RLock()
 	defer mg.mu.RUnlock()
 
-	if row < len(mg.currentPage) && col < len(mg.currentPage[row]) && mg.currentPage[row][col] != nil {
+	if row < len(mg.currentPage) && col < len(mg.currentPage[row]) &&
+		mg.currentPage[row][col] != nil {
 		chart := mg.currentPage[row][col]
 		chartView := chart.View()
 

--- a/core/internal/leet/metricsgrid_test.go
+++ b/core/internal/leet/metricsgrid_test.go
@@ -11,7 +11,11 @@ import (
 	"github.com/wandb/wandb/core/internal/observability"
 )
 
-func newMetricsGrid(t *testing.T, rows, cols, width, height int, focus *leet.Focus) *leet.MetricsGrid {
+func newMetricsGrid(
+	t *testing.T,
+	rows, cols, width, height int,
+	focus *leet.Focus,
+) *leet.MetricsGrid {
 	t.Helper()
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
@@ -184,7 +188,10 @@ func TestMetricsGrid_Inspection_FocusedOnly(t *testing.T) {
 	require.NotNil(t, ch0)
 
 	// Choose anchor X=3 -> rel pixel.
-	relPX := int(math.Round((3.0 - ch0.ViewMinX()) / (ch0.ViewMaxX() - ch0.ViewMinX()) * float64(ch0.GraphWidth())))
+	relPX := int(math.Round(
+		(3.0 - ch0.ViewMinX()) / (ch0.ViewMaxX() - ch0.ViewMinX()) *
+			float64(ch0.GraphWidth()),
+	))
 	adjX := computeAdjustedX(t, ch0, dims.CellWWithPadding, 0, relPX)
 
 	// Start non-synced inspection on (row=0,col=0).
@@ -193,7 +200,10 @@ func TestMetricsGrid_Inspection_FocusedOnly(t *testing.T) {
 	require.False(t, grid.TestChartAt(0, 1).IsInspecting(), "other chart should not be inspecting")
 
 	// Move to X=5; only the focused chart updates.
-	relPX = int(math.Round((5.0 - ch0.ViewMinX()) / (ch0.ViewMaxX() - ch0.ViewMinX()) * float64(ch0.GraphWidth())))
+	relPX = int(math.Round(
+		(5.0 - ch0.ViewMinX()) / (ch0.ViewMaxX() - ch0.ViewMinX()) *
+			float64(ch0.GraphWidth()),
+	))
 	adjX = computeAdjustedX(t, ch0, dims.CellWWithPadding, 0, relPX)
 	grid.UpdateInspection(adjX, 0, 0, dims)
 
@@ -233,7 +243,10 @@ func TestMetricsGrid_Inspection_Synchronized_BroadcastAndEnd(t *testing.T) {
 	require.NotNil(t, chB)
 
 	// Start synchronized at X=3 on alpha.
-	relPX := int(math.Round((3.0 - chA.ViewMinX()) / (chA.ViewMaxX() - chA.ViewMinX()) * float64(chA.GraphWidth())))
+	relPX := int(math.Round(
+		(3.0 - chA.ViewMinX()) / (chA.ViewMaxX() - chA.ViewMinX()) *
+			float64(chA.GraphWidth()),
+	))
 	adjX := computeAdjustedX(t, chA, dims.CellWWithPadding, 0, relPX)
 	grid.StartInspection(adjX, 0, 0, dims /*synced*/, true)
 	require.True(t, grid.TestSyncInspectActive())
@@ -249,7 +262,10 @@ func TestMetricsGrid_Inspection_Synchronized_BroadcastAndEnd(t *testing.T) {
 	require.InDelta(t, 2.0, xB, 1e-6)
 
 	// Move synchronized anchor to ~X=7.
-	relPX = int(math.Round((7.0 - chA.ViewMinX()) / (chA.ViewMaxX() - chA.ViewMinX()) * float64(chA.GraphWidth())))
+	relPX = int(math.Round(
+		(7.0 - chA.ViewMinX()) / (chA.ViewMaxX() - chA.ViewMinX()) *
+			float64(chA.GraphWidth()),
+	))
 	adjX = computeAdjustedX(t, chA, dims.CellWWithPadding, 0, relPX)
 	grid.UpdateInspection(adjX, 0, 0, dims)
 

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -357,7 +357,9 @@ func (m *Model) ShouldRestart() bool {
 func (m *Model) logPanic(context string) {
 	if r := recover(); r != nil {
 		stackTrace := string(debug.Stack())
-		m.logger.CaptureError(fmt.Errorf("PANIC in %s: %v\nStack trace:\n%s", context, r, stackTrace))
+		m.logger.CaptureError(
+			fmt.Errorf("PANIC in %s: %v\nStack trace:\n%s", context, r, stackTrace),
+		)
 		panic(r)
 	}
 }

--- a/core/internal/leet/reader_test.go
+++ b/core/internal/leet/reader_test.go
@@ -259,7 +259,11 @@ func TestReadAvailableRecords_BatchProcessing(t *testing.T) {
 				{NestedKey: []string{"loss"}, ValueJson: fmt.Sprintf("%f", float64(i)*0.1)},
 			},
 		}
-		require.NoError(t, w.Write(&spb.Record{RecordType: &spb.Record_History{History: h}}), "write history %d", i)
+		require.NoError(t,
+			w.Write(&spb.Record{RecordType: &spb.Record_History{History: h}}),
+			"write history %d",
+			i,
+		)
 	}
 	w.Close()
 

--- a/core/internal/leet/rightsidebar_test.go
+++ b/core/internal/leet/rightsidebar_test.go
@@ -30,7 +30,10 @@ func TestRightSidebar_UpdateDimensions_ToggleAndViewHeader(t *testing.T) {
 	expandRightSidebar(t, rs, termWidth, false)
 
 	// Width should equal clamped int(termWidth * SidebarWidthRatio).
-	want := min(max(int(float64(termWidth)*leet.SidebarWidthRatio), leet.SidebarMinWidth), leet.SidebarMaxWidth)
+	want := min(
+		max(int(float64(termWidth)*leet.SidebarWidthRatio), leet.SidebarMinWidth),
+		leet.SidebarMaxWidth,
+	)
 	require.Equal(t, want, rs.Width())
 
 	// Ensure View renders header text once visible and grid ensured.

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -218,7 +218,9 @@ var (
 
 // Chart styles.
 var (
-	borderStyle = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(colorLayout)
+	borderStyle = lipgloss.NewStyle().
+			BorderStyle(lipgloss.RoundedBorder()).
+			BorderForeground(colorLayout)
 
 	titleStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 
@@ -247,9 +249,14 @@ var (
 
 // Left sidebar styles.
 var (
-	leftSidebarStyle              = lipgloss.NewStyle().Padding(0, 1)
-	leftSidebarBorderStyle        = lipgloss.NewStyle().Border(RightBorder).BorderForeground(colorLayout)
-	leftSidebarHeaderStyle        = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).MarginBottom(1)
+	leftSidebarStyle       = lipgloss.NewStyle().Padding(0, 1)
+	leftSidebarBorderStyle = lipgloss.NewStyle().
+				Border(RightBorder).
+				BorderForeground(colorLayout)
+	leftSidebarHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorSubheading).
+				MarginBottom(1)
 	leftSidebarSectionHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading)
 	leftSidebarSectionStyle       = lipgloss.NewStyle().Foreground(colorText).Bold(true)
 	leftSidebarKeyStyle           = lipgloss.NewStyle().Foreground(colorItemKey)
@@ -270,8 +277,11 @@ var (
 var (
 	rightSidebarStyle       = lipgloss.NewStyle().Padding(0, 1)
 	rightSidebarBorderStyle = lipgloss.NewStyle().Border(LeftBorder).BorderForeground(colorLayout)
-	rightSidebarHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(colorSubheading).MarginLeft(1)
-	LeftBorder              = lipgloss.Border{
+	rightSidebarHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorSubheading).
+				MarginLeft(1)
+	LeftBorder = lipgloss.Border{
 		Top:         string(unicodeSpace),
 		Bottom:      string(unicodeSpace),
 		Left:        string(boxLightVertical),

--- a/core/internal/leet/systemmetrics.go
+++ b/core/internal/leet/systemmetrics.go
@@ -227,7 +227,9 @@ var metricDefs = []MetricDef{
 	{Name: "Neuron Model Code", Unit: UnitGiB, MinY: 0, MaxY: 32, AutoRange: true,
 		Regex: regexp.MustCompile(`^trn\.\d+\.neuroncore_memory_usage\.model_code(\/l:.+)?$`)},
 	{Name: "Neuron Scratchpad", Unit: UnitGiB, MinY: 0, MaxY: 32, AutoRange: true,
-		Regex: regexp.MustCompile(`^trn\.\d+\.neuroncore_memory_usage\.model_shared_scratchpad(\/l:.+)?$`)},
+		Regex: regexp.MustCompile(
+			`^trn\.\d+\.neuroncore_memory_usage\.model_shared_scratchpad(\/l:.+)?$`,
+		)},
 	{Name: "Neuron Runtime", Unit: UnitGiB, MinY: 0, MaxY: 32, AutoRange: true,
 		Regex: regexp.MustCompile(`^trn\.\d+\.neuroncore_memory_usage\.runtime_memory(\/l:.+)?$`)},
 	{Name: "Neuron Tensors", Unit: UnitGiB, MinY: 0, MaxY: 32, AutoRange: true,

--- a/core/internal/leet/systemmetrics_test.go
+++ b/core/internal/leet/systemmetrics_test.go
@@ -27,7 +27,12 @@ func TestMatchMetricDef_BasicFamilies(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			def := leet.MatchMetricDef(tc.metric)
-			require.Equal(t, fmt.Sprintf("%s (%s)", tc.wantName, tc.wantUnit), def.Title(), "metric: %s", tc.metric)
+			require.Equal(t,
+				fmt.Sprintf("%s (%s)", tc.wantName, tc.wantUnit),
+				def.Title(),
+				"metric: %s",
+				tc.metric,
+			)
 		})
 	}
 }

--- a/core/internal/leet/systemmetricsgrid.go
+++ b/core/internal/leet/systemmetricsgrid.go
@@ -244,7 +244,9 @@ func (g *SystemMetricsGrid) HandleMouseClick(row, col int) bool {
 	g.logger.Debug(fmt.Sprintf("systemmetricsgrid: HandleMouseClick: row=%d, col=%d", row, col))
 
 	if g.focus.Type == FocusSystemChart && row == g.focus.Row && col == g.focus.Col {
-		g.logger.Debug("systemmetricsgrid: HandleMouseClick: clicking on focused chart - unfocusing")
+		g.logger.Debug(
+			"systemmetricsgrid: HandleMouseClick: clicking on focused chart - unfocusing",
+		)
 		g.ClearFocus()
 		return false
 	}

--- a/core/internal/leet/systemmetricsgrid_test.go
+++ b/core/internal/leet/systemmetricsgrid_test.go
@@ -116,7 +116,11 @@ func TestSystemMetricsGrid_NavigateWithPowerMetrics(t *testing.T) {
 
 	// Verify page changed (different charts)
 	if firstPageChart != nil && secondPageChart != nil {
-		require.NotEqual(t, firstPageChart, secondPageChart, "navigation did not change displayed charts")
+		require.NotEqual(t,
+			firstPageChart,
+			secondPageChart,
+			"navigation did not change displayed charts",
+		)
 	}
 
 	// Test navigation backward (wrap around)

--- a/core/internal/leet/tui_test.go
+++ b/core/internal/leet/tui_test.go
@@ -96,7 +96,11 @@ func TestMetricsAndSystemMetrics_RenderAndSeriesCount(t *testing.T) {
 	// Seed minimal run + metrics so both the main grid and system grid can render.
 	writeRecord(t, writer, &spb.Record{
 		RecordType: &spb.Record_Run{
-			Run: &spb.RunRecord{RunId: "test-run", DisplayName: "Test Run", Project: "test-project"},
+			Run: &spb.RunRecord{
+				RunId:       "test-run",
+				DisplayName: "Test Run",
+				Project:     "test-project",
+			},
 		},
 	})
 	writeRecord(t, writer, &spb.Record{

--- a/core/internal/monitor/cwmetadata.go
+++ b/core/internal/monitor/cwmetadata.go
@@ -115,7 +115,11 @@ func (cwm *CoreWeaveMetadata) Sample() (*spb.StatsRecord, error) {
 // metadata from the CoreWeave metadata endpoint using the Get method.
 func (cwm *CoreWeaveMetadata) Probe(ctx context.Context) *spb.EnvironmentRecord {
 	if cwm.graphqlClient == nil {
-		cwm.logger.Debug("cwmetadata: error collecting data", "error", fmt.Errorf("GraphQL client is nil"))
+		cwm.logger.Debug(
+			"cwmetadata: error collecting data",
+			"error",
+			fmt.Errorf("GraphQL client is nil"),
+		)
 		return nil
 	}
 
@@ -133,7 +137,8 @@ func (cwm *CoreWeaveMetadata) Probe(ctx context.Context) *spb.EnvironmentRecord 
 		cwm.graphqlClient,
 		entity,
 	)
-	if err != nil || data == nil || data.GetEntity() == nil || data.GetEntity().GetOrganization() == nil {
+	if err != nil || data == nil || data.GetEntity() == nil ||
+		data.GetEntity().GetOrganization() == nil {
 		return nil
 	}
 	coreWeaveOrgID := data.GetEntity().GetOrganization().GetCoreWeaveOrganizationId()
@@ -194,7 +199,11 @@ func (cwm *CoreWeaveMetadata) fetchMetadata() (*http.Response, error) {
 		return nil, fmt.Errorf("could not fetch metadata from endpoint %s (nil response)", fullURL)
 	}
 
-	cwm.logger.Debug("cwmetadata: received response", "url", fullURL, "status_code", resp.StatusCode)
+	cwm.logger.Debug(
+		"cwmetadata: received response",
+		"url", fullURL,
+		"status_code", resp.StatusCode,
+	)
 	return resp, nil
 }
 
@@ -268,7 +277,11 @@ func (cwm *CoreWeaveMetadata) buildFieldMap(data *CoreWeaveInstanceData) map[str
 }
 
 // parseLine parses a single line of metadata and updates the corresponding field.
-func (cwm *CoreWeaveMetadata) parseLine(line string, lineNumber int, fieldMap map[string]reflect.Value) {
+func (cwm *CoreWeaveMetadata) parseLine(
+	line string,
+	lineNumber int,
+	fieldMap map[string]reflect.Value,
+) {
 	line = strings.TrimSpace(line)
 	if line == "" {
 		return
@@ -276,7 +289,11 @@ func (cwm *CoreWeaveMetadata) parseLine(line string, lineNumber int, fieldMap ma
 
 	parts := strings.SplitN(line, ":", 2)
 	if len(parts) != 2 {
-		cwm.logger.Debug("cwmetadata: malformed line", "line_number", lineNumber, "line_content", line)
+		cwm.logger.Debug(
+			"cwmetadata: malformed line",
+			"line_number", lineNumber,
+			"line_content", line,
+		)
 		return
 	}
 

--- a/core/internal/monitor/cwmetadata_test.go
+++ b/core/internal/monitor/cwmetadata_test.go
@@ -168,7 +168,14 @@ func TestCoreWeaveMetadataProbe(t *testing.T) {
 				)
 			},
 			httpServerHandler: func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte("cluster_name: partial-cluster\norg_id: partial-org\ninvalid line\nregion: partial-region"))
+				_, _ = w.Write(
+					[]byte(
+						"cluster_name: partial-cluster" +
+							"\norg_id: partial-org" +
+							"\ninvalid line" +
+							"\nregion: partial-region",
+					),
+				)
 			},
 			expectedEnvironment: &spb.EnvironmentRecord{
 				Coreweave: &spb.CoreWeaveInfo{

--- a/core/internal/monitor/dcgm_exporter.go
+++ b/core/internal/monitor/dcgm_exporter.go
@@ -120,7 +120,10 @@ func NewDCGMExporter(params DCGMExporterParams) *DCGMExporter {
 		RoundTripper: roundTripper,
 	})
 	if err != nil {
-		params.Logger.Error("monitor: dcgm_exporter: error creating Prometheus API client", "error", err)
+		params.Logger.Error(
+			"monitor: dcgm_exporter: error creating Prometheus API client",
+			"error", err,
+		)
 		return nil
 	}
 
@@ -327,17 +330,26 @@ func (de *DCGMExporter) Sample() (*spb.StatsRecord, error) {
 			v1.WithTimeout(DefaultOpenMetricsTimeout),
 		)
 		if err != nil {
-			de.logger.Error("monitor: dcgm_exporter: error querying Prometheus API endpoint", "error", err)
+			de.logger.Error(
+				"monitor: dcgm_exporter: error querying Prometheus API endpoint",
+				"error", err,
+			)
 			return nil, err
 		}
 		if len(warnings) > 0 {
-			de.logger.Warn("monitor: openmetrics: warnings querying Prometheus API endpoint", "warnings", warnings)
+			de.logger.Warn(
+				"monitor: openmetrics: warnings querying Prometheus API endpoint",
+				"warnings", warnings,
+			)
 		}
 
 		// model.Vector is expected.
 		vector, ok := result.(model.Vector)
 		if !ok {
-			de.logger.Error("monitor: dcgm: unexpected result type", "type", fmt.Sprintf("%T", result))
+			de.logger.Error(
+				"monitor: dcgm: unexpected result type",
+				"type", fmt.Sprintf("%T", result),
+			)
 			continue
 		}
 
@@ -377,17 +389,26 @@ func (de *DCGMExporter) Probe(ctx context.Context) *spb.EnvironmentRecord {
 			v1.WithTimeout(DefaultOpenMetricsTimeout),
 		)
 		if err != nil {
-			de.logger.Error("monitor: dcgm_exporter: error querying Prometheus API endpoint", "error", err)
+			de.logger.Error(
+				"monitor: dcgm_exporter: error querying Prometheus API endpoint",
+				"error", err,
+			)
 			return nil
 		}
 		if len(warnings) > 0 {
-			de.logger.Warn("monitor: openmetrics: warnings querying Prometheus API endpoint", "warnings", warnings)
+			de.logger.Warn(
+				"monitor: openmetrics: warnings querying Prometheus API endpoint",
+				"warnings", warnings,
+			)
 		}
 
 		// Process the results based on type
 		vector, ok := result.(model.Vector)
 		if !ok {
-			de.logger.Error("monitor: dcgm: unexpected result type", "type", fmt.Sprintf("%T", result))
+			de.logger.Error(
+				"monitor: dcgm: unexpected result type",
+				"type", fmt.Sprintf("%T", result),
+			)
 			continue
 		}
 
@@ -395,7 +416,10 @@ func (de *DCGMExporter) Probe(ctx context.Context) *spb.EnvironmentRecord {
 		for _, sample := range vector {
 			gm, err := newGPUMetric(sample)
 			if err != nil {
-				de.logger.Debug("monitor: dcgm_exporter: error parsing GPU metric", "error", err)
+				de.logger.Debug(
+					"monitor: dcgm_exporter: error parsing GPU metric",
+					"error", err,
+				)
 				continue
 			}
 

--- a/core/internal/monitor/dcgm_exporter_test.go
+++ b/core/internal/monitor/dcgm_exporter_test.go
@@ -273,7 +273,11 @@ func TestProbe(t *testing.T) {
 
 		metadata := exporter.Probe(context.Background())
 		require.NotNil(t, metadata)
-		assert.Equal(t, uint32(1), metadata.GpuCount, "Should only detect GPU with complete information")
+		assert.Equal(t,
+			uint32(1),
+			metadata.GpuCount,
+			"Should only detect GPU with complete information",
+		)
 	})
 
 	t.Run("missing uuid", func(t *testing.T) {
@@ -296,7 +300,11 @@ func TestProbe(t *testing.T) {
 
 		metadata := exporter.Probe(context.Background())
 		require.NotNil(t, metadata)
-		assert.Equal(t, uint32(1), metadata.GpuCount, "Should only detect GPU with complete information")
+		assert.Equal(t,
+			uint32(1),
+			metadata.GpuCount,
+			"Should only detect GPU with complete information",
+		)
 	})
 }
 
@@ -344,5 +352,9 @@ func TestDCGMExporterAuth(t *testing.T) {
 	result, err := exporter.Sample()
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, "Bearer test-token-123", receivedToken, "Expected Authorization header to be sent with request")
+	assert.Equal(t,
+		"Bearer test-token-123",
+		receivedToken,
+		"Expected Authorization header to be sent with request",
+	)
 }

--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -363,7 +363,8 @@ func (sm *SystemMonitor) Start(git *spb.GitRepoRecord) {
 //
 // This operation may take some time, so we perform it on a best-effort basis.
 func (sm *SystemMonitor) Probe() {
-	if !sm.settings.IsDisableMeta() && !sm.settings.IsDisableMachineInfo() && sm.settings.IsPrimary() {
+	if !sm.settings.IsDisableMeta() && !sm.settings.IsDisableMachineInfo() &&
+		sm.settings.IsPrimary() {
 		go func() {
 			sm.logger.Debug("monitor: collecting the environment and resource information")
 

--- a/core/internal/monitor/monitor_test.go
+++ b/core/internal/monitor/monitor_test.go
@@ -71,39 +71,74 @@ func TestSystemMonitor_UnexpectedTransitions(t *testing.T) {
 
 	// Resume when stopped
 	sm.Resume()
-	assert.Equal(t, monitor.StateStopped, sm.GetState(), "Resume should not change state when stopped")
+	assert.Equal(
+		t,
+		monitor.StateStopped,
+		sm.GetState(),
+		"Resume should not change state when stopped",
+	)
 
 	// Pause when stopped
 	sm.Pause()
-	assert.Equal(t, monitor.StateStopped, sm.GetState(), "Pause should not change state when stopped")
+	assert.Equal(
+		t,
+		monitor.StateStopped,
+		sm.GetState(),
+		"Pause should not change state when stopped",
+	)
 
 	// Start and then unexpected transitions
 	sm.Start(nil)
 	assert.Equal(t, monitor.StateRunning, sm.GetState(), "Start should change state to running")
 
 	sm.Start(nil) // Start when already running
-	assert.Equal(t, monitor.StateRunning, sm.GetState(), "Start should not change state when already running")
+	assert.Equal(
+		t,
+		monitor.StateRunning,
+		sm.GetState(),
+		"Start should not change state when already running",
+	)
 
 	sm.Resume() // Resume when running
-	assert.Equal(t, monitor.StateRunning, sm.GetState(), "Resume should not change state when running")
+	assert.Equal(
+		t,
+		monitor.StateRunning,
+		sm.GetState(),
+		"Resume should not change state when running",
+	)
 
 	// Pause and then unexpected transitions
 	sm.Pause()
 	assert.Equal(t, monitor.StatePaused, sm.GetState(), "Pause should change state to paused")
 
 	sm.Pause() // Pause when already paused
-	assert.Equal(t, monitor.StatePaused, sm.GetState(), "Pause should not change state when already paused")
+	assert.Equal(
+		t,
+		monitor.StatePaused,
+		sm.GetState(),
+		"Pause should not change state when already paused",
+	)
 
 	sm.Start(nil) // Start when paused
 	assert.Equal(t, monitor.StatePaused, sm.GetState(), "Start should not change state when paused")
 
 	// Finish from any state
 	sm.Finish()
-	assert.Equal(t, monitor.StateStopped, sm.GetState(), "Finish should change state to stopped from paused")
+	assert.Equal(
+		t,
+		monitor.StateStopped,
+		sm.GetState(),
+		"Finish should change state to stopped from paused",
+	)
 
 	sm.Start(nil)
 	sm.Finish()
-	assert.Equal(t, monitor.StateStopped, sm.GetState(), "Finish should change state to stopped from running")
+	assert.Equal(
+		t,
+		monitor.StateStopped,
+		sm.GetState(),
+		"Finish should change state to stopped from running",
+	)
 }
 
 func TestSystemMonitor_FullCycle(t *testing.T) {
@@ -142,11 +177,25 @@ func TestShouldCaptureSamplingErr(t *testing.T) {
 		err  error
 		want bool
 	}{
-		{"NetstatMissing", errors.New(`exec: "netstat": executable file not found in $PATH`), false},
+		{
+			"NetstatMissing",
+			errors.New(`exec: "netstat": executable file not found in $PATH`),
+			false,
+		},
 		{"GrpcUnavailable", status.Error(codes.Unavailable, "connection error"), false},
-		{"ConnRefused", errors.New(`transport: Error while dialing: dial unix /tmp/x.sock: connect: connection refused`), false},
+		{
+			"ConnRefused",
+			errors.New(
+				`transport: Error while dialing: dial unix /tmp/x.sock: connect: connection refused`,
+			),
+			false,
+		},
 		{"WinIncorrectFunction", errors.New("Incorrect function."), false},
-		{"MissingProcDiskstats", errors.New("open /proc/diskstats: no such file or directory"), false},
+		{
+			"MissingProcDiskstats",
+			errors.New("open /proc/diskstats: no such file or directory"),
+			false,
+		},
 		{"OtherError", errors.New("some other error"), true},
 	}
 	for _, tt := range tests {

--- a/core/internal/monitor/portfile_test.go
+++ b/core/internal/monitor/portfile_test.go
@@ -83,7 +83,11 @@ func TestReadFile(t *testing.T) {
 					t.Fatal("Expected an error, but got nil")
 				}
 				if !strings.Contains(err.Error(), tc.expectedErrMsg) {
-					t.Errorf("Expected error message to contain %q, but got %q", tc.expectedErrMsg, err.Error())
+					t.Errorf(
+						"Expected error message to contain %q, but got %q",
+						tc.expectedErrMsg,
+						err.Error(),
+					)
 				}
 			} else {
 				if err != nil {

--- a/core/internal/monitor/system.go
+++ b/core/internal/monitor/system.go
@@ -343,7 +343,9 @@ func (s *System) collectNetworkMetrics(metrics map[string]any) error {
 }
 
 // collectSystemMemoryMetrics gathers system-wide memory statistics.
-func (s *System) collectSystemMemoryMetrics(metrics map[string]any) (*mem.VirtualMemoryStat, error) {
+func (s *System) collectSystemMemoryMetrics(
+	metrics map[string]any,
+) (*mem.VirtualMemoryStat, error) {
 	virtualMem, err := mem.VirtualMemory()
 	if err != nil {
 		return nil, err

--- a/core/internal/monitor/trainium.go
+++ b/core/internal/monitor/trainium.go
@@ -333,7 +333,10 @@ func (t *Trainium) Sample() (*spb.StatsRecord, error) {
 			err = json.Unmarshal(jsonBytes, &hostMemoryUsage)
 		}
 		if err != nil {
-			t.logger.CaptureError(fmt.Errorf("trainium: failed to unmarshal host memory usage: %v", err))
+			t.logger.CaptureError(
+				fmt.Errorf(
+					"trainium: failed to unmarshal host memory usage: %v",
+					err))
 		}
 	}
 
@@ -350,7 +353,8 @@ func (t *Trainium) Sample() (*spb.StatsRecord, error) {
 				}
 			}
 			if err != nil {
-				t.logger.CaptureError(fmt.Errorf("trainium: failed to unmarshal neuroncore memory usage: %v", err))
+				t.logger.CaptureError(
+					fmt.Errorf("trainium: failed to unmarshal neuroncore memory usage: %v", err))
 			}
 		}
 	}
@@ -361,7 +365,9 @@ func (t *Trainium) Sample() (*spb.StatsRecord, error) {
 	if localRank != "" {
 		localRankInt, _ := strconv.Atoi(localRank)
 		neuroncoreUtilization = map[int]float64{localRankInt: neuroncoreUtilization[localRankInt]}
-		neuroncoreMemoryUsage = map[int]NeuronCoreMemoryUsage{localRankInt: neuroncoreMemoryUsage[localRankInt]}
+		neuroncoreMemoryUsage = map[int]NeuronCoreMemoryUsage{
+			localRankInt: neuroncoreMemoryUsage[localRankInt],
+		}
 	}
 
 	stats := TrainiumStats{

--- a/core/internal/observability/logging_test.go
+++ b/core/internal/observability/logging_test.go
@@ -27,8 +27,13 @@ func TestNewTags(t *testing.T) {
 			expect: observability.Tags{"key2": "456"},
 		},
 		{
-			name:   "Tags from a mix of slog.Attr, string, and int",
-			input:  []interface{}{slog.Attr{Key: "key3", Value: slog.StringValue("value3")}, "key4", 789, slog.Any("key5", "value5")},
+			name: "Tags from a mix of slog.Attr, string, and int",
+			input: []interface{}{
+				slog.Attr{Key: "key3", Value: slog.StringValue("value3")},
+				"key4",
+				789,
+				slog.Any("key5", "value5"),
+			},
 			expect: observability.Tags{"key3": "value3", "key4": "789", "key5": "value5"},
 		},
 		{
@@ -42,8 +47,13 @@ func TestNewTags(t *testing.T) {
 			expect: observability.Tags{},
 		},
 		{
-			name:   "Tags from a mix of slog.Attr, map[string]string, string, and int",
-			input:  []interface{}{slog.Attr{Key: "key8", Value: slog.Int64Value(123)}, map[string]string{"key9": "value9"}, "key10", 10},
+			name: "Tags from a mix of slog.Attr, map[string]string, string, and int",
+			input: []interface{}{
+				slog.Attr{Key: "key8", Value: slog.Int64Value(123)},
+				map[string]string{"key9": "value9"},
+				"key10",
+				10,
+			},
 			expect: observability.Tags{"key8": "123", "key10": "10"},
 		},
 	}

--- a/core/internal/runbranch/resume.go
+++ b/core/internal/runbranch/resume.go
@@ -104,8 +104,10 @@ func (rb *ResumeBranch) UpdateForResume(
 		if err != nil && rb.mode == "must" {
 			info := &spb.ErrorInfo{
 				Code: spb.ErrorInfo_USAGE,
-				Message: fmt.Sprintf("The run (%s) failed to resume, and the `resume` argument is set to 'must'.",
-					params.RunID),
+				Message: fmt.Sprintf(
+					"The run (%s) failed to resume, and the `resume` argument is set to 'must'.",
+					params.RunID,
+				),
 			}
 			err = fmt.Errorf("could not resume run: %s", err)
 			return &BranchError{Err: err, Response: info}

--- a/core/internal/runbranch/resume_test.go
+++ b/core/internal/runbranch/resume_test.go
@@ -419,8 +419,18 @@ func TestMustResumeValidSummary(t *testing.T) {
 	// check the value of the summary are correct
 	assert.Len(t, params.Summary, 4, "GetUpdates should return correct summary")
 	assert.Equal(t, 0.5, params.Summary["loss"], "GetUpdates should return correct summary")
-	assert.Equal(t, float64(40.2), params.Summary["_runtime"], "GetUpdates should return correct summary")
-	assert.Equal(t, float64(20.3), params.Summary["_wandb"].(map[string]any)["runtime"], "GetUpdates should return correct summary")
+	assert.Equal(
+		t,
+		float64(40.2),
+		params.Summary["_runtime"],
+		"GetUpdates should return correct summary",
+	)
+	assert.Equal(
+		t,
+		float64(20.3),
+		params.Summary["_wandb"].(map[string]any)["runtime"],
+		"GetUpdates should return correct summary",
+	)
 
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
@@ -617,7 +627,12 @@ func TestMustResumeValidEvents(t *testing.T) {
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 
 	assert.Len(t, params.Summary, 1, "GetUpdates should return correct summary")
-	assert.Equal(t, int64(20), params.Summary["_runtime"], "GetUpdates should return correct summary")
+	assert.Equal(
+		t,
+		int64(20),
+		params.Summary["_runtime"],
+		"GetUpdates should return correct summary",
+	)
 }
 
 func TestMustResumeNullValue(t *testing.T) {
@@ -701,8 +716,17 @@ func TestMustResumeNullValue(t *testing.T) {
 
 			err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 			assert.NotNil(t, err, "GetUpdates should return an error")
-			assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
-			assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
+			assert.IsType(
+				t,
+				&runbranch.BranchError{},
+				err,
+				"GetUpdates should return a BranchError",
+			)
+			assert.NotNil(
+				t,
+				err.(*runbranch.BranchError).Response,
+				"BranchError should have a response",
+			)
 		})
 	}
 }
@@ -838,8 +862,17 @@ func TestMustResumeInvalidHistory(t *testing.T) {
 
 			err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 			assert.NotNil(t, err, "GetUpdates should return an error")
-			assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
-			assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
+			assert.IsType(
+				t,
+				&runbranch.BranchError{},
+				err,
+				"GetUpdates should return a BranchError",
+			)
+			assert.NotNil(
+				t,
+				err.(*runbranch.BranchError).Response,
+				"BranchError should have a response",
+			)
 		})
 	}
 }
@@ -946,8 +979,17 @@ func TestMustResumeInvalidConfig(t *testing.T) {
 
 			err = resumeState.UpdateForResume(&runbranch.RunParams{}, runconfig.New())
 			assert.NotNil(t, err, "GetUpdates should return an error")
-			assert.IsType(t, &runbranch.BranchError{}, err, "GetUpdates should return a BranchError")
-			assert.NotNil(t, err.(*runbranch.BranchError).Response, "BranchError should have a response")
+			assert.IsType(
+				t,
+				&runbranch.BranchError{},
+				err,
+				"GetUpdates should return a BranchError",
+			)
+			assert.NotNil(
+				t,
+				err.(*runbranch.BranchError).Response,
+				"BranchError should have a response",
+			)
 		})
 	}
 }
@@ -1007,10 +1049,30 @@ func TestNotNeverResumeFileStreamOffset(t *testing.T) {
 			params := &runbranch.RunParams{}
 			err = resumeState.UpdateForResume(params, runconfig.New())
 			assert.Nil(t, err, "GetUpdates should not return an error")
-			assert.Len(t, params.FileStreamOffset, 3, "GetUpdates should return correct file stream offset")
-			assert.Equal(t, 10, params.FileStreamOffset[filestream.HistoryChunk], "GetUpdates should return correct file stream offset")
-			assert.Equal(t, 13, params.FileStreamOffset[filestream.EventsChunk], "GetUpdates should return correct file stream offset")
-			assert.Equal(t, 15, params.FileStreamOffset[filestream.OutputChunk], "GetUpdates should return correct file stream offset")
+			assert.Len(
+				t,
+				params.FileStreamOffset,
+				3,
+				"GetUpdates should return correct file stream offset",
+			)
+			assert.Equal(
+				t,
+				10,
+				params.FileStreamOffset[filestream.HistoryChunk],
+				"GetUpdates should return correct file stream offset",
+			)
+			assert.Equal(
+				t,
+				13,
+				params.FileStreamOffset[filestream.EventsChunk],
+				"GetUpdates should return correct file stream offset",
+			)
+			assert.Equal(
+				t,
+				15,
+				params.FileStreamOffset[filestream.OutputChunk],
+				"GetUpdates should return correct file stream offset",
+			)
 		})
 	}
 }
@@ -1069,9 +1131,24 @@ func TestExtractRunState(t *testing.T) {
 	assert.Nil(t, err, "GetUpdates should not return an error")
 
 	// Test FileStreamOffset
-	assert.Equal(t, historyLineCount, params.FileStreamOffset[filestream.HistoryChunk], "Incorrect history line count")
-	assert.Equal(t, eventsLineCount, params.FileStreamOffset[filestream.EventsChunk], "Incorrect events line count")
-	assert.Equal(t, logLineCount, params.FileStreamOffset[filestream.OutputChunk], "Incorrect log line count")
+	assert.Equal(
+		t,
+		historyLineCount,
+		params.FileStreamOffset[filestream.HistoryChunk],
+		"Incorrect history line count",
+	)
+	assert.Equal(
+		t,
+		eventsLineCount,
+		params.FileStreamOffset[filestream.EventsChunk],
+		"Incorrect events line count",
+	)
+	assert.Equal(
+		t,
+		logLineCount,
+		params.FileStreamOffset[filestream.OutputChunk],
+		"Incorrect log line count",
+	)
 
 	// Test StartingStep
 	assert.Equal(t, int64(5), params.StartingStep, "Incorrect starting step")
@@ -1256,7 +1333,12 @@ func TestExtractRunStateNilCases(t *testing.T) {
 
 			if tc.expectError {
 				assert.NotNil(t, err, "GetUpdates should return an error")
-				assert.Contains(t, err.Error(), tc.errorContains, "Error message should contain expected text")
+				assert.Contains(
+					t,
+					err.Error(),
+					tc.errorContains,
+					"Error message should contain expected text",
+				)
 			} else {
 				assert.Nil(t, err, "GetUpdates should not return an error")
 			}

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -454,7 +454,11 @@ func TestUploader(t *testing.T) {
 			})
 			// Wait until CreateRunFiles scheduling is done.
 			uploader.(UploaderTesting).FlushSchedulingForTest()
-			require.Len(t, fakeFileTransfer.Tasks(), 1, "first upload should schedule exactly one task")
+			require.Len(t,
+				fakeFileTransfer.Tasks(),
+				1,
+				"first upload should schedule exactly one task",
+			)
 
 			// Complete the first upload so savedFile records the last uploaded state.
 			fakeFileTransfer.Tasks()[0].Complete(nil)
@@ -496,7 +500,11 @@ func TestUploader(t *testing.T) {
 				},
 			})
 			uploader.(UploaderTesting).FlushSchedulingForTest()
-			require.Len(t, fakeFileTransfer.Tasks(), 1, "first upload should schedule exactly one task")
+			require.Len(t,
+				fakeFileTransfer.Tasks(),
+				1,
+				"first upload should schedule exactly one task",
+			)
 
 			// Complete the first upload.
 			fakeFileTransfer.Tasks()[0].Complete(nil)

--- a/core/internal/sentry_ext/client.go
+++ b/core/internal/sentry_ext/client.go
@@ -181,7 +181,8 @@ func RemoveBottomFrames(event *sentry.Event, hint *sentry.EventHint) *sentry.Eve
 			// TODO: think of a better way to do this without hard-coding the
 			// file names this is a hack to remove the bottom-most 3 frames that
 			// are internal to core
-			if strings.HasSuffix(frame.AbsPath, "client.go") || strings.HasSuffix(frame.AbsPath, "logging.go") {
+			if strings.HasSuffix(frame.AbsPath, "client.go") ||
+				strings.HasSuffix(frame.AbsPath, "logging.go") {
 				frames = frames[:j]
 			} else {
 				break

--- a/core/internal/sentry_ext/client_test.go
+++ b/core/internal/sentry_ext/client_test.go
@@ -207,5 +207,10 @@ func TestRemoveBottomFrames(t *testing.T) {
 	}
 
 	actualFrames := modifiedEvent.Exception[0].Stacktrace.Frames
-	assert.Equal(t, expectedFrames, actualFrames, "The bottom-most sentry.go and logging.go frames should be removed")
+	assert.Equal(
+		t,
+		expectedFrames,
+		actualFrames,
+		"The bottom-most sentry.go and logging.go frames should be removed",
+	)
 }

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -568,7 +568,10 @@ func (h *Handler) handleCodeSave() {
 
 	programAbsolute := h.settings.GetProgramAbsolutePath()
 	if _, err := os.Stat(programAbsolute); err != nil {
-		h.logger.Warn("handleCodeSave: program absolute path does not exist", "path", programAbsolute)
+		h.logger.Warn(
+			"handleCodeSave: program absolute path does not exist",
+			"path", programAbsolute,
+		)
 		return
 	}
 

--- a/core/internal/stream/handler_test.go
+++ b/core/internal/stream/handler_test.go
@@ -868,7 +868,12 @@ func TestHandleHeader(t *testing.T) {
 	record = (<-handler.OutChan()).(runwork.WorkRecord).Record
 
 	versionInfo := fmt.Sprintf("%s+%s", version.Version, sha)
-	assert.Equal(t, versionInfo, record.GetHeader().GetVersionInfo().GetProducer(), "wrong version info")
+	assert.Equal(
+		t,
+		versionInfo,
+		record.GetHeader().GetVersionInfo().GetProducer(),
+		"wrong version info",
+	)
 }
 
 func TestHandleDerivedSummary(t *testing.T) {
@@ -972,7 +977,12 @@ func TestHandleDerivedSummary(t *testing.T) {
 				}
 			}
 
-			assert.Equal(t, tc.expectedSummaryRecords, seenSummaryRecords, "wrong number of summary records")
+			assert.Equal(
+				t,
+				tc.expectedSummaryRecords,
+				seenSummaryRecords,
+				"wrong number of summary records",
+			)
 		})
 	}
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -1019,7 +1019,10 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 
 // sendRequestRunFinishWithoutExit triggers the shutdown of the stream without marking the run as finished
 // on the server.
-func (s *Sender) sendRequestRunFinishWithoutExit(record *spb.Record, _ *spb.RunFinishWithoutExitRequest) {
+func (s *Sender) sendRequestRunFinishWithoutExit(
+	record *spb.Record,
+	_ *spb.RunFinishWithoutExitRequest,
+) {
 	if s.finishWithoutExitRecord != nil {
 		s.logger.CaptureError(
 			errors.New("sender: received RequestRunFinishWithoutExit more than once, ignoring"))
@@ -1118,7 +1121,10 @@ func (s *Sender) sendRequestLogArtifact(record *spb.Record, msg *spb.LogArtifact
 		if result.Err != nil {
 			response.ErrorMessage = result.Err.Error()
 			// TODO: it will send error to sentry, do we want it?
-			s.logger.CaptureError(fmt.Errorf("sender: failed to log artifact: %v", result.Err), "artifactID", result.ArtifactID)
+			s.logger.CaptureError(
+				fmt.Errorf("sender: failed to log artifact: %v", result.Err),
+				"artifactID", result.ArtifactID,
+			)
 		} else {
 			response.ArtifactId = result.ArtifactID
 		}
@@ -1144,7 +1150,9 @@ func (s *Sender) sendRequestDownloadArtifact(record *spb.Record, msg *spb.Downlo
 
 	if s.graphqlClient == nil {
 		// Offline mode handling:
-		s.logger.Error("sender: sendRequestDownloadArtifact: cannot download artifact in offline mode")
+		s.logger.Error(
+			"sender: sendRequestDownloadArtifact: cannot download artifact in offline mode",
+		)
 		response.ErrorMessage = "Artifact downloads are not supported in offline mode."
 	} else if err := artifacts.NewArtifactDownloader(
 		s.runWork.BeforeEndCtx(),

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -262,13 +262,33 @@ func TestLinkRegistryArtifact(t *testing.T) {
 		errorMessage      string
 	}{
 		{"Link registry artifact with orgName updated server", "orgName", false, ""},
-		{"Link registry artifact with orgName old server", "orgName", true, expectLinkArtifactFailure},
-		{"Link registry artifact with orgEntity name updated server", "orgEntityName_123", false, ""},
+		{
+			"Link registry artifact with orgName old server",
+			"orgName",
+			true,
+			expectLinkArtifactFailure,
+		},
+		{
+			"Link registry artifact with orgEntity name updated server",
+			"orgEntityName_123",
+			false,
+			"",
+		},
 		{"Link registry artifact with orgEntity name old server", "orgEntityName_123", true, ""},
 		{"Link registry artifact with short hand path updated server", "", false, ""},
 		{"Link registry artifact with short hand path old server", "", true, "unsupported"},
-		{"Link with wrong org/orgEntity name with updated server", "potato", false, "update the target path"},
-		{"Link with wrong org/orgEntity name with updated server", "potato", true, expectLinkArtifactFailure},
+		{
+			"Link with wrong org/orgEntity name with updated server",
+			"potato",
+			false,
+			"update the target path",
+		},
+		{
+			"Link with wrong org/orgEntity name with updated server",
+			"potato",
+			true,
+			expectLinkArtifactFailure,
+		},
 	}
 	for _, tc := range testCases {
 		mockGQL := gqlmock.NewMockClient()

--- a/core/pkg/artifacts/file_helper.go
+++ b/core/pkg/artifacts/file_helper.go
@@ -12,7 +12,9 @@ import (
 //
 // Returns the path to the temporary file, the Base64-encoded MD5 digest of the JSON data,
 // the size of the file, and an error if something goes wrong during the process.
-func WriteJSONToTempFileWithMetadata(data any) (filename string, digest string, size int64, err error) {
+func WriteJSONToTempFileWithMetadata(
+	data any,
+) (filename string, digest string, size int64, err error) {
 	// Create a temporary file
 	f, err := os.CreateTemp("", "tmpfile-")
 	if err != nil {

--- a/core/pkg/artifacts/linker.go
+++ b/core/pkg/artifacts/linker.go
@@ -89,7 +89,10 @@ func (al *ArtifactLinker) Link() (response *gql.LinkArtifactResponse, err error)
 // the organization parameter, or an error if it is empty. Otherwise, this returns the
 // fetched value after validating that the given organization, if not empty, matches
 // either the org's display or entity name.
-func (al *ArtifactLinker) resolveOrgEntityName(portfolioEntity string, organization string) (string, error) {
+func (al *ArtifactLinker) resolveOrgEntityName(
+	portfolioEntity string,
+	organization string,
+) (string, error) {
 	orgFieldNames, err := GetGraphQLFields(al.Ctx, al.GraphqlClient, "Organization")
 	if err != nil {
 		return "", err
@@ -131,8 +134,12 @@ func (al *ArtifactLinker) resolveOrgEntityName(portfolioEntity string, organizat
 	inputMatchesOrgName := organization == orgDisplayName
 	inputMatchesOrgEntityName := organization == orgEntityName
 	if organization != "" && !inputMatchesOrgName && !inputMatchesOrgEntityName {
-		return "", fmt.Errorf("artifact belongs to the organization %q and cannot be linked/fetched with %q. "+
-			"Please update the target path with the correct organization name", orgDisplayName, organization)
+		return "", fmt.Errorf(
+			"artifact belongs to the organization %q and cannot be linked/fetched with %q. "+
+				"Please update the target path with the correct organization name",
+			orgDisplayName,
+			organization,
+		)
 	}
 	return orgEntityName, nil
 }

--- a/core/pkg/artifacts/multipart.go
+++ b/core/pkg/artifacts/multipart.go
@@ -179,7 +179,12 @@ func (worker *multipartHashWorker) hashFileParts(
 		partSize := min(worker.chunkSize, worker.fileSize-offset)
 		hexMD5, err := hashencode.ComputeReaderHexMD5(io.NewSectionReader(file, offset, partSize))
 		if err != nil {
-			return fmt.Errorf("worker %d failed to compute hash for part %d: %w", worker.id, part, err)
+			return fmt.Errorf(
+				"worker %d failed to compute hash for part %d: %w",
+				worker.id,
+				part,
+				err,
+			)
 		}
 
 		// Each worker is updating different index of the partsInfo slice so there is no race condition.

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -141,6 +141,7 @@ type ArtifactSaver struct {
 }
 
 type multipartUploadInfo = []gql.CreateArtifactFilesCreateArtifactFilesCreateArtifactFilesPayloadFilesFileConnectionEdgesFileEdgeNodeFileUploadMultipartUrlsUploadUrlPartsUploadUrlPart
+
 type updateArtifactManifestAttrs = gql.UpdateArtifactManifestUpdateArtifactManifestUpdateArtifactManifestPayloadArtifactManifest
 
 type serverFileResponse struct {
@@ -275,7 +276,9 @@ func (as *ArtifactSaver) updateManifest(
 		return updateArtifactManifestAttrs{}, err
 	}
 	if response == nil || response.GetUpdateArtifactManifest() == nil {
-		return updateArtifactManifestAttrs{}, fmt.Errorf("received invalid response from UpdateArtifactManifest")
+		return updateArtifactManifestAttrs{}, fmt.Errorf(
+			"received invalid response from UpdateArtifactManifest",
+		)
 	}
 	return response.GetUpdateArtifactManifest().ArtifactManifest, nil
 }
@@ -751,7 +754,8 @@ func (as *ArtifactSaver) Save() (artifactID string, rerr error) {
 		return artifactID, nil
 	}
 	// DELETED is for old servers, see https://github.com/wandb/wandb/pull/6190
-	if artifactAttrs.State != gql.ArtifactStatePending && artifactAttrs.State != gql.ArtifactStateDeleted {
+	if artifactAttrs.State != gql.ArtifactStatePending &&
+		artifactAttrs.State != gql.ArtifactStateDeleted {
 		return "", fmt.Errorf("unexpected artifact state %v", artifactAttrs.State)
 	}
 
@@ -780,7 +784,12 @@ func (as *ArtifactSaver) Save() (artifactID string, rerr error) {
 		_ = os.Remove(manifestFile)
 	}()
 
-	uploadUrl, uploadHeaders, err := as.upsertManifest(artifactID, baseArtifactId, manifestAttrs.Id, manifestDigest)
+	uploadUrl, uploadHeaders, err := as.upsertManifest(
+		artifactID,
+		baseArtifactId,
+		manifestAttrs.Id,
+		manifestDigest,
+	)
 	if err != nil {
 		return "", fmt.Errorf("ArtifactSaver.upsertManifest: %w", err)
 	}

--- a/core/pkg/artifacts/utils.go
+++ b/core/pkg/artifacts/utils.go
@@ -16,7 +16,11 @@ func IsArtifactRegistryProject(project string) bool {
 }
 
 // GetGraphQLInputFields returns the fields of a GraphQL input type given its name.
-func GetGraphQLInputFields(ctx context.Context, client graphql.Client, typeName string) ([]string, error) {
+func GetGraphQLInputFields(
+	ctx context.Context,
+	client graphql.Client,
+	typeName string,
+) ([]string, error) {
 	response, err := gql.InputFields(ctx, client, typeName)
 	if err != nil {
 		return nil, err
@@ -34,7 +38,11 @@ func GetGraphQLInputFields(ctx context.Context, client graphql.Client, typeName 
 }
 
 // GetGraphQLFields returns the fields for a given a GraphQL object type name into a string array.
-func GetGraphQLFields(ctx context.Context, client graphql.Client, typeName string) ([]string, error) {
+func GetGraphQLFields(
+	ctx context.Context,
+	client graphql.Client,
+	typeName string,
+) ([]string, error) {
 	response, err := gql.TypeFields(ctx, client, typeName)
 	if err != nil {
 		return nil, err

--- a/core/pkg/launch/job_builder.go
+++ b/core/pkg/launch/job_builder.go
@@ -201,7 +201,11 @@ func MakeArtifactNameSafe(name string) string {
 
 }
 
-func NewJobBuilder(settings *settings.Settings, logger *observability.CoreLogger, verbose bool) *JobBuilder {
+func NewJobBuilder(
+	settings *settings.Settings,
+	logger *observability.CoreLogger,
+	verbose bool,
+) *JobBuilder {
 	jobBuilder := JobBuilder{
 		settings:            settings,
 		isNotebookRun:       settings.Proto.GetXJupyter().GetValue(),
@@ -280,7 +284,9 @@ func (j *JobBuilder) GetSourceType(metadata RunMetadata) (*SourceType, error) {
 	case string(ArtifactSourceType):
 		if !j.hasArtifactJobIngredients() {
 			j.logIfVerbose("No artifact job ingredients found, not creating job artifact", Warn)
-			return nil, fmt.Errorf("no artifact job ingredients found, but source type set to artifact")
+			return nil, fmt.Errorf(
+				"no artifact job ingredients found, but source type set to artifact",
+			)
 		}
 		finalSourceType = ArtifactSourceType
 		return &finalSourceType, nil
@@ -368,7 +374,11 @@ func (j *JobBuilder) hasImageJobIngredients(metadata RunMetadata) bool {
 	return metadata.Docker != nil
 }
 
-func (j *JobBuilder) getSourceAndName(sourceType SourceType, programRelpath *string, metadata RunMetadata) (Source, *string, error) {
+func (j *JobBuilder) getSourceAndName(
+	sourceType SourceType,
+	programRelpath *string,
+	metadata RunMetadata,
+) (Source, *string, error) {
 	switch sourceType {
 	case RepoSourceType:
 		if programRelpath == nil {
@@ -414,7 +424,10 @@ func (j *JobBuilder) HandlePathsAboveRoot(programRelpath, root string) (string, 
 	return fullProgramPath, nil
 }
 
-func (j *JobBuilder) createRepoJobSource(programRelpath string, metadata RunMetadata) (*GitSource, *string, error) {
+func (j *JobBuilder) createRepoJobSource(
+	programRelpath string,
+	metadata RunMetadata,
+) (*GitSource, *string, error) {
 	j.logger.Debug("jobBuilder: creating repo job source")
 	fullProgramPath := programRelpath
 	if j.isNotebookRun {
@@ -425,14 +438,19 @@ func (j *JobBuilder) createRepoJobSource(programRelpath string, metadata RunMeta
 
 		_, err = os.Stat(filepath.Join(cwd, filepath.Base(programRelpath)))
 		if os.IsNotExist(err) {
-			j.logIfVerbose("Unable to find program entrypoint in current directory, not creating job artifact.", Warn)
+			j.logIfVerbose(
+				"Unable to find program entrypoint in current directory, not creating job artifact.",
+				Warn,
+			)
 			return nil, nil, nil
 		} else if err != nil {
 			return nil, nil, err
 		}
 
 		if metadata.Root == nil || j.settings.Proto.XJupyterRoot == nil {
-			return nil, nil, fmt.Errorf("no root path in metadata, or settings missing jupyter root, not creating job artifact")
+			return nil, nil, fmt.Errorf(
+				"no root path in metadata, or settings missing jupyter root, not creating job artifact",
+			)
 		}
 		fullProgramPath, err = j.HandlePathsAboveRoot(programRelpath, *metadata.Root)
 		if err != nil {
@@ -454,7 +472,10 @@ func (j *JobBuilder) createRepoJobSource(programRelpath string, metadata RunMeta
 
 }
 
-func (j *JobBuilder) createArtifactJobSource(programRelPath string, metadata RunMetadata) (*ArtifactSource, *string, error) {
+func (j *JobBuilder) createArtifactJobSource(
+	programRelPath string,
+	metadata RunMetadata,
+) (*ArtifactSource, *string, error) {
 	j.logger.Debug("jobBuilder: creating artifact job source")
 	var fullProgramRelPath string
 	// TODO: should we just always exit early if the path doesn't exist?
@@ -466,7 +487,10 @@ func (j *JobBuilder) createArtifactJobSource(programRelPath string, metadata Run
 		if _, err := os.Stat(programRelPath); os.IsNotExist(err) {
 			fullProgramRelPath = filepath.Base(programRelPath)
 			if _, err := os.Stat(filepath.Base(fullProgramRelPath)); os.IsNotExist(err) {
-				j.logIfVerbose("No program path found when generating artifact job source for a non-colab notebook run. See https://docs.wandb.ai/guides/launch/create-job", Warn)
+				j.logIfVerbose(
+					"No program path found when generating artifact job source for a non-colab notebook run. See https://docs.wandb.ai/guides/launch/create-job",
+					Warn,
+				)
 				return nil, nil, err
 			}
 		}
@@ -577,7 +601,10 @@ func (j *JobBuilder) Build(
 
 	if metadata.Python == nil {
 		j.logger.Debug("jobBuilder: no python version found in metadata")
-		j.logIfVerbose("No python version found in metadata, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job", Warn)
+		j.logIfVerbose(
+			"No python version found in metadata, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job",
+			Warn,
+		)
 		return nil, nil
 	}
 
@@ -598,7 +625,10 @@ func (j *JobBuilder) Build(
 	// all jobs except image jobs need to specify a program path
 	if *sourceType != ImageSourceType && programRelpath == nil {
 		j.logger.Debug("jobBuilder: no program path found")
-		j.logIfVerbose("No program path found, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job", Warn)
+		j.logIfVerbose(
+			"No program path found, not creating job artifact. See https://docs.wandb.ai/guides/launch/create-job",
+			Warn,
+		)
 		return nil, nil
 	}
 
@@ -665,7 +695,10 @@ func (j *JobBuilder) buildArtifact(
 ) (*spb.ArtifactRecord, error) {
 	artifactBuilder := artifacts.NewArtifactBuilder(baseArtifact)
 
-	err := artifactBuilder.AddFile(filepath.Join(fileDir, REQUIREMENTS_FNAME), FROZEN_REQUIREMENTS_FNAME)
+	err := artifactBuilder.AddFile(
+		filepath.Join(fileDir, REQUIREMENTS_FNAME),
+		FROZEN_REQUIREMENTS_FNAME,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -706,7 +739,9 @@ func (j *JobBuilder) HandleUseArtifactRecord(record *spb.Record) {
 
 	// if empty job name, disable job builder
 	if useArtifact.Partial != nil && len(useArtifact.Partial.JobName) == 0 {
-		j.logger.Debug("jobBuilder: no job name found in partial use artifact record, disabling job builder")
+		j.logger.Debug(
+			"jobBuilder: no job name found in partial use artifact record, disabling job builder",
+		)
 		j.Disable = true
 		return
 	}

--- a/core/pkg/launch/job_builder_test.go
+++ b/core/pkg/launch/job_builder_test.go
@@ -114,9 +114,21 @@ func TestJobBuilderRepo(t *testing.T) {
 				err = json.NewDecoder(jobFile).Decode(&data)
 				assert.Nil(t, err)
 				assert.Equal(t, "3.11.2", data["runtime"])
-				assert.Equal(t, "1234567890", data["source"].(map[string]interface{})["git"].(map[string]interface{})["commit"])
-				assert.Equal(t, "example.com", data["source"].(map[string]interface{})["git"].(map[string]interface{})["remote"])
-				assert.Equal(t, []interface{}([]interface{}{"python3.11", "/path/to/train.py"}), data["source"].(map[string]interface{})["entrypoint"])
+				assert.Equal(
+					t,
+					"1234567890",
+					data["source"].(map[string]interface{})["git"].(map[string]interface{})["commit"],
+				)
+				assert.Equal(
+					t,
+					"example.com",
+					data["source"].(map[string]interface{})["git"].(map[string]interface{})["remote"],
+				)
+				assert.Equal(
+					t,
+					[]interface{}([]interface{}{"python3.11", "/path/to/train.py"}),
+					data["source"].(map[string]interface{})["entrypoint"],
+				)
 			}
 		}
 	})
@@ -186,9 +198,21 @@ func TestJobBuilderRepo(t *testing.T) {
 				err = json.NewDecoder(jobFile).Decode(&data)
 				assert.Nil(t, err)
 				assert.Equal(t, "3.11.2", data["runtime"])
-				assert.Equal(t, "1234567890", data["source"].(map[string]interface{})["git"].(map[string]interface{})["commit"])
-				assert.Equal(t, "example.com", data["source"].(map[string]interface{})["git"].(map[string]interface{})["remote"])
-				assert.Equal(t, []interface{}([]interface{}{"python3.11", "Untitled.ipynb"}), data["source"].(map[string]interface{})["entrypoint"])
+				assert.Equal(
+					t,
+					"1234567890",
+					data["source"].(map[string]interface{})["git"].(map[string]interface{})["commit"],
+				)
+				assert.Equal(
+					t,
+					"example.com",
+					data["source"].(map[string]interface{})["git"].(map[string]interface{})["remote"],
+				)
+				assert.Equal(
+					t,
+					[]interface{}([]interface{}{"python3.11", "Untitled.ipynb"}),
+					data["source"].(map[string]interface{})["entrypoint"],
+				)
 			}
 		}
 	})
@@ -249,9 +273,17 @@ func TestJobBuilderArtifact(t *testing.T) {
 				err = json.NewDecoder(jobFile).Decode(&data)
 				assert.Nil(t, err)
 				assert.Equal(t, "3.11.2", data["runtime"])
-				assert.Equal(t, "wandb-artifact://_id/testArtifactId", data["source"].(map[string]interface{})["artifact"])
+				assert.Equal(
+					t,
+					"wandb-artifact://_id/testArtifactId",
+					data["source"].(map[string]interface{})["artifact"],
+				)
 				assert.Equal(t, "artifact", data["source_type"])
-				assert.Equal(t, []interface{}([]interface{}{"python3.11", "/path/to/train.py"}), data["source"].(map[string]interface{})["entrypoint"])
+				assert.Equal(
+					t,
+					[]interface{}([]interface{}{"python3.11", "/path/to/train.py"}),
+					data["source"].(map[string]interface{})["entrypoint"],
+				)
 			}
 		}
 	})
@@ -321,9 +353,17 @@ func TestJobBuilderArtifact(t *testing.T) {
 				err = json.NewDecoder(jobFile).Decode(&data)
 				assert.Nil(t, err)
 				assert.Equal(t, "3.11.2", data["runtime"])
-				assert.Equal(t, "wandb-artifact://_id/testArtifactId", data["source"].(map[string]interface{})["artifact"])
+				assert.Equal(
+					t,
+					"wandb-artifact://_id/testArtifactId",
+					data["source"].(map[string]interface{})["artifact"],
+				)
 				assert.Equal(t, "artifact", data["source_type"])
-				assert.Equal(t, []interface{}([]interface{}{"python3.11", "Untitled.ipynb"}), data["source"].(map[string]interface{})["entrypoint"])
+				assert.Equal(
+					t,
+					[]interface{}([]interface{}{"python3.11", "Untitled.ipynb"}),
+					data["source"].(map[string]interface{})["entrypoint"],
+				)
 			}
 		}
 	})
@@ -381,7 +421,11 @@ func TestJobBuilderImage(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, "3.11.2", data["runtime"])
 				assert.Equal(t, "image", data["source_type"])
-				assert.Equal(t, "testImage:testTag", data["source"].(map[string]interface{})["image"])
+				assert.Equal(
+					t,
+					"testImage:testTag",
+					data["source"].(map[string]interface{})["image"],
+				)
 			}
 		}
 	})
@@ -543,37 +587,40 @@ func TestJobBuilderHandleUseArtifactRecord(t *testing.T) {
 
 	})
 
-	t.Run("HandleUseArtifactRecord disables job builder when handling partial job with no name", func(t *testing.T) {
-		settingsProto := &spb.Settings{}
-		artifactRecord := &spb.Record{
-			RecordType: &spb.Record_UseArtifact{
-				UseArtifact: &spb.UseArtifactRecord{
-					Id:   "testID",
-					Type: "job",
-					Name: "partialArtifact",
-					Partial: &spb.PartialJobArtifact{
-						JobName: "",
-						SourceInfo: &spb.JobSource{
-							SourceType: "image",
-							Runtime:    "3.11.2",
-							Source: &spb.Source{
-								Image: &spb.ImageSource{
-									Image: "testImage:v0",
+	t.Run(
+		"HandleUseArtifactRecord disables job builder when handling partial job with no name",
+		func(t *testing.T) {
+			settingsProto := &spb.Settings{}
+			artifactRecord := &spb.Record{
+				RecordType: &spb.Record_UseArtifact{
+					UseArtifact: &spb.UseArtifactRecord{
+						Id:   "testID",
+						Type: "job",
+						Name: "partialArtifact",
+						Partial: &spb.PartialJobArtifact{
+							JobName: "",
+							SourceInfo: &spb.JobSource{
+								SourceType: "image",
+								Runtime:    "3.11.2",
+								Source: &spb.Source{
+									Image: &spb.ImageSource{
+										Image: "testImage:v0",
+									},
 								},
 							},
 						},
 					},
 				},
-			},
-		}
-		jobBuilder := NewJobBuilder(
-			settings.From(settingsProto),
-			observabilitytest.NewTestLogger(t),
-			true,
-		)
-		jobBuilder.HandleUseArtifactRecord(artifactRecord)
-		assert.True(t, jobBuilder.Disable)
-	})
+			}
+			jobBuilder := NewJobBuilder(
+				settings.From(settingsProto),
+				observabilitytest.NewTestLogger(t),
+				true,
+			)
+			jobBuilder.HandleUseArtifactRecord(artifactRecord)
+			assert.True(t, jobBuilder.Disable)
+		},
+	)
 
 }
 func TestJobBuilderGetSourceType(t *testing.T) {
@@ -734,8 +781,14 @@ func TestJobBuilderGetSourceType(t *testing.T) {
 func TestUtilFunctions(t *testing.T) {
 
 	t.Run("makeArtifactNameSafe truncates to 128 characters", func(t *testing.T) {
-		name := MakeArtifactNameSafe("this is a very long name that is longer than 128 characters and should be truncated down to one hundred and twenty eight characters with the first 63 chars, and the last 63 chars separated by ..")
-		assert.Equal(t, "this_is_a_very_long_name_that_is_longer_than_128_characters_and.._with_the_first_63_chars__and_the_last_63_chars_separated_by_..", name)
+		name := MakeArtifactNameSafe(
+			"this is a very long name that is longer than 128 characters and should be truncated down to one hundred and twenty eight characters with the first 63 chars, and the last 63 chars separated by ..",
+		)
+		assert.Equal(
+			t,
+			"this_is_a_very_long_name_that_is_longer_than_128_characters_and.._with_the_first_63_chars__and_the_last_63_chars_separated_by_..",
+			name,
+		)
 
 	})
 	t.Run("handlePathsAboveRoot works when notebook started above git root", func(t *testing.T) {
@@ -747,7 +800,10 @@ func TestUtilFunctions(t *testing.T) {
 			observabilitytest.NewTestLogger(t),
 			true,
 		)
-		path, err := jobBuilder.HandlePathsAboveRoot("gitRoot/a/notebook.ipynb", "/path/to/jupyterRoot/gitRoot")
+		path, err := jobBuilder.HandlePathsAboveRoot(
+			"gitRoot/a/notebook.ipynb",
+			"/path/to/jupyterRoot/gitRoot",
+		)
 		assert.Nil(t, err)
 		assert.Equal(t, "a/notebook.ipynb", path)
 	})
@@ -833,7 +889,10 @@ func TestWandbConfigParameters(t *testing.T) {
 		InputSource: &spb.JobInputSource{
 			Source: &spb.JobInputSource_RunConfig{},
 		},
-		IncludePaths: []*spb.JobInputPath{{Path: []string{"key1"}}, {Path: []string{"key3", "key4"}}},
+		IncludePaths: []*spb.JobInputPath{
+			{Path: []string{"key1"}},
+			{Path: []string{"key3", "key4"}},
+		},
 		ExcludePaths: []*spb.JobInputPath{{Path: []string{"key3", "key4", "key6"}}},
 	})
 	artifact, err := jobBuilder.Build(ctx, gql, runConfig, nil)
@@ -941,7 +1000,10 @@ func TestWandbConfigParametersWithInputSchema(t *testing.T) {
 		InputSource: &spb.JobInputSource{
 			Source: &spb.JobInputSource_RunConfig{},
 		},
-		IncludePaths: []*spb.JobInputPath{{Path: []string{"key1"}}, {Path: []string{"key3", "key4"}}},
+		IncludePaths: []*spb.JobInputPath{
+			{Path: []string{"key1"}},
+			{Path: []string{"key3", "key4"}},
+		},
 		ExcludePaths: []*spb.JobInputPath{{Path: []string{"key3", "key4", "key6"}}},
 		InputSchema:  string(inputSchema),
 	})

--- a/core/pkg/leveldb/record_internal_test.go
+++ b/core/pkg/leveldb/record_internal_test.go
@@ -713,7 +713,12 @@ func TestSeekRecord(t *testing.T) {
 
 			rData, _ := io.ReadAll(rec)
 			if !bytes.Equal(rData, recs.records[i]) {
-				t.Fatalf("Unexpected output in record #%d's data, got %v want %v", i, rData, recs.records[i])
+				t.Fatalf(
+					"Unexpected output in record #%d's data, got %v want %v",
+					i,
+					rData,
+					recs.records[i],
+				)
 			}
 		}
 	}

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -390,7 +390,12 @@ func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
 	sentryClient.CaptureMessage("wandb-core", nil)
 
 	if err := nc.streamMux.AddStream(streamId, strm); err != nil {
-		slog.Error("handleInformInit: error adding stream", "err", err, "streamId", streamId, "id", nc.id)
+		slog.Error(
+			"handleInformInit: error adding stream",
+			"err", err,
+			"streamId", streamId,
+			"id", nc.id,
+		)
 		// TODO: should we Close the stream?
 		return
 	}
@@ -522,7 +527,12 @@ func (nc *Connection) handleInformFinish(msg *spb.ServerInformFinishRequest) {
 	// Attempt to remove the stream from the stream multiplexer
 	strm, err := nc.streamMux.RemoveStream(streamId)
 	if err != nil {
-		slog.Error("handleInformFinish: error removing stream", "err", err, "streamId", streamId, "id", nc.id)
+		slog.Error(
+			"handleInformFinish: error removing stream",
+			"err", err,
+			"streamId", streamId,
+			"id", nc.id,
+		)
 		return
 	}
 


### PR DESCRIPTION
Enables `golines` in `golangci-lint` with the very generous 100-character default line limit and applies fixes.

One should still aim for ~80 character lines. Longer than that usually means too much nesting, overly verbose naming, or too much info on one line. Sometimes it is OK to exceed 80 characters for alignment purposes. But exceeding 100 characters is 🤮 

I tweaked a few fixes manually to avoid completely barbaric formatting.