### PR TITLE
chore: update required hatch version to fix incompatability with virtualenv

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -189,7 +189,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Hatch
-        run: pip install hatch==1.12
+        run: pip install hatch==1.16
 
       - name: Create sdist
         run: hatch build -t sdist


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

With virtualenv version `21.0.0` python discovery logic moved into its own package

```
The Python discovery logic has been extracted into a standalone python-discovery package on PyPI (documentation) and is now consumed as a dependency.
```

As a result `hatch` has [updated](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.5) to fix the incompatibility. 
```
Handle a breaking change in virtualenv by only supporting the latest version and adding python-discovery as a dependency.
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

### Before updating hatch
```bash
> pip install hatch==1.12
> hatch build -t sdist
Environment `default` is incompatible: module 'virtualenv.discovery.builtin' has no attribute 'propose_interpreters'
```

### After updating hatch
```bash
> pip install hatch==1.16
❯ hatch build -t sdist
───────────────────────────────────────────────────────────────── sdist ─────────────────────────────────────────────────────────────────
dist/wandb-0.25.1.dev1.tar.gz

```


<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
