### PR TITLE
fix: authenticate in wandb beta sync

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,3 +21,6 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - After `wandb login --host <invalid-url>`, using `wandb login --host <valid-url>` works as usual (@timoffex in https://github.com/wandb/wandb/pull/11207)
   - Regression introduced in 0.24.0
+- `wandb beta sync` correctly loads credentials (@timoffex in https://github.com/wandb/wandb/pull/11231)
+  - Regression introduced in 0.24.0
+  - Caused `wandb beta sync` to get stuck on `Syncing...`

--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -13,7 +13,7 @@ from wandb.cli import beta_sync, cli
 from wandb.proto import wandb_server_pb2 as spb
 from wandb.proto import wandb_sync_pb2
 from wandb.sdk import wandb_setup
-from wandb.sdk.lib import asyncio_compat
+from wandb.sdk.lib import asyncio_compat, wbauth
 from wandb.sdk.lib.printer import new_printer
 from wandb.sdk.mailbox.mailbox import Mailbox
 from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
@@ -180,11 +180,17 @@ def skip_asyncio_sleep(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(beta_sync, "_SLEEP", do_nothing)
 
 
+def _unauthenticate_for_test() -> None:
+    """Clear auth to verify that syncing explicitly authenticates."""
+    wbauth.unauthenticate_session(update_settings=True)
+
+
 def test_syncs_run(
     tmp_path: pathlib.Path,
     wandb_backend_spy: WandbBackendSpy,
     runner: CliRunner,
 ):
+    _unauthenticate_for_test()
     test_file = tmp_path / "test_file.txt"
     test_file.touch()
 

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -13,7 +13,7 @@ import wandb
 from wandb.errors import term
 from wandb.proto.wandb_sync_pb2 import ServerSyncResponse
 from wandb.sdk import wandb_setup
-from wandb.sdk.lib import asyncio_compat
+from wandb.sdk.lib import asyncio_compat, wbauth
 from wandb.sdk.lib.printer import Printer, new_printer
 from wandb.sdk.lib.progress import progress_printer
 from wandb.sdk.lib.service.service_connection import ServiceConnection
@@ -86,6 +86,15 @@ def sync(
     _print_sorted_paths(wandb_files, verbose=verbose, root=cwd)
 
     if ask_for_confirmation and not term.confirm("Sync the listed runs?"):
+        return
+
+    # Authenticate the session. This updates the singleton settings credentials.
+    if not wbauth.authenticate_session(
+        host=singleton.settings.base_url,
+        source="wandb sync",
+        no_offline=True,
+    ):
+        term.termlog("Not authenticated.")
         return
 
     service = singleton.ensure_service()


### PR DESCRIPTION
Fixes `wandb beta sync` which currently fails to load credentials.

Tests didn't catch this because they propagate credentials through environment variables like `WANDB_API_KEY`. I added a `wbauth.unauthenticate_session()` to a test to catch this in the future.