### PR TITLE
chore: mention <0.63.0 incompatibility in changelog

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Notable Changes
+
+This version drops compatibility with server versions older than 0.63.0 (for Dedicated Cloud and Self-Managed W&B deployments).
+
 ### Added
 
 - `wandb beta core start|stop` commands to run a detached `wandb-core` service and reuse it across multiple processes via the `WANDB_SERVICE` env var (@dmitryduev in https://github.com/wandb/wandb/pull/11418)


### PR DESCRIPTION
PRs #11584 - #11603 dropped GQL introspection checks meant for compatibility with older servers.

It's possible that the SDK will still work with older servers in many cases, but I figured it's worth mentioning in the changelog for anyone working through an upgrade.