### PR TITLE
refactor: use synctest in filestream

### DIFF
--- a/core/internal/filestream/collectloop_test.go
+++ b/core/internal/filestream/collectloop_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/observability"
-	"github.com/wandb/wandb/core/internal/waiting"
 )
 
 func TestCollectLoop_BatchesWhileWaiting(t *testing.T) {
@@ -31,7 +30,7 @@ func TestCollectLoop_BatchesWhileWaiting(t *testing.T) {
 	requests <- &FileStreamRequest{UploadedFiles: set("two")}
 	requests <- &FileStreamRequest{UploadedFiles: set("three")}
 
-	req, _ := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
+	req, _ := transmissions.NextRequest(make(<-chan time.Time))
 	transmissions.IgnoreFutureRequests()
 
 	assert.Len(t, req.Uploaded, 3)
@@ -52,8 +51,8 @@ func TestCollectLoop_SendsLastRequestImmediately(t *testing.T) {
 
 	transmissions := loop.Start(state, requests)
 	close(requests)
-	request1, ok1 := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
-	request2, ok2 := transmissions.NextRequest(waiting.NewStopwatch(time.Second))
+	request1, ok1 := transmissions.NextRequest(make(<-chan time.Time))
+	request2, ok2 := transmissions.NextRequest(make(<-chan time.Time))
 
 	assert.True(t, ok1)
 	assert.NotNil(t, request1)

--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -90,7 +90,7 @@ func (fs *fileStream) startTransmitting(
 	}.Start(state, requests)
 
 	feedback := TransmitLoop{
-		HeartbeatStopwatch:     fs.heartbeatStopwatch,
+		HeartbeatPeriod:        fs.heartbeatPeriod,
 		Send:                   fs.send,
 		LogFatalAndStopWorking: fs.logFatalAndStopWorking,
 	}.Start(transmissions)

--- a/core/internal/filestream/transmitchan_test.go
+++ b/core/internal/filestream/transmitchan_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/wandb/wandb/core/internal/filestream"
-	"github.com/wandb/wandb/core/internal/waiting"
 )
 
 // nonEmptyRequest makes a non-empty FileStream JSON request for testing.
@@ -23,7 +22,7 @@ func TestTransmitChan(t *testing.T) {
 	requestIn := nonEmptyRequest()
 
 	go ch.Push(requestIn)
-	requestOut, ok := ch.NextRequest(waiting.NewStopwatch(time.Second))
+	requestOut, ok := ch.NextRequest(make(<-chan time.Time))
 
 	assert.True(t, ok)
 	assert.Equal(t, requestIn, requestOut)
@@ -31,8 +30,10 @@ func TestTransmitChan(t *testing.T) {
 
 func TestTransmitChan_Heartbeat(t *testing.T) {
 	ch := filestream.NewTransmitChan()
+	heartbeatCh := make(chan time.Time, 1)
+	heartbeatCh <- time.Now()
 
-	requestOut, ok := ch.NextRequest(waiting.NewStopwatch(0))
+	requestOut, ok := ch.NextRequest(heartbeatCh)
 
 	assert.True(t, ok)
 	assert.Equal(t, &filestream.FileStreamRequestJSON{}, requestOut)
@@ -45,7 +46,7 @@ func TestTransmitChan_PreparePush_ReturnsNonBlockingChannel(t *testing.T) {
 	// Read in a loop until the end of the test.
 	go func() {
 		for {
-			_, ok := ch.NextRequest(waiting.NewStopwatch(time.Second))
+			_, ok := ch.NextRequest(make(<-chan time.Time))
 			if !ok {
 				break
 			}

--- a/core/internal/filestream/transmitloop_test.go
+++ b/core/internal/filestream/transmitloop_test.go
@@ -2,19 +2,18 @@ package filestream_test
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/wandb/wandb/core/internal/filestream"
-	"github.com/wandb/wandb/core/internal/waiting"
-	"github.com/wandb/wandb/core/internal/waitingtest"
 )
 
 func TestTransmitLoop_Sends(t *testing.T) {
 	outputs := make(chan *FileStreamRequestJSON)
 	loop := TransmitLoop{
-		HeartbeatStopwatch:     waiting.NewStopwatch(time.Second),
+		HeartbeatPeriod:        time.Hour,
 		LogFatalAndStopWorking: func(err error) {},
 		Send: func(
 			ftd *FileStreamRequestJSON,
@@ -41,29 +40,39 @@ func TestTransmitLoop_Sends(t *testing.T) {
 }
 
 func TestTransmitLoop_SendsHeartbeats(t *testing.T) {
-	heartbeat := waitingtest.NewFakeStopwatch()
-	inputs := NewTransmitChan()
-	defer inputs.Close()
-	outputs := make(chan *FileStreamRequestJSON)
-	loop := TransmitLoop{
-		HeartbeatStopwatch:     heartbeat,
-		LogFatalAndStopWorking: func(err error) {},
-		Send: func(
-			ftd *FileStreamRequestJSON,
-			c chan<- map[string]any,
-		) error {
-			outputs <- ftd
-			return nil
-		},
-	}
+	synctest.Test(t, func(t *testing.T) {
+		inputs := NewTransmitChan()
+		defer inputs.Close()
+		outputs := make(chan *FileStreamRequestJSON)
+		loop := TransmitLoop{
+			HeartbeatPeriod:        5 * time.Minute,
+			LogFatalAndStopWorking: func(err error) {},
+			Send: func(
+				ftd *FileStreamRequestJSON,
+				c chan<- map[string]any,
+			) error {
+				outputs <- ftd
+				return nil
+			},
+		}
 
-	loop.Start(inputs)
-	heartbeat.SetDone()
+		startTime := time.Now()
+		loop.Start(inputs)
 
-	select {
-	case result := <-outputs:
-		assert.Zero(t, *result)
-	case <-time.After(time.Second):
-		t.Error("timeout after 1 second")
-	}
+		// Wait until a heartbeat.
+		time.Sleep(5 * time.Minute)
+		// Heartbeat timer should reset before Send(). Pretend Send() blocks.
+		time.Sleep(3 * time.Minute)
+
+		result1 := <-outputs // First heartbeat (queued after first sleep).
+		result1Time := time.Now()
+
+		result2 := <-outputs // Second heartbeat after only 2 more minutes.
+		result2Time := time.Now()
+
+		assert.Zero(t, *result1)
+		assert.Zero(t, *result2)
+		assert.InEpsilon(t, 8*time.Minute, result1Time.Sub(startTime), 0.01)
+		assert.InEpsilon(t, 2*time.Minute, result2Time.Sub(result1Time), 0.01)
+	})
 }

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -225,7 +225,7 @@ func NewFileStream(
 	return factory.New(
 		fileStreamRetryClient,
 		extraWork.BeforeEndCtx(),
-		/*heartbeatStopwatch=*/ nil,
+		/*heartbeatPeriod=*/ 0, // use default
 		transmitRateLimit,
 	)
 }


### PR DESCRIPTION
Replaces usage of `internal/waiting` in `internal/filestream` by `testing/synctest`.