### PR TITLE
feat(leet): add colorblind-friendly color palettes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Per-chart log-scale (Y-axis) support in W&B LEET TUI (`wandb beta leet` command, toggle on a selected chart with `y`) (@dmitryduev in https://github.com/wandb/wandb/pull/11523)
 - Standalone system monitor mode in W&B LEET TUI (`wandb beta leet symon` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11559)
 - Bucketed heatmap chart mode for system metrics expressed as percentages (e.g. GPU utilization) in W&B LEET TUI (`wandb beta leet` command, cycle chart mode on a selected chart with `y`) (@dmitryduev in https://github.com/wandb/wandb/pull/11568)
+- Colorblind-friendly `dusk-shore` (gradient) and `clear-signal` (cycle) color schemes in W&B LEET TUI (`wandb beta leet` command, configure with `wandb beta leet config`) (@dmitryduev in https://github.com/wandb/wandb/pull/XXXXX)
 
 ### Changed
 

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -323,6 +323,49 @@ var colorSchemes = map[string][]compat.AdaptiveColor{
 		compat.AdaptiveColor{Light: lipgloss.Color("#B8A8E8"), Dark: lipgloss.Color("#D6C9FF")},
 		compat.AdaptiveColor{Light: lipgloss.Color("#5538B0"), Dark: lipgloss.Color("#6645D1")},
 	},
+	// This palette has been tested with deuteranopia, protanopia, and tritanopia
+	// simulators. Those forms of color blindness are less common than deuteranomaly.
+	// This palette focuses on siennas/blues/grays only, which
+	// are commonly colorblind-friendly across most forms of color blindness.
+	// Gradient ordering: warm siennas → cool blues → neutral grays.
+	"dusk-shore": {
+		compat.AdaptiveColor{Light: lipgloss.Color("#823520"), Dark: lipgloss.Color("#994228")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#BA5028"), Dark: lipgloss.Color("#D96534")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#D86030"), Dark: lipgloss.Color("#FC8F58")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#E89865"), Dark: lipgloss.Color("#FFBA91")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#78A8E8"), Dark: lipgloss.Color("#A4C9FC")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#4880DA"), Dark: lipgloss.Color("#629DF5")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#2E68CC"), Dark: lipgloss.Color("#397EED")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#2258BE"), Dark: lipgloss.Color("#286CE0")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#606872"), Dark: lipgloss.Color("#79808A")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
+	},
+	// Same colorblind-friendly sienna/blue/gray palette as "dusk-shore", but with
+	// colors interleaved for maximum visual differentiation between adjacent series.
+	"clear-signal": {
+		compat.AdaptiveColor{Light: lipgloss.Color("#BA5028"), Dark: lipgloss.Color("#D96534")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#2258BE"), Dark: lipgloss.Color("#286CE0")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#4880DA"), Dark: lipgloss.Color("#629DF5")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#823520"), Dark: lipgloss.Color("#994228")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#606872"), Dark: lipgloss.Color("#79808A")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#D86030"), Dark: lipgloss.Color("#FC8F58")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#E89865"), Dark: lipgloss.Color("#FFBA91")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#78A8E8"), Dark: lipgloss.Color("#A4C9FC")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#2E68CC"), Dark: lipgloss.Color("#397EED")},
+		compat.AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
+	},
 }
 
 // GraphColors returns the palette for the requested scheme.


### PR DESCRIPTION
Description
-----------
Add two colorblind-friendly palettes to LEET TUI designed for users with deuteranopia, protanopia, and tritanopia:

- `dusk-shore` - sienna/blue/gray gradient, suitable for per-plot single-run mode
- `clear-signal` - same colors interleaved for maximum differentiation between adjacent series

Both palettes restrict the gamut to siennas, blues, and neutral grays — a combination that remains distinguishable across most forms of color blindness. Light-mode values reuse existing derivations from wandb-vibe-10/wandb-vibe-20 where possible for consistency.

<img width="1710" height="1014" alt="image" src="https://github.com/user-attachments/assets/d4697f47-ed6c-431f-a473-d1ac681fe35d" />

<img width="1321" height="615" alt="image" src="https://github.com/user-attachments/assets/c0c47dd7-62d0-458a-9bec-5bf6a8d1c43c" />

"Borrowed" from https://www.notion.so/wandbai/Colorblind-safe-color-palettes-238e2f5c7ef380e7a203e0e910385d25 and https://github.com/wandb/core/pull/32348 🙏🏻.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
