### PR TITLE
fix: print a valid URL at the end of a run

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Fixed
 
-- Fixed `Run.__exit__` type annotations to accept `None` values, which are passed when no exception is raised.
+- Fixed `Run.__exit__` type annotations to accept `None` values, which are passed when no exception is raised (@moldhouse in https://github.com/wandb/wandb/pull/11100)
 - Fixed `Invalid Client ID digest` error when creating artifacts after calling `random.seed()`. Client IDs could collide when random state was seeded deterministically. (@pingleiwandb in https://github.com/wandb/wandb/pull/11039)
-- Fixed regression for calling `api.run()` on a Sweeps run. (@willtryagain in https://github.com/wandb/wandb/pull/11088 and @kelu-wandb in https://github.com/wandb/wandb/pull/11097)
+- Fixed regression for calling `api.run()` on a Sweeps run (@willtryagain in https://github.com/wandb/wandb/pull/11088 and @kelu-wandb in https://github.com/wandb/wandb/pull/11097)
+- Fixed the "View run at" message printed at the end of a run which sometimes did not include a URL (@timoffex in https://github.com/wandb/wandb/pull/11113)

--- a/core/internal/runbranch/state.go
+++ b/core/internal/runbranch/state.go
@@ -1,6 +1,8 @@
 package runbranch
 
 import (
+	"errors"
+	"net/url"
 	"slices"
 	"time"
 
@@ -15,6 +17,26 @@ type RunPath struct {
 	Entity  string
 	Project string
 	RunID   string
+}
+
+// URL returns the URL for the run path given the URL for the W&B web UI.
+//
+// If the run's entity or project is not known, this returns an error.
+func (path RunPath) URL(appURL string) (string, error) {
+	switch {
+	case len(path.Entity) == 0:
+		return "", errors.New("no entity")
+	case len(path.Project) == 0:
+		return "", errors.New("no project")
+	case len(path.RunID) == 0:
+		return "", errors.New("no run ID")
+	}
+
+	entity := url.PathEscape(path.Entity)
+	project := url.PathEscape(path.Project)
+	runID := url.PathEscape(path.RunID)
+
+	return url.JoinPath(appURL, entity, project, "runs", runID)
 }
 
 type BranchPoint struct {

--- a/core/internal/runbranch/state_test.go
+++ b/core/internal/runbranch/state_test.go
@@ -98,3 +98,46 @@ func TestSetsSummary(t *testing.T) {
 		},
 		updatedProto.Summary)
 }
+
+func TestRunPath_URL(t *testing.T) {
+	t.Run("produces clean escaped URL", func(t *testing.T) {
+		path := runbranch.RunPath{
+			Entity:  "entity with space",
+			Project: "project?",
+			// Common special characters people include in run IDs.
+			// Just the forward slash should be URL-escaped.
+			RunID: "me@machine/x=1&y=+$2",
+		}
+
+		url, err := path.URL("https://my-web-ui///")
+
+		assert.NoError(t, err)
+		assert.Equal(t,
+			"https://my-web-ui/entity%20with%20space/project%3F/runs/me@machine%2Fx=1&y=+$2",
+			url)
+	})
+
+	t.Run("no entity", func(t *testing.T) {
+		path := runbranch.RunPath{Project: "project", RunID: "id"}
+
+		_, err := path.URL("https://wandb.ai")
+
+		assert.ErrorContains(t, err, "no entity")
+	})
+
+	t.Run("no project", func(t *testing.T) {
+		path := runbranch.RunPath{Entity: "entity", RunID: "id"}
+
+		_, err := path.URL("https://wandb.ai")
+
+		assert.ErrorContains(t, err, "no project")
+	})
+
+	t.Run("no ID", func(t *testing.T) {
+		path := runbranch.RunPath{Entity: "entity", Project: "project"}
+
+		_, err := path.URL("https://wandb.ai")
+
+		assert.ErrorContains(t, err, "no run ID")
+	})
+}

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -201,6 +201,13 @@ func (s *Settings) GetSyncDir() string {
 	return s.Proto.SyncDir.GetValue()
 }
 
+// GetAppURL returns the base URL for the W&B UI.
+//
+// Used for constructing printable URLs like the run URL.
+func (s *Settings) GetAppURL() string {
+	return s.Proto.AppUrl.GetValue()
+}
+
 // The URL for the W&B backend.
 //
 // Used for GraphQL and "filestream" operations.


### PR DESCRIPTION
Fixes: #10956

Print a valid URL at the end of a run instead of a line like

```
wandb: 🚀 View run splendid-fog-121 at:
```

with no URL included.

This message comes from wandb-core which was reading the `run_url` setting. Its value is computed in Python, but only when the entity and project are known. These are available after the first UpsertBucket request when initializing a run, so this was relying on wandb-core and the Python client mutating and passing Settings back and forth, which is why it eventually broke.

Refactored it to not be like that. The `run_url` setting is still problematic; I'll see about removing it. In general, settings should be computed exclusively from inputs.