### PR TITLE
chore: set TZ env var before running synctest

### DIFF
--- a/core/internal/runsync/logging_test.go
+++ b/core/internal/runsync/logging_test.go
@@ -17,11 +17,12 @@ import (
 )
 
 func TestOpenDebugSyncLogFile(t *testing.T) {
+	// Set TZ to UTC so that time.Now() uses UTC and not the local zone.
+	t.Setenv("TZ", "UTC")
+
 	synctest.Test(t, func(t *testing.T) {
 		// synctest time starts at 2000-01-01 at midnight UTC.
 		// Wait until 2000-01-02 at 3:04:05 for a more reliable assertion.
-		// Set TZ to UTC so that time.Now() uses UTC and not the local zone.
-		t.Setenv("TZ", "UTC")
 		time.Sleep(27*time.Hour + 4*time.Minute + 5*time.Second)
 
 		// Test that OpenDebugSyncLogFile creates the directory.


### PR DESCRIPTION
Sets the timezone environment variable before invoking `synctest.Test` because this test started failing for me locally in pre-commit with a timestamp that's 8 hours off.


```
  --- FAIL: TestOpenDebugSyncLogFile (0.00s)
      logging_test.go:39: 
          	Error Trace:	/Users/timoffex/Documents/workspace/wandb/main/core/internal/runsync/logging_test.go:39
          	Error:      	Not equal: 
          	            	expected: "debug-sync.20000102.030405.log"
          	            	actual  : "debug-sync.20000101.190405.log"
```

I'm not really sure why this started to happen as there was no Go version update, and the test succeeds if I run it directly with `go test`. But it's pretty clear that the problem is timezone related.