### PR TITLE
fix: always pass SparseList by pointer

### DIFF
--- a/core/internal/filestream/filestreamrequest.go
+++ b/core/internal/filestream/filestreamrequest.go
@@ -30,7 +30,7 @@ type FileStreamRequest struct {
 	// Unlike history and system metrics, we often update past lines in
 	// console logs due to terminal emulation. For example, this is how
 	// tqdm-like progress bars work.
-	ConsoleLines sparselist.SparseList[string]
+	ConsoleLines *sparselist.SparseList[string]
 
 	// UploadedFiles is a set of files that have been uploaded.
 	//
@@ -69,7 +69,11 @@ func (r *FileStreamRequest) Merge(next *FileStreamRequest) {
 		r.SummaryUpdates.Merge(next.SummaryUpdates)
 	}
 
-	r.ConsoleLines.Update(next.ConsoleLines)
+	if r.ConsoleLines == nil {
+		r.ConsoleLines = next.ConsoleLines
+	} else {
+		r.ConsoleLines.Update(next.ConsoleLines)
+	}
 
 	if r.UploadedFiles == nil {
 		r.UploadedFiles = next.UploadedFiles

--- a/core/internal/filestream/filestreamrequest_test.go
+++ b/core/internal/filestream/filestreamrequest_test.go
@@ -79,10 +79,10 @@ func TestSummary_Merge_CombinesUpdates(t *testing.T) {
 }
 
 func TestConsole_MergeUpdatesPreferringLast(t *testing.T) {
-	req1 := &FileStreamRequest{}
+	req1 := &FileStreamRequest{ConsoleLines: &sparselist.SparseList[string]{}}
 	req1.ConsoleLines.Put(0, "req1 - 0")
 	req1.ConsoleLines.Put(5, "req1 - 5")
-	req2 := &FileStreamRequest{}
+	req2 := &FileStreamRequest{ConsoleLines: &sparselist.SparseList[string]{}}
 	req2.ConsoleLines.Put(0, "req2 - 0")
 	req2.ConsoleLines.Put(6, "req2 - 6")
 

--- a/core/internal/filestream/filestreamstate_test.go
+++ b/core/internal/filestream/filestreamstate_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runsummary"
+	"github.com/wandb/wandb/core/internal/sparselist"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -74,6 +75,7 @@ func TestState_IsAtSizeLimit_UnsentSummary(t *testing.T) {
 func TestState_IsAtSizeLimit_Console(t *testing.T) {
 	state := &FileStreamState{MaxRequestSizeBytes: 10}
 	request := &FileStreamRequest{}
+	request.ConsoleLines = &sparselist.SparseList[string]{}
 	request.ConsoleLines.Put(0, "one")
 	request.ConsoleLines.Put(1, "two")
 	request.ConsoleLines.Put(2, "this line is too long")
@@ -84,6 +86,7 @@ func TestState_IsAtSizeLimit_Console(t *testing.T) {
 func TestState_IsAtSizeLimit_ConsoleSmallRun(t *testing.T) {
 	state := &FileStreamState{MaxRequestSizeBytes: 10}
 	request := &FileStreamRequest{}
+	request.ConsoleLines = &sparselist.SparseList[string]{}
 	request.ConsoleLines.Put(0, "one")
 	request.ConsoleLines.Put(1, "two")
 	request.ConsoleLines.Put(10, "too long but in a different run")
@@ -293,6 +296,7 @@ func TestState_Pop_FullConsoleLines(t *testing.T) {
 		ConsoleLineOffset:   7,
 	}
 	request := &FileStreamRequest{}
+	request.ConsoleLines = &sparselist.SparseList[string]{}
 	request.ConsoleLines.Put(10, "line 17")
 	request.ConsoleLines.Put(11, "line 18")
 
@@ -309,6 +313,7 @@ func TestState_Pop_FullConsoleLines(t *testing.T) {
 func TestState_Pop_ConsoleLinesLimitedBySize(t *testing.T) {
 	state := &FileStreamState{ConsoleLineOffset: 7}
 	request := &FileStreamRequest{}
+	request.ConsoleLines = &sparselist.SparseList[string]{}
 	request.ConsoleLines.Put(6, "line 13")
 	request.ConsoleLines.Put(7, "line 14")
 
@@ -328,6 +333,7 @@ func TestState_Pop_ConsoleLinesMoreThanOneRun(t *testing.T) {
 		ConsoleLineOffset:   7,
 	}
 	request := &FileStreamRequest{}
+	request.ConsoleLines = &sparselist.SparseList[string]{}
 	request.ConsoleLines.Put(10, "run1_a")
 	request.ConsoleLines.Put(11, "run1_b")
 	request.ConsoleLines.Put(20, "run2_a")

--- a/core/internal/filestream/updatelogs.go
+++ b/core/internal/filestream/updatelogs.go
@@ -6,7 +6,7 @@ import (
 
 // LogsUpdate is new lines in a run's console output.
 type LogsUpdate struct {
-	Lines sparselist.SparseList[string]
+	Lines *sparselist.SparseList[string]
 }
 
 func (u *LogsUpdate) Apply(ctx UpdateContext) error {

--- a/core/internal/runconsolelogs/debouncedwriter.go
+++ b/core/internal/runconsolelogs/debouncedwriter.go
@@ -14,10 +14,10 @@ type debouncedWriter struct {
 	wg sync.WaitGroup
 
 	isFlushing bool
-	flush      func(sparselist.SparseList[*RunLogsLine])
+	flush      func(*sparselist.SparseList[*RunLogsLine])
 	rateLimit  *rate.Limiter
 
-	buffer sparselist.SparseList[*RunLogsLine]
+	buffer *sparselist.SparseList[*RunLogsLine]
 }
 
 // NewDebouncedWriter creates a writer that buffers changes and invokes flush
@@ -26,11 +26,12 @@ type debouncedWriter struct {
 // Stops invoking `flush` after the context is cancelled.
 func NewDebouncedWriter(
 	rateLimit *rate.Limiter,
-	flush func(sparselist.SparseList[*RunLogsLine]),
+	flush func(*sparselist.SparseList[*RunLogsLine]),
 ) *debouncedWriter {
 	return &debouncedWriter{
 		flush:     flush,
 		rateLimit: rateLimit,
+		buffer:    &sparselist.SparseList[*RunLogsLine]{},
 	}
 }
 
@@ -68,7 +69,7 @@ func (b *debouncedWriter) loopFlushBuffer() {
 		}
 
 		lines := b.buffer
-		b.buffer = sparselist.SparseList[*RunLogsLine]{}
+		b.buffer = &sparselist.SparseList[*RunLogsLine]{}
 		b.mu.Unlock()
 
 		b.flush(lines)

--- a/core/internal/runconsolelogs/debouncedwriter_test.go
+++ b/core/internal/runconsolelogs/debouncedwriter_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func TestInvokesCallback(t *testing.T) {
-	flushes := make(chan sparselist.SparseList[*RunLogsLine], 1)
+	flushes := make(chan *sparselist.SparseList[*RunLogsLine], 1)
 	writer := NewDebouncedWriter(
 		rate.NewLimiter(rate.Inf, 1),
-		func(lines sparselist.SparseList[*RunLogsLine]) {
+		func(lines *sparselist.SparseList[*RunLogsLine]) {
 			flushes <- lines
 		},
 	)

--- a/core/internal/runconsolelogs/filestreamwriter.go
+++ b/core/internal/runconsolelogs/filestreamwriter.go
@@ -27,7 +27,7 @@ type filestreamWriter struct {
 }
 
 func (w *filestreamWriter) SendChanged(
-	changes sparselist.SparseList[*RunLogsLine],
+	changes *sparselist.SparseList[*RunLogsLine],
 ) {
 	lines := sparselist.Map(changes, func(line *RunLogsLine) string {
 		if w.Structured {

--- a/core/internal/runconsolelogs/linefile.go
+++ b/core/internal/runconsolelogs/linefile.go
@@ -62,7 +62,7 @@ func CreateLineFile(path string, perm fs.FileMode) (*lineFile, error) {
 // UpdateLines replaces lines in the file.
 //
 // This is written for performance when updating lines near the end of the file.
-func (f *lineFile) UpdateLines(lines sparselist.SparseList[string]) (err error) {
+func (f *lineFile) UpdateLines(lines *sparselist.SparseList[string]) (err error) {
 	if lines.Len() == 0 {
 		return nil
 	}

--- a/core/internal/runconsolelogs/linefile_test.go
+++ b/core/internal/runconsolelogs/linefile_test.go
@@ -29,7 +29,7 @@ func TestUpdateLines(t *testing.T) {
 	require.NoError(t, err)
 
 	// TEST: Append new lines.
-	lines := sparselist.SparseList[string]{}
+	lines := &sparselist.SparseList[string]{}
 	lines.Put(0, "one")
 	lines.Put(1, "two")
 	lines.Put(3, "four")
@@ -42,7 +42,7 @@ func TestUpdateLines(t *testing.T) {
 		string(content))
 
 	// TEST: Modify old lines, use non-ASCII characters.
-	lines = sparselist.SparseList[string]{}
+	lines = &sparselist.SparseList[string]{}
 	lines.Put(1, "two 💥") // 💥 takes 4 UTF-8 codepoints
 	lines.Put(2, "three, added")
 	lines.Put(6, "seven, new")

--- a/core/internal/runconsolelogs/outputfilewriter.go
+++ b/core/internal/runconsolelogs/outputfilewriter.go
@@ -83,7 +83,7 @@ func NewOutputFileWriter(params OutputFileWriterParams) *outputFileWriter {
 //
 // If w.broken is true, this is a no-op.
 func (w *outputFileWriter) WriteToFile(
-	changes sparselist.SparseList[*RunLogsLine],
+	changes *sparselist.SparseList[*RunLogsLine],
 ) error {
 	if w.broken {
 		return nil
@@ -104,7 +104,7 @@ func (w *outputFileWriter) WriteToFile(
 		}
 	}
 
-	lines := sparselist.SparseList[string]{}
+	lines := &sparselist.SparseList[string]{}
 	var addedBytes int64
 
 	changes.ForEach(func(globalLineNum int, line *RunLogsLine) {

--- a/core/internal/runconsolelogs/outputfilewriter_test.go
+++ b/core/internal/runconsolelogs/outputfilewriter_test.go
@@ -79,14 +79,14 @@ func TestOutputFileWriterRotationBySize(t *testing.T) {
 	})
 
 	// Write first batch - should fit in one chunk.
-	changes1 := sparselist.SparseList[*RunLogsLine]{}
+	changes1 := &sparselist.SparseList[*RunLogsLine]{}
 	changes1.Put(0, makeRunLogsLine(strings.Repeat("a", 30)))
 	changes1.Put(1, makeRunLogsLine(strings.Repeat("b", 30)))
 	err := writer.WriteToFile(changes1)
 	assert.NoError(t, err)
 
 	// Write second batch - should trigger rotation (total > 100 bytes).
-	changes2 := sparselist.SparseList[*RunLogsLine]{}
+	changes2 := &sparselist.SparseList[*RunLogsLine]{}
 	changes2.Put(2, makeRunLogsLine(strings.Repeat("c", 30)))
 	changes2.Put(3, makeRunLogsLine(strings.Repeat("d", 30)))
 	err = writer.WriteToFile(changes2)
@@ -96,7 +96,7 @@ func TestOutputFileWriterRotationBySize(t *testing.T) {
 	assert.Len(t, uploader.uploadedPaths, 1)
 
 	// Write more data to create the second chunk file.
-	changes3 := sparselist.SparseList[*RunLogsLine]{}
+	changes3 := &sparselist.SparseList[*RunLogsLine]{}
 	changes3.Put(4, makeRunLogsLine("e"))
 	err = writer.WriteToFile(changes3)
 	assert.NoError(t, err)
@@ -125,7 +125,7 @@ func TestOutputFileWriterRotationByTime(t *testing.T) {
 	})
 
 	// Write initial lines.
-	changes1 := sparselist.SparseList[*RunLogsLine]{}
+	changes1 := &sparselist.SparseList[*RunLogsLine]{}
 	changes1.Put(0, makeRunLogsLine("first batch"))
 	err := writer.WriteToFile(changes1)
 	assert.NoError(t, err)
@@ -134,7 +134,7 @@ func TestOutputFileWriterRotationByTime(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Write more lines - should trigger time-based rotation.
-	changes2 := sparselist.SparseList[*RunLogsLine]{}
+	changes2 := &sparselist.SparseList[*RunLogsLine]{}
 	changes2.Put(1, makeRunLogsLine("second batch"))
 	err = writer.WriteToFile(changes2)
 	assert.NoError(t, err)
@@ -143,7 +143,7 @@ func TestOutputFileWriterRotationByTime(t *testing.T) {
 	assert.Len(t, uploader.uploadedPaths, 1)
 
 	// Write data to ensure second chunk file is created.
-	changes3 := sparselist.SparseList[*RunLogsLine]{}
+	changes3 := &sparselist.SparseList[*RunLogsLine]{}
 	changes3.Put(2, makeRunLogsLine("more data"))
 	err = writer.WriteToFile(changes3)
 	assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestOutputFileWriterNoRotation(t *testing.T) {
 	})
 
 	// Write some data.
-	changes := sparselist.SparseList[*RunLogsLine]{}
+	changes := &sparselist.SparseList[*RunLogsLine]{}
 	changes.Put(0, makeRunLogsLine("line 1"))
 	changes.Put(1, makeRunLogsLine("line 2"))
 	changes.Put(2, makeRunLogsLine("line 3"))
@@ -230,12 +230,12 @@ func TestOutputFileWriterEmptyChanges(t *testing.T) {
 	})
 
 	// Write empty changes.
-	emptyChanges := sparselist.SparseList[*RunLogsLine]{}
+	emptyChanges := &sparselist.SparseList[*RunLogsLine]{}
 	err := writer.WriteToFile(emptyChanges)
 	assert.NoError(t, err)
 
 	// Write actual data.
-	changes := sparselist.SparseList[*RunLogsLine]{}
+	changes := &sparselist.SparseList[*RunLogsLine]{}
 	changes.Put(0, makeRunLogsLine("content"))
 	err = writer.WriteToFile(changes)
 	assert.NoError(t, err)
@@ -263,7 +263,7 @@ func TestOutputFileWriterBothSizeAndTime(t *testing.T) {
 	})
 
 	// Size-based rotation should happen first.
-	changes1 := sparselist.SparseList[*RunLogsLine]{}
+	changes1 := &sparselist.SparseList[*RunLogsLine]{}
 	for i := range 5 {
 		changes1.Put(i, makeRunLogsLine(strings.Repeat("x", 50)))
 	}
@@ -274,7 +274,7 @@ func TestOutputFileWriterBothSizeAndTime(t *testing.T) {
 	assert.Len(t, uploader.uploadedPaths, 1)
 
 	// Write small data to create new chunk.
-	changes2 := sparselist.SparseList[*RunLogsLine]{}
+	changes2 := &sparselist.SparseList[*RunLogsLine]{}
 	changes2.Put(5, makeRunLogsLine("small"))
 	err = writer.WriteToFile(changes2)
 	assert.NoError(t, err)
@@ -283,7 +283,7 @@ func TestOutputFileWriterBothSizeAndTime(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Trigger rotation check with another write.
-	changes3 := sparselist.SparseList[*RunLogsLine]{}
+	changes3 := &sparselist.SparseList[*RunLogsLine]{}
 	changes3.Put(6, makeRunLogsLine("trigger"))
 	err = writer.WriteToFile(changes3)
 	assert.NoError(t, err)
@@ -292,7 +292,7 @@ func TestOutputFileWriterBothSizeAndTime(t *testing.T) {
 	assert.Len(t, uploader.uploadedPaths, 2)
 
 	// Write data to create third chunk.
-	changes4 := sparselist.SparseList[*RunLogsLine]{}
+	changes4 := &sparselist.SparseList[*RunLogsLine]{}
 	changes4.Put(7, makeRunLogsLine("final"))
 	err = writer.WriteToFile(changes4)
 	assert.NoError(t, err)
@@ -321,7 +321,7 @@ func TestOutputFileWriterCrossChunkLineModification(t *testing.T) {
 	})
 
 	// Write lines 0-3 (triggers rotation at ~120 bytes).
-	changes1 := sparselist.SparseList[*RunLogsLine]{}
+	changes1 := &sparselist.SparseList[*RunLogsLine]{}
 	changes1.Put(0, makeRunLogsLine(strings.Repeat("a", 30)))
 	changes1.Put(1, makeRunLogsLine(strings.Repeat("b", 30)))
 	changes1.Put(2, makeRunLogsLine(strings.Repeat("c", 30)))
@@ -333,7 +333,7 @@ func TestOutputFileWriterCrossChunkLineModification(t *testing.T) {
 	assert.Len(t, uploader.uploadedPaths, 1)
 
 	// Try to modify line 1 from the previous chunk - should be silently ignored.
-	changes2 := sparselist.SparseList[*RunLogsLine]{}
+	changes2 := &sparselist.SparseList[*RunLogsLine]{}
 	changes2.Put(1, makeRunLogsLine("modified line 1"))
 	changes2.Put(4, makeRunLogsLine("new line 4"))
 	err = writer.WriteToFile(changes2)

--- a/core/internal/runconsolelogs/runconsolelogs.go
+++ b/core/internal/runconsolelogs/runconsolelogs.go
@@ -145,7 +145,7 @@ func New(params Params) *Sender {
 
 	writer := NewDebouncedWriter(
 		rate.NewLimiter(rate.Every(10*time.Millisecond), 1),
-		func(lines sparselist.SparseList[*RunLogsLine]) {
+		func(lines *sparselist.SparseList[*RunLogsLine]) {
 			if fileWriter != nil {
 				if err := fileWriter.WriteToFile(lines); err != nil {
 					params.Logger.CaptureError(

--- a/core/internal/runconsolelogs/runconsolelogs_test.go
+++ b/core/internal/runconsolelogs/runconsolelogs_test.go
@@ -81,7 +81,7 @@ func TestFileStreamUpdatesDisabled(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	request := fileStream.GetRequest(settings.New())
-	assert.Equal(t, []sparselist.Run[string]{}, request.ConsoleLines.ToRuns())
+	assert.Empty(t, request.ConsoleLines.ToRuns())
 }
 
 func TestSender_Multipart_WritesChunkAndUploadsOnFinish(t *testing.T) {

--- a/core/internal/sparselist/sparselist.go
+++ b/core/internal/sparselist/sparselist.go
@@ -9,11 +9,14 @@ import (
 
 // SparseList is a list where many indices are not set.
 //
-// A `SparseList[T]` is isomorphic to `(int, []*T)` but uses less memory when
+// A `SparseList[T]` is like `(int, []*T)` but uses less memory when
 // many values are nil and can perform some operations more efficiently. The
 // extra 'int' is there because a `SparseList` can have negative indices.
 //
 // The zero value is an empty list.
+//
+// A nil SparseList is like a nil map: all getter methods treat it like an
+// empty SparseList, and all mutating methods panic.
 type SparseList[T any] struct {
 	items        map[int]T
 	firstIndex   int
@@ -23,11 +26,19 @@ type SparseList[T any] struct {
 
 // Len returns the number of indices in the list that are set.
 func (l *SparseList[T]) Len() int {
+	if l == nil {
+		return 0
+	}
+
 	return len(l.items)
 }
 
 // FirstIndex is the smallest index that is set, if Len > 0.
 func (l *SparseList[T]) FirstIndex() int {
+	if l == nil {
+		return 0
+	}
+
 	if !l.boundsCached {
 		l.recomputeBounds()
 	}
@@ -37,6 +48,10 @@ func (l *SparseList[T]) FirstIndex() int {
 
 // LastIndex is the largest index that is set, if Len > 0.
 func (l *SparseList[T]) LastIndex() int {
+	if l == nil {
+		return 0
+	}
+
 	if !l.boundsCached {
 		l.recomputeBounds()
 	}
@@ -82,7 +97,7 @@ func (l *SparseList[T]) Put(index int, item T) {
 //
 // The second return value indicates whether there was anything at the index.
 func (l *SparseList[T]) Get(index int) (T, bool) {
-	if len(l.items) == 0 {
+	if l == nil || len(l.items) == 0 {
 		return *new(T), false
 	}
 
@@ -109,7 +124,11 @@ func (l *SparseList[T]) Delete(index int) {
 }
 
 // Update overwrites the data in this list by the other list.
-func (l *SparseList[T]) Update(other SparseList[T]) {
+func (l *SparseList[T]) Update(other *SparseList[T]) {
+	if other.Len() == 0 {
+		return
+	}
+
 	if l.items == nil {
 		l.items = make(map[int]T)
 	}
@@ -150,14 +169,18 @@ func (l *SparseList[T]) FirstRunValues() iter.Seq[T] {
 
 // ForEach invokes a callback on each value in the list.
 func (l *SparseList[T]) ForEach(fn func(int, T)) {
+	if l == nil {
+		return
+	}
+
 	for i, x := range l.items {
 		fn(i, x)
 	}
 }
 
 // Map returns a new list by applying a transformation to each element.
-func Map[T, U any](list SparseList[T], fn func(T) U) SparseList[U] {
-	result := SparseList[U]{}
+func Map[T, U any](list *SparseList[T], fn func(T) U) *SparseList[U] {
+	result := &SparseList[U]{}
 
 	list.ForEach(func(i int, x T) {
 		result.Put(i, fn(x))
@@ -177,6 +200,10 @@ type Run[T any] struct {
 
 // ToRuns returns the runs of consecutive values in the list.
 func (l *SparseList[T]) ToRuns() []Run[T] {
+	if l == nil {
+		return nil
+	}
+
 	indices := make([]int, 0, len(l.items))
 	for listIdx := range l.items {
 		indices = append(indices, listIdx)

--- a/core/internal/sparselist/sparselist_test.go
+++ b/core/internal/sparselist/sparselist_test.go
@@ -1,14 +1,38 @@
 package sparselist_test
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wandb/wandb/core/internal/sparselist"
 )
 
+func TestNilSparseList(t *testing.T) {
+	var nilList *sparselist.SparseList[string]
+
+	assert.Equal(t, 0, nilList.Len())
+	assert.Equal(t, 0, nilList.FirstIndex())
+	assert.Equal(t, 0, nilList.LastIndex())
+
+	assert.Zero(t, nilList.GetOrZero(0))
+	s, ok := nilList.Get(0)
+	assert.Zero(t, s)
+	assert.False(t, ok)
+
+	assert.Empty(t, maps.Collect(nilList.FirstRun()))
+	assert.Empty(t, slices.Collect(nilList.FirstRunValues()))
+	nilList.ForEach(func(i int, s string) { t.Fatal("shouldn't run") })
+
+	assert.Empty(t, nilList.ToRuns())
+
+	list := &sparselist.SparseList[string]{}
+	assert.NotPanics(t, func() { list.Update(nilList) })
+}
+
 func TestSparseListGet(t *testing.T) {
-	list := sparselist.SparseList[string]{}
+	list := &sparselist.SparseList[string]{}
 
 	_, existed := list.Get(0)
 	assert.False(t, existed)
@@ -20,7 +44,7 @@ func TestSparseListGet(t *testing.T) {
 }
 
 func TestSparseListRuns(t *testing.T) {
-	list := sparselist.SparseList[string]{}
+	list := &sparselist.SparseList[string]{}
 
 	list.Put(0, "zero")
 	list.Put(1, "one")
@@ -38,7 +62,7 @@ func TestSparseListRuns(t *testing.T) {
 }
 
 func TestSparseListEmpty(t *testing.T) {
-	emptyList := sparselist.SparseList[string]{}
+	emptyList := &sparselist.SparseList[string]{}
 
 	assert.Equal(t,
 		[]sparselist.Run[string]{},
@@ -46,11 +70,11 @@ func TestSparseListEmpty(t *testing.T) {
 }
 
 func TestSparseListUpdate(t *testing.T) {
-	list1 := sparselist.SparseList[string]{}
+	list1 := &sparselist.SparseList[string]{}
 	list1.Put(0, "a")
 	list1.Put(1, "b")
 	list1.Put(2, "c")
-	list2 := sparselist.SparseList[string]{}
+	list2 := &sparselist.SparseList[string]{}
 	list2.Put(1, "x")
 	list2.Put(3, "y")
 
@@ -64,7 +88,7 @@ func TestSparseListUpdate(t *testing.T) {
 }
 
 func TestSparseListIndices(t *testing.T) {
-	list := sparselist.SparseList[string]{}
+	list := &sparselist.SparseList[string]{}
 
 	list.Put(-1, "a")
 	list.Put(99, "b")
@@ -84,7 +108,7 @@ func TestSparseListIndices(t *testing.T) {
 }
 
 func TestSparseListMap(t *testing.T) {
-	list := sparselist.SparseList[float64]{}
+	list := &sparselist.SparseList[float64]{}
 	list.Put(0, 1.23)
 	list.Put(1, 4.56)
 	list.Put(2, 7.89)


### PR DESCRIPTION
Use `*SparseList` everywhere instead of `SparseList`.

I originally did it this way for convenience, so that a zero value could be modified without any initialization. It made sense when `SparseList` was just `map[int]T`, but it doesn't now that there are `firstIndex` and `lastIndex` fields:

```go
list1 := sparselist.SparseList[string]{}
list1.Put(1, "line 1")
list1.LastIndex() // => 1

list2 := list1
list2.Put(2, "line 2")
list2.Len()       // => 2
list2.LastIndex() // => 2

// list1's items map was copied by reference and updated by list2's Put()
list1.Len()       // => 2
// But list1's lastIndex was copied by value and not updated.
list1.LastIndex() // => 1 (WRONG)
```

I looked for bugs this could have caused, but miraculously, I think everything worked out because of the patterns in which we call `SparseList` methods. Best not to push our luck any further.

Risk: This change can cause `nil` panics. I looked at each usage carefully, and I'm hoping that test coverage is enough to detect anything I missed.