### PR TITLE
fix: repetitive tracebacks after "socket.send() raised exception"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,3 +20,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Sweep agents now exit gracefully when the sweep is deleted, instead of running indefinitely with repeated 404 errors (@domphan-wandb in https://github.com/wandb/wandb/pull/11226)
+- `wandb-core` crashes no longer produce extremely long, repetitive tracebacks in older Python versions (@timoffex in https://github.com/wandb/wandb/pull/11284)


### PR DESCRIPTION
Fixes huge tracebacks output after a `wandb-core` crash.

Fixes WB-31072.

The tracebacks have long repeated sections because asyncio's StreamReader/StreamWriter store and re-raise an exception. When `wandb-core` crashes, the next communication attempt raises a `ConnectionResetError`. This usually triggers error handling logic that attempts to send even more data to `wandb-core` as it cannot distinguish between a `wandb-core` crash and other types of errors. Each time the exception is raised, the traceback is lengthened.

~~I'm not sure how exactly, but this can easily result in extremely long tracebacks (megabytes of text).~~ Since each `raise` statement during stack unwinding mutates an exception's traceback, the traceback is lengthened by the entire callstack leading up to the `raise saved_exception` statement each time it's triggered.

This problem may be fixed in Python >= 3.11, but I haven't tested. See https://bugs.python.org/issue45924.

## Testing

To reproduce the issue, print and call `run.log()` in a loop, and then `pkill wandb-core`. Without the fix, this outputs many `socket.send() raised exception` lines and exception tracebacks with this repeated section:

```
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/asyncio_manager.py", line 181, in fn_wrap_exceptions
    await fn()
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/service/service_client.py", line 38, in publish
    await self._send_server_request(request)
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/service/service_client.py", line 64, in _send_server_request
    await self._writer.drain()
  File "/Users/timoffex/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none/lib/python3.10/asyncio/streams.py", line 359, in drain
    raise exc
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/asyncio_manager.py", line 181, in fn_wrap_exceptions
    await fn()
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/service/service_client.py", line 38, in publish
    await self._send_server_request(request)
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/service/service_client.py", line 64, in _send_server_request
    await self._writer.drain()
  File "/Users/timoffex/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none/lib/python3.10/asyncio/streams.py", line 359, in drain
    raise exc
  File "/Users/timoffex/Documents/workspace/wandb/wandb/sdk/lib/asyncio_manager.py", line 181, in fn_wrap_exceptions
    await fn()
```