### PR TITLE
chore: force-push dev-bump branch in release workflow

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -394,7 +394,9 @@ jobs:
           git checkout -b bump-${new_version}
           bump2version patch --no-tag --no-commit --config-file .bumpversion.cfg --new-version ${new_version}
           git commit -am "chore(sdk): bump version to ${new_version}"
-          git push -u origin bump-${new_version}
+          # Force push so re-runs of the release workflow succeed even when the
+          # dev-bump branch was already created by an earlier run.
+          git push -u -f origin bump-${new_version}
 
       - name: Create Pull Request
         env:
@@ -402,7 +404,11 @@ jobs:
         run: |
           IFS='.' read -r major minor patch <<< "${{ github.event.inputs.version }}"
           new_version="${major}.${minor}.$((patch + 1)).dev1"
-          gh pr create --base main --head bump-${new_version} --title "chore(sdk): bump version to ${new_version}" --body "This PR bumps the version to the next dev version after the release of ${{ github.event.inputs.version }}."
+          if gh pr view "bump-${new_version}" --json number >/dev/null 2>&1; then
+            echo "PR already open for bump-${new_version}; force push updated it."
+          else
+            gh pr create --base main --head bump-${new_version} --title "chore(sdk): bump version to ${new_version}" --body "This PR bumps the version to the next dev version after the release of ${{ github.event.inputs.version }}."
+          fi
 
   publish-release-notes:
     name: Publish Release Notes


### PR DESCRIPTION
Description
-----------
The create-dev-branch job in release-sdk.yml pushes bump-<next>.dev1 without -f. On a fresh release this works, but on a re-run of the release workflow it fails with a non-fast-forward rejection: prepare-release force-pushes release-<version> at a new SHA, so the dev-bump branch gets a different commit than what's already on origin from the prior run.

Hit this while re-running the 0.26.1 SDK release — the first run succeeded through create-dev-branch (opening PR #11778), and the re-run's git push -u origin bump-0.26.2.dev1 rejected.

Fix: add -f to mirror prepare-release's force-push, and make gh pr create idempotent so re-runs update the existing PR instead of erroring on "PR already exists".