### PR TITLE
chore: fix test_public_api.py::test_viewer

### DIFF
--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -948,12 +948,16 @@ def test_query_team(user, api):
     assert repr(t.members[0]) == f"<Member {user} (USER)>"
 
 
-def test_viewer(user, api):
+def test_viewer(user: str, api: wandb.Api):
     v = api.viewer
     assert v.admin is False
     assert v.username == user
-    assert v.api_keys == [user]
     assert v.teams == [user]
+
+    # api_keys returns IDs of API keys. In tests, the API key ID is a prefix
+    # of the API key, which is also the username.
+    assert len(v.api_keys) == 1
+    assert user.startswith(v.api_keys[0])
 
 
 def test_create_team_exists(wandb_backend_spy):


### PR DESCRIPTION
Loosens an assertion in `test_viewer` that started failing because it assumes that API keys are equal to their IDs in tests.

The ID of a legacy API key (like those in tests) is the key minus the last 20 characters.