### PR TITLE
refactor: sentry RemoveBottomFrames function

### DIFF
--- a/core/internal/sentry_ext/client_test.go
+++ b/core/internal/sentry_ext/client_test.go
@@ -3,7 +3,6 @@ package sentry_ext_test
 import (
 	"testing"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/wandb/wandb/core/internal/sentry_ext"
@@ -33,43 +32,4 @@ func TestNew(t *testing.T) {
 			assert.NotNil(t, sc, "New() should return a non-nil sentry client")
 		})
 	}
-}
-
-func TestRemoveBottomFrames(t *testing.T) {
-	// Mock event with stack trace containing frames to be removed
-	event := &sentry.Event{
-		Exception: []sentry.Exception{
-			{
-				Stacktrace: &sentry.Stacktrace{
-					Frames: []sentry.Frame{
-						{AbsPath: "/path/to/file1.go"},
-						{AbsPath: "/path/to/file2.go"},
-						{AbsPath: "/path/to/client.go"},
-						{AbsPath: "/path/to/logging.go"},
-					},
-				},
-			},
-		},
-	}
-
-	// Mock hint (not used in our function, so it can be nil)
-	hint := (*sentry.EventHint)(nil)
-
-	// Call the function under test
-	modifiedEvent := sentry_ext.RemoveBottomFrames(event, hint)
-
-	// Validate the result: The last two frames should be preserved,
-	// as well as the first non-matching frame before the last two.
-	expectedFrames := []sentry.Frame{
-		{AbsPath: "/path/to/file1.go"},
-		{AbsPath: "/path/to/file2.go"},
-	}
-
-	actualFrames := modifiedEvent.Exception[0].Stacktrace.Frames
-	assert.Equal(
-		t,
-		expectedFrames,
-		actualFrames,
-		"The bottom-most sentry.go and logging.go frames should be removed",
-	)
 }

--- a/core/internal/sentry_ext/sentrystacktrace.go
+++ b/core/internal/sentry_ext/sentrystacktrace.go
@@ -1,0 +1,56 @@
+package sentry_ext
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/getsentry/sentry-go"
+)
+
+var (
+	// coreLoggerPackage is the Go import path for the CoreLogger.
+	//
+	// Hard-coded to avoid import cycle. Correctness checked in unit test
+	// using reflection.
+	coreLoggerPackage = "github.com/wandb/wandb/core/internal/observability"
+
+	// sentryExtPackage is the Go import path for this package.
+	//
+	// Specifically, "github.com/wandb/wandb/core/internal/sentry_ext".
+	sentryExtPackage = reflect.TypeFor[Client]().PkgPath()
+)
+
+// RemoveLoggerFrames is a [sentry.EventProcessor] that strips internal
+// logging infrastructure frames from the top of each stack trace.
+//
+// For Sentry events captured via [CoreLogger.CaptureError] and similar methods,
+// the stack trace's top frame will be the caller of the logger method.
+func RemoveLoggerFrames(
+	event *sentry.Event,
+	hint *sentry.EventHint,
+) *sentry.Event {
+	for _, exception := range event.Exception {
+		if exception.Stacktrace == nil {
+			continue
+		}
+
+		// Frames are ordered caller-first (caller before callee).
+		frames := exception.Stacktrace.Frames
+		for len(frames) > 0 && shouldHideFrame(&frames[len(frames)-1]) {
+			frames = frames[:len(frames)-1]
+		}
+
+		exception.Stacktrace.Frames = frames
+	}
+
+	return event
+}
+
+// shouldHideFrame reports whether a stack frame should be hidden in Sentry.
+//
+// Accepts sentry.Frame by pointer as it is a large struct.
+func shouldHideFrame(frame *sentry.Frame) bool {
+	// Same strategy the Sentry SDK uses to filter out its own frames.
+	return strings.HasPrefix(frame.Module, coreLoggerPackage) ||
+		strings.HasPrefix(frame.Module, sentryExtPackage)
+}

--- a/core/internal/sentry_ext/sentrystacktrace_test.go
+++ b/core/internal/sentry_ext/sentrystacktrace_test.go
@@ -1,0 +1,74 @@
+package sentry_ext_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/sentry_ext"
+)
+
+// makeStacktrace creates a stacktrace with the given sequence of modules
+// as its frames.
+func makeStacktrace(modules ...string) *sentry.Stacktrace {
+	stacktrace := &sentry.Stacktrace{}
+
+	for _, module := range modules {
+		stacktrace.Frames = append(stacktrace.Frames,
+			sentry.Frame{Module: module})
+	}
+
+	return stacktrace
+}
+
+func TestRemoveLoggerFrames(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *sentry.Stacktrace
+		expected *sentry.Stacktrace
+	}{
+		{"skips nil stacktrace", nil, nil},
+
+		{
+			name: "removes trailing logger frames",
+			input: makeStacktrace(
+				"github.com/wandb/wandb/core/internal/sentry_ext",
+				"github.com/wandb/wandb/core/pkg/server",
+				"github.com/wandb/wandb/core/internal/observability",
+				"github.com/wandb/wandb/core/pkg/server",
+				"github.com/wandb/wandb/core/pkg/server",
+				"github.com/wandb/wandb/core/internal/observability",
+				reflect.TypeFor[observability.CoreLogger]().PkgPath(),
+				"github.com/wandb/wandb/core/internal/sentry_ext",
+			),
+			expected: makeStacktrace(
+				"github.com/wandb/wandb/core/internal/sentry_ext",
+				"github.com/wandb/wandb/core/pkg/server",
+				"github.com/wandb/wandb/core/internal/observability",
+				"github.com/wandb/wandb/core/pkg/server",
+				"github.com/wandb/wandb/core/pkg/server",
+			),
+		},
+	}
+
+	// Apply RemoveLoggerFrames to all stack traces in one go
+	// to test that it loops over an event's exceptions.
+	event := &sentry.Event{}
+	for _, tt := range tests {
+		event.Exception = append(event.Exception,
+			sentry.Exception{Stacktrace: tt.input})
+	}
+	result := sentry_ext.RemoveLoggerFrames(event, nil)
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t,
+				tt.expected,
+				result.Exception[i].Stacktrace,
+			)
+		})
+	}
+}


### PR DESCRIPTION
Makes `sentry_ext.RemoveBottomFrames` more robust and moves it to a separate file.

This will make the `git diff` nicer when I remove `sentry_ext` and move this to `observability`.