### PR TITLE
fix: test windows poll for token fix

### DIFF
--- a/wandb/sdk/lib/service/service_process.py
+++ b/wandb/sdk/lib/service/service_process.py
@@ -111,7 +111,13 @@ def _launch_server(
 ) -> ServiceProcess:
     """Launch server and set ports."""
     if platform.system() == "Windows":
-        creationflags: int = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+        # DETACHED_PROCESS (0x8) prevents the child from inheriting or
+        # allocating a console.
+        # Without it, the Go runtime's package init code in
+        # lipgloss/v2/compat opens CONIN$/CONOUT$
+        # which blocks forever trying to query the terminal background color.
+        _detached_process = 0x00000008
+        creationflags: int = subprocess.CREATE_NEW_PROCESS_GROUP | _detached_process  # type: ignore[attr-defined]
         start_new_session = False
     else:
         creationflags = 0


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

I noticed that https://github.com/wandb/wandb/pull/11459 is the first commit that the windows tests started failing. Using our good friend Claude to help investigate, it hypothesized that lipgloss is [querying CONIN](https://github.com/wandb/wandb/blob/a1597300e9d890de0b235a146e7a7d476c823bea/core/vendor/charm.land/lipgloss/v2/query.go#L36-L45) on windows when piping stdin, this causes the read to block forever before the wandb-core process sets up the server to handle requests from the wandb SDK.

Adding [**DETACHED_PROCESS** **(**0x00000008)](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags) prevents windows from allocating a console object which will fail when attempting to read from the console device, and prevent the hanging that is happening.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [ ] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->