### PR TITLE
chore: revert google-auth constraint in CI

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -65,8 +65,6 @@ requests~=2.23
 responses
 prometheus_client
 google-cloud-aiplatform
-google-auth~=2.45
-google-auth!=2.46.0  # https://github.com/googleapis/google-auth-library-python/issues/1915
 
 # See:
 # - https://github.com/boto/botocore/pull/1107


### PR DESCRIPTION
Undo PR #11148 since `google-auth==2.46.0` has been yanked.

I also removed the `google-auth~=2.45` constraint because our tests only indirectly depend on `google-auth` via `google-cloud-aiplatform`. We can pin it by using a compiled requirements file if we want using `uv pip compile`.