### PR TITLE
refactor: drop internal api fail_run_queue_item_introspection()

### DIFF
--- a/tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -387,38 +387,6 @@ async def test_thread_finish_run_fail_start(mocker, clean_agent):
 
 
 @pytest.mark.asyncio
-async def test_thread_finish_run_fail_start_old_server(mocker, clean_agent):
-    """Tests that if a run does not exist, the run queue item is not failed for old servers."""
-    _setup_thread_finish(mocker)
-    mock_config = {
-        "entity": "test-entity",
-        "project": "test-project",
-    }
-    mocker.api.get_run_state.side_effect = CommError("failed")
-    mocker.patch("wandb.sdk.launch.agent.agent.RUN_INFO_GRACE_PERIOD", 1)
-
-    agent = LaunchAgent(api=mocker.api, config=mock_config)
-    agent._gorilla_supports_fail_run_queue_items = False
-    mock_saver = MagicMock()
-    job = JobAndRunStatusTracker("run_queue_item_id", "test-queue", mock_saver)
-    job.run_id = "test_run_id"
-    job.run_queue_item_id = "asdasd"
-    job.project = "test-project"
-    run = MagicMock()
-
-    async def mock_get_logs():
-        return "logs"
-
-    run.get_logs = mock_get_logs
-    job.run = run
-    agent._jobs_lock = MagicMock()
-    agent._jobs = {"thread_1": job}
-    await agent.finish_thread_id("thread_1")
-    assert len(agent._jobs) == 0
-    mocker.api.fail_run_queue_item.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_thread_finish_run_fail_different_entity(mocker, clean_agent):
     """Tests that no check is made if the agent entity does not match."""
     _setup_thread_finish(mocker)

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -208,9 +208,6 @@ class Api:
     def update_launch_agent_status(self, *args, **kwargs):
         return self.api.update_launch_agent_status(*args, **kwargs)
 
-    def fail_run_queue_item_introspection(self, *args, **kwargs):
-        return self.api.fail_run_queue_item_introspection(*args, **kwargs)
-
     def fail_run_queue_item(self, *args, **kwargs):
         return self.api.fail_run_queue_item(*args, **kwargs)
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -642,11 +642,6 @@ class Api:
             )
 
     @normalize_exceptions
-    def fail_run_queue_item_introspection(self) -> bool:
-        _, _, mutations = self.server_info_introspection()
-        return "failRunQueueItem" in mutations
-
-    @normalize_exceptions
     def fail_run_queue_item_fields_introspection(self) -> list:
         if self.fail_run_queue_item_input_info:
             return self.fail_run_queue_item_input_info
@@ -679,8 +674,6 @@ class Api:
         stage: str,
         file_paths: list[str] | None = None,
     ) -> bool:
-        if not self.fail_run_queue_item_introspection():
-            return False
         variable_values: dict[str, str | (list[str] | None)] = {
             "runQueueItemId": run_queue_item_id,
         }

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -231,11 +231,6 @@ class LaunchAgent:
         if env_agent_version and env_agent_version != "wandb-launch-agent":
             self.version = env_agent_version
 
-        # serverside creation
-        self._gorilla_supports_fail_run_queue_items = (
-            self._api.fail_run_queue_item_introspection()
-        )
-
         self._queues: list[str] = config.get("queues", ["default"])
 
         # remove project field from agent config before sending to back end
@@ -295,9 +290,8 @@ class LaunchAgent:
         phase: str,
         files: list[str] | None = None,
     ) -> None:
-        if self._gorilla_supports_fail_run_queue_items:
-            fail_rqi = event_loop_thread_exec(self._api.fail_run_queue_item)
-            await fail_rqi(run_queue_item_id, message, phase, files)
+        fail_rqi = event_loop_thread_exec(self._api.fail_run_queue_item)
+        await fail_rqi(run_queue_item_id, message, phase, files)
 
     def _init_agent_run(self) -> None:
         settings = wandb.Settings(


### PR DESCRIPTION
The failRunQueueItem mutation [exists in 0.63.0](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L3660), the minimum supported server version.