### PR TITLE
chore: action to ban new GraphQL introspection

### DIFF
--- a/.github/scripts/ban-graphql-introspection-test.sh
+++ b/.github/scripts/ban-graphql-introspection-test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tests ban-graphql-introspection.sh.
+#
+# Exits with code 1 if something doesn't work.
+
+set -euo pipefail
+
+SHELL_SCRIPT=$( realpath "${0/%-test.sh/.sh}" )
+echo "Script path is $SHELL_SCRIPT"
+
+# Create an empty git repo in a temporary directory.
+TEMP_DIR=$( mktemp -d )
+cd "$TEMP_DIR"
+echo "Testing in $TEMP_DIR"
+git init
+# git commit requires name and email
+git config user.name "Anonymous"
+git config user.email "<>"
+
+
+# Set up a test file and add GQL introspection to it.
+TEST_FILE=ban-graphql-introspection.txt
+
+# Initial content:
+cat >"$TEST_FILE" <<EOF
+Line 1 contains __type but is unchanged.
+Line 2 contains __type but will be deleted.
+EOF
+git add "$TEST_FILE" && git commit -m initial
+
+# Updated content:
+cat >"$TEST_FILE" <<EOF
+Line 1 contains __type but is unchanged.
+Line 2 had GQL introspection that got removed.
+Line 3 uses __schema, which is not allowed.
+Line 4 uses __type, also not allowed.
+Line 5 uses __typename, which is OK.
+EOF
+git add "$TEST_FILE" && git commit -m initial
+
+
+# Check that the expected output is produced.
+# The script exits with code 1, which we just ignore.
+RESULT=$( bash "$SHELL_SCRIPT" || exit 0 )
+EXPECTED="\
+===================================================================
+Found text that looks like GraphQL introspection.
+The SDK may not rely on GraphQL introspection because it is
+turned off in some W&B server deployments, and may eventually
+be turned off in SaaS.
+
+If this finding is wrong, include this text in your PR description:
+  I solemnly swear I am not adding GQL introspection.
+===================================================================
+ACTION is 'unset', emitting error annotations.
+
+********************************************************************************
+ban-graphql-introspection.txt
+********************************************************************************
+-Line 2 contains __type but will be deleted.
++Line 2 had GQL introspection that got removed.
++Line 3 uses __schema, which is not allowed.
+::error file=ban-graphql-introspection.txt,line=3::Potential GraphQL introspection here.
++Line 4 uses __type, also not allowed.
+::error file=ban-graphql-introspection.txt,line=4::Potential GraphQL introspection here.
+PR_REF not set, exiting with code 1 without checking PR description."
+
+# Exits with code 1 if there's a diff.
+diff -c1 <( echo "$EXPECTED" ) <( echo "$RESULT" )
+echo "*** PASSED TEST ***"

--- a/.github/scripts/ban-graphql-introspection.py
+++ b/.github/scripts/ban-graphql-introspection.py
@@ -1,0 +1,65 @@
+"""Finds GQL introspection in git diff patch output.
+
+Takes the output of `git show -p --unified=0` and looks for added lines
+that include GQL introspection. Outputs GitHub workflow "::error" commands.
+"""
+
+# ruff: noqa T201 (allow print())
+
+from __future__ import annotations
+
+import re
+from collections import deque
+
+MESSAGE = "Potential GraphQL introspection here."
+
+file_context: str = ""
+context: deque[str] = deque(maxlen=3)  # up to 3 lines of context for errors
+file: str | None = None
+line: int | None = None
+
+while True:
+    try:
+        text = input()
+    except EOFError:
+        break
+
+    # Extract file names and line numbers from patch headers:
+    if text.startswith("+++ b/"):
+        file = text[6:]
+        file_context = file
+        context.clear()
+        continue
+    if match := re.match(r"^@@ \S+ \+(\d+)", text):
+        line = int(match.group(1))
+        continue
+
+    # Accumulate context to display before errors.
+    #
+    # GitHub replaces ::error printouts with their message in the logs,
+    # making the logs a series of
+    #   Error: Potential GraphQL introspection here.
+    #   Error: Potential GraphQL introspection here.
+    #   Error: Potential GraphQL introspection here.
+    #   Error: Potential GraphQL introspection here.
+    # lines that aren't useful on their own.
+    if len(text) > 0 and text[0] in "+- ":
+        context.append(text)
+
+    # Check for added lines containing GQL introspection.
+    if text.startswith("+"):
+        if file is None or line is None:
+            raise AssertionError
+
+        if re.search(r"\b(__type|__schema)\b", text):
+            if file_context:
+                print("\n" + "*" * 80)
+                print(file_context)
+                print("*" * 80)
+                file_context = ""  # don't repeat filename unnecessarily
+            print("\n".join(context))
+            context.clear()
+
+            print(f"::error file={file},line={line}::{MESSAGE}")
+
+        line += 1

--- a/.github/scripts/ban-graphql-introspection.sh
+++ b/.github/scripts/ban-graphql-introspection.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bans GraphQL introspection.
+#
+# This finds any new lines in the current commit that look like they contain
+# GraphQL introspection. If it finds anything, it prints ::error commands that
+# GitHub can interpret to annotate the current PR and exits with code 1.
+#
+# See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message
+
+set -euo pipefail
+
+# Default values for environment variables.
+ACTION="${ACTION:-unset}"
+PR_REF="${PR_REF:-}"
+
+SCRIPT="${0/%.sh/.py}"
+MAGIC_WORDS="I solemnly swear I am not adding GQL introspection."
+
+# GitHub checks out the PR's "merge" branch, which is the proposed merge commit
+# on main. In this case, "HEAD^" refers to the first parent of the merge, which
+# is a commit on main, so the diff shows the changes the PR would make to main.
+PROBLEMS=$(
+    git diff -p --unified=0 --format=tformat: HEAD^ HEAD |
+    python "$SCRIPT"
+)
+if [[ -z "$PROBLEMS" ]]; then
+    echo "All good!"
+    exit 0
+fi
+
+echo "==================================================================="
+echo "Found text that looks like GraphQL introspection."
+echo "The SDK may not rely on GraphQL introspection because it is"
+echo "turned off in some W&B server deployments, and may eventually"
+echo "be turned off in SaaS."
+echo
+echo "If this finding is wrong, include this text in your PR description:"
+echo "  $MAGIC_WORDS"
+echo "==================================================================="
+
+# Output error annotations unless there's no new commit.
+case "$ACTION" in
+    edited)
+        echo "Not emitting new error annotations for a PR description edit."
+        ;;
+
+    *)
+        echo "ACTION is '$ACTION', emitting error annotations."
+        echo "$PROBLEMS"
+        ;;
+esac
+
+if [[ -z "$PR_REF" ]]; then
+    echo "PR_REF not set, exiting with code 1 without checking PR description."
+    exit 1
+fi
+
+PR_DESC=$( gh pr view --json body --template '{{.body}}' "$PR_REF" )
+if [[ "$PR_DESC" == *"$MAGIC_WORDS"* ]]; then
+    echo "PR contained magic words, exiting with code 0."
+    exit 0
+else
+    echo "PR did not contain magic words, exiting with code 1."
+    exit 1
+fi

--- a/.github/workflows/ban-graphql-introspection.yml
+++ b/.github/workflows/ban-graphql-introspection.yml
@@ -1,0 +1,32 @@
+name: Ban GraphQL introspection
+
+on:
+  pull_request:
+    types:
+      # Default types: any change to a PR's contents.
+      - opened
+      - reopened
+      - synchronize
+      # Also trigger if a PR's description changes to detect the magic words
+      # that disable this check.
+      - edited
+
+jobs:
+  ban-graphql-introspection:
+    name: Detect added GraphQL introspection
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2 # To allow diffing against HEAD^
+
+      - name: Test self
+        run: .github/scripts/ban-graphql-introspection-test.sh
+
+      - name: Run ban-graphql-introspection.sh
+        run: .github/scripts/ban-graphql-introspection.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTION: ${{ github.event.action }}
+          PR_REF: ${{ github.head_ref }}


### PR DESCRIPTION
Adds a GitHub workflow that finds `__type` or `__schema` on new lines and emits errors.

We can make this a required check because it can be bypassed by adding this text to a PR's description:

> I solemnly swear I am not adding GQL introspection.

That causes the check to exit with code 0 (so it's marked successful) but keeps the error annotations (see the annotations on this PR).