### PR TITLE
chore: speed up test_flow_decostep

### DIFF
--- a/tests/system_tests/test_functional/metaflow/flow_decostep.py
+++ b/tests/system_tests/test_functional/metaflow/flow_decostep.py
@@ -29,11 +29,6 @@ class WandbExampleFlowDecoStep(FlowSpec):
     @step
     def start(self):
         self.raw_df = pd.read_csv(self.raw_data)
-        self.next(self.split_data)
-
-    @wandb_log(datasets=True)
-    @step
-    def split_data(self):
         X = self.raw_df.drop("Wine", axis=1)  # noqa: N806
         y = self.raw_df[["Wine"]]
         self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(

--- a/tests/system_tests/test_functional/metaflow/test_metaflow.py
+++ b/tests/system_tests/test_functional/metaflow/test_metaflow.py
@@ -57,7 +57,7 @@ def test_flow_decostep(wandb_backend_spy):
 
     with wandb_backend_spy.freeze() as snapshot:
         run_ids = snapshot.run_ids()
-        assert len(run_ids) == 4
+        assert len(run_ids) == 3
         for run_id in run_ids:
             config = snapshot.config(run_id=run_id)
             assert config["seed"]["value"] == 1337


### PR DESCRIPTION
Same concept as PR #11716: run fewer Metaflow steps because the test doesn't need them. Each step is very slow.