### PR TITLE
chore: speed up and stabilize Windows unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
     resource_class: m4pro.medium
 
   windows:
-    resource_class: windows.xlarge
+    resource_class: windows.large
     machine:
       image: windows-server-2022-gui:current
       shell: bash.exe

--- a/noxfile.py
+++ b/noxfile.py
@@ -197,7 +197,16 @@ def unit_tests(session: nox.Session) -> None:
     By default this runs all unit tests, but specific tests can be selected
     by passing them via positional arguments.
     """
-    install_wandb(session)
+    is_windows = platform.system() == "Windows"
+
+    if is_windows:
+        # Linux already exercises the heavier Go race/coverage and Rust extension
+        # build paths. Skipping them on Windows keeps this job focused on Python
+        # compatibility and avoids multi-minute rebuilds.
+        session.env["WANDB_BUILD_SKIP_WANDB_XPU"] = "true"
+        session.env["WANDB_BUILD_SKIP_ORJSON"] = "true"
+
+    install_wandb(session, dev=not is_windows)
 
     install_timed(
         session,
@@ -213,7 +222,7 @@ def unit_tests(session: nox.Session) -> None:
         session,
         paths=paths,
         # TODO: consider relaxing this once the test memory usage is under control.
-        opts={"n": "8"},
+        opts={"n": "4" if is_windows else "8"},
     )
 
 

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -396,7 +396,13 @@ def test_image_from_matplotlib_with_image():
 def test_fail_to_make_file(
     mock_run,
     image,
+    monkeypatch,
 ):
+    monkeypatch.setattr(
+        wandb.util,
+        "_get_max_cli_version",
+        lambda: pytest.fail("_get_max_cli_version() should not be called"),
+    )
     with pytest.raises(
         ValueError,
         match="is invalid. Please remove invalid filename characters",

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -393,16 +393,11 @@ def test_image_from_matplotlib_with_image():
 @pytest.mark.skipif(
     platform.system() != "Windows", reason="Failure case is only happening on Windows"
 )
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_fail_to_make_file(
     mock_run,
     image,
-    monkeypatch,
 ):
-    monkeypatch.setattr(
-        wandb.util,
-        "_get_max_cli_version",
-        lambda: pytest.fail("_get_max_cli_version() should not be called"),
-    )
     with pytest.raises(
         ValueError,
         match="is invalid. Please remove invalid filename characters",

--- a/tests/unit_tests/test_media/test_media_logging.py
+++ b/tests/unit_tests/test_media/test_media_logging.py
@@ -119,14 +119,10 @@ def test_log_media_saves_to_run_directory(mock_run, request, media_object):
     ],
 )
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_with_invalid_character_on_windows(
-    mock_run, image_media, invalid_character, monkeypatch
+    mock_run, image_media, invalid_character
 ):
-    monkeypatch.setattr(
-        wandb.util,
-        "_get_max_cli_version",
-        lambda: pytest.fail("_get_max_cli_version() should not be called"),
-    )
     run = mock_run()
     with pytest.raises(ValueError, match="Path .* is invalid"):
         image_media.bind_to_run(run, f"image{invalid_character}test", 0)

--- a/tests/unit_tests/test_media/test_media_logging.py
+++ b/tests/unit_tests/test_media/test_media_logging.py
@@ -120,8 +120,13 @@ def test_log_media_saves_to_run_directory(mock_run, request, media_object):
 )
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
 def test_log_media_with_invalid_character_on_windows(
-    mock_run, image_media, invalid_character
+    mock_run, image_media, invalid_character, monkeypatch
 ):
+    monkeypatch.setattr(
+        wandb.util,
+        "_get_max_cli_version",
+        lambda: pytest.fail("_get_max_cli_version() should not be called"),
+    )
     run = mock_run()
     with pytest.raises(ValueError, match="Path .* is invalid"):
         image_media.bind_to_run(run, f"image{invalid_character}test", 0)

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -515,6 +515,10 @@ class Image(BatchableMedia):
                 "Image media created by a reference to external storage cannot currently be added to a run"
             )
 
+        # Validate the key before checking server capabilities so invalid
+        # Windows filenames fail fast instead of blocking on a version lookup.
+        util.make_file_path_upload_safe(str(key))
+
         if (
             not _server_accepts_artifact_path(run)
             or self._get_artifact_entry_ref_url() is None


### PR DESCRIPTION
Description
-----------
Fix Windows-only media test flakes by validating invalid image/media keys before any server-version lookup, so those tests fail fast instead of timing out or crashing xdist workers. Also slim down the Windows unit_tests job by skipping unnecessary heavy build paths, reducing pytest worker count, and moving the job to a smaller Windows executor to cut runtime and CircleCI cost.
