### PR TITLE
chore: explicitly add tensorboard to requirements_dev.txt

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -28,6 +28,7 @@ jupyter
 ipykernel
 nbclient
 
+tensorboard
 tensorflow~=2.20; sys_platform != 'darwin'
 numpy<2.4.0  # tensorflow==2.20.0 uses deprecated args removed in numpy==2.4.0
 


### PR DESCRIPTION
It is [no longer](https://github.com/tensorflow/tensorflow/releases/tag/v2.21.0) pulled in by tensorflow starting with the 2.21.0 release. It is used explicitly in some tests (like tests/system_tests/test_functional/test_tensorboard/test_tf_summary.py).

I'll rerun the action after merging this to update #11380 with the regenerated requirements.