### PR TITLE
fix(sweeps): ensure that sweep context is removed when agent exits

### DIFF
--- a/tests/system_tests/test_sweep/test_wandb_agent_full.py
+++ b/tests/system_tests/test_sweep/test_wandb_agent_full.py
@@ -317,3 +317,66 @@ def test_public_api_sweep_agent_runs_lists_finished_run(user):
     runs_list = list(public_agent.runs(per_page=2))
     assert len(runs_list) == 3
     assert {r.state for r in runs_list} == {"finished"}
+
+
+def test_normal_run_after_agent_does_not_overwrite_sweep_run(user, runner, monkeypatch):
+    """After running a sweep agent, a normal wandb.init() creates a separate run.
+
+    Matches WB-8766: create sweep, run agent (1 run), then create a normal run
+    with an explicit id. The normal run must be separate and must not overwrite
+    the sweep run.
+    """
+    import time
+
+    with runner.isolated_filesystem():
+        project_name = "test-normal-run-after-agent"
+        public_api = Api()
+        public_api.create_project(project_name, user)
+
+        sweep_run_ids = []
+
+        def sweep_train():
+            run = wandb.init()
+            sweep_run_ids.append(run.id)
+            run.log({"a": run.config["a"], "accuracy": run.config["a"] * 4})
+            run.finish()
+
+        sweep_config = {
+            "name": "sweep-normal-run-sep",
+            "method": "random",
+            "metric": {"name": "accuracy", "goal": "maximize"},
+            "parameters": {"a": {"values": [1, 2, 3, 4]}},
+        }
+        monkeypatch.setenv("WANDB_CONSOLE", "off")
+        sweep_id = wandb.sweep(sweep_config, project=project_name, entity=user)
+        wandb.agent(sweep_id, function=sweep_train, count=1, project=project_name)
+
+        assert len(sweep_run_ids) == 1, "Agent should have run 1 sweep run"
+        sweep_run_id = sweep_run_ids[0]
+
+        # Create a normal run (not part of the sweep) with an explicit id.
+        normal_run_id = f"normal-run-{hash(time.time())}"
+        run = wandb.init(
+            project=project_name,
+            entity=user,
+            config={"a": 1},
+            id=normal_run_id,
+        )
+        try:
+            run.log({"accuracy": 4})
+            assert run.id == normal_run_id, "Normal run should keep the explicit id"
+            assert run.sweep_id is None, "Normal run must not be part of the sweep"
+            # Sweep run must still exist and be unchanged (not overwritten).
+            sweep_runs = list(
+                public_api.runs(f"{user}/{project_name}", {"sweep": sweep_id})
+            )
+            assert len(sweep_runs) == 1, "There must still be exactly 1 sweep run"
+            assert sweep_run_id in {r.id for r in sweep_runs}
+        finally:
+            run.finish()
+
+        # Normal run should appear as its own run, not under the sweep.
+        all_runs = list(public_api.runs(f"{user}/{project_name}"))
+        run_ids = {r.id for r in all_runs}
+        assert normal_run_id in run_ids
+        assert sweep_run_id in run_ids

--- a/tests/unit_tests/test_wandb_agent_teardown.py
+++ b/tests/unit_tests/test_wandb_agent_teardown.py
@@ -1,0 +1,56 @@
+"""Unit tests for agent teardown behavior.
+
+These tests verify that after wandb.agent() exits (normally or by exception),
+global state is cleared so a subsequent wandb.init() creates a normal run,
+not a sweep run. Open-source developers can use these to ensure changes
+around agent teardown do not break this functionality.
+"""
+
+import os
+from unittest import mock
+
+import pytest
+from wandb import env, wandb_agent
+from wandb.sdk import wandb_setup
+
+
+def test_agent_teardown_clears_sweep_id_on_exception(runner, monkeypatch):
+    with runner.isolated_filesystem():
+        """When agent() raises, the finally block must clear settings.sweep_id."""
+        monkeypatch.setattr(
+            "wandb.sdk.wandb_login._login",
+            mock.Mock(side_effect=RuntimeError("login failed")),
+        )
+        # Ensure we have a singleton and pollute sweep_id to simulate prior sweep state.
+        os.environ[env.SWEEP_ID] = "fake-sweep-id"
+        settings = wandb_setup.singleton().settings
+        assert settings.sweep_id == "fake-sweep-id"
+        with pytest.raises(RuntimeError, match="login failed"):
+            wandb_agent.agent("entity/project/sweep-id", function=None)
+
+        assert settings.sweep_id is None, (
+            "agent() finally must clear settings.sweep_id so the next init() is a normal run"
+        )
+        assert wandb_agent._is_running() is False
+
+
+def test_agent_teardown_clears_sweep_id_on_normal_return(runner, monkeypatch):
+    with runner.isolated_filesystem():
+        """When agent() returns normally, the finally block must clear settings.sweep_id."""
+        monkeypatch.setattr(
+            "wandb.sdk.wandb_login._login", mock.Mock(return_value=None)
+        )
+        monkeypatch.setattr(
+            "wandb.wandb_agent.run_agent",
+            mock.Mock(return_value=None),
+        )
+
+        os.environ[env.SWEEP_ID] = "fake-sweep-id"
+        settings = wandb_setup.singleton().settings
+        assert settings.sweep_id == "fake-sweep-id"
+        wandb_agent.agent("entity/project/sweep-id", function=None)
+
+        assert settings.sweep_id is None, (
+            "agent() finally must clear settings.sweep_id so the next init() is a normal run"
+        )
+        assert wandb_agent._is_running() is False

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -208,11 +208,6 @@ class _WandbInit:
     def warn_env_vars_change_after_setup(self) -> _PrinterCallback:
         """Warn if environment variables changed after `wandb.setup()`.
 
-        Note: Running an agent through pyagent() (pass function=...) will trigger this warning.
-        pyagent() uses a thread to call _run_job.
-        This causes WANDB_SWEEP_ID, WANDB_PROJECT, and WANDB_ENTITY to be cleared,
-        did_environment_change() returns True, which then triggers this warning.
-
         Returns:
             A callback to print any generated warnings.
         """

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -208,6 +208,11 @@ class _WandbInit:
     def warn_env_vars_change_after_setup(self) -> _PrinterCallback:
         """Warn if environment variables changed after `wandb.setup()`.
 
+        Note: Running an agent through pyagent() (pass function=...) will trigger this warning.
+        pyagent() uses a thread to call _run_job.
+        This causes WANDB_SWEEP_ID, WANDB_PROJECT, and WANDB_ENTITY to be cleared,
+        did_environment_change() returns True, which then triggers this warning.
+
         Returns:
             A callback to print any generated warnings.
         """

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -678,9 +678,12 @@ def agent(
     finally:
         _INSTANCES -= 1
 
-        # clear the sweep id from the settings,
-        # else wandb.init() will not reinitialize in
-        # clear_run_path_if_sweep_or_launch()
+        # Clear sweep_id from the global settings singleton so that a subsequent
+        # wandb.init() call does not think it is still inside a sweep. Without
+        # this, clear_run_path_if_sweep_or_launch() in wandb_init.py will see a
+        # non-empty sweep_id and silently ignore the project/entity/run_id
+        # arguments passed to wandb.init(), preventing the user from
+        # reinitializing their run after the agent exits.
         wandb_setup.singleton().settings.sweep_id = None
 
 

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -17,7 +17,7 @@ from typing import Any, Callable
 
 import wandb
 from wandb import util
-from wandb.sdk import wandb_login
+from wandb.sdk import wandb_login, wandb_setup
 from wandb.sdk.lib import config_util, ipython
 
 logger = logging.getLogger(__name__)
@@ -677,6 +677,11 @@ def agent(
         )
     finally:
         _INSTANCES -= 1
+
+        # clear the sweep id from the settings,
+        # else wandb.init() will not reinitialize in
+        # clear_run_path_if_sweep_or_launch()
+        wandb_setup.singleton().settings.sweep_id = None
 
 
 _INSTANCES = 0


### PR DESCRIPTION
Description
-----------
- Fixes WB-8766

This change modifies both the pyagent() and run_agent() agent flows to cleanup the sweep_id when the agent exits. Without this, the user is unable to init(reinit) as the sweep ID will remain in the project settings.

Note: only the run_agent actively modifies the env variables passed to the subprocess, so these env variables are removed from the env before the function returns, iff. they were originally set.

The pyagent() implementation uses threads, so once _run_job completes for each job, the project, entity, and sweep_id env vars are already being reset for the whole process. However, the settings.sweep_id was not being cleared (settings need to be reloaded). Calling _load_settings again caused the user to be logged out, so clearing only the sweep_id field seems to be a good compromise

Testing
-------
Added unit tests and system tests. Ran user's example code that was failing