### PR TITLE
refactor: use wberrors in filestream

### DIFF
--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observability/wberrors"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/waiting"
 	"github.com/wandb/wandb/core/internal/wboperation"
@@ -219,7 +220,8 @@ func (fs *fileStream) StreamUpdate(update Update) {
 	defer fs.mu.Unlock()
 
 	if fs.isFinished {
-		fs.logger.CaptureError(fmt.Errorf("filestream: StreamUpdate after Finish"))
+		fs.logger.CaptureError(
+			wberrors.Newf("filestream: StreamUpdate after Finish"))
 		return
 	}
 
@@ -259,7 +261,7 @@ func (fs *fileStream) IsStopped() bool { return fs.stopState.Load() }
 // when we can't guarantee correctness, in which case we stop uploading
 // data but continue to save it to disk to avoid data loss.
 func (fs *fileStream) logFatalAndStopWorking(err error) {
-	fs.logger.CaptureFatal(fmt.Errorf("filestream: fatal error: %v", err))
+	fs.logger.CaptureFatal(wberrors.Enrichf(err, "filestream: fatal error"))
 	fs.deadChanOnce.Do(func() {
 		close(fs.deadChan)
 		fs.printer.Errorf(

--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-retryablehttp"
 
+	"github.com/wandb/wandb/core/internal/observability/wberrors"
 	"github.com/wandb/wandb/core/internal/wboperation"
 )
 
@@ -126,12 +128,12 @@ func (fs *fileStream) send(
 ) error {
 	// Stop working after death to avoid data corruption.
 	if fs.isDead() {
-		return fmt.Errorf("filestream: can't send because I am dead")
+		return wberrors.Newf("filestream: can't send because I am dead")
 	}
 
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("filestream: json marshal error in send(): %v", err)
+		return wberrors.Enrichf(err, "filestream: json marshal error in send()")
 	}
 	fs.logger.Debug("filestream: post request", "request", string(jsonData))
 
@@ -145,7 +147,7 @@ func (fs *fileStream) send(
 		bytes.NewReader(jsonData),
 	)
 	if err != nil {
-		return fmt.Errorf("filestream: error constructing request: %v", err)
+		return wberrors.Enrichf(err, "filestream: error constructing request")
 	}
 	req.Header.Set("Content-Type", "application/json")
 
@@ -153,37 +155,32 @@ func (fs *fileStream) send(
 
 	switch {
 	case err != nil:
-		return fmt.Errorf(
-			"filestream: error making HTTP request: %v. got response: %v",
-			err,
-			resp,
-		)
+		return wberrors.Enrichf(err, "filestream: error making HTTP request")
+
 	case resp.StatusCode < 200 || resp.StatusCode > 300:
 		// If we reach here, that means all retries were exhausted. This could
 		// mean, for instance, that the user's internet connection broke.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
 		_ = resp.Body.Close()
 
-		return fmt.Errorf(
-			"filestream: failed to upload: %v url=%v: %s",
-			resp.Status,
-			req.URL,
-			string(body),
-		)
+		return wberrors.Newf("filestream: failed to upload").
+			Attr(slog.String("status", resp.Status)).
+			Attr(slog.String("url", req.URL.String())).
+			Attr(slog.String("response", string(body)))
 	}
 
 	defer func(Body io.ReadCloser) {
 		if err = Body.Close(); err != nil {
-			fs.logger.CaptureError(
-				fmt.Errorf("filestream: error closing response body: %v", err))
+			fs.logger.CaptureError(wberrors.Enrichf(err,
+				"filestream: error closing response body"))
 		}
 	}(resp.Body)
 
 	var res map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
-		fs.logger.CaptureError(
-			fmt.Errorf("filestream: json decode error: %v", err))
+		fs.logger.CaptureError(wberrors.Enrichf(err,
+			"filestream: json decode error"))
 	}
 	feedbackChan <- res
 	fs.logger.Debug("filestream: post response", "response", res)

--- a/core/internal/filestream/filestreamstate.go
+++ b/core/internal/filestream/filestreamstate.go
@@ -1,13 +1,13 @@
 package filestream
 
 import (
-	"fmt"
 	"maps"
 	"slices"
 	"time"
 
 	"github.com/wandb/wandb/core/internal/nullify"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observability/wberrors"
 	"github.com/wandb/wandb/core/internal/runsummary"
 )
 
@@ -199,16 +199,16 @@ func (s *FileStreamState) popSummary(
 
 		if err != nil {
 			// A partial success is possible, so we log and continue.
-			logger.CaptureError(
-				fmt.Errorf("filestream: error applying summary updates: %v", err))
+			logger.CaptureError(wberrors.Enrichf(err,
+				"filestream: error applying summary updates"))
 		}
 
 		summaryJSON, err := s.RunSummary.Serialize()
 		if err != nil {
 			// On error, we don't modify UnsentSummary so that we still upload
 			// a previous successfully-serialized value.
-			logger.CaptureError(
-				fmt.Errorf("filestream: failed to serialize summary: %v", err))
+			logger.CaptureError(wberrors.Enrichf(err,
+				"filestream: failed to serialize summary"))
 		} else {
 			s.UnsentSummary = string(summaryJSON)
 			s.LastRunSummarySize = len(summaryJSON)

--- a/core/internal/filestream/updatehistory.go
+++ b/core/internal/filestream/updatehistory.go
@@ -1,9 +1,10 @@
 package filestream
 
 import (
-	"fmt"
+	"log/slog"
 	"time"
 
+	"github.com/wandb/wandb/core/internal/observability/wberrors"
 	"github.com/wandb/wandb/core/internal/runhistory"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -19,21 +20,16 @@ func (u *HistoryUpdate) Apply(ctx UpdateContext) error {
 	for _, item := range u.Record.Item {
 		err := rh.SetFromRecord(item)
 		if err != nil {
-
 			ctx.Logger.CaptureError(
-				fmt.Errorf(
-					"filestream: failed to apply history record: %v",
-					err,
-				),
-				"key", item.Key,
-				"nested_key", item.NestedKey,
+				wberrors.Enrichf(err, "filestream: failed to apply history").
+					Attr(slog.String("key", item.Key)).
+					Attr(slog.Any("nested_key", item.NestedKey)), // TODO: check
 			)
 		}
 	}
 	line, err := rh.ToExtendedJSON()
 	if err != nil {
-		return fmt.Errorf(
-			"filestream: failed to serialize history: %v", err)
+		return wberrors.Enrichf(err, "filestream: failed to serialize history")
 	}
 
 	// Override the default max line length if the user has set a custom value.

--- a/core/internal/filestream/updatestats.go
+++ b/core/internal/filestream/updatestats.go
@@ -1,11 +1,12 @@
 package filestream
 
 import (
-	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/wandb/simplejsonext"
 
+	"github.com/wandb/wandb/core/internal/observability/wberrors"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -28,8 +29,8 @@ func (u *StatsUpdate) Apply(ctx UpdateContext) error {
 		val, err := simplejsonext.UnmarshalString(item.ValueJson)
 		if err != nil {
 			ctx.Logger.CaptureError(
-				fmt.Errorf("filestream: failed to marshal StatsItem: %v", err),
-				"key", item.Key,
+				wberrors.Enrichf(err, "filestream: failed to marshal StatsItem").
+					Attr(slog.String("key", item.Key)),
 			)
 			continue
 		}
@@ -48,11 +49,8 @@ func (u *StatsUpdate) Apply(ctx UpdateContext) error {
 	switch {
 	case err != nil:
 		// This is a non-blocking failure, so we don't return an error.
-		ctx.Logger.CaptureError(
-			fmt.Errorf(
-				"filestream: failed to marshal system metrics: %v",
-				err,
-			))
+		ctx.Logger.CaptureError(wberrors.Enrichf(err,
+			"filestream: failed to marshal system metrics"))
 	case len(line) > int(maxLineBytes):
 		// This is a non-blocking failure as well.
 		ctx.Logger.CaptureWarn(


### PR DESCRIPTION
Updates `internal/filestream` to use `wberrors` for all errors.