### PR TITLE
fix(sdk): fix/add type hints in `wandb.apis.public.history`

### DIFF
--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import contextlib
 import json
 import weakref
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Dict, Iterator
 
 from typing_extensions import Self, TypeAlias
 from wandb_gql import gql
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from . import runs
     from .api import Api, RetryingClient
 
-_RowDict: TypeAlias = dict[str, Any]
+_RowDict: TypeAlias = Dict[str, Any]
 """Type alias for a single history row as a dict."""
 
 


### PR DESCRIPTION
## Description

Adds missing type hints in `wandb.apis.public.history`. Continues the pattern from #11133, #11134, and #11142.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

No intended functional changes to runtime behavior. Existing checks must continue to pass.