### PR TITLE
chore: check if target dir is writable for debug cli logs

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -44,7 +44,7 @@ from .beta import beta
 
 # Send cli logs to wandb/debug-cli.<username>.log by default and fallback to a temp dir.
 _wandb_dir = old_core.wandb_dir(env.get_dir())
-if not os.path.exists(_wandb_dir):
+if not os.path.exists(_wandb_dir) or not os.access(_wandb_dir, os.W_OK):
     _wandb_dir = tempfile.gettempdir()
 
 try:


### PR DESCRIPTION
Description
-----------
Address a case where on a shared machine, `/tmp/wandb` may exist, but be owned by a different user.
