### PR TITLE
fix(artifacts): drop `supports_enable_tracking_var()` introspection helper only needed on past-EOL servers

### DIFF
--- a/wandb/sdk/artifacts/_gqlutils.py
+++ b/wandb/sdk/artifacts/_gqlutils.py
@@ -79,18 +79,6 @@ def server_supports(client: RetryingClient, feature: str | int) -> bool:
     return server_features(client).get(name) or False
 
 
-def supports_enable_tracking_var(client: RetryingClient) -> bool:
-    """Return True if `Project.artifact` accepts `enableTracking`."""
-    typ = type_info(client, "Project")
-    if (
-        typ
-        and typ.fields
-        and (art_field := next((f for f in typ.fields if f.name == "artifact"), None))
-    ):
-        return any("enableTracking" == arg.name for arg in art_field.args)
-    return False
-
-
 def allowed_fields(client: RetryingClient, typename: str) -> set[str]:
     """Returns the allowed field names for a given GraphQL type."""
     typ = type_info(client, typename)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -73,7 +73,6 @@ from ._gqlutils import (
     org_info_from_entity,
     resolve_org_entity_name,
     server_supports,
-    supports_enable_tracking_var,
     type_info,
 )
 from ._validators import ensure_logged, ensure_not_finalized
@@ -330,14 +329,13 @@ class Artifact:
         if server_supports(client, pb.PROJECT_ARTIFACT_COLLECTION_MEMBERSHIP):
             return cls._membership_from_name(path=path, client=client)
 
-        omit_vars = None if supports_enable_tracking_var(client) else {"enableTracking"}
         gql_vars = {
             "entity": path.prefix,
             "project": path.project,
             "name": path.name,
             "enableTracking": enable_tracking,
         }
-        gql_op = gql_compat(ARTIFACT_BY_NAME_GQL, omit_variables=omit_vars)
+        gql_op = gql(ARTIFACT_BY_NAME_GQL)
         data = client.execute(gql_op, variable_values=gql_vars)
         result = ArtifactByName.model_validate(data)
 


### PR DESCRIPTION
Description
-----------
- Fixes https://wandb.atlassian.net/browse/WB-30024

Removes backwards-compatibility logic for past-EOL servers that didn't support the `enableTracking` variable on `Project.artifact` queries.

- Remove `supports_enable_tracking_var()` helper from `_gqlutils.py`

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Existing tests. No behavior changes for supported servers.