### PR TITLE
chore(leet): clean up live-stream completion, media retries, and batched system metric ingestion

### DIFF
--- a/core/internal/leet/leveldbhistorysource.go
+++ b/core/internal/leet/leveldbhistorysource.go
@@ -28,6 +28,8 @@ type LevelDBHistorySource struct {
 	exitSeen bool
 	// exitCode is the exit code of the run if the exit record has been seen.
 	exitCode int32
+	// fileCompleteEmitted is true after the terminal FileCompleteMsg has been emitted.
+	fileCompleteEmitted bool
 }
 
 func NewLevelDBHistorySource(
@@ -79,15 +81,21 @@ func (hs *LevelDBHistorySource) Read(
 			HasMore: false,
 		}, nil
 	}
+	if hs.exitSeen && hs.fileCompleteEmitted {
+		return ChunkedBatchMsg{
+			Msgs:    []tea.Msg{},
+			HasMore: false,
+		}, io.EOF
+	}
 
 	var msgs []tea.Msg
 	var histories []HistoryMsg
 	var summaries []SummaryMsg
-	recordCount := 0
+	scannedCount := 0
 	startTime := time.Now()
 	var err error
 
-	for recordCount < chunkSize && time.Since(startTime) < maxTimePerChunk {
+	for scannedCount < chunkSize && time.Since(startTime) < maxTimePerChunk {
 		record, readErr := hs.store.Read()
 		if readErr != nil {
 			if errors.Is(readErr, io.EOF) {
@@ -104,6 +112,7 @@ func (hs *LevelDBHistorySource) Read(
 		if record == nil {
 			continue
 		}
+		scannedCount++
 
 		// Handle exit record first to avoid double FileComplete.
 		if exit, ok := record.RecordType.(*spb.Record_Exit); ok && exit.Exit != nil {
@@ -121,7 +130,6 @@ func (hs *LevelDBHistorySource) Read(
 			default:
 				msgs = append(msgs, msg)
 			}
-			recordCount++
 		}
 	}
 
@@ -132,18 +140,19 @@ func (hs *LevelDBHistorySource) Read(
 		msgs = append(msgs, hs.concatenateSummary(summaries))
 	}
 
-	if hs.exitSeen {
+	if hs.exitSeen && !hs.fileCompleteEmitted {
 		msgs = append(msgs, FileCompleteMsg{ExitCode: hs.exitCode})
+		hs.fileCompleteEmitted = true
 	}
 
 	// Determine if there's more to read,
 	// i.e. whether we have records and didn't hit EOF, there might be more.
-	hasMore := !hs.exitSeen && recordCount > 0
+	hasMore := !hs.exitSeen && scannedCount > 0
 
 	return ChunkedBatchMsg{
 		Msgs:     msgs,
 		HasMore:  hasMore,
-		Progress: recordCount,
+		Progress: scannedCount,
 	}, err
 }
 

--- a/core/internal/leet/leveldbhistorysource_test.go
+++ b/core/internal/leet/leveldbhistorysource_test.go
@@ -66,7 +66,7 @@ func TestReadAllRecordsChunked_HistoryThenExit(t *testing.T) {
 	batch, ok := msg.(leet.ChunkedBatchMsg)
 	require.True(t, ok)
 	require.False(t, batch.HasMore)
-	require.Equal(t, 1, batch.Progress)
+	require.Equal(t, 2, batch.Progress)
 	require.Equal(t, 2, len(batch.Msgs))
 
 	assert.IsType(t, leet.HistoryMsg{}, batch.Msgs[0])
@@ -74,6 +74,84 @@ func TestReadAllRecordsChunked_HistoryThenExit(t *testing.T) {
 	assert.EqualValues(t, 0.42, batch.Msgs[0].(leet.HistoryMsg).Metrics["loss"].Y[0])
 	assert.IsType(t, leet.FileCompleteMsg{}, batch.Msgs[1])
 	assert.EqualValues(t, 0, batch.Msgs[1].(leet.FileCompleteMsg).ExitCode)
+}
+
+func TestLevelDBHistorySource_FileCompleteEmittedOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "complete-once.wandb")
+
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
+	require.NoError(t,
+		w.Write(&spb.Record{
+			RecordType: &spb.Record_Exit{
+				Exit: &spb.RunExitRecord{ExitCode: 0},
+			},
+		}))
+	require.NoError(t, w.Close())
+
+	reader, err := leet.NewLevelDBHistorySource(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
+	defer reader.Close()
+
+	msg, err := reader.Read(leet.BootLoadChunkSize, leet.BootLoadMaxTime)
+	require.NoError(t, err)
+	batch, ok := msg.(leet.ChunkedBatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch.Msgs, 1)
+	require.IsType(t, leet.FileCompleteMsg{}, batch.Msgs[0])
+
+	msg, err = reader.Read(leet.BootLoadChunkSize, leet.BootLoadMaxTime)
+	require.ErrorIs(t, err, io.EOF)
+	batch, ok = msg.(leet.ChunkedBatchMsg)
+	require.True(t, ok)
+	require.Empty(t, batch.Msgs)
+}
+
+func TestLevelDBHistorySource_UnsupportedRecordsKeepChunking(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unsupported-then-history.wandb")
+
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
+	for range 2 {
+		require.NoError(t,
+			w.Write(&spb.Record{
+				RecordType: &spb.Record_Files{Files: &spb.FilesRecord{}},
+			}))
+	}
+	require.NoError(t,
+		w.Write(&spb.Record{
+			RecordType: &spb.Record_History{
+				History: &spb.HistoryRecord{
+					Item: []*spb.HistoryItem{
+						{NestedKey: []string{"_step"}, ValueJson: "3"},
+						{NestedKey: []string{"loss"}, ValueJson: "0.25"},
+					},
+				},
+			},
+		}))
+	require.NoError(t, w.Close())
+
+	reader, err := leet.NewLevelDBHistorySource(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
+	defer reader.Close()
+
+	msg, err := reader.Read(2, leet.BootLoadMaxTime)
+	require.NoError(t, err)
+	batch, ok := msg.(leet.ChunkedBatchMsg)
+	require.True(t, ok)
+	require.True(t, batch.HasMore)
+	require.Equal(t, 2, batch.Progress)
+	require.Empty(t, batch.Msgs)
+
+	msg, err = reader.Read(2, leet.BootLoadMaxTime)
+	require.NoError(t, err)
+	batch, ok = msg.(leet.ChunkedBatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch.Msgs, 1)
+	hist, ok := batch.Msgs[0].(leet.HistoryMsg)
+	require.True(t, ok)
+	require.Equal(t, 3.0, hist.Metrics["loss"].X[0])
+	require.Equal(t, 0.25, hist.Metrics["loss"].Y[0])
 }
 
 //gocyclo:ignore

--- a/core/internal/leet/mediapane.go
+++ b/core/internal/leet/mediapane.go
@@ -836,17 +836,24 @@ type mediaRenderKey struct {
 	height int
 }
 
+const mediaErrorRetryAfter = time.Second
+
+type mediaRenderError struct {
+	text string
+	at   time.Time
+}
+
 type mediaImageRenderer struct {
 	mu       sync.RWMutex
 	decoded  map[string]image.Image
-	errors   map[string]string
+	errors   map[string]mediaRenderError
 	rendered map[mediaRenderKey]string
 }
 
 func newMediaImageRenderer() *mediaImageRenderer {
 	return &mediaImageRenderer{
 		decoded:  make(map[string]image.Image),
-		errors:   make(map[string]string),
+		errors:   make(map[string]mediaRenderError),
 		rendered: make(map[mediaRenderKey]string),
 	}
 }
@@ -866,24 +873,29 @@ func (r *mediaImageRenderer) Render(path string, width, height int) string {
 		return rendered
 	}
 	img := r.decoded[path]
-	errText := r.errors[path]
+	errEntry, hasErr := r.errors[path]
 	r.mu.RUnlock()
 
-	if img == nil && errText == "" {
+	if img == nil && hasErr && time.Since(errEntry.at) < mediaErrorRetryAfter {
+		return renderMediaPlaceholder(width, height, truncateValue(errEntry.text, width))
+	}
+
+	if img == nil {
 		loaded, err := loadMediaImage(path)
 		r.mu.Lock()
 		if err != nil {
-			errText = err.Error()
-			r.errors[path] = errText
+			errEntry = mediaRenderError{text: err.Error(), at: time.Now()}
+			r.errors[path] = errEntry
 		} else {
 			img = loaded
 			r.decoded[path] = img
+			delete(r.errors, path)
 		}
 		r.mu.Unlock()
 	}
 
 	if img == nil {
-		return renderMediaPlaceholder(width, height, truncateValue(errText, width))
+		return renderMediaPlaceholder(width, height, truncateValue(errEntry.text, width))
 	}
 
 	rendered := renderANSIImage(img, width, height)

--- a/core/internal/leet/rightsidebar.go
+++ b/core/internal/leet/rightsidebar.go
@@ -253,10 +253,7 @@ func (rs *RightSidebar) ProcessStatsMsg(msg StatsMsg) {
 		"rightsidebar: ProcessStatsMsg: processing %d metrics (state=%v, width=%d)",
 		len(msg.Metrics), rs.animState, rs.animState.Value()))
 
-	// Add all data points to the grid.
-	for metricName, value := range msg.Metrics {
-		rs.metricsGrid.AddDataPoint(metricName, msg.Timestamp, value)
-	}
+	rs.metricsGrid.ProcessStats(msg)
 }
 
 // calculateGridHeight returns the available height for the metrics grid.

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -908,6 +908,9 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 func (r *Run) handleBatched(msg BatchedRecordsMsg) []tea.Cmd {
 	r.logger.Debug(fmt.Sprintf("model: BatchedRecordsMsg received with %d messages", len(msg.Msgs)))
 	cmds := r.handleRecordsBatch(msg.Msgs, true)
+	if r.runState != RunStateRunning {
+		return cmds
+	}
 	cmds = append(
 		cmds,
 		r.ReadLiveBatchCmd(r.historySource),
@@ -918,6 +921,10 @@ func (r *Run) handleBatched(msg BatchedRecordsMsg) []tea.Cmd {
 // handleHeartbeat triggers a live read and re-arms the heartbeat.
 func (r *Run) handleHeartbeat() []tea.Cmd {
 	r.logger.Debug("model: processing HeartbeatMsg")
+	if r.runState != RunStateRunning {
+		r.heartbeatMgr.Stop()
+		return nil
+	}
 	r.heartbeatMgr.Reset(r.isRunning)
 	return []tea.Cmd{
 		r.ReadLiveBatchCmd(r.historySource),
@@ -927,6 +934,9 @@ func (r *Run) handleHeartbeat() []tea.Cmd {
 
 // handleFileChange coalesces change notifications into a read.
 func (r *Run) handleFileChange() []tea.Cmd {
+	if r.runState != RunStateRunning {
+		return nil
+	}
 	r.heartbeatMgr.Reset(r.isRunning)
 	return []tea.Cmd{
 		r.ReadLiveBatchCmd(r.historySource),

--- a/core/internal/leet/symon.go
+++ b/core/internal/leet/symon.go
@@ -141,9 +141,7 @@ func (s *Symon) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return s, cmd
 
 	case StatsMsg:
-		for metricName, value := range msg.Metrics {
-			s.grid.AddDataPoint(metricName, msg.Timestamp, value)
-		}
+		s.grid.ProcessStats(msg)
 		s.resizeGrid()
 		cmd := s.sampleLaterCmd()
 		return s, cmd

--- a/core/internal/leet/systemmetricsgrid.go
+++ b/core/internal/leet/systemmetricsgrid.go
@@ -179,6 +179,35 @@ func (g *SystemMetricsGrid) createMetricChart(def *MetricDef) systemMetricChart 
 // Drawing is deferred to the next View() call to avoid redundant redraws
 // when processing a batch of metrics from a single stats record.
 func (g *SystemMetricsGrid) AddDataPoint(metricName string, timestamp int64, value float64) {
+	if g.addDataPoint(metricName, timestamp, value) {
+		g.refreshChartSet()
+	}
+}
+
+// ProcessStats ingests all metrics from a single stats record, batching any
+// chart creation/filtering/redraw work.
+func (g *SystemMetricsGrid) ProcessStats(msg StatsMsg) {
+	if len(msg.Metrics) == 0 {
+		return
+	}
+
+	chartSetChanged := false
+	for metricName, value := range msg.Metrics {
+		if g.addDataPoint(metricName, msg.Timestamp, value) {
+			chartSetChanged = true
+		}
+	}
+	if chartSetChanged {
+		g.refreshChartSet()
+	}
+}
+
+// addDataPoint adds a sample and reports whether the chart set changed.
+func (g *SystemMetricsGrid) addDataPoint(
+	metricName string,
+	timestamp int64,
+	value float64,
+) bool {
 	g.logger.Debug(fmt.Sprintf(
 		"SystemMetricsGrid.AddDataPoint: metric=%s, timestamp=%d, value=%f",
 		metricName, timestamp, value))
@@ -187,41 +216,48 @@ func (g *SystemMetricsGrid) AddDataPoint(metricName string, timestamp int64, val
 	if def == nil {
 		g.logger.Debug(fmt.Sprintf(
 			"SystemMetricsGrid.AddDataPoint: no definition for metric=%s", metricName))
-		return
+		return false
 	}
 
 	baseKey := ExtractBaseKey(metricName)
 	seriesName := ExtractSeriesName(metricName)
 
-	chart := g.getOrCreateChart(baseKey, def)
+	chart, created := g.getOrCreateChart(baseKey, def)
 	chart.AddDataPoint(seriesName, timestamp, value)
+	return created
 }
 
 // getOrCreateChart returns a chart for the given baseKey.
-func (g *SystemMetricsGrid) getOrCreateChart(baseKey string, def *MetricDef) systemMetricChart {
+func (g *SystemMetricsGrid) getOrCreateChart(
+	baseKey string,
+	def *MetricDef,
+) (systemMetricChart, bool) {
 	chart, exists := g.byBaseKey[baseKey]
 	if !exists {
 		g.logger.Debug(fmt.Sprintf("systemmetricsgrid: creating new chart for baseKey=%s", baseKey))
 		chart = g.createMetricChart(def)
 		g.byBaseKey[baseKey] = chart
 		g.addChart(chart)
+		return chart, true
 	}
-	return chart
+	return chart, false
 }
 
-// addChart adds a chart to the ordered list and updates pagination.
+// addChart adds a chart to the ordered list.
 func (g *SystemMetricsGrid) addChart(chart systemMetricChart) {
 	g.ordered = append(g.ordered, chart)
 	sort.Slice(g.ordered, func(i, j int) bool {
 		return g.ordered[i].Title() < g.ordered[j].Title()
 	})
 
+	g.logger.Debug(fmt.Sprintf(
+		"SystemMetricsGrid.addChart: chart added, total=%d",
+		len(g.ordered)))
+}
+
+func (g *SystemMetricsGrid) refreshChartSet() {
 	g.ApplyFilter()
 	g.drawVisible()
-
-	g.logger.Debug(fmt.Sprintf(
-		"SystemMetricsGrid.addChart: chart added, total=%d, pages=%d",
-		len(g.ordered), g.nav.TotalPages()))
 }
 
 // LoadCurrentPage loads charts for the current page.

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -697,9 +697,7 @@ func (w *Workspace) handleWorkspaceRecord(run *WorkspaceRun, msg tea.Msg) {
 
 	case StatsMsg:
 		grid := w.getOrCreateSystemMetricsGrid(run.Key)
-		for metricName, value := range m.Metrics {
-			grid.AddDataPoint(metricName, m.Timestamp, value)
-		}
+		grid.ProcessStats(m)
 
 	case SystemInfoMsg:
 		w.getOrCreateRunOverview(run.Key).ProcessSystemInfoMsg(m.Record)


### PR DESCRIPTION
Description
-----------
It's still springtime, so this PR tightens several LEET live-data paths that could cause stale or repeated work for active runs. It makes transaction-log completion idempotent, ensures chunk reads continue across unsupported records, allows transient media file/decode failures to recover, and batches system metric chart creation/filtering/redraw work per stats record instead of per metric.

Also adds regression coverage for completion emission and chunk progress semantics.