### PR TITLE
fix: raise error on ID conflict during reinit="create_new"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,3 +13,7 @@ sections:
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- Made `wandb.init(id=run_id, reinit="create_new")` raise an error when another run in the same script with the same `run_id` is still running (@timoffex in https://github.com/wandb/wandb/pull/11759)

--- a/core/internal/stream/stream_mux.go
+++ b/core/internal/stream/stream_mux.go
@@ -30,7 +30,7 @@ func (sm *StreamMux) AddStream(streamId string, stream *Stream) error {
 		sm.mux[streamId] = stream
 		return nil
 	} else {
-		return fmt.Errorf("stream already exists")
+		return fmt.Errorf("run ID %s is in use", streamId)
 	}
 }
 

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -322,7 +322,7 @@ func (nc *Connection) handleIncomingRequests() {
 		case *spb.ServerRequest_Authenticate:
 			nc.handleAuthenticate(msg.RequestId, x.Authenticate)
 		case *spb.ServerRequest_InformInit:
-			nc.handleInformInit(x.InformInit)
+			nc.handleInformInit(msg.RequestId, x.InformInit)
 		case *spb.ServerRequest_InformAttach:
 			nc.handleInformAttach(msg.RequestId, x.InformAttach)
 		case *spb.ServerRequest_RecordPublish:
@@ -378,7 +378,10 @@ func (nc *Connection) handleCancel(msg *spb.ServerCancelRequest) {
 // This function is invoked when the server receives an `InformInit` message
 // from the client. It creates a new stream, associates it with the connection.
 // Also starts the stream and adds the connection as a responder to the stream.
-func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
+func (nc *Connection) handleInformInit(
+	requestID string,
+	msg *spb.ServerInformInitRequest,
+) {
 	s := settings.From(msg.GetSettings())
 
 	streamId := msg.GetXInfo().GetStreamId()
@@ -391,8 +394,6 @@ func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
 		nc.logLevel,
 		s,
 	)
-	strm.Start()
-	slog.Info("handleInformInit: stream started", "streamId", streamId, "id", nc.id)
 
 	if err := nc.streamMux.AddStream(streamId, strm); err != nil {
 		slog.Error(
@@ -401,8 +402,23 @@ func (nc *Connection) handleInformInit(msg *spb.ServerInformInitRequest) {
 			"streamId", streamId,
 			"id", nc.id,
 		)
-		// TODO: should we Close the stream?
-		return
+
+		nc.Respond(&spb.ServerResponse{
+			RequestId: requestID,
+			ServerResponseType: &spb.ServerResponse_ErrorResponse{
+				ErrorResponse: &spb.ServerErrorResponse{
+					Message: err.Error(),
+				},
+			},
+		})
+	} else {
+		strm.Start()
+		slog.Info(
+			"handleInformInit: stream started",
+			"streamId", streamId,
+			"id", nc.id,
+		)
+		nc.Respond(&spb.ServerResponse{RequestId: requestID})
 	}
 }
 

--- a/core/pkg/service_go_proto/wandb_server.pb.go
+++ b/core/pkg/service_go_proto/wandb_server.pb.go
@@ -308,6 +308,11 @@ func (*ServerStatusResponse) Descriptor() ([]byte, []int) {
 	return file_wandb_proto_wandb_server_proto_rawDescGZIP(), []int{5}
 }
 
+// Declare a run.
+//
+// This creates a Stream in wandb-core without uploading the run.
+// The Stream can receive messages after a successful response to this request.
+// The response may be an error.
 type ServerInformInitRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Settings      *Settings              `protobuf:"bytes,1,opt,name=settings,proto3" json:"settings,omitempty"`

--- a/tests/system_tests/test_core/test_wandb_init_reinit.py
+++ b/tests/system_tests/test_core/test_wandb_init_reinit.py
@@ -9,6 +9,21 @@ def test_reinit_create_new__does_not_modify_wandb_run():
         assert wandb.run is None
 
 
+def test_reinit_create_new__fails_on_id_conflict():
+    with wandb.init(mode="offline") as run1:
+        with pytest.raises(match=r"run ID \w+ is in use"):
+            wandb.init(id=run1.id, mode="offline", reinit="create_new")
+
+
+def test_reinit_create_new__can_reuse_id_after_finish():
+    with wandb.init(mode="offline") as run1:
+        pass
+
+    # Allowed because run1 is finished.
+    with wandb.init(id=run1.id, mode="offline", reinit="create_new"):
+        pass
+
+
 def test_reinit_default__controls_wandb_run():
     with wandb.init(mode="offline") as run:
         assert wandb.run is run

--- a/wandb/proto/wandb_server.proto
+++ b/wandb/proto/wandb_server.proto
@@ -41,6 +41,11 @@ message ServerStatusRequest {
 
 message ServerStatusResponse {}
 
+// Declare a run.
+//
+// This creates a Stream in wandb-core without uploading the run.
+// The Stream can receive messages after a successful response to this request.
+// The response may be an error.
 message ServerInformInitRequest {
   Settings settings = 1;
   _RecordInfo _info = 200;

--- a/wandb/sdk/lib/service/service_connection.py
+++ b/wandb/sdk/lib/service/service_connection.py
@@ -260,7 +260,7 @@ class ServiceConnection:
         settings: wandb_settings_pb2.Settings,
         run_id: str,  # TODO: remove and use the settings param
     ) -> InterfaceBase:
-        """Initialize a run in wandb-core.
+        """Declare a run in wandb-core.
 
         Args:
             settings: The settings for the run.
@@ -268,13 +268,21 @@ class ServiceConnection:
 
         Returns:
             An interface for sending messages for the run.
+
+        Raises:
+            ServerResponseError: If there was an error, like if the run ID
+                is already in use.
         """
         request = spb.ServerInformInitRequest()
         request.settings.CopyFrom(settings)
         request._info.stream_id = run_id
-        self._asyncer.run(
-            lambda: self._client.publish(spb.ServerRequest(inform_init=request))
-        )
+
+        async def init_and_wait_for_response() -> None:
+            server_request = spb.ServerRequest(inform_init=request)
+            handle = await self._client.deliver(server_request)
+            await handle.wait_async(timeout=None)
+
+        self._asyncer.run(init_and_wait_for_response)
 
         return InterfaceSock(
             self._asyncer,


### PR DESCRIPTION
Makes `wandb.init()` raise an error if given an ID that's already in use.

Rather than adding a check specific to the `reinit` mode (which allows creating multiple runs in the same script), I changed `inform_init` to return an error when it fails. Its implementation already logged an error when given an ID that conflicted with an existing Stream, but that was not propagated to the client.

I didn't update the C# client as it doesn't have a `reinit` setting, but we should make `TcpClient.SendAsync()` turn `ServerErrorResponse` into an error, just like `mailbox.ResponseHandle` does in Python.

Fixes WB-29327.
