### PR TITLE
fix(sdk): check whether run files query result is none

### DIFF
--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -192,10 +192,10 @@ class Files(SizedPaginator["File"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            return self.last_response["project"]["run"]["files"]["pageInfo"][
-                "hasNextPage"
-            ]
+        if self.last_response and (
+            files := self.last_response["project"]["run"]["files"]
+        ):
+            return files["pageInfo"]["hasNextPage"]
         else:
             return True
 
@@ -205,8 +205,10 @@ class Files(SizedPaginator["File"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            return self.last_response["project"]["run"]["files"]["edges"][-1]["cursor"]
+        if self.last_response and (
+            files := self.last_response["project"]["run"]["files"]
+        ):
+            return files["edges"][-1]["cursor"]
         else:
             return None
 
@@ -222,10 +224,12 @@ class Files(SizedPaginator["File"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        return [
-            File(self.client, r["node"], self.run)
-            for r in self.last_response["project"]["run"]["files"]["edges"]
-        ]
+        if self.last_response and (
+            files := self.last_response["project"]["run"]["files"]
+        ):
+            return [File(self.client, r["node"], self.run) for r in files["edges"]]
+        else:
+            return []
 
     def __repr__(self) -> str:
         return f"<{nameof(type(self))} {'/'.join(self.run.path)} ({len(self)})>"


### PR DESCRIPTION
Description
-----------
- Fixes #11351 

Adds checks to handle case where the result of a run files query is None.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Tested locally using personal wandb project.