### PR TITLE
perf: use deque for pending upload job queue in StepUpload

### DIFF
--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -7,6 +7,7 @@ import logging
 import queue
 import sys
 import threading
+from collections import deque
 from collections.abc import MutableMapping, MutableSequence, MutableSet
 from typing import TYPE_CHECKING, Callable, NamedTuple, Union
 
@@ -90,7 +91,7 @@ class StepUpload:
 
         # Indexed by files' `save_name`'s, which are their ID's in the Run.
         self._running_jobs: MutableMapping[LogicalPath, RequestUpload] = {}
-        self._pending_jobs: MutableSequence[RequestUpload] = []
+        self._pending_jobs: deque[RequestUpload] = deque()
 
         self._artifacts: MutableMapping[str, ArtifactStatus] = {}
 
@@ -149,7 +150,7 @@ class StepUpload:
             self._running_jobs.pop(job.save_name)
             # If we have any pending jobs, start one now
             if self._pending_jobs:
-                event = self._pending_jobs.pop(0)
+                event = self._pending_jobs.popleft()
                 self._start_upload_job(event)
         elif isinstance(event, RequestCommitArtifact):
             if event.artifact_id not in self._artifacts:


### PR DESCRIPTION
## Problem

`_pending_jobs` in `StepUpload` is a FIFO queue drained front-to-back via `.pop(0)` inside the upload event loop. Each `.pop(0)` on a Python list is **O(n)** because it shifts all remaining elements.

## Solution

Switch `_pending_jobs` from `list` to `collections.deque` and replace `.pop(0)` with `.popleft()` for **O(1)** front removal. The `.append()` call remains unchanged as deque supports it natively.

## Changes

- `wandb/filesync/step_upload.py`: Import `deque`, type `_pending_jobs` as `deque[RequestUpload]`, use `.popleft()`