### PR TITLE
refactor: use synctest in tensorboard

### DIFF
--- a/core/internal/runsync/runsyncer.go
+++ b/core/internal/runsync/runsyncer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/stream"
 	"github.com/wandb/wandb/core/internal/tensorboard"
-	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/wboperation"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -71,7 +70,7 @@ func (f *RunSyncerFactory) New(
 	sender := f.SenderFactory.New(runWork)
 	tbHandler := f.TBHandlerFactory.New(
 		runWork,
-		/*fileReadDelay=*/ waiting.NewDelay(5*time.Second),
+		/*fileReadDelay=*/ 5*time.Second,
 	)
 	recordParser := f.RecordParserFactory.New(runWork.BeforeEndCtx(), tbHandler)
 	runReader := f.RunReaderFactory.New(

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -18,7 +18,6 @@ import (
 	"github.com/wandb/wandb/core/internal/sharedmode"
 	"github.com/wandb/wandb/core/internal/tensorboard"
 	"github.com/wandb/wandb/core/internal/transactionlog"
-	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/wboperation"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -110,7 +109,7 @@ func NewStream(
 	runWork := runwork.New(BufferSize, logger)
 	tbHandler := tbHandlerFactory.New(
 		runWork,
-		/*fileReadDelay=*/ waiting.NewDelay(5*time.Second),
+		/*fileReadDelay=*/ 5*time.Second,
 	)
 	recordParser := recordParserFactory.New(runWork.BeforeEndCtx(), tbHandler)
 

--- a/core/internal/tensorboard/tensorboard.go
+++ b/core/internal/tensorboard/tensorboard.go
@@ -26,7 +26,6 @@ import (
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/tensorboard/tbproto"
-	"github.com/wandb/wandb/core/internal/waiting"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -53,7 +52,7 @@ type TBHandler struct {
 	extraWork      runwork.ExtraWork
 	logger         *observability.CoreLogger
 	settings       *settings.Settings
-	fileReadDelay  waiting.Delay
+	fileReadDelay  time.Duration
 
 	// streams is the list of event streams for all tracked directories.
 	streams []*tfEventStream
@@ -67,7 +66,7 @@ type TBHandlerFactory struct {
 
 func (f *TBHandlerFactory) New(
 	extraWork runwork.ExtraWork,
-	fileReadDelay waiting.Delay,
+	fileReadDelay time.Duration,
 ) *TBHandler {
 	tb := &TBHandler{
 		rootDirGuesser: NewRootDirGuesser(f.Logger),

--- a/core/internal/tensorboard/tensorboard_test.go
+++ b/core/internal/tensorboard/tensorboard_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,6 @@ import (
 	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/tensorboard"
-	"github.com/wandb/wandb/core/internal/waitingtest"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -40,7 +40,7 @@ func setupTest(t *testing.T, opts testOptions) testContext {
 	t.Helper()
 
 	runWork := runworktest.New()
-	fileReadDelay := waitingtest.NewFakeDelay()
+	fileReadDelay := time.Hour
 
 	tmpdir := t.TempDir()
 	toPath := func(slashPath string) string {


### PR DESCRIPTION
Replaces usage of `internal/waiting` in `internal/tensorboard` by `testing/synctest`.