### PR TITLE
chore: use `>` instead of `|` in the regenerate-requirements action message

### DIFF
--- a/.github/workflows/regenerate-requirements.yml
+++ b/.github/workflows/regenerate-requirements.yml
@@ -29,7 +29,7 @@ jobs:
           branch: regenerate-requirements
           delete-branch: true
           title: "chore: update Python requirements"
-          body: |
+          body: >
             Applies updates from `requirements/generate.sh`.
 
             Please approve and merge if tests pass. If tests fail due to


### PR DESCRIPTION
Remove unintentional line breaks from the PR descriptions generated in `regenerate-requirements.yml`.