### PR TITLE
fix(sdk): correct `Run.__exit__` type annotations to accept `None`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,4 +19,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Fixed
 
+- Fixed `Run.__exit__` type annotations to accept `None` values, which are passed when no exception is raised.
 - Fixed `Invalid Client ID digest` error when creating artifacts after calling `random.seed()`. Client IDs could collide when random state was seeded deterministically. (@pingleiwandb in https://github.com/wandb/wandb/pull/11039)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3631,9 +3631,9 @@ class Run:
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> bool:
         exception_raised = exc_type is not None
         if exception_raised:


### PR DESCRIPTION
The `__exit__` method receives `None` for all three arguments when no exception is raised, but the type annotations didn't allow for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This issue was initially picked up by `ty` with the following error:

```sh
error[invalid-context-manager]: Object of type `Run` cannot be used with `with` because it does not correctly implement `__exit__`
   |
20 |     with wandb.init(project="project", entity="entity", name=run_name) as wandb_run:
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
info: rule `invalid-context-manager` is enabled by default
```