### PR TITLE
fix(artifacts): fix client type hints (`Client -> RetryingClient`)

### DIFF
--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -9,7 +9,6 @@ from typing import (
     Iterable,
     Iterator,
     Mapping,
-    Protocol,
     Sized,
     TypeVar,
     overload,
@@ -22,17 +21,13 @@ if TYPE_CHECKING:
     from wandb_graphql.language.ast import Document
 
     from wandb._pydantic import Connection
+    from wandb.apis.public.api import RetryingClient
 
 _WandbT = TypeVar("_WandbT")
 """Generic type variable for a W&B object."""
 
 _NodeT = TypeVar("_NodeT")
 """Generic type variable for a parsed GraphQL relay node."""
-
-
-# Structural type hint for the client instance
-class _Client(Protocol):
-    def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]: ...
 
 
 class Paginator(Iterator[_WandbT], ABC):
@@ -42,11 +37,11 @@ class Paginator(Iterator[_WandbT], ABC):
 
     def __init__(
         self,
-        client: _Client,
+        client: RetryingClient,
         variables: Mapping[str, Any],
         per_page: int = 50,  # We don't allow unbounded paging
     ):
-        self.client: _Client = client
+        self.client = client
 
         # shallow copy partly guards against mutating the original input
         self.variables: dict[str, Any] = dict(variables)

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -40,9 +40,9 @@ from .files import File
 from .utils import gql_compat
 
 if TYPE_CHECKING:
-    from wandb_gql import Client
     from wandb_graphql.language.ast import Document
 
+    from wandb.apis.public.api import RetryingClient
     from wandb.sdk.artifacts._generated import (
         ArtifactAliasFragment,
         ArtifactCollectionFragment,
@@ -87,7 +87,12 @@ class _ArtifactCollectionAliases(RelayPaginator["ArtifactAliasFragment", str]):
     QUERY: ClassVar[Document | None] = None
     last_response: Connection[ArtifactAliasFragment] | None
 
-    def __init__(self, client: Client, collection_id: str, per_page: int = 1_000):
+    def __init__(
+        self,
+        client: RetryingClient,
+        collection_id: str,
+        per_page: int = 1_000,
+    ):
         if self.QUERY is None:
             from wandb.sdk.artifacts._generated import ARTIFACT_COLLECTION_ALIASES_GQL
 
@@ -126,7 +131,7 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         entity: str,
         project: str,
         per_page: int = 50,
@@ -185,7 +190,7 @@ class ArtifactType:
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         entity: str,
         project: str,
         type_name: str,
@@ -283,7 +288,7 @@ class ArtifactCollections(
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         entity: str,
         project: str,
         type_name: str,
@@ -357,7 +362,7 @@ class ArtifactCollection:
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         entity: str,
         project: str,
         name: str,
@@ -698,7 +703,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         entity: str,
         project: str,
         collection_name: str,
@@ -796,7 +801,7 @@ class RunArtifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         run: Run,
         mode: Literal["logged", "used"] = "logged",
         per_page: int = 50,
@@ -850,7 +855,7 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         artifact: Artifact,
         names: Sequence[str] | None = None,
         per_page: int = 50,

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -8,12 +8,13 @@ from typing import TYPE_CHECKING, Any, Iterator, Mapping
 from pydantic import ValidationError
 from typing_extensions import override
 
-from wandb.apis.paginator import RelayPaginator, _Client
+from wandb.apis.paginator import RelayPaginator
 
 if TYPE_CHECKING:
     from wandb_graphql.language.ast import Document
 
     from wandb._pydantic import Connection
+    from wandb.apis.public.api import RetryingClient
     from wandb.automations import Automation
     from wandb.automations._generated import ProjectTriggersFields
 
@@ -29,7 +30,7 @@ class Automations(RelayPaginator["ProjectTriggersFields", "Automation"]):
 
     def __init__(
         self,
-        client: _Client,
+        client: RetryingClient,
         variables: Mapping[str, Any],
         per_page: int = 50,
         *,

--- a/wandb/apis/public/integrations.py
+++ b/wandb/apis/public/integrations.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from wandb_graphql.language.ast import Document
 
     from wandb._pydantic import Connection
-    from wandb.apis.paginator import _Client
+    from wandb.apis.public.api import RetryingClient
     from wandb.automations import Integration, SlackIntegration, WebhookIntegration
     from wandb.automations._generated import (
         SlackIntegrationFields,
@@ -35,7 +35,12 @@ class Integrations(RelayPaginator["IntegrationFields", "Integration"]):
     QUERY: ClassVar[Document | None] = None
     last_response: Connection[IntegrationFields] | None
 
-    def __init__(self, client: _Client, variables: dict[str, Any], per_page: int = 50):
+    def __init__(
+        self,
+        client: RetryingClient,
+        variables: dict[str, Any],
+        per_page: int = 50,
+    ):
         if self.QUERY is None:
             from wandb.automations._generated import INTEGRATIONS_BY_ENTITY_GQL
 

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -9,7 +9,7 @@ from wandb_gql import gql
 from wandb._strutils import ensureprefix
 
 if TYPE_CHECKING:
-    from wandb_gql import Client
+    from wandb.apis.public.api import RetryingClient
 
 
 class Visibility(str, Enum):
@@ -93,7 +93,9 @@ def ensure_registry_prefix_on_names(query: Any, in_name: bool = False) -> Any:
 
 
 @lru_cache(maxsize=10)
-def fetch_org_entity_from_organization(client: Client, organization: str) -> str:
+def fetch_org_entity_from_organization(
+    client: RetryingClient, organization: str
+) -> str:
     """Fetch the org entity from the organization.
 
     Args:

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -31,8 +31,7 @@ from ._utils import (
 from .registries_search import Collections, Versions
 
 if TYPE_CHECKING:
-    from wandb_gql import Client
-
+    from wandb.apis.public.api import RetryingClient
     from wandb.sdk.artifacts._generated import RegistryFragment
 
 
@@ -47,7 +46,7 @@ class Registry:
 
     def __init__(
         self,
-        client: Client,
+        client: RetryingClient,
         organization: str,
         entity: str,
         name: str,
@@ -223,7 +222,7 @@ class Registry:
     @tracked
     def create(
         cls,
-        client: Client,
+        client: RetryingClient,
         organization: str,
         name: str,
         visibility: Literal["organization", "restricted"],

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -623,9 +623,11 @@ class Artifact:
         The collection that an artifact originates from is known as
         the source sequence.
         """
+        if (client := self._client) is None:
+            raise RuntimeError("Client not initialized")
         base_name = self.name.split(":")[0]
         return ArtifactCollection(
-            self._client, self.entity, self.project, base_name, self.type
+            client, self.entity, self.project, base_name, self.type
         )
 
     @property
@@ -673,9 +675,11 @@ class Artifact:
 
         The source collection is the collection that the artifact was logged from.
         """
+        if (client := self._client) is None:
+            raise RuntimeError("Client not initialized")
         base_name = self.source_name.split(":")[0]
         return ArtifactCollection(
-            self._client, self.source_entity, self.source_project, base_name, self.type
+            client, self.source_entity, self.source_project, base_name, self.type
         )
 
     @property
@@ -2307,7 +2311,9 @@ class Artifact:
         Raises:
             ArtifactNotLoggedError: If the artifact is not logged.
         """
-        return ArtifactFiles(self._client, self, names, per_page)
+        if (client := self._client) is None:
+            raise RuntimeError("Client not initialized")
+        return ArtifactFiles(client, self, names, per_page)
 
     def _default_root(self, include_version: bool = True) -> FilePathStr:
         name = self.source_name if include_version else self.source_name.split(":")[0]


### PR DESCRIPTION
Description
-----------
- Fixes https://wandb.atlassian.net/browse/WB-30036

PR fixes type hints for GraphQL client args/attributes across various paginator and artifacts code.

- Updates type hints from `wandb_gql.Client -> RetryingClient`, as in practice we only ever pass a `RetryingClient` (not `gql.Client`) in:
  - `artifacts.py` (`ArtifactTypes`, `ArtifactCollections`, `Artifacts`, etc.)
  - `automations.py`
  - `integrations.py`
  - `registries/_utils.py` and `registry.py`
- Removes `_Client` Protocol from `paginator.py` and use `RetryingClient` directly.
- Adds explicit runtime checks against `self._client is None` in `artifact.py` methods to continue passing mypy checks.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
No intended functional changes. Existing tests must continue to pass.