### PR TITLE
chore: simplify SDK release workflow with mode selection dropdown

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,5 +1,5 @@
 name: Build and Release W&B SDK
-run-name: SDK ${{ inputs.version }} release${{ inputs.dry-run && ' (dry-run)' || '' }}
+run-name: "SDK ${{ inputs.version }} — ${{ inputs.mode }}"
 
 on:
   workflow_dispatch:
@@ -8,15 +8,19 @@ on:
         type: string
         description: "Version to assign to the release"
         required: true
-      dry-run:
-        type: boolean
-        description: "Dry run (avoid uploading to PyPI)"
-        default: true
-      update-changelog:
-        type: boolean
-        description: "Update changelog and release notes"
-        required: false
-        default: false
+      mode:
+        type: choice
+        description: >-
+          Release mode:
+          1) test-release — TestPyPI only.
+          2) pre-release — PyPI + TestPyPI, no notes.
+          3) release — PyPI + TestPyPI, notes + PR + Slack.
+        required: true
+        default: test-release
+        options:
+          - test-release
+          - pre-release
+          - release
 
 jobs:
   prepare-release:
@@ -49,7 +53,7 @@ jobs:
           bump2version patch --no-tag --no-commit --config-file .bumpversion.cfg --new-version ${{ github.event.inputs.version }}
 
       - name: Update CHANGELOG.md
-        if: ${{ inputs.update-changelog }}
+        if: ${{ inputs.mode == 'release' }}
         run: |
           python tools/changelog.py \
             --version ${{ github.event.inputs.version }}
@@ -106,7 +110,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     needs: prepare-release
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -123,8 +127,6 @@ jobs:
 
       ##################################################
       # Install Go
-      #
-      # See comment above CIBW_BEFORE_ALL_LINUX.
       ##################################################
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -141,7 +143,7 @@ jobs:
           package-dir: .
           output-dir: dist
         env:
-          CIBW_ARCHS_LINUX: x86_64 #aarch64 is handled by build-linux-arm64-wheels
+          CIBW_ARCHS_LINUX: x86_64 # aarch64 is handled by build-linux-arm64-wheels
           CIBW_ARCHS_MACOS: x86_64 arm64 # arm64 == aarch64
 
           # Work around https://github.com/matthew-brett/delocate/issues/204
@@ -307,7 +309,7 @@ jobs:
           python -c "import wandb; run = wandb.init(); run.finish()"
 
   pypi-publish:
-    if: ${{ !inputs.dry-run }}
+    if: ${{ inputs.mode != 'test-release' }}
     name: Publish to PyPI
     needs: [verify-test-pypi, verify-test-pypi-sdist]
     runs-on: ubuntu-latest
@@ -338,7 +340,7 @@ jobs:
     name: Create dev branch and PR
     needs: pypi-publish
     runs-on: ubuntu-latest
-    if: ${{ inputs.update-changelog && !inputs.dry-run }}
+    if: ${{ inputs.mode == 'release' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -379,7 +381,7 @@ jobs:
     name: Publish Release Notes
     needs: pypi-publish
     runs-on: ubuntu-latest
-    if: ${{ inputs.update-changelog && !inputs.dry-run }}
+    if: ${{ inputs.mode == 'release' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -408,7 +410,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   slack:
-    if: ${{ !inputs.dry-run }}
+    if: ${{ inputs.mode == 'release' }}
     name: Post to Slack
     needs: publish-release-notes
     runs-on: ubuntu-latest
@@ -438,6 +440,7 @@ jobs:
   # In the event of a failure building wandb/core, the actor that ran this
   # release will be notified.
   notify-core:
+    if: ${{ inputs.mode != 'test-release' }}
     name: notify wandb/core of release
     runs-on: ubuntu-latest
     needs: [pypi-publish]
@@ -463,5 +466,9 @@ jobs:
             {
               "version": "${{ inputs.version }}",
               "actor": "${{ github.actor }}",
-              "actor_id": "${{ github.actor_id }}"
+              "actor_id": "${{ github.actor_id }}",
+              "repository": "${{ github.repository }}",
+              "workflow_ref": "${{ github.workflow_ref }}",
+              "run_id": "${{ github.run_id }}",
+              "mode": "${{ inputs.mode }}"
             }


### PR DESCRIPTION
## Description
- Replaces separate boolean inputs with a single dropdown selection for release mode
- Introduces three distinct modes:
  - `test-release`: Publishes to TestPyPI only
  - `pre-release`: Publishes to both PyPI and TestPyPI without release notes
  - `release`: Full release with PyPI publishing, release notes, PR creation, and Slack notification
- Reduces wheel build timeout from 60 to 30 minutes
