### PR TITLE
refactor: revert wandb login key validation change

### DIFF
--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -331,9 +331,6 @@ def _login(
         return True, None
 
     if key:
-        if problems := auth.check_api_key(key):
-            raise AuthenticationError(problems)
-
         if verify:
             _verify_login(key, wlogin._settings.base_url)
 


### PR DESCRIPTION
Removes the API key validation introduced in PR #10879 for keys explicitly passed to `wandb.login()` as it would break integration tests.