### PR TITLE
refactor: logger hierarchy

### DIFF
--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -278,7 +278,7 @@ Flags:
 			logWriter,
 			&slog.HandlerOptions{Level: slog.Level(*logLevel)},
 		)),
-		sentry.CurrentHub(),
+		observability.NewSentryContext(sentry.CurrentHub()),
 	)
 
 	if *editConfig {

--- a/core/internal/observability/sentrycontext.go
+++ b/core/internal/observability/sentrycontext.go
@@ -1,0 +1,69 @@
+package observability
+
+import (
+	"sync"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// SentryContext is a mutex-protected [sentry.Hub] that allows derived loggers
+// to share Sentry tags.
+type SentryContext struct {
+	mu  sync.Mutex
+	hub *sentry.Hub
+}
+
+// NewSentryContext creates a new SentryContext cloning the given hub.
+//
+// The hub must not be nil.
+func NewSentryContext(hub *sentry.Hub) *SentryContext {
+	if hub == nil {
+		panic("observability: NewSentryContext: nil hub")
+	}
+
+	hub = hub.Clone()
+	hub.Scope().AddEventProcessor(RemoveLoggerFrames)
+	return &SentryContext{hub: hub}
+}
+
+// AddTags mutates the base tags for this context.
+//
+// Holds the mutex.
+func (sc *SentryContext) AddTags(tags map[string]string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.hub.Scope().SetTags(tags)
+}
+
+// SetUser mutates the User for this context.
+//
+// Holds the mutex.
+func (sc *SentryContext) SetUser(user sentry.User) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.hub.Scope().SetUser(user)
+}
+
+// WithScope pushes a new scope on the hub's stack and runs the function.
+//
+// The scope can be accessed with `hub.Scope()` and is safe to mutate,
+// for instance to set tags. Modifications to the scope only last until
+// the function returns.
+//
+// Holds the mutex.
+func (sc *SentryContext) WithScope(fn func(hub *sentry.Hub)) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	sc.hub.PushScope()
+	defer sc.hub.PopScope()
+	fn(sc.hub)
+}
+
+// Flush flushes the Sentry hub.
+//
+// Does not hold the mutex because this does not mutate the hub.
+func (sc *SentryContext) Flush(timeout time.Duration) bool {
+	return sc.hub.Flush(timeout)
+}

--- a/core/internal/observability/sentrycontext_test.go
+++ b/core/internal/observability/sentrycontext_test.go
@@ -1,0 +1,51 @@
+package observability_test
+
+import (
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+// newTestHub returns a Sentry hub using a MockTransport for testing outputs.
+func newTestHub(t *testing.T) (*sentry.Hub, *sentry.MockTransport) {
+	transport := &sentry.MockTransport{}
+
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+
+	hub := sentry.NewHub(client, sentry.NewScope())
+	return hub, transport
+}
+
+func TestSentryContextTags(t *testing.T) {
+	hub, transport := newTestHub(t)
+	sc := observability.NewSentryContext(hub)
+
+	sc.AddTags(map[string]string{"base1": "tag1"})
+	sc.WithScope(func(h *sentry.Hub) {
+		h.Scope().SetTag("scoped1", "value1")
+		h.CaptureMessage("scoped message")
+	})
+	sc.AddTags(map[string]string{"base2": "tag2"})
+	sc.WithScope(func(h *sentry.Hub) {
+		h.Scope().SetTag("scoped2", "value2")
+		h.CaptureMessage("scoped message")
+	})
+
+	events := transport.Events()
+	require.Len(t, events, 2)
+
+	assert.Equal(t, map[string]string{
+		"base1":   "tag1",
+		"scoped1": "value1",
+	}, events[0].Tags)
+	assert.Equal(t, map[string]string{
+		"base1":   "tag1",
+		"base2":   "tag2",
+		"scoped2": "value2",
+	}, events[1].Tags)
+}

--- a/core/internal/observabilitytest/logging.go
+++ b/core/internal/observabilitytest/logging.go
@@ -2,9 +2,13 @@ package observabilitytest
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/observability"
 )
@@ -36,4 +40,49 @@ func NewRecordingTestLogger(t *testing.T) (
 		slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
 		nil,
 	), recordedLogs
+}
+
+// NewSentryTestLogger is like NewRecordingTestLogger but also returns a
+// mock Sentry transport for checking captured events.
+func NewSentryTestLogger(t *testing.T) (
+	*observability.CoreLogger,
+	*bytes.Buffer,
+	*sentry.MockTransport,
+) {
+	t.Helper()
+
+	recordedLogs := &bytes.Buffer{}
+	writer := io.MultiWriter(t.Output(), recordedLogs)
+
+	transport := &sentry.MockTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+	hub := sentry.NewHub(client, sentry.NewScope())
+
+	return observability.NewCoreLogger(
+		slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
+		observability.NewSentryContext(hub),
+	), recordedLogs, transport
+}
+
+// ExtractLogs extracts structured logs from the [NewRecordingTestLogger]
+// buffer, dropping keys not useful for testing.
+//
+// Specifically, the "time" key is dropped. Records will always contain
+// the "level" and "msg" keys, plus custom slog attrs.
+func ExtractLogs(t *testing.T, buf *bytes.Buffer) []map[string]string {
+	records := make([]map[string]string, 0)
+
+	// The JSONHandler encodes newlines as \n, so the only actual newlines
+	// are used to separate records.
+	for line := range bytes.Lines(buf.Bytes()) {
+		var record map[string]string
+		require.NoError(t, json.Unmarshal(line, &record))
+
+		delete(record, "time")
+
+		records = append(records, record)
+	}
+
+	return records
 }

--- a/core/internal/runsync/logging.go
+++ b/core/internal/runsync/logging.go
@@ -82,6 +82,6 @@ func NewSyncLogger(
 				logFile.Writer(),
 				&slog.HandlerOptions{Level: logLevel},
 			)),
-		sentry.CurrentHub(),
+		observability.NewSentryContext(sentry.CurrentHub()),
 	)
 }

--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -67,7 +67,7 @@ func (f *RunReaderFactory) New(
 
 // ExtractRunInfo reads and returns basic run information.
 func (r *RunReader) ExtractRunInfo(ctx context.Context) (*RunInfo, error) {
-	r.logger.Info("runsync: getting info", "path", r.path)
+	r.logger.Info("runsync: getting info")
 
 	reader, err := r.open()
 	if err != nil {
@@ -110,7 +110,7 @@ func (r *RunReader) ExtractRunInfo(ctx context.Context) (*RunInfo, error) {
 // Closes RunWork at the end, even on error. If there was no Exit record,
 // creates one with an exit code of 1.
 func (r *RunReader) ProcessTransactionLog(ctx context.Context) error {
-	r.logger.Info("runsync: starting to read", "path", r.path)
+	r.logger.Info("runsync: starting to read")
 
 	// Abort any async work on cancellation.
 	cancelAbort := context.AfterFunc(ctx, r.runWork.Abort)
@@ -128,7 +128,7 @@ func (r *RunReader) ProcessTransactionLog(ctx context.Context) error {
 		record, err := r.nextUpdatedRecord(ctx, reader, !r.seenExit /*retryEOF*/)
 
 		if errors.Is(err, io.EOF) {
-			r.logger.Info("runsync: done reading", "path", r.path)
+			r.logger.Info("runsync: done reading")
 			return nil
 		}
 
@@ -162,7 +162,7 @@ func (r *RunReader) closeRunWork() {
 	if !r.seenExit {
 		r.logger.Warn(
 			"runsync: no exit record encountered, using exit code 1 (failed)",
-			"path", r.path)
+		)
 
 		r.parseAndAddWork(
 			&spb.Record{
@@ -223,7 +223,6 @@ func (r *RunReader) nextUpdatedRecord(
 			(retryEOF && errors.Is(err, io.EOF)) {
 			r.logger.Info(
 				"runsync: retrying read error in live mode",
-				"path", r.path,
 				"error", err)
 
 			if err := reader.ResetLastRead(); err != nil {

--- a/core/internal/runsync/runsyncer.go
+++ b/core/internal/runsync/runsyncer.go
@@ -165,8 +165,7 @@ func (rs *RunSyncer) markSynced() {
 	if err != nil {
 		rs.logger.Error(
 			"runsync: couldn't create .synced file",
-			"error", err,
-			"path", rs.path)
+			"error", err)
 	}
 }
 

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -59,8 +59,11 @@ func (f *RunSyncOperationFactory) New(
 			continue
 		}
 
-		s := MakeSyncSettings(globalSettings, userPath)
-		factory := InjectRunSyncerFactory(s, op.logger)
+		factory := InjectRunSyncerFactory(
+			MakeSyncSettings(globalSettings, userPath),
+			op.logger.With([]any{"sync_path", userPath}, nil),
+		)
+
 		op.syncers = append(op.syncers,
 			factory.New(path, ToDisplayPath(userPath, cwd), updates, live))
 	}

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -164,13 +164,9 @@ func (h *Handler) OutChan() <-chan runwork.Work {
 //gocyclo:ignore
 func (h *Handler) Do(allWork <-chan runwork.Work) {
 	defer h.logger.Reraise()
-	h.logger.Info("handler: started", "stream_id", h.settings.GetRunID())
+	h.logger.Info("handler: started")
 	for work := range allWork {
-		h.logger.Debug(
-			"handler: got work",
-			"work", work,
-			"stream_id", h.settings.GetRunID(),
-		)
+		h.logger.Debug("handler: got work", "work", work)
 
 		if work.Accept(h.handleRecord) {
 			h.fwdWork(work)
@@ -180,7 +176,7 @@ func (h *Handler) Do(allWork <-chan runwork.Work) {
 }
 
 func (h *Handler) Close() {
-	h.logger.Info("handler: closed", "stream_id", h.settings.GetRunID())
+	h.logger.Info("handler: closed")
 	close(h.outChan)
 	close(h.fwdChan)
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -216,7 +216,7 @@ func (h *Sender) ResponseChan() <-chan *spb.Result {
 // Do processes all work on the input channel.
 func (s *Sender) Do(allWork <-chan runwork.Work) {
 	defer s.logger.Reraise()
-	s.logger.Info("sender: started", "stream_id", s.settings.GetRunID())
+	s.logger.Info("sender: started")
 
 	hangDetectionInChan := make(chan runwork.Work, 32)
 	hangDetectionOutChan := make(chan struct{}, 32)
@@ -225,11 +225,7 @@ func (s *Sender) Do(allWork <-chan runwork.Work) {
 	for work := range allWork {
 		hangDetectionInChan <- work
 
-		s.logger.Debug(
-			"sender: got work",
-			"work", work,
-			"stream_id", s.settings.GetRunID(),
-		)
+		s.logger.Debug("sender: got work", "work", work)
 
 		s.mu.Lock()
 		work.Process(s.sendRecord, s.outChan)
@@ -242,7 +238,7 @@ func (s *Sender) Do(allWork <-chan runwork.Work) {
 	close(hangDetectionOutChan)
 
 	s.Close()
-	s.logger.Info("sender: closed", "stream_id", s.settings.GetRunID())
+	s.logger.Info("sender: closed")
 }
 
 // warnOnLongOperations logs a warning for each message received

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -177,7 +177,7 @@ func (s *Stream) Start() {
 		}(ch)
 	}
 
-	s.logger.Info("stream: started", "id", s.settings.GetRunID())
+	s.logger.Info("stream: started")
 }
 
 // maybeSavingToTransactionLog saves work from the channel into a transaction
@@ -188,17 +188,14 @@ func (s *Stream) maybeSavingToTransactionLog(
 	work <-chan runwork.Work,
 ) <-chan runwork.Work {
 	if s.settings.IsSkipTransactionLog() {
-		s.logger.Info(
-			"stream: skipping transaction log due to settings",
-			"id", s.settings.GetRunID())
+		s.logger.Info("stream: skipping transaction log due to settings")
 		return work
 	}
 
 	w, err := transactionlog.OpenWriter(s.settings.GetTransactionLogPath())
 	if err != nil {
-		s.logger.Error(
-			fmt.Sprintf("stream: error opening transaction log for writing: %v", err),
-			"id", s.settings.GetRunID())
+		s.logger.Error(fmt.Sprintf(
+			"stream: error opening transaction log for writing: %v", err))
 		return work
 	}
 
@@ -209,9 +206,8 @@ func (s *Stream) maybeSavingToTransactionLog(
 	if err != nil {
 		// Capture the error because if we can open for writing,
 		// why can't we open for reading?
-		s.logger.CaptureError(
-			fmt.Errorf("stream: error opening transaction log for reading: %v", err),
-			"id", s.settings.GetRunID())
+		s.logger.CaptureError(fmt.Errorf(
+			"stream: error opening transaction log for reading: %v", err))
 		return work
 	}
 
@@ -248,10 +244,10 @@ func (s *Stream) HandleRecord(record *spb.Record) {
 
 // Close waits for all run messages to be fully processed.
 func (s *Stream) Close() {
-	s.logger.Info("stream: closing", "id", s.settings.GetRunID())
+	s.logger.Info("stream: closing")
 	s.runWork.Close()
 	s.wg.Wait()
-	s.logger.Info("stream: closed", "id", s.settings.GetRunID())
+	s.logger.Info("stream: closed")
 
 	if s.loggerFile != nil {
 		// Sync the file instead of closing it, in case we keep writing to it.

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -31,7 +31,8 @@ import (
 func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceManager, debugCorePath DebugCorePath, logLevel slog.Level, settings2 *settings.Settings) *Stream {
 	clientID := sharedmode.RandomClientID()
 	streamStreamLoggerFile := openStreamLoggerFile(settings2)
-	coreLogger := streamLogger(streamStreamLoggerFile, settings2, logLevel)
+	sentryContext := streamSentryContext(settings2)
+	coreLogger := streamLogger(streamStreamLoggerFile, sentryContext, settings2, logLevel)
 	wbBaseURL := BaseURLFromSettings(coreLogger, settings2)
 	credentialProvider := CredentialsFromSettings(coreLogger, settings2)
 	peeker := &observability.Peeker{}

--- a/core/internal/tensorboard/tfeventconverter.go
+++ b/core/internal/tensorboard/tfeventconverter.go
@@ -48,7 +48,7 @@ func (h *TFEventConverter) ConvertNext(
 			continue
 		}
 
-		taggedLogger := logger.With("tag", tag)
+		taggedLogger := logger.With([]any{"tag", tag}, nil)
 
 		switch h.rememberPluginName(tag, value) {
 		case "":


### PR DESCRIPTION
Refines `CoreLogger` hierarchy methods by changing `With()` and removing `SetGlobalTags()`.

All loggers in the same hierarchy log to the same `slog.Logger` and Sentry client. The hierarchy allows child loggers to set new slog attributes and Sentry tags for just that logger.

Every slog attr is a Sentry tag, but not every Sentry tag is a slog attr. For instance, adding a `run_url` attr to every `debug-internal.log` message would be too verbose, but it is very useful to have in Sentry. Previously, `With` only amended slog attrs, not Sentry tags.

All loggers in a hierarchy share a `SentryContext`, which can be mutated through the `AddTags` and `SetUser` methods. This is necessary because of our multi-step `Stream` initialization: the `Stream` logger is created immediately, but certain details about a run are only available after it's upserted. This will be necessary to fix `run_url` in Sentry later (`streamlogger.go` currently sets it on init, but it's usually empty at that point).

Completes WB-30707 as a side effect (enables Sentry for `wandb beta sync`).