### PR TITLE
refactor: include record number in Sender.sendRecord panic

### DIFF
--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -393,10 +393,14 @@ func (s *Sender) sendRecord(record *spb.Record) {
 		s.sendArtifact(record, x.Artifact)
 	case nil:
 		s.logger.CaptureFatalAndPanic(
-			errors.New("sender: sendRecord: nil RecordType"))
+			fmt.Errorf(
+				"sender: sendRecord: nil RecordType, number %d",
+				record.GetNum()))
 	default:
 		s.logger.CaptureFatalAndPanic(
-			fmt.Errorf("sender: sendRecord: unexpected type %T", x))
+			fmt.Errorf(
+				"sender: sendRecord: unexpected type %T, number %d",
+				x, record.GetNum()))
 	}
 }
 


### PR DESCRIPTION
Include a record number for debugging when panicking in Sender.sendRecord(). I found this useful when updating the transaction log reader code.