### PR TITLE
chore(automations): use valid url in system tests

### DIFF
--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -146,7 +146,11 @@ def webhook(
     """A "registered" webhook integration for automation system tests."""
     name = make_name("test-webhook")
     entity = api.default_entity
-    yield make_webhook_integration(name=name, entity=entity, url="fake-url")
+    yield make_webhook_integration(
+        name=name,
+        entity=entity,
+        url="https://example.com/webhook",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -67,7 +67,9 @@ def test_fetch_webhook_integrations(
     # Create multiple webhook integrations
     created_hooks = [
         make_webhook_integration(
-            name=make_name("test-webhook"), entity=api.default_entity, url="fake-url"
+            name=make_name("test-webhook"),
+            entity=api.default_entity,
+            url="https://example.com/webhook",
         )
         for _ in range(3)
     ]
@@ -96,7 +98,7 @@ def test_fetch_slack_integrations(
     make_webhook_integration(
         name=make_name("test-webhook"),
         entity=api.default_entity,
-        url="fake-url",
+        url="https://example.com/webhook",
     )
 
     # Fetch the slack integrations (for now there won't be any)


### PR DESCRIPTION

Description
-----------

Fix 400 errors when passing `fake-url` which is not a valid url.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable. N/A, just fixing the test fixture, no behavior change in SDK.


Testing
-------
How was this PR tested?

Let CI run.