### PR TITLE
feat: detect run initialization errors in wandb beta sync

### DIFF
--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -138,12 +138,21 @@ func (r *RunReader) ProcessTransactionLog(ctx context.Context) error {
 			return err
 		}
 
-		r.parseAndAddWork(record)
-
 		switch {
+		default: // No special handling for most records.
+			r.parseAndAddWork(record)
+
 		case record.GetExit() != nil:
+			r.parseAndAddWork(record)
 			r.seenExit = true
+
 		case record.GetRun() != nil:
+			// Fail early if initializing the run (UpsertBucket) fails.
+			err := r.waitForRunRecord(ctx, record)
+			if err != nil {
+				return err
+			}
+
 			// The RunStart request is required to come after a Run record,
 			// but its contents are irrelevant when syncing. It causes
 			// the Sender to start FileStream.
@@ -252,10 +261,80 @@ func (r *RunReader) nextUpdatedRecord(
 	return
 }
 
+// waitForRunRecord sends the given Run record and waits for a response.
+//
+// Returns an error if the run fails to initialize.
+func (r *RunReader) waitForRunRecord(
+	ctx context.Context,
+	record *spb.Record,
+) error {
+	response, err := r.parseAndDoRequest(ctx, "sync-run-init", record)
+	if err != nil {
+		return err
+	}
+
+	// Check the error built into the RunResult type.
+	errMsg := response.GetResultCommunicate().
+		GetRunResult().
+		GetError().
+		GetMessage()
+	if errMsg != "" {
+		return &SyncError{
+			Message:  fmt.Sprintf("runreader: init error: %v", errMsg),
+			UserText: errMsg,
+		}
+	}
+
+	return nil
+}
+
+// parseAndDoRequest pushes a record to RunWork and waits for a response.
+//
+// The request ID is only used for debugging.
+//
+// Returns an error on ServerErrorResponse.
+func (r *RunReader) parseAndDoRequest(
+	ctx context.Context,
+	id string,
+	record *spb.Record,
+) (*spb.ServerResponse, error) {
+	requestCtx, cancelRequest := context.WithCancel(ctx)
+	defer cancelRequest()
+
+	responseCh := make(chan *spb.ServerResponse, 1)
+	request := runwork.NewRequest(id, requestCtx, cancelRequest, responseCh)
+
+	r.addWork(runwork.Work{
+		WorkImpl: r.recordParser.Parse(record),
+		Request:  request,
+	})
+
+	select {
+	case response := <-responseCh:
+		if message := response.GetErrorResponse().GetMessage(); message != "" {
+			return nil, &SyncError{
+				Message: fmt.Sprintf(
+					"runsync: error response to %s: %s",
+					id, message),
+				UserText: message,
+			}
+		}
+
+		return response, nil
+
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 // parseAndAddWork parses the record and pushes it to RunWork.
 func (r *RunReader) parseAndAddWork(record *spb.Record) {
 	work := runwork.NoRequest(r.recordParser.Parse(record))
+	r.addWork(work)
+}
 
+// addWork pushes a work item to RunWork.
+func (r *RunReader) addWork(work runwork.Work) {
 	wg := &sync.WaitGroup{}
 
 	// NOTE: Don't use AddWorkOrCancel to avoid setting seenExit for

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -224,6 +224,57 @@ func Test_CreatesExitRecordIfNotSeen(t *testing.T) {
 		x.FakeRunWork.AllWorkImpls())
 }
 
+func Test_ParsesInitFailure(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		ErrMsg   string
+		Response *spb.ServerResponse
+	}{
+		{"ServerErrorResponse", "Generic error!", &spb.ServerResponse{
+			ServerResponseType: &spb.ServerResponse_ErrorResponse{
+				ErrorResponse: &spb.ServerErrorResponse{
+					Message: "Generic error!",
+				},
+			},
+		}},
+
+		{"RunResult", "Run init error!", &spb.ServerResponse{
+			ServerResponseType: &spb.ServerResponse_ResultCommunicate{
+				ResultCommunicate: &spb.Result{
+					ResultType: &spb.Result_RunResult{
+						RunResult: &spb.RunUpdateResult{
+							Error: &spb.ErrorInfo{
+								Message: "Run init error!",
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			x := setup(t)
+			wandbFileWithRecords(t,
+				x.TransactionLog,
+				&spb.Record{
+					Num:        1,
+					RecordType: &spb.Record_Run{Run: &spb.RunRecord{}},
+				})
+			x.FakeRunWork.QueueResponse(tc.Response)
+			x.MockRecordParser.EXPECT().
+				Parse(gomock.Any()).
+				Times(2). // Run then Exit (no RunStart due to error)
+				Return(&testWork{})
+
+			err := x.RunReader.ProcessTransactionLog(t.Context())
+
+			assert.ErrorContains(t, err, tc.ErrMsg)
+		})
+	}
+}
+
 func Test_CreatesRunStartRequest(t *testing.T) {
 	x := setup(t)
 	wandbFileWithRecords(t,
@@ -241,6 +292,8 @@ func Test_CreatesRunStartRequest(t *testing.T) {
 		x.MockRecordParser.EXPECT().Parse(isRunStartRequest()).Return(runStartWork),
 		x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(exitWork),
 	)
+	// The Run record requires a response.
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
 
 	err := x.RunReader.ProcessTransactionLog(context.Background())
 	require.NoError(t, err)

--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -217,6 +217,23 @@ def test_syncs_run(
         assert "test_file.txt" in files
 
 
+def test_sync_reports_init_error(
+    runner: CliRunner,
+    wandb_backend_spy: WandbBackendSpy,
+):
+    with wandb.init(mode="offline") as run:
+        pass
+    gql = wandb_backend_spy.gql
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="UpsertBucket"),
+        gql.once(content="fake UpsertBucket error", status=400),
+    )
+
+    result = runner.invoke(cli.beta, f"sync {run.settings.sync_dir}")
+
+    assert "fake UpsertBucket error" in result.output
+
+
 def test_sync_defaults_to_wandb_dir(tmp_path: pathlib.Path, runner: CliRunner):
     global_settings = wandb_setup.singleton().settings
     global_settings.root_dir = str(tmp_path)


### PR DESCRIPTION
Updates `wandb beta sync` to detect run initialization errors, print them out, and stop the sync.

Completes WB-30384.

```
❯ wandb beta sync wandb/latest-run --no-skip-synced --entity=timoffex-test-entity
wandb: Syncing 1 run(s):
wandb:   wandb/latest-run/run-if8u7v7u.wandb
wandb: Loading settings from ...
wandb: [wandb sync] Loaded credentials for ...
```

Before:
```
wandb: [timoffex-test-entity/uncategorized/if8u7v7u] Finished syncing wandb/latest-run/run-if8u7v7u.wandb
```

After:
```
wandb: ERROR Error uploading run: returned error 404: {"data":{"upsertBucket":null},"errors":[{"message":"entity timoffex-test-entity not found during upsertBucket","path":["upsertBucket"]}]}
```

(The fact that the error includes unparsed JSON should be fixed in `runupserter`, not here)