### PR TITLE
fix(save): escape brackets in literal paths to fix glob matching (#11510)

### DIFF
--- a/tests/unit_tests/test_wandb_save.py
+++ b/tests/unit_tests/test_wandb_save.py
@@ -240,6 +240,29 @@ def test_save_hardlink_fallback_when_symlink_fails(
     assert paths == {"a.hl", "b.hl"}
 
 
+
+def test_save_path_with_brackets(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    mock_run,
+    parse_records,
+    record_q,
+):
+    """Test that save works when path contains brackets (fixes #11510)."""
+    monkeypatch.chdir(tmp_path)
+    path_with_bracket = pathlib.Path("dir", "test_[whatever]", "checkpoint_0.pt")
+    path_with_bracket.parent.mkdir(parents=True, exist_ok=True)
+    path_with_bracket.touch()
+
+    run = mock_run()
+    run.save(str(path_with_bracket), base_path="dir", policy="now")
+
+    assert pathlib.Path(run.dir, "test_[whatever]", "checkpoint_0.pt").exists()
+    parsed = parse_records(record_q)
+    file_record = parsed.files[0].files[0]
+    assert file_record.path == str(pathlib.Path("test_[whatever]", "checkpoint_0.pt"))
+
+
 def test_save_copy_fallback_when_links_unavailable(
     monkeypatch,
     mock_run,

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2175,12 +2175,19 @@ class Run:
             tel.feature.save = True
 
         files_root = pathlib.Path(self._settings.files_dir)
-        preexisting = set(files_root.glob(relative_glob_str))
+        # When path contains "[" or "]" but no "*" or "?", treat as literal path.
+        # Otherwise glob interprets brackets as character class and fails to match.
+        full_glob_pattern = str(base_path / relative_glob_str)
+        relative_glob_pattern = str(relative_glob_str)
+        if "*" not in full_glob_pattern and "?" not in full_glob_pattern:
+            full_glob_pattern = glob.escape(full_glob_pattern)
+            relative_glob_pattern = glob.escape(relative_glob_pattern)
+        preexisting = set(files_root.glob(relative_glob_pattern))
 
         # Expand sources deterministically.
         src_paths = [
             pathlib.Path(p).absolute()
-            for p in sorted(glob.glob(GlobStr(str(base_path / relative_glob_str))))
+            for p in sorted(glob.glob(GlobStr(full_glob_pattern)))
         ]
 
         stats = LinkStats()


### PR DESCRIPTION
Fixes #11510

`run.save()` fails when path contains `[` or `]` because glob interprets them as character class. Use `glob.escape()` for literal paths (no `*` or `?`).

Made with [Cursor](https://cursor.com)