### PR TITLE
refactor: drop internal api push_to_run_queue_introspection()

### DIFF
--- a/tests/system_tests/test_launch/test_launch_add.py
+++ b/tests/system_tests/test_launch/test_launch_add.py
@@ -5,7 +5,6 @@ import pytest
 import wandb
 from wandb.apis.public import Api as PublicApi
 from wandb.sdk.internal.internal_api import Api as InternalApi
-from wandb.sdk.internal.internal_api import UnsupportedError
 from wandb.sdk.launch._launch_add import launch_add
 from wandb.sdk.launch.utils import LAUNCH_DEFAULT_PROJECT, LaunchError
 
@@ -308,19 +307,7 @@ def test_launch_add_with_priority(
     push_to_run_queue_spy,
     runner,
     user,
-    monkeypatch,
 ):
-    def patched_push_to_run_queue_introspection(*args, **kwargs):
-        args[0].server_supports_template_variables = True
-        args[0].server_push_to_run_queue_supports_priority = True
-        return (True, True)
-
-    monkeypatch.setattr(
-        wandb.sdk.internal.internal_api.Api,
-        "push_to_run_queue_introspection",
-        patched_push_to_run_queue_introspection,
-    )
-
     queue_name = "prio_queue"
     proj = "test1"
     queue_config = {}
@@ -355,17 +342,6 @@ def test_launch_add_with_priority_to_no_prio_queue_raises(
     monkeypatch,
 ):
     _ = use_local_wandb_backend
-
-    def patched_push_to_run_queue_introspection(*args, **kwargs):
-        args[0].server_supports_template_variables = True
-        args[0].server_push_to_run_queue_supports_priority = True
-        return (True, True)
-
-    monkeypatch.setattr(
-        wandb.sdk.internal.internal_api.Api,
-        "push_to_run_queue_introspection",
-        patched_push_to_run_queue_introspection,
-    )
 
     # Backend returns 4xx if you attempt to push an item with
     # non-default priority to a queue that doesn't support priority
@@ -478,78 +454,6 @@ def test_launch_add_template_variables_legacy_push(
 
     assert push_to_run_queue_spy.total_calls == 1
     assert push_to_run_queue_by_name_spy.total_calls == 0
-
-
-def test_launch_add_template_variables_not_supported(user, monkeypatch):
-    queue_name = "tvqueue"
-    proj = "test1"
-    queue_config = {"e": ["{{var1}}"]}
-    template_variables = {"var1": "a"}
-
-    def patched_push_to_run_queue_introspection(*args, **kwargs):
-        args[0].server_supports_template_variables = False
-        return (False, False)
-
-    monkeypatch.setattr(
-        wandb.sdk.internal.internal_api.Api,
-        "push_to_run_queue_introspection",
-        patched_push_to_run_queue_introspection,
-    )
-    api = PublicApi(api_key=user)
-    api.create_run_queue(
-        entity=user,
-        name=queue_name,
-        type="local-container",
-        config=queue_config,
-    )
-    with pytest.raises(UnsupportedError):
-        _ = launch_add(
-            template_variables=template_variables,
-            project=proj,
-            entity=user,
-            queue_name=queue_name,
-            docker_image="abc:latest",
-        )
-
-
-def test_launch_add_template_variables_not_supported_legacy_push(
-    runner, user, monkeypatch
-):
-    queue_name = "tvqueue"
-    proj = "test1"
-    queue_config = {"e": ["{{var1}}"]}
-    template_variables = {"var1": "a"}
-
-    def patched_push_to_run_queue_introspection(*args, **kwargs):
-        args[0].server_supports_template_variables = False
-        return (False, False)
-
-    monkeypatch.setattr(
-        wandb.sdk.internal.internal_api.Api,
-        "push_to_run_queue_introspection",
-        patched_push_to_run_queue_introspection,
-    )
-    monkeypatch.setattr(
-        wandb.sdk.internal.internal_api.Api,
-        "push_to_run_queue_by_name",
-        lambda *args, **kwargs: None,
-    )
-    with runner.isolated_filesystem():
-        api = PublicApi(api_key=user)
-        api.create_run_queue(
-            entity=user,
-            name=queue_name,
-            type="local-container",
-            config=queue_config,
-        )
-        with pytest.raises(UnsupportedError):
-            _ = launch_add(
-                template_variables=template_variables,
-                project=proj,
-                entity=user,
-                queue_name=queue_name,
-                docker_image="abc:latest",
-            )
 
 
 def test_display_updated_runspec(

--- a/tests/system_tests/test_launch/test_launch_public_api.py
+++ b/tests/system_tests/test_launch/test_launch_public_api.py
@@ -3,9 +3,8 @@ import json
 import pytest
 import wandb
 import wandb.apis.public
-import wandb.util
 from wandb import Api
-from wandb.sdk.internal.internal_api import UnsupportedError
+from wandb.errors import UnsupportedError
 
 SWEEP_CONFIGURATION = {
     "method": "random",
@@ -17,34 +16,6 @@ SWEEP_CONFIGURATION = {
         "lr": {"max": 0.1, "min": 0.0001},
     },
 }
-
-
-def test_create_run_queue_template_variables_not_supported(runner, user, monkeypatch):
-    queue_name = "tvqueue"
-    queue_config = {"e": ["{{var1}}"]}
-    queue_template_variables = {
-        "var1": {"schema": {"type": "string", "enum": ["a", "b"]}}
-    }
-
-    def patched_push_to_run_queue_introspection(*args, **kwargs):
-        args[0].server_supports_template_variables = False, False
-        return False, False
-
-    monkeypatch.setattr(
-        wandb.sdk.internal.internal_api.Api,
-        "push_to_run_queue_introspection",
-        patched_push_to_run_queue_introspection,
-    )
-    with runner.isolated_filesystem():
-        api = Api(api_key=user)
-        with pytest.raises(UnsupportedError):
-            api.create_run_queue(
-                entity=user,
-                name=queue_name,
-                type="local-container",
-                config=queue_config,
-                template_variables=queue_template_variables,
-            )
 
 
 def test_upsert_run_queue(user):

--- a/tests/unit_tests/test_launch/test_internal_api.py
+++ b/tests/unit_tests/test_launch/test_internal_api.py
@@ -41,10 +41,8 @@ def test_push_to_run_queue_by_name(monkeypatch):
     mock_run_spec = {"test-key": "test-value"}
     mock_gql_response = {"pushToRunQueueByName": {"runSpec": json.dumps(mock_run_spec)}}
     _api.api.gql = MagicMock(return_value=mock_gql_response)
-    _api.api.push_to_run_queue_introspection = MagicMock()
     monkeypatch.setattr(wandb.sdk.internal.internal_api, "gql", lambda x: x)
 
-    _api.api.server_push_to_run_queue_supports_priority = True
     push_kwargs = {
         "entity": "test-entity",
         "project": "test-project",

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -35,7 +35,7 @@ import wandb
 from wandb import env, util
 from wandb.analytics import get_sentry
 from wandb.apis.normalize import normalize_exceptions, parse_backend_error_messages
-from wandb.errors import AuthenticationError, CommError, UnsupportedError, UsageError
+from wandb.errors import AuthenticationError, CommError, UsageError
 from wandb.integration.sagemaker import parse_sm_secrets
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk import wandb_setup
@@ -352,8 +352,6 @@ class Api:
         self._server_settings_type: list[str] | None = None
         self.fail_run_queue_item_input_info: list[str] | None = None
         self.create_launch_agent_input_info: list[str] | None = None
-        self.server_supports_template_variables: bool | None = None
-        self.server_push_to_run_queue_supports_priority: bool | None = None
 
         self._server_features_cache: dict[str, bool] | None = None
 
@@ -642,43 +640,6 @@ class Api:
                 if res
                 else []
             )
-
-    @normalize_exceptions
-    def push_to_run_queue_introspection(self) -> tuple[bool, bool]:
-        query_string = """
-            query ProbePushToRunQueueInput {
-                PushToRunQueueInputType: __type(name: "PushToRunQueueInput") {
-                    name
-                    inputFields {
-                        name
-                    }
-                }
-            }
-        """
-
-        if (
-            self.server_supports_template_variables is None
-            or self.server_push_to_run_queue_supports_priority is None
-        ):
-            query = gql(query_string)
-            res = self.gql(query)
-            self.server_supports_template_variables = "templateVariableValues" in [
-                x["name"]
-                for x in (
-                    res.get("PushToRunQueueInputType", {}).get("inputFields", [{}])
-                )
-            ]
-            self.server_push_to_run_queue_supports_priority = "priority" in [
-                x["name"]
-                for x in (
-                    res.get("PushToRunQueueInputType", {}).get("inputFields", [{}])
-                )
-            ]
-
-        return (
-            self.server_supports_template_variables,
-            self.server_push_to_run_queue_supports_priority,
-        )
 
     @normalize_exceptions
     def create_default_resource_config_introspection(self) -> bool:
@@ -1421,38 +1382,30 @@ class Api:
     ) -> dict[str, Any] | None:
         if not self.create_default_resource_config_introspection():
             raise Exception()
-        supports_template_vars, _ = self.push_to_run_queue_introspection()
 
         mutation_params = """
             $entityName: String!,
             $resource: String!,
-            $config: JSONString!
+            $config: JSONString!,
+            $templateVariables: JSONString
         """
         mutation_inputs = """
             entityName: $entityName,
             resource: $resource,
-            config: $config
+            config: $config,
+            templateVariables: $templateVariables
         """
-
-        if supports_template_vars:
-            mutation_params += ", $templateVariables: JSONString"
-            mutation_inputs += ", templateVariables: $templateVariables"
-        else:
-            if template_variables is not None:
-                raise UnsupportedError(
-                    "server does not support template variables, please update server instance to >=0.46"
-                )
 
         variable_values = {
             "entityName": entity,
             "resource": resource,
             "config": config,
         }
-        if supports_template_vars:
-            if template_variables is not None:
-                variable_values["templateVariables"] = json.dumps(template_variables)
-            else:
-                variable_values["templateVariables"] = "{}"
+
+        if template_variables is not None:
+            variable_values["templateVariables"] = json.dumps(template_variables)
+        else:
+            variable_values["templateVariables"] = "{}"
 
         query = gql(
             f"""
@@ -1595,9 +1548,6 @@ class Api:
         template_variables: dict[str, int | float | str] | None,
         priority: int | None = None,
     ) -> dict[str, Any] | None:
-        self.push_to_run_queue_introspection()
-        """Queryless mutation, should be used before legacy fallback method."""
-
         mutation_params = """
             $entityName: String!,
             $projectName: String!,
@@ -1618,29 +1568,15 @@ class Api:
             "queueName": queue_name,
             "runSpec": run_spec,
         }
-        if self.server_push_to_run_queue_supports_priority:
-            if priority is not None:
-                variables["priority"] = priority
-                mutation_params += ", $priority: Int"
-                mutation_input += ", priority: $priority"
-        else:
-            if priority is not None:
-                raise UnsupportedError(
-                    "server does not support priority, please update server instance to >=0.46"
-                )
+        if priority is not None:
+            variables["priority"] = priority
+            mutation_params += ", $priority: Int"
+            mutation_input += ", priority: $priority"
 
-        if self.server_supports_template_variables:
-            if template_variables is not None:
-                variables.update(
-                    {"templateVariableValues": json.dumps(template_variables)}
-                )
-                mutation_params += ", $templateVariableValues: JSONString"
-                mutation_input += ", templateVariableValues: $templateVariableValues"
-        else:
-            if template_variables is not None:
-                raise UnsupportedError(
-                    "server does not support template variables, please update server instance to >=0.46"
-                )
+        if template_variables is not None:
+            variables.update({"templateVariableValues": json.dumps(template_variables)})
+            mutation_params += ", $templateVariableValues: JSONString"
+            mutation_input += ", templateVariableValues: $templateVariableValues"
 
         mutation = gql(
             f"""
@@ -1718,7 +1654,6 @@ class Api:
         project_queue: str,
         priority: int | None = None,
     ) -> dict[str, Any] | None:
-        self.push_to_run_queue_introspection()
         entity = launch_spec.get("queue_entity") or launch_spec["entity"]
         run_spec = json.dumps(launch_spec)
 
@@ -1791,18 +1726,10 @@ class Api:
             queueID: $queueID,
             runSpec: $runSpec
         """
-        if self.server_supports_template_variables:
-            if template_variables is not None:
-                mutation_params += ", $templateVariableValues: JSONString"
-                mutation_input += ", templateVariableValues: $templateVariableValues"
-                variables.update(
-                    {"templateVariableValues": json.dumps(template_variables)}
-                )
-        else:
-            if template_variables is not None:
-                raise UnsupportedError(
-                    "server does not support template variables, please update server instance to >=0.46"
-                )
+        if template_variables is not None:
+            mutation_params += ", $templateVariableValues: JSONString"
+            mutation_input += ", templateVariableValues: $templateVariableValues"
+            variables.update({"templateVariableValues": json.dumps(template_variables)})
 
         mutation = gql(
             f"""


### PR DESCRIPTION
PushToRunQueueInput [supports templateVariableValues and priority in 0.63.0](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L3934-L3940), the minimum supported server version.