### PR TITLE
refactor: use synctest in runupserter

### DIFF
--- a/core/internal/runupserter/runupdatework.go
+++ b/core/internal/runupserter/runupdatework.go
@@ -13,7 +13,6 @@ import (
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/wboperation"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -88,7 +87,7 @@ func (w *RunUpdateWork) initRun(results chan<- *spb.Result) {
 	upserter, err := InitRun(w.Record, RunUpserterParams{
 		Settings: w.Settings,
 
-		DebounceDelay: waiting.NewDelay(runUpsertDebounceSeconds * time.Second),
+		DebounceDelay: runUpsertDebounceSeconds * time.Second,
 
 		ClientID:           w.ClientID,
 		BeforeRunEndCtx:    w.BeforeRunEndCtx,

--- a/core/internal/runupsertertest/runupsertertest.go
+++ b/core/internal/runupsertertest/runupsertertest.go
@@ -13,7 +13,6 @@ import (
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runupserter"
 	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/waiting"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -36,9 +35,6 @@ func NewTestUpserter(
 ) *runupserter.RunUpserter {
 	t.Helper()
 
-	if params.DebounceDelay == nil {
-		params.DebounceDelay = waiting.NoDelay()
-	}
 	if params.ClientID == "" {
 		params.ClientID = "test-client-id"
 	}


### PR DESCRIPTION
Replaces usage of `internal/waiting` in `internal/runupserter` by `testing/synctest`.