### PR TITLE
chore: constrain NumPy version in CI

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -34,6 +34,7 @@ nbclient~=0.10.1
 tensorflow==2.9.2; python_version < '3.9' and sys_platform != 'darwin'
 tensorflow-macos==2.9.2; python_version < '3.9' and sys_platform == 'darwin'
 tensorflow~=2.20; python_version >= '3.9' and sys_platform != 'darwin'
+numpy<2.4.0  # tensorflow==2.20.0 uses deprecated args removed in numpy==2.4.0
 
 # This is a transitive dependency of `tensorflow` via `tensorboard`
 # which fails to specify an upper bound causing import errors.


### PR DESCRIPTION

NumPy 2.4.0 removed [some deprecated parameters](https://numpy.org/doc/stable/release/2.4.0-notes.html#removed-newshape-parameter-from-numpy-reshape) that the latest version of tensorflow (2.20.0) still uses, [breaking some tests](https://app.circleci.com/pipelines/github/wandb/wandb/59266/workflows/556b8245-1890-4e7d-96ea-3e8d6826f736/jobs/1588446) in tests/system_tests/test_functional/test_tensorboard/test_tensorboardX.py:

```
Traceback (most recent call last):
  File "/root/project/tests/system_tests/test_functional/test_tensorboard/test_tensorboardX.py", line 51, in test_add_gif
    writer.add_video(
    ~~~~~~~~~~~~~~~~^
        "example",
        ^^^^^^^^^^
    ...<3 lines>...
        i + 1,
        ^^^^^^
    )
    ^
  File "/root/project/.nox/functional_tests-3-13/lib/python3.13/site-packages/tensorboardX/writer.py", line 858, in add_video
    summary = video(tag, vid_tensor, fps, dataformats=dataformats)
  File "/root/project/.nox/functional_tests-3-13/lib/python3.13/site-packages/tensorboardX/summary.py", line 360, in video
    tensor = _prepare_video(tensor)
  File "/root/project/.nox/functional_tests-3-13/lib/python3.13/site-packages/tensorboardX/utils.py", line 63, in _prepare_video
    V = np.reshape(V, newshape=(n_rows, n_cols, t, c, h, w))
TypeError: reshape() got an unexpected keyword argument 'newshape'
```