### PR TITLE
chore: update hatch version constraint that was failing to build sdist in clean env

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -189,7 +189,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Hatch
-        run: pip install hatch==1.16
+        run: pip install hatch~=1.16
 
       - name: Create sdist
         run: hatch build -t sdist


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Follow up for https://github.com/wandb/wandb/pull/11433, `pip install hatch==1.16` was not installing the latest version `1.16.5` that fixed the `virtualenv` change that broke sdist builds because it install `1.16.0` rather than the latest version.  
Changing to `hatch~=1.16` will install version `1.16.5`

when testing there must have been a lingering dependency that allows hatch == 1.16 to build, but a fresh env to fail for older versions.

Running in a sandbox env reveals this

```bash
❯ docker run --rm -v "$(pwd):/src" -w /src python:3.12 bash -c "pip install -q hatch==1.16 && hatch build -t sdist"
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 25.0.1 -> 26.0.1
[notice] To update, run: pip install --upgrade pip
Environment `hatch-build` is incompatible: module 'virtualenv.discovery.builtin' has no attribute 'propose_interpreters'

```

but allowing for the latest 1.16 version gives

```bash
❯ docker run --rm -v "$(pwd):/src" -w /src python:3.12 bash -c "pip install -q hatch~=1.16 && hatch build -t sdist"
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 25.0.1 -> 26.0.1
[notice] To update, run: pip install --upgrade pip
Creating environment: hatch-build
Checking dependencies
Syncing dependencies
Inspecting build dependencies
──────────────────────────────────── sdist ─────────────────────────────────────
dist/wandb-0.25.1.dev1.tar.gz
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->