### PR TITLE
refactor: loosen console tests to work when warnings are emitted

### DIFF
--- a/tests/system_tests/test_functional/console_capture/test_console_capture.py
+++ b/tests/system_tests/test_functional/console_capture/test_console_capture.py
@@ -23,8 +23,8 @@ def test_patch_stdout_and_stderr():
 
     exit_code = proc.wait()  # on error, stderr may have useful details
     assert proc.stderr and proc.stdout
-    assert proc.stderr.read() == b"I AM STDERR\n"
-    assert proc.stdout.read() == b"I AM STDOUT\n"
+    assert proc.stderr.read().endswith(b"I AM STDERR\n")
+    assert proc.stdout.read().endswith(b"I AM STDOUT\n")
     assert exit_code == 0
 
 

--- a/tests/system_tests/test_functional/terminput/test_terminput.py
+++ b/tests/system_tests/test_functional/terminput/test_terminput.py
@@ -167,7 +167,9 @@ def test_basic_prompt():
         tester.wait_for_text(b"PROMPT: ")
         tester.send_input(b"the prompt\n")
 
-    assert tester.unstyled_output() == [
+    # Trim initial lines, which may include 3rd party warnings
+    # depending on versions of installed packages.
+    assert tester.unstyled_output()[-3:] == [
         "wandb: PROMPT: the prompt",
         "Got result: the prompt",
         "DONE",
@@ -183,15 +185,13 @@ def test_abort():
         tester.send_input(b"\x03")
 
     lines = tester.unstyled_output()
-    assert lines[0] in (
+    assert lines[-2] in (
         # On macOS:
         "wandb: PROMPT: ^C",
         # On Linux:
         "wandb: PROMPT: this may be ignored^C",
     )
-    assert lines[1:] == [
-        "INTERRUPT!",
-    ]
+    assert lines[-1] == "INTERRUPT!"
 
 
 def test_abort_timeout():
@@ -203,15 +203,13 @@ def test_abort_timeout():
         tester.send_input(b"\x03")
 
     lines = tester.unstyled_output()
-    assert lines[0] in (
+    assert lines[-2] in (
         # On macOS:
         "wandb: PROMPT: (10 second timeout) ^C",
         # On Linux:
         "wandb: PROMPT: (10 second timeout) this may be ignored^C",
     )
-    assert lines[1:] == [
-        "INTERRUPT!",
-    ]
+    assert lines[-1] == "INTERRUPT!"
 
 
 def test_hidden_prompt():
@@ -219,7 +217,7 @@ def test_hidden_prompt():
         tester.wait_for_text(b"PROMPT: ")
         tester.send_input(b"the prompt\n")
 
-    assert tester.unstyled_output() == [
+    assert tester.unstyled_output()[-3:] == [
         "wandb: PROMPT: ",
         "Got result: the prompt",
         "DONE",
@@ -231,7 +229,7 @@ def test_timeout():
         # Don't send any input, just let it time out.
         pass
 
-    assert tester.unstyled_output() == [
+    assert tester.unstyled_output()[-2:] == [
         "wandb: PROMPT: (0 second timeout) ",
         "TIMEOUT!",
     ]

--- a/tests/system_tests/test_functional/wb_logging/test_wb_logging_last_resort.py
+++ b/tests/system_tests/test_functional/wb_logging/test_wb_logging_last_resort.py
@@ -10,7 +10,9 @@ def test_wb_logging_last_resort():
         stderr=subprocess.STDOUT,
     ).splitlines()
 
-    assert output == [
+    # Trim initial lines, which may include 3rd party warnings
+    # depending on versions of installed packages.
+    assert output[-2:] == [
         b"lastResort (before configuring)",
         b"stream handler (after configuring)",
     ]


### PR DESCRIPTION
Updates checks like `assert console_lines == ["a", "b", "c"]` to `assert console_lines[-3:] == ["a", "b", "c"]`.

The recent `requirements.txt` update job [is failing](https://app.circleci.com/pipelines/github/wandb/wandb/62050/workflows/9b68a9fc-c1a0-4a49-b3de-b66b71c8cb94/jobs/1633998/tests) because some updates are causing warnings, which break tests that assert on the exact output of a script.