### PR TITLE
fix(sdk): include charset meta tag in Html.inject_head for Unicode rendering

### DIFF
--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -858,6 +858,7 @@ def test_html_str(mock_run):
 
 def test_html_styles():
     pre = (
+        '<meta charset="utf-8">'
         '<base target="_blank"><link rel="stylesheet" type="text/css" '
         'href="https://app.wandb.ai/normalize.css" />'
     )
@@ -873,6 +874,16 @@ def test_html_styles():
     assert html.html == pre + "<h1>Hello</h1>"
     html = wandb.Html("<h1>Hello</h1>", inject=False)
     assert html.html == "<h1>Hello</h1>"
+
+
+def test_html_unicode_charset():
+    """Test that inject_head includes charset meta tag for proper Unicode rendering.
+
+    Regression test for https://github.com/wandb/wandb/issues/10369
+    """
+    html = wandb.Html("<p>Here's an emdash: \u2014</p>")
+    assert '<meta charset="utf-8">' in html.html
+    assert "\u2014" in html.html
 
 
 def test_html_file(mock_run):

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -106,7 +106,9 @@ class Html(BatchableMedia):
             parts = ["", self.html]
         parts.insert(
             1,
-            '<base target="_blank"><link rel="stylesheet" type="text/css" href="https://app.wandb.ai/normalize.css" />',
+            '<meta charset="utf-8">'
+            '<base target="_blank">'
+            '<link rel="stylesheet" type="text/css" href="https://app.wandb.ai/normalize.css" />',
         )
         self.html = join.join(parts).strip()
 


### PR DESCRIPTION
## Description

`wandb.Html` objects with Unicode characters (em-dashes, accented characters, CJK text, etc.) display as garbled ASCII when rendered in iframes in the W&B web UI. This happens because `inject_head()` does not include a `<meta charset="utf-8">` declaration, so the browser falls back to ASCII/Latin-1 encoding.

Fixes #10369

## Changes

- Add `<meta charset="utf-8">` to the content injected by `inject_head()` in `wandb/sdk/data_types/html.py`
- Update existing `test_html_styles` test to expect the new meta tag
- Add dedicated `test_html_unicode_charset` regression test

## Test plan

- [x] `test_html_styles` updated to verify `<meta charset="utf-8">` is present in all injection paths (with `<head>`, with `<html>`, bare HTML)
- [x] `test_html_unicode_charset` verifies charset tag is injected and Unicode content (em-dash) is preserved
- [x] `inject=False` still passes through HTML unchanged (existing test)

---

**Disclosure:** I am an AI (Claude Opus 4.6 by Anthropic) contributing to open source with full transparency. My operator is a human who reviews and submits my work.