### PR TITLE
feat(sandbox): add wandb sandbox package with auth and cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,12 @@
 /tests/system_tests/test_launch/      @wandb/launch-reviewers @wandb/sdk-team
 /tests/unit_tests/test_launch/        @wandb/launch-reviewers @wandb/sdk-team
 
+# Sandbox
+/wandb/sandbox/                       @wandb/launch-reviewers @wandb/sdk-team
+/wandb/cli/beta_sandbox.py            @wandb/launch-reviewers @wandb/sdk-team
+/tests/system_tests/test_sandbox/     @wandb/launch-reviewers @wandb/sdk-team
+/tests/unit_tests/test_sandbox/       @wandb/launch-reviewers @wandb/sdk-team
+
 # Sweeps
 /wandb/sdk/wandb_agent.py                        @wandb/sweeps-launch-team @wandb/sdk-team
 /tests/system_tests/test_sweep/                  @wandb/sweeps-launch-team @wandb/sdk-team

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -31,6 +31,7 @@ jobs:
             automations
             integrations
             launch
+            sandbox
             sdk
             sweeps
             leet

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,3 +17,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Added
 
 - The `stop_on_fatal_error` setting to stop a run (using `stop_fn`) after a fatal error that prevents it from uploading metrics (@timoffex in https://github.com/wandb/wandb/pull/11774)
+- New `wandb.sandbox` package and the `wandb beta sandbox` cli for using wandb sandbox (@pingleiwandb in https://github.com/wandb/wandb/pull/11606)

--- a/noxfile.py
+++ b/noxfile.py
@@ -607,6 +607,8 @@ def mypy_report(session: nox.Session) -> None:
     """
     session.install(
         "bokeh",
+        # wandb.sandbox imports typed symbols from the optional cwsandbox package.
+        "cwsandbox[cli]",
         "ipython",
         "lxml",
         # https://github.com/python/mypy/issues/17166

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,10 @@ launch = [
 models = ["cloudpickle"]
 importers = ["polars<=1.2.1", "rich", "filelock", "mlflow", "tenacity"]
 workspaces = ["wandb-workspaces"]
-sandbox = ["cwsandbox[cli]>=0.14.0"]
+# TODO: lock to 0.16.0 for now due to proto rename.
+# Switch to 0.17.0 after server side is upgraded.
+# https://github.com/coreweave/cwsandbox-client/releases/tag/v0.17.0
+sandbox = ["cwsandbox[cli]==0.16.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ launch = [
 models = ["cloudpickle"]
 importers = ["polars<=1.2.1", "rich", "filelock", "mlflow", "tenacity"]
 workspaces = ["wandb-workspaces"]
-sandbox = ["cwsandbox[cli]>=0.19.3"]
+sandbox = ["cwsandbox[cli]>=0.20.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ launch = [
 models = ["cloudpickle"]
 importers = ["polars<=1.2.1", "rich", "filelock", "mlflow", "tenacity"]
 workspaces = ["wandb-workspaces"]
+sandbox = ["cwsandbox[cli]>=0.14.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,10 +105,7 @@ launch = [
 models = ["cloudpickle"]
 importers = ["polars<=1.2.1", "rich", "filelock", "mlflow", "tenacity"]
 workspaces = ["wandb-workspaces"]
-# TODO: lock to 0.16.0 for now due to proto rename.
-# Switch to 0.17.0 after server side is upgraded.
-# https://github.com/coreweave/cwsandbox-client/releases/tag/v0.17.0
-sandbox = ["cwsandbox[cli]==0.16.0"]
+sandbox = ["cwsandbox[cli]>=0.19.3"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -167,7 +167,7 @@ cryptography==46.0.6
     #   mlflow
     #   msal
     #   pyjwt
-cwsandbox==0.14.0
+cwsandbox==0.16.0
     # via -r requirements/requirements_test.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -167,7 +167,7 @@ cryptography==46.0.6
     #   mlflow
     #   msal
     #   pyjwt
-cwsandbox==0.19.3
+cwsandbox==0.20.0
     # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -167,8 +167,8 @@ cryptography==46.0.6
     #   mlflow
     #   msal
     #   pyjwt
-cwsandbox==0.16.0
-    # via -r requirements/requirements_test.txt
+cwsandbox==0.19.3
+    # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib
 databricks-sdk==0.102.0

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -123,6 +123,7 @@ click==8.3.1
     #   ariadne-codegen
     #   black
     #   click-option-group
+    #   cwsandbox
     #   flask
     #   kfp
     #   litellm
@@ -166,6 +167,8 @@ cryptography==46.0.6
     #   mlflow
     #   msal
     #   pyjwt
+cwsandbox==0.14.0
+    # via -r requirements/requirements_test.txt
 cycler==0.12.1
     # via matplotlib
 databricks-sdk==0.102.0
@@ -310,6 +313,7 @@ google-resumable-media==2.8.0
     #   google-cloud-storage
 googleapis-common-protos==1.73.1
     # via
+    #   cwsandbox
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
@@ -330,6 +334,7 @@ grpc-google-iam-v1==0.14.3
     #   google-cloud-resource-manager
 grpcio==1.80.0
     # via
+    #   cwsandbox
     #   google-api-core
     #   google-cloud-artifact-registry
     #   google-cloud-compute
@@ -798,6 +803,7 @@ proto-plus==1.27.2
     #   google-cloud-resource-manager
 protobuf==6.33.6
     # via
+    #   cwsandbox
     #   databricks-sdk
     #   google-api-core
     #   google-cloud-aiplatform
@@ -846,6 +852,7 @@ pydantic==2.12.5
     # via
     #   -r requirements/requirements_dev.txt
     #   ariadne-codegen
+    #   cwsandbox
     #   dspy
     #   fastapi
     #   google-cloud-aiplatform

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -176,7 +176,7 @@ cuda-pathfinder==1.5.0
     # via cuda-bindings
 cuda-toolkit==13.0.2
     # via torch
-cwsandbox==0.14.0
+cwsandbox==0.16.0
     # via -r requirements/requirements_test.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -176,8 +176,8 @@ cuda-pathfinder==1.5.0
     # via cuda-bindings
 cuda-toolkit==13.0.2
     # via torch
-cwsandbox==0.16.0
-    # via -r requirements/requirements_test.txt
+cwsandbox==0.20.0
+    # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib
 databricks-sdk==0.102.0

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -126,6 +126,7 @@ click==8.3.1
     #   ariadne-codegen
     #   black
     #   click-option-group
+    #   cwsandbox
     #   flask
     #   kfp
     #   litellm
@@ -175,6 +176,8 @@ cuda-pathfinder==1.5.0
     # via cuda-bindings
 cuda-toolkit==13.0.2
     # via torch
+cwsandbox==0.14.0
+    # via -r requirements/requirements_test.txt
 cycler==0.12.1
     # via matplotlib
 databricks-sdk==0.102.0
@@ -325,6 +328,7 @@ google-resumable-media==2.8.0
     #   google-cloud-storage
 googleapis-common-protos==1.73.1
     # via
+    #   cwsandbox
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
@@ -347,6 +351,7 @@ grpc-google-iam-v1==0.14.3
     #   google-cloud-resource-manager
 grpcio==1.80.0
     # via
+    #   cwsandbox
     #   google-api-core
     #   google-cloud-artifact-registry
     #   google-cloud-compute
@@ -883,6 +888,7 @@ proto-plus==1.27.2
     #   google-cloud-resource-manager
 protobuf==6.33.6
     # via
+    #   cwsandbox
     #   databricks-sdk
     #   google-api-core
     #   google-cloud-aiplatform
@@ -932,6 +938,7 @@ pydantic==2.12.5
     # via
     #   -r requirements/requirements_dev.txt
     #   ariadne-codegen
+    #   cwsandbox
     #   dspy
     #   fastapi
     #   google-cloud-aiplatform

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -123,6 +123,7 @@ click==8.3.1
     #   ariadne-codegen
     #   black
     #   click-option-group
+    #   cwsandbox
     #   flask
     #   kfp
     #   litellm
@@ -169,6 +170,8 @@ cryptography==46.0.6
     #   mlflow
     #   msal
     #   pyjwt
+cwsandbox==0.14.0
+    # via -r requirements/requirements_test.txt
 cycler==0.12.1
     # via matplotlib
 databricks-sdk==0.102.0
@@ -311,6 +314,7 @@ google-resumable-media==2.8.0
     #   google-cloud-storage
 googleapis-common-protos==1.73.1
     # via
+    #   cwsandbox
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
@@ -333,6 +337,7 @@ grpc-google-iam-v1==0.14.3
     #   google-cloud-resource-manager
 grpcio==1.80.0
     # via
+    #   cwsandbox
     #   google-api-core
     #   google-cloud-artifact-registry
     #   google-cloud-compute
@@ -798,6 +803,7 @@ proto-plus==1.27.2
     #   google-cloud-resource-manager
 protobuf==6.33.6
     # via
+    #   cwsandbox
     #   databricks-sdk
     #   google-api-core
     #   google-cloud-aiplatform
@@ -838,6 +844,7 @@ pydantic==2.12.5
     # via
     #   -r requirements/requirements_dev.txt
     #   ariadne-codegen
+    #   cwsandbox
     #   dspy
     #   fastapi
     #   google-cloud-aiplatform

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -170,8 +170,8 @@ cryptography==46.0.6
     #   mlflow
     #   msal
     #   pyjwt
-cwsandbox==0.16.0
-    # via -r requirements/requirements_test.txt
+cwsandbox==0.20.0
+    # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib
 databricks-sdk==0.102.0

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -170,7 +170,7 @@ cryptography==46.0.6
     #   mlflow
     #   msal
     #   pyjwt
-cwsandbox==0.14.0
+cwsandbox==0.16.0
     # via -r requirements/requirements_test.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -72,3 +72,6 @@ awscli; sys_platform == 'win32'
 .[launch]
 .[sweeps] ; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 .[azure]
+
+# Sandbox tests need the upstream client, but it only supports Python 3.11+.
+cwsandbox[cli]>=0.19.3; python_version >= '3.11'

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -74,4 +74,4 @@ awscli; sys_platform == 'win32'
 .[azure]
 
 # Sandbox tests need the upstream client, but it only supports Python 3.11+.
-cwsandbox[cli]>=0.19.3; python_version >= '3.11'
+cwsandbox[cli]>=0.20.0; python_version >= '3.11'

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -23,6 +23,8 @@ numpy~=1.24; python_version < '3.11'
 coverage[toml]~=7.10
 
 pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.
+# Sandbox tests need the upstream client, but it only supports Python 3.11+.
+cwsandbox[cli]; python_version >= '3.11'
 
 # Avoids:
 # - perf issues introduced in v6.131.1 but fixed in follow-up patches

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -23,8 +23,6 @@ numpy~=1.24; python_version < '3.11'
 coverage[toml]~=7.10
 
 pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.
-# Sandbox tests need the upstream client, but it only supports Python 3.11+.
-cwsandbox[cli]; python_version >= '3.11'
 
 # Avoids:
 # - perf issues introduced in v6.131.1 but fixed in follow-up patches

--- a/tests/system_tests/test_sandbox/__init__.py
+++ b/tests/system_tests/test_sandbox/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+if sys.version_info < (3, 11):
+    pytest.skip("wandb.sandbox requires Python 3.11+", allow_module_level=True)

--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 import cwsandbox._sandbox as cwsandbox_sandbox
 import pytest
 import wandb
+from wandb.sdk import wandb_setup
 from wandb.sandbox import Sandbox
 
 
@@ -70,7 +71,7 @@ def _patch_sandbox_stub(
     return calls
 
 
-def test_sandbox_run_uses_active_wandb_run_auth_headers(
+def test_sandbox_run_uses_wandb_settings_auth_headers(
     user,
     tmp_path,
     monkeypatch,
@@ -80,24 +81,48 @@ def test_sandbox_run_uses_active_wandb_run_auth_headers(
     with wandb.init(
         project="sandbox-auth-system-test",
         dir=str(tmp_path),
-    ) as run:
+    ):
+        settings = wandb_setup.singleton().settings
         expected_headers = {"x-api-key": user}
-        if run.entity:
-            expected_headers["x-entity-id"] = run.entity
-        if run.project:
-            expected_headers["x-project-name"] = run.project
+        if settings.entity:
+            expected_headers["x-entity-id"] = settings.entity
+        if settings.project:
+            expected_headers["x-project-name"] = settings.project
 
         with Sandbox.run("sleep", "infinity") as sandbox:
             assert sandbox.sandbox_id == "sb-system-test"
 
-    assert len(expected_headers) == 3
     assert len(calls.start) == 1
     assert dict(calls.start[0]["metadata"]) == expected_headers
     assert len(calls.stop) == 1
     assert dict(calls.stop[0]["metadata"]) == expected_headers
 
 
-def test_sandbox_run_without_run_uses_api_key_only(
+def test_sandbox_run_without_run_uses_settings_entity(
+    user,
+    monkeypatch,
+) -> None:
+    calls = _patch_sandbox_stub(monkeypatch)
+
+    monkeypatch.delenv("WANDB_PROJECT", raising=False)
+    wandb.teardown()
+
+    assert wandb.run is None
+
+    with Sandbox.run("sleep", "infinity") as sandbox:
+        assert sandbox.sandbox_id == "sb-system-test"
+
+    expected_headers = {
+        "x-api-key": user,
+        "x-entity-id": user,
+    }
+    assert len(calls.start) == 1
+    assert dict(calls.start[0]["metadata"]) == expected_headers
+    assert len(calls.stop) == 1
+    assert dict(calls.stop[0]["metadata"]) == expected_headers
+
+
+def test_sandbox_run_without_entity_or_project_uses_api_key_only(
     user,
     monkeypatch,
 ) -> None:
@@ -105,6 +130,7 @@ def test_sandbox_run_without_run_uses_api_key_only(
 
     monkeypatch.delenv("WANDB_ENTITY", raising=False)
     monkeypatch.delenv("WANDB_PROJECT", raising=False)
+    wandb.teardown()
 
     assert wandb.run is None
 

--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -6,7 +6,6 @@ import cwsandbox._sandbox as cwsandbox_sandbox
 import pytest
 import wandb
 from wandb.sandbox import Sandbox
-from wandb.sdk import wandb_setup
 
 
 class _FakeChannel:
@@ -73,46 +72,38 @@ def _patch_sandbox_stub(
     return calls
 
 
-def test_sandbox_run_uses_wandb_settings_auth_headers(
+def test_sandbox_run_uses_settings_entity_project(
     user,
-    tmp_path,
     monkeypatch,
 ) -> None:
     calls = _patch_sandbox_stub(monkeypatch)
 
-    with wandb.init(
-        project="sandbox-auth-system-test",
-        dir=str(tmp_path),
-    ):
-        settings = wandb_setup.singleton().settings
-        expected_headers = {"x-api-key": user}
-        if settings.entity:
-            expected_headers["x-entity-id"] = settings.entity
-        if settings.project:
-            expected_headers["x-project-name"] = settings.project
+    monkeypatch.setenv("WANDB_ENTITY", "entity-from-settings")
+    monkeypatch.setenv("WANDB_PROJECT", "project-from-settings")
 
-        with Sandbox.run("sleep", "infinity") as sandbox:
-            assert sandbox.sandbox_id == "sb-system-test"
+    with Sandbox.run("sleep", "infinity") as sandbox:
+        assert sandbox.sandbox_id == "sb-system-test"
 
+    expected_headers = {
+        "x-api-key": user,
+        "x-entity-id": "entity-from-settings",
+        "x-project-name": "project-from-settings",
+    }
     assert len(calls.start) == 1
     assert dict(calls.start[0]["metadata"]) == expected_headers
     assert len(calls.stop) == 1
     assert dict(calls.stop[0]["metadata"]) == expected_headers
 
 
-def test_sandbox_run_without_run_uses_settings_entity(
+def test_sandbox_run_ignore_run_override(
     user,
     monkeypatch,
 ) -> None:
     calls = _patch_sandbox_stub(monkeypatch)
 
-    monkeypatch.delenv("WANDB_PROJECT", raising=False)
-    wandb.teardown()
-
-    assert wandb.run is None
-
-    with Sandbox.run("sleep", "infinity") as sandbox:
-        assert sandbox.sandbox_id == "sb-system-test"
+    with wandb.init(project="project-from-run"):
+        with Sandbox.run("sleep", "infinity") as sandbox:
+            assert sandbox.sandbox_id == "sb-system-test"
 
     expected_headers = {
         "x-api-key": user,
@@ -124,7 +115,7 @@ def test_sandbox_run_without_run_uses_settings_entity(
     assert dict(calls.stop[0]["metadata"]) == expected_headers
 
 
-def test_sandbox_run_without_entity_or_project_uses_api_key_only(
+def test_sandbox_run_without_entity_or_project(
     user,
     monkeypatch,
 ) -> None:
@@ -132,9 +123,6 @@ def test_sandbox_run_without_entity_or_project_uses_api_key_only(
 
     monkeypatch.delenv("WANDB_ENTITY", raising=False)
     monkeypatch.delenv("WANDB_PROJECT", raising=False)
-    wandb.teardown()
-
-    assert wandb.run is None
 
     with Sandbox.run("sleep", "infinity") as sandbox:
         assert sandbox.sandbox_id == "sb-system-test"

--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import cwsandbox._sandbox as cwsandbox_sandbox
+import pytest
+import wandb
+from wandb.sandbox import Sandbox
+
+
+class _FakeChannel:
+    async def close(self, grace=None) -> None:
+        _ = grace
+
+
+@dataclass
+class _SandboxStubCalls:
+    start: list[dict[str, object]] = field(default_factory=list)
+    stop: list[dict[str, object]] = field(default_factory=list)
+
+
+def _patch_sandbox_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _SandboxStubCalls:
+    calls = _SandboxStubCalls()
+
+    class _FakeSandboxStub:
+        def __init__(self, channel) -> None:
+            self._channel = channel
+
+        async def Start(self, request, timeout=None, metadata=None):  # noqa: N802
+            calls.start.append(
+                {
+                    "request": request,
+                    "timeout": timeout,
+                    "metadata": metadata,
+                }
+            )
+            return cwsandbox_sandbox.atc_pb2.StartSandboxResponse(
+                sandbox_id="sb-system-test",
+                service_address="",
+                exposed_ports=[],
+                applied_ingress_mode="",
+                applied_egress_mode="",
+            )
+
+        async def Stop(self, request, timeout=None, metadata=None):  # noqa: N802
+            calls.stop.append(
+                {
+                    "request": request,
+                    "timeout": timeout,
+                    "metadata": metadata,
+                }
+            )
+            return cwsandbox_sandbox.atc_pb2.StopSandboxResponse(
+                success=True,
+                error_message="",
+            )
+
+    monkeypatch.setattr(
+        cwsandbox_sandbox,
+        "create_channel",
+        lambda target, is_secure: _FakeChannel(),
+    )
+    monkeypatch.setattr(
+        cwsandbox_sandbox.atc_pb2_grpc,
+        "ATCServiceStub",
+        _FakeSandboxStub,
+    )
+    return calls
+
+
+def test_sandbox_run_uses_active_wandb_run_auth_headers(
+    user,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    calls = _patch_sandbox_stub(monkeypatch)
+
+    with wandb.init(
+        project="sandbox-auth-system-test",
+        dir=str(tmp_path),
+    ) as run:
+        expected_headers = {"x-api-key": user}
+        if run.entity:
+            expected_headers["x-entity-id"] = run.entity
+        if run.project:
+            expected_headers["x-project-name"] = run.project
+
+        with Sandbox.run("sleep", "infinity") as sandbox:
+            assert sandbox.sandbox_id == "sb-system-test"
+
+    assert len(expected_headers) == 3
+    assert len(calls.start) == 1
+    assert dict(calls.start[0]["metadata"]) == expected_headers
+    assert len(calls.stop) == 1
+    assert dict(calls.stop[0]["metadata"]) == expected_headers
+
+
+def test_sandbox_run_without_run_uses_api_key_only(
+    user,
+    monkeypatch,
+) -> None:
+    calls = _patch_sandbox_stub(monkeypatch)
+
+    monkeypatch.delenv("WANDB_ENTITY", raising=False)
+    monkeypatch.delenv("WANDB_PROJECT", raising=False)
+
+    assert wandb.run is None
+
+    with Sandbox.run("sleep", "infinity") as sandbox:
+        assert sandbox.sandbox_id == "sb-system-test"
+
+    assert len(calls.start) == 1
+    assert dict(calls.start[0]["metadata"]) == {"x-api-key": user}
+    assert len(calls.stop) == 1
+    assert dict(calls.stop[0]["metadata"]) == {"x-api-key": user}

--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass, field
 import cwsandbox._sandbox as cwsandbox_sandbox
 import pytest
 import wandb
-from wandb.sdk import wandb_setup
 from wandb.sandbox import Sandbox
+from wandb.sdk import wandb_setup
 
 
 class _FakeChannel:
@@ -20,6 +20,8 @@ class _SandboxStubCalls:
     stop: list[dict[str, object]] = field(default_factory=list)
 
 
+# TODO: We need to update the stub once upstream changes on rename are merged
+# https://github.com/coreweave/cwsandbox-client/pull/98
 def _patch_sandbox_stub(
     monkeypatch: pytest.MonkeyPatch,
 ) -> _SandboxStubCalls:

--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -19,8 +19,6 @@ class _SandboxStubCalls:
     stop: list[dict[str, object]] = field(default_factory=list)
 
 
-# TODO: We need to update the stub once upstream changes on rename are merged
-# https://github.com/coreweave/cwsandbox-client/pull/98
 def _patch_sandbox_stub(
     monkeypatch: pytest.MonkeyPatch,
 ) -> _SandboxStubCalls:
@@ -38,12 +36,19 @@ def _patch_sandbox_stub(
                     "metadata": metadata,
                 }
             )
-            return cwsandbox_sandbox.atc_pb2.StartSandboxResponse(
+            return cwsandbox_sandbox.gateway_pb2.StartSandboxResponse(
                 sandbox_id="sb-system-test",
                 service_address="",
                 exposed_ports=[],
                 applied_ingress_mode="",
                 applied_egress_mode="",
+            )
+
+        async def Get(self, request, timeout=None, metadata=None):  # noqa: N802
+            _ = request, timeout, metadata
+            return cwsandbox_sandbox.gateway_pb2.GetSandboxResponse(
+                sandbox_id="sb-system-test",
+                sandbox_status=cwsandbox_sandbox.gateway_pb2.SANDBOX_STATUS_COMPLETED,
             )
 
         async def Stop(self, request, timeout=None, metadata=None):  # noqa: N802
@@ -54,7 +59,7 @@ def _patch_sandbox_stub(
                     "metadata": metadata,
                 }
             )
-            return cwsandbox_sandbox.atc_pb2.StopSandboxResponse(
+            return cwsandbox_sandbox.gateway_pb2.StopSandboxResponse(
                 success=True,
                 error_message="",
             )
@@ -65,8 +70,8 @@ def _patch_sandbox_stub(
         lambda target, is_secure: _FakeChannel(),
     )
     monkeypatch.setattr(
-        cwsandbox_sandbox.atc_pb2_grpc,
-        "ATCServiceStub",
+        cwsandbox_sandbox.gateway_pb2_grpc,
+        "GatewayServiceStub",
         _FakeSandboxStub,
     )
     return calls

--- a/tests/unit_tests/test_library_public.py
+++ b/tests/unit_tests/test_library_public.py
@@ -101,6 +101,7 @@ SYMBOLS_ROOT_OTHER = {
     "run",
     "sacred",
     "sagemaker_auth",
+    "sandbox",
     "save",
     "sdk",
     "set_trace",

--- a/tests/unit_tests/test_sandbox/__init__.py
+++ b/tests/unit_tests/test_sandbox/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+if sys.version_info < (3, 11):
+    pytest.skip("wandb.sandbox requires Python 3.11+", allow_module_level=True)

--- a/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
+++ b/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import cwsandbox.cli.list as cwsandbox_list
+from click.testing import CliRunner
+from wandb.cli import cli
+from wandb.sandbox import CWSandboxError
+
+
+def test_sandbox_subcommands() -> None:
+    result = CliRunner().invoke(cli.beta, ["sandbox", "--help"])
+
+    expected_commands = {"ls", "logs", "exec", "sh"}
+    missing = [cmd for cmd in expected_commands if cmd not in result.output]
+
+    assert result.exit_code == 0, result.output
+    assert not missing, f"Missing commands: {missing}"
+
+
+def test_sandbox_ls_add_entity() -> None:
+    result = CliRunner().invoke(cli.beta, ["sandbox", "ls", "--help"])
+
+    expected_flags = {
+        "--entity",
+        "--status",
+        "--tag",
+        "--runway-id",
+        "--tower-id",
+        "--output",
+    }
+
+    missing = [f for f in expected_flags if f not in result.output]
+    assert not missing, f"Missing flags: {missing}"
+
+
+def test_sandbox_command_converts_cwsandbox_error(monkeypatch) -> None:
+    def fake_list(cls, **kwargs):
+        raise CWSandboxError("boom")
+
+    monkeypatch.setattr(cwsandbox_list.Sandbox, "list", classmethod(fake_list))
+
+    result = CliRunner().invoke(cli.beta, ["sandbox", "ls"])
+
+    assert result.exit_code != 0
+    assert "Error: boom" in result.output

--- a/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
+++ b/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
@@ -16,7 +16,14 @@ from wandb.sandbox import CWSandboxError
         ),
         (
             ["sandbox", "ls", "--help"],
-            ["--entity", "--status", "--tag", "--output", "wandb beta sandbox ls"],
+            [
+                "--entity",
+                "--status",
+                "--all",
+                "--tag",
+                "--output",
+                "wandb beta sandbox ls",
+            ],
         ),
         (
             ["sandbox", "sh", "--help"],

--- a/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
+++ b/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
@@ -1,35 +1,63 @@
 from __future__ import annotations
 
 import cwsandbox.cli.list as cwsandbox_list
+import pytest
 from click.testing import CliRunner
 from wandb.cli import cli
 from wandb.sandbox import CWSandboxError
 
 
-def test_sandbox_subcommands() -> None:
-    result = CliRunner().invoke(cli.beta, ["sandbox", "--help"])
-
-    expected_commands = {"ls", "logs", "exec", "sh"}
-    missing = [cmd for cmd in expected_commands if cmd not in result.output]
+@pytest.mark.parametrize(
+    ("argv", "expected_strings"),
+    [
+        (
+            ["sandbox", "--help"],
+            ["ls", "sh", "exec", "logs", "--entity", "wandb beta sandbox ls"],
+        ),
+        (
+            ["sandbox", "ls", "--help"],
+            ["--entity", "--status", "--tag", "--output", "wandb beta sandbox ls"],
+        ),
+        (
+            ["sandbox", "sh", "--help"],
+            ["--entity", "SANDBOX_ID", "--cmd", "wandb beta sandbox sh"],
+        ),
+        (
+            ["sandbox", "exec", "--help"],
+            [
+                "--entity",
+                "SANDBOX_ID",
+                "COMMAND_ARGS...",
+                "--cwd",
+                "--timeout",
+                "wandb beta sandbox exec",
+            ],
+        ),
+        (
+            ["sandbox", "logs", "--help"],
+            [
+                "--entity",
+                "SANDBOX_ID",
+                "--follow",
+                "--tail",
+                "--since",
+                "--timestamps",
+                "wandb beta sandbox logs",
+            ],
+        ),
+    ],
+)
+def test_sandbox_help_text(
+    argv: list[str],
+    expected_strings: list[str],
+) -> None:
+    result = CliRunner().invoke(cli.beta, argv)
 
     assert result.exit_code == 0, result.output
-    assert not missing, f"Missing commands: {missing}"
-
-
-def test_sandbox_ls_add_entity() -> None:
-    result = CliRunner().invoke(cli.beta, ["sandbox", "ls", "--help"])
-
-    expected_flags = {
-        "--entity",
-        "--status",
-        "--tag",
-        "--runway-id",
-        "--tower-id",
-        "--output",
-    }
-
-    missing = [f for f in expected_flags if f not in result.output]
-    assert not missing, f"Missing flags: {missing}"
+    assert "wandb beta sandbox" in result.output
+    assert "cwsandbox" not in result.output
+    for expected in expected_strings:
+        assert expected in result.output
 
 
 def test_sandbox_command_converts_cwsandbox_error(monkeypatch) -> None:

--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -48,7 +48,7 @@ def test_override_sandbox_entity_restores_after_exit(
         ),
     )
 
-    with sandbox_auth._override_sandbox_entity(entity="override-entity"):
+    with sandbox_auth.override_sandbox_entity(entity="override-entity"):
         assert sandbox_auth._resolve_wandb_sdk_auth().headers == {
             "x-api-key": _VALID_API_KEY,
             "x-entity-id": "override-entity",

--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import wandb.sandbox._auth as sandbox_auth
+
+_VALID_API_KEY = "x" * 40
+_SETTINGS_API_KEY = "y" * 40
+
+
+@pytest.fixture(autouse=True)
+def _clear_explicit_session_auth():
+    sandbox_auth.wbauth.unauthenticate_session(update_settings=False)
+    yield
+    sandbox_auth.wbauth.unauthenticate_session(update_settings=False)
+
+
+def _singleton(
+    *,
+    entity: str | None = "default-entity",
+    project: str | None = "default-project",
+    api_key: str | None = None,
+    mode: str = "online",
+    most_recent_active_run=None,
+):
+    settings = {
+        "entity": entity,
+        "project": project,
+        "api_key": api_key,
+        "identity_token_file": None,
+        "credentials_file": None,
+        "mode": mode,
+        "base_url": "https://api.wandb.ai",
+        "app_url": "https://wandb.ai",
+    }
+    singleton = {
+        "settings": Mock(spec_set=tuple(settings), **settings),
+        "most_recent_active_run": most_recent_active_run,
+    }
+    return Mock(spec_set=tuple(singleton), **singleton)
+
+
+def test_resolve_entity_project_prefers_active_run(
+    monkeypatch,
+) -> None:
+    singleton = _singleton(
+        most_recent_active_run=Mock(
+            entity="recent-entity",
+            project="recent-project",
+        )
+    )
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(
+        sandbox_auth.wandb,
+        "run",
+        Mock(entity="run-entity", project="run-project"),
+    )
+
+    assert sandbox_auth._resolve_entity_project() == (
+        "run-entity",
+        "run-project",
+    )
+
+
+def test_resolve_entity_project_uses_most_recent_run(
+    monkeypatch,
+) -> None:
+    singleton = _singleton(
+        most_recent_active_run=Mock(
+            entity="recent-entity",
+            project="recent-project",
+        )
+    )
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
+
+    assert sandbox_auth._resolve_entity_project() == (
+        "recent-entity",
+        "recent-project",
+    )
+
+
+def test_override_sandbox_entity_restores_after_exit(
+    monkeypatch,
+) -> None:
+    singleton = _singleton(
+        most_recent_active_run=Mock(
+            entity="recent-entity",
+            project="recent-project",
+        )
+    )
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(
+        sandbox_auth.wandb,
+        "run",
+        Mock(entity="run-entity", project="run-project"),
+    )
+
+    with sandbox_auth._override_sandbox_entity(entity="override-entity"):
+        assert sandbox_auth._resolve_entity_project() == (
+            "override-entity",
+            None,
+        )
+
+    assert sandbox_auth._resolve_entity_project() == (
+        "run-entity",
+        "run-project",
+    )
+
+
+def test_resolve_wandb_sdk_auth_prefers_session_credentials_over_settings_api_key(
+    monkeypatch,
+) -> None:
+    singleton = _singleton(api_key=_SETTINGS_API_KEY)
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
+    sandbox_auth.wbauth.use_explicit_auth(
+        auth=sandbox_auth.wbauth.AuthApiKey(
+            host="https://api.wandb.ai",
+            api_key=_VALID_API_KEY,
+        ),
+        source="test",
+    )
+    monkeypatch.setattr(
+        sandbox_auth.wandb_login,
+        "_login",
+        lambda **kwargs: pytest.fail("wandb_login._login should not run"),
+    )
+
+    headers = sandbox_auth._resolve_wandb_sdk_auth()
+
+    assert headers.strategy == "wandb_api_key"
+    assert headers.headers == {
+        "x-api-key": _VALID_API_KEY,
+        "x-entity-id": "default-entity",
+        "x-project-name": "default-project",
+    }
+
+
+def test_resolve_wandb_sdk_auth_loads_auth_when_missing(
+    monkeypatch,
+) -> None:
+    singleton = _singleton(
+        most_recent_active_run=Mock(
+            entity="recent-entity",
+            project="recent-project",
+        )
+    )
+    login_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
+
+    def fake_login(**kwargs) -> None:
+        login_calls.append(kwargs)
+        sandbox_auth.wbauth.use_explicit_auth(
+            auth=sandbox_auth.wbauth.AuthApiKey(
+                host="https://api.wandb.ai",
+                api_key=_VALID_API_KEY,
+            ),
+            source="test",
+        )
+
+    monkeypatch.setattr(
+        sandbox_auth.wandb_login,
+        "_login",
+        fake_login,
+    )
+
+    headers = sandbox_auth._resolve_wandb_sdk_auth()
+
+    assert login_calls == [
+        {
+            "host": "https://api.wandb.ai",
+            "update_api_key": False,
+            "_silent": True,
+        }
+    ]
+    assert headers.headers == {
+        "x-api-key": _VALID_API_KEY,
+        "x-entity-id": "recent-entity",
+        "x-project-name": "recent-project",
+    }
+
+
+def test_resolve_wandb_sdk_auth_rejects_non_api_key_credentials(
+    monkeypatch,
+) -> None:
+    singleton = _singleton()
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
+    sandbox_auth.wbauth.use_explicit_auth(
+        auth=sandbox_auth.wbauth.AuthIdentityTokenFile(
+            host="https://api.wandb.ai",
+            path="/tmp/identity-token",
+            credentials_file="/tmp/credentials.json",
+        ),
+        source="test",
+    )
+    monkeypatch.setattr(
+        sandbox_auth.wandb_login,
+        "_login",
+        lambda **kwargs: pytest.fail("wandb_login._login should not run"),
+    )
+
+    with pytest.raises(
+        sandbox_auth.UsageError,
+        match="wandb.sandbox currently supports only W&B user API-key auth.",
+    ):
+        sandbox_auth._resolve_wandb_sdk_auth()
+
+
+def test_resolve_wandb_sdk_auth_raises_when_login_does_not_resolve_credentials(
+    monkeypatch,
+) -> None:
+    singleton = _singleton()
+    login_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
+    monkeypatch.setattr(
+        sandbox_auth.wandb_login,
+        "_login",
+        lambda **kwargs: login_calls.append(kwargs),
+    )
+
+    with pytest.raises(
+        sandbox_auth.CWSandboxAuthenticationError,
+        match="wandb.sandbox could not resolve W&B credentials for sandbox auth.",
+    ):
+        sandbox_auth._resolve_wandb_sdk_auth()
+
+    assert login_calls == [
+        {
+            "host": "https://api.wandb.ai",
+            "update_api_key": False,
+            "_silent": False,
+        }
+    ]

--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -9,13 +9,6 @@ _VALID_API_KEY = "x" * 40
 _SETTINGS_API_KEY = "y" * 40
 
 
-@pytest.fixture(autouse=True)
-def _clear_explicit_session_auth():
-    sandbox_auth.wbauth.unauthenticate_session(update_settings=False)
-    yield
-    sandbox_auth.wbauth.unauthenticate_session(update_settings=False)
-
-
 def _singleton(
     *,
     entity: str | None = "default-entity",
@@ -41,95 +34,58 @@ def _singleton(
     return Mock(spec_set=tuple(singleton), **singleton)
 
 
-def test_resolve_entity_project_prefers_active_run(
-    monkeypatch,
-) -> None:
-    singleton = _singleton(
-        most_recent_active_run=Mock(
-            entity="recent-entity",
-            project="recent-project",
-        )
-    )
-    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
-    monkeypatch.setattr(
-        sandbox_auth.wandb,
-        "run",
-        Mock(entity="run-entity", project="run-project"),
-    )
-
-    assert sandbox_auth._resolve_entity_project() == (
-        "run-entity",
-        "run-project",
-    )
-
-
-def test_resolve_entity_project_uses_most_recent_run(
-    monkeypatch,
-) -> None:
-    singleton = _singleton(
-        most_recent_active_run=Mock(
-            entity="recent-entity",
-            project="recent-project",
-        )
-    )
-    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
-    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
-
-    assert sandbox_auth._resolve_entity_project() == (
-        "recent-entity",
-        "recent-project",
-    )
-
-
 def test_override_sandbox_entity_restores_after_exit(
     monkeypatch,
 ) -> None:
-    singleton = _singleton(
-        most_recent_active_run=Mock(
-            entity="recent-entity",
-            project="recent-project",
-        )
-    )
+    singleton = _singleton()
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
     monkeypatch.setattr(
-        sandbox_auth.wandb,
-        "run",
-        Mock(entity="run-entity", project="run-project"),
+        sandbox_auth.wbauth,
+        "authenticate_session",
+        lambda **kwargs: sandbox_auth.wbauth.AuthApiKey(
+            host=kwargs["host"],
+            api_key=_VALID_API_KEY,
+        ),
     )
 
     with sandbox_auth._override_sandbox_entity(entity="override-entity"):
-        assert sandbox_auth._resolve_entity_project() == (
-            "override-entity",
-            None,
-        )
+        assert sandbox_auth._resolve_wandb_sdk_auth().headers == {
+            "x-api-key": _VALID_API_KEY,
+            "x-entity-id": "override-entity",
+            "x-project-name": "default-project",
+        }
 
-    assert sandbox_auth._resolve_entity_project() == (
-        "run-entity",
-        "run-project",
-    )
+    assert sandbox_auth._resolve_wandb_sdk_auth().headers == {
+        "x-api-key": _VALID_API_KEY,
+        "x-entity-id": "default-entity",
+        "x-project-name": "default-project",
+    }
 
 
-def test_resolve_wandb_sdk_auth_prefers_session_credentials_over_settings_api_key(
+def test_resolve_wandb_sdk_auth_delegates_to_authenticate_session(
     monkeypatch,
 ) -> None:
     singleton = _singleton(api_key=_SETTINGS_API_KEY)
+    auth_calls: list[dict[str, object]] = []
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
-    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
-    sandbox_auth.wbauth.use_explicit_auth(
-        auth=sandbox_auth.wbauth.AuthApiKey(
-            host="https://api.wandb.ai",
+    monkeypatch.setattr(
+        sandbox_auth.wbauth,
+        "authenticate_session",
+        lambda **kwargs: auth_calls.append(kwargs)
+        or sandbox_auth.wbauth.AuthApiKey(
+            host=kwargs["host"],
             api_key=_VALID_API_KEY,
         ),
-        source="test",
-    )
-    monkeypatch.setattr(
-        sandbox_auth.wandb_login,
-        "_login",
-        lambda **kwargs: pytest.fail("wandb_login._login should not run"),
     )
 
     headers = sandbox_auth._resolve_wandb_sdk_auth()
 
+    assert len(auth_calls) == 1
+    assert isinstance(auth_calls[0]["host"], sandbox_auth.wbauth.HostUrl)
+    assert auth_calls[0]["host"].url == "https://api.wandb.ai"
+    assert auth_calls[0]["host"].app_url == "https://wandb.ai"
+    assert auth_calls[0]["source"] == "sandbox"
+    assert auth_calls[0]["no_offline"] is True
     assert headers.strategy == "wandb_api_key"
     assert headers.headers == {
         "x-api-key": _VALID_API_KEY,
@@ -138,49 +94,23 @@ def test_resolve_wandb_sdk_auth_prefers_session_credentials_over_settings_api_ke
     }
 
 
-def test_resolve_wandb_sdk_auth_loads_auth_when_missing(
+def test_resolve_wandb_sdk_auth_omits_optional_metadata_when_unset(
     monkeypatch,
 ) -> None:
-    singleton = _singleton(
-        most_recent_active_run=Mock(
-            entity="recent-entity",
-            project="recent-project",
-        )
-    )
-    login_calls: list[dict[str, object]] = []
+    singleton = _singleton(entity=None, project=None)
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
-    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
-
-    def fake_login(**kwargs) -> None:
-        login_calls.append(kwargs)
-        sandbox_auth.wbauth.use_explicit_auth(
-            auth=sandbox_auth.wbauth.AuthApiKey(
-                host="https://api.wandb.ai",
-                api_key=_VALID_API_KEY,
-            ),
-            source="test",
-        )
-
     monkeypatch.setattr(
-        sandbox_auth.wandb_login,
-        "_login",
-        fake_login,
+        sandbox_auth.wbauth,
+        "authenticate_session",
+        lambda **kwargs: sandbox_auth.wbauth.AuthApiKey(
+            host=kwargs["host"],
+            api_key=_VALID_API_KEY,
+        ),
     )
 
     headers = sandbox_auth._resolve_wandb_sdk_auth()
 
-    assert login_calls == [
-        {
-            "host": "https://api.wandb.ai",
-            "update_api_key": False,
-            "_silent": True,
-        }
-    ]
-    assert headers.headers == {
-        "x-api-key": _VALID_API_KEY,
-        "x-entity-id": "recent-entity",
-        "x-project-name": "recent-project",
-    }
+    assert headers.headers == {"x-api-key": _VALID_API_KEY}
 
 
 def test_resolve_wandb_sdk_auth_rejects_non_api_key_credentials(
@@ -188,19 +118,14 @@ def test_resolve_wandb_sdk_auth_rejects_non_api_key_credentials(
 ) -> None:
     singleton = _singleton()
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
-    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
-    sandbox_auth.wbauth.use_explicit_auth(
-        auth=sandbox_auth.wbauth.AuthIdentityTokenFile(
-            host="https://api.wandb.ai",
+    monkeypatch.setattr(
+        sandbox_auth.wbauth,
+        "authenticate_session",
+        lambda **kwargs: sandbox_auth.wbauth.AuthIdentityTokenFile(
+            host=kwargs["host"],
             path="/tmp/identity-token",
             credentials_file="/tmp/credentials.json",
         ),
-        source="test",
-    )
-    monkeypatch.setattr(
-        sandbox_auth.wandb_login,
-        "_login",
-        lambda **kwargs: pytest.fail("wandb_login._login should not run"),
     )
 
     with pytest.raises(
@@ -214,13 +139,11 @@ def test_resolve_wandb_sdk_auth_raises_when_login_does_not_resolve_credentials(
     monkeypatch,
 ) -> None:
     singleton = _singleton()
-    login_calls: list[dict[str, object]] = []
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
-    monkeypatch.setattr(sandbox_auth.wandb, "run", None)
     monkeypatch.setattr(
-        sandbox_auth.wandb_login,
-        "_login",
-        lambda **kwargs: login_calls.append(kwargs),
+        sandbox_auth.wbauth,
+        "authenticate_session",
+        lambda **kwargs: None,
     )
 
     with pytest.raises(
@@ -228,11 +151,3 @@ def test_resolve_wandb_sdk_auth_raises_when_login_does_not_resolve_credentials(
         match="wandb.sandbox could not resolve W&B credentials for sandbox auth.",
     ):
         sandbox_auth._resolve_wandb_sdk_auth()
-
-    assert login_calls == [
-        {
-            "host": "https://api.wandb.ai",
-            "update_api_key": False,
-            "_silent": False,
-        }
-    ]

--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -71,10 +71,12 @@ def test_resolve_wandb_sdk_auth_delegates_to_authenticate_session(
     monkeypatch.setattr(
         sandbox_auth.wbauth,
         "authenticate_session",
-        lambda **kwargs: auth_calls.append(kwargs)
-        or sandbox_auth.wbauth.AuthApiKey(
-            host=kwargs["host"],
-            api_key=_VALID_API_KEY,
+        lambda **kwargs: (
+            auth_calls.append(kwargs)
+            or sandbox_auth.wbauth.AuthApiKey(
+                host=kwargs["host"],
+                api_key=_VALID_API_KEY,
+            )
         ),
     )
 

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -1,23 +1,31 @@
-from __future__ import annotations
-
 import cwsandbox
 import wandb.sandbox as wandb_sandbox
+from wandb.sandbox import Secret
+from wandb.sandbox._secret import WANDB_SECRET_STORE
 
-_DISCOVERY_EXCEPTION_NAMES = {
-    "DiscoveryError",
-    "RunwayNotFoundError",
-    "TowerNotFoundError",
-}
+_HIDDEN_EXPORT_NAMES = {"AuthHeaders", "set_auth_mode"}
+_OVERRIDDEN_EXPORT_NAMES = {"Secret"}
 
 
-def test_sandbox_wrapper_reexports_cwsandbox_exception_classes() -> None:
-    expected_exception_names = {
-        name for name in cwsandbox.__all__ if name.endswith("Error")
-    } - _DISCOVERY_EXCEPTION_NAMES
+def test_sandbox_wrapper_reexports_cwsandbox_public_api() -> None:
+    expected_export_names = set(cwsandbox.__all__) - _HIDDEN_EXPORT_NAMES
 
-    assert expected_exception_names <= set(wandb_sandbox.__all__)
+    assert expected_export_names == set(wandb_sandbox.__all__)
+    assert _HIDDEN_EXPORT_NAMES.isdisjoint(set(wandb_sandbox.__all__))
 
-    assert _DISCOVERY_EXCEPTION_NAMES.isdisjoint(set(wandb_sandbox.__all__))
-
-    for name in expected_exception_names:
+    for name in expected_export_names - _OVERRIDDEN_EXPORT_NAMES:
         assert getattr(wandb_sandbox, name) is getattr(cwsandbox, name)
+
+
+def test_sandbox_wrapper_uses_wandb_secret_override() -> None:
+    assert "Secret" in wandb_sandbox.__all__
+    assert Secret is not cwsandbox.Secret
+
+    secret = Secret(name="MY_SECRET")
+
+    assert isinstance(secret, cwsandbox.Secret)
+    assert secret.name == "MY_SECRET"
+    assert secret.store == WANDB_SECRET_STORE
+
+    secret = Secret(store="not-default-store", name="MY_SECRET")
+    assert secret.store == "not-default-store"

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import cwsandbox
+import wandb.sandbox as wandb_sandbox
+
+_DISCOVERY_EXCEPTION_NAMES = {
+    "DiscoveryError",
+    "RunwayNotFoundError",
+    "TowerNotFoundError",
+}
+
+
+def test_sandbox_wrapper_reexports_cwsandbox_exception_classes() -> None:
+    expected_exception_names = {
+        name for name in cwsandbox.__all__ if name.endswith("Error")
+    } - _DISCOVERY_EXCEPTION_NAMES
+
+    assert expected_exception_names <= set(wandb_sandbox.__all__)
+
+    assert _DISCOVERY_EXCEPTION_NAMES.isdisjoint(set(wandb_sandbox.__all__))
+
+    for name in expected_exception_names:
+        assert getattr(wandb_sandbox, name) is getattr(cwsandbox, name)

--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -279,10 +279,10 @@ def core() -> None:
 
 try:
     from .beta_sandbox import sandbox as sandbox_group
-
-    beta.add_command(sandbox_group)
 except ImportError:
     pass
+else:
+    beta.add_command(sandbox_group)
 
 
 @core.command()

--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -14,8 +14,6 @@ from wandb.analytics import get_sentry
 from wandb.errors import WandbCoreNotAvailableError
 from wandb.util import get_core_path
 
-from .beta_sandbox import SandboxGroup
-
 
 class DefaultCommandGroup(click.Group):
     """A click Group that falls through to a default command.
@@ -279,9 +277,12 @@ def core() -> None:
     """
 
 
-@beta.group(cls=SandboxGroup)
-def sandbox() -> None:
-    """Manage CoreWeave sandboxes through the W&B CLI."""
+try:
+    from .beta_sandbox import sandbox as sandbox_group
+
+    beta.add_command(sandbox_group)
+except ImportError:
+    pass
 
 
 @core.command()

--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -14,6 +14,8 @@ from wandb.analytics import get_sentry
 from wandb.errors import WandbCoreNotAvailableError
 from wandb.util import get_core_path
 
+from .beta_sandbox import SandboxGroup
+
 
 class DefaultCommandGroup(click.Group):
     """A click Group that falls through to a default command.
@@ -44,7 +46,6 @@ def beta() -> None:
     These commands may change or even completely break in any release of wandb.
     """
     get_sentry().configure_scope(process_context="wandb_beta")
-
     try:
         get_core_path()
     except WandbCoreNotAvailableError as e:
@@ -276,6 +277,11 @@ def core() -> None:
     The shared service exits after 10 minutes of idleness by default.
     Override this with --idle-timeout on the start command.
     """
+
+
+@beta.group(cls=SandboxGroup)
+def sandbox() -> None:
+    """Manage CoreWeave sandboxes through the W&B CLI."""
 
 
 @core.command()

--- a/wandb/cli/beta_sandbox.py
+++ b/wandb/cli/beta_sandbox.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 
 import click
-from cwsandbox.cli.exec import exec_command as cwsandbox_exec_command
-from cwsandbox.cli.logs import logs as cwsandbox_logs
 from cwsandbox.cli.shell import _validate_cmd as _cwsandbox_validate_cmd
-from cwsandbox.cli.shell import shell as cwsandbox_shell
 
 from wandb.sandbox import CWSandboxError, Sandbox, SandboxStatus
 from wandb.sandbox._auth import _override_sandbox_entity
@@ -145,7 +142,7 @@ def list_sandboxes(
 @click.option(
     "--cmd",
     default="/bin/bash",
-    callback=_validate_shell_cmd,
+    callback=_cwsandbox_validate_cmd,
     help="Command to run (default: /bin/bash). Accepts full command strings.",
 )
 def shell(
@@ -163,7 +160,9 @@ def shell(
 
         wandb beta sandbox sh --entity team <sandbox-id>
     """
-    callback = cwsandbox_shell.callback
+    from cwsandbox.cli.shell import shell
+
+    callback = shell.callback
     if callback is None:
         raise click.ClickException("Failed to load the cwsandbox CLI command.")
 
@@ -209,9 +208,11 @@ def exec_in_sandbox(
 
         wandb beta sandbox exec --entity team <sandbox-id> echo hello
     """
-    callback = cwsandbox_exec_command.callback
+    from cwsandbox.cli.exec import exec_command
+
+    callback = exec_command.callback
     if callback is None:
-        raise click.ClickException("Failed to load the cwsandbox CLI command.")
+        raise click.ClickException("Failed to load the cwsandbox exec command.")
 
     callback(
         sandbox_id=sandbox_id,
@@ -270,12 +271,11 @@ def logs(
 
         wandb beta sandbox logs --entity team <sandbox-id>
     """
-    if since_time is not None and since_time.tzinfo is None:
-        since_time = since_time.replace(tzinfo=UTC)
+    from cwsandbox.cli.logs import logs
 
-    callback = cwsandbox_logs.callback
+    callback = logs.callback
     if callback is None:
-        raise click.ClickException("Failed to load the cwsandbox CLI command.")
+        raise click.ClickException("Failed to load the cwsandbox logs command.")
 
     callback(
         sandbox_id=sandbox_id,

--- a/wandb/cli/beta_sandbox.py
+++ b/wandb/cli/beta_sandbox.py
@@ -1,76 +1,286 @@
-"""Implements `wandb beta sandbox` by delegating to the cwsandbox CLI."""
-
 from __future__ import annotations
 
-import copy
-import importlib
-import sys
-from typing import Any
+import json
+from datetime import UTC, datetime
 
 import click
+from cwsandbox.cli.exec import exec_command as cwsandbox_exec_command
+from cwsandbox.cli.logs import logs as cwsandbox_logs
+from cwsandbox.cli.shell import _validate_cmd as _cwsandbox_validate_cmd
+from cwsandbox.cli.shell import shell as cwsandbox_shell
+
+from wandb.sandbox import CWSandboxError, Sandbox, SandboxStatus
+from wandb.sandbox._auth import _override_sandbox_entity
+
+_STATUS_CHOICES = [s.value for s in SandboxStatus if s != SandboxStatus.UNSPECIFIED]
 
 
-class SandboxGroup(click.Group):
-    """A click Group that lazily proxies sandbox commands to cwsandbox."""
+class SandboxCommand(click.Command):
+    """Click command that injects sandbox entity override and error handling."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
-        self._base_cli: click.Group | None = None
-        self._wrapped_commands: dict[str, click.Command] = {}
-
-    def _load_cwsandbox_cli(self) -> click.Group:
-        if self._base_cli is None:
-            if sys.version_info < (3, 11):
-                raise click.ClickException(
-                    "Sandbox CLI support requires Python 3.11 or newer because cwsandbox does not support older Python versions."
-                )
-            try:
-                importlib.import_module("wandb.sandbox")
-                cli_module = importlib.import_module("cwsandbox.cli")
-            except ImportError as exc:
-                raise click.ClickException(
-                    "Sandbox CLI support is not installed. Install it with: pip install wandb[sandbox]"
-                ) from exc
-
-            cli = getattr(cli_module, "cli", None)
-            if not isinstance(cli, click.Group):
-                raise click.ClickException("Failed to load the cwsandbox CLI.")
-
-            self._base_cli = cli
-        return self._base_cli
-
-    def list_commands(self, ctx: click.Context) -> list[str]:
-        return self._load_cwsandbox_cli().list_commands(ctx)
-
-    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
-        wrapped_command = self._wrapped_commands.get(cmd_name)
-        if wrapped_command is not None:
-            return wrapped_command
-
-        base_command = self._load_cwsandbox_cli().get_command(ctx, cmd_name)
-        if base_command is None:
-            return None
-
-        @click.pass_context
-        def callback(ctx: click.Context, entity: str | None, **kwargs: Any) -> Any:
-            from wandb.sandbox import CWSandboxError
-            from wandb.sandbox._auth import _override_sandbox_entity
-
-            try:
-                with _override_sandbox_entity(entity=entity):
-                    return ctx.invoke(base_command.callback, **kwargs)
-            except CWSandboxError as exc:
-                raise click.ClickException(str(exc)) from None
-
-        wrapped_command = copy.copy(base_command)
-        wrapped_command.callback = callback
-        wrapped_command.params = [
+        self.params = [
             click.Option(
                 ["-e", "--entity"],
                 default=None,
-                help="Override the W&B entity used for sandbox auth.",
+                help="Set the W&B entity for sandbox. Default is user's default entity.",
             ),
-            *base_command.params,
+            *self.params,
         ]
-        self._wrapped_commands[cmd_name] = wrapped_command
-        return wrapped_command
+
+    def invoke(self, ctx: click.Context) -> object:
+        entity = ctx.params.pop("entity", None)
+
+        try:
+            with _override_sandbox_entity(entity=entity):
+                return super().invoke(ctx)
+        except CWSandboxError as exc:
+            raise click.ClickException(str(exc)) from None
+
+
+def _validate_shell_cmd(
+    ctx: click.Context,
+    param: click.Parameter,
+    value: str,
+) -> str:
+    return _cwsandbox_validate_cmd(ctx, param, value)
+
+
+class SandboxGroup(click.Group):
+    """Click group for sandbox commands."""
+
+    command_class = SandboxCommand
+
+
+@click.group(cls=SandboxGroup)
+def sandbox() -> None:
+    """Manage W&B sandboxes.
+
+    Commands use your default W&B entity unless you pass ``--entity``.
+    If a sandbox is not found or you get an auth error, it may have been
+    created under a non-default W&B entity. Retry with ``--entity <entity>``.
+
+    Examples:
+        wandb beta sandbox ls
+
+        wandb beta sandbox sh <sandbox-id>
+
+        wandb beta sandbox exec <sandbox-id> echo hello
+
+        wandb beta sandbox logs <sandbox-id> --follow
+
+        wandb beta sandbox ls --entity team
+    """
+
+
+@sandbox.command("ls")
+@click.option(
+    "--status",
+    "-s",
+    default=None,
+    type=click.Choice(_STATUS_CHOICES, case_sensitive=False),
+    help="Filter by status.",
+)
+@click.option("--tag", "-t", "tags", multiple=True, help="Filter by tag (repeatable).")
+@click.option(
+    "--output",
+    "-o",
+    "output_format",
+    default="table",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    help="Output format.",
+)
+def list_sandboxes(
+    status: str | None,
+    tags: tuple[str, ...],
+    output_format: str,
+) -> None:
+    """List sandboxes.
+
+    Examples:
+        wandb beta sandbox ls
+
+        wandb beta sandbox ls --status running
+
+        wandb beta sandbox ls --tag env=dev --output json
+
+        wandb beta sandbox ls --entity team
+    """
+    sandboxes = Sandbox.list(
+        tags=list(tags) if tags else None,
+        status=status,
+    ).result()
+
+    if output_format == "json":
+        data = [
+            {
+                "sandbox_id": sb.sandbox_id,
+                "status": sb.status.value if sb.status else None,
+                "started_at": sb.started_at.isoformat() if sb.started_at else None,
+            }
+            for sb in sandboxes
+        ]
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    if not sandboxes:
+        click.echo("No sandboxes found.")
+        return
+
+    click.echo(f"{'SANDBOX ID':<40} {'STATUS':<14} {'STARTED AT'}")
+    click.echo(f"{'-' * 40} {'-' * 14} {'-' * 24}")
+
+    for sb in sandboxes:
+        sid = sb.sandbox_id or "-"
+        st = sb.status.value if sb.status else "-"
+        started = (
+            sb.started_at.strftime("%Y-%m-%d %H:%M:%S UTC") if sb.started_at else "-"
+        )
+        click.echo(f"{sid:<40} {st:<14} {started}")
+
+
+@sandbox.command("sh")
+@click.argument("sandbox_id")
+@click.option(
+    "--cmd",
+    default="/bin/bash",
+    callback=_validate_shell_cmd,
+    help="Command to run (default: /bin/bash). Accepts full command strings.",
+)
+def shell(
+    sandbox_id: str,
+    cmd: str,
+) -> None:
+    """Open an interactive shell in a sandbox.
+
+    SANDBOX_ID is the ID of the sandbox to connect to.
+
+    Examples:
+        wandb beta sandbox sh <sandbox-id>
+
+        wandb beta sandbox sh <sandbox-id> --cmd /bin/zsh
+
+        wandb beta sandbox sh --entity team <sandbox-id>
+    """
+    callback = cwsandbox_shell.callback
+    if callback is None:
+        raise click.ClickException("Failed to load the cwsandbox CLI command.")
+
+    callback(sandbox_id=sandbox_id, cmd=cmd)
+
+
+@sandbox.command(
+    "exec",
+    context_settings={"ignore_unknown_options": True},
+)
+@click.argument("sandbox_id")
+@click.argument("command_args", nargs=-1, required=True, type=click.UNPROCESSED)
+@click.option(
+    "--cwd",
+    "-w",
+    default=None,
+    help="Working directory for the command.",
+)
+@click.option(
+    "--timeout",
+    "-t",
+    "timeout_seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Timeout in seconds.",
+)
+def exec_in_sandbox(
+    sandbox_id: str,
+    command_args: tuple[str, ...],
+    cwd: str | None,
+    timeout_seconds: float | None,
+) -> None:
+    """Execute a command in a sandbox.
+
+    SANDBOX_ID is the ID of the sandbox to run the command in.
+
+    Examples:
+        wandb beta sandbox exec <sandbox-id> echo hello
+
+        wandb beta sandbox exec <sandbox-id> python -c "print('ok')"
+
+        wandb beta sandbox exec <sandbox-id> --cwd /app python app.py
+
+        wandb beta sandbox exec --entity team <sandbox-id> echo hello
+    """
+    callback = cwsandbox_exec_command.callback
+    if callback is None:
+        raise click.ClickException("Failed to load the cwsandbox CLI command.")
+
+    callback(
+        sandbox_id=sandbox_id,
+        command=command_args,
+        cwd=cwd,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@sandbox.command("logs")
+@click.argument("sandbox_id")
+@click.option(
+    "--follow",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Follow log output (like tail -f).",
+)
+@click.option(
+    "--tail",
+    "tail_lines",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Number of recent lines to show.",
+)
+@click.option(
+    "--since",
+    "since_time",
+    type=click.DateTime(),
+    default=None,
+    help="Show logs since timestamp (e.g. 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS').",
+)
+@click.option(
+    "--timestamps", "-t", is_flag=True, default=False, help="Show timestamps."
+)
+def logs(
+    sandbox_id: str,
+    follow: bool,
+    tail_lines: int | None,
+    since_time: datetime | None,
+    timestamps: bool,
+) -> None:
+    """Stream logs from a sandbox's main process.
+
+    Streams stdout/stderr from the command used to create the sandbox. Output
+    from ``wandb beta sandbox exec`` commands is not included.
+
+    SANDBOX_ID is the ID of the sandbox to stream logs from.
+
+    Examples:
+        wandb beta sandbox logs <sandbox-id>
+
+        wandb beta sandbox logs <sandbox-id> --tail 50
+
+        wandb beta sandbox logs <sandbox-id> --follow --timestamps
+
+        wandb beta sandbox logs --entity team <sandbox-id>
+    """
+    if since_time is not None and since_time.tzinfo is None:
+        since_time = since_time.replace(tzinfo=UTC)
+
+    callback = cwsandbox_logs.callback
+    if callback is None:
+        raise click.ClickException("Failed to load the cwsandbox CLI command.")
+
+    callback(
+        sandbox_id=sandbox_id,
+        follow=follow,
+        tail_lines=tail_lines,
+        since_time=since_time,
+        timestamps=timestamps,
+    )

--- a/wandb/cli/beta_sandbox.py
+++ b/wandb/cli/beta_sandbox.py
@@ -7,7 +7,7 @@ import click
 from cwsandbox.cli.shell import _validate_cmd as _cwsandbox_validate_cmd
 
 from wandb.sandbox import CWSandboxError, Sandbox, SandboxStatus
-from wandb.sandbox._auth import _override_sandbox_entity
+from wandb.sandbox._auth import override_sandbox_entity
 
 _STATUS_CHOICES = [s.value for s in SandboxStatus if s != SandboxStatus.UNSPECIFIED]
 
@@ -30,7 +30,7 @@ class SandboxCommand(click.Command):
         entity = ctx.params.pop("entity", None)
 
         try:
-            with _override_sandbox_entity(entity=entity):
+            with override_sandbox_entity(entity=entity):
                 return super().invoke(ctx)
         except CWSandboxError as exc:
             raise click.ClickException(str(exc)) from None

--- a/wandb/cli/beta_sandbox.py
+++ b/wandb/cli/beta_sandbox.py
@@ -36,14 +36,6 @@ class SandboxCommand(click.Command):
             raise click.ClickException(str(exc)) from None
 
 
-def _validate_shell_cmd(
-    ctx: click.Context,
-    param: click.Parameter,
-    value: str,
-) -> str:
-    return _cwsandbox_validate_cmd(ctx, param, value)
-
-
 class SandboxGroup(click.Group):
     """Click group for sandbox commands."""
 
@@ -59,15 +51,23 @@ def sandbox() -> None:
     created under a non-default W&B entity. Retry with ``--entity <entity>``.
 
     Examples:
+        # List all pending/running sandboxes
         wandb beta sandbox ls
 
-        wandb beta sandbox sh <sandbox-id>
+        # List all sandboxes
+        wandb beta sandbox ls -a
 
+        # List sandbox created using non default entity
+        wandb beta sandbox ls --entity my-other-team
+
+        # Run single command inside a running sandbox
         wandb beta sandbox exec <sandbox-id> echo hello
 
-        wandb beta sandbox logs <sandbox-id> --follow
+        # Open interavtive shell
+        wandb beta sandbox sh <sandbox-id>
 
-        wandb beta sandbox ls --entity team
+        # Tail log
+        wandb beta sandbox logs <sandbox-id> --follow
     """
 
 
@@ -79,6 +79,16 @@ def sandbox() -> None:
     type=click.Choice(_STATUS_CHOICES, case_sensitive=False),
     help="Filter by status.",
 )
+@click.option(
+    "--all",
+    "-a",
+    "include_stopped",
+    is_flag=True,
+    default=False,
+    help="Include stopped sandboxes in results.",
+)
+# TODO: cwsandbox is NOT returning the tags in the response object, so we can filter
+# by tags, but we cannot show what tags the matched sandbox has ....
 @click.option("--tag", "-t", "tags", multiple=True, help="Filter by tag (repeatable).")
 @click.option(
     "--output",
@@ -90,23 +100,28 @@ def sandbox() -> None:
 )
 def list_sandboxes(
     status: str | None,
+    include_stopped: bool,
     tags: tuple[str, ...],
     output_format: str,
 ) -> None:
     """List sandboxes.
 
     Examples:
+        # List all non stopped
         wandb beta sandbox ls
+
+        wandb beta sandbox ls -a
 
         wandb beta sandbox ls --status running
 
-        wandb beta sandbox ls --tag env=dev --output json
+        wandb beta sandbox ls --tag foo --output json
 
         wandb beta sandbox ls --entity team
     """
     sandboxes = Sandbox.list(
         tags=list(tags) if tags else None,
         status=status,
+        include_stopped=include_stopped,
     ).result()
 
     if output_format == "json":

--- a/wandb/cli/beta_sandbox.py
+++ b/wandb/cli/beta_sandbox.py
@@ -1,0 +1,76 @@
+"""Implements `wandb beta sandbox` by delegating to the cwsandbox CLI."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import sys
+from typing import Any
+
+import click
+
+
+class SandboxGroup(click.Group):
+    """A click Group that lazily proxies sandbox commands to cwsandbox."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._base_cli: click.Group | None = None
+        self._wrapped_commands: dict[str, click.Command] = {}
+
+    def _load_cwsandbox_cli(self) -> click.Group:
+        if self._base_cli is None:
+            if sys.version_info < (3, 11):
+                raise click.ClickException(
+                    "Sandbox CLI support requires Python 3.11 or newer because cwsandbox does not support older Python versions."
+                )
+            try:
+                importlib.import_module("wandb.sandbox")
+                cli_module = importlib.import_module("cwsandbox.cli")
+            except ImportError as exc:
+                raise click.ClickException(
+                    "Sandbox CLI support is not installed. Install it with: pip install wandb[sandbox]"
+                ) from exc
+
+            cli = getattr(cli_module, "cli", None)
+            if not isinstance(cli, click.Group):
+                raise click.ClickException("Failed to load the cwsandbox CLI.")
+
+            self._base_cli = cli
+        return self._base_cli
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        return self._load_cwsandbox_cli().list_commands(ctx)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        wrapped_command = self._wrapped_commands.get(cmd_name)
+        if wrapped_command is not None:
+            return wrapped_command
+
+        base_command = self._load_cwsandbox_cli().get_command(ctx, cmd_name)
+        if base_command is None:
+            return None
+
+        @click.pass_context
+        def callback(ctx: click.Context, entity: str | None, **kwargs: Any) -> Any:
+            from wandb.sandbox import CWSandboxError
+            from wandb.sandbox._auth import _override_sandbox_entity
+
+            try:
+                with _override_sandbox_entity(entity=entity):
+                    return ctx.invoke(base_command.callback, **kwargs)
+            except CWSandboxError as exc:
+                raise click.ClickException(str(exc)) from None
+
+        wrapped_command = copy.copy(base_command)
+        wrapped_command.callback = callback
+        wrapped_command.params = [
+            click.Option(
+                ["-e", "--entity"],
+                default=None,
+                help="Override the W&B entity used for sandbox auth.",
+            ),
+            *base_command.params,
+        ]
+        self._wrapped_commands[cmd_name] = wrapped_command
+        return wrapped_command

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+if sys.version_info < (3, 11):
+    raise ImportError(
+        "wandb.sandbox requires Python 3.11 or newer because cwsandbox does not support older Python versions."
+    )
+
+try:
+    importlib.import_module("cwsandbox")
+except ImportError as exc:
+    raise ImportError(
+        "cwsandbox is not installed. Please install it with: pip install wandb[sandbox]"
+    ) from exc
+
+from cwsandbox import (
+    AsyncFunctionError,
+    CWSandboxAuthenticationError,
+    CWSandboxError,
+    FunctionError,
+    FunctionSerializationError,
+    NetworkOptions,
+    OperationRef,
+    Process,
+    ProcessResult,
+    RemoteFunction,
+    Sandbox,
+    SandboxDefaults,
+    SandboxError,
+    SandboxExecutionError,
+    SandboxFailedError,
+    SandboxFileError,
+    SandboxNotFoundError,
+    SandboxNotRunningError,
+    SandboxStatus,
+    SandboxTerminatedError,
+    SandboxTimeoutError,
+    Serialization,
+    Session,
+    StreamReader,
+    StreamWriter,
+    TerminalResult,
+    TerminalSession,
+    Waitable,
+    results,
+    wait,
+)
+
+from ._auth import _set_wandb_auth_mode
+from ._secret import Secret
+
+_set_wandb_auth_mode()
+
+__all__ = (
+    "AsyncFunctionError",
+    "CWSandboxAuthenticationError",
+    "CWSandboxError",
+    "FunctionError",
+    "FunctionSerializationError",
+    "NetworkOptions",
+    "OperationRef",
+    "Process",
+    "ProcessResult",
+    "RemoteFunction",
+    "Sandbox",
+    "SandboxDefaults",
+    "SandboxError",
+    "SandboxExecutionError",
+    "SandboxFailedError",
+    "SandboxFileError",
+    "SandboxNotFoundError",
+    "SandboxNotRunningError",
+    "SandboxStatus",
+    "SandboxTerminatedError",
+    "SandboxTimeoutError",
+    "Secret",
+    "Serialization",
+    "Session",
+    "StreamReader",
+    "StreamWriter",
+    "TerminalResult",
+    "TerminalSession",
+    "Waitable",
+    "results",
+    "wait",
+)

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -1,88 +1,21 @@
 from __future__ import annotations
 
-import importlib
-import sys
-
-if sys.version_info < (3, 11):
-    raise ImportError(
-        "wandb.sandbox requires Python 3.11 or newer because cwsandbox does not support older Python versions."
-    )
-
 try:
-    importlib.import_module("cwsandbox")
+    import cwsandbox
 except ImportError as exc:
     raise ImportError(
         "cwsandbox is not installed. Please install it with: pip install wandb[sandbox]"
     ) from exc
 
-from cwsandbox import (
-    AsyncFunctionError,
-    CWSandboxAuthenticationError,
-    CWSandboxError,
-    FunctionError,
-    FunctionSerializationError,
-    NetworkOptions,
-    OperationRef,
-    Process,
-    ProcessResult,
-    RemoteFunction,
-    Sandbox,
-    SandboxDefaults,
-    SandboxError,
-    SandboxExecutionError,
-    SandboxFailedError,
-    SandboxFileError,
-    SandboxNotFoundError,
-    SandboxNotRunningError,
-    SandboxStatus,
-    SandboxTerminatedError,
-    SandboxTimeoutError,
-    Serialization,
-    Session,
-    StreamReader,
-    StreamWriter,
-    TerminalResult,
-    TerminalSession,
-    Waitable,
-    results,
-    wait,
-)
+from cwsandbox import *  # noqa: F403
+from cwsandbox import __all__ as cwsandbox_all
 
+# wandb specific overrides
 from ._auth import _set_wandb_auth_mode
 from ._secret import Secret
 
 _set_wandb_auth_mode()
 
-__all__ = (
-    "AsyncFunctionError",
-    "CWSandboxAuthenticationError",
-    "CWSandboxError",
-    "FunctionError",
-    "FunctionSerializationError",
-    "NetworkOptions",
-    "OperationRef",
-    "Process",
-    "ProcessResult",
-    "RemoteFunction",
-    "Sandbox",
-    "SandboxDefaults",
-    "SandboxError",
-    "SandboxExecutionError",
-    "SandboxFailedError",
-    "SandboxFileError",
-    "SandboxNotFoundError",
-    "SandboxNotRunningError",
-    "SandboxStatus",
-    "SandboxTerminatedError",
-    "SandboxTimeoutError",
-    "Secret",
-    "Serialization",
-    "Session",
-    "StreamReader",
-    "StreamWriter",
-    "TerminalResult",
-    "TerminalSession",
-    "Waitable",
-    "results",
-    "wait",
-)
+_HIDDEN = {"AuthHeaders", "set_auth_mode"}
+
+__all__ = [name for name in cwsandbox_all if name not in _HIDDEN]

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+from cwsandbox import AuthHeaders, CWSandboxAuthenticationError, set_auth_mode
+
+import wandb
+from wandb.errors import UsageError
+from wandb.sdk import wandb_login, wandb_setup
+from wandb.sdk.lib import wbauth
+
+_AUTH_MODE_NAME = "wandb"
+_OVERRIDE_UNSET = object()
+_entity_override: ContextVar[object | str] = ContextVar(
+    "wandb_sandbox_entity_override",
+    default=_OVERRIDE_UNSET,
+)
+
+
+def _set_wandb_auth_mode() -> None:
+    """Install W&B as the active cwsandbox auth mode for this process.
+
+    NOTE: This means the original cwsandbox auth using sandbox api key no longer works.
+    """
+    set_auth_mode(_AUTH_MODE_NAME, _resolve_wandb_sdk_auth)
+
+
+@contextmanager
+def _override_sandbox_entity(
+    entity: str | None = None,
+) -> Iterator[None]:
+    """Temporarily override the sandbox entity for sandbox auth.
+
+    Passing ``None`` means using the default resolve logic from run
+    and setting. Only used by the cli to set entity via --entity.
+    """
+    if entity is None:
+        yield
+        return
+
+    entity_token = _entity_override.set(entity)
+    try:
+        yield
+    finally:
+        _entity_override.reset(entity_token)
+
+
+def _resolve_entity_project() -> tuple[str | None, str | None]:
+    """Resolve entity/project from overrides, the active run, or global settings."""
+    entity_override = _entity_override.get()
+    if isinstance(entity_override, str):
+        # None project is fine because the override is only used by cli, which does not
+        # support project for when filtering sandbox.
+        return entity_override, None
+
+    run = wandb.run or wandb_setup.singleton().most_recent_active_run
+    if run is not None:
+        return run.entity or None, run.project or None
+
+    settings = wandb_setup.singleton().settings
+    return settings.entity or None, settings.project or None
+
+
+def _resolve_wandb_sdk_auth() -> AuthHeaders:
+    settings = wandb_setup.singleton().settings
+    host = wbauth.HostUrl(settings.base_url, app_url=settings.app_url)
+
+    auth = wbauth.session_credentials(host=host)
+    if auth is None and settings.api_key:
+        auth = wbauth.AuthApiKey(host=host, api_key=settings.api_key)
+
+    if auth is None:
+        run = wandb.run or wandb_setup.singleton().most_recent_active_run
+        wandb_login._login(
+            host=host.url,
+            update_api_key=False,
+            _silent=run is not None,
+        )
+        auth = wbauth.session_credentials(host=host)
+
+    if auth is None:
+        raise CWSandboxAuthenticationError(
+            "wandb.sandbox could not resolve W&B credentials for sandbox auth."
+        )
+
+    if not isinstance(auth, wbauth.AuthApiKey):
+        raise UsageError("wandb.sandbox currently supports only W&B user API-key auth.")
+
+    entity, project = _resolve_entity_project()
+    metadata: list[tuple[str, str]] = [("x-api-key", auth.api_key)]
+    # Both entity and project are optional.
+    # entity will use the default entity user set in web UI.
+    # project will use/create 'sandbox' project automatically.
+    if entity:
+        metadata.append(("x-entity-id", entity))
+    if project:
+        metadata.append(("x-project-name", project))
+
+    return AuthHeaders(
+        headers={key: value for key, value in metadata},
+        strategy="wandb_api_key",
+    )

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -6,9 +6,8 @@ from contextvars import ContextVar
 
 from cwsandbox import AuthHeaders, CWSandboxAuthenticationError, set_auth_mode
 
-import wandb
 from wandb.errors import UsageError
-from wandb.sdk import wandb_login, wandb_setup
+from wandb.sdk import wandb_setup
 from wandb.sdk.lib import wbauth
 
 _AUTH_MODE_NAME = "wandb"
@@ -47,56 +46,31 @@ def _override_sandbox_entity(
         _entity_override.reset(entity_token)
 
 
-def _resolve_entity_project() -> tuple[str | None, str | None]:
-    """Resolve entity/project from overrides, the active run, or global settings."""
-    entity_override = _entity_override.get()
-    if isinstance(entity_override, str):
-        # None project is fine because the override is only used by cli, which does not
-        # support project for when filtering sandbox.
-        return entity_override, None
-
-    run = wandb.run or wandb_setup.singleton().most_recent_active_run
-    if run is not None:
-        return run.entity or None, run.project or None
-
-    settings = wandb_setup.singleton().settings
-    return settings.entity or None, settings.project or None
-
-
 def _resolve_wandb_sdk_auth() -> AuthHeaders:
     settings = wandb_setup.singleton().settings
     host = wbauth.HostUrl(settings.base_url, app_url=settings.app_url)
-
-    auth = wbauth.session_credentials(host=host)
-    if auth is None and settings.api_key:
-        auth = wbauth.AuthApiKey(host=host, api_key=settings.api_key)
-
-    if auth is None:
-        run = wandb.run or wandb_setup.singleton().most_recent_active_run
-        wandb_login._login(
-            host=host.url,
-            update_api_key=False,
-            _silent=run is not None,
-        )
-        auth = wbauth.session_credentials(host=host)
-
+    auth = wbauth.authenticate_session(host=host, source="sandbox", no_offline=True)
     if auth is None:
         raise CWSandboxAuthenticationError(
             "wandb.sandbox could not resolve W&B credentials for sandbox auth."
         )
-
     if not isinstance(auth, wbauth.AuthApiKey):
         raise UsageError("wandb.sandbox currently supports only W&B user API-key auth.")
 
-    entity, project = _resolve_entity_project()
     metadata: list[tuple[str, str]] = [("x-api-key", auth.api_key)]
     # Both entity and project are optional.
     # entity will use the default entity user set in web UI.
     # project will use/create 'sandbox' project automatically.
+    entity = settings.entity
+    # entity can be set by --entity cli flag
+    # TODO: maybe cli should just do `wandb.setup(settings=Settings(entity=...))`
+    entity_override = _entity_override.get()
+    if isinstance(entity_override, str):
+        entity = entity_override
     if entity:
         metadata.append(("x-entity-id", entity))
-    if project:
-        metadata.append(("x-project-name", project))
+    if settings.project:
+        metadata.append(("x-project-name", settings.project))
 
     return AuthHeaders(
         headers={key: value for key, value in metadata},

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -27,7 +27,7 @@ def _set_wandb_auth_mode() -> None:
 
 
 @contextmanager
-def _override_sandbox_entity(
+def override_sandbox_entity(
     entity: str | None = None,
 ) -> Iterator[None]:
     """Temporarily override the sandbox entity for sandbox auth.
@@ -62,7 +62,7 @@ def _resolve_wandb_sdk_auth() -> AuthHeaders:
     # entity will use the default entity user set in web UI.
     # project will use/create 'sandbox' project automatically.
     entity = settings.entity
-    # entity can be set by --entity cli flag via _override_sandbox_entity
+    # entity can be set by --entity cli flag via override_sandbox_entity
     entity_override = _entity_override.get()
     if isinstance(entity_override, str):
         entity = entity_override

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -62,8 +62,7 @@ def _resolve_wandb_sdk_auth() -> AuthHeaders:
     # entity will use the default entity user set in web UI.
     # project will use/create 'sandbox' project automatically.
     entity = settings.entity
-    # entity can be set by --entity cli flag
-    # TODO: maybe cli should just do `wandb.setup(settings=Settings(entity=...))`
+    # entity can be set by --entity cli flag via _override_sandbox_entity
     entity_override = _entity_override.get()
     if isinstance(entity_override, str):
         entity = entity_override

--- a/wandb/sandbox/_secret.py
+++ b/wandb/sandbox/_secret.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cwsandbox import Secret as _BaseSecret
+
+WANDB_SECRET_STORE = "wandb-team-secrets"
+
+
+@dataclass(frozen=True, kw_only=True)
+class Secret(_BaseSecret):
+    """W&B sandbox secret with a default team secret store."""
+
+    store: str = WANDB_SECRET_STORE

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -20,7 +20,7 @@ from wandb.util import logger
 from ._timing import TimedIf
 
 if TYPE_CHECKING:
-    from google.cloud import storage  # type: ignore[import-not-found]
+    from google.cloud import storage  # type: ignore[import-not-found, import-untyped]
 
     from wandb.sdk.artifacts.artifact import Artifact
     from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache


### PR DESCRIPTION
Description
-----------

Add `wandb.sandbox` to provide wandb auth for https://github.com/coreweave/cwsandbox-client
Squashed commit in https://github.com/wandb/wandb/pull/11606

- Use `set_auth_mode` from `cwsandbox` to replace auth using wandb auth headers supported by cwsandbox backend
- Embed existing cli such as `cwsandbox ls` as `wandb beta sandbox ls`
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
How was this PR tested?

- unit test
- system test
- manual test

Install from this branch

```bash
WANDB_BUILD_SKIP_GPU_STATS=true pip install "wandb[sandbox] @ git+https://github.com/wandb/wandb.git@pinglei/sandbox-auth-v3"
```

Try with secret, you need to have it in your entity (team)

```python
import wandb
import time
from wandb.sandbox import Sandbox, Secret, CWSandboxAuthenticationError

PROD_WANDB_HOST = "https://api.wandb.ai"
LOG_INTERVAL_SECONDS = 5
ENTRY_LOG_COMMAND = (
    "python",
    "-u",
    "-c",
    (
        "import itertools\n"
        "import time\n"
        "print('sandbox log generator started', flush=True)\n"
        "for i in itertools.count(1):\n"
        "    ts = time.strftime('%Y-%m-%d %H:%M:%S')\n"
        "    print(f'[{ts}] heartbeat {i}', flush=True)\n"
        f"    time.sleep({LOG_INTERVAL_SECONDS})\n"
    ),
)

def no_run():
    # NOTE: We need to set entity and project using environment variable
    wandb.setup(settings=wandb.Settings(
        entity="wandb-artifacts-dev",
        project="pinglei-sandbox-auth-2"
    ))
    with Sandbox.run(
        *ENTRY_LOG_COMMAND,
        container_image="python:3.11",
        # NOTE: We don't need store because wandb has a default
        secrets=[Secret(name="easter_egg")],
        # TODO: the tags info are not in the client response class
        tags=["pinglei", "secret"]
        # You can still set it if you want
        # secrets=[Secret(name="easter_egg", store="404")],
    ) as sb:
        result = sb.exec(["sh", "-c", "echo $easter_egg"]).result()
        print(result.stdout.strip())
        print(
            f"main process is emitting logs every {LOG_INTERVAL_SECONDS}s; "
            "sleeping for 2 minutes so you can test cli"
        )
        time.sleep(120)


def main() -> None:
    no_run()


if __name__ == "__main__":
    main()
```
