### PR TITLE
feat(integration): add aviato integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ gpu_stats/target/
 # Outputs of tools/local_wandb_server.py
 tools/local_wandb_server.state.lock
 tools/local_wandb_server.state
+
+# wandb run logs (local dev)
+wandb/run-*/
+wandb/latest-run
+wandb/debug*.log
+artifacts/

--- a/aviato-wandb-example.py
+++ b/aviato-wandb-example.py
@@ -1,0 +1,118 @@
+"""End-to-end example: wandb + aviato integration.
+
+Demonstrates that wandb.integration.aviato automatically:
+1. Injects WANDB_API_KEY, WANDB_ENTITY, WANDB_PROJECT into every sandbox
+2. Tags sandboxes with the wandb run name
+3. Logs each sandbox ID to the wandb run on start
+
+Each sandbox runs a simulated "training" loop that logs metrics (noisy sin
+wave) back to W&B — no manual credential setup needed.
+
+Setup (from the wandb repo root):
+    # 1. Install wandb from local checkout
+    uv pip install -e .
+
+    # 2. Install buf CLI and authenticate (needed for aviato's protobuf deps)
+    brew install bufbuild/buf/buf   # macOS, or see https://buf.build/docs/installation/
+    buf registry login              # opens browser
+
+    # 3. Install aviato-client from local checkout
+    uv pip install -e ../aviato-client --extra-index-url https://buf.build/gen/python
+
+Run:
+    python aviato-wandb-example.py
+    DEBUG=1 python aviato-wandb-example.py   # verbose logging
+"""
+
+import logging
+import os
+import textwrap
+
+if os.environ.get("DEBUG"):
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(name)s %(message)s")
+
+import aviato
+
+import wandb
+
+# Script that each sandbox runs — simulates training with a noisy sin wave.
+# Credentials are injected automatically by the integration.
+TRAIN_SCRIPT = textwrap.dedent("""\
+    import math
+    import random
+    import wandb
+
+    lr = {lr}
+    epochs = {epochs}
+    label = "{label}"
+
+    with wandb.init(project="aviato-wandb-example", job_type="train", name=label) as run:
+        for epoch in range(epochs):
+            t = epoch / epochs
+            # lr shifts the phase and amplitude so each sandbox traces a different curve
+            loss = math.sin(t * math.pi * 2 + lr * 500) * (0.3 + lr * 50) + 0.5 + random.gauss(0, 0.05)
+            acc = max(0, 1 - loss) + random.gauss(0, 0.03)
+            run.log({{"epoch": epoch, "loss": loss, "accuracy": acc, "lr": lr}})
+        print(f"{{label}}: final loss={{loss:.4f}}, accuracy={{acc:.4f}}")
+""")
+
+with wandb.init(
+    project="aviato-wandb-example",
+    job_type="orchestrator",
+    settings=wandb.Settings(init_timeout=120),
+) as run:
+    wandb.termlog(f"W&B run: {run.url}")
+
+    with aviato.Session() as session:
+        # --- Single sandbox ---
+        wandb.termlog("single sandbox...")
+        sb = session.sandbox(
+            container_image="python:3.11",
+            network=aviato.NetworkOptions(egress_mode="internet"),
+        )
+        aviato.wait([sb])
+        wandb.termlog(f"  {sb.sandbox_id} RUNNING")
+
+        sb.exec(["pip", "install", "wandb", "-q"]).result()
+        result = sb.exec(
+            [
+                "python",
+                "-c",
+                TRAIN_SCRIPT.format(lr=0.01, epochs=20, label="single-sandbox"),
+            ]
+        ).result()
+        wandb.termlog(f"  {result.stdout.strip()}")
+
+        # --- Multiple sandboxes in parallel ---
+        NUM = 3
+        configs = [
+            {"lr": 0.001 * (i + 1), "epochs": 20 + i * 10, "label": f"parallel-{i}"}
+            for i in range(NUM)
+        ]
+
+        wandb.termlog(f"creating {NUM} sandboxes in parallel...")
+        sandboxes = [
+            session.sandbox(
+                container_image="python:3.11",
+                network=aviato.NetworkOptions(egress_mode="internet"),
+            )
+            for _ in range(NUM)
+        ]
+
+        aviato.wait(sandboxes)
+        for s in sandboxes:
+            wandb.termlog(f"  {s.sandbox_id} RUNNING")
+
+        # Install wandb in all sandboxes (parallel)
+        installs = [s.exec(["pip", "install", "wandb", "-q"]) for s in sandboxes]
+        aviato.results(installs)
+
+        # Run training in all sandboxes (parallel)
+        procs = [
+            s.exec(["python", "-c", TRAIN_SCRIPT.format(**cfg)])
+            for s, cfg in zip(sandboxes, configs)
+        ]
+        for _cfg, r in zip(configs, aviato.results(procs)):
+            wandb.termlog(f"  {r.stdout.strip()}")
+
+    wandb.termlog("done — check your W&B dashboard!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ models = ["cloudpickle"]
 perf = ["orjson"]
 importers = ["polars<=1.2.1", "rich", "filelock", "mlflow", "tenacity"]
 workspaces = ["wandb-workspaces"]
+aviato = ["aviato"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/unit_tests/test_aviato_integration.py
+++ b/tests/unit_tests/test_aviato_integration.py
@@ -1,0 +1,412 @@
+"""Tests for wandb.integration.aviato — Session, SandboxDefaults, Sandbox monkeypatch."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from dataclasses import dataclass, field, replace
+from typing import Any
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fake aviato module — mirrors Session / SandboxDefaults / Sandbox just enough
+# for the integration to work without installing aviato.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeSandboxDefaults:
+    environment_variables: dict[str, str] = field(default_factory=dict)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def with_overrides(self, **kwargs: Any) -> _FakeSandboxDefaults:
+        return replace(self, **kwargs)
+
+    def merge_environment_variables(
+        self, additional: dict[str, str] | None
+    ) -> dict[str, str]:
+        merged = dict(self.environment_variables)
+        if additional:
+            merged.update(additional)
+        return merged
+
+    def merge_tags(self, additional: list[str] | None) -> list[str]:
+        base = list(self.tags)
+        if additional:
+            base.extend(additional)
+        return base
+
+
+class _FakeSandbox:
+    def __init__(self, sandbox_id: str | None = None) -> None:
+        self.sandbox_id = sandbox_id
+
+    async def _start_async(self) -> str:
+        self.sandbox_id = self.sandbox_id or "sb-fake"
+        return self.sandbox_id
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        defaults: _FakeSandboxDefaults | None = None,
+    ) -> None:
+        self._defaults = defaults or _FakeSandboxDefaults()
+        self._sandboxes: dict[int, _FakeSandbox] = {}
+        self._closed = False
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+
+def _make_fake_aviato_module() -> types.ModuleType:
+    mod = types.ModuleType("aviato")
+    mod.Session = _FakeSession  # type: ignore[attr-defined]
+    mod.SandboxDefaults = _FakeSandboxDefaults  # type: ignore[attr-defined]
+    mod.Sandbox = _FakeSandbox  # type: ignore[attr-defined]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_aviato(monkeypatch: pytest.MonkeyPatch):
+    """Inject fake aviato into sys.modules and clean up after each test."""
+    # Save true originals before any patching
+    orig_enter = _FakeSession.__enter__
+    orig_exit = _FakeSession.__exit__
+    orig_aenter = _FakeSession.__aenter__
+    orig_aexit = _FakeSession.__aexit__
+    orig_merge = _FakeSandboxDefaults.merge_environment_variables
+    orig_start = _FakeSandbox._start_async
+
+    fake = _make_fake_aviato_module()
+    monkeypatch.setitem(sys.modules, "aviato", fake)
+    yield
+    # Restore true originals — prevents wrapping accumulation across tests
+    _FakeSession.__enter__ = orig_enter  # type: ignore[assignment]
+    _FakeSession.__exit__ = orig_exit  # type: ignore[assignment]
+    _FakeSession.__aenter__ = orig_aenter  # type: ignore[assignment]
+    _FakeSession.__aexit__ = orig_aexit  # type: ignore[assignment]
+    _FakeSandboxDefaults.merge_environment_variables = orig_merge  # type: ignore[assignment]
+    _FakeSandbox._start_async = orig_start  # type: ignore[assignment]
+    for cls in (_FakeSession, _FakeSandboxDefaults, _FakeSandbox):
+        for attr in list(vars(cls)):
+            if attr.startswith("_wandb_"):
+                delattr(cls, attr)
+
+
+@pytest.fixture()
+def mock_run(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    run = mock.Mock()
+    run.id = "abc123"
+    run.name = "crimson-sunset-42"
+    run._settings.api_key = "test-api-key"
+    run.entity = "test-entity"
+    run.project = "test-project"
+    run._settings.base_url = "https://api.wandb.ai"
+    monkeypatch.setattr("wandb.run", run)
+    return run
+
+
+# ---------------------------------------------------------------------------
+# patch / unpatch
+# ---------------------------------------------------------------------------
+
+
+def test_patch_sets_flag():
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    assert getattr(_FakeSession, "_wandb_patched", False) is True
+
+
+def test_patch_is_idempotent():
+    from wandb.integration.aviato import patch
+
+    patch()
+    enter_after_first = _FakeSession.__enter__
+
+    patch()  # second call — no-op
+    assert _FakeSession.__enter__ is enter_after_first
+
+
+def test_unpatch_restores_originals():
+    original_enter = _FakeSession.__enter__
+    original_merge = _FakeSandboxDefaults.merge_environment_variables
+    original_start = _FakeSandbox._start_async
+
+    from wandb.integration.aviato import patch, unpatch
+
+    patch()
+    unpatch()
+
+    assert _FakeSession.__enter__ is original_enter
+    assert _FakeSandboxDefaults.merge_environment_variables is original_merge
+    assert _FakeSandbox._start_async is original_start
+    assert not hasattr(_FakeSession, "_wandb_patched")
+
+
+def test_unpatch_noop_when_not_patched():
+    from wandb.integration.aviato import unpatch
+
+    unpatch()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# 1. Environment variable injection (merge_environment_variables)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_env_injects_wandb_vars(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    defaults = _FakeSandboxDefaults()
+    merged = defaults.merge_environment_variables(None)
+
+    assert merged["WANDB_API_KEY"] == "test-api-key"
+    assert merged["WANDB_ENTITY"] == "test-entity"
+    assert merged["WANDB_PROJECT"] == "test-project"
+    assert "WANDB_BASE_URL" not in merged  # default URL excluded
+
+
+def test_merge_env_no_run(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("wandb.run", None)
+
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    defaults = _FakeSandboxDefaults()
+    merged = defaults.merge_environment_variables(None)
+
+    assert merged == {}
+
+
+def test_merge_env_user_vars_win(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    defaults = _FakeSandboxDefaults(
+        environment_variables={"WANDB_PROJECT": "user-override"}
+    )
+    merged = defaults.merge_environment_variables(None)
+
+    assert merged["WANDB_PROJECT"] == "user-override"  # user wins
+    assert merged["WANDB_API_KEY"] == "test-api-key"  # injected
+
+
+def test_merge_env_additional_vars_win(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    defaults = _FakeSandboxDefaults()
+    merged = defaults.merge_environment_variables(
+        {"WANDB_ENTITY": "sandbox-override", "MY_VAR": "hello"}
+    )
+
+    assert merged["WANDB_ENTITY"] == "sandbox-override"  # additional wins
+    assert merged["MY_VAR"] == "hello"  # preserved
+    assert merged["WANDB_API_KEY"] == "test-api-key"  # injected
+
+
+def test_merge_env_base_url_injected_for_non_default(mock_run: mock.Mock):
+    mock_run._settings.base_url = "https://custom.wandb.ai"
+
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    defaults = _FakeSandboxDefaults()
+    merged = defaults.merge_environment_variables(None)
+
+    assert merged["WANDB_BASE_URL"] == "https://custom.wandb.ai"
+
+
+# ---------------------------------------------------------------------------
+# 2. Session.__enter__ — run ID tagging
+# ---------------------------------------------------------------------------
+
+
+def test_enter_tags_with_run_id(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    session = _FakeSession()
+    session.__enter__()
+
+    assert "wandb-crimson-sunset-42" in session._defaults.tags
+
+
+def test_enter_preserves_existing_tags(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    session = _FakeSession(defaults=_FakeSandboxDefaults(tags=("my-app", "prod")))
+    session.__enter__()
+
+    assert "my-app" in session._defaults.tags
+    assert "prod" in session._defaults.tags
+    assert "wandb-crimson-sunset-42" in session._defaults.tags
+
+
+def test_enter_no_run_no_tag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("wandb.run", None)
+
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    session = _FakeSession()
+    session.__enter__()
+
+    assert session._defaults.tags == ()
+
+
+def test_enter_skips_tag_for_invalid_k8s_name(mock_run: mock.Mock):
+    mock_run.name = "!!!totally invalid!!!"
+
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    session = _FakeSession()
+    session.__enter__()
+
+    # Tag is rejected (not mangled) — no wandb tag added
+    assert session._defaults.tags == ()
+
+
+def test_enter_no_duplicate_tag(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    session = _FakeSession(
+        defaults=_FakeSandboxDefaults(tags=("wandb-crimson-sunset-42",))
+    )
+    session.__enter__()
+
+    assert session._defaults.tags.count("wandb-crimson-sunset-42") == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Sandbox._start_async — log sandbox ID immediately
+# ---------------------------------------------------------------------------
+
+
+def _join_log_threads(timeout: float = 1.0) -> None:
+    """Wait for any daemon threads spawned by _patched_start to finish."""
+    for t in threading.enumerate():
+        if t.daemon and t.name.startswith("Thread"):
+            t.join(timeout)
+
+
+@pytest.mark.asyncio
+async def test_start_logs_sandbox_id(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    sb = _FakeSandbox(sandbox_id="sb-999")
+    sandbox_id = await sb._start_async()
+
+    assert sandbox_id == "sb-999"
+    _join_log_threads()
+    mock_run.log.assert_called_once_with({"aviato/sandbox_id": "sb-999"})
+
+
+@pytest.mark.asyncio
+async def test_start_no_run_no_log(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("wandb.run", None)
+
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    sb = _FakeSandbox(sandbox_id="sb-999")
+    sandbox_id = await sb._start_async()
+
+    _join_log_threads()
+    assert sandbox_id == "sb-999"  # original still works
+
+
+@pytest.mark.asyncio
+async def test_start_log_failure_does_not_propagate(mock_run: mock.Mock):
+    mock_run.log.side_effect = RuntimeError("wandb down")
+
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    sb = _FakeSandbox(sandbox_id="sb-999")
+    sandbox_id = await sb._start_async()
+
+    _join_log_threads()
+    assert sandbox_id == "sb-999"  # sandbox start not affected
+
+
+# ---------------------------------------------------------------------------
+# Async enter path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aenter_tags_with_run_id(mock_run: mock.Mock):
+    from wandb.integration.aviato import patch
+
+    patch()
+
+    session = _FakeSession()
+    await session.__aenter__()
+
+    assert "wandb-crimson-sunset-42" in session._defaults.tags
+
+
+# ---------------------------------------------------------------------------
+# setup()
+# ---------------------------------------------------------------------------
+
+
+def test_setup_patches_when_aviato_imported():
+    from wandb.integration.aviato import setup
+
+    setup()
+
+    assert getattr(_FakeSession, "_wandb_patched", False) is True
+
+
+def test_setup_registers_import_hook_when_aviato_not_imported(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delitem(sys.modules, "aviato")
+
+    with mock.patch("wandb.util.add_import_hook") as mock_add_hook:
+        from wandb.integration.aviato import setup
+
+        setup()
+
+        mock_add_hook.assert_called_once()
+        assert mock_add_hook.call_args[0][0] == "aviato"

--- a/wandb/integration/aviato/__init__.py
+++ b/wandb/integration/aviato/__init__.py
@@ -1,0 +1,289 @@
+"""Aviato integration for W&B.
+
+Monkeypatches aviato so that an active ``wandb.run`` automatically:
+
+1. Injects W&B credentials (``WANDB_API_KEY``, ``WANDB_ENTITY``,
+   ``WANDB_PROJECT``) as environment variables into **every** sandbox
+   — via ``SandboxDefaults.merge_environment_variables``.
+2. Tags sandboxes with the wandb run ID — via ``Session.__enter__``.
+3. Logs each sandbox ID to the wandb run as soon as the backend
+   accepts it — via ``Sandbox._start_async``.
+
+Usage::
+
+    import aviato
+    import wandb
+
+    with wandb.init(project="my-project") as run:
+        with aviato.Session() as session:
+            sb = session.sandbox(...)
+            # sb has WANDB_API_KEY, WANDB_ENTITY, WANDB_PROJECT
+            # sb is tagged with the wandb run ID
+            # sb's sandbox_id is logged to wandb immediately on start
+
+Activation:
+    - Automatic: called from ``wandb.init()``.  If aviato is already
+      imported, patches immediately.  If not, registers an import hook
+      so the patch fires whenever ``import aviato`` happens later.
+    - Manual: ``from wandb.integration.aviato import patch; patch()``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def setup() -> None:
+    """Auto-setup called from ``wandb.init()``.
+
+    If aviato is already imported, patches immediately.  Otherwise
+    registers an import hook so the patch fires on first
+    ``import aviato``.
+    """
+    if "aviato" in sys.modules:
+        try:
+            patch()
+        except Exception as e:
+            logger.warning("Failed to auto-patch aviato: %s", e)
+    else:
+        from wandb.util import add_import_hook
+
+        def _on_aviato_import() -> None:
+            try:
+                patch()
+            except Exception as e:
+                logger.warning("Failed to auto-patch aviato: %s", e)
+
+        add_import_hook("aviato", _on_aviato_import)
+
+
+def patch() -> None:
+    """Monkeypatch aviato to integrate with W&B.
+
+    Safe to call multiple times — subsequent calls are no-ops.
+
+    Raises:
+        ImportError: If aviato is not installed.
+    """
+    import aviato
+
+    if getattr(aviato.Session, "_wandb_patched", False):
+        return
+
+    _patch_merge_environment_variables(aviato)
+    _patch_session_enter(aviato)
+    _patch_sandbox_start(aviato)
+
+    aviato.Session._wandb_patched = True  # type: ignore[attr-defined]
+    logger.debug("Patched aviato with W&B integration")
+
+
+def unpatch() -> None:
+    """Restore original aviato methods."""
+    try:
+        import aviato
+    except ImportError:
+        return
+
+    if not getattr(aviato.Session, "_wandb_patched", False):
+        return
+
+    _unpatch_merge_environment_variables(aviato)
+    _unpatch_session_enter(aviato)
+    _unpatch_sandbox_start(aviato)
+
+    del aviato.Session._wandb_patched  # type: ignore[attr-defined]
+    logger.debug("Unpatched aviato")
+
+
+# ---------------------------------------------------------------------------
+# 1. Environment variable injection (SandboxDefaults.merge_environment_variables)
+# ---------------------------------------------------------------------------
+
+
+def _get_wandb_env() -> dict[str, str]:
+    """Build dict of W&B env vars to inject, or empty dict if no active run."""
+    import wandb
+
+    run = wandb.run
+    if run is None:
+        return {}
+
+    env: dict[str, str] = {}
+
+    api_key = run._settings.api_key
+    if api_key:
+        env["WANDB_API_KEY"] = api_key
+
+    if run.entity:
+        env["WANDB_ENTITY"] = run.entity
+
+    if run.project:
+        env["WANDB_PROJECT"] = run.project
+
+    base_url = run._settings.base_url
+    if base_url and base_url != "https://api.wandb.ai":
+        env["WANDB_BASE_URL"] = base_url
+
+    return env
+
+
+def _patch_merge_environment_variables(aviato: Any) -> None:
+    defaults_cls = aviato.SandboxDefaults
+    original = defaults_cls.merge_environment_variables
+
+    def _patched_merge(self: Any, additional: dict[str, str] | None) -> dict[str, str]:
+        # Original merge: defaults ← additional (additional wins)
+        merged = original(self, additional)
+        # Inject wandb env vars underneath — user/additional values win
+        wandb_env = _get_wandb_env()
+        if wandb_env:
+            merged = {**wandb_env, **merged}
+        return merged
+
+    defaults_cls._wandb_original_merge_env = original  # type: ignore[attr-defined]
+    defaults_cls.merge_environment_variables = _patched_merge  # type: ignore[assignment]
+
+
+def _unpatch_merge_environment_variables(aviato: Any) -> None:
+    defaults_cls = aviato.SandboxDefaults
+    if hasattr(defaults_cls, "_wandb_original_merge_env"):
+        defaults_cls.merge_environment_variables = (
+            defaults_cls._wandb_original_merge_env
+        )
+        del defaults_cls._wandb_original_merge_env
+
+
+# ---------------------------------------------------------------------------
+# 2. Session.__enter__ — tag sandboxes with the wandb run ID
+# ---------------------------------------------------------------------------
+
+
+def _is_valid_k8s_label(value: str) -> bool:
+    """Check if a string is a valid Kubernetes label value.
+
+    K8s labels must match ``([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]``:
+    alphanumeric, hyphens, underscores, dots; must start and end with
+    an alphanumeric character; max 63 chars.
+    """
+    import re
+
+    if not value or len(value) > 63:
+        return False
+    return bool(re.fullmatch(r"[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?", value))
+
+
+def _get_wandb_run_tag() -> str | None:
+    """Return a K8s-safe tag like ``wandb-<run-name>``, or None if not usable.
+
+    Returns None (skips tagging) if the run name produces an invalid
+    Kubernetes label value — better to skip than to silently mangle.
+    """
+    import wandb
+
+    run = wandb.run
+    if run is None or not run.name:
+        return None
+    tag = f"wandb-{run.name}"
+    if not _is_valid_k8s_label(tag):
+        logger.warning(
+            "Skipping aviato sandbox tagging: run name %r produces "
+            "invalid K8s label %r",
+            run.name,
+            tag,
+        )
+        return None
+    return tag
+
+
+def _patch_session_enter(aviato: Any) -> None:
+    original_enter = aviato.Session.__enter__
+    original_aenter = aviato.Session.__aenter__
+
+    def _patched_enter(self: Any) -> Any:
+        _tag_session_defaults(self)
+        return original_enter(self)
+
+    async def _patched_aenter(self: Any) -> Any:
+        _tag_session_defaults(self)
+        return await original_aenter(self)
+
+    aviato.Session._wandb_original_enter = original_enter  # type: ignore[attr-defined]
+    aviato.Session._wandb_original_aenter = original_aenter  # type: ignore[attr-defined]
+    aviato.Session.__enter__ = _patched_enter  # type: ignore[assignment]
+    aviato.Session.__aenter__ = _patched_aenter  # type: ignore[assignment]
+
+
+def _unpatch_session_enter(aviato: Any) -> None:
+    if hasattr(aviato.Session, "_wandb_original_enter"):
+        aviato.Session.__enter__ = aviato.Session._wandb_original_enter
+        aviato.Session.__aenter__ = aviato.Session._wandb_original_aenter
+        del aviato.Session._wandb_original_enter
+        del aviato.Session._wandb_original_aenter
+
+
+def _tag_session_defaults(session: Any) -> None:
+    """Add wandb run ID tag to session defaults."""
+    tag = _get_wandb_run_tag()
+    if tag is None:
+        return
+
+    existing_tags = session._defaults.tags
+    if tag not in existing_tags:
+        session._defaults = session._defaults.with_overrides(
+            tags=(*existing_tags, tag),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Sandbox._start_async — log sandbox ID as soon as it's available
+# ---------------------------------------------------------------------------
+
+
+def _patch_sandbox_start(aviato: Any) -> None:
+    sandbox_cls = aviato.Sandbox
+    original_start = sandbox_cls._start_async
+
+    async def _patched_start(self: Any) -> str:
+        sandbox_id = await original_start(self)
+        # Fire-and-forget — don't block sandbox creation on wandb logging
+        import threading
+
+        threading.Thread(
+            target=_log_sandbox_id, args=(sandbox_id,), daemon=True
+        ).start()
+        return sandbox_id
+
+    sandbox_cls._wandb_original_start_async = original_start  # type: ignore[attr-defined]
+    sandbox_cls._start_async = _patched_start  # type: ignore[assignment]
+
+
+def _unpatch_sandbox_start(aviato: Any) -> None:
+    sandbox_cls = aviato.Sandbox
+    if hasattr(sandbox_cls, "_wandb_original_start_async"):
+        sandbox_cls._start_async = sandbox_cls._wandb_original_start_async
+        del sandbox_cls._wandb_original_start_async
+
+
+def _log_sandbox_id(sandbox_id: str) -> None:
+    """Log a single sandbox ID to the active wandb run."""
+    import wandb
+
+    run = wandb.run
+    if run is None:
+        return
+
+    try:
+        run.log({"aviato/sandbox_id": sandbox_id})
+        logger.debug("Logged aviato sandbox %s to wandb", sandbox_id)
+    except Exception as e:
+        logger.warning("Failed to log aviato sandbox ID to wandb: %s", e)

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -33,6 +33,7 @@ from wandb.errors import CommError, Error, UsageError
 from wandb.errors.links import url_registry
 from wandb.errors.util import ProtobufErrorHandler
 from wandb.integration import sagemaker, weave
+from wandb.integration.aviato import setup as aviato_setup
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
 from wandb.sdk.lib import ipython as wb_ipython
 from wandb.sdk.lib import progress, runid, wb_logging
@@ -1579,6 +1580,9 @@ def init(  # noqa: C901
 
             # Set up automatic Weave integration if Weave is installed
             weave.setup(run_settings.entity, run_settings.project)
+
+            # Patch aviato.Session to inject W&B env vars into sandboxes
+            aviato_setup()
 
             return run
 


### PR DESCRIPTION
## Summary
- Adds `wandb.integration.aviato` that monkeypatches aviato to automatically inject W&B credentials, tag sandboxes with the run name, and log sandbox IDs
- Activates automatically from `wandb.init()` via import hook (works regardless of import order)
- Adds `aviato` optional dependency in pyproject.toml
- 20 unit tests covering patch/unpatch, env injection, tagging, sandbox ID logging, async paths

## Test plan
- [x] `pytest tests/unit_tests/test_aviato_integration.py -v` — 20 tests pass
- [ ] Manual e2e test with `python aviato-wandb-example.py`
- [ ] Verify sandbox tags visible in aviato dashboard
- [ ] Verify WANDB_API_KEY, WANDB_ENTITY, WANDB_PROJECT present in sandbox env