### PR TITLE
chore(leet): fix run id extraction

### DIFF
--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -367,7 +367,7 @@ func extractRunID(folderName string) string {
 	// Normalize: strip optional "offline-" prefix.
 	name := strings.TrimPrefix(folderName, "offline-")
 
-	const prefixLen = len("run-") + len("YYYYMMDD_HHMMSS-") // 20
+	const prefixLen = len("run-YYYYMMDD_HHMMSS-") // 20
 	if len(name) <= prefixLen || !strings.HasPrefix(name, "run-") {
 		return ""
 	}


### PR DESCRIPTION
Description
-----------
Fixes https://weights-biases.sentry.io/issues/7242602419/?project=4507273364242432&referrer=project-issue-stream (run IDs containing hyphens).