### PR TITLE
chore: workflow to regenerate requirements_dev.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,3 @@ updates:
       interval: daily
     reviewers:
       - wandb/sdk-team
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily
-    reviewers:
-      - wandb/sdk-team

--- a/.github/workflows/regenerate-requirements.yml
+++ b/.github/workflows/regenerate-requirements.yml
@@ -1,0 +1,39 @@
+name: Regenerate Python Requirements
+
+on:
+  # Allow manual runs.
+  workflow_dispatch:
+
+  # Run weekly on Monday at 9 or 10 AM Pacific time (17:00 UTC).
+  schedule: [cron: "0 17 * * 1"]
+
+jobs:
+  regenerate-requirements:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Run requirements/generate.sh
+        run: bash requirements/generate.sh
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: regenerate-requirements
+          delete-branch: true
+          title: "chore: update Python requirements"
+          body: |
+            Applies updates from `requirements/generate.sh`.
+
+            Please approve and merge if tests pass. If tests fail due to
+            a dependency update, consider improving the tests or implementation.
+            If CI fails because of a bug in a dependency, update
+            `requirements/requirements_dev.txt` and rerun the action. Consider
+            filing a bug for the dependency.


### PR DESCRIPTION
Dependabot doesn't understand the versioning scheme used by our requirements files, so this PR adds an alternative workflow that runs weekly.

Uses the `peter-evans/create-pull-request` action. The SDK release action uses `peter-evans/repository-dispatch` to communicate with `wandb/core`.

The action will update a branch named `regenerate-requirements` each time it runs. I'm not sure who the author will be for the automated runs (it might be the last person who touched this YAML file).