### PR TITLE
chore: update requirements/generate.sh

### DIFF
--- a/requirements/generate.sh
+++ b/requirements/generate.sh
@@ -13,11 +13,12 @@ function platform_python_name() {
 
 # Compiles requirements for a Python version ($1) and platform ($2).
 function compile() {
-    uv pip compile \
+    uv pip compile --upgrade \
         --python-version "$1" \
         --python-platform "$(platform_python_name $2)" \
         requirements/requirements_dev.txt \
-        -o "requirements/requirements_dev.$1.$2.txt"
+        -o "requirements/requirements_dev.$1.$2.txt" \
+        >/dev/null  # https://github.com/astral-sh/uv/issues/3701
 }
 
 compile 3.9 darwin


### PR DESCRIPTION
Adds the `--upgrade` flag because `uv pip compile` otherwise uses the pinned versions in the output file, and reduces spam in the output.