### PR TITLE
chore: prevent test_wb_logging_last_resort from breaking due to warnings

### DIFF
--- a/tests/system_tests/test_functional/wb_logging/test_wb_logging_last_resort.py
+++ b/tests/system_tests/test_functional/wb_logging/test_wb_logging_last_resort.py
@@ -6,13 +6,12 @@ def test_wb_logging_last_resort():
     script = pathlib.Path(__file__).parent / "last_resort.py"
 
     output = subprocess.check_output(
-        ["python", str(script)],
+        # Prevent warnings from 3rd party libraries from polluting the output.
+        ["python", "-W", "ignore", str(script)],
         stderr=subprocess.STDOUT,
     ).splitlines()
 
-    # Trim initial lines, which may include 3rd party warnings
-    # depending on versions of installed packages.
-    assert output[-2:] == [
+    assert output == [
         b"lastResort (before configuring)",
         b"stream handler (after configuring)",
     ]


### PR DESCRIPTION
Disables warnings in the script launched by `test_wb_logging_last_resort.py` so that it can assert on the script's exact output.

Fixes the test failure [here](https://app.circleci.com/pipelines/github/wandb/wandb/62060/workflows/e17dcfc6-66a3-4354-9558-dc3a0b2df95f/jobs/1634170/tests) to unblock #11380 .

I updated this earlier to look at `output[-2:]`, but the line `lastResort (before configuring)` occurs at the start of the output. Loosening the test to check `output[0]` and `output[-1]` would be incorrect because the test also means to check the absence of `lastResort (after configuring -- not output)` (and `assert "..." not in "..."` is fragile / bad practice).