### PR TITLE
fix(leet): makeslice: cap out of range panic in pagedlist

### DIFF
--- a/core/internal/leet/pagedlist.go
+++ b/core/internal/leet/pagedlist.go
@@ -29,6 +29,28 @@ func (s *PagedList) SetItemsPerPage(n int) {
 		n = 1
 	}
 	s.itemsPerPage = n
+
+	// Clamp currentPage so it stays valid after the page size changes.
+	totalItems := len(s.FilteredItems)
+	if totalItems == 0 {
+		s.currentPage = 0
+		s.currentLine = 0
+		return
+	}
+	totalPages := (totalItems + s.itemsPerPage - 1) / s.itemsPerPage
+	if s.currentPage >= totalPages {
+		s.currentPage = totalPages - 1
+	}
+	// Also clamp currentLine to the items available on the (now‑valid) page.
+	itemsOnPage := s.itemsPerPage
+	if s.currentPage == totalPages-1 {
+		if remainder := totalItems % s.itemsPerPage; remainder != 0 {
+			itemsOnPage = remainder
+		}
+	}
+	if s.currentLine >= itemsOnPage {
+		s.currentLine = itemsOnPage - 1
+	}
 }
 
 // Up navigates to previous item.

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -9,65 +9,65 @@ import (
 )
 
 // TestFocusState returns the current focus state
-func (m *Run) TestFocusState() *Focus {
-	return m.focus
+func (r *Run) TestFocusState() *Focus {
+	return r.focus
 }
 
-func (m *Run) TestRunID() string {
-	return m.leftSidebar.runOverview.runID
+func (r *Run) TestRunID() string {
+	return r.leftSidebar.runOverview.runID
 }
 
-func (m *Run) TestRunDisplayName() string {
-	return m.leftSidebar.runOverview.displayName
+func (r *Run) TestRunDisplayName() string {
+	return r.leftSidebar.runOverview.displayName
 }
 
-func (m *Run) TestRunProject() string {
-	return m.leftSidebar.runOverview.project
+func (r *Run) TestRunProject() string {
+	return r.leftSidebar.runOverview.project
 }
 
 // TestRunState returns the current run state
-func (m *Run) TestRunState() RunState {
-	return m.runState
+func (r *Run) TestRunState() RunState {
+	return r.runState
 }
 
 // TestLeftSidebarVisible returns true if the left sidebar is visible
-func (m *Run) TestLeftSidebarVisible() bool {
-	return m.leftSidebar.IsVisible()
+func (r *Run) TestLeftSidebarVisible() bool {
+	return r.leftSidebar.IsVisible()
 }
 
 // TestSidebarIsFiltering returns true if the sidebar has an active filter
-func (m *Run) TestSidebarIsFiltering() bool {
-	return m.leftSidebar.IsFiltering()
+func (r *Run) TestSidebarIsFiltering() bool {
+	return r.leftSidebar.IsFiltering()
 }
 
 // TestSidebarFilterQuery returns the current sidebar filter query
-func (m *Run) TestSidebarFilterQuery() string {
-	return m.leftSidebar.FilterQuery()
+func (r *Run) TestSidebarFilterQuery() string {
+	return r.leftSidebar.FilterQuery()
 }
 
 // TestGetLeftSidebar returns the left sidebar for testing
-func (m *Run) TestGetLeftSidebar() *RunOverviewSidebar {
-	return m.leftSidebar
+func (r *Run) TestGetLeftSidebar() *RunOverviewSidebar {
+	return r.leftSidebar
 }
 
 // TestHandleRecordMsg processes a record message
-func (m *Run) TestHandleRecordMsg(msg tea.Msg) (*Run, tea.Cmd) {
-	return m.handleRecordMsg(msg)
+func (r *Run) TestHandleRecordMsg(msg tea.Msg) (*Run, tea.Cmd) {
+	return r.handleRecordMsg(msg)
 }
 
 // TestHandleChartGridClick handles a click on the main chart grid
-func (m *Run) TestHandleChartGridClick(row, col int) {
-	m.metricsGrid.HandleClick(row, col)
+func (r *Run) TestHandleChartGridClick(row, col int) {
+	r.metricsGrid.HandleClick(row, col)
 }
 
 // TestSetMainChartFocus sets focus to a main chart
-func (m *Run) TestSetMainChartFocus(row, col int) {
-	m.metricsGrid.setFocus(row, col)
+func (r *Run) TestSetMainChartFocus(row, col int) {
+	r.metricsGrid.setFocus(row, col)
 }
 
 // TestClearMainChartFocus clears focus from main charts
-func (m *Run) TestClearMainChartFocus() {
-	m.metricsGrid.clearFocus()
+func (r *Run) TestClearMainChartFocus() {
+	r.metricsGrid.clearFocus()
 }
 
 // TestForceExpand forces the sidebar to expanded state without animation


### PR DESCRIPTION
Description
-----------
Fix for a possible panic that looks like this:

```shell
runtime error: makeslice: cap out of range

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x1400012f2c0, {0x102561a00, 0x102915310})
        /Users/dduev/code/wandb/core/vendor/github.com/charmbracelet/bubbletea/tea.go:847 +0x90
github.com/charmbracelet/bubbletea.(*Program).Run.func2()
        /Users/dduev/code/wandb/core/vendor/github.com/charmbracelet/bubbletea/tea.go:638 +0xc4
panic({0x102561a00?, 0x102915310?})
        /opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/panic.go:783 +0x120
github.com/wandb/wandb/core/internal/leet.(*RunOverviewSidebar).renderSectionItems(0x1400030ac80, 0x1400012f040, 0x0?)
        /Users/dduev/code/wandb/core/internal/leet/runoverviewsidebar.go:434 +0x90
github.com/wandb/wandb/core/internal/leet.(*RunOverviewSidebar).renderSection(0x1400030ac80, 0x1012f8184?, 0x2f)
        /Users/dduev/code/wandb/core/internal/leet/runoverviewsidebar.go:373 +0x80
github.com/wandb/wandb/core/internal/leet.(*RunOverviewSidebar).buildSectionLines(0x1400030ac80, 0x2f)
        /Users/dduev/code/wandb/core/internal/leet/runoverviewsidebar.go:345 +0x88
github.com/wandb/wandb/core/internal/leet.(*RunOverviewSidebar).View(0x1400030ac80, 0x36)
        /Users/dduev/code/wandb/core/internal/leet/runoverviewsidebar.go:169 +0x1f8
github.com/wandb/wandb/core/internal/leet.(*Workspace).renderRunOverview(0x1400012f180)
        /Users/dduev/code/wandb/core/internal/leet/workspace.go:283 +0x134
github.com/wandb/wandb/core/internal/leet.(*Workspace).View(0x1400012f180)
        /Users/dduev/code/wandb/core/internal/leet/workspace.go:198 +0x128
github.com/wandb/wandb/core/internal/leet.(*Model).View(0x14000443930?)
        /Users/dduev/code/wandb/core/internal/leet/model.go:154 +0x80
github.com/charmbracelet/bubbletea.(*Program).eventLoop(0x1400012f2c0, {0x10293de00?, 0x14000628dc0?}, 0x14000055c70)
        /Users/dduev/code/wandb/core/vendor/github.com/charmbracelet/bubbletea/tea.go:502 +0x6e4
github.com/charmbracelet/bubbletea.(*Program).Run(0x1400012f2c0)
        /Users/dduev/code/wandb/core/vendor/github.com/charmbracelet/bubbletea/tea.go:716 +0x840
main.leetMain({0x140000500a0, 0x2, 0x2})
        /Users/dduev/code/wandb/core/cmd/wandb-core/main.go:286 +0x658
main.run({0x14000050090?, 0x100cf4dac?, 0x1038caf28?})
        /Users/dduev/code/wandb/core/cmd/wandb-core/main.go:51 +0x5c
main.main()
        /Users/dduev/code/wandb/core/cmd/wandb-core/main.go:46 +0x50
```