### PR TITLE
refactor: rewrite `api/credentials.go` using HTTPWrapper and apply it in the correct place

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -52,8 +52,7 @@ type RetryableClient interface {
 type clientImpl struct {
 	baseURL *url.URL
 
-	retryableHTTP      RetryableClient    // underlying HTTP client
-	credentialProvider CredentialProvider // credentials for W&B requests only
+	retryableHTTP RetryableClient // underlying HTTP client
 
 	logger *slog.Logger
 }
@@ -185,6 +184,7 @@ func NewClient(opts ClientOptions) RetryableClient {
 	}
 
 	wandbOnlyLayers := httplayers.LimitTo(opts.BaseURL, httplayers.Concat(
+		opts.CredentialProvider,
 		httplayers.ExtraHeaders(extraHeaders),
 		ResponseBasedRateLimiter(),
 	))
@@ -197,9 +197,8 @@ func NewClient(opts ClientOptions) RetryableClient {
 			))
 
 	return &clientImpl{
-		baseURL:            opts.BaseURL,
-		retryableHTTP:      retryableHTTP,
-		credentialProvider: opts.CredentialProvider,
-		logger:             opts.Logger,
+		baseURL:       opts.BaseURL,
+		retryableHTTP: retryableHTTP,
+		logger:        opts.Logger,
 	}
 }

--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -30,12 +30,6 @@ func (client *clientImpl) isToWandb(req *retryablehttp.Request) bool {
 func (client *clientImpl) sendToWandbBackend(
 	req *retryablehttp.Request,
 ) (*http.Response, error) {
-	err := client.credentialProvider.Apply(req.Request)
-	if err != nil {
-		return nil, fmt.Errorf("api: failed provide credentials for "+
-			"request: %v", err)
-	}
-
 	resp, err := client.send(req)
 
 	// This is a bug that happens with retryablehttp sometimes.


### PR DESCRIPTION
Slightly refactors `credentials.go` in terms of HTTPWrapper and applies it immediately before sending a request.

PR #11159 incorrectly removed `PrepareRetry`, making it so that credentials don't get refreshed on retries. But even before that PR, credential refreshing happened outside of rate-limiting (it was outside of `retryablehttp.Client.Do()`, whereas rate limiting was inside the `Transport`) which was not exactly correct.