### PR TITLE
refactor: use ServerRequest.request_id in C# client

### DIFF
--- a/experimental/client-csharp/src/Wandb/Internal/SocketInterface.cs
+++ b/experimental/client-csharp/src/Wandb/Internal/SocketInterface.cs
@@ -220,6 +220,7 @@ namespace Wandb.Internal
         {
             ArgumentNullException.ThrowIfNull(record);
 
+            string requestId = Guid.NewGuid().ToString();
             record.Info = new _RecordInfo
             {
                 StreamId = _streamId
@@ -227,11 +228,12 @@ namespace Wandb.Internal
             record.Control = new Control
             {
                 ReqResp = true,
-                MailboxSlot = Guid.NewGuid().ToString()
+                MailboxSlot = requestId
             };
 
             ServerRequest request = new()
             {
+                RequestId = requestId,
                 RecordCommunicate = record
             };
             ServerResponse? response = await _client.SendAsync(request, timeoutMilliseconds).ConfigureAwait(false) ?? throw new TimeoutException("The request timed out.");

--- a/experimental/client-csharp/src/Wandb/Internal/TcpClient.cs
+++ b/experimental/client-csharp/src/Wandb/Internal/TcpClient.cs
@@ -208,10 +208,7 @@ namespace Wandb.Internal
         /// <param name="message">The message to process.</param>
         private void ProcessReceivedMessage(ServerResponse message)
         {
-            // TODO: This must exist in the message, but need to gracefully handle it if it doesn't
-            var messageId = message.ResultCommunicate != null
-                ? message.ResultCommunicate.Control.MailboxSlot
-                : string.Empty;
+            var messageId = message.RequestId;
 
             // A special case/hack for login messages
             if (string.IsNullOrEmpty(messageId))


### PR DESCRIPTION
Updates the C# client to use `request_id` which replaces `mailbox_slot`.

`wandb-core` always sets `ServerResponse.request_id` when responding (in `responder.go`). There is still some code that expects `mailbox_slot` on incoming requests, but this is being removed.