### PR TITLE
fix: race conditions in beta_scan_history

### DIFF
--- a/core/internal/runhistoryreader/reader.go
+++ b/core/internal/runhistoryreader/reader.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -17,6 +18,10 @@ import (
 
 // HistoryReader downloads and reads an existing run's logged metrics.
 type HistoryReader struct {
+	// mu serializes calls to GetHistorySteps and Release.
+	// The Rust FFI readers are not safe for concurrent use.
+	mu sync.Mutex
+
 	// graphqlClient is the client to use to query the W&B backend.
 	graphqlClient graphql.Client
 
@@ -101,11 +106,16 @@ func (h *HistoryReader) GetRunId() string {
 // GetHistorySteps gets all history rows for HistoryReader's keys
 // that fall between minStep and maxStep.
 // Returns a list of KVMapLists, where each item in the list is a history row.
+//
+// It is safe to call from multiple goroutines.
 func (h *HistoryReader) GetHistorySteps(
 	ctx context.Context,
 	minStep int64,
 	maxStep int64,
 ) ([]parquet.KeyValueList, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	results := []parquet.KeyValueList{}
 	for _, reader := range h.parquetReaders {
 		resultsForPartition, err := reader.ScanStepRange(ctx, minStep, maxStep)
@@ -145,7 +155,12 @@ func (h *HistoryReader) GetHistorySteps(
 
 // Release calls the Release method on each partition's ParquetDataIterator
 // and frees any Rust resources.
+//
+// It is safe to call from multiple goroutines.
 func (h *HistoryReader) Release() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	for _, reader := range h.parquetReaders {
 		reader.Release()
 	}

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -24,9 +25,20 @@ type RunHistoryAPIHandler struct {
 	graphqlClient graphql.Client
 	httpClient    *retryablehttp.Client
 
+	// mu protects scanHistoryReaders and downloadOperations from
+	// concurrent access by goroutines spawned in handleApi.
+	// RWMutex allows concurrent map reads while serializing writes.
+	mu sync.RWMutex
+
+	// rustArrowOnce guards one-time initialization of rustArrowWrapper.
+	rustArrowOnce sync.Once
+
 	// rustArrowWrapper is the wrapper for the Rust Arrow library.
 	// It is used to provide FFI functions to the Go code for reading parquet files.
 	rustArrowWrapper *ffi.RustArrowWrapper
+
+	// rustArrowInitializationErr records an error from initializing rustArrowWrapper.
+	rustArrowInitializationErr error
 
 	// currentRequestId is the id of the last scan init request made.
 	//
@@ -91,19 +103,20 @@ func (f *RunHistoryAPIHandler) HandleRequest(
 func (f *RunHistoryAPIHandler) handleScanRunHistoryInit(
 	request *spb.ScanRunHistoryInit,
 ) *spb.ApiResponse {
-	if f.rustArrowWrapper == nil {
-		rustArrowWrapper, err := ffi.NewRustArrowWrapper()
-		if err != nil {
-			return &spb.ApiResponse{
-				Response: &spb.ApiResponse_ApiErrorResponse{
-					ApiErrorResponse: &spb.ApiErrorResponse{
-						Message: "RustArrowWrapper not initialized.",
-					},
+	f.rustArrowOnce.Do(func() {
+		f.rustArrowWrapper, f.rustArrowInitializationErr = ffi.NewRustArrowWrapper()
+	})
+	if f.rustArrowInitializationErr != nil {
+		return &spb.ApiResponse{
+			Response: &spb.ApiResponse_ApiErrorResponse{
+				ApiErrorResponse: &spb.ApiErrorResponse{
+					Message: fmt.Sprintf(
+						"RustArrowWrapper initialization failed: %v",
+						f.rustArrowInitializationErr,
+					),
 				},
-			}
+			},
 		}
-
-		f.rustArrowWrapper = rustArrowWrapper
 	}
 
 	localHub := sentry.CurrentHub().Clone()
@@ -140,7 +153,9 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryInit(
 		}
 	}
 
+	f.mu.Lock()
 	f.scanHistoryReaders[requestId] = historyReader
+	f.mu.Unlock()
 
 	return &spb.ApiResponse{
 		Response: &spb.ApiResponse_ReadRunHistoryResponse{
@@ -162,7 +177,9 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryRead(
 ) *spb.ApiResponse {
 	requestId := request.GetRequestId()
 
+	f.mu.RLock()
 	historyReader, ok := f.scanHistoryReaders[requestId]
+	f.mu.RUnlock()
 
 	if !ok || historyReader == nil {
 		return &spb.ApiResponse{
@@ -253,10 +270,16 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryCleanup(
 	request *spb.ScanRunHistoryCleanup,
 ) *spb.ApiResponse {
 	requestId := request.GetRequestId()
+
+	f.mu.Lock()
 	historyReader, ok := f.scanHistoryReaders[requestId]
 	if ok && historyReader != nil {
-		historyReader.Release()
 		delete(f.scanHistoryReaders, requestId)
+	}
+	f.mu.Unlock()
+
+	if ok && historyReader != nil {
+		historyReader.Release()
 	}
 
 	return &spb.ApiResponse{
@@ -332,7 +355,10 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistoryInit(
 	}
 
 	requestId := f.currentRequestId.Add(1)
+
+	f.mu.Lock()
 	f.downloadOperations[requestId] = downloadOperation
+	f.mu.Unlock()
 
 	return &spb.ApiResponse{
 		Response: &spb.ApiResponse_ReadRunHistoryResponse{
@@ -352,7 +378,13 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistoryInit(
 func (f *RunHistoryAPIHandler) handleDownloadRunHistory(
 	request *spb.DownloadRunHistory,
 ) *spb.ApiResponse {
+	f.mu.Lock()
 	downloadOperation, ok := f.downloadOperations[request.GetRequestId()]
+	if ok {
+		delete(f.downloadOperations, request.GetRequestId())
+	}
+	f.mu.Unlock()
+
 	if !ok || downloadOperation == nil {
 		return &spb.ApiResponse{
 			Response: &spb.ApiResponse_ApiErrorResponse{
@@ -368,8 +400,6 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistory(
 	for file, err := range errors {
 		errorsMap[file] = err.Error()
 	}
-
-	delete(f.downloadOperations, request.GetRequestId())
 	return &spb.ApiResponse{
 		Response: &spb.ApiResponse_ReadRunHistoryResponse{
 			ReadRunHistoryResponse: &spb.ReadRunHistoryResponse{
@@ -391,7 +421,10 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistoryStatus(
 ) *spb.ApiResponse {
 	requestId := request.GetRequestId()
 
+	f.mu.RLock()
 	downloadOperation, ok := f.downloadOperations[requestId]
+	f.mu.RUnlock()
+
 	if !ok || downloadOperation == nil {
 		return &spb.ApiResponse{
 			Response: &spb.ApiResponse_ApiErrorResponse{


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes: WB-32660

What does the PR do? Include a concise description of the PR contents.

Fixes multiple possible race conditions which could cause seg faults when reading/cleaning up scans over multiple threads.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [ ] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

Sample script - creates and shares a beta scan history object across multiple threads to force a segfault

```python
import concurrent.futures
import os

os.environ["WANDB_SILENT"] = "true"

import wandb

wandb.login(host="https://api.wandb.ai")

api = wandb.Api(timeout=300)
run = api.run("jacobromerotest/perf-run-width/runs/1tygovch")
list(run.beta_scan_history(keys=None, page_size=10, max_step=10))

scan = run.beta_scan_history(keys=None, page_size=500)
iter(scan)

def read_page(thread_id):
    scan._load_next()
    return thread_id, len(scan.rows)

with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
    futures = [pool.submit(read_page, i) for i in range(6)]
    for f in concurrent.futures.as_completed(futures, timeout=180):
        f.result()
        
```

###   
After this change

- no segfault

### Before this change

```bash
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1040ac4f0]

goroutine 40 [running]:
sync.(*WaitGroup).Go.func1.1()
        /Users/jacob.romero/.local/share/mise/installs/go/1.26.1/src/sync/waitgroup.go:251 +0x48
panic({0x1070b1040?, 0x10772f0d0?})
        /Users/jacob.romero/.local/share/mise/installs/go/1.26.1/src/runtime/panic.go:860 +0x12c
github.com/wandb/wandb/core/internal/runhistoryreader/parquet/iterator.(*RowGroupIterator).Value(0x3bc42a9e05a0)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/runhistoryreader/parquet/iterator/row_group_iterator.go:152 +0x134
github.com/wandb/wandb/core/internal/runhistoryreader/parquet/iterator.(*ParquetDataIterator).Value(...)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/runhistoryreader/parquet/iterator/parquet_data_iterator.go:119
github.com/wandb/wandb/core/internal/runhistoryreader/parquet/iterator.(*multiIterator).Value(...)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/runhistoryreader/parquet/iterator/multi_iterator.go:29
github.com/wandb/wandb/core/internal/runhistoryreader.(*HistoryReader).getParquetHistory(0x3bc4364b1540, {0x107510b48, 0x1077c9ea0}, 0x0, 0x1f4)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/runhistoryreader/reader.go:164 +0x1c4
github.com/wandb/wandb/core/internal/runhistoryreader.(*HistoryReader).GetHistorySteps(0x3bc4364b1540, {0x107510b48, 0x1077c9ea0}, 0x0, 0x1f4)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/runhistoryreader/reader.go:98 +0x3c
github.com/wandb/wandb/core/internal/wbapi.(*RunHistoryAPIHandler).handleScanRunHistoryRead(0x3bc437286501?, 0x3bc42f96d340)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/wbapi/readrunhistoryhandler.go:182 +0x98
github.com/wandb/wandb/core/internal/wbapi.(*RunHistoryAPIHandler).HandleRequest(0x3bc432215560?, 0x3bc4408fa0f0?)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/wbapi/readrunhistoryhandler.go:87 +0xc8
github.com/wandb/wandb/core/internal/wbapi.(*WandbAPI).HandleRequest(0x3bc4284223a8, {0x3bc42987c180?, 0x0?}, 0x3bc42a9e0a50)
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/internal/wbapi/wbapi.go:49 +0x90
github.com/wandb/wandb/core/pkg/server.(*Connection).handleApi.func1()
        /Users/jacob.romero/workspace/wandb-wt/betascanmt/core/pkg/server/connection.go:691 +0x34
sync.(*WaitGroup).Go.func1()
        /Users/jacob.romero/.local/share/mise/installs/go/1.26.1/src/sync/waitgroup.go:258 +0x48
created by sync.(*WaitGroup).Go in goroutine 
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->