### PR TITLE
fix: use mutable policy in Artifact.new_file() to prevent file loss during offline sync

### DIFF
--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1434,7 +1434,7 @@ class Artifact:
             raise
 
         self.add_file(
-            path, name=name, policy="immutable", skip_cache=True, overwrite=overwrite
+            path, name=name, policy="mutable", skip_cache=True, overwrite=overwrite
         )
 
     @ensure_not_finalized


### PR DESCRIPTION
Fixes #10968

`Artifact.new_file()` creates files in a `tempfile.TemporaryDirectory` and then calls `add_file()` with `policy="immutable"`. The immutable policy tells wandb to use the file in-place without copying it. But since the file lives in a `TemporaryDirectory`, it gets deleted when the directory is garbage collected (e.g. when the program exits).

This means `wandb sync --sync-all` in offline mode can't find the file and fails with `FileNotFoundError`.

Switching to `policy="mutable"` makes `add_file()` copy the file to wandb's staging directory, so it survives temp dir cleanup. Added a test that verifies the staged file persists after the temp dir is cleaned up.