### PR TITLE
feat(sdk): add runs.summaries() for bulk summary metrics retrieval

### DIFF
--- a/tests/unit_tests/test_public_api/test_runs_configs.py
+++ b/tests/unit_tests/test_public_api/test_runs_configs.py
@@ -1,0 +1,150 @@
+"""Tests for Runs.configs() method."""
+
+from unittest import mock
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from wandb.apis.public.runs import Runs
+
+
+def _make_mock_run(run_id: str, config: dict | None = None):
+    """Create a mock Run with the given id and config."""
+    run = mock.MagicMock()
+    run.id = run_id
+    run.config = config if config is not None else {}
+    return run
+
+
+def _make_mock_runs(run_specs: list[tuple[str, dict | None]]):
+    """Create a mock Runs object that iterates over mock runs.
+
+    Args:
+        run_specs: List of (run_id, config) tuples.
+    """
+    mock_runs = mock.MagicMock(spec=Runs)
+    mock_run_objects = [_make_mock_run(rid, cfg) for rid, cfg in run_specs]
+    mock_runs.__iter__ = mock.MagicMock(return_value=iter(mock_run_objects))
+    return mock_runs
+
+
+class TestConfigsDefaultFormat:
+    def test_returns_list_of_dicts(self):
+        runs = _make_mock_runs([
+            ("run1", {"lr": 0.01, "epochs": 10}),
+            ("run2", {"lr": 0.001, "epochs": 20}),
+        ])
+        result = Runs.configs(runs, format="default")
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_includes_run_id(self):
+        runs = _make_mock_runs([
+            ("run1", {"lr": 0.01}),
+        ])
+        result = Runs.configs(runs, format="default")
+        assert result[0]["run_id"] == "run1"
+        assert result[0]["lr"] == 0.01
+
+    def test_skips_empty_configs(self):
+        runs = _make_mock_runs([
+            ("run1", {"lr": 0.01}),
+            ("run2", {}),
+            ("run3", None),
+            ("run4", {"lr": 0.1}),
+        ])
+        result = Runs.configs(runs, format="default")
+        assert len(result) == 2
+        assert result[0]["run_id"] == "run1"
+        assert result[1]["run_id"] == "run4"
+
+    def test_empty_runs(self):
+        runs = _make_mock_runs([])
+        result = Runs.configs(runs, format="default")
+        assert result == []
+
+    def test_all_empty_configs(self):
+        runs = _make_mock_runs([
+            ("run1", {}),
+            ("run2", {}),
+        ])
+        result = Runs.configs(runs, format="default")
+        assert result == []
+
+
+class TestConfigsPolarsFormat:
+    def test_returns_polars_dataframe(self):
+        runs = _make_mock_runs([
+            ("run1", {"lr": 0.01, "epochs": 10}),
+            ("run2", {"lr": 0.001, "epochs": 20}),
+        ])
+        result = Runs.configs(runs, format="polars")
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 2
+
+    def test_columns_sorted(self):
+        runs = _make_mock_runs([
+            ("run1", {"z_param": 1, "a_param": 2, "m_param": 3}),
+        ])
+        result = Runs.configs(runs, format="polars")
+        assert result.columns == ["a_param", "m_param", "run_id", "z_param"]
+
+    def test_includes_run_id_column(self):
+        runs = _make_mock_runs([
+            ("abc123", {"lr": 0.01}),
+        ])
+        result = Runs.configs(runs, format="polars")
+        assert "run_id" in result.columns
+        assert result["run_id"].to_list() == ["abc123"]
+
+    def test_empty_returns_empty_dataframe(self):
+        runs = _make_mock_runs([])
+        result = Runs.configs(runs, format="polars")
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 0
+
+    def test_heterogeneous_configs(self):
+        """Runs with different config keys produce a DataFrame with all keys."""
+        runs = _make_mock_runs([
+            ("run1", {"lr": 0.01}),
+            ("run2", {"batch_size": 32}),
+        ])
+        result = Runs.configs(runs, format="polars")
+        assert len(result) == 2
+        assert set(result.columns) == {"lr", "batch_size", "run_id"}
+
+
+class TestConfigsPandasFormat:
+    def test_returns_pandas_dataframe(self):
+        runs = _make_mock_runs([
+            ("run1", {"lr": 0.01, "epochs": 10}),
+        ])
+        result = Runs.configs(runs, format="pandas")
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 1
+
+    def test_columns_sorted(self):
+        runs = _make_mock_runs([
+            ("run1", {"z_param": 1, "a_param": 2}),
+        ])
+        result = Runs.configs(runs, format="pandas")
+        assert list(result.columns) == ["a_param", "run_id", "z_param"]
+
+    def test_empty_returns_empty_dataframe(self):
+        runs = _make_mock_runs([])
+        result = Runs.configs(runs, format="pandas")
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+
+
+class TestConfigsValidation:
+    def test_invalid_format_raises_error(self):
+        runs = _make_mock_runs([("run1", {"lr": 0.01})])
+        with pytest.raises(Exception, match="Invalid format"):
+            Runs.configs(runs, format="invalid")
+
+    def test_invalid_format_csv(self):
+        runs = _make_mock_runs([("run1", {"lr": 0.01})])
+        with pytest.raises(Exception, match="Invalid format"):
+            Runs.configs(runs, format="csv")

--- a/tests/unit_tests/test_public_api/test_runs_configs.py
+++ b/tests/unit_tests/test_public_api/test_runs_configs.py
@@ -1,11 +1,12 @@
 """Tests for Runs.configs() method."""
 
+from __future__ import annotations
+
 from unittest import mock
 
 import pandas as pd
 import polars as pl
 import pytest
-
 from wandb.apis.public.runs import Runs
 
 
@@ -31,29 +32,35 @@ def _make_mock_runs(run_specs: list[tuple[str, dict | None]]):
 
 class TestConfigsDefaultFormat:
     def test_returns_list_of_dicts(self):
-        runs = _make_mock_runs([
-            ("run1", {"lr": 0.01, "epochs": 10}),
-            ("run2", {"lr": 0.001, "epochs": 20}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"lr": 0.01, "epochs": 10}),
+                ("run2", {"lr": 0.001, "epochs": 20}),
+            ]
+        )
         result = Runs.configs(runs, format="default")
         assert isinstance(result, list)
         assert len(result) == 2
 
     def test_includes_run_id(self):
-        runs = _make_mock_runs([
-            ("run1", {"lr": 0.01}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"lr": 0.01}),
+            ]
+        )
         result = Runs.configs(runs, format="default")
         assert result[0]["run_id"] == "run1"
         assert result[0]["lr"] == 0.01
 
     def test_skips_empty_configs(self):
-        runs = _make_mock_runs([
-            ("run1", {"lr": 0.01}),
-            ("run2", {}),
-            ("run3", None),
-            ("run4", {"lr": 0.1}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"lr": 0.01}),
+                ("run2", {}),
+                ("run3", None),
+                ("run4", {"lr": 0.1}),
+            ]
+        )
         result = Runs.configs(runs, format="default")
         assert len(result) == 2
         assert result[0]["run_id"] == "run1"
@@ -65,35 +72,43 @@ class TestConfigsDefaultFormat:
         assert result == []
 
     def test_all_empty_configs(self):
-        runs = _make_mock_runs([
-            ("run1", {}),
-            ("run2", {}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {}),
+                ("run2", {}),
+            ]
+        )
         result = Runs.configs(runs, format="default")
         assert result == []
 
 
 class TestConfigsPolarsFormat:
     def test_returns_polars_dataframe(self):
-        runs = _make_mock_runs([
-            ("run1", {"lr": 0.01, "epochs": 10}),
-            ("run2", {"lr": 0.001, "epochs": 20}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"lr": 0.01, "epochs": 10}),
+                ("run2", {"lr": 0.001, "epochs": 20}),
+            ]
+        )
         result = Runs.configs(runs, format="polars")
         assert isinstance(result, pl.DataFrame)
         assert len(result) == 2
 
     def test_columns_sorted(self):
-        runs = _make_mock_runs([
-            ("run1", {"z_param": 1, "a_param": 2, "m_param": 3}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"z_param": 1, "a_param": 2, "m_param": 3}),
+            ]
+        )
         result = Runs.configs(runs, format="polars")
         assert result.columns == ["a_param", "m_param", "run_id", "z_param"]
 
     def test_includes_run_id_column(self):
-        runs = _make_mock_runs([
-            ("abc123", {"lr": 0.01}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("abc123", {"lr": 0.01}),
+            ]
+        )
         result = Runs.configs(runs, format="polars")
         assert "run_id" in result.columns
         assert result["run_id"].to_list() == ["abc123"]
@@ -106,10 +121,12 @@ class TestConfigsPolarsFormat:
 
     def test_heterogeneous_configs(self):
         """Runs with different config keys produce a DataFrame with all keys."""
-        runs = _make_mock_runs([
-            ("run1", {"lr": 0.01}),
-            ("run2", {"batch_size": 32}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"lr": 0.01}),
+                ("run2", {"batch_size": 32}),
+            ]
+        )
         result = Runs.configs(runs, format="polars")
         assert len(result) == 2
         assert set(result.columns) == {"lr", "batch_size", "run_id"}
@@ -117,17 +134,21 @@ class TestConfigsPolarsFormat:
 
 class TestConfigsPandasFormat:
     def test_returns_pandas_dataframe(self):
-        runs = _make_mock_runs([
-            ("run1", {"lr": 0.01, "epochs": 10}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"lr": 0.01, "epochs": 10}),
+            ]
+        )
         result = Runs.configs(runs, format="pandas")
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 1
 
     def test_columns_sorted(self):
-        runs = _make_mock_runs([
-            ("run1", {"z_param": 1, "a_param": 2}),
-        ])
+        runs = _make_mock_runs(
+            [
+                ("run1", {"z_param": 1, "a_param": 2}),
+            ]
+        )
         result = Runs.configs(runs, format="pandas")
         assert list(result.columns) == ["a_param", "run_id", "z_param"]
 

--- a/tests/unit_tests/test_public_api/test_runs_configs.py
+++ b/tests/unit_tests/test_public_api/test_runs_configs.py
@@ -193,3 +193,25 @@ class TestConfigsUpgradeToFull:
         Runs.configs(mock_runs, format="default")
 
         mock_runs.upgrade_to_full.assert_called_once()
+
+
+class TestConfigsErrorHandling:
+    """Verify individual run failures don't break the whole collection."""
+
+    def test_failing_run_skipped_with_warning(self):
+        mock_runs = mock.MagicMock(spec=Runs)
+        run1 = _make_mock_run("run1", {"lr": 0.01})
+        run2 = mock.MagicMock()
+        run2.id = "run2"
+        type(run2).config = mock.PropertyMock(side_effect=RuntimeError("API error"))
+        run3 = _make_mock_run("run3", {"lr": 0.03})
+        mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1, run2, run3]))
+
+        with mock.patch("wandb.termwarn") as mock_warn:
+            result = Runs.configs(mock_runs, format="default")
+
+        assert len(result) == 2
+        assert result[0]["run_id"] == "run1"
+        assert result[1]["run_id"] == "run3"
+        mock_warn.assert_called_once()
+        assert "run2" in mock_warn.call_args[0][0]

--- a/tests/unit_tests/test_public_api/test_runs_configs.py
+++ b/tests/unit_tests/test_public_api/test_runs_configs.py
@@ -182,32 +182,14 @@ class TestConfigsDoesNotMutate:
         assert "run_id" not in original_config
 
 
-class TestConfigsParallelLoading:
-    """Verify parallel pre-loading of lazy run data."""
+class TestConfigsUpgradeToFull:
+    """Verify configs() calls upgrade_to_full() to load lazy run data."""
 
-    def test_parallel_loads_lazy_runs(self):
+    def test_calls_upgrade_to_full(self):
         mock_runs = mock.MagicMock(spec=Runs)
         run1 = _make_mock_run("run1", {"lr": 0.01})
-        run1._lazy = True
-        run1._full_data_loaded = False
-        run2 = _make_mock_run("run2", {"lr": 0.02})
-        run2._lazy = True
-        run2._full_data_loaded = False
-        mock_runs.objects = [run1, run2]
-        mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1, run2]))
-
-        Runs.configs(mock_runs, format="default")
-
-        run1.load_full_data.assert_called_once()
-        run2.load_full_data.assert_called_once()
-
-    def test_skips_non_lazy_runs(self):
-        mock_runs = mock.MagicMock(spec=Runs)
-        run1 = _make_mock_run("run1", {"lr": 0.01})
-        run1._lazy = False
-        mock_runs.objects = [run1]
         mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1]))
 
         Runs.configs(mock_runs, format="default")
 
-        run1.load_full_data.assert_not_called()
+        mock_runs.upgrade_to_full.assert_called_once()

--- a/tests/unit_tests/test_public_api/test_runs_configs.py
+++ b/tests/unit_tests/test_public_api/test_runs_configs.py
@@ -163,12 +163,12 @@ class TestConfigsPandasFormat:
 class TestConfigsValidation:
     def test_invalid_format_raises_error(self):
         runs = _make_mock_runs([("run1", {"lr": 0.01})])
-        with pytest.raises(Exception, match="Invalid format"):
+        with pytest.raises(ValueError, match="Invalid format"):
             Runs.configs(runs, format="invalid")
 
     def test_invalid_format_csv(self):
         runs = _make_mock_runs([("run1", {"lr": 0.01})])
-        with pytest.raises(Exception, match="Invalid format"):
+        with pytest.raises(ValueError, match="Invalid format"):
             Runs.configs(runs, format="csv")
 
 

--- a/tests/unit_tests/test_public_api/test_runs_configs.py
+++ b/tests/unit_tests/test_public_api/test_runs_configs.py
@@ -27,6 +27,7 @@ def _make_mock_runs(run_specs: list[tuple[str, dict | None]]):
     mock_runs = mock.MagicMock(spec=Runs)
     mock_run_objects = [_make_mock_run(rid, cfg) for rid, cfg in run_specs]
     mock_runs.__iter__ = mock.MagicMock(return_value=iter(mock_run_objects))
+    mock_runs.objects = mock_run_objects
     return mock_runs
 
 
@@ -169,3 +170,44 @@ class TestConfigsValidation:
         runs = _make_mock_runs([("run1", {"lr": 0.01})])
         with pytest.raises(Exception, match="Invalid format"):
             Runs.configs(runs, format="csv")
+
+
+class TestConfigsDoesNotMutate:
+    """Verify configs() does not mutate run.config in-place."""
+
+    def test_original_config_unchanged(self):
+        original_config = {"lr": 0.01, "epochs": 10}
+        runs = _make_mock_runs([("run1", original_config)])
+        Runs.configs(runs, format="default")
+        assert "run_id" not in original_config
+
+
+class TestConfigsParallelLoading:
+    """Verify parallel pre-loading of lazy run data."""
+
+    def test_parallel_loads_lazy_runs(self):
+        mock_runs = mock.MagicMock(spec=Runs)
+        run1 = _make_mock_run("run1", {"lr": 0.01})
+        run1._lazy = True
+        run1._full_data_loaded = False
+        run2 = _make_mock_run("run2", {"lr": 0.02})
+        run2._lazy = True
+        run2._full_data_loaded = False
+        mock_runs.objects = [run1, run2]
+        mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1, run2]))
+
+        Runs.configs(mock_runs, format="default")
+
+        run1.load_full_data.assert_called_once()
+        run2.load_full_data.assert_called_once()
+
+    def test_skips_non_lazy_runs(self):
+        mock_runs = mock.MagicMock(spec=Runs)
+        run1 = _make_mock_run("run1", {"lr": 0.01})
+        run1._lazy = False
+        mock_runs.objects = [run1]
+        mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1]))
+
+        Runs.configs(mock_runs, format="default")
+
+        run1.load_full_data.assert_not_called()

--- a/tests/unit_tests/test_public_api/test_runs_summary_metrics.py
+++ b/tests/unit_tests/test_public_api/test_runs_summary_metrics.py
@@ -1,0 +1,219 @@
+"""Tests for Runs.summary_metrics() method."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pandas as pd
+import polars as pl
+import pytest
+from wandb.apis.public.runs import Runs
+
+
+def _make_mock_run(run_id: str, summary: dict | None = None):
+    """Create a mock Run with the given id and summary_metrics."""
+    run = mock.MagicMock()
+    run.id = run_id
+    run.summary_metrics = summary if summary is not None else {}
+    return run
+
+
+def _make_mock_runs(run_specs: list[tuple[str, dict | None]]):
+    """Create a mock Runs object that iterates over mock runs.
+
+    Args:
+        run_specs: List of (run_id, summary_metrics) tuples.
+    """
+    mock_runs = mock.MagicMock(spec=Runs)
+    mock_run_objects = [_make_mock_run(rid, sm) for rid, sm in run_specs]
+    mock_runs.__iter__ = mock.MagicMock(return_value=iter(mock_run_objects))
+    mock_runs.objects = mock_run_objects
+    return mock_runs
+
+
+class TestSummaryMetricsDefaultFormat:
+    def test_returns_list_of_dicts(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {"loss": 0.5, "accuracy": 0.9}),
+                ("run2", {"loss": 0.3, "accuracy": 0.95}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="default")
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_includes_run_id(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {"loss": 0.5}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="default")
+        assert result[0]["run_id"] == "run1"
+        assert result[0]["loss"] == 0.5
+
+    def test_skips_empty_summaries(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {"loss": 0.5}),
+                ("run2", {}),
+                ("run3", None),
+                ("run4", {"loss": 0.1}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="default")
+        assert len(result) == 2
+        assert result[0]["run_id"] == "run1"
+        assert result[1]["run_id"] == "run4"
+
+    def test_empty_runs(self):
+        runs = _make_mock_runs([])
+        result = Runs.summary_metrics(runs, format="default")
+        assert result == []
+
+    def test_all_empty_summaries(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {}),
+                ("run2", {}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="default")
+        assert result == []
+
+
+class TestSummaryMetricsPolarsFormat:
+    def test_returns_polars_dataframe(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {"loss": 0.5, "accuracy": 0.9}),
+                ("run2", {"loss": 0.3, "accuracy": 0.95}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="polars")
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 2
+
+    def test_columns_sorted(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {"z_metric": 1.0, "a_metric": 2.0, "m_metric": 3.0}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="polars")
+        assert result.columns == ["a_metric", "m_metric", "run_id", "z_metric"]
+
+    def test_includes_run_id_column(self):
+        runs = _make_mock_runs(
+            [
+                ("abc123", {"loss": 0.5}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="polars")
+        assert "run_id" in result.columns
+        assert result["run_id"].to_list() == ["abc123"]
+
+    def test_empty_returns_empty_dataframe(self):
+        runs = _make_mock_runs([])
+        result = Runs.summary_metrics(runs, format="polars")
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 0
+
+    def test_heterogeneous_metrics(self):
+        """Runs with different metric keys produce a DataFrame with all keys."""
+        runs = _make_mock_runs(
+            [
+                ("run1", {"loss": 0.5}),
+                ("run2", {"accuracy": 0.9}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="polars")
+        assert len(result) == 2
+        assert set(result.columns) == {"loss", "accuracy", "run_id"}
+
+
+class TestSummaryMetricsPandasFormat:
+    def test_returns_pandas_dataframe(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {"loss": 0.5, "accuracy": 0.9}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="pandas")
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 1
+
+    def test_columns_sorted(self):
+        runs = _make_mock_runs(
+            [
+                ("run1", {"z_metric": 1.0, "a_metric": 2.0}),
+            ]
+        )
+        result = Runs.summary_metrics(runs, format="pandas")
+        assert list(result.columns) == ["a_metric", "run_id", "z_metric"]
+
+    def test_empty_returns_empty_dataframe(self):
+        runs = _make_mock_runs([])
+        result = Runs.summary_metrics(runs, format="pandas")
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+
+
+class TestSummaryMetricsValidation:
+    def test_invalid_format_raises_error(self):
+        runs = _make_mock_runs([("run1", {"loss": 0.5})])
+        with pytest.raises(ValueError, match="Invalid format"):
+            Runs.summary_metrics(runs, format="invalid")
+
+    def test_invalid_format_csv(self):
+        runs = _make_mock_runs([("run1", {"loss": 0.5})])
+        with pytest.raises(ValueError, match="Invalid format"):
+            Runs.summary_metrics(runs, format="csv")
+
+
+class TestSummaryMetricsDoesNotMutate:
+    """Verify summary_metrics() does not mutate run.summary_metrics in-place."""
+
+    def test_original_summary_unchanged(self):
+        original_summary = {"loss": 0.5, "accuracy": 0.9}
+        runs = _make_mock_runs([("run1", original_summary)])
+        Runs.summary_metrics(runs, format="default")
+        assert "run_id" not in original_summary
+
+
+class TestSummaryMetricsUpgradeToFull:
+    """Verify summary_metrics() calls upgrade_to_full() to load lazy run data."""
+
+    def test_calls_upgrade_to_full(self):
+        mock_runs = mock.MagicMock(spec=Runs)
+        run1 = _make_mock_run("run1", {"loss": 0.5})
+        mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1]))
+
+        Runs.summary_metrics(mock_runs, format="default")
+
+        mock_runs.upgrade_to_full.assert_called_once()
+
+
+class TestSummaryMetricsErrorHandling:
+    """Verify individual run failures don't break the whole collection."""
+
+    def test_failing_run_skipped_with_warning(self):
+        mock_runs = mock.MagicMock(spec=Runs)
+        run1 = _make_mock_run("run1", {"loss": 0.5})
+        run2 = mock.MagicMock()
+        run2.id = "run2"
+        type(run2).summary_metrics = mock.PropertyMock(
+            side_effect=RuntimeError("API error")
+        )
+        run3 = _make_mock_run("run3", {"loss": 0.1})
+        mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1, run2, run3]))
+
+        with mock.patch("wandb.termwarn") as mock_warn:
+            result = Runs.summary_metrics(mock_runs, format="default")
+
+        assert len(result) == 2
+        assert result[0]["run_id"] == "run1"
+        assert result[1]["run_id"] == "run3"
+        mock_warn.assert_called_once()
+        assert "run2" in mock_warn.call_args[0][0]

--- a/tests/unit_tests/test_public_api/test_runs_summary_metrics.py
+++ b/tests/unit_tests/test_public_api/test_runs_summary_metrics.py
@@ -1,4 +1,4 @@
-"""Tests for Runs.summary_metrics() method."""
+"""Tests for Runs.summaries() method."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ class TestSummaryMetricsDefaultFormat:
                 ("run2", {"loss": 0.3, "accuracy": 0.95}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="default")
+        result = Runs.summaries(runs, format="default")
         assert isinstance(result, list)
         assert len(result) == 2
 
@@ -49,7 +49,7 @@ class TestSummaryMetricsDefaultFormat:
                 ("run1", {"loss": 0.5}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="default")
+        result = Runs.summaries(runs, format="default")
         assert result[0]["run_id"] == "run1"
         assert result[0]["loss"] == 0.5
 
@@ -62,14 +62,14 @@ class TestSummaryMetricsDefaultFormat:
                 ("run4", {"loss": 0.1}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="default")
+        result = Runs.summaries(runs, format="default")
         assert len(result) == 2
         assert result[0]["run_id"] == "run1"
         assert result[1]["run_id"] == "run4"
 
     def test_empty_runs(self):
         runs = _make_mock_runs([])
-        result = Runs.summary_metrics(runs, format="default")
+        result = Runs.summaries(runs, format="default")
         assert result == []
 
     def test_all_empty_summaries(self):
@@ -79,7 +79,7 @@ class TestSummaryMetricsDefaultFormat:
                 ("run2", {}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="default")
+        result = Runs.summaries(runs, format="default")
         assert result == []
 
 
@@ -91,7 +91,7 @@ class TestSummaryMetricsPolarsFormat:
                 ("run2", {"loss": 0.3, "accuracy": 0.95}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="polars")
+        result = Runs.summaries(runs, format="polars")
         assert isinstance(result, pl.DataFrame)
         assert len(result) == 2
 
@@ -101,7 +101,7 @@ class TestSummaryMetricsPolarsFormat:
                 ("run1", {"z_metric": 1.0, "a_metric": 2.0, "m_metric": 3.0}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="polars")
+        result = Runs.summaries(runs, format="polars")
         assert result.columns == ["a_metric", "m_metric", "run_id", "z_metric"]
 
     def test_includes_run_id_column(self):
@@ -110,13 +110,13 @@ class TestSummaryMetricsPolarsFormat:
                 ("abc123", {"loss": 0.5}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="polars")
+        result = Runs.summaries(runs, format="polars")
         assert "run_id" in result.columns
         assert result["run_id"].to_list() == ["abc123"]
 
     def test_empty_returns_empty_dataframe(self):
         runs = _make_mock_runs([])
-        result = Runs.summary_metrics(runs, format="polars")
+        result = Runs.summaries(runs, format="polars")
         assert isinstance(result, pl.DataFrame)
         assert len(result) == 0
 
@@ -128,7 +128,7 @@ class TestSummaryMetricsPolarsFormat:
                 ("run2", {"accuracy": 0.9}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="polars")
+        result = Runs.summaries(runs, format="polars")
         assert len(result) == 2
         assert set(result.columns) == {"loss", "accuracy", "run_id"}
 
@@ -140,7 +140,7 @@ class TestSummaryMetricsPandasFormat:
                 ("run1", {"loss": 0.5, "accuracy": 0.9}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="pandas")
+        result = Runs.summaries(runs, format="pandas")
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 1
 
@@ -150,12 +150,12 @@ class TestSummaryMetricsPandasFormat:
                 ("run1", {"z_metric": 1.0, "a_metric": 2.0}),
             ]
         )
-        result = Runs.summary_metrics(runs, format="pandas")
+        result = Runs.summaries(runs, format="pandas")
         assert list(result.columns) == ["a_metric", "run_id", "z_metric"]
 
     def test_empty_returns_empty_dataframe(self):
         runs = _make_mock_runs([])
-        result = Runs.summary_metrics(runs, format="pandas")
+        result = Runs.summaries(runs, format="pandas")
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 0
 
@@ -164,12 +164,12 @@ class TestSummaryMetricsValidation:
     def test_invalid_format_raises_error(self):
         runs = _make_mock_runs([("run1", {"loss": 0.5})])
         with pytest.raises(ValueError, match="Invalid format"):
-            Runs.summary_metrics(runs, format="invalid")
+            Runs.summaries(runs, format="invalid")
 
     def test_invalid_format_csv(self):
         runs = _make_mock_runs([("run1", {"loss": 0.5})])
         with pytest.raises(ValueError, match="Invalid format"):
-            Runs.summary_metrics(runs, format="csv")
+            Runs.summaries(runs, format="csv")
 
 
 class TestSummaryMetricsDoesNotMutate:
@@ -178,7 +178,7 @@ class TestSummaryMetricsDoesNotMutate:
     def test_original_summary_unchanged(self):
         original_summary = {"loss": 0.5, "accuracy": 0.9}
         runs = _make_mock_runs([("run1", original_summary)])
-        Runs.summary_metrics(runs, format="default")
+        Runs.summaries(runs, format="default")
         assert "run_id" not in original_summary
 
 
@@ -190,7 +190,7 @@ class TestSummaryMetricsUpgradeToFull:
         run1 = _make_mock_run("run1", {"loss": 0.5})
         mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1]))
 
-        Runs.summary_metrics(mock_runs, format="default")
+        Runs.summaries(mock_runs, format="default")
 
         mock_runs.upgrade_to_full.assert_called_once()
 
@@ -210,7 +210,7 @@ class TestSummaryMetricsErrorHandling:
         mock_runs.__iter__ = mock.MagicMock(return_value=iter([run1, run2, run3]))
 
         with mock.patch("wandb.termwarn") as mock_warn:
-            result = Runs.summary_metrics(mock_runs, format="default")
+            result = Runs.summaries(mock_runs, format="default")
 
         assert len(result) == 2
         assert result[0]["run_id"] == "run1"

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -526,9 +526,7 @@ class Runs(SizedPaginator["Run"]):
                     continue
                 configs.append({**config_data, "run_id": run.id})
             except Exception as e:
-                wandb.termwarn(
-                    f"Failed to collect config for run {run.id}: {e}"
-                )
+                wandb.termwarn(f"Failed to collect config for run {run.id}: {e}")
                 continue
 
         # Format conversion

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -553,6 +553,74 @@ class Runs(SizedPaginator["Run"]):
             combined_df = combined_df.select(sorted(combined_df.columns))
             return combined_df
 
+    @normalize_exceptions
+    def summary_metrics(
+        self,
+        format: Literal["default", "pandas", "polars"] = "default",
+    ) -> list[dict[str, Any]] | pd.DataFrame | pl.DataFrame:
+        """Return summary metrics for all runs that fit the filters conditions.
+
+        Args:
+            format: Format to return data in, options are "default", "pandas",
+                "polars"
+        Returns:
+            pandas.DataFrame: If `format="pandas"`, returns a `pandas.DataFrame`
+                of run summary metrics.
+            polars.DataFrame: If `format="polars"`, returns a `polars.DataFrame`
+                of run summary metrics.
+            list of dicts: If `format="default"`, returns a list of dicts
+                containing run summary metrics with a `run_id` key.
+
+        Note:
+            Returned dicts are shallow copies. Nested values share references
+            with the underlying run objects. Mutating nested values will not
+            affect the server unless ``Run.update()`` is called.
+        """
+        if format not in ("default", "pandas", "polars"):
+            raise ValueError(
+                f"Invalid format: {format}. Must be one of 'default', 'pandas', 'polars'"
+            )
+
+        # Ensure all runs have full data loaded
+        self.upgrade_to_full()
+
+        summaries = []
+        for run in self:
+            try:
+                metrics = run.summary_metrics
+                if not metrics:
+                    continue
+                summaries.append({**metrics, "run_id": run.id})
+            except Exception as e:
+                wandb.termwarn(
+                    f"Failed to collect summary metrics for run {run.id}: {e}"
+                )
+                continue
+
+        # Format conversion
+        if format == "default":
+            return summaries
+
+        if format == "pandas":
+            pd = util.get_module(
+                "pandas", required="Exporting pandas DataFrame requires pandas"
+            )
+            if not summaries:
+                return pd.DataFrame()
+            combined_df = pd.DataFrame.from_records(summaries)
+            combined_df = combined_df[sorted(combined_df.columns)]
+            return combined_df
+
+        if format == "polars":
+            pl = util.get_module(
+                "polars", required="Exporting polars DataFrame requires polars"
+            )
+            if not summaries:
+                return pl.DataFrame()
+            combined_df = pl.from_dicts(summaries)
+            combined_df = combined_df.select(sorted(combined_df.columns))
+            return combined_df
+
     def __repr__(self) -> str:
         return f"<{nameof(type(self))} {self.entity}/{self.project}>"
 

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -502,6 +502,12 @@ class Runs(SizedPaginator["Run"]):
                 of run configs.
             list of dicts: If `format="default"`, returns a list of dicts
                 containing run configs with a `run_id` key.
+
+        Note:
+            Returned config dicts are shallow copies. Nested values (e.g. dicts
+            within configs) share references with the underlying run objects.
+            Mutating nested values will not affect the server unless
+            ``Run.update()`` is called.
         """
         if format not in ("default", "pandas", "polars"):
             raise ValueError(

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -554,7 +554,7 @@ class Runs(SizedPaginator["Run"]):
             return combined_df
 
     @normalize_exceptions
-    def summary_metrics(
+    def summaries(
         self,
         format: Literal["default", "pandas", "polars"] = "default",
     ) -> list[dict[str, Any]] | pd.DataFrame | pl.DataFrame:

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -508,21 +508,8 @@ class Runs(SizedPaginator["Run"]):
                 f"Invalid format: {format}. Must be one of 'default', 'pandas', 'polars'"
             )
 
-        # Parallel pre-load for lazy runs
-        lazy_runs = [
-            run
-            for run in self.objects
-            if getattr(run, "_lazy", False)
-            and not getattr(run, "_full_data_loaded", False)
-        ]
-        if lazy_runs:
-            from concurrent.futures import ThreadPoolExecutor
-
-            max_workers = min(len(lazy_runs), 10)
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [executor.submit(run.load_full_data) for run in lazy_runs]
-                for future in futures:
-                    future.result()
+        # Ensure all runs have full data loaded
+        self.upgrade_to_full()
 
         # Single collection pass — copy config to avoid mutating run.config
         configs = []

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -514,10 +514,16 @@ class Runs(SizedPaginator["Run"]):
         # Single collection pass — copy config to avoid mutating run.config
         configs = []
         for run in self:
-            config_data = run.config
-            if not config_data:
+            try:
+                config_data = run.config
+                if not config_data:
+                    continue
+                configs.append({**config_data, "run_id": run.id})
+            except Exception as e:
+                wandb.termwarn(
+                    f"Failed to collect config for run {run.id}: {e}"
+                )
                 continue
-            configs.append({**config_data, "run_id": run.id})
 
         # Format conversion
         if format == "default":

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -508,48 +508,53 @@ class Runs(SizedPaginator["Run"]):
                 f"Invalid format: {format}. Must be one of 'default', 'pandas', 'polars'"
             )
 
-        configs = []
+        # Parallel pre-load for lazy runs
+        lazy_runs = [
+            run
+            for run in self.objects
+            if getattr(run, "_lazy", False)
+            and not getattr(run, "_full_data_loaded", False)
+        ]
+        if lazy_runs:
+            from concurrent.futures import ThreadPoolExecutor
 
+            max_workers = min(len(lazy_runs), 10)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(run.load_full_data) for run in lazy_runs
+                ]
+                for future in futures:
+                    future.result()
+
+        # Single collection pass — copy config to avoid mutating run.config
+        configs = []
+        for run in self:
+            config_data = run.config
+            if not config_data:
+                continue
+            configs.append({**config_data, "run_id": run.id})
+
+        # Format conversion
         if format == "default":
-            for run in self:
-                config_data = run.config
-                if not config_data:
-                    continue
-                config_data["run_id"] = run.id
-                configs.append(config_data)
             return configs
 
         if format == "pandas":
             pd = util.get_module(
                 "pandas", required="Exporting pandas DataFrame requires pandas"
             )
-            for run in self:
-                config_data = run.config
-                if not config_data:
-                    continue
-                config_data["run_id"] = run.id
-                configs.append(config_data)
             if not configs:
                 return pd.DataFrame()
             combined_df = pd.DataFrame.from_records(configs)
-            # sort columns for consistency
-            combined_df = combined_df[(sorted(combined_df.columns))]
+            combined_df = combined_df[sorted(combined_df.columns)]
             return combined_df
 
         if format == "polars":
             pl = util.get_module(
                 "polars", required="Exporting polars DataFrame requires polars"
             )
-            for run in self:
-                config_data = run.config
-                if not config_data:
-                    continue
-                config_data["run_id"] = run.id
-                configs.append(config_data)
             if not configs:
                 return pl.DataFrame()
             combined_df = pl.from_dicts(configs)
-            # sort columns for consistency
             combined_df = combined_df.select(sorted(combined_df.columns))
             return combined_df
 

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -520,9 +520,7 @@ class Runs(SizedPaginator["Run"]):
 
             max_workers = min(len(lazy_runs), 10)
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [
-                    executor.submit(run.load_full_data) for run in lazy_runs
-                ]
+                futures = [executor.submit(run.load_full_data) for run in lazy_runs]
                 for future in futures:
                     future.result()
 


### PR DESCRIPTION
## Summary

- Adds `runs.summaries()` method to the `Runs` class, providing a simple way to collect summary metrics from all matching runs into a single DataFrame
- Supports polars, pandas, and list-of-dicts output formats, following the same pattern as `runs.configs()` from #11282
- Calls `upgrade_to_full()` for parallel pre-loading of lazy run data, avoiding the N+1 query problem when `lazy=True` (the default)

### API

```python
api = wandb.Api()
runs = api.runs("entity/project", filters={"state": "finished"})

# Polars DataFrame (one row per run, columns = metric keys + run_id)
summaries = runs.summaries(format="polars")

# Combine with configs for full picture
configs = runs.configs(format="polars")
full = configs.join(summaries, on="run_id")
```

## Test plan

- [x] Unit tests for all three output formats (polars, pandas, default)
- [x] Tests for empty runs, skipped empty summaries, sorted columns
- [x] Tests for invalid format validation
- [x] Tests for heterogeneous metric keys across runs
- [x] Tests for mutation safety (original summary_metrics unchanged)
- [x] Tests for upgrade_to_full() call
- [x] Tests for per-run error handling (failing run skipped with warning)

Ref: [WB-29760](https://wandb.atlassian.net/browse/WB-29760)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WB-29760]: https://wandb.atlassian.net/browse/WB-29760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ