### PR TITLE
fix: Add pydantic>=2 lower bound to prevent import crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "PyYAML",
     "platformdirs",
     "typing_extensions>=4.8,<5",
-    "pydantic<3",
+    "pydantic>=2,<3",
     "eval_type_backport; python_version < '3.10'",
     "packaging",
 ]


### PR DESCRIPTION
## Summary
- Adds `>=2` lower bound to the `pydantic` dependency in `pyproject.toml`
- Prevents `ImportError` when `import wandb` is called with pydantic 1.x installed

Closes #10864

## What was happening

The dependency spec `pydantic<3` allows pydantic 1.x to be installed, but the codebase imports pydantic v2 APIs (`ConfigDict`, `model_dump`, `model_serializer`) that don't exist in v1.x. Installing `wandb` with `pydantic==1.9.2` succeeds, but `import wandb` crashes with:

```
ImportError: cannot import name 'ConfigDict' from 'pydantic'
```

## Fix

Changed `pydantic<3` to `pydantic>=2,<3` so pip/uv will reject pydantic 1.x at install time rather than failing at import time.

## Test plan
- [ ] `pip install wandb 'pydantic==1.9.2'` should now fail at install time with a dependency conflict
- [ ] `pip install wandb` continues to work with pydantic 2.x