### PR TITLE
refactor: increase output.log writer debounce time

### DIFF
--- a/core/internal/runconsolelogs/debouncedwriter.go
+++ b/core/internal/runconsolelogs/debouncedwriter.go
@@ -13,6 +13,9 @@ type debouncedWriter struct {
 	mu sync.Mutex
 	wg sync.WaitGroup
 
+	rateLimitCtx    context.Context // context for debouncing
+	cancelRateLimit func()          // cancels rateLimitCtx to flush changes
+
 	isFlushing bool
 	flush      func(*sparselist.SparseList[*RunLogsLine])
 	rateLimit  *rate.Limiter
@@ -28,7 +31,12 @@ func NewDebouncedWriter(
 	rateLimit *rate.Limiter,
 	flush func(*sparselist.SparseList[*RunLogsLine]),
 ) *debouncedWriter {
+	rateLimitCtx, cancelRateLimit := context.WithCancel(context.Background())
+
 	return &debouncedWriter{
+		rateLimitCtx:    rateLimitCtx,
+		cancelRateLimit: cancelRateLimit,
+
 		flush:     flush,
 		rateLimit: rateLimit,
 		buffer:    &sparselist.SparseList[*RunLogsLine]{},
@@ -54,11 +62,9 @@ func (b *debouncedWriter) OnChanged(lineNum int, line *RunLogsLine) {
 
 func (b *debouncedWriter) loopFlushBuffer() {
 	for {
-		err := b.rateLimit.Wait(context.Background())
-		if err != nil {
-			// Not possible: canceled or deadline exceeded.
-			return
-		}
+		// An error happens only if the context is canceled, in which case
+		// we stop rate limiting.
+		_ = b.rateLimit.Wait(b.rateLimitCtx)
 
 		b.mu.Lock()
 
@@ -77,5 +83,6 @@ func (b *debouncedWriter) loopFlushBuffer() {
 }
 
 func (b *debouncedWriter) Finish() {
+	b.cancelRateLimit()
 	b.wg.Wait()
 }

--- a/core/internal/runconsolelogs/debouncedwriter_test.go
+++ b/core/internal/runconsolelogs/debouncedwriter_test.go
@@ -2,33 +2,38 @@ package runconsolelogs_test
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	. "github.com/wandb/wandb/core/internal/runconsolelogs"
 	"github.com/wandb/wandb/core/internal/sparselist"
 	"golang.org/x/time/rate"
 )
 
-func TestInvokesCallback(t *testing.T) {
-	flushes := make(chan *sparselist.SparseList[*RunLogsLine], 1)
-	writer := NewDebouncedWriter(
-		rate.NewLimiter(rate.Inf, 1),
-		func(lines *sparselist.SparseList[*RunLogsLine]) {
-			flushes <- lines
-		},
-	)
+func TestDebouncesAndInvokesCallback(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var flushes []*sparselist.SparseList[*RunLogsLine]
+		writer := NewDebouncedWriter(
+			rate.NewLimiter(rate.Every(time.Second), 1),
+			func(lines *sparselist.SparseList[*RunLogsLine]) {
+				flushes = append(flushes, lines)
+			},
+		)
 
-	line := &RunLogsLine{}
-	line.Content = []rune("content")
-	writer.OnChanged(1, line)
-	writer.Finish()
+		writer.OnChanged(1, RunLogsLineForTest("content 1"))
+		writer.OnChanged(2, RunLogsLineForTest("content 2"))
+		time.Sleep(time.Second) // flushes after the debounce period expires
+		writer.OnChanged(3, RunLogsLineForTest("content 3"))
+		writer.Finish() // flushes immediately
 
-	select {
-	case lines := <-flushes:
-		lineActual, _ := lines.Get(1)
-		assert.Equal(t, "content", string(lineActual.Content))
-	case <-time.After(time.Second):
-		t.Error("timeout after 1 second")
-	}
+		require.Len(t, flushes, 2)
+		assert.Equal(t,
+			map[int]string{1: "content 1", 2: "content 2"},
+			sparselist.Map(flushes[0], (*RunLogsLine).ContentAsString).ToMap())
+		assert.Equal(t,
+			map[int]string{3: "content 3"},
+			sparselist.Map(flushes[1], (*RunLogsLine).ContentAsString).ToMap())
+	})
 }

--- a/core/internal/runconsolelogs/filestreamwriter.go
+++ b/core/internal/runconsolelogs/filestreamwriter.go
@@ -1,12 +1,16 @@
 package runconsolelogs
 
 import (
+	"time"
+
 	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/sparselist"
+	"golang.org/x/time/rate"
 )
 
 // filestreamWriter sends modified console log lines to the filestream.
 type filestreamWriter struct {
+	debouncer  *debouncedWriter
 	FileStream filestream.FileStream
 
 	// Structured controls the format of uploaded lines.
@@ -26,22 +30,49 @@ type filestreamWriter struct {
 	Structured bool
 }
 
-func (w *filestreamWriter) SendChanged(
-	changes *sparselist.SparseList[*RunLogsLine],
+func NewFileStreamWriter(
+	structured bool,
+	fileStream filestream.FileStream,
+) *filestreamWriter {
+	w := &filestreamWriter{
+		FileStream: fileStream,
+		Structured: structured,
+	}
+
+	w.debouncer = NewDebouncedWriter(
+		// This short delay prevents every single character change from
+		// triggering a relatively expensive merging logic.
+		rate.NewLimiter(rate.Every(10*time.Millisecond), 1),
+		w.sendBatch,
+	)
+
+	return w
+}
+
+// UpdateLine sends a console logs update through FileStream.
+func (w *filestreamWriter) UpdateLine(lineNum int, line *RunLogsLine) {
+	w.debouncer.OnChanged(lineNum, line)
+}
+
+func (w *filestreamWriter) sendBatch(
+	lines *sparselist.SparseList[*RunLogsLine],
 ) {
-	lines := sparselist.Map(changes, func(line *RunLogsLine) string {
-		if w.Structured {
-			s, err := line.StructuredFormat()
-			if err != nil {
-				return line.LegacyFormat()
-			}
-			return s
-		}
-
-		return line.LegacyFormat()
-	})
-
 	w.FileStream.StreamUpdate(&filestream.LogsUpdate{
-		Lines: lines,
+		Lines: sparselist.Map(lines, func(line *RunLogsLine) string {
+			if w.Structured {
+				if s, err := line.StructuredFormat(); err == nil {
+					return s
+				} else {
+					return line.LegacyFormat()
+				}
+			}
+
+			return line.LegacyFormat()
+		}),
 	})
+}
+
+// Finish flushes all accumulated updates.
+func (w *filestreamWriter) Finish() {
+	w.debouncer.Finish()
 }

--- a/core/internal/runconsolelogs/filestreamwriter_test.go
+++ b/core/internal/runconsolelogs/filestreamwriter_test.go
@@ -1,0 +1,62 @@
+package runconsolelogs_test
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/internal/filestream"
+	"github.com/wandb/wandb/core/internal/filestreamtest"
+	. "github.com/wandb/wandb/core/internal/runconsolelogs"
+)
+
+func TestWritesStructuredFormat(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fileStream := filestreamtest.NewFakeFileStream()
+		w := NewFileStreamWriter(true, fileStream)
+
+		line1 := RunLogsLineForTest("content 1")
+		line1Str, err := line1.StructuredFormat()
+		require.NoError(t, err)
+
+		line2 := RunLogsLineForTest("content 2")
+		line2Str, err := line2.StructuredFormat()
+		require.NoError(t, err)
+
+		w.UpdateLine(1, line1)
+		w.UpdateLine(2, line2)
+		w.Finish()
+
+		updates := fileStream.GetUpdates()
+		require.Len(t, updates, 1) // Updates combined by debouncing.
+		update, ok := updates[0].(*filestream.LogsUpdate)
+		require.True(t, ok)
+		assert.Equal(t, line1Str, update.Lines.GetOrZero(1))
+		assert.Equal(t, line2Str, update.Lines.GetOrZero(2))
+	})
+}
+
+func TestWritesLegacyFormat(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fileStream := filestreamtest.NewFakeFileStream()
+		w := NewFileStreamWriter(false, fileStream)
+
+		line1 := RunLogsLineForTest("content 1")
+		line1Str := line1.LegacyFormat()
+
+		line2 := RunLogsLineForTest("content 2")
+		line2Str := line2.LegacyFormat()
+
+		w.UpdateLine(1, line1)
+		w.UpdateLine(2, line2)
+		w.Finish()
+
+		updates := fileStream.GetUpdates()
+		require.Len(t, updates, 1) // Updates combined by debouncing.
+		update, ok := updates[0].(*filestream.LogsUpdate)
+		require.True(t, ok)
+		assert.Equal(t, line1Str, update.Lines.GetOrZero(1))
+		assert.Equal(t, line2Str, update.Lines.GetOrZero(2))
+	})
+}

--- a/core/internal/runconsolelogs/outputfilewriter_test.go
+++ b/core/internal/runconsolelogs/outputfilewriter_test.go
@@ -1,41 +1,43 @@
 package runconsolelogs_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/filetransfer"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/paths"
 	. "github.com/wandb/wandb/core/internal/runconsolelogs"
-	"github.com/wandb/wandb/core/internal/sparselist"
-	"github.com/wandb/wandb/core/internal/terminalemulator"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
-// Helper to create a RunLogsLine with content.
-func makeRunLogsLine(content string) *RunLogsLine {
-	return &RunLogsLine{
-		LineContent: terminalemulator.LineContent{
-			Content: []rune(content),
-		},
-	}
-}
-
 // Helper to verify chunk files exist and return their paths.
 func getChunkFiles(t *testing.T, tmpDir string) []string {
+	t.Helper()
+
 	files, err := filepath.Glob(filepath.Join(tmpDir, "logs", "*.log"))
-	fmt.Println(files)
 	require.NoError(t, err)
+	t.Logf("Found chunk files: %v", files)
+
 	sort.Strings(files) // Sort for consistent ordering
 	return files
+}
+
+// waitToDebounce waits enough time for the debouncing mechanism to flush.
+//
+// Must be called inside synctest.Test().
+func waitToDebounce(t *testing.T) {
+	t.Helper()
+	time.Sleep(5 * time.Second)
+	synctest.Wait()
 }
 
 // FakeUploader implements the Uploader interface.
@@ -66,129 +68,119 @@ func (f *FakeUploader) Finish() {}
 
 // TestOutputFileWriterRotationBySize verifies that chunks rotate based on size.
 func TestOutputFileWriterRotationBySize(t *testing.T) {
-	tmpDir := t.TempDir()
-	uploader := NewFakeUploader()
+	synctest.Test(t, func(t *testing.T) {
+		tmpDir := t.TempDir()
+		uploader := NewFakeUploader()
 
-	writer := NewOutputFileWriter(OutputFileWriterParams{
-		FilesDir:         tmpDir,
-		OutputFileName:   "output.log",
-		Multipart:        true,
-		MaxChunkBytes:    100, // Small size to trigger rotation
-		MaxChunkDuration: 0,   // No time-based rotation
-		Uploader:         uploader,
+		writer := NewOutputFileWriter(OutputFileWriterParams{
+			Multipart:     true,
+			MaxChunkBytes: 100,
+
+			FilesDir:       tmpDir,
+			OutputFileName: "output.log",
+			Logger:         observabilitytest.NewTestLogger(t),
+			UploaderOrNil:  uploader,
+		})
+
+		// Write first batch - should fit in one chunk.
+		writer.UpdateLine(0, RunLogsLineForTest(strings.Repeat("a", 30)))
+		writer.UpdateLine(1, RunLogsLineForTest(strings.Repeat("b", 30)))
+		waitToDebounce(t)
+
+		// Write second batch - should trigger rotation (total > 100 bytes).
+		writer.UpdateLine(2, RunLogsLineForTest(strings.Repeat("c", 30)))
+		writer.UpdateLine(3, RunLogsLineForTest(strings.Repeat("d", 30)))
+		waitToDebounce(t)
+
+		// First chunk should have been uploaded during rotation.
+		assert.Len(t, uploader.uploadedPaths, 1)
+
+		// Write more data to create the second chunk file.
+		writer.UpdateLine(4, RunLogsLineForTest("e"))
+		synctest.Wait()
+
+		writer.Finish()
+
+		// Should have created and uploaded 2 chunk files.
+		assert.Len(t, getChunkFiles(t, tmpDir), 2)
+		assert.Len(t, uploader.uploadedPaths, 2)
 	})
-
-	// Write first batch - should fit in one chunk.
-	changes1 := &sparselist.SparseList[*RunLogsLine]{}
-	changes1.Put(0, makeRunLogsLine(strings.Repeat("a", 30)))
-	changes1.Put(1, makeRunLogsLine(strings.Repeat("b", 30)))
-	err := writer.WriteToFile(changes1)
-	assert.NoError(t, err)
-
-	// Write second batch - should trigger rotation (total > 100 bytes).
-	changes2 := &sparselist.SparseList[*RunLogsLine]{}
-	changes2.Put(2, makeRunLogsLine(strings.Repeat("c", 30)))
-	changes2.Put(3, makeRunLogsLine(strings.Repeat("d", 30)))
-	err = writer.WriteToFile(changes2)
-	assert.NoError(t, err)
-
-	// First chunk should have been uploaded during rotation.
-	assert.Len(t, uploader.uploadedPaths, 1)
-
-	// Write more data to create the second chunk file.
-	changes3 := &sparselist.SparseList[*RunLogsLine]{}
-	changes3.Put(4, makeRunLogsLine("e"))
-	err = writer.WriteToFile(changes3)
-	assert.NoError(t, err)
-
-	writer.Finish()
-
-	// Should have created 2 chunk files.
-	chunkFiles := getChunkFiles(t, tmpDir)
-	assert.Equal(t, 2, len(chunkFiles))
-	// Both should have been uploaded.
-	assert.Len(t, uploader.uploadedPaths, 2)
 }
 
 // TestOutputFileWriterRotationByTime verifies that chunks rotate based on time.
 func TestOutputFileWriterRotationByTime(t *testing.T) {
-	tmpDir := t.TempDir()
-	uploader := NewFakeUploader()
+	synctest.Test(t, func(t *testing.T) {
+		tmpDir := t.TempDir()
+		uploader := NewFakeUploader()
 
-	writer := NewOutputFileWriter(OutputFileWriterParams{
-		FilesDir:         tmpDir,
-		OutputFileName:   "output.log",
-		Multipart:        true,
-		MaxChunkBytes:    0,                      // No size-based rotation.
-		MaxChunkDuration: 100 * time.Millisecond, // Short duration for testing.
-		Uploader:         uploader,
+		writer := NewOutputFileWriter(OutputFileWriterParams{
+			Multipart:        true,
+			MaxChunkDuration: 5 * time.Minute,
+
+			FilesDir:       tmpDir,
+			OutputFileName: "output.log",
+			Logger:         observabilitytest.NewTestLogger(t),
+			UploaderOrNil:  uploader,
+		})
+
+		// Write initial line.
+		writer.UpdateLine(0, RunLogsLineForTest("first batch"))
+		waitToDebounce(t)
+
+		// Wait for the chunking threshold.
+		time.Sleep(5 * time.Minute)
+
+		// Write more lines - should trigger time-based rotation.
+		writer.UpdateLine(1, RunLogsLineForTest("second batch"))
+		waitToDebounce(t)
+
+		// First chunk should have been uploaded.
+		assert.Len(t, uploader.uploadedPaths, 1)
+
+		// Write data to ensure second chunk file is created.
+		writer.UpdateLine(2, RunLogsLineForTest("more data"))
+		waitToDebounce(t)
+
+		writer.Finish()
+
+		// Should have created and uploaded 2 chunk files.
+		assert.Len(t, getChunkFiles(t, tmpDir), 2)
+		assert.Len(t, uploader.uploadedPaths, 2)
 	})
-
-	// Write initial lines.
-	changes1 := &sparselist.SparseList[*RunLogsLine]{}
-	changes1.Put(0, makeRunLogsLine("first batch"))
-	err := writer.WriteToFile(changes1)
-	assert.NoError(t, err)
-
-	// Wait for time threshold.
-	time.Sleep(150 * time.Millisecond)
-
-	// Write more lines - should trigger time-based rotation.
-	changes2 := &sparselist.SparseList[*RunLogsLine]{}
-	changes2.Put(1, makeRunLogsLine("second batch"))
-	err = writer.WriteToFile(changes2)
-	assert.NoError(t, err)
-
-	// First chunk should have been uploaded.
-	assert.Len(t, uploader.uploadedPaths, 1)
-
-	// Write data to ensure second chunk file is created.
-	changes3 := &sparselist.SparseList[*RunLogsLine]{}
-	changes3.Put(2, makeRunLogsLine("more data"))
-	err = writer.WriteToFile(changes3)
-	assert.NoError(t, err)
-
-	writer.Finish()
-
-	// Should have created 2 chunk files.
-	chunkFiles := getChunkFiles(t, tmpDir)
-	assert.Equal(t, 2, len(chunkFiles))
-	// Both should have been uploaded
-	assert.Len(t, uploader.uploadedPaths, 2)
 }
 
 // TestOutputFileWriterNoRotation verifies behavior when no rotation occurs.
 func TestOutputFileWriterNoRotation(t *testing.T) {
-	tmpDir := t.TempDir()
-	uploader := NewFakeUploader()
+	synctest.Test(t, func(t *testing.T) {
+		tmpDir := t.TempDir()
+		uploader := NewFakeUploader()
 
-	writer := NewOutputFileWriter(OutputFileWriterParams{
-		FilesDir:         tmpDir,
-		OutputFileName:   "output.log",
-		Multipart:        true,
-		MaxChunkBytes:    10000, // Large size to prevent rotation.
-		MaxChunkDuration: 0,     // No time-based rotation.
-		Uploader:         uploader,
+		writer := NewOutputFileWriter(OutputFileWriterParams{
+			Multipart:     true,
+			MaxChunkBytes: 10000, // Large size to prevent rotation.
+
+			FilesDir:       tmpDir,
+			OutputFileName: "output.log",
+
+			Logger:        observabilitytest.NewTestLogger(t),
+			UploaderOrNil: uploader,
+		})
+
+		// Write some data.
+		writer.UpdateLine(0, RunLogsLineForTest("line 1"))
+		writer.UpdateLine(1, RunLogsLineForTest("line 2"))
+		writer.UpdateLine(2, RunLogsLineForTest("line 3"))
+		waitToDebounce(t)
+
+		// No uploads yet (no rotation occurred).
+		assert.Len(t, uploader.uploadedPaths, 0)
+
+		writer.Finish()
+
+		// Should have created and uploaded 1 chunk file.
+		assert.Len(t, getChunkFiles(t, tmpDir), 1)
+		assert.Len(t, uploader.uploadedPaths, 1)
 	})
-
-	// Write some data.
-	changes := &sparselist.SparseList[*RunLogsLine]{}
-	changes.Put(0, makeRunLogsLine("line 1"))
-	changes.Put(1, makeRunLogsLine("line 2"))
-	changes.Put(2, makeRunLogsLine("line 3"))
-	err := writer.WriteToFile(changes)
-	assert.NoError(t, err)
-
-	// No uploads yet (no rotation occurred).
-	assert.Len(t, uploader.uploadedPaths, 0)
-
-	writer.Finish()
-
-	// Should have created 1 chunk file.
-	chunkFiles := getChunkFiles(t, tmpDir)
-	assert.Equal(t, 1, len(chunkFiles))
-	// Finish should upload the final chunk.
-	assert.Len(t, uploader.uploadedPaths, 1)
 }
 
 // TestOutputFileWriterNoData verifies behavior when no data is written.
@@ -197,156 +189,63 @@ func TestOutputFileWriterNoData(t *testing.T) {
 	uploader := NewFakeUploader()
 
 	writer := NewOutputFileWriter(OutputFileWriterParams{
-		FilesDir:         tmpDir,
-		OutputFileName:   "output.log",
-		Multipart:        true,
-		MaxChunkBytes:    100,
-		MaxChunkDuration: 0,
-		Uploader:         uploader,
+		Multipart:     true,
+		MaxChunkBytes: 100,
+
+		FilesDir:       tmpDir,
+		OutputFileName: "output.log",
+		UploaderOrNil:  uploader,
 	})
 
 	// Finish without writing any data.
 	writer.Finish()
 
 	// No files should be created.
-	chunkFiles := getChunkFiles(t, tmpDir)
-	assert.Equal(t, 0, len(chunkFiles))
-	// No uploads should occur.
-	assert.Len(t, uploader.uploadedPaths, 0)
-}
-
-// TestOutputFileWriterEmptyChanges verifies handling of empty change sets.
-func TestOutputFileWriterEmptyChanges(t *testing.T) {
-	tmpDir := t.TempDir()
-	uploader := NewFakeUploader()
-
-	writer := NewOutputFileWriter(OutputFileWriterParams{
-		FilesDir:         tmpDir,
-		OutputFileName:   "output.log",
-		Multipart:        true,
-		MaxChunkBytes:    100,
-		MaxChunkDuration: 0,
-		Uploader:         uploader,
-	})
-
-	// Write empty changes.
-	emptyChanges := &sparselist.SparseList[*RunLogsLine]{}
-	err := writer.WriteToFile(emptyChanges)
-	assert.NoError(t, err)
-
-	// Write actual data.
-	changes := &sparselist.SparseList[*RunLogsLine]{}
-	changes.Put(0, makeRunLogsLine("content"))
-	err = writer.WriteToFile(changes)
-	assert.NoError(t, err)
-
-	writer.Finish()
-
-	// Should have 1 file and 1 upload.
-	chunkFiles := getChunkFiles(t, tmpDir)
-	assert.Equal(t, 1, len(chunkFiles))
-	assert.Len(t, uploader.uploadedPaths, 1)
-}
-
-// TestOutputFileWriterBothSizeAndTime verifies rotation with both size and time limits.
-func TestOutputFileWriterBothSizeAndTime(t *testing.T) {
-	tmpDir := t.TempDir()
-	uploader := NewFakeUploader()
-
-	writer := NewOutputFileWriter(OutputFileWriterParams{
-		FilesDir:         tmpDir,
-		OutputFileName:   "output.log",
-		Multipart:        true,
-		MaxChunkBytes:    200,
-		MaxChunkDuration: 100 * time.Millisecond,
-		Uploader:         uploader,
-	})
-
-	// Size-based rotation should happen first.
-	changes1 := &sparselist.SparseList[*RunLogsLine]{}
-	for i := range 5 {
-		changes1.Put(i, makeRunLogsLine(strings.Repeat("x", 50)))
-	}
-	err := writer.WriteToFile(changes1)
-	assert.NoError(t, err)
-
-	// Should have rotated due to size.
-	assert.Len(t, uploader.uploadedPaths, 1)
-
-	// Write small data to create new chunk.
-	changes2 := &sparselist.SparseList[*RunLogsLine]{}
-	changes2.Put(5, makeRunLogsLine("small"))
-	err = writer.WriteToFile(changes2)
-	assert.NoError(t, err)
-
-	// Wait for time limit.
-	time.Sleep(150 * time.Millisecond)
-
-	// Trigger rotation check with another write.
-	changes3 := &sparselist.SparseList[*RunLogsLine]{}
-	changes3.Put(6, makeRunLogsLine("trigger"))
-	err = writer.WriteToFile(changes3)
-	assert.NoError(t, err)
-
-	// Should have rotated due to time.
-	assert.Len(t, uploader.uploadedPaths, 2)
-
-	// Write data to create third chunk.
-	changes4 := &sparselist.SparseList[*RunLogsLine]{}
-	changes4.Put(7, makeRunLogsLine("final"))
-	err = writer.WriteToFile(changes4)
-	assert.NoError(t, err)
-
-	writer.Finish()
-
-	// Should have at least 3 chunks total.
-	chunkFiles := getChunkFiles(t, tmpDir)
-	assert.GreaterOrEqual(t, len(chunkFiles), 3)
-	assert.Equal(t, len(chunkFiles), len(uploader.uploadedPaths))
+	assert.Empty(t, getChunkFiles(t, tmpDir))
+	assert.Empty(t, uploader.uploadedPaths)
 }
 
 // TestOutputFileWriterCrossChunkLineModification verifies that attempting
 // to modify a line from a previous chunk after rotation is handled correctly.
 func TestOutputFileWriterCrossChunkLineModification(t *testing.T) {
-	tmpDir := t.TempDir()
-	uploader := NewFakeUploader()
+	synctest.Test(t, func(t *testing.T) {
+		tmpDir := t.TempDir()
+		uploader := NewFakeUploader()
 
-	writer := NewOutputFileWriter(OutputFileWriterParams{
-		FilesDir:         tmpDir,
-		OutputFileName:   "output.log",
-		Multipart:        true,
-		MaxChunkBytes:    100,
-		MaxChunkDuration: 0,
-		Uploader:         uploader,
+		writer := NewOutputFileWriter(OutputFileWriterParams{
+			Multipart:     true,
+			MaxChunkBytes: 100,
+
+			FilesDir:       tmpDir,
+			OutputFileName: "output.log",
+			Logger:         observabilitytest.NewTestLogger(t),
+			UploaderOrNil:  uploader,
+		})
+
+		// Write lines 0-3 (triggers rotation at ~120 bytes).
+		writer.UpdateLine(0, RunLogsLineForTest(strings.Repeat("a", 30)))
+		writer.UpdateLine(1, RunLogsLineForTest(strings.Repeat("b", 30)))
+		writer.UpdateLine(2, RunLogsLineForTest(strings.Repeat("c", 30)))
+		writer.UpdateLine(3, RunLogsLineForTest(strings.Repeat("d", 30)))
+		waitToDebounce(t)
+
+		// First chunk should be rotated.
+		assert.Len(t, uploader.uploadedPaths, 1)
+
+		// Try to modify line 1 from the previous chunk - should be silently ignored.
+		writer.UpdateLine(1, RunLogsLineForTest("modified line 1"))
+		writer.UpdateLine(4, RunLogsLineForTest("new line 4"))
+		waitToDebounce(t)
+
+		writer.Finish()
+
+		// Should have 2 chunks total.
+		chunkFiles := getChunkFiles(t, tmpDir)
+		assert.Len(t, chunkFiles, 2)
+
+		// Second chunk should only contain line 4 (line 1 modification was dropped).
+		content, err := os.ReadFile(chunkFiles[1])
+		require.NoError(t, err)
+		assert.Equal(t, "new line 4\n", string(content))
 	})
-
-	// Write lines 0-3 (triggers rotation at ~120 bytes).
-	changes1 := &sparselist.SparseList[*RunLogsLine]{}
-	changes1.Put(0, makeRunLogsLine(strings.Repeat("a", 30)))
-	changes1.Put(1, makeRunLogsLine(strings.Repeat("b", 30)))
-	changes1.Put(2, makeRunLogsLine(strings.Repeat("c", 30)))
-	changes1.Put(3, makeRunLogsLine(strings.Repeat("d", 30)))
-	err := writer.WriteToFile(changes1)
-	assert.NoError(t, err)
-
-	// First chunk should be rotated.
-	assert.Len(t, uploader.uploadedPaths, 1)
-
-	// Try to modify line 1 from the previous chunk - should be silently ignored.
-	changes2 := &sparselist.SparseList[*RunLogsLine]{}
-	changes2.Put(1, makeRunLogsLine("modified line 1"))
-	changes2.Put(4, makeRunLogsLine("new line 4"))
-	err = writer.WriteToFile(changes2)
-	assert.NoError(t, err)
-
-	writer.Finish()
-
-	// Should have 2 chunks total.
-	chunkFiles := getChunkFiles(t, tmpDir)
-	assert.Equal(t, 2, len(chunkFiles))
-
-	// Second chunk should only contain line 4 (line 1 modification was dropped).
-	content, err := os.ReadFile(chunkFiles[1])
-	require.NoError(t, err)
-	assert.Equal(t, "new line 4\n", string(content))
 }

--- a/core/internal/runconsolelogs/runconsolelogs_test.go
+++ b/core/internal/runconsolelogs/runconsolelogs_test.go
@@ -132,8 +132,7 @@ func TestSender_LabelChangesOutputFileName_SingleFile(t *testing.T) {
 	s.StreamLogs(&spb.OutputRawRecord{Line: "hello\n"})
 	s.Finish()
 
-	rel, _ := paths.Relative("output_train.log")
-	want := filepath.Join(dir, string(*rel))
+	want := filepath.Join(dir, "output_train.log")
 
 	_, err := os.Stat(want)
 	require.NoError(t, err, "expected labeled output file to exist")

--- a/core/internal/runconsolelogs/runlogschangemodel.go
+++ b/core/internal/runconsolelogs/runlogschangemodel.go
@@ -46,6 +46,15 @@ type RunLogsLine struct {
 	StreamLabel string
 }
 
+// RunLogsLineForTest returns a RunLogsLine with the specified content.
+//
+// Defined for testing.
+func RunLogsLineForTest(content string) *RunLogsLine {
+	line := &RunLogsLine{}
+	line.Content = []rune(content)
+	return line
+}
+
 // Clone returns a deep copy of the line.
 func (l *RunLogsLine) Clone() *RunLogsLine {
 	return &RunLogsLine{

--- a/core/internal/sparselist/sparselist.go
+++ b/core/internal/sparselist/sparselist.go
@@ -198,6 +198,15 @@ type Run[T any] struct {
 	Items []T
 }
 
+// ToMap returns this list as a map from indices to values.
+func (l *SparseList[T]) ToMap() map[int]T {
+	if l == nil {
+		return nil
+	}
+
+	return maps.Clone(l.items)
+}
+
 // ToRuns returns the runs of consecutive values in the list.
 func (l *SparseList[T]) ToRuns() []Run[T] {
 	if l == nil {

--- a/core/internal/sparselist/sparselist_test.go
+++ b/core/internal/sparselist/sparselist_test.go
@@ -26,6 +26,7 @@ func TestNilSparseList(t *testing.T) {
 	nilList.ForEach(func(i int, s string) { t.Fatal("shouldn't run") })
 
 	assert.Empty(t, nilList.ToRuns())
+	assert.Empty(t, nilList.ToMap())
 
 	list := &sparselist.SparseList[string]{}
 	assert.NotPanics(t, func() { list.Update(nilList) })
@@ -81,10 +82,8 @@ func TestSparseListUpdate(t *testing.T) {
 	list1.Update(list2)
 
 	assert.Equal(t,
-		[]sparselist.Run[string]{
-			{Start: 0, Items: []string{"a", "x", "c", "y"}},
-		},
-		list1.ToRuns())
+		map[int]string{0: "a", 1: "x", 2: "c", 3: "y"},
+		list1.ToMap())
 }
 
 func TestSparseListIndices(t *testing.T) {
@@ -117,8 +116,6 @@ func TestSparseListMap(t *testing.T) {
 		func(x float64) float64 { return -x })
 
 	assert.Equal(t,
-		[]sparselist.Run[float64]{
-			{Start: 0, Items: []float64{-1.23, -4.56, -7.89}},
-		},
-		result.ToRuns())
+		map[int]float64{0: -1.23, 1: -4.56, 2: -7.89},
+		result.ToMap())
 }

--- a/core/internal/terminalemulator/lines.go
+++ b/core/internal/terminalemulator/lines.go
@@ -25,6 +25,11 @@ type LineContent struct {
 	Content []rune
 }
 
+// ContentAsString returns a copy of the line's current content.
+func (l *LineContent) ContentAsString() string {
+	return string(l.Content)
+}
+
 // PutChar updates the line and returns whether it was modified.
 func (l *LineContent) PutChar(c rune, offset int) bool {
 	if offset >= l.MaxLength {


### PR DESCRIPTION
Fixes WB-29793.

Increases the debounce time for disk writes from 10ms to 5s to reduce expensive open() / close() calls on distributed filesystems.

I removed two tests in `outputfilewriter_test.go`: the one for an empty list and the one that tests both size-based and time-based chunking. The empty list one is impossible through the new public interface (`UpdateLine`) and the latter seems unnecessary because the two chunking modes are tested separately and don't interact in any interesting way (the `shouldRotate()` function essentially combines the two conditions with a logical OR).

I added `filestreamwriter_test.go` because almost no test failed when I accidentally made it use the legacy format if `err == nil` instead of `err != nil`.