### PR TITLE
refactor(artifacts): migrate `Artifacts` paginator to fetch memberships instead of source artifacts

### DIFF
--- a/tools/graphql_codegen/artifacts/artifacts.graphql
+++ b/tools/graphql_codegen/artifacts/artifacts.graphql
@@ -87,22 +87,23 @@ query ProjectArtifacts(
   $collection: String!
   $cursor: String
   $perPage: Int = 50
-  $order: String
-  $filters: JSONString
+  # $order: String
+  # $filters: JSONString
   $includeAliases: Boolean = true
 ) {
   project(entityName: $entity, name: $project) {
     artifactType(name: $type) {
       artifactCollection(name: $collection) {
-        artifacts(after: $cursor, first: $perPage, order: $order, filters: $filters) {
-          totalCount
+        artifactMemberships(after: $cursor, first: $perPage) {
+          # totalCount  # TODO: reimplement this
           pageInfo {
             ...PageInfoFragment
           }
           edges {
-            version
+            # version
             node {
-              ...ArtifactFragment
+              # ...ArtifactFragment
+              ...ArtifactMembershipFragment
             }
           }
         }

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -6,18 +6,14 @@ collections.
 
 from __future__ import annotations
 
-import json
 from copy import copy
 from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     Collection,
     Iterable,
-    List,
     Literal,
-    Mapping,
     Sequence,
     TypeVar,
 )
@@ -26,7 +22,7 @@ from typing_extensions import override
 from wandb_gql import gql
 
 from wandb._iterutils import always_list
-from wandb._pydantic import Connection, ConnectionWithTotal, Edge
+from wandb._pydantic import Connection, ConnectionWithTotal
 from wandb._strutils import nameof
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import RelayPaginator, SizedRelayPaginator
@@ -48,12 +44,14 @@ if TYPE_CHECKING:
         ArtifactAliasFragment,
         ArtifactCollectionFragment,
         ArtifactFragment,
+        ArtifactMembershipFragment,
         ArtifactTypeFragment,
         FileFragment,
     )
     from wandb.sdk.artifacts._models.pagination import (
         ArtifactCollectionConnection,
         ArtifactFileConnection,
+        ArtifactMembershipConnection,
         ArtifactTypeConnection,
     )
     from wandb.sdk.artifacts.artifact import Artifact
@@ -664,15 +662,7 @@ class ArtifactCollection:
         return f"<ArtifactCollection {self.name} ({self.type})>"
 
 
-class _ArtifactEdgeGeneric(Edge[TNode]):
-    version: str  # Extra field defined only on VersionedArtifactEdge
-
-
-class _ArtifactConnectionGeneric(ConnectionWithTotal[TNode]):
-    edges: List[_ArtifactEdgeGeneric]  # noqa: UP006
-
-
-class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
+class Artifacts(SizedRelayPaginator["ArtifactMembershipFragment", "Artifact"]):
     """An iterable collection of artifact versions associated with a project.
 
     Optionally pass in filters to narrow down the results based on specific criteria.
@@ -695,7 +685,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     QUERY: Document  # Must be set per-instance
 
     # Loosely-annotated to avoid importing heavy types at module import time.
-    last_response: _ArtifactConnectionGeneric | None
+    last_response: ArtifactMembershipConnection | None
 
     def __init__(
         self,
@@ -704,8 +694,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
         project: str,
         collection_name: str,
         type: str,
-        filters: Mapping[str, Any] | None = None,
-        order: str | None = None,
+        *,
         per_page: int = 50,
         tags: str | list[str] | None = None,
     ):
@@ -718,22 +707,19 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
         self.collection_name = collection_name
         self.type = type
         self.project = project
-        self.filters = {"state": "COMMITTED"} if filters is None else filters
         self.tags = always_list(tags or [])
-        self.order = order
         variables = {
             "entity": self.entity,
             "project": self.project,
-            "order": self.order,
             "type": self.type,
             "collection": self.collection_name,
-            "filters": json.dumps(self.filters),
         }
         super().__init__(client, variables=variables, per_page=per_page)
 
     @override
     def _update_response(self) -> None:
-        from wandb.sdk.artifacts._generated import ArtifactFragment, ProjectArtifacts
+        from wandb.sdk.artifacts._generated import ProjectArtifacts
+        from wandb.sdk.artifacts._models.pagination import ArtifactMembershipConnection
 
         data = self.client.execute(self.QUERY, variable_values=self.variables)
         result = ProjectArtifacts.model_validate(data)
@@ -743,34 +729,32 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
             (proj := result.project)
             and (type_ := proj.artifact_type)
             and (collection := type_.artifact_collection)
-            and (conn := collection.artifacts)
+            and (conn := collection.artifact_memberships)
         ):
             raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
 
-        self.last_response = _ArtifactConnectionGeneric[
-            ArtifactFragment
-        ].model_validate(conn)
+        self.last_response = ArtifactMembershipConnection.model_validate(conn)
 
-    # FIXME: For now, we deliberately override the signatures of:
-    # - `_convert()`
-    # - `convert_objects()`
-    # ... since the prior implementation must get `version` from the GQL edge
-    # (i.e. `edge.version`), which lives outside of the GQL node (`edge.node`).
-    #
-    # In the future, we should move to fetching artifacts via (GQL) artifactMemberships,
-    # not (GQL) artifacts, so we don't have to deal with this hack.
     @override
-    def _convert(self, edge: _ArtifactEdgeGeneric[ArtifactFragment]) -> Artifact:
+    def _convert(self, node: ArtifactMembershipFragment) -> Artifact | None:
         from wandb.sdk.artifacts._validators import FullArtifactPath
         from wandb.sdk.artifacts.artifact import Artifact
 
-        return Artifact._from_attrs(
-            path=FullArtifactPath(
-                prefix=self.entity,
-                project=self.project,
-                name=f"{self.collection_name}:{edge.version}",
+        if not (
+            (collection := node.artifact_collection)
+            and (project := collection.project)
+            and node.artifact
+            and (version_idx := node.version_index) is not None
+        ):
+            return None
+
+        return Artifact._from_membership(
+            membership=node,
+            target=FullArtifactPath(
+                prefix=project.entity.name,
+                project=project.name,
+                name=f"{collection.name}:v{version_idx}",
             ),
-            src_art=edge.node,
             client=self.client,
         )
 
@@ -780,9 +764,9 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if (conn := self.last_response) is None:
+        if not (artifacts := super().convert_objects()):
             return []
-        artifacts = (self._convert(edge) for edge in conn.edges if edge.node)
+        # parent method is overridden to maintain this prior client-side tag filtering logic
         required_tags = set(self.tags or [])
         return [art for art in artifacts if required_tags.issubset(art.tags)]
 

--- a/wandb/sdk/artifacts/_generated/operations.py
+++ b/wandb/sdk/artifacts/_generated/operations.py
@@ -569,20 +569,18 @@ fragment ArtifactTypeFragment on ArtifactType {
 """
 
 PROJECT_ARTIFACTS_GQL = """
-query ProjectArtifacts($entity: String!, $project: String!, $type: String!, $collection: String!, $cursor: String, $perPage: Int = 50, $order: String, $filters: JSONString, $includeAliases: Boolean = true) {
+query ProjectArtifacts($entity: String!, $project: String!, $type: String!, $collection: String!, $cursor: String, $perPage: Int = 50, $includeAliases: Boolean = true) {
   project(entityName: $entity, name: $project) {
     artifactType(name: $type) {
       artifactCollection(name: $collection) {
         __typename
-        artifacts(after: $cursor, first: $perPage, order: $order, filters: $filters) {
-          totalCount
+        artifactMemberships(after: $cursor, first: $perPage) {
           pageInfo {
             ...PageInfoFragment
           }
           edges {
-            version
             node {
-              ...ArtifactFragment
+              ...ArtifactMembershipFragment
             }
           }
         }
@@ -627,6 +625,21 @@ fragment ArtifactFragment on Artifact {
       ...CollectionInfoFragment
     }
     ...ArtifactAliasFragment
+  }
+}
+
+fragment ArtifactMembershipFragment on ArtifactCollectionMembership {
+  __typename
+  id
+  versionIndex
+  aliases {
+    ...ArtifactAliasFragment
+  }
+  artifactCollection {
+    ...CollectionInfoFragment
+  }
+  artifact {
+    ...ArtifactFragment
   }
 }
 

--- a/wandb/sdk/artifacts/_generated/project_artifacts.py
+++ b/wandb/sdk/artifacts/_generated/project_artifacts.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 
 from wandb._pydantic import GQLResult, Typename
 
-from .fragments import ArtifactFragment, PageInfoFragment
+from .fragments import ArtifactMembershipFragment, PageInfoFragment
 
 
 class ProjectArtifacts(GQLResult):
@@ -33,23 +33,29 @@ class ProjectArtifactsProjectArtifactTypeArtifactCollection(GQLResult):
     typename__: Typename[
         Literal["ArtifactCollection", "ArtifactPortfolio", "ArtifactSequence"]
     ]
-    artifacts: Optional[ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifacts]
+    artifact_memberships: ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactMemberships = Field(
+        alias="artifactMemberships"
+    )
 
 
-class ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifacts(GQLResult):
-    total_count: int = Field(alias="totalCount")
+class ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactMemberships(
+    GQLResult
+):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactsEdges]
+    edges: List[
+        ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactMembershipsEdges
+    ]
 
 
-class ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactsEdges(GQLResult):
-    version: str
-    node: ArtifactFragment
+class ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactMembershipsEdges(
+    GQLResult
+):
+    node: Optional[ArtifactMembershipFragment]
 
 
 ProjectArtifacts.model_rebuild()
 ProjectArtifactsProject.model_rebuild()
 ProjectArtifactsProjectArtifactType.model_rebuild()
 ProjectArtifactsProjectArtifactTypeArtifactCollection.model_rebuild()
-ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifacts.model_rebuild()
-ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactsEdges.model_rebuild()
+ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactMemberships.model_rebuild()
+ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactMembershipsEdges.model_rebuild()


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Migrates the `Artifacts` paginator to query for `artifactMemberships()`, rather than on (source) `artifacts()`, much like we already do in the `Versions` paginator used by the Registry API.

NOTE: This PR arguably/formally includes some breaking changes -- [TODO: expand]

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
