### PR TITLE
fix: unuploaded data due to broken flow control

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Notable Changes
+
+Runs created with `wandb==0.24.0` may fail to upload some data, which this release fixes. Missing data is stored in the run's `.wandb` file and can be reuploaded with `wandb sync`.
+
 ### Added
 
 - `download_history_exports` in `api.Run` class to download exported run history in parquet file format (@jacobromero in https://github.com/wandb/wandb/pull/11094)
@@ -28,3 +32,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 - `wandb beta sync` correctly loads credentials (@timoffex in https://github.com/wandb/wandb/pull/11231)
   - Regression introduced in 0.24.0
   - Caused `wandb beta sync` to get stuck on `Syncing...`
+- Fixed occasional unuploaded data in 0.24.0 (@timoffex in https://github.com/wandb/wandb/pull/11249)
+  - All data is stored in the run's `.wandb` file and can be reuploaded with `wandb sync`


### PR DESCRIPTION
Fixes occasional data loss due to flow control being broken in 0.24.0.

When the uploader is blocked, flow control discards records that have been saved to the `.wandb` "transaction log" file to reduce memory usage, and it reloads them when the uploader is unblocked. It uses `transactionlog.Reader`'s `SeekRecord()` to seek to the byte offset of a saved chunk and then calls `Read()`.

A refactor included in 0.24.0 changed how `transactionlog.Reader` verifies the `.wandb` file header, doing it in the first call to `Read()`. Verifying the header is only possible when the reader is positioned in the first 32 KiB of the file and returns an error otherwise. `SeekRecord()` was not updated, so when flow control triggered after the first 32 KiB of data, it encountered a `Read()` error.

When flow control fails to recover a chunk of records, the chunk is skipped and flow control is turned off to prevent further data loss. This would have manifested as a missing chunk of data in affected runs. The data can be recovered with `wandb sync`.