### PR TITLE
chore: increase test_client_csharp timeout

### DIFF
--- a/tests/system_tests/test_experimental/test_client_csharp.py
+++ b/tests/system_tests/test_experimental/test_client_csharp.py
@@ -2,7 +2,10 @@ import os
 import pathlib
 import subprocess
 
+import pytest
 
+
+@pytest.mark.timeout(300)
 def test_client_sharp(wandb_backend_spy):
     script_path = (
         pathlib.Path(__file__).parent.parent.parent.parent


### PR DESCRIPTION
This test builds the C# client, which can take a while. Increase its timeout to 300s (I lowered the default from 300s to 60s recently).