### PR TITLE
chore: run the check-docs-reference action only when main is the base branch

### DIFF
--- a/.github/workflows/validate-docs-pr.yml
+++ b/.github/workflows/validate-docs-pr.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-docs-reference:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'mаin'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description
This PR adds a conditional check to the `validate-docs-pr.yml` workflow to only run the `check-docs-reference` job when the pull request's base branch is `main`. This prevents the workflow from running unnecessarily on PRs targeting other branches (e.g. on graphite stacks).
