### PR TITLE
fix(artifacts): `Run.log_artifact` from an "api-fetched" `Run` fails if `WANB_PROJECT`/`WANDB_ENTITY` is set to another entity or project

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1247,6 +1247,8 @@ class Run(Attrs):
             artifact.type,
             artifact_collection_name,
             artifact.digest,
+            entity_name=self.entity,
+            project_name=self.project,
             aliases=aliases,
             tags=tags,
         )


### PR DESCRIPTION
## Description

- Fixes [WB-29463](https://wandb.atlassian.net/browse/WB-29463)

`run.log_artifact()` on API-retrieved runs was using `WANDB_PROJECT`/`WANDB_ENTITY` env vars instead of the run's actual entity/project, causing a 404 error.

**Context:**
- There are two distinct `Run` types: the live run from `wandb.init()`, and the `Run` fetched via `wandb.Api().run(...)` (in `wandb/apis/public/runs.py`)
- This bug in question occurs on the API-fetched `Run` type (NOT the `Run` type created by `wandb.init()`).  The former's `Run.log_artifact()` method uses the legacy `wandb.apis.internal.Api` class (which is, somewhat confusingly DIFFERENT than the the `InternalApi` class that other code imports from `wandb.sdk.internal.internal_api`)

**Fix:** Pass explicit `entity_name` and `project_name` to the legacy `wandb.apis.internal.Api.create_artifact()` method, matching the existing pattern in `use_artifact()`.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

See added system test. Confirmed test fails as described without fix, passes with fix.

[WB-29463]: https://wandb.atlassian.net/browse/WB-29463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ