### PR TITLE
docs(sdk): fix code block formatting in sync docstrings

### DIFF
--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -147,15 +147,21 @@ def sync(
 
     For example, to sync all runs in a directory:
 
-        wandb beta sync ./wandb
+    ```shell
+    wandb beta sync ./wandb
+    ```
 
     To sync a specific run:
 
-        wandb beta sync ./wandb/run-20250813_124246-n67z9ude
+    ```shell
+    wandb beta sync ./wandb/run-20250813_124246-n67z9ude
+    ```
 
     Or equivalently:
 
-        wandb beta sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb
+    ```shell
+    wandb beta sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb
+    ```
     """
     from . import beta_sync
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -555,11 +555,15 @@ def sync(
 
     To sync a specific run:
 
-        wandb sync ./wandb/run-20250813_124246-n67z9ude
+    ```shell
+    wandb sync ./wandb/run-20250813_124246-n67z9ude
+    ```
 
     Or equivalently:
 
-        wandb sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb
+    ```shell
+    wandb sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb
+    ```
     """
     api = _get_cling_api()
     if not api.is_authenticated:


### PR DESCRIPTION
Description
-----------
Fix unstyled code blocks in `wandb sync` and `wandb beta sync` CLI ref docstrings

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
N/A