### PR TITLE
chore: specify go version in sdist verification step in release action

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -296,6 +296,9 @@ jobs:
 
       - name: Set up latest Go
         uses: actions/setup-go@v6
+        with:
+          go-version-file: core/go.mod
+          cache-dependency-path: core/go.sum
 
       - name: Install wandb from TestPyPI with --no-binary
         run: |


### PR DESCRIPTION
Description
-----------
...it was missing a with version file block and picking up a wrong (default) version.