### PR TITLE
chore(leet): configurable default console log pane visibility in single-run mode

### DIFF
--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -100,6 +100,7 @@ type Config struct {
 	// Single-run view sidebar visibility states.
 	LeftSidebarVisible  bool `json:"left_sidebar_visible"  leet:"desc=Show left sidebar in single run view by default."`
 	RightSidebarVisible bool `json:"right_sidebar_visible" leet:"desc=Show right sidebar in single run view by default."`
+	ConsoleLogsVisible  bool `json:"console_logs_visible"  leet:"desc=Show console logs pane in single run mode by default."`
 
 	// Workspace view pane visibility states.
 	WorkspaceOverviewVisible      bool `json:"workspace_overview_visible"       leet:"desc=Show run overview sidebar in workspace mode by default."`
@@ -155,6 +156,7 @@ func NewConfigManager(path string, logger *observability.CoreLogger) *ConfigMana
 			HeartbeatInterval:             DefaultHeartbeatInterval,
 			LeftSidebarVisible:            true,
 			RightSidebarVisible:           true,
+			ConsoleLogsVisible:            false,
 			WorkspaceOverviewVisible:      true,
 			WorkspaceSystemMetricsVisible: false,
 			WorkspaceConsoleLogsVisible:   false,
@@ -567,6 +569,22 @@ func (cm *ConfigManager) SetRightSidebarVisible(visible bool) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config.RightSidebarVisible = visible
+	return cm.save()
+}
+
+// ConsoleLogsVisible returns whether the console logs pane
+// should be visible in single-run mode.
+func (cm *ConfigManager) ConsoleLogsVisible() bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.config.ConsoleLogsVisible
+}
+
+// SetConsoleLogsVisible sets the single-run console logs pane visibility.
+func (cm *ConfigManager) SetConsoleLogsVisible(visible bool) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.config.ConsoleLogsVisible = visible
 	return cm.save()
 }
 

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -99,8 +99,8 @@ func NewRun(
 	ro := NewRunOverview()
 	runOverviewAnimState := NewAnimatedValue(cfg.LeftSidebarVisible(), SidebarMinWidth)
 
-	// TODO: make it configurable?
-	consoleLogsPaneAnimState := NewAnimatedValue(false, ConsoleLogsPaneMinHeight)
+	consoleLogsPaneAnimState := NewAnimatedValue(
+		cfg.ConsoleLogsVisible(), ConsoleLogsPaneMinHeight)
 
 	metricsGrid := NewMetricsGrid(cfg, cfg.MetricsGrid, focus, logger)
 	metricsGrid.SetSingleSeriesColorMode(cfg.SingleRunColorMode())


### PR DESCRIPTION
Description
-----------
Make the default console log pane visibility in single-run mode configurable (and thus persisted between tui launches).