### PR TITLE
chore: record flow control telemetry

### DIFF
--- a/core/internal/runhandle/runhandle.go
+++ b/core/internal/runhandle/runhandle.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 	"sync"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/wandb/wandb/core/internal/runupserter"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
 // RunHandle contains objects that are initialized after the first RunRecord.
@@ -21,6 +24,10 @@ type RunHandle struct {
 	//
 	// It is nil before the run is initialized.
 	upserter *runupserter.RunUpserter
+
+	// unsentTelemetry is telemetry that was recorded before the run
+	// was initialized.
+	unsentTelemetry *spb.TelemetryRecord
 }
 
 func New() *RunHandle {
@@ -30,6 +37,28 @@ func New() *RunHandle {
 // Ready returns a channel that's closed after Init is called the first time.
 func (h *RunHandle) Ready() <-chan struct{} {
 	return h.ready
+}
+
+// UpdateTelemetry records updates to the run's telemetry.
+//
+// If the run is not yet initialized, the telemetry change is stored and
+// applied once the run becomes initialized.
+func (h *RunHandle) UpdateTelemetry(telemetry *spb.TelemetryRecord) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.upserter != nil {
+		h.upserter.UpdateTelemetry(telemetry)
+		return
+	}
+
+	// If the run hasn't been initialized, buffer the telemetry to send
+	// it later.
+	if h.unsentTelemetry == nil {
+		h.unsentTelemetry = &spb.TelemetryRecord{}
+	}
+
+	proto.Merge(h.unsentTelemetry, telemetry)
 }
 
 // Init sets the run upserter.
@@ -48,6 +77,11 @@ func (h *RunHandle) Init(upserter *runupserter.RunUpserter) error {
 
 	h.upserter = upserter
 	close(h.ready)
+
+	if h.unsentTelemetry != nil {
+		upserter.UpdateTelemetry(h.unsentTelemetry)
+		h.unsentTelemetry = nil // Release memory.
+	}
 
 	return nil
 }

--- a/core/internal/runhandle/runhandle_test.go
+++ b/core/internal/runhandle/runhandle_test.go
@@ -1,0 +1,65 @@
+package runhandle_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/internal/gqlmock"
+	"github.com/wandb/wandb/core/internal/runhandle"
+	"github.com/wandb/wandb/core/internal/runupserter"
+	"github.com/wandb/wandb/core/internal/runupsertertest"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// fakeTelemetryRecord returns a fake TelemetryRecord for testing.
+func fakeTelemetryRecord() *spb.TelemetryRecord {
+	return &spb.TelemetryRecord{
+		Feature: &spb.Feature{Save: true},
+	}
+}
+
+// fakeTelemetryEncoded returns the encoded version of fakeTelemetryRecord
+// that would be uploaded in an UpsertBucket request.
+func fakeTelemetryEncoded() *runupsertertest.Telemetry {
+	return &runupsertertest.Telemetry{FeatureNumbers: []int{3}} // 3 = save
+}
+
+func TestUpdateTelemetry_BeforeInit(t *testing.T) {
+	runHandle := runhandle.New()
+	mockGQL := gqlmock.NewMockClient()
+	runupsertertest.StubUpsertBucket(t, mockGQL)
+	runupsertertest.StubUpsertBucket(t, mockGQL)
+	upserter := runupsertertest.NewTestUpserter(t,
+		"test-entity", "test-project", "test-run",
+		runupserter.RunUpserterParams{
+			GraphqlClientOrNil: mockGQL,
+		})
+
+	runHandle.UpdateTelemetry(fakeTelemetryRecord())
+	require.NoError(t, runHandle.Init(upserter))
+	upserter.Finish()
+
+	telemetry := runupsertertest.UpsertBucketTelemetry(t, mockGQL.AllRequests())
+	assert.Equal(t, fakeTelemetryEncoded(), telemetry)
+}
+
+func TestUpdateTelemetry_AfterInit(t *testing.T) {
+	runHandle := runhandle.New()
+	mockGQL := gqlmock.NewMockClient()
+	runupsertertest.StubUpsertBucket(t, mockGQL)
+	runupsertertest.StubUpsertBucket(t, mockGQL)
+	upserter := runupsertertest.NewTestUpserter(t,
+		"test-entity", "test-project", "test-run",
+		runupserter.RunUpserterParams{
+			GraphqlClientOrNil: mockGQL,
+		})
+
+	require.NoError(t, runHandle.Init(upserter))
+	runHandle.UpdateTelemetry(fakeTelemetryRecord())
+	upserter.Finish()
+
+	telemetry := runupsertertest.UpsertBucketTelemetry(t, mockGQL.AllRequests())
+	assert.Equal(t, fakeTelemetryEncoded(), telemetry)
+}

--- a/core/internal/runupsertertest/runupsertertest.go
+++ b/core/internal/runupsertertest/runupsertertest.go
@@ -2,16 +2,18 @@ package runupsertertest
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/featurechecker"
+	"github.com/wandb/wandb/core/internal/gqlmock"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runupserter"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/waiting"
-	"github.com/wandb/wandb/core/internal/wboperation"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -19,8 +21,39 @@ import (
 // and makes no requests.
 func NewOfflineUpserter(t *testing.T) *runupserter.RunUpserter {
 	t.Helper()
+	return NewTestUpserter(t,
+		"test-entity", "test-project", "test-run",
+		runupserter.RunUpserterParams{},
+	)
+}
 
-	testLogger := observabilitytest.NewTestLogger(t)
+// NewTestUpserter creates a RunUpserter with test defaults for required
+// parameters that are unspecified.
+func NewTestUpserter(
+	t *testing.T,
+	entity, project, runID string,
+	params runupserter.RunUpserterParams,
+) *runupserter.RunUpserter {
+	t.Helper()
+
+	if params.DebounceDelay == nil {
+		params.DebounceDelay = waiting.NoDelay()
+	}
+	if params.ClientID == "" {
+		params.ClientID = "test-client-id"
+	}
+	if params.Settings == nil {
+		params.Settings = settings.New()
+	}
+	if params.BeforeRunEndCtx == nil {
+		params.BeforeRunEndCtx = context.Background()
+	}
+	if params.Logger == nil {
+		params.Logger = observabilitytest.NewTestLogger(t)
+	}
+	if params.FeatureProvider == nil {
+		params.FeatureProvider = featurechecker.NewServerFeaturesCache(nil, params.Logger)
+	}
 
 	record := &spb.Record{RecordType: &spb.Record_Run{
 		Run: &spb.RunRecord{
@@ -29,19 +62,90 @@ func NewOfflineUpserter(t *testing.T) *runupserter.RunUpserter {
 			RunId:   "test-run",
 		},
 	}}
-	params := runupserter.RunUpserterParams{
-		DebounceDelay:      waiting.NoDelay(),
-		ClientID:           "test-client-id",
-		Settings:           settings.New(),
-		BeforeRunEndCtx:    context.Background(),
-		Operations:         wboperation.NewOperations(),
-		FeatureProvider:    featurechecker.NewServerFeaturesCache(nil, testLogger),
-		GraphqlClientOrNil: nil,
-		Logger:             testLogger,
-	}
 
 	upserter, err := runupserter.InitRun(record, params)
 	require.NoError(t, err)
 
 	return upserter
+}
+
+// StubUpsertBucket stubs a single call to UpsertBucket to return a basic
+// response.
+func StubUpsertBucket(t *testing.T, mockGQL *gqlmock.MockClient) {
+	mockGQL.StubMatchOnce(gqlmock.WithOpName("UpsertBucket"), `{
+		"upsertBucket": {
+			"bucket": {
+				"id": "storage ID",
+				"name": "run ID",
+				"displayName": "display name",
+				"sweepName": "sweep ID",
+				"project": {
+					"name": "project name",
+					"entity": {"name": "entity name"}
+				}
+			}
+		}
+	}`)
+}
+
+// Telemetry is the telemetry uploaded through an UpsertBucket request.
+type Telemetry struct {
+	// FeatureNumbers is the list of enabled features, specified by their
+	// field numbers in the telemetry Feature proto.
+	FeatureNumbers []int `json:"3"`
+}
+
+// upsertBucketConfig is the structure of an UpsertBucket config string.
+type upsertBucketConfig struct {
+	Internal struct {
+		Value struct {
+			Telemetry *Telemetry `json:"t"`
+		}
+	} `json:"_wandb"`
+}
+
+// UpsertBucketTelemetry extracts the final telemetry uploaded by the run
+// upserter given a sequence of requests.
+func UpsertBucketTelemetry(
+	t *testing.T,
+	requests []*graphql.Request,
+) *Telemetry {
+	t.Helper()
+
+	for i := range len(requests) {
+		// Loop in reverse and take the last value.
+		idx := len(requests) - i - 1
+		request := requests[idx]
+
+		if request.OpName != "UpsertBucket" {
+			continue
+		}
+
+		input := jsonMarshalToMap(t, request.Variables)
+		config, hasConfig := input["config"]
+		if !hasConfig {
+			continue
+		}
+
+		configString := config.(string)
+		var configValue upsertBucketConfig
+		err := json.Unmarshal([]byte(configString), &configValue)
+		require.NoError(t, err)
+
+		return configValue.Internal.Value.Telemetry
+	}
+
+	return nil
+}
+
+// jsonMarshalToMap converts a value to a map by marshalling to JSON and
+// unmarshalling.
+func jsonMarshalToMap(t *testing.T, value any) (ret map[string]any) {
+	bytes, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(bytes, &ret)
+	require.NoError(t, err)
+
+	return ret
 }

--- a/core/internal/stream/flowcontrol.go
+++ b/core/internal/stream/flowcontrol.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/wire"
 
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/transactionlog"
 )
@@ -15,7 +16,8 @@ var flowControlProviders = wire.NewSet(
 )
 
 type FlowControlFactory struct {
-	Logger *observability.CoreLogger
+	Logger    *observability.CoreLogger
+	RunHandle *runhandle.RunHandle
 }
 
 // FlowControl is an infinite-buffered channel for Work.
@@ -40,7 +42,7 @@ func (f *FlowControlFactory) New(
 ) *FlowControl {
 	return &FlowControl{
 		out:    make(chan runwork.Work),
-		buffer: NewFlowControlBuffer(params, f.Logger),
+		buffer: NewFlowControlBuffer(params, f.Logger, f.RunHandle),
 		reader: reader,
 
 		flushWriter:  flushWriter,

--- a/core/internal/stream/flowcontrol_test.go
+++ b/core/internal/stream/flowcontrol_test.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/wandb/wandb/core/internal/observabilitytest"
+	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/settings"
@@ -45,7 +46,10 @@ func setup(
 	ctrl := gomock.NewController(t)
 	mockRecordParser := streamtest.NewMockRecordParser(ctrl)
 
-	flowControlFactory := &stream.FlowControlFactory{Logger: testLogger}
+	flowControlFactory := &stream.FlowControlFactory{
+		Logger:    testLogger,
+		RunHandle: runhandle.New(),
+	}
 	writerFactory := &stream.WriterFactory{
 		Logger:   testLogger,
 		Settings: settings.New(),

--- a/core/internal/stream/flowcontrolbuffer_test.go
+++ b/core/internal/stream/flowcontrolbuffer_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/wandb/wandb/core/internal/observabilitytest"
+	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/stream"
@@ -31,7 +32,7 @@ func TestUnsavedWork_HeldInMemory(t *testing.T) {
 	buf := stream.NewFlowControlBuffer(stream.FlowControlParams{
 		InMemorySize: 10,
 		Limit:        10,
-	}, observabilitytest.NewTestLogger(t))
+	}, observabilitytest.NewTestLogger(t), runhandle.New())
 
 	buf.Add(newUnsavedWork("item 1"))
 
@@ -43,7 +44,7 @@ func TestSavedWork_HeldInMemoryThenOffloaded(t *testing.T) {
 	buf := stream.NewFlowControlBuffer(stream.FlowControlParams{
 		InMemorySize: 2,
 		Limit:        10,
-	}, observabilitytest.NewTestLogger(t))
+	}, observabilitytest.NewTestLogger(t), runhandle.New())
 
 	buf.Add(newSavedWork("saved 1", 1, 10))
 	buf.Add(newSavedWork("saved 2", 2, 20))
@@ -64,7 +65,7 @@ func TestStopOffloading_PreventsOffloading(t *testing.T) {
 	buf := stream.NewFlowControlBuffer(stream.FlowControlParams{
 		InMemorySize: 0,
 		Limit:        10,
-	}, observabilitytest.NewTestLogger(t))
+	}, observabilitytest.NewTestLogger(t), runhandle.New())
 
 	buf.Add(newSavedWork("saved 1", 1, 10))
 	buf.StopOffloading()
@@ -80,7 +81,7 @@ func TestNonConsecutiveSavedWork_DifferentChunks(t *testing.T) {
 	buf := stream.NewFlowControlBuffer(stream.FlowControlParams{
 		InMemorySize: 0,
 		Limit:        10,
-	}, observabilitytest.NewTestLogger(t))
+	}, observabilitytest.NewTestLogger(t), runhandle.New())
 
 	buf.Add(newSavedWork("saved 1", 1, 10))
 	buf.Add(newSavedWork("saved 5", 5, 50))
@@ -97,7 +98,7 @@ func TestBackedUp_Offloads(t *testing.T) {
 	buf := stream.NewFlowControlBuffer(stream.FlowControlParams{
 		InMemorySize: 2,
 		Limit:        10,
-	}, observabilitytest.NewTestLogger(t))
+	}, observabilitytest.NewTestLogger(t), runhandle.New())
 
 	buf.Add(newSavedWork("saved 1", 1, 10)) // In-memory.
 	buf.Add(newSavedWork("saved 2", 2, 20)) // In-memory.
@@ -116,7 +117,7 @@ func TestBackedUp_AfterCleared_StoresInMemory(t *testing.T) {
 	buf := stream.NewFlowControlBuffer(stream.FlowControlParams{
 		InMemorySize: 2,
 		Limit:        10,
-	}, observabilitytest.NewTestLogger(t))
+	}, observabilitytest.NewTestLogger(t), runhandle.New())
 	buf.Add(newSavedWork("saved 1", 1, 10)) // In-memory.
 	buf.Add(newSavedWork("saved 2", 2, 20)) // In-memory.
 	buf.Add(newSavedWork("saved 3", 3, 20)) // Offloaded, now we're backed up.

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -38,13 +38,14 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 	peeker := &observability.Peeker{}
 	client := NewGraphQLClient(wbBaseURL, clientID, credentialProvider, coreLogger, peeker, settings2)
 	serverFeaturesCache := featurechecker.NewServerFeaturesCache(client, coreLogger)
+	runHandle := runhandle.New()
 	flowControlFactory := &FlowControlFactory{
-		Logger: coreLogger,
+		Logger:    coreLogger,
+		RunHandle: runHandle,
 	}
 	fileTransferStats := filetransfer.NewFileTransferStats()
 	mailboxMailbox := mailbox.New()
 	wandbOperations := wboperation.NewOperations()
-	runHandle := runhandle.New()
 	systemMonitorFactory := &monitor.SystemMonitorFactory{
 		Logger:             coreLogger,
 		RunHandle:          runHandle,


### PR DESCRIPTION
Reuses the old `flow_control_overflow` telemetry field to detect when flow control offloading is triggered.

Completes WB-30794.