### PR TITLE
fix: regex-escape path in test_settings_file.py

### DIFF
--- a/tests/unit_tests/test_lib/test_settings_file.py
+++ b/tests/unit_tests/test_lib/test_settings_file.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import textwrap
 
 import pytest
@@ -19,7 +20,7 @@ def test_error_writing(tmp_path: pathlib.Path):
 
     with pytest.raises(
         settings_file.SaveSettingsError,
-        match=f"Error updating settings at {local_settings}",
+        match=f"Error updating settings at {re.escape(str(local_settings))}",
     ):
         system_settings.save()
 


### PR DESCRIPTION
Fixes a test on Windows that didn't escape a filesystem path in a regex.

```
Invalid regex pattern provided to 'match': incomplete escape \U at position 29
```