### PR TITLE
fix: add safety checks to api paginators

### DIFF
--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -39,7 +39,7 @@ class Paginator(Iterator[_WandbT], ABC):
         self.per_page: int = per_page
         self.objects: list[_WandbT] = []
         self.index: int = -1
-        self.last_response: object | None = None
+        self.last_response: dict[str, Any] | None = None
 
     def __iter__(self) -> Iterator[_WandbT]:
         self.index = -1

--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -39,7 +39,7 @@ class Paginator(Iterator[_WandbT], ABC):
         self.per_page: int = per_page
         self.objects: list[_WandbT] = []
         self.index: int = -1
-        self.last_response: dict[str, Any] | None = None
+        self.last_response: Any | None = None
 
     def __iter__(self) -> Iterator[_WandbT]:
         self.index = -1
@@ -107,6 +107,8 @@ class Paginator(Iterator[_WandbT], ABC):
 
 class SizedPaginator(Paginator[_WandbT], Sized, ABC):
     """A Paginator for objects with a known total count."""
+
+    last_response: dict[str, Any] | None = None
 
     @property
     def length(self) -> int | None:

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -234,10 +234,14 @@ class Files(SizedPaginator["File"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        return [
-            File(self.client, r["node"], self.run)
-            for r in self.last_response["project"]["run"]["files"]["edges"]
-        ]
+        if not self.last_response:
+            return []
+
+        project = self.last_response.get("project") or {}
+        run_data = project.get("run") or {}
+        files_data = run_data.get("files") or {}
+        edges = files_data.get("edges") or []
+        return [File(self.client, r["node"], self.run) for r in edges]
 
     def __repr__(self) -> str:
         return f"<{nameof(type(self))} {'/'.join(self.run.path)} ({len(self)})>"

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -183,12 +183,12 @@ class Files(SizedPaginator["File"]):
         if not self.last_response:
             self._load_page()
 
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            run_data = project.get("run") or {}
-            return run_data.get("fileCount", 0)
+        if not self.last_response:
+            return 0
 
-        return 0
+        project = self.last_response.get("project") or {}
+        run_data = project.get("run") or {}
+        return run_data.get("fileCount", 0)
 
     @property
     def more(self) -> bool:
@@ -196,14 +196,14 @@ class Files(SizedPaginator["File"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            run_data = project.get("run") or {}
-            files_data = run_data.get("files") or {}
-            page_info = files_data.get("pageInfo") or {}
-            return page_info.get("hasNextPage", False)
+        if not self.last_response:
+            return True
 
-        return True
+        project = self.last_response.get("project") or {}
+        run_data = project.get("run") or {}
+        files_data = run_data.get("files") or {}
+        page_info = files_data.get("pageInfo") or {}
+        return page_info.get("hasNextPage", False)
 
     @property
     def cursor(self) -> str | None:
@@ -211,15 +211,15 @@ class Files(SizedPaginator["File"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            run_data = project.get("run") or {}
-            files_data = run_data.get("files") or {}
-            edges = files_data.get("edges") or []
-            if edges:
-                return edges[-1].get("cursor")
+        if not self.last_response:
             return None
 
+        project = self.last_response.get("project") or {}
+        run_data = project.get("run") or {}
+        files_data = run_data.get("files") or {}
+        edges = files_data.get("edges") or []
+        if edges:
+            return edges[-1].get("cursor")
         return None
 
     def update_variables(self) -> None:

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -183,7 +183,12 @@ class Files(SizedPaginator["File"]):
         if not self.last_response:
             self._load_page()
 
-        return self.last_response["project"]["run"]["fileCount"]
+        if self.last_response:
+            project = self.last_response.get("project") or {}
+            run_data = project.get("run") or {}
+            return run_data.get("fileCount", 0)
+
+        return 0
 
     @property
     def more(self) -> bool:
@@ -192,16 +197,13 @@ class Files(SizedPaginator["File"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            has_next_page = (
-                self.last_response.get("project", {})
-                .get("run", {})
-                .get("files", {})
-                .get("pageInfo", {})
-                .get("hasNextPage", False)
-            )
-            return has_next_page
+            project = self.last_response.get("project") or {}
+            run_data = project.get("run") or {}
+            files_data = run_data.get("files") or {}
+            page_info = files_data.get("pageInfo") or {}
+            return page_info.get("hasNextPage", False)
 
-        return False
+        return True
 
     @property
     def cursor(self) -> str | None:
@@ -210,9 +212,15 @@ class Files(SizedPaginator["File"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            return self.last_response["project"]["run"]["files"]["edges"][-1]["cursor"]
-        else:
+            project = self.last_response.get("project") or {}
+            run_data = project.get("run") or {}
+            files_data = run_data.get("files") or {}
+            edges = files_data.get("edges") or []
+            if edges:
+                return edges[-1].get("cursor")
             return None
+
+        return None
 
     def update_variables(self) -> None:
         """Updates the GraphQL query variables for pagination.

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -111,7 +111,7 @@ class Files(SizedPaginator["File"]):
     def _get_query(self) -> Document:
         """Generate query dynamically based on server capabilities."""
         return gql(
-            f"""
+            f"""#graphql
             query RunFiles($project: String!, $entity: String!, $name: String!, $fileCursor: String,
                 $fileLimit: Int = 50, $fileNames: [String] = [], $upload: Boolean = false, $pattern: String) {{
                 project(name: $project, entityName: $entity) {{
@@ -192,11 +192,16 @@ class Files(SizedPaginator["File"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            return self.last_response["project"]["run"]["files"]["pageInfo"][
-                "hasNextPage"
-            ]
-        else:
-            return True
+            has_next_page = (
+                self.last_response.get("project", {})
+                .get("run", {})
+                .get("files", {})
+                .get("pageInfo", {})
+                .get("hasNextPage", False)
+            )
+            return has_next_page
+
+        return False
 
     @property
     def cursor(self) -> str | None:

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -218,9 +218,11 @@ class Files(SizedPaginator["File"]):
         run_data = project.get("run") or {}
         files_data = run_data.get("files") or {}
         edges = files_data.get("edges") or []
-        if edges:
-            return edges[-1].get("cursor")
-        return None
+
+        if not edges:
+            return None
+
+        return edges[-1].get("cursor")
 
     def update_variables(self) -> None:
         """Updates the GraphQL query variables for pagination.

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -141,10 +141,18 @@ class Reports(SizedPaginator["BetaReport"]):
 
     def convert_objects(self) -> list[BetaReport]:
         """Converts GraphQL edges to File objects."""
-        if self.last_response["project"] is None:
+        if not self.last_response:
+            return []
+
+        project = self.last_response.get("project")
+        if project is None:
             raise ValueError(
                 f"Project {self.variables['project']} does not exist under entity {self.variables['entity']}"
             )
+
+        all_views = project.get("allViews") or {}
+        edges = all_views.get("edges") or []
+
         return [
             BetaReport(
                 self.client,
@@ -152,7 +160,7 @@ class Reports(SizedPaginator["BetaReport"]):
                 entity=self.project.entity,
                 project=self.project.name,
             )
-            for r in self.last_response["project"]["allViews"]["edges"]
+            for r in edges
         ]
 
     def __repr__(self) -> str:

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -98,9 +98,10 @@ class Reports(SizedPaginator["BetaReport"]):
         <!-- lazydoc-ignore: internal -->
         """
         # TODO: Add the count the backend
-        if self.last_response:
-            return len(self.objects)
-        return None
+        if not self.last_response:
+            return None
+
+        return len(self.objects)
 
     @property
     def more(self) -> bool:
@@ -108,13 +109,13 @@ class Reports(SizedPaginator["BetaReport"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            views_data = project.get("allViews") or {}
-            page_info = views_data.get("pageInfo") or {}
-            return page_info.get("hasNextPage", False)
+        if not self.last_response:
+            return True
 
-        return True
+        project = self.last_response.get("project") or {}
+        views_data = project.get("allViews") or {}
+        page_info = views_data.get("pageInfo") or {}
+        return page_info.get("hasNextPage", False)
 
     @property
     def cursor(self) -> str | None:
@@ -122,12 +123,14 @@ class Reports(SizedPaginator["BetaReport"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            views_data = project.get("allViews") or {}
-            edges = views_data.get("edges") or []
-            if edges:
-                return edges[-1].get("cursor")
+        if not self.last_response:
+            return None
+
+        project = self.last_response.get("project") or {}
+        views_data = project.get("allViews") or {}
+        edges = views_data.get("edges") or []
+        if edges:
+            return edges[-1].get("cursor")
         return None
 
     def update_variables(self) -> None:

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -129,9 +129,11 @@ class Reports(SizedPaginator["BetaReport"]):
         project = self.last_response.get("project") or {}
         views_data = project.get("allViews") or {}
         edges = views_data.get("edges") or []
-        if edges:
-            return edges[-1].get("cursor")
-        return None
+
+        if not edges:
+            return None
+
+        return edges[-1].get("cursor")
 
     def update_variables(self) -> None:
         """Updates the GraphQL query variables for pagination."""

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -109,15 +109,12 @@ class Reports(SizedPaginator["BetaReport"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            has_next_page = (
-                self.last_response.get("project", {})
-                .get("allViews", {})
-                .get("pageInfo", {})
-                .get("hasNextPage", False)
-            )
-            return has_next_page
+            project = self.last_response.get("project") or {}
+            views_data = project.get("allViews") or {}
+            page_info = views_data.get("pageInfo") or {}
+            return page_info.get("hasNextPage", False)
 
-        return False
+        return True
 
     @property
     def cursor(self) -> str | None:
@@ -126,7 +123,11 @@ class Reports(SizedPaginator["BetaReport"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            return self.last_response["project"]["allViews"]["edges"][-1]["cursor"]
+            project = self.last_response.get("project") or {}
+            views_data = project.get("allViews") or {}
+            edges = views_data.get("edges") or []
+            if edges:
+                return edges[-1].get("cursor")
         return None
 
     def update_variables(self) -> None:

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -109,10 +109,15 @@ class Reports(SizedPaginator["BetaReport"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            return bool(
-                self.last_response["project"]["allViews"]["pageInfo"]["hasNextPage"]
+            has_next_page = (
+                self.last_response.get("project", {})
+                .get("allViews", {})
+                .get("pageInfo", {})
+                .get("hasNextPage", False)
             )
-        return True
+            return has_next_page
+
+        return False
 
     @property
     def cursor(self) -> str | None:

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -296,7 +296,11 @@ class Runs(SizedPaginator["Run"]):
         objs = []
         if self.last_response is None or self.last_response.get("project") is None:
             raise ValueError("Could not find project {}".format(self.project))
-        for run_response in self.last_response["project"]["runs"]["edges"]:
+
+        project = self.last_response.get("project") or {}
+        runs_data = project.get("runs") or {}
+        edges = runs_data.get("edges") or []
+        for run_response in edges:
             run = Run(
                 self.client,
                 self.entity,

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -264,13 +264,13 @@ class Runs(SizedPaginator["Run"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            runs_data = project.get("runs") or {}
-            page_info = runs_data.get("pageInfo") or {}
-            return page_info.get("hasNextPage", False)
+        if not self.last_response:
+            return True
 
-        return True
+        project = self.last_response.get("project") or {}
+        runs_data = project.get("runs") or {}
+        page_info = runs_data.get("pageInfo") or {}
+        return page_info.get("hasNextPage", False)
 
     @property
     def cursor(self):
@@ -278,14 +278,14 @@ class Runs(SizedPaginator["Run"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            runs_data = project.get("runs") or {}
-            edges = runs_data.get("edges") or []
-            if edges:
-                return edges[-1].get("cursor")
+        if not self.last_response:
             return None
 
+        project = self.last_response.get("project") or {}
+        runs_data = project.get("runs") or {}
+        edges = runs_data.get("edges") or []
+        if edges:
+            return edges[-1].get("cursor")
         return None
 
     def convert_objects(self) -> list[Run]:

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -253,8 +253,8 @@ class Runs(SizedPaginator["Run"]):
             self._load_page()
 
         if self.last_response:
-            run_count = self.last_response.get("project", {}).get("runCount", 0)
-            return run_count
+            project = self.last_response.get("project") or {}
+            return project.get("runCount", 0)
 
         return 0
 
@@ -265,15 +265,12 @@ class Runs(SizedPaginator["Run"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            has_next_page = (
-                self.last_response.get("project", {})
-                .get("runs", {})
-                .get("pageInfo", {})
-                .get("hasNextPage", False)
-            )
-            return has_next_page
+            project = self.last_response.get("project") or {}
+            runs_data = project.get("runs") or {}
+            page_info = runs_data.get("pageInfo") or {}
+            return page_info.get("hasNextPage", False)
 
-        return False
+        return True
 
     @property
     def cursor(self):
@@ -282,9 +279,14 @@ class Runs(SizedPaginator["Run"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            return self.last_response["project"]["runs"]["edges"][-1]["cursor"]
-        else:
+            project = self.last_response.get("project") or {}
+            runs_data = project.get("runs") or {}
+            edges = runs_data.get("edges") or []
+            if edges:
+                return edges[-1].get("cursor")
             return None
+
+        return None
 
     def convert_objects(self) -> list[Run]:
         """Converts GraphQL edges to Runs objects.

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -251,7 +251,12 @@ class Runs(SizedPaginator["Run"]):
         """
         if not self.last_response:
             self._load_page()
-        return self.last_response["project"]["runCount"]
+
+        if self.last_response:
+            run_count = self.last_response.get("project", {}).get("runCount", 0)
+            return run_count
+
+        return 0
 
     @property
     def more(self) -> bool:
@@ -260,11 +265,15 @@ class Runs(SizedPaginator["Run"]):
         <!-- lazydoc-ignore: internal -->
         """
         if self.last_response:
-            return bool(
-                self.last_response["project"]["runs"]["pageInfo"]["hasNextPage"]
+            has_next_page = (
+                self.last_response.get("project", {})
+                .get("runs", {})
+                .get("pageInfo", {})
+                .get("hasNextPage", False)
             )
-        else:
-            return True
+            return has_next_page
+
+        return False
 
     @property
     def cursor(self):

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -252,11 +252,11 @@ class Runs(SizedPaginator["Run"]):
         if not self.last_response:
             self._load_page()
 
-        if self.last_response:
-            project = self.last_response.get("project") or {}
-            return project.get("runCount", 0)
+        if not self.last_response:
+            return 0
 
-        return 0
+        project = self.last_response.get("project") or {}
+        return project.get("runCount", 0)
 
     @property
     def more(self) -> bool:
@@ -284,9 +284,11 @@ class Runs(SizedPaginator["Run"]):
         project = self.last_response.get("project") or {}
         runs_data = project.get("runs") or {}
         edges = runs_data.get("edges") or []
-        if edges:
-            return edges[-1].get("cursor")
-        return None
+
+        if not edges:
+            return None
+
+        return edges[-1].get("cursor")
 
     def convert_objects(self) -> list[Run]:
         """Converts GraphQL edges to Runs objects.

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -114,11 +114,9 @@ class Sweeps(SizedPaginator["Sweep"]):
         """
         if self.last_response is None:
             self._load_page()
-        return (
-            total
-            if (total := self.last_response.project.total_sweeps) is not None
-            else 0
-        )
+        if self.last_response and self.last_response.project:
+            return self.last_response.project.total_sweeps
+        return 0
 
     @property
     @override
@@ -127,9 +125,14 @@ class Sweeps(SizedPaginator["Sweep"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
+        if (
+            self.last_response
+            and self.last_response.project
+            and self.last_response.project.sweeps
+            and self.last_response.project.sweeps.page_info
+        ):
             return self.last_response.project.sweeps.page_info.has_next_page
-        return True
+        return False
 
     @property
     @override

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -112,12 +112,13 @@ class Sweeps(SizedPaginator["Sweep"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response is None:
+        if not self.last_response:
             self._load_page()
 
-        if self.last_response and self.last_response.project:
-            return self.last_response.project.total_sweeps
-        return 0
+        if not self.last_response or not self.last_response.project:
+            return 0
+
+        return self.last_response.project.total_sweeps
 
     @property
     @override

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -114,6 +114,7 @@ class Sweeps(SizedPaginator["Sweep"]):
         """
         if self.last_response is None:
             self._load_page()
+
         if self.last_response and self.last_response.project:
             return self.last_response.project.total_sweeps
         return 0
@@ -132,7 +133,8 @@ class Sweeps(SizedPaginator["Sweep"]):
             and self.last_response.project.sweeps.page_info
         ):
             return self.last_response.project.sweeps.page_info.has_next_page
-        return False
+
+        return True
 
     @property
     @override
@@ -141,8 +143,14 @@ class Sweeps(SizedPaginator["Sweep"]):
 
         <!-- lazydoc-ignore: internal -->
         """
-        if self.last_response:
+        if (
+            self.last_response
+            and self.last_response.project
+            and self.last_response.project.sweeps
+            and self.last_response.project.sweeps.page_info
+        ):
             return self.last_response.project.sweeps.page_info.end_cursor
+
         return None
 
     @override


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-31441, https://github.com/wandb/wandb/issues/11351



What does the PR do? Include a concise description of the PR contents.

There are many areas in the public API when iterating over objects where the response from the backend is blindly subscripted. This results in a `TypeError: 'NoneType' object is not subscriptable`

This PR adds checks around many of the locations where this could happen

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [ ] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

- Similar test script to the one provided in the GH issue

```python
import wandb

project = "my-project"
api = wandb.Api()
run = next(iter(api.runs(project)))
files = list(run.files(pattern="%.badext"))  # no files matching pattern
```

### After this change

```bash
wandb: Loading settings from /Users/jacob.romero/.config/wandb/settings
wandb: [wandb.Api()] Loaded credentials for https://dogfood.wandb.io from /Users/jacob.romero/.netrc.
<Run jacob-romero/testgit/fiqthfkd (finished)>
```

### Before this change

```bash
wandb: Loading settings from /Users/jacob.romero/.config/wandb/settings
wandb: [wandb.Api()] Loaded credentials for https://dogfood.wandb.io from /Users/jacob.romero/.netrc.
<Run jacob-romero/testgit/fiqthfkd (finished)>
Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/test/api/filequery.py", line 7, in <module>
    files = list(run.files(pattern="%.badext"))  # no files matching pattern
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/paginator.py", line 99, in __next__
    if not self._load_page():
           ^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/paginator.py", line 77, in _load_page
    if not self.more:
           ^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/public/files.py", line 195, in more
    return self.last_response["project"]["run"]["files"]["pageInfo"][
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```



<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->