### PR TITLE
refactor: use synctest in runfiles

### DIFF
--- a/core/internal/runfiles/runfiles.go
+++ b/core/internal/runfiles/runfiles.go
@@ -6,6 +6,8 @@
 package runfiles
 
 import (
+	"time"
+
 	"github.com/Khan/genqlient/graphql"
 	"github.com/google/wire"
 
@@ -16,7 +18,6 @@ import (
 	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/watcher"
 	"github.com/wandb/wandb/core/internal/wboperation"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -78,7 +79,7 @@ type UploaderFactory struct {
 // within this duration of each other are combined into a single GraphQL call.
 // It also affects how often "live" files are reuploaded.
 func (f *UploaderFactory) New(
-	batchDelay waiting.Delay,
+	batchDelay time.Duration,
 	extraWork runwork.ExtraWork,
 	fileStream filestream.FileStream,
 ) Uploader {

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/watcher"
 	"github.com/wandb/wandb/core/internal/wboperation"
 
@@ -59,7 +59,7 @@ type uploader struct {
 
 func newUploader(
 	f *UploaderFactory,
-	batchDelay waiting.Delay,
+	batchDelay time.Duration,
 	extraWork runwork.ExtraWork,
 	fileStream filestream.FileStream,
 ) *uploader {

--- a/core/internal/runfilestest/runfilestest.go
+++ b/core/internal/runfilestest/runfilestest.go
@@ -2,6 +2,7 @@ package runfilestest
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,6 @@ import (
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/watcher"
 	"github.com/wandb/wandb/core/internal/watchertest"
 	"github.com/wandb/wandb/core/internal/wboperation"
@@ -35,7 +35,7 @@ type Params struct {
 	RunHandle    *runhandle.RunHandle
 	Settings     *settings.Settings
 
-	BatchDelay waiting.Delay
+	BatchDelay time.Duration
 	ExtraWork  runwork.ExtraWork
 	FileStream filestream.FileStream
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -27,7 +27,6 @@ import (
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sharedmode"
-	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/watcher"
 	"github.com/wandb/wandb/core/internal/wboperation"
 	"github.com/wandb/wandb/core/pkg/artifacts"
@@ -151,7 +150,7 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 	var runfilesUploader runfiles.Uploader
 	if !f.Settings.IsOffline() {
 		runfilesUploader = f.RunfilesUploaderFactory.New(
-			/*batchDelay=*/ waiting.NewDelay(5*time.Second),
+			/*batchDelay=*/ 5*time.Second,
 			runWork,
 			fileStream,
 		)


### PR DESCRIPTION
Replaces usage of `internal/waiting` in `internal/runfiles` by `testing/synctest`.