### PR TITLE
refactor: drop internal api launch_agent_introspection()

### DIFF
--- a/tests/system_tests/test_launch/test_launch_cli.py
+++ b/tests/system_tests/test_launch/test_launch_cli.py
@@ -20,7 +20,7 @@ def _setup_agent(monkeypatch, pop_func):
 
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.create_launch_agent",
-        lambda c, e, p, q, a, v, g: {"launchAgentId": "mock_agent_id"},
+        lambda c, e, p, q, a, v: {"launchAgentId": "mock_agent_id"},
     )
 
 
@@ -33,11 +33,11 @@ def test_agent_stop_polling(runner, monkeypatch, user, test_settings):
 
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.get_launch_agent",
-        lambda c, i, g: {"id": "mock_agent_id", "name": "blah", "stopPolling": True},
+        lambda c, i: {"id": "mock_agent_id", "name": "blah", "stopPolling": True},
     )
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.update_launch_agent_status",
-        lambda c, i, s, g: {"success": True},
+        lambda c, i, s: {"success": True},
     )
 
     args = ["--entity", user, "--queue", "default"]
@@ -62,11 +62,11 @@ def test_agent_update_failed(runner, monkeypatch, user, test_settings):
 
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.get_launch_agent",
-        lambda c, i, g: {"id": "mock_agent_id", "name": "blah", "stopPolling": False},
+        lambda c, i: {"id": "mock_agent_id", "name": "blah", "stopPolling": False},
     )
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.update_launch_agent_status",
-        lambda c, i, s, g: {"success": False},
+        lambda c, i, s: {"success": False},
     )
 
     with runner.isolated_filesystem():
@@ -99,12 +99,12 @@ def test_launch_agent_launch_error_continue(runner, monkeypatch, user, test_sett
 
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.get_launch_agent",
-        lambda c, i, g: {"id": "mock_agent_id", "name": "blah", "stopPolling": False},
+        lambda c, i: {"id": "mock_agent_id", "name": "blah", "stopPolling": False},
     )
 
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.update_launch_agent_status",
-        lambda c, i, s, g: {"success": True},
+        lambda c, i, s: {"success": True},
     )
 
     with runner.isolated_filesystem():
@@ -218,11 +218,11 @@ def test_launch_supplied_logfile(runner, monkeypatch, wandb_caplog, user):
 
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.get_launch_agent",
-        lambda c, i, g: {"id": "mock_agent_id", "name": "blah", "stopPolling": True},
+        lambda c, i: {"id": "mock_agent_id", "name": "blah", "stopPolling": True},
     )
     monkeypatch.setattr(
         "wandb.sdk.internal.internal_api.Api.update_launch_agent_status",
-        lambda c, i, s, g: {"success": True},
+        lambda c, i, s: {"success": True},
     )
 
     with runner.isolated_filesystem():

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -208,9 +208,6 @@ class Api:
     def update_launch_agent_status(self, *args, **kwargs):
         return self.api.update_launch_agent_status(*args, **kwargs)
 
-    def launch_agent_introspection(self, *args, **kwargs):
-        return self.api.launch_agent_introspection(*args, **kwargs)
-
     def fail_run_queue_item_introspection(self, *args, **kwargs):
         return self.api.fail_run_queue_item_introspection(*args, **kwargs)
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -670,21 +670,6 @@ class Api:
         return self.server_use_artifact_input_info
 
     @normalize_exceptions
-    def launch_agent_introspection(self) -> str | None:
-        query = gql(
-            """
-            query LaunchAgentIntrospection {
-                LaunchAgentType: __type(name: "LaunchAgent") {
-                    name
-                }
-            }
-        """
-        )
-
-        res = self.gql(query)
-        return res.get("LaunchAgentType") or None
-
-    @normalize_exceptions
     def create_run_queue_introspection(self) -> tuple[bool, bool, bool]:
         _, _, mutations = self.server_info_introspection()
         query_string = """
@@ -2058,7 +2043,6 @@ class Api:
         queues: list[str],
         agent_config: dict[str, Any],
         version: str,
-        gorilla_agent_support: bool,
     ) -> dict:
         project_queues = self.get_project_run_queues(entity, project)
         if not project_queues:
@@ -2079,13 +2063,6 @@ class Api:
                 f"Could not start launch agent: Not all of requested queues ({', '.join(queues)}) found. "
                 f"Available queues for this project: {','.join([q['name'] for q in project_queues])}"
             )
-
-        if not gorilla_agent_support:
-            # if gorilla doesn't support launch agents, return a client-generated id
-            return {
-                "success": True,
-                "launchAgentId": None,
-            }
 
         hostname = socket.gethostname()
 
@@ -2142,14 +2119,7 @@ class Api:
         self,
         agent_id: str,
         status: str,
-        gorilla_agent_support: bool,
     ) -> dict:
-        if not gorilla_agent_support:
-            # if gorilla doesn't support launch agents, this is a no-op
-            return {
-                "success": True,
-            }
-
         mutation = gql(
             """
             mutation updateLaunchAgent($agentId: ID!, $agentStatus: String){
@@ -2172,13 +2142,7 @@ class Api:
         return result
 
     @normalize_exceptions
-    def get_launch_agent(self, agent_id: str, gorilla_agent_support: bool) -> dict:
-        if not gorilla_agent_support:
-            return {
-                "id": None,
-                "name": "",
-                "stopPolling": False,
-            }
+    def get_launch_agent(self, agent_id: str) -> dict:
         query = gql(
             """
             query LaunchAgent($agentId: ID!) {

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -232,9 +232,6 @@ class LaunchAgent:
             self.version = env_agent_version
 
         # serverside creation
-        self.gorilla_supports_agents = (
-            self._api.launch_agent_introspection() is not None
-        )
         self._gorilla_supports_fail_run_queue_items = (
             self._api.fail_run_queue_item_introspection()
         )
@@ -253,7 +250,6 @@ class LaunchAgent:
             self._queues,
             sent_config,
             self.version,
-            self.gorilla_supports_agents,
         )
         self._id = create_response["launchAgentId"]
         if self._api.entity_is_team(self._entity):
@@ -261,9 +257,7 @@ class LaunchAgent:
                 f"{LOG_PREFIX}Agent is running on team entity ({self._entity}). Members of this team will be able to run code on this device."
             )
 
-        agent_response = self._api.get_launch_agent(
-            self._id, self.gorilla_supports_agents
-        )
+        agent_response = self._api.get_launch_agent(self._id)
         self._name = agent_response["name"]
         self._init_agent_run()
 
@@ -306,20 +300,18 @@ class LaunchAgent:
             await fail_rqi(run_queue_item_id, message, phase, files)
 
     def _init_agent_run(self) -> None:
-        # TODO: has it been long enough that all backends support agents?
-        self._wandb_run = None
-
-        if self.gorilla_supports_agents:
-            settings = wandb.Settings(
-                silent=True, disable_git=True, disable_job_creation=True
-            )
-            self._wandb_run = wandb.init(
-                project=self._project,
-                entity=self._entity,
-                settings=settings,
-                id=self._name,
-                job_type=HIDDEN_AGENT_RUN_TYPE,
-            )
+        settings = wandb.Settings(
+            silent=True,
+            disable_git=True,
+            disable_job_creation=True,
+        )
+        self._wandb_run = wandb.init(
+            project=self._project,
+            entity=self._entity,
+            settings=settings,
+            id=self._name,
+            job_type=HIDDEN_AGENT_RUN_TYPE,
+        )
 
     @property
     def thread_ids(self) -> list[int]:
@@ -389,9 +381,7 @@ class LaunchAgent:
             status: Status to update the agent to.
         """
         _update_status = event_loop_thread_exec(self._api.update_launch_agent_status)
-        update_ret = await _update_status(
-            self._id, status, self.gorilla_supports_agents
-        )
+        update_ret = await _update_status(self._id, status)
         if not update_ret["success"]:
             wandb.termerror(f"{LOG_PREFIX}Failed to update agent status to {status}")
 
@@ -591,9 +581,7 @@ class LaunchAgent:
             while True:
                 job = None
                 self._ticks += 1
-                agent_response = self._api.get_launch_agent(
-                    self._id, self.gorilla_supports_agents
-                )
+                agent_response = self._api.get_launch_agent(self._id)
                 if agent_response["stopPolling"]:
                     # shutdown process and all jobs if requested from ui
                     raise KeyboardInterrupt  # noqa: TRY301


### PR DESCRIPTION
The LaunchAgent type [exists in 0.63.0](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L926), the minimum supported server version.

The other updated InternalApi methods were only being used in `agent.py` (based on grepping the codebase).