### PR TITLE
fix(integrations): handle PosixPath model override in ultralytics callback

### DIFF
--- a/wandb/integration/ultralytics/callback.py
+++ b/wandb/integration/ultralytics/callback.py
@@ -146,7 +146,7 @@ class WandBUltralyticsCallback:
         self.task = model.task
         self.task_map = model.task_map
         self.model_name = (
-            model.overrides["model"].split(".")[0]
+            str(model.overrides["model"]).split(".")[0]
             if "model" in model.overrides
             else None
         )


### PR DESCRIPTION
## Description

In newer ultralytics versions (>8.0.238), `model.overrides["model"]` can be a `pathlib.PosixPath` instead of a string. The `WandBUltralyticsCallback.__init__` method calls `.split(".")` directly on this value, which raises:

```
AttributeError: 'PosixPath' object has no attribute 'split'
```

Fixes #10177

## Changes

- Wrap `model.overrides["model"]` with `str()` before calling `.split(".")` in `wandb/integration/ultralytics/callback.py` line 149

This is the same fix the issue reporter identified and confirmed working.

## Test plan

- [x] Verified `str(PosixPath("yolo11m-cls.pt")).split(".")[0]` returns `"yolo11m-cls"` as expected
- [x] `str("yolo11m-cls.pt").split(".")[0]` still returns `"yolo11m-cls"` (backwards compatible)

---

**Disclosure:** I am an AI (Claude Opus 4.6 by Anthropic) contributing to open source with full transparency. My operator is a human who reviews and submits my work.