### PR TITLE
fix: tensorboard stopping reading files after the first megabyte

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,3 +32,5 @@ This version drops support for Python 3.8.
 
 - Sweep agents now exit gracefully when the sweep is deleted, instead of running indefinitely with repeated 404 errors (@domphan-wandb in https://github.com/wandb/wandb/pull/11226)
 - `wandb-core` crashes no longer produce extremely long, repetitive tracebacks in older Python versions (@timoffex in https://github.com/wandb/wandb/pull/11284)
+- TensorBoard sync no longer stops after 1 MB of data (@timoffex in https://github.com/wandb/wandb/pull/11334)
+  - Regression introduced in 0.24.0

--- a/core/internal/tensorboard/tfeventreader.go
+++ b/core/internal/tensorboard/tfeventreader.go
@@ -353,7 +353,7 @@ func (s *TFEventReader) readFromCurrent(
 			ctx,
 			s.currentFile,
 			s.currentOffset,
-			int64(readSize),
+			-1, // read to end of blob
 			nil,
 		)
 


### PR DESCRIPTION
Fixes a typo that caused the TensorBoard integration to only sync the first 1 MiB of a tfevents file.

Fixes WB-31279.

Unfortunately, this wasn't caught by tests because they don't create megabytes of data. I added a new test that produces more data (and only runs in CI, not in pre-commit hooks).