### PR TITLE
chore: unblock CI by pinning uv==0.10.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
     steps:
       - run:
           name: Install Python dependencies
-          command: python -m pip install -U nox pip uv
+          command: python -m pip install -U nox pip uv==0.10.4
           no_output_timeout: 5m
 
       - run:
@@ -128,7 +128,7 @@ commands:
     steps:
       - run:
           name: Upgrade pip and uv
-          command: python -m pip install -U pip uv
+          command: python -m pip install -U pip uv==0.10.4
       - run:
           name: Install tool dependencies
           command: |
@@ -407,7 +407,7 @@ jobs:
       - install_rust
       - run:
           name: Install Python dependencies
-          command: python -m pip install -U nox pip uv
+          command: python -m pip install -U nox pip uv==0.10.4
           no_output_timeout: 5m
       - run:
           name: Ensure proto files were generated


### PR DESCRIPTION
Description
-----------
The latest uv release (0.10.5) changed linking behavior, which throws off the wandb-core binary permissions during installation in some environments.

Relevant GH issue: https://github.com/astral-sh/uv/issues/18181.

REMEMBER TO UNPIN UV ONCE THIS IS RESOLVED!!

Default LinkMode changed from Hardlink → Clone on Linux, and reflink doesn't preserve file permissions. Default link mode on Linux switched to Clone:
In crates/uv-fs/src/link.rs (new file, extracted from linker.rs):

```rust
// OLD (0.10.4) — crates/uv-install-wheel/src/linker.rs
impl Default for LinkMode {
    fn default() -> Self {
        if cfg!(any(target_os = "macos", target_os = "ios")) {
            Self::Clone          // Clone only on macOS/iOS
        } else {
            Self::Hardlink       // ← Linux used Hardlink
        }
    }
}

// NEW (0.10.5) — crates/uv-fs/src/link.rs
impl Default for LinkMode {
    fn default() -> Self {
        if cfg!(any(target_os = "macos", target_os = "ios", target_os = "linux")) {
            Self::Clone          // ← Linux now uses Clone too!
        } else {
            Self::Hardlink
        }
    }
}
```

The reflink_copy crate's Linux implementation doesn't copy permissions
```rust
rustpub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
    let src = fs::File::open(from)?;
    let dest = AutoRemovedFile::create_new(to)?;   // ← creates with 0o666 & !umask = 0o644
    rustix::fs::ioctl_ficlone(&dest, &src)?;        // ← clones DATA only, not permissions
    dest.persist();
    Ok(())
}
```

Where AutoRemovedFile::create_new does:

```rust
rustlet inner = File::options().write(true).create_new(true).open(path)?;
// This creates the file with mode 0o666 & !umask → typically 0o644 (-rw-r--r--)
```

The FICLONE ioctl only clones data blocks at the filesystem level. It does not copy the source file's permission bits. So the destination keeps its creation-time permissions of 0o644.
Contrast with macOS, where clonefile() performs a full filesystem-level clone including metadata/permissions — so the bug never appeared there.
