### PR TITLE
feat(launch): allow custom exclude paths for code artifacts (#11427)

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Added
 
+- `wandb job create` code artifacts now support customizable exclude lists via `--exclude` CLI flag, `WANDB_LAUNCH_CODE_EXCLUDE` environment variable, and `.wandbignore` file in the source directory. Common virtual environment and cache directories (`.venv`, `__pycache__`, etc.) are excluded by default. (Fixes #11427)
 - Run console logs pane in W&B LEET TUI (`wandb beta leet` command, toggle with `l`). (@dmitryduev in https://github.com/wandb/wandb/pull/11345)
 - System metrics pane in multi-run workspace mode in W&B LEET TUI (`wandb beta leet` command, toggle with `s`). (@dmitryduev in https://github.com/wandb/wandb/pull/11391)
 - System metrics filtering in W&B LEET TUI (`wandb beta leet` command, toggle with `\`). (@dmitryduev in https://github.com/wandb/wandb/pull/11391)

--- a/tests/unit_tests/test_launch/test_create_job.py
+++ b/tests/unit_tests/test_launch/test_create_job.py
@@ -12,7 +12,10 @@ from wandb.sdk.launch.create_job import (
     _create_artifact_metadata,
     _create_repo_metadata,
     _dump_metadata_and_requirements,
+    _get_exclude_paths,
+    _load_wandbignore,
     _make_code_artifact_name,
+    _should_exclude,
 )
 from wandb.sdk.launch.utils import get_current_python_version
 
@@ -171,3 +174,42 @@ def test_create_repo_metadata_custom_dockerfile(monkeypatch, tmp_path):
     # dockerfile.write_text("FROM python:3.9")
     # result = _create_repo_metadata("", "", dockerfile=dockerfile)
     # assert result["dockerfile"] == "Dockerfile"
+
+
+def test_load_wandbignore_no_file(tmp_path):
+    assert _load_wandbignore(str(tmp_path)) == []
+
+
+def test_load_wandbignore_with_file(tmp_path):
+    ignore_file = tmp_path / ".wandbignore"
+    ignore_file.write_text("   \n# comment\ndata/\n*.log\n")
+    assert _load_wandbignore(str(tmp_path)) == ["data/", "*.log"]
+
+
+def test_get_exclude_paths_defaults(tmp_path):
+    excludes = _get_exclude_paths(str(tmp_path))
+    assert ".venv" in excludes
+    assert "__pycache__" in excludes
+    assert "wandb" in excludes
+
+
+def test_get_exclude_paths_env_var(monkeypatch, tmp_path):
+    monkeypatch.setenv("WANDB_LAUNCH_CODE_EXCLUDE", " a , b/c ")
+    excludes = _get_exclude_paths(str(tmp_path))
+    assert "a" in excludes
+    assert "b/c" in excludes
+
+
+def test_get_exclude_paths_explicit(tmp_path):
+    excludes = _get_exclude_paths(str(tmp_path), extra_excludes=["explicit_dir/"])
+    assert "explicit_dir/" in excludes
+
+
+def test_should_exclude():
+    excludes = ["venv", "*.egg-info", "data/"]
+    assert _should_exclude("venv/bin/activate", excludes) is True
+    assert _should_exclude("venv", excludes) is True
+    assert _should_exclude("my_lib.egg-info/PKG-INFO", excludes) is True
+    assert _should_exclude("data/train.csv", excludes) is True
+    assert _should_exclude("src/venv_utils.py", excludes) is False
+

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1968,6 +1968,13 @@ def describe(job):
     type=click.Choice(("git", "code", "image")),
 )
 @click.option(
+    "--exclude",
+    "-x",
+    "exclude_paths",
+    help="Paths or glob patterns to exclude from the code artifact. Can be repeated.",
+    multiple=True,
+)
+@click.option(
     "--service",
     "-s",
     "services",
@@ -1999,6 +2006,7 @@ def create(
     dockerfile,
     services,
     schema,
+    exclude_paths,
 ):
     """Create a job from a source, without a wandb run.
 
@@ -2056,6 +2064,7 @@ def create(
         dockerfile=dockerfile,
         services=services,
         schema=schema_dict if schema else None,
+        exclude_paths=list(exclude_paths) if exclude_paths else None,
     )
     if not artifact:
         wandb.termerror("Job creation failed")

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -86,6 +86,7 @@ _EXECUTABLE = "WANDB_X_EXECUTABLE"
 LAUNCH_QUEUE_NAME = "WANDB_LAUNCH_QUEUE_NAME"
 LAUNCH_QUEUE_ENTITY = "WANDB_LAUNCH_QUEUE_ENTITY"
 LAUNCH_TRACE_ID = "WANDB_LAUNCH_TRACE_ID"
+LAUNCH_CODE_EXCLUDE = "WANDB_LAUNCH_CODE_EXCLUDE"
 ENABLE_DCGM_PROFILING = "WANDB_ENABLE_DCGM_PROFILING"
 
 # For testing, to be removed in future version
@@ -506,6 +507,21 @@ def get_launch_trace_id(env: MutableMapping | None = None) -> str | None:
         env = os.environ
     val = env.get(LAUNCH_TRACE_ID, None)
     return val
+
+
+def get_code_artifact_exclude(
+    default: list[str] | None = None, env: MutableMapping | None = None
+) -> list[str]:
+    """Return extra paths to exclude when creating code artifacts.
+
+    The value of WANDB_LAUNCH_CODE_EXCLUDE should be a comma-separated list of
+    path names or glob patterns, e.g. ``data,*.egg-info``.
+    """
+    if env is None:
+        env = os.environ
+    val = env.get(LAUNCH_CODE_EXCLUDE, "")
+    extra = [p.strip() for p in val.split(",") if p.strip()]
+    return extra if extra else (default or [])
 
 
 def get_credentials_file(default: str, env: MutableMapping | None = None) -> Path:

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
 import os
@@ -9,6 +10,7 @@ import tempfile
 from typing import Any
 
 import wandb
+from wandb import env as wandb_env
 from wandb.apis.internal import Api
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.internal.job_builder import JobBuilder
@@ -26,7 +28,75 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 _logger = logging.getLogger("wandb")
 
 
-CODE_ARTIFACT_EXCLUDE_PATHS = ["wandb", ".git"]
+CODE_ARTIFACT_EXCLUDE_PATHS = [
+    "wandb",
+    ".git",
+    ".venv",
+    "venv",
+    "env",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    "node_modules",
+    ".mypy_cache",
+    ".pytest_cache",
+]
+
+
+def _load_wandbignore(path: str) -> list[str]:
+    """Read exclusion patterns from a .wandbignore file in `path`.
+
+    Lines starting with ``#`` and blank lines are ignored, matching
+    the behaviour of ``.gitignore``.
+    """
+    ignore_file = os.path.join(path, ".wandbignore")
+    if not os.path.exists(ignore_file):
+        return []
+    patterns: list[str] = []
+    with open(ignore_file) as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                patterns.append(stripped)
+    return patterns
+
+
+def _get_exclude_paths(
+    path: str,
+    extra_excludes: list[str] | None = None,
+) -> list[str]:
+    """Return the merged exclude list from all four priority layers.
+
+    Priority order (highest to lowest):
+    1. ``extra_excludes`` – explicit API / CLI argument
+    2. ``WANDB_LAUNCH_CODE_EXCLUDE`` env var (comma-separated)
+    3. `.wandbignore` file in the source directory
+    4. ``CODE_ARTIFACT_EXCLUDE_PATHS`` hardcoded defaults
+    """
+    excludes: list[str] = list(CODE_ARTIFACT_EXCLUDE_PATHS)
+    excludes.extend(_load_wandbignore(path))
+    excludes.extend(wandb_env.get_code_artifact_exclude())
+    if extra_excludes:
+        excludes.extend(extra_excludes)
+    return excludes
+
+
+def _should_exclude(rel_path: str, excludes: list[str]) -> bool:
+    """Return True if *rel_path* matches any pattern in *excludes*.
+
+    Matching is done against both the top-level path component and the
+    full relative path so that both bare names (``venv``) and glob
+    patterns (``*.egg-info``) work as expected.
+    """
+    top_component = rel_path.split(os.sep)[0]
+    for pattern in excludes:
+        # Strip trailing slashes so a pattern like "data/" matches a top component "data"
+        pattern = pattern.rstrip("/\\")
+        if fnmatch.fnmatch(top_component, pattern):
+            return True
+        if fnmatch.fnmatch(rel_path, pattern):
+            return True
+    return False
 
 
 def create_job(
@@ -42,6 +112,7 @@ def create_job(
     git_hash: str | None = None,
     build_context: str | None = None,
     dockerfile: str | None = None,
+    exclude_paths: list[str] | None = None,
 ) -> Artifact | None:
     """Create a job from a path, not as the output of a run.
 
@@ -77,6 +148,7 @@ def create_job(
             aliases=["train"],
             runtime="3.9",
             entrypoint="train.py",
+            exclude_paths=[".venv", "data"],
         )
         # then run the newly created job
         artifact_job.call()
@@ -98,6 +170,7 @@ def create_job(
         git_hash,
         build_context,
         dockerfile,
+        exclude_paths=exclude_paths,
     )
 
     return artifact_job
@@ -120,6 +193,7 @@ def _create_job(
     base_image: str | None = None,
     services: dict[str, str] | None = None,
     schema: dict[str, Any] | None = None,
+    exclude_paths: list[str] | None = None,
 ) -> tuple[Artifact | None, str, list[str]]:
     wandb.termlog(f"Creating launch job of type: {job_type}...")
 
@@ -185,6 +259,7 @@ def _create_job(
             entity=entity,
             project=project,
             name=name,
+            exclude_paths=exclude_paths,
         )
         if not job_name:
             return None, "", []
@@ -442,16 +517,17 @@ def _make_code_artifact(
     entity: str | None,
     project: str | None,
     name: str | None,
+    exclude_paths: list[str] | None = None,
 ) -> str | None:
     """Helper for creating and logging code artifacts.
+
+    Walks the source directory, skipping any paths that match the
+    merged exclude list (defaults + .wandbignore + env var +
+    explicit ``exclude_paths`` argument).
 
     Returns the name of the eventual job.
     """
     entrypoint_list = entrypoint.split(" ")
-    # We no longer require the entrypoint to end in an existing file. But we
-    # need something to use as the default job artifact name. In the future we
-    # may require the user to provide a job name explicitly when calling
-    # wandb job create.
     entrypoint_file = entrypoint_list[-1]
     artifact_name = _make_code_artifact_name(os.path.join(path, entrypoint_file), name)
     code_artifact = wandb.Artifact(
@@ -460,22 +536,37 @@ def _make_code_artifact(
         description="Code artifact for job",
     )
 
+    # Build the merged exclusion list once, then walk the source tree,
+    # pruning excluded directories *before* os.walk descends into them.
+    # This is more efficient than adding everything then calling remove().
+    excludes = _get_exclude_paths(path, extra_excludes=exclude_paths)
     try:
-        code_artifact.add_dir(path)
+        for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
+            rel_dir = os.path.relpath(dirpath, path)
+            # Prune excluded subdirectories in-place so os.walk skips them.
+            dirnames[:] = [
+                d for d in dirnames
+                if not _should_exclude(
+                    d if rel_dir == "." else os.path.join(rel_dir, d),
+                    excludes,
+                )
+            ]
+            for fname in filenames:
+                physical_path = os.path.join(dirpath, fname)
+                logical_path = os.path.relpath(physical_path, path)
+                if not _should_exclude(logical_path, excludes):
+                    code_artifact._add_local_file(
+                        name=logical_path,
+                        path=physical_path,
+                    )
     except Exception as e:
         if os.path.islink(path):
             wandb.termerror(
-                "Symlinks are not supported for code artifact jobs, please copy the code into a directory and try again"
+                "Symlinks are not supported for code artifact jobs, please copy "
+                "the code into a directory and try again"
             )
         wandb.termerror(f"Error adding to code artifact: {e}")
         return None
-
-    # Remove paths we don't want to include, if present
-    for item in CODE_ARTIFACT_EXCLUDE_PATHS:
-        try:
-            code_artifact.remove(item)
-        except FileNotFoundError:
-            pass
 
     res, _ = api.create_artifact(
         artifact_type_name="code",


### PR DESCRIPTION

Code artifacts now support customizable exclude lists, preventing unnecessary hashing and uploading of large directories like `.venv` or `node_modules` during `wandb job create`. 

- Add `--exclude` / `-x` flag to `wandb job create`
- Add `WANDB_LAUNCH_CODE_EXCLUDE` environment variable support
- Add support for `.wandbignore` files in source directory
- Expand default exclusions (`.venv`, `venv`, [env](cci:1://file:///Users/bvpranay/wandb/wandb/env.py:138:0-149:20), `__pycache__`, etc.)
- Optimize creation by skipping excluded directories during `os.walk`
- Add comprehensive unit tests covering ignore parsing and fnmatch rules

- Fixes #11427

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Added 6 new unit tests to [tests/unit_tests/test_launch/test_create_job.py](cci:7://file:///Users/bvpranay/wandb/tests/unit_tests/test_launch/test_create_job.py:0:0-0:0) that verify:
- Correct parsing of `.wandbignore` files (skipping blanks and comments).
- Correct resolution of `WANDB_LAUNCH_CODE_EXCLUDE` environment variables.
- Merging across all 4 layers of overrides (API/CLI > Env Var > .wandbignore > Defaults).
- `fnmatch` wildcard pattern matching logic recursively skipping mapped directories.
All tests pass locally.
