### PR TITLE
chore: enable mypy for wandb/sdk/wandb_login.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,7 +399,6 @@ module = [
     "wandb.apis.reports.v2",
     "wandb.apis.workspaces",
     "wandb.proto.*",
-    "wandb.sdk.wandb_login",
     "wandb.cli.*",
     "wandb.wandb_torch.*",
     "wandb.wandb_controller.*",

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -179,7 +179,7 @@ def _login(
         return False, None
 
     if key:
-        auth = _use_explicit_key(
+        auth: wbauth.Auth | None = _use_explicit_key(
             key,
             host=host_url,
             settings=settings,


### PR DESCRIPTION
Removes the old ignore for `wandb_login` now that it's been significantly refactored.