### PR TITLE
refactor: use a UTC timestamp for wandb beta sync logs

### DIFF
--- a/core/internal/runsync/logging.go
+++ b/core/internal/runsync/logging.go
@@ -53,7 +53,7 @@ func OpenDebugSyncLogFile(
 		return nil, err
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	dateStr := now.Format("20060102")
 	timeStr := now.Format("150405")
 

--- a/core/internal/runsync/logging_test.go
+++ b/core/internal/runsync/logging_test.go
@@ -17,9 +17,6 @@ import (
 )
 
 func TestOpenDebugSyncLogFile(t *testing.T) {
-	// Set TZ to UTC so that time.Now() uses UTC and not the local zone.
-	t.Setenv("TZ", "UTC")
-
 	synctest.Test(t, func(t *testing.T) {
 		// synctest time starts at 2000-01-01 at midnight UTC.
 		// Wait until 2000-01-02 at 3:04:05 for a more reliable assertion.


### PR DESCRIPTION
Use a UTC timestamp for naming `wandb/logs/debug-sync-<time>.log`.

This makes the test more robust and may avoid some problems around daylight savings, but the trade-off is that the filenames are a little harder to understand.

There's no risk with naming conflicts because the underlying code ensures a unique filename. This also only affects `wandb beta sync`, which is not yet commonly used.