### PR TITLE
chore: better debugging for the test_asyncio_compat_run flake

### DIFF
--- a/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
+++ b/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
@@ -13,13 +13,17 @@ async def pass_if_cancelled() -> None:
     global _got_cancelled
 
     try:
-        print("TEST READY", flush=True)
         print(f"Ready at {time.monotonic()}", file=sys.stderr)
+        print("TEST READY", flush=True)
         await asyncio.sleep(5)
+
+        # If this happens, the CI machine is running too slowly.
+        print(f"Finished sleeping at {time.monotonic()}", file=sys.stderr)
 
     except asyncio.CancelledError:
         # The test sends a SIGINT to the process, which we expect
         # asyncio_compat.run() to turn into task cancellation.
+        print(f"CancelledError caught at {time.monotonic()}", file=sys.stderr)
         with _got_cancelled_lock:
             _got_cancelled = True
         raise


### PR DESCRIPTION
Continue the attempts in PR #9660 to debug the flake in this test. Since the flake started happening more frequently after we switched to different runners, I think it could be a resource issue, but that's contradicted by the printed timestamps:

```
Ready at 432.78742203
FAIL: Interrupted but not cancelled (432.788117834)
```

My expectation is that `Interrupted but not cancelled` cannot run until `pass_if_cancelled()` exits, and the only way that can exit less than 1ms after `Ready at ...` is through the `asyncio.CancelledError` exception handler. I added some prints to verify that.

I also reordered the `TEST READY` and `Ready at` messages in case buffering affects the accuracy of the printed timestamps.  The test sends SIGINT after the subprocess prints `TEST READY`, so technically the SIGINT could have come in before the `Ready at ...` message.
