### PR TITLE
refactor: remove x_sync setting usage in wandb-core

### DIFF
--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -87,9 +87,6 @@ func TestUploader(t *testing.T) {
 	// The _offline mode to set on Settings.
 	var isOffline bool
 
-	// The _sync mode to set on Settings.
-	var isSync bool
-
 	// Resets test objects and runs a given test.
 	runTest := func(
 		name string,
@@ -101,7 +98,6 @@ func TestUploader(t *testing.T) {
 		syncDir = t.TempDir()
 		ignoreGlobs = []string{}
 		isOffline = false
-		isSync = false
 		configure()
 
 		fakeFileStream = filestreamtest.NewFakeFileStream()
@@ -117,7 +113,6 @@ func TestUploader(t *testing.T) {
 			SyncDir:     &wrapperspb.StringValue{Value: syncDir},
 			IgnoreGlobs: &spb.ListStringValue{Value: ignoreGlobs},
 			XOffline:    &wrapperspb.BoolValue{Value: isOffline},
-			XSync:       &wrapperspb.BoolValue{Value: isSync},
 		})
 		filesDir = settings.GetFilesDir()
 
@@ -171,22 +166,6 @@ func TestUploader(t *testing.T) {
 
 			assert.True(t,
 				fakeFileWatcher.IsWatching(filepath.Join(filesDir, "test.txt")))
-		})
-
-	runTest("Process with 'now' policy during sync is no-op",
-		func() { isSync = true },
-		func(t *testing.T) {
-			stubCreateRunFilesOneFile(mockGQLClient, "test.txt")
-			writeEmptyFile(t, filepath.Join(filesDir, "test.txt"))
-
-			uploader.Process(&spb.FilesRecord{
-				Files: []*spb.FilesItem{
-					{Path: "test.txt", Policy: spb.FilesItem_NOW},
-				},
-			})
-			uploader.Finish()
-
-			assert.Len(t, fakeFileTransfer.Tasks(), 0)
 		})
 
 	runTest("Process sets file category",

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -113,11 +113,6 @@ func (u *uploader) Process(record *spb.FilesRecord) {
 	}
 	defer u.stateMu.Unlock()
 
-	// Ignore file records in sync mode---we just upload everything at the end.
-	if u.settings.IsSync() {
-		return
-	}
-
 	nowFiles := make([]paths.RelativePath, 0)
 
 	for _, file := range record.GetFiles() {

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -87,11 +87,6 @@ func (s *Settings) IsOffline() bool {
 	return s.Proto.XOffline.GetValue()
 }
 
-// Whether we are syncing a run from the transaction log.
-func (s *Settings) IsSync() bool {
-	return s.Proto.XSync.GetValue()
-}
-
 // Path to the transaction log file, that is being synced.
 func (s *Settings) GetTransactionLogPath() string {
 	return s.Proto.SyncFile.GetValue()

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -465,13 +465,6 @@ func (h *Handler) handleHeader(record *spb.Record) {
 }
 
 func (h *Handler) handleRequestRunStart(record *spb.Record, request *spb.RunStartRequest) {
-	// if sync is enabled, we don't need to do anything just forward the record
-	// to the sender so it can start the relevant components
-	if h.settings.IsSync() {
-		h.fwdRecord(record)
-		return
-	}
-
 	var ok bool
 	run := request.Run
 
@@ -689,7 +682,7 @@ func (h *Handler) handleExit(record *spb.Record, exit *spb.RunExitRecord) {
 	h.runTimer.Stop()
 	exit.Runtime = int32(h.runTimer.Elapsed().Seconds())
 
-	if !h.settings.IsSync() && !h.settings.IsEnableServerSideDerivedSummary() {
+	if !h.settings.IsEnableServerSideDerivedSummary() {
 		h.updateRunTiming()
 	}
 


### PR DESCRIPTION
Completes WB-29994.

Removes `settings.IsSync()` and updates all codepaths.

The `x_sync` setting was used in the legacy pure-Python sync implementation (which is still around), but it is never set in `wandb beta sync`. The check in `handler.go` was completely unused (since the Handler is not used when syncing), and the `sender.go` branches were unneeded because beta sync doesn't use `SyncFinishRequest`. The `runfiles/uploader.go` was also not needed; due to hashing, we won't upload files more than necessary anyway.

I'm not sure if `wandb beta sync` handles run timing correctly. The code in `handler.go` is a little suspicious.