### PR TITLE
fix: sdist smoke test not including parquet-rust-wrapper

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -20,6 +20,7 @@ exclude = [
 include = [
     "core",
     "xpu",
+    "parquet-rust-wrapper",
     "wandb/vendor/wandb_orjson",
     "wandb/py.typed",
     "package_readme.md",


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

the parquet-rust-wrapper was not being included in the sdist build of the SDK. This cause the [smoke test to fail](https://github.com/wandb/wandb/actions/runs/24221345345/job/70716186587).  This PR adds that path as included in the sdist build.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?
`python -m build --sdist`

- Before

![image.png](https://app.graphite.com/user-attachments/assets/bfb87ff3-961c-4509-83a6-0c78c6d7462d.png)

- After

![image.png](https://app.graphite.com/user-attachments/assets/52f34a89-8c6c-4036-80a0-c9c64c2ef0f3.png)

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
