### PR TITLE
refactor: delete api.Client.Send in favor of api.Client.Do

### DIFF
--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -9,36 +8,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/wandb/core/internal/wboperation"
 )
-
-func (client *clientImpl) Send(req *Request) (*http.Response, error) {
-	ctx := req.Context
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	retryableReq, err := retryablehttp.NewRequestWithContext(
-		ctx,
-		req.Method,
-		client.backend.baseURL.JoinPath(req.Path).String(),
-		req.Body,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("api: failed to create request: %v", err)
-	}
-
-	for headerKey, headerValue := range req.Headers {
-		retryableReq.Header.Set(headerKey, headerValue)
-	}
-
-	// Prevent the connection from being re-used in case of an error.
-	// TODO: There is an unlikely scenario when an attempt to reuse the connection
-	// will result in not retrying an otherwise retryable request.
-	// This is safe, however leads to a small performance hit and resource waste.
-	// We are being extra cautious here, but this should be revisited.
-	retryableReq.Close = true
-
-	return client.sendToWandbBackend(retryableReq)
-}
 
 func (client *clientImpl) Do(req *http.Request) (*http.Response, error) {
 	retryableReq, err := retryablehttp.FromRequest(req)

--- a/core/internal/apitest/apitest.go
+++ b/core/internal/apitest/apitest.go
@@ -1,7 +1,6 @@
 package apitest
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -112,19 +111,6 @@ func (c *FakeClient) WaitUntilRequestCount(
 }
 
 var _ api.Client = &FakeClient{}
-
-func (c *FakeClient) Send(req *api.Request) (*http.Response, error) {
-	httpReq, err := http.NewRequest(
-		req.Method,
-		c.baseURL.JoinPath(req.Path).String(),
-		bytes.NewReader(req.Body),
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	return c.Do(httpReq)
-}
 
 func (c *FakeClient) Do(req *http.Request) (*http.Response, error) {
 	c.Lock()

--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -3,6 +3,7 @@ package filestream
 
 import (
 	"fmt"
+	"net/url"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -114,6 +115,7 @@ type fileStream struct {
 
 	// The client for making API requests.
 	apiClient api.Client
+	baseURL   *url.URL
 
 	// The rate limit for sending data to the backend.
 	transmitRateLimit *rate.Limiter
@@ -138,6 +140,7 @@ var FileStreamProviders = wire.NewSet(
 )
 
 type FileStreamFactory struct {
+	BaseURL    api.WBBaseURL
 	Logger     *observability.CoreLogger
 	Operations *wboperation.WandbOperations
 	Printer    *observability.Printer
@@ -164,6 +167,7 @@ func (f *FileStreamFactory) New(
 		operations:   f.Operations,
 		printer:      f.Printer,
 		apiClient:    apiClient,
+		baseURL:      f.BaseURL,
 		processChan:  make(chan Update, BufferSize),
 		feedbackWait: &sync.WaitGroup{},
 		deadChanOnce: &sync.Once{},

--- a/core/internal/runsync/wire.go
+++ b/core/internal/runsync/wire.go
@@ -42,6 +42,7 @@ var runSyncerFactoryBindings = wire.NewSet(
 	runReaderProviders,
 	runSyncerProviders,
 	sharedmode.RandomClientID,
+	stream.BaseURLFromSettings,
 	stream.NewBackend,
 	stream.NewFileTransferManager,
 	stream.NewGraphQLClient,

--- a/core/internal/runsync/wire_gen.go
+++ b/core/internal/runsync/wire_gen.go
@@ -29,7 +29,8 @@ import (
 func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.CoreLogger) *RunSyncerFactory {
 	wandbOperations := wboperation.NewOperations()
 	printer := observability.NewPrinter()
-	backend := stream.NewBackend(logger, settings2)
+	wbBaseURL := stream.BaseURLFromSettings(logger, settings2)
+	backend := stream.NewBackend(wbBaseURL, logger, settings2)
 	peeker := &observability.Peeker{}
 	clientID := sharedmode.RandomClientID()
 	client := stream.NewGraphQLClient(backend, settings2, peeker, clientID)
@@ -49,6 +50,7 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 		Operations: wandbOperations,
 	}
 	fileStreamFactory := &filestream.FileStreamFactory{
+		BaseURL:    wbBaseURL,
 		Logger:     logger,
 		Operations: wandbOperations,
 		Printer:    printer,
@@ -105,7 +107,7 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 // wire.go:
 
 var runSyncerFactoryBindings = wire.NewSet(wire.Bind(new(api.Peeker), new(*observability.Peeker)), wire.Struct(new(observability.Peeker)), featurechecker.NewServerFeaturesCache, filestream.FileStreamProviders, filetransfer.NewFileTransferStats, mailbox.New, observability.NewPrinter, provideFileWatcher, runfiles.UploaderProviders, runhandle.New, runReaderProviders,
-	runSyncerProviders, sharedmode.RandomClientID, stream.NewBackend, stream.NewFileTransferManager, stream.NewGraphQLClient, stream.RecordParserProviders, stream.SenderProviders, tensorboard.TBHandlerProviders, wboperation.NewOperations,
+	runSyncerProviders, sharedmode.RandomClientID, stream.BaseURLFromSettings, stream.NewBackend, stream.NewFileTransferManager, stream.NewGraphQLClient, stream.RecordParserProviders, stream.SenderProviders, tensorboard.TBHandlerProviders, wboperation.NewOperations,
 )
 
 func provideFileWatcher(logger *observability.CoreLogger) watcher.Watcher {

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -45,7 +45,8 @@ func makeSender(t *testing.T, client graphql.Client) testFixtures {
 		Console: &wrapperspb.StringValue{Value: "off"},
 		ApiKey:  &wrapperspb.StringValue{Value: "test-api-key"},
 	})
-	backend := stream.NewBackend(logger, settings)
+	baseURL := stream.BaseURLFromSettings(logger, settings)
+	backend := stream.NewBackend(baseURL, logger, settings)
 	fileStreamFactory := &filestream.FileStreamFactory{
 		Logger:   logger,
 		Printer:  observability.NewPrinter(),

--- a/core/internal/stream/streaminject.go
+++ b/core/internal/stream/streaminject.go
@@ -40,6 +40,7 @@ var streamProviders = wire.NewSet(
 	NewStream,
 	wire.Bind(new(api.Peeker), new(*observability.Peeker)),
 	wire.Struct(new(observability.Peeker)),
+	BaseURLFromSettings,
 	featurechecker.NewServerFeaturesCache,
 	filestream.FileStreamProviders,
 	filetransfer.NewFileTransferStats,

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -42,7 +42,9 @@ func NewRunHistoryAPIHandler(
 	settings *settings.Settings,
 	sentryClient *sentry_ext.Client,
 ) *RunHistoryAPIHandler {
-	backend := stream.NewBackend(observability.NewNoOpLogger(), settings)
+	logger := observability.NewNoOpLogger()
+	baseURL := stream.BaseURLFromSettings(logger, settings)
+	backend := stream.NewBackend(baseURL, logger, settings)
 	graphqlClient := stream.NewGraphQLClient(
 		backend,
 		settings,

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -454,7 +454,9 @@ func (nc *Connection) handleAuthenticate(msg *spb.ServerAuthenticateRequest) {
 		ApiKey:  &wrapperspb.StringValue{Value: msg.ApiKey},
 		BaseUrl: &wrapperspb.StringValue{Value: msg.BaseUrl},
 	})
-	backend := stream.NewBackend(observability.NewNoOpLogger(), s) // TODO: use a real logger
+	logger := observability.NewNoOpLogger() // TODO: use a real logger
+	baseURL := stream.BaseURLFromSettings(logger, s)
+	backend := stream.NewBackend(baseURL, logger, s)
 	graphqlClient := stream.NewGraphQLClient(backend, s, &observability.Peeker{}, "" /*clientId*/)
 
 	data, err := gql.Viewer(context.Background(), graphqlClient)


### PR DESCRIPTION
Removes `api.Request` and consolidates `Send()` with `Do()`, with the intention of making `api.Client` usable for more than just the W&B backend.

The original vision was for components that intend to communicate with the W&B server to explicitly use `api.Client` to enable W&B-specific handling, like rate limits and auth injection. GraphQL was the first obstacle to this because it requires a generic `http.RoundTripper` forcing the creation of `api.Client.Do()` and the `isToWandb()` helper function. It could still use `api.Client` because all its requests went to W&B; in contrast, file uploads and downloads may communicate with arbitrary servers, so `internal/filetransfer/` uses a `retryablehttp.Client`.

Because of that, `internal/filetransfer/` lacks `internal/api/`'s custom retry logging and `wboperation` support, neither of which is specific to communications with W&B server. Those could be factored out of `api.Client`, but since `api.Client` has to implement `Do()` anyway, there's little advantage in keeping it as a separate layer of abstraction, so I'm refactoring it into a more general `http` enhancement layer. I will probably rename it too.