### PR TITLE
refactor: drop internal api create_launch_agent_fields_introspection()

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -350,7 +350,6 @@ class Api:
         self.server_supports_enabling_artifact_usage_tracking: bool | None = None
         self._max_cli_version: str | None = None
         self._server_settings_type: list[str] | None = None
-        self.create_launch_agent_input_info: list[str] | None = None
 
         self._server_features_cache: dict[str, bool] | None = None
 
@@ -1749,31 +1748,6 @@ class Api:
         return result
 
     @normalize_exceptions
-    def create_launch_agent_fields_introspection(self) -> list:
-        if self.create_launch_agent_input_info:
-            return self.create_launch_agent_input_info
-        query_string = """
-           query ProbeServerCreateLaunchAgentInput {
-                CreateLaunchAgentInputInfoType: __type(name:"CreateLaunchAgentInput") {
-                    inputFields{
-                        name
-                    }
-                }
-            }
-        """
-
-        query = gql(query_string)
-        res = self.gql(query)
-
-        self.create_launch_agent_input_info = [
-            field.get("name", "")
-            for field in res.get("CreateLaunchAgentInputInfoType", {}).get(
-                "inputFields", [{}]
-            )
-        ]
-        return self.create_launch_agent_input_info
-
-    @normalize_exceptions
     def create_launch_agent(
         self,
         entity: str,
@@ -1809,30 +1783,27 @@ class Api:
             "project": project,
             "queues": polling_queue_ids,
             "hostname": hostname,
+            "agentConfig": json.dumps(agent_config),
+            "version": version,
         }
 
         mutation_params = """
             $entity: String!,
             $project: String!,
             $queues: [ID!]!,
-            $hostname: String!
+            $hostname: String!,
+            $agentConfig: JSONString,
+            $version: String
         """
 
         mutation_input = """
             entityName: $entity,
             projectName: $project,
             runQueues: $queues,
-            hostname: $hostname
+            hostname: $hostname,
+            agentConfig: $agentConfig,
+            version: $version
         """
-
-        if "agentConfig" in self.create_launch_agent_fields_introspection():
-            variable_values["agentConfig"] = json.dumps(agent_config)
-            mutation_params += ", $agentConfig: JSONString"
-            mutation_input += ", agentConfig: $agentConfig"
-        if "version" in self.create_launch_agent_fields_introspection():
-            variable_values["version"] = version
-            mutation_params += ", $version: String"
-            mutation_input += ", version: $version"
 
         mutation = gql(
             f"""


### PR DESCRIPTION
CreateLaunchAgentInput [has the agentConfig and version fields in 0.63.0](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L4007-L4015).