### PR TITLE
refactor: drop internal api create_run_queue_introspection()

### DIFF
--- a/tests/system_tests/test_launch/test_launch_add.py
+++ b/tests/system_tests/test_launch/test_launch_add.py
@@ -321,17 +321,6 @@ def test_launch_add_with_priority(
         patched_push_to_run_queue_introspection,
     )
 
-    def patched_create_run_queue_introspection(*args, **kwargs):
-        args[0].server_create_run_queue_supports_drc = True
-        args[0].server_create_run_queue_supports_priority = True
-        return (True, True, True)
-
-    monkeypatch.setattr(
-        wandb.sdk.internal.internal_api.Api,
-        "create_run_queue_introspection",
-        patched_create_run_queue_introspection,
-    )
-
     queue_name = "prio_queue"
     proj = "test1"
     queue_config = {}

--- a/tests/unit_tests/test_launch/test_internal_api.py
+++ b/tests/unit_tests/test_launch/test_internal_api.py
@@ -1,10 +1,8 @@
 import json
 from unittest.mock import MagicMock
 
-import pytest
 import wandb
 from wandb.apis import internal
-from wandb.errors import UnsupportedError
 
 
 def test_create_run_queue(monkeypatch):
@@ -12,7 +10,6 @@ def test_create_run_queue(monkeypatch):
 
     # prioritization_mode present on server
     _api.api.gql = MagicMock(return_value={"createRunQueue": "test-result"})
-    _api.api.create_run_queue_introspection = MagicMock(return_value=(True, True, True))
     mock_gql = MagicMock(return_value="test-gql-resp")
     monkeypatch.setattr(wandb.sdk.internal.internal_api, "gql", mock_gql)
 
@@ -34,33 +31,6 @@ def test_create_run_queue(monkeypatch):
             "queueName": "test-queue",
             "access": "test-access",
             "prioritizationMode": "test-prioritization-mode",
-            "defaultResourceConfigID": "test-config-id",
-        },
-    )
-
-    # prioritization_mode not present on server
-    _api.api.gql = MagicMock(return_value={"createRunQueue": "test-result"})
-    _api.api.create_run_queue_introspection = MagicMock(
-        return_value=(True, True, False)
-    )
-    mock_gql = MagicMock(return_value="test-gql-resp")
-    monkeypatch.setattr(wandb.sdk.internal.internal_api, "gql", mock_gql)
-
-    # trying to use prioritization_mode gives error
-    with pytest.raises(UnsupportedError):
-        _api.create_run_queue(**kwargs)
-
-    # able to create queue without prioritization_mode
-    del kwargs["prioritization_mode"]
-    resp = _api.create_run_queue(**kwargs)
-    assert resp == "test-result"
-    _api.api.gql.assert_called_once_with(
-        "test-gql-resp",
-        {
-            "entity": "test-entity",
-            "project": "test-project",
-            "queueName": "test-queue",
-            "access": "test-access",
             "defaultResourceConfigID": "test-config-id",
         },
     )

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -352,8 +352,6 @@ class Api:
         self._server_settings_type: list[str] | None = None
         self.fail_run_queue_item_input_info: list[str] | None = None
         self.create_launch_agent_input_info: list[str] | None = None
-        self.server_create_run_queue_supports_drc: bool | None = None
-        self.server_create_run_queue_supports_priority: bool | None = None
         self.server_supports_template_variables: bool | None = None
         self.server_push_to_run_queue_supports_priority: bool | None = None
 
@@ -644,45 +642,6 @@ class Api:
                 if res
                 else []
             )
-
-    @normalize_exceptions
-    def create_run_queue_introspection(self) -> tuple[bool, bool, bool]:
-        _, _, mutations = self.server_info_introspection()
-        query_string = """
-           query ProbeCreateRunQueueInput {
-               CreateRunQueueInputType: __type(name: "CreateRunQueueInput") {
-                   name
-                   inputFields {
-                       name
-                   }
-                }
-            }
-        """
-        if (
-            self.server_create_run_queue_supports_drc is None
-            or self.server_create_run_queue_supports_priority is None
-        ):
-            query = gql(query_string)
-            res = self.gql(query)
-            if res is None:
-                raise CommError("Could not get CreateRunQueue input from GQL.")
-            self.server_create_run_queue_supports_drc = "defaultResourceConfigID" in [
-                x["name"]
-                for x in (
-                    res.get("CreateRunQueueInputType", {}).get("inputFields", [{}])
-                )
-            ]
-            self.server_create_run_queue_supports_priority = "prioritizationMode" in [
-                x["name"]
-                for x in (
-                    res.get("CreateRunQueueInputType", {}).get("inputFields", [{}])
-                )
-            ]
-        return (
-            "createRunQueue" in mutations,
-            self.server_create_run_queue_supports_drc,
-            self.server_create_run_queue_supports_priority,
-        )
 
     @normalize_exceptions
     def upsert_run_queue_introspection(self) -> bool:
@@ -1532,94 +1491,40 @@ class Api:
         prioritization_mode: str | None = None,
         config_id: str | None = None,
     ) -> dict[str, Any] | None:
-        (
-            create_run_queue,
-            supports_drc,
-            supports_prioritization,
-        ) = self.create_run_queue_introspection()
-        if not create_run_queue:
-            raise UnsupportedError(
-                "run queue creation is not supported by this version of "
-                "wandb server. Consider updating to the latest version."
-            )
-        if not supports_drc and config_id is not None:
-            raise UnsupportedError(
-                "default resource configurations are not supported by this version "
-                "of wandb server. Consider updating to the latest version."
-            )
-        if not supports_prioritization and prioritization_mode is not None:
-            raise UnsupportedError(
-                "launch prioritization is not supported by this version of "
-                "wandb server. Consider updating to the latest version."
-            )
-
-        if supports_prioritization:
-            query = gql(
-                """
-            mutation createRunQueue(
-                $entity: String!,
-                $project: String!,
-                $queueName: String!,
-                $access: RunQueueAccessType!,
-                $prioritizationMode: RunQueuePrioritizationMode,
-                $defaultResourceConfigID: ID,
-            ) {
-                createRunQueue(
-                    input: {
-                        entityName: $entity,
-                        projectName: $project,
-                        queueName: $queueName,
-                        access: $access,
-                        prioritizationMode: $prioritizationMode
-                        defaultResourceConfigID: $defaultResourceConfigID
-                    }
-                ) {
-                    success
-                    queueID
-                }
-            }
+        query = gql(
             """
-            )
-            variable_values = {
-                "entity": entity,
-                "project": project,
-                "queueName": queue_name,
-                "access": access,
-                "prioritizationMode": prioritization_mode,
-                "defaultResourceConfigID": config_id,
-            }
-        else:
-            query = gql(
-                """
-            mutation createRunQueue(
-                $entity: String!,
-                $project: String!,
-                $queueName: String!,
-                $access: RunQueueAccessType!,
-                $defaultResourceConfigID: ID,
-            ) {
-                createRunQueue(
-                    input: {
-                        entityName: $entity,
-                        projectName: $project,
-                        queueName: $queueName,
-                        access: $access,
-                        defaultResourceConfigID: $defaultResourceConfigID
-                    }
-                ) {
-                    success
-                    queueID
+        mutation createRunQueue(
+            $entity: String!,
+            $project: String!,
+            $queueName: String!,
+            $access: RunQueueAccessType!,
+            $prioritizationMode: RunQueuePrioritizationMode,
+            $defaultResourceConfigID: ID,
+        ) {
+            createRunQueue(
+                input: {
+                    entityName: $entity,
+                    projectName: $project,
+                    queueName: $queueName,
+                    access: $access,
+                    prioritizationMode: $prioritizationMode
+                    defaultResourceConfigID: $defaultResourceConfigID
                 }
+            ) {
+                success
+                queueID
             }
-            """
-            )
-            variable_values = {
-                "entity": entity,
-                "project": project,
-                "queueName": queue_name,
-                "access": access,
-                "defaultResourceConfigID": config_id,
-            }
+        }
+        """
+        )
+        variable_values = {
+            "entity": entity,
+            "project": project,
+            "queueName": queue_name,
+            "access": access,
+            "prioritizationMode": prioritization_mode,
+            "defaultResourceConfigID": config_id,
+        }
 
         result: dict[str, Any] | None = self.gql(query, variable_values)[
             "createRunQueue"


### PR DESCRIPTION
CreateRunQueueInput [supports defaultResourceConfigId and prioritizationMode in 0.63.0](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L3812-L3820), the minimum supported server version.