### PR TITLE
fix(sdk): allow api-* subdomains in base URL validation

### DIFF
--- a/tests/unit_tests/test_lib/test_auth_host_url.py
+++ b/tests/unit_tests/test_lib/test_auth_host_url.py
@@ -43,3 +43,17 @@ def test_app_url_default():
     url = HostUrl("https://api.wandb.ai")
 
     assert url.app_url == "https://wandb.ai"
+
+
+@pytest.mark.parametrize(
+    "raw_url",
+    (
+        "https://api-forest.wandb.ai",
+        "https://api-shared.wandb.ai",
+    ),
+)
+def test_accepts_api_subdomain_variants(raw_url: str):
+    """api-* subdomains (e.g. api-forest) are valid server addresses."""
+    url = HostUrl(raw_url)
+
+    assert url.url == raw_url

--- a/wandb/sdk/lib/wbauth/host_url.py
+++ b/wandb/sdk/lib/wbauth/host_url.py
@@ -29,7 +29,7 @@ class HostUrl:
 
         # Checks for wandb.ai.
         if re.match(r".*wandb\.ai[^\.]*$", url):
-            if "api." not in url:
+            if not re.search(r"//api[.\-]", url):
                 # A user might guess that app.wandb.ai is the default cloud server.
                 raise ValueError(
                     f"{url!r} is not a valid server address,"


### PR DESCRIPTION
## Summary
- `HostUrl` validator rejected valid `api-*` subdomain URLs like `https://api-forest.wandb.ai` because it only checked for `api.` in the URL
- Updated the check to accept both `api.` and `api-` prefixed subdomains (e.g. `api-forest`, `api-shared`)
- Affects both `wandb.init()` and `wandb agent` code paths

## Test plan
- [ ] Added parametrized test for `api-forest` and `api-shared` subdomain URLs
- [ ] Verify existing `https://api.wandb.ai` tests still pass
- [ ] Verify invalid URLs like `https://app.wandb.ai` are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)