### PR TITLE
refactor: drop GQL introspection from InternalApi.max_cli_version

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -959,13 +959,6 @@ class Api:
         if self._max_cli_version is not None:
             return self._max_cli_version
 
-        query_types, server_info_types, _ = self.server_info_introspection()
-        cli_version_exists = (
-            "serverInfo" in query_types and "cliVersionInfo" in server_info_types
-        )
-        if not cli_version_exists:
-            return None
-
         _, server_info = self.viewer_server_info()
         self._max_cli_version = server_info.get("cliVersionInfo", {}).get(
             "max_cli_version"


### PR DESCRIPTION
Removes GraphQL introspection from `InternalApi.max_cli_version` as the `ServerInfo.cliVersionInfo` field [exists in 0.63.0](https://github.com/wandb/core/blob/4e96edb6246657896bde6da938ef7325c4973b4a/services/gorilla/schema.graphql#L375) ([tag link](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L375)), the minimum supported server version.