### PR TITLE
fix: initialize transactionlog.Reader.logger

### DIFF
--- a/core/internal/transactionlog/reader.go
+++ b/core/internal/transactionlog/reader.go
@@ -59,7 +59,7 @@ func NewReader(
 		return nil, fmt.Errorf("transactionlog: bad header: %v", err)
 	}
 
-	return &Reader{reader: reader, source: source}, nil
+	return &Reader{reader: reader, source: source, logger: logger}, nil
 }
 
 // SeekRecord seeks the underlying file to a specific offset.


### PR DESCRIPTION
The parameter was unused!

This would have caused a panic in `Close()` if closing the source returned an error.