### PR TITLE
chore(launch): mock getting kube context in tests.system_tests.test_launch.test_launch_kubernetes

### DIFF
--- a/tests/system_tests/test_launch/test_launch_kubernetes.py
+++ b/tests/system_tests/test_launch/test_launch_kubernetes.py
@@ -371,6 +371,11 @@ def setup_mock_kubernetes_client(monkeypatch, jobs, pods, mock_job_base):
         "get_kube_context_and_api_client",
         _mock_get_context_and_client,
     )
+    monkeypatch.setattr(
+        kubernetes_runner,
+        "get_kube_context_and_api_client",
+        _mock_get_context_and_client,
+    )
 
     async def mock_create_from_dict(jobd, jobs_dict, mock_status):
         name = jobd["metadata"].get("name")


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.
Mocks the call to getting a kube context in a test without a valid cluster config. Older versions of kubernetes_asyncio were more lenient and would allow for empty clusters, but a recent update doesn't allow it.

We weren't mocking in this case but we can.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
