### PR TITLE
refactor: rewrite Connection.handleAuthenticate

### DIFF
--- a/core/internal/api/credentials.go
+++ b/core/internal/api/credentials.go
@@ -45,6 +45,12 @@ func NewCredentialProvider(
 	return NoopCredentialProvider{}, nil
 }
 
+// NewAPIKeyCredentialProvider returns a credential provider that uses the given
+// API key.
+func NewAPIKeyCredentialProvider(apiKey string) CredentialProvider {
+	return &apiKeyCredentialProvider{apiKey}
+}
+
 var _ CredentialProvider = &apiKeyCredentialProvider{}
 
 type apiKeyCredentialProvider struct {


### PR DESCRIPTION
Cleans up `handleAuthenticate`:

* Breaks out a `handleAuthenticateImpl` that can return a `ServerAuthenticateResponse` instead of using a deeply nested `nc.Respond()` followed by an easy-to-forget `return` 
* Avoids using `stream_init.go` functions which are meant to be used to construct a Stream:
  * It shouldn't have needed to create a Settings object
  * It was adding empty `X-WANDB-USERNAME` and `X-WANDB-USER-EMAIL` headers
  * I was annoyed at having had to update this code several times while refactoring `stream_init.go`

I'll be factoring out the HTTP client logic in `stream_init.go`, after which it can be reused more properly here. A similar change needs to happen for `core/internal/wbapi/readrunhistoryhandler.go`, although in its case there is a real Settings object.

## Testing

This appears to be tested by experimental/client-csharp/examples/Basic/Program.cs, which should run in tests/system_tests/test_experimental/test_client_csharp.py as part of the experimental-tests-linux jobs, but the job doesn't record code coverage.