### PR TITLE
refactor: drop internal api server_artifact_input_introspection()

### DIFF
--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -893,13 +893,6 @@ def test_construct_use_artifact_query_with_every_field(mocker: MockerFixture):
 
     mocker.patch.object(api, "settings", side_effect=lambda x: "default-" + x)
 
-    # Mock the server introspection methods
-    mocker.patch.object(
-        api,
-        "server_use_artifact_input_introspection",
-        return_value={"usedAs": "String"},
-    )
-
     # Simulate server support for ALL known features
     mock_server_features = dict.fromkeys(
         chain(ServerFeature.keys(), ServerFeature.values()),
@@ -966,9 +959,6 @@ def test_construct_use_artifact_query_without_entity_project():
     api.settings = Mock(side_effect=lambda x: "default-" + x)
 
     # Mock methods to return False for entity/project support
-    api.server_use_artifact_input_introspection = Mock(
-        return_value={"usedAs": "String"}
-    )
     api._server_features = Mock(return_value={})
 
     query, variables = api._construct_use_artifact_query(
@@ -994,8 +984,6 @@ def test_construct_use_artifact_query_without_used_as():
     api = internal.InternalApi()
     api.settings = Mock(side_effect=lambda x: "default-" + x)
 
-    # Mock methods to return empty dict for introspection
-    api.server_use_artifact_input_introspection = Mock(return_value={})
     # Simulate server support for ALL known features
     mock_server_features = dict.fromkeys(
         chain(ServerFeature.keys(), ServerFeature.values()),

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -344,7 +344,6 @@ class Api:
         self.query_types: list[str] | None = None
         self.mutation_types: list[str] | None = None
         self.server_info_types: list[str] | None = None
-        self.server_use_artifact_input_info: list[str] | None = None
         self.server_create_artifact_input_info: list[str] | None = None
         self.server_artifact_fields_info: list[str] | None = None
         self.server_organization_type_fields_info: list[str] | None = None
@@ -645,29 +644,6 @@ class Api:
                 if res
                 else []
             )
-
-    def server_use_artifact_input_introspection(self) -> list:
-        query_string = """
-           query ProbeServerUseArtifactInput {
-               UseArtifactInputInfoType: __type(name: "UseArtifactInput") {
-                   name
-                   inputFields {
-                       name
-                   }
-                }
-            }
-        """
-
-        if self.server_use_artifact_input_info is None:
-            query = gql(query_string)
-            res = self.gql(query)
-            self.server_use_artifact_input_info = [
-                field.get("name", "")
-                for field in res.get("UseArtifactInputInfoType", {}).get(
-                    "inputFields", [{}]
-                )
-            ]
-        return self.server_use_artifact_input_info
 
     @normalize_exceptions
     def create_run_queue_introspection(self) -> tuple[bool, bool, bool]:
@@ -3717,8 +3693,7 @@ class Api:
             "artifactID: $artifactID",
         ]
 
-        artifact_types = self.server_use_artifact_input_introspection()
-        if "usedAs" in artifact_types and use_as:
+        if use_as:
             query_vars.append("$usedAs: String")
             query_args.append("usedAs: $usedAs")
 


### PR DESCRIPTION
The only use was in `InternalApi._construct_use_artifact_query()`, which checked for the presence of the `usedAs` field, which [exists in 0.63.0](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L5699), the minimum supported server version.