### PR TITLE
feat: ctrl+c during wandb beta sync cancels it somewhat

### DIFF
--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -1,6 +1,7 @@
 package runsync_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -150,7 +151,7 @@ func Test_Extract_FindsRunRecord(t *testing.T) {
 			},
 		}})
 
-	runInfo, err := x.RunReader.ExtractRunInfo()
+	runInfo, err := x.RunReader.ExtractRunInfo(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, &runsync.RunInfo{
@@ -165,7 +166,7 @@ func Test_Extract_ErrorIfNoRunRecord(t *testing.T) {
 	x := setup(t)
 	wandbFileWithRecords(t, x.TransactionLog)
 
-	runInfo, err := x.RunReader.ExtractRunInfo()
+	runInfo, err := x.RunReader.ExtractRunInfo(context.Background())
 
 	assert.Nil(t, runInfo)
 	assert.ErrorContains(t, err, "didn't find run info")
@@ -174,7 +175,7 @@ func Test_Extract_ErrorIfNoRunRecord(t *testing.T) {
 func Test_Extract_ErrorIfNoFile(t *testing.T) {
 	x := setup(t)
 
-	runInfo, err := x.RunReader.ExtractRunInfo()
+	runInfo, err := x.RunReader.ExtractRunInfo(context.Background())
 
 	assert.Nil(t, runInfo)
 	assert.ErrorContains(t, err, "failed to open reader")
@@ -197,7 +198,7 @@ func Test_TurnsAllRecordsIntoWork(t *testing.T) {
 		x.MockRecordParser.EXPECT().Parse(isExitRecord(0)).Return(exitWork),
 	)
 
-	err := x.RunReader.ProcessTransactionLog()
+	err := x.RunReader.ProcessTransactionLog(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -215,7 +216,7 @@ func Test_CreatesExitRecordIfNotSeen(t *testing.T) {
 		x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(exitWork),
 	)
 
-	err := x.RunReader.ProcessTransactionLog()
+	err := x.RunReader.ProcessTransactionLog(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -241,7 +242,7 @@ func Test_CreatesRunStartRequest(t *testing.T) {
 		x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(exitWork),
 	)
 
-	err := x.RunReader.ProcessTransactionLog()
+	err := x.RunReader.ProcessTransactionLog(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -253,7 +254,7 @@ func Test_FileNotFoundError(t *testing.T) {
 	x := setup(t)
 	x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(&testWork{})
 
-	err := x.RunReader.ProcessTransactionLog()
+	err := x.RunReader.ProcessTransactionLog(context.Background())
 
 	var syncErr *runsync.SyncError
 	require.ErrorAs(t, err, &syncErr)
@@ -271,7 +272,7 @@ func Test_FilePermissionError(t *testing.T) {
 	require.NoError(t, err)
 	x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(&testWork{})
 
-	err = x.RunReader.ProcessTransactionLog()
+	err = x.RunReader.ProcessTransactionLog(context.Background())
 
 	var syncErr *runsync.SyncError
 	require.ErrorAs(t, err, &syncErr)
@@ -296,7 +297,7 @@ func Test_CorruptFileError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, wandbFile.Close())
 
-	err = x.RunReader.ProcessTransactionLog()
+	err = x.RunReader.ProcessTransactionLog(context.Background())
 
 	assert.ErrorContains(t, err, "error getting next record")
 }

--- a/core/internal/runsync/runsyncmanager.go
+++ b/core/internal/runsync/runsyncmanager.go
@@ -1,6 +1,7 @@
 package runsync
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -48,6 +49,7 @@ func (m *RunSyncManager) InitSync(
 
 // DoSync starts a sync operation and blocks until it completes.
 func (m *RunSyncManager) DoSync(
+	ctx context.Context,
 	request *spb.ServerSyncRequest,
 ) *spb.ServerSyncResponse {
 	m.mu.Lock()
@@ -68,7 +70,7 @@ func (m *RunSyncManager) DoSync(
 		}}}
 	}
 
-	response := op.Do(int(request.GetParallelism()))
+	response := op.Do(ctx, int(request.GetParallelism()))
 
 	m.mu.Lock()
 	delete(m.ongoingSyncOps, request.Id)

--- a/core/internal/runsync/runsyncmanager_test.go
+++ b/core/internal/runsync/runsyncmanager_test.go
@@ -1,6 +1,7 @@
 package runsync_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ func Test_DoSync_NotPrepped(t *testing.T) {
 	m := runsync.NewRunSyncManager()
 	request := &spb.ServerSyncRequest{Id: "bad-id"}
 
-	response := m.DoSync(request)
+	response := m.DoSync(context.Background(), request)
 
 	assert.Len(t, response.Messages, 1)
 	assert.Equal(t,

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -630,7 +630,10 @@ func (nc *Connection) handleSync(
 	go func() {
 		defer wg.Done()
 
-		response := nc.runSyncManager.DoSync(request)
+		ctx, cancel := nc.requestCanceller.Context(id)
+		defer cancel()
+
+		response := nc.runSyncManager.DoSync(ctx, request)
 		nc.Respond(&spb.ServerResponse{
 			RequestId: id,
 			ServerResponseType: &spb.ServerResponse_SyncResponse{


### PR DESCRIPTION
Makes `Ctrl+C` during `wandb beta sync` cancel the sync.

Part of WB-30383.

This just stops reading from the transaction log. There's no mechanism yet to cancel ongoing network operations; that's in PR #11232.