### PR TITLE
refactor: define runwork.Request

### DIFF
--- a/core/internal/runwork/request.go
+++ b/core/internal/runwork/request.go
@@ -1,0 +1,128 @@
+package runwork
+
+import (
+	"context"
+	"sync/atomic"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// Request is a ServerRequest for a run that requires a response.
+//
+// This should not be used outside for anything unrelated to runwork.
+//
+// A non-nil Request requires a response unless it is cancelled, or else
+// a context leak occurs. It is good practice to call WillNotRespond on any
+// Request value (whether or not it is nil) in codepaths where a response
+// is not expected. WillNotRespond raises an error on the client if it was
+// awaiting a response.
+//
+// Since many ServerRequests don't require a response (like history updates),
+// is it OK to assume Request is nil on their codepaths and not do anything
+// with it. This risks creating a context leak if the client asks for
+// a response, but in that case, the client will hang while waiting for it.
+type Request struct {
+	requestID string // the ServerRequest's request_id
+
+	ctx       context.Context
+	cancelCtx context.CancelFunc
+
+	responded  atomic.Bool // makes Respond() a no-op after the first call
+	responseCh chan<- *spb.ServerResponse
+}
+
+// NewRequest creates a request.
+//
+// The context defines the request's lifetime. If it is cancelled before
+// a response is produced, that means that a response is no longer needed.
+//
+// When the request gets a response, it is pushed to responseCh
+// and the context cancellation function is invoked.
+//
+// The caller must guarantee that the request is not responded to after
+// responseCh is closed. In practice, that means waiting for all goroutines
+// with a reference to the Request to exit, probably via a WaitGroup.
+func NewRequest(
+	requestID string,
+	ctx context.Context,
+	cancelCtx context.CancelFunc,
+	responseCh chan<- *spb.ServerResponse,
+) *Request {
+	return &Request{
+		requestID:  requestID,
+		ctx:        ctx,
+		cancelCtx:  cancelCtx,
+		responseCh: responseCh,
+	}
+}
+
+// Context is cancelled when the Request is cancelled or responded to.
+//
+// Panics if the request is nil.
+//
+// This Context must only be used for operations that are needed for
+// producing a response, since once a response is produced, all operations
+// using this Context get cancelled.
+//
+// This should usually be coupled with ExtraWork.BeforeEndCtx() using
+//
+//	cleanup := beforeEndCtx.AfterFunc(request.WillNotRespond)
+//	defer cleanup()
+//
+// to terminate the request if the stream is shutting down.
+func (r *Request) Context() context.Context {
+	if r == nil {
+		panic("runwork: nil Request has no Context")
+	}
+
+	return r.ctx
+}
+
+// Respond responds to the request and cancels its Context.
+//
+// This sets the request ID on the response.
+// Responses after the first one are ignored.
+// Safe to call in multiple goroutines simultaneously.
+//
+// If the request is already cancelled, this does nothing.
+//
+// For convenience, this may be called on a nil Request, in which case it is
+// a no-op.
+func (r *Request) Respond(response *spb.ServerResponse) {
+	if r == nil {
+		return
+	}
+
+	if r.responded.Swap(true) {
+		return
+	}
+
+	defer r.cancelCtx()
+
+	response.RequestId = r.requestID
+
+	select {
+	case r.responseCh <- response:
+	case <-r.ctx.Done():
+	}
+}
+
+// WillNotRespond responds to the request with a "no response" error.
+//
+// A function that receives a Request and neither passes it anywhere nor
+// responds to it should generally call this. This is used for Records
+// where a response is not expected or if a function is cancelled.
+//
+// This raises an error on the client side if the client expected a response.
+//
+// For convenience, this may be called on a nil Request, in which case it is
+// a no-op.
+func (r *Request) WillNotRespond() {
+	r.Respond(&spb.ServerResponse{
+		ServerResponseType: &spb.ServerResponse_ErrorResponse{
+			ErrorResponse: &spb.ServerErrorResponse{
+				Message: "No response.",
+			},
+		},
+	})
+}

--- a/core/internal/runwork/request_test.go
+++ b/core/internal/runwork/request_test.go
@@ -1,0 +1,88 @@
+package runwork_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wandb/wandb/core/internal/runwork"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func newRequestForTests(t *testing.T, id string) (
+	*runwork.Request,
+	chan *spb.ServerResponse,
+	context.CancelFunc,
+) {
+	responses := make(chan *spb.ServerResponse)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	t.Cleanup(cancelCtx)
+
+	return runwork.NewRequest(id, ctx, cancelCtx, responses), responses, cancelCtx
+}
+
+func TestNilRequest(t *testing.T) {
+	var request *runwork.Request
+
+	assert.Panics(t, func() { request.Context() })
+	assert.NotPanics(t, func() { request.Respond(nil) })
+	assert.NotPanics(t, func() { request.WillNotRespond() })
+}
+
+func TestRespond_SetsID(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		request, responses, _ := newRequestForTests(t, "test ID")
+
+		go request.Respond(&spb.ServerResponse{})
+		response := <-responses
+
+		assert.Equal(t, "test ID", response.RequestId)
+	})
+}
+
+func TestRespond_CancelsCtx(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		request, responses, _ := newRequestForTests(t, "test ID")
+
+		go request.Respond(&spb.ServerResponse{})
+		<-responses
+
+		// synctest fails the test if this blocks.
+		<-request.Context().Done()
+	})
+}
+
+func TestRespond_OnlyOnce(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		request, responses, _ := newRequestForTests(t, "test ID")
+
+		// Respond in several goroutines simultaneously.
+		for range 10 {
+			go request.Respond(&spb.ServerResponse{})
+		}
+
+		// Only a single response should go through.
+		// Any extra goroutines attempting to write on the channel will
+		// panic once it closes, failing the test.
+		<-responses
+		close(responses)
+	})
+}
+
+func TestRespond_GivesUpOnceCancelled(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		request, _, cancel := newRequestForTests(t, "test ID")
+
+		// Wait until Respond() blocks on writing to the channel.
+		wg := &sync.WaitGroup{}
+		wg.Go(func() { request.Respond(&spb.ServerResponse{}) })
+		synctest.Wait()
+
+		cancel()  // cancelling should release the goroutine
+		wg.Wait() // synctest panics if this deadlocks
+	})
+}

--- a/core/internal/runworktest/requests.go
+++ b/core/internal/runworktest/requests.go
@@ -1,0 +1,29 @@
+package runworktest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wandb/wandb/core/internal/runwork"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// SimpleRequest creates a request for testing.
+//
+// The request's context is cancelled at the end of the test.
+// The output channel is 1-buffered, so that responding to the request does
+// not block.
+func SimpleRequest(
+	t *testing.T,
+	id string,
+) (*runwork.Request, <-chan *spb.ServerResponse) {
+	t.Helper()
+
+	// t.Context() is cancelled at the end of the test, so invoking cancel()
+	// in t.Cleanup() is not required.
+	ctx, cancel := context.WithCancel(t.Context())
+	outputs := make(chan *spb.ServerResponse, 1)
+
+	return runwork.NewRequest(id, ctx, cancel, outputs), outputs
+}


### PR DESCRIPTION
Defines a new `runwork.Request` type which will simplify response logic.

Instead of code like this:

```go
// In sender:
if record.GetControl().GetMailboxSlot() == "" {
	return
}
outChan <- &spb.Result{
	ResultType: resultType,
	Control:    record.Control,
}
```

... responses will be returned like this:

```go
// "mailbox_slot == ''" check is built-in.
// Request ID is automatically set, no need to propagate control.
request.Respond(&spb.Result{ResultType: resultType})
```

The `outChan` handling will also be simplified. Right now, `Handler` and `Sender` create their own buffered output channels that `Stream` is responsible for fully consuming. `Stream` forwards results to a `Dispatcher`, which chooses a `Responder` based on the result's `control.connection_id`, which invokes a `Connection.Respond()` method, which adds to yet another channel that `Connection` is responsible for processing.

The `runwork.Request` approach will get rid of most of the `Record.control` field and intermediate channels. A `Connection` will create a `runwork.Request` for any `ServerRequest` that has an ID. The `runwork.Request` will be passed around until a response is produced, which will directly write to that `Connection`'s channel, bypassing the need for the Dispatcher/Responder mechanism.