### PR TITLE
refactor: process Sender responses in wandb beta sync

### DIFF
--- a/core/internal/runsync/runsyncer.go
+++ b/core/internal/runsync/runsyncer.go
@@ -144,6 +144,17 @@ func (rs *RunSyncer) Sync(ctx context.Context) error {
 		return nil
 	})
 
+	// Consume the Sender's output channel to prevent it from blocking.
+	//
+	// This is one of the expectations of using the Sender, but we don't
+	// currently process the responses. The channel closes when `sender.Do()`
+	// finishes.
+	g.Go(func() error {
+		for range rs.sender.ResponseChan() {
+		}
+		return nil
+	})
+
 	err := g.Wait()
 	if err != nil {
 		return err


### PR DESCRIPTION
Processes `Sender.ResponseChan()` so that it doesn't block.

The `Sender` sends responses to records based on whether they have a `mailbox_slot`; most records saved in the `.wandb` file don't, with the exception of the initial Run record and the Exit record. We don't use the responses in `wandb beta sync` yet.

Actually, the fact that we save `mailbox_slot` to the `.wandb` file is a design flaw, as `mailbox_slot` only makes sense within the lifetime of a process.