### PR TITLE
fix(artifacts): reseed random state for client IDs on fork

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,3 +21,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Changed
 
 - JSON serialization and deserialization now use `orjson` for improved performance (@jacobromero in https://github.com/wandb/wandb/pull/11163)
+
+### Fixed
+
+- Fixed artifact client ID collisions in forked child processes by reseeding the fast ID generator after `fork()` (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11491)

--- a/tests/unit_tests/test_lib/test_runid.py
+++ b/tests/unit_tests/test_lib/test_runid.py
@@ -1,23 +1,26 @@
+import multiprocessing as mp
 import random
+from concurrent.futures import ProcessPoolExecutor
 
-import pytest
-from wandb.sdk.lib import runid
+from pytest import fixture, mark
+from wandb.sdk.lib.runid import generate_fast_id, generate_id
 
 
 def test_generate_id_is_base36():
     # Given reasonable randomness assumptions, generating an 1000-digit string should
     # hit all 36 characters at least once >99.9999999999% of the time.
-    new_id = runid.generate_id(1000)
+    new_id = generate_id(1000)
     assert len(new_id) == 1000
     assert set(new_id) == set("0123456789abcdefghijklmnopqrstuvwxyz")
 
 
 def test_generate_id_default_8_chars():
-    assert len(runid.generate_id()) == 8
+    assert len(generate_id()) == 8
 
 
-@pytest.fixture
+@fixture
 def isolate_random_state():
+    """Isolate the random state to avoid affecting other tests."""
     orig_state = random.getstate()
     try:
         yield
@@ -25,12 +28,29 @@ def isolate_random_state():
         random.setstate(orig_state)
 
 
-@pytest.mark.usefixtures("isolate_random_state")
-def test_generate_fast_id_independent_of_global_seed():
+@mark.usefixtures("isolate_random_state")
+def test_generate_fast_id_is_independent_of_global_seed():
     random.seed(42)
-    id1 = runid.generate_fast_id(128)
+    id1 = generate_fast_id(128)
 
     random.seed(42)
-    id2 = runid.generate_fast_id(128)
+    id2 = generate_fast_id(128)
 
     assert id1 != id2, "generate_fast_id should not be affected by global random.seed()"
+
+
+@mark.usefixtures("isolate_random_state")
+@mark.parametrize(
+    "start_method",
+    mp.get_all_start_methods(),  # Supported start methods will be platform-dependent
+)
+def test_generate_fast_id_is_fork_safe(start_method: str):
+    """Check that generate_fast_id doesn't produce duplicate IDs child processes.
+
+    This can happen if `fork`-ed child processes all erroneously inherit the same
+    random state from the parent process.
+    """
+    with ProcessPoolExecutor(2, mp.get_context(start_method)) as executor:
+        generated_ids = executor.map(generate_fast_id, [128] * 2)
+
+    assert len(set(generated_ids)) == 2

--- a/wandb/sdk/lib/runid.py
+++ b/wandb/sdk/lib/runid.py
@@ -1,5 +1,6 @@
 """runid util."""
 
+import os
 import random
 import secrets
 from string import ascii_lowercase, digits
@@ -9,6 +10,13 @@ _ID_CHARS = f"{ascii_lowercase}{digits}"
 # Create a dedicated Random instance with its own state so it
 # is not affected by global random.seed() calls
 _random = random.Random()
+
+
+# Reset the random number generator on forking a new process to avoid multiple processes using the same seed.
+# The `random` module basically does this internally for python's global random state.
+# This is only necessary on platforms that support the `fork` multiprocessing start method (e.g. POSIX).
+if hasattr(os, "fork"):
+    os.register_at_fork(after_in_child=_random.seed)
 
 
 def generate_id(length: int = 8) -> str:


### PR DESCRIPTION
## JIRA Issue(s)

Fixes https://wandb.atlassian.net/browse/WB-29707

## Description

PR fixes artifact client ID generation in forked child processes.

- Reseeds the dedicated fast RNG used for artifact client IDs after `fork()`.
- Prevents parent and child processes from inheriting identical RNG state and generating colliding client IDs.
- Keeps the existing fast non-cryptographic ID path while making it safe across process forks.

## Testing