### PR TITLE
fix(sdk): return yielded max step for history scans

### DIFF
--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -51,7 +51,7 @@ class BetaHistoryScan(Iterator[_RowDict]):
     ):
         self.run = run
         self.min_step = min_step
-        self.max_step = max_step
+        self._stop_step = max_step
         self.keys = keys
         self.page_size = page_size
         self._service_api = service_api
@@ -93,6 +93,11 @@ class BetaHistoryScan(Iterator[_RowDict]):
             self._scan_request_id,
         )
 
+    @property
+    def max_step(self) -> int:
+        """The highest step that can be yielded by this scan."""
+        return self._stop_step - 1
+
     def __iter__(self) -> Self:
         self.scan_offset = 0
         self.page_offset = self.min_step
@@ -105,14 +110,14 @@ class BetaHistoryScan(Iterator[_RowDict]):
                 row = self.rows[self.scan_offset]
                 self.scan_offset += 1
                 return row
-            if self.page_offset >= self.max_step:
+            if self.page_offset >= self._stop_step:
                 raise StopIteration()
             self._load_next()
 
     def _load_next(self) -> None:
         from wandb.proto import wandb_api_pb2 as pb
 
-        max_step = min(self.page_offset + self.page_size, self.max_step)
+        max_step = min(self.page_offset + self.page_size, self._stop_step)
 
         read_run_history_request = pb.ReadRunHistoryRequest(
             scan_run_history=pb.ScanRunHistory(
@@ -186,7 +191,7 @@ class HistoryScan(Iterator[_RowDict]):
             client: The client instance to use for making API calls to the W&B backend.
             run: The run object whose history is to be scanned.
             min_step: The minimum step to start scanning from.
-            max_step: The maximum step to scan up to.
+            max_step: The exclusive upper bound for scanned history rows.
             page_size: Number of history rows to fetch per page.
                 Default page_size is 1000.
         """
@@ -194,10 +199,15 @@ class HistoryScan(Iterator[_RowDict]):
         self.run = run
         self.page_size = page_size
         self.min_step = min_step
-        self.max_step = max_step
+        self._stop_step = max_step
         self.page_offset = min_step  # minStep for next page
         self.scan_offset = 0  # index within current page of rows
         self.rows: list[_RowDict] = []  # current page of rows
+
+    @property
+    def max_step(self) -> int:
+        """The highest step that can be yielded by this scan."""
+        return self._stop_step - 1
 
     def __iter__(self) -> Self:
         self.page_offset = self.min_step
@@ -215,7 +225,7 @@ class HistoryScan(Iterator[_RowDict]):
                 row = self.rows[self.scan_offset]
                 self.scan_offset += 1
                 return row
-            if self.page_offset >= self.max_step:
+            if self.page_offset >= self._stop_step:
                 raise StopIteration()
             self._load_next()
 
@@ -224,8 +234,8 @@ class HistoryScan(Iterator[_RowDict]):
     @normalize_exceptions
     def _load_next(self) -> None:
         max_step = self.page_offset + self.page_size
-        if max_step > self.max_step:
-            max_step = self.max_step
+        if max_step > self._stop_step:
+            max_step = self._stop_step
         variables = {
             "entity": self.run.entity,
             "project": self.run.project,
@@ -276,7 +286,7 @@ class SampledHistoryScan(Iterator[_RowDict]):
             run: The run object whose history is to be sampled.
             keys: List of keys to sample from the history.
             min_step: The minimum step to start sampling from.
-            max_step: The maximum step to sample up to.
+            max_step: The exclusive upper bound for sampled history rows.
             page_size: Number of sampled history rows to fetch per page.
                 Default page_size is 1000.
         """
@@ -285,10 +295,15 @@ class SampledHistoryScan(Iterator[_RowDict]):
         self.keys = keys
         self.page_size = page_size
         self.min_step = min_step
-        self.max_step = max_step
+        self._stop_step = max_step
         self.page_offset = min_step  # minStep for next page
         self.scan_offset = 0  # index within current page of rows
         self.rows: list[_RowDict] = []  # current page of rows
+
+    @property
+    def max_step(self) -> int:
+        """The highest step that can be yielded by this scan."""
+        return self._stop_step - 1
 
     def __iter__(self) -> Self:
         self.page_offset = self.min_step
@@ -306,7 +321,7 @@ class SampledHistoryScan(Iterator[_RowDict]):
                 row = self.rows[self.scan_offset]
                 self.scan_offset += 1
                 return row
-            if self.page_offset >= self.max_step:
+            if self.page_offset >= self._stop_step:
                 raise StopIteration()
             self._load_next()
 
@@ -315,8 +330,8 @@ class SampledHistoryScan(Iterator[_RowDict]):
     @normalize_exceptions
     def _load_next(self) -> None:
         max_step = self.page_offset + self.page_size
-        if max_step > self.max_step:
-            max_step = self.max_step
+        if max_step > self._stop_step:
+            max_step = self._stop_step
         variables = {
             "entity": self.run.entity,
             "project": self.run.project,


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
Fixes https://wandb.atlassian.net/browse/WB-32260

- fix `BetaHistoryScan.max_step`, `HistoryScan.max_step`, and `SampledHistoryScan.max_step` so they reflect the highest step users can actually observe when iterating rows
- keep the internal exclusive pagination bound private instead of exposing it via the public `max_step` attribute
- clarify history scan docstrings so the exclusive request bound and the yielded max step are easier to distinguish

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [X] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
Code:
````
import wandb

api = wandb.Api()
run = api.run("luis_team_test/test_group_forking_broken/731nqnyp")


def dump_scan(name, scan):
    rows = list(scan)
    print(f"{name} max step:", scan.max_step)
    print(f"{name} min step:", scan.min_step)
    print(f"{name} last row: {rows[-1] if rows else None}")


beta_scan_history = run.beta_scan_history()
dump_scan("beta_scan_history", beta_scan_history)

scan_history = run.scan_history()
dump_scan("scan_history", scan_history)

sampled_scan_history = run.scan_history(keys=["metric1", "metric2"])
dump_scan("sampled_scan_history", sampled_scan_history)
````
Before:
````

beta_scan_history max step: 10
beta_scan_history min step: 0
beta_scan_history last row: {'_step': 9, '_timestamp': 1773754475.857375, 'metric1': 9, 'metric2': 81, '_runtime': 0.338074042}
scan_history max step: 10
scan_history min step: 0
scan_history last row: {'metric1': 9, 'metric2': 81, '_runtime': 0.338074042, '_step': 9, '_timestamp': 1773754475.857375}
sampled_scan_history max step: 10
sampled_scan_history min step: 0
sampled_scan_history last row: {'metric1': 9, 'metric2': 81}
````
After:
````

beta_scan_history max step: 9
beta_scan_history min step: 0
beta_scan_history last row: {'_step': 9, '_timestamp': 1773754475.857375, 'metric1': 9, 'metric2': 81, '_runtime': 0.338074042}
scan_history max step: 9
scan_history min step: 0
scan_history last row: {'_runtime': 0.338074042, '_step': 9, '_timestamp': 1773754475.857375, 'metric1': 9, 'metric2': 81}
sampled_scan_history max step: 9
sampled_scan_history min step: 0
sampled_scan_history last row: {'metric1': 9, 'metric2': 81}
````
<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
