### PR TITLE
chore(artifacts): rename `Artifact._assign_attrs` arg (`art -> src_art`) for clarity

### DIFF
--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -770,7 +770,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
                 project=self.project,
                 name=f"{self.collection_name}:{edge.version}",
             ),
-            attrs=edge.node,
+            src_art=edge.node,
             client=self.client,
         )
 
@@ -836,7 +836,7 @@ class RunArtifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
                 project=node.artifact_sequence.project.name,
                 name=f"{node.artifact_sequence.name}:v{node.version_index}",
             ),
-            attrs=node,
+            src_art=node,
             client=self.client,
         )
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Mostly cosmetic, follow-up cleanup PR from #11090.  Renames the `ArtifactFragment` argument of internal methods like `Artifact._from_attrs()` to `src_art` for more explicit clarity (i.e. "an `ArtifactFragment` describes a source artifact version")

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
