### PR TITLE
refactor: use api.RetryableClient as its main interface

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -34,24 +34,16 @@ const (
 // WBBaseURL is the address of the W&B backend, like https://api.wandb.ai.
 type WBBaseURL *url.URL
 
-// A retrying HTTP client with special handling for the W&B backend.
-//
-// There is one Client per API provided by the backend, where "API" is a
-// collection of related HTTP endpoints. It's expected that different APIs
-// have different properties such as rate-limits and ideal retry behaviors.
+// RetryableClient is an HTTP client with retries and special handling for W&B.
 //
 // The client is responsible for setting auth headers, retrying
 // gracefully, and respecting rate-limit response headers.
-type Client interface {
+type RetryableClient interface {
 	// Sends an HTTP request with retries.
 	//
 	// There is special handling if the request is for the W&B backend.
 	//
 	// It is guaranteed that the response is non-nil unless there is an error.
-	Do(*http.Request) (*http.Response, error)
-}
-
-type RetryableClient interface {
 	Do(*retryablehttp.Request) (*http.Response, error)
 }
 
@@ -133,8 +125,8 @@ type ClientOptions struct {
 	Logger *slog.Logger
 }
 
-// NewClient returns a new [Client] for making HTTP requests.
-func NewClient(opts ClientOptions) Client {
+// NewClient returns a new [RetryableClient] for making HTTP requests.
+func NewClient(opts ClientOptions) RetryableClient {
 	if opts.BaseURL == nil {
 		panic("api: nil BaseURL")
 	}

--- a/core/internal/api/api_test.go
+++ b/core/internal/api/api_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/api"
@@ -33,7 +34,7 @@ func TestDo(t *testing.T) {
 		},
 	})
 
-	testRequest, err := http.NewRequest(
+	testRequest, err := retryablehttp.NewRequest(
 		http.MethodGet,
 		server.URL+"/wandb/some/test/path",
 		bytes.NewReader([]byte("my test request")),
@@ -69,7 +70,7 @@ func TestDo_ToWandb_SetsAuth(t *testing.T) {
 
 	{
 		defer server.Close()
-		req, _ := http.NewRequest(
+		req, _ := retryablehttp.NewRequest(
 			http.MethodGet,
 			server.URL+"/wandb/xyz",
 			bytes.NewBufferString("test body"),
@@ -94,7 +95,7 @@ func TestDo_NotToWandb_NoAuth(t *testing.T) {
 
 	{
 		defer server.Close()
-		req, _ := http.NewRequest(
+		req, _ := retryablehttp.NewRequest(
 			http.MethodGet,
 			server.URL+"/notwandb/xyz",
 			bytes.NewBufferString("test body"),
@@ -114,7 +115,7 @@ func newClient(
 	t *testing.T,
 	settings *wbsettings.Settings,
 	opts api.ClientOptions,
-) api.Client {
+) api.RetryableClient {
 	baseURL, err := url.Parse(settings.GetBaseURL())
 	require.NoError(t, err)
 	opts.BaseURL = baseURL
@@ -170,7 +171,7 @@ func TestNewClientWithProxy(t *testing.T) {
 	client := api.NewClient(clientOptions)
 
 	// Create a test request
-	testReq, err := http.NewRequest("GET", "http://api.example.com/test", nil)
+	testReq, err := retryablehttp.NewRequest("GET", "http://api.example.com/test", nil)
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
 	}
@@ -225,7 +226,7 @@ func TestNewClientWithRetry(t *testing.T) {
 	})
 
 	// Create a test request
-	testReq, err := http.NewRequest("GET", serverURL, nil)
+	testReq, err := retryablehttp.NewRequest("GET", serverURL, nil)
 	require.NoError(t, err)
 	resp, err := client.Do(testReq)
 	require.NoError(t, err)

--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -9,12 +9,7 @@ import (
 	"github.com/wandb/wandb/core/internal/wboperation"
 )
 
-func (client *clientImpl) Do(req *http.Request) (*http.Response, error) {
-	retryableReq, err := retryablehttp.FromRequest(req)
-	if err != nil {
-		return nil, fmt.Errorf("api: failed to parse request: %v", err)
-	}
-
+func (client *clientImpl) Do(req *retryablehttp.Request) (*http.Response, error) {
 	if !client.isToWandb(req) {
 		if client.logger != nil {
 			client.logger.Warn(
@@ -25,14 +20,14 @@ func (client *clientImpl) Do(req *http.Request) (*http.Response, error) {
 			)
 		}
 
-		return client.send(retryableReq)
+		return client.send(req)
 	}
 
-	return client.sendToWandbBackend(retryableReq)
+	return client.sendToWandbBackend(req)
 }
 
 // Returns whether the request would go to the W&B backend.
-func (client *clientImpl) isToWandb(req *http.Request) bool {
+func (client *clientImpl) isToWandb(req *retryablehttp.Request) bool {
 	if req.URL.Host != client.baseURL.Host {
 		return false
 	}

--- a/core/internal/api/standardclient.go
+++ b/core/internal/api/standardclient.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// HTTPDoer is the interface implemented by http.Client.
+type HTTPDoer interface {
+	// Do is the same as http.Client.Do.
+	Do(*http.Request) (*http.Response, error)
+}
+
+// AsStandardClient returns an http.Client-compatible wrapper.
+//
+// The wrapper passes the given http.Request to retryablehttp.FromRequest().
+// Due to http.NewRequest sometimes wrapping the Body in a NopCloser,
+// it can lose its Seek() method, causing FromRequest() to load it fully
+// into memory.
+func AsStandardClient(c RetryableClient) HTTPDoer {
+	return &standardClient{c}
+}
+
+type standardClient struct{ client RetryableClient }
+
+func (s standardClient) Do(req *http.Request) (*http.Response, error) {
+	retryingReq, err := retryablehttp.FromRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("api: StandardClient.Do(): %v", err)
+	}
+
+	return s.client.Do(retryingReq)
+}

--- a/core/internal/apitest/apitest.go
+++ b/core/internal/apitest/apitest.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/wandb/core/internal/api"
 )
 
@@ -110,9 +111,9 @@ func (c *FakeClient) WaitUntilRequestCount(
 	}
 }
 
-var _ api.Client = &FakeClient{}
+var _ api.RetryableClient = &FakeClient{}
 
-func (c *FakeClient) Do(req *http.Request) (*http.Response, error) {
+func (c *FakeClient) Do(req *retryablehttp.Request) (*http.Response, error) {
 	c.Lock()
 	defer c.Unlock()
 

--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -114,7 +114,7 @@ type fileStream struct {
 	printer *observability.Printer
 
 	// The client for making API requests.
-	apiClient api.Client
+	apiClient api.RetryableClient
 	baseURL   *url.URL
 
 	// The rate limit for sending data to the backend.
@@ -149,7 +149,7 @@ type FileStreamFactory struct {
 
 // New returns a new FileStream.
 func (f *FileStreamFactory) New(
-	apiClient api.Client,
+	apiClient api.RetryableClient,
 	heartbeatStopwatch waiting.Stopwatch,
 	transmitRateLimit *rate.Limiter,
 ) FileStream {

--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/wandb/core/internal/wboperation"
 )
 
@@ -137,7 +138,7 @@ func (fs *fileStream) send(
 	op := fs.trackUploadOperation(data)
 	defer op.Finish()
 
-	req, err := http.NewRequestWithContext(
+	req, err := retryablehttp.NewRequestWithContext(
 		op.Context(context.Background()),
 		http.MethodPost,
 		fs.baseURL.JoinPath(fs.path).String(),

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -161,7 +161,7 @@ func NewGraphQLClient(
 	httpClient := api.NewClient(opts)
 	endpoint := fmt.Sprintf("%s/graphql", settings.GetBaseURL())
 
-	return graphql.NewClient(endpoint, httpClient)
+	return graphql.NewClient(endpoint, api.AsStandardClient(httpClient))
 }
 
 func NewFileStream(

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -491,7 +491,7 @@ func (nc *Connection) handleAuthenticateImpl(
 
 	graphqlClient := graphql.NewClient(
 		baseURL.JoinPath("graphql").String(),
-		apiClient,
+		api.AsStandardClient(apiClient),
 	)
 
 	data, err := gql.Viewer(context.Background(), graphqlClient)


### PR DESCRIPTION
Makes `api.RetryableClient` the main interface returned by `api.NewClient()` and creates an `AsStandardClient()` wrapper.

Using `retryablehttp.Request` directly instead of `http.Request` is necessary because `http.NewRequest()` loses the request body's `Seek()` implementation after wrapping it in a `NopCloser`, making `retryablehttp.FromRequest()` load the entire request body into memory, which is a no-go for file uploads.