### PR TITLE
chore: use a real logger in wbapi

### DIFF
--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -7,7 +7,6 @@ package wbapi
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/hashicorp/go-retryablehttp"
 
@@ -36,9 +35,7 @@ type WandbAPI struct {
 }
 
 // New returns a new WandbAPI.
-func New(s *settings.Settings) *WandbAPI {
-	logger := observability.NewNoOpLogger()
-
+func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 	baseURL := stream.BaseURLFromSettings(logger, s)
 	credentialProvider := stream.CredentialsFromSettings(logger, s)
 	graphqlClient := stream.NewGraphQLClient(
@@ -55,10 +52,7 @@ func New(s *settings.Settings) *WandbAPI {
 	httpClient.RetryWaitMin = s.GetFileTransferRetryWaitMin()
 	httpClient.RetryWaitMax = s.GetFileTransferRetryWaitMax()
 	httpClient.HTTPClient.Timeout = s.GetFileTransferTimeout()
-	httpClient.Logger = observability.NewCoreLogger(
-		slog.Default(),
-		nil,
-	)
+	httpClient.Logger = logger
 
 	featureProvider := featurechecker.New(graphqlClient, logger)
 

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -645,7 +645,8 @@ func (nc *Connection) handleSyncStatus(
 // handleApiInit sets up a new wandbAPI instance.
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	s := settings.From(request.GetSettings())
-	wbapiInstance := wbapi.New(s)
+	logger := observability.NewCoreLogger(slog.Default(), nil)
+	wbapiInstance := wbapi.New(s, logger)
 	wbApiId := nc.apiManager.AddWandbAPI(wbapiInstance)
 
 	nc.Respond(&spb.ServerResponse{


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Changes wbapi.go to accept a logger object, rather than creating a Noop logger. Preventing us from being able to debug issues in that code path.

## Testing

How was this PR tested?

- Added debug log at the start of wbapi.New

```
logger.Debug("wbapi: New")
```

Verified in the core process logs.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->