### PR TITLE
refactor: drop gql introspection in runs.py

### DIFF
--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -10,26 +10,10 @@ from requests import HTTPError
 from wandb import Api
 from wandb.apis import internal
 from wandb.apis._generated import ProjectFragment, UserFragment
-from wandb.apis.public import runs
 from wandb.errors import UsageError
 from wandb.sdk import wandb_login
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.lib import wbauth
-
-
-@pytest.fixture(autouse=True)
-def patch_server_features(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Prevent unit tests from attempting to contact the real server."""
-    monkeypatch.setattr(
-        runs,
-        "_server_provides_project_id_for_run",
-        lambda *args, **kwargs: False,
-    )
-    monkeypatch.setattr(
-        runs,
-        "_server_provides_internal_id_for_project",
-        lambda *args, **kwargs: False,
-    )
 
 
 def test_api_auto_login_no_tty():

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -2,22 +2,6 @@ from unittest import mock
 
 import pytest
 import wandb
-from wandb.apis.public import runs
-
-
-@pytest.fixture(autouse=True)
-def patch_server_features(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Prevent unit tests from attempting to contact the real server."""
-    monkeypatch.setattr(
-        runs,
-        "_server_provides_project_id_for_run",
-        lambda *args, **kwargs: False,
-    )
-    monkeypatch.setattr(
-        runs,
-        "_server_provides_internal_id_for_project",
-        lambda *args, **kwargs: False,
-    )
 
 
 @pytest.mark.parametrize(

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -48,7 +48,7 @@ from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import SizedPaginator
 from wandb.apis.public import utils
 from wandb.apis.public.const import RETRY_TIMEDELTA
-from wandb.apis.public.runs import Run, _server_provides_internal_id_for_project
+from wandb.apis.public.runs import Run
 from wandb.sdk.lib import retry
 from wandb.util import POW_2_BYTES, download_file_from_url, no_retry_auth, to_human_size
 
@@ -110,13 +110,12 @@ class Files(SizedPaginator["File"]):
 
     def _get_query(self) -> Document:
         """Generate query dynamically based on server capabilities."""
-        with_internal_id = _server_provides_internal_id_for_project(self.client)
         return gql(
             f"""
             query RunFiles($project: String!, $entity: String!, $name: String!, $fileCursor: String,
                 $fileLimit: Int = 50, $fileNames: [String] = [], $upload: Boolean = false, $pattern: String) {{
                 project(name: $project, entityName: $entity) {{
-                    {"internalId" if with_internal_id else ""}
+                    internalId
                     run(name: $name) {{
                         fileCount
                         ...RunFilesFragment

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -127,9 +127,7 @@ RUN_FRAGMENT_NAME = "RunFragment"
 LIGHTWEIGHT_RUN_FRAGMENT_NAME = "LightweightRunFragment"
 
 
-def _create_runs_query(
-    *, lazy: bool, with_internal_id: bool, with_project_id: bool
-) -> gql:
+def _create_runs_query(*, lazy: bool) -> gql:
     """Create GraphQL query for runs with appropriate fragment."""
     fragment = LIGHTWEIGHT_RUN_FRAGMENT if lazy else RUN_FRAGMENT
     fragment_name = LIGHTWEIGHT_RUN_FRAGMENT_NAME if lazy else RUN_FRAGMENT_NAME
@@ -138,13 +136,13 @@ def _create_runs_query(
         f"""#graphql
         query Runs($project: String!, $entity: String!, $cursor: String, $perPage: Int = 50, $order: String, $filters: JSONString) {{
             project(name: $project, entityName: $entity) {{
-                {"internalId" if with_internal_id else ""}
+                internalId
                 runCount(filters: $filters)
                 readOnly
                 runs(filters: $filters, after: $cursor, first: $perPage, order: $order) {{
                     edges {{
                         node {{
-                            {"projectId" if with_project_id else ""}
+                            projectId
                             ...{fragment_name}
                         }}
                         cursor
@@ -159,48 +157,6 @@ def _create_runs_query(
         {fragment}
         """
     )
-
-
-@normalize_exceptions
-def _server_provides_internal_id_for_project(client: RetryingClient) -> bool:
-    """Returns True if the server allows us to query the internalId field for a project."""
-    query_string = """
-       query ProbeProjectInput {
-            ProjectType: __type(name:"Project") {
-                fields {
-                    name
-                }
-            }
-        }
-    """
-
-    # Only perform the query once to avoid extra network calls
-    query = gql(query_string)
-    res = client.execute(query)
-    return "internalId" in [
-        x["name"] for x in (res.get("ProjectType", {}).get("fields", [{}]))
-    ]
-
-
-@normalize_exceptions
-def _server_provides_project_id_for_run(client: RetryingClient) -> bool:
-    """Returns True if the server allows us to query the projectId field for a run."""
-    query_string = """
-       query ProbeRunInput {
-            RunType: __type(name:"Run") {
-                fields {
-                    name
-                }
-            }
-        }
-    """
-
-    # Only perform the query once to avoid extra network calls
-    query = gql(query_string)
-    res = client.execute(query)
-    return "projectId" in [
-        x["name"] for x in (res.get("RunType", {}).get("fields", [{}]))
-    ]
 
 
 @normalize_exceptions
@@ -265,11 +221,7 @@ class Runs(SizedPaginator["Run"]):
         if not order:
             order = "+created_at"
 
-        self.QUERY = _create_runs_query(
-            lazy=lazy,
-            with_internal_id=_server_provides_internal_id_for_project(client),
-            with_project_id=_server_provides_project_id_for_run(client),
-        )
+        self.QUERY = _create_runs_query(lazy=lazy)
 
         self.entity = entity
         self.project = project
@@ -480,11 +432,7 @@ class Runs(SizedPaginator["Run"]):
         self._lazy = False
 
         # Regenerate query with full fragment
-        self.QUERY = _create_runs_query(
-            lazy=False,
-            with_internal_id=_server_provides_internal_id_for_project(self.client),
-            with_project_id=_server_provides_project_id_for_run(self.client),
-        )
+        self.QUERY = _create_runs_query(lazy=False)
 
         # Upgrade any existing runs that have been loaded - use parallel loading for performance
         lazy_runs = [run for run in self.objects if run._lazy]
@@ -570,7 +518,6 @@ class Run(Attrs):
         self._metadata: dict[str, Any] | None = None
         self._state = _attrs.get("state", "not found")
         self.server_provides_internal_id_field: bool | None = None
-        self._server_provides_project_id_field: bool | None = None
         self._is_loaded: bool = False
         self._service_api: ServiceApi | None = service_api
 
@@ -722,18 +669,12 @@ class Run(Attrs):
         self, fragment: str, fragment_name: str, force: bool = False
     ) -> dict[str, Any]:
         """Load run data using specified GraphQL fragment."""
-        # Cache the server capability check to avoid repeated network calls
-        if self._server_provides_project_id_field is None:
-            self._server_provides_project_id_field = (
-                _server_provides_project_id_for_run(self.client)
-            )
-
         query = gql(
             f"""#graphql
         query Run($project: String!, $entity: String!, $name: String!) {{
             project(name: $project, entityName: $entity) {{
                 run(name: $name) {{
-                    {"projectId" if self._server_provides_project_id_field else ""}
+                    projectId
                     ...{fragment_name}
                 }}
             }}


### PR DESCRIPTION
[Run.projectId](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L1133) and [Project.internalId](https://github.com/wandb/core/blob/local/v0.63.0/services/gorilla/schema.graphql#L642) are in 0.63.0, the minimum supported server version.