### PR TITLE
chore: fix proto-python nox session by installing older setuptools

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -485,29 +485,41 @@ def proto_python(session: nox.Session, pb: int) -> None:
 
 def _generate_proto_python(session: nox.Session, pb: int) -> None:
     if pb == 3:
-        session.install("protobuf==3.20.3")
-        session.install("mypy-protobuf==3.4.0")
-        session.install("grpcio==1.47.5")
-        session.install("grpcio-tools==1.47.5")
+        session.install(
+            "protobuf==3.20.3",
+            "mypy-protobuf==3.3.0",  # 3.4.0 requires protobuf>=4.21.8
+            "grpcio==1.47.5",
+            "grpcio-tools==1.47.5",
+            "packaging",
+            "setuptools<70",  # provides pkg_resources for grpcio-tools
+        )
     elif pb == 4:
-        session.install("protobuf~=4.23.4")
-        session.install("mypy-protobuf~=3.5.0")
-        session.install("grpcio~=1.51.0")
-        session.install("grpcio-tools~=1.51.0")
+        session.install(
+            "protobuf~=4.23.4",
+            "mypy-protobuf~=3.5.0",
+            "grpcio~=1.51.0",
+            "grpcio-tools~=1.51.0",
+            "packaging",
+            "setuptools<70",  # provides pkg_resources for grpcio-tools
+        )
     elif pb == 5:
-        session.install("protobuf~=5.27.0")
-        session.install("mypy-protobuf~=3.6.0")
-        session.install("grpcio~=1.64.1")
-        session.install("grpcio-tools~=1.64.1")
+        session.install(
+            "protobuf~=5.27.0",
+            "mypy-protobuf~=3.6.0",
+            "grpcio~=1.64.1",
+            "grpcio-tools~=1.64.1",
+            "packaging",
+        )
     elif pb == 6:
-        session.install("protobuf~=6.32.1")
-        session.install("mypy-protobuf~=3.6.0")
-        session.install("grpcio~=1.75.0")
-        session.install("grpcio-tools~=1.75.0")
+        session.install(
+            "protobuf~=6.32.1",
+            "mypy-protobuf~=3.6.0",
+            "grpcio~=1.75.0",
+            "grpcio-tools~=1.75.0",
+            "packaging",
+        )
     else:
         session.error("Invalid protobuf version given. `pb` must be 3, 4, 5, or 6.")
-
-    session.install("packaging")
 
     with session.chdir("wandb/proto"):
         session.run("python", "wandb_generate_proto.py")

--- a/wandb/proto/v3/wandb_api_pb2.pyi
+++ b/wandb/proto/v3/wandb_api_pb2.pyi
@@ -24,7 +24,7 @@ class _ErrorType:
     ValueType = typing.NewType("ValueType", builtins.int)
     V: typing_extensions.TypeAlias = ValueType
 
-class _ErrorTypeEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_ErrorType.ValueType], builtins.type):
+class _ErrorTypeEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_ErrorType.ValueType], builtins.type):  # noqa: F821
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
     UNKNOWN_ERROR: _ErrorType.ValueType  # 0
     INCOMPLETE_RUN_HISTORY_ERROR: _ErrorType.ValueType  # 1
@@ -35,7 +35,6 @@ UNKNOWN_ERROR: ErrorType.ValueType  # 0
 INCOMPLETE_RUN_HISTORY_ERROR: ErrorType.ValueType  # 1
 global___ErrorType = ErrorType
 
-@typing_extensions.final
 class ServerApiInitRequest(google.protobuf.message.Message):
     """ServerApiInitRequest instructs the backend process
     to initialize resources to handle ApiRequests.
@@ -58,7 +57,6 @@ class ServerApiInitRequest(google.protobuf.message.Message):
 
 global___ServerApiInitRequest = ServerApiInitRequest
 
-@typing_extensions.final
 class ApiRequest(google.protobuf.message.Message):
     """ApiRequest is a request to the backend process
     to perform an action related to an API call.
@@ -80,7 +78,6 @@ class ApiRequest(google.protobuf.message.Message):
 
 global___ApiRequest = ApiRequest
 
-@typing_extensions.final
 class ServerApiInitResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -95,7 +92,6 @@ class ServerApiInitResponse(google.protobuf.message.Message):
 
 global___ServerApiInitResponse = ServerApiInitResponse
 
-@typing_extensions.final
 class ApiResponse(google.protobuf.message.Message):
     """ApiResponse is a response from the backend process for an ApiRequest."""
 
@@ -119,7 +115,6 @@ class ApiResponse(google.protobuf.message.Message):
 
 global___ApiResponse = ApiResponse
 
-@typing_extensions.final
 class ApiErrorResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -139,7 +134,6 @@ class ApiErrorResponse(google.protobuf.message.Message):
 
 global___ApiErrorResponse = ApiErrorResponse
 
-@typing_extensions.final
 class ReadRunHistoryRequest(google.protobuf.message.Message):
     """Start of Scan run history"""
 
@@ -179,7 +173,6 @@ class ReadRunHistoryRequest(google.protobuf.message.Message):
 
 global___ReadRunHistoryRequest = ReadRunHistoryRequest
 
-@typing_extensions.final
 class ReadRunHistoryResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -217,7 +210,6 @@ class ReadRunHistoryResponse(google.protobuf.message.Message):
 
 global___ReadRunHistoryResponse = ReadRunHistoryResponse
 
-@typing_extensions.final
 class ScanRunHistoryInit(google.protobuf.message.Message):
     """ScanRunHistoryInit is a request to initialize
     a scan over a run's history.
@@ -253,7 +245,6 @@ class ScanRunHistoryInit(google.protobuf.message.Message):
 
 global___ScanRunHistoryInit = ScanRunHistoryInit
 
-@typing_extensions.final
 class ScanRunHistoryInitResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -268,7 +259,6 @@ class ScanRunHistoryInitResponse(google.protobuf.message.Message):
 
 global___ScanRunHistoryInitResponse = ScanRunHistoryInitResponse
 
-@typing_extensions.final
 class ScanRunHistory(google.protobuf.message.Message):
     """ScanRunHistory is a request to scan
     over a portion of a run's history.
@@ -293,7 +283,6 @@ class ScanRunHistory(google.protobuf.message.Message):
 
 global___ScanRunHistory = ScanRunHistory
 
-@typing_extensions.final
 class RunHistoryResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -309,7 +298,6 @@ class RunHistoryResponse(google.protobuf.message.Message):
 
 global___RunHistoryResponse = RunHistoryResponse
 
-@typing_extensions.final
 class HistoryRow(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -325,7 +313,6 @@ class HistoryRow(google.protobuf.message.Message):
 
 global___HistoryRow = HistoryRow
 
-@typing_extensions.final
 class ParquetHistoryItem(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -343,7 +330,6 @@ class ParquetHistoryItem(google.protobuf.message.Message):
 
 global___ParquetHistoryItem = ParquetHistoryItem
 
-@typing_extensions.final
 class ScanRunHistoryCleanup(google.protobuf.message.Message):
     """ScanRunHistoryCleanup is a request to cleanup
     any resources associated with a scan request.
@@ -362,7 +348,6 @@ class ScanRunHistoryCleanup(google.protobuf.message.Message):
 
 global___ScanRunHistoryCleanup = ScanRunHistoryCleanup
 
-@typing_extensions.final
 class ScanRunHistoryCleanupResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -372,7 +357,6 @@ class ScanRunHistoryCleanupResponse(google.protobuf.message.Message):
 
 global___ScanRunHistoryCleanupResponse = ScanRunHistoryCleanupResponse
 
-@typing_extensions.final
 class DownloadRunHistoryInit(google.protobuf.message.Message):
     """Download run history"""
 
@@ -409,7 +393,6 @@ class DownloadRunHistoryInit(google.protobuf.message.Message):
 
 global___DownloadRunHistoryInit = DownloadRunHistoryInit
 
-@typing_extensions.final
 class DownloadRunHistoryInitResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -433,7 +416,6 @@ class DownloadRunHistoryInitResponse(google.protobuf.message.Message):
 
 global___DownloadRunHistoryInitResponse = DownloadRunHistoryInitResponse
 
-@typing_extensions.final
 class DownloadRunHistory(google.protobuf.message.Message):
     """A request to start a download operation for a run's history exports."""
 
@@ -451,13 +433,11 @@ class DownloadRunHistory(google.protobuf.message.Message):
 
 global___DownloadRunHistory = DownloadRunHistory
 
-@typing_extensions.final
 class DownloadRunHistoryResponse(google.protobuf.message.Message):
     """A response to a DownloadRunHistoryStart request."""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class ErrorsEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -491,7 +471,6 @@ class DownloadRunHistoryResponse(google.protobuf.message.Message):
 
 global___DownloadRunHistoryResponse = DownloadRunHistoryResponse
 
-@typing_extensions.final
 class IncompleteRunHistoryError(google.protobuf.message.Message):
     """IncompleteRunHistoryError is an error that is returned when the run history
     has live data that has not been exported to parquet files yet.
@@ -505,7 +484,6 @@ class IncompleteRunHistoryError(google.protobuf.message.Message):
 
 global___IncompleteRunHistoryError = IncompleteRunHistoryError
 
-@typing_extensions.final
 class DownloadRunHistoryStatus(google.protobuf.message.Message):
     """DownloadRunHistoryStatus requests the status of an ongoing download operation."""
 
@@ -523,7 +501,6 @@ class DownloadRunHistoryStatus(google.protobuf.message.Message):
 
 global___DownloadRunHistoryStatus = DownloadRunHistoryStatus
 
-@typing_extensions.final
 class DownloadRunHistoryStatusResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 

--- a/wandb/proto/v3/wandb_base_pb2.pyi
+++ b/wandb/proto/v3/wandb_base_pb2.pyi
@@ -14,7 +14,6 @@ else:
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 
-@typing_extensions.final
 class _RecordInfo(google.protobuf.message.Message):
     """
     _RecordInfo, _RequestInfo: extra info for all records and requests
@@ -36,7 +35,6 @@ class _RecordInfo(google.protobuf.message.Message):
 
 global____RecordInfo = _RecordInfo
 
-@typing_extensions.final
 class _RequestInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -51,7 +49,6 @@ class _RequestInfo(google.protobuf.message.Message):
 
 global____RequestInfo = _RequestInfo
 
-@typing_extensions.final
 class _ResultInfo(google.protobuf.message.Message):
     """
     _ResultInfo: extra info for all results

--- a/wandb/proto/v3/wandb_internal_pb2.pyi
+++ b/wandb/proto/v3/wandb_internal_pb2.pyi
@@ -26,7 +26,7 @@ class _ServerFeature:
     ValueType = typing.NewType("ValueType", builtins.int)
     V: typing_extensions.TypeAlias = ValueType
 
-class _ServerFeatureEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_ServerFeature.ValueType], builtins.type):
+class _ServerFeatureEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_ServerFeature.ValueType], builtins.type):  # noqa: F821
     DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
     LARGE_FILENAMES: _ServerFeature.ValueType  # 0
     """Indicates that the server supports recieving an array of filenames as metadata."""
@@ -109,7 +109,6 @@ TOTAL_COUNT_IN_FILE_CONNECTION: ServerFeature.ValueType  # 15
 """Indicates that the server supports returning the total file count in a file connection."""
 global___ServerFeature = ServerFeature
 
-@typing_extensions.final
 class Record(google.protobuf.message.Message):
     """***********************
     Records and Results
@@ -237,7 +236,6 @@ class Record(google.protobuf.message.Message):
 
 global___Record = Record
 
-@typing_extensions.final
 class Control(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -281,7 +279,6 @@ class Control(google.protobuf.message.Message):
 
 global___Control = Control
 
-@typing_extensions.final
 class Result(google.protobuf.message.Message):
     """
     Result: all results
@@ -339,7 +336,6 @@ class Result(google.protobuf.message.Message):
 
 global___Result = Result
 
-@typing_extensions.final
 class FinalRecord(google.protobuf.message.Message):
     """
     FinalRecord
@@ -360,7 +356,6 @@ class FinalRecord(google.protobuf.message.Message):
 
 global___FinalRecord = FinalRecord
 
-@typing_extensions.final
 class VersionInfo(google.protobuf.message.Message):
     """
     Version definition
@@ -389,7 +384,6 @@ class VersionInfo(google.protobuf.message.Message):
 
 global___VersionInfo = VersionInfo
 
-@typing_extensions.final
 class HeaderRecord(google.protobuf.message.Message):
     """
     HeaderRecord
@@ -414,7 +408,6 @@ class HeaderRecord(google.protobuf.message.Message):
 
 global___HeaderRecord = HeaderRecord
 
-@typing_extensions.final
 class FooterRecord(google.protobuf.message.Message):
     """
     FooterRecord
@@ -435,7 +428,6 @@ class FooterRecord(google.protobuf.message.Message):
 
 global___FooterRecord = FooterRecord
 
-@typing_extensions.final
 class BranchPoint(google.protobuf.message.Message):
     """A point in a run from which another run can be branched."""
 
@@ -461,7 +453,6 @@ class BranchPoint(google.protobuf.message.Message):
 
 global___BranchPoint = BranchPoint
 
-@typing_extensions.final
 class RunRecord(google.protobuf.message.Message):
     """
     RunRecord: wandb/sdk/wandb_run/Run
@@ -557,7 +548,6 @@ class RunRecord(google.protobuf.message.Message):
 
 global___RunRecord = RunRecord
 
-@typing_extensions.final
 class GitRepoRecord(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -575,7 +565,6 @@ class GitRepoRecord(google.protobuf.message.Message):
 
 global___GitRepoRecord = GitRepoRecord
 
-@typing_extensions.final
 class RunUpdateResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -596,7 +585,6 @@ class RunUpdateResult(google.protobuf.message.Message):
 
 global___RunUpdateResult = RunUpdateResult
 
-@typing_extensions.final
 class ErrorInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -633,7 +621,6 @@ class ErrorInfo(google.protobuf.message.Message):
 
 global___ErrorInfo = ErrorInfo
 
-@typing_extensions.final
 class RunExitRecord(google.protobuf.message.Message):
     """
     RunExitRecord: exit status of process
@@ -660,7 +647,6 @@ class RunExitRecord(google.protobuf.message.Message):
 
 global___RunExitRecord = RunExitRecord
 
-@typing_extensions.final
 class RunExitResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -670,7 +656,6 @@ class RunExitResult(google.protobuf.message.Message):
 
 global___RunExitResult = RunExitResult
 
-@typing_extensions.final
 class RunPreemptingRecord(google.protobuf.message.Message):
     """
     RunPreemptingRecord: run being preempted
@@ -691,7 +676,6 @@ class RunPreemptingRecord(google.protobuf.message.Message):
 
 global___RunPreemptingRecord = RunPreemptingRecord
 
-@typing_extensions.final
 class RunPreemptingResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -701,7 +685,6 @@ class RunPreemptingResult(google.protobuf.message.Message):
 
 global___RunPreemptingResult = RunPreemptingResult
 
-@typing_extensions.final
 class SettingsRecord(google.protobuf.message.Message):
     """
     SettingsRecord: wandb/sdk/wandb_settings/Settings
@@ -726,7 +709,6 @@ class SettingsRecord(google.protobuf.message.Message):
 
 global___SettingsRecord = SettingsRecord
 
-@typing_extensions.final
 class SettingsItem(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -744,7 +726,6 @@ class SettingsItem(google.protobuf.message.Message):
 
 global___SettingsItem = SettingsItem
 
-@typing_extensions.final
 class HistoryStep(google.protobuf.message.Message):
     """
     HistoryRecord: wandb/sdk/wandb_history/History
@@ -763,7 +744,6 @@ class HistoryStep(google.protobuf.message.Message):
 
 global___HistoryStep = HistoryStep
 
-@typing_extensions.final
 class HistoryRecord(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -788,7 +768,6 @@ class HistoryRecord(google.protobuf.message.Message):
 
 global___HistoryRecord = HistoryRecord
 
-@typing_extensions.final
 class HistoryItem(google.protobuf.message.Message):
     """
     HistoryItem:
@@ -818,7 +797,6 @@ class HistoryItem(google.protobuf.message.Message):
 
 global___HistoryItem = HistoryItem
 
-@typing_extensions.final
 class HistoryResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -828,7 +806,6 @@ class HistoryResult(google.protobuf.message.Message):
 
 global___HistoryResult = HistoryResult
 
-@typing_extensions.final
 class OutputRecord(google.protobuf.message.Message):
     """
     OutputRecord: console output
@@ -872,7 +849,6 @@ class OutputRecord(google.protobuf.message.Message):
 
 global___OutputRecord = OutputRecord
 
-@typing_extensions.final
 class OutputResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -882,7 +858,6 @@ class OutputResult(google.protobuf.message.Message):
 
 global___OutputResult = OutputResult
 
-@typing_extensions.final
 class OutputRawRecord(google.protobuf.message.Message):
     """
     OutputRawRecord: raw console output
@@ -926,7 +901,6 @@ class OutputRawRecord(google.protobuf.message.Message):
 
 global___OutputRawRecord = OutputRawRecord
 
-@typing_extensions.final
 class OutputRawResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -936,7 +910,6 @@ class OutputRawResult(google.protobuf.message.Message):
 
 global___OutputRawResult = OutputRawResult
 
-@typing_extensions.final
 class MetricRecord(google.protobuf.message.Message):
     """
     MetricRecord: wandb/sdk/wandb_metric/Metric
@@ -1007,7 +980,6 @@ class MetricRecord(google.protobuf.message.Message):
 
 global___MetricRecord = MetricRecord
 
-@typing_extensions.final
 class MetricResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1017,7 +989,6 @@ class MetricResult(google.protobuf.message.Message):
 
 global___MetricResult = MetricResult
 
-@typing_extensions.final
 class MetricOptions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1039,7 +1010,6 @@ class MetricOptions(google.protobuf.message.Message):
 
 global___MetricOptions = MetricOptions
 
-@typing_extensions.final
 class MetricControl(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1054,7 +1024,6 @@ class MetricControl(google.protobuf.message.Message):
 
 global___MetricControl = MetricControl
 
-@typing_extensions.final
 class MetricSummary(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1090,7 +1059,6 @@ class MetricSummary(google.protobuf.message.Message):
 
 global___MetricSummary = MetricSummary
 
-@typing_extensions.final
 class ConfigRecord(google.protobuf.message.Message):
     """
     ConfigRecord: wandb/sdk/wandb_config/Config
@@ -1119,7 +1087,6 @@ class ConfigRecord(google.protobuf.message.Message):
 
 global___ConfigRecord = ConfigRecord
 
-@typing_extensions.final
 class ConfigItem(google.protobuf.message.Message):
     """
     ConfigItem:
@@ -1149,7 +1116,6 @@ class ConfigItem(google.protobuf.message.Message):
 
 global___ConfigItem = ConfigItem
 
-@typing_extensions.final
 class ConfigResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1159,7 +1125,6 @@ class ConfigResult(google.protobuf.message.Message):
 
 global___ConfigResult = ConfigResult
 
-@typing_extensions.final
 class SummaryRecord(google.protobuf.message.Message):
     """
     SummaryRecord: wandb/sdk/wandb_summary/Summary
@@ -1188,7 +1153,6 @@ class SummaryRecord(google.protobuf.message.Message):
 
 global___SummaryRecord = SummaryRecord
 
-@typing_extensions.final
 class SummaryItem(google.protobuf.message.Message):
     """
     SummaryItem:
@@ -1218,7 +1182,6 @@ class SummaryItem(google.protobuf.message.Message):
 
 global___SummaryItem = SummaryItem
 
-@typing_extensions.final
 class SummaryResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1228,7 +1191,6 @@ class SummaryResult(google.protobuf.message.Message):
 
 global___SummaryResult = SummaryResult
 
-@typing_extensions.final
 class FilesRecord(google.protobuf.message.Message):
     """Files added to a run, such as through run.save()."""
 
@@ -1251,7 +1213,6 @@ class FilesRecord(google.protobuf.message.Message):
 
 global___FilesRecord = FilesRecord
 
-@typing_extensions.final
 class FilesItem(google.protobuf.message.Message):
     """One or more files being saved with a run."""
 
@@ -1315,7 +1276,6 @@ class FilesItem(google.protobuf.message.Message):
 
 global___FilesItem = FilesItem
 
-@typing_extensions.final
 class FilesResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1325,7 +1285,6 @@ class FilesResult(google.protobuf.message.Message):
 
 global___FilesResult = FilesResult
 
-@typing_extensions.final
 class StatsRecord(google.protobuf.message.Message):
     """
     StatsRecord: system metrics
@@ -1368,7 +1327,6 @@ class StatsRecord(google.protobuf.message.Message):
 
 global___StatsRecord = StatsRecord
 
-@typing_extensions.final
 class StatsItem(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1386,7 +1344,6 @@ class StatsItem(google.protobuf.message.Message):
 
 global___StatsItem = StatsItem
 
-@typing_extensions.final
 class ArtifactRecord(google.protobuf.message.Message):
     """
     ArtifactRecord: track artifacts
@@ -1470,7 +1427,6 @@ class ArtifactRecord(google.protobuf.message.Message):
 
 global___ArtifactRecord = ArtifactRecord
 
-@typing_extensions.final
 class ArtifactManifest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1503,7 +1459,6 @@ class ArtifactManifest(google.protobuf.message.Message):
 
 global___ArtifactManifest = ArtifactManifest
 
-@typing_extensions.final
 class ArtifactManifestEntry(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1544,7 +1499,6 @@ class ArtifactManifestEntry(google.protobuf.message.Message):
 
 global___ArtifactManifestEntry = ArtifactManifestEntry
 
-@typing_extensions.final
 class ExtraItem(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1562,7 +1516,6 @@ class ExtraItem(google.protobuf.message.Message):
 
 global___ExtraItem = ExtraItem
 
-@typing_extensions.final
 class StoragePolicyConfigItem(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1580,7 +1533,6 @@ class StoragePolicyConfigItem(google.protobuf.message.Message):
 
 global___StoragePolicyConfigItem = StoragePolicyConfigItem
 
-@typing_extensions.final
 class ArtifactResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1590,7 +1542,6 @@ class ArtifactResult(google.protobuf.message.Message):
 
 global___ArtifactResult = ArtifactResult
 
-@typing_extensions.final
 class LinkArtifactResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1600,7 +1551,6 @@ class LinkArtifactResult(google.protobuf.message.Message):
 
 global___LinkArtifactResult = LinkArtifactResult
 
-@typing_extensions.final
 class LinkArtifactRequest(google.protobuf.message.Message):
     """
     LinkArtifactRequest: link artifact to portfolio
@@ -1643,7 +1593,6 @@ class LinkArtifactRequest(google.protobuf.message.Message):
 
 global___LinkArtifactRequest = LinkArtifactRequest
 
-@typing_extensions.final
 class LinkArtifactResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1663,7 +1612,6 @@ class LinkArtifactResponse(google.protobuf.message.Message):
 
 global___LinkArtifactResponse = LinkArtifactResponse
 
-@typing_extensions.final
 class TBRecord(google.protobuf.message.Message):
     """Indicates a directory of TensorBoard tfevents files to sync with the run."""
 
@@ -1717,7 +1665,6 @@ class TBRecord(google.protobuf.message.Message):
 
 global___TBRecord = TBRecord
 
-@typing_extensions.final
 class TBResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1727,7 +1674,6 @@ class TBResult(google.protobuf.message.Message):
 
 global___TBResult = TBResult
 
-@typing_extensions.final
 class AlertRecord(google.protobuf.message.Message):
     """
     AlertRecord: store alert notifications
@@ -1760,7 +1706,6 @@ class AlertRecord(google.protobuf.message.Message):
 
 global___AlertRecord = AlertRecord
 
-@typing_extensions.final
 class AlertResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -1770,7 +1715,6 @@ class AlertResult(google.protobuf.message.Message):
 
 global___AlertResult = AlertResult
 
-@typing_extensions.final
 class Request(google.protobuf.message.Message):
     """***********************
     Requests and Responses
@@ -1946,7 +1890,6 @@ class Request(google.protobuf.message.Message):
 
 global___Request = Request
 
-@typing_extensions.final
 class Response(google.protobuf.message.Message):
     """
     Response: all non persistent responses to Requests
@@ -2068,7 +2011,6 @@ class Response(google.protobuf.message.Message):
 
 global___Response = Response
 
-@typing_extensions.final
 class DeferRequest(google.protobuf.message.Message):
     """
     DeferRequest: internal message to defer work
@@ -2127,7 +2069,6 @@ class DeferRequest(google.protobuf.message.Message):
 
 global___DeferRequest = DeferRequest
 
-@typing_extensions.final
 class PauseRequest(google.protobuf.message.Message):
     """
     PauseRequest: internal message to pause the heartbeat
@@ -2148,7 +2089,6 @@ class PauseRequest(google.protobuf.message.Message):
 
 global___PauseRequest = PauseRequest
 
-@typing_extensions.final
 class PauseResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2158,7 +2098,6 @@ class PauseResponse(google.protobuf.message.Message):
 
 global___PauseResponse = PauseResponse
 
-@typing_extensions.final
 class ResumeRequest(google.protobuf.message.Message):
     """
     ResumeRequest: internal message to resume the heartbeat
@@ -2179,7 +2118,6 @@ class ResumeRequest(google.protobuf.message.Message):
 
 global___ResumeRequest = ResumeRequest
 
-@typing_extensions.final
 class ResumeResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2189,7 +2127,6 @@ class ResumeResponse(google.protobuf.message.Message):
 
 global___ResumeResponse = ResumeResponse
 
-@typing_extensions.final
 class LoginRequest(google.protobuf.message.Message):
     """Old request, no longer used for logging in (if it ever was)."""
 
@@ -2211,7 +2148,6 @@ class LoginRequest(google.protobuf.message.Message):
 
 global___LoginRequest = LoginRequest
 
-@typing_extensions.final
 class LoginResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2226,7 +2162,6 @@ class LoginResponse(google.protobuf.message.Message):
 
 global___LoginResponse = LoginResponse
 
-@typing_extensions.final
 class GetSummaryRequest(google.protobuf.message.Message):
     """
     GetSummaryRequest: request consolidated summary
@@ -2247,7 +2182,6 @@ class GetSummaryRequest(google.protobuf.message.Message):
 
 global___GetSummaryRequest = GetSummaryRequest
 
-@typing_extensions.final
 class GetSummaryResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2263,7 +2197,6 @@ class GetSummaryResponse(google.protobuf.message.Message):
 
 global___GetSummaryResponse = GetSummaryResponse
 
-@typing_extensions.final
 class GetSystemMetricsRequest(google.protobuf.message.Message):
     """
     GetSystemMetrics: request system metrics
@@ -2284,7 +2217,6 @@ class GetSystemMetricsRequest(google.protobuf.message.Message):
 
 global___GetSystemMetricsRequest = GetSystemMetricsRequest
 
-@typing_extensions.final
 class SystemMetricSample(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2304,7 +2236,6 @@ class SystemMetricSample(google.protobuf.message.Message):
 
 global___SystemMetricSample = SystemMetricSample
 
-@typing_extensions.final
 class SystemMetricsBuffer(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2320,11 +2251,9 @@ class SystemMetricsBuffer(google.protobuf.message.Message):
 
 global___SystemMetricsBuffer = SystemMetricsBuffer
 
-@typing_extensions.final
 class GetSystemMetricsResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class SystemMetricsEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2354,7 +2283,6 @@ class GetSystemMetricsResponse(google.protobuf.message.Message):
 
 global___GetSystemMetricsResponse = GetSystemMetricsResponse
 
-@typing_extensions.final
 class StatusRequest(google.protobuf.message.Message):
     """
     StatusRequest:
@@ -2375,7 +2303,6 @@ class StatusRequest(google.protobuf.message.Message):
 
 global___StatusRequest = StatusRequest
 
-@typing_extensions.final
 class StatusResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2390,7 +2317,6 @@ class StatusResponse(google.protobuf.message.Message):
 
 global___StatusResponse = StatusResponse
 
-@typing_extensions.final
 class StopStatusRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2407,7 +2333,6 @@ class StopStatusRequest(google.protobuf.message.Message):
 
 global___StopStatusRequest = StopStatusRequest
 
-@typing_extensions.final
 class StopStatusResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2422,7 +2347,6 @@ class StopStatusResponse(google.protobuf.message.Message):
 
 global___StopStatusResponse = StopStatusResponse
 
-@typing_extensions.final
 class NetworkStatusRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2439,7 +2363,6 @@ class NetworkStatusRequest(google.protobuf.message.Message):
 
 global___NetworkStatusRequest = NetworkStatusRequest
 
-@typing_extensions.final
 class NetworkStatusResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2455,7 +2378,6 @@ class NetworkStatusResponse(google.protobuf.message.Message):
 
 global___NetworkStatusResponse = NetworkStatusResponse
 
-@typing_extensions.final
 class HttpResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2473,7 +2395,6 @@ class HttpResponse(google.protobuf.message.Message):
 
 global___HttpResponse = HttpResponse
 
-@typing_extensions.final
 class InternalMessagesRequest(google.protobuf.message.Message):
     """
     InternalMessagesRequest:
@@ -2494,7 +2415,6 @@ class InternalMessagesRequest(google.protobuf.message.Message):
 
 global___InternalMessagesRequest = InternalMessagesRequest
 
-@typing_extensions.final
 class InternalMessagesResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2511,7 +2431,6 @@ class InternalMessagesResponse(google.protobuf.message.Message):
 
 global___InternalMessagesResponse = InternalMessagesResponse
 
-@typing_extensions.final
 class InternalMessages(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2527,7 +2446,6 @@ class InternalMessages(google.protobuf.message.Message):
 
 global___InternalMessages = InternalMessages
 
-@typing_extensions.final
 class PollExitRequest(google.protobuf.message.Message):
     """
     PollExitRequest:
@@ -2548,7 +2466,6 @@ class PollExitRequest(google.protobuf.message.Message):
 
 global___PollExitRequest = PollExitRequest
 
-@typing_extensions.final
 class PollExitResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2580,7 +2497,6 @@ class PollExitResponse(google.protobuf.message.Message):
 
 global___PollExitResponse = PollExitResponse
 
-@typing_extensions.final
 class OperationStatsRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2597,7 +2513,6 @@ class OperationStatsRequest(google.protobuf.message.Message):
 
 global___OperationStatsRequest = OperationStatsRequest
 
-@typing_extensions.final
 class OperationStatsResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2614,7 +2529,6 @@ class OperationStatsResponse(google.protobuf.message.Message):
 
 global___OperationStatsResponse = OperationStatsResponse
 
-@typing_extensions.final
 class OperationStats(google.protobuf.message.Message):
     """Information about ongoing operations in the internal process.
 
@@ -2670,7 +2584,6 @@ class OperationStats(google.protobuf.message.Message):
 
 global___OperationStats = OperationStats
 
-@typing_extensions.final
 class Operation(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2723,7 +2636,6 @@ class Operation(google.protobuf.message.Message):
 
 global___Operation = Operation
 
-@typing_extensions.final
 class SenderMarkRequest(google.protobuf.message.Message):
     """
     Sender requests
@@ -2737,7 +2649,6 @@ class SenderMarkRequest(google.protobuf.message.Message):
 
 global___SenderMarkRequest = SenderMarkRequest
 
-@typing_extensions.final
 class SyncFinishRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2747,7 +2658,6 @@ class SyncFinishRequest(google.protobuf.message.Message):
 
 global___SyncFinishRequest = SyncFinishRequest
 
-@typing_extensions.final
 class SyncResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2767,7 +2677,6 @@ class SyncResponse(google.protobuf.message.Message):
 
 global___SyncResponse = SyncResponse
 
-@typing_extensions.final
 class SenderReadRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2788,7 +2697,6 @@ class SenderReadRequest(google.protobuf.message.Message):
 
 global___SenderReadRequest = SenderReadRequest
 
-@typing_extensions.final
 class StatusReportRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2811,7 +2719,6 @@ class StatusReportRequest(google.protobuf.message.Message):
 
 global___StatusReportRequest = StatusReportRequest
 
-@typing_extensions.final
 class SummaryRecordRequest(google.protobuf.message.Message):
     """
     Requests wrapping Records
@@ -2832,7 +2739,6 @@ class SummaryRecordRequest(google.protobuf.message.Message):
 
 global___SummaryRecordRequest = SummaryRecordRequest
 
-@typing_extensions.final
 class TelemetryRecordRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2849,7 +2755,6 @@ class TelemetryRecordRequest(google.protobuf.message.Message):
 
 global___TelemetryRecordRequest = TelemetryRecordRequest
 
-@typing_extensions.final
 class ServerInfoRequest(google.protobuf.message.Message):
     """
     ServerInfoRequest:
@@ -2870,7 +2775,6 @@ class ServerInfoRequest(google.protobuf.message.Message):
 
 global___ServerInfoRequest = ServerInfoRequest
 
-@typing_extensions.final
 class ServerInfoResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2891,7 +2795,6 @@ class ServerInfoResponse(google.protobuf.message.Message):
 
 global___ServerInfoResponse = ServerInfoResponse
 
-@typing_extensions.final
 class ServerMessages(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2907,7 +2810,6 @@ class ServerMessages(google.protobuf.message.Message):
 
 global___ServerMessages = ServerMessages
 
-@typing_extensions.final
 class ServerMessage(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2934,7 +2836,6 @@ class ServerMessage(google.protobuf.message.Message):
 
 global___ServerMessage = ServerMessage
 
-@typing_extensions.final
 class FileCounts(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2958,7 +2859,6 @@ class FileCounts(google.protobuf.message.Message):
 
 global___FileCounts = FileCounts
 
-@typing_extensions.final
 class FilePusherStats(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2979,7 +2879,6 @@ class FilePusherStats(google.protobuf.message.Message):
 
 global___FilePusherStats = FilePusherStats
 
-@typing_extensions.final
 class FilesUploaded(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -2995,7 +2894,6 @@ class FilesUploaded(google.protobuf.message.Message):
 
 global___FilesUploaded = FilesUploaded
 
-@typing_extensions.final
 class FileTransferInfoRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3040,7 +2938,6 @@ class FileTransferInfoRequest(google.protobuf.message.Message):
 
 global___FileTransferInfoRequest = FileTransferInfoRequest
 
-@typing_extensions.final
 class LocalInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3058,7 +2955,6 @@ class LocalInfo(google.protobuf.message.Message):
 
 global___LocalInfo = LocalInfo
 
-@typing_extensions.final
 class ShutdownRequest(google.protobuf.message.Message):
     """
     ShutdownRequest:
@@ -3079,7 +2975,6 @@ class ShutdownRequest(google.protobuf.message.Message):
 
 global___ShutdownRequest = ShutdownRequest
 
-@typing_extensions.final
 class ShutdownResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3089,7 +2984,6 @@ class ShutdownResponse(google.protobuf.message.Message):
 
 global___ShutdownResponse = ShutdownResponse
 
-@typing_extensions.final
 class AttachRequest(google.protobuf.message.Message):
     """
     AttachRequest:
@@ -3113,7 +3007,6 @@ class AttachRequest(google.protobuf.message.Message):
 
 global___AttachRequest = AttachRequest
 
-@typing_extensions.final
 class AttachResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3134,7 +3027,6 @@ class AttachResponse(google.protobuf.message.Message):
 
 global___AttachResponse = AttachResponse
 
-@typing_extensions.final
 class TestInjectRequest(google.protobuf.message.Message):
     """
     TestInjectRequest:
@@ -3197,7 +3089,6 @@ class TestInjectRequest(google.protobuf.message.Message):
 
 global___TestInjectRequest = TestInjectRequest
 
-@typing_extensions.final
 class TestInjectResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3207,7 +3098,6 @@ class TestInjectResponse(google.protobuf.message.Message):
 
 global___TestInjectResponse = TestInjectResponse
 
-@typing_extensions.final
 class HistoryAction(google.protobuf.message.Message):
     """
     PartialHistoryRequest:
@@ -3226,7 +3116,6 @@ class HistoryAction(google.protobuf.message.Message):
 
 global___HistoryAction = HistoryAction
 
-@typing_extensions.final
 class PartialHistoryRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3255,7 +3144,6 @@ class PartialHistoryRequest(google.protobuf.message.Message):
 
 global___PartialHistoryRequest = PartialHistoryRequest
 
-@typing_extensions.final
 class PartialHistoryResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3265,7 +3153,6 @@ class PartialHistoryResponse(google.protobuf.message.Message):
 
 global___PartialHistoryResponse = PartialHistoryResponse
 
-@typing_extensions.final
 class SampledHistoryRequest(google.protobuf.message.Message):
     """
     SampledHistoryRequest:
@@ -3286,7 +3173,6 @@ class SampledHistoryRequest(google.protobuf.message.Message):
 
 global___SampledHistoryRequest = SampledHistoryRequest
 
-@typing_extensions.final
 class SampledHistoryItem(google.protobuf.message.Message):
     """
     SampledHistoryItem:
@@ -3321,7 +3207,6 @@ class SampledHistoryItem(google.protobuf.message.Message):
 
 global___SampledHistoryItem = SampledHistoryItem
 
-@typing_extensions.final
 class SampledHistoryResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3337,7 +3222,6 @@ class SampledHistoryResponse(google.protobuf.message.Message):
 
 global___SampledHistoryResponse = SampledHistoryResponse
 
-@typing_extensions.final
 class RunStatusRequest(google.protobuf.message.Message):
     """
     RunStatusRequest:
@@ -3358,7 +3242,6 @@ class RunStatusRequest(google.protobuf.message.Message):
 
 global___RunStatusRequest = RunStatusRequest
 
-@typing_extensions.final
 class RunStatusResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3385,7 +3268,6 @@ class RunStatusResponse(google.protobuf.message.Message):
 
 global___RunStatusResponse = RunStatusResponse
 
-@typing_extensions.final
 class RunStartRequest(google.protobuf.message.Message):
     """
     RunStartRequest: start the run
@@ -3410,7 +3292,6 @@ class RunStartRequest(google.protobuf.message.Message):
 
 global___RunStartRequest = RunStartRequest
 
-@typing_extensions.final
 class RunStartResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3420,7 +3301,6 @@ class RunStartResponse(google.protobuf.message.Message):
 
 global___RunStartResponse = RunStartResponse
 
-@typing_extensions.final
 class RunFinishWithoutExitRequest(google.protobuf.message.Message):
     """
     RunFinishWithoutExitRequest: finish the run without updating the exit status on the server
@@ -3441,7 +3321,6 @@ class RunFinishWithoutExitRequest(google.protobuf.message.Message):
 
 global___RunFinishWithoutExitRequest = RunFinishWithoutExitRequest
 
-@typing_extensions.final
 class RunFinishWithoutExitResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3451,7 +3330,6 @@ class RunFinishWithoutExitResponse(google.protobuf.message.Message):
 
 global___RunFinishWithoutExitResponse = RunFinishWithoutExitResponse
 
-@typing_extensions.final
 class CheckVersionRequest(google.protobuf.message.Message):
     """
     CheckVersion:
@@ -3475,7 +3353,6 @@ class CheckVersionRequest(google.protobuf.message.Message):
 
 global___CheckVersionRequest = CheckVersionRequest
 
-@typing_extensions.final
 class CheckVersionResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3496,7 +3373,6 @@ class CheckVersionResponse(google.protobuf.message.Message):
 
 global___CheckVersionResponse = CheckVersionResponse
 
-@typing_extensions.final
 class JobInfoRequest(google.protobuf.message.Message):
     """
     JobInfo:
@@ -3517,7 +3393,6 @@ class JobInfoRequest(google.protobuf.message.Message):
 
 global___JobInfoRequest = JobInfoRequest
 
-@typing_extensions.final
 class JobInfoResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3535,7 +3410,6 @@ class JobInfoResponse(google.protobuf.message.Message):
 
 global___JobInfoResponse = JobInfoResponse
 
-@typing_extensions.final
 class LogArtifactRequest(google.protobuf.message.Message):
     """
     LogArtifact:
@@ -3566,7 +3440,6 @@ class LogArtifactRequest(google.protobuf.message.Message):
 
 global___LogArtifactRequest = LogArtifactRequest
 
-@typing_extensions.final
 class LogArtifactResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3584,7 +3457,6 @@ class LogArtifactResponse(google.protobuf.message.Message):
 
 global___LogArtifactResponse = LogArtifactResponse
 
-@typing_extensions.final
 class DownloadArtifactRequest(google.protobuf.message.Message):
     """
     DownloadArtifact:
@@ -3620,7 +3492,6 @@ class DownloadArtifactRequest(google.protobuf.message.Message):
 
 global___DownloadArtifactRequest = DownloadArtifactRequest
 
-@typing_extensions.final
 class DownloadArtifactResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3635,7 +3506,6 @@ class DownloadArtifactResponse(google.protobuf.message.Message):
 
 global___DownloadArtifactResponse = DownloadArtifactResponse
 
-@typing_extensions.final
 class KeepaliveRequest(google.protobuf.message.Message):
     """
     Keepalive:
@@ -3656,7 +3526,6 @@ class KeepaliveRequest(google.protobuf.message.Message):
 
 global___KeepaliveRequest = KeepaliveRequest
 
-@typing_extensions.final
 class KeepaliveResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3666,7 +3535,6 @@ class KeepaliveResponse(google.protobuf.message.Message):
 
 global___KeepaliveResponse = KeepaliveResponse
 
-@typing_extensions.final
 class ArtifactInfo(google.protobuf.message.Message):
     """
     Job info specific for Partial -> Job upgrade
@@ -3698,7 +3566,6 @@ class ArtifactInfo(google.protobuf.message.Message):
 
 global___ArtifactInfo = ArtifactInfo
 
-@typing_extensions.final
 class GitInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3716,7 +3583,6 @@ class GitInfo(google.protobuf.message.Message):
 
 global___GitInfo = GitInfo
 
-@typing_extensions.final
 class GitSource(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3746,7 +3612,6 @@ class GitSource(google.protobuf.message.Message):
 
 global___GitSource = GitSource
 
-@typing_extensions.final
 class ImageSource(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3761,7 +3626,6 @@ class ImageSource(google.protobuf.message.Message):
 
 global___ImageSource = ImageSource
 
-@typing_extensions.final
 class Source(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3786,7 +3650,6 @@ class Source(google.protobuf.message.Message):
 
 global___Source = Source
 
-@typing_extensions.final
 class JobSource(google.protobuf.message.Message):
     """
     Mirrors JobSourceDict:
@@ -3816,7 +3679,6 @@ class JobSource(google.protobuf.message.Message):
 
 global___JobSource = JobSource
 
-@typing_extensions.final
 class PartialJobArtifact(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3836,7 +3698,6 @@ class PartialJobArtifact(google.protobuf.message.Message):
 
 global___PartialJobArtifact = PartialJobArtifact
 
-@typing_extensions.final
 class UseArtifactRecord(google.protobuf.message.Message):
     """
     UseArtifact:
@@ -3870,7 +3731,6 @@ class UseArtifactRecord(google.protobuf.message.Message):
 
 global___UseArtifactRecord = UseArtifactRecord
 
-@typing_extensions.final
 class UseArtifactResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3880,7 +3740,6 @@ class UseArtifactResult(google.protobuf.message.Message):
 
 global___UseArtifactResult = UseArtifactResult
 
-@typing_extensions.final
 class CancelRequest(google.protobuf.message.Message):
     """
     Cancel:
@@ -3905,7 +3764,6 @@ class CancelRequest(google.protobuf.message.Message):
 
 global___CancelRequest = CancelRequest
 
-@typing_extensions.final
 class CancelResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3915,7 +3773,6 @@ class CancelResponse(google.protobuf.message.Message):
 
 global___CancelResponse = CancelResponse
 
-@typing_extensions.final
 class ProbeSystemInfoRequest(google.protobuf.message.Message):
     """
     Run environment including system, hardware, software, and execution parameters.
@@ -3929,7 +3786,6 @@ class ProbeSystemInfoRequest(google.protobuf.message.Message):
 
 global___ProbeSystemInfoRequest = ProbeSystemInfoRequest
 
-@typing_extensions.final
 class DiskInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3947,7 +3803,6 @@ class DiskInfo(google.protobuf.message.Message):
 
 global___DiskInfo = DiskInfo
 
-@typing_extensions.final
 class MemoryInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3962,7 +3817,6 @@ class MemoryInfo(google.protobuf.message.Message):
 
 global___MemoryInfo = MemoryInfo
 
-@typing_extensions.final
 class CpuInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -3980,7 +3834,6 @@ class CpuInfo(google.protobuf.message.Message):
 
 global___CpuInfo = CpuInfo
 
-@typing_extensions.final
 class AppleInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4013,7 +3866,6 @@ class AppleInfo(google.protobuf.message.Message):
 
 global___AppleInfo = AppleInfo
 
-@typing_extensions.final
 class GpuNvidiaInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4040,7 +3892,6 @@ class GpuNvidiaInfo(google.protobuf.message.Message):
 
 global___GpuNvidiaInfo = GpuNvidiaInfo
 
-@typing_extensions.final
 class GpuAmdInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4091,7 +3942,6 @@ class GpuAmdInfo(google.protobuf.message.Message):
 
 global___GpuAmdInfo = GpuAmdInfo
 
-@typing_extensions.final
 class TrainiumInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4115,7 +3965,6 @@ class TrainiumInfo(google.protobuf.message.Message):
 
 global___TrainiumInfo = TrainiumInfo
 
-@typing_extensions.final
 class TPUInfo(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4139,7 +3988,6 @@ class TPUInfo(google.protobuf.message.Message):
 
 global___TPUInfo = TPUInfo
 
-@typing_extensions.final
 class CoreWeaveInfo(google.protobuf.message.Message):
     """CoreWeaveInfo stores information about a CoreWeave compute environment."""
 
@@ -4162,7 +4010,6 @@ class CoreWeaveInfo(google.protobuf.message.Message):
 
 global___CoreWeaveInfo = CoreWeaveInfo
 
-@typing_extensions.final
 class EnvironmentRecord(google.protobuf.message.Message):
     """EnvironmentRecord stores a snapshot of the system, hardware, software,
     and execution parameters captured at a run writer initialization.
@@ -4182,7 +4029,6 @@ class EnvironmentRecord(google.protobuf.message.Message):
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class DiskEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4200,7 +4046,6 @@ class EnvironmentRecord(google.protobuf.message.Message):
         def HasField(self, field_name: typing_extensions.Literal["value", b"value"]) -> builtins.bool: ...
         def ClearField(self, field_name: typing_extensions.Literal["key", b"key", "value", b"value"]) -> None: ...
 
-    @typing_extensions.final
     class SlurmEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4370,11 +4215,9 @@ class EnvironmentRecord(google.protobuf.message.Message):
 
 global___EnvironmentRecord = EnvironmentRecord
 
-@typing_extensions.final
 class PythonPackagesRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class PythonPackage(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4402,7 +4245,6 @@ class PythonPackagesRequest(google.protobuf.message.Message):
 
 global___PythonPackagesRequest = PythonPackagesRequest
 
-@typing_extensions.final
 class JobInputPath(google.protobuf.message.Message):
     """Path within nested configuration object.
 
@@ -4426,7 +4268,6 @@ class JobInputPath(google.protobuf.message.Message):
 
 global___JobInputPath = JobInputPath
 
-@typing_extensions.final
 class JobInputSource(google.protobuf.message.Message):
     """Specifies a source for job inputs.
 
@@ -4437,7 +4278,6 @@ class JobInputSource(google.protobuf.message.Message):
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class RunConfigSource(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4445,7 +4285,6 @@ class JobInputSource(google.protobuf.message.Message):
             self,
         ) -> None: ...
 
-    @typing_extensions.final
     class ConfigFileSource(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -4476,7 +4315,6 @@ class JobInputSource(google.protobuf.message.Message):
 
 global___JobInputSource = JobInputSource
 
-@typing_extensions.final
 class JobInputRequest(google.protobuf.message.Message):
     """Specifies a new source for job inputs.
 
@@ -4516,7 +4354,6 @@ class JobInputRequest(google.protobuf.message.Message):
 
 global___JobInputRequest = JobInputRequest
 
-@typing_extensions.final
 class ServerFeatureRequest(google.protobuf.message.Message):
     """*
     A request to the backend process for the features supported by the server.
@@ -4540,7 +4377,6 @@ class ServerFeatureRequest(google.protobuf.message.Message):
 
 global___ServerFeatureRequest = ServerFeatureRequest
 
-@typing_extensions.final
 class ServerFeatureResponse(google.protobuf.message.Message):
     """*
     A response to a ServerFeatureRequest with the status of each requested feature.
@@ -4561,7 +4397,6 @@ class ServerFeatureResponse(google.protobuf.message.Message):
 
 global___ServerFeatureResponse = ServerFeatureResponse
 
-@typing_extensions.final
 class ServerFeatureItem(google.protobuf.message.Message):
     """*
     The feature details to be requested in a ServerFeatureRequest.

--- a/wandb/proto/v3/wandb_server_pb2.pyi
+++ b/wandb/proto/v3/wandb_server_pb2.pyi
@@ -19,7 +19,6 @@ else:
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 
-@typing_extensions.final
 class ServerAuthenticateRequest(google.protobuf.message.Message):
     """Authentication messages.
 
@@ -51,7 +50,6 @@ class ServerAuthenticateRequest(google.protobuf.message.Message):
 
 global___ServerAuthenticateRequest = ServerAuthenticateRequest
 
-@typing_extensions.final
 class ServerAuthenticateResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -74,7 +72,6 @@ class ServerAuthenticateResponse(google.protobuf.message.Message):
 
 global___ServerAuthenticateResponse = ServerAuthenticateResponse
 
-@typing_extensions.final
 class ServerShutdownRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -91,7 +88,6 @@ class ServerShutdownRequest(google.protobuf.message.Message):
 
 global___ServerShutdownRequest = ServerShutdownRequest
 
-@typing_extensions.final
 class ServerShutdownResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -101,7 +97,6 @@ class ServerShutdownResponse(google.protobuf.message.Message):
 
 global___ServerShutdownResponse = ServerShutdownResponse
 
-@typing_extensions.final
 class ServerStatusRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -118,7 +113,6 @@ class ServerStatusRequest(google.protobuf.message.Message):
 
 global___ServerStatusRequest = ServerStatusRequest
 
-@typing_extensions.final
 class ServerStatusResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -128,7 +122,6 @@ class ServerStatusResponse(google.protobuf.message.Message):
 
 global___ServerStatusResponse = ServerStatusResponse
 
-@typing_extensions.final
 class ServerInformInitRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -149,7 +142,6 @@ class ServerInformInitRequest(google.protobuf.message.Message):
 
 global___ServerInformInitRequest = ServerInformInitRequest
 
-@typing_extensions.final
 class ServerInformInitResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -159,7 +151,6 @@ class ServerInformInitResponse(google.protobuf.message.Message):
 
 global___ServerInformInitResponse = ServerInformInitResponse
 
-@typing_extensions.final
 class ServerInformFinishRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -176,7 +167,6 @@ class ServerInformFinishRequest(google.protobuf.message.Message):
 
 global___ServerInformFinishRequest = ServerInformFinishRequest
 
-@typing_extensions.final
 class ServerInformFinishResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -186,7 +176,6 @@ class ServerInformFinishResponse(google.protobuf.message.Message):
 
 global___ServerInformFinishResponse = ServerInformFinishResponse
 
-@typing_extensions.final
 class ServerInformAttachRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -203,7 +192,6 @@ class ServerInformAttachRequest(google.protobuf.message.Message):
 
 global___ServerInformAttachRequest = ServerInformAttachRequest
 
-@typing_extensions.final
 class ServerInformAttachResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -224,7 +212,6 @@ class ServerInformAttachResponse(google.protobuf.message.Message):
 
 global___ServerInformAttachResponse = ServerInformAttachResponse
 
-@typing_extensions.final
 class ServerInformDetachRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -241,7 +228,6 @@ class ServerInformDetachRequest(google.protobuf.message.Message):
 
 global___ServerInformDetachRequest = ServerInformDetachRequest
 
-@typing_extensions.final
 class ServerInformDetachResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -251,7 +237,6 @@ class ServerInformDetachResponse(google.protobuf.message.Message):
 
 global___ServerInformDetachResponse = ServerInformDetachResponse
 
-@typing_extensions.final
 class ServerInformTeardownRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -271,7 +256,6 @@ class ServerInformTeardownRequest(google.protobuf.message.Message):
 
 global___ServerInformTeardownRequest = ServerInformTeardownRequest
 
-@typing_extensions.final
 class ServerInformTeardownResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -281,7 +265,6 @@ class ServerInformTeardownResponse(google.protobuf.message.Message):
 
 global___ServerInformTeardownResponse = ServerInformTeardownResponse
 
-@typing_extensions.final
 class ServerCancelRequest(google.protobuf.message.Message):
     """Cancels a previously sent ServerRequest.
 
@@ -303,7 +286,6 @@ class ServerCancelRequest(google.protobuf.message.Message):
 
 global___ServerCancelRequest = ServerCancelRequest
 
-@typing_extensions.final
 class ServerRequest(google.protobuf.message.Message):
     """
     ServerRequest, ServerResponse: used in sock server
@@ -388,7 +370,6 @@ class ServerRequest(google.protobuf.message.Message):
 
 global___ServerRequest = ServerRequest
 
-@typing_extensions.final
 class ServerResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 

--- a/wandb/proto/v3/wandb_settings_pb2.pyi
+++ b/wandb/proto/v3/wandb_settings_pb2.pyi
@@ -17,7 +17,6 @@ else:
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 
-@typing_extensions.final
 class ListStringValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -33,7 +32,6 @@ class ListStringValue(google.protobuf.message.Message):
 
 global___ListStringValue = ListStringValue
 
-@typing_extensions.final
 class ListIntValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -49,11 +47,9 @@ class ListIntValue(google.protobuf.message.Message):
 
 global___ListIntValue = ListIntValue
 
-@typing_extensions.final
 class MapStringKeyStringValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class ValueEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -81,11 +77,9 @@ class MapStringKeyStringValue(google.protobuf.message.Message):
 
 global___MapStringKeyStringValue = MapStringKeyStringValue
 
-@typing_extensions.final
 class MapStringKeyMapStringKeyStringValue(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class ValueEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -115,7 +109,6 @@ class MapStringKeyMapStringKeyStringValue(google.protobuf.message.Message):
 
 global___MapStringKeyMapStringKeyStringValue = MapStringKeyMapStringKeyStringValue
 
-@typing_extensions.final
 class OpenMetricsFilters(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -137,7 +130,6 @@ class OpenMetricsFilters(google.protobuf.message.Message):
 
 global___OpenMetricsFilters = OpenMetricsFilters
 
-@typing_extensions.final
 class RunMoment(google.protobuf.message.Message):
     """A point in a run from which another run can be branched."""
 
@@ -163,7 +155,6 @@ class RunMoment(google.protobuf.message.Message):
 
 global___RunMoment = RunMoment
 
-@typing_extensions.final
 class Settings(google.protobuf.message.Message):
     """Settings for the SDK.
 

--- a/wandb/proto/v3/wandb_sync_pb2.pyi
+++ b/wandb/proto/v3/wandb_sync_pb2.pyi
@@ -20,7 +20,6 @@ else:
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 
-@typing_extensions.final
 class ServerInitSyncRequest(google.protobuf.message.Message):
     """Prepares a sync operation to replay one or more .wandb files.
 
@@ -30,7 +29,6 @@ class ServerInitSyncRequest(google.protobuf.message.Message):
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing_extensions.final
     class TagReplacementsEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -104,7 +102,6 @@ class ServerInitSyncRequest(google.protobuf.message.Message):
 
 global___ServerInitSyncRequest = ServerInitSyncRequest
 
-@typing_extensions.final
 class ServerInitSyncResponse(google.protobuf.message.Message):
     """Indicates a sync operation is ready."""
 
@@ -122,7 +119,6 @@ class ServerInitSyncResponse(google.protobuf.message.Message):
 
 global___ServerInitSyncResponse = ServerInitSyncResponse
 
-@typing_extensions.final
 class ServerSyncRequest(google.protobuf.message.Message):
     """Begins a sync operation created by ServerInitSyncRequest.
 
@@ -151,7 +147,6 @@ class ServerSyncRequest(google.protobuf.message.Message):
 
 global___ServerSyncRequest = ServerSyncRequest
 
-@typing_extensions.final
 class ServerSyncResponse(google.protobuf.message.Message):
     """Indicates a sync operation completed, either successfully or with errors."""
 
@@ -170,7 +165,6 @@ class ServerSyncResponse(google.protobuf.message.Message):
 
 global___ServerSyncResponse = ServerSyncResponse
 
-@typing_extensions.final
 class ServerSyncStatusRequest(google.protobuf.message.Message):
     """Checks the status of an ongoing sync operation."""
 
@@ -188,7 +182,6 @@ class ServerSyncStatusRequest(google.protobuf.message.Message):
 
 global___ServerSyncStatusRequest = ServerSyncStatusRequest
 
-@typing_extensions.final
 class ServerSyncStatusResponse(google.protobuf.message.Message):
     """The status of a sync operation."""
 
@@ -214,7 +207,6 @@ class ServerSyncStatusResponse(google.protobuf.message.Message):
 
 global___ServerSyncStatusResponse = ServerSyncStatusResponse
 
-@typing_extensions.final
 class ServerSyncMessage(google.protobuf.message.Message):
     """ServerSyncMessage is a console message generated during a sync operation."""
 

--- a/wandb/proto/v3/wandb_telemetry_pb2.pyi
+++ b/wandb/proto/v3/wandb_telemetry_pb2.pyi
@@ -15,7 +15,6 @@ else:
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 
-@typing_extensions.final
 class TelemetryRecord(google.protobuf.message.Message):
     """
     Telemetry
@@ -80,7 +79,6 @@ class TelemetryRecord(google.protobuf.message.Message):
 
 global___TelemetryRecord = TelemetryRecord
 
-@typing_extensions.final
 class TelemetryResult(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -90,7 +88,6 @@ class TelemetryResult(google.protobuf.message.Message):
 
 global___TelemetryResult = TelemetryResult
 
-@typing_extensions.final
 class Imports(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -402,7 +399,6 @@ class Imports(google.protobuf.message.Message):
 
 global___Imports = Imports
 
-@typing_extensions.final
 class Feature(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -696,7 +692,6 @@ class Feature(google.protobuf.message.Message):
 
 global___Feature = Feature
 
-@typing_extensions.final
 class Env(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -748,7 +743,6 @@ class Env(google.protobuf.message.Message):
 
 global___Env = Env
 
-@typing_extensions.final
 class Labels(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -772,7 +766,6 @@ class Labels(google.protobuf.message.Message):
 
 global___Labels = Labels
 
-@typing_extensions.final
 class Deprecated(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -888,7 +881,6 @@ class Deprecated(google.protobuf.message.Message):
 
 global___Deprecated = Deprecated
 
-@typing_extensions.final
 class Issues(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 


### PR DESCRIPTION
Fixes the session which currently breaks in the `code-check` CI job, and refactors `_generate_proto_python` to install requirements in one go instead of using multiple `pip install` commands.