### PR TITLE
chore(leet): migrate from lipgloss v2 compat to native adaptive colors

### DIFF
--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/NimbleMarkets/ntcharts/v2/canvas"
 	"github.com/NimbleMarkets/ntcharts/v2/canvas/graph"
 	"github.com/NimbleMarkets/ntcharts/v2/canvas/runes"
@@ -81,7 +80,7 @@ type Series struct {
 	yMinPositive float64
 }
 
-func NewSeries(name string, palette []compat.AdaptiveColor) *Series {
+func NewSeries(name string, palette []AdaptiveColor) *Series {
 	md := MetricData{
 		X: make([]float64, 0, initDataSliceCap),
 		Y: make([]float64, 0, initDataSliceCap),
@@ -168,7 +167,7 @@ type EpochLineChart struct {
 	order []string
 
 	// palette provides colors for new series added to this chart.
-	palette []compat.AdaptiveColor
+	palette []AdaptiveColor
 
 	// focused indicates whether this chart has input focus in the grid.
 	focused bool
@@ -331,7 +330,7 @@ func (c *EpochLineChart) maxXLabelWidth() int {
 
 // SetPalette updates the color palette for new series.
 // Existing series retain their current colors.
-func (c *EpochLineChart) SetPalette(colors []compat.AdaptiveColor) {
+func (c *EpochLineChart) SetPalette(colors []AdaptiveColor) {
 	if len(colors) == 0 {
 		colors = GraphColors(DefaultColorScheme)
 	}

--- a/core/internal/leet/epochlinechart_test.go
+++ b/core/internal/leet/epochlinechart_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/stretchr/testify/require"
 
 	leet "github.com/wandb/wandb/core/internal/leet"
@@ -270,7 +269,7 @@ func TestTimeSeriesLineChart_LogY_FormatsTicksWithMetricUnits(t *testing.T) {
 		Width:  80,
 		Height: 20,
 		Def:    def,
-		BaseColor: compat.AdaptiveColor{
+		BaseColor: leet.AdaptiveColor{
 			Light: lipgloss.Color("#FF00FF"),
 			Dark:  lipgloss.Color("#FF00FF"),
 		},

--- a/core/internal/leet/frenchfrieschart.go
+++ b/core/internal/leet/frenchfrieschart.go
@@ -9,12 +9,11 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 )
 
 const frenchFriesCell = "█"
 
-func renderFrenchFriesCells(colors []compat.AdaptiveColor) []string {
+func renderFrenchFriesCells(colors []AdaptiveColor) []string {
 	if len(colors) == 0 {
 		colors = FrenchFriesColors(DefaultFrenchFriesColorScheme)
 	}
@@ -102,7 +101,7 @@ type FrenchFriesChart struct {
 type FrenchFriesChartParams struct {
 	Width, Height int
 	Def           *MetricDef
-	Colors        []compat.AdaptiveColor
+	Colors        []AdaptiveColor
 	Now           time.Time
 }
 

--- a/core/internal/leet/frenchfrieschart_test.go
+++ b/core/internal/leet/frenchfrieschart_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/leet"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestFrenchFriesChart_UsesProvidedPalette(t *testing.T) {
-	palette := []compat.AdaptiveColor{
+	palette := []leet.AdaptiveColor{
 		{Light: lipgloss.Color("#112233"), Dark: lipgloss.Color("#112233")},
 		{Light: lipgloss.Color("#445566"), Dark: lipgloss.Color("#445566")},
 		{Light: lipgloss.Color("#778899"), Dark: lipgloss.Color("#778899")},

--- a/core/internal/leet/metricsgrid.go
+++ b/core/internal/leet/metricsgrid.go
@@ -8,7 +8,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 
 	"github.com/wandb/wandb/core/internal/observability"
 )
@@ -52,14 +51,14 @@ type MetricsGrid struct {
 	filter *Filter
 
 	// Stable color assignment.
-	colorOfTitle map[string]compat.AdaptiveColor
+	colorOfTitle map[string]AdaptiveColor
 	nextColorIdx int
 
 	// Palette for main metrics charts (derived from config.ColorScheme()).
-	palette []compat.AdaptiveColor
+	palette []AdaptiveColor
 
 	// Palette for per-plot mode in single-run view (derived from config.PerPlotColorScheme()).
-	perPlotPalette []compat.AdaptiveColor
+	perPlotPalette []AdaptiveColor
 
 	// When set to ColorModePerPlot, single-series charts are colored per chart title.
 	// Default is ColorModePerSeries (stable run-id color).
@@ -68,7 +67,7 @@ type MetricsGrid struct {
 	// seriesColorForKey optionally overrides per-series colors keyed by series
 	// name (for example workspace run paths). Intended for workspace multi-run
 	// view.
-	seriesColorForKey func(string) compat.AdaptiveColor
+	seriesColorForKey func(string) AdaptiveColor
 
 	// synchronized inspection session state (active only between press/release)
 	syncInspectActive bool
@@ -94,7 +93,7 @@ func NewMetricsGrid(
 		focus:                 focus,
 		filter:                NewFilter(),
 		logger:                logger,
-		colorOfTitle:          make(map[string]compat.AdaptiveColor),
+		colorOfTitle:          make(map[string]AdaptiveColor),
 		palette:               palette,
 		perPlotPalette:        perPlotPalette,
 		singleSeriesColorMode: ColorModePerSeries,
@@ -123,7 +122,7 @@ func (mg *MetricsGrid) SetSingleSeriesColorMode(mode string) {
 // Callers should set this before processing data so newly created series render
 // with the intended colors from their first frame.
 func (mg *MetricsGrid) SetSeriesColorProvider(
-	provider func(string) compat.AdaptiveColor,
+	provider func(string) AdaptiveColor,
 ) {
 	mg.mu.Lock()
 	defer mg.mu.Unlock()
@@ -271,7 +270,7 @@ func (mg *MetricsGrid) effectiveChartCountNoLock() int {
 }
 
 // colorForNoLock returns a stable color for a given metric title.
-func (mg *MetricsGrid) colorForNoLock(title string) compat.AdaptiveColor {
+func (mg *MetricsGrid) colorForNoLock(title string) AdaptiveColor {
 	if c, ok := mg.colorOfTitle[title]; ok {
 		return c
 	}

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -122,7 +122,7 @@ func NewModel(params ModelParams) *Model {
 // regardless of the starting mode. If starting in single-run mode, the run's
 // reader and watcher commands are also started.
 func (m *Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{}
+	cmds := []tea.Cmd{tea.RequestBackgroundColor}
 
 	// Workspace always exists; initialize its long‑running commands.
 	if m.workspace != nil {
@@ -145,6 +145,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if wsMsg, ok := msg.(tea.WindowSizeMsg); ok {
 		m.width, m.height = wsMsg.Width, wsMsg.Height
 		m.help.SetSize(wsMsg.Width, wsMsg.Height)
+	}
+
+	if bgMsg, ok := msg.(tea.BackgroundColorMsg); ok {
+		SetDarkBackground(bgMsg.IsDark())
 	}
 
 	if handled, cmd := m.handleHelp(msg); handled {

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -7,12 +7,41 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/muesli/termenv"
 )
+
+// darkBackground tracks whether the terminal has a dark background.
+// Default is true (most terminals are dark). Updated at runtime when
+// Bubble Tea delivers tea.BackgroundColorMsg — no terminal query at
+// package init, which avoids hangs on Windows.
+var darkBackground atomic.Bool
+
+func init() { darkBackground.Store(true) }
+
+// SetDarkBackground updates the cached terminal-background flag.
+// Call this from your Bubble Tea Update when you receive
+// tea.BackgroundColorMsg.
+func SetDarkBackground(dark bool) { darkBackground.Store(dark) }
+
+// IsDarkBackground reports the current cached value.
+func IsDarkBackground() bool { return darkBackground.Load() }
+
+// AdaptiveColor picks between Light and Dark variants based on the
+// terminal background, using the lipgloss v2 LightDark API.
+// This replaces charm.land/lipgloss/v2/AdaptiveColor.
+type AdaptiveColor struct {
+	Light color.Color
+	Dark  color.Color
+}
+
+// RGBA implements color.Color by delegating to the appropriate variant.
+func (c AdaptiveColor) RGBA() (uint32, uint32, uint32, uint32) {
+	return lipgloss.LightDark(darkBackground.Load())(c.Light, c.Dark).RGBA()
+}
 
 // Terminal background detection (cached).
 var (
@@ -62,7 +91,7 @@ func getOddRunStyleColor() color.Color {
 		return blendRGB(termBgR, termBgG, termBgB, 128, 128, 128, 0.05)
 	}
 
-	return compat.AdaptiveColor{
+	return AdaptiveColor{
 		Light: lipgloss.Color("#d0d0d0"),
 		Dark:  lipgloss.Color("#1c1c1c"),
 	}
@@ -156,9 +185,9 @@ const (
 	mediumShadeBlock rune = '\u2592' // ▒
 )
 
-func uniformAdaptiveColor(hex string) compat.AdaptiveColor {
+func uniformAdaptiveColor(hex string) AdaptiveColor {
 	c := lipgloss.Color(hex)
-	return compat.AdaptiveColor{Light: c, Dark: c}
+	return AdaptiveColor{Light: c, Dark: c}
 }
 
 // WANDB brand colors.
@@ -169,7 +198,7 @@ var (
 )
 
 // Secondary colors.
-var teal450 = compat.AdaptiveColor{
+var teal450 = AdaptiveColor{
 	Light: lipgloss.Color("#10BFCC"),
 	Dark:  lipgloss.Color("#E1F7FA"),
 }
@@ -177,26 +206,26 @@ var teal450 = compat.AdaptiveColor{
 // Functional colors not specific to any visual component.
 var (
 	// Color for main items such as chart titles.
-	colorAccent = compat.AdaptiveColor{
+	colorAccent = AdaptiveColor{
 		Light: lipgloss.Color("#6c6c6c"),
 		Dark:  lipgloss.Color("#bcbcbc"),
 	}
 
 	// Main text color that appears the most frequently on the screen.
-	colorText = compat.AdaptiveColor{
+	colorText = AdaptiveColor{
 		Light: lipgloss.Color("#8a8a8a"), // ANSI color 245
 		Dark:  lipgloss.Color("#8a8a8a"),
 	}
 
 	// Color for extra or parenthetical text or information.
 	// Axis lines in charts.
-	colorSubtle = compat.AdaptiveColor{
+	colorSubtle = AdaptiveColor{
 		Light: lipgloss.Color("#585858"), // ANSI color 240
 		Dark:  lipgloss.Color("#585858"),
 	}
 
 	// Color for layout elements, like borders and separator lines.
-	colorLayout = compat.AdaptiveColor{
+	colorLayout = AdaptiveColor{
 		Light: lipgloss.Color("#949494"),
 		Dark:  lipgloss.Color("#444444"),
 	}
@@ -212,20 +241,20 @@ var (
 
 	// Color for lower-level headings; more frequent than headings.
 	// Help page keys, metrics grid header.
-	colorSubheading = compat.AdaptiveColor{
+	colorSubheading = AdaptiveColor{
 		Light: lipgloss.Color("#3a3a3a"),
 		Dark:  lipgloss.Color("#eeeeee"),
 	}
 
 	// Colors for key-value pairs such as run summary or config items.
 	colorItemKey   = lipgloss.Color("243")
-	colorItemValue = compat.AdaptiveColor{
+	colorItemValue = AdaptiveColor{
 		Light: lipgloss.Color("#262626"),
 		Dark:  lipgloss.Color("#d0d0d0"),
 	}
 
 	// Color used for the selected line in lists.
-	colorSelected = compat.AdaptiveColor{
+	colorSelected = AdaptiveColor{
 		Dark:  lipgloss.Color("#FCBC32"),
 		Light: lipgloss.Color("#FCBC32"),
 	}
@@ -253,88 +282,88 @@ const leetArt = `
 // Each scheme consists of an ordered list of colors,
 // where each new graph, and/or a line on a multi-line graph takes the next color.
 // Colors get reused in a cyclic manner.
-var colorSchemes = map[string][]compat.AdaptiveColor{
+var colorSchemes = map[string][]AdaptiveColor{
 	"sunset-glow": { // Golden-pink gradient
-		compat.AdaptiveColor{Light: lipgloss.Color("#B84FD4"), Dark: lipgloss.Color("#E281FE")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#BD5AB9"), Dark: lipgloss.Color("#E78DE3")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#BF60AB"), Dark: lipgloss.Color("#E993D5")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#C36C91"), Dark: lipgloss.Color("#ED9FBB")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#C67283"), Dark: lipgloss.Color("#F0A5AD")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#C87875"), Dark: lipgloss.Color("#F2AB9F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#CC8451"), Dark: lipgloss.Color("#F6B784")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#CE8A45"), Dark: lipgloss.Color("#F8BD78")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#D19038"), Dark: lipgloss.Color("#FBC36B")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#D59C1C"), Dark: lipgloss.Color("#FFCF4F")},
+		AdaptiveColor{Light: lipgloss.Color("#B84FD4"), Dark: lipgloss.Color("#E281FE")},
+		AdaptiveColor{Light: lipgloss.Color("#BD5AB9"), Dark: lipgloss.Color("#E78DE3")},
+		AdaptiveColor{Light: lipgloss.Color("#BF60AB"), Dark: lipgloss.Color("#E993D5")},
+		AdaptiveColor{Light: lipgloss.Color("#C36C91"), Dark: lipgloss.Color("#ED9FBB")},
+		AdaptiveColor{Light: lipgloss.Color("#C67283"), Dark: lipgloss.Color("#F0A5AD")},
+		AdaptiveColor{Light: lipgloss.Color("#C87875"), Dark: lipgloss.Color("#F2AB9F")},
+		AdaptiveColor{Light: lipgloss.Color("#CC8451"), Dark: lipgloss.Color("#F6B784")},
+		AdaptiveColor{Light: lipgloss.Color("#CE8A45"), Dark: lipgloss.Color("#F8BD78")},
+		AdaptiveColor{Light: lipgloss.Color("#D19038"), Dark: lipgloss.Color("#FBC36B")},
+		AdaptiveColor{Light: lipgloss.Color("#D59C1C"), Dark: lipgloss.Color("#FFCF4F")},
 	},
 	"blush-tide": { // Pink-teal gradient
-		compat.AdaptiveColor{Light: lipgloss.Color("#D94F8C"), Dark: lipgloss.Color("#F9A7CC")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#CA60AC"), Dark: lipgloss.Color("#EEB3E0")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#B96FC4"), Dark: lipgloss.Color("#E4BFEE")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#A77DD4"), Dark: lipgloss.Color("#DBC9F7")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#9489DF"), Dark: lipgloss.Color("#D5D3FC")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#8095E5"), Dark: lipgloss.Color("#D1DCFE")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#6AA1E6"), Dark: lipgloss.Color("#D0E5FF")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#50ACE2"), Dark: lipgloss.Color("#D3ECFE")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#33B6D9"), Dark: lipgloss.Color("#D8F2FC")},
-		compat.AdaptiveColor{
+		AdaptiveColor{Light: lipgloss.Color("#D94F8C"), Dark: lipgloss.Color("#F9A7CC")},
+		AdaptiveColor{Light: lipgloss.Color("#CA60AC"), Dark: lipgloss.Color("#EEB3E0")},
+		AdaptiveColor{Light: lipgloss.Color("#B96FC4"), Dark: lipgloss.Color("#E4BFEE")},
+		AdaptiveColor{Light: lipgloss.Color("#A77DD4"), Dark: lipgloss.Color("#DBC9F7")},
+		AdaptiveColor{Light: lipgloss.Color("#9489DF"), Dark: lipgloss.Color("#D5D3FC")},
+		AdaptiveColor{Light: lipgloss.Color("#8095E5"), Dark: lipgloss.Color("#D1DCFE")},
+		AdaptiveColor{Light: lipgloss.Color("#6AA1E6"), Dark: lipgloss.Color("#D0E5FF")},
+		AdaptiveColor{Light: lipgloss.Color("#50ACE2"), Dark: lipgloss.Color("#D3ECFE")},
+		AdaptiveColor{Light: lipgloss.Color("#33B6D9"), Dark: lipgloss.Color("#D8F2FC")},
+		AdaptiveColor{
 			Light: lipgloss.Color("#10BFCC"), Dark: lipgloss.Color("#E1F7FA")}, // == teal450
 	},
 	"gilded-lagoon": { // Golden-teal gradient
-		compat.AdaptiveColor{Light: lipgloss.Color("#D59C1C"), Dark: lipgloss.Color("#FFCF4F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#C2A636"), Dark: lipgloss.Color("#EADB74")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#AFAD4C"), Dark: lipgloss.Color("#DAE492")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#9CB35F"), Dark: lipgloss.Color("#CFEBAB")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#8AB872"), Dark: lipgloss.Color("#C8EFC0")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#77BB83"), Dark: lipgloss.Color("#C5F3D2")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#62BE95"), Dark: lipgloss.Color("#C7F5E1")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#4CBFA6"), Dark: lipgloss.Color("#CDF6ED")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#32C0B9"), Dark: lipgloss.Color("#D5F7F5")},
-		compat.AdaptiveColor{
+		AdaptiveColor{Light: lipgloss.Color("#D59C1C"), Dark: lipgloss.Color("#FFCF4F")},
+		AdaptiveColor{Light: lipgloss.Color("#C2A636"), Dark: lipgloss.Color("#EADB74")},
+		AdaptiveColor{Light: lipgloss.Color("#AFAD4C"), Dark: lipgloss.Color("#DAE492")},
+		AdaptiveColor{Light: lipgloss.Color("#9CB35F"), Dark: lipgloss.Color("#CFEBAB")},
+		AdaptiveColor{Light: lipgloss.Color("#8AB872"), Dark: lipgloss.Color("#C8EFC0")},
+		AdaptiveColor{Light: lipgloss.Color("#77BB83"), Dark: lipgloss.Color("#C5F3D2")},
+		AdaptiveColor{Light: lipgloss.Color("#62BE95"), Dark: lipgloss.Color("#C7F5E1")},
+		AdaptiveColor{Light: lipgloss.Color("#4CBFA6"), Dark: lipgloss.Color("#CDF6ED")},
+		AdaptiveColor{Light: lipgloss.Color("#32C0B9"), Dark: lipgloss.Color("#D5F7F5")},
+		AdaptiveColor{
 			Light: lipgloss.Color("#10BFCC"), Dark: lipgloss.Color("#E1F7FA")}, // == teal450
 	},
 	"bootstrap-vibe": { // Badge-friendly palette with familiar utility tones
-		compat.AdaptiveColor{Light: lipgloss.Color("#6c757d"), Dark: lipgloss.Color("#a7b0b8")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#0d6efd"), Dark: lipgloss.Color("#78aefc")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#198754"), Dark: lipgloss.Color("#72cf9d")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#0dcaf0"), Dark: lipgloss.Color("#7be3fa")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#fd7e14"), Dark: lipgloss.Color("#ffb574")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#dc3545"), Dark: lipgloss.Color("#f28a93")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#6f42c1"), Dark: lipgloss.Color("#b99aff")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#20c997"), Dark: lipgloss.Color("#83e6ca")},
+		AdaptiveColor{Light: lipgloss.Color("#6c757d"), Dark: lipgloss.Color("#a7b0b8")},
+		AdaptiveColor{Light: lipgloss.Color("#0d6efd"), Dark: lipgloss.Color("#78aefc")},
+		AdaptiveColor{Light: lipgloss.Color("#198754"), Dark: lipgloss.Color("#72cf9d")},
+		AdaptiveColor{Light: lipgloss.Color("#0dcaf0"), Dark: lipgloss.Color("#7be3fa")},
+		AdaptiveColor{Light: lipgloss.Color("#fd7e14"), Dark: lipgloss.Color("#ffb574")},
+		AdaptiveColor{Light: lipgloss.Color("#dc3545"), Dark: lipgloss.Color("#f28a93")},
+		AdaptiveColor{Light: lipgloss.Color("#6f42c1"), Dark: lipgloss.Color("#b99aff")},
+		AdaptiveColor{Light: lipgloss.Color("#20c997"), Dark: lipgloss.Color("#83e6ca")},
 	},
 	"wandb-vibe-10": {
-		compat.AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#3DBAC4"), Dark: lipgloss.Color("#58D3DB")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#42B88A"), Dark: lipgloss.Color("#5ED6A4")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#E85565"), Dark: lipgloss.Color("#FF7A88")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#9AC24A"), Dark: lipgloss.Color("#BBE06B")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#E0AD20"), Dark: lipgloss.Color("#FFCF4D")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#C85EE8"), Dark: lipgloss.Color("#E180FF")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#9475E8"), Dark: lipgloss.Color("#B199FF")},
+		AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
+		AdaptiveColor{Light: lipgloss.Color("#3DBAC4"), Dark: lipgloss.Color("#58D3DB")},
+		AdaptiveColor{Light: lipgloss.Color("#42B88A"), Dark: lipgloss.Color("#5ED6A4")},
+		AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
+		AdaptiveColor{Light: lipgloss.Color("#E85565"), Dark: lipgloss.Color("#FF7A88")},
+		AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
+		AdaptiveColor{Light: lipgloss.Color("#9AC24A"), Dark: lipgloss.Color("#BBE06B")},
+		AdaptiveColor{Light: lipgloss.Color("#E0AD20"), Dark: lipgloss.Color("#FFCF4D")},
+		AdaptiveColor{Light: lipgloss.Color("#C85EE8"), Dark: lipgloss.Color("#E180FF")},
+		AdaptiveColor{Light: lipgloss.Color("#9475E8"), Dark: lipgloss.Color("#B199FF")},
 	},
 	"wandb-vibe-20": {
-		compat.AdaptiveColor{Light: lipgloss.Color("#AEAFB3"), Dark: lipgloss.Color("#D4D5D9")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#7AD4DB"), Dark: lipgloss.Color("#A9EDF2")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#04707F"), Dark: lipgloss.Color("#038194")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#6DDBA8"), Dark: lipgloss.Color("#A1F0CB")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#00704A"), Dark: lipgloss.Color("#00875A")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#EAA0A5"), Dark: lipgloss.Color("#FFC7CA")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#B82038"), Dark: lipgloss.Color("#CC2944")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#8FBDE8"), Dark: lipgloss.Color("#BDD9FF")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#B0D470"), Dark: lipgloss.Color("#D0ED9D")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#4E7424"), Dark: lipgloss.Color("#5F8A2D")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#EAC860"), Dark: lipgloss.Color("#FFE49E")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#9A5E10"), Dark: lipgloss.Color("#B8740F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#D99DE8"), Dark: lipgloss.Color("#EFC2FC")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#8528A8"), Dark: lipgloss.Color("#9E36C2")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#B8A8E8"), Dark: lipgloss.Color("#D6C9FF")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#5538B0"), Dark: lipgloss.Color("#6645D1")},
+		AdaptiveColor{Light: lipgloss.Color("#AEAFB3"), Dark: lipgloss.Color("#D4D5D9")},
+		AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
+		AdaptiveColor{Light: lipgloss.Color("#7AD4DB"), Dark: lipgloss.Color("#A9EDF2")},
+		AdaptiveColor{Light: lipgloss.Color("#04707F"), Dark: lipgloss.Color("#038194")},
+		AdaptiveColor{Light: lipgloss.Color("#6DDBA8"), Dark: lipgloss.Color("#A1F0CB")},
+		AdaptiveColor{Light: lipgloss.Color("#00704A"), Dark: lipgloss.Color("#00875A")},
+		AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
+		AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
+		AdaptiveColor{Light: lipgloss.Color("#EAA0A5"), Dark: lipgloss.Color("#FFC7CA")},
+		AdaptiveColor{Light: lipgloss.Color("#B82038"), Dark: lipgloss.Color("#CC2944")},
+		AdaptiveColor{Light: lipgloss.Color("#8FBDE8"), Dark: lipgloss.Color("#BDD9FF")},
+		AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
+		AdaptiveColor{Light: lipgloss.Color("#B0D470"), Dark: lipgloss.Color("#D0ED9D")},
+		AdaptiveColor{Light: lipgloss.Color("#4E7424"), Dark: lipgloss.Color("#5F8A2D")},
+		AdaptiveColor{Light: lipgloss.Color("#EAC860"), Dark: lipgloss.Color("#FFE49E")},
+		AdaptiveColor{Light: lipgloss.Color("#9A5E10"), Dark: lipgloss.Color("#B8740F")},
+		AdaptiveColor{Light: lipgloss.Color("#D99DE8"), Dark: lipgloss.Color("#EFC2FC")},
+		AdaptiveColor{Light: lipgloss.Color("#8528A8"), Dark: lipgloss.Color("#9E36C2")},
+		AdaptiveColor{Light: lipgloss.Color("#B8A8E8"), Dark: lipgloss.Color("#D6C9FF")},
+		AdaptiveColor{Light: lipgloss.Color("#5538B0"), Dark: lipgloss.Color("#6645D1")},
 	},
 	// This palette has been tested with deuteranopia, protanopia, and tritanopia
 	// simulators. Those forms of color blindness are less common than deuteranomaly.
@@ -342,42 +371,42 @@ var colorSchemes = map[string][]compat.AdaptiveColor{
 	// are commonly colorblind-friendly across most forms of color blindness.
 	// Gradient ordering: warm siennas → cool blues → neutral grays.
 	"dusk-shore": {
-		compat.AdaptiveColor{Light: lipgloss.Color("#823520"), Dark: lipgloss.Color("#994228")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#BA5028"), Dark: lipgloss.Color("#D96534")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#D86030"), Dark: lipgloss.Color("#FC8F58")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#E89865"), Dark: lipgloss.Color("#FFBA91")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#78A8E8"), Dark: lipgloss.Color("#A4C9FC")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#4880DA"), Dark: lipgloss.Color("#629DF5")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#2E68CC"), Dark: lipgloss.Color("#397EED")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#2258BE"), Dark: lipgloss.Color("#286CE0")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#606872"), Dark: lipgloss.Color("#79808A")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
+		AdaptiveColor{Light: lipgloss.Color("#823520"), Dark: lipgloss.Color("#994228")},
+		AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
+		AdaptiveColor{Light: lipgloss.Color("#BA5028"), Dark: lipgloss.Color("#D96534")},
+		AdaptiveColor{Light: lipgloss.Color("#D86030"), Dark: lipgloss.Color("#FC8F58")},
+		AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
+		AdaptiveColor{Light: lipgloss.Color("#E89865"), Dark: lipgloss.Color("#FFBA91")},
+		AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
+		AdaptiveColor{Light: lipgloss.Color("#78A8E8"), Dark: lipgloss.Color("#A4C9FC")},
+		AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
+		AdaptiveColor{Light: lipgloss.Color("#4880DA"), Dark: lipgloss.Color("#629DF5")},
+		AdaptiveColor{Light: lipgloss.Color("#2E68CC"), Dark: lipgloss.Color("#397EED")},
+		AdaptiveColor{Light: lipgloss.Color("#2258BE"), Dark: lipgloss.Color("#286CE0")},
+		AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
+		AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
+		AdaptiveColor{Light: lipgloss.Color("#606872"), Dark: lipgloss.Color("#79808A")},
+		AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
 	},
 	// Same colorblind-friendly sienna/blue/gray palette as "dusk-shore", but with
 	// colors interleaved for maximum visual differentiation between adjacent series.
 	"clear-signal": {
-		compat.AdaptiveColor{Light: lipgloss.Color("#BA5028"), Dark: lipgloss.Color("#D96534")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#2258BE"), Dark: lipgloss.Color("#286CE0")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#4880DA"), Dark: lipgloss.Color("#629DF5")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#823520"), Dark: lipgloss.Color("#994228")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#606872"), Dark: lipgloss.Color("#79808A")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#D86030"), Dark: lipgloss.Color("#FC8F58")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#E89865"), Dark: lipgloss.Color("#FFBA91")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#78A8E8"), Dark: lipgloss.Color("#A4C9FC")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#2E68CC"), Dark: lipgloss.Color("#397EED")},
-		compat.AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
+		AdaptiveColor{Light: lipgloss.Color("#BA5028"), Dark: lipgloss.Color("#D96534")},
+		AdaptiveColor{Light: lipgloss.Color("#2258BE"), Dark: lipgloss.Color("#286CE0")},
+		AdaptiveColor{Light: lipgloss.Color("#4880DA"), Dark: lipgloss.Color("#629DF5")},
+		AdaptiveColor{Light: lipgloss.Color("#823520"), Dark: lipgloss.Color("#994228")},
+		AdaptiveColor{Light: lipgloss.Color("#E07040"), Dark: lipgloss.Color("#FCA36F")},
+		AdaptiveColor{Light: lipgloss.Color("#EAB08A"), Dark: lipgloss.Color("#FFCFB2")},
+		AdaptiveColor{Light: lipgloss.Color("#8A8D91"), Dark: lipgloss.Color("#B1B4B9")},
+		AdaptiveColor{Light: lipgloss.Color("#606872"), Dark: lipgloss.Color("#79808A")},
+		AdaptiveColor{Light: lipgloss.Color("#5A96E0"), Dark: lipgloss.Color("#7DB1FA")},
+		AdaptiveColor{Light: lipgloss.Color("#2850A8"), Dark: lipgloss.Color("#1F59C4")},
+		AdaptiveColor{Light: lipgloss.Color("#A84728"), Dark: lipgloss.Color("#C2562F")},
+		AdaptiveColor{Light: lipgloss.Color("#D86030"), Dark: lipgloss.Color("#FC8F58")},
+		AdaptiveColor{Light: lipgloss.Color("#E89865"), Dark: lipgloss.Color("#FFBA91")},
+		AdaptiveColor{Light: lipgloss.Color("#78A8E8"), Dark: lipgloss.Color("#A4C9FC")},
+		AdaptiveColor{Light: lipgloss.Color("#2E68CC"), Dark: lipgloss.Color("#397EED")},
+		AdaptiveColor{Light: lipgloss.Color("#454B54"), Dark: lipgloss.Color("#565C66")},
 	},
 	// Sequential palettes suitable for French Fries percentage heatmaps.
 	"traffic-light": {
@@ -460,7 +489,7 @@ var colorSchemes = map[string][]compat.AdaptiveColor{
 	},
 }
 
-func colorSchemeOrDefault(scheme, fallback string) []compat.AdaptiveColor {
+func colorSchemeOrDefault(scheme, fallback string) []AdaptiveColor {
 	if colors, ok := colorSchemes[scheme]; ok && len(colors) > 0 {
 		return colors
 	}
@@ -470,14 +499,14 @@ func colorSchemeOrDefault(scheme, fallback string) []compat.AdaptiveColor {
 // GraphColors returns the palette for the requested scheme.
 //
 // If the scheme is unknown, it falls back to DefaultColorScheme.
-func GraphColors(scheme string) []compat.AdaptiveColor {
+func GraphColors(scheme string) []AdaptiveColor {
 	return colorSchemeOrDefault(scheme, DefaultColorScheme)
 }
 
 // FrenchFriesColors returns the palette for the requested French Fries heatmap scheme.
 //
 // If the scheme is unknown, it falls back to DefaultFrenchFriesColorScheme.
-func FrenchFriesColors(scheme string) []compat.AdaptiveColor {
+func FrenchFriesColors(scheme string) []AdaptiveColor {
 	return colorSchemeOrDefault(scheme, DefaultFrenchFriesColorScheme)
 }
 
@@ -516,11 +545,11 @@ var (
 	inspectionLineStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 
 	inspectionLegendStyle = lipgloss.NewStyle().
-				Foreground(compat.AdaptiveColor{
+				Foreground(AdaptiveColor{
 			Light: lipgloss.Color("#111111"),
 			Dark:  lipgloss.Color("#EEEEEE"),
 		}).
-		Background(compat.AdaptiveColor{
+		Background(AdaptiveColor{
 			Light: lipgloss.Color("#EEEEEE"),
 			Dark:  lipgloss.Color("#333333"),
 		})
@@ -543,15 +572,15 @@ var runOverviewTagLightText = lipgloss.Color("#ffffff")
 // runOverviewTagBackgroundColor returns the background color for a tag badge.
 // It deterministically maps tag to a color in the given scheme so that the
 // same tag always gets the same color.
-func runOverviewTagBackgroundColor(scheme, tag string) compat.AdaptiveColor {
+func runOverviewTagBackgroundColor(scheme, tag string) AdaptiveColor {
 	colors := GraphColors(scheme)
 	return colors[colorIndex(tag, len(colors))]
 }
 
 // runOverviewTagForegroundColor picks a foreground color (light or dark) for
 // each adaptive variant of bg that satisfies WCAG contrast requirements.
-func runOverviewTagForegroundColor(bg compat.AdaptiveColor) compat.AdaptiveColor {
-	return compat.AdaptiveColor{
+func runOverviewTagForegroundColor(bg AdaptiveColor) AdaptiveColor {
+	return AdaptiveColor{
 		Light: runOverviewTagTextColor(bg.Light),
 		Dark:  runOverviewTagTextColor(bg.Dark),
 	}
@@ -759,7 +788,7 @@ var (
 var (
 	workspaceHeaderLines = 1
 
-	colorSelectedRunInactiveStyle = compat.AdaptiveColor{
+	colorSelectedRunInactiveStyle = AdaptiveColor{
 		Light: lipgloss.Color("#F5D28A"),
 		Dark:  lipgloss.Color("#6B5200"),
 	}

--- a/core/internal/leet/symon.go
+++ b/core/internal/leet/symon.go
@@ -98,7 +98,7 @@ func NewSymon(params SymonParams) *Symon {
 
 // Init starts the initial sampling pass.
 func (s *Symon) Init() tea.Cmd {
-	return s.sampleNowCmd()
+	return tea.Batch(tea.RequestBackgroundColor, s.sampleNowCmd())
 }
 
 // Update handles resize events, help/restart shortcuts, user input, and live
@@ -108,6 +108,10 @@ func (s *Symon) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.width, s.height = ws.Width, ws.Height
 		s.help.SetSize(ws.Width, ws.Height)
 		s.resizeGrid()
+	}
+
+	if bgMsg, ok := msg.(tea.BackgroundColorMsg); ok {
+		SetDarkBackground(bgMsg.IsDark())
 	}
 
 	if handled, cmd := s.handleHelp(msg); handled {

--- a/core/internal/leet/systemmetricsgrid.go
+++ b/core/internal/leet/systemmetricsgrid.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 
 	"github.com/wandb/wandb/core/internal/observability"
 )
@@ -102,7 +101,7 @@ func (g *SystemMetricsGrid) effectiveGridSize() GridSize {
 }
 
 // nextPaletteColor returns the next color from the active system palette.
-func (g *SystemMetricsGrid) nextPaletteColor() compat.AdaptiveColor {
+func (g *SystemMetricsGrid) nextPaletteColor() AdaptiveColor {
 	palette := GraphColors(g.config.SystemColorScheme())
 	color := palette[g.nextColor%len(palette)]
 	g.nextColor++
@@ -114,10 +113,10 @@ func (g *SystemMetricsGrid) nextPaletteColor() compat.AdaptiveColor {
 //
 // The first call returns the color after the base color,
 // so the base can be used for the first series.
-func (g *SystemMetricsGrid) anchoredSeriesColorProvider(baseIdx int) func() compat.AdaptiveColor {
+func (g *SystemMetricsGrid) anchoredSeriesColorProvider(baseIdx int) func() AdaptiveColor {
 	palette := GraphColors(g.config.SystemColorScheme())
 	idx := baseIdx + 1
-	return func() compat.AdaptiveColor {
+	return func() AdaptiveColor {
 		c := palette[idx%len(palette)]
 		idx++
 		return c
@@ -136,7 +135,7 @@ func (g *SystemMetricsGrid) createMetricChart(def *MetricDef) systemMetricChart 
 
 	// Base color by color mode.
 	var (
-		baseColor compat.AdaptiveColor
+		baseColor AdaptiveColor
 		baseIdx   int
 	)
 	colorMode := g.config.SystemColorMode()

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2/compat"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -87,7 +86,7 @@ func (c *TimeSeriesLineChart) TestSeriesCount() int {
 }
 
 // TestSeriesColor returns the configured color for a series key.
-func (c *TimeSeriesLineChart) TestSeriesColor(key string) compat.AdaptiveColor {
+func (c *TimeSeriesLineChart) TestSeriesColor(key string) AdaptiveColor {
 	return c.seriesColors[key]
 }
 

--- a/core/internal/leet/timeserieslinechart.go
+++ b/core/internal/leet/timeserieslinechart.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 )
 
 const (
@@ -33,12 +32,12 @@ type TimeSeriesLineChart struct {
 	series map[string]struct{}
 
 	// seriesColors stores the assigned color for each underlying series key.
-	seriesColors map[string]compat.AdaptiveColor
-	baseColor    compat.AdaptiveColor
+	seriesColors map[string]AdaptiveColor
+	baseColor    AdaptiveColor
 
 	// colorProvider yields the next color for additional series on this chart.
 	// It is anchored to the chart's base color so multi-series colors are stable per chart.
-	colorProvider func() compat.AdaptiveColor
+	colorProvider func() AdaptiveColor
 
 	tailWindow time.Duration
 	viewWindow time.Duration
@@ -54,8 +53,8 @@ type TimeSeriesLineChart struct {
 type TimeSeriesLineChartParams struct {
 	Width, Height int
 	Def           *MetricDef
-	BaseColor     compat.AdaptiveColor
-	ColorProvider func() compat.AdaptiveColor
+	BaseColor     AdaptiveColor
+	ColorProvider func() AdaptiveColor
 	Now           time.Time
 }
 
@@ -69,7 +68,7 @@ func NewTimeSeriesLineChart(params *TimeSeriesLineChartParams) *TimeSeriesLineCh
 		EpochLineChart: baseChart,
 		def:            params.Def,
 		series:         make(map[string]struct{}),
-		seriesColors:   make(map[string]compat.AdaptiveColor),
+		seriesColors:   make(map[string]AdaptiveColor),
 		baseColor:      params.BaseColor,
 		colorProvider:  params.ColorProvider,
 		tailWindow:     tailWindow,
@@ -263,7 +262,7 @@ func (c *TimeSeriesLineChart) addPoint(seriesKey string, x, y float64) {
 	c.dirty = true
 }
 
-func (c *TimeSeriesLineChart) nextSeriesColor() compat.AdaptiveColor {
+func (c *TimeSeriesLineChart) nextSeriesColor() AdaptiveColor {
 	if c.colorProvider == nil {
 		return c.baseColor
 	}

--- a/core/internal/leet/timeserieslinechart_test.go
+++ b/core/internal/leet/timeserieslinechart_test.go
@@ -6,22 +6,21 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/leet"
 )
 
 // stubColorProvider returns deterministic colors for series creation order.
-func stubColorProvider(colors ...string) func() compat.AdaptiveColor {
+func stubColorProvider(colors ...string) func() leet.AdaptiveColor {
 	i := 0
-	return func() compat.AdaptiveColor {
+	return func() leet.AdaptiveColor {
 		if len(colors) == 0 {
-			return compat.AdaptiveColor{}
+			return leet.AdaptiveColor{}
 		}
 		c := colors[i%len(colors)]
 		i++
-		return compat.AdaptiveColor{
+		return leet.AdaptiveColor{
 			Light: lipgloss.Color(c), Dark: lipgloss.Color(c)}
 	}
 }
@@ -40,7 +39,7 @@ func TestNewTimeSeriesLineChart_ConstructsAndInitializes(t *testing.T) {
 	ch := leet.NewTimeSeriesLineChart(&leet.TimeSeriesLineChartParams{
 		80, 20,
 		def,
-		compat.AdaptiveColor{
+		leet.AdaptiveColor{
 			Light: lipgloss.Color("#FF00FF"), Dark: lipgloss.Color("#FF00FF")}, // base color
 		stubColorProvider("#00FF00"), // provider for subsequent series
 		now,
@@ -65,7 +64,7 @@ func TestAddDataPoint_DefaultSeries_BookKeeping(t *testing.T) {
 	}
 	now := time.Unix(1_700_000_000, 0)
 	ch := leet.NewTimeSeriesLineChart(&leet.TimeSeriesLineChartParams{
-		80, 20, def, compat.AdaptiveColor{
+		80, 20, def, leet.AdaptiveColor{
 			Light: lipgloss.Color("#ABCDEF"), Dark: lipgloss.Color("#ABCDEF")},
 		stubColorProvider(), now})
 
@@ -111,7 +110,7 @@ func TestAddDataPoint_NamedSeries_CreatesSeriesOnDemand(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	ch := leet.NewTimeSeriesLineChart(&leet.TimeSeriesLineChartParams{
 		80, 20, def,
-		compat.AdaptiveColor{
+		leet.AdaptiveColor{
 			Light: lipgloss.Color("#FF00FF"), Dark: lipgloss.Color("#FF00FF")},
 		stubColorProvider("#00FF00", "#0000FF"), now})
 
@@ -142,11 +141,11 @@ func TestDefaultAndNamedSeries_GetDistinctColors(t *testing.T) {
 		Percentage: false,
 	}
 	now := time.Unix(1_700_000_000, 0)
-	baseColor := compat.AdaptiveColor{
+	baseColor := leet.AdaptiveColor{
 		Light: lipgloss.Color("#FF00FF"),
 		Dark:  lipgloss.Color("#FF00FF"),
 	}
-	nextColor := compat.AdaptiveColor{
+	nextColor := leet.AdaptiveColor{
 		Light: lipgloss.Color("#00FF00"),
 		Dark:  lipgloss.Color("#00FF00"),
 	}
@@ -182,7 +181,7 @@ func TestFormatXAxisTick_NarrowSystemChartsKeepEndpointLabels(t *testing.T) {
 		Width:  leet.MinMetricChartWidth,
 		Height: 8,
 		Def:    def,
-		BaseColor: compat.AdaptiveColor{
+		BaseColor: leet.AdaptiveColor{
 			Light: lipgloss.Color("#FF00FF"), Dark: lipgloss.Color("#FF00FF")},
 		ColorProvider: stubColorProvider("#00FF00"),
 		Now:           now,
@@ -221,7 +220,7 @@ func TestFormatXAxisTick_WideSystemChartsKeepInteriorLabels(t *testing.T) {
 		Width:  80,
 		Height: 12,
 		Def:    def,
-		BaseColor: compat.AdaptiveColor{
+		BaseColor: leet.AdaptiveColor{
 			Light: lipgloss.Color("#FF00FF"), Dark: lipgloss.Color("#FF00FF")},
 		ColorProvider: stubColorProvider("#00FF00"),
 		Now:           now,

--- a/core/internal/leet/timeserieslinechart_zoom_test.go
+++ b/core/internal/leet/timeserieslinechart_zoom_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/leet"
@@ -28,7 +27,7 @@ func TestTimeSeriesLineChart_AutoTrailFreezeAndShowAll(t *testing.T) {
 		80,
 		20,
 		def,
-		compat.AdaptiveColor{Light: lipgloss.Color("#FF00FF"), Dark: lipgloss.Color("#FF00FF")},
+		leet.AdaptiveColor{Light: lipgloss.Color("#FF00FF"), Dark: lipgloss.Color("#FF00FF")},
 		stubColorProvider("#00FF00"),
 		start,
 	})

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -9,7 +9,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 
 	"github.com/wandb/wandb/core/internal/observability"
 )
@@ -1333,12 +1332,12 @@ func (w *Workspace) runPathForKey(runKey string) string {
 	return runWandbFile(w.wandbDir, runKey)
 }
 
-func (w *Workspace) runColorForKey(runKey string) compat.AdaptiveColor {
+func (w *Workspace) runColorForKey(runKey string) AdaptiveColor {
 	runPath := w.runPathForKey(runKey)
 	if w.runColors == nil {
 		colors := GraphColors(w.config.ColorScheme())
 		if len(colors) == 0 {
-			return compat.AdaptiveColor{}
+			return AdaptiveColor{}
 		}
 		return colors[colorIndex(runPath, len(colors))]
 	}

--- a/core/internal/leet/workspace_runcolors.go
+++ b/core/internal/leet/workspace_runcolors.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 )
 
 const (
@@ -31,24 +30,24 @@ const (
 // The workspace owns this allocator on the Bubble Tea update goroutine, so it
 // does not require internal locking.
 type workspaceRunColors struct {
-	palette  []compat.AdaptiveColor
-	assigned map[string]compat.AdaptiveColor // run path -> color
-	used     map[string]string               // serialized color -> run path
+	palette  []AdaptiveColor
+	assigned map[string]AdaptiveColor // run path -> color
+	used     map[string]string        // serialized color -> run path
 }
 
-func newWorkspaceRunColors(palette []compat.AdaptiveColor) *workspaceRunColors {
+func newWorkspaceRunColors(palette []AdaptiveColor) *workspaceRunColors {
 	if len(palette) == 0 {
 		palette = GraphColors(DefaultColorScheme)
 	}
 	return &workspaceRunColors{
-		palette:  append([]compat.AdaptiveColor(nil), palette...),
-		assigned: make(map[string]compat.AdaptiveColor),
+		palette:  append([]AdaptiveColor(nil), palette...),
+		assigned: make(map[string]AdaptiveColor),
 		used:     make(map[string]string),
 	}
 }
 
 // Assign returns the stable color for runPath, allocating one if needed.
-func (a *workspaceRunColors) Assign(runPath string) compat.AdaptiveColor {
+func (a *workspaceRunColors) Assign(runPath string) AdaptiveColor {
 	if c, ok := a.assigned[runPath]; ok {
 		return c
 	}
@@ -73,7 +72,7 @@ func (a *workspaceRunColors) Release(runPath string) {
 	}
 }
 
-func (a *workspaceRunColors) pickColor(runPath string) compat.AdaptiveColor {
+func (a *workspaceRunColors) pickColor(runPath string) AdaptiveColor {
 	base := a.palette[colorIndex(runPath, len(a.palette))]
 	if a.isAvailable(base, runPath) {
 		return base
@@ -90,14 +89,14 @@ func (a *workspaceRunColors) pickColor(runPath string) compat.AdaptiveColor {
 }
 
 func (a *workspaceRunColors) isAvailable(
-	c compat.AdaptiveColor,
+	c AdaptiveColor,
 	runPath string,
 ) bool {
 	owner, ok := a.used[workspaceRunColorKey(c)]
 	return !ok || owner == runPath
 }
 
-func workspaceRunColorKey(c compat.AdaptiveColor) string {
+func workspaceRunColorKey(c AdaptiveColor) string {
 	return normalizeWorkspaceRunColorComponent(c.Light) +
 		"|" +
 		normalizeWorkspaceRunColorComponent(c.Dark)
@@ -131,7 +130,7 @@ func workspaceRunColorComponentRGB(component any) (uint8, uint8, uint8, bool) {
 // so adjacent collisions remain visually distinct. Saturation and lightness use
 // a reflected walk instead of simple clamping, which avoids collapsing repeated
 // attempts to identical black, white, or gray endpoints.
-func workspaceRunColorVariant(base compat.AdaptiveColor, step int) compat.AdaptiveColor {
+func workspaceRunColorVariant(base AdaptiveColor, step int) AdaptiveColor {
 	if step <= 0 {
 		return base
 	}
@@ -165,7 +164,7 @@ func workspaceRunColorVariant(base compat.AdaptiveColor, step int) compat.Adapti
 		saturationDelta = -0.5 * workspaceRunColorSaturationStep * magnitude
 	}
 
-	return compat.AdaptiveColor{
+	return AdaptiveColor{
 		Light: adjustWorkspaceRunColor(base.Light, hueShift, saturationDelta, lightnessDelta),
 		Dark:  adjustWorkspaceRunColor(base.Dark, hueShift, saturationDelta, lightnessDelta),
 	}

--- a/core/internal/leet/workspace_runcolors_test.go
+++ b/core/internal/leet/workspace_runcolors_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/observability"
 )
 
-func testWorkspaceRunColorPalette() []compat.AdaptiveColor {
-	return []compat.AdaptiveColor{{
+func testWorkspaceRunColorPalette() []AdaptiveColor {
+	return []AdaptiveColor{{
 		Light: lipgloss.Color("#3DBAC4"),
 		Dark:  lipgloss.Color("#58D3DB"),
 	}}

--- a/wandb/sdk/lib/service/service_process.py
+++ b/wandb/sdk/lib/service/service_process.py
@@ -111,13 +111,7 @@ def _launch_server(
 ) -> ServiceProcess:
     """Launch server and set ports."""
     if platform.system() == "Windows":
-        # DETACHED_PROCESS (0x8) prevents the child from inheriting or
-        # allocating a console.
-        # Without it, the Go runtime's package init code in
-        # lipgloss/v2/compat opens CONIN$/CONOUT$
-        # which blocks forever trying to query the terminal background color.
-        _detached_process = 0x00000008
-        creationflags: int = subprocess.CREATE_NEW_PROCESS_GROUP | _detached_process  # type: ignore[attr-defined]
+        creationflags: int = subprocess.CREATE_NEW_PROCESS_GROUP
         start_new_session = False
     else:
         creationflags = 0


### PR DESCRIPTION
Description
-----------
Replace `charm.land/lipgloss/v2/compat.AdaptiveColor` with a local `AdaptiveColor` type that uses the v2-native `lipgloss.LightDark` API. The `compat` package detects the terminal background at package init via a blocking terminal query, which can hang on Windows. 
The new approach defers detection to Bubble Tea's async `tea.BackgroundColorMsg`, defaulting to dark until the runtime reports the actual value.