### PR TITLE
fix: ignore offline mode in wandb beta sync

### DIFF
--- a/core/internal/runsync/syncsettings.go
+++ b/core/internal/runsync/syncsettings.go
@@ -20,6 +20,9 @@ func MakeSyncSettings(
 ) *settings.Settings {
 	syncSettings := proto.CloneOf(globalSettings)
 
+	// Syncing ignores offline mode.
+	syncSettings.XOffline = wrapperspb.Bool(false)
+
 	// This determines files_dir.
 	syncSettings.SyncDir = wrapperspb.String(filepath.Dir(wandbFile))
 


### PR DESCRIPTION
Makes `wandb beta sync` ignore `WANDB_MODE=offline`.

Important when using `wandb offline`, which updates the settings file that's used to populate settings when syncing. We must read the settings file because it defines the W&B server URL to which to upload.