### PR TITLE
fix: console capture deadlock from GC

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,3 +22,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Warning message when `run.log_artifact` does not create a new version because the artifact content is identical to an existing version. (@pingleiwandb in https://github.com/wandb/wandb/pull/11340)
 - `Project.collections()` to fetch filtered and ordered artifact collections in a project. (@amusipatla-wandb in https://github.com/wandb/wandb/pull/11319)
 - `wandb purge-cache` command to clean up cached files (@jacobromero in https://github.com/wandb/wandb/pull/10996)
+
+### Fixed
+
+- Fixed a rare deadlock caused when GC triggers at an unlucky time and runs a `__del__` method that prints (@timoffex in https://github.com/wandb/wandb/pull/11402)


### PR DESCRIPTION
Fixes a deadlock that happens when GC triggers at an unlucky time and executes a `__del__` method that prints.

The solution is to go back to using a reentrant lock.

I had switched this from `RLock` to `Lock` in PR #10683 because it had previously created a false sense of security and was no longer needed with the changes in the PR. Unnecessarily using an `RLock` instead of a `Lock` can turn deadlocks into infinite loops, which are arguably worse.

However, I had not considered that Python runs GC in the same thread as code. [PEP 556](https://peps.python.org/pep-0556/) (an old, deferred proposal for threaded GC) mentions some of the challenges.

> Interrupting application code at arbitrary points to execute finalization code that may rely on a consistent internal state and/or on acquiring synchronization primitives gives rise to reentrancy issues that even the most seasoned experts have trouble fixing properly [1].  
>   
> This PEP bases itself on the observation that, despite the apparent similarities, same-thread reentrancy is a fundamentally harder problem than multi-thread synchronization. Instead of letting each developer or library author struggle with extremely hard reentrancy issues, one by one, this PEP proposes to allow the GC to run in a separate thread where well-known multi-thread synchronization practices are sufficient.

Too bad it was not implemented.