### PR TITLE
fix(leet): park off-screen system metric charts and batch drawing

### DIFF
--- a/core/internal/leet/frenchfrieschart.go
+++ b/core/internal/leet/frenchfrieschart.go
@@ -142,6 +142,11 @@ func (c *FrenchFriesChart) View() string {
 	return c.rendered
 }
 
+// Park minimizes memory for off-screen charts by shrinking to 1x1.
+func (c *FrenchFriesChart) Park() {
+	c.Resize(parkedCanvasSize, parkedCanvasSize)
+}
+
 func (c *FrenchFriesChart) Resize(width, height int) {
 	width = max(width, 0)
 	height = max(height, 0)

--- a/core/internal/leet/frenchfriestogglechart.go
+++ b/core/internal/leet/frenchfriestogglechart.go
@@ -47,6 +47,12 @@ func (c *frenchFriesToggleChart) View() string {
 	return c.activeChart().View()
 }
 
+// Park minimizes memory for both underlying charts.
+func (c *frenchFriesToggleChart) Park() {
+	c.line.Park()
+	c.frenchFries.Park()
+}
+
 func (c *frenchFriesToggleChart) Resize(width, height int) {
 	c.line.Resize(width, height)
 	c.frenchFries.Resize(width, height)

--- a/core/internal/leet/systemmetricchart.go
+++ b/core/internal/leet/systemmetricchart.go
@@ -8,6 +8,7 @@ type systemMetricChart interface {
 	View() string
 	Resize(width, height int)
 	DrawIfNeeded()
+	Park()
 	AddDataPoint(seriesName string, timestamp int64, value float64)
 	GraphWidth() int
 	GraphHeight() int

--- a/core/internal/leet/systemmetricsgrid.go
+++ b/core/internal/leet/systemmetricsgrid.go
@@ -2,7 +2,6 @@ package leet
 
 import (
 	"fmt"
-	"slices"
 	"sort"
 	"time"
 
@@ -39,6 +38,9 @@ type SystemMetricsGrid struct {
 
 	// Coloring state for per-plot mode.
 	nextColor int // next palette index
+
+	// lastDrawnCharts holds charts from the last visible page for parking.
+	lastDrawnCharts map[systemMetricChart]struct{}
 
 	// synchronized inspection session state (active only between press/release)
 	syncInspectActive bool
@@ -174,6 +176,9 @@ func (g *SystemMetricsGrid) createMetricChart(def *MetricDef) systemMetricChart 
 }
 
 // AddDataPoint adds a new data point to the appropriate metric chart.
+//
+// Drawing is deferred to the next View() call to avoid redundant redraws
+// when processing a batch of metrics from a single stats record.
 func (g *SystemMetricsGrid) AddDataPoint(metricName string, timestamp int64, value float64) {
 	g.logger.Debug(fmt.Sprintf(
 		"SystemMetricsGrid.AddDataPoint: metric=%s, timestamp=%d, value=%f",
@@ -191,9 +196,6 @@ func (g *SystemMetricsGrid) AddDataPoint(metricName string, timestamp int64, val
 
 	chart := g.getOrCreateChart(baseKey, def)
 	chart.AddDataPoint(seriesName, timestamp, value)
-	if g.isChartVisible(chart) {
-		chart.DrawIfNeeded()
-	}
 }
 
 // getOrCreateChart returns a chart for the given baseKey.
@@ -506,27 +508,32 @@ func (g *SystemMetricsGrid) Resize(width, height int) {
 	g.drawVisible()
 }
 
+// drawVisible resizes and draws charts on the current page.
+//
+// Charts no longer visible are parked to reduce memory usage.
 func (g *SystemMetricsGrid) drawVisible() {
 	dims := g.calculateChartDimensions()
+
+	currentCharts := make(map[systemMetricChart]struct{})
 	for row := range g.currentPage {
 		for col := range g.currentPage[row] {
-			chart := g.currentPage[row][col]
-			if chart == nil {
-				continue
+			if chart := g.currentPage[row][col]; chart != nil {
+				currentCharts[chart] = struct{}{}
 			}
-			chart.Resize(dims.CellW, dims.CellH)
-			chart.DrawIfNeeded()
 		}
 	}
-}
 
-func (g *SystemMetricsGrid) isChartVisible(target systemMetricChart) bool {
-	for row := range g.currentPage {
-		if slices.Contains(g.currentPage[row], target) {
-			return true
+	for ch := range g.lastDrawnCharts {
+		if _, stillVisible := currentCharts[ch]; !stillVisible {
+			ch.Park()
 		}
 	}
-	return false
+	g.lastDrawnCharts = currentCharts
+
+	for ch := range currentCharts {
+		ch.Resize(dims.CellW, dims.CellH)
+		ch.DrawIfNeeded()
+	}
 }
 
 func (g *SystemMetricsGrid) syncFocusToCurrentPage() {
@@ -560,9 +567,21 @@ func (g *SystemMetricsGrid) syncFocusToCurrentPage() {
 }
 
 // View renders the system metrics grid.
+//
+// Dirty visible charts are drawn before rendering so that data added
+// since the last frame is reflected without per-point draw overhead.
 func (g *SystemMetricsGrid) View() string {
 	dims := g.calculateChartDimensions()
 	size := g.effectiveGridSize()
+
+	// Draw any visible charts that received new data since the last frame.
+	for row := range g.currentPage {
+		for col := range g.currentPage[row] {
+			if chart := g.currentPage[row][col]; chart != nil {
+				chart.DrawIfNeeded()
+			}
+		}
+	}
 
 	var rows []string
 	for row := range size.Rows {

--- a/core/internal/leet/timeserieslinechart.go
+++ b/core/internal/leet/timeserieslinechart.go
@@ -120,6 +120,11 @@ func (c *TimeSeriesLineChart) AddDataPoint(seriesName string, timestamp int64, v
 	c.applyRanges()
 }
 
+// Park minimizes canvas memory for off-screen charts.
+func (c *TimeSeriesLineChart) Park() {
+	c.EpochLineChart.Park()
+}
+
 // Resize updates the underlying chart size and reapplies the current view policy.
 func (c *TimeSeriesLineChart) Resize(width, height int) {
 	c.EpochLineChart.Resize(width, height)


### PR DESCRIPTION
Description
-----------
System metrics with many charts (e.g. 8-GPU runs with 236 metric keys / 35 charts) caused ~68 MB heap usage and ~103 GB (!!) of allocation churn per load. 
Two issues: SystemMetricsGrid never parked off-screen chart canvases (each canvas.Cell is 656 bytes), and AddDataPoint triggered a full canvas redraw on every single metric rather than once per render frame. Adds parking (matching MetricsGrid's existing pattern) and defers drawing to View(). 

Testing
-------
On a real 8-GPU run: heap -20%, total allocations 134x lower, load time 62x faster.