### PR TITLE
fix(artifacts): fix validation error on fetching ArtifactCollection.aliases

### DIFF
--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -419,8 +419,8 @@ class ArtifactCollection:
             aliases = list(
                 _ArtifactCollectionAliases(self.client, collection_id=self.id)
             )
-            self._saved.aliases = aliases
-            self._current.aliases = aliases.copy()
+            self._saved = self._saved.model_copy(update={"aliases": aliases})
+            self._current = self._current.model_copy(update={"aliases": aliases})
 
         return list(self._saved.aliases)
 

--- a/wandb/sdk/artifacts/_models/artifact_collection.py
+++ b/wandb/sdk/artifacts/_models/artifact_collection.py
@@ -53,6 +53,10 @@ class ArtifactCollectionData(ArtifactsBase):
     aliases: Optional[Tuple[str, ...]] = Field(default=None, frozen=True)
     """All aliases assigned to artifact versions within this collection.
 
+    Deliberately immutable since this should be a read-only attribute.
+    Collection aliases are gathered from member artifact versions and should
+    not be directly editable on the artifact collection itself.
+
     Note:
         `None` indicates that aliases have not been fetched or parsed yet for
         any reason, NOT that aliases are absent in this collection.


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes [WB-29902](https://wandb.atlassian.net/browse/WB-29902)

Fixes the `pydantic.ValidationError` (`frozen_field`) encountered on attempting to fetch `ArtifactCollection.aliases`.

Adds a test for `ArtifactCollection.aliases`, which it seems was previously uncovered by tests.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
See added system tests

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->


[WB-29902]: https://wandb.atlassian.net/browse/WB-29902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ