### PR TITLE
refactor: avoid IO when rereading a record in live mode

### DIFF
--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -155,7 +155,7 @@ func (r *RunReader) closeRunWork() {
 
 // open returns an opened transaction log Reader.
 func (r *RunReader) open() (*transactionlog.Reader, error) {
-	reader, err := transactionlog.OpenReader(r.path, r.logger)
+	reader, err := transactionlog.OpenReader(r.path, r.logger, true /*live*/)
 
 	if err == nil {
 		return reader, nil

--- a/core/internal/stream/flowcontrol_test.go
+++ b/core/internal/stream/flowcontrol_test.go
@@ -147,16 +147,13 @@ func TestStopsDiscardingOnStoreError(t *testing.T) {
 
 	t.Run("broken Read", func(t *testing.T) {
 		_, w := transactionlogtest.ReaderWriter(t)
-		r := transactionlogtest.RecordThenErrorReader(t, &spb.Record{Num: 1})
+		r := transactionlogtest.ErrorReader(t)
 		x := setup(t, r, w, stream.FlowControlParams{
 			InMemorySize: 0,
 			Limit:        1000,
 		})
-		x.MockRecordParser.EXPECT().
-			Parse(gomock.Any()).
-			Return(&runworktest.NoopWork{})
 
-		feedInputUntilOutputCount(t, x, 2)
+		feedInputUntilOutputCount(t, x, 1)
 
 		assert.Contains(t, x.Logs.String(), "failed reading")
 	})

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -210,6 +210,7 @@ func (s *Stream) maybeSavingToTransactionLog(
 	r, err := transactionlog.OpenReader(
 		s.settings.GetTransactionLogPath(),
 		s.logger,
+		/*live*/ false, // backward seeking not needed for flow control
 	)
 	if err != nil {
 		// Capture the error because if we can open for writing,

--- a/core/internal/transactionlog/bufferedreadseeker.go
+++ b/core/internal/transactionlog/bufferedreadseeker.go
@@ -1,0 +1,123 @@
+package transactionlog
+
+import (
+	"io"
+	"slices"
+)
+
+// BufferedReadSeeker wraps an io.ReadSeeker to buffer data near its end
+// to allow for efficient rereading.
+type BufferedReadSeeker struct {
+	reader io.ReadSeeker
+
+	// buf contains the data from the end of the reader.
+	buf []byte
+
+	// bufStart and bufEnd define the range of bytes in the reader that
+	// is buffered in buf. Their difference equals the length of buf.
+	bufStart, bufEnd int64
+
+	// pos <= readerEnd store the reading position and the reader's actual
+	// position.
+	//
+	// If pos is not between bufStart and bufEnd, then it equals readerEnd.
+	pos, readerEnd int64
+}
+
+func NewBufferedReadSeeker(
+	reader io.ReadSeeker,
+	readerPos int64,
+) *BufferedReadSeeker {
+	return &BufferedReadSeeker{
+		reader:    reader,
+		bufStart:  readerPos,
+		bufEnd:    readerPos,
+		pos:       readerPos,
+		readerEnd: readerPos,
+	}
+}
+
+// SetSeekCutoff indicates the data before the offset will not be sought
+// and need not be buffered.
+//
+// This may free some buffer capacity.
+//
+// Seeking to before the offset is still allowed but may not benefit from
+// buffering.
+func (r *BufferedReadSeeker) SetSeekCutoff(offset int64) {
+	newStart := min(offset, r.bufEnd)
+	if newStart <= r.bufStart || newStart > r.pos {
+		return
+	}
+
+	// Amortize discarding similarly to how append() amortizes allocations.
+	nDiscard := int(newStart - r.bufStart)
+	if 2*nDiscard < len(r.buf) {
+		return
+	}
+
+	r.buf = slices.Clone(r.buf[nDiscard:])
+	r.bufStart = newStart
+}
+
+// Read implements io.Reader.Read.
+func (r *BufferedReadSeeker) Read(p []byte) (n int, err error) {
+	// Return buffered data if we're in the buffered region.
+	if r.bufStart <= r.pos && r.pos < r.bufEnd {
+		start := int(r.pos - r.bufStart)
+		n = copy(p, r.buf[start:])
+		r.pos += int64(n)
+		return
+	}
+
+	// Ensure bufEnd == readerEnd so that we can append new data to the buffer.
+	if r.bufEnd != r.readerEnd {
+		r.buf = nil
+		r.bufStart, r.bufEnd = r.readerEnd, r.readerEnd
+	}
+
+	n, err = r.reader.Read(p)
+
+	// Since pos was not inside the buffered region, pos == readerEnd.
+	r.readerEnd += int64(n)
+	r.pos = r.readerEnd
+
+	// Append new data to the buffer.
+	r.buf = append(r.buf, p[:n]...)
+	r.bufEnd = r.readerEnd
+
+	return
+}
+
+// Seek implements io.Seeker.Seek.
+func (r *BufferedReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	var targetOffset int64
+	switch whence {
+	case io.SeekStart:
+		targetOffset = offset
+	case io.SeekCurrent:
+		targetOffset = r.readerEnd + offset
+	case io.SeekEnd:
+		targetOffset = r.readerEnd - offset
+	}
+
+	// Skip IO when seeking to a buffered region.
+	if r.bufStart <= targetOffset && targetOffset <= r.bufEnd {
+		r.pos = targetOffset
+		return r.pos, nil
+	}
+
+	o, err := r.reader.Seek(offset, whence)
+	r.pos = o
+	r.readerEnd = o
+	return r.pos, err
+}
+
+// Close implements io.Closer.Close.
+func (r *BufferedReadSeeker) Close() error {
+	if closer, ok := r.reader.(io.Closer); ok {
+		return closer.Close()
+	}
+
+	return nil
+}

--- a/core/internal/transactionlog/reader.go
+++ b/core/internal/transactionlog/reader.go
@@ -17,7 +17,7 @@ import (
 // Not safe for use in multiple goroutines.
 type Reader struct {
 	reader *leveldb.Reader // nil when closed
-	source io.ReadCloser
+	source io.ReadSeeker
 	logger *observability.CoreLogger
 
 	// lastReadOffset is the offset the last Read started at, used for retrying
@@ -29,16 +29,19 @@ type Reader struct {
 //
 // Wraps errors from the os.Open() call so that they can be checked with
 // errors.Is().
+//
+// The `live` argument is the same as for NewReader.
 func OpenReader(
 	path string,
 	logger *observability.CoreLogger,
+	live bool,
 ) (*Reader, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("transactionlog: error opening file %w", err)
 	}
 
-	reader, err := NewReader(f, logger)
+	reader, err := NewReader(f, logger, live)
 
 	if err != nil {
 		_ = f.Close()
@@ -50,12 +53,25 @@ func OpenReader(
 
 // NewReader starts reading a .wandb file from the given source.
 //
+// The source's seek position must be 0.
+//
+// The `live` argument hints at whether ResetLastRead will be used
+// to retry read errors in a W&B file that's being actively written.
+// It increases memory usage by buffering each record but allows
+// ResetLastRead to avoid IO.
+//
 // On success, takes ownership of the source (it should not be used except
 // through the returned Reader).
 func NewReader(
-	source io.ReadCloser,
+	source io.ReadSeeker,
 	logger *observability.CoreLogger,
+	live bool,
 ) (*Reader, error) {
+	if live {
+		// Add buffering to avoid IO for ResetLastRead().
+		source = NewBufferedReadSeeker(source, 0)
+	}
+
 	reader := leveldb.NewReaderExt(source, leveldb.CRCAlgoIEEE)
 
 	err := reader.VerifyWandbHeader(wandbStoreVersion)
@@ -93,6 +109,13 @@ func (r *Reader) Read() (*spb.Record, error) {
 	recordReader, recordOffset, err := r.reader.NextWithOffset()
 	r.lastReadOffset = recordOffset
 
+	// Set the cutoff to the block position, since seeking to the record
+	// will require seeking to the start of its block.
+	if bufferedSource, ok := r.source.(*BufferedReadSeeker); ok {
+		blockOffset, _ := leveldb.BlockOffset(recordOffset)
+		bufferedSource.SetSeekCutoff(blockOffset)
+	}
+
 	switch {
 	case errors.Is(err, io.EOF):
 		return nil, err
@@ -125,15 +148,24 @@ func (r *Reader) ResetLastRead() error {
 //
 // The reader may not be used after.
 func (r *Reader) Close() {
-	err := r.source.Close()
+	if r.reader == nil || r.source == nil {
+		r.logger.CaptureError(errors.New("transactionlog: already closed"))
+		return
+	}
+
+	closer, ok := r.source.(io.Closer)
+	r.reader = nil
+	r.source = nil // allow any buffer to be garbage collected
+
+	if !ok {
+		return
+	}
 
 	// Since we only use the file for reading, we do not care about
 	// errors when closing, but they could indicate other issues with
 	// the user's system.
-	if err != nil {
+	if err := closer.Close(); err != nil {
 		r.logger.Warn(
 			fmt.Sprintf("transactionlog: error closing reader: %v", err))
 	}
-
-	r.reader = nil
 }

--- a/core/internal/transactionlogtest/readers.go
+++ b/core/internal/transactionlogtest/readers.go
@@ -5,6 +5,46 @@ import (
 	"io"
 )
 
+// ToggleableReadSeeker wraps an io.ReadSeeker to return errors when toggled.
+type ToggleableReadSeeker struct {
+	r       io.ReadSeeker
+	readErr error
+	seekErr error
+}
+
+func NewToggleableReadSeeker(r io.ReadSeeker) *ToggleableReadSeeker {
+	return &ToggleableReadSeeker{r, nil, nil}
+}
+
+// SetError sets or clears the error for both Read and Seek.
+func (rs *ToggleableReadSeeker) SetError(err error) {
+	rs.readErr = err
+	rs.seekErr = err
+}
+
+// SetSeekError sets or clears just the error for Seek.
+func (rs *ToggleableReadSeeker) SetSeekError(err error) {
+	rs.seekErr = err
+}
+
+// Read implements io.Reader.Read.
+func (rs *ToggleableReadSeeker) Read(p []byte) (int, error) {
+	if rs.readErr != nil {
+		return 0, rs.readErr
+	} else {
+		return rs.r.Read(p)
+	}
+}
+
+// Seek implements io.Seeker.Seek.
+func (rs *ToggleableReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	if rs.seekErr != nil {
+		return 0, rs.seekErr
+	} else {
+		return rs.r.Seek(offset, whence)
+	}
+}
+
 // readSeekCloser combines independent io.Reader, io.Seeker and io.Closer
 // instances.
 type readSeekCloser struct {

--- a/core/pkg/leveldb/record.go
+++ b/core/pkg/leveldb/record.go
@@ -134,6 +134,13 @@ var (
 	errZeroChunk = errors.New("leveldb/record: block appears to be zeroed")
 )
 
+// BlockOffset returns the position of the block containing a seek position.
+func BlockOffset(position int64) (block int64, offset int) {
+	block = position &^ blockSizeMask
+	offset = int(position & blockSizeMask)
+	return
+}
+
 type flusher interface {
 	Flush() error
 }
@@ -467,8 +474,7 @@ func (r *Reader) SeekRecord(offset int64) error {
 	r.recovering, r.last = false, false
 
 	// Seek to an exact block offset.
-	r.nextChunkStart = int(offset & blockSizeMask)
-	r.blockOffset = offset &^ blockSizeMask
+	r.blockOffset, r.nextChunkStart = BlockOffset(offset)
 	_, r.err = s.Seek(r.blockOffset, io.SeekStart)
 
 	return r.err


### PR DESCRIPTION
Adds a 'live' mode to `transactionlog.Reader` that buffers the last record so that `ResetLastRead(); Read()` avoids unnecessary IO.

This is implemented by wrapping the file IO in a new `BufferedReadSeeker` struct that buffers all data it reads. The `transactionlog.Reader` calls `SetSeekCutoff()` after each record to discard older data which is not covered by the no-IO guarantee.

`BufferedReadSeeker` does not use a `sync.Pool` for the buffer and simply relies on Go's `append` to reuse allocations when possible. I have not tested the performance of this yet, but note that a naive `sync.Pool` would leak memory after a large record because it wouldn't be able to free unused capacity (until reading pauses for enough time).

`SetSeekCutoff` attempts to reduce memory operations by only remaking the buffer when at least half of it is unused. This is useful if a small record is followed by a large record because it avoids needing to copy the large record's slice. When all records are roughly the same size, this results in cloning the buffer on every `SetSeekCutoff`, but it probably allows Go to reuse allocations with its GC's internal free lists. I have not verified this.