### PR TITLE
feat: create wbapi.FeaturesHandler and ServiceApi.feature_enabled

### DIFF
--- a/core/internal/wbapi/featureshandler.go
+++ b/core/internal/wbapi/featureshandler.go
@@ -1,0 +1,41 @@
+package wbapi
+
+import (
+	"context"
+
+	"github.com/wandb/wandb/core/internal/featurechecker"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// FeaturesHandler responds to FeaturesRequests.
+type FeaturesHandler struct {
+	featureProvider *featurechecker.FeatureProvider
+}
+
+func NewFeaturesHandler(
+	featureProvider *featurechecker.FeatureProvider,
+) *FeaturesHandler {
+	return &FeaturesHandler{featureProvider: featureProvider}
+}
+
+// HandleRequest produces the response for a FeaturesRequest.
+//
+// It cannot error out: errors are logged and default values are returned.
+func (h *FeaturesHandler) HandleRequest(
+	ctx context.Context,
+	request *spb.FeaturesRequest,
+) *spb.ApiResponse {
+	response := &spb.FeaturesResponse{}
+
+	for _, feature := range request.Features {
+		if h.featureProvider.Enabled(ctx, feature) {
+			response.Enabled = append(response.Enabled, feature)
+		}
+	}
+
+	return &spb.ApiResponse{
+		Response: &spb.ApiResponse_FeaturesResponse{
+			FeaturesResponse: response,
+		},
+	}
+}

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -3,7 +3,6 @@ package wbapi
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"sync/atomic"
 	"time"
@@ -13,11 +12,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/simplejsonext"
 
-	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runhistoryreader"
 	"github.com/wandb/wandb/core/internal/runhistoryreader/parquet"
-	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/stream"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -45,29 +41,10 @@ type RunHistoryAPIHandler struct {
 	downloadOperations map[int32]*parquet.RunHistoryDownloadOperation
 }
 
-func NewRunHistoryAPIHandler(s *settings.Settings) *RunHistoryAPIHandler {
-	logger := observability.NewNoOpLogger()
-	baseURL := stream.BaseURLFromSettings(logger, s)
-	credentialProvider := stream.CredentialsFromSettings(logger, s)
-	graphqlClient := stream.NewGraphQLClient(
-		baseURL,
-		"", /*clientID*/
-		credentialProvider,
-		logger,
-		&observability.Peeker{},
-		s,
-	)
-
-	httpClient := retryablehttp.NewClient()
-	httpClient.RetryMax = int(s.GetFileTransferMaxRetries())
-	httpClient.RetryWaitMin = s.GetFileTransferRetryWaitMin()
-	httpClient.RetryWaitMax = s.GetFileTransferRetryWaitMax()
-	httpClient.HTTPClient.Timeout = s.GetFileTransferTimeout()
-	httpClient.Logger = observability.NewCoreLogger(
-		slog.Default(),
-		nil,
-	)
-
+func NewRunHistoryAPIHandler(
+	graphqlClient graphql.Client,
+	httpClient *retryablehttp.Client,
+) *RunHistoryAPIHandler {
 	return &RunHistoryAPIHandler{
 		graphqlClient:      graphqlClient,
 		httpClient:         httpClient,

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -6,7 +6,15 @@
 package wbapi
 
 import (
+	"context"
+	"log/slog"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/wandb/wandb/core/internal/featurechecker"
+	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/stream"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -23,23 +31,52 @@ type WandbAPI struct {
 
 	settings *settings.Settings
 
+	featuresHandler      *FeaturesHandler
 	runHistoryApiHandler *RunHistoryAPIHandler
 }
 
 // New returns a new WandbAPI.
 func New(s *settings.Settings) *WandbAPI {
+	logger := observability.NewNoOpLogger()
+
+	baseURL := stream.BaseURLFromSettings(logger, s)
+	credentialProvider := stream.CredentialsFromSettings(logger, s)
+	graphqlClient := stream.NewGraphQLClient(
+		baseURL,
+		"", /*clientID*/
+		credentialProvider,
+		logger,
+		&observability.Peeker{},
+		s,
+	)
+
+	httpClient := retryablehttp.NewClient()
+	httpClient.RetryMax = int(s.GetFileTransferMaxRetries())
+	httpClient.RetryWaitMin = s.GetFileTransferRetryWaitMin()
+	httpClient.RetryWaitMax = s.GetFileTransferRetryWaitMax()
+	httpClient.HTTPClient.Timeout = s.GetFileTransferTimeout()
+	httpClient.Logger = observability.NewCoreLogger(
+		slog.Default(),
+		nil,
+	)
+
+	featureProvider := featurechecker.New(graphqlClient, logger)
+
 	return &WandbAPI{
-		semaphore:            make(chan struct{}, maxConcurrency),
-		settings:             s,
-		runHistoryApiHandler: NewRunHistoryAPIHandler(s),
+		semaphore: make(chan struct{}, maxConcurrency),
+		settings:  s,
+
+		featuresHandler:      NewFeaturesHandler(featureProvider),
+		runHistoryApiHandler: NewRunHistoryAPIHandler(graphqlClient, httpClient),
 	}
 }
 
 // HandleRequest handles an API request and returns an API response,
 // or nil if not response is needed.
 //
-// HandleRequest Blocks until the request is processed.
+// HandleRequest blocks until the request is processed.
 func (p *WandbAPI) HandleRequest(
+	ctx context.Context,
 	id string,
 	request *spb.ApiRequest,
 ) *spb.ApiResponse {
@@ -47,10 +84,12 @@ func (p *WandbAPI) HandleRequest(
 	p.semaphore <- struct{}{}
 	defer func() { <-p.semaphore }()
 
-	if _, ok := request.Request.(*spb.ApiRequest_ReadRunHistoryRequest); ok {
-		return p.runHistoryApiHandler.HandleRequest(
-			request.GetReadRunHistoryRequest(),
-		)
+	switch req := request.Request.(type) {
+	case *spb.ApiRequest_FeaturesRequest:
+		return p.featuresHandler.HandleRequest(ctx, req.FeaturesRequest)
+	case *spb.ApiRequest_ReadRunHistoryRequest:
+		// TODO: Propagate ctx here.
+		return p.runHistoryApiHandler.HandleRequest(req.ReadRunHistoryRequest)
 	}
 
 	return nil

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -687,7 +687,10 @@ func (nc *Connection) handleApi(
 	}
 
 	wg.Go(func() {
-		response := wbapiInstance.HandleRequest(id, request)
+		ctx, cancelCtx := nc.requestCanceller.Context(id)
+		defer cancelCtx()
+
+		response := wbapiInstance.HandleRequest(ctx, id, request)
 
 		if response != nil {
 			nc.Respond(&spb.ServerResponse{

--- a/tests/system_tests/test_api/test_service_api.py
+++ b/tests/system_tests/test_api/test_service_api.py
@@ -1,0 +1,70 @@
+from wandb.apis.public.service_api import ServiceApi
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk import wandb_setup
+
+from tests.fixtures.wandb_backend_spy import WandbBackendSpy
+
+
+def stub_server_features_query(
+    wandb_backend_spy: WandbBackendSpy,
+    *,
+    enabled: list[pb.ServerFeature.ValueType],
+) -> None:
+    gql = wandb_backend_spy.gql
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="ServerFeaturesQuery"),
+        gql.once(
+            content={
+                "data": {
+                    "serverInfo": {
+                        "features": [
+                            {
+                                "name": pb.ServerFeature.Name(feature),
+                                "isEnabled": True,
+                            }
+                            for feature in enabled
+                        ]
+                    }
+                }
+            }
+        ),
+    )
+
+
+def test_feature_flags(wandb_backend_spy: WandbBackendSpy):
+    stub_server_features_query(
+        wandb_backend_spy,
+        enabled=[pb.ServerFeature.CLIENT_IDS],
+    )
+
+    api = ServiceApi(wandb_setup.singleton().settings)
+    enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
+
+    assert enabled
+
+
+def test_feature_flags_timeout(wandb_backend_spy: WandbBackendSpy):
+    stub_server_features_query(
+        wandb_backend_spy,
+        enabled=[pb.ServerFeature.CLIENT_IDS],
+    )
+
+    # Should return False on timeout.
+    api = ServiceApi(wandb_setup.singleton().settings)
+    enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS, timeout=0)
+
+    assert not enabled
+
+
+def test_feature_flags_error(wandb_backend_spy: WandbBackendSpy):
+    gql = wandb_backend_spy.gql
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="ServerFeaturesQuery"),
+        gql.once(content={}, status=400),
+    )
+
+    # Should return False on error.
+    api = ServiceApi(wandb_setup.singleton().settings)
+    enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
+
+    assert not enabled

--- a/wandb/apis/public/service_api.py
+++ b/wandb/apis/public/service_api.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import uuid
 import weakref
 
-from wandb.proto.wandb_api_pb2 import ApiRequest, ApiResponse
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.proto.wandb_api_pb2 import ApiRequest, ApiResponse, FeaturesRequest
 from wandb.sdk import wandb_settings, wandb_setup
-from wandb.sdk.lib.service.service_connection import ServiceConnection
+from wandb.sdk.lib.service.service_connection import (
+    ServiceConnection,
+    WandbApiFailedError,
+)
 from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
+
+_logger = logging.getLogger(__name__)
 
 
 def _cleanup(connection: ServiceConnection | None, api_id: str) -> None:
@@ -72,3 +79,28 @@ class ServiceApi:
         conn = self._get_service_connection()
         request.api_id = self._api_id
         return await conn.api_request_async(request)
+
+    def feature_enabled(
+        self,
+        feature: pb.ServerFeature,
+        *,
+        timeout: float = 10,
+    ) -> bool:
+        """Returns whether a single server feature is enabled.
+
+        On timeout or normal error, this logs and returns False.
+
+        Args:
+            feature: The name of a boolean feature to check.
+            timeout: The timeout to use. Defaults to 10 seconds.
+        """
+        req = ApiRequest(features_request=FeaturesRequest(features=[feature]))
+
+        try:
+            resp = self.send_api_request(req, timeout=timeout)
+        except WandbApiFailedError:
+            # NOTE: The feature's integer value is logged here.
+            _logger.exception("Failed to load feature %s", feature)
+            return False
+
+        return feature in resp.features_response.enabled


### PR DESCRIPTION
Implements `FeaturesRequest` in `ServiceApi`.

Completes WB-32063.

I chose to only define `feature_enabled` for now since most places only query a single boolean feature at a time. I'm not completely convinced yet that passing a list of features in `FeaturesRequest` is better than just returning everything and caching in `ServiceApi`, so I might revisit that later, but it's not important to do early since it won't affect the `ServiceApi` interface.

This PR also moves HTTP client construction up into `wbapi.WandbApi` from `wbapi.RunHistoryAPIHandler` so that it can be used by `wbapi.FeaturesHandler` as well. It makes more sense to have a single HTTP client per `WandbAPI` instance rather than per request type.