### PR TITLE
chore(cli): when making graphql calls, add header with client source (cli vs sdk) so server can tag metrics

### DIFF
--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -13,6 +13,8 @@ import wandb
 import wandb.docker
 from wandb import env
 from wandb.cli import cli
+from wandb.sdk import wandb_setup
+from wandb.sdk.internal.internal_api import Api as InternalApi
 
 DOCKER_SHA = (
     "wandb/deepo@sha256:"
@@ -621,3 +623,29 @@ def test_purge_cache_subdirectories(runner, monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert "Deleted 1 file(s)" in result.output
     assert not file.exists()
+
+
+@pytest.fixture
+def _reset_cli_only_mode():
+    settings = wandb_setup.singleton().settings
+    original = settings.x_cli_only_mode
+    settings.x_cli_only_mode = False
+    yield
+    settings.x_cli_only_mode = original
+
+
+def test_cli_group_sets_x_cli_only_mode(runner, _reset_cli_only_mode):
+    result = runner.invoke(cli.cli, [])
+    assert result.exit_code == 0
+    assert wandb_setup.singleton().settings.x_cli_only_mode is True
+
+
+def test_internal_api_tags_sdk_by_default(_reset_cli_only_mode):
+    api = InternalApi()
+    assert api.client.transport.headers["X-WANDB-Client-Source"] == "sdk"
+
+
+def test_internal_api_tags_cli_when_flag_set(_reset_cli_only_mode):
+    wandb_setup.singleton().settings.x_cli_only_mode = True
+    api = InternalApi()
+    assert api.client.transport.headers["X-WANDB-Client-Source"] == "cli"

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -226,6 +226,7 @@ class Api:
                 headers={
                     "User-Agent": self.user_agent,
                     "Use-Admin-Privileges": "true",
+                    "X-WANDB-Client-Source": "sdk",
                 },
                 use_json=True,
                 # this timeout won't apply when the DNS lookup fails. in that case, it will be 60s

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -170,9 +170,6 @@ def _get_cling_api(reset=None):
         _api = None
         wandb.teardown()
     if _api is None:
-        # TODO(jhr): make a settings object that is better for non runs.
-        # only override the necessary setting
-        wandb_setup.singleton().settings.x_cli_only_mode = True
         _api = InternalApi()
     return _api
 
@@ -223,6 +220,8 @@ class RunGroup(click.Group):
 @click.pass_context
 def cli(ctx):
     _setup_logger()
+
+    wandb_setup.singleton().settings.x_cli_only_mode = True
 
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -365,7 +364,6 @@ def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):
     relogin = True if key or relogin else False
 
     global_settings = wandb_setup.singleton().settings
-    global_settings.x_cli_only_mode = True
     global_settings.x_disable_viewer = relogin and not verify
 
     wandb.login(

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -291,12 +291,18 @@ class Api:
             self._environ.get("WANDB__PROXIES", "{}")
         )
 
+        if wandb_setup.singleton().settings.x_cli_only_mode:
+            client_source = "cli"
+        else:
+            client_source = "sdk"
+
         self.client = Client(
             transport=GraphQLSession(
                 headers={
                     "User-Agent": self.user_agent,
                     "X-WANDB-USERNAME": env.get_username(env=self._environ),
                     "X-WANDB-USER-EMAIL": env.get_user_email(env=self._environ),
+                    "X-WANDB-Client-Source": client_source,
                     **self._extra_http_headers,
                 },
                 use_json=True,

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -573,7 +573,15 @@ class Settings(BaseModel, validate_assignment=True):
     # a part of the public API as they may change or be removed in future versions.
 
     x_cli_only_mode: bool = False
-    """Flag to indicate that the SDK is running in CLI-only mode.
+    """Flag to indicate that this Python process is the wandb CLI (`wandb <cmd>`).
+
+    Set once at the top of the cli click group callback so every `wandb <cmd>`
+    invocation has this True. Used to:
+    - skip program introspection / code-path setup in Settings._infer_run_settings
+      (only needed for wandb.init, not for CLI commands)
+    - bypass the offline short-circuit in wandb_login._login (an explicit
+      `wandb login` should proceed even if WANDB_MODE=offline)
+    - tag outgoing GraphQL traffic as `client_source=cli` in InternalApi
 
     <!-- lazydoc-ignore-class-attributes -->
     """


### PR DESCRIPTION
Description
-----------

Set `X-WANDB-Client-Source` header to `cli` or `sdk` based on what the user is using.

Also consolidates `x_cli_only_mode=True` into a single assignment at the top of the [`cli()`](https://github.com/wandb/wandb/blob/c53841a8fe7376f52a7002353c9945dfe4dbebb0/wandb/cli/cli.py#L224) click group callback. Previously the flag was set ad-hoc in [`_get_cling_api()`](https://github.com/wandb/wandb/blob/c53841a8fe7376f52a7002353c9945dfe4dbebb0/wandb/cli/cli.py#L166) and the [`login` handler](https://github.com/wandb/wandb/blob/c53841a8fe7376f52a7002353c9945dfe4dbebb0/wandb/cli/cli.py#L368).

Five commands now have `x_cli_only_mode=True` where they didn't before: `wandb scheduler`, `docker-run`, `docker`, `server start`, `pull`, and it seems like this was not intentional.

The flag only controls two things:
1. program introspection skip in [`Settings.update_from_system_environment`](https://github.com/wandb/wandb/blob/c53841a8fe7376f52a7002353c9945dfe4dbebb0/wandb/sdk/wandb_settings.py#L2035)
2. [offline short-circuit bypass in `_login`](https://github.com/wandb/wandb/blob/c53841a8fe7376f52a7002353c9945dfe4dbebb0/wandb/sdk/wandb_login.py#L89).

None of the five commands call `wandb.init()`, and only `scheduler` touches login, but it's already passing `no_offline=True`, which is all that the flag affects. Both hooks are no-ops in practice.

No changelog update because not user-facing.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- [x] Added unit tests. Also e2e tested along wiht server updates locally.