### PR TITLE
refactor: don't panic on nil sentry in CaptureFatalAndPanic

### DIFF
--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -147,6 +147,10 @@ func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 
 // Reraise reports panics to Sentry.
 func (cl *CoreLogger) Reraise(args ...any) {
+	if cl.sentry == nil {
+		return
+	}
+
 	if err := recover(); err != nil {
 		cl.sentry.Reraise(err, cl.withArgs(args...))
 	}


### PR DESCRIPTION
Prevents `CaptureFatalAndPanic` from panicking extra when `sentry` is `nil`.

All other CoreLogger methods check whether `sentry` is nil.