### PR TITLE
refactor: use ServiceApi.feature_enabled() in Api

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -47,7 +47,7 @@ from wandb.errors import UsageError
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
 from wandb.sdk import wandb_login, wandb_setup
-from wandb.sdk.artifacts._gqlutils import resolve_org_entity_name, server_supports
+from wandb.sdk.artifacts._gqlutils import resolve_org_entity_name
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.launch.utils import LAUNCH_DEFAULT_PROJECT
 from wandb.sdk.lib import retry, runid, wbauth
@@ -1801,10 +1801,11 @@ class Api:
         )
         ```
         """
-        if not server_supports(self.client, pb.ARTIFACT_REGISTRY_SEARCH):
+        if not self._service_api.feature_enabled(pb.ARTIFACT_REGISTRY_SEARCH):
             raise RuntimeError(
-                "Registry search API is not enabled on this wandb server version. "
-                "Please upgrade your server version or contact support at support@wandb.com."
+                "Registry search API is not enabled on this wandb server version."
+                + " Please upgrade your server version or contact support"
+                + " at support@wandb.com."
             )
 
         organization = organization or fetch_org_from_settings_or_entity(
@@ -1841,10 +1842,11 @@ class Api:
         registry.save()
         ```
         """
-        if not server_supports(self.client, pb.ARTIFACT_REGISTRY_SEARCH):
+        if not self._service_api.feature_enabled(pb.ARTIFACT_REGISTRY_SEARCH):
             raise RuntimeError(
-                "api.registry() is not enabled on this wandb server version. "
-                "Please upgrade your server version or contact support at support@wandb.com."
+                "api.registry() is not enabled on this wandb server version."
+                + " Please upgrade your server version or contact support"
+                + " at support@wandb.com."
             )
         organization = organization or fetch_org_from_settings_or_entity(
             self.settings, self.default_entity
@@ -1898,12 +1900,13 @@ class Api:
         )
         ```
         """
-        if not server_supports(
-            self.client, pb.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION
+        if not self._service_api.feature_enabled(
+            pb.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION,
         ):
             raise RuntimeError(
-                "create_registry api is not enabled on this wandb server version. "
-                "Please upgrade your server version or contact support at support@wandb.com."
+                "create_registry api is not enabled on this wandb server version."
+                + " Please upgrade your server version or contact support"
+                + " at support@wandb.com."
             )
 
         organization = organization or fetch_org_from_settings_or_entity(
@@ -2052,12 +2055,12 @@ class Api:
         supports_event = (
             (event is None)
             or (event in ALWAYS_SUPPORTED_EVENTS)
-            or server_supports(self.client, f"AUTOMATION_EVENT_{event.value}")
+            or self._service_api.feature_enabled(f"AUTOMATION_EVENT_{event.value}")
         )
         supports_action = (
             (action is None)
             or (action in ALWAYS_SUPPORTED_ACTIONS)
-            or server_supports(self.client, f"AUTOMATION_ACTION_{action.value}")
+            or self._service_api.feature_enabled(f"AUTOMATION_ACTION_{action.value}")
         )
         return supports_event and supports_action
 

--- a/wandb/apis/public/service_api.py
+++ b/wandb/apis/public/service_api.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import uuid
 import weakref
+from typing import cast
 
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_api_pb2 import ApiRequest, ApiResponse, FeaturesRequest
@@ -82,7 +83,7 @@ class ServiceApi:
 
     def feature_enabled(
         self,
-        feature: pb.ServerFeature,
+        feature: pb.ServerFeature | str,
         *,
         timeout: float = 10,
     ) -> bool:
@@ -91,9 +92,24 @@ class ServiceApi:
         On timeout or normal error, this logs and returns False.
 
         Args:
-            feature: The name of a boolean feature to check.
+            feature: The enum constant or name of the boolean feature to
+                check. Prefer to use the enum constants when possible, since
+                they have better type-checking. For unknown or incorrect names,
+                this returns False.
             timeout: The timeout to use. Defaults to 10 seconds.
         """
+        if isinstance(feature, str):
+            try:
+                # NOTE: pb.ServerFeature is not an actual runtime type.
+                #
+                # All protobuf enums are represented as integers.
+                # It is guaranteed that the return value of Value
+                # is a valid enum (if it exists), hence the cast.
+                feature = cast(pb.ServerFeature, pb.ServerFeature.Value(feature))
+            except ValueError:
+                # SERVER_FEATURE_UNSPECIFIED is always disabled.
+                return False
+
         req = ApiRequest(features_request=FeaturesRequest(features=[feature]))
 
         try:

--- a/wandb/sdk/artifacts/_gqlutils.py
+++ b/wandb/sdk/artifacts/_gqlutils.py
@@ -31,7 +31,7 @@ def org_info_from_entity(
 
 
 @lru_cache(maxsize=16)
-def server_features(client: RetryingClient) -> dict[str, bool]:
+def _server_features(client: RetryingClient) -> dict[str, bool]:
     """Returns a mapping of `{server_feature_name (str) -> is_enabled (bool)}`.
 
     Results are cached per client instance.
@@ -54,6 +54,9 @@ def server_features(client: RetryingClient) -> dict[str, bool]:
 def server_supports(client: RetryingClient, feature: str | int) -> bool:
     """Return whether the current server supports the given feature.
 
+    NOTE: This is deprecated. Please use `ServiceApi.feature_enabled()` when
+    possible, like in all public API code.
+
     Good to use for features that have a fallback mechanism for older servers.
     """
     # If we're given the protobuf enum value, convert to a string name.
@@ -65,7 +68,7 @@ def server_supports(client: RetryingClient, feature: str | int) -> bool:
         name = ServerFeature.Name(feature) if isinstance(feature, int) else feature
     except ValueError:
         return False  # Invalid int-like value, assume unsupported
-    return server_features(client).get(name) or False
+    return _server_features(client).get(name) or False
 
 
 @dataclass(frozen=True)

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -621,6 +621,10 @@ class Api:
     def _server_supports(self, feature: int | str) -> bool:
         """Return whether the current server supports the given feature.
 
+        NOTE: This is deprecated. Outside of this file, please use
+        `ServiceApi.feature_enabled()`. The `ServiceApi` is a sort of
+        replacement to this "internal" `Api` class.
+
         This also caches the underlying lookup of server feature flags,
         and it maps {feature_name (str) -> is_enabled (bool)}.
 


### PR DESCRIPTION
Updates `Api` to use `ServiceApi.feature_enabled()` and adds notes to two similar functions (one in `InternalApi`, one standalone in Artifacts' `_gqlutils.py`) deprecating them and suggesting this alternative.