### PR TITLE
fix(leet): prevent divide-by-zero panic in mouse handlers on tiny terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ This version drops compatibility with server versions older than 0.63.0 (for Ded
 - `wandb beta core start|stop` commands to run a detached `wandb-core` service and reuse it across multiple processes via the `WANDB_SERVICE` env var (@dmitryduev in https://github.com/wandb/wandb/pull/11418)
 - Run filtering by metadata in multi-run workspace mode in W&B LEET TUI (`wandb beta leet` command, activate with `f`) (@dmitryduev in https://github.com/wandb/wandb/pull/11497 and https://github.com/wandb/wandb/pull/11534)
 - Run overview displays tags and notes in W&B LEET TUI (`wandb beta leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11523)
-- Per-chart log-scale (Y-axis) support in W&B LEET TUI (`wandb beta leet` command, toggle on a selected chart with `y`) (@dmitryduev in https://github.com/wandb/wandb/pull/11523)
+- Per-chart log-scale (Y-axis) support in W&B LEET TUI (`wandb beta leet` command, toggle on a selected chart with `y`) (@dmitryduev in https://github.com/wandb/wandb/pull/11537)
 - Standalone system monitor mode in W&B LEET TUI (`wandb beta leet symon` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11559)
 - Bucketed heatmap chart mode for system metrics expressed as percentages (e.g. GPU utilization) in W&B LEET TUI (`wandb beta leet` command, cycle chart mode on a selected chart with `y`) (@dmitryduev in https://github.com/wandb/wandb/pull/11568 and https://github.com/wandb/wandb/pull/11607)
-- Colorblind-friendly `dusk-shore` (gradient) and `clear-signal` (cycle) color schemes in W&B LEET TUI (`wandb beta leet` command, configure with `wandb beta leet config`) (@dmitryduev in https://github.com/wandb/wandb/pull/11578)
+- Colorblind-friendly `dusk-shore` (gradient) and `clear-signal` (cycle) color schemes in W&B LEET TUI (`wandb beta leet` command, configure with `wandb beta leet config`) (@dmitryduev in https://github.com/wandb/wandb/pull/11577)
 - `disable_git_fork_point` to prevent calculating git diff patch files closest ancestor commit when no upstream branch is set (@jacobromero in https://github.com/wandb/wandb/pull/10132)
 - Media pane for displaying `wandb.Image` data as ANSI thumbnails in W&B LEET TUI (`wandb beta leet` command), with grid layout, X-axis scrubbing, fullscreen mode, and keyboard/mouse navigation (@dmitryduev in
   https://github.com/wandb/wandb/pull/11630)

--- a/core/internal/leet/rightsidebar.go
+++ b/core/internal/leet/rightsidebar.go
@@ -83,6 +83,9 @@ func (rs *RightSidebar) gridMouseTarget(x, y int) (systemGridMouseTarget, bool) 
 	}
 
 	target.dims = rs.metricsGrid.calculateChartDimensions()
+	if target.dims.CellHWithPadding == 0 || target.dims.CellWWithPadding == 0 {
+		return systemGridMouseTarget{}, false
+	}
 	target.row = target.adjustedY / target.dims.CellHWithPadding
 	target.col = target.adjustedX / target.dims.CellWWithPadding
 	return target, true

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -244,6 +244,11 @@ func (r *Run) handleMainContentMouse(msg tea.MouseMsg, layout Layout) (*Run, tea
 		layout.height,
 	)
 
+	// Grid too small to interact with (e.g. tiny terminal).
+	if dims.CellHWithPadding == 0 || dims.CellWWithPadding == 0 {
+		return r, nil
+	}
+
 	// Chart 2D indices on the grid.
 	row := adjustedY / dims.CellHWithPadding
 	col := adjustedX / dims.CellWWithPadding

--- a/core/internal/leet/symon.go
+++ b/core/internal/leet/symon.go
@@ -335,6 +335,9 @@ func (s *Symon) handleMouse(msg tea.MouseMsg) tea.Cmd {
 	}
 
 	dims := s.grid.calculateChartDimensions()
+	if dims.CellHWithPadding == 0 || dims.CellWWithPadding == 0 {
+		return nil
+	}
 	row := adjustedY / dims.CellHWithPadding
 	col := adjustedX / dims.CellWWithPadding
 

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -161,6 +161,9 @@ func (w *Workspace) handleMetricsMouse(msg tea.MouseMsg, layout Layout) tea.Cmd 
 	}
 
 	dims := w.metricsGrid.CalculateChartDimensions(layout.mainContentAreaWidth, layout.height)
+	if dims.CellHWithPadding == 0 || dims.CellWWithPadding == 0 {
+		return nil
+	}
 
 	row := adjustedY / dims.CellHWithPadding
 	col := adjustedX / dims.CellWWithPadding
@@ -217,6 +220,9 @@ func (w *Workspace) handleSystemMetricsMouse(msg tea.MouseMsg, layout Layout) te
 	}
 
 	dims := grid.calculateChartDimensions()
+	if dims.CellHWithPadding == 0 || dims.CellWWithPadding == 0 {
+		return nil
+	}
 	row := adjustedY / dims.CellHWithPadding
 	col := adjustedX / dims.CellWWithPadding
 


### PR DESCRIPTION
Description
-----------
Fix for this one: https://weights-biases.sentry.io/issues/7407076775/?project=4507273364242432