### PR TITLE
chore: lower default pytest timeout from 5m to 60s

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -144,7 +144,7 @@ def run_pytest(
     session.notify("combine_test_results")
 
     # (pytest-timeout) Per-test timeout.
-    pytest_opts.append(f"--timeout={opts.get('timeout', 300)}")
+    pytest_opts.append(f"--timeout={opts.get('timeout', 60)}")
 
     # (pytest-xdist) Run tests in parallel.
     pytest_opts.append(f"-n={opts.get('n', 'auto')}")


### PR DESCRIPTION
No test takes close to 60s as far as I'm aware. Something recently caused a bunch of sweeps and launch tests to hit timeouts, causing a [system-tests job to run for over an hour](https://app.circleci.com/pipelines/github/wandb/wandb/61665/workflows/15a6beda-0abe-43ba-b282-aa5f7b202c8d/jobs/1627562).