### PR TITLE
fix: Handle RANK import failure in ultralytics >= 8.3.239

### DIFF
--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -48,8 +48,14 @@ try:
 
     try:
         from ultralytics.yolo.utils import RANK, __version__
-    except ModuleNotFoundError:
-        from ultralytics.utils import RANK, __version__
+    except (ModuleNotFoundError, ImportError):
+        try:
+            from ultralytics.utils import RANK, __version__
+        except ImportError:
+            import os
+
+            RANK = int(os.environ.get("LOCAL_RANK", os.environ.get("RANK", -1)))
+            __version__ = ultralytics.__version__
 
     from wandb.integration.ultralytics.bbox_utils import (
         plot_bbox_predictions,


### PR DESCRIPTION
## Summary
- Fixes `NameError: name 'RANK' is not defined` when using `add_wandb_callback()` with ultralytics >= 8.3.239
- Adds fallback to `LOCAL_RANK`/`RANK` environment variables when the import fails

Closes #11099

## What was happening

In ultralytics >= 8.3.239, `RANK` may no longer be directly importable from `ultralytics.utils`. The inner `try/except` at line 49-52 only catches `ModuleNotFoundError`, not `ImportError`, so when `RANK` is missing from `ultralytics.utils` the `ImportError` bubbles up to the outer `except Exception` at line 71 which silently swallows it. Then at line 504, `if RANK in [-1, 0]:` raises `NameError`.

## Fix

- Broadened the inner `except` to catch `ImportError` (parent of `ModuleNotFoundError`)
- Added a final fallback that reads `LOCAL_RANK`/`RANK` from the environment, which is the standard mechanism PyTorch distributed uses to communicate rank to subprocesses

## Test plan
- [ ] `add_wandb_callback(model)` works with ultralytics >= 8.3.239
- [ ] Still works with older ultralytics versions that export `RANK` from `ultralytics.utils`
- [ ] Single-GPU (non-distributed) usage defaults to RANK=-1 correctly