### PR TITLE
security(artifacts): validate blob names to prevent path traversal in Azure downloads

### DIFF
--- a/core/internal/filetransfer/file_transfer_azure.go
+++ b/core/internal/filetransfer/file_transfer_azure.go
@@ -549,7 +549,14 @@ func (ft *AzureFileTransfer) downloadFiles(
 	for _, blobName := range blobNames {
 		g.Go(func() error {
 			objectRelativePath, _ := strings.CutPrefix(blobName, blobInfo.BlobPrefix)
-			localPath := filepath.Join(task.PathOrPrefix, filepath.FromSlash(objectRelativePath))
+			localRelPath := filepath.FromSlash(objectRelativePath)
+			if localRelPath != "" && !filepath.IsLocal(localRelPath) {
+				return fmt.Errorf(
+					"invalid blob name %q: path traversal detected",
+					blobName,
+				)
+			}
+			localPath := filepath.Join(task.PathOrPrefix, localRelPath)
 			return ft.downloadBlobToFile(blobInfo, blobName, task, localPath)
 		})
 	}


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

Description
-----------

## Path Traversal in Azure Blob Download via Untrusted Blob Names

### Location
`core/internal/filetransfer/file_transfer_azure.go:540-557`

### Description
The `downloadFiles()` function constructs local file paths from untrusted Azure blob names without validation. Blob names retrieved from Azure storage via `listBlobsWithPrefix()` could contain path traversal sequences (e.g., `../../../etc/cron.d/malicious`) that escape the intended download directory (`task.PathOrPrefix`).

An attacker with write access to an Azure storage bucket referenced by an artifact could craft blob names containing `..` components. When a victim downloads that artifact, files would be written outside the intended directory.

### Analysis Notes
The `downloadFiles()` function at line 550-551 constructs local paths by joining `task.PathOrPrefix` with `objectRelativePath` derived from blob names. The codebase already uses `filepath.IsLocal()` for the same purpose in `core/internal/tensorboard/tensorboard.go:292`. The same vulnerable pattern also exists in the S3 and GCS file transfer implementations.

### Fix Applied
Added `filepath.IsLocal()` validation on the relative path derived from blob names before constructing the local file path. If the relative path is non-empty and not local (i.e., contains `..` path traversal components), the download is rejected with a descriptive error. This matches the existing validation pattern used in `core/internal/tensorboard/tensorboard.go`.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
- `go vet ./internal/filetransfer/...` — passed, no issues
- `gofmt -d file_transfer_azure.go` — passed, no formatting changes needed
- `go test ./internal/filetransfer/... -v` — all 17 tests passed (Azure, GCS, S3, Default transfer tests)

## Contribution Notes
- PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) using the `security` type and `artifacts` scope as defined in the project's CONTRIBUTING.md
- No CHANGELOG.unreleased.md file exists in the repository; this checkbox is not applicable
- Note: The same vulnerable pattern exists in `file_transfer_s3.go:288-289` and `file_transfer_gcs.go:187-188` and should be addressed similarly