### PR TITLE
refactor: create httplayerstest

### DIFF
--- a/core/internal/api/credentials_test.go
+++ b/core/internal/api/credentials_test.go
@@ -11,12 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/apitest"
+	"github.com/wandb/wandb/core/internal/httplayerstest"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	wbsettings "github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
+
+func exampleGetRequest(t *testing.T) *http.Request {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+	return req
+}
 
 func TestNewAPIKeyCredentialProvider(t *testing.T) {
 	settings := wbsettings.From(&spb.Settings{
@@ -28,12 +35,16 @@ func TestNewAPIKeyCredentialProvider(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	require.NoError(t, err)
-	err = credentialProvider.Apply(req)
-	require.NoError(t, err)
+	reqs, err := httplayerstest.MapRequest(t,
+		credentialProvider,
+		exampleGetRequest(t),
+	)
 
-	assert.Equal(t, "Basic YXBpOnRlc3QtYXBpLWtleQ==", req.Header.Get("Authorization"))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t,
+		"Basic YXBpOnRlc3QtYXBpLWtleQ==",
+		reqs[0].Header.Get("Authorization"))
 }
 
 func TestNewAPIKeyCredentialProvider_NoAPIKey(t *testing.T) {
@@ -102,12 +113,14 @@ func TestNewOAuth2CredentialProvider(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	require.NoError(t, err)
-	err = credentialProvider.Apply(req)
-	require.NoError(t, err)
+	reqs, err := httplayerstest.MapRequest(t,
+		credentialProvider,
+		exampleGetRequest(t),
+	)
 
-	assert.Equal(t, "Bearer "+token, req.Header.Get("Authorization"))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "Bearer "+token, reqs[0].Header.Get("Authorization"))
 
 	// validate credentials file was written correctly
 	file, err := os.ReadFile(credentialsFile)
@@ -173,12 +186,14 @@ func TestNewOAuth2CredentialProvider_RefreshesToken(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	require.NoError(t, err)
-	err = credentialProvider.Apply(req)
-	require.NoError(t, err)
+	reqs, err := httplayerstest.MapRequest(t,
+		credentialProvider,
+		exampleGetRequest(t),
+	)
 
-	assert.Equal(t, "Bearer "+token, req.Header.Get("Authorization"))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "Bearer "+token, reqs[0].Header.Get("Authorization"))
 
 	// validate credentials file was written correctly
 	file, err := os.ReadFile(credsFile.Name())
@@ -243,25 +258,24 @@ func TestNewOAuth2CredentialProvider_RefreshesTokenOnce(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// issue 2 requests
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	require.NoError(t, err)
-	req2, err := http.NewRequest("GET", "http://example.com", nil)
-	require.NoError(t, err)
+	recorder := httplayerstest.NewHTTPDoRecorder(t)
 
 	var errGroup errgroup.Group
-	errGroup.Go(func() error {
-		return credentialProvider.Apply(req)
-	})
-	errGroup.Go(func() error {
-		return credentialProvider.Apply(req2)
-	})
+	for range 2 {
+		errGroup.Go(func() error {
+			wrappedRecorder := credentialProvider.WrapHTTP(recorder.RecordHTTP)
+			_, err := wrappedRecorder(exampleGetRequest(t))
+			return err
+		})
+	}
 
 	err = errGroup.Wait()
 	require.NoError(t, err)
 
-	assert.Equal(t, "Bearer fake-token", req.Header.Get("Authorization"))
-	assert.Equal(t, "Bearer fake-token", req2.Header.Get("Authorization"))
+	calls := recorder.Calls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, "Bearer fake-token", calls[0].Header.Get("Authorization"))
+	assert.Equal(t, "Bearer fake-token", calls[1].Header.Get("Authorization"))
 
 	// auth server should only be called once
 	assert.Equal(t, 1, len(server.Requests()))
@@ -315,12 +329,14 @@ func TestNewOAuth2CredentialProvider_CreatesNewTokenForNewBaseURL(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	require.NoError(t, err)
-	err = credentialProvider.Apply(req)
-	require.NoError(t, err)
+	reqs, err := httplayerstest.MapRequest(t,
+		credentialProvider,
+		exampleGetRequest(t),
+	)
 
-	assert.Equal(t, "Bearer fake-token", req.Header.Get("Authorization"))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "Bearer "+token, reqs[0].Header.Get("Authorization"))
 
 	// credentials file should have 2 entries
 	file, err := os.ReadFile(credsFile.Name())

--- a/core/internal/httplayerstest/httpdorecorder.go
+++ b/core/internal/httplayerstest/httpdorecorder.go
@@ -1,0 +1,67 @@
+package httplayerstest
+
+import (
+	"bufio"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/internal/httplayers"
+)
+
+// MapRequest records the calls made by a wrapper to an inner HTTPDoFunc
+// that always returns a successful response.
+//
+// Returns the requests made and any error returned by the wrapper.
+func MapRequest(
+	t *testing.T,
+	wrapper httplayers.HTTPWrapper,
+	req *http.Request,
+) ([]*http.Request, error) {
+	recorder := NewHTTPDoRecorder(t)
+	_, err := wrapper.WrapHTTP(recorder.RecordHTTP)(req)
+	return recorder.Calls(), err
+}
+
+// HTTPDoRecorder provides an HTTPDoFunc that records calls made to it.
+type HTTPDoRecorder struct {
+	t     *testing.T
+	mu    sync.Mutex
+	calls []*http.Request
+}
+
+// NewHTTPDoRecorder creates a new HTTPDoRecorder that returns a 200-status
+// response and nil error on each call.
+func NewHTTPDoRecorder(t *testing.T) *HTTPDoRecorder {
+	return &HTTPDoRecorder{t: t}
+}
+
+// Calls returns the *http.Request values collected from calls to the recorder.
+func (r *HTTPDoRecorder) Calls() []*http.Request {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.calls)
+}
+
+// RecordHTTP records the request and returns a fake response.
+func (r *HTTPDoRecorder) RecordHTTP(req *http.Request) (*http.Response, error) {
+	// Close the body like a real Do function.
+	if req.Body != nil {
+		defer req.Body.Close()
+	}
+
+	r.mu.Lock()
+	r.calls = append(r.calls, req)
+	r.mu.Unlock()
+
+	response, err := http.ReadResponse(
+		bufio.NewReader(strings.NewReader("HTTP/1.1 200 OK\r\n\r\n")),
+		req,
+	)
+	require.NoError(r.t, err)
+
+	return response, nil
+}

--- a/core/internal/httplayerstest/httpwrapperrecorder.go
+++ b/core/internal/httplayerstest/httpwrapperrecorder.go
@@ -1,0 +1,41 @@
+package httplayerstest
+
+import (
+	"net/http"
+	"slices"
+	"sync"
+
+	"github.com/wandb/wandb/core/internal/httplayers"
+)
+
+// HTTPWrapperRecorder wraps an HTTPDoFunc in a layer that records calls
+// made to it.
+type HTTPWrapperRecorder struct {
+	mu    sync.Mutex
+	calls []*http.Request
+}
+
+// NewHTTPWrapperRecorder creates a new HTTPWrapperRecorder.
+func NewHTTPWrapperRecorder() *HTTPWrapperRecorder {
+	return &HTTPWrapperRecorder{}
+}
+
+// Calls returns the *http.Request values collected from calls to the recorder.
+func (r *HTTPWrapperRecorder) Calls() []*http.Request {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.calls)
+}
+
+// WrapHTTP implements HTTPWrapper.WrapHTTP.
+func (r *HTTPWrapperRecorder) WrapHTTP(
+	send httplayers.HTTPDoFunc,
+) httplayers.HTTPDoFunc {
+	return func(req *http.Request) (*http.Response, error) {
+		r.mu.Lock()
+		r.calls = append(r.calls, req)
+		r.mu.Unlock()
+
+		return send(req)
+	}
+}


### PR DESCRIPTION
Creates `httplayerstest` and uses it to rewrite some tests, in particular `internal/api/credentials_test.go`. Removes `CredentialProvider.Apply`, which only existed for the test.