### PR TITLE
refactor: drop RunWork.SetDone

### DIFF
--- a/core/internal/runsync/errors.go
+++ b/core/internal/runsync/errors.go
@@ -1,6 +1,7 @@
 package runsync
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/wandb/wandb/core/internal/observability"
@@ -26,6 +27,35 @@ func (e *SyncError) Error() string {
 	} else {
 		return e.Message
 	}
+}
+
+// FirstSyncError returns the first available SyncError, if any, and logs
+// the other ones.
+//
+// If none of the errors are SyncErrors, joins all of them using errors.Join.
+func FirstSyncError(logger *observability.CoreLogger, errs ...error) error {
+	var syncErr *SyncError
+
+	// Find a SyncError.
+	for _, err := range errs {
+		var ok bool
+		if syncErr, ok = err.(*SyncError); ok {
+			break
+		}
+	}
+
+	if syncErr == nil {
+		return errors.Join(errs...)
+	}
+
+	// Log all the errors that we aren't returning.
+	for _, err := range errs {
+		if err != nil && err != syncErr {
+			LogSyncFailure(logger, err)
+		}
+	}
+
+	return syncErr
 }
 
 // LogSyncFailure logs and possibly captures an error that prevents sync

--- a/core/internal/runsync/errors_test.go
+++ b/core/internal/runsync/errors_test.go
@@ -1,11 +1,13 @@
 package runsync_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/wandb/wandb/core/internal/observabilitytest"
 	. "github.com/wandb/wandb/core/internal/runsync"
 )
 
@@ -34,4 +36,30 @@ func TestToUserText_UnknownError(t *testing.T) {
 	userText := ToUserText(err)
 
 	assert.Equal(t, "Internal error: test error", userText)
+}
+
+func TestFirstSyncError_NoSyncError(t *testing.T) {
+	logger, logs := observabilitytest.NewRecordingTestLogger(t)
+	err1 := fmt.Errorf("test error 1")
+	var err2Nil error
+	err3 := fmt.Errorf("test error 3")
+
+	result := FirstSyncError(logger, err1, err2Nil, err3)
+
+	assert.EqualError(t, result, errors.Join(err1, err3).Error())
+	assert.Empty(t, logs.String())
+}
+
+func TestFirstSyncError_FindsSyncError(t *testing.T) {
+	logger, logs := observabilitytest.NewRecordingTestLogger(t)
+	err1 := fmt.Errorf("test error 1")
+	syncErr := &SyncError{Message: "test sync error"}
+	var err2Nil error
+	err3 := fmt.Errorf("test error 3")
+
+	result := FirstSyncError(logger, err1, syncErr, err2Nil, err3)
+
+	assert.Equal(t, syncErr, result)
+	assert.Contains(t, logs.String(), err1.Error())
+	assert.Contains(t, logs.String(), err3.Error())
 }

--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -109,20 +109,28 @@ func (r *RunReader) ExtractRunInfo(ctx context.Context) (*RunInfo, error) {
 //
 // Closes RunWork at the end, even on error. If there was no Exit record,
 // creates one with an exit code of 1.
-func (r *RunReader) ProcessTransactionLog(ctx context.Context) error {
+func (r *RunReader) ProcessTransactionLog(ctx context.Context) (err error) {
 	r.logger.Info("runsync: starting to read")
 
-	// Abort any async work on cancellation.
-	cancelAbort := context.AfterFunc(ctx, r.runWork.Abort)
-	defer cancelAbort() // must run after closeRunWork()
+	defer r.runWork.Close()
 
-	defer r.closeRunWork()
+	// Abort the run's uploads if the sync is cancelled.
+	cancelAbort := context.AfterFunc(ctx, r.runWork.Abort)
+	defer cancelAbort()
 
 	reader, err := r.open()
 	if err != nil {
 		return err
 	}
 	defer reader.Close()
+
+	// Make an Exit request if one was missing, so that the run's state
+	// is updated to failed. This can happen when syncing a partially-written
+	// transaction log.
+	defer func() {
+		exitErr := r.sendExitIfNotSeen(ctx)
+		err = FirstSyncError(r.logger, err, exitErr)
+	}()
 
 	for {
 		record, err := r.nextUpdatedRecord(ctx, reader, !r.seenExit /*retryEOF*/)
@@ -143,8 +151,13 @@ func (r *RunReader) ProcessTransactionLog(ctx context.Context) error {
 			r.parseAndAddWork(record)
 
 		case record.GetExit() != nil:
-			r.parseAndAddWork(record)
 			r.seenExit = true
+
+			// Block until the Exit is processed.
+			_, err := r.parseAndDoRequest(ctx, "sync-run-exit", record)
+			if err != nil {
+				return err
+			}
 
 		case record.GetRun() != nil:
 			// Fail early if initializing the run (UpsertBucket) fails.
@@ -166,24 +179,25 @@ func (r *RunReader) ProcessTransactionLog(ctx context.Context) error {
 	}
 }
 
-// closeRunWork closes RunWork creating an exit record if one hasn't been seen.
-func (r *RunReader) closeRunWork() {
-	if !r.seenExit {
-		r.logger.Warn(
-			"runsync: no exit record encountered, using exit code 1 (failed)",
-		)
-
-		r.parseAndAddWork(
-			&spb.Record{
-				RecordType: &spb.Record_Exit{
-					Exit: &spb.RunExitRecord{
-						ExitCode: 1,
-					},
-				},
-			})
+// sendExitIfNotSeen creates and waits for an exit record if one wasn't seen.
+func (r *RunReader) sendExitIfNotSeen(ctx context.Context) error {
+	if r.seenExit {
+		return nil
 	}
 
-	r.runWork.Close()
+	r.logger.Warn(
+		"runsync: no exit record encountered, using exit code 1 (failed)",
+	)
+
+	_, err := r.parseAndDoRequest(ctx, "sync-run-exit",
+		&spb.Record{
+			RecordType: &spb.Record_Exit{
+				Exit: &spb.RunExitRecord{
+					ExitCode: 1,
+				},
+			},
+		})
+	return err
 }
 
 // open returns an opened transaction log Reader.

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -37,7 +37,6 @@ func setup(t *testing.T) testFixtures {
 	transactionLog := filepath.Join(t.TempDir(), "test-run.wandb")
 
 	fakeRunWork := runworktest.New()
-	fakeRunWork.SetDone() // so that Close() doesn't block
 
 	mockCtrl := gomock.NewController(t)
 	mockRecordParser := streamtest.NewMockRecordParser(mockCtrl)
@@ -189,6 +188,7 @@ func Test_TurnsAllRecordsIntoWork(t *testing.T) {
 		&spb.Record{Num: 2},
 		exitRecord(0),
 	)
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{}) // for the exit record
 	work1 := &testWork{ID: 1}
 	work2 := &testWork{ID: 2}
 	exitWork := &testWork{ID: 3}
@@ -209,6 +209,7 @@ func Test_TurnsAllRecordsIntoWork(t *testing.T) {
 func Test_CreatesExitRecordIfNotSeen(t *testing.T) {
 	x := setup(t)
 	wandbFileWithRecords(t, x.TransactionLog, &spb.Record{Num: 1})
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{}) // for the exit record
 	work1 := &testWork{ID: 1}
 	exitWork := &testWork{ID: 2}
 	gomock.InOrder(
@@ -292,7 +293,8 @@ func Test_CreatesRunStartRequest(t *testing.T) {
 		x.MockRecordParser.EXPECT().Parse(isRunStartRequest()).Return(runStartWork),
 		x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(exitWork),
 	)
-	// The Run record requires a response.
+	// The Run and Exit records require a response.
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
 	x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
 
 	err := x.RunReader.ProcessTransactionLog(context.Background())
@@ -305,7 +307,6 @@ func Test_CreatesRunStartRequest(t *testing.T) {
 
 func Test_FileNotFoundError(t *testing.T) {
 	x := setup(t)
-	x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(&testWork{})
 
 	err := x.RunReader.ProcessTransactionLog(context.Background())
 
@@ -323,7 +324,6 @@ func Test_FilePermissionError(t *testing.T) {
 	wandbFileWithRecords(t, x.TransactionLog)
 	err := os.Chmod(x.TransactionLog, 0o200) // write-only
 	require.NoError(t, err)
-	x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(&testWork{})
 
 	err = x.RunReader.ProcessTransactionLog(context.Background())
 
@@ -341,6 +341,7 @@ func Test_FilePermissionError(t *testing.T) {
 func Test_CorruptFileError(t *testing.T) {
 	x := setup(t)
 	wandbFileWithRecords(t, x.TransactionLog)
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{}) // for the exit record
 	x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(&testWork{})
 
 	// Add data to the file that doesn't follow the LevelDB format.

--- a/core/internal/runwork/runwork.go
+++ b/core/internal/runwork/runwork.go
@@ -55,16 +55,10 @@ type RunWork interface {
 	// This cancels the run's context, causing any current or future upload
 	// operations to fail immediately.
 	//
-	// SetDone and Close still need to be called. In practice, this means an
-	// Exit record must be generated after a call to Abort to trigger SetDone.
+	// Close still needs to be called to close the channel.
 	Abort()
 
-	// SetDone indicates that the run is done, unblocking Close().
-	//
-	// It does not close the channel or cancel any work.
-	SetDone()
-
-	// Close blocks until SetDone(), closes the channel, cancels BeforeEndCtx.
+	// Close closes the channel and cancels BeforeEndCtx.
 	//
 	// It is safe to call concurrently or multiple times.
 	// Any ongoing or future AddWork() calls discard their work and return
@@ -83,9 +77,6 @@ type runWork struct {
 	closedMu sync.Mutex    // locked for closing `closed`
 	closed   chan struct{} // closed on Close()
 
-	doneMu sync.Mutex    // locked for closing `done`
-	done   chan struct{} // closed on SetDone()
-
 	internalWork chan Work
 	endCtx       context.Context
 	endCtxCancel func()
@@ -99,7 +90,6 @@ func New(bufferSize int, logger *observability.CoreLogger) RunWork {
 	return &runWork{
 		addWorkCV:    sync.NewCond(&sync.Mutex{}),
 		closed:       make(chan struct{}),
-		done:         make(chan struct{}),
 		internalWork: make(chan Work, bufferSize),
 		endCtx:       endCtx,
 		endCtxCancel: endCtxCancel,
@@ -213,21 +203,7 @@ func (rw *runWork) Abort() {
 	rw.endCtxCancel()
 }
 
-func (rw *runWork) SetDone() {
-	rw.doneMu.Lock()
-	defer rw.doneMu.Unlock()
-
-	select {
-	case <-rw.done:
-		// No-op, already closed.
-	default:
-		close(rw.done)
-	}
-}
-
 func (rw *runWork) Close() {
-	<-rw.done
-
 	rw.closedMu.Lock()
 
 	select {

--- a/core/internal/runwork/runwork_test.go
+++ b/core/internal/runwork/runwork_test.go
@@ -67,7 +67,6 @@ func TestAddWorkConcurrent(t *testing.T) {
 		}()
 	}
 	wgProducer.Wait()
-	rw.SetDone()
 	rw.Close()
 	wgConsumer.Wait()
 
@@ -80,7 +79,6 @@ func TestAddWorkAfterClose(t *testing.T) {
 	rw := runwork.New(0, observability.NewCoreLogger(logger, nil))
 	req := newTestRequest(t)
 
-	rw.SetDone()
 	rw.Close()
 	rw.AddWork(runwork.Work{
 		WorkImpl: runwork.WorkFromRecord(&spb.Record{}),
@@ -101,7 +99,6 @@ func TestCloseDuringAddWork(t *testing.T) {
 		// Increase odds that Close() happens while AddWork() is
 		// blocked on a channel write.
 		<-time.After(5 * time.Millisecond)
-		rw.SetDone()
 		rw.Close()
 	}()
 	rw.AddWork(runwork.Work{
@@ -117,8 +114,6 @@ func TestCloseDuringAddWork(t *testing.T) {
 func TestCloseAfterClose(t *testing.T) {
 	rw := runwork.New(0, observabilitytest.NewTestLogger(t))
 
-	rw.SetDone()
-	rw.SetDone()
 	rw.Close()
 	rw.Close()
 
@@ -132,10 +127,7 @@ func TestRaceAddWorkClose(t *testing.T) {
 			// and this test doesn't wait for goroutines to exit.
 			rw := runwork.New(0, observability.NewNoOpLogger())
 
-			go func() {
-				rw.SetDone()
-				rw.Close()
-			}()
+			go rw.Close()
 			go rw.AddWork(runwork.NoRequest(
 				runwork.WorkFromRecord(&spb.Record{}),
 			))
@@ -147,41 +139,10 @@ func TestRaceAddWorkClose(t *testing.T) {
 func TestCloseCancelsContext(t *testing.T) {
 	rw := runwork.New(0, observabilitytest.NewTestLogger(t))
 
-	go func() {
-		rw.SetDone()
-		rw.Close()
-	}()
+	go rw.Close()
 	<-rw.BeforeEndCtx().Done()
 
 	assert.Error(t, rw.BeforeEndCtx().Err())
-}
-
-func TestCloseBlocksUntilDone(t *testing.T) {
-	rw := runwork.New(0, observabilitytest.NewTestLogger(t))
-	wg := &sync.WaitGroup{}
-	count := 0
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for range rw.Chan() {
-			count++
-		}
-	}()
-
-	// All AddWork() calls should go despite racing with Close()
-	// because SetDone() is only called at the end.
-	go rw.Close()
-	for range 10 {
-		<-time.After(time.Millisecond)
-		rw.AddWork(runwork.NoRequest(
-			runwork.WorkFromRecord(&spb.Record{}),
-		))
-	}
-	rw.SetDone()
-	wg.Wait()
-
-	assert.Equal(t, 10, count)
 }
 
 func Test_AddWorkOrCancel_CancelledBefore(t *testing.T) {

--- a/core/internal/runworktest/runworktest.go
+++ b/core/internal/runworktest/runworktest.go
@@ -126,10 +126,6 @@ func (w *FakeRunWork) Abort() {
 	w.rw.Abort()
 }
 
-func (w *FakeRunWork) SetDone() {
-	w.rw.SetDone()
-}
-
 func (w *FakeRunWork) Close() {
 	w.rw.Close()
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -601,11 +601,6 @@ func (s *Sender) finishRunSync(
 	// printing `run.finish()` progress, and it was necessary to "close"
 	// the progress bar shown in Jupyter. Yes, that was the only purpose.
 	s.fileTransferStats.SetDone()
-
-	// Prevent any new work from being added.
-	//
-	// Note that any work queued up at this point still gets processed.
-	s.runWork.SetDone()
 }
 
 // finishFileStream waits for FileStream uploads to complete.

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -222,12 +223,17 @@ func (s *Stream) HandleRecord(record *spb.Record, request *runwork.Request) {
 	work.Schedule(&sync.WaitGroup{}, func() { s.runWork.AddWork(work) })
 }
 
-// Close waits for all run messages to be fully processed.
+// Close closes the stream and blocks until all its work is processed.
+//
+// Any incoming requests after this will immediately error out.
+//
+// This assumes that an exit record has been or will be pushed,
+// or else this blocks indefinitely.
 func (s *Stream) Close() {
-	s.logger.Info("stream: closing")
+	s.logger.Info("stream: finishing up")
 	s.runWork.Close()
 	s.wg.Wait()
-	s.logger.Info("stream: closed")
+	s.logger.Info("stream: all finished")
 
 	if s.loggerFile != nil {
 		// Sync the file instead of closing it, in case we keep writing to it.
@@ -235,17 +241,35 @@ func (s *Stream) Close() {
 	}
 }
 
-// FinishAndClose emits an exit record, waits for all run messages
-// to be fully processed, and prints the run footer to the terminal.
+// FinishAndClose emits an exit record, closes the stream and prints a footer.
+//
+// In contrast to Close, this assumes that an exit record has not and will
+// not be pushed by any other source. If there has already been an exit record,
+// this may shut down the run abruptly.
+//
+// This is used to shut down the stream if the client didn't do it explicitly.
 func (s *Stream) FinishAndClose(exitCode int32) {
+	// Use a synthetic exit request to detect when uploads finish.
+	exitCtx, cancelExit := context.WithCancel(context.Background())
+	exitResponse := make(chan *spb.ServerResponse, 1)
+	exitRequest := runwork.NewRequest(
+		"",
+		exitCtx,
+		cancelExit,
+		exitResponse,
+	)
+
 	s.HandleRecord(&spb.Record{
 		RecordType: &spb.Record_Exit{
 			Exit: &spb.RunExitRecord{
 				ExitCode: exitCode,
 			}},
 		Control: &spb.Control{AlwaysSend: true},
-	}, nil)
+	}, exitRequest)
 
+	// Wait until all uploads complete (or, if this is a duplicate exit,
+	// until it is rejected by the Sender).
+	<-exitCtx.Done()
 	s.Close()
 
 	s.printFooter()

--- a/core/internal/stream/stream_mux.go
+++ b/core/internal/stream/stream_mux.go
@@ -58,17 +58,18 @@ func (sm *StreamMux) RemoveStream(streamId string) (*Stream, error) {
 }
 
 // FinishAndCloseAllStreams closes all streams in the mux.
+//
+// Blocks until all streams are done.
 func (sm *StreamMux) FinishAndCloseAllStreams(exitCode int32) {
 	sm.mutex.RLock()
 	defer sm.mutex.RUnlock()
 
 	wg := sync.WaitGroup{}
 	for streamId, stream := range sm.mux {
-		wg.Add(1)
-		go func(stream *Stream) {
+		wg.Go(func() {
 			stream.FinishAndClose(exitCode)
-			wg.Done()
-		}(stream)
+		})
+
 		// delete all streams from mux
 		delete(sm.mux, streamId)
 	}


### PR DESCRIPTION
Removes the `RunWork.SetDone()` method, simplifying the stream shutdown logic.

`RunWork.SetDone()` was a synchronization mechanism that existed solely for `Stream.FinishAndClose()`. It was the only way for the Sender to communicate that it has finished processing the Exit record to allow the Stream to close its input channel. Now that `runwork.Request` exists, Stream can create a request and wait for Sender to respond to it.