### PR TITLE
refactor: add module_user fixture for automations tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ import pytest
 import wandb
 import wandb.util
 from click.testing import CliRunner
-from wandb import Api
 from wandb.errors import term
 from wandb.sdk.interface.interface_queue import InterfaceQueue
 from wandb.sdk.lib import filesystem, module, runid, wbauth
@@ -238,12 +237,6 @@ def env_teardown():
 def clean_up():
     yield
     wandb.teardown()
-
-
-@pytest.fixture
-def api() -> Api:
-    with unittest.mock.patch("wandb.sdk.wandb_login._verify_login"):
-        return Api()
 
 
 # --------------------------------

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import os
+import contextlib
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass
 from typing import Callable
 
 import pytest
+import wandb
 
 from tests.fixtures.wandb_backend_spy import (
     WandbBackendProxy,
@@ -94,15 +95,85 @@ def wandb_verbose(request):
 
 
 @pytest.fixture
-def user(mocker, backend_fixture_factory) -> Iterator[str]:
+def user(
+    request: pytest.FixtureRequest,
+    backend_fixture_factory: BackendFixtureFactory,
+) -> Iterator[str]:
+    """A user created for the duration of a test.
+
+    This cannot be used together with module_user. If module_user is also
+    requested by the test or one of its fixtures, this raises an error.
+
+    Sets login-related environment variables.
+    """
+    if "module_user" in request.fixturenames:
+        message = "Cannot use `user` and `module_user` fixtures together."
+        raise AssertionError(message)
+
+    with _user(backend_fixture_factory) as user:
+        yield user
+
+
+@pytest.fixture(scope="module")
+def module_user(
+    backend_fixture_factory: BackendFixtureFactory,
+) -> Iterator[str]:
+    """A new user shared by all tests in a module.
+
+    Just like `user`, but is shared by multiple tests.
+
+    This is used in some test files with many tests where mutating the same
+    test user's data does not affect correctness, and creating a user for
+    each test is slow.
+    """
+    with _user(backend_fixture_factory) as user:
+        yield user
+
+
+@contextlib.contextmanager
+def _user(backend_fixture_factory: BackendFixtureFactory) -> Iterator[str]:
     username = backend_fixture_factory.make_user()
-    envvars = {
-        "WANDB_API_KEY": username,
-        "WANDB_ENTITY": username,
-        "WANDB_USERNAME": username,
-    }
-    mocker.patch.dict(os.environ, envvars)
-    yield username
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("WANDB_API_KEY", username)
+        monkeypatch.setenv("WANDB_ENTITY", username)
+        monkeypatch.setenv("WANDB_USERNAME", username)
+
+        yield username
+
+
+@pytest.fixture
+@pytest.mark.usefixtures("skip_verify_login")
+def api(user: str) -> wandb.Api:
+    """A wandb.Api that can be used for the duration of a test."""
+    return wandb.Api(api_key=user)
+
+
+@pytest.fixture
+def module_api(make_module_api: Callable[[], wandb.Api]) -> wandb.Api:
+    """A wandb.Api using the `module_user` fixture.
+
+    Despite the name, this is function-scoped and exists only to force tests
+    to be explicit when they rely on `module_user`.
+
+    Module-scoped fixtures should use `make_module_api` directly.
+    """
+    return make_module_api()
+
+
+@pytest.fixture(scope="module")
+@pytest.mark.usefixtures("skip_verify_login")
+def make_module_api(module_user: str) -> Callable[[], wandb.Api]:
+    """A callback that creates a wandb.Api using the `module_user` fixture.
+
+    The returned object becomes invalid after `wandb.teardown()`, which is
+    called between tests.
+    """
+
+    def callback() -> wandb.Api:
+        return wandb.Api(api_key=module_user)
+
+    return callback
 
 
 @dataclass

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -7,7 +7,7 @@ from string import ascii_lowercase, digits
 from typing import Callable, Union
 
 import wandb
-from pytest import FixtureRequest, MonkeyPatch, fixture, skip
+from pytest import FixtureRequest, fixture, skip
 from typing_extensions import TypeAlias
 from wandb import Artifact
 from wandb.apis.public import ArtifactCollection, Project
@@ -59,61 +59,47 @@ def make_name(worker_id: str) -> Callable[[str], str]:
 
 
 @fixture(scope="module")
-def user(backend_fixture_factory) -> Iterator[str]:
-    """A module-scoped user that overrides the default `user` fixture from the root-level `conftest.py`."""
-    username = backend_fixture_factory.make_user(admin=True)
-
-    # The `monkeypatch` fixture is strictly function-scoped, so we use a
-    # context manager to patch for this module-scoped fixture
-    envvars = dict.fromkeys(
-        ("WANDB_API_KEY", "WANDB_ENTITY", "WANDB_USERNAME"), username
-    )
-    with MonkeyPatch.context() as mpatch:
-        for k, v in envvars.items():
-            mpatch.setenv(k, v)
-        yield username
-
-
-# Request the `user` fixture to ensure env variables are set
-@fixture(scope="module")
-def api(user: str) -> wandb.Api:
-    """A redefined, module-scoped `Api` fixture for tests in this module.
-
-    Note that this overrides the default `api` fixture from the root-level
-    `conftest.py`.  This is necessary for any tests in these subfolders,
-    since the default `api` fixture is function-scoped, meaning it does not
-    play well with other module-scoped fixtures.
-    """
-    return wandb.Api(api_key=user)
-
-
-@fixture(scope="module")
-def project(user, api, make_name) -> Project:
+def project(
+    module_user: str,
+    make_module_api: Callable[[], wandb.Api],
+    make_name,
+) -> Project:
     """A wandb Project for tests in this module."""
     # Create the project first if it doesn't exist yet
     name = make_name("test-project")
-    api.create_project(name=name, entity=user)
-    return api.project(name=name, entity=user)
+    api = make_module_api()
+    api.create_project(name=name, entity=module_user)
+    return api.project(name=name, entity=module_user)
 
 
 @fixture(scope="module")
-def artifact(user, project, make_name) -> Artifact:
+def artifact(module_user: str, project: Project, make_name) -> Artifact:
     name = make_name("test-artifact")
-    with wandb.init(entity=user, project=project.name) as run:
+    with wandb.init(entity=module_user, project=project.name) as run:
         artifact = Artifact(name, "dataset")
         logged_artifact = run.log_artifact(artifact)
         return logged_artifact.wait()
 
 
 @fixture(scope="module")
-def artifact_collection(artifact, api) -> ArtifactCollection:
+def artifact_collection(
+    artifact: Artifact,
+    make_module_api: Callable[[], wandb.Api],
+) -> ArtifactCollection:
     """A test ArtifactCollection for tests in this module."""
-    return api.artifact(name=artifact.qualified_name, type=artifact.type).collection
+    return (
+        make_module_api()
+        .artifact(
+            name=artifact.qualified_name,
+            type=artifact.type,
+        )
+        .collection
+    )
 
 
 @fixture(scope="module")
 def make_webhook_integration(
-    api: wandb.Api,
+    make_module_api: Callable[[], wandb.Api],
 ) -> Callable[[str, str, str], WebhookIntegration]:
     """A module-scoped factory for creating WebhookIntegrations."""
     from wandb.automations._generated import CreateGenericWebhookIntegrationInput
@@ -129,6 +115,7 @@ def make_webhook_integration(
         )
         gql_op = gql(CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL)
         gql_vars = {"input": gql_input.model_dump()}
+        api = make_module_api()
         data = api.client.execute(gql_op, variable_values=gql_vars)
 
         result = CreateGenericWebhookIntegration(**data)
@@ -140,13 +127,13 @@ def make_webhook_integration(
 
 @fixture(scope="module")
 def webhook(
-    api,
+    make_module_api: Callable[[], wandb.Api],
     make_webhook_integration: Callable[[str, str, str], WebhookIntegration],
     make_name: Callable[[str], str],
 ) -> Iterator[WebhookIntegration]:
     """A "registered" webhook integration for automation system tests."""
     name = make_name("test-webhook")
-    entity = api.default_entity
+    entity = make_module_api().default_entity
     yield make_webhook_integration(
         name=name,
         entity=entity,
@@ -188,13 +175,15 @@ def scope_type(request: FixtureRequest) -> ScopeType:
 
 @fixture(params=valid_input_events(), ids=lambda x: f"event={x.value}")
 def event_type(
-    request: FixtureRequest, scope_type: ScopeType, api: wandb.Api
+    request: FixtureRequest,
+    scope_type: ScopeType,
+    module_api: wandb.Api,
 ) -> EventType:
     """A fixture that parametrizes over all valid event types."""
 
     event_type = request.param
 
-    if not api._supports_automation(event=event_type):
+    if not module_api._supports_automation(event=event_type):
         skip(f"Server does not support event type: {event_type!r}")
 
     if (event_type, scope_type) in invalid_events_and_scopes():
@@ -204,11 +193,14 @@ def event_type(
 
 
 @fixture(params=valid_input_actions(), ids=lambda x: f"action={x.value}")
-def action_type(request: type[FixtureRequest], api: wandb.Api) -> ActionType:
+def action_type(
+    request: type[FixtureRequest],
+    module_api: wandb.Api,
+) -> ActionType:
     """A fixture that parametrizes over all valid action types."""
     action_type = request.param
 
-    if not api._supports_automation(action=action_type):
+    if not module_api._supports_automation(action=action_type):
         skip(f"Server does not support action type: {action_type!r}")
 
     return action_type

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -40,45 +40,49 @@ def automation_name(make_name: Callable[[str], str]) -> str:
 
 
 @fixture
-def reset_automations(api: wandb.Api):
+def reset_automations(module_api: wandb.Api):
     """Request this fixture to remove any saved automations both before and after the test."""
     # There has to be a better way to do this
-    for automation in api.automations():
-        api.delete_automation(automation)
+    for automation in module_api.automations():
+        module_api.delete_automation(automation)
     yield
-    for automation in api.automations():
-        api.delete_automation(automation)
+    for automation in module_api.automations():
+        module_api.delete_automation(automation)
 
 
 # ------------------------------------------------------------------------------
-def test_no_initial_automations(api: wandb.Api, reset_automations):
+def test_no_initial_automations(module_api: wandb.Api, reset_automations):
     """No automations should be fetched by the API prior to creating any."""
-    assert list(api.automations()) == []
+    assert list(module_api.automations()) == []
 
 
-def test_no_initial_integrations(user, api: wandb.Api):
+def test_no_initial_integrations(module_api: wandb.Api):
     """No automations should be fetched by the API prior to creating any."""
-    assert list(api.integrations()) == []
-    assert list(api.slack_integrations()) == []
-    assert list(api.webhook_integrations()) == []
+    assert list(module_api.integrations()) == []
+    assert list(module_api.slack_integrations()) == []
+    assert list(module_api.webhook_integrations()) == []
 
 
 def test_fetch_webhook_integrations(
-    user, api: wandb.Api, make_name, make_webhook_integration
+    module_api: wandb.Api,
+    make_name,
+    make_webhook_integration,
 ):
     """Test fetching webhook integrations."""
     # Create multiple webhook integrations
     created_hooks = [
         make_webhook_integration(
             name=make_name("test-webhook"),
-            entity=api.default_entity,
+            entity=module_api.default_entity,
             url="https://example.com/webhook",
         )
         for _ in range(3)
     ]
     created_hooks_by_name = {wh.name: wh for wh in created_hooks}
 
-    fetched_hooks = list(api.webhook_integrations(entity=api.default_entity))
+    fetched_hooks = list(
+        module_api.webhook_integrations(entity=module_api.default_entity)
+    )
     filtered_hooks = [wh for wh in fetched_hooks if wh.name in created_hooks_by_name]
 
     assert len(filtered_hooks) == len(created_hooks)
@@ -91,7 +95,9 @@ def test_fetch_webhook_integrations(
 
 
 def test_fetch_slack_integrations(
-    user, api: wandb.Api, make_name, make_webhook_integration
+    module_api: wandb.Api,
+    make_name,
+    make_webhook_integration,
 ):
     """Test fetching slack integrations."""
     # We don't currently have an easy way of creating real Slack integrations in the backend
@@ -100,32 +106,37 @@ def test_fetch_slack_integrations(
     # Create a webhook integration only to check that it's omitted from slack_integrations()
     make_webhook_integration(
         name=make_name("test-webhook"),
-        entity=api.default_entity,
+        entity=module_api.default_entity,
         url="https://example.com/webhook",
     )
 
     # Fetch the slack integrations (for now there won't be any)
-    fetched_slack_integrations = list(api.slack_integrations(entity=api.default_entity))
+    fetched_slack_integrations = list(
+        module_api.slack_integrations(entity=module_api.default_entity)
+    )
     assert len(fetched_slack_integrations) == 0
 
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_automation(
-    user: str,
-    api: wandb.Api,
+    module_user: str,
+    module_api: wandb.Api,
     event,
     action,
     automation_name: str,
 ):
-    created = api.create_automation(
+    created = module_api.create_automation(
         (event >> action), name=automation_name, description="test description"
     )
 
     # We should be able to fetch the automation by name (optionally filtering by entity)
     assert created.name == automation_name
 
-    fetched_a = api.automation(entity=user, name=created.name)
-    fetched_b = api.automation(name=created.name)
+    fetched_a = module_api.automation(
+        entity=module_user,
+        name=created.name,
+    )
+    fetched_b = module_api.automation(name=created.name)
 
     # NOTE: On older server versions, the ID returned returned by create_automation()
     # seems to have an (encoded) index that's off by 1, vs. the ID returned by
@@ -134,7 +145,9 @@ def test_create_automation(
     # event to determine if this is a "newer" server.
     assert fetched_a.id == fetched_b.id  # these should at least be the same
 
-    is_older_server = not api._supports_automation(event=EventType.RUN_METRIC_THRESHOLD)
+    is_older_server = not module_api._supports_automation(
+        event=EventType.RUN_METRIC_THRESHOLD
+    )
     exclude = {"id"} if is_older_server else None
 
     assert fetched_a.model_dump(exclude=exclude) == created.model_dump(exclude=exclude)
@@ -143,26 +156,28 @@ def test_create_automation(
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_existing_automation_raises_by_default_if_existing(
-    api: wandb.Api,
+    module_api: wandb.Api,
     event,
     action,
     automation_name: str,
 ):
-    created = api.create_automation(
+    created = module_api.create_automation(
         (event >> action),
         name=automation_name,
     )
     with raises(CommError):
-        api.create_automation((event >> action), name=created.name)
+        module_api.create_automation((event >> action), name=created.name)
 
     # Fetching the automation by name should return the original automation,
     # unchanged.
-    fetched = api.automation(name=created.name)
+    fetched = module_api.automation(name=created.name)
 
     # NOTE: On older server versions, the ID returned has an encoded index that's off by 1.
     # This seems fixed on newer servers.  Use RUN_METRIC_THRESHOLD support as a proxy for identifying
     # newer servers.
-    is_older_server = not api._supports_automation(event=EventType.RUN_METRIC_THRESHOLD)
+    is_older_server = not module_api._supports_automation(
+        event=EventType.RUN_METRIC_THRESHOLD
+    )
     exclude = {"id"} if is_older_server else None
 
     assert fetched.model_dump(exclude=exclude) == created.model_dump(exclude=exclude)
@@ -170,19 +185,19 @@ def test_create_existing_automation_raises_by_default_if_existing(
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_existing_automation_fetches_existing_if_requested(
-    api: wandb.Api,
+    module_api: wandb.Api,
     event,
     action,
     automation_name: str,
 ):
-    created = api.create_automation(
+    created = module_api.create_automation(
         (event >> action),
         name=automation_name,
     )
 
     # Since we request the prior automation if it exists, any extra values
     # that would normally be set on the created object will be ignored.
-    existing = api.create_automation(
+    existing = module_api.create_automation(
         (event >> action),
         name=created.name,
         description="ignored description",
@@ -190,12 +205,14 @@ def test_create_existing_automation_fetches_existing_if_requested(
     )
 
     # Fetch the automation by name
-    fetched = api.automation(name=created.name)
+    fetched = module_api.automation(name=created.name)
 
     # NOTE: On older server versions, the ID returned has an encoded index that's off by 1.
     # This seems fixed on newer servers.  Use RUN_METRIC_THRESHOLD support as a proxy for identifying
     # newer servers.
-    is_older_server = not api._supports_automation(event=EventType.RUN_METRIC_THRESHOLD)
+    is_older_server = not module_api._supports_automation(
+        event=EventType.RUN_METRIC_THRESHOLD
+    )
     exclude = {"id"} if is_older_server else None
 
     assert created.model_dump(exclude=exclude) == existing.model_dump(exclude=exclude)
@@ -210,7 +227,7 @@ def test_create_existing_automation_fetches_existing_if_requested(
 def test_create_automation_for_run_metric_threshold_event(
     project,
     webhook,
-    api: wandb.Api,
+    module_api: wandb.Api,
     automation_name: str,
 ):
     """Check that creating an automation for the `RUN_METRIC_THRESHOLD` event works, and the automation is saved with the expected filter."""
@@ -244,24 +261,30 @@ def test_create_automation_for_run_metric_threshold_event(
         payload={"test": {"key": "value"}},
     )
 
-    server_supports_event = api._supports_automation(event=event.event_type)
+    server_supports_event = module_api._supports_automation(
+        event=event.event_type,
+    )
 
     if not server_supports_event:
         with raises(CommError):
-            api.create_automation(
-                (event >> action), name=automation_name, description="test description"
+            module_api.create_automation(
+                (event >> action),
+                name=automation_name,
+                description="test description",
             )
 
     else:
         # The server supports the event, so there should be an automation to check
-        created = api.create_automation(
-            (event >> action), name=automation_name, description="test description"
+        created = module_api.create_automation(
+            (event >> action),
+            name=automation_name,
+            description="test description",
         )
         assert isinstance(created, Automation)
         assert created.event.filter == expected_filter
 
         # Refetch it to be sure
-        refetched = api.automation(name=automation_name)
+        refetched = module_api.automation(name=automation_name)
         assert isinstance(refetched, Automation)
         assert refetched.event.filter == expected_filter
         assert refetched.action.request_payload == {"test": {"key": "value"}}
@@ -271,7 +294,7 @@ def test_create_automation_for_run_metric_threshold_event(
 def test_create_automation_for_run_metric_change_event(
     project,
     webhook,
-    api: wandb.Api,
+    module_api: wandb.Api,
     automation_name: str,
 ):
     """Check that creating an automation for the `RUN_METRIC_CHANGE` event works, and the automation is saved with the expected filter."""
@@ -304,23 +327,29 @@ def test_create_automation_for_run_metric_change_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = api._supports_automation(event=event.event_type)
+    server_supports_event = module_api._supports_automation(
+        event=event.event_type,
+    )
 
     if not server_supports_event:
         with raises(CommError):
-            api.create_automation(
-                (event >> action), name=automation_name, description="test description"
+            module_api.create_automation(
+                (event >> action),
+                name=automation_name,
+                description="test description",
             )
     else:
         # The server supports the event, so there should be an automation to check
-        created = api.create_automation(
-            (event >> action), name=automation_name, description="test description"
+        created = module_api.create_automation(
+            (event >> action),
+            name=automation_name,
+            description="test description",
         )
         assert isinstance(created, Automation)
         assert created.event.filter == expected_filter
 
         # Refetch it to be sure
-        refetched = api.automation(name=automation_name)
+        refetched = module_api.automation(name=automation_name)
         assert isinstance(refetched, Automation)
         assert refetched.event.filter == expected_filter
 
@@ -329,7 +358,7 @@ def test_create_automation_for_run_metric_change_event(
 def test_create_automation_for_run_state_event(
     project,
     webhook,
-    api: wandb.Api,
+    module_api: wandb.Api,
     automation_name: str,
 ):
     """Check that creating an automation for the `RUN_STATE` event works, and the automation is saved with the expected filter."""
@@ -349,23 +378,29 @@ def test_create_automation_for_run_state_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = api._supports_automation(event=event.event_type)
+    server_supports_event = module_api._supports_automation(
+        event=event.event_type,
+    )
 
     if not server_supports_event:
         with raises(CommError):
-            api.create_automation(
-                (event >> action), name=automation_name, description="test description"
+            module_api.create_automation(
+                (event >> action),
+                name=automation_name,
+                description="test description",
             )
     else:
         # The server supports the event, so there should be an automation to check
-        created = api.create_automation(
-            (event >> action), name=automation_name, description="test description"
+        created = module_api.create_automation(
+            (event >> action),
+            name=automation_name,
+            description="test description",
         )
         assert isinstance(created, Automation)
         assert created.event.filter == expected_filter
 
         # Refetch it to be sure
-        refetched = api.automation(name=automation_name)
+        refetched = module_api.automation(name=automation_name)
         assert isinstance(refetched, Automation)
         assert refetched.event.filter == expected_filter
 
@@ -374,7 +409,7 @@ def test_create_automation_for_run_state_event(
 def test_create_automation_for_run_metric_zscore_event(
     project,
     webhook,
-    api: wandb.Api,
+    module_api: wandb.Api,
     automation_name: str,
 ):
     """Check that creating an automation for the `RUN_METRIC_ZSCORE` event works, and the automation is saved with the expected filter."""
@@ -409,97 +444,108 @@ def test_create_automation_for_run_metric_zscore_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = api._supports_automation(event=event.event_type)
+    server_supports_event = module_api._supports_automation(event=event.event_type)
 
     if not server_supports_event:
         with raises(CommError):
-            api.create_automation(
-                (event >> action), name=automation_name, description="test description"
+            module_api.create_automation(
+                (event >> action),
+                name=automation_name,
+                description="test description",
             )
     else:
         # The server supports the event, so there should be an automation to check
-        created = api.create_automation(
-            (event >> action), name=automation_name, description="test description"
+        created = module_api.create_automation(
+            (event >> action),
+            name=automation_name,
+            description="test description",
         )
         assert isinstance(created, Automation)
         assert created.event.filter == expected_filter
 
         # Refetch it to be sure
-        refetched = api.automation(name=automation_name)
+        refetched = module_api.automation(name=automation_name)
         assert isinstance(refetched, Automation)
         assert refetched.event.filter == expected_filter
 
 
 @fixture
 def created_automation(
-    api: wandb.Api, reset_automations, event, action, automation_name: str
+    module_api: wandb.Api,
+    reset_automations,
+    event,
+    action,
+    automation_name: str,
 ) -> Automation:
     """An already-created automation that we can use for testing."""
-    created = api.create_automation((event >> action), name=automation_name)
+    created = module_api.create_automation(
+        (event >> action),
+        name=automation_name,
+    )
 
     # Fetch the automation by name (avoids the off-by-1 index issue on older servers)
-    fetched = api.automation(name=created.name)
+    fetched = module_api.automation(name=created.name)
 
     assert created.name == fetched.name == automation_name  # Sanity check
     return fetched
 
 
 def test_delete_automation(
-    api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api, automation_name: str, created_automation: Automation
 ):
-    assert api.automation(name=automation_name) == created_automation
+    assert module_api.automation(name=automation_name) == created_automation
 
-    api.delete_automation(created_automation)
+    module_api.delete_automation(created_automation)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        api.automation(name=automation_name)
+        module_api.automation(name=automation_name)
 
 
 def test_delete_automation_by_id(
-    api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api, automation_name: str, created_automation: Automation
 ):
-    assert api.automation(name=automation_name) == created_automation
+    assert module_api.automation(name=automation_name) == created_automation
 
-    api.delete_automation(created_automation.id)
+    module_api.delete_automation(created_automation.id)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        api.automation(name=automation_name)
+        module_api.automation(name=automation_name)
 
 
 def test_automation_cannot_be_deleted_again(
-    api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api, automation_name: str, created_automation: Automation
 ):
-    assert api.automation(name=automation_name) == created_automation
+    assert module_api.automation(name=automation_name) == created_automation
 
-    api.delete_automation(created_automation)
+    module_api.delete_automation(created_automation)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        api.automation(name=automation_name)
+        module_api.automation(name=automation_name)
 
     # Deleting the automation again (by object or ID) should raise the same error
     with raises(CommError):
-        api.delete_automation(created_automation)
+        module_api.delete_automation(created_automation)
     with raises(CommError):
-        api.delete_automation(created_automation.id)
+        module_api.delete_automation(created_automation.id)
 
 
 @mark.usefixtures(reset_automations.__name__)
-def test_delete_automation_raises_on_invalid_id(api: wandb.Api):
+def test_delete_automation_raises_on_invalid_id(module_api: wandb.Api):
     with raises(CommError):
-        api.delete_automation("invalid-automation-id")
+        module_api.delete_automation("invalid-automation-id")
 
 
 @fixture
-def skip_if_edit_automations_not_supported_on_server(api: wandb.Api):
+def skip_if_edit_automations_not_supported_on_server(module_api: wandb.Api):
     # HACK: Use NO_OP as a proxy for whether the server is "new enough"
     #
     # FIXME: We need a better way to check this in the absence of
     # - a prior server feature flag
     # - use of GraphQL introspection queries
-    if not api._supports_automation(action=ActionType.NO_OP):
+    if not module_api._supports_automation(action=ActionType.NO_OP):
         skip("Server does not support editing automations")
 
 
@@ -508,48 +554,55 @@ class TestUpdateAutomation:
     @fixture
     def old_automation(
         self,
-        api: wandb.Api,
+        module_api: wandb.Api,
         event,
         action,
         automation_name: str,
     ):
         """The original automation to be updated."""
         # Setup: Create the original automation
-        automation = api.create_automation(
-            (event >> action), name=automation_name, description="orig description"
+        automation = module_api.create_automation(
+            (event >> action),
+            name=automation_name,
+            description="orig description",
         )
         yield automation
 
         # Cleanup: Delete the automation for good measure
-        api.delete_automation(automation)
-        assert len(list(api.automations(name=automation_name))) == 0
+        module_api.delete_automation(automation)
+        assert len(list(module_api.automations(name=automation_name))) == 0
 
-    def test_update_name(self, api: wandb.Api, old_automation: Automation):
+    def test_update_name(self, module_api: wandb.Api, old_automation: Automation):
         updated_value = "new-name"
 
         old_automation.name = updated_value
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         assert new_automation.name == updated_value
 
-    def test_update_description(self, api: wandb.Api, old_automation: Automation):
+    def test_update_description(
+        self, module_api: wandb.Api, old_automation: Automation
+    ):
         new_value = "new description"
 
         old_automation.description = new_value
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         assert new_automation.description == new_value
 
-    def test_update_enabled(self, api: wandb.Api, old_automation: Automation):
+    def test_update_enabled(self, module_api: wandb.Api, old_automation: Automation):
         new_value = False
 
         old_automation.enabled = new_value
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         assert new_automation.enabled == new_value
 
     def test_update_action_to_webhook(
-        self, api: wandb.Api, old_automation: Automation, webhook: WebhookIntegration
+        self,
+        module_api: wandb.Api,
+        old_automation: Automation,
+        webhook: WebhookIntegration,
     ):
         # This is deliberately an "input" action, even though saved automations
         # will have a "saved" action on them.  We want to check that this is still
@@ -562,7 +615,7 @@ class TestUpdateAutomation:
         )
 
         old_automation.action = webhook_action
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         new_action = new_automation.action
         assert isinstance(new_action, SavedWebhookAction)
@@ -570,13 +623,15 @@ class TestUpdateAutomation:
         assert new_action.integration.id == webhook_id
         assert new_action.request_payload == new_payload
 
-    def test_update_action_to_no_op(self, api: wandb.Api, old_automation: Automation):
+    def test_update_action_to_no_op(
+        self, module_api: wandb.Api, old_automation: Automation
+    ):
         # This is deliberately an "input" action, even though saved automations
         # will have a "saved" action on them.  We want to check that this is still
         # handled correctly and reliably.
 
         old_automation.action = DoNothing()
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         new_action = new_automation.action
         # NO_OP actions don't have meaningful fields besides these
@@ -585,32 +640,41 @@ class TestUpdateAutomation:
 
     # This is only meaningful if the original automation has a webhook action
     @mark.parametrize("action_type", [ActionType.GENERIC_WEBHOOK], indirect=True)
-    def test_update_webhook_payload(self, api: wandb.Api, old_automation: Automation):
+    def test_update_webhook_payload(
+        self,
+        module_api: wandb.Api,
+        old_automation: Automation,
+    ):
         new_payload = {"new-key": "new-value"}
 
         old_automation.action.request_payload = new_payload
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         assert new_automation.action.request_payload == new_payload
 
     # This is only meaningful if the original automation has a notification action
     @mark.parametrize("action_type", [ActionType.NOTIFICATION], indirect=True)
     def test_update_notification_message(
-        self, api: wandb.Api, old_automation: Automation
+        self,
+        module_api: wandb.Api,
+        old_automation: Automation,
     ):
         new_message = "new message"
 
         old_automation.action.message = new_message
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         assert new_automation.action.message == new_message
 
     def test_update_scope_to_project(
-        self, api: wandb.Api, old_automation: Automation, project: Project
+        self,
+        module_api: wandb.Api,
+        old_automation: Automation,
+        project: Project,
     ):
         old_automation.scope = project
 
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
         updated_scope = new_automation.scope
 
         assert isinstance(updated_scope, ProjectScope)
@@ -633,7 +697,7 @@ class TestUpdateAutomation:
     )
     def test_update_scope_to_artifact_collection(
         self,
-        api: wandb.Api,
+        module_api: wandb.Api,
         old_automation: Automation,
         event_type: EventType,
         artifact_collection: ArtifactCollection,
@@ -641,7 +705,7 @@ class TestUpdateAutomation:
         assert old_automation.event.event_type == event_type  # Consistency check
 
         old_automation.scope = artifact_collection
-        new_automation = api.update_automation(old_automation)
+        new_automation = module_api.update_automation(old_automation)
 
         updated_scope = new_automation.scope
 
@@ -661,7 +725,7 @@ class TestUpdateAutomation:
     )
     def test_update_scope_to_artifact_collection_fails_for_incompatible_event(
         self,
-        api: wandb.Api,
+        module_api: wandb.Api,
         old_automation: Automation,
         event_type: EventType,
         artifact_collection: ArtifactCollection,
@@ -671,7 +735,7 @@ class TestUpdateAutomation:
 
         with raises(CommError):
             old_automation.scope = artifact_collection
-            api.update_automation(old_automation)
+            module_api.update_automation(old_automation)
 
     MUTATION_EVENT_TYPE_TO_CLASS = {
         EventType.ADD_ARTIFACT_ALIAS: OnAddArtifactAlias,
@@ -687,7 +751,7 @@ class TestUpdateAutomation:
     )
     def test_update_event_preserves_filter(
         self,
-        api: wandb.Api,
+        module_api: wandb.Api,
         old_automation: Automation,
         event_type: EventType,
         artifact_collection: ArtifactCollection,
@@ -700,8 +764,8 @@ class TestUpdateAutomation:
         )
         expected_filter = new_event.filter
 
-        updated = api.update_automation(old_automation, event=new_event)
-        refetched = api.automation(name=old_automation.name)
+        updated = module_api.update_automation(old_automation, event=new_event)
+        refetched = module_api.automation(name=old_automation.name)
 
         assert updated.event.event_type == event_type
         assert updated.event.filter.filter == expected_filter
@@ -710,13 +774,13 @@ class TestUpdateAutomation:
 
     def test_update_non_event_fields_preserves_filter(
         self,
-        api: wandb.Api,
+        module_api: wandb.Api,
         old_automation: Automation,
     ):
         """Updating only the name must not alter the event filter."""
         original_filter = old_automation.event.filter
 
-        updated = api.update_automation(old_automation, name="updated-name")
+        updated = module_api.update_automation(old_automation, name="updated-name")
 
         assert updated.name == "updated-name"
         assert updated.event.filter == original_filter
@@ -740,7 +804,7 @@ class TestUpdateAutomation:
     )
     def test_update_run_event_preserves_filter(
         self,
-        api: wandb.Api,
+        module_api: wandb.Api,
         old_automation: Automation,
         event_type: EventType,
         project: Project,
@@ -750,8 +814,8 @@ class TestUpdateAutomation:
         new_event = factory(project)
         expected_filter = new_event.filter
 
-        updated = api.update_automation(old_automation, event=new_event)
-        refetched = api.automation(name=old_automation.name)
+        updated = module_api.update_automation(old_automation, event=new_event)
+        refetched = module_api.automation(name=old_automation.name)
 
         assert updated.event.event_type == new_event.event_type
         assert updated.event.filter == expected_filter
@@ -771,12 +835,12 @@ class TestUpdateAutomation:
     )
     def test_update_via_kwargs(
         self,
-        api: wandb.Api,
+        module_api: wandb.Api,
         old_automation: Automation,
         updates: dict[str, Any],
     ):
         # Update the automation
-        new_automation = api.update_automation(old_automation, **updates)
+        new_automation = module_api.update_automation(old_automation, **updates)
         for name, value in updates.items():
             assert getattr(new_automation, name) == value
 
@@ -799,15 +863,17 @@ class TestPaginatedAutomations:
     @fixture(scope="class")
     def setup_paginated_automations(
         self,
-        user: str,
-        api: wandb.Api,
+        module_user: str,
+        make_module_api: Callable[[], wandb.Api],
         webhook: WebhookIntegration,
         num_projects: int,
         make_name: Callable[[str], str],
     ):
+        setup_api = make_module_api()
+
         # HACK: Is there a way to ensure a clean slate for each test?
-        for id_ in api.automations():
-            api.delete_automation(id_)
+        for id_ in setup_api.automations():
+            setup_api.delete_automation(id_)
 
         # NOTE: For now, pagination is per project, NOT per automation, so
         # to test pagination, we'll create each automation in a separate project.
@@ -819,40 +885,43 @@ class TestPaginatedAutomations:
         created_automation_ids = deque()
         for project_name, automation_name in zip(project_names, automation_names):
             # Create the placeholder project for the automation
-            api.create_project(name=project_name, entity=user)
-            project = api.project(name=project_name, entity=user)
+            setup_api.create_project(name=project_name, entity=module_user)
+            project = setup_api.project(name=project_name, entity=module_user)
 
             # Create the actual automation
             event = OnLinkArtifact(scope=project)
             action = SendWebhook.from_integration(webhook)
-            created = api.create_automation(
-                event >> action, name=automation_name, description="test description"
+            created = setup_api.create_automation(
+                event >> action,
+                name=automation_name,
+                description="test description",
             )
 
             # Refetch (to avoid the off-by-1 index issue on older servers) and retain for later cleanup
-            refetched_id = api.automation(name=created.name).id
+            refetched_id = setup_api.automation(name=created.name).id
             created_automation_ids.append(refetched_id)
 
         yield
 
         # This particular fixture is deliberately class-scoped, but clean up the automations for good measure
+        cleanup_api = make_module_api()
         for id_ in created_automation_ids:
-            api.delete_automation(id_)
+            cleanup_api.delete_automation(id_)
 
     @mark.usefixtures(setup_paginated_automations.__name__)
     def test_paginated_automations(
         self,
         mocker,
-        user,
-        api: wandb.Api,
+        module_user: str,
+        module_api: wandb.Api,
         num_projects,
         page_size,
     ):
         # Spy on the client method that makes the GQL request.  Not ideal, but it may have to do for now
-        client_spy = mocker.spy(api.client, "execute")
+        client_spy = mocker.spy(module_api.client, "execute")
 
         # Fetch the automations
-        list(api.automations(entity=user, per_page=page_size))
+        list(module_api.automations(entity=module_user, per_page=page_size))
 
         # Check that the number of GQL requests is at least what we expect from the pagination params
         # Note that a (cached) introspection query may add an extra request the first time this is

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,9 +1,11 @@
+import unittest.mock
 from collections.abc import Generator
 from datetime import timedelta
 from queue import Queue
 from typing import Callable
 
 import pytest
+import wandb
 from hypothesis import settings
 
 settings.register_profile(
@@ -12,6 +14,17 @@ settings.register_profile(
     deadline=timedelta(seconds=1),
 )
 settings.load_profile("ci")
+
+
+@pytest.fixture
+def api() -> wandb.Api:
+    """A fake wandb.Api instance.
+
+    Unit tests can't talk to a local-testcontainer, so most methods on this
+    will fail unless patched.
+    """
+    with unittest.mock.patch("wandb.sdk.wandb_login._verify_login"):
+        return wandb.Api()
 
 
 # --------------------------------


### PR DESCRIPTION
Creates proper module-scoped `user` and `api` fixtures for automations tests.

Automations tests were using module-scoped overrides of the `user` and `api` fixtures to not create a new user for each of the 900+ tests generated through parametrization. However, a module-scoped `api` fixture is invalid because `wandb.Api` technically cannot be reused across `wandb.teardown()` calls.

This was never a problem before, but now `wandb.Api` holds a `ServiceApi` handle to a `wandb-core` backing object, and using the same `ServiceApi` after `wandb.teardown()` raises an error.

See docstrings for the new fixtures.