### PR TITLE
chore(artifacts): use list_blobs only in store_path

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,3 +23,8 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Changed
 
 - Changed CPU and memory system metric percentages in Linux containers to use cgroup v2 resource limits instead of host node totals. Set the private `x_stats_no_cgroup` setting to `True` to opt out (@dmitryduev in https://github.com/wandb/wandb/pull/11796)
+
+### Fixed
+
+- Fixed `artifact.add_reference("gs://...")` to use `list_blobs` instead of `get_blob` when tracking external files on Google Cloud Storage. Accessing public buckets with anonymous credentials still uses `get_blob`.
+  (@pingleiwandb in https://github.com/wandb/wandb/pull/11145)

--- a/tests/system_tests/test_artifacts/test_references_gcs.py
+++ b/tests/system_tests/test_artifacts/test_references_gcs.py
@@ -111,7 +111,7 @@ def test_add_gs_reference_object(artifact, no_list_blobs_permission):
     )
     artifact.add_reference("gs://my-bucket/my_object.pb")
 
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+    # assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {
@@ -234,6 +234,13 @@ def test_add_gs_reference_with_dir_paths(artifact):
             "size": 10,
         },
     }
+
+
+def test_add_gs_reference_with_non_dir_prefix_fails(artifact):
+    """Non-directory prefixes like 'my_folder/my_object_' should fail."""
+    mock_gcs(artifact, blobs=["my_folder/my_object_1.pb"])
+    with pytest.raises(ValueError, match="is not same or a parent folder of"):
+        artifact.add_reference("gs://my-bucket/my_folder/my_object_")
 
 
 def test_load_gs_reference_with_dir_paths(artifact):

--- a/tests/system_tests/test_artifacts/test_references_gcs.py
+++ b/tests/system_tests/test_artifacts/test_references_gcs.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import os
+
+from pytest import fixture, raises
+from wandb import Artifact
+from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
+from wandb.sdk.artifacts.artifact_state import ArtifactState
+from wandb.sdk.artifacts.storage_handlers.gcs_handler import (
+    GCSHandler,
+    _GCSIsADirectoryError,
+)
+
+
+@fixture
+def artifact() -> Artifact:
+    return Artifact(type="dataset", name="data-artifact")
+
+
+def mock_gcs(artifact, override_blob_name="my_object.pb", path=False, hash=True):
+    class Blob:
+        def __init__(
+            self, name: str = override_blob_name, metadata=None, generation: int = 1
+        ):
+            self.md5_hash = "1234567890abcde" if hash else None
+            self.etag = "1234567890abcde"
+            self.generation = generation
+            self.name = name
+            self.size = 10
+
+    class GSBucket:
+        def __init__(self):
+            self.versioning_enabled = True
+
+        def reload(self, *args, **kwargs):
+            return
+
+        def get_blob(self, key=override_blob_name, *args, **kwargs):
+            return (
+                None
+                if path or key != override_blob_name
+                else Blob(generation=kwargs.get("generation"))
+            )
+
+        # https://docs.cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.bucket.Bucket#google_cloud_storage_bucket_Bucket_list_blobs
+        def list_blobs(self, *args, **kwargs):
+            versions: bool = kwargs.get("versions", False)
+            prefix: str = kwargs.get("prefix", "")
+            # For versioned lookups, return blobs with different generations
+            if versions and prefix == override_blob_name:
+                return [
+                    Blob(name=override_blob_name, generation=1),
+                    Blob(name=override_blob_name, generation=2),
+                    Blob(name=override_blob_name, generation=3),
+                ]
+            # For directory paths (ends with /)
+            if override_blob_name.endswith("/"):
+                return [
+                    Blob(name=override_blob_name),
+                    Blob(name=os.path.join(override_blob_name, "my_other_object.pb")),
+                ]
+            # For single file lookup (prefix matches exact filename)
+            if prefix == override_blob_name and not path:
+                return [Blob(name=override_blob_name)]
+            # For directory listing (path=True means treat as directory)
+            if path or prefix == "":
+                return [
+                    Blob(name="my_object.pb"),
+                    Blob(name="my_other_object.pb"),
+                ]
+            # Default: return just the matching blob
+            return [Blob(name=override_blob_name)]
+
+    class GSClient:
+        def bucket(self, bucket):
+            return GSBucket()
+
+    mock = GSClient()
+    for handler in artifact.manifest.storage_policy._handler._handlers:
+        if isinstance(handler, GCSHandler):
+            handler._client = mock
+    return mock
+
+
+def test_add_gs_reference_object(artifact):
+    mock_gcs(artifact)
+    artifact.add_reference("gs://my-bucket/my_object.pb")
+
+    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
+    assert manifest_contents == {
+        "my_object.pb": {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_object.pb",
+            "extra": {"versionID": 1},
+            "size": 10,
+        },
+    }
+
+
+def test_load_gs_reference_object_without_generation_and_mismatched_etag(
+    artifact,
+):
+    mock_gcs(artifact)
+    artifact.add_reference("gs://my-bucket/my_object.pb")
+    artifact._state = ArtifactState.COMMITTED
+    entry = artifact.get_entry("my_object.pb")
+    entry.extra = {}
+    entry.digest = "abad0"
+
+    with raises(ValueError, match="Digest mismatch"):
+        entry.download()
+
+
+def test_add_gs_reference_object_with_version(artifact):
+    mock_gcs(artifact)
+    artifact.add_reference("gs://my-bucket/my_object.pb#2")
+
+    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
+    assert manifest_contents == {
+        "my_object.pb": {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_object.pb",
+            "extra": {"versionID": 2},
+            "size": 10,
+        },
+    }
+
+
+def test_add_gs_reference_object_with_name(artifact):
+    mock_gcs(artifact)
+    artifact.add_reference("gs://my-bucket/my_object.pb", name="renamed.pb")
+
+    assert artifact.digest == "bd85fe009dc9e408a5ed9b55c95f47b2"
+    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
+    assert manifest_contents == {
+        "renamed.pb": {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_object.pb",
+            "extra": {"versionID": 1},
+            "size": 10,
+        },
+    }
+
+
+def test_add_gs_reference_path(capsys, artifact):
+    mock_gcs(artifact, path=True)
+    artifact.add_reference("gs://my-bucket/")
+
+    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
+    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
+    assert manifest_contents == {
+        "my_object.pb": {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_object.pb",
+            "extra": {"versionID": 1},
+            "size": 10,
+        },
+        "my_other_object.pb": {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_other_object.pb",
+            "extra": {"versionID": 1},
+            "size": 10,
+        },
+    }
+    _, err = capsys.readouterr()
+    assert "Added 2 objects" in err
+
+
+def test_add_gs_reference_object_no_md5(artifact):
+    mock_gcs(artifact, hash=False)
+    artifact.add_reference("gs://my-bucket/my_object.pb")
+
+    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
+    assert manifest_contents == {
+        "my_object.pb": {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_object.pb",
+            "extra": {"versionID": 1},
+            "size": 10,
+        },
+    }
+
+
+def test_add_gs_reference_with_dir_paths(artifact):
+    mock_gcs(artifact, override_blob_name="my_folder/")
+    artifact.add_reference("gs://my-bucket/my_folder/")
+
+    # uploading a reference to a folder path should add entries for
+    # everything returned by the list_blobs call
+    assert len(artifact.manifest.entries) == 1
+    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
+    assert manifest_contents == {
+        "my_other_object.pb": {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_folder/my_other_object.pb",
+            "extra": {"versionID": 1},
+            "size": 10,
+        },
+    }
+
+
+def test_load_gs_reference_with_dir_paths(artifact):
+    mock = mock_gcs(artifact, override_blob_name="my_folder/")
+    artifact.add_reference("gs://my-bucket/my_folder/")
+
+    gcs_handler = GCSHandler()
+    gcs_handler._client = mock
+
+    # simple case where ref ends with "/"
+    simple_entry = ArtifactManifestEntry(
+        path="my-bucket/my_folder",
+        ref="gs://my-bucket/my_folder/",
+        digest="1234567890abcde",
+        size=0,
+        extra={"versionID": 1},
+    )
+    with raises(_GCSIsADirectoryError):
+        gcs_handler.load_path(simple_entry, local=True)
+
+    # case where we didn't store "/" and have to use get_blob
+    entry = ArtifactManifestEntry(
+        path="my-bucket/my_folder",
+        ref="gs://my-bucket/my_folder",
+        digest="1234567890abcde",
+        size=0,
+        extra={"versionID": 1},
+    )
+    with raises(_GCSIsADirectoryError):
+        gcs_handler.load_path(entry, local=True)

--- a/tests/system_tests/test_artifacts/test_references_gcs.py
+++ b/tests/system_tests/test_artifacts/test_references_gcs.py
@@ -57,9 +57,10 @@ def mock_gcs(
         def get_blob(self, key, *args, **kwargs):
             generation = kwargs.get("generation")
             for blob in normalized_blobs:
-                if blob.name == key:
-                    if generation is None or blob.generation == generation:
-                        return blob
+                if blob.name == key and (
+                    generation is None or blob.generation == generation
+                ):
+                    return blob
             return None
 
         # https://docs.cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.bucket.Bucket#google_cloud_storage_bucket_Bucket_list_blobs

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -28,15 +28,10 @@ from wandb.sdk.artifacts.artifact_file_cache import (
     get_artifact_file_cache,
 )
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-from wandb.sdk.artifacts.artifact_state import ArtifactState
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
 from wandb.sdk.artifacts.exceptions import (
     ArtifactFinalizedError,
     ArtifactNotLoggedError,
-)
-from wandb.sdk.artifacts.storage_handlers.gcs_handler import (
-    GCSHandler,
-    _GCSIsADirectoryError,
 )
 from wandb.sdk.artifacts.storage_handlers.http_handler import HTTPHandler
 from wandb.sdk.artifacts.storage_handlers.s3_handler import S3Handler
@@ -117,71 +112,6 @@ def mock_boto(artifact, path=False, content_type=None, version_id="1"):
             handler._s3 = mock
             handler._botocore = util.get_module("botocore")
             handler._botocore.exceptions = util.get_module("botocore.exceptions")
-    return mock
-
-
-def mock_gcs(artifact, override_blob_name="my_object.pb", path=False, hash=True):
-    class Blob:
-        def __init__(
-            self, name: str = override_blob_name, metadata=None, generation: int = 1
-        ):
-            self.md5_hash = "1234567890abcde" if hash else None
-            self.etag = "1234567890abcde"
-            self.generation = generation
-            self.name = name
-            self.size = 10
-
-    class GSBucket:
-        def __init__(self):
-            self.versioning_enabled = True
-
-        def reload(self, *args, **kwargs):
-            return
-
-        def get_blob(self, key=override_blob_name, *args, **kwargs):
-            return (
-                None
-                if path or key != override_blob_name
-                else Blob(generation=kwargs.get("generation"))
-            )
-
-        # https://docs.cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.bucket.Bucket#google_cloud_storage_bucket_Bucket_list_blobs
-        def list_blobs(self, *args, **kwargs):
-            versions: bool = kwargs.get("versions", False)
-            prefix: str = kwargs.get("prefix", "")
-            # For versioned lookups, return blobs with different generations
-            if versions and prefix == override_blob_name:
-                return [
-                    Blob(name=override_blob_name, generation=1),
-                    Blob(name=override_blob_name, generation=2),
-                    Blob(name=override_blob_name, generation=3),
-                ]
-            # For directory paths (ends with /)
-            if override_blob_name.endswith("/"):
-                return [
-                    Blob(name=override_blob_name),
-                    Blob(name=os.path.join(override_blob_name, "my_other_object.pb")),
-                ]
-            # For single file lookup (prefix matches exact filename)
-            if prefix == override_blob_name and not path:
-                return [Blob(name=override_blob_name)]
-            # For directory listing (path=True means treat as directory)
-            if path or prefix == "":
-                return [
-                    Blob(name="my_object.pb"),
-                    Blob(name="my_other_object.pb"),
-                ]
-            # Default: return just the matching blob
-            return [Blob(name=override_blob_name)]
-
-    class GSClient:
-        def bucket(self, bucket):
-            return GSBucket()
-
-    mock = GSClient()
-    for handler in artifact.manifest.storage_policy._handler._handlers:
-        if isinstance(handler, GCSHandler):
-            handler._client = mock
     return mock
 
 
@@ -889,156 +819,6 @@ def test_add_reference_s3_no_checksum(artifact):
             "ref": "s3://my_bucket/file1.txt",
         }
     }
-
-
-def test_add_gs_reference_object(artifact):
-    mock_gcs(artifact)
-    artifact.add_reference("gs://my-bucket/my_object.pb")
-
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
-    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    assert manifest_contents == {
-        "my_object.pb": {
-            "digest": "1234567890abcde",
-            "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": 1},
-            "size": 10,
-        },
-    }
-
-
-def test_load_gs_reference_object_without_generation_and_mismatched_etag(
-    artifact,
-):
-    mock_gcs(artifact)
-    artifact.add_reference("gs://my-bucket/my_object.pb")
-    artifact._state = ArtifactState.COMMITTED
-    entry = artifact.get_entry("my_object.pb")
-    entry.extra = {}
-    entry.digest = "abad0"
-
-    with raises(ValueError, match="Digest mismatch"):
-        entry.download()
-
-
-def test_add_gs_reference_object_with_version(artifact):
-    mock_gcs(artifact)
-    artifact.add_reference("gs://my-bucket/my_object.pb#2")
-
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
-    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    assert manifest_contents == {
-        "my_object.pb": {
-            "digest": "1234567890abcde",
-            "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": 2},
-            "size": 10,
-        },
-    }
-
-
-def test_add_gs_reference_object_with_name(artifact):
-    mock_gcs(artifact)
-    artifact.add_reference("gs://my-bucket/my_object.pb", name="renamed.pb")
-
-    assert artifact.digest == "bd85fe009dc9e408a5ed9b55c95f47b2"
-    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    assert manifest_contents == {
-        "renamed.pb": {
-            "digest": "1234567890abcde",
-            "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": 1},
-            "size": 10,
-        },
-    }
-
-
-def test_add_gs_reference_path(capsys, artifact):
-    mock_gcs(artifact, path=True)
-    artifact.add_reference("gs://my-bucket/")
-
-    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
-    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    assert manifest_contents == {
-        "my_object.pb": {
-            "digest": "1234567890abcde",
-            "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": 1},
-            "size": 10,
-        },
-        "my_other_object.pb": {
-            "digest": "1234567890abcde",
-            "ref": "gs://my-bucket/my_other_object.pb",
-            "extra": {"versionID": 1},
-            "size": 10,
-        },
-    }
-    _, err = capsys.readouterr()
-    assert "Added 2 objects" in err
-
-
-def test_add_gs_reference_object_no_md5(artifact):
-    mock_gcs(artifact, hash=False)
-    artifact.add_reference("gs://my-bucket/my_object.pb")
-
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
-    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    assert manifest_contents == {
-        "my_object.pb": {
-            "digest": "1234567890abcde",
-            "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": 1},
-            "size": 10,
-        },
-    }
-
-
-def test_add_gs_reference_with_dir_paths(artifact):
-    mock_gcs(artifact, override_blob_name="my_folder/")
-    artifact.add_reference("gs://my-bucket/my_folder/")
-
-    # uploading a reference to a folder path should add entries for
-    # everything returned by the list_blobs call
-    assert len(artifact.manifest.entries) == 1
-    manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    assert manifest_contents == {
-        "my_other_object.pb": {
-            "digest": "1234567890abcde",
-            "ref": "gs://my-bucket/my_folder/my_other_object.pb",
-            "extra": {"versionID": 1},
-            "size": 10,
-        },
-    }
-
-
-def test_load_gs_reference_with_dir_paths(artifact):
-    mock = mock_gcs(artifact, override_blob_name="my_folder/")
-    artifact.add_reference("gs://my-bucket/my_folder/")
-
-    gcs_handler = GCSHandler()
-    gcs_handler._client = mock
-
-    # simple case where ref ends with "/"
-    simple_entry = ArtifactManifestEntry(
-        path="my-bucket/my_folder",
-        ref="gs://my-bucket/my_folder/",
-        digest="1234567890abcde",
-        size=0,
-        extra={"versionID": 1},
-    )
-    with raises(_GCSIsADirectoryError):
-        gcs_handler.load_path(simple_entry, local=True)
-
-    # case where we didn't store "/" and have to use get_blob
-    entry = ArtifactManifestEntry(
-        path="my-bucket/my_folder",
-        ref="gs://my-bucket/my_folder",
-        digest="1234567890abcde",
-        size=0,
-        extra={"versionID": 1},
-    )
-    with raises(_GCSIsADirectoryError):
-        gcs_handler.load_path(entry, local=True)
 
 
 @fixture

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -122,11 +122,12 @@ def mock_boto(artifact, path=False, content_type=None, version_id="1"):
 
 def mock_gcs(artifact, override_blob_name="my_object.pb", path=False, hash=True):
     class Blob:
-        def __init__(self, name=override_blob_name, metadata=None, generation=None):
+        def __init__(
+            self, name: str = override_blob_name, metadata=None, generation: int = 1
+        ):
             self.md5_hash = "1234567890abcde" if hash else None
             self.etag = "1234567890abcde"
-            # NOTE: Real GCS API returns generation as int
-            self.generation = generation if generation is not None else 1
+            self.generation = generation
             self.name = name
             self.size = 10
 
@@ -144,9 +145,10 @@ def mock_gcs(artifact, override_blob_name="my_object.pb", path=False, hash=True)
                 else Blob(generation=kwargs.get("generation"))
             )
 
-        def list_blobs(
-            self, prefix="", versions=False, max_results=None, *args, **kwargs
-        ):
+        # https://docs.cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.bucket.Bucket#google_cloud_storage_bucket_Bucket_list_blobs
+        def list_blobs(self, *args, **kwargs):
+            versions: bool = kwargs.get("versions", False)
+            prefix: str = kwargs.get("prefix", "")
             # For versioned lookups, return blobs with different generations
             if versions and prefix == override_blob_name:
                 return [

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -143,17 +143,31 @@ def mock_gcs(artifact, override_blob_name="my_object.pb", path=False, hash=True)
                 else Blob(generation=kwargs.get("generation"))
             )
 
-        def list_blobs(self, *args, **kwargs):
+        def list_blobs(self, prefix="", versions=False, max_results=None, *args, **kwargs):
+            # For versioned lookups, return blobs with different generations
+            if versions and prefix == override_blob_name:
+                return [
+                    Blob(name=override_blob_name, generation="1"),
+                    Blob(name=override_blob_name, generation="2"),
+                    Blob(name=override_blob_name, generation="3"),
+                ]
+            # For directory paths (ends with /)
             if override_blob_name.endswith("/"):
                 return [
                     Blob(name=override_blob_name),
                     Blob(name=os.path.join(override_blob_name, "my_other_object.pb")),
                 ]
-            else:
+            # For single file lookup (prefix matches exact filename)
+            if prefix == override_blob_name and not path:
+                return [Blob(name=override_blob_name)]
+            # For directory listing (path=True means treat as directory)
+            if path or prefix == "":
                 return [
-                    Blob(name=override_blob_name),
+                    Blob(name="my_object.pb"),
                     Blob(name="my_other_object.pb"),
                 ]
+            # Default: return just the matching blob
+            return [Blob(name=override_blob_name)]
 
     class GSClient:
         def bucket(self, bucket):
@@ -955,7 +969,7 @@ def test_add_gs_reference_path(capsys, artifact):
         },
     }
     _, err = capsys.readouterr()
-    assert "Generating checksum" in err
+    assert "Added 2 objects" in err
 
 
 def test_add_gs_reference_object_no_md5(artifact):

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -125,7 +125,8 @@ def mock_gcs(artifact, override_blob_name="my_object.pb", path=False, hash=True)
         def __init__(self, name=override_blob_name, metadata=None, generation=None):
             self.md5_hash = "1234567890abcde" if hash else None
             self.etag = "1234567890abcde"
-            self.generation = generation or "1"
+            # NOTE: Real GCS API returns generation as int
+            self.generation = generation if generation is not None else 1
             self.name = name
             self.size = 10
 
@@ -143,13 +144,15 @@ def mock_gcs(artifact, override_blob_name="my_object.pb", path=False, hash=True)
                 else Blob(generation=kwargs.get("generation"))
             )
 
-        def list_blobs(self, prefix="", versions=False, max_results=None, *args, **kwargs):
+        def list_blobs(
+            self, prefix="", versions=False, max_results=None, *args, **kwargs
+        ):
             # For versioned lookups, return blobs with different generations
             if versions and prefix == override_blob_name:
                 return [
-                    Blob(name=override_blob_name, generation="1"),
-                    Blob(name=override_blob_name, generation="2"),
-                    Blob(name=override_blob_name, generation="3"),
+                    Blob(name=override_blob_name, generation=1),
+                    Blob(name=override_blob_name, generation=2),
+                    Blob(name=override_blob_name, generation=3),
                 ]
             # For directory paths (ends with /)
             if override_blob_name.endswith("/"):
@@ -896,7 +899,7 @@ def test_add_gs_reference_object(artifact):
         "my_object.pb": {
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": "1"},
+            "extra": {"versionID": 1},
             "size": 10,
         },
     }
@@ -926,7 +929,7 @@ def test_add_gs_reference_object_with_version(artifact):
         "my_object.pb": {
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": "2"},
+            "extra": {"versionID": 2},
             "size": 10,
         },
     }
@@ -942,7 +945,7 @@ def test_add_gs_reference_object_with_name(artifact):
         "renamed.pb": {
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": "1"},
+            "extra": {"versionID": 1},
             "size": 10,
         },
     }
@@ -958,13 +961,13 @@ def test_add_gs_reference_path(capsys, artifact):
         "my_object.pb": {
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": "1"},
+            "extra": {"versionID": 1},
             "size": 10,
         },
         "my_other_object.pb": {
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_other_object.pb",
-            "extra": {"versionID": "1"},
+            "extra": {"versionID": 1},
             "size": 10,
         },
     }
@@ -982,7 +985,7 @@ def test_add_gs_reference_object_no_md5(artifact):
         "my_object.pb": {
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_object.pb",
-            "extra": {"versionID": "1"},
+            "extra": {"versionID": 1},
             "size": 10,
         },
     }
@@ -1000,7 +1003,7 @@ def test_add_gs_reference_with_dir_paths(artifact):
         "my_other_object.pb": {
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_folder/my_other_object.pb",
-            "extra": {"versionID": "1"},
+            "extra": {"versionID": 1},
             "size": 10,
         },
     }

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -224,7 +224,7 @@ class GCSHandler(StorageHandler):
                 # When version specified, require exact key match (old get_blob behavior)
                 # to avoid matching file that only matches the prefix.
                 and (
-                    gcs_path.version is not None
+                    gcs_path.version is None
                     or (
                         str(obj.generation) == gcs_path.version
                         and obj.name == gcs_path.key

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -306,7 +306,8 @@ class GCSHandler(StorageHandler):
         #   my_folder/my_obj       | no    | partial filename
         posix_prefix = PurePosixPath(gcs_path.key)
         is_exact_match = gcs_path.key == obj.name
-        is_within_folder = not is_exact_match and posix_key.is_relative_to(posix_prefix)
+        # not using is_relative_to because of python 3.8
+        is_within_folder = posix_prefix in posix_key.parents
         valid_prefix = is_exact_match or is_within_folder
         if not valid_prefix:
             raise ValueError(

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -208,7 +208,7 @@ class GCSHandler(StorageHandler):
     ) -> list[ArtifactManifestEntry]:
         with TimedIf(enabled=True):
             # Return different versions as blobs if user specified a version
-            # https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.client.Client#google_cloud_storage_client_Client_list_blobs
+            # https://docs.cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.bucket.Bucket#google_cloud_storage_bucket_Bucket_list_blobs
             objects = bucket.list_blobs(
                 prefix=gcs_path.key,
                 max_results=max_objects,
@@ -253,7 +253,9 @@ class GCSHandler(StorageHandler):
         path: str,
         name: StrPath | None,
     ) -> list[ArtifactManifestEntry]:
-        obj = bucket.get_blob(gcs_path.key, generation=gcs_path.version)
+        # https://docs.cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.bucket.Bucket#google_cloud_storage_bucket_Bucket_get_blob
+        generation = int(gcs_path.version) if gcs_path.version is not None else None
+        obj = bucket.get_blob(gcs_path.key, generation=generation)
 
         if obj is None and gcs_path.version is not None:
             raise ValueError(f"Object does not exist: {path}#{gcs_path.version}")

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -17,6 +17,8 @@ from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHand
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 from wandb.util import logger
 
+from ._timing import TimedIf
+
 if TYPE_CHECKING:
     from google.cloud import storage  # type: ignore[import-not-found, import-untyped]
 
@@ -204,23 +206,31 @@ class GCSHandler(StorageHandler):
         name: StrPath | None,
         max_objects: int,
     ) -> list[ArtifactManifestEntry]:
-        # Return different versions as blobs if user specified a version
-        # https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.client.Client#google_cloud_storage_client_Client_list_blobs
-        versions = gcs_path.version is not None
-        objects = bucket.list_blobs(
-            prefix=gcs_path.key, max_results=max_objects, versions=versions
-        )
+        with TimedIf(enabled=True):
+            # Return different versions as blobs if user specified a version
+            # https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.client.Client#google_cloud_storage_client_Client_list_blobs
+            objects = bucket.list_blobs(
+                prefix=gcs_path.key,
+                max_results=max_objects,
+                versions=gcs_path.version is not None,
+            )
 
-        entries = [
-            self._entry_from_obj(obj, path, name, prefix=gcs_path.key)
-            for obj in objects
-            if obj
-            and not obj.name.endswith("/")
-            # When version specified, require exact key match (old get_blob behavior)
-            # to avoid matching file that only matches the prefix.
-            and (gcs_path.version is None or obj.name == gcs_path.key)
-            and (gcs_path.version is None or str(obj.generation) == gcs_path.version)
-        ]
+            entries = [
+                self._entry_from_obj(obj, path, name, prefix=gcs_path.key)
+                for obj in objects
+                if obj
+                # Skip folder
+                and not obj.name.endswith("/")
+                # When version specified, require exact key match (old get_blob behavior)
+                # to avoid matching file that only matches the prefix.
+                and (
+                    gcs_path.version is not None
+                    or (
+                        str(obj.generation) == gcs_path.version
+                        and obj.name == gcs_path.key
+                    )
+                )
+            ]
 
         if len(entries) > 1:
             termlog(f"Added {len(entries)} objects with prefix {gcs_path.key!r}")
@@ -252,6 +262,10 @@ class GCSHandler(StorageHandler):
             # Object doesn't exist or it is a folder.
             # We cannot list files because we already called list_blobs
             # before get_blob in _store_path_via_list.
+            return []
+
+        # Filter out directory markers with empty blob
+        if obj.name and obj.name.endswith("/"):
             return []
 
         # Single object found
@@ -291,6 +305,10 @@ class GCSHandler(StorageHandler):
                 # Single file, use just the filename
                 posix_name = PurePosixPath(posix_key.name)
                 posix_ref = posix_path
+        # FIXME: This breaks when the prefix is not a folder
+        # also same code is copy pased in s3_hander.py
+        # azure_handler.py actuall have different logic and has
+        # external contribution in https://github.com/wandb/wandb/pull/7876/changes
         elif is_under_prefix:
             # Directory with custom name override
             relpath = posix_key.relative_to(posix_prefix)

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -17,8 +17,6 @@ from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHand
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 from wandb.util import logger
 
-from ._timing import TimedIf
-
 if TYPE_CHECKING:
     from google.cloud import storage  # type: ignore[import-not-found, import-untyped]
 
@@ -246,6 +244,8 @@ class GCSHandler(StorageHandler):
             ref=f"{self._scheme}://{posix_ref}",
             digest=obj.etag,
             size=obj.size,
+            # NOTE: gcs returns int for generation
+            # https://docs.cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_generation
             extra={"versionID": obj.generation},
         )
 

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -17,9 +17,6 @@ from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHand
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 from wandb.util import logger
 
-from google.auth.exceptions import GoogleAuthError
-from google.api_core.exceptions import GoogleAPICallError
-
 if TYPE_CHECKING:
     from google.cloud import storage  # type: ignore[import-not-found, import-untyped]
 
@@ -150,6 +147,16 @@ class GCSHandler(StorageHandler):
         checksum: bool = True,
         max_objects: int | None = None,
     ) -> list[ArtifactManifestEntry]:
+        # google-cloud-storage is optional dependency that requires
+        # pip install wandb[gcp]. Importing these modules at top of file
+        # breaks users doing pip install wandb without [gcp].
+        from google.api_core.exceptions import (  # type: ignore[import-not-found]
+            GoogleAPICallError,
+        )
+        from google.auth.exceptions import (  # type: ignore[import-not-found]
+            GoogleAuthError,
+        )
+
         client = self.init_gcs()
 
         # After parsing any query params / fragments for additional context,
@@ -175,8 +182,9 @@ class GCSHandler(StorageHandler):
         # anonymous credentials on public buckets only allows get_blob without list_blobs.
         #
         # For our system test, the error comes from anonymous credentials:
-        # google.auth.exceptions.InvalidOperation: Anonymous credentials cannot be refreshed
-        # For blob client, all the exceptions on operations as based from:
+        # google.auth.exceptions.InvalidOperation:
+        # Anonymous credentials cannot be refreshed
+        # For blob client, all the exceptions on operations are based on:
         # google.api_core.exceptions.GoogleAPICallError
         #
         # The fallback can lead to unnessary retries when user does not
@@ -208,6 +216,9 @@ class GCSHandler(StorageHandler):
             for obj in objects
             if obj
             and not obj.name.endswith("/")
+            # When version specified, require exact key match (old get_blob behavior)
+            # to avoid matching file that only matches the prefix.
+            and (gcs_path.version is None or obj.name == gcs_path.key)
             and (gcs_path.version is None or str(obj.generation) == gcs_path.version)
         ]
 

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -17,6 +17,9 @@ from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHand
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 from wandb.util import logger
 
+from google.auth.exceptions import GoogleAuthError
+from google.api_core.exceptions import GoogleAPICallError
+
 if TYPE_CHECKING:
     from google.cloud import storage  # type: ignore[import-not-found, import-untyped]
 
@@ -167,13 +170,21 @@ class GCSHandler(StorageHandler):
 
         bucket = client.bucket(gcs_path.bucket)
 
-        # Try list_blobs first (requires storage.objects.list permission).
-        # Fall back to get_blob if list fails (for backward compatibility with
-        # anonymous credentials on public buckets that allow object access but
-        # not listing).
+        # Try list_blobs first. Fallback to get_blob for backward compatibility.
+        # Using get_blob is a valid use case for public buckets.
+        # anonymous credentials on public buckets only allows get_blob without list_blobs.
+        #
+        # For our system test, the error comes from anonymous credentials:
+        # google.auth.exceptions.InvalidOperation: Anonymous credentials cannot be refreshed
+        # For blob client, all the exceptions on operations as based from:
+        # google.api_core.exceptions.GoogleAPICallError
+        #
+        # The fallback can lead to unnessary retries when user does not
+        # have either get or list permission. The performance penalty is limited
+        # because _store_path_via_get only get at most one file.
         try:
             return self._store_path_via_list(bucket, gcs_path, path, name, max_objects)
-        except Exception as e:
+        except (GoogleAuthError, GoogleAPICallError) as e:
             logger.warning(f"list_blobs failed, falling back to get_blob: {e}")
             return self._store_path_via_get(bucket, gcs_path, path, name)
 
@@ -185,7 +196,6 @@ class GCSHandler(StorageHandler):
         name: StrPath | None,
         max_objects: int,
     ) -> list[ArtifactManifestEntry]:
-        """Store path using list_blobs (requires storage.objects.list permission)."""
         # Return different versions as blobs if user specified a version
         # https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.client.Client#google_cloud_storage_client_Client_list_blobs
         versions = gcs_path.version is not None
@@ -222,23 +232,15 @@ class GCSHandler(StorageHandler):
         path: str,
         name: StrPath | None,
     ) -> list[ArtifactManifestEntry]:
-        """Store path using get_blob (requires storage.objects.get permission).
-
-        This is the fallback path for when list_blobs fails due to permission
-        issues (e.g., anonymous credentials on public buckets).
-
-        Note: This fallback only works for single files, not directories.
-        Directory references require list permission.
-        """
         obj = bucket.get_blob(gcs_path.key, generation=gcs_path.version)
 
         if obj is None and gcs_path.version is not None:
             raise ValueError(f"Object does not exist: {path}#{gcs_path.version}")
 
         if obj is None:
-            # Object doesn't exist at exact key.
-            # In fallback mode (no list permission), we can't enumerate directories.
-            # Return empty list - the object simply doesn't exist at this path.
+            # Object doesn't exist or it is a folder.
+            # We cannot list files because we already called list_blobs
+            # before get_blob in _store_path_via_list.
             return []
 
         # Single object found


### PR DESCRIPTION
Description
-----------

- Fixes WB-27752

Instead of using both `get_blob` and `list_blobs`, only use `list_blobs` by default.

- Still need to fallback to `get_blob` when `list_blobs` for anonymous on public buckets
- Remove the conditional timing log because we can no longer tell if the key is a prefix or file without `get_blob`, Using `endsWith("/")` only works for folder but does not work things like `test-` for `test-a.txt`, `test-b.txt`
- The naming logic in `_entry_from_obj` still works without the `multi` flag by checking if the prefix is in parent 
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

- [x] manual test
- [x] unit test

Manual test written by claude code... should put it into a gist.. too long