### PR TITLE
chore: maybe fix debouncedwriter_test flake

### DIFF
--- a/core/internal/runconsolelogs/debouncedwriter_test.go
+++ b/core/internal/runconsolelogs/debouncedwriter_test.go
@@ -24,7 +24,7 @@ func TestDebouncesAndInvokesCallback(t *testing.T) {
 
 		writer.OnChanged(1, RunLogsLineForTest("content 1"))
 		writer.OnChanged(2, RunLogsLineForTest("content 2"))
-		time.Sleep(time.Second) // flushes after the debounce period expires
+		time.Sleep(2 * time.Second) // flushes after the debounce period expires
 		writer.OnChanged(3, RunLogsLineForTest("content 3"))
 		writer.Finish() // flushes immediately
 


### PR DESCRIPTION
The `time.Sleep(time.Second)` in the test seems to have resulted in a race with the 1-second rate limit in this [pre-commit run](https://github.com/wandb/wandb/runs/59239895914). Having the test sleep for strictly more than a second should avoid the race.

NOTE: The test doesn't actually sleep as it runs using `testing/synctest`.