### PR TITLE
refactor: allow cancelling a run

### DIFF
--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -2,7 +2,6 @@ package filestream
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -140,7 +139,7 @@ func (fs *fileStream) send(
 	defer op.Finish()
 
 	req, err := retryablehttp.NewRequestWithContext(
-		op.Context(context.Background()),
+		op.Context(fs.beforeRunEndCtx),
 		http.MethodPost,
 		fs.baseURL.JoinPath(fs.path).String(),
 		bytes.NewReader(jsonData),

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -252,6 +252,7 @@ func (u *uploader) FlushSchedulingForTest() {
 func (u *uploader) knownFile(runPath paths.RelativePath) *savedFile {
 	if u.knownFiles[runPath] == nil {
 		u.knownFiles[runPath] = newSavedFile(
+			u.extraWork.BeforeEndCtx(),
 			u.fs,
 			u.ftm,
 			u.logger,

--- a/core/internal/runworktest/runworktest.go
+++ b/core/internal/runworktest/runworktest.go
@@ -83,6 +83,10 @@ func (w *FakeRunWork) Chan() <-chan runwork.Work {
 	panic("FakeRunWork.Chan() is not implemented")
 }
 
+func (w *FakeRunWork) Abort() {
+	w.rw.Abort()
+}
+
 func (w *FakeRunWork) SetDone() {
 	w.rw.SetDone()
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -137,6 +137,7 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 	var fileStream fs.FileStream
 	if !f.Settings.IsOffline() {
 		fileStream = NewFileStream(
+			runWork,
 			f.FileStreamFactory,
 			f.BaseURL,
 			f.ClientID,

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -16,6 +16,7 @@ import (
 	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sharedmode"
 )
@@ -164,6 +165,7 @@ func NewGraphQLClient(
 }
 
 func NewFileStream(
+	extraWork runwork.ExtraWork,
 	factory *filestream.FileStreamFactory,
 	baseURL api.WBBaseURL,
 	clientID sharedmode.ClientID,
@@ -222,6 +224,7 @@ func NewFileStream(
 
 	return factory.New(
 		fileStreamRetryClient,
+		extraWork.BeforeEndCtx(),
 		/*heartbeatStopwatch=*/ nil,
 		transmitRateLimit,
 	)


### PR DESCRIPTION
Adds a `RunWork.Abort()` method to cancel the `BeforeEndCtx()` early and uses it as part of `beta sync` cancellation.

Completes WB-30383.

Most places that correctly use `BeforeEndCtx()` for network operations don't need to change, but I had to add an explicit skip in `FileStream.StreamUpdate()` because an initial `UpsertBucket` failure (e.g. a permission error) can leave it in a non-started state where it always blocks.

Artifacts don't pass explicit contexts, so artifact upload operations won't be cancelled. I'm not sure how well artifacts work in offline mode, so this shouldn't affect `beta sync`, but it'll probably lead to problems later on. Search for uses of `context.Background()`.