### PR TITLE
chore: speed up test_flow_foreach

### DIFF
--- a/tests/system_tests/test_functional/metaflow/flow_foreach.py
+++ b/tests/system_tests/test_functional/metaflow/flow_foreach.py
@@ -32,15 +32,11 @@ class WandbForeachFlow(FlowSpec):
         help="path to the raw data",
     )
 
+    @wandb_log(datasets=True, models=True, others=True)
     @step
     def start(self):
         self.models = ["RandomForestClassifier", "GradientBoostingClassifier"]
         self.raw_df = pd.read_csv(self.raw_data)
-        self.next(self.split_data)
-
-    @wandb_log(datasets=True, models=True, others=True)
-    @step
-    def split_data(self):
         X = self.raw_df.drop("Wine", axis=1)  # noqa: N806
         y = self.raw_df[["Wine"]]
         self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(

--- a/tests/system_tests/test_functional/metaflow/test_metaflow.py
+++ b/tests/system_tests/test_functional/metaflow/test_metaflow.py
@@ -81,7 +81,7 @@ def test_flow_foreach(wandb_backend_spy):
 
     with wandb_backend_spy.freeze() as snapshot:
         run_ids = snapshot.run_ids()
-        assert len(run_ids) == 6
+        assert len(run_ids) == 5
         for run_id in run_ids:
             config = snapshot.config(run_id=run_id)
             assert config["seed"]["value"] == 1337


### PR DESCRIPTION
Same concept as PRs #11716, #11717, #11718 and #11719: run fewer Metaflow steps because the test doesn't need them. Each step is very slow.