### PR TITLE
feat: add setting to control wandb stage directory name

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -72,7 +72,7 @@ When preparing a release that can include breaking changes, consider applying ch
 
 - Require `format` argument when initializing `wandb.Video`
     - Owner: @jacobromero
-    - can do in >=0.20
+    - Can do in >=0.20
 
 - Remove the `start_method` setting:
     - Owner: @kptkin
@@ -86,7 +86,7 @@ When preparing a release that can include breaking changes, consider applying ch
 
 - Remove normalization of image data on `wandb.Image`
     - Owner: @jacobromero
-    - can do in >=0.21
+    - Can do in >=0.21
 
 - Disallow calling `wandb.save` without args:
     - Owner: @dmitryduev
@@ -116,18 +116,22 @@ When preparing a release that can include breaking changes, consider applying ch
 - Remove `wandb.apis.paginator.SizedPaginator::length`:
     - Owner: @jacobromero
     - Deprecated in 0.21.0
-    - can do in >= 0.22
+    - Can do in >=0.22
 
 - Make `wandb.apis.public.runs.Run::load()` private:
     - Owner: @jacobromero
-    - Can do in >= 0.22
+    - Can do in >=0.22
 
 - Remove `wandb.beta.workflows`, `wandb.beta.workflows::log_model()`, `wandb.beta.workflows::link_model()`, `wandb.beta.workflows::use_model()`:
     - Owner: @tonyyli-wandb
     - Deprecated in 0.21.1 (https://github.com/wandb/wandb/pull/10205)
-    - can do in >= 0.23
+    - Can do in >=0.23
 
 - Remove the `anonymous` setting and corresponding parameter from `wandb.init()` and `wandb.login()`:
     - Owner: @timoffex
     - Deprecated after 0.23.0
     - Can do after May 2026. It depends on when the PyTorch Lightning W&B integration (and possibly others) can be updated to not pass `anonymous` (even set to `None`)
+
+- Use `.wandb` staging directory unconditionally in `wandb.Settings.wandb_dir` and deprecate + remove `wandb.Settings.use_dot_wandb`.
+    - Owner: @dmitryduev
+    - Can do in >= 0.24

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -459,6 +459,13 @@ class Settings(BaseModel, validate_assignment=True):
     table_raise_on_max_row_limit_exceeded: bool = False
     """Whether to raise an exception when table row limits are exceeded."""
 
+    use_dot_wandb: Optional[bool] = None
+    """Whether to use a hidden `.wandb` or visible `wandb` directory for run data.
+
+    If True, the SDK uses `.wandb`. If False, `wandb`.
+    If not set, defaults to `.wandb` if it already exists, otherwise `wandb`.
+    """
+
     username: Optional[str] = None
     """Username."""
 
@@ -1727,13 +1734,13 @@ class Settings(BaseModel, validate_assignment=True):
     @property
     def wandb_dir(self) -> str:
         """Full path to the wandb directory."""
-        stage_dir = (
-            ".wandb" + os.sep
-            if os.path.exists(os.path.join(self.root_dir, ".wandb"))
-            else "wandb" + os.sep
-        )
-        path = os.path.join(self.root_dir, stage_dir)
-        return os.path.expanduser(path)
+        if self.use_dot_wandb is None:
+            use_dot = pathlib.Path(self.root_dir, ".wandb").exists()
+        else:
+            use_dot = self.use_dot_wandb
+
+        dirname = ".wandb" if use_dot else "wandb"
+        return str(pathlib.Path(self.root_dir, dirname).expanduser())
 
     # Methods to collect and update settings from different sources.
     #


### PR DESCRIPTION
## Description

Fixes #10997.

Adds a setting `use_dot_wandb` to make the SDK use `.wandb` as the staging dir instead of `wandb` (preserving the current behavior if `use_dot_wandb` is unset).

We should plan to use `.wandb` unconditionally:
1) Remove the condition on the `.wandb` dir existence + make `use_dot_wandb: bool = False` by default.
2) Make `use_dot_wandb: bool = True`.
3) Remove it.
