### PR TITLE
fix(artifacts): avoid using global random instance for client id

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,3 +12,7 @@ Add here any changes made in a PR that are relevant to end users. Allowed sectio
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- Fixed `Invalid Client ID digest` error when creating artifacts after calling `random.seed()`. Client IDs could collide when random state was seeded deterministically. (@pingleiwandb in https://github.com/wandb/wandb/pull/11039)

--- a/tests/unit_tests/test_lib/test_runid.py
+++ b/tests/unit_tests/test_lib/test_runid.py
@@ -1,3 +1,6 @@
+import random
+
+import pytest
 from wandb.sdk.lib import runid
 
 
@@ -11,3 +14,23 @@ def test_generate_id_is_base36():
 
 def test_generate_id_default_8_chars():
     assert len(runid.generate_id()) == 8
+
+
+@pytest.fixture
+def isolate_random_state():
+    orig_state = random.getstate()
+    try:
+        yield
+    finally:
+        random.setstate(orig_state)
+
+
+@pytest.mark.usefixtures("isolate_random_state")
+def test_generate_fast_id_independent_of_global_seed():
+    random.seed(42)
+    id1 = runid.generate_fast_id(128)
+
+    random.seed(42)
+    id2 = runid.generate_fast_id(128)
+
+    assert id1 != id2, "generate_fast_id should not be affected by global random.seed()"

--- a/wandb/sdk/lib/runid.py
+++ b/wandb/sdk/lib/runid.py
@@ -6,6 +6,10 @@ from string import ascii_lowercase, digits
 
 _ID_CHARS = f"{ascii_lowercase}{digits}"
 
+# Create a dedicated Random instance with its own state so it
+# is not affected by global random.seed() calls
+_random = random.Random()
+
 
 def generate_id(length: int = 8) -> str:
     """Generate a random base-36 string of `length` digits."""
@@ -19,5 +23,8 @@ def generate_fast_id(length: int = 8) -> str:
 
     In local testing at the time of implementation, this is ~30-50x faster than
     `generate_id` when generating 128-character IDs.
+
+    Uses a dedicated Random instance to avoid being affected by global
+    random.seed() calls from user code or libraries.
     """
-    return "".join(random.choices(_ID_CHARS, k=length))
+    return "".join(_random.choices(_ID_CHARS, k=length))


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-29707

We switched to use `random.choices` in https://github.com/wandb/wandb/pull/10819 If user set `random.seed` they would get `Invalid Client ID digest`.

```
ValueError: ArtifactSaver.createArtifact: returned error 400: {"data":{"createArtifact":null},"errors":[{"message":"Invalid Client ID digest","path":["createArtifact"]}]}
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

- [x] unit test
- [ ] system test

```
import wandb
import random
from datetime import datetime

ENTITY = "reg-team-2"
PROJECT = "pinglei-test"


def log_once():
    with open("lora.txt", "w") as f:
        f.write(f"this is not real lora {datetime.now()}")
    with wandb.init(
        entity=ENTITY, project=PROJECT, name="test_invalid_client_id"
    ) as run:
        # https://wandb.ai/reg-team-2/pinglei-test/artifacts/lora/my-artifact/v0/overview
        artifact = wandb.Artifact(
            "my-artifact",
            type="lora",
            storage_region="coreweave-us",
            metadata={"wandb.base_model": "invalid model"},
        )
        artifact.add_file("lora.txt")
        run.log_artifact(artifact)
        artifact.wait()


def log_after_setting_seed():
    random.seed(42)
    log_once()


def main():
    wandb.login()
    # log_once() # works
    log_after_setting_seed()  # ValueError: ArtifactSaver.createArtifact: returned error 400: {"data":{"createArtifact":null},"errors":[{"message":"Invalid Client ID digest","path":["createArtifact"]}]}


if __name__ == "__main__":
    main()

```