### PR TITLE
fix(leet): restore evenly-spaced Y-axis tick labels after ntcharts 2.0.1

### DIFF
--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -560,7 +560,16 @@ func (c *EpochLineChart) HandleZoom(direction string, mouseX int) {
 // Draw renders all series using Braille patterns.
 func (c *EpochLineChart) Draw() {
 	c.Clear()
+
+	// Draw axes and X labels via ntcharts, but suppress its Y labels and
+	// draw our own. ntcharts v2.0.1 forces a label at graphHeight, which
+	// stacks on top of the previous tick when graphHeight is just above a
+	// multiple of yStep (e.g. "4.86" sitting on row y=6 and "4.05" on y=5).
+	origYFmter := c.YLabelFormatter
+	c.YLabelFormatter = func(int, float64) string { return "" }
 	c.DrawXYAxisAndLabel()
+	c.YLabelFormatter = origYFmter
+	c.drawYLabels()
 
 	if c.GraphWidth() <= 0 || c.GraphHeight() <= 0 {
 		c.dirty = false
@@ -578,6 +587,47 @@ func (c *EpochLineChart) Draw() {
 
 	c.drawInspectionOverlay(startX)
 	c.dirty = false
+}
+
+// drawYLabels draws Y-axis tick labels at positions i = 0, yStep, 2*yStep, ...
+// and optionally at graphHeight when there's enough gap above the previous
+// tick. Replaces ntcharts' drawYLabel, which in v2.0.1 unconditionally draws
+// a label at graphHeight and stacks it onto the previous tick when graphHeight
+// mod yStep is small.
+func (c *EpochLineChart) drawYLabels() {
+	yStep := c.YStep()
+	graphH := c.GraphHeight()
+	if yStep <= 0 || graphH <= 0 {
+		return
+	}
+	viewMinY, viewMaxY := c.ViewMinY(), c.ViewMaxY()
+	increment := (viewMaxY - viewMinY) / float64(graphH)
+	origin := c.Origin()
+
+	draw := func(i int, lastVal string) string {
+		v := viewMinY + increment*float64(i)
+		s := c.YLabelFormatter(i, v)
+		if s == "" || s == lastVal {
+			return lastVal
+		}
+		c.Canvas.SetStringWithStyle(
+			canvas.Point{X: origin.X - len(s), Y: origin.Y - i},
+			s, c.LabelStyle,
+		)
+		return s
+	}
+
+	var lastVal string
+	lastI := 0
+	for i := 0; i <= graphH; i += yStep {
+		lastVal = draw(i, lastVal)
+		lastI = i
+	}
+	// Add a top tick when the last stepped tick fell short of graphHeight
+	// and there's room for a non-adjacent label.
+	if lastI < graphH && graphH-lastI >= (yStep+1)/2 {
+		draw(graphH, lastVal)
+	}
 }
 
 // drawSeries renders a single series onto the canvas.

--- a/core/internal/leet/epochlinechart_test.go
+++ b/core/internal/leet/epochlinechart_test.go
@@ -2,6 +2,7 @@ package leet_test
 
 import (
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,6 +112,107 @@ func TestEpochLineChart_ZoomNearRightAnchorsToTail(t *testing.T) {
 
 	// Expect the right edge to be close to the last data point (~39).
 	require.Less(t, math.Abs(c.ViewMaxX()-39.0), 1.0)
+}
+
+// TestEpochLineChart_YLabelsDoNotStack guards against the ntcharts v2.0.1
+// regression where drawYLabel forces a label at graphHeight, stacking it
+// directly above the previous tick when graphHeight mod yStep is small.
+//
+// At height 8 the chart has graphHeight=6 and yStep=5, so the buggy
+// behavior places labels on rows i=5 and i=6 (adjacent). After the fix
+// only rows i=0 and i=5 carry labels.
+func TestEpochLineChart_YLabelsDoNotStack(t *testing.T) {
+	m := "loss"
+	c := leet.NewEpochLineChart(m)
+	c.Resize(80, 8)
+	c.AddData(m, leet.MetricData{
+		X: []float64{0, 1, 2, 3, 4, 5},
+		Y: []float64{4.86, 4.0, 3.0, 2.0, 1.0, 0.5},
+	})
+	c.Draw()
+
+	lines := strings.Split(stripANSI(c.View()), "\n")
+	require.GreaterOrEqual(t, len(lines), 7,
+		"expected chart to be at least 7 rows tall")
+
+	// Locate the Y-axis column ('│' for axis, '└' for the bottom-left corner).
+	axisCol := -1
+	for _, line := range lines {
+		if i := strings.IndexAny(line, "│└"); i >= 0 {
+			axisCol = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, axisCol, 0, "expected to find Y-axis column")
+
+	// Collect plot rows that carry a non-blank Y label (text left of axis).
+	var labeledRows []int
+	for r, line := range lines {
+		// Skip the X-axis label row, which lives below the axis line and
+		// has no Y label of its own.
+		if !strings.ContainsAny(line, "│└") {
+			continue
+		}
+		if axisCol > len(line) {
+			continue
+		}
+		if strings.TrimSpace(line[:axisCol]) != "" {
+			labeledRows = append(labeledRows, r)
+		}
+	}
+	require.GreaterOrEqual(t, len(labeledRows), 1, "expected at least one Y label")
+
+	for i := 1; i < len(labeledRows); i++ {
+		require.Greater(t, labeledRows[i]-labeledRows[i-1], 1,
+			"Y labels stacked on adjacent rows %d and %d:\n%s",
+			labeledRows[i-1], labeledRows[i], strings.Join(lines, "\n"))
+	}
+}
+
+// TestEpochLineChart_YLabelsKeepTopTickWhenSpaced verifies that we still
+// draw a label at graphHeight when the gap above the previous stepped tick
+// is large enough to avoid stacking. Height 13 → graphHeight=11; ticks at
+// i=0,5,10 leave a 1-row gap to graphHeight=11 (no top tick), so we test a
+// height where the gap >= yStep/2 instead.
+func TestEpochLineChart_YLabelsKeepTopTickWhenSpaced(t *testing.T) {
+	m := "loss"
+	c := leet.NewEpochLineChart(m)
+	// Height 10 → graphHeight=8; stepped ticks at i=0,5; gap to top = 3 >= 3,
+	// so a top tick at i=8 is added.
+	c.Resize(80, 10)
+	c.AddData(m, leet.MetricData{
+		X: []float64{0, 1, 2, 3, 4, 5},
+		Y: []float64{10, 8, 6, 4, 2, 0},
+	})
+	c.Draw()
+
+	lines := strings.Split(stripANSI(c.View()), "\n")
+	axisCol := -1
+	for _, line := range lines {
+		if i := strings.IndexAny(line, "│└"); i >= 0 {
+			axisCol = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, axisCol, 0)
+
+	var labeledRows []int
+	for r, line := range lines {
+		if !strings.ContainsAny(line, "│└") {
+			continue
+		}
+		if axisCol <= len(line) && strings.TrimSpace(line[:axisCol]) != "" {
+			labeledRows = append(labeledRows, r)
+		}
+	}
+	require.GreaterOrEqual(t, len(labeledRows), 3,
+		"expected at least 3 Y labels (top + middle + bottom):\n%s",
+		strings.Join(lines, "\n"))
+	// And still no stacking.
+	for i := 1; i < len(labeledRows); i++ {
+		require.Greater(t, labeledRows[i]-labeledRows[i-1], 1,
+			"Y labels stacked on rows %d and %d", labeledRows[i-1], labeledRows[i])
+	}
 }
 
 func TestTruncateTitle(t *testing.T) {


### PR DESCRIPTION
Description
-----------
ntcharts 2.0.1 changed `drawYLabel` to force a label at `graphHeight`.

Override Y-label drawing in `EpochLineChart`: suppress ntcharts' built-in Y labels via the formatter, then draw at `i = 0, yStep, 2*yStep, ...`, adding a top tick only when there's enough gap to avoid stacking.

TimeSeriesLineChart inherits the fix through Draw().
