### PR TITLE
feat: stop_fn setting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Added
 
 - `Api` methods returning artifacts, registries, automations, and related paginators now accept an optional `start` argument to resume iteration from a saved cursor (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11651)
+- The `stop_fn` setting to customize how a run is stopped (@timoffex in https://github.com/wandb/wandb/pull/11773)
+  - Allows overriding the default of sending a SIGINT to the Python process
 
 ### Fixed
 

--- a/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
+++ b/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
@@ -6,11 +6,15 @@ import sys
 import time
 
 import wandb
+import wandb.sdk.wandb_run
 
 if __name__ == "__main__":
     # The stop status is delivered via a FileStream response.
     settings = wandb.Settings(x_file_stream_transmit_interval=0.1)
     start_time: float | None = None
+
+    # Use a faster polling interval to speed up the test.
+    wandb.sdk.wandb_run._STOP_POLLING_INTERVAL = 0.1
 
     try:
         with wandb.init(settings=settings):

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -1,10 +1,14 @@
 import pathlib
 import subprocess
+import threading
+
+import pytest
+import wandb
 
 from tests.fixtures.wandb_backend_spy import WandbBackendSpy
 
 
-def test_run_stops_if_asked(wandb_backend_spy: WandbBackendSpy):
+def test_run_stop_interrupts(wandb_backend_spy: WandbBackendSpy):
     wandb_backend_spy.stub_filestream(
         {"stopped": True},
         status=200,
@@ -12,3 +16,18 @@ def test_run_stops_if_asked(wandb_backend_spy: WandbBackendSpy):
 
     script = pathlib.Path(__file__).parent / "pass_if_interrupted.py"
     subprocess.check_call(["python", str(script)])
+
+
+def test_uses_stop_fn(
+    monkeypatch: pytest.MonkeyPatch,
+    wandb_backend_spy: WandbBackendSpy,
+):
+    monkeypatch.setattr("wandb.sdk.wandb_run._STOP_POLLING_INTERVAL", 0.1)
+    stopped = threading.Event()
+    wandb_backend_spy.stub_filestream(
+        {"stopped": True},
+        status=200,
+    )
+
+    with wandb.init(settings=wandb.Settings(stop_fn=stopped.set)):
+        assert stopped.wait(timeout=30)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -136,6 +136,8 @@ logger = logging.getLogger("wandb")
 EXIT_TIMEOUT = 60
 RE_LABEL = re.compile(r"[a-zA-Z0-9_-]+$")
 
+_STOP_POLLING_INTERVAL = 15
+
 
 class TeardownStage(IntEnum):
     EARLY = 1
@@ -167,13 +169,11 @@ class RunStatusChecker:
         run_id: str,
         interface: InterfaceBase,
         settings: Settings,
-        stop_polling_interval: int = 15,
         retry_polling_interval: int = 5,
         internal_messages_polling_interval: int = 10,
     ) -> None:
         self._run_id = run_id
         self._interface = interface
-        self._stop_polling_interval = stop_polling_interval
         self._retry_polling_interval = retry_polling_interval
         self._internal_messages_polling_interval = internal_messages_polling_interval
         self._settings = settings
@@ -295,19 +295,32 @@ class RunStatusChecker:
         def _process_stop_status(result: Result) -> None:
             from wandb.agents import pyagent
 
-            stop_status = result.response.stop_status_response
-            if stop_status.run_should_stop and not pyagent.is_running():  # type: ignore
-                # TODO(frz): This check is required
-                # until WB-3606 is resolved on server side.
-                interrupt.interrupt_main()
+            # TODO: Remove the pyagent.is_running() check if safe to do so.
+            # See WB-3606.
+            if pyagent.is_running():
                 return
+
+            stop_status = result.response.stop_status_response
+            if not stop_status.run_should_stop:
+                return
+
+            if stop_fn := self._settings.stop_fn:
+                stop_fn()
+            else:
+                interrupt.interrupt_main()
+
+            # Only stop once.
+            self._abandon_status_check(
+                self._stop_status_lock,
+                self._stop_status_handle,
+            )
 
         with wb_logging.log_to_run(self._run_id):
             try:
                 self._loop_check_status(
                     lock=self._stop_status_lock,
                     set_handle=lambda x: setattr(self, "_stop_status_handle", x),
-                    timeout=self._stop_polling_interval,
+                    timeout=_STOP_POLLING_INTERVAL,
                     request=self._interface.deliver_stop_status,
                     process=_process_stop_status,
                 )

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -22,7 +22,7 @@ from urllib.parse import quote, unquote
 
 from google.protobuf.wrappers_pb2 import BoolValue, DoubleValue, Int32Value, StringValue
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Self
+from typing_extensions import Callable, Self
 
 import wandb
 from wandb import env, util
@@ -57,6 +57,7 @@ CLIENT_ONLY_SETTINGS = (
     "max_end_of_run_history_metrics",
     "max_end_of_run_summary_metrics",
     "reinit",
+    "stop_fn",
     "x_files_dir",
     "x_sync_dir_suffix",
 )
@@ -426,6 +427,20 @@ class Settings(BaseModel, validate_assignment=True):
 
     settings_system: Optional[str] = None
     """Path to the system-wide settings file."""
+
+    stop_fn: Optional[Callable[[], None]] = None
+    """A callback to execute to stop the run.
+
+    A run can be stopped through the web UI, or after a fatal error
+    (if configured via a setting).
+
+    By default, to stop a run, W&B sends a SIGINT to the main thread.
+    Set this callback to override this behavior, like to use a different
+    signal or to take some other action before interrupting.
+
+    The callback runs in a separate thread. It runs soon after a stop is
+    requested, but not immediately.
+    """
 
     max_end_of_run_history_metrics: int = 10
     """Maximum number of history sparklines to display at the end of a run."""


### PR DESCRIPTION
Creates the `stop_fn` setting to customize how a run is stopped.

Since this is a function, it cannot be set using an environment variable. It must be set in Python:

```python
settings = wandb.Settings(stop_fn=...)

# To affect all future runs in the same process:
wandb.setup(settings=settings)

# To customize an individual run:
wandb.init(settings=settings)
```

There are setups that swallow `SIGINT`, like Ray remote workers (https://github.com/ray-project/ray/issues/31805, WB-31991), and setups where `SIGINT` may already mean something, like in SLURM (WB-25703). This allows customizing the behavior.

This setting should not be used as a hack to disable the web UI stop button (like via `stop_fn=lambda: None`) as a run may be stopped for other reasons. For instance, PR #11774 allows stopping a run after a fatal error.