### PR TITLE
refactor: use term* functions in wandb beta sync

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,12 @@ def patch_prompt(monkeypatch):
 
 
 @pytest.fixture
-def runner():
+def runner(monkeypatch: pytest.MonkeyPatch):
+    # Allow terminput() usage when invoking with the CliRunner.
+    #
+    # This assumes that terminput() is only called within a runner.invoke()
+    # in tests that use the runner fixture.
+    monkeypatch.setattr(term, "can_use_terminput", lambda: True)
     return CliRunner()
 
 

--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -196,7 +196,7 @@ def test_syncs_run(
     result = runner.invoke(cli.beta, f"sync {run.settings.sync_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "Syncing 1 run(s):"
+    assert lines[0] == "wandb: Syncing 1 run(s):"
     assert lines[1].endswith(f"run-{run.id}.wandb")
     # More lines possible depending on status updates. Not deterministic.
     assert lines[-1].startswith(f"wandb: [{run.path}] Finished syncing")
@@ -228,13 +228,13 @@ def test_sync_defaults_to_wandb_dir(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, "sync", input="n")
 
     assert result.output.splitlines() == [
-        "Syncing 5 run(s):",
-        f"  {paths[0]}",
-        f"  {paths[1]}",
-        f"  {paths[2]}",
-        f"  {paths[3]}",
-        f"  {paths[4]}",
-        "Sync the listed runs? [y/N]: n",
+        "wandb: Syncing 5 run(s):",
+        f"wandb:   {paths[0]}",
+        f"wandb:   {paths[1]}",
+        f"wandb:   {paths[2]}",
+        f"wandb:   {paths[3]}",
+        f"wandb:   {paths[4]}",
+        "wandb: Sync the listed runs? [y/n] n",
     ]
 
 
@@ -323,8 +323,8 @@ def test_merges_symlinks(
     result = runner.invoke(cli.beta, "sync --dry-run .")
 
     assert result.output.splitlines() == [
-        "Would sync 1 run(s):",
-        "  actual-run/run.wandb",
+        "wandb: Would sync 1 run(s):",
+        "wandb:   actual-run/run.wandb",
     ]
 
 
@@ -335,7 +335,7 @@ def test_sync_wandb_file(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {file}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "Would sync 1 run(s):"
+    assert lines[0] == "wandb: Would sync 1 run(s):"
     assert lines[1].endswith("run.wandb")
 
 
@@ -347,7 +347,7 @@ def test_sync_run_directory(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {run_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "Would sync 1 run(s):"
+    assert lines[0] == "wandb: Would sync 1 run(s):"
     assert lines[1].endswith("run.wandb")
 
 
@@ -365,7 +365,7 @@ def test_sync_wandb_directory(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {wandb_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "Would sync 2 run(s):"
+    assert lines[0] == "wandb: Would sync 2 run(s):"
     assert lines[1].endswith("run-1.wandb")
     assert lines[2].endswith("run-2.wandb")
 
@@ -383,10 +383,10 @@ def test_truncates_printed_paths(
     result = runner.invoke(cli.beta, f"sync --dry-run {tmp_path}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "Would sync 20 run(s):"
+    assert lines[0] == "wandb: Would sync 20 run(s):"
     for line in lines[1:6]:
-        assert re.fullmatch(r"  .+/run-\d+\.wandb", line)
-    assert lines[6] == "  +15 more (pass --verbose to see all)"
+        assert re.fullmatch(r"wandb:   .+/run-\d+\.wandb", line)
+    assert lines[6] == "wandb:   +15 more (pass --verbose to see all)"
 
 
 def test_prints_relative_paths(
@@ -406,11 +406,11 @@ def test_prints_relative_paths(
     result = runner.invoke(cli.beta, f"sync --dry-run {tmp_path}")
 
     assert result.output.splitlines() == [
-        "Would sync 2 run(s):",
+        "wandb: Would sync 2 run(s):",
         *sorted(
             [
-                "  run-relative.wandb",
-                f"  {dir2_not / 'run-absolute.wandb'}",
+                "wandb:   run-relative.wandb",
+                f"wandb:   {dir2_not / 'run-absolute.wandb'}",
             ]
         ),
     ]

--- a/tests/unit_tests/test_term.py
+++ b/tests/unit_tests/test_term.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import wandb
 from wandb import util
@@ -135,3 +137,31 @@ def test_can_use_terminput_databricks(
     monkeypatch.setattr(util, "_is_databricks", lambda: True)
 
     assert not term.can_use_terminput()
+
+
+@pytest.mark.parametrize(
+    "inputs, expected_result",
+    (
+        ([" y "], True),
+        (["Y "], True),
+        (["yes"], True),
+        ([" n"], False),
+        (["No "], False),
+        ([" N"], False),
+        (["", "yellow", "no"], False),
+        (["no yes", "yes"], True),
+    ),
+)
+def test_confirm(
+    inputs: list[str],
+    expected_result: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    remaining_inputs = list(inputs)
+
+    def mock_terminput(*args, **kwargs) -> str:
+        return remaining_inputs.pop()
+
+    monkeypatch.setattr(term, "_terminput", mock_terminput)
+
+    assert term.confirm("What?") == expected_result

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -9,9 +9,8 @@ import time
 from itertools import filterfalse
 from typing import Iterable, Iterator
 
-import click
-
 import wandb
+from wandb.errors import term
 from wandb.proto.wandb_sync_pb2 import ServerSyncResponse
 from wandb.sdk import wandb_setup
 from wandb.sdk.lib import asyncio_compat
@@ -75,18 +74,18 @@ def sync(
     )
 
     if not wandb_files:
-        click.echo("No runs to sync.")
+        term.termlog("No runs to sync.")
         return
 
     if dry_run:
-        click.echo(f"Would sync {len(wandb_files)} run(s):")
+        term.termlog(f"Would sync {len(wandb_files)} run(s):")
         _print_sorted_paths(wandb_files, verbose=verbose, root=cwd)
         return
 
-    click.echo(f"Syncing {len(wandb_files)} run(s):")
+    term.termlog(f"Syncing {len(wandb_files)} run(s):")
     _print_sorted_paths(wandb_files, verbose=verbose, root=cwd)
 
-    if ask_for_confirmation and not click.confirm("Sync the listed runs?"):
+    if ask_for_confirmation and not term.confirm("Sync the listed runs?"):
         return
 
     service = singleton.ensure_service()
@@ -124,13 +123,13 @@ def _to_unique_files(
         try:
             stat = path.stat()
         except OSError as e:
-            click.echo(f"Failed to stat {path}: {e}")
+            term.termerror(f"Failed to stat {path}: {e}")
             continue
 
         id = (stat.st_ino, stat.st_dev)
 
         if verbose and (other_path := id_to_path.get(id)):
-            click.echo(f"{path} is the same as {other_path}")
+            term.termlog(f"{path} is the same as {other_path}")
 
         id_to_path[id] = path
 
@@ -300,8 +299,8 @@ def _print_sorted_paths(
     max_lines = len(sorted_paths) if verbose else _MAX_LIST_LINES
 
     for i in range(min(len(sorted_paths), max_lines)):
-        click.echo(f"  {sorted_paths[i]}")
+        term.termlog(f"  {sorted_paths[i]}")
 
     if len(sorted_paths) > max_lines:
         remaining = len(sorted_paths) - max_lines
-        click.echo(f"  +{remaining:,d} more (pass --verbose to see all)")
+        term.termlog(f"  +{remaining:,d} more (pass --verbose to see all)")

--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -320,6 +320,26 @@ def terminput(
     return _terminput(prefixed_prompt, timeout=timeout, hide=hide)
 
 
+def confirm(prompt: str) -> bool:
+    """Prompt the user with a yes/no question.
+
+    Args:
+        prompt: A prompt ending with a question mark (not whitespace),
+            like "Are you sure?".
+
+    Returns:
+        The user's choice.
+    """
+    prompt = f"{prompt} [y/n] "
+    while True:
+        answer = terminput(prompt).strip().lower()
+
+        if answer in ("n", "no"):
+            return False
+        if answer in ("y", "yes"):
+            return True
+
+
 def _terminput(
     prefixed_prompt: str,
     *,


### PR DESCRIPTION
Completes WB-30026.

Uses termlog(), termerror() and terminput() instead of click.echo() and click.confirm() for consistent output.