### PR TITLE
feat: print the run URL in wandb beta sync

### DIFF
--- a/core/internal/runsync/wire_gen.go
+++ b/core/internal/runsync/wire_gen.go
@@ -93,8 +93,10 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 		Operations:          wandbOperations,
 		Printer:             printer,
 		RecordParserFactory: recordParserFactory,
+		RunHandle:           runHandle,
 		RunReaderFactory:    runReaderFactory,
 		SenderFactory:       senderFactory,
+		Settings:            settings2,
 		TBHandlerFactory:    tbHandlerFactory,
 	}
 	return runSyncerFactory


### PR DESCRIPTION
Completes WB-29996.

Prints the URL to which a run is being synced in `wandb beta sync`.