### PR TITLE
refactor: rewrite ServerFeaturesCache to better match FeaturesRequest interface

### DIFF
--- a/core/internal/featurechecker/features.go
+++ b/core/internal/featurechecker/features.go
@@ -2,7 +2,6 @@ package featurechecker
 
 import (
 	"context"
-	"sync"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -11,107 +10,121 @@ import (
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
-// ServerFeaturesCache loads optional server capabilities.
+// FeatureProvider fetches the values of server features.
 //
-// Server features are loaded only once per run and then cached.
-type ServerFeaturesCache struct {
-	features      map[spb.ServerFeature]Feature
+// It is not guaranteed that current feature values are returned.
+// Features may change at runtime, like if a server update happens,
+// but callers may assume that these changes are backward compatible
+// and that acting according to old feature values is okay.
+//
+// See the documentation on the FeaturesRequest proto for more detail.
+type FeatureProvider struct {
+	// mu is a mutex implemented using a binary semaphore (1-buffered channel).
+	//
+	// A channel is used instead of an actual mutex for compatibility with
+	// context cancellation. Specifically, it is necessary for this:
+	//
+	// 	go fp.Enabled(ctx1, feat1) // makes query with ctx1
+	// 	go fp.Enabled(ctx2, feat2) // blocks while query is running
+	// 	cancelCtx1() // first call fails; second call queries with ctx2
+	//
+	// This is not perfect (ideally the request would not be cancelled),
+	// but it is an edge case and this approach is sufficient for correctness.
+	mu chan struct{}
+
+	// boolFeatures is the state of feature flags.
+	//
+	// It is nil until loaded.
+	boolFeatures map[spb.ServerFeature]bool
+
 	graphqlClient graphql.Client
 	logger        *observability.CoreLogger
-
-	initOnce sync.Once     // used to trigger loading features in a goroutine
-	initDone chan struct{} // closed after features have been loaded
 }
 
-// Feature represents a server capability that is either enabled or disabled.
-//
-// This is used to determine if certain functionality is available on the server,
-// and gate code paths within the SDK.
-type Feature struct {
-	Enabled bool
-	Name    string
-}
+func New(
+	graphqlClient graphql.Client,
+	logger *observability.CoreLogger,
+) *FeatureProvider {
+	return &FeatureProvider{
+		mu: make(chan struct{}, 1),
 
-func NewServerFeaturesCachePreloaded(
-	features map[spb.ServerFeature]Feature,
-) *ServerFeaturesCache {
-	sf := &ServerFeaturesCache{
-		graphqlClient: nil,
-		logger:        observability.NewNoOpLogger(),
-		initDone:      make(chan struct{}),
+		graphqlClient: graphqlClient,
+		logger:        logger,
 	}
+}
 
-	sf.initOnce.Do(func() {
-		defer close(sf.initDone)
-		sf.features = features
-	})
+// NewPreloaded returns a feature checker with preloaded values.
+//
+// Used for testing.
+func NewPreloaded(features map[spb.ServerFeature]bool) *FeatureProvider {
+	sf := New(nil, observability.NewNoOpLogger())
+
+	if features != nil {
+		sf.boolFeatures = features
+	} else {
+		sf.boolFeatures = make(map[spb.ServerFeature]bool)
+	}
 
 	return sf
 }
 
-func NewServerFeaturesCache(
-	graphqlClient graphql.Client,
-	logger *observability.CoreLogger,
-) *ServerFeaturesCache {
-	return &ServerFeaturesCache{
-		graphqlClient: graphqlClient,
-		logger:        logger,
-		initDone:      make(chan struct{}),
-	}
-}
-
-// loadFeatures populates features and closes initDone at the end.
-func (sf *ServerFeaturesCache) loadFeatures(ctx context.Context) {
-	defer close(sf.initDone)
-	sf.features = make(map[spb.ServerFeature]Feature)
-
-	if sf.graphqlClient == nil {
-		sf.logger.Warn(
+// lockedLoadFeatures queries and returns features.
+func (fp *FeatureProvider) lockedLoadFeatures(ctx context.Context) {
+	if fp.graphqlClient == nil {
+		fp.logger.Warn(
 			"featurechecker: GraphQL client is nil, skipping feature loading",
 		)
 		return
 	}
 
-	// Query the server for the features provided by the server
-	resp, err := gql.ServerFeaturesQuery(ctx, sf.graphqlClient)
+	resp, err := gql.ServerFeaturesQuery(ctx, fp.graphqlClient)
 	if err != nil {
-		sf.logger.Error(
+		fp.logger.Error(
 			"featurechecker: failed to load features, all will be disabled",
 			"error", err)
 		return
 	}
 
+	if resp.ServerInfo == nil {
+		fp.logger.Error("featurechecker: response serverInfo nil")
+		return
+	}
+
+	fp.boolFeatures = make(map[spb.ServerFeature]bool)
 	for _, f := range resp.ServerInfo.Features {
-		featureName := spb.ServerFeature(spb.ServerFeature_value[f.Name])
-		sf.features[featureName] = Feature{
-			Name:    f.Name,
-			Enabled: f.IsEnabled,
+		if f == nil {
+			fp.logger.Error("featurechecker: nil feature in response")
+			return
 		}
+
+		featureName := spb.ServerFeature(spb.ServerFeature_value[f.Name])
+		fp.boolFeatures[featureName] = f.IsEnabled
 	}
 }
 
-func (sf *ServerFeaturesCache) GetFeature(
+// Enabled returns whether a named feature is enabled.
+//
+// Returns false if the feature is not a boolean feature or if there is
+// an error loading the feature.
+func (fp *FeatureProvider) Enabled(
 	ctx context.Context,
 	feature spb.ServerFeature,
-) *Feature {
-	sf.initOnce.Do(func() { go sf.loadFeatures(ctx) })
-
+) bool {
 	select {
 	case <-ctx.Done():
-		sf.logger.Warn(
+		fp.logger.Warn(
 			"featurechecker: failed to get feature",
 			"name", feature.String(),
 			"error", ctx.Err())
-	case <-sf.initDone:
+		return false
+
+	case fp.mu <- struct{}{}:
+		defer func() { <-fp.mu }()
 	}
 
-	cachedFeature, ok := sf.features[feature]
-	if !ok {
-		return &Feature{
-			Name:    feature.String(),
-			Enabled: false,
-		}
+	if fp.boolFeatures == nil {
+		fp.lockedLoadFeatures(ctx)
 	}
 
-	return &cachedFeature
+	return fp.boolFeatures[feature]
 }

--- a/core/internal/featurechecker/features_test.go
+++ b/core/internal/featurechecker/features_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 
@@ -20,7 +21,7 @@ func stubServerFeaturesQuery(mockGQL *gqlmock.MockClient) {
 			"serverInfo": {
 				"features": [
 					{
-						"name": "LARGE_FILENAMES",
+						"name": "CLIENT_IDS",
 						"isEnabled": true
 					},
 					{
@@ -33,109 +34,101 @@ func stubServerFeaturesQuery(mockGQL *gqlmock.MockClient) {
 	)
 }
 
-func TestServerFeaturesInitialization(t *testing.T) {
-	// Arrange
+func TestEnabled(t *testing.T) {
 	mockGQL := gqlmock.NewMockClient()
 	stubServerFeaturesQuery(mockGQL)
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
+	featureProvider := featurechecker.New(
 		mockGQL,
 		observabilitytest.NewTestLogger(t),
 	)
 
-	// Assert - features are not loaded until Get is called
-	assert.Equal(t, 0, len(mockGQL.AllRequests()))
+	clientIDs := featureProvider.Enabled(
+		t.Context(), spb.ServerFeature_CLIENT_IDS)
+	artifactTags := featureProvider.Enabled(
+		t.Context(), spb.ServerFeature_ARTIFACT_TAGS)
+	largeFilenames := featureProvider.Enabled(
+		t.Context(), spb.ServerFeature_LARGE_FILENAMES)
 
-	// Act
-	serverFeaturesCache.GetFeature(
-		context.Background(),
-		spb.ServerFeature_LARGE_FILENAMES,
-	)
-
-	// Assert - Features are loaded after Get is called
-	assert.Equal(t, 1, len(mockGQL.AllRequests()))
+	assert.True(t, clientIDs)       // explicitly enabled
+	assert.False(t, artifactTags)   // explicitly disabled
+	assert.False(t, largeFilenames) // not in response
 }
 
-func TestGetFeature(t *testing.T) {
-	// Arrange
-	mockGQL := gqlmock.NewMockClient()
-	stubServerFeaturesQuery(mockGQL)
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		mockGQL,
-		observabilitytest.NewTestLogger(t),
-	)
+func TestCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx1, cancel1 := context.WithCancel(t.Context())
+		mockGQL := gqlmock.NewMockClient()
+		featureProvider := featurechecker.New(
+			mockGQL,
+			observabilitytest.NewTestLogger(t),
+		)
 
-	// Act
-	enabledFeatureValue := serverFeaturesCache.GetFeature(
-		context.Background(),
-		spb.ServerFeature_LARGE_FILENAMES,
-	)
-	disabledFeatureValue := serverFeaturesCache.GetFeature(
-		context.Background(),
-		spb.ServerFeature_ARTIFACT_TAGS,
-	)
+		// Hang on the first request.
+		mockGQL.StubAnyHang()
+		go featureProvider.Enabled(ctx1, spb.ServerFeature_CLIENT_IDS)
+		synctest.Wait()
 
-	// Assert
-	assert.True(t, enabledFeatureValue.Enabled)
-	assert.False(t, disabledFeatureValue.Enabled)
-	assert.Equal(t, 1, len(mockGQL.AllRequests()))
+		// Make the second request, which will block while the first is hanging.
+		stubServerFeaturesQuery(mockGQL) // succeed on second request
+		result2 := make(chan bool)
+		go func() {
+			result2 <- featureProvider.Enabled(t.Context(), spb.ServerFeature_CLIENT_IDS)
+		}()
+		synctest.Wait()
+
+		// Cancel the first request's context.
+		cancel1()
+
+		// Second request should make a GraphQL query with its own context.
+		assert.True(t, <-result2)
+	})
 }
 
-func TestGetFeature_MissingWithDefaultValue(t *testing.T) {
-	// Arrange
-	mockGQL := gqlmock.NewMockClient()
-	stubServerFeaturesQuery(mockGQL)
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		mockGQL,
-		observabilitytest.NewTestLogger(t),
-	)
+func TestNilClient(t *testing.T) {
+	logger, logs := observabilitytest.NewRecordingTestLogger(t)
+	featureProvider := featurechecker.New(nil, logger)
 
-	// Act
-	missingFeatureValue := serverFeaturesCache.GetFeature(
-		context.Background(),
-		spb.ServerFeature_ARTIFACT_TAGS,
-	)
+	enabled := featureProvider.Enabled(t.Context(), spb.ServerFeature_CLIENT_IDS)
 
-	// Assert
-	assert.False(t, missingFeatureValue.Enabled)
-	assert.Equal(t, 1, len(mockGQL.AllRequests()))
+	assert.False(t, enabled)
+	assert.Contains(t, logs.String(), "GraphQL client is nil, skipping")
 }
 
-func TestCreateFeaturesCache_WithNullGraphQLClient(t *testing.T) {
-	// Arrange
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		nil,
-		observabilitytest.NewTestLogger(t),
-	)
-
-	// Act
-	feature := serverFeaturesCache.GetFeature(
-		context.Background(),
-		spb.ServerFeature_LARGE_FILENAMES,
-	)
-
-	// Assert
-	assert.False(t, feature.Enabled)
-}
-
-func TestGetFeature_GraphQLError(t *testing.T) {
-	// Arrange
+func TestError(t *testing.T) {
 	mockGQL := gqlmock.NewMockClient()
 	mockGQL.StubMatchWithError(
 		gqlmock.WithOpName("ServerFeaturesQuery"),
 		fmt.Errorf("GraphQL Error: Internal Server Error"),
 	)
+	logger, logs := observabilitytest.NewRecordingTestLogger(t)
+	featureProvider := featurechecker.New(mockGQL, logger)
 
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(
-		mockGQL,
-		observabilitytest.NewTestLogger(t),
-	)
+	enabled := featureProvider.Enabled(t.Context(), spb.ServerFeature_CLIENT_IDS)
 
-	feature := serverFeaturesCache.GetFeature(
-		context.Background(),
-		spb.ServerFeature_LARGE_FILENAMES,
-	)
+	assert.False(t, enabled)
+	assert.Contains(t, logs.String(), "GraphQL Error: Internal Server Error")
+}
 
-	// Assert
-	assert.False(t, feature.Enabled)
-	assert.Equal(t, 1, len(mockGQL.AllRequests()))
+func TestInvalidResponse_NilServerInfo(t *testing.T) {
+	mockGQL := gqlmock.NewMockClient()
+	mockGQL.StubAnyOnce(`{}`)
+	logger, logs := observabilitytest.NewRecordingTestLogger(t)
+	featureProvider := featurechecker.New(mockGQL, logger)
+
+	enabled := featureProvider.Enabled(t.Context(), spb.ServerFeature_CLIENT_IDS)
+
+	assert.False(t, enabled)
+	assert.Contains(t, logs.String(), "response serverInfo nil")
+}
+
+func TestInvalidResponse_NilFeature(t *testing.T) {
+	mockGQL := gqlmock.NewMockClient()
+	mockGQL.StubAnyOnce(`{ "serverInfo": { "features": [ null ] } }`)
+	logger, logs := observabilitytest.NewRecordingTestLogger(t)
+	featureProvider := featurechecker.New(mockGQL, logger)
+
+	enabled := featureProvider.Enabled(t.Context(), spb.ServerFeature_CLIENT_IDS)
+
+	assert.False(t, enabled)
+	assert.Contains(t, logs.String(), "nil feature in response")
 }

--- a/core/internal/gqlmock/gqlmock.go
+++ b/core/internal/gqlmock/gqlmock.go
@@ -89,24 +89,53 @@ func (c *MockClient) StubMatchWithError(
 		})
 }
 
+// StubMatchHang hangs forever on the next matching request until the request
+// context is cancelled.
+//
+// Useful for testing cancellation.
+func (c *MockClient) StubMatchHang(requestMatcher gomock.Matcher) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.stubs = append(c.stubs,
+		&stubbedRequest{
+			requestMatcher,
+			handlerReturningNever(),
+		})
+}
+
 // StubAnyOnce registers a response for the next request.
 func (c *MockClient) StubAnyOnce(responseJSON string) {
 	c.StubMatchOnce(gomock.Any(), responseJSON)
 }
 
+// StubAnyHang is StubMatchHang that matches any request.
+func (c *MockClient) StubAnyHang() {
+	c.StubMatchHang(gomock.Any())
+}
+
 func handlerReturningJSON(
 	responseJSON string,
-) func(*graphql.Request, *graphql.Response) error {
-	return func(_ *graphql.Request, resp *graphql.Response) error {
+) func(context.Context, *graphql.Request, *graphql.Response) error {
+	return func(_ context.Context, _ *graphql.Request, resp *graphql.Response) error {
 		// Return the JSON error to make it easier to tell if a test's
 		// JSON is incorrect.
 		return json.Unmarshal([]byte(responseJSON), resp.Data)
 	}
 }
 
-func handlerReturningError(err error) func(*graphql.Request, *graphql.Response) error {
-	return func(_ *graphql.Request, resp *graphql.Response) error {
+func handlerReturningError(
+	err error,
+) func(context.Context, *graphql.Request, *graphql.Response) error {
+	return func(_ context.Context, _ *graphql.Request, resp *graphql.Response) error {
 		return err
+	}
+}
+
+func handlerReturningNever() func(context.Context, *graphql.Request, *graphql.Response) error {
+	return func(ctx context.Context, _ *graphql.Request, resp *graphql.Response) error {
+		<-ctx.Done()
+		return ctx.Err()
 	}
 }
 
@@ -132,12 +161,12 @@ func (c *MockClient) MakeRequest(
 	resp *graphql.Response,
 ) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.requests = append(c.requests, req)
+	stub := c.stubFor(req)
+	c.mu.Unlock()
 
-	if stub := c.stubFor(req); stub != nil {
-		return stub.Handle(req, resp)
+	if stub != nil {
+		return stub.Handle(ctx, req, resp)
 	}
 
 	return &notStubbedError{req}
@@ -146,7 +175,7 @@ func (c *MockClient) MakeRequest(
 // A stubbedRequest is a request matcher and a response function.
 type stubbedRequest struct {
 	gomock.Matcher
-	Handle func(*graphql.Request, *graphql.Response) error
+	Handle func(context.Context, *graphql.Request, *graphql.Response) error
 }
 
 // stubFor pops and returns the first stub that matches the request.

--- a/core/internal/runsync/wire.go
+++ b/core/internal/runsync/wire.go
@@ -31,7 +31,7 @@ func InjectRunSyncerFactory(
 var runSyncerFactoryBindings = wire.NewSet(
 	wire.Bind(new(api.Peeker), new(*observability.Peeker)),
 	wire.Struct(new(observability.Peeker)),
-	featurechecker.NewServerFeaturesCache,
+	featurechecker.New,
 	filestream.FileStreamProviders,
 	filetransfer.NewFileTransferStats,
 	mailbox.New,

--- a/core/internal/runsync/wire_gen.go
+++ b/core/internal/runsync/wire_gen.go
@@ -34,10 +34,10 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 	credentialProvider := stream.CredentialsFromSettings(logger, settings2)
 	peeker := &observability.Peeker{}
 	client := stream.NewGraphQLClient(wbBaseURL, clientID, credentialProvider, logger, peeker, settings2)
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(client, logger)
+	featureProvider := featurechecker.New(client, logger)
 	runHandle := runhandle.New()
 	recordParserFactory := &stream.RecordParserFactory{
-		FeatureProvider:    serverFeaturesCache,
+		FeatureProvider:    featureProvider,
 		GraphqlClientOrNil: client,
 		Logger:             logger,
 		Operations:         wandbOperations,
@@ -76,7 +76,7 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 		Logger:                  logger,
 		Operations:              wandbOperations,
 		Settings:                settings2,
-		FeatureProvider:         serverFeaturesCache,
+		FeatureProvider:         featureProvider,
 		FileStreamFactory:       fileStreamFactory,
 		FileTransferManager:     fileTransferManager,
 		FileTransferStats:       fileTransferStats,
@@ -107,7 +107,7 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 
 // wire.go:
 
-var runSyncerFactoryBindings = wire.NewSet(wire.Bind(new(api.Peeker), new(*observability.Peeker)), wire.Struct(new(observability.Peeker)), featurechecker.NewServerFeaturesCache, filestream.FileStreamProviders, filetransfer.NewFileTransferStats, mailbox.New, observability.NewPrinter, provideFileWatcher, runfiles.UploaderProviders, runhandle.New, runReaderProviders,
+var runSyncerFactoryBindings = wire.NewSet(wire.Bind(new(api.Peeker), new(*observability.Peeker)), wire.Struct(new(observability.Peeker)), featurechecker.New, filestream.FileStreamProviders, filetransfer.NewFileTransferStats, mailbox.New, observability.NewPrinter, provideFileWatcher, runfiles.UploaderProviders, runhandle.New, runReaderProviders,
 	runSyncerProviders, sharedmode.RandomClientID, stream.BaseURLFromSettings, stream.CredentialsFromSettings, stream.NewFileTransferManager, stream.NewGraphQLClient, stream.RecordParserProviders, stream.SenderProviders, tensorboard.TBHandlerProviders, wboperation.NewOperations,
 )
 

--- a/core/internal/runupserter/runupdatework.go
+++ b/core/internal/runupserter/runupdatework.go
@@ -50,7 +50,7 @@ type RunUpdateWork struct {
 	Settings           *settings.Settings
 	BeforeRunEndCtx    context.Context
 	Operations         *wboperation.WandbOperations
-	FeatureProvider    *featurechecker.ServerFeaturesCache
+	FeatureProvider    *featurechecker.FeatureProvider
 	GraphqlClientOrNil graphql.Client
 	Logger             *observability.CoreLogger
 }

--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -69,7 +69,7 @@ type RunUpserterParams struct {
 	Settings           *settings.Settings
 	BeforeRunEndCtx    context.Context
 	Operations         *wboperation.WandbOperations
-	FeatureProvider    *featurechecker.ServerFeaturesCache
+	FeatureProvider    *featurechecker.FeatureProvider
 	GraphqlClientOrNil graphql.Client
 	Logger             *observability.CoreLogger
 }
@@ -126,10 +126,10 @@ func InitRun(
 
 	// Initialize the run metrics.
 	enableServerExpandedMetrics := params.Settings.IsEnableServerSideExpandGlobMetrics()
-	if enableServerExpandedMetrics && !params.FeatureProvider.GetFeature(
+	if enableServerExpandedMetrics && !params.FeatureProvider.Enabled(
 		params.BeforeRunEndCtx,
 		spb.ServerFeature_EXPAND_DEFINED_METRIC_GLOBS,
-	).Enabled {
+	) {
 		params.Logger.Warn(
 			"runupserter: server does not expand metric globs" +
 				" but the x_server_side_expand_glob_metrics setting is set;" +

--- a/core/internal/runupserter/runupserter_test.go
+++ b/core/internal/runupserter/runupserter_test.go
@@ -36,12 +36,10 @@ func runRecord(run *spb.RunRecord) *spb.Record {
 func testParams(t *testing.T) runupserter.RunUpserterParams {
 	t.Helper()
 	return runupserter.RunUpserterParams{
-		Settings:        settings.New(),
-		BeforeRunEndCtx: context.Background(),
-		Operations:      nil,
-		FeatureProvider: featurechecker.NewServerFeaturesCachePreloaded(
-			map[spb.ServerFeature]featurechecker.Feature{},
-		),
+		Settings:           settings.New(),
+		BeforeRunEndCtx:    context.Background(),
+		Operations:         nil,
+		FeatureProvider:    featurechecker.NewPreloaded(nil),
 		GraphqlClientOrNil: nil,
 		Logger:             observabilitytest.NewTestLogger(t),
 		ClientID:           "test",

--- a/core/internal/runupsertertest/runupsertertest.go
+++ b/core/internal/runupsertertest/runupsertertest.go
@@ -48,7 +48,7 @@ func NewTestUpserter(
 		params.Logger = observabilitytest.NewTestLogger(t)
 	}
 	if params.FeatureProvider == nil {
-		params.FeatureProvider = featurechecker.NewServerFeaturesCache(nil, params.Logger)
+		params.FeatureProvider = featurechecker.NewPreloaded(nil)
 	}
 
 	record := &spb.Record{RecordType: &spb.Record_Run{

--- a/core/internal/stream/recordparser.go
+++ b/core/internal/stream/recordparser.go
@@ -34,7 +34,7 @@ type RecordParser interface {
 
 // RecordParserFactory constructs the real RecordParser.
 type RecordParserFactory struct {
-	FeatureProvider    *featurechecker.ServerFeaturesCache
+	FeatureProvider    *featurechecker.FeatureProvider
 	GraphqlClientOrNil graphql.Client
 	Logger             *observability.CoreLogger
 	Operations         *wboperation.WandbOperations

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -47,7 +47,7 @@ type SenderFactory struct {
 	Logger                  *observability.CoreLogger
 	Operations              *wboperation.WandbOperations
 	Settings                *settings.Settings
-	FeatureProvider         *featurechecker.ServerFeaturesCache
+	FeatureProvider         *featurechecker.FeatureProvider
 	FileStreamFactory       *fs.FileStreamFactory
 	FileTransferManager     filetransfer.FileTransferManager
 	FileTransferStats       filetransfer.FileTransferStats
@@ -166,10 +166,10 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 		Multipart:             f.Settings.IsConsoleMultipart(),
 		ChunkMaxBytes:         f.Settings.GetConsoleChunkMaxBytes(),
 		ChunkMaxSeconds:       f.Settings.GetConsoleChunkMaxSeconds(),
-		Structured: f.FeatureProvider.GetFeature(
+		Structured: f.FeatureProvider.Enabled(
 			context.Background(),
 			spb.ServerFeature_STRUCTURED_CONSOLE_LOGS,
-		).Enabled,
+		),
 	}
 
 	s := &Sender{
@@ -187,10 +187,10 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 			f.FileStreamFactory.Printer,
 			f.GraphqlClient,
 			f.FileTransferManager,
-			f.FeatureProvider.GetFeature(
+			f.FeatureProvider.Enabled(
 				context.Background(),
 				spb.ServerFeature_USE_ARTIFACT_WITH_ENTITY_AND_PROJECT_INFORMATION,
-			).Enabled,
+			),
 		),
 		networkPeeker:     f.Peeker,
 		graphqlClient:     f.GraphqlClient,

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -78,7 +78,7 @@ func makeSender(t *testing.T, client graphql.Client) testFixtures {
 		RunfilesUploaderFactory: runfilesUploaderFactory,
 		Mailbox:                 mailbox.New(),
 		GraphqlClient:           client,
-		FeatureProvider:         featurechecker.NewServerFeaturesCache(nil, logger),
+		FeatureProvider:         featurechecker.New(nil, logger),
 		RunHandle:               runHandle,
 	}
 	return testFixtures{

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -42,7 +42,7 @@ type Stream struct {
 	operations *wboperation.WandbOperations
 
 	// featureProvider checks server capabilities.
-	featureProvider *featurechecker.ServerFeaturesCache
+	featureProvider *featurechecker.FeatureProvider
 
 	// graphqlClientOrNil is used for GraphQL operations to the W&B backend.
 	//
@@ -90,7 +90,7 @@ type DebugCorePath string
 func NewStream(
 	clientID sharedmode.ClientID,
 	debugCorePath DebugCorePath,
-	featureProvider *featurechecker.ServerFeaturesCache,
+	featureProvider *featurechecker.FeatureProvider,
 	flowControlFactory *FlowControlFactory,
 	graphqlClientOrNil graphql.Client,
 	handlerFactory *HandlerFactory,

--- a/core/internal/stream/streaminject.go
+++ b/core/internal/stream/streaminject.go
@@ -40,7 +40,7 @@ var streamProviders = wire.NewSet(
 	wire.Struct(new(observability.Peeker)),
 	BaseURLFromSettings,
 	CredentialsFromSettings,
-	featurechecker.NewServerFeaturesCache,
+	featurechecker.New,
 	filestream.FileStreamProviders,
 	filetransfer.NewFileTransferStats,
 	flowControlProviders,

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -37,7 +37,7 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 	credentialProvider := CredentialsFromSettings(coreLogger, settings2)
 	peeker := &observability.Peeker{}
 	client := NewGraphQLClient(wbBaseURL, clientID, credentialProvider, coreLogger, peeker, settings2)
-	serverFeaturesCache := featurechecker.NewServerFeaturesCache(client, coreLogger)
+	featureProvider := featurechecker.New(client, coreLogger)
 	runHandle := runhandle.New()
 	flowControlFactory := &FlowControlFactory{
 		Logger:    coreLogger,
@@ -66,7 +66,7 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 		TerminalPrinter:      printer,
 	}
 	recordParserFactory := &RecordParserFactory{
-		FeatureProvider:    serverFeaturesCache,
+		FeatureProvider:    featureProvider,
 		GraphqlClientOrNil: client,
 		Logger:             coreLogger,
 		Operations:         wandbOperations,
@@ -99,7 +99,7 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 		Logger:                  coreLogger,
 		Operations:              wandbOperations,
 		Settings:                settings2,
-		FeatureProvider:         serverFeaturesCache,
+		FeatureProvider:         featureProvider,
 		FileStreamFactory:       fileStreamFactory,
 		FileTransferManager:     fileTransferManager,
 		FileTransferStats:       fileTransferStats,
@@ -118,7 +118,7 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 		Logger:   coreLogger,
 		Settings: settings2,
 	}
-	stream := NewStream(clientID, debugCorePath, serverFeaturesCache, flowControlFactory, client, handlerFactory, streamStreamLoggerFile, coreLogger, wandbOperations, recordParserFactory, senderFactory, settings2, runHandle, tbHandlerFactory, writerFactory)
+	stream := NewStream(clientID, debugCorePath, featureProvider, flowControlFactory, client, handlerFactory, streamStreamLoggerFile, coreLogger, wandbOperations, recordParserFactory, senderFactory, settings2, runHandle, tbHandlerFactory, writerFactory)
 	return stream
 }
 
@@ -126,7 +126,7 @@ func InjectStream(commit GitCommitHash, gpuResourceManager *monitor.GPUResourceM
 
 var streamProviders = wire.NewSet(
 	NewStream, wire.Bind(new(api.Peeker), new(*observability.Peeker)), wire.Struct(new(observability.Peeker)), BaseURLFromSettings,
-	CredentialsFromSettings, featurechecker.NewServerFeaturesCache, filestream.FileStreamProviders, filetransfer.NewFileTransferStats, flowControlProviders,
+	CredentialsFromSettings, featurechecker.New, filestream.FileStreamProviders, filetransfer.NewFileTransferStats, flowControlProviders,
 	handlerProviders, mailbox.New, monitor.SystemMonitorProviders, NewFileTransferManager,
 	NewGraphQLClient, observability.NewPrinter, provideFileWatcher,
 	RecordParserProviders, runfiles.UploaderProviders, runhandle.New, SenderProviders, sharedmode.RandomClientID, streamLoggerProviders, tensorboard.TBHandlerProviders, wboperation.NewOperations, WriterProviders,


### PR DESCRIPTION
Renames `ServerFeaturesCache` to `FeatureProvider` (since that is the variable name used for it everywhere) and rewrites it to be more ergonomic and to better match the `FeaturesRequest` proto added in PR #11547.

The unusual `semaphoreMu` construct is a complexity tradeoff. It keeps `New()` callsites simple while correctly implementing `Enabled()`. The original implementation would have failed the new `TestCancellation()` test I added. An alternative would have been to pass a context to `New()`, but that makes it not injectable with `wire` (since contexts should be passed explicitly) and possibly loads features too eagerly.

---

More detail on `TestCancellation()`: concurrent calls to `Enabled()` should not be able to cancel each other or affect each others' timeouts. That is, if `Enabled(ctxWithShortTimeout, flag)` is called before `Enabled(ctxWithLongTimeout, flag)` , and then `ctxWithShortTimeout` expires, the second `Enabled()` call should keep trying until its longer timeout expires.

Using `context.Background()` or allowing these cancellation interactions could have bitten us in the future.