### PR TITLE
chore: don't upgrade by default in `requirements/generate.sh`

### DIFF
--- a/.github/workflows/regenerate-requirements.yml
+++ b/.github/workflows/regenerate-requirements.yml
@@ -21,7 +21,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Run requirements/generate.sh
-        run: bash requirements/generate.sh
+        run: bash requirements/generate.sh --upgrade
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8

--- a/requirements/generate.sh
+++ b/requirements/generate.sh
@@ -2,6 +2,39 @@
 
 set -e
 
+function print_help() {
+    echo "Usage: generate.sh [--upgrade]"
+    echo
+    echo "Pass --upgrade to upgrade all requirements."
+    echo
+    echo "Otherwise, this will apply any new requirements_dev.txt constraints"
+    echo "while trying to preserve any currently pinned versions."
+}
+
+PIP_COMPILE_ARGS=()
+
+# Parse arguments.
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --upgrade)
+            PIP_COMPILE_ARGS+=( "--upgrade" )
+            ;;
+
+        --help)
+            print_help
+            exit 0
+            ;;
+
+        *)
+            echo "Unknown argument: $1" >&2
+            print_help >&2
+            exit 1
+            ;;
+    esac
+
+    shift
+done
+
 # Maps platform.system() output ($1) to a platform understood by uv.
 function platform_python_name() {
     if [ "$1" = darwin ]; then
@@ -13,7 +46,7 @@ function platform_python_name() {
 
 # Compiles requirements for a Python version ($1) and platform ($2).
 function compile() {
-    uv pip compile --upgrade \
+    uv pip compile "${PIP_COMPILE_ARGS[@]}" \
         --python-version "$1" \
         --python-platform "$(platform_python_name $2)" \
         requirements/requirements_dev.txt \


### PR DESCRIPTION
This prevents `./requirements/generate.sh` from making unnecessary changes if you just wanted to add a new package to `requirements_dev.txt`. Upgrades will happen in the weekly cron job.