### PR TITLE
chore(leet): add -h help flag

### DIFF
--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -78,6 +78,7 @@ def leet(ctx: click.Context) -> None:
     hidden=True,
     help="Serve /debug/pprof/* on this address (e.g. 127.0.0.1:6060).",
 )
+@click.help_option("-h", "--help")
 def run(path: str | None = None, pprof: str = "") -> None:
     """Launch the LEET TUI.
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Adds the `-h` flag to `wandb beta leet` to display help. Right now you always have to do `wandb beta leet --help` to show the help text.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

- `wandb beta leet --help`

```bash
Usage: wandb beta leet run [OPTIONS] [PATH]

  Launch the LEET TUI.

  PATH can be a .wandb file, a run directory, or a wandb directory. If
  omitted, searches for the latest run.

Options:
  -h, --help  Show this message and exit.
```

- `wandb beta leet -h`

```bash
Usage: wandb beta leet run [OPTIONS] [PATH]

  Launch the LEET TUI.

  PATH can be a .wandb file, a run directory, or a wandb directory. If
  omitted, searches for the latest run.

Options:
  -h, --help  Show this message and exit.
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

Prior to this change

```bash
❯ wandb beta leet -h
Usage: wandb beta leet run [OPTIONS] [PATH]
Try 'wandb beta leet run --help' for help.

Error: No such option: -h
```