### PR TITLE
chore: update docs related to run shutdown

### DIFF
--- a/core/internal/runwork/runwork.go
+++ b/core/internal/runwork/runwork.go
@@ -64,9 +64,15 @@ type RunWork interface {
 	// It does not close the channel or cancel any work.
 	SetDone()
 
-	// Close blocks until SetDone() is called and closes the output channel.
+	// Close blocks until SetDone(), closes the channel, cancels BeforeEndCtx.
 	//
 	// It is safe to call concurrently or multiple times.
+	// Any ongoing or future AddWork() calls discard their work and return
+	// immediately.
+	//
+	// Calling Close means that (1) all uploads have completed and (2) there
+	// will be no more queries (like OperationStats requests). In other words,
+	// wandb-core can forget about the run and cancel any remaining operations.
 	Close()
 }
 

--- a/core/pkg/service_go_proto/wandb_internal.pb.go
+++ b/core/pkg/service_go_proto/wandb_internal.pb.go
@@ -1993,7 +1993,18 @@ func (x *ErrorInfo) GetCode() ErrorInfo_ErrorCode {
 	return ErrorInfo_UNKNOWN
 }
 
-// RunExitRecord: exit status of process
+// Complete the run and wait for it to upload.
+//
+// This record is special because it is written to the transaction log
+// but also requires a response, unlike other record types. It plays an
+// important role in finishing a run: First, after sending this, the client
+// guarantees not to send any more run-modifying records (but can still query
+// things like OperationStats). Second, a response to this record means
+// that all of the run's data has been uploaded.
+//
+// After getting a response to this record, the client may make some final
+// queries and must end with an "inform_finish" request to allow the internal
+// service to clean up.
 type RunExitRecord struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ExitCode      int32                  `protobuf:"varint,1,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`

--- a/core/pkg/service_go_proto/wandb_server.pb.go
+++ b/core/pkg/service_go_proto/wandb_server.pb.go
@@ -396,6 +396,10 @@ func (*ServerInformInitResponse) Descriptor() ([]byte, []int) {
 	return file_wandb_proto_wandb_server_proto_rawDescGZIP(), []int{7}
 }
 
+// Indicate that no more requests will be sent for a run.
+//
+// The `_info.stream_id` is the ID of the run for which no more requests
+// will be sent on the current connection.
 type ServerInformFinishRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	XInfo         *XRecordInfo           `protobuf:"bytes,200,opt,name=_info,json=Info,proto3" json:"_info,omitempty"`

--- a/wandb/proto/wandb_internal.proto
+++ b/wandb/proto/wandb_internal.proto
@@ -190,9 +190,18 @@ message ErrorInfo {
   ErrorCode code = 2;
 }
 
-/*
- * RunExitRecord: exit status of process
- */
+// Complete the run and wait for it to upload.
+//
+// This record is special because it is written to the transaction log
+// but also requires a response, unlike other record types. It plays an
+// important role in finishing a run: First, after sending this, the client
+// guarantees not to send any more run-modifying records (but can still query
+// things like OperationStats). Second, a response to this record means
+// that all of the run's data has been uploaded.
+//
+// After getting a response to this record, the client may make some final
+// queries and must end with an "inform_finish" request to allow the internal
+// service to clean up.
 message RunExitRecord {
   int32 exit_code = 1;
   int32 runtime = 2;

--- a/wandb/proto/wandb_server.proto
+++ b/wandb/proto/wandb_server.proto
@@ -48,6 +48,10 @@ message ServerInformInitRequest {
 
 message ServerInformInitResponse {}
 
+// Indicate that no more requests will be sent for a run.
+//
+// The `_info.stream_id` is the ID of the run for which no more requests
+// will be sent on the current connection.
 message ServerInformFinishRequest {
   _RecordInfo _info = 200;
 }

--- a/xpu/src/wandb_internal.rs
+++ b/xpu/src/wandb_internal.rs
@@ -908,7 +908,18 @@ pub mod error_info {
         }
     }
 }
-/// RunExitRecord: exit status of process
+/// Complete the run and wait for it to upload.
+///
+/// This record is special because it is written to the transaction log
+/// but also requires a response, unlike other record types. It plays an
+/// important role in finishing a run: First, after sending this, the client
+/// guarantees not to send any more run-modifying records (but can still query
+/// things like OperationStats). Second, a response to this record means
+/// that all of the run's data has been uploaded.
+///
+/// After getting a response to this record, the client may make some final
+/// queries and must end with an "inform_finish" request to allow the internal
+/// service to clean up.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RunExitRecord {
     #[prost(int32, tag = "1")]


### PR DESCRIPTION
Updates the docs for `RunExitRecord`, `ServerFinishRequest` and `RunWork.Close()`.

Run / Stream shutdown is unfortunately complex. The expectation is that these things happen in order:

1. The client sends an exit record
2. The Sender processes and responds to the exit record
3. The client sends its final message for the run, which must be a `ServerFinishRequest`
4. `RunWork.Close()` gets called

That's for when `run.finish()` is invoked. For `wandb.teardown()`, steps (1) and (3) get faked by `Stream.FinishAndClose()`, which relies on the Sender calling `RunWork.SetDone()` to detect that step (2) happened (whereas the client waits for a response to the record).

`wandb beta sync` works similarly to `Stream.FinishAndClose()`, except that it may read the exit record from the transaction log instead of generating one. It also relies on `RunWork.Close()` blocking until `RunWork.SetDone()` to detect the end of step (2).

(By the way, `RunWork`'s `SetDone()` and `Close()` methods just give names to a pattern that existed from the early days of `wandb-core` but was implemented using raw contexts and channels!)

I was able to get rid of `SetDone()` in PR #11680, but I had to go back and redo my work several times as I remembered new details about the assumptions here.