### PR TITLE
refactor: use `split()` instead of `rsplit()` for API key prefixes

### DIFF
--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -171,7 +171,7 @@ class BackendFixtureFactory:
 
     def make_user(self, name: str | None = None, admin: bool = False) -> str:
         """Create a new user and return their username."""
-        name = name or (f"user-{self.worker_id}-{random_string(length=40)}")
+        name = name or (f"user_{self.worker_id}-{random_string(length=40)}")
 
         self.send_cmds(
             UserCmd("up", username=name, admin=admin),

--- a/tests/unit_tests/test_lib/test_auth_validation.py
+++ b/tests/unit_tests/test_lib/test_auth_validation.py
@@ -6,9 +6,9 @@ from wandb.sdk.lib.auth import validation
     "key, problems",
     (
         ("", "API key is empty."),
-        ("some-prefix-" + "A" * 39, "API key must have 40+ characters, has 39."),
-        ("some-prefix-" + "A" * 40, None),
-        ("some-prefix-" + "A" * 60, None),
+        ("some_prefix-" + "A" * 39, "API key must have 40+ characters, has 39."),
+        ("some_prefix-" + "A" * 40, None),
+        ("some_prefix-" + "A" * 60, None),
         ("*", "API key may only contain"),
     ),
 )

--- a/wandb/sdk/lib/auth/validation.py
+++ b/wandb/sdk/lib/auth/validation.py
@@ -19,13 +19,18 @@ def check_api_key(key: str) -> str | None:
         return "API key is empty."
 
     # On-prem API keys have a variable-length prefix followed by a dash.
-    parts = key.rsplit("-", 1)
+    #
+    # NOTE: This should be rsplit(), but it is split() to be backward compatible
+    # with tests that rely on that. It should be safe to change to rsplit()
+    # once our tests are updated.
+    parts = key.split("-", 1)
     if len(parts) == 1:
         secret = parts[0]
     else:
         _, secret = parts
 
-    if not re.fullmatch(r"\w+", secret):
+    # NOTE: Dashes only allowed because of split() instead of rsplit() above.
+    if not re.fullmatch(r"[\w-]+", secret):
         return "API key may only contain the letters A-Z, digits and underscores."
 
     if (secret_len := len(secret)) < 40:


### PR DESCRIPTION
Revert the fix implemented in PR #10847 to avoid breaking integration tests on the next release.