### PR TITLE
chore(launch): address security vulnerabilities in agent

### DIFF
--- a/tools/launch_release/build/Dockerfile
+++ b/tools/launch_release/build/Dockerfile
@@ -7,11 +7,11 @@ RUN apk add --no-cache python3 git py3-pip gcc python3-dev curl
 
 # Install Go
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        curl -L https://go.dev/dl/go1.25.7.linux-amd64.tar.gz | tar -C /usr/local -xzf -; \
+    curl -L https://go.dev/dl/go1.25.7.linux-amd64.tar.gz | tar -C /usr/local -xzf -; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
-        curl -L https://go.dev/dl/go1.25.7.linux-arm64.tar.gz | tar -C /usr/local -xzf -; \
+    curl -L https://go.dev/dl/go1.25.7.linux-arm64.tar.gz | tar -C /usr/local -xzf -; \
     else \
-        echo "Unsupported architecture: $TARGETARCH" && exit 1; \
+    echo "Unsupported architecture: $TARGETARCH" && exit 1; \
     fi
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV WANDB_BUILD_SKIP_GPU_STATS=true
@@ -26,6 +26,8 @@ RUN pip3 install --upgrade pip \
 RUN adduser -D -s /bin/sh -u 1000 -G root launch_agent
 
 ENV HOME=/home/launch_agent
+
+RUN rm -rf /usr/local/go/src/*
 
 USER launch_agent
 WORKDIR /home/launch_agent


### PR DESCRIPTION
Description
-----------
Addresses security vulnerabilities raised in: https://weightsandbiases.slack.com/archives/C01UUUHP153/p1771448787203639

The majority was fixed by pulling in the latest chainguard image and also updating the golang version from 1.25.3 to 1.25.7.

We also remove the go source files once the `wandb` build completes to avoid alerting on vendored packages.

Build: https://github.com/wandb/wandb/actions/runs/22635653118

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
WizCLI:
```
wizcli docker scan --image wandb/launch-agent-dev:npun-sec-fix-20260223-03
██╗    ██╗ ████╗ ███████╗ ██████╗ ██╗      ████╗
██║    ██║  ██╔╝ ╚══███╔╝██╔════╝ ██║       ██╔╝
██║ █╗ ██║  ██║    ███╔╝ ██║      ██║       ██║
██║███╗██║  ██║   ███╔╝  ██║      ██║       ██║
╚███╔███╔╝ ████╗ ███████╗╚██████╗ ███████╗ ████╗
 ╚══╝╚══╝  ╚═══╝ ╚══════╝ ╚═════╝ ╚══════╝ ╚═══╝
Connecting to Wiz                                                                                                                                  
 SUCCESS  Connected to Wiz                                                                                                                         
Initializing scan                                                                                                                                  
 SUCCESS  Scan initialized                                                                                                                         
Scanning wandb/launch-agent-dev:npun-sec-fix-20260223-03                                                                                           
 SUCCESS  Local scanning complete                                                                                                                  
Finalizing scan                                                                                                                                    
 SUCCESS  Scan finalized                                                                                                                           
Libraries:
╭────┬───────────────┬────────────────┬──────────┬───────────────────────┬─────────┬───────────────┬────────────────────────┬─────────────────╮
│    │ Name          │ CVE            │ Severity │ Public Exploit        │ Version │ Fixed Version │ Source                 │ Failed Policies │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  1 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  2 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  3 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  4 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  5 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  6 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  7 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  8 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│  9 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│ 10 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
├────┼───────────────┼────────────────┼──────────┼───────────────────────┼─────────┼───────────────┼────────────────────────┼─────────────────┤
│ 11 │ golang-stdlib │ CVE-2025-68121 │ CRITICAL │ 💥 Has public exploit │ 1.26.0  │               │ https://nvd.nist.gov/v │                 │
│    │               │                │          │                       │         │               │ uln/detail/CVE-2025-68 │                 │
│    │               │                │          │                       │         │               │ 121                    │                 │
╰────┴───────────────┴────────────────┴──────────┴───────────────────────┴─────────┴───────────────┴────────────────────────┴─────────────────╯

CPEs:
╭───┬─────────────────────┬────────────────┬──────────┬─────────────────────┬─────────┬───────────────┬─────────────────────┬─────────────────╮
│   │ Name                │ CVE            │ Severity │ Public Exploit      │ Version │ Fixed Version │ Source              │ Failed Policies │
├───┼─────────────────────┼────────────────┼──────────┼─────────────────────┼─────────┼───────────────┼─────────────────────┼─────────────────┤
│ 1 │ cpe:2.3:a:golang:go │ CVE-2025-68121 │ CRITICAL │ 💥 Has public explo │ 1.26.0  │               │ https://nvd.nist.go │                 │
│   │                     │                │          │ it                  │         │               │ v/vuln/detail/CVE-2 │                 │
│   │                     │                │          │                     │         │               │ 025-68121           │                 │
╰───┴─────────────────────┴────────────────┴──────────┴─────────────────────┴─────────┴───────────────┴─────────────────────┴─────────────────╯

No results found:
	IaC, SAST, OS packages, Applications, End of life technologies, Malware, Sensitive data, Secrets, Host misconfigurations, License Findings (Software Management), Patch Management Findings (Software Management), AI Models

Results summary:
	Libraries: 11 results
		Severity: 11 CRITICAL
	CPEs: 1 result
		Severity: 1 CRITICAL

Scan summary:
	Verdict: PASSED_BY_POLICY
	Failed Policies: 
	Evaluated Policies: Default vulnerabilities policy, Default secrets policy
	Wiz Cloud Event: https://app.wiz.io/findings/cicd-scans#~%2528cicd_scan~%25270069a729-200b-8bb2-9e5d-2d59700a8001%252A2c2026-03-03T18%2525%25252A3a33%2525%25252A3a01.712200803Z%2527%2529
```

... launch release testing notes coming soon ...