### PR TITLE
refactor: entity and project in wandb_backend_spy

### DIFF
--- a/tests/fixtures/wandb_backend_spy/proxy.py
+++ b/tests/fixtures/wandb_backend_spy/proxy.py
@@ -190,7 +190,11 @@ class WandbBackendProxy:
             response = await self._relay(request)
 
         if spy:
-            spy.post_graphql(await request.body(), response.body)
+            spy.post_graphql(
+                await request.body(),
+                response.body,
+                response_code=response.status_code,
+            )
 
         return response
 


### PR DESCRIPTION
Updates `wandb_backend_spy` to track runs by their full path rather than just ID.

I only added `entity` and `project` parameters to the `history()` method, though in theory they could be added to all. Even better would be to have a single method that returns something like `_RunData`.

Used in the next PR, which tests changing a run's `--entity` and `--project` in `wandb beta sync`.