### PR TITLE
refactor: drop internal api server_artifact_introspection()

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -345,7 +345,6 @@ class Api:
         self.mutation_types: list[str] | None = None
         self.server_info_types: list[str] | None = None
         self.server_create_artifact_input_info: list[str] | None = None
-        self.server_artifact_fields_info: list[str] | None = None
         self._max_cli_version: str | None = None
         self._server_settings_type: list[str] | None = None
 
@@ -3526,27 +3525,6 @@ class Api:
         _id: str | None = response["createArtifactType"]["artifactType"]["id"]
         return _id
 
-    def server_artifact_introspection(self) -> list[str]:
-        query_string = """
-            query ProbeServerArtifact {
-                ArtifactInfoType: __type(name:"Artifact") {
-                    fields {
-                        name
-                    }
-                }
-            }
-        """
-
-        if self.server_artifact_fields_info is None:
-            query = gql(query_string)
-            res = self.gql(query)
-            input_fields = res.get("ArtifactInfoType", {}).get("fields", [{}])
-            self.server_artifact_fields_info = [
-                field["name"] for field in input_fields if "name" in field
-            ]
-
-        return self.server_artifact_fields_info
-
     def server_create_artifact_introspection(self) -> list[str]:
         query_string = """
             query ProbeServerCreateArtifactInput {
@@ -3671,18 +3649,6 @@ class Api:
         history_step: int | None = None,
     ) -> tuple[dict, dict]:
         fields = self.server_create_artifact_introspection()
-        artifact_fields = self.server_artifact_introspection()
-        if ("ttlIsInherited" not in artifact_fields) and ttl_duration_seconds:
-            wandb.termwarn(
-                "Server not compatible with setting Artifact TTLs, please upgrade the server to use Artifact TTL"
-            )
-            # ttlDurationSeconds is only usable if ttlIsInherited is also present
-            ttl_duration_seconds = None
-        if ("tags" not in artifact_fields) and tags:
-            wandb.termwarn(
-                "Server not compatible with Artifact tags. "
-                "To use Artifact tags, please upgrade the server to v0.85 or higher."
-            )
 
         query_template = self._get_create_artifact_mutation(
             fields, history_step, distributed_id


### PR DESCRIPTION
The Artifact type has the [ttlIsInherited and tags fields in 0.63.0](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L2715-L2718), the minimum supported server version.