### PR TITLE
refactor: tensorboard syscall behavior

### DIFF
--- a/core/internal/tensorboard/tfeventreader_test.go
+++ b/core/internal/tensorboard/tfeventreader_test.go
@@ -181,6 +181,7 @@ func runTest(
 		logger,
 		func() time.Time { return ctx.Now },
 	)
+	defer ctx.Reader.Close()
 
 	for _, step := range testSteps {
 		step.Do(t, ctx)

--- a/core/internal/tensorboard/tfeventstream.go
+++ b/core/internal/tensorboard/tfeventstream.go
@@ -87,6 +87,8 @@ func (s *tfEventStream) Start() {
 }
 
 func (s *tfEventStream) loop() {
+	defer s.reader.Close()
+
 	// Whether we're in the final stage where we read all remaining events.
 	//
 	// Stop() may be invoked while we're asleep, during which time more events


### PR DESCRIPTION
Completes WB-29794.

Keep tfevents files open for longer when syncing them with `wandb.init(sync_tensorboard=True)`.

## Testing

I checked that `sync_tensorboard` still works correctly with GCP and a local filesystem for a small run, in addition to the existing integration tests under `tests/system_tests/test_functional/test_tensorboard/`.

I didn't count open() / close() syscalls or perform any benchmarking.