### PR TITLE
refactor: improve ServicePollForTokenError message

### DIFF
--- a/tests/unit_tests/test_lib/test_service_port_file.py
+++ b/tests/unit_tests/test_lib/test_service_port_file.py
@@ -107,7 +107,7 @@ def test_fails_if_no_known_connection_method(tmp_path, running_process):
 def test_times_out_if_file_never_created(tmp_path, running_process):
     with pytest.raises(
         service_port_file.ServicePollForTokenError,
-        match="Failed to read port info after 30 seconds.",
+        match="Failed to read port info after 30 seconds",
     ):
         service_port_file.poll_for_token(
             tmp_path / "ports",
@@ -122,7 +122,7 @@ def test_times_out_if_file_incomplete(tmp_path, running_process):
 
     with pytest.raises(
         service_port_file.ServicePollForTokenError,
-        match="Failed to read port info after 30 seconds.",
+        match="Failed to read port info after 30 seconds",
     ):
         service_port_file.poll_for_token(
             port_file,

--- a/wandb/sdk/lib/service/service_port_file.py
+++ b/wandb/sdk/lib/service/service_port_file.py
@@ -61,7 +61,8 @@ def poll_for_token(
         _SLEEP(max(0, min(0.2, end_time - _MONOTONIC())))
 
     raise ServicePollForTokenError(
-        f"Failed to read port info after {timeout} seconds.",
+        f"Failed to read port info after {timeout} seconds"
+        + f" (wandb-core PID={proc.pid}): {file}",
     )
 
 


### PR DESCRIPTION
Adds the `wandb-core` PID and the port file path to the `ServicePollForTokenError` message to help debug.

One can look at the port file and check whether it exists, its permissions and its contents. The file isn't usually deleted when `wandb-core` exits, so if it doesn't exist that means it wasn't written (but this can change in the future). The PID can be useful to tell if `wandb-core` is still running (though if the error stopped the user's script, then `wandb-core` probably exited anyway).