### PR TITLE
fix: wandb.init() raw JSON error

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spf13/afero v1.15.0
 	github.com/stretchr/testify v1.11.1
+	github.com/vektah/gqlparser/v2 v2.5.32
 	github.com/wandb/simplejsonext v0.0.0-20250915191530-b44163b534be
 	go.uber.org/mock v0.6.0
 	gocloud.dev v0.45.0
@@ -142,7 +143,6 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
-	github.com/vektah/gqlparser/v2 v2.5.32 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/core/internal/runupserter/runupdateerror.go
+++ b/core/internal/runupserter/runupdateerror.go
@@ -2,30 +2,75 @@ package runupserter
 
 import (
 	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Khan/genqlient/graphql"
 
 	"github.com/wandb/wandb/core/internal/runbranch"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
-// runUpdateErrorFromBranchError converts a resume, rewind or fork error
-// to a RunUpdateError.
+// ToRunUpdateError converts error types seen by the runupserter
+// into RunUpdateError.
 //
-// Other values including nil are returned unchanged.
-func runUpdateErrorFromBranchError(err error) error {
+// Generic errors including nil are returned unchanged.
+func ToRunUpdateError(err error) error {
 	if err == nil {
 		return nil
 	}
 
 	var runBranchError *runbranch.BranchError
 	if errors.As(err, &runBranchError) {
-		return &RunUpdateError{
-			Cause:       runBranchError.Err,
-			UserMessage: runBranchError.Response.GetMessage(),
-			Code:        runBranchError.Response.GetCode(),
-		}
+		return fromRunBranchError(runBranchError)
+	}
+
+	var gqlError *graphql.HTTPError
+	if errors.As(err, &gqlError) {
+		return fromGQLError(gqlError)
 	}
 
 	return err
+}
+
+func fromRunBranchError(runBranchError *runbranch.BranchError) *RunUpdateError {
+	return &RunUpdateError{
+		Cause:       runBranchError.Err,
+		UserMessage: runBranchError.Response.GetMessage(),
+		Code:        runBranchError.Response.GetCode(),
+	}
+}
+
+func fromGQLError(gqlError *graphql.HTTPError) *RunUpdateError {
+	var userMessage string
+
+	switch {
+	case len(gqlError.Response.Errors) == 0:
+		userMessage = gqlError.Error()
+	case len(gqlError.Response.Errors) == 1:
+		userMessage = gqlError.Response.Errors[0].Message
+	default:
+		var messages []string
+		for _, err := range gqlError.Response.Errors {
+			messages = append(messages, err.Message)
+		}
+		joinedMessages := strings.Join(messages, "; ")
+		userMessage = fmt.Sprintf("[%s]", joinedMessages)
+	}
+
+	if userMessage == "" {
+		// An empty UserMessage is treated like "no error" by the client.
+		//
+		// This can happen if the backend returns an empty response and
+		// an error status.
+		userMessage = "<no message>"
+	}
+
+	return &RunUpdateError{
+		Cause:       gqlError,
+		UserMessage: userMessage,
+		Code:        spb.ErrorInfo_COMMUNICATION,
+	}
 }
 
 type RunUpdateError struct {

--- a/core/internal/runupserter/runupdateerror_test.go
+++ b/core/internal/runupserter/runupdateerror_test.go
@@ -1,0 +1,96 @@
+package runupserter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/wandb/wandb/core/internal/runbranch"
+	"github.com/wandb/wandb/core/internal/runupserter"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func Test_ToRunUpdateError_BranchError(t *testing.T) {
+	err := &runbranch.BranchError{
+		Err: errors.New("test err"),
+		Response: &spb.ErrorInfo{
+			Message: "test error message",
+			Code:    spb.ErrorInfo_UNSUPPORTED,
+		},
+	}
+
+	result := runupserter.ToRunUpdateError(err)
+
+	runUpdateError := result.(*runupserter.RunUpdateError)
+	assert.ErrorContains(t, runUpdateError, "test err")
+	assert.Equal(t, "test error message", runUpdateError.UserMessage)
+	assert.Equal(t, spb.ErrorInfo_UNSUPPORTED, runUpdateError.Code)
+}
+
+func Test_ToRunUpdateError_GQLError_One(t *testing.T) {
+	err := &graphql.HTTPError{
+		StatusCode: 400,
+		Response: graphql.Response{
+			Errors: gqlerror.List{
+				{Message: "gql error message"},
+			},
+		},
+	}
+
+	result := runupserter.ToRunUpdateError(err)
+
+	runUpdateError := result.(*runupserter.RunUpdateError)
+	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
+	assert.Equal(t, "gql error message", runUpdateError.UserMessage)
+	assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
+}
+
+func Test_ToRunUpdateError_GQLError_Many(t *testing.T) {
+	err := &graphql.HTTPError{
+		StatusCode: 400,
+		Response: graphql.Response{
+			Errors: gqlerror.List{
+				{Message: "gql 1"},
+				{Message: "gql 2"},
+			},
+		},
+	}
+
+	result := runupserter.ToRunUpdateError(err)
+
+	runUpdateError := result.(*runupserter.RunUpdateError)
+	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
+	assert.Equal(t, "[gql 1; gql 2]", runUpdateError.UserMessage)
+	assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
+}
+
+func Test_ToRunUpdateError_GQLError_None(t *testing.T) {
+	err := &graphql.HTTPError{
+		StatusCode: 400,
+		Response:   graphql.Response{}, // no GQL errors (unusual)
+	}
+
+	result := runupserter.ToRunUpdateError(err)
+
+	runUpdateError := result.(*runupserter.RunUpdateError)
+	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
+	assert.Contains(t, runUpdateError.UserMessage, "400")
+}
+
+func Test_ToRunUpdateError_GQLError_Empty(t *testing.T) {
+	err := &graphql.HTTPError{
+		StatusCode: 400,
+		Response: graphql.Response{
+			Errors: gqlerror.List{{Message: ""}}, // no error body (unusual)
+		},
+	}
+
+	result := runupserter.ToRunUpdateError(err)
+
+	runUpdateError := result.(*runupserter.RunUpdateError)
+	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
+	assert.Contains(t, runUpdateError.UserMessage, "<no message>")
+}

--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -178,7 +178,7 @@ func InitRun(
 		err := upserter.updateMetadataForResume(ctx, params.Settings.GetResume())
 
 		if err != nil {
-			return nil, runUpdateErrorFromBranchError(err)
+			return nil, ToRunUpdateError(err)
 		}
 
 	case branchPoint != nil && branchPoint.GetRun() == runRecord.RunId:
@@ -186,7 +186,7 @@ func InitRun(
 		err := upserter.updateMetadataForRewind(ctx, branchPoint)
 
 		if err != nil {
-			return nil, runUpdateErrorFromBranchError(err)
+			return nil, ToRunUpdateError(err)
 		}
 
 	case branchPoint != nil && branchPoint.GetRun() != "":
@@ -194,7 +194,7 @@ func InitRun(
 		err := upserter.updateMetadataForFork(branchPoint)
 
 		if err != nil {
-			return nil, runUpdateErrorFromBranchError(err)
+			return nil, ToRunUpdateError(err)
 		}
 	}
 
@@ -214,11 +214,7 @@ func InitRun(
 	)
 
 	if err != nil {
-		return nil, &RunUpdateError{
-			UserMessage: fmt.Sprintf("Error uploading run: %v", err),
-			Cause:       err,
-			Code:        spb.ErrorInfo_COMMUNICATION,
-		}
+		return nil, ToRunUpdateError(err)
 	}
 
 	// Fill some metadata based on the server response.

--- a/core/internal/runupserter/runupserter_test.go
+++ b/core/internal/runupserter/runupserter_test.go
@@ -2,14 +2,15 @@ package runupserter_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -161,13 +162,21 @@ func TestInitRun_UpsertError(t *testing.T) {
 	params.GraphqlClientOrNil = mockClient
 	mockClient.StubMatchWithError(
 		gqlmock.WithOpName("UpsertBucket"),
-		errors.New("test error"),
+		&graphql.HTTPError{
+			StatusCode: 500,
+			Response: graphql.Response{
+				Errors: gqlerror.List{
+					{Message: "Everything is broken"},
+				},
+			},
+		},
 	)
 
 	upserter, err := runupserter.InitRun(runRecord(&spb.RunRecord{}), params)
 
 	assert.Nil(t, upserter)
-	assert.ErrorContains(t, err, "test error")
+	runUpdateError := err.(*runupserter.RunUpdateError)
+	assert.Equal(t, "Everything is broken", runUpdateError.UserMessage)
 }
 
 func TestInitRun_Offline(t *testing.T) {


### PR DESCRIPTION
Changes `runupserter` to parse out the GraphQL `"errors"` field into a user message, so that we don't print the raw JSON response unnecessarily.

We should probably do this for all GQL errors, but I don't have a good pattern in mind yet.

Fixes WB-32038.

```
# Before:
❯ python -c 'import wandb; wandb.init(entity="timoffex-does-not-exist")'
wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from /Users/timoffex/.netrc.
wandb: Currently logged in as: timoffex (wandb) to https://api.wandb.ai. Use `wandb login --relogin` to f
orce relogin
wandb: ERROR Error uploading run: returned error 404: {"data":{"upsertBucket":null},"errors":[{"message":
"entity timoffex-does-not-exist not found during upsertBucket","path":["upsertBucket"]}]}


# After:
❯ python -c 'import wandb; wandb.init(entity="timoffex-does-not-exist")'
wandb: [wandb.login()] Loaded credentials for https://api.wandb.ai from /Users/timoffex/.netrc.
wandb: Currently logged in as: timoffex (wandb) to https://api.wandb.ai. Use `wandb login --relogin` to f
orce relogin
wandb: ERROR entity timoffex-does-not-exist not found during upsertBucket
```

Also improves the same message for `wandb beta sync`.