### PR TITLE
fix(artifacts): avoid pydantic frozen-field error when caching collection aliases

### DIFF
--- a/wandb/sdk/artifacts/_models/artifact_collection.py
+++ b/wandb/sdk/artifacts/_models/artifact_collection.py
@@ -50,7 +50,7 @@ class ArtifactCollectionData(ArtifactsBase):
     entity: str = Field(frozen=True)
     """The name of the entity that owns this collection's project."""
 
-    aliases: Optional[Tuple[str, ...]] = Field(default=None, frozen=True)
+    aliases: Optional[Tuple[str, ...]] = Field(default=None, frozen=False)
     """All aliases assigned to artifact versions within this collection.
 
     Note:


### PR DESCRIPTION
`ArtifactCollection.aliases` raised a Pydantic frozen_field ValidationError when lazily caching aliases. Made it non-frozen so the public API can cache aliases after initial load.
fixes WB-29902