### PR TITLE
refactor: use api.RetryableClient for file uploads/downloads

### DIFF
--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -10,20 +10,11 @@ import (
 )
 
 func (client *clientImpl) Do(req *retryablehttp.Request) (*http.Response, error) {
-	if !client.isToWandb(req) {
-		if client.logger != nil {
-			client.logger.Warn(
-				fmt.Sprintf(
-					"api: unexpected request through W&B HTTP client: %v",
-					req.URL,
-				),
-			)
-		}
-
+	if client.isToWandb(req) {
+		return client.sendToWandbBackend(req)
+	} else {
 		return client.send(req)
 	}
-
-	return client.sendToWandbBackend(req)
 }
 
 // Returns whether the request would go to the W&B backend.

--- a/core/internal/filetransfer/file_transfer_default_test.go
+++ b/core/internal/filetransfer/file_transfer_default_test.go
@@ -7,10 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
@@ -19,296 +18,249 @@ import (
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
+// newFileTransfer returns a new DefaultFileTransfer for tests that uses
+// a non-retrying HTTP client.
+func newFileTransfer(t *testing.T) *filetransfer.DefaultFileTransfer {
+	t.Helper()
+
+	client := retryablehttp.NewClient()
+	client.RetryMax = 0
+
+	return filetransfer.NewDefaultFileTransfer(
+		client,
+		observabilitytest.NewTestLogger(t),
+		filetransfer.NewFileTransferStats(),
+	)
+}
+
+// runServer starts a server for the duration of the test running the given
+// handler function.
+//
+// Returns the server's URL.
+func runServer(
+	t *testing.T,
+	handler func(w http.ResponseWriter, r *http.Request),
+) string {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	return server.URL
+}
+
+// writeTempFile creates a temporary file with the given contents and returns
+// its path.
+func writeTempFile(t *testing.T, content []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test-data.txt")
+	err := os.WriteFile(path, content, 0o644)
+	require.NoError(t, err)
+
+	return path
+}
+
 func TestDefaultFileTransfer_Download(t *testing.T) {
-	// Content to be downloaded
+	path := filepath.Join(t.TempDir(), "test-file.txt")
 	contentExpected := []byte("test content for download")
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodGet)
 
-	// Creating a mock HTTP server
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		// add body to the response
 		_, err := w.Write(contentExpected)
 		assert.NoError(t, err)
+	})
 
-		// Assertions
-		// Compare the method
-		assert.Equal(t, r.Method, http.MethodGet)
-	}))
-	defer mockServer.Close()
-
-	// Creating a file transfer
-	ft := newFileTransfer(t, nil, nil)
-
-	// Mocking task
 	task := &filetransfer.DefaultDownloadTask{
-		Path: "test-download-file.txt",
-		Url:  mockServer.URL,
+		Path: path,
+		Url:  testURL,
 	}
-	defer func() {
-		_ = os.Remove(task.Path)
-	}()
+	err := newFileTransfer(t).Download(task)
 
-	// Performing the download
-	err := ft.Download(task)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// Read the downloaded file
-	content, err := os.ReadFile(task.Path)
+	content, err := os.ReadFile(path)
 	assert.NoError(t, err)
 	assert.Equal(t, contentExpected, content)
 	assert.Equal(t, task.Response.StatusCode, http.StatusOK)
 }
 
 func TestDefaultFileTransfer_Upload(t *testing.T) {
-	// Content to be uploaded
-	contentExpected := []byte("test content for upload")
-
-	// Headers to be tested
-	headers := []string{
+	expectedContent := []byte("test content for upload")
+	path := writeTempFile(t, expectedContent)
+	expectedHeaders := []string{
 		"X-Test-1:x:: test",
 		"X-Test-2:",
 		"X-Test-3",
 		"X-Test-4: test",
 	}
-
-	// Creating a mock HTTP server
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		// Reading the body
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		// Assertions
-
-		// Compare the content
-		assert.Equal(t, contentExpected, body)
-
-		// Compare the method
+		assert.Equal(t, expectedContent, body)
 		assert.Equal(t, r.Method, http.MethodPut)
-
-		// Compare the headers
 		assert.Equal(t, r.Header.Get("X-Test-1"), "x:: test")
 		assert.Equal(t, r.Header.Get("X-Test-2"), "")
 		assert.Equal(t, r.Header.Get("X-Test-3"), "")
 		assert.Equal(t, r.Header.Get("X-Test-4"), "test")
-	}))
-	defer mockServer.Close()
+	})
 
-	// Creating a file transfer
-	ft := newFileTransfer(t, nil, nil)
-
-	// Creating a file to be uploaded
-	filename := "test-upload-file.txt"
-	err := os.WriteFile(filename, contentExpected, 0644)
-	assert.NoError(t, err)
-	defer func() {
-		_ = os.Remove(filename)
-	}()
-
-	// Mocking task
 	task := &filetransfer.DefaultUploadTask{
-		Path:    filename,
-		Url:     mockServer.URL,
-		Headers: headers,
+		Path:    path,
+		Url:     testURL,
+		Headers: expectedHeaders,
 	}
+	err := newFileTransfer(t).Upload(task)
 
-	// Performing the upload
-	err = ft.Upload(task)
 	assert.NoError(t, err)
 	assert.Equal(t, task.Response.StatusCode, http.StatusOK)
 }
 
 func TestDefaultFileTransfer_UploadOffsetChunk(t *testing.T) {
-	entireContent := []byte("test content for upload")
+	path := writeTempFile(t, []byte("test content for upload"))
 	expectedContent := []byte("content")
-
-	chunkCheckHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedContent, body)
 	})
-	server := httptest.NewServer(chunkCheckHandler)
 
-	ft := newFileTransfer(t, impatientClient(), nil)
-
-	tempFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
-	_, err = tempFile.Write(entireContent)
-	assert.NoError(t, err)
-	_ = tempFile.Close()
-	defer func() {
-		_ = os.Remove(tempFile.Name())
-	}()
-
-	task := &filetransfer.DefaultUploadTask{
-		Path:   tempFile.Name(),
-		Url:    server.URL,
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path:   path,
+		Url:    testURL,
 		Offset: 5,
 		Size:   7,
-	}
+	})
 
-	err = ft.Upload(task)
 	assert.NoError(t, err)
 }
 
 func TestDefaultFileTransfer_UploadOffsetChunkOverlong(t *testing.T) {
-	entireContent := []byte("test content for upload")
+	path := writeTempFile(t, []byte("test content for upload"))
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {})
 
-	chunkCheckHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	})
-	server := httptest.NewServer(chunkCheckHandler)
-
-	ft := newFileTransfer(t, impatientClient(), nil)
-
-	tempFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
-	_, err = tempFile.Write(entireContent)
-	assert.NoError(t, err)
-	_ = tempFile.Close()
-	defer func() {
-		_ = os.Remove(tempFile.Name())
-	}()
-
-	task := &filetransfer.DefaultUploadTask{
-		Path:   tempFile.Name(),
-		Url:    server.URL,
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path:   path,
+		Url:    testURL,
 		Offset: 17,
 		Size:   1000,
-	}
+	})
 
-	err = ft.Upload(task)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "offset + size exceeds the file size")
+	assert.ErrorContains(t, err, "offset + size exceeds the file size")
 }
 
 func TestDefaultFileTransfer_UploadNotFound(t *testing.T) {
-	fnfHandler := func(w http.ResponseWriter, r *http.Request) {
+	path := writeTempFile(t, []byte("test data"))
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-	}
-	handlerCalled, err := uploadToServerWithCountedHandler(t, fnfHandler)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "404")
-	// 404s shouldn't be retried.
-	assert.Equal(t, 1, handlerCalled)
+	})
+
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path: path,
+		Url:  testURL,
+	})
+
+	assert.ErrorContains(t, err, "404")
 }
 
 func TestDefaultFileTransfer_UploadErrorWithBody(t *testing.T) {
+	path := writeTempFile(t, []byte("test data"))
 	errorBody := "detailed error message from server"
-	errorHandler := func(w http.ResponseWriter, r *http.Request) {
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(errorBody))
-	}
-	handlerCalled, err := uploadToServerWithCountedHandler(t, errorHandler)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "400")
-	assert.Contains(t, err.Error(), errorBody)
-	// 400s shouldn't be retried.
-	assert.Equal(t, 1, handlerCalled)
+	})
+
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path: path,
+		Url:  testURL,
+	})
+
+	assert.ErrorContains(t, err, "400")
+	assert.ErrorContains(t, err, errorBody)
 }
 
 func TestDefaultFileTransfer_UploadErrorWithLargeBody(t *testing.T) {
-	// Create an error body larger than 1024 bytes
+	path := writeTempFile(t, []byte("test data"))
 	largeErrorBody := strings.Repeat("error message ", 100)
-	errorHandler := func(w http.ResponseWriter, r *http.Request) {
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(largeErrorBody))
-	}
-	handlerCalled, err := uploadToServerWithCountedHandler(t, errorHandler)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "400")
-	assert.Contains(t, err.Error(), "error message")
+	})
+
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path: path,
+		Url:  testURL,
+	})
+
+	assert.ErrorContains(t, err, "400")
+	assert.ErrorContains(t, err, "error message")
 	// 100 bytes for the prefix in the error
 	assert.Less(t, len(err.Error()), 1024+100)
-	// 400s shouldn't be retried.
-	assert.Equal(t, 1, handlerCalled)
 }
 
 func TestDefaultFileTransfer_UploadErrorWithUnreadableBody(t *testing.T) {
-	errorHandler := func(w http.ResponseWriter, r *http.Request) {
+	path := writeTempFile(t, []byte("test data"))
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", "100")
 		w.WriteHeader(http.StatusBadRequest)
 		// Close connection without sending body to simulate read error
 		hj, ok := w.(http.Hijacker)
-		if ok {
-			conn, _, err := hj.Hijack()
-			if err == nil {
-				_ = conn.Close()
-			}
-		}
-	}
-	handlerCalled, err := uploadToServerWithCountedHandler(t, errorHandler)
+		require.True(t, ok, "webserver doesn't support hijacking")
+
+		conn, _, err := hj.Hijack()
+		require.NoError(t, err, "hijacking error")
+
+		_ = conn.Close()
+	})
+
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path: path,
+		Url:  testURL,
+	})
+
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "400")
 	assert.Contains(t, err.Error(), "error reading body")
-	// 400s shouldn't be retried.
-	assert.Equal(t, 1, handlerCalled)
 }
 
 func TestDefaultFileTransfer_UploadConnectionClosed(t *testing.T) {
-	closeHandler := func(w http.ResponseWriter, r *http.Request) {
+	path := writeTempFile(t, []byte("test data"))
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		hj, ok := w.(http.Hijacker)
-		assert.True(t, ok, "webserver doesn't support hijacking")
+		require.True(t, ok, "webserver doesn't support hijacking")
+
 		conn, _, err := hj.Hijack()
-		assert.NoError(t, err, "hijacking error")
+		require.NoError(t, err, "hijacking error")
+
 		_ = conn.Close()
-	}
-	handlerCalled, err := uploadToServerWithCountedHandler(t, closeHandler)
-	assert.Error(t, err)
-	assert.Condition(t, func() bool {
-		return strings.Contains(err.Error(), "EOF") ||
-			strings.Contains(err.Error(), "connection reset")
 	})
-	assert.Equal(t, 2, handlerCalled)
+
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path: path,
+		Url:  testURL,
+	})
+
+	// Can be "EOF", "use of closed network connection" or others.
+	assert.Error(t, err)
 }
 
 func TestDefaultFileTransfer_UploadContextCancelled(t *testing.T) {
+	path := writeTempFile(t, []byte("test data"))
 	ctx, cancel := context.WithCancel(context.Background())
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		cancel()
-	}))
-	ft := newFileTransfer(t, impatientClient(), nil)
+	})
 
-	tempFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
-	defer func() {
-		_ = os.Remove(tempFile.Name())
-	}()
-
-	err = ft.Upload(&filetransfer.DefaultUploadTask{
-		Path:    tempFile.Name(),
-		Url:     server.URL,
+	err := newFileTransfer(t).Upload(&filetransfer.DefaultUploadTask{
+		Path:    path,
+		Url:     testURL,
 		Context: ctx,
 	})
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "context canceled")
-	// Context cancellation shouldn't result in a retry.
-	assert.NotContains(t, err.Error(), "giving up after 2 attempt(s)")
-}
-
-func TestDefaultFileTransfer_UploadNoServer(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ft := newFileTransfer(t, impatientClient(), nil)
-
-	tempFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
-	defer func() {
-		_ = os.Remove(tempFile.Name())
-	}()
-
-	task := &filetransfer.DefaultUploadTask{
-		Path: tempFile.Name(),
-		Url:  server.URL,
-	}
-
-	// Close the server before the upload begins.
-	server.Close()
-
-	err = ft.Upload(task)
-	assert.Error(t, err)
-	assert.Nil(t, task.Response)
-	assert.Contains(t, err.Error(), "connection refused")
-	assert.Contains(t, err.Error(), "giving up after 2 attempt(s)")
 }
 
 func TestProgressReader_TracksProgress(t *testing.T) {
@@ -338,164 +290,4 @@ func TestProgressReader_TracksProgress(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 0, lastProcessed)
 	assert.EqualValues(t, 9, lastTotal)
-}
-
-// Start test server and count number of times the handler was called
-func uploadToServerWithCountedHandler(
-	t *testing.T,
-	handler func(w http.ResponseWriter, r *http.Request),
-) (int, error) {
-	handlerCalled := int64(0)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt64(&handlerCalled, 1)
-		handler(w, r)
-	}))
-	defer server.Close()
-	ft := newFileTransfer(t, impatientClient(), nil)
-
-	tempFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
-	defer func() {
-		_ = os.Remove(tempFile.Name())
-	}()
-
-	task := &filetransfer.DefaultUploadTask{
-		Path: tempFile.Name(),
-		Url:  server.URL,
-	}
-
-	err = ft.Upload(task)
-	return int(atomic.LoadInt64(&handlerCalled)), err
-}
-
-func impatientClient() *retryablehttp.Client {
-	client := retryablehttp.NewClient()
-	client.RetryMax = 1
-	client.RetryWaitMin = 1 * time.Millisecond
-	return client
-}
-
-// newFileTransfer creates a new DefaultFileTransfer with optional
-// custom client and extra headers
-func newFileTransfer(
-	t *testing.T,
-	client *retryablehttp.Client,
-	extraHeaders map[string]string,
-) *filetransfer.DefaultFileTransfer {
-	if client == nil {
-		client = retryablehttp.NewClient()
-	}
-	return filetransfer.NewDefaultFileTransfer(
-		client,
-		observabilitytest.NewTestLogger(t),
-		filetransfer.NewFileTransferStats(),
-		extraHeaders,
-	)
-}
-
-// newFileTransferWithExtraHeaders creates a new DefaultFileTransfer
-// with the provided extra headers
-func newFileTransferWithExtraHeaders(
-	t *testing.T,
-	extraHeaders map[string]string,
-) *filetransfer.DefaultFileTransfer {
-	return newFileTransfer(t, nil, extraHeaders)
-}
-
-// verifyHeadersInRequest verifies that the HTTP request contains
-// the expected headers.
-// We use r.Header.Get(key) instead of assert.EqualValues() because:
-// - r.Header is of type http.Header (map[string][]string)
-// - expectedHeaders is of type map[string]string
-func verifyHeadersInRequest(
-	t *testing.T,
-	r *http.Request,
-	expectedHeaders map[string]string,
-) {
-	// Mark as helper to show the caller's location when assert fails
-	// inside a helper function.
-	t.Helper()
-	for key, expectedValue := range expectedHeaders {
-		assert.Equal(
-			t,
-			expectedValue,
-			r.Header.Get(key),
-			"Header %s should have value %s",
-			key,
-			expectedValue,
-		)
-	}
-}
-
-func TestDefaultFileTransfer_DownloadWithExtraHeaders(t *testing.T) {
-	contentExpected := []byte("test content for download")
-	extraHeaders := map[string]string{
-		"X-Custom-Header-1": "value1",
-		"X-Custom-Header-2": "value2",
-	}
-
-	// Creating a mock HTTP server
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write(contentExpected)
-		assert.NoError(t, err)
-
-		assert.Equal(t, http.MethodGet, r.Method)
-		verifyHeadersInRequest(t, r, extraHeaders)
-	}))
-	defer mockServer.Close()
-
-	ft := newFileTransferWithExtraHeaders(t, extraHeaders)
-
-	task := &filetransfer.DefaultDownloadTask{
-		Path: "test-download-file-with-headers.txt",
-		Url:  mockServer.URL,
-	}
-	defer func() {
-		_ = os.Remove(task.Path)
-	}()
-
-	err := ft.Download(task)
-	require.NoError(t, err)
-
-	content, err := os.ReadFile(task.Path)
-	require.NoError(t, err)
-	assert.Equal(t, contentExpected, content)
-	assert.Equal(t, http.StatusOK, task.Response.StatusCode)
-}
-
-func TestDefaultFileTransfer_UploadWithExtraHeaders(t *testing.T) {
-	contentExpected := []byte("test content for upload")
-	extraHeaders := map[string]string{
-		"X-Custom-Upload-1": "upload-value1",
-		"X-Custom-Upload-2": "upload-value2",
-	}
-
-	// Creating a mock HTTP server
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, contentExpected, body)
-
-		assert.Equal(t, http.MethodPut, r.Method)
-		verifyHeadersInRequest(t, r, extraHeaders)
-	}))
-	defer mockServer.Close()
-
-	ft := newFileTransferWithExtraHeaders(t, extraHeaders)
-
-	filename := "test-upload-file-with-headers.txt"
-	err := os.WriteFile(filename, contentExpected, 0644)
-	require.NoError(t, err)
-	defer func() {
-		_ = os.Remove(filename)
-	}()
-
-	task := &filetransfer.DefaultUploadTask{
-		Path: filename,
-		Url:  mockServer.URL,
-	}
-
-	err = ft.Upload(task)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, task.Response.StatusCode)
 }

--- a/core/internal/filetransfer/file_transfers.go
+++ b/core/internal/filetransfer/file_transfers.go
@@ -1,7 +1,7 @@
 package filetransfer
 
 import (
-	"github.com/hashicorp/go-retryablehttp"
+	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/observability"
 )
 
@@ -40,13 +40,12 @@ type FileTransfers struct {
 
 // NewFileTransfers creates a new fileTransfers
 func NewFileTransfers(
-	client *retryablehttp.Client,
+	client api.RetryableClient,
 	logger *observability.CoreLogger,
 	fileTransferStats FileTransferStats,
-	extraHeaders map[string]string,
 ) *FileTransfers {
 	// Default transfer for presigned urls.
-	defaultFileTransfer := NewDefaultFileTransfer(client, logger, fileTransferStats, extraHeaders)
+	defaultFileTransfer := NewDefaultFileTransfer(client, logger, fileTransferStats)
 	// NOTE: Cloud specific handlers are for reference artifacts.
 	// We do NOT pass the extra headers through the vendor specific SDK for now.
 	// See https://docs.wandb.ai/models/artifacts/track-external-files

--- a/core/internal/runsync/wire_gen.go
+++ b/core/internal/runsync/wire_gen.go
@@ -57,7 +57,7 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 		Settings:   settings2,
 	}
 	fileTransferStats := filetransfer.NewFileTransferStats()
-	fileTransferManager := stream.NewFileTransferManager(fileTransferStats, logger, settings2)
+	fileTransferManager := stream.NewFileTransferManager(wbBaseURL, fileTransferStats, logger, settings2)
 	watcher := provideFileWatcher(logger)
 	uploaderFactory := &runfiles.UploaderFactory{
 		FileTransfer: fileTransferManager,

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -53,6 +53,7 @@ func makeSender(t *testing.T, client graphql.Client) testFixtures {
 		Settings: settings,
 	}
 	fileTransferManager := stream.NewFileTransferManager(
+		baseURL,
 		filetransfer.NewFileTransferStats(),
 		logger,
 		settings,

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -80,7 +80,7 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 		Printer:    printer,
 		Settings:   settings2,
 	}
-	fileTransferManager := NewFileTransferManager(fileTransferStats, coreLogger, settings2)
+	fileTransferManager := NewFileTransferManager(wbBaseURL, fileTransferStats, coreLogger, settings2)
 	watcher := provideFileWatcher(coreLogger)
 	uploaderFactory := &runfiles.UploaderFactory{
 		FileTransfer: fileTransferManager,


### PR DESCRIPTION
Makes `DefaultFileTransfer` use the client created by `api.NewClient()` instead of using `retryablehttp.NewClient()` and duplicating the customization logic.

As a side effect, this completes WB-26645 since `api.NewClient()` includes retry logging and integrates with `wboperation`. HTTP errors for file uploads now show up in the console:

![Screenshot 2026-01-08 at 2.57.30 PM.png](https://app.graphite.com/user-attachments/assets/cf5b4cd9-dbc9-43db-8526-7153ac162c25.png)

(I got the screenshot by turning off WiFi during a run. The error is unhelpfully long because it includes the request URL, but at least it hints that something is wrong, and the full error can be seen in `debug-internal.log`.)

This also cleans up the sloppy `file_transfer_default_test.go` file.