### PR TITLE
chore: use invalid default base url in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,12 +38,22 @@ pytest_plugins = [
 # --------------------------------
 
 
-@pytest.fixture(autouse=True)
-def setup_wandb_env_variables(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture(autouse=True, scope="session")
+def setup_wandb_env_variables() -> Iterator[None]:
     """Configures wandb env variables to suitable defaults for tests."""
-    # Set the _network_buffer setting to 1000 to increase the likelihood
-    # of triggering flow control logic.
-    monkeypatch.setenv("WANDB_X_NETWORK_BUFFER", "1000")
+    with pytest.MonkeyPatch().context() as monkeypatch:
+        # Override the base URL, which otherwise defaults to https://api.wandb.ai
+        # Tests may override this further (like to point to a local server),
+        # but if not, it prevents tests from accidentally hitting real endpoints.
+        #
+        # It is important that this runs as early as possible, hence the session
+        # scope. If a test overrides this and doesn't reset it, that should be
+        # considered a bug in the test, not in the choice of scope!
+        #
+        # Fun fact: the 'invalid' domain is described in RFC 6761 section 6.4.
+        monkeypatch.setenv("WANDB_BASE_URL", "https://invalid")
+
+        yield
 
 
 # --------------------------------

--- a/tests/system_tests/test_launch/test_launch_cli.py
+++ b/tests/system_tests/test_launch/test_launch_cli.py
@@ -163,6 +163,7 @@ def patched_run_run_entry(cmd, dir):
     return mock_run
 
 
+@pytest.mark.usefixtures("user")
 def test_launch_supplied_docker_image(
     runner,
     monkeypatch,
@@ -307,6 +308,7 @@ def test_launch_supplied_logfile(runner, monkeypatch, wandb_caplog, user):
         ),
     ],
 )
+@pytest.mark.usefixtures("user")
 def test_launch_template_vars(command_inputs, expected_error, runner, monkeypatch):
     mock_template_variables = [
         {"name": "test_str", "schema": json.dumps({"type": "string"})},

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -17,6 +17,19 @@ settings.load_profile("ci")
 
 
 @pytest.fixture
+def patch_max_cli_version(monkeypatch: pytest.MonkeyPatch):
+    """Make util._get_max_cli_version() always return None.
+
+    By default, this fails in unit tests (usually times out).
+
+    Tests that invoke `_get_max_cli_version()` but don't care about the version
+    should use this fixture. It is not autouse because that can conflict with
+    other patches or with tests for the function itself.
+    """
+    monkeypatch.setattr("wandb.util._get_max_cli_version", lambda: None)
+
+
+@pytest.fixture
 def api() -> wandb.Api:
     """A fake wandb.Api instance.
 

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -164,6 +164,7 @@ def test_captions(
     assert wandb.Image.all_captions([wbone, wbtwo]) == ["Cool", "Nice"]
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_bind_image(
     mock_run,
     image,
@@ -179,6 +180,7 @@ def test_image_accepts_other_images():
     assert image_a == image_b
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_bounding_boxes(
     mock_run,
     image,
@@ -199,6 +201,7 @@ def test_image_accepts_bounding_boxes(
     assert os.path.exists(os.path.join(run.dir, path))
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_bounding_boxes_optional_args(
     mock_run,
     image,
@@ -224,6 +227,7 @@ def test_image_accepts_bounding_boxes_optional_args(
     assert os.path.exists(os.path.join(run.dir, path))
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_masks(
     mock_run,
     image,
@@ -242,6 +246,7 @@ def test_image_accepts_masks(
     assert os.path.exists(os.path.join(run.dir, path))
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_masks_without_class_labels(
     mock_run,
     image,
@@ -261,6 +266,7 @@ def test_image_accepts_masks_without_class_labels(
     assert os.path.exists(os.path.join(run.dir, path))
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_seq_to_json(
     mock_run,
     image,
@@ -272,6 +278,7 @@ def test_image_seq_to_json(
     assert os.path.exists(os.path.join(run.dir, "media", "images", "test_0_0.png"))
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_max_images(mock_run):
     run = mock_run()
     large_image = np.random.randint(255, size=(10, 10))

--- a/tests/unit_tests/test_launch/test_project/test_project.py
+++ b/tests/unit_tests/test_launch/test_project/test_project.py
@@ -213,8 +213,14 @@ def test_project_parse_existing_requirements_invalid_requirement(
     assert "Unable to parse line" in wandb_caplog.text
 
 
-def test_get_env_vars_dict(mock_project_args, test_api):
+def test_get_env_vars_dict(
+    mock_project_args,
+    test_api,
+    monkeypatch: pytest.MonkeyPatch,
+):
     """Test that env vars are correctly set from a launch project."""
+    monkeypatch.setenv("WANDB_BASE_URL", "https://launch-test.invalid")
+
     project = LaunchProject(**mock_project_args)
     project._queue_name = "mock-queue"
     project._queue_entity = "mock-test-entity"
@@ -226,7 +232,7 @@ def test_get_env_vars_dict(mock_project_args, test_api):
     assert env_vars == {
         "WANDB_API_KEY": None,
         "WANDB_ARTIFACTS": "{}",
-        "WANDB_BASE_URL": "https://api.wandb.ai",
+        "WANDB_BASE_URL": "https://launch-test.invalid",
         "WANDB_CONFIG": "{}",
         "WANDB_DOCKER": "mock-test-image:v0",
         "WANDB_ENTITY": "mock-test-entity",
@@ -241,20 +247,27 @@ def test_get_env_vars_dict(mock_project_args, test_api):
     }
 
 
-def test_get_env_vars_dict_with_low_max_length(mock_project_args, test_api):
+def test_get_env_vars_dict_with_low_max_length(
+    mock_project_args,
+    test_api,
+    monkeypatch: pytest.MonkeyPatch,
+):
     """Test that we break config over multiple env vars when it exceeds the max length."""
+    monkeypatch.setenv("WANDB_BASE_URL", "https://launch-test.invalid")
     project = LaunchProject(**mock_project_args)
     project.override_config = {
         "learning_rate": 0.01,
         "batch_size": 32,
     }
+
     env_vars = project.get_env_vars_dict(test_api, 12)
     run_id = env_vars.pop("WANDB_RUN_ID")
+
     assert len(run_id) == 8
     assert env_vars == {
         "WANDB_API_KEY": None,
         "WANDB_ARTIFACTS": "{}",
-        "WANDB_BASE_URL": "https://api.wandb.ai",
+        "WANDB_BASE_URL": "https://launch-test.invalid",
         "WANDB_CONFIG_0": '{"learning_r',
         "WANDB_CONFIG_1": 'ate": 0.01, ',
         "WANDB_CONFIG_2": '"batch_size"',

--- a/tests/unit_tests/test_media/test_media_logging.py
+++ b/tests/unit_tests/test_media/test_media_logging.py
@@ -96,6 +96,7 @@ def plotly_media() -> wandb.Plotly:
         "plotly_media",
     ],
 )
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_saves_to_run_directory(mock_run, request, media_object):
     run = mock_run(use_magic_mock=True)
     media_object = request.getfixturevalue(media_object)
@@ -126,6 +127,7 @@ def test_log_media_with_invalid_character_on_windows(
         image_media.bind_to_run(run, f"image{invalid_character}test", 0)
 
 
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_with_path_traversal(mock_run, image_media):
     run = mock_run()
     image_media.bind_to_run(run, "../../../image", 0)
@@ -143,6 +145,7 @@ def test_log_media_with_path_traversal(mock_run, image_media):
         "my///image",
     ],
 )
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_prefixed_with_multiple_slashes(mock_run, media_key, image_media):
     run = mock_run()
     image_media.bind_to_run(run, media_key, 0)

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -104,6 +104,7 @@ def test_parse_path_default_entity(path: str):
 @pytest.mark.usefixtures("skip_verify_login")
 def test_parse_path_no_entity(path: str):
     api = Api(api_key="fake" * 10)
+    api._default_entity = ""
 
     with pytest.raises(ValueError, match="missing entity"):
         api._parse_path(path)

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -10,6 +10,19 @@ from wandb.sdk import wandb_login, wandb_setup
 from wandb.sdk.lib.credentials import _expires_at_fmt
 
 
+@pytest.fixture(autouse=True)
+def suppress_logged_in_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # HACK: Prevent the test from attempting to connect to the fake URLs.
+    #
+    # The banner fetches viewer info; keep login unit tests focused on prompt
+    # and config behavior instead of network-backed account lookups.
+    monkeypatch.setattr(
+        wandb_login,
+        "_print_logged_in_message",
+        lambda *args, **kwargs: None,
+    )
+
+
 def test_login_timeout(emulated_terminal):
     emulated_terminal.queue_input("junk")
     emulated_terminal.queue_input("more")
@@ -86,14 +99,7 @@ def test_login(test_settings):
     "local_settings",
     "skip_verify_login",
 )
-def test_login_sets_api_base_url(monkeypatch: pytest.MonkeyPatch):
-    # HACK: Prevent the test from attempting to connect to the fake URLs.
-    monkeypatch.setattr(
-        wandb_login,
-        "_print_logged_in_message",
-        lambda *args, **kwargs: None,
-    )
-
+def test_login_sets_api_base_url():
     base_url = "https://api.test.host.ai"
     wandb.login(key="test" * 10, host=base_url)
     assert wandb_setup.singleton().settings.base_url == base_url


### PR DESCRIPTION
Sets `WANDB_BASE_URL` to an invalid value in the top-level `conftest.py` at the earliest possible point (a session-scoped autouse fixture). This should help prevent most mistakes, like the unit tests that were hitting prod through `_get_max_cli_version()`, which this PR also fixes.

I removed the `WANDB_X_NETWORK_BUFFER` line because this setting is unused. Can probably delete it altogether.