### PR TITLE
test(launch): allow python executable variants in test_get_entrypoint

### DIFF
--- a/tests/unit_tests/test_launch/test_create_job.py
+++ b/tests/unit_tests/test_launch/test_create_job.py
@@ -123,12 +123,14 @@ def test_get_entrypoint():
 
     program_relpath = builder._get_program_relpath(job_source, metadata)
     entrypoint = builder._get_entrypoint(program_relpath, metadata)
-    assert entrypoint == ["python3", "main.py"]
+    assert entrypoint[1] == "main.py"
+    assert entrypoint[0].startswith("python")
 
     metadata = {"python": "3.9", "codePath": "main.py", "_partial": "v0"}
     program_relpath = builder._get_program_relpath(job_source, metadata)
     entrypoint = builder._get_entrypoint(program_relpath, metadata)
-    assert entrypoint == ["python3", "main.py"]
+    assert entrypoint[1] == "main.py"
+    assert entrypoint[0].startswith("python")
 
     metadata = {"codePath": "main.py"}
     program_relpath = builder._get_program_relpath(job_source, metadata)


### PR DESCRIPTION
<!-- Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable) --> <!-- No internal ticket or GitHub issue associated with this test portability fix -->

What does the PR do? Include a concise description of the PR contents.

The unit test test_get_entrypoint previously asserted that the entrypoint executable must be exactly "python3". However, the implementation derives the interpreter name from sys.executable, whose basename can vary by environment (e.g. python, python3, python3.13, etc.). This caused the test to fail in virtual environments where the interpreter executable is named python.

This PR updates the test assertions to validate that the resolved entrypoint corresponds to a valid Python executable rather than requiring the exact string "python3", ensuring consistent behavior across environments without modifying runtime logic.



## Testing

How was this PR tested?

Ran:

pytest tests/unit_tests/test_launch/test_create_job.py::test_get_entrypoint -v

Verified the test previously failed in a macOS Python 3.13 virtual environment where the executable name is python