### PR TITLE
fix(sdk): allow api-* subdomains (e.g. api-forest, api-shared) in base URL validation

### DIFF
--- a/tests/unit_tests/test_wandb_settings.py
+++ b/tests/unit_tests/test_wandb_settings.py
@@ -299,6 +299,8 @@ def test_validate_mode():
     "url",
     [
         "https://api.wandb.ai",
+        "https://api-forest.wandb.ai",
+        "https://api-shared.wandb.ai",
         "https://wandb.ai.other.crazy.domain.com",
         "https://127.0.0.1",
         "https://localhost",

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1010,7 +1010,9 @@ class Settings(BaseModel, validate_assignment=True):
         """
         urls.validate_url(value)
         # wandb.ai-specific checks
-        if re.match(r".*wandb\.ai[^\.]*$", value) and "api." not in value:
+        if re.match(r".*wandb\.ai[^\.]*$", value) and not re.search(
+            r"//api[.\-]", value
+        ):
             # user might guess app.wandb.ai or wandb.ai is the default cloud server
             raise ValueError(
                 f"{value} is not a valid server address, did you mean https://api.wandb.ai?"


### PR DESCRIPTION
Description
-----------

The `base_url` validator in `Settings` rejected valid `api-*` subdomains like `https://api-forest.wandb.ai` and `https://api-shared.wandb.ai`. The old check used `"api." not in value` to detect non-API wandb.ai URLs, but this string check fails for hyphenated subdomains (`api-forest` contains `api-` not `api.`).

Replaced the string containment check with `re.search(r"//api[.\-]", value)` which matches both `api.` and `api-` immediately after the protocol prefix.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

### Human Review Checklist
- [ ] Verify the regex character class `[.\-]` correctly matches literal dot and hyphen (it does — inside `[]`, `.` is literal)
- [ ] Confirm existing rejection cases still work: `https://wandb.ai`, `https://app.wandb.ai`, `http://api.wandb.ai`
- [ ] Consider whether the `//` anchor is sufficient or if edge cases exist (e.g. URLs with port numbers or paths before the domain)

Testing
-------
- Added `https://api-forest.wandb.ai` and `https://api-shared.wandb.ai` to the `test_validate_base_url` parametrized test
- All 17 base URL validation tests pass (both valid and invalid URL cases)
- Ruff lint and format checks pass

Link to Devin session: https://app.devin.ai/sessions/6de308de025642d59b73a76f7a1e569d
Requested by: @wandbjake