### PR TITLE
chore(sdk): update server_image_tag to current EOL server v0.63.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -589,7 +589,7 @@ workflows:
                 [
                   "us-central1-docker.pkg.dev/wandb-client-cicd/images/local-testcontainer",
                 ]
-              server_image_tag: ["0.48.0"]
+              server_image_tag: ["0.63.0"]
 
       - nox-tests-linux:
           name: notebook-tests-linux-<<matrix.python>>


### PR DESCRIPTION
Description
-----------
- Fixes https://wandb.atlassian.net/browse/WB-30022

At the time of writing, the EOL server version is 0.63.0, I.e. we no longer officially support earlier server versions.  We should be able to safely update the "min server version" CI job to reflect this.

This will let us remove older business logic / workarounds / hacks / cruft.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
How was this PR tested?