### PR TITLE
refactor: create a .synced file in wandb beta sync

### DIFF
--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -201,6 +201,9 @@ def test_syncs_run(
     # More lines possible depending on status updates. Not deterministic.
     assert lines[-1].startswith(f"wandb: [{run.path}] Finished syncing")
 
+    synced_file = pathlib.Path(run.settings.sync_file + ".synced")
+    assert synced_file.exists()
+
     with wandb_backend_spy.freeze() as snapshot:
         history = snapshot.history(run_id=run.id)
         assert len(history) == 1


### PR DESCRIPTION
Makes `wandb beta sync` create a `.synced` file when it finishes syncing a run.

This may happen even if the Sender fails to upload it; we don't have a mechanism to detect this in the RunSyncer.