### PR TITLE
fix(sdk): eliminate N+1 GraphQL introspection queries in run iteration

### DIFF
--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -265,10 +265,11 @@ class Runs(SizedPaginator["Run"]):
         if not order:
             order = "+created_at"
 
+        self._server_provides_project_id = _server_provides_project_id_for_run(client)
         self.QUERY = _create_runs_query(
             lazy=lazy,
             with_internal_id=_server_provides_internal_id_for_project(client),
-            with_project_id=_server_provides_project_id_for_run(client),
+            with_project_id=self._server_provides_project_id,
         )
 
         self.entity = entity
@@ -340,6 +341,7 @@ class Runs(SizedPaginator["Run"]):
                 include_sweeps=self._include_sweeps,
                 lazy=self._lazy,
                 service_api=self._service_api,
+                server_provides_project_id=self._server_provides_project_id,
             )
             objs.append(run)
 
@@ -543,6 +545,7 @@ class Run(Attrs):
         include_sweeps: bool = True,
         lazy: bool = True,
         service_api: ServiceApi | None = None,
+        server_provides_project_id: bool | None = None,
     ):
         """Initialize a Run object.
 
@@ -570,7 +573,7 @@ class Run(Attrs):
         self._metadata: dict[str, Any] | None = None
         self._state = _attrs.get("state", "not found")
         self.server_provides_internal_id_field: bool | None = None
-        self._server_provides_project_id_field: bool | None = None
+        self._server_provides_project_id_field: bool | None = server_provides_project_id
         self._is_loaded: bool = False
         self._service_api: ServiceApi | None = service_api
 


### PR DESCRIPTION
## Summary

- **`Runs.__init__`** already calls `_server_provides_project_id_for_run()` to build its GraphQL query, but discards the result. Each `Run` constructed by the paginator then independently re-queries the server via `_load_with_fragment()`, producing **N+1 redundant introspection calls**.
- On large projects (72K+ runs in `wandb/large_runs_demo`), this overwhelms the GraphQL API and causes **502 Bad Gateway** errors before any actual data is fetched.
- Fix: cache the result on `Runs` and pass it through `convert_objects()` to each `Run`, so the existing `None` guard in `_load_with_fragment()` skips the network call. Standalone `Run` construction (outside `Runs`) is unaffected — it falls back to the existing per-instance query.

Affects all run iteration paths: `histories()`, `configs()`, `summaries()`, `aggregate_history()`, and plain `for run in api.runs()` loops.

## Test plan

- [ ] Existing unit tests pass (25/25 on `feat/runs-scan-histories` branch where this was first validated)
- [ ] Verify `api.runs("wandb/large_runs_demo", per_page=50)` iteration completes without 502 errors
- [ ] Verify standalone `Run` construction (e.g., `api.run("entity/project/run_id")`) still works (falls back to per-instance introspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)