### PR TITLE
fix(sdk): remove erroneous api argument from Sweep.get call

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -709,7 +709,6 @@ class Run(Attrs):
                 # just for the sake of this one.
                 self.sweep = public.Sweep.get(
                     self.client,
-                    self._api,
                     self.entity,
                     self.project,
                     self.sweep_name,


### PR DESCRIPTION
When fetching a run that belongs to a sweep via `api.run()`, the SDK incorrectly passed `self._api` as the second positional argument to `Sweep.get()` causing the `entity` parameter to receive a `wandb.Api` object instead of a string.

This resulted in:
`TypeError: Object of type Api is not JSON serializable`

when building the GraphQL request payload.
fixes https://github.com/wandb/wandb/issues/11083, WB-29937
