### PR TITLE
chore: constrain kubernetes_asyncio in CI

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -80,3 +80,7 @@ awscli~=1.42; sys_platform == 'win32'
 .[launch]
 .[sweeps] ; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 .[azure]
+
+# Added indirectly via [launch].
+# Breaks 3.8 CI due to https://github.com/tomplus/kubernetes_asyncio/issues/391
+kubernetes-asyncio<34.3; python_version <= '3.8'


### PR DESCRIPTION
Fixes CI breakage from https://github.com/tomplus/kubernetes_asyncio/issues/391

A few Python 3.13 tests are still broken, but this may be due to a version incompatibility, in which case a constraint should be added in the `[launch]` extra.