### PR TITLE
feat(sdk): add cascading deletion for forked runs

### DIFF
--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -10,7 +10,9 @@ from requests import HTTPError
 from wandb import Api
 from wandb.apis import internal
 from wandb.apis._generated import ProjectFragment, UserFragment
+from wandb.apis.public import api as public_api
 from wandb.errors import UsageError
+from wandb.errors.errors import CommError
 from wandb.sdk import wandb_login
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.lib import wbauth
@@ -396,3 +398,36 @@ def test_api_uses_as_requests_auth(mocker: MockerFixture):
     Api()
 
     mock_auth.as_requests_auth.assert_called_once()
+
+
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_run_delete_forking(monkeypatch, mock_wandb_log):
+    """Test delete with and without delete_all_descendants."""
+    api = wandb.Api()
+    run = wandb.apis.public.Run(
+        client=api.client,
+        entity="test-entity",
+        project="test-project",
+        run_id="test-run",
+        attrs={"id": "abc123", "state": "finished"},
+    )
+
+    def execute_side_effect(*args, **kwargs):
+        if kwargs.get("variable_values", {}).get("deleteAllDescendants"):
+            return {"deleteRun": {"numDeleted": 3}}
+        raise CommError("Cannot delete run with descendants")
+
+    mock_execute = MagicMock(side_effect=execute_side_effect)
+    monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
+
+    with pytest.raises(CommError):
+        run.delete(delete_all_descendants=False)
+    assert mock_execute.call_count == 1
+    first_call_vars = mock_execute.call_args_list[0].kwargs["variable_values"]
+    assert first_call_vars["deleteAllDescendants"] is False
+
+    run.delete(delete_all_descendants=True)
+    assert mock_execute.call_count == 2
+    second_call_vars = mock_execute.call_args_list[1].kwargs["variable_values"]
+    assert second_call_vars["deleteAllDescendants"] is True
+    mock_wandb_log.assert_logged("Deleted 3 runs")

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -401,33 +401,47 @@ def test_api_uses_as_requests_auth(mocker: MockerFixture):
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_run_delete_forking(monkeypatch, mock_wandb_log):
-    """Test delete with and without delete_all_descendants."""
+def test_run_delete_forking_without_cascade(monkeypatch):
+    """Test that delete raises CommError when run has descendants and delete_all_descendants=False."""
     api = wandb.Api()
     run = wandb.apis.public.Run(
         client=api.client,
         entity="test-entity",
         project="test-project",
         run_id="test-run",
-        attrs={"id": "abc123", "state": "finished"},
+        attrs={"id": "abc123"},
     )
 
-    def execute_side_effect(*args, **kwargs):
-        if kwargs.get("variable_values", {}).get("deleteAllDescendants"):
-            return {"deleteRun": {"numDeleted": 3}}
-        raise CommError("Cannot delete run with descendants")
-
-    mock_execute = MagicMock(side_effect=execute_side_effect)
+    mock_execute = MagicMock(
+        side_effect=CommError("Cannot delete run with descendants")
+    )
     monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
 
     with pytest.raises(CommError):
         run.delete(delete_all_descendants=False)
-    assert mock_execute.call_count == 1
-    first_call_vars = mock_execute.call_args_list[0].kwargs["variable_values"]
-    assert first_call_vars["deleteAllDescendants"] is False
+    assert (
+        mock_execute.call_args.kwargs["variable_values"]["deleteAllDescendants"]
+        is False
+    )
+
+
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_run_delete_forking_with_cascade(monkeypatch, mock_wandb_log):
+    """Test that delete succeeds and logs when delete_all_descendants=True."""
+    api = wandb.Api()
+    run = wandb.apis.public.Run(
+        client=api.client,
+        entity="test-entity",
+        project="test-project",
+        run_id="test-run",
+        attrs={"id": "abc123"},
+    )
+
+    mock_execute = MagicMock(return_value={"deleteRun": {"numDeleted": 3}})
+    monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
 
     run.delete(delete_all_descendants=True)
-    assert mock_execute.call_count == 2
-    second_call_vars = mock_execute.call_args_list[1].kwargs["variable_values"]
-    assert second_call_vars["deleteAllDescendants"] is True
-    mock_wandb_log.assert_logged("Deleted 3 runs")
+    assert (
+        mock_execute.call_args.kwargs["variable_values"]["deleteAllDescendants"] is True
+    )
+    mock_wandb_log.assert_logged("Deleted 3 run(s)")

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -402,33 +402,47 @@ def test_api_uses_as_requests_auth(mocker: MockerFixture):
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_run_delete_forking(monkeypatch, mock_wandb_log):
-    """Test delete with and without delete_all_descendants."""
+def test_run_delete_forking_without_cascade(monkeypatch):
+    """Test that delete raises CommError when run has descendants and delete_all_descendants=False."""
     api = wandb.Api()
     run = wandb.apis.public.Run(
         client=api.client,
         entity="test-entity",
         project="test-project",
         run_id="test-run",
-        attrs={"id": "abc123", "state": "finished"},
+        attrs={"id": "abc123"},
     )
 
-    def execute_side_effect(*args, **kwargs):
-        if kwargs.get("variable_values", {}).get("deleteAllDescendants"):
-            return {"deleteRun": {"numDeleted": 3}}
-        raise CommError("Cannot delete run with descendants")
-
-    mock_execute = MagicMock(side_effect=execute_side_effect)
+    mock_execute = MagicMock(
+        side_effect=CommError("Cannot delete run with descendants")
+    )
     monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
 
     with pytest.raises(CommError):
         run.delete(delete_all_descendants=False)
-    assert mock_execute.call_count == 1
-    first_call_vars = mock_execute.call_args_list[0].kwargs["variable_values"]
-    assert first_call_vars["deleteAllDescendants"] is False
+    assert (
+        mock_execute.call_args.kwargs["variable_values"]["deleteAllDescendants"]
+        is False
+    )
+
+
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_run_delete_forking_with_cascade(monkeypatch, mock_wandb_log):
+    """Test that delete succeeds and logs when delete_all_descendants=True."""
+    api = wandb.Api()
+    run = wandb.apis.public.Run(
+        client=api.client,
+        entity="test-entity",
+        project="test-project",
+        run_id="test-run",
+        attrs={"id": "abc123"},
+    )
+
+    mock_execute = MagicMock(return_value={"deleteRun": {"numDeleted": 3}})
+    monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
 
     run.delete(delete_all_descendants=True)
-    assert mock_execute.call_count == 2
-    second_call_vars = mock_execute.call_args_list[1].kwargs["variable_values"]
-    assert second_call_vars["deleteAllDescendants"] is True
-    mock_wandb_log.assert_logged("Deleted 3 runs")
+    assert (
+        mock_execute.call_args.kwargs["variable_values"]["deleteAllDescendants"] is True
+    )
+    mock_wandb_log.assert_logged("Deleted 3 run(s)")

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -12,7 +12,6 @@ from wandb.apis import internal
 from wandb.apis._generated import ProjectFragment, UserFragment
 from wandb.apis.public import api as public_api
 from wandb.errors import UsageError
-from wandb.errors.errors import CommError
 from wandb.sdk import wandb_login
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.lib import wbauth
@@ -402,33 +401,8 @@ def test_api_uses_as_requests_auth(mocker: MockerFixture):
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_run_delete_forking_without_cascade(monkeypatch):
-    """Test that delete raises CommError when run has descendants and delete_all_descendants=False."""
-    api = wandb.Api()
-    run = wandb.apis.public.Run(
-        client=api.client,
-        entity="test-entity",
-        project="test-project",
-        run_id="test-run",
-        attrs={"id": "abc123"},
-    )
-
-    mock_execute = MagicMock(
-        side_effect=CommError("Cannot delete run with descendants")
-    )
-    monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
-
-    with pytest.raises(CommError):
-        run.delete(delete_all_descendants=False)
-    assert (
-        mock_execute.call_args.kwargs["variable_values"]["deleteAllDescendants"]
-        is False
-    )
-
-
-@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_run_delete_forking_with_cascade(monkeypatch, mock_wandb_log):
-    """Test that delete succeeds and logs when delete_all_descendants=True."""
+def test_run_delete_logs_num_deleted(monkeypatch, mock_wandb_log):
+    """Test that delete logs the number of deleted runs."""
     api = wandb.Api()
     run = wandb.apis.public.Run(
         client=api.client,
@@ -441,8 +415,5 @@ def test_run_delete_forking_with_cascade(monkeypatch, mock_wandb_log):
     mock_execute = MagicMock(return_value={"deleteRun": {"numDeleted": 3}})
     monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
 
-    run.delete(delete_all_descendants=True)
-    assert (
-        mock_execute.call_args.kwargs["variable_values"]["deleteAllDescendants"] is True
-    )
+    run.delete()
     mock_wandb_log.assert_logged("Deleted 3 run(s)")

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -10,7 +10,9 @@ from requests import HTTPError
 from wandb import Api
 from wandb.apis import internal
 from wandb.apis._generated import ProjectFragment, UserFragment
+from wandb.apis.public import api as public_api
 from wandb.errors import UsageError
+from wandb.errors.errors import CommError
 from wandb.sdk import wandb_login
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.lib import wbauth
@@ -397,3 +399,36 @@ def test_api_uses_as_requests_auth(mocker: MockerFixture):
     Api()
 
     mock_auth.as_requests_auth.assert_called_once()
+
+
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_run_delete_forking(monkeypatch, mock_wandb_log):
+    """Test delete with and without delete_all_descendants."""
+    api = wandb.Api()
+    run = wandb.apis.public.Run(
+        client=api.client,
+        entity="test-entity",
+        project="test-project",
+        run_id="test-run",
+        attrs={"id": "abc123", "state": "finished"},
+    )
+
+    def execute_side_effect(*args, **kwargs):
+        if kwargs.get("variable_values", {}).get("deleteAllDescendants"):
+            return {"deleteRun": {"numDeleted": 3}}
+        raise CommError("Cannot delete run with descendants")
+
+    mock_execute = MagicMock(side_effect=execute_side_effect)
+    monkeypatch.setattr(public_api.RetryingClient, "execute", mock_execute)
+
+    with pytest.raises(CommError):
+        run.delete(delete_all_descendants=False)
+    assert mock_execute.call_count == 1
+    first_call_vars = mock_execute.call_args_list[0].kwargs["variable_values"]
+    assert first_call_vars["deleteAllDescendants"] is False
+
+    run.delete(delete_all_descendants=True)
+    assert mock_execute.call_count == 2
+    second_call_vars = mock_execute.call_args_list[1].kwargs["variable_values"]
+    assert second_call_vars["deleteAllDescendants"] is True
+    mock_wandb_log.assert_logged("Deleted 3 runs")

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1016,7 +1016,9 @@ class Run(Attrs):
                 "$deleteArtifacts: Boolean" if delete_artifacts else "",
                 "$deleteAllDescendants: Boolean" if delete_all_descendants else "",
                 "deleteArtifacts: $deleteArtifacts" if delete_artifacts else "",
-                "deleteAllDescendants: $deleteAllDescendants" if delete_all_descendants else "",
+                "deleteAllDescendants: $deleteAllDescendants"
+                if delete_all_descendants
+                else "",
             )
         )
 

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -986,14 +986,14 @@ class Run(Attrs):
     def delete(
         self,
         delete_artifacts: bool = False,
-        delete_all_children: bool = False,
+        delete_all_descendants: bool = False,
     ) -> None:
         """Delete the given run from the wandb backend.
 
         Args:
             delete_artifacts (bool, optional): Whether to delete the artifacts
                 associated with the run.
-            delete_all_children (bool, optional): Whether to delete all children
+            delete_all_descendants (bool, optional): Whether to delete all children
                 associated with the run.
         """
         mutation = gql(
@@ -1008,25 +1008,28 @@ class Run(Attrs):
                     {}
                     {}
                 }}) {{
-                    clientMutationId
+                    numDeleted
                 }}
             }}
         """.format(
                 "$deleteArtifacts: Boolean" if delete_artifacts else "",
-                "$deleteAllChildren: Boolean" if delete_all_children else "",
+                "$deleteAllDescendants: Boolean" if delete_all_descendants else "",
                 "deleteArtifacts: $deleteArtifacts" if delete_artifacts else "",
-                "deleteAllChildren: $deleteAllChildren" if delete_all_children else "",
+                "deleteAllDescendants: $deleteAllDescendants" if delete_all_descendants else "",
             )
         )
 
-        self.client.execute(
+        result = self.client.execute(
             mutation,
             variable_values={
                 "id": self.storage_id,
                 "deleteArtifacts": delete_artifacts,
-                "deleteAllChildren": delete_all_children,
+                "deleteAllDescendants": delete_all_descendants,
             },
         )
+        num_deleted = result["deleteRun"]["numDeleted"]
+        if num_deleted > 0:
+            wandb.termlog(f"Deleted {num_deleted} runs")
 
     def save(self) -> None:
         """Persist changes to the run object to the W&B backend."""

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1031,8 +1031,8 @@ class Run(Attrs):
             },
         )
         num_deleted = result["deleteRun"]["numDeleted"]
-        if num_deleted > 0:
-            wandb.termlog(f"Deleted {num_deleted} runs")
+        if num_deleted:
+            wandb.termlog(f"Deleted {num_deleted} run(s)")
 
     def save(self) -> None:
         """Persist changes to the run object to the W&B backend."""

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -983,11 +983,17 @@ class Run(Attrs):
         self.summary.update()
 
     @normalize_exceptions
-    def delete(self, delete_artifacts: bool = False) -> None:
+    def delete(
+        self,
+        delete_artifacts: bool = False,
+        delete_all_children: bool = False,
+    ) -> None:
         """Delete the given run from the wandb backend.
 
         Args:
             delete_artifacts (bool, optional): Whether to delete the artifacts
+                associated with the run.
+            delete_all_children (bool, optional): Whether to delete all children
                 associated with the run.
         """
         mutation = gql(
@@ -995,9 +1001,11 @@ class Run(Attrs):
             mutation DeleteRun(
                 $id: ID!,
                 {}
+                {}
             ) {{
                 deleteRun(input: {{
                     id: $id,
+                    {}
                     {}
                 }}) {{
                     clientMutationId
@@ -1005,7 +1013,9 @@ class Run(Attrs):
             }}
         """.format(
                 "$deleteArtifacts: Boolean" if delete_artifacts else "",
+                "$deleteAllChildren: Boolean" if delete_all_children else "",
                 "deleteArtifacts: $deleteArtifacts" if delete_artifacts else "",
+                "deleteAllChildren: $deleteAllChildren" if delete_all_children else "",
             )
         )
 
@@ -1014,6 +1024,7 @@ class Run(Attrs):
             variable_values={
                 "id": self.storage_id,
                 "deleteArtifacts": delete_artifacts,
+                "deleteAllChildren": delete_all_children,
             },
         )
 

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -993,8 +993,8 @@ class Run(Attrs):
         Args:
             delete_artifacts (bool, optional): Whether to delete the artifacts
                 associated with the run.
-            delete_all_descendants (bool, optional): Whether to delete all children
-                associated with the run.
+            delete_all_descendants (bool, optional): Whether to delete all runs forked
+                from this run.
         """
         mutation = gql(
             """
@@ -1008,6 +1008,7 @@ class Run(Attrs):
                     {}
                     {}
                 }}) {{
+                    clientMutationId
                     numDeleted
                 }}
             }}

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -986,26 +986,21 @@ class Run(Attrs):
     def delete(
         self,
         delete_artifacts: bool = False,
-        delete_all_descendants: bool = False,
     ) -> None:
         """Delete the given run from the wandb backend.
 
         Args:
             delete_artifacts (bool, optional): Whether to delete the artifacts
                 associated with the run.
-            delete_all_descendants (bool, optional): Whether to delete all runs forked
-                from this run.
         """
         mutation = gql(
             """
             mutation DeleteRun(
                 $id: ID!,
                 {}
-                {}
             ) {{
                 deleteRun(input: {{
                     id: $id,
-                    {}
                     {}
                 }}) {{
                     clientMutationId
@@ -1014,11 +1009,7 @@ class Run(Attrs):
             }}
         """.format(
                 "$deleteArtifacts: Boolean" if delete_artifacts else "",
-                "$deleteAllDescendants: Boolean" if delete_all_descendants else "",
                 "deleteArtifacts: $deleteArtifacts" if delete_artifacts else "",
-                "deleteAllDescendants: $deleteAllDescendants"
-                if delete_all_descendants
-                else "",
             )
         )
 
@@ -1027,7 +1018,6 @@ class Run(Attrs):
             variable_values={
                 "id": self.storage_id,
                 "deleteArtifacts": delete_artifacts,
-                "deleteAllDescendants": delete_all_descendants,
             },
         )
         num_deleted = result["deleteRun"]["numDeleted"]


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

Add flag on `delete()` that allows cascading deletion of descendant runs created via forking

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

Unit Tests and Local Dev

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
