### PR TITLE
feat(integration): add run.SandboxSession for aviato

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ gpu_stats/target/
 # Outputs of tools/local_wandb_server.py
 tools/local_wandb_server.state.lock
 tools/local_wandb_server.state
+
+# wandb run logs (local dev)
+wandb/run-*/
+wandb/latest-run
+wandb/debug*.log
+artifacts/

--- a/aviato-wandb-example.py
+++ b/aviato-wandb-example.py
@@ -1,0 +1,119 @@
+"""End-to-end example: wandb + aviato integration via run.SandboxSession.
+
+Demonstrates that run.SandboxSession automatically:
+1. Injects WANDB_API_KEY, WANDB_ENTITY, WANDB_PROJECT into every sandbox
+2. Tags sandboxes with the wandb run name
+3. Logs each sandbox ID to the wandb run on start
+
+Each sandbox runs a simulated "training" loop that logs metrics (noisy sin
+wave) back to W&B — no manual credential setup needed.
+
+Setup (from the wandb repo root):
+    # 1. Install wandb from local checkout
+    uv pip install -e .
+
+    # 2. Install buf CLI and authenticate (needed for aviato's protobuf deps)
+    brew install bufbuild/buf/buf   # macOS, or see https://buf.build/docs/installation/
+    buf registry login              # opens browser
+
+    # 3. Install aviato-client from local checkout
+    uv pip install -e ../aviato-client --extra-index-url https://buf.build/gen/python
+
+Run:
+    python aviato-wandb-example.py
+    DEBUG=1 python aviato-wandb-example.py   # verbose logging
+"""
+
+import logging
+import os
+import textwrap
+
+if os.environ.get("DEBUG"):
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(name)s %(message)s")
+
+import aviato
+
+import wandb
+
+# Script that each sandbox runs — simulates training with a noisy sin wave.
+# Credentials are injected automatically by the integration.
+TRAIN_SCRIPT = textwrap.dedent("""\
+    import math
+    import random
+    import wandb
+
+    lr = {lr}
+    epochs = {epochs}
+    label = "{label}"
+
+    with wandb.init(project="aviato-wandb-example", job_type="train", name=label) as run:
+        for epoch in range(epochs):
+            t = epoch / epochs
+            # lr shifts the phase and amplitude so each sandbox traces a different curve
+            loss = math.sin(t * math.pi * 2 + lr * 500) * (0.3 + lr * 50) + 0.5 + random.gauss(0, 0.05)
+            acc = max(0, 1 - loss) + random.gauss(0, 0.03)
+            run.log({{"epoch": epoch, "loss": loss, "accuracy": acc, "lr": lr}})
+        print(f"{{label}}: final loss={{loss:.4f}}, accuracy={{acc:.4f}}")
+""")
+
+with wandb.init(
+    project="aviato-wandb-example",
+    job_type="orchestrator",
+    settings=wandb.Settings(init_timeout=120),
+) as run:
+    wandb.termlog(f"W&B run: {run.url}")
+
+    # run.SandboxSession is aviato.Session with W&B integration baked in
+    with run.SandboxSession() as session:
+        # --- Single sandbox ---
+        wandb.termlog("single sandbox...")
+        sb = session.sandbox(
+            container_image="python:3.11",
+            network=aviato.NetworkOptions(egress_mode="internet"),
+        )
+        aviato.wait([sb])
+        wandb.termlog(f"  {sb.sandbox_id} RUNNING")
+
+        sb.exec(["pip", "install", "wandb", "-q"]).result()
+        result = sb.exec(
+            [
+                "python",
+                "-c",
+                TRAIN_SCRIPT.format(lr=0.01, epochs=20, label="single-sandbox"),
+            ]
+        ).result()
+        wandb.termlog(f"  {result.stdout.strip()}")
+
+        # --- Multiple sandboxes in parallel ---
+        NUM = 3
+        configs = [
+            {"lr": 0.001 * (i + 1), "epochs": 20 + i * 10, "label": f"parallel-{i}"}
+            for i in range(NUM)
+        ]
+
+        wandb.termlog(f"creating {NUM} sandboxes in parallel...")
+        sandboxes = [
+            session.sandbox(
+                container_image="python:3.11",
+                network=aviato.NetworkOptions(egress_mode="internet"),
+            )
+            for _ in range(NUM)
+        ]
+
+        aviato.wait(sandboxes)
+        for s in sandboxes:
+            wandb.termlog(f"  {s.sandbox_id} RUNNING")
+
+        # Install wandb in all sandboxes (parallel)
+        installs = [s.exec(["pip", "install", "wandb", "-q"]) for s in sandboxes]
+        aviato.results(installs)
+
+        # Run training in all sandboxes (parallel)
+        procs = [
+            s.exec(["python", "-c", TRAIN_SCRIPT.format(**cfg)])
+            for s, cfg in zip(sandboxes, configs)
+        ]
+        for _cfg, r in zip(configs, aviato.results(procs)):
+            wandb.termlog(f"  {r.stdout.strip()}")
+
+    wandb.termlog("done — check your W&B dashboard!")

--- a/tests/unit_tests/test_aviato_session.py
+++ b/tests/unit_tests/test_aviato_session.py
@@ -1,0 +1,305 @@
+"""Tests for wandb.integration.aviato.SandboxSession."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from dataclasses import dataclass, field, replace
+from typing import Any
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fake aviato module — mirrors Session / SandboxDefaults / Sandbox just enough
+# for the integration to work without installing aviato.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeSandboxDefaults:
+    environment_variables: dict[str, str] = field(default_factory=dict)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def with_overrides(self, **kwargs: Any) -> _FakeSandboxDefaults:
+        return replace(self, **kwargs)
+
+    def merge_environment_variables(
+        self, additional: dict[str, str] | None
+    ) -> dict[str, str]:
+        merged = dict(self.environment_variables)
+        if additional:
+            merged.update(additional)
+        return merged
+
+    def merge_tags(self, additional: list[str] | None) -> list[str]:
+        base = list(self.tags)
+        if additional:
+            base.extend(additional)
+        return base
+
+
+class _FakeSandbox:
+    def __init__(self, sandbox_id: str | None = None, **kwargs: Any) -> None:
+        self.sandbox_id = sandbox_id
+
+    async def _start_async(self) -> str:
+        self.sandbox_id = self.sandbox_id or "sb-fake"
+        return self.sandbox_id
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        defaults: _FakeSandboxDefaults | None = None,
+        report_to: list[str] | None = None,
+    ) -> None:
+        self._defaults = defaults or _FakeSandboxDefaults()
+        self._sandboxes: dict[int, _FakeSandbox] = {}
+        self._closed = False
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+    def sandbox(self, **kwargs: Any) -> _FakeSandbox:
+        sb = _FakeSandbox(**kwargs)
+        self._sandboxes[id(sb)] = sb
+        return sb
+
+
+def _make_fake_aviato_module() -> types.ModuleType:
+    mod = types.ModuleType("aviato")
+    mod.Session = _FakeSession  # type: ignore[attr-defined]
+    mod.SandboxDefaults = _FakeSandboxDefaults  # type: ignore[attr-defined]
+    mod.Sandbox = _FakeSandbox  # type: ignore[attr-defined]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_aviato(monkeypatch: pytest.MonkeyPatch):
+    """Inject fake aviato into sys.modules for every test."""
+    fake = _make_fake_aviato_module()
+    monkeypatch.setitem(sys.modules, "aviato", fake)
+    # Also clear cached imports of our module so it re-imports with the fake
+    for key in list(sys.modules):
+        if key.startswith("wandb.integration.aviato"):
+            monkeypatch.delitem(sys.modules, key, raising=False)
+
+
+@pytest.fixture()
+def mock_run(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    run = mock.Mock()
+    run.id = "abc123"
+    run.name = "crimson-sunset-42"
+    run._settings.api_key = "test-api-key"
+    run.entity = "test-entity"
+    run.project = "test-project"
+    run._settings.base_url = "https://api.wandb.ai"
+    monkeypatch.setattr("wandb.run", run)
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _join_log_threads(timeout: float = 1.0) -> None:
+    """Wait for any daemon threads spawned by sandbox start hooks."""
+    for t in threading.enumerate():
+        if t.daemon and t.name.startswith("Thread"):
+            t.join(timeout)
+
+
+# ---------------------------------------------------------------------------
+# Environment variable injection
+# ---------------------------------------------------------------------------
+
+
+def test_injects_wandb_env_vars(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+
+    assert session._defaults.environment_variables["WANDB_API_KEY"] == "test-api-key"
+    assert session._defaults.environment_variables["WANDB_ENTITY"] == "test-entity"
+    assert session._defaults.environment_variables["WANDB_PROJECT"] == "test-project"
+    assert "WANDB_BASE_URL" not in session._defaults.environment_variables
+
+
+def test_no_run_no_injection(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("wandb.run", None)
+
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+
+    assert session._defaults.environment_variables == {}
+
+
+def test_user_env_vars_take_precedence(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    user_defaults = _FakeSandboxDefaults(
+        environment_variables={"WANDB_PROJECT": "user-override", "MY_VAR": "hello"}
+    )
+    session = SandboxSession(defaults=user_defaults)
+
+    assert session._defaults.environment_variables["WANDB_PROJECT"] == "user-override"
+    assert session._defaults.environment_variables["MY_VAR"] == "hello"
+    assert session._defaults.environment_variables["WANDB_API_KEY"] == "test-api-key"
+
+
+def test_base_url_injected_for_non_default(mock_run: mock.Mock):
+    mock_run._settings.base_url = "https://custom.wandb.ai"
+
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+
+    assert (
+        session._defaults.environment_variables["WANDB_BASE_URL"]
+        == "https://custom.wandb.ai"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session enter — run name tagging
+# ---------------------------------------------------------------------------
+
+
+def test_enter_tags_with_run_name(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+    session.__enter__()
+
+    assert "wandb-crimson-sunset-42" in session._defaults.tags
+
+
+def test_enter_preserves_existing_tags(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession(defaults=_FakeSandboxDefaults(tags=("my-app", "prod")))
+    session.__enter__()
+
+    assert "my-app" in session._defaults.tags
+    assert "prod" in session._defaults.tags
+    assert "wandb-crimson-sunset-42" in session._defaults.tags
+
+
+def test_enter_no_run_no_tag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("wandb.run", None)
+
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+    session.__enter__()
+
+    assert session._defaults.tags == ()
+
+
+def test_enter_no_duplicate_tag(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession(
+        defaults=_FakeSandboxDefaults(tags=("wandb-crimson-sunset-42",))
+    )
+    session.__enter__()
+
+    assert session._defaults.tags.count("wandb-crimson-sunset-42") == 1
+
+
+def test_enter_skips_invalid_k8s_name(mock_run: mock.Mock):
+    mock_run.name = "!!!totally invalid!!!"
+
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+    session.__enter__()
+
+    assert session._defaults.tags == ()
+
+
+@pytest.mark.asyncio
+async def test_aenter_tags_with_run_name(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+    await session.__aenter__()
+
+    assert "wandb-crimson-sunset-42" in session._defaults.tags
+
+
+# ---------------------------------------------------------------------------
+# Sandbox start — log sandbox ID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sandbox_start_logs_id(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+    sb = session.sandbox(sandbox_id="sb-999")
+    sandbox_id = await sb._start_async()
+
+    assert sandbox_id == "sb-999"
+    _join_log_threads()
+    mock_run.log.assert_called_once_with({"aviato/sandbox_id": "sb-999"})
+
+
+@pytest.mark.asyncio
+async def test_sandbox_start_no_run_no_log(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("wandb.run", None)
+
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+    sb = session.sandbox(sandbox_id="sb-999")
+    sandbox_id = await sb._start_async()
+
+    _join_log_threads()
+    assert sandbox_id == "sb-999"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_start_log_failure_no_propagate(mock_run: mock.Mock):
+    mock_run.log.side_effect = RuntimeError("wandb down")
+
+    from wandb.integration.aviato.session import SandboxSession
+
+    session = SandboxSession()
+    sb = session.sandbox(sandbox_id="sb-999")
+    sandbox_id = await sb._start_async()
+
+    _join_log_threads()
+    assert sandbox_id == "sb-999"
+
+
+# ---------------------------------------------------------------------------
+# run.SandboxSession property
+# ---------------------------------------------------------------------------
+
+
+def test_run_sandbox_session_property(mock_run: mock.Mock):
+    from wandb.integration.aviato.session import SandboxSession
+
+    # Simulate what the property does
+    assert SandboxSession is not None
+    assert issubclass(SandboxSession, _FakeSession)

--- a/wandb/integration/aviato/__init__.py
+++ b/wandb/integration/aviato/__init__.py
@@ -1,0 +1,21 @@
+"""Aviato integration for W&B.
+
+Provides ``SandboxSession``, a subclass of ``aviato.Session`` that
+automatically injects W&B credentials, tags sandboxes with the run name,
+and logs sandbox IDs to the active wandb run.
+
+Usage::
+
+    import wandb
+
+    run = wandb.init(project="my-project")
+    with run.SandboxSession() as session:
+        sb = session.sandbox(container_image="python:3.11")
+        # sb has WANDB_API_KEY, WANDB_ENTITY, WANDB_PROJECT
+        # sb is tagged with the wandb run name
+        # sb's sandbox_id is logged to wandb on start
+"""
+
+from wandb.integration.aviato.session import SandboxSession
+
+__all__ = ["SandboxSession"]

--- a/wandb/integration/aviato/session.py
+++ b/wandb/integration/aviato/session.py
@@ -1,0 +1,150 @@
+"""SandboxSession — aviato.Session subclass with W&B integration."""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from typing import Any
+
+import aviato
+
+import wandb
+
+logger = logging.getLogger(__name__)
+
+
+def _get_wandb_env() -> dict[str, str]:
+    """Build dict of W&B env vars to inject, or empty dict if no active run."""
+    run = wandb.run
+    if run is None:
+        return {}
+
+    env: dict[str, str] = {}
+
+    api_key = run._settings.api_key
+    if api_key:
+        env["WANDB_API_KEY"] = api_key
+
+    if run.entity:
+        env["WANDB_ENTITY"] = run.entity
+
+    if run.project:
+        env["WANDB_PROJECT"] = run.project
+
+    base_url = run._settings.base_url
+    if base_url and base_url != "https://api.wandb.ai":
+        env["WANDB_BASE_URL"] = base_url
+
+    return env
+
+
+def _is_valid_k8s_label(value: str) -> bool:
+    """Check if a string is a valid Kubernetes label value."""
+    if not value or len(value) > 63:
+        return False
+    return bool(re.fullmatch(r"[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?", value))
+
+
+def _get_wandb_run_tag() -> str | None:
+    """Return a K8s-safe tag like ``wandb-<run-name>``, or None if not usable."""
+    run = wandb.run
+    if run is None or not run.name:
+        return None
+    tag = f"wandb-{run.name}"
+    if not _is_valid_k8s_label(tag):
+        logger.warning(
+            "Skipping aviato sandbox tagging: run name %r produces "
+            "invalid K8s label %r",
+            run.name,
+            tag,
+        )
+        return None
+    return tag
+
+
+def _log_sandbox_id(sandbox_id: str) -> None:
+    """Log a single sandbox ID to the active wandb run."""
+    run = wandb.run
+    if run is None:
+        return
+
+    try:
+        run.log({"aviato/sandbox_id": sandbox_id})
+        logger.debug("Logged aviato sandbox %s to wandb", sandbox_id)
+    except Exception as e:
+        logger.warning("Failed to log aviato sandbox ID to wandb: %s", e)
+
+
+class SandboxSession(aviato.Session):
+    """aviato.Session with automatic W&B integration.
+
+    Extends ``aviato.Session`` so that an active ``wandb.run`` automatically:
+
+    1. Injects W&B credentials (``WANDB_API_KEY``, ``WANDB_ENTITY``,
+       ``WANDB_PROJECT``) as environment variables into every sandbox.
+    2. Tags sandboxes with the wandb run name.
+    3. Logs each sandbox ID to the wandb run on start.
+
+    User-provided environment variables and tags always take precedence.
+
+    Example::
+
+        run = wandb.init(project="my-project")
+        with run.SandboxSession() as session:
+            sb = session.sandbox(container_image="python:3.11")
+    """
+
+    def __init__(
+        self,
+        defaults: aviato.SandboxDefaults | None = None,
+        report_to: list[str] | None = None,
+    ) -> None:
+        defaults = defaults or aviato.SandboxDefaults()
+
+        # Inject W&B env vars underneath user-provided ones
+        wandb_env = _get_wandb_env()
+        if wandb_env:
+            merged_env = {**wandb_env, **defaults.environment_variables}
+            defaults = defaults.with_overrides(environment_variables=merged_env)
+
+        super().__init__(defaults=defaults, report_to=report_to)
+
+    def __enter__(self) -> SandboxSession:
+        self._tag_defaults()
+        return super().__enter__()  # type: ignore[return-value]
+
+    async def __aenter__(self) -> SandboxSession:
+        self._tag_defaults()
+        return await super().__aenter__()  # type: ignore[return-value]
+
+    def sandbox(self, **kwargs: Any) -> aviato.Sandbox:
+        sb = super().sandbox(**kwargs)
+        self._hook_sandbox_start(sb)
+        return sb
+
+    def _tag_defaults(self) -> None:
+        """Add wandb run name tag to session defaults."""
+        tag = _get_wandb_run_tag()
+        if tag is None:
+            return
+
+        existing_tags = self._defaults.tags
+        if tag not in existing_tags:
+            self._defaults = self._defaults.with_overrides(
+                tags=(*existing_tags, tag),
+            )
+
+    def _hook_sandbox_start(self, sb: aviato.Sandbox) -> None:
+        """Hook into sandbox start to log sandbox_id to wandb."""
+        original_start = sb._start_async
+
+        async def _patched_start() -> str:
+            sandbox_id = await original_start()
+            # Fire-and-forget — don't block sandbox creation
+            threading.Thread(
+                target=_log_sandbox_id, args=(sandbox_id,), daemon=True
+            ).start()
+            return sandbox_id
+
+        sb._start_async = _patched_start  # type: ignore[assignment]

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -813,6 +813,23 @@ class Run:
         return self._torch_history
 
     @property
+    def SandboxSession(self) -> type:  # noqa: N802
+        """Return the aviato SandboxSession class with W&B integration.
+
+        Requires aviato to be installed. The returned class is a subclass
+        of ``aviato.Session`` that automatically injects W&B credentials,
+        tags sandboxes with the run name, and logs sandbox IDs.
+
+        Example::
+
+            with run.SandboxSession() as session:
+                sb = session.sandbox(container_image="python:3.11")
+        """
+        from wandb.integration.aviato.session import SandboxSession
+
+        return SandboxSession
+
+    @property
     @_log_to_run
     @_attach
     def settings(self) -> Settings:


### PR DESCRIPTION
## Summary
- Adds `SandboxSession`, a subclass of `aviato.Session` with W&B integration baked in
- Accessible via `run.SandboxSession` property — no monkeypatching, clean subclass
- Automatically injects W&B credentials, tags sandboxes with run name, logs sandbox IDs
- 14 unit tests passing

## Usage
```python
run = wandb.init(project="my-project")
with run.SandboxSession() as session:
    sb = session.sandbox(container_image="python:3.11")
    # WANDB_API_KEY, WANDB_ENTITY, WANDB_PROJECT injected
    # sandbox tagged with wandb-<run-name>
    # sandbox ID logged to wandb on start
```

## Test plan
- [x] `pytest tests/unit_tests/test_aviato_session.py -v` — 14 tests pass
- [ ] Manual e2e test with `python aviato-wandb-example.py`
- [ ] Verify sandbox tags and env vars in aviato dashboard