### PR TITLE
fix: wbapi not ignoring offline mode setting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,4 +21,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Made `wandb.init(id=run_id, reinit="create_new")` raise an error when another run in the same script with the same `run_id` is still running (@timoffex in https://github.com/wandb/wandb/pull/11759)
-- `wandb.Api` no longer fails GraphQL server feature checks when used in `offline` mode (@jacobromero in https://github.com/wandb/wandb/pull/11762)
+- `wandb.Api` no longer raises an error for some api operations when offline mode is enabled via the `WANDB_MODE` environment variable or the `mode` setting. (@jacobromero in https://github.com/wandb/wandb/pull/11762)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,3 +21,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Made `wandb.init(id=run_id, reinit="create_new")` raise an error when another run in the same script with the same `run_id` is still running (@timoffex in https://github.com/wandb/wandb/pull/11759)
+- `wandb.Api` no longer fails GraphQL server feature checks when used in `offline` mode (@jacobromero in https://github.com/wandb/wandb/pull/11762)

--- a/core/internal/api/gql_client.go
+++ b/core/internal/api/gql_client.go
@@ -1,25 +1,25 @@
-package gql
+package api
 
 import (
 	"fmt"
+	"log/slog"
 	"maps"
 
 	"github.com/Khan/genqlient/graphql"
 
-	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/clients"
-	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/sharedmode"
 )
 
 func NewGQLClient(
-	baseURL api.WBBaseURL,
+	baseURL WBBaseURL,
 	clientID sharedmode.ClientID,
-	credentialProvider api.CredentialProvider,
-	logger *observability.CoreLogger,
-	peeker *observability.Peeker,
+	credentialProvider CredentialProvider,
+	logger *slog.Logger,
+	peeker Peeker,
 	s *settings.Settings,
+	extraHeaders map[string]string,
 ) graphql.Client {
 	// TODO: This is used for the service account feature to associate the run
 	// with the specified user. Note that we are using environment variables
@@ -36,27 +36,15 @@ func NewGQLClient(
 		"X-WANDB-USERNAME":   s.GetUserName(),
 		"X-WANDB-USER-EMAIL": s.GetEmail(),
 	}
-	maps.Copy(graphqlHeaders, s.GetExtraHTTPHeaders())
-	// This header is used to indicate to the backend that the run is in shared
-	// mode to prevent a race condition when two UpsertRun requests are made
-	// simultaneously for the same run ID in shared mode.
-	if s.IsSharedMode() {
-		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
-		graphqlHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
-	}
-	// When enabled, this header instructs the backend to compute the derived summary
-	// using history updates, instead of relying on the SDK to calculate and send it.
-	if s.IsEnableServerSideDerivedSummary() {
-		graphqlHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
-	}
+	maps.Copy(graphqlHeaders, extraHeaders)
 
-	opts := api.ClientOptions{
+	opts := ClientOptions{
 		BaseURL:         baseURL,
 		RetryPolicy:     clients.CheckRetry,
-		RetryMax:        api.DefaultRetryMax,
-		RetryWaitMin:    api.DefaultRetryWaitMin,
-		RetryWaitMax:    api.DefaultRetryWaitMax,
-		NonRetryTimeout: api.DefaultNonRetryTimeout,
+		RetryMax:        DefaultRetryMax,
+		RetryWaitMin:    DefaultRetryWaitMin,
+		RetryWaitMax:    DefaultRetryWaitMax,
+		NonRetryTimeout: DefaultNonRetryTimeout,
 		ExtraHeaders:    graphqlHeaders,
 		NetworkPeeker:   peeker,
 		Proxy: clients.ProxyFn(
@@ -65,7 +53,7 @@ func NewGQLClient(
 		),
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 		CredentialProvider: credentialProvider,
-		Logger:             logger.Logger,
+		Logger:             logger,
 	}
 	if retryMax := s.GetGraphQLMaxRetries(); retryMax > 0 {
 		opts.RetryMax = int(retryMax)
@@ -80,8 +68,8 @@ func NewGQLClient(
 		opts.NonRetryTimeout = timeout
 	}
 
-	httpClient := api.NewClient(opts)
+	httpClient := NewClient(opts)
 	endpoint := fmt.Sprintf("%s/graphql", s.GetBaseURL())
 
-	return graphql.NewClient(endpoint, api.AsStandardClient(httpClient))
+	return graphql.NewClient(endpoint, AsStandardClient(httpClient))
 }

--- a/core/internal/api/gql_client.go
+++ b/core/internal/api/gql_client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -18,8 +19,24 @@ func NewGQLClient(
 	logger *slog.Logger,
 	peeker Peeker,
 	s *settings.Settings,
-	graphqlHeaders map[string]string,
+	extraHeaders map[string]string,
 ) graphql.Client {
+	// TODO: This is used for the service account feature to associate the run
+	// with the specified user. Note that we are using environment variables
+	// here, instead of the settings object (which is ideally would be the only
+	// setting used). We are doing this because, the default setting populates
+	// the username with a value that not necessarily matches the username in
+	// our app. There is also a precedence issue, where if the username is set
+	// it will always be used, even if the email is set. Causing the owner of
+	// to be wrong.
+	// We should consider using the settings object here. But we need to make
+	// sure that the username setting is populated correctly. Leaving this as is
+	// for now just to avoid breakage in the service account feature.
+	graphqlHeaders := map[string]string{
+		"X-WANDB-USERNAME":   s.GetUserName(),
+		"X-WANDB-USER-EMAIL": s.GetEmail(),
+	}
+	maps.Copy(graphqlHeaders, extraHeaders)
 
 	opts := ClientOptions{
 		BaseURL:         baseURL,

--- a/core/internal/api/gql_client.go
+++ b/core/internal/api/gql_client.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"log/slog"
-	"maps"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -19,24 +18,8 @@ func NewGQLClient(
 	logger *slog.Logger,
 	peeker Peeker,
 	s *settings.Settings,
-	extraHeaders map[string]string,
+	graphqlHeaders map[string]string,
 ) graphql.Client {
-	// TODO: This is used for the service account feature to associate the run
-	// with the specified user. Note that we are using environment variables
-	// here, instead of the settings object (which is ideally would be the only
-	// setting used). We are doing this because, the default setting populates
-	// the username with a value that not necessarily matches the username in
-	// our app. There is also a precedence issue, where if the username is set
-	// it will always be used, even if the email is set. Causing the owner of
-	// to be wrong.
-	// We should consider using the settings object here. But we need to make
-	// sure that the username setting is populated correctly. Leaving this as is
-	// for now just to avoid breakage in the service account feature.
-	graphqlHeaders := map[string]string{
-		"X-WANDB-USERNAME":   s.GetUserName(),
-		"X-WANDB-USER-EMAIL": s.GetEmail(),
-	}
-	maps.Copy(graphqlHeaders, extraHeaders)
 
 	opts := ClientOptions{
 		BaseURL:         baseURL,

--- a/core/internal/clients/proxy.go
+++ b/core/internal/clients/proxy.go
@@ -1,0 +1,40 @@
+package clients
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// ProxyFn returns a function that returns a proxy URL for a given hhtp.Request.
+//
+// The function first checks if there's a custom proxy setting for the request
+// URL scheme. If not, it falls back to the default environment proxy settings.
+// If there is, it returns the custom proxy URL.
+//
+// This is useful if the user only want to proxy traffic to W&B, but not other traffic,
+// as the standard environment proxy settings would potentially proxy all traffic.
+//
+// The custom proxy URLs are passed as arguments to the function.
+//
+// The default environment proxy settings are read from the environment variables
+// HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
+func ProxyFn(httpProxy, httpsProxy string) func(req *http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		if req.URL.Scheme == "http" && httpProxy != "" {
+			proxyURLParsed, err := url.Parse(httpProxy)
+			if err != nil {
+				return nil, err
+			}
+			return proxyURLParsed, nil
+		} else if req.URL.Scheme == "https" && httpsProxy != "" {
+			proxyURLParsed, err := url.Parse(httpsProxy)
+			if err != nil {
+				return nil, err
+			}
+			return proxyURLParsed, nil
+		}
+
+		// Fall back to the default environment proxy settings
+		return http.ProxyFromEnvironment(req)
+	}
+}

--- a/core/internal/clients/proxy.go
+++ b/core/internal/clients/proxy.go
@@ -5,36 +5,21 @@ import (
 	"net/url"
 )
 
-// ProxyFn returns a function that returns a proxy URL for a given http.Request.
+// ProxyFn returns an http.Transport.Proxy function that routes requests
+// through httpProxy or httpsProxy based on the request scheme, falling back
+// to http.ProxyFromEnvironment when no custom proxy is configured.
 //
-// The function first checks if there's a custom proxy setting for the request
-// URL scheme. If not, it falls back to the default environment proxy settings.
-// If there is, it returns the custom proxy URL.
-//
-// This is useful if the user only want to proxy traffic to W&B, but not other traffic,
-// as the standard environment proxy settings would potentially proxy all traffic.
-//
-// The custom proxy URLs are passed as arguments to the function.
-//
-// The default environment proxy settings are read from the environment variables
-// HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
+// This lets callers proxy only W&B traffic; HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+// would otherwise route all traffic through the proxy.
 func ProxyFn(httpProxy, httpsProxy string) func(req *http.Request) (*url.URL, error) {
 	return func(req *http.Request) (*url.URL, error) {
-		if req.URL.Scheme == "http" && httpProxy != "" {
-			proxyURLParsed, err := url.Parse(httpProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURLParsed, nil
-		} else if req.URL.Scheme == "https" && httpsProxy != "" {
-			proxyURLParsed, err := url.Parse(httpsProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURLParsed, nil
+		switch {
+		case req.URL.Scheme == "http" && httpProxy != "":
+			return url.Parse(httpProxy)
+		case req.URL.Scheme == "https" && httpsProxy != "":
+			return url.Parse(httpsProxy)
+		default:
+			return http.ProxyFromEnvironment(req)
 		}
-
-		// Fall back to the default environment proxy settings
-		return http.ProxyFromEnvironment(req)
 	}
 }

--- a/core/internal/clients/proxy.go
+++ b/core/internal/clients/proxy.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 )
 
-// ProxyFn returns a function that returns a proxy URL for a given hhtp.Request.
+// ProxyFn returns a function that returns a proxy URL for a given http.Request.
 //
 // The function first checks if there's a custom proxy setting for the request
 // URL scheme. If not, it falls back to the default environment proxy settings.

--- a/core/internal/clients/proxy_test.go
+++ b/core/internal/clients/proxy_test.go
@@ -1,10 +1,10 @@
-package stream_test
+package clients_test
 
 import (
 	"net/http"
 	"testing"
 
-	"github.com/wandb/wandb/core/internal/stream"
+	"github.com/wandb/wandb/core/internal/clients"
 )
 
 func TestProxyFn(t *testing.T) {
@@ -66,7 +66,7 @@ func TestProxyFn(t *testing.T) {
 				t.Fatalf("http.NewRequest failed: %v", err)
 			}
 
-			proxyFn := stream.ProxyFn(tt.httpProxy, tt.httpsProxy)
+			proxyFn := clients.ProxyFn(tt.httpProxy, tt.httpsProxy)
 			proxyURL, err := proxyFn(req)
 
 			if tt.expectedError {

--- a/core/internal/gql/gql_client.go
+++ b/core/internal/gql/gql_client.go
@@ -1,0 +1,87 @@
+package gql
+
+import (
+	"fmt"
+	"maps"
+
+	"github.com/Khan/genqlient/graphql"
+
+	"github.com/wandb/wandb/core/internal/api"
+	"github.com/wandb/wandb/core/internal/clients"
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/sharedmode"
+)
+
+func NewGQLClient(
+	baseURL api.WBBaseURL,
+	clientID sharedmode.ClientID,
+	credentialProvider api.CredentialProvider,
+	logger *observability.CoreLogger,
+	peeker *observability.Peeker,
+	s *settings.Settings,
+) graphql.Client {
+	// TODO: This is used for the service account feature to associate the run
+	// with the specified user. Note that we are using environment variables
+	// here, instead of the settings object (which is ideally would be the only
+	// setting used). We are doing this because, the default setting populates
+	// the username with a value that not necessarily matches the username in
+	// our app. There is also a precedence issue, where if the username is set
+	// it will always be used, even if the email is set. Causing the owner of
+	// to be wrong.
+	// We should consider using the settings object here. But we need to make
+	// sure that the username setting is populated correctly. Leaving this as is
+	// for now just to avoid breakage in the service account feature.
+	graphqlHeaders := map[string]string{
+		"X-WANDB-USERNAME":   s.GetUserName(),
+		"X-WANDB-USER-EMAIL": s.GetEmail(),
+	}
+	maps.Copy(graphqlHeaders, s.GetExtraHTTPHeaders())
+	// This header is used to indicate to the backend that the run is in shared
+	// mode to prevent a race condition when two UpsertRun requests are made
+	// simultaneously for the same run ID in shared mode.
+	if s.IsSharedMode() {
+		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
+		graphqlHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
+	}
+	// When enabled, this header instructs the backend to compute the derived summary
+	// using history updates, instead of relying on the SDK to calculate and send it.
+	if s.IsEnableServerSideDerivedSummary() {
+		graphqlHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
+	}
+
+	opts := api.ClientOptions{
+		BaseURL:         baseURL,
+		RetryPolicy:     clients.CheckRetry,
+		RetryMax:        api.DefaultRetryMax,
+		RetryWaitMin:    api.DefaultRetryWaitMin,
+		RetryWaitMax:    api.DefaultRetryWaitMax,
+		NonRetryTimeout: api.DefaultNonRetryTimeout,
+		ExtraHeaders:    graphqlHeaders,
+		NetworkPeeker:   peeker,
+		Proxy: clients.ProxyFn(
+			s.GetHTTPProxy(),
+			s.GetHTTPSProxy(),
+		),
+		InsecureDisableSSL: s.IsInsecureDisableSSL(),
+		CredentialProvider: credentialProvider,
+		Logger:             logger.Logger,
+	}
+	if retryMax := s.GetGraphQLMaxRetries(); retryMax > 0 {
+		opts.RetryMax = int(retryMax)
+	}
+	if retryWaitMin := s.GetGraphQLRetryWaitMin(); retryWaitMin > 0 {
+		opts.RetryWaitMin = retryWaitMin
+	}
+	if retryWaitMax := s.GetGraphQLRetryWaitMax(); retryWaitMax > 0 {
+		opts.RetryWaitMax = retryWaitMax
+	}
+	if timeout := s.GetGraphQLTimeout(); timeout > 0 {
+		opts.NonRetryTimeout = timeout
+	}
+
+	httpClient := api.NewClient(opts)
+	endpoint := fmt.Sprintf("%s/graphql", s.GetBaseURL())
+
+	return graphql.NewClient(endpoint, api.AsStandardClient(httpClient))
+}

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -70,7 +70,10 @@ func NewGraphQLClient(
 		return nil
 	}
 
-	extraHeaders := make(map[string]string)
+	extraHeaders := map[string]string{
+		"X-WANDB-USERNAME":   s.GetUserName(),
+		"X-WANDB-USER-EMAIL": s.GetEmail(),
+	}
 	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
 
 	// This header is used to indicate to the backend that the run is in shared

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -5,16 +5,17 @@ package stream
 import (
 	"fmt"
 	"maps"
-	"net/http"
 	"net/url"
 
-	"github.com/Khan/genqlient/graphql"
 	"golang.org/x/time/rate"
+
+	"github.com/Khan/genqlient/graphql"
 
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/filetransfer"
+	"github.com/wandb/wandb/core/internal/gql"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
@@ -56,40 +57,9 @@ func CredentialsFromSettings(
 	return credentialProvider
 }
 
-// ProxyFn returns a function that returns a proxy URL for a given hhtp.Request.
+// NewGraphQLClient creates a new GraphQL client.
 //
-// The function first checks if there's a custom proxy setting for the request
-// URL scheme. If not, it falls back to the default environment proxy settings.
-// If there is, it returns the custom proxy URL.
-//
-// This is useful if the user only want to proxy traffic to W&B, but not other traffic,
-// as the standard environment proxy settings would potentially proxy all traffic.
-//
-// The custom proxy URLs are passed as arguments to the function.
-//
-// The default environment proxy settings are read from the environment variables
-// HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
-func ProxyFn(httpProxy, httpsProxy string) func(req *http.Request) (*url.URL, error) {
-	return func(req *http.Request) (*url.URL, error) {
-		if req.URL.Scheme == "http" && httpProxy != "" {
-			proxyURLParsed, err := url.Parse(httpProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURLParsed, nil
-		} else if req.URL.Scheme == "https" && httpsProxy != "" {
-			proxyURLParsed, err := url.Parse(httpsProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURLParsed, nil
-		}
-
-		// Fall back to the default environment proxy settings
-		return http.ProxyFromEnvironment(req)
-	}
-}
-
+// If the offline setting is true, it returns nil.
 func NewGraphQLClient(
 	baseURL api.WBBaseURL,
 	clientID sharedmode.ClientID,
@@ -102,66 +72,14 @@ func NewGraphQLClient(
 		return nil
 	}
 
-	// TODO: This is used for the service account feature to associate the run
-	// with the specified user. Note that we are using environment variables
-	// here, instead of the settings object (which is ideally would be the only
-	// setting used). We are doing this because, the default setting populates
-	// the username with a value that not necessarily matches the username in
-	// our app. There is also a precedence issue, where if the username is set
-	// it will always be used, even if the email is set. Causing the owner of
-	// to be wrong.
-	// We should consider using the settings object here. But we need to make
-	// sure that the username setting is populated correctly. Leaving this as is
-	// for now just to avoid breakage in the service account feature.
-	graphqlHeaders := map[string]string{
-		"X-WANDB-USERNAME":   s.GetUserName(),
-		"X-WANDB-USER-EMAIL": s.GetEmail(),
-	}
-	maps.Copy(graphqlHeaders, s.GetExtraHTTPHeaders())
-	// This header is used to indicate to the backend that the run is in shared
-	// mode to prevent a race condition when two UpsertRun requests are made
-	// simultaneously for the same run ID in shared mode.
-	if s.IsSharedMode() {
-		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
-		graphqlHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
-	}
-	// When enabled, this header instructs the backend to compute the derived summary
-	// using history updates, instead of relying on the SDK to calculate and send it.
-	if s.IsEnableServerSideDerivedSummary() {
-		graphqlHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
-	}
-
-	opts := api.ClientOptions{
-		BaseURL:            baseURL,
-		RetryPolicy:        clients.CheckRetry,
-		RetryMax:           api.DefaultRetryMax,
-		RetryWaitMin:       api.DefaultRetryWaitMin,
-		RetryWaitMax:       api.DefaultRetryWaitMax,
-		NonRetryTimeout:    api.DefaultNonRetryTimeout,
-		ExtraHeaders:       graphqlHeaders,
-		NetworkPeeker:      peeker,
-		Proxy:              ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
-		InsecureDisableSSL: s.IsInsecureDisableSSL(),
-		CredentialProvider: credentialProvider,
-		Logger:             logger.Logger,
-	}
-	if retryMax := s.GetGraphQLMaxRetries(); retryMax > 0 {
-		opts.RetryMax = int(retryMax)
-	}
-	if retryWaitMin := s.GetGraphQLRetryWaitMin(); retryWaitMin > 0 {
-		opts.RetryWaitMin = retryWaitMin
-	}
-	if retryWaitMax := s.GetGraphQLRetryWaitMax(); retryWaitMax > 0 {
-		opts.RetryWaitMax = retryWaitMax
-	}
-	if timeout := s.GetGraphQLTimeout(); timeout > 0 {
-		opts.NonRetryTimeout = timeout
-	}
-
-	httpClient := api.NewClient(opts)
-	endpoint := fmt.Sprintf("%s/graphql", s.GetBaseURL())
-
-	return graphql.NewClient(endpoint, api.AsStandardClient(httpClient))
+	return gql.NewGQLClient(
+		baseURL,
+		clientID,
+		credentialProvider,
+		logger,
+		peeker,
+		s,
+	)
 }
 
 func NewFileStream(
@@ -189,15 +107,18 @@ func NewFileStream(
 	}
 
 	opts := api.ClientOptions{
-		BaseURL:            baseURL,
-		RetryPolicy:        clients.RetryMostFailures,
-		RetryMax:           filestream.DefaultRetryMax,
-		RetryWaitMin:       filestream.DefaultRetryWaitMin,
-		RetryWaitMax:       filestream.DefaultRetryWaitMax,
-		NonRetryTimeout:    filestream.DefaultNonRetryTimeout,
-		ExtraHeaders:       fileStreamHeaders,
-		NetworkPeeker:      peeker,
-		Proxy:              ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
+		BaseURL:         baseURL,
+		RetryPolicy:     clients.RetryMostFailures,
+		RetryMax:        filestream.DefaultRetryMax,
+		RetryWaitMin:    filestream.DefaultRetryWaitMin,
+		RetryWaitMax:    filestream.DefaultRetryWaitMax,
+		NonRetryTimeout: filestream.DefaultNonRetryTimeout,
+		ExtraHeaders:    fileStreamHeaders,
+		NetworkPeeker:   peeker,
+		Proxy: clients.ProxyFn(
+			s.GetHTTPProxy(),
+			s.GetHTTPSProxy(),
+		),
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 		CredentialProvider: credentialProvider,
 		Logger:             logger.Logger,
@@ -250,7 +171,10 @@ func NewFileTransferManager(
 		RetryWaitMax:    filetransfer.DefaultRetryWaitMax,
 		NonRetryTimeout: filetransfer.DefaultNonRetryTimeout,
 
-		Proxy: ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
+		Proxy: clients.ProxyFn(
+			s.GetHTTPProxy(),
+			s.GetHTTPSProxy(),
+		),
 
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -5,7 +5,6 @@ package stream
 import (
 	"fmt"
 	"maps"
-	"net/http"
 	"net/url"
 
 	"github.com/Khan/genqlient/graphql"
@@ -56,40 +55,9 @@ func CredentialsFromSettings(
 	return credentialProvider
 }
 
-// ProxyFn returns a function that returns a proxy URL for a given hhtp.Request.
+// NewGraphQLClient creates a new GraphQL client.
 //
-// The function first checks if there's a custom proxy setting for the request
-// URL scheme. If not, it falls back to the default environment proxy settings.
-// If there is, it returns the custom proxy URL.
-//
-// This is useful if the user only want to proxy traffic to W&B, but not other traffic,
-// as the standard environment proxy settings would potentially proxy all traffic.
-//
-// The custom proxy URLs are passed as arguments to the function.
-//
-// The default environment proxy settings are read from the environment variables
-// HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
-func ProxyFn(httpProxy, httpsProxy string) func(req *http.Request) (*url.URL, error) {
-	return func(req *http.Request) (*url.URL, error) {
-		if req.URL.Scheme == "http" && httpProxy != "" {
-			proxyURLParsed, err := url.Parse(httpProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURLParsed, nil
-		} else if req.URL.Scheme == "https" && httpsProxy != "" {
-			proxyURLParsed, err := url.Parse(httpsProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURLParsed, nil
-		}
-
-		// Fall back to the default environment proxy settings
-		return http.ProxyFromEnvironment(req)
-	}
-}
-
+// If the offline setting is true, it returns nil.
 func NewGraphQLClient(
 	baseURL api.WBBaseURL,
 	clientID sharedmode.ClientID,
@@ -102,66 +70,34 @@ func NewGraphQLClient(
 		return nil
 	}
 
-	// TODO: This is used for the service account feature to associate the run
-	// with the specified user. Note that we are using environment variables
-	// here, instead of the settings object (which is ideally would be the only
-	// setting used). We are doing this because, the default setting populates
-	// the username with a value that not necessarily matches the username in
-	// our app. There is also a precedence issue, where if the username is set
-	// it will always be used, even if the email is set. Causing the owner of
-	// to be wrong.
-	// We should consider using the settings object here. But we need to make
-	// sure that the username setting is populated correctly. Leaving this as is
-	// for now just to avoid breakage in the service account feature.
-	graphqlHeaders := map[string]string{
+	extraHeaders := map[string]string{
 		"X-WANDB-USERNAME":   s.GetUserName(),
 		"X-WANDB-USER-EMAIL": s.GetEmail(),
 	}
-	maps.Copy(graphqlHeaders, s.GetExtraHTTPHeaders())
+	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
+
 	// This header is used to indicate to the backend that the run is in shared
 	// mode to prevent a race condition when two UpsertRun requests are made
 	// simultaneously for the same run ID in shared mode.
 	if s.IsSharedMode() {
-		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
-		graphqlHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
+		extraHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
+		extraHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
 	}
 	// When enabled, this header instructs the backend to compute the derived summary
 	// using history updates, instead of relying on the SDK to calculate and send it.
 	if s.IsEnableServerSideDerivedSummary() {
-		graphqlHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
+		extraHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
 	}
 
-	opts := api.ClientOptions{
-		BaseURL:            baseURL,
-		RetryPolicy:        clients.CheckRetry,
-		RetryMax:           api.DefaultRetryMax,
-		RetryWaitMin:       api.DefaultRetryWaitMin,
-		RetryWaitMax:       api.DefaultRetryWaitMax,
-		NonRetryTimeout:    api.DefaultNonRetryTimeout,
-		ExtraHeaders:       graphqlHeaders,
-		NetworkPeeker:      peeker,
-		Proxy:              ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
-		InsecureDisableSSL: s.IsInsecureDisableSSL(),
-		CredentialProvider: credentialProvider,
-		Logger:             logger.Logger,
-	}
-	if retryMax := s.GetGraphQLMaxRetries(); retryMax > 0 {
-		opts.RetryMax = int(retryMax)
-	}
-	if retryWaitMin := s.GetGraphQLRetryWaitMin(); retryWaitMin > 0 {
-		opts.RetryWaitMin = retryWaitMin
-	}
-	if retryWaitMax := s.GetGraphQLRetryWaitMax(); retryWaitMax > 0 {
-		opts.RetryWaitMax = retryWaitMax
-	}
-	if timeout := s.GetGraphQLTimeout(); timeout > 0 {
-		opts.NonRetryTimeout = timeout
-	}
-
-	httpClient := api.NewClient(opts)
-	endpoint := fmt.Sprintf("%s/graphql", s.GetBaseURL())
-
-	return graphql.NewClient(endpoint, api.AsStandardClient(httpClient))
+	return api.NewGQLClient(
+		baseURL,
+		clientID,
+		credentialProvider,
+		logger.Logger,
+		peeker,
+		s,
+		extraHeaders,
+	)
 }
 
 func NewFileStream(
@@ -189,15 +125,18 @@ func NewFileStream(
 	}
 
 	opts := api.ClientOptions{
-		BaseURL:            baseURL,
-		RetryPolicy:        clients.RetryMostFailures,
-		RetryMax:           filestream.DefaultRetryMax,
-		RetryWaitMin:       filestream.DefaultRetryWaitMin,
-		RetryWaitMax:       filestream.DefaultRetryWaitMax,
-		NonRetryTimeout:    filestream.DefaultNonRetryTimeout,
-		ExtraHeaders:       fileStreamHeaders,
-		NetworkPeeker:      peeker,
-		Proxy:              ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
+		BaseURL:         baseURL,
+		RetryPolicy:     clients.RetryMostFailures,
+		RetryMax:        filestream.DefaultRetryMax,
+		RetryWaitMin:    filestream.DefaultRetryWaitMin,
+		RetryWaitMax:    filestream.DefaultRetryWaitMax,
+		NonRetryTimeout: filestream.DefaultNonRetryTimeout,
+		ExtraHeaders:    fileStreamHeaders,
+		NetworkPeeker:   peeker,
+		Proxy: clients.ProxyFn(
+			s.GetHTTPProxy(),
+			s.GetHTTPSProxy(),
+		),
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 		CredentialProvider: credentialProvider,
 		Logger:             logger.Logger,
@@ -250,7 +189,10 @@ func NewFileTransferManager(
 		RetryWaitMax:    filetransfer.DefaultRetryWaitMax,
 		NonRetryTimeout: filetransfer.DefaultNonRetryTimeout,
 
-		Proxy: ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
+		Proxy: clients.ProxyFn(
+			s.GetHTTPProxy(),
+			s.GetHTTPSProxy(),
+		),
 
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -7,9 +7,8 @@ import (
 	"maps"
 	"net/url"
 
-	"golang.org/x/time/rate"
-
 	"github.com/Khan/genqlient/graphql"
+	"golang.org/x/time/rate"
 
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/clients"

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -70,10 +70,7 @@ func NewGraphQLClient(
 		return nil
 	}
 
-	extraHeaders := map[string]string{
-		"X-WANDB-USERNAME":   s.GetUserName(),
-		"X-WANDB-USER-EMAIL": s.GetEmail(),
-	}
+	extraHeaders := make(map[string]string)
 	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
 
 	// This header is used to indicate to the backend that the run is in shared

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -5,6 +5,7 @@ package stream
 import (
 	"fmt"
 	"maps"
+	"net/http"
 	"net/url"
 
 	"github.com/Khan/genqlient/graphql"
@@ -55,9 +56,40 @@ func CredentialsFromSettings(
 	return credentialProvider
 }
 
-// NewGraphQLClient creates a new GraphQL client.
+// ProxyFn returns a function that returns a proxy URL for a given hhtp.Request.
 //
-// If the offline setting is true, it returns nil.
+// The function first checks if there's a custom proxy setting for the request
+// URL scheme. If not, it falls back to the default environment proxy settings.
+// If there is, it returns the custom proxy URL.
+//
+// This is useful if the user only want to proxy traffic to W&B, but not other traffic,
+// as the standard environment proxy settings would potentially proxy all traffic.
+//
+// The custom proxy URLs are passed as arguments to the function.
+//
+// The default environment proxy settings are read from the environment variables
+// HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
+func ProxyFn(httpProxy, httpsProxy string) func(req *http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		if req.URL.Scheme == "http" && httpProxy != "" {
+			proxyURLParsed, err := url.Parse(httpProxy)
+			if err != nil {
+				return nil, err
+			}
+			return proxyURLParsed, nil
+		} else if req.URL.Scheme == "https" && httpsProxy != "" {
+			proxyURLParsed, err := url.Parse(httpsProxy)
+			if err != nil {
+				return nil, err
+			}
+			return proxyURLParsed, nil
+		}
+
+		// Fall back to the default environment proxy settings
+		return http.ProxyFromEnvironment(req)
+	}
+}
+
 func NewGraphQLClient(
 	baseURL api.WBBaseURL,
 	clientID sharedmode.ClientID,
@@ -70,34 +102,66 @@ func NewGraphQLClient(
 		return nil
 	}
 
-	extraHeaders := map[string]string{
+	// TODO: This is used for the service account feature to associate the run
+	// with the specified user. Note that we are using environment variables
+	// here, instead of the settings object (which is ideally would be the only
+	// setting used). We are doing this because, the default setting populates
+	// the username with a value that not necessarily matches the username in
+	// our app. There is also a precedence issue, where if the username is set
+	// it will always be used, even if the email is set. Causing the owner of
+	// to be wrong.
+	// We should consider using the settings object here. But we need to make
+	// sure that the username setting is populated correctly. Leaving this as is
+	// for now just to avoid breakage in the service account feature.
+	graphqlHeaders := map[string]string{
 		"X-WANDB-USERNAME":   s.GetUserName(),
 		"X-WANDB-USER-EMAIL": s.GetEmail(),
 	}
-	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
-
+	maps.Copy(graphqlHeaders, s.GetExtraHTTPHeaders())
 	// This header is used to indicate to the backend that the run is in shared
 	// mode to prevent a race condition when two UpsertRun requests are made
 	// simultaneously for the same run ID in shared mode.
 	if s.IsSharedMode() {
-		extraHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
-		extraHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
+		graphqlHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
+		graphqlHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
 	}
 	// When enabled, this header instructs the backend to compute the derived summary
 	// using history updates, instead of relying on the SDK to calculate and send it.
 	if s.IsEnableServerSideDerivedSummary() {
-		extraHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
+		graphqlHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
 	}
 
-	return api.NewGQLClient(
-		baseURL,
-		clientID,
-		credentialProvider,
-		logger.Logger,
-		peeker,
-		s,
-		extraHeaders,
-	)
+	opts := api.ClientOptions{
+		BaseURL:            baseURL,
+		RetryPolicy:        clients.CheckRetry,
+		RetryMax:           api.DefaultRetryMax,
+		RetryWaitMin:       api.DefaultRetryWaitMin,
+		RetryWaitMax:       api.DefaultRetryWaitMax,
+		NonRetryTimeout:    api.DefaultNonRetryTimeout,
+		ExtraHeaders:       graphqlHeaders,
+		NetworkPeeker:      peeker,
+		Proxy:              ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
+		InsecureDisableSSL: s.IsInsecureDisableSSL(),
+		CredentialProvider: credentialProvider,
+		Logger:             logger.Logger,
+	}
+	if retryMax := s.GetGraphQLMaxRetries(); retryMax > 0 {
+		opts.RetryMax = int(retryMax)
+	}
+	if retryWaitMin := s.GetGraphQLRetryWaitMin(); retryWaitMin > 0 {
+		opts.RetryWaitMin = retryWaitMin
+	}
+	if retryWaitMax := s.GetGraphQLRetryWaitMax(); retryWaitMax > 0 {
+		opts.RetryWaitMax = retryWaitMax
+	}
+	if timeout := s.GetGraphQLTimeout(); timeout > 0 {
+		opts.NonRetryTimeout = timeout
+	}
+
+	httpClient := api.NewClient(opts)
+	endpoint := fmt.Sprintf("%s/graphql", s.GetBaseURL())
+
+	return graphql.NewClient(endpoint, api.AsStandardClient(httpClient))
 }
 
 func NewFileStream(
@@ -125,18 +189,15 @@ func NewFileStream(
 	}
 
 	opts := api.ClientOptions{
-		BaseURL:         baseURL,
-		RetryPolicy:     clients.RetryMostFailures,
-		RetryMax:        filestream.DefaultRetryMax,
-		RetryWaitMin:    filestream.DefaultRetryWaitMin,
-		RetryWaitMax:    filestream.DefaultRetryWaitMax,
-		NonRetryTimeout: filestream.DefaultNonRetryTimeout,
-		ExtraHeaders:    fileStreamHeaders,
-		NetworkPeeker:   peeker,
-		Proxy: clients.ProxyFn(
-			s.GetHTTPProxy(),
-			s.GetHTTPSProxy(),
-		),
+		BaseURL:            baseURL,
+		RetryPolicy:        clients.RetryMostFailures,
+		RetryMax:           filestream.DefaultRetryMax,
+		RetryWaitMin:       filestream.DefaultRetryWaitMin,
+		RetryWaitMax:       filestream.DefaultRetryWaitMax,
+		NonRetryTimeout:    filestream.DefaultNonRetryTimeout,
+		ExtraHeaders:       fileStreamHeaders,
+		NetworkPeeker:      peeker,
+		Proxy:              ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 		CredentialProvider: credentialProvider,
 		Logger:             logger.Logger,
@@ -189,10 +250,7 @@ func NewFileTransferManager(
 		RetryWaitMax:    filetransfer.DefaultRetryWaitMax,
 		NonRetryTimeout: filetransfer.DefaultNonRetryTimeout,
 
-		Proxy: clients.ProxyFn(
-			s.GetHTTPProxy(),
-			s.GetHTTPSProxy(),
-		),
+		Proxy: ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
 
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -14,7 +14,6 @@ import (
 	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/filetransfer"
-	"github.com/wandb/wandb/core/internal/gql"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
@@ -71,13 +70,30 @@ func NewGraphQLClient(
 		return nil
 	}
 
-	return gql.NewGQLClient(
+	extraHeaders := make(map[string]string)
+	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
+
+	// This header is used to indicate to the backend that the run is in shared
+	// mode to prevent a race condition when two UpsertRun requests are made
+	// simultaneously for the same run ID in shared mode.
+	if s.IsSharedMode() {
+		extraHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
+		extraHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
+	}
+	// When enabled, this header instructs the backend to compute the derived summary
+	// using history updates, instead of relying on the SDK to calculate and send it.
+	if s.IsEnableServerSideDerivedSummary() {
+		extraHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
+	}
+
+	return api.NewGQLClient(
 		baseURL,
 		clientID,
 		credentialProvider,
-		logger,
+		logger.Logger,
 		peeker,
 		s,
+		extraHeaders,
 	)
 }
 

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -7,13 +7,16 @@ package wbapi
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
 
+	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/featurechecker"
+	"github.com/wandb/wandb/core/internal/gql"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/stream"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -36,10 +39,20 @@ type WandbAPI struct {
 
 // New returns a new WandbAPI.
 func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
-	baseURL := stream.BaseURLFromSettings(logger, s)
-	credentialProvider := stream.CredentialsFromSettings(logger, s)
-	graphqlClient := stream.NewGraphQLClient(
-		baseURL,
+	baseURL, err := url.Parse(s.GetBaseURL())
+	if err != nil {
+		logger.CaptureFatalAndPanic(
+			fmt.Errorf("parsing base URL: %v", err))
+	}
+
+	credentialProvider, err := api.NewCredentialProvider(s, logger.Logger)
+	if err != nil {
+		logger.CaptureFatalAndPanic(
+			fmt.Errorf("creating credential provider: %v", err))
+	}
+
+	graphqlClient := gql.NewGQLClient(
+		api.WBBaseURL(baseURL),
 		"", /*clientID*/
 		credentialProvider,
 		logger,

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -7,16 +7,13 @@ package wbapi
 
 import (
 	"context"
-	"fmt"
-	"maps"
-	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/featurechecker"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/stream"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -39,32 +36,15 @@ type WandbAPI struct {
 
 // New returns a new WandbAPI.
 func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
-	baseURL, err := url.Parse(s.GetBaseURL())
-	if err != nil {
-		logger.CaptureFatalAndPanic(
-			fmt.Errorf("parsing base URL: %v", err))
-	}
-
-	credentialProvider, err := api.NewCredentialProvider(s, logger.Logger)
-	if err != nil {
-		logger.CaptureFatalAndPanic(
-			fmt.Errorf("creating credential provider: %v", err))
-	}
-
-	extraHeaders := map[string]string{
-		"X-WANDB-USERNAME":   s.GetUserName(),
-		"X-WANDB-USER-EMAIL": s.GetEmail(),
-	}
-	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
-
-	graphqlClient := api.NewGQLClient(
-		api.WBBaseURL(baseURL),
+	baseURL := stream.BaseURLFromSettings(logger, s)
+	credentialProvider := stream.CredentialsFromSettings(logger, s)
+	graphqlClient := stream.NewGraphQLClient(
+		baseURL,
 		"", /*clientID*/
 		credentialProvider,
-		logger.Logger,
+		logger,
 		&observability.Peeker{},
 		s,
-		extraHeaders,
 	)
 
 	httpClient := retryablehttp.NewClient()

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/featurechecker"
-	"github.com/wandb/wandb/core/internal/gql"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -51,13 +50,14 @@ func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 			fmt.Errorf("creating credential provider: %v", err))
 	}
 
-	graphqlClient := gql.NewGQLClient(
+	graphqlClient := api.NewGQLClient(
 		api.WBBaseURL(baseURL),
 		"", /*clientID*/
 		credentialProvider,
-		logger,
+		logger.Logger,
 		&observability.Peeker{},
 		s,
+		s.GetExtraHTTPHeaders(),
 	)
 
 	httpClient := retryablehttp.NewClient()

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -7,13 +7,16 @@ package wbapi
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
 
+	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/featurechecker"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
-	"github.com/wandb/wandb/core/internal/stream"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -36,15 +39,32 @@ type WandbAPI struct {
 
 // New returns a new WandbAPI.
 func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
-	baseURL := stream.BaseURLFromSettings(logger, s)
-	credentialProvider := stream.CredentialsFromSettings(logger, s)
-	graphqlClient := stream.NewGraphQLClient(
-		baseURL,
+	baseURL, err := url.Parse(s.GetBaseURL())
+	if err != nil {
+		logger.CaptureFatalAndPanic(
+			fmt.Errorf("parsing base URL: %v", err))
+	}
+
+	credentialProvider, err := api.NewCredentialProvider(s, logger.Logger)
+	if err != nil {
+		logger.CaptureFatalAndPanic(
+			fmt.Errorf("creating credential provider: %v", err))
+	}
+
+	extraHeaders := map[string]string{
+		"X-WANDB-USERNAME":   s.GetUserName(),
+		"X-WANDB-USER-EMAIL": s.GetEmail(),
+	}
+	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
+
+	graphqlClient := api.NewGQLClient(
+		api.WBBaseURL(baseURL),
 		"", /*clientID*/
 		credentialProvider,
-		logger,
+		logger.Logger,
 		&observability.Peeker{},
 		s,
+		extraHeaders,
 	)
 
 	httpClient := retryablehttp.NewClient()

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -37,17 +37,18 @@ type WandbAPI struct {
 }
 
 // New returns a new WandbAPI.
-func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
+func New(
+	s *settings.Settings,
+	logger *observability.CoreLogger,
+) (*WandbAPI, error) {
 	baseURL, err := url.Parse(s.GetBaseURL())
 	if err != nil {
-		logger.CaptureFatalAndPanic(
-			fmt.Errorf("parsing base URL: %v", err))
+		return nil, fmt.Errorf("error parsing base URL: %v", err)
 	}
 
 	credentialProvider, err := api.NewCredentialProvider(s, logger.Logger)
 	if err != nil {
-		logger.CaptureFatalAndPanic(
-			fmt.Errorf("creating credential provider: %v", err))
+		return nil, fmt.Errorf("error reading credentials: %v", err)
 	}
 
 	graphqlClient := api.NewGQLClient(
@@ -75,7 +76,7 @@ func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 
 		featuresHandler:      NewFeaturesHandler(featureProvider),
 		runHistoryApiHandler: NewRunHistoryAPIHandler(graphqlClient, httpClient),
-	}
+	}, nil
 }
 
 // HandleRequest handles an API request and returns an API response,

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -8,6 +8,7 @@ package wbapi
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -50,6 +51,12 @@ func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 			fmt.Errorf("creating credential provider: %v", err))
 	}
 
+	extraHeaders := map[string]string{
+		"X-WANDB-USERNAME":   s.GetUserName(),
+		"X-WANDB-USER-EMAIL": s.GetEmail(),
+	}
+	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
+
 	graphqlClient := api.NewGQLClient(
 		api.WBBaseURL(baseURL),
 		"", /*clientID*/
@@ -57,7 +64,7 @@ func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 		logger.Logger,
 		&observability.Peeker{},
 		s,
-		s.GetExtraHTTPHeaders(),
+		extraHeaders,
 	)
 
 	httpClient := retryablehttp.NewClient()

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -8,7 +8,6 @@ package wbapi
 import (
 	"context"
 	"fmt"
-	"maps"
 	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -51,12 +50,6 @@ func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 			fmt.Errorf("creating credential provider: %v", err))
 	}
 
-	extraHeaders := map[string]string{
-		"X-WANDB-USERNAME":   s.GetUserName(),
-		"X-WANDB-USER-EMAIL": s.GetEmail(),
-	}
-	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
-
 	graphqlClient := api.NewGQLClient(
 		api.WBBaseURL(baseURL),
 		"", /*clientID*/
@@ -64,7 +57,7 @@ func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 		logger.Logger,
 		&observability.Peeker{},
 		s,
-		extraHeaders,
+		s.GetExtraHTTPHeaders(),
 	)
 
 	httpClient := retryablehttp.NewClient()

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -662,7 +662,20 @@ func (nc *Connection) handleSyncStatus(
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	s := settings.From(request.GetSettings())
 	logger := observability.NewCoreLogger(slog.Default(), nil)
-	wbapiInstance := wbapi.New(s, logger)
+	wbapiInstance, err := wbapi.New(s, logger)
+	if err != nil {
+		nc.Respond(&spb.ServerResponse{
+			RequestId: id,
+			ServerResponseType: &spb.ServerResponse_ErrorResponse{
+				ErrorResponse: &spb.ServerErrorResponse{
+					Message: err.Error(),
+				},
+			},
+		})
+
+		return
+	}
+
 	wbApiId := nc.apiManager.AddWandbAPI(wbapiInstance)
 
 	nc.Respond(&spb.ServerResponse{

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,7 @@ def env_teardown():
 
 @pytest.fixture(scope="function", autouse=True)
 def clean_up():
+    wandb.teardown()
     yield
     wandb.teardown()
 

--- a/tests/system_tests/test_api/test_service_api.py
+++ b/tests/system_tests/test_api/test_service_api.py
@@ -1,4 +1,3 @@
-import pytest
 from wandb.apis.public.service_api import ServiceApi
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk import wandb_setup
@@ -69,20 +68,3 @@ def test_feature_flags_error(wandb_backend_spy: WandbBackendSpy):
     enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
 
     assert not enabled
-
-
-@pytest.mark.skip(reason="Temporarily reverted wbapi offline fix to isolate CI flakes")
-def test_feature_flags__ignores_offline_mode(
-    wandb_backend_spy,
-    monkeypatch,
-):
-    monkeypatch.setenv("WANDB_MODE", "offline")
-    stub_server_features_query(
-        wandb_backend_spy,
-        enabled=[pb.ServerFeature.CLIENT_IDS],
-    )
-
-    api = ServiceApi(wandb_setup.singleton().settings)
-    enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
-
-    assert enabled

--- a/tests/system_tests/test_api/test_service_api.py
+++ b/tests/system_tests/test_api/test_service_api.py
@@ -68,3 +68,19 @@ def test_feature_flags_error(wandb_backend_spy: WandbBackendSpy):
     enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
 
     assert not enabled
+
+
+def test_feature_flags__ignores_offline_mode(
+    wandb_backend_spy,
+    monkeypatch,
+):
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    stub_server_features_query(
+        wandb_backend_spy,
+        enabled=[pb.ServerFeature.CLIENT_IDS],
+    )
+
+    api = ServiceApi(wandb_setup.singleton().settings)
+    enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
+
+    assert enabled

--- a/tests/system_tests/test_api/test_service_api.py
+++ b/tests/system_tests/test_api/test_service_api.py
@@ -1,3 +1,4 @@
+import pytest
 from wandb.apis.public.service_api import ServiceApi
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk import wandb_setup
@@ -70,6 +71,7 @@ def test_feature_flags_error(wandb_backend_spy: WandbBackendSpy):
     assert not enabled
 
 
+@pytest.mark.skip(reason="Temporarily reverted wbapi offline fix to isolate CI flakes")
 def test_feature_flags__ignores_offline_mode(
     wandb_backend_spy,
     monkeypatch,

--- a/tests/system_tests/test_api/test_service_api.py
+++ b/tests/system_tests/test_api/test_service_api.py
@@ -68,3 +68,21 @@ def test_feature_flags_error(wandb_backend_spy: WandbBackendSpy):
     enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
 
     assert not enabled
+
+
+def test_feature_flags__ignores_offline_mode(
+    wandb_backend_spy: WandbBackendSpy,
+    monkeypatch,
+):
+    """Verify that ServiceApi.feature_enabled works even in offline mode."""
+    stub_server_features_query(
+        wandb_backend_spy,
+        enabled=[pb.ServerFeature.CLIENT_IDS],
+    )
+
+    monkeypatch.setenv("WANDB_MODE", "offline")
+
+    api = ServiceApi(wandb_setup.singleton().settings)
+    enabled = api.feature_enabled(pb.ServerFeature.CLIENT_IDS)
+
+    assert enabled


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do?

This PR fixes a bug when initializing a wbapi.go instance, the `mode` setting is being used. This can cause issues when creating a `wandb.Api` instance after the service has been setup in `offline` mode breaking an GraphQL requests from sending.

After this PR `wbapi.go` ignores the `mode` setting which, since offline mode for an Api instance doesn't make sense.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [ ] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

```python
import os

import wandb

os.environ["WANDB_MODE"] = "offline"
run = wandb.init(mode="offline")
run.log({"metric": 1.0})
run.finish()
api = wandb.Api()
regs = api.registries().collections().versions()
```

### After

```bash
❯ python repro_offline_to_online_api.py
wandb: Tracking run with wandb version 0.26.1.dev1
wandb: W&B syncing is set to `offline` in this directory. Run `wandb online` or set WANDB_MODE=online to enable cloud syncing.
wandb: Run data is saved locally in /Users/jacob.romero/workspace/wandb/wandb/offline-run-20260421_130206-s44rmmcx
wandb:
wandb: Run history:
wandb: metric ▁
wandb:
wandb: Run summary:
wandb: metric 1
wandb:
wandb: You can sync this run to the cloud by running:
wandb: wandb sync /Users/jacob.romero/workspace/wandb/wandb/offline-run-20260421_130206-s44rmmcx
wandb: Find logs at: ./wandb/offline-run-20260421_130206-s44rmmcx/logs
wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from /Users/jacob.romero/.netrc.
```

### Before

```bash
❯ python repro_offline_to_online_api.py
wandb: Tracking run with wandb version 0.26.1.dev1
wandb: W&B syncing is set to `offline` in this directory. Run `wandb online` or set WANDB_MODE=online to enable cloud syncing.
wandb: Run data is saved locally in /Users/jacob.romero/workspace/wandb/wandb/offline-run-20260421_130253-3ertw7tm
wandb:
wandb: Run history:
wandb: metric ▁
wandb:
wandb: Run summary:
wandb: metric 1
wandb:
wandb: You can sync this run to the cloud by running:
wandb: wandb sync /Users/jacob.romero/workspace/wandb/wandb/offline-run-20260421_130253-3ertw7tm
wandb: Find logs at: ./wandb/offline-run-20260421_130253-3ertw7tm/logs
wandb: [wandb.Api()] Loaded credentials for https://api.wandb.ai from /Users/jacob.romero/.netrc.
Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/wandb/repro_offline_to_online_api.py", line 10, in <module>
    regs = api.registries().collections().versions()
           ^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/_analytics.py", line 56, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/workspace/wandb/wandb/apis/public/api.py", line 1878, in registries
    raise RuntimeError(
RuntimeError: Registry search API is not enabled on this wandb server version. Please upgrade your server version or contact support at support@wandb.com.

```