### PR TITLE
fix(sdk): fix/add type hints in `wandb.apis.public.runs`

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -45,6 +45,7 @@ from wandb_gql import gql
 
 import wandb
 from wandb import env, util
+from wandb._strutils import nameof
 from wandb.apis import public
 from wandb.apis.attrs import Attrs
 from wandb.apis.internal import Api as InternalApi
@@ -456,7 +457,7 @@ class Runs(SizedPaginator["Run"]):
             return combined_df
 
     def __repr__(self) -> str:
-        return f"<Runs {self.entity}/{self.project}>"
+        return f"<{nameof(type(self))} {self.entity}/{self.project}>"
 
     def upgrade_to_full(self) -> None:
         """Upgrade this Runs collection from lazy to full mode.
@@ -1454,7 +1455,7 @@ class Run(Attrs):
         return self.to_html()
 
     def __repr__(self) -> str:
-        return "<Run {} ({})>".format("/".join(self.path), self.state)
+        return f"<{nameof(type(self))} {'/'.join(self.path)} ({self.state})>"
 
     def beta_scan_history(
         self,


### PR DESCRIPTION
## Description

Adds missing type hints in `wandb.apis.public.runs`. Split out from #11130 to reduce noise in that PR.

Also fixes the `Run.create` classmethod constructor to correctly return `cls(...)` instead of `Run(...)`, to match the typical expectation for such methods (i.e. should return `Self`).

_Side note:_ If we later decide that `.create()` should always return a `Run` (even when in a subclass of `Run`), some more conventional + type-safe ways to do this are:

- define `Run.create()` as a `@staticmethod` instead, OR
- forbid subclassing entirely by decorating `Run` with `@final`


- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

No intended functional changes to runtime behavior.  Existing checks must continue to pass.