### PR TITLE
refactor: drop gql introspection in files.py

### DIFF
--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -14,7 +14,6 @@ import wandb.util
 from wandb import Api
 from wandb.apis._generated import ProjectFragment, UserFragment
 from wandb.apis._generated.generate_api_key import GenerateApiKey
-from wandb.apis.public import File
 from wandb.errors.errors import CommError
 from wandb.old.summary import Summary
 
@@ -978,16 +977,12 @@ def test_delete_files_for_multiple_runs(
         file = run.files()[0]
         file.delete()
 
-        expected_variables = {
+        assert "projectId" in delete_spy.requests[0].variables
+        assert "projectId" in delete_spy.requests[0].query
+        assert delete_spy.requests[0].variables == {
             "files": [file.id],
+            "projectId": runs[0]._project_internal_id,
         }
-        # For system tests on newer server version, the projectId is provided
-        if file._server_accepts_project_id_for_delete_file():
-            assert "projectId" in delete_spy.requests[0].variables
-            assert "projectId" in delete_spy.requests[0].query
-            expected_variables["projectId"] = runs[0]._project_internal_id
-
-        assert delete_spy.requests[0].variables == expected_variables
 
 
 def test_delete_file(
@@ -1030,28 +1025,17 @@ def test_delete_file(
     file = run.files()[0]
     file.delete()
 
-    # For system tests on newer server version, the projectId is provided
-    if file._server_accepts_project_id_for_delete_file():
-        assert "projectId" in delete_spy.requests[0].variables
-        assert "projectId" in delete_spy.requests[0].query
-        assert delete_spy.requests[0].variables == {
-            "files": [file.id],
-            "projectId": run._project_internal_id,
-        }
-    # For some older server versions, the projectId is not provided
-    else:
-        assert "projectId" not in delete_spy.requests[0].variables
-        assert "projectId" not in delete_spy.requests[0].query
-        assert delete_spy.requests[0].variables == {
-            "files": [file.id],
-        }
+    assert "projectId" in delete_spy.requests[0].variables
+    assert "projectId" in delete_spy.requests[0].query
+    assert delete_spy.requests[0].variables == {
+        "files": [file.id],
+        "projectId": run._project_internal_id,
+    }
 
 
 def test_run_parses_run_project_id(user, stub_run_gql_once):
     stub_run_gql_once(project_id="123")
     api = Api()
-    if not File(api.client, {})._server_accepts_project_id_for_delete_file():
-        pytest.skip("Server does not support project_id for deletion")
 
     with wandb.init(project="test") as run:
         run.log({"scalar": 1})
@@ -1065,8 +1049,6 @@ def test_run_parses_run_project_id(user, stub_run_gql_once):
 def test_run_fails_parse_run_project_id(user, stub_run_gql_once):
     stub_run_gql_once(project_id="Unparseable")
     api = Api()
-    if not File(api.client, {})._server_accepts_project_id_for_delete_file():
-        pytest.skip("Server does not support project_id for deletion")
 
     with wandb.init(project="test") as run:
         run.log({"scalar": 1})

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -270,7 +270,6 @@ class File(Attrs):
         self.client = client
         self._attrs = attrs
         self.run = run
-        self.server_supports_delete_file_with_project_id: bool | None = None
         self._download_decorated: Callable[..., Any] | None = None
         super().__init__(dict(attrs))
 
@@ -366,30 +365,21 @@ class File(Attrs):
     @normalize_exceptions
     def delete(self) -> None:
         """Delete the file from the W&B server."""
-        project_id_mutation_fragment = ""
-        project_id_variable_fragment = ""
         variable_values = {
             "files": [self.id],
+            "projectId": self.run._project_internal_id,
         }
 
-        # Add projectId to mutation and variables if the server supports it.
-        # Otherwise, do not include projectId in mutation for older server versions which do not support it.
-        if self._server_accepts_project_id_for_delete_file():
-            variable_values["projectId"] = self.run._project_internal_id
-            project_id_variable_fragment = ", $projectId: Int"
-            project_id_mutation_fragment = "projectId: $projectId"
-
-        mutation_string = """
-            mutation deleteFiles($files: [ID!]!{}) {{
-                deleteFiles(input: {{
+        mutation = gql("""
+            mutation deleteFiles($files: [ID!]!, $projectId: Int) {
+                deleteFiles(input: {
                     files: $files
-                    {}
-                }}) {{
+                    projectId: $projectId
+                }) {
                     success
-                }}
-            }}
-            """.format(project_id_variable_fragment, project_id_mutation_fragment)
-        mutation = gql(mutation_string)
+                }
+            }
+        """)
 
         self.client.execute(
             mutation,
@@ -400,36 +390,3 @@ class File(Attrs):
         classname = nameof(type(self))
         size = to_human_size(self.size, units=POW_2_BYTES)
         return f"<{classname} {self.name} ({self.mimetype}) {size}>"
-
-    @normalize_exceptions
-    def _server_accepts_project_id_for_delete_file(self) -> bool:
-        """Returns True if the server supports deleting files with a projectId.
-
-        This check is done by utilizing GraphQL introspection in the available fields on the DeleteFiles API.
-        """
-        query_string = """
-           query ProbeDeleteFilesProjectIdInput {
-                DeleteFilesProjectIdInputType: __type(name:"DeleteFilesInput") {
-                    inputFields{
-                        name
-                    }
-                }
-            }
-        """
-
-        # Only perform the query once to avoid extra network calls
-        if self.server_supports_delete_file_with_project_id is None:
-            query = gql(query_string)
-            res = self.client.execute(query)
-
-            # If projectId is in the inputFields, the server supports deleting files with a projectId
-            self.server_supports_delete_file_with_project_id = "projectId" in [
-                x["name"]
-                for x in (
-                    res.get("DeleteFilesProjectIdInputType", {}).get(
-                        "inputFields", [{}]
-                    )
-                )
-            ]
-
-        return self.server_supports_delete_file_with_project_id


### PR DESCRIPTION
[DeleteFilesInput.projectId](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L4675) exists in 0.63.0, the minimum supported server version.