### PR TITLE
fix(sdk): use warning instead of info log when API key can't be verified

### DIFF
--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -331,7 +331,16 @@ def _print_logged_in_message(settings: wandb.Settings, *, host: str) -> None:
 
         login_state_str = f"Currently logged in as: {click.style(username, fg='yellow')}{entity_str}{host_str}"
     else:
-        login_state_str = "W&B API key is configured"
+        login_info_str = (
+            f"Use {click.style('`wandb login --relogin`', bold=True)}"
+            " to force relogin"
+        )
+        term.termwarn(
+            f"W&B API key is configured but could not be verified"
+            f" (unable to retrieve username). {login_info_str}",
+            repeat=False,
+        )
+        return
 
     login_info_str = (
         f"Use {click.style('`wandb login --relogin`', bold=True)} to force relogin"


### PR DESCRIPTION
## Summary

When `wandb.login()` succeeds but the username can't be retrieved from the server, `_print_logged_in_message` currently shows `"W&B API key is configured"` via `termlog`. This looks like a successful login confirmation, which is misleading — the key exists but couldn't actually be verified.

This changes the else branch to use `termwarn` with a clearer message: `"W&B API key is configured but could not be verified (unable to retrieve username)"`, and returns early so the subsequent "Currently logged in as:" line (which would have empty/None state) is never reached.

**Before:**
```
wandb: W&B API key is configured. Use `wandb login --relogin` to force relogin
```

**After:**
```
wandb: WARNING W&B API key is configured but could not be verified (unable to retrieve username). Use `wandb login --relogin` to force relogin
```

The change is limited to the `else` branch of `_print_logged_in_message` in `wandb/sdk/wandb_login.py` — no other code paths are affected.

Fixes #11089