### PR TITLE
fix: replace bare except with except BaseException in response_handle

### DIFF
--- a/wandb/sdk/mailbox/response_handle.py
+++ b/wandb/sdk/mailbox/response_handle.py
@@ -112,7 +112,7 @@ class MailboxResponseHandle(MailboxHandle[spb.ServerResponse]):
                     f"Timed out waiting for response on {self._address}"
                 ) from e
 
-        except:
+        except BaseException:
             self.cancel()
             raise
 


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except BaseException:` in `wandb/sdk/mailbox/response_handle.py`.

A bare `except:` catches everything including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. Since this block performs cleanup (`self.cancel()`) and then re-raises with `raise`, `BaseException` is the correct replacement — it preserves the intended broad exception catch for cleanup purposes while being explicit and PEP 8-compliant.

**Change:**
```python
# Before
except:
    self.cancel()
    raise

# After
except BaseException:
    self.cancel()
    raise
```

## Testing
No behavior change — style/correctness fix only. The exception handling and cleanup logic is identical.