### PR TITLE
fix: replace deprecated API calls in sentry analytics

### DIFF
--- a/wandb/analytics/sentry.py
+++ b/wandb/analytics/sentry.py
@@ -265,7 +265,7 @@ class Sentry:
             if tags.get(obj_url, None):
                 continue
             try:
-                app_url = wandb.util.app_url(tags["base_url"])  # type: ignore[index]
+                app_url = wandb.util.api_to_app_url(tags["base_url"])  # type: ignore[index]
                 entity, project = (quote(tags[k]) for k in ("entity", "project"))  # type: ignore[index]
                 self.scope.set_tag(
                     obj_url,
@@ -276,7 +276,7 @@ class Sentry:
 
         email = tags.get("email")
         if email:
-            self.scope.user = {"email": email}
+            self.scope.set_user({"email": email})
 
         self.start_session()
 


### PR DESCRIPTION
## Summary
Fixes #11522.
**Root cause:** `wandb/analytics/sentry.py` used deprecated `wandb.util.app_url()` and `Scope.user` setter (Sentry SDK), generating `DeprecationWarning` messages on every `wandb.init()` call.
**Fix:** Replaced deprecated API calls with their non-deprecated equivalents.
## Changes
- `wandb/analytics/sentry.py`: Updated deprecated API calls
## Testing
- Verified fix addresses reported deprecation warnings
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)