### PR TITLE
chore: add buf.yaml for buf-lsp support

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,8 @@
+# We don't use the buf CLI yet, but this file allows buf-lsp to
+# correctly resolve import paths, improving the IDE experience.
+version: v2
+
+lint:
+  except:
+    - PACKAGE_DIRECTORY_MATCH # wandb/proto/ package is "wandb_internal"
+    - PACKAGE_VERSION_SUFFIX # we don't use version suffixes


### PR DESCRIPTION
`buf-lsp` is a protobuf language server. It's included by default in Zed and is probably a good idea to use in other IDEs as well. Adding this file allows it to resolve import paths; I also disabled two lints that don't apply to us.