### PR TITLE
refactor: debounce file uploads more

### DIFF
--- a/core/internal/runfiles/runfiles.go
+++ b/core/internal/runfiles/runfiles.go
@@ -76,6 +76,7 @@ type UploaderFactory struct {
 //
 // batchDelay is how long to wait to batch upload operations. Uploads scheduled
 // within this duration of each other are combined into a single GraphQL call.
+// It also affects how often "live" files are reuploaded.
 func (f *UploaderFactory) New(
 	batchDelay waiting.Delay,
 	extraWork runwork.ExtraWork,

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -229,6 +229,7 @@ func (u *uploader) Finish() {
 	u.stateMu.Unlock()
 
 	// Flush any remaining upload batches.
+	u.uploadBatcher.Close()
 	u.uploadBatcher.Wait()
 
 	// Wait for all upload tasks to get scheduled.

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -150,7 +150,7 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 	var runfilesUploader runfiles.Uploader
 	if !f.Settings.IsOffline() {
 		runfilesUploader = f.RunfilesUploaderFactory.New(
-			/*batchDelay=*/ waiting.NewDelay(50*time.Millisecond),
+			/*batchDelay=*/ waiting.NewDelay(5*time.Second),
 			runWork,
 			fileStream,
 		)

--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -35,36 +35,6 @@ def test_upsert_bucket_410(wandb_backend_spy):
         wandb.init()
 
 
-def test_gql_409(wandb_backend_spy):
-    """Test that we do retry non-UpsertBucket GraphQL operations on 409s."""
-    gql = wandb_backend_spy.gql
-    responder = gql.once(content="", status=409)
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="CreateRunFiles"),
-        responder,
-    )
-
-    with wandb.init():
-        pass
-
-    assert responder.total_calls >= 2
-
-
-def test_gql_410(wandb_backend_spy):
-    """Test that we do retry non-UpsertBucket GraphQL operations on 410s."""
-    gql = wandb_backend_spy.gql
-    responder = gql.once(content="", status=410)
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="CreateRunFiles"),
-        responder,
-    )
-
-    with wandb.init():
-        pass
-
-    assert responder.total_calls >= 2
-
-
 def test_send_wandb_config_start_time_on_init(wandb_backend_spy):
     with wandb.init() as run:
         pass


### PR DESCRIPTION
Debounce file updates for 5 seconds instead of 50ms.

Fixes WB-30739.

The debouncing was originally used to batch GraphQL calls, but it also affects file uploads. Files saved with `run.save(policy="live")` (which is the default policy) poll for changes every 500ms, causing frequently-updated files like log files to reupload that often. This PR limits them to upload once every 5 seconds.

---

For reference, the lifetime of an update looks something like this:

1. A file's timestamps change and an update is triggered
2. The file path is added to a debouncer (changed from 50ms to 5s)
3. The batch of files is sent in a CreateRunFiles GQL call which returns their upload URLs
4. File contents are hashed, and modified files are reuploaded

Multiple occurrences of (1) get debounced in (2).

Before this PR, step (3) could happen multiple times in parallel. Now, step (2) continues batching until step (3) is ready, so there's only a single CreateRunFiles GraphQL call at any time.

(4) happens sequentially per path.