### PR TITLE
fix: do not crash wandb-core when failing to create a wbapi instance

### DIFF
--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -37,17 +37,18 @@ type WandbAPI struct {
 }
 
 // New returns a new WandbAPI.
-func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
+func New(
+	s *settings.Settings,
+	logger *observability.CoreLogger,
+) (*WandbAPI, error) {
 	baseURL, err := url.Parse(s.GetBaseURL())
 	if err != nil {
-		logger.CaptureFatalAndPanic(
-			fmt.Errorf("parsing base URL: %v", err))
+		return nil, fmt.Errorf("error parsing base URL: %v", err)
 	}
 
 	credentialProvider, err := api.NewCredentialProvider(s, logger.Logger)
 	if err != nil {
-		logger.CaptureFatalAndPanic(
-			fmt.Errorf("creating credential provider: %v", err))
+		return nil, fmt.Errorf("error reading credentials: %v", err)
 	}
 
 	graphqlClient := api.NewGQLClient(
@@ -75,7 +76,7 @@ func New(s *settings.Settings, logger *observability.CoreLogger) *WandbAPI {
 
 		featuresHandler:      NewFeaturesHandler(featureProvider),
 		runHistoryApiHandler: NewRunHistoryAPIHandler(graphqlClient, httpClient),
-	}
+	}, nil
 }
 
 // HandleRequest handles an API request and returns an API response,

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -662,7 +662,20 @@ func (nc *Connection) handleSyncStatus(
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	s := settings.From(request.GetSettings())
 	logger := observability.NewCoreLogger(slog.Default(), nil)
-	wbapiInstance := wbapi.New(s, logger)
+	wbapiInstance, err := wbapi.New(s, logger)
+	if err != nil {
+		nc.Respond(&spb.ServerResponse{
+			RequestId: id,
+			ServerResponseType: &spb.ServerResponse_ErrorResponse{
+				ErrorResponse: &spb.ServerErrorResponse{
+					Message: err.Error(),
+				},
+			},
+		})
+
+		return
+	}
+
 	wbApiId := nc.apiManager.AddWandbAPI(wbapiInstance)
 
 	nc.Respond(&spb.ServerResponse{


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Fixes the `wbapi.New` function to return an error in the event that it cannot create a new instance, rather than crashing. The error is then propagated back to the client.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
