### PR TITLE
feat(sandbox): init sandbox package and auth

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -34,6 +34,7 @@ jobs:
             sdk
             sweeps
             leet
+            sandbox
           requireScope: false
           # Ensures the subject doesn't start with an uppercase character.
           subjectPattern: ^(?![A-Z]).+$

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,9 @@ import nox
 nox.options.default_venv_backend = "uv"
 
 _SUPPORTED_PYTHONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+_CWSANDBOX_PYTHON_MIN = (3, 11)
+_CWSANDBOX_PYTHON_MAX = (3, 14)
+_CWSANDBOX_REQUIREMENT = "cwsandbox>=0.9.0"
 
 # Directories in which to create temporary per-session directories
 # containing test results and pytest/Go coverage.
@@ -54,6 +57,16 @@ def install_wandb(session: nox.Session, dev: bool = True):
         install_timed(session, "--reinstall", "--refresh-package", "wandb", ".")
     else:
         install_timed(session, "--force-reinstall", ".")
+
+
+def _supports_cwsandbox(python_version: str) -> bool:
+    version = tuple(int(part) for part in python_version.split("."))
+    return _CWSANDBOX_PYTHON_MIN <= version < _CWSANDBOX_PYTHON_MAX
+
+
+def install_cwsandbox(session: nox.Session) -> None:
+    if _supports_cwsandbox(session.python):
+        install_timed(session, _CWSANDBOX_REQUIREMENT)
 
 
 def get_session_file_name(session: nox.Session) -> str:
@@ -194,6 +207,7 @@ def unit_tests(session: nox.Session) -> None:
         # For test_reports:
         "polyfactory",
     )
+    install_cwsandbox(session)
 
     paths = session.posargs or ["tests/unit_tests"]
 
@@ -560,7 +574,7 @@ def proto_check_go(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="mypy-report")
+@nox.session(name="mypy-report", python="3.13")
 def mypy_report(session: nox.Session) -> None:
     """Type-check the code with mypy.
 
@@ -569,6 +583,7 @@ def mypy_report(session: nox.Session) -> None:
     """
     session.install(
         "bokeh",
+        _CWSANDBOX_REQUIREMENT,
         "ipython",
         "lxml",
         # https://github.com/python/mypy/issues/17166

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ media = [
     "plotly>=5.18.0",
     "rdkit",
 ]
+# https://docs.coreweave.com/products/coreweave-sandbox/client
+# TODO: We should bump the version after the secret PR is merged upstream
+sandbox = ["cwsandbox>=0.9.0; python_version >= '3.11' and python_version < '3.14'"]
 sweeps = ["sweeps>=0.2.0"]
 launch = [
     "wandb[aws]",

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -30,3 +30,5 @@ pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.
 hypothesis>=6.131.7
 
 hypothesis-fspaths
+
+cwsandbox>=0.9.0; python_version >= '3.11' and python_version < '3.14'

--- a/tests/unit_tests/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox_auth.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("cwsandbox")
+
+from wandb.sandbox import _auth as sandbox_auth
+from wandb.sdk import wandb_login, wandb_setup
+from wandb.sdk.lib import wbauth
+
+
+@pytest.fixture(autouse=True)
+def clear_session_auth() -> None:
+    wbauth.unauthenticate_session()
+    yield
+    wbauth.unauthenticate_session()
+
+
+@pytest.mark.usefixtures("local_settings")
+def test_resolve_auth_context_uses_configured_base_url_for_session_auth(
+    dummy_api_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    qa_url = "https://api.qa.wandb.ai"
+    settings = wandb_setup.singleton().settings
+    settings.base_url = qa_url
+    settings.entity = "qa-entity"
+    settings.project = "qa-project"
+    monkeypatch.setattr(sandbox_auth, "_current_run", lambda: None)
+
+    wbauth.use_explicit_auth(
+        wbauth.AuthApiKey(api_key=dummy_api_key, host=qa_url),
+        source="test",
+    )
+
+    context = sandbox_auth.resolve_auth_context()
+
+    assert context.strategy == "wandb_api_key"
+    assert context.entity == "qa-entity"
+    assert context.project == "qa-project"
+    assert context.metadata == (
+        ("x-api-key", dummy_api_key),
+        ("x-entity-id", "qa-entity"),
+        ("x-project-name", "qa-project"),
+    )
+
+
+@pytest.mark.usefixtures("local_settings")
+def test_resolve_auth_context_uses_configured_base_url_for_lazy_login(
+    dummy_api_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    qa_url = "https://api.qa.wandb.ai"
+    settings = wandb_setup.singleton().settings
+    settings.base_url = qa_url
+    settings.api_key = None
+    settings.entity = None
+    settings.project = None
+    monkeypatch.setattr(sandbox_auth, "_current_run", lambda: None)
+
+    login_calls: dict[str, object] = {}
+
+    def fake_login(
+        *, host: str, update_api_key: bool, _silent: bool
+    ) -> tuple[bool, str]:
+        login_calls["host"] = host
+        login_calls["update_api_key"] = update_api_key
+        login_calls["silent"] = _silent
+        wbauth.use_explicit_auth(
+            wbauth.AuthApiKey(api_key=dummy_api_key, host=host),
+            source="test",
+        )
+        return True, dummy_api_key
+
+    monkeypatch.setattr(wandb_login, "_login", fake_login)
+
+    context = sandbox_auth.resolve_auth_context()
+
+    assert login_calls == {
+        "host": qa_url,
+        "update_api_key": False,
+        "silent": False,
+    }
+    assert context.strategy == "wandb_api_key"
+    assert context.metadata == (("x-api-key", dummy_api_key),)

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -1,0 +1,43 @@
+import importlib
+
+try:
+    importlib.import_module("cwsandbox")
+except ImportError as exc:
+    raise ImportError(
+        "cwsandbox is not installed. Please install it with: pip install wandb[sandbox]"
+    ) from exc
+
+from cwsandbox import (
+    NetworkOptions,
+    OperationRef,
+    Process,
+    ProcessResult,
+    SandboxDefaults,
+    SandboxStatus,
+    Serialization,
+    StreamReader,
+    StreamWriter,
+    Waitable,
+    results,
+    wait,
+)
+
+from ._sandbox import Sandbox
+from ._session import Session
+
+__all__ = (
+    "NetworkOptions",
+    "OperationRef",
+    "Process",
+    "ProcessResult",
+    "Sandbox",
+    "SandboxDefaults",
+    "SandboxStatus",
+    "Serialization",
+    "Session",
+    "StreamReader",
+    "StreamWriter",
+    "Waitable",
+    "results",
+    "wait",
+)

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import wandb
+from wandb.errors import UsageError
+from wandb.sdk import wandb_login, wandb_setup
+from wandb.sdk.lib import wbauth
+
+
+@dataclass(frozen=True)
+class SandboxAuthContext:
+    metadata: tuple[tuple[str, str], ...]
+    strategy: str
+    entity: str | None = None
+    project: str | None = None
+
+
+def resolve_auth_context() -> SandboxAuthContext:
+    """Resolve auth metadata for `wandb.sandbox`.
+
+    Resolution order:
+    1. Explicit `CWSANDBOX_API_KEY`
+    2. In-memory W&B session auth
+    3. Loaded W&B settings api_key
+    4. Lazy W&B login/auth resolution
+
+    TODO: If `cwsandbox` exposes protected auth hooks for instance and class
+    operations, this wrapper can delegate more directly instead of maintaining
+    its own auth-resolution entry point.
+    """
+    cwsandbox_api_key = os.environ.get("CWSANDBOX_API_KEY")
+    if cwsandbox_api_key:
+        return SandboxAuthContext(
+            metadata=(("authorization", f"Bearer {cwsandbox_api_key}"),),
+            strategy="cwsandbox_api_key",
+        )
+
+    host = _current_wandb_host()
+    settings = wandb_setup.singleton().settings
+
+    auth = wbauth.session_credentials(host=host)
+    if auth is None and settings.api_key:
+        auth = wbauth.AuthApiKey(host=host, api_key=settings.api_key)
+
+    if auth is None:
+        _ensure_wandb_auth_loaded(host.url)
+        auth = wbauth.session_credentials(host=host)
+
+    if auth is None:
+        raise UsageError("No W&B API key configured. Use `wandb.login()` first.")
+
+    if not isinstance(auth, wbauth.AuthApiKey):
+        raise UsageError("wandb.sandbox currently supports only W&B user API-key auth.")
+
+    entity, project = resolve_effective_entity_project()
+    metadata: list[tuple[str, str]] = [("x-api-key", auth.api_key)]
+    if entity:
+        metadata.append(("x-entity-id", entity))
+    if project:
+        metadata.append(("x-project-name", project))
+
+    return SandboxAuthContext(
+        metadata=tuple(metadata),
+        strategy="wandb_api_key",
+        entity=entity,
+        project=project,
+    )
+
+
+def resolve_cwsandbox_metadata() -> tuple[tuple[str, str], ...]:
+    """Resolve gRPC metadata for `cwsandbox` RPCs."""
+    return resolve_auth_context().metadata
+
+
+def resolve_effective_entity_project() -> tuple[str | None, str | None]:
+    """Resolve entity/project from the active W&B run or global settings."""
+    run = _current_run()
+    if run is not None:
+        entity = run.entity or None
+        project = run.project or None
+        return entity, project
+
+    settings = wandb_setup.singleton().settings
+    entity = settings.entity or None
+    project = settings.project or None
+    return entity, project
+
+
+def _ensure_wandb_auth_loaded(host: str) -> None:
+    """Load auth lazily using W&B's existing login path."""
+    wandb_login._login(
+        host=host,
+        update_api_key=False,
+        _silent=_should_suppress_auth_output(),
+    )
+
+
+def _current_run():
+    """Return the best current run candidate for auth propagation."""
+    if wandb.run is not None:
+        return wandb.run
+
+    return wandb_setup.singleton().most_recent_active_run
+
+
+def _should_suppress_auth_output() -> bool:
+    """Avoid duplicate auth output when a run is already active."""
+    return _current_run() is not None
+
+
+def _current_wandb_host() -> wbauth.HostUrl:
+    """Return the configured W&B API host for auth resolution."""
+    settings = wandb_setup.singleton().settings
+    return wbauth.HostUrl(settings.base_url, app_url=settings.app_url)

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -1,0 +1,221 @@
+"""Sandbox wrapper with wandb integration.
+
+- Auth
+- Entity and Project from active wandb run, e.g. wandb.init(entity="foo", project="bar")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import grpc
+from cwsandbox import Sandbox as CWSandboxSandbox
+from cwsandbox._defaults import (
+    DEFAULT_BASE_URL,
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    SandboxDefaults,
+)
+from cwsandbox._network import create_channel, parse_grpc_target
+from cwsandbox._proto import atc_pb2, atc_pb2_grpc
+from cwsandbox._sandbox import SandboxStatus, _translate_rpc_error
+from cwsandbox.exceptions import SandboxError
+
+from ._auth import SandboxAuthContext, resolve_auth_context
+
+logger = logging.getLogger(__name__)
+
+
+class Sandbox(CWSandboxSandbox):
+    """W&B-aware wrapper around `cwsandbox.Sandbox`."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._wandb_auth_context: SandboxAuthContext | None = None
+
+    @classmethod
+    def session(
+        cls,
+        defaults: SandboxDefaults | None = None,
+    ):
+        from ._session import Session
+
+        return Session(defaults)
+
+    async def _ensure_client(self) -> None:
+        if self._channel is not None:
+            return
+
+        # Instance operations are the one place where we can cheaply bind a
+        # stable auth context to this sandbox without patching `cwsandbox`
+        # process-wide.
+        context = self._wandb_auth_context or resolve_auth_context()
+        self._wandb_auth_context = context
+
+        target, is_secure = parse_grpc_target(self._base_url)
+        channel = create_channel(target, is_secure)
+        stub = atc_pb2_grpc.ATCServiceStub(channel)  # type: ignore[no-untyped-call]
+        self._channel = channel
+        self._stub = stub
+        self._auth_metadata = context.metadata
+        logger.debug("Initialized W&B sandbox gRPC channel for %s", self._base_url)
+
+    @classmethod
+    async def _list_async(
+        cls,
+        *,
+        tags: list[str] | None = None,
+        status: str | None = None,
+        runway_ids: list[str] | None = None,
+        tower_ids: list[str] | None = None,
+        include_stopped: bool = False,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> list[Sandbox]:
+        # Upstream resolves auth inside this method body via a module-level
+        # helper, so we currently need a local override to avoid a global patch.
+        effective_base_url = (
+            base_url or os.environ.get("CWSANDBOX_BASE_URL") or DEFAULT_BASE_URL
+        ).rstrip("/")
+        timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else DEFAULT_REQUEST_TIMEOUT_SECONDS
+        )
+
+        status_enum = SandboxStatus(status) if status is not None else None
+        auth_context = resolve_auth_context()
+        auth_metadata = auth_context.metadata
+
+        target, is_secure = parse_grpc_target(effective_base_url)
+        channel = create_channel(target, is_secure)
+        stub = atc_pb2_grpc.ATCServiceStub(channel)  # type: ignore[no-untyped-call]
+
+        try:
+            request_kwargs: dict[str, Any] = {}
+            if tags:
+                request_kwargs["tags"] = tags
+            if status_enum:
+                request_kwargs["status"] = status_enum.to_proto()
+            if runway_ids is not None:
+                request_kwargs["runway_ids"] = runway_ids
+            if tower_ids is not None:
+                request_kwargs["tower_ids"] = tower_ids
+            if include_stopped:
+                request_kwargs["include_stopped"] = True
+
+            request = atc_pb2.ListSandboxesRequest(**request_kwargs)
+            try:
+                response = await stub.List(
+                    request, timeout=timeout, metadata=auth_metadata
+                )
+            except grpc.RpcError as exc:
+                raise _translate_rpc_error(exc, operation="List sandboxes") from exc
+
+            sandboxes = [
+                cls._from_sandbox_info(
+                    sb,
+                    base_url=effective_base_url,
+                    timeout_seconds=timeout,
+                )
+                for sb in response.sandboxes
+            ]
+            for sandbox in sandboxes:
+                sandbox._wandb_auth_context = auth_context
+            return sandboxes
+        finally:
+            await channel.close(grace=None)
+
+    @classmethod
+    async def _from_id_async(
+        cls,
+        sandbox_id: str,
+        *,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> Sandbox:
+        # Same reason as `_list_async`: upstream has no class-level auth hook
+        # for this path yet, so we override the RPC entry point locally.
+        effective_base_url = (
+            base_url or os.environ.get("CWSANDBOX_BASE_URL") or DEFAULT_BASE_URL
+        ).rstrip("/")
+        timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else DEFAULT_REQUEST_TIMEOUT_SECONDS
+        )
+
+        auth_context = resolve_auth_context()
+        auth_metadata = auth_context.metadata
+
+        target, is_secure = parse_grpc_target(effective_base_url)
+        channel = create_channel(target, is_secure)
+        stub = atc_pb2_grpc.ATCServiceStub(channel)  # type: ignore[no-untyped-call]
+
+        try:
+            request = atc_pb2.GetSandboxRequest(sandbox_id=sandbox_id)
+            try:
+                response = await stub.Get(
+                    request, timeout=timeout, metadata=auth_metadata
+                )
+            except grpc.RpcError as exc:
+                raise _translate_rpc_error(
+                    exc, sandbox_id=sandbox_id, operation="Get sandbox"
+                ) from exc
+
+            sandbox = cls._from_sandbox_info(
+                response,
+                base_url=effective_base_url,
+                timeout_seconds=timeout,
+            )
+            sandbox._wandb_auth_context = auth_context
+            return sandbox
+        finally:
+            await channel.close(grace=None)
+
+    @classmethod
+    async def _delete_async(
+        cls,
+        sandbox_id: str,
+        *,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+        missing_ok: bool = False,
+    ) -> None:
+        # Same reason as `_list_async`: without an upstream hook, class-level
+        # auth-sensitive operations need a wrapper-side override.
+        effective_base_url = (
+            base_url or os.environ.get("CWSANDBOX_BASE_URL") or DEFAULT_BASE_URL
+        ).rstrip("/")
+        timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else DEFAULT_REQUEST_TIMEOUT_SECONDS
+        )
+
+        auth_metadata = resolve_auth_context().metadata
+
+        target, is_secure = parse_grpc_target(effective_base_url)
+        channel = create_channel(target, is_secure)
+        stub = atc_pb2_grpc.ATCServiceStub(channel)  # type: ignore[no-untyped-call]
+
+        try:
+            request = atc_pb2.DeleteSandboxRequest(sandbox_id=sandbox_id)
+            try:
+                response = await stub.Delete(
+                    request, timeout=timeout, metadata=auth_metadata
+                )
+            except grpc.RpcError as exc:
+                if exc.code() == grpc.StatusCode.NOT_FOUND and missing_ok:
+                    return
+                raise _translate_rpc_error(
+                    exc, sandbox_id=sandbox_id, operation="Delete sandbox"
+                ) from exc
+
+            if not response.success:
+                raise SandboxError(
+                    f"Failed to delete sandbox: {response.error_message}"
+                )
+        finally:
+            await channel.close(grace=None)

--- a/wandb/sandbox/_session.py
+++ b/wandb/sandbox/_session.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from cwsandbox import Session as CWSandboxSession
+from cwsandbox._defaults import DEFAULT_BASE_URL
+from cwsandbox.exceptions import SandboxError
+
+from ._sandbox import Sandbox
+
+
+class Session(CWSandboxSession):
+    """W&B-aware wrapper around `cwsandbox.Session`."""
+
+    def sandbox(
+        self,
+        *,
+        command: str | None = None,
+        args: list[str] | None = None,
+        container_image: str | None = None,
+        tags: list[str] | None = None,
+        runway_ids: list[str] | None = None,
+        tower_ids: list[str] | None = None,
+        resources: dict | None = None,
+        mounted_files: list[dict] | None = None,
+        s3_mount: dict | None = None,
+        ports: list[dict] | None = None,
+        network=None,
+        max_timeout_seconds: int | None = None,
+        environment_variables: dict[str, str] | None = None,
+    ) -> Sandbox:
+        # Upstream instantiates the base `cwsandbox.Sandbox` here, so we need
+        # a local factory override to keep returning the W&B-aware subclass.
+        if self._closed:
+            raise SandboxError(
+                "Cannot create sandbox: session is closed. "
+                "Create a new session or call sandbox() before close()."
+            )
+
+        sandbox = Sandbox(
+            command=command,
+            args=args,
+            container_image=container_image,
+            tags=tags,
+            runway_ids=runway_ids,
+            tower_ids=tower_ids,
+            resources=resources,
+            mounted_files=mounted_files,
+            s3_mount=s3_mount,
+            ports=ports,
+            network=network,
+            max_timeout_seconds=max_timeout_seconds,
+            environment_variables=environment_variables,
+            defaults=self._defaults,
+            _session=self,
+        )
+        self._register_sandbox(sandbox)
+        self._record_sandbox_created()
+        return sandbox
+
+    async def _list_async(
+        self,
+        *,
+        tags: list[str] | None = None,
+        status: str | None = None,
+        runway_ids: list[str] | None = None,
+        tower_ids: list[str] | None = None,
+        include_stopped: bool = False,
+        adopt: bool = False,
+    ) -> list[Sandbox]:
+        # Upstream `Session` routes through the base `Sandbox` class, so this
+        # override keeps lookups returning the W&B-aware subclass.
+        merged_tags = self._defaults.merge_tags(tags)
+
+        if runway_ids is not None:
+            effective_runway_ids = list(runway_ids)
+        elif self._defaults.runway_ids:
+            effective_runway_ids = list(self._defaults.runway_ids)
+        else:
+            effective_runway_ids = None
+
+        if tower_ids is not None:
+            effective_tower_ids = list(tower_ids)
+        elif self._defaults.tower_ids:
+            effective_tower_ids = list(self._defaults.tower_ids)
+        else:
+            effective_tower_ids = None
+
+        sandboxes = await Sandbox._list_async(
+            tags=merged_tags if merged_tags else None,
+            status=status,
+            runway_ids=effective_runway_ids,
+            tower_ids=effective_tower_ids,
+            include_stopped=include_stopped,
+            base_url=None
+            if self._defaults.base_url == DEFAULT_BASE_URL
+            else self._defaults.base_url,
+            timeout_seconds=self._defaults.request_timeout_seconds,
+        )
+
+        if adopt:
+            for sandbox in sandboxes:
+                self._register_sandbox(sandbox)
+                sandbox._session = self
+
+        return sandboxes
+
+    async def _from_id_async(
+        self,
+        sandbox_id: str,
+        *,
+        adopt: bool = True,
+    ) -> Sandbox:
+        # Same reason as `_list_async`: keep attach/reconnect paths returning
+        # the W&B-aware subclass instead of the upstream base class.
+        sandbox = await Sandbox._from_id_async(
+            sandbox_id,
+            base_url=None
+            if self._defaults.base_url == DEFAULT_BASE_URL
+            else self._defaults.base_url,
+            timeout_seconds=self._defaults.request_timeout_seconds,
+        )
+
+        if adopt:
+            self._register_sandbox(sandbox)
+            sandbox._session = self
+
+        return sandbox


### PR DESCRIPTION
Description
-----------

A bit cleaner version of https://github.com/wandb/wandb/pull/11499 that only has auth logic.
NOT ready for review, just for building rc release so people can pip install to test functionality.

- Fixes WB-NNNNN

Changes

- Add a new wandb.sandbox  package for setting wandb auth, project et.c base on current run
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
