### PR TITLE
refactor: drop internal api server_settings_introspection()

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -342,7 +342,6 @@ class Api:
         self._azure_blob_module = util.get_module("azure.storage.blob")
 
         self._max_cli_version: str | None = None
-        self._server_settings_type: list[str] | None = None
 
         self._server_features_cache: dict[str, bool] | None = None
 
@@ -561,33 +560,6 @@ class Api:
             run = run or slug or self.current_run_id or env.get_run(env=self._environ)
             assert run, "run must be specified"
         return project, run
-
-    @normalize_exceptions
-    def server_settings_introspection(self) -> None:
-        query_string = """
-           query ProbeServerSettings {
-               ServerSettingsType: __type(name: "ServerSettings") {
-                   ...fieldData
-                }
-            }
-
-            fragment fieldData on __Type {
-                fields {
-                    name
-                }
-            }
-        """
-        if self._server_settings_type is None:
-            query = gql(query_string)
-            res = self.gql(query)
-            self._server_settings_type = (
-                [
-                    field.get("name", "")
-                    for field in res.get("ServerSettingsType", {}).get("fields", [{}])
-                ]
-                if res
-                else []
-            )
 
     @normalize_exceptions
     def fail_run_queue_item(
@@ -1823,7 +1795,7 @@ class Api:
         sweep_name: str | None = None,
         summary_metrics: str | None = None,
         num_retries: int | None = None,
-    ) -> tuple[dict, bool, list | None]:
+    ) -> tuple[dict, bool]:
         """Update a run.
 
         Args:
@@ -1908,29 +1880,10 @@ class Api:
                     historyLineCount
                 }
                 inserted
-                _Server_Settings_
             }
         }
         """
-        self.server_settings_introspection()
 
-        server_settings_string = (
-            """
-        serverSettings {
-                serverMessages{
-                    utfText
-                    plainText
-                    htmlText
-                    messageType
-                    messageLevel
-                }
-         }
-        """
-            if self._server_settings_type
-            else ""
-        )
-
-        query_string = query_string.replace("_Server_Settings_", server_settings_string)
         mutation = gql(query_string)
         config_str = json.dumps(config) if config else None
         if not description or description.isspace():
@@ -1988,18 +1941,9 @@ class Api:
             if entity_obj:
                 self.set_setting("entity", entity_obj["name"])
 
-        server_messages = None
-        if self._server_settings_type:
-            server_messages = (
-                response["upsertBucket"]
-                .get("serverSettings", {})
-                .get("serverMessages", [])
-            )
-
         return (
             response["upsertBucket"]["bucket"],
             response["upsertBucket"]["inserted"],
-            server_messages,
         )
 
     @normalize_exceptions

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -219,7 +219,6 @@ class SendManager:
     _rewind_response: dict[str, Any] | None
     _cached_server_info: dict[str, Any]
     _cached_viewer: dict[str, Any]
-    _server_messages: list[dict[str, Any]]
     _ds: datastore.DataStore | None
     _output_raw_streams: dict[StreamLiterals, _OutputRawStream]
     _output_raw_file: filesystem.CRDedupedFile | None
@@ -273,7 +272,6 @@ class SendManager:
 
         self._cached_server_info = dict()
         self._cached_viewer = dict()
-        self._server_messages = []
 
         # State updated by resuming
         self._resume_state = ResumeState()
@@ -1010,10 +1008,9 @@ class SendManager:
         if is_rewinding:
             assert self._rewind_response
             server_run = self._rewind_response
-            server_messages = None
             inserted = True
         else:
-            server_run, inserted, server_messages = self._api.upsert_run(
+            server_run, inserted = self._api.upsert_run(
                 name=run.run_id,
                 entity=run.entity or None,
                 project=run.project or None,
@@ -1035,7 +1032,6 @@ class SendManager:
         if run.sweep_id:
             self._job_builder.disable = True
 
-        self._server_messages = server_messages or []
         self._run = run
 
         if self._resume_state.resumed and is_rewinding:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -621,19 +621,17 @@ class Scheduler(ABC):
     def _create_run(self) -> dict[str, Any]:
         """Use the public api to create a blank run."""
         try:
-            run: list[dict[str, Any]] = self._api.upsert_run(
+            server_run, inserted = self._api.upsert_run(
                 project=self._project,
                 entity=self._entity,
                 sweep_name=self._sweep_id,
             )
-            if run:
-                return run[0]
+            return server_run
         except Exception as e:
             _logger.debug(f"[_create_run] {e}")
             raise SchedulerError(
                 "Error creating run from scheduler, check API connection and CLI version."
             )
-        return {}
 
     def _set_sweep_state(self, state: str) -> None:
         wandb.termlog(f"{LOG_PREFIX}Updating sweep state to: {state.lower()}")


### PR DESCRIPTION
The `ServerSettings` type seems to have never existed according to `git log -S'ServerSettings'` in the core repo. I'd guess this was planned and never added?

I grepped for `\bupsert_bucket\(` and found only two callsites that use the return values, so I deleted its third return value and updated the callsites.