### PR TITLE
fix(launch): pin launch init container image to prevent drift

### DIFF
--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -1543,7 +1543,7 @@ def test_emptydir_fetch_script(
     init = next(
         c for c in pod_spec["initContainers"] if c["name"] == "wandb-source-code-init"
     )
-    assert init["image"] == "wandb/launch-agent:latest"
+    assert init["image"] == "wandb/launch-agent:0.25.1"
     script = init["command"][-1]
     for expected in expected_in_script:
         assert expected in script

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -1394,7 +1394,7 @@ def _build_source_init_container(
         init_env.append(api_key_env)
     return {
         "name": "wandb-source-code-init",
-        "image": "wandb/launch-agent:latest",
+        "image": "jzhaowandb/launch-agent-dev:main-v1",
         "volumeMounts": [
             {"name": "wandb-source-code-volume", "mountPath": CODE_MOUNT_DIR}
         ],

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -1394,7 +1394,7 @@ def _build_source_init_container(
         init_env.append(api_key_env)
     return {
         "name": "wandb-source-code-init",
-        "image": "jzhaowandb/launch-agent-dev:main-v1",
+        "image": "wandb/launch-agent:0.25.1",
         "volumeMounts": [
             {"name": "wandb-source-code-volume", "mountPath": CODE_MOUNT_DIR}
         ],


### PR DESCRIPTION
Description
-----------
Pin the launch init container image, using latest causes unexpect drift if the image is updated so an older version of the launch agent can suddenly break.