### PR TITLE
chore(artifacts): nonfunctional cleanup - artifacts system tests

### DIFF
--- a/tests/system_tests/test_artifacts/conftest.py
+++ b/tests/system_tests/test_artifacts/conftest.py
@@ -1,9 +1,11 @@
-import pytest
+from __future__ import annotations
+
 import wandb
+from pytest import fixture
 from wandb.sdk.artifacts.artifact import Artifact
 
 
-@pytest.fixture
+@fixture
 def logged_artifact(user, example_files) -> Artifact:
     with wandb.init(entity=user, project="project") as run:
         artifact = wandb.Artifact("test-artifact", "dataset")
@@ -13,7 +15,7 @@ def logged_artifact(user, example_files) -> Artifact:
     return wandb.Api().artifact(f"{user}/project/test-artifact:v0")
 
 
-@pytest.fixture
+@fixture
 def linked_artifact(user, logged_artifact) -> Artifact:
     with wandb.init(entity=user, project="other-project") as run:
         run.link_artifact(logged_artifact, "linked-from-portfolio")

--- a/tests/system_tests/test_artifacts/test_artifact_cli.py
+++ b/tests/system_tests/test_artifacts/test_artifact_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 from pathlib import Path

--- a/tests/system_tests/test_artifacts/test_artifact_saver.py
+++ b/tests/system_tests/test_artifacts/test_artifact_saver.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
-import pytest
+from pytest import mark, raises
 from wandb.sdk.artifacts.artifact_saver import ArtifactSaver
 from wandb.sdk.internal import file_pusher, file_stream, internal_api
 
@@ -78,7 +80,7 @@ def test_calls_commit_on_success():
     api.commit_artifact.assert_called_once()
 
 
-@pytest.mark.timeout(1)
+@mark.timeout(1)
 class TestReraisesErr:
     def _save_artifact(self, api: Mock):
         stream = Mock(spec=file_stream.FileStreamApi)
@@ -103,27 +105,27 @@ class TestReraisesErr:
 
     def test_use_artifact_err_reraised(self):
         exc = Exception("test-exc")
-        with pytest.raises(Exception, match="test-exc"):
+        with raises(Exception, match="test-exc"):
             self._save_artifact(api=make_api(use_artifact=Mock(side_effect=exc)))
 
     def test_create_artifact_err_reraised(self):
         exc = Exception("test-exc")
-        with pytest.raises(Exception, match="test-exc"):
+        with raises(Exception, match="test-exc"):
             self._save_artifact(api=make_api(create_artifact=Mock(side_effect=exc)))
 
     def test_create_artifact_manifest_err_reraised(self):
         exc = Exception("test-exc")
-        with pytest.raises(Exception, match="test-exc"):
+        with raises(Exception, match="test-exc"):
             self._save_artifact(
                 api=make_api(create_artifact_manifest=Mock(side_effect=exc))
             )
 
     def test_upload_file_retry_err_reraised(self):
         exc = Exception("test-exc")
-        with pytest.raises(Exception, match="test-exc"):
+        with raises(Exception, match="test-exc"):
             self._save_artifact(api=make_api(upload_file_retry=Mock(side_effect=exc)))
 
     def test_commit_artifact_err_reraised(self):
         exc = Exception("test-exc")
-        with pytest.raises(Exception, match="test-exc"):
+        with raises(Exception, match="test-exc"):
             self._save_artifact(api=make_api(commit_artifact=Mock(side_effect=exc)))

--- a/tests/system_tests/test_artifacts/test_data_types.py
+++ b/tests/system_tests/test_artifacts/test_data_types.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import matplotlib
 import numpy as np
-import pytest
 import wandb
+from pytest import fixture, mark, raises
 from wandb import data_types
 from wandb.sdk.data_types import _dtypes
 from wandb.sdk.internal import incremental_table_util
@@ -27,7 +29,7 @@ def filter_artifacts_by_type(run, *artifact_types):
     return [art for art in run.logged_artifacts() if art.type in artifact_types]
 
 
-@pytest.fixture
+@fixture
 def sample_data():
     artifact = wandb.Artifact("N", type="dataset")
     artifact.save()
@@ -39,10 +41,10 @@ def test_wb_value(user, sample_data, test_settings):
     public_art = run.use_artifact("N:latest")
 
     wbvalue = data_types.WBValue()
-    with pytest.raises(NotImplementedError):
+    with raises(NotImplementedError):
         wbvalue.to_json(local_art)
 
-    with pytest.raises(NotImplementedError):
+    with raises(NotImplementedError):
         data_types.WBValue.from_json({}, public_art)
 
     assert data_types.WBValue.with_suffix("item") == "item.json"
@@ -83,7 +85,7 @@ def test_log_dataframe(user, test_settings):
     assert len(table_artifacts) == 1
 
 
-@pytest.mark.parametrize("log_mode", ["IMMUTABLE", "MUTABLE", "INCREMENTAL"])
+@mark.parametrize("log_mode", ["IMMUTABLE", "MUTABLE", "INCREMENTAL"])
 def test_table_logged_from_run_with_special_characters_in_name(
     user, test_settings, log_mode
 ):
@@ -99,7 +101,7 @@ def test_table_logged_from_run_with_special_characters_in_name(
         run.log({"my-table": table}, step=1)
 
 
-@pytest.mark.parametrize("max_cli_version", ["0.10.33", "0.11.0"])
+@mark.parametrize("max_cli_version", ["0.10.33", "0.11.0"])
 def test_reference_table_logging(
     user, test_settings, wandb_backend_spy, max_cli_version
 ):
@@ -510,5 +512,5 @@ def test_incremental_tables_cannot_be_logged_on_multiple_runs(
 
     with wandb.init(settings=test_settings(), mode="offline") as run2:
         incr_table.add_data(2, "2")
-        with pytest.raises(AssertionError):
+        with raises(AssertionError):
             run2.log({"table": incr_table})

--- a/tests/system_tests/test_artifacts/test_link_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_link_artifacts.py
@@ -1,5 +1,7 @@
-import pytest
+from __future__ import annotations
+
 import wandb
+from pytest import raises
 
 
 def test_get_artifact_collection_from_linked_artifact(linked_artifact):
@@ -36,7 +38,7 @@ def test_unlink_artifact(logged_artifact, linked_artifact, api):
     assert api.artifact_exists(linked_artifact_path) is False
 
     # Unlinking the source artifact should not be possible
-    with pytest.raises(ValueError, match=r"use 'Artifact.delete' instead"):
+    with raises(ValueError, match=r"use 'Artifact.delete' instead"):
         source_artifact.unlink()
 
     # ... and the source artifact should *still* exist

--- a/tests/system_tests/test_artifacts/test_misc2.py
+++ b/tests/system_tests/test_artifacts/test_misc2.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from typing import Callable
 
 import numpy as np
-import pytest
 import wandb
+from pytest import mark, raises
 from wandb.sdk.artifacts.exceptions import ArtifactNotLoggedError
 
 
@@ -38,7 +40,7 @@ def test_lazy_artifact_passthrough(user):
 
         t1 = wandb.Table(columns=[], data=[])
         e = art.add(t1, "t1")
-        with pytest.raises(ValueError):
+        with raises(ValueError):
             e.ref_target()
 
         # These getters should be valid both before and after logging
@@ -103,13 +105,13 @@ def test_lazy_artifact_passthrough(user):
         for valid_getter in testable_getters_valid:
             _ = getattr(art, valid_getter)
         for invalid_getter in testable_getters_invalid:
-            with pytest.raises(ArtifactNotLoggedError):
+            with raises(ArtifactNotLoggedError):
                 _ = getattr(art, invalid_getter)
 
         for valid_setter in testable_setters_valid:
             setattr(art, valid_setter, setter_data.get(valid_setter, valid_setter))
         for invalid_setter in testable_setters_invalid:
-            with pytest.raises(ArtifactNotLoggedError):
+            with raises(ArtifactNotLoggedError):
                 setattr(
                     art, invalid_setter, setter_data.get(invalid_setter, invalid_setter)
                 )
@@ -119,7 +121,7 @@ def test_lazy_artifact_passthrough(user):
             _ = attr_method(*params.get(valid_method, []))
         for invalid_method in testable_methods_invalid:
             attr_method = getattr(art, invalid_method)
-            with pytest.raises(ArtifactNotLoggedError):
+            with raises(ArtifactNotLoggedError):
                 _ = attr_method(*params.get(invalid_method, []))
 
         # THE LOG
@@ -128,13 +130,13 @@ def test_lazy_artifact_passthrough(user):
         for valid_getter in testable_getters_valid:
             _ = getattr(art, valid_getter)
         for invalid_getter in testable_getters_invalid:
-            with pytest.raises(ArtifactNotLoggedError):
+            with raises(ArtifactNotLoggedError):
                 _ = getattr(art, invalid_getter)
 
         for valid_setter in testable_setters_valid:
             setattr(art, valid_setter, setter_data.get(valid_setter, valid_setter))
         for invalid_setter in testable_setters_invalid:
-            with pytest.raises(ArtifactNotLoggedError):
+            with raises(ArtifactNotLoggedError):
                 setattr(
                     art, invalid_setter, setter_data.get(invalid_setter, invalid_setter)
                 )
@@ -144,7 +146,7 @@ def test_lazy_artifact_passthrough(user):
             _ = attr_method(*params.get(valid_method, []))
         for invalid_method in testable_methods_invalid:
             attr_method = getattr(art, invalid_method)
-            with pytest.raises(ArtifactNotLoggedError):
+            with raises(ArtifactNotLoggedError):
                 _ = attr_method(*params.get(invalid_method, []))
 
         # THE ALL IMPORTANT WAIT
@@ -182,7 +184,7 @@ def test_reference_download(user):
 
         entry = artifact.get_entry("file1.txt")
         entry.download()
-        with pytest.raises(ValueError):
+        with raises(ValueError):
             assert entry.ref_target()
 
 
@@ -196,7 +198,7 @@ def _create_artifact_and_set_metadata(metadata):
 # regardless of whether we set the metadata by passing it into the constructor
 # or by setting the attribute after creation; so, parametrize how we build the
 # artifact, and run tests both ways.
-@pytest.mark.parametrize(
+@mark.parametrize(
     "create_artifact",
     [
         lambda metadata: wandb.Artifact("foo", "dataset", metadata=metadata),
@@ -222,13 +224,13 @@ class TestArtifactChecksMetadata:
     def test_validates_metadata_err(
         self, create_artifact: Callable[..., wandb.Artifact]
     ):
-        with pytest.raises(TypeError):
+        with raises(TypeError):
             create_artifact(metadata=123)
 
-        with pytest.raises(TypeError):
+        with raises(TypeError):
             create_artifact(metadata=[])
 
-        with pytest.raises(TypeError):
+        with raises(TypeError):
             create_artifact(metadata={"unserializable": object()})
 
     def test_deepcopies_metadata(self, create_artifact: Callable[..., wandb.Artifact]):

--- a/tests/system_tests/test_artifacts/test_model_workflows.py
+++ b/tests/system_tests/test_artifacts/test_model_workflows.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import pathlib
 
-import pytest
 import wandb
+from pytest import raises
 from wandb import env
 
 
@@ -15,7 +17,7 @@ class FakeArtifact:
 
 def test_offline_link_artifact(user):
     run = wandb.init(mode="offline")
-    with pytest.raises(NotImplementedError):
+    with raises(NotImplementedError):
         run.link_artifact(FakeArtifact(), "entity/project/portfolio", "latest")
     run.finish()
 
@@ -63,7 +65,7 @@ def test_use_model_error_artifact_type(
 
     logged_artifact = run.log_artifact(local_path, name="test-model", type="dataset")
     logged_artifact.wait()
-    with pytest.raises(AssertionError):
+    with raises(AssertionError):
         _ = run.use_model("test-model:v0")
     run.finish()
 
@@ -95,7 +97,7 @@ def test_link_model_error_artifact_type(
 
     logged_artifact = run.log_artifact(local_path, name="test_model", type="dataset")
     logged_artifact.wait()
-    with pytest.raises(AssertionError):
+    with raises(AssertionError):
         run.link_model(local_path, "test_portfolio", "test_model")
     run.finish()
 

--- a/tests/system_tests/test_artifacts/test_wandb_run_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_run_artifacts.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 from unittest import mock
 
-import pytest
 import wandb
+from pytest import fixture, mark, raises
+from wandb.errors import CommError
 
 
-@pytest.fixture
+@fixture
 def sample_data():
     artifact = wandb.Artifact("boom-data", type="dataset")
     artifact.save()
@@ -21,19 +24,19 @@ def test_artifacts_in_config(user, sample_data, test_settings):
         run.config.dataset = artifact
         run.config.logged_artifact = logged_artifact
         run.config.update({"myarti": artifact})
-        with pytest.raises(ValueError) as e_info:
+        with raises(ValueError) as e_info:
             run.config.nested_dataset = {"nested": artifact}
         assert str(e_info.value) == (
             "Instances of wandb.Artifact can only be top level keys in a run's config"
         )
 
-        with pytest.raises(ValueError) as e_info:
+        with raises(ValueError) as e_info:
             run.config.dict_nested = {"one_nest": {"two_nest": artifact}}
         assert str(e_info.value) == (
             "Instances of wandb.Artifact can only be top level keys in a run's config"
         )
 
-        with pytest.raises(ValueError) as e_info:
+        with raises(ValueError) as e_info:
             run.config.update({"one_nest": {"two_nest": artifact}})
         assert str(e_info.value) == (
             "Instances of wandb.Artifact can only be top level keys in a run's config"
@@ -312,7 +315,7 @@ def test_log_code_settings(user):
     wandb.Api().artifact(f"{artifact_name}:v0")
 
 
-@pytest.mark.parametrize("save_code", [True, False])
+@mark.parametrize("save_code", [True, False])
 def test_log_code_env(wandb_backend_spy, save_code):
     # test for WB-7468
     with mock.patch.dict("os.environ", WANDB_SAVE_CODE=str(save_code).lower()):
@@ -340,5 +343,5 @@ def test_log_code_env(wandb_backend_spy, save_code):
         if save_code:
             wandb.Api().artifact(f"{artifact_name}:v0")
         else:
-            with pytest.raises(wandb.errors.CommError):
+            with raises(CommError):
                 wandb.Api().artifact(f"{artifact_name}:v0")


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

Non-functional cleanup / stylistic nits for code in artifact test modules.  Separated to reduce noise in upstack PRs.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->