### PR TITLE
refactor: wberrors

### DIFF
--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+
+	"github.com/wandb/wandb/core/internal/observability/wberrors"
 )
 
 type Tags map[string]string
@@ -114,15 +116,32 @@ func (cl *CoreLogger) With(
 	}
 }
 
+// withWBErrorAttrs combines WBError attrs with a list of explicit attrs.
+func withWBErrorAttrs(err error, args []any) []any {
+	attrs := wberrors.Attrs(err)
+	if len(attrs) == 0 {
+		return args
+	}
+
+	attrsAsAny := make([]any, 0, len(attrs)+len(args))
+	for _, attr := range attrs {
+		attrsAsAny = append(attrsAsAny, attr)
+	}
+	return append(attrsAsAny, args...)
+}
+
 // CaptureError logs an error and sends it to Sentry.
 func (cl *CoreLogger) CaptureError(err error, args ...any) {
-	cl.Error(err.Error(), args...)
+	cl.Error(err.Error(), withWBErrorAttrs(err, args)...)
 	cl.captureException(err, args...)
 }
 
 // CaptureFatal logs a fatal error and sends it to Sentry.
 func (cl *CoreLogger) CaptureFatal(err error, args ...any) {
-	cl.Log(context.Background(), LevelFatal, err.Error(), args...)
+	cl.Log(
+		context.Background(), LevelFatal, err.Error(),
+		withWBErrorAttrs(err, args)...,
+	)
 	cl.captureException(err, args...)
 }
 
@@ -136,7 +155,10 @@ func (cl *CoreLogger) CaptureFatalAndPanic(err error, args ...any) {
 
 	// Log panics to debug-core.log as well. This helps debugging if there are
 	// multiple active debug files.
-	slog.Log(context.Background(), LevelFatal, err.Error(), args...)
+	slog.Log(
+		context.Background(), LevelFatal, err.Error(),
+		withWBErrorAttrs(err, args)...,
+	)
 
 	// Try to finish uploads to Sentry before re-panicking.
 	if cl.sentryCtx != nil {
@@ -166,12 +188,22 @@ func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 
 // captureException uploads an error to Sentry if possible and allowed.
 func (cl *CoreLogger) captureException(err error, args ...any) {
-	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(err.Error()) {
+	if cl.sentryCtx == nil ||
+		wberrors.SkipSentry(err) ||
+		!cl.captureRateLimiter.AllowCapture(err.Error()) {
 		return
 	}
 
 	cl.sentryCtx.WithScope(func(hub *sentry.Hub) {
 		hub.Scope().SetTags(cl.withArgs(args...))
+		hub.Scope().SetTags(wberrors.Tags(err))
+
+		if fp := wberrors.ExtraFingerprint(err); len(fp) > 0 {
+			hub.Scope().SetFingerprint(
+				append([]string{"{{ default }}"}, fp...),
+			)
+		}
+
 		hub.CaptureException(err)
 	})
 }

--- a/core/internal/observability/wberrors/wberrors.go
+++ b/core/internal/observability/wberrors/wberrors.go
@@ -1,0 +1,233 @@
+// Package wberrors defines a rich error type for wandb-core.
+//
+// `fmt.Errorf` is replaced by Newf, Enrichf and Bubblef:
+//
+//   - Newf constructs an error from a formatted message.
+//   - Enrichf is like Newf, but it preserves an underlying error's data.
+//     It is like using `fmt.Errorf` with the `%v` verb.
+//   - Bubblef is like Enrichf, but it exposes the underlying error.
+//     It is like using `fmt.Errorf` with the `%w` verb.
+//
+// `errors.Join` has no replacement; using it to combine errors will discard
+// enrichment data.
+//
+// The methods SkipSentryIf, Attr and Fingerprint enrich an error; see their
+// documentation. All of them return the error itself to allow for method
+// chaining:
+//
+//	return wberrors.Enrichf(err, "failed to open %s", filename).
+//		Attr(slog.String("path", path)).
+//		SkipSentryIf(os.IsPermission(err))
+//
+// To ensure enriched attributes make it to the logging code, all code must
+// use Newf, Enrichf and Bubblef. Never use `fmt.Errorf` to wrap an error, since
+// that will discard its extra data. For consistency, never use `fmt.Errorf`
+// or `errors.New` even to create a fresh error; prefer Newf.
+//
+// Become familiar with https://google.github.io/styleguide/go/best-practices.html#error-handling
+package wberrors
+
+import (
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+)
+
+// Attrs returns any slog attrs stored in the error.
+func Attrs(err error) []slog.Attr {
+	if wberr, ok := err.(*Error); ok {
+		attrs := make([]slog.Attr, 0, len(wberr.attrs))
+
+		for key, value := range wberr.attrs {
+			attrs = append(attrs, slog.Attr{Key: key, Value: value})
+		}
+
+		return attrs
+	}
+
+	return nil
+}
+
+// Tags returns the Sentry tags stored in the error.
+func Tags(err error) map[string]string {
+	if wberr, ok := err.(*Error); ok {
+		tags := make(map[string]string, len(wberr.attrs))
+
+		for key, value := range wberr.attrs {
+			tags[key] = value.String()
+		}
+
+		return tags
+	}
+
+	return nil
+}
+
+// SkipSentry returns true if the error was marked as not needing to be
+// captured.
+//
+// This allows lower-level code to filter out uninteresting error conditions.
+func SkipSentry(err error) bool {
+	if wberr, ok := err.(*Error); ok {
+		return wberr.noSentry
+	}
+
+	return false
+}
+
+// ExtraFingerprint returns additional parts to include in the error's Sentry
+// fingerprint.
+func ExtraFingerprint(err error) []string {
+	if wberr, ok := err.(*Error); ok {
+		return wberr.fingerprint
+	}
+
+	return nil
+}
+
+// Error is a standard Go error with additional info for W&B observability.
+//
+// Errors are *not* safe for concurrent use. Prefer to construct and mutate an
+// error in a single statement using method chaining. Never mutate an error
+// you didn't construct or that was constructed in a different goroutine.
+//
+// See the package documentation.
+type Error struct {
+	msg string // error message or context
+	err error  // wrapped error or nil
+
+	noSentry    bool     // whether to skip Sentry upload
+	fingerprint []string // extra Sentry fingerprint data
+
+	// attrs is structured data to associate to the error.
+	//
+	// It is meant to be included in structured logging using slog and also
+	// uploaded as tags to Sentry if the error is captured.
+	attrs map[string]slog.Value
+}
+
+// Newf creates a new error using Sprintf to construct the message.
+func Newf(format string, args ...any) *Error {
+	return &Error{msg: fmt.Sprintf(format, args...)}
+}
+
+// Enrichf enriches an error without exposing it through `errors.Unwrap`.
+//
+// Given an empty format string, the resulting error's string representation
+// is the same as the given error's. Otherwise, Sprintf is used to construct
+// a message that is prepended to the given error's message with a separating
+// colon.
+//
+//	wberrors.Enrichf(err, "mypackage: hit %d problems", numProblems)
+//	is like
+//	fmt.Errorf("mypackage: hit %d problems: %v", numProblems, err)
+//
+// If the given error is already enriched, then its fingerprint and attrs are
+// copied over. If it skips Sentry upload, the resulting error will skip Sentry
+// upload too.
+func Enrichf(err error, format string, args ...any) *Error {
+	return wrap(fmt.Sprintf(format, args...), err, false)
+}
+
+// Bubblef is like Enrichf, but exposes the given error through `errors.Unwrap`.
+//
+// The resulting error matches the inner error using `errors.Is`.
+//
+// In most cases, you should use Enrichf instead. A function may use Bubblef
+// when it's intentionally designed to propagate inner errors for the caller
+// to inspect using `errors.Is` or `errors.As`. Do not bubble an error if it
+// would expose implementation details.
+//
+//	wberrors.Bubblef(err, "mypackage: hit %d problems", numProblems)
+//	is like
+//	fmt.Errorf("mypackage: hit %d problems: %w", numProblems, err)
+//
+// See https://go.dev/blog/go1.13-errors#whether-to-wrap
+func Bubblef(err error, format string, args ...any) *Error {
+	return wrap(fmt.Sprintf(format, args...), err, true)
+}
+
+func wrap(msg string, err error, shouldWrap bool) *Error {
+	if err == nil {
+		panic("wberrors: cannot wrap nil error")
+	}
+
+	wrapped := &Error{}
+
+	switch {
+	case shouldWrap:
+		wrapped.msg = msg
+		wrapped.err = err
+	case msg == "":
+		wrapped.msg = err.Error()
+	default:
+		wrapped.msg = fmt.Sprintf("%s: %v", msg, err)
+	}
+
+	if wberr, ok := err.(*Error); ok {
+		wrapped.noSentry = wberr.noSentry
+		wrapped.fingerprint = slices.Clone(wberr.fingerprint)
+		wrapped.attrs = maps.Clone(wberr.attrs)
+	}
+
+	return wrapped
+}
+
+// Attr associates structured data to the error and returns the error.
+//
+// The key-value pair is included when the error is logged via `slog`.
+//
+// It is also added as a tag in the associated Sentry event if this error is
+// captured.
+//
+// If the error already has an attr with the same key, it is overwritten.
+// These attrs take precedence over attrs included by the logger.
+func (e *Error) Attr(attr slog.Attr) *Error {
+	if e.attrs == nil {
+		e.attrs = make(map[string]slog.Value)
+	}
+
+	e.attrs[attr.Key] = attr.Value
+	return e
+}
+
+// SkipSentryIf marks the error as one that should not be uploaded to Sentry
+// if the condition is true, and returns it.
+//
+// If the condition is false, the error is unchanged.
+func (e *Error) SkipSentryIf(condition bool) *Error {
+	e.noSentry = e.noSentry || condition
+	return e
+}
+
+// Fingerprint appends to the error's Sentry fingerprint and returns the error.
+//
+// Sentry events with the same fingerprint are grouped into the same issue.
+// Appending extra information to the error, like an HTTP status code,
+// results in more granular Sentry issues.
+//
+// See https://docs.sentry.io/platforms/go/usage/sdk-fingerprinting/.
+func (e *Error) Fingerprint(parts ...string) *Error {
+	e.fingerprint = append(e.fingerprint, parts...)
+	return e
+}
+
+// Error implements error.Error.
+func (e *Error) Error() string {
+	switch {
+	case e.err == nil:
+		return e.msg
+	case e.msg == "":
+		return e.err.Error()
+	default:
+		return fmt.Sprintf("%s: %v", e.msg, e.err)
+	}
+}
+
+// Unwrap returns the inner error.
+//
+// This works with the `errors.Unwrap()` and `errors.Is()` functions.
+func (e *Error) Unwrap() error {
+	return e.err
+}

--- a/core/internal/observability/wberrors/wberrors_test.go
+++ b/core/internal/observability/wberrors/wberrors_test.go
@@ -1,0 +1,195 @@
+package wberrors_test
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wandb/wandb/core/internal/observability/wberrors"
+)
+
+func TestNewfFormat(t *testing.T) {
+	assert.Equal(t,
+		"the number is 3",
+		wberrors.Newf("the number is %d", 3).Error())
+}
+
+func TestWrapNil_Panics(t *testing.T) {
+	// Wrapping a nil error should panic early because calling Error() on
+	// a nil error seems to hang, at least in tests. Better a panic than
+	// a hang.
+
+	t.Run("Enrichf", func(t *testing.T) {
+		assert.Panics(t, func() {
+			_ = wberrors.Enrichf(nil, "text")
+		})
+	})
+
+	t.Run("Bubblef", func(t *testing.T) {
+		assert.Panics(t, func() {
+			_ = wberrors.Bubblef(nil, "text")
+		})
+	})
+}
+
+func TestEnrichfFormat(t *testing.T) {
+	t.Run("no message", func(t *testing.T) {
+		assert.Equal(t,
+			"EOF",
+			wberrors.Enrichf(io.EOF, "").Error())
+	})
+
+	t.Run("with format", func(t *testing.T) {
+		assert.Equal(t,
+			"failed (123): EOF",
+			wberrors.Enrichf(io.EOF, "failed (%d)", 123).Error())
+	})
+}
+
+func TestBubblefFormat(t *testing.T) {
+	t.Run("no message", func(t *testing.T) {
+		assert.Equal(t,
+			"EOF",
+			wberrors.Bubblef(io.EOF, "").Error())
+	})
+
+	t.Run("with format", func(t *testing.T) {
+		assert.Equal(t,
+			"failed (123): EOF",
+			wberrors.Bubblef(io.EOF, "failed (%d)", 123).Error())
+	})
+}
+
+func TestEnrichfDoesNotWrap(t *testing.T) {
+	assert.NotErrorIs(t,
+		wberrors.Enrichf(io.EOF, ""),
+		io.EOF)
+}
+
+func TestBubblefWraps(t *testing.T) {
+	assert.ErrorIs(t,
+		wberrors.Bubblef(io.EOF, ""),
+		io.EOF)
+}
+
+func TestAttrs(t *testing.T) {
+	t.Run("none if not enriched", func(t *testing.T) {
+		assert.Empty(t, wberrors.Attrs(io.EOF))
+	})
+
+	t.Run("none by default", func(t *testing.T) {
+		assert.Empty(t, wberrors.Attrs(wberrors.Newf("")))
+	})
+
+	t.Run("copies when wrapping", func(t *testing.T) {
+		err1 := wberrors.Newf("").
+			Attr(slog.String("key1", "value1")).
+			Attr(slog.String("key2", "value2"))
+
+		err2 := wberrors.Enrichf(err1, "").
+			Attr(slog.String("key2", "overwritten")).
+			Attr(slog.String("key3", "value3"))
+
+		// Original error not mutated.
+		assert.ElementsMatch(t,
+			[]slog.Attr{
+				slog.String("key1", "value1"),
+				slog.String("key2", "value2"),
+			},
+			wberrors.Attrs(err1))
+		// Wrapped error copies attrs; new values take precedence.
+		assert.ElementsMatch(t,
+			[]slog.Attr{
+				slog.String("key1", "value1"),
+				slog.String("key2", "overwritten"),
+				slog.String("key3", "value3"),
+			},
+			wberrors.Attrs(err2))
+	})
+}
+
+func TestTags(t *testing.T) {
+	t.Run("none if not enriched", func(t *testing.T) {
+		assert.Empty(t, wberrors.Tags(io.EOF))
+	})
+
+	t.Run("none by default", func(t *testing.T) {
+		assert.Empty(t, wberrors.Tags(wberrors.Newf("")))
+	})
+
+	t.Run("copies when wrapping", func(t *testing.T) {
+		err1 := wberrors.Newf("").
+			Attr(slog.String("key1", "value1")).
+			Attr(slog.String("key2", "value2"))
+
+		err2 := wberrors.Enrichf(err1, "").
+			Attr(slog.String("key2", "overwritten")).
+			Attr(slog.String("key3", "value3"))
+
+		// Original error not mutated.
+		assert.Equal(t,
+			map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			wberrors.Tags(err1))
+		// Wrapped error copies tags; new values take precedence.
+		assert.Equal(t,
+			map[string]string{
+				"key1": "value1",
+				"key2": "overwritten",
+				"key3": "value3",
+			},
+			wberrors.Tags(err2))
+	})
+}
+
+func TestSkipSentryIf(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"false if not enriched", io.EOF, false},
+		{"false by default", wberrors.Newf(""), false},
+		{"true if set", wberrors.Newf("").SkipSentryIf(true), true},
+
+		{"true if inherited",
+			wberrors.Enrichf(
+				wberrors.Newf("").SkipSentryIf(true), "",
+			),
+			true},
+
+		{"not clearable",
+			wberrors.Enrichf(
+				wberrors.Newf("").SkipSentryIf(true), "",
+			).SkipSentryIf(false),
+			true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, wberrors.SkipSentry(tc.err))
+		})
+	}
+}
+
+func TestFingerprint(t *testing.T) {
+	t.Run("none if not enriched", func(t *testing.T) {
+		assert.Empty(t, wberrors.ExtraFingerprint(io.EOF))
+	})
+
+	t.Run("none by default", func(t *testing.T) {
+		assert.Empty(t, wberrors.ExtraFingerprint(wberrors.Newf("")))
+	})
+
+	t.Run("copies when wrapping", func(t *testing.T) {
+		err1 := wberrors.Newf("").Fingerprint("one")
+		err2 := wberrors.Enrichf(err1, "").Fingerprint("two")
+
+		assert.Equal(t, []string{"one"}, wberrors.ExtraFingerprint(err1))
+		assert.Equal(t, []string{"one", "two"}, wberrors.ExtraFingerprint(err2))
+	})
+}


### PR DESCRIPTION
Creates the `wberrors` package for errors enriched with `wandb-core` specific details. See its documentation.

I chose the verbs "enrich" and "bubble" to represent the two ways to wrap an error (`%v` and `%w`). I considered "wrap", but it's not a good replacement for "enrich" because it'd be surprising if you couldn't `errors.Unwrap` a "wrapped" error, and it's not a good replacement of "bubble" because "wrapping an error" is a common enough expression that it's tempting to default to `wberrors.Wrap`. "Bubble" refers to "bubbling up", like how one might say an error "bubbles up" through a call stack until it's handled. "Enrich" refers to adding extra context.

The methods end with `f` because that's the Go convention for `Printf`\-like functions. I think there's a linter that checks that arguments to `Printf`\-like functions match the format string.

`Enrichf` and `Bubblef` take an error as the first argument and the format as the second, which flips the `fmt.Errorf("failed: %v", err)` pattern, but this should work better with `Printf` linters. `Enrichf("got status %d", err, status)` looks like a mistake compared to `Enrichf(err, "got status %d", status)`. I considered a syntax that matches `fmt.Errorf` by using `fmt.Errorf` under the hood, but there's no way to extract the wrapped error from `fmt.Errorf("%v", err)` and this felt overly complicated.

I decided not to support `errors.Join()` because I couldn't think of how to combine tags and Sentry metadata reasonably for an error tree. Code that needs `errors.Join` with enrichment should choose a main error and format the rest (I'll add a utility if it seems useful).