### PR TITLE
chore: install rust toolchain and update python version in sdist check step in release action

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -292,7 +292,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Set up latest Go
         uses: actions/setup-go@v6
@@ -302,6 +302,7 @@ jobs:
 
       - name: Install wandb from TestPyPI with --no-binary
         run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           python -m pip install \
             --no-binary wandb \
             --extra-index-url https://test.pypi.org/simple/ \


### PR DESCRIPTION
Description
-----------
rust is needed to build gpu_stats binary + 3.12 is the most representative version atm.
