### PR TITLE
fix: create standard run files in offline mode

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ This version drops support for Python 3.8.
 ### Changed
 
 - Python 3.8 is no longer supported (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11198, https://github.com/wandb/wandb/pull/11290, https://github.com/wandb/wandb/pull/11164)
+- The `wandb-summary.json`, `wandb-metadata.json`, `output.log` and `config.yaml` files are now generated even in offline mode (@timoffex in https://github.com/wandb/wandb/pull/11279)
 
 ### Fixed
 

--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -267,7 +267,7 @@ func (sm *SystemMonitor) GetState() int32 {
 func (sm *SystemMonitor) probeExecutionContext() *spb.Record {
 	sm.logger.Debug("monitor: probing execution environment")
 
-	return &spb.Record{RecordType: &spb.Record_Environment{Environment: &spb.EnvironmentRecord{
+	environmentRecord := &spb.EnvironmentRecord{
 		Os:            sm.settings.GetOS(),
 		Python:        sm.settings.GetPython(),
 		Host:          sm.settings.GetHostProcessorName(),
@@ -285,7 +285,18 @@ func (sm *SystemMonitor) probeExecutionContext() *spb.Record {
 		Git:           sm.git,
 
 		WriterId: string(sm.writerID),
-	}}}
+	}
+
+	return &spb.Record{
+		RecordType: &spb.Record_Environment{Environment: environmentRecord},
+
+		// Set AlwaysSend to true to ensure the wandb-metadata.json file
+		// is created.
+		//
+		// TODO: Get rid of AlwaysSend and let the Sender handle offline mode
+		//   to decouple how a record is created from how it's processed.
+		Control: &spb.Control{AlwaysSend: true},
+	}
 }
 
 // probeResources gathers system information from all resources and merges their metadata.
@@ -335,7 +346,16 @@ func (sm *SystemMonitor) probeResources() *spb.Record {
 		e.GpuType = sm.settings.GetStatsGpuType()
 	}
 
-	return &spb.Record{RecordType: &spb.Record_Environment{Environment: e}}
+	return &spb.Record{
+		RecordType: &spb.Record_Environment{Environment: e},
+
+		// Set AlwaysSend to true to ensure the wandb-metadata.json file
+		// is created.
+		//
+		// TODO: Get rid of AlwaysSend and let the Sender handle offline mode
+		//   to decouple how a record is created from how it's processed.
+		Control: &spb.Control{AlwaysSend: true},
+	}
 }
 
 // Start begins resource monitoring.

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -74,6 +74,12 @@ class InterfaceShared(InterfaceBase, abc.ABC):
     ) -> None:
         rec = pb.Record()
         rec.output_raw.CopyFrom(outdata)
+
+        # Required to ensure the output.log file is written in offline mode.
+        #
+        # TODO: Make this decision in wandb-core, NOT in the client code.
+        rec.control.always_send = True
+
         self._publish(rec, nowait=nowait)
 
     def _publish_cancel(self, cancel: pb.CancelRequest) -> None:


### PR DESCRIPTION
Create `output.log`, `wandb-summary.json`, `config.yaml` and `wandb-metadata.json` even when running in offline mode.

Fixes WB-24267 and issue #9646.

Their contents are already stored in the `.wandb` file, and since we don't upload files in offline mode, we weren't generating those files before. Some people would find them useful to have, in particular `wandb-summary.json` and `output.log`.