### PR TITLE
refactor: make exit requests cancellable

### DIFF
--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -118,17 +118,6 @@ type Sender struct {
 	// exitCode is the exit code received by the Sender.
 	exitCode int32
 
-	// exitRequest is the request for an Exit record.
-	//
-	// It may be nil even if receivedExit is true, which just means that
-	// a response is not necessary.
-	exitRequest *runwork.Request
-
-	// finishWithoutExitRequest is the request for a FinishWithoutExit record.
-	//
-	// It's like exitRequest, but requires a different response type.
-	finishWithoutExitRequest *runwork.Request
-
 	// jobBuilder is the job builder for creating jobs from the run
 	// that allow users to re-run the run with different configurations
 	jobBuilder *launch.JobBuilder
@@ -293,22 +282,6 @@ func (s *Sender) respond(
 			ResultCommunicate: &spb.Result{
 				ResultType: &spb.Result_Response{
 					Response: response,
-				},
-			},
-		},
-	})
-}
-
-// respondToExit responds with a "RunExitResult" proto.
-func (s *Sender) respondToExit(
-	request *runwork.Request,
-	exit *spb.RunExitResult,
-) {
-	request.Respond(&spb.ServerResponse{
-		ServerResponseType: &spb.ServerResponse_ResultCommunicate{
-			ResultCommunicate: &spb.Result{
-				ResultType: &spb.Result_ExitResult{
-					ExitResult: exit,
 				},
 			},
 		},
@@ -540,10 +513,13 @@ func (s *Sender) sendJobFlush() {
 //
 // Everything happens in a separate goroutine during which the Sender
 // continues to process incoming work.
-func (s *Sender) startFinishRun() {
+func (s *Sender) startFinishRun(
+	exitRequest *runwork.Request,
+	exitResponse *spb.ServerResponse,
+) {
 	go func() {
 		defer s.logger.Reraise()
-		s.finishRunSync()
+		s.finishRunSync(exitRequest, exitResponse)
 	}()
 }
 
@@ -555,7 +531,30 @@ func (s *Sender) startFinishRun() {
 //
 // This starts after an Exit record is received, after which no more
 // run-modifying records can be generated. Requests may still be processed.
-func (s *Sender) finishRunSync() {
+//
+// On success, the exitResponse is sent to the exitRequest (if any).
+// The caller provides a response because there are multiple exit request types
+// with their own corresponding response types.
+//
+// If the exit request is cancelled, the run is aborted.
+func (s *Sender) finishRunSync(
+	exitRequest *runwork.Request,
+	exitResponse *spb.ServerResponse,
+) {
+	defer exitRequest.Respond(exitResponse)
+
+	// Abort upload operations if the Exit request is cancelled before
+	// we can respond to it.
+	//
+	// The shutdown stages will all still happen, but faster.
+	if exitRequest != nil {
+		cancelAbortOnRequestFinish := context.AfterFunc(
+			exitRequest.Context(),
+			s.runWork.Abort,
+		)
+		defer cancelAbortOnRequestFinish()
+	}
+
 	// Finish uploading captured console logs.
 	s.consoleLogsSender.Finish()
 
@@ -602,16 +601,6 @@ func (s *Sender) finishRunSync() {
 	// printing `run.finish()` progress, and it was necessary to "close"
 	// the progress bar shown in Jupyter. Yes, that was the only purpose.
 	s.fileTransferStats.SetDone()
-
-	// Respond to the client's exit record, if necessary.
-	if s.exitRequest != nil {
-		s.respondToExit(s.exitRequest, &spb.RunExitResult{})
-	}
-	if s.finishWithoutExitRequest != nil {
-		s.respond(s.finishWithoutExitRequest, &spb.Response{
-			ResponseType: &spb.Response_RunFinishWithoutExitResponse{},
-		})
-	}
 
 	// Prevent any new work from being added.
 	//
@@ -974,9 +963,20 @@ func (s *Sender) sendRequestRunFinishWithoutExit(
 	}
 
 	s.exitWithoutCode = true
-	s.finishWithoutExitRequest = request
 
-	s.startFinishRun()
+	response := &spb.ServerResponse{
+		ServerResponseType: &spb.ServerResponse_ResultCommunicate{
+			ResultCommunicate: &spb.Result{
+				ResultType: &spb.Result_Response{
+					Response: &spb.Response{
+						ResponseType: &spb.Response_RunFinishWithoutExitResponse{},
+					},
+				},
+			},
+		},
+	}
+
+	s.startFinishRun(request, response)
 }
 
 // sendExit sends an exit record to the server and triggers the shutdown of
@@ -988,9 +988,17 @@ func (s *Sender) sendExit(_ *spb.RunExitRecord, request *runwork.Request) {
 		return
 	}
 
-	s.exitRequest = request
+	response := &spb.ServerResponse{
+		ServerResponseType: &spb.ServerResponse_ResultCommunicate{
+			ResultCommunicate: &spb.Result{
+				ResultType: &spb.Result_ExitResult{
+					ExitResult: &spb.RunExitResult{},
+				},
+			},
+		},
+	}
 
-	s.startFinishRun()
+	s.startFinishRun(request, response)
 }
 
 // sendMetric updates the metrics in the run config.


### PR DESCRIPTION
Abort uploads if Ctrl-C is pressed during `run.finish()` or inside the Run context manager. The run will be marked Crashed (since FileStream requests get cancelled, so an exit code is not uploaded).

This is built on top of the new `runwork.Request` abstraction. `Ctrl-C` during `deliver_exit()` in `run.finish()` sends a `ServerCancelRequest` message that causes `connection.go` to cancel the corresponding `runwork.Request`'s context (see Caveats).

## Ctrl-C repetition

This fixes the triple Ctrl-C issue when using `wandb.init()` as a context manager: once `run.finish()` is cancelled, its `Stream` cleans up quickly and doesn't block the `atexit` hook running `wandb.teardown()`. For example:

```python
with wandb.init() as run:
    run.save(HUGE_FILE)
    do_expensive_blocking_operation() # press Ctrl-C here
```

Pressing Ctrl-C in `do_expensive_blocking_operation()` required **three** Ctrl-C presses prior to this PR: once for the method, once for the context manager `__exit__` (the implicit `run.finish()`) and once for the implicit `wandb.teardown()`. Now, it only requires two: once for `do_expensive_blocking_operation()` and once for `run.finish()`, after which `wandb.teardown()` completes quickly.

We could bring this down to just one by aborting a run if `KeyboardInterrupt` is raised inside the Run context manager, but that would be surprising to users who expect some data from before Ctrl-C to still upload.

## Caveats

* Depending on the timing of the `KeyboardInterrupt`, the cancellation request may not send
* The cancellation request will take time if the socket buffer is backed up
* The run gets marked Crashed after a few minutes. We could in theory make a best-effort attempt to upload a failed exit code (to mark the run Failed sooner), but it's not straightforward yet.

## Testing

Writing good tests for Ctrl+C behavior is tricky unfortunately. I only tested manually.

It's tricky because a test would have to make `wandb-core` block in `run.finish()` and wait until that happens. We could add utilities to the `wandb_backend_spy` fixture for hanging a request. The test would then have to wait for and hang a FileStream request that sets an exit code (since that's the only way to be sure we're inside `Sender.finishRunSync()`).