### PR TITLE
fix: tensorcore utilization metric and TPU 7x duty cycle fan-out

### DIFF
--- a/xpu/src/tpu_libtpu.rs
+++ b/xpu/src/tpu_libtpu.rs
@@ -1209,7 +1209,7 @@ struct TpuChip {
     devices_per_chip: u32,
     /// Fan-out factor for per-chip metrics (like duty cycle) to per-device keys.
     /// V2/V3 report duty cycle per-chip but have 2 devices, so we fan out.
-    /// V4+ and V7X report per-device natively, so no fan-out (1).
+    /// V4+ and 7x report per-device natively, so no fan-out (1).
     duty_cycle_fanout: u32,
 }
 
@@ -1269,7 +1269,7 @@ fn tpu_chip_from_pci_ids(device_id: &str, subsystem_id: &str) -> Option<TpuChip>
             name: "7x".into(),
             hbm_gib: 192,
             devices_per_chip: 2,
-            duty_cycle_fanout: 1, // V7X reports per-device natively
+            duty_cycle_fanout: 1, // 7x reports per-device natively
         }),
         _ => None,
     }

--- a/xpu/src/tpu_libtpu.rs
+++ b/xpu/src/tpu_libtpu.rs
@@ -81,7 +81,7 @@ impl TpuMonitor {
     async fn collect_tpu_metrics(&self) -> Vec<(String, MetricValue)> {
         let mut metrics = Vec::new();
         let mut sdk_failures: Vec<&MetricSpec> = Vec::new();
-        let dpc = self.chip.devices_per_chip;
+        let dpc = self.chip.duty_cycle_fanout;
 
         // Phase 1: collect from SDK.
         if let Some(sdk) = &self.sdk {
@@ -206,7 +206,7 @@ struct MetricSpec {
 
 const METRICS: &[MetricSpec] = &[
     MetricSpec {
-        sdk_names: &["tensorcore_utilization", "tensorcore_util"],
+        sdk_names: &["tensorcore_util", "tensorcore_utilization"],
         grpc_name: None,
         key: "tpu.{}.tensorcoreUtilization",
         unit: "",
@@ -491,7 +491,10 @@ impl SdkClient {
         }
 
         for alias in spec.sdk_names {
-            if self.read_metric(alias).is_ok() {
+            if let Ok(data) = self.read_metric(alias) {
+                if data.values.is_empty() {
+                    continue; // handle exists but no data; try next alias
+                }
                 let alias = (*alias).to_string();
                 self.resolved.insert(cache_key.to_string(), alias.clone());
                 return Some(alias);
@@ -745,13 +748,13 @@ impl MetricSpec {
     fn format_sdk(
         &self,
         data: &SdkMetricData,
-        devices_per_chip: u32,
+        duty_cycle_fanout: u32,
         out: &mut Vec<(String, MetricValue)>,
     ) {
         match self.shape {
             MetricShape::Gauge => emit_per_device(out, self.key, &data.values, 1),
             MetricShape::DutyCycle => {
-                emit_per_device(out, self.key, &data.values, devices_per_chip)
+                emit_per_device(out, self.key, &data.values, duty_cycle_fanout)
             }
             MetricShape::LabeledDist => {
                 emit_labeled_dist(out, self.key, self.unit, &data.description, &data.values)
@@ -767,10 +770,10 @@ impl MetricSpec {
     fn format_grpc(
         &self,
         tpu_metric: &proto::TpuMetric,
-        devices_per_chip: u32,
+        duty_cycle_fanout: u32,
         out: &mut Vec<(String, MetricValue)>,
     ) {
-        let dpc = devices_per_chip.max(1) as i64;
+        let dpc = duty_cycle_fanout.max(1) as i64;
         match self.shape {
             MetricShape::Gauge | MetricShape::DutyCycle => {
                 // key contains `{}` for device index; extract suffix after last `.{}`.
@@ -1202,7 +1205,12 @@ const GOOGLE_TPU_VENDOR_ID: &str = "0x1ae0";
 struct TpuChip {
     name: String,
     hbm_gib: u32,
+    /// Number of logical devices per physical chip. Used for metadata only.
     devices_per_chip: u32,
+    /// Fan-out factor for per-chip metrics (like duty cycle) to per-device keys.
+    /// V2/V3 report duty cycle per-chip but have 2 devices, so we fan out.
+    /// V4+ and V7X report per-device natively, so no fan-out (1).
+    duty_cycle_fanout: u32,
 }
 
 impl Default for TpuChip {
@@ -1211,6 +1219,7 @@ impl Default for TpuChip {
             name: String::new(),
             hbm_gib: 0,
             devices_per_chip: 1,
+            duty_cycle_fanout: 1,
         }
     }
 }
@@ -1222,11 +1231,13 @@ fn tpu_chip_from_pci_ids(device_id: &str, subsystem_id: &str) -> Option<TpuChip>
                 name: "v2".into(),
                 hbm_gib: 8,
                 devices_per_chip: 2,
+                duty_cycle_fanout: 2,
             }),
             "0x004f" => Some(TpuChip {
                 name: "v3".into(),
                 hbm_gib: 16,
                 devices_per_chip: 2,
+                duty_cycle_fanout: 2,
             }),
             _ => None,
         },
@@ -1234,26 +1245,31 @@ fn tpu_chip_from_pci_ids(device_id: &str, subsystem_id: &str) -> Option<TpuChip>
             name: "v4".into(),
             hbm_gib: 32,
             devices_per_chip: 1,
+            duty_cycle_fanout: 1,
         }),
         "0x0063" => Some(TpuChip {
             name: "v5e".into(),
             hbm_gib: 16,
             devices_per_chip: 1,
+            duty_cycle_fanout: 1,
         }),
         "0x0062" => Some(TpuChip {
             name: "v5p".into(),
             hbm_gib: 95,
             devices_per_chip: 1,
+            duty_cycle_fanout: 1,
         }),
         "0x006f" => Some(TpuChip {
             name: "v6e".into(),
             hbm_gib: 32,
             devices_per_chip: 1,
+            duty_cycle_fanout: 1,
         }),
         "0x0076" => Some(TpuChip {
             name: "7x".into(),
             hbm_gib: 192,
             devices_per_chip: 2,
+            duty_cycle_fanout: 1, // V7X reports per-device natively
         }),
         _ => None,
     }


### PR DESCRIPTION
## Description

Follow-up on https://github.com/wandb/wandb/pull/11528.

Two fixes for TPU system metrics:

- `tensorcore_util` not collected on v5p/v6e: The SDK metric name `tensorcore_utilization` returns a valid handle but 0 values on newer TPUs. The actual working name is `tensorcore_util`. Fixed by swapping alias priority and making `resolve_metric_name` skip aliases that return empty values, so ghost metrics don't block working ones.
- 7x (Ironwood) duty cycle fan-out: Pre-7x chips with multiple devices per chip (V2/V3) report duty cycle per-chip, requiring fan-out to per-device keys. 7x has 2 devices/chip but reports per-device natively (matching Google's get_chip_usage_new in tpu-info). Added duty_cycle_fanout field to TpuChip so 7x gets no fan-out while V2/V3 retain it.

## Testing

Tested on a v5p-8 vm in GCP. Trained Karpathy's nanogpt on openwebtext: https://wandb.ai/wandb_fc/tpu-test/runs/6zjvurir

Same run displayed with LEET:

<img width="1723" height="1020" alt="image" src="https://github.com/user-attachments/assets/7f3698bd-73d8-4873-8051-72656bd3233c" />

<img width="1520" height="901" alt="image" src="https://github.com/user-attachments/assets/c361f779-58af-4b37-b80e-c877c29914f8" />

<img width="1721" height="1019" alt="image" src="https://github.com/user-attachments/assets/f6a08372-1eba-44bf-bcb9-45e7bde6cd3c" />


<details>
<summary><h3>TL;DR: TPU testing steps (v5p-8, OpenWebText, nanoGPT.jax)</h3></summary>

## Prerequisites

- GCP project with TPU quota (e.g. `wandb-client-cicd`)
- `gcloud` CLI authenticated

## 1. Create TPU VM with SSD

```bash
# Create a 500GB SSD for data (boot disk is too small for OpenWebText)
gcloud compute disks create tpu-data-ssd \
  --size=500GB --type=pd-ssd \
  --zone=us-east5-a --project=wandb-client-cicd

# Create v5p-8 spot instance with the SSD attached
gcloud compute tpus tpu-vm create tpu-v5p-8 \
  --zone=us-east5-a \
  --project=wandb-client-cicd \
  --accelerator-type=v5p-8 \
  --version=v5p-ubuntu-2204 \
  --spot \
  --data-disk source=projects/wandb-client-cicd/zones/us-east5-a/disks/tpu-data-ssd,mode=read-write
```

## 2. SSH in and mount the SSD

```bash
gcloud compute tpus tpu-vm ssh --zone=us-east5-a --project=wandb-client-cicd tpu-v5p-8

# On the VM:
sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0 /dev/nvme0n2
sudo mkdir -p /mnt/data
sudo mount /dev/nvme0n2 /mnt/data
sudo chmod 777 /mnt/data
```

## 3. Install dependencies

```bash
# uv
curl -LsSf https://astral.sh/uv/install.sh | sh
source ~/.bashrc

# Go (for building wandb-core)
curl -fsSL https://go.dev/dl/go1.26.1.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
export PATH="/usr/local/go/bin:$PATH"

# Rust (for building wandb-xpu)
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
source ~/.cargo/env

# Python venv on the SSD
cd /mnt/data
uv venv .venv
source .venv/bin/activate

# JAX with TPU support + training deps
uv pip install jax[tpu] wandb tiktoken datasets flax optax orbax-checkpoint

# Install wandb from the branch under test (if needed)
pip install --force-reinstall --no-deps \
  "wandb @ git+https://github.com/wandb/wandb.git@BRANCH_NAME"
```

## 4. Clone nanoGPT.jax and prepare data

```bash
cd /mnt/data
git clone https://github.com/changgyhub/nanoGPT.jax.git
cd nanoGPT.jax

# Redirect HuggingFace cache to SSD (boot disk is too small)
export HF_HOME=/mnt/data/.cache/huggingface
export HF_DATASETS_CACHE=/mnt/data/.cache/huggingface/datasets
export TMPDIR=/mnt/data/tmp
mkdir -p $HF_DATASETS_CACHE $TMPDIR

# Prepare Shakespeare (fast, for quick tests)
cd data/shakespeare_char && python prepare.py && cd ../..

# Prepare OpenWebText (slow, ~54GB download + tokenization)
mkdir -p data/openwebtext
curl -O https://raw.githubusercontent.com/karpathy/nanoGPT/master/data/openwebtext/prepare.py
mv prepare.py data/openwebtext/
pip install tiktoken datasets
cd data/openwebtext && python prepare.py && cd ../..
```

## 5. Copy the training script

Copy `train_pmap.py` (below) to the VM as `train.py`, replacing the original:

```bash
# From your laptop:
gcloud compute tpus tpu-vm scp --zone=us-east5-a --project=wandb-client-cicd \
  train_pmap.py tpu-v5p-8:/mnt/data/nanoGPT.jax/train.py
```

## 6. Run training

```bash
cd /mnt/data/nanoGPT.jax
source /mnt/data/.venv/bin/activate
export WANDB_API_KEY=your_key

# Quick test on Shakespeare (all chips, pmap)
python train.py --dataset=shakespeare_char --max_iters=5000 --eval_interval=500 --batch_size=16

# Full run on OpenWebText
python train.py --dataset=openwebtext --max_iters=10000 --eval_interval=1000
```

## 7. Copy run data locally

```bash
# From your laptop:
mkdir -p ~/.wandb/run-YYYYMMDD_HHMMSS-RUNID
gcloud compute tpus tpu-vm scp --recurse --zone=us-east5-a --project=wandb-client-cicd \
  "tpu-v5p-8:/mnt/data/nanoGPT.jax/wandb/run-YYYYMMDD_HHMMSS-RUNID/*" \
  ~/.wandb/run-YYYYMMDD_HHMMSS-RUNID/
```

## 8. Cleanup

```bash
# Delete the TPU VM
gcloud compute tpus tpu-vm delete tpu-v5p-8 \
  --zone=us-east5-a --project=wandb-client-cicd --quiet

# Delete the SSD (or keep for reuse)
gcloud compute disks delete tpu-data-ssd \
  --zone=us-east5-a --project=wandb-client-cicd --quiet
```

## Training script: `train_pmap.py`

nanoGPT.jax with `jax.pmap` data parallelism across all TPU chips,
instrumented with W&B (28 metrics, 5s system metric sampling).

```python
"""
nanoGPT.jax training with pmap (data-parallel across all TPU chips).
Instrumented with W&B for TPU metric testing.

Usage:
    python train.py --dataset=shakespeare_char --max_iters=5000 --eval_interval=500 --batch_size=16
    python train.py --dataset=openwebtext --max_iters=10000 --eval_interval=1000
"""

import os
import time
import math
import pickle
from functools import partial

import numpy as np
import jax
import jax.numpy as jnp
from flax.training import train_state

import wandb
from model import GPTConfig, GPT


# -----------------------------------------------------------------------------
# default config values designed to train a gpt2 (124M) on OpenWebText
# I/O
out_dir = "out"
eval_interval = 2000
log_interval = 1
eval_iters = 200
eval_only = False
always_save_checkpoint = False
init_from = "scratch"
# data
dataset = "openwebtext"
gradient_accumulation_steps = 5 * 8
batch_size = 12  # per-device batch size
block_size = 1024
# model
n_layer = 12
n_head = 12
n_embd = 768
dropout = 0.0
use_bias = False
# adamw optimizer
learning_rate = 6e-4
max_iters = 600000
weight_decay = 1e-1
beta1 = 0.9
beta2 = 0.95
grad_clip = 1.0
# learning rate decay settings
decay_lr = True
warmup_iters = 2000
lr_decay_iters = 600000
min_lr = 6e-5
# sampling
sample_max_tokens = 200
sample_temperature = 0.8
sample_top_k = 40

# -----------------------------------------------------------------------------
num_devices = jax.device_count()
tokens_per_iter = gradient_accumulation_steps * batch_size * num_devices * block_size
print(f"devices: {num_devices}, tokens per iteration will be: {tokens_per_iter:,}")

config_keys = [
    k
    for k, v in globals().items()
    if not k.startswith("_") and isinstance(v, (int, float, bool, str))
]
exec(open("configurator.py").read())
config = {k: globals()[k] for k in config_keys}

# recompute after configurator overrides
tokens_per_iter = gradient_accumulation_steps * batch_size * num_devices * block_size

# -----------------------------------------------------------------------------
# W&B setup
devices = jax.devices()
device_kind = devices[0].device_kind if devices else "unknown"

run_name = f"{device_kind}-{num_devices}chip-nanogpt-{n_layer}L{n_embd}D"
wandb.init(
    project=os.environ.get("WANDB_PROJECT", "tpu-test"),
    name=run_name,
    config={
        "model/n_layer": n_layer,
        "model/n_head": n_head,
        "model/n_embd": n_embd,
        "model/block_size": block_size,
        "model/vocab_size": None,
        "training/batch_size_per_device": batch_size,
        "training/num_devices": num_devices,
        "training/effective_batch_size": batch_size * num_devices,
        "training/gradient_accumulation_steps": gradient_accumulation_steps,
        "training/tokens_per_iter": tokens_per_iter,
        "training/max_iters": max_iters,
        "training/learning_rate": learning_rate,
        "training/weight_decay": weight_decay,
        "training/grad_clip": grad_clip,
        "training/precision": "bf16",
        "device/kind": device_kind,
        "device/count": num_devices,
    },
    settings=wandb.Settings(x_stats_sampling_interval=5),
)

# -----------------------------------------------------------------------------
# poor man's data loader
data_dir = os.path.join("data", dataset)
train_data = np.memmap(os.path.join(data_dir, "train.bin"), dtype=np.uint16, mode="r")
val_data = np.memmap(os.path.join(data_dir, "val.bin"), dtype=np.uint16, mode="r")
total_train_tokens = len(train_data)


def get_batch(split):
    """Get a batch sharded across devices: (num_devices, batch_size, block_size)."""
    data = train_data if split == "train" else val_data
    total_batch = batch_size * num_devices
    ix = np.random.randint(len(data) - block_size, size=(total_batch,))
    x = np.stack([data[i : i + block_size].astype(np.int32) for i in ix])
    y = np.stack([data[i + 1 : i + 1 + block_size].astype(np.int32) for i in ix])
    x = x.reshape(num_devices, batch_size, block_size)
    y = y.reshape(num_devices, batch_size, block_size)
    return x, y


def get_batch_single(split):
    """Get a single-device batch for eval: (batch_size, block_size)."""
    data = train_data if split == "train" else val_data
    ix = np.random.randint(len(data) - block_size, size=(batch_size,))
    x = np.stack([data[i : i + block_size].astype(np.int32) for i in ix])
    y = np.stack([data[i + 1 : i + 1 + block_size].astype(np.int32) for i in ix])
    return x, y


# -----------------------------------------------------------------------------
iter_num = 0
best_val_loss = 1e9

meta_path = os.path.join(data_dir, "meta.pkl")
meta = None
vocab_size = None
if os.path.exists(meta_path):
    with open(meta_path, "rb") as f:
        meta = pickle.load(f)
    vocab_size = meta["vocab_size"]
    print(f"found vocab_size = {vocab_size} (inside {meta_path})")
else:
    vocab_size = 50304
    print(f"defaulting to vocab_size of GPT-2 to {vocab_size}")

wandb.config.update({"model/vocab_size": vocab_size}, allow_val_change=True)

# -----------------------------------------------------------------------------
# Encode/decode helpers (character-level vs BPE)
SAMPLE_PROMPT = (
    "Three men in a Tesla \u2014 to say nothing of the dog \u2014 set out from\n"
    "San Francisco on a Tuesday morning. Harris had insisted on bringing his laptop\n"
    "so he could fine-tune a model on the drive to Tahoe. George, who had recently\n"
    "pivoted from crypto to AI agents, declared that"
)

if meta is not None and "stoi" in meta:
    stoi = meta["stoi"]
    itos = meta["itos"]
    encode = lambda s: [stoi.get(c, 0) for c in s]
    decode = lambda tokens: "".join(itos.get(t, "?") for t in tokens)
elif meta is not None and "chars" in meta:
    chars = meta["chars"]
    stoi = {ch: i for i, ch in enumerate(chars)}
    itos = {i: ch for i, ch in enumerate(chars)}
    encode = lambda s: [stoi.get(c, 0) for c in s]
    decode = lambda tokens: "".join(itos.get(t, "?") for t in tokens)
else:
    import tiktoken

    _enc = tiktoken.get_encoding("gpt2")
    encode = _enc.encode
    decode = _enc.decode

# -----------------------------------------------------------------------------
# model init
model_args = dict(
    n_layer=n_layer,
    n_head=n_head,
    n_embd=n_embd,
    block_size=block_size,
    use_bias=use_bias,
    vocab_size=vocab_size,
    dropout=dropout,
)

if init_from == "scratch":
    print("Initializing a new model from scratch")
    gptconf = GPTConfig(**model_args)
    model = GPT(gptconf)
    state = model.configure_state(**config)
    params = state.params
    n_params = sum(p.size for p in jax.tree.leaves(params))
    print(f"Model parameters: {n_params / 1e6:.1f}M")
    wandb.config.update(
        {"model/params_M": round(n_params / 1e6, 1)}, allow_val_change=True
    )
else:
    raise NotImplementedError(f"init_from='{init_from}' not supported in pmap mode.")

if block_size < model.config.block_size:
    model.crop_block_size(block_size)
    model_args["block_size"] = block_size

# Estimated FLOPs per token: ~6N for a dense transformer (forward + backward)
flops_per_token = 6 * n_params
flops_per_iter = flops_per_token * tokens_per_iter

# Per-device peak FLOPS (bf16). Conservative estimates; actual may be higher.
DEVICE_PEAK_FLOPS = {
    "TPU v5 lite": 197e12,   # v5e: 197 TFLOPS bf16
    "TPU v5p": 459e12,       # v5p: 459 TFLOPS bf16
    "TPU v5": 459e12,        # v5p alt name
    "TPU v6e": 918e12,       # v6e (Trillium): 918 TFLOPS bf16
    "TPU v4": 275e12,        # v4: 275 TFLOPS bf16
    "TPU v3": 123e12,        # v3: 123 TFLOPS bf16
}
peak_flops_per_device = DEVICE_PEAK_FLOPS.get(device_kind, 200e12)
peak_flops_total = peak_flops_per_device * num_devices
print(f"Device: {device_kind} | Peak BF16 FLOPS/device: {peak_flops_per_device:.2e}")
print(f"Estimated FLOPs/iter: {flops_per_iter:.2e}")

wandb.config.update({
    "model/flops_per_token": flops_per_token,
    "device/peak_flops_per_device": peak_flops_per_device,
}, allow_val_change=True)

# replicate state across devices for pmap
state = jax.tree.map(lambda x: jnp.stack([x] * num_devices), state)


# -----------------------------------------------------------------------------
# forward / train step
@partial(jax.jit, static_argnames=("train",))
def forward_single(state, batch, *, train: bool):
    """Single-device forward for eval."""
    inputs, labels = batch
    rngs = {}
    if train and dropout > 0.0:
        rngs["dropout"] = jax.random.fold_in(jax.random.PRNGKey(0), state.step)
    return state.apply_fn(
        {"params": state.params},
        inputs,
        train=train,
        targets=labels,
        rngs=rngs,
    )


@partial(jax.pmap, axis_name="devices", donate_argnums=(0,))
def train_step(state, batch):
    """Data-parallel train step. Returns loss, updated state, and grad stats."""
    inputs, labels = batch

    def loss_fn(params):
        rngs = {}
        if dropout > 0.0:
            rngs["dropout"] = jax.random.fold_in(jax.random.PRNGKey(0), state.step)
        _, loss = state.apply_fn(
            {"params": params},
            inputs,
            train=True,
            targets=labels,
            rngs=rngs,
        )
        return loss

    loss, grads = jax.value_and_grad(loss_fn)(state.params)
    # average gradients and loss across devices
    grads = jax.lax.pmean(grads, axis_name="devices")
    loss = jax.lax.pmean(loss, axis_name="devices")

    # gradient statistics (before clipping)
    grad_leaves = jax.tree.leaves(grads)
    grad_norm = jnp.sqrt(sum(jnp.sum(g**2) for g in grad_leaves))
    grad_max = jnp.max(jnp.array([jnp.max(jnp.abs(g)) for g in grad_leaves]))

    # clip gradients
    if grad_clip > 0.0:
        clip_coeff = jnp.minimum(1.0, grad_clip / (grad_norm + 1e-6))
        grads = jax.tree.map(lambda g: g * clip_coeff, grads)
        clipped_grad_norm = jnp.sqrt(
            sum(jnp.sum(g**2) for g in jax.tree.leaves(grads))
        )
    else:
        clipped_grad_norm = grad_norm

    state = state.apply_gradients(grads=grads)

    # parameter statistics (after update)
    param_leaves = jax.tree.leaves(state.params)
    param_norm = jnp.sqrt(sum(jnp.sum(p**2) for p in param_leaves))

    # update-to-weight ratio: how big is the step relative to the weights
    update_norm = jnp.sqrt(
        sum(jnp.sum(g**2) for g in jax.tree.leaves(grads))
    )
    update_ratio = update_norm / (param_norm + 1e-8)

    aux = {
        "grad_norm": grad_norm,
        "grad_norm_clipped": clipped_grad_norm,
        "grad_max": grad_max,
        "param_norm": param_norm,
        "update_ratio": update_ratio,
    }
    return loss, state, aux


# -----------------------------------------------------------------------------
# generation / sampling
def sample_from_model(eval_state, prompt=SAMPLE_PROMPT, max_new_tokens=200,
                      temperature=0.8, top_k=40):
    """Autoregressive generation for qualitative eval."""
    prompt_ids = encode(prompt)[-block_size:]
    tokens = jnp.array(prompt_ids, dtype=jnp.int32)[None, :]
    rng = jax.random.PRNGKey(iter_num)

    for _ in range(max_new_tokens):
        tokens_cond = tokens[:, -block_size:]
        logits, _ = forward_single(
            eval_state, (tokens_cond, tokens_cond), train=False,
        )
        logits = logits[:, -1, :] / temperature
        if top_k > 0:
            k = min(top_k, logits.shape[-1])
            top_vals = jax.lax.top_k(logits, k)[0]
            logits = jnp.where(logits < top_vals[:, -1:], -1e9, logits)
        rng, sample_rng = jax.random.split(rng)
        next_token = jax.random.categorical(sample_rng, logits, axis=-1)
        tokens = jnp.concatenate([tokens, next_token[:, None]], axis=1)

    return decode(tokens[0].tolist())


# -----------------------------------------------------------------------------
# loss estimation
def estimate_loss(eval_state):
    out = {}
    for split in ["train", "val"]:
        losses = np.zeros(eval_iters)
        for k in range(eval_iters):
            batch = get_batch_single(split)
            _, loss = forward_single(eval_state, batch, train=False)
            losses[k] = float(loss)
        out[split] = losses.mean()
    return out


# -----------------------------------------------------------------------------
# learning rate schedule (cosine with warmup)
def get_lr(it):
    if it < warmup_iters:
        return learning_rate * it / warmup_iters
    if it > lr_decay_iters:
        return min_lr
    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
    return min_lr + coeff * (learning_rate - min_lr)


# -----------------------------------------------------------------------------
# training loop
print(f"\nTraining on {num_devices} {device_kind} chips")
print(f"Tokens per iteration: {tokens_per_iter:,}")
print(f"Total training tokens in dataset: {total_train_tokens:,}")

# EMA tracking for smoothed loss
loss_ema = None
loss_ema_alpha = 0.99

# timing
total_tokens_seen = 0
train_start = time.time()
t0 = time.time()

while True:
    # evaluate and sample
    if iter_num % eval_interval == 0:
        eval_state = jax.tree.map(lambda x: x[0], state)
        losses = estimate_loss(eval_state)
        train_loss, val_loss = losses["train"], losses["val"]
        print(
            f"iter {iter_num} loss: "
            f"train loss {train_loss:.4f}, val loss {val_loss:.4f}"
        )
        is_best_val = val_loss < best_val_loss
        if is_best_val:
            best_val_loss = val_loss

        # bits per byte: loss / ln(2) (for BPE; approximation for char-level)
        train_bpb = train_loss / math.log(2)
        val_bpb = val_loss / math.log(2)

        wandb.log(
            {
                "eval/train_loss": train_loss,
                "eval/val_loss": val_loss,
                "eval/train_ppl": math.exp(min(train_loss, 20)),
                "eval/val_ppl": math.exp(min(val_loss, 20)),
                "eval/train_bpb": train_bpb,
                "eval/val_bpb": val_bpb,
                "eval/best_val_loss": best_val_loss,
                "eval/generalization_gap": val_loss - train_loss,
            },
            step=iter_num,
        )

        # sample from the model
        print(f"\n{'=' * 70}")
        print(f"SAMPLE @ iter {iter_num}:")
        print(f"{'=' * 70}")
        text = sample_from_model(
            eval_state,
            max_new_tokens=sample_max_tokens,
            temperature=sample_temperature,
            top_k=sample_top_k,
        )
        print(text)
        print(f"{'=' * 70}\n")

    if iter_num == 0 and eval_only:
        break

    loss, state, aux = train_step(state, get_batch("train"))

    # timing and logging
    t1 = time.time()
    dt = t1 - t0
    t0 = t1
    total_tokens_seen += tokens_per_iter

    if iter_num % log_interval == 0:
        # extract scalars (replicated across devices; take first)
        lossf = float(loss[0]) * gradient_accumulation_steps
        grad_norm = float(aux["grad_norm"][0])
        grad_norm_clipped = float(aux["grad_norm_clipped"][0])
        grad_max = float(aux["grad_max"][0])
        param_norm = float(aux["param_norm"][0])
        update_ratio = float(aux["update_ratio"][0])

        tokens_sec = tokens_per_iter / dt if dt > 0 else 0
        lr = get_lr(iter_num)

        # EMA smoothed loss
        if loss_ema is None:
            loss_ema = lossf
        else:
            loss_ema = loss_ema_alpha * loss_ema + (1 - loss_ema_alpha) * lossf

        # MFU: model FLOPs utilization
        achieved_flops = flops_per_iter / dt if dt > 0 else 0
        mfu = achieved_flops / peak_flops_total * 100  # percentage

        # progress
        progress = iter_num / max_iters
        epoch = total_tokens_seen / total_train_tokens
        elapsed_min = (t1 - train_start) / 60
        eta_min = elapsed_min / max(progress, 1e-8) * (1 - progress) if progress > 0.001 else 0

        print(
            f"iter {iter_num}: loss {lossf:.4f}, "
            f"time {dt * 1000:.2f}ms, {tokens_sec:,.0f} tok/s, "
            f"mfu {mfu:.1f}%"
        )

        wandb.log(
            {
                # loss
                "train/loss": lossf,
                "train/loss_ema": loss_ema,
                "train/perplexity": math.exp(min(lossf, 20)),
                "train/bpb": lossf / math.log(2),
                # optimization
                "optim/lr": lr,
                "optim/grad_norm": grad_norm,
                "optim/grad_norm_clipped": grad_norm_clipped,
                "optim/grad_max": grad_max,
                "optim/grad_clip_ratio": grad_norm_clipped / (grad_norm + 1e-8),
                "optim/param_norm": param_norm,
                "optim/update_ratio": update_ratio,
                # performance
                "perf/step_time_ms": dt * 1000,
                "perf/tokens_per_sec": tokens_sec,
                "perf/mfu_pct": mfu,
                "perf/achieved_tflops": achieved_flops / 1e12,
                # progress
                "progress/tokens_seen": total_tokens_seen,
                "progress/epoch": epoch,
                "progress/pct_done": progress * 100,
                "progress/elapsed_min": elapsed_min,
                "progress/eta_min": eta_min,
            },
            step=iter_num,
        )
    iter_num += 1

    if iter_num > max_iters:
        break

total_time = (time.time() - train_start) / 60
print(f"\nTraining complete. {iter_num} iters in {total_time:.1f} min.")
print(f"Total tokens seen: {total_tokens_seen:,}")
print(f"Best val loss: {best_val_loss:.4f}")
wandb.finish()
```

</details>
