### PR TITLE
fix: orjson not built in editable wheel

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -83,6 +83,10 @@ class CustomBuildHook(BuildHookInterface):
         if self._include_gpu_stats():
             self._build_gpu_stats()
 
+        # Build vendored orjson if not skipped.
+        if self._include_orjson():
+            self._build_orjson()
+
     def _get_platform_tag(self) -> str:
         """Returns the platform tag for the current platform."""
         # Replace dots, spaces and dashes with underscores following


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

when building wandb locally in an editable wheel, then vendored orjson is never built.
This may cause issue when it is built manually for one python version but gets used in a different version later since its not rebuilt. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
