### PR TITLE
fix(sdk): convert Reports paginator from `SizedPaginator` to `SizedRelayPaginator`

### DIFF
--- a/tools/graphql_codegen/api/reports.graphql
+++ b/tools/graphql_codegen/api/reports.graphql
@@ -1,30 +1,35 @@
+fragment ViewFragment on View {
+  id
+  name
+  displayName
+  description
+  user {
+    username
+    photoUrl
+    email
+  }
+  spec
+  updatedAt
+  createdAt
+}
+
 query ProjectViews(
   $project: String!
   $entity: String!
-  $reportCursor: String
-  $reportLimit: Int!
+  $cursor: String
+  $perPage: Int!
   $viewType: String = "runs"
   $viewName: String
 ) {
   project(name: $project, entityName: $entity) {
-    allViews(viewType: $viewType, viewName: $viewName, first: $reportLimit, after: $reportCursor) {
+    allViews(viewType: $viewType, viewName: $viewName, after: $cursor, first: $perPage) {
+      totalCount
       pageInfo {
         ...PageInfoFragment
       }
       edges {
         node {
-          id
-          name
-          displayName
-          description
-          user {
-            username
-            photoUrl
-            email
-          }
-          spec
-          updatedAt
-          createdAt
+          ...ViewFragment
         }
       }
     }

--- a/wandb/apis/_generated/__init__.py
+++ b/wandb/apis/_generated/__init__.py
@@ -108,6 +108,7 @@ __all__ = [
     "SweepFragment",
     "UserFragment",
     "UserInfoFragment",
+    "ViewFragment",
     "ArtifactState",
     "RunQueueAccessType",
     "RunQueueItemState",
@@ -145,6 +146,7 @@ from .fragments import (
     SweepFragment,
     UserFragment,
     UserInfoFragment,
+    ViewFragment,
 )
 from .generate_api_key import GenerateApiKey
 from .get_default_entity import GetDefaultEntity

--- a/wandb/apis/_generated/fragments.py
+++ b/wandb/apis/_generated/fragments.py
@@ -175,6 +175,23 @@ class UserInfoFragment(GQLResult):
     admin: Optional[bool]
 
 
+class ViewFragment(GQLResult):
+    id: GQLId
+    name: Optional[str]
+    display_name: Optional[str] = Field(alias="displayName")
+    description: Optional[str]
+    user: Optional[ViewFragmentUser]
+    spec: Optional[str]
+    updated_at: Optional[str] = Field(alias="updatedAt")
+    created_at: str = Field(alias="createdAt")
+
+
+class ViewFragmentUser(GQLResult):
+    username: Optional[str]
+    photo_url: Optional[str] = Field(alias="photoUrl")
+    email: Optional[str]
+
+
 ApiKeyFragment.model_rebuild()
 CreatedProjectFragment.model_rebuild()
 FileFragment.model_rebuild()
@@ -194,3 +211,5 @@ UserFragmentTeams.model_rebuild()
 UserFragmentTeamsEdges.model_rebuild()
 UserFragmentTeamsEdgesNode.model_rebuild()
 UserInfoFragment.model_rebuild()
+ViewFragment.model_rebuild()
+ViewFragmentUser.model_rebuild()

--- a/wandb/apis/_generated/operations.py
+++ b/wandb/apis/_generated/operations.py
@@ -343,31 +343,21 @@ fragment CreatedProjectFragment on Project {
 """
 
 PROJECT_VIEWS_GQL = """
-query ProjectViews($project: String!, $entity: String!, $reportCursor: String, $reportLimit: Int!, $viewType: String = "runs", $viewName: String) {
+query ProjectViews($project: String!, $entity: String!, $cursor: String, $perPage: Int!, $viewType: String = "runs", $viewName: String) {
   project(name: $project, entityName: $entity) {
     allViews(
       viewType: $viewType
       viewName: $viewName
-      first: $reportLimit
-      after: $reportCursor
+      after: $cursor
+      first: $perPage
     ) {
+      totalCount
       pageInfo {
         ...PageInfoFragment
       }
       edges {
         node {
-          id
-          name
-          displayName
-          description
-          user {
-            username
-            photoUrl
-            email
-          }
-          spec
-          updatedAt
-          createdAt
+          ...ViewFragment
         }
       }
     }
@@ -378,6 +368,21 @@ fragment PageInfoFragment on PageInfo {
   __typename
   endCursor
   hasNextPage
+}
+
+fragment ViewFragment on View {
+  id
+  name
+  displayName
+  description
+  user {
+    username
+    photoUrl
+    email
+  }
+  spec
+  updatedAt
+  createdAt
 }
 """
 

--- a/wandb/apis/_generated/project_views.py
+++ b/wandb/apis/_generated/project_views.py
@@ -7,9 +7,9 @@ from typing import List, Optional
 
 from pydantic import Field
 
-from wandb._pydantic import GQLId, GQLResult
+from wandb._pydantic import GQLResult
 
-from .fragments import PageInfoFragment
+from .fragments import PageInfoFragment, ViewFragment
 
 
 class ProjectViews(GQLResult):
@@ -21,33 +21,16 @@ class ProjectViewsProject(GQLResult):
 
 
 class ProjectViewsProjectAllViews(GQLResult):
+    total_count: int = Field(alias="totalCount")
     page_info: PageInfoFragment = Field(alias="pageInfo")
     edges: List[ProjectViewsProjectAllViewsEdges]
 
 
 class ProjectViewsProjectAllViewsEdges(GQLResult):
-    node: Optional[ProjectViewsProjectAllViewsEdgesNode]
-
-
-class ProjectViewsProjectAllViewsEdgesNode(GQLResult):
-    id: GQLId
-    name: Optional[str]
-    display_name: Optional[str] = Field(alias="displayName")
-    description: Optional[str]
-    user: Optional[ProjectViewsProjectAllViewsEdgesNodeUser]
-    spec: Optional[str]
-    updated_at: Optional[str] = Field(alias="updatedAt")
-    created_at: str = Field(alias="createdAt")
-
-
-class ProjectViewsProjectAllViewsEdgesNodeUser(GQLResult):
-    username: Optional[str]
-    photo_url: Optional[str] = Field(alias="photoUrl")
-    email: Optional[str]
+    node: Optional[ViewFragment]
 
 
 ProjectViews.model_rebuild()
 ProjectViewsProject.model_rebuild()
 ProjectViewsProjectAllViews.model_rebuild()
 ProjectViewsProjectAllViewsEdges.model_rebuild()
-ProjectViewsProjectAllViewsEdgesNode.model_rebuild()


### PR DESCRIPTION
## Description

Converts `Reports` from `SizedPaginator` to `SizedRelayPaginator`, using cursor-based Relay pagination and requesting the `totalCount` field from the `ViewConnection` type.

Builds on #11137 which added validated types for Reports GQL data.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

No intended functional changes. Existing tests must continue to pass.