### PR TITLE
chore: promote beta_scan_history to scan_history

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,3 +19,8 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Removed the unsupported `wandb.apis.importers` API (@dmitryduev in https://github.com/wandb/wandb/pull/11923)
 - Removed stale OpenAI, Cohere, and LangChain LLM integrations, including legacy autologging and tracing APIs (@dmitryduev in https://github.com/wandb/wandb/pull/11925)
 - Removed the deprecated Keras `WandbCallback` and the legacy `wandb.integration.yolov8` callback package (@dmitryduev in https://github.com/wandb/wandb/pull/11926)
+
+### Changed
+
+- `Run.scan_history()` now reads from exported parquet history when available, which can significantly improve throughput for runs with large history (@jacobromero in https://github.com/wandb/wandb/pull/11797)
+    - This was introduced under `beta_scan_history` in `v0.23.1`

--- a/core/internal/runhistoryreader/reader.go
+++ b/core/internal/runhistoryreader/reader.go
@@ -61,6 +61,10 @@ func New(
 	useCache bool,
 	rustArrowWrapper *ffi.RustArrowWrapper,
 ) (*HistoryReader, error) {
+	if len(keys) > 0 && !slices.Contains(keys, "_step") {
+		keys = append([]string{"_step"}, keys...)
+	}
+
 	historyReader := &HistoryReader{
 		entity:        entity,
 		graphqlClient: graphqlClient,

--- a/tests/system_tests/test_api/conftest.py
+++ b/tests/system_tests/test_api/conftest.py
@@ -19,19 +19,53 @@ class ParquetFileHandler(http.server.SimpleHTTPRequestHandler):
 
     parquet_files: dict[str, bytes] = {}
 
-    def do_GET(self):
+    def _resolve_content(self) -> bytes | None:
         path = self.path.lstrip("/")
+        return self.parquet_files.get(path)
 
-        if path in self.parquet_files:
-            content = self.parquet_files[path]
+    def do_HEAD(self):
+        content = self._resolve_content()
+        if content is not None:
             self.send_response(200)
+            self.send_header("Content-Length", str(len(content)))
+            self.send_header("Accept-Ranges", "bytes")
             self.end_headers()
-            self.wfile.write(content)
         else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_GET(self):
+        content = self._resolve_content()
+        if content is None:
             self.send_response(404)
             self.send_header("Content-Type", "text/plain")
             self.end_headers()
             self.wfile.write(b"File not found")
+            return
+
+        range_header = self.headers.get("Range")
+        if range_header:
+            # Parse "bytes=START-END"
+            range_spec = range_header.replace("bytes=", "")
+            start_str, end_str = range_spec.split("-")
+            start = int(start_str)
+            end = int(end_str) + 1 if end_str else len(content)
+            end = min(end, len(content))
+
+            body = content[start:end]
+            self.send_response(206)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header(
+                "Content-Range",
+                f"bytes {start}-{end - 1}/{len(content)}",
+            )
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
 
 
 class ParquetHTTPServer:

--- a/tests/system_tests/test_api/test_public_api_history.py
+++ b/tests/system_tests/test_api/test_public_api_history.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import wandb
 from wandb.apis.public import DownloadHistoryResult, IncompleteRunHistoryError, Run
+from wandb.errors import CommError
 
 
 def stub_run_parquet_history(
@@ -62,7 +63,7 @@ def stub_api_run_history_keys(wandb_backend_spy, last_step: int):
     )
 
 
-def test_run_beta_scan_history(
+def test_run_scan_history(
     wandb_backend_spy,
     parquet_file_server,
     monkeypatch,
@@ -88,7 +89,7 @@ def test_run_beta_scan_history(
         f"{run.entity}/{run.project}/{run.id}",
     )
 
-    scan = run.beta_scan_history()
+    scan = run.scan_history()
 
     history = [row for row in scan]
     assert history == [
@@ -157,7 +158,7 @@ def test_run_scan_history__iter_resets(
         f"{run.entity}/{run.project}/{run.id}",
     )
 
-    scan = run.beta_scan_history()
+    scan = run.scan_history()
 
     history = []
     i = 0
@@ -184,7 +185,7 @@ def test_run_scan_history__iter_resets(
     ]
 
 
-def test_run_beta_scan_history__exits_on_run_max_step(
+def test_run_scan_history__exits_on_run_max_step(
     wandb_backend_spy,
     parquet_file_server,
     monkeypatch,
@@ -209,7 +210,7 @@ def test_run_beta_scan_history__exits_on_run_max_step(
         f"{run.entity}/{run.project}/{run.id}",
     )
 
-    scan = run.beta_scan_history(max_step=100)
+    scan = run.scan_history(max_step=100)
 
     history = [row for row in scan]
     assert history == [
@@ -219,7 +220,7 @@ def test_run_beta_scan_history__exits_on_run_max_step(
     ]
 
 
-def test_run_beta_scan_history__exits_on_requested_max_step(
+def test_run_scan_history__exits_on_requested_max_step(
     wandb_backend_spy,
     parquet_file_server,
     monkeypatch,
@@ -245,12 +246,50 @@ def test_run_beta_scan_history__exits_on_requested_max_step(
         f"{run.entity}/{run.project}/{run.id}",
     )
 
-    scan = run.beta_scan_history(max_step=1)
+    scan = run.scan_history(max_step=1)
 
     history = [row for row in scan]
     assert history == [
         {"_step": 0, "acc": 0.5, "loss": 1.0},
     ]
+
+
+@pytest.mark.parametrize(
+    "keys,error_msg",
+    [
+        ("acc", "keys must be specified in a list"),
+        ([["acc"]], "keys argument must be a list of strings"),
+    ],
+    ids=["keys_not_a_list", "keys_not_list_of_strings"],
+)
+def test_run_scan_history__keys_bad_arg(
+    wandb_backend_spy,
+    parquet_file_server,
+    monkeypatch,
+    keys,
+    error_msg,
+):
+    monkeypatch.setenv("WANDB_CACHE_DIR", tempfile.mkdtemp())
+
+    parquet_data_path = "parquet/1.parquet"
+    run_data = {
+        "_step": [0, 1, 2],
+        "acc": [0.5, 0.75, 0.9],
+        "loss": [1.0, 0.5, 0.1],
+    }
+    parquet_file_server.serve_data_as_parquet_file(parquet_data_path, run_data)
+    stub_run_parquet_history(
+        wandb_backend_spy, parquet_file_server, [parquet_data_path]
+    )
+    stub_api_run_history_keys(wandb_backend_spy, 2)
+    with wandb.init() as run:
+        pass
+    run = wandb.Api().run(
+        f"{run.entity}/{run.project}/{run.id}",
+    )
+
+    with pytest.raises(CommError, match=error_msg):
+        run.scan_history(keys=keys)
 
 
 @pytest.mark.parametrize(

--- a/tests/system_tests/test_api/test_public_api_history.py
+++ b/tests/system_tests/test_api/test_public_api_history.py
@@ -99,6 +99,39 @@ def test_run_scan_history(
     ]
 
 
+def test_run_scan_history__next_called_directly(
+    wandb_backend_spy,
+    parquet_file_server,
+    monkeypatch,
+):
+    monkeypatch.setenv("WANDB_CACHE_DIR", tempfile.mkdtemp())
+
+    parquet_data_path = "parquet/1.parquet"
+    run_data = {
+        "_step": [0, 1, 2],
+        "acc": [0.5, 0.75, 0.9],
+        "loss": [1.0, 0.5, 0.1],
+    }
+    parquet_file_server.serve_data_as_parquet_file(parquet_data_path, run_data)
+    stub_run_parquet_history(
+        wandb_backend_spy, parquet_file_server, [parquet_data_path]
+    )
+    stub_api_run_history_keys(wandb_backend_spy, 2)
+    with wandb.init() as run:
+        pass
+    run = wandb.Api().run(
+        f"{run.entity}/{run.project}/{run.id}",
+    )
+
+    scan = run.scan_history()
+
+    assert next(scan) == {"_step": 0, "acc": 0.5, "loss": 1.0}
+    assert next(scan) == {"_step": 1, "acc": 0.75, "loss": 0.5}
+    assert next(scan) == {"_step": 2, "acc": 0.9, "loss": 0.1}
+    with pytest.raises(StopIteration):
+        next(scan)
+
+
 def test_run_scan_history__with_keys(
     wandb_backend_spy,
     parquet_file_server,

--- a/tests/system_tests/test_api/test_public_api_history.py
+++ b/tests/system_tests/test_api/test_public_api_history.py
@@ -98,7 +98,41 @@ def test_run_beta_scan_history(
     ]
 
 
-def test_run_beta_scan_history__iter_resets(
+def test_run_scan_history__with_keys(
+    wandb_backend_spy,
+    parquet_file_server,
+    monkeypatch,
+):
+    monkeypatch.setenv("WANDB_CACHE_DIR", tempfile.mkdtemp())
+
+    parquet_data_path = "parquet/1.parquet"
+    run_data = {
+        "_step": [0, 1, 2],
+        "acc": [0.5, 0.75, 0.9],
+        "loss": [1.0, 0.5, 0.1],
+    }
+    parquet_file_server.serve_data_as_parquet_file(parquet_data_path, run_data)
+    stub_run_parquet_history(
+        wandb_backend_spy, parquet_file_server, [parquet_data_path]
+    )
+    stub_api_run_history_keys(wandb_backend_spy, 2)
+    with wandb.init() as run:
+        pass
+    run = wandb.Api().run(
+        f"{run.entity}/{run.project}/{run.id}",
+    )
+
+    scan = run.scan_history(keys=["loss"])
+
+    history = [row for row in scan]
+    assert history == [
+        {"_step": 0, "loss": 1.0},
+        {"_step": 1, "loss": 0.5},
+        {"_step": 2, "loss": 0.1},
+    ]
+
+
+def test_run_scan_history__iter_resets(
     wandb_backend_spy,
     parquet_file_server,
     monkeypatch,

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -252,12 +252,6 @@ def test_run_history_keys_bad_arg(stub_run_gql_once, mock_wandb_log):
     run.history(keys=[["acc"]], pandas=False)
     mock_wandb_log.assert_errored("keys argument must be a list of strings")
 
-    run.scan_history(keys="acc")
-    mock_wandb_log.assert_errored("keys must be specified in a list")
-
-    run.scan_history(keys=[["acc"]])
-    mock_wandb_log.assert_errored("keys argument must be a list of strings")
-
 
 def test_run_summary(wandb_backend_spy):
     seed_run = Api().create_run()

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -16,7 +16,6 @@ __all__ = (
     "Files",
     "HistoryScan",  # doc:exclude
     "IncompleteRunHistoryError",
-    "SampledHistoryScan",  # doc:exclude
     "SlackIntegrations",  # doc:exclude
     "WebhookIntegrations",  # doc:exclude
     "Job",  # doc:exclude
@@ -58,7 +57,7 @@ from wandb.apis.public.artifacts import (
 )
 from wandb.apis.public.automations import Automations
 from wandb.apis.public.files import FILE_FRAGMENT, File, Files
-from wandb.apis.public.history import BetaHistoryScan, HistoryScan, SampledHistoryScan
+from wandb.apis.public.history import HistoryScan
 from wandb.apis.public.integrations import SlackIntegrations, WebhookIntegrations
 from wandb.apis.public.jobs import (
     Job,

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -75,6 +75,7 @@ class HistoryScan(Iterator[_RowDict]):
         )
 
         self.scan_offset = 0
+        self.page_offset = self.min_step
         self.rows: list[_RowDict] = []
         self.keys = keys
 

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -19,20 +19,18 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 from typing_extensions import Self
 
-from wandb.apis.normalize import normalize_exceptions
 from wandb.proto import wandb_api_pb2 as pb
 from wandb.sdk.mailbox.mailbox import MailboxClosedError
 
 if TYPE_CHECKING:
     from . import runs
-    from .api import RetryingClient
     from .service_api import ServiceApi
 
 _RowDict: TypeAlias = dict[str, Any]
 """Type alias for a single history row as a dict."""
 
 
-class BetaHistoryScan(Iterator[_RowDict]):
+class HistoryScan(Iterator[_RowDict]):
     """Iterator for scanning complete run history.
 
     <!-- lazydoc-ignore-class: internal -->
@@ -161,205 +159,3 @@ class BetaHistoryScan(Iterator[_RowDict]):
             service_api.send_api_request(
                 pb.ApiRequest(read_run_history_request=scan_run_history_cleanup_request)
             )
-
-
-class HistoryScan(Iterator[_RowDict]):
-    """Iterator for scanning complete run history.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
-
-    QUERY = """
-        query HistoryPage($entity: String!, $project: String!, $run: String!, $minStep: Int64!, $maxStep: Int64!, $pageSize: Int!) {
-            project(name: $project, entityName: $entity) {
-                run(name: $run) {
-                    history(minStep: $minStep, maxStep: $maxStep, samples: $pageSize)
-                }
-            }
-        }
-        """
-
-    def __init__(
-        self,
-        client: RetryingClient,
-        run: runs.Run,
-        min_step: int,
-        max_step: int,
-        page_size: int = 1_000,
-        *,
-        service_api: ServiceApi,
-    ):
-        """Initialize a HistoryScan instance.
-
-        Args:
-            client: Legacy GraphQL client retained for API compatibility;
-                history rows are fetched through `service_api`.
-            run: The run object whose history is to be scanned.
-            min_step: The minimum step to start scanning from.
-            max_step: The exclusive upper bound for scanned history rows.
-            page_size: Number of history rows to fetch per page.
-                Default page_size is 1000.
-            service_api: Interface to the wandb-core service that performs
-                W&B API calls for this scan.
-        """
-        self.client = client
-        self.run = run
-        self.page_size = page_size
-        self.min_step = min_step
-        self._stop_step = max_step
-        self.page_offset = min_step  # minStep for next page
-        self.scan_offset = 0  # index within current page of rows
-        self.rows: list[_RowDict] = []  # current page of rows
-        self._service_api = service_api
-
-    @property
-    def max_step(self) -> int:
-        """The highest step that can be yielded by this scan."""
-        return self._stop_step - 1
-
-    def __iter__(self) -> Self:
-        self.page_offset = self.min_step
-        self.scan_offset = 0
-        self.rows = []
-        return self
-
-    def __next__(self) -> _RowDict:
-        """Return the next row of history data with automatic pagination.
-
-        <!-- lazydoc-ignore: internal -->
-        """
-        while True:
-            if self.scan_offset < len(self.rows):
-                row = self.rows[self.scan_offset]
-                self.scan_offset += 1
-                return row
-            if self.page_offset >= self._stop_step:
-                raise StopIteration()
-            self._load_next()
-
-    next = __next__
-
-    @normalize_exceptions
-    def _load_next(self) -> None:
-        max_step = self.page_offset + self.page_size
-        if max_step > self._stop_step:
-            max_step = self._stop_step
-        variables = {
-            "entity": self.run.entity,
-            "project": self.run.project,
-            "run": self.run.id,
-            "minStep": int(self.page_offset),
-            "maxStep": int(max_step),
-            "pageSize": int(self.page_size),
-        }
-
-        res = self._service_api.execute_graphql(self.QUERY, variables)
-        res = res["project"]["run"]["history"]
-        self.rows = [json.loads(row) for row in res]
-        self.page_offset += self.page_size
-        self.scan_offset = 0
-
-
-class SampledHistoryScan(Iterator[_RowDict]):
-    """Iterator for sampling run history data.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
-
-    QUERY = """
-        query SampledHistoryPage($entity: String!, $project: String!, $run: String!, $spec: JSONString!) {
-            project(name: $project, entityName: $entity) {
-                run(name: $run) {
-                    sampledHistory(specs: [$spec])
-                }
-            }
-        }
-        """
-
-    def __init__(
-        self,
-        client: RetryingClient,
-        run: runs.Run,
-        keys: list[str],
-        min_step: int,
-        max_step: int,
-        page_size: int = 1_000,
-        *,
-        service_api: ServiceApi,
-    ):
-        """Initialize a SampledHistoryScan instance.
-
-        Args:
-            client: Legacy GraphQL client retained for API compatibility;
-                sampled history rows are fetched through `service_api`.
-            run: The run object whose history is to be sampled.
-            keys: List of keys to sample from the history.
-            min_step: The minimum step to start sampling from.
-            max_step: The exclusive upper bound for sampled history rows.
-            page_size: Number of sampled history rows to fetch per page.
-                Default page_size is 1000.
-            service_api: Interface to the wandb-core service that performs
-                W&B API calls for this scan.
-        """
-        self.client = client
-        self.run = run
-        self.keys = keys
-        self.page_size = page_size
-        self.min_step = min_step
-        self._stop_step = max_step
-        self.page_offset = min_step  # minStep for next page
-        self.scan_offset = 0  # index within current page of rows
-        self.rows: list[_RowDict] = []  # current page of rows
-        self._service_api = service_api
-
-    @property
-    def max_step(self) -> int:
-        """The highest step that can be yielded by this scan."""
-        return self._stop_step - 1
-
-    def __iter__(self) -> Self:
-        self.page_offset = self.min_step
-        self.scan_offset = 0
-        self.rows = []
-        return self
-
-    def __next__(self) -> _RowDict:
-        """Return the next row of sampled history data with automatic pagination.
-
-        <!-- lazydoc-ignore: internal -->
-        """
-        while True:
-            if self.scan_offset < len(self.rows):
-                row = self.rows[self.scan_offset]
-                self.scan_offset += 1
-                return row
-            if self.page_offset >= self._stop_step:
-                raise StopIteration()
-            self._load_next()
-
-    next = __next__
-
-    @normalize_exceptions
-    def _load_next(self) -> None:
-        max_step = self.page_offset + self.page_size
-        if max_step > self._stop_step:
-            max_step = self._stop_step
-        variables = {
-            "entity": self.run.entity,
-            "project": self.run.project,
-            "run": self.run.id,
-            "spec": json.dumps(
-                {
-                    "keys": self.keys,
-                    "minStep": int(self.page_offset),
-                    "maxStep": int(max_step),
-                    "samples": int(self.page_size),
-                }
-            ),
-        }
-
-        res = self._service_api.execute_graphql(self.QUERY, variables)
-        res = res["project"]["run"]["sampledHistory"]
-        self.rows = res[0]
-        self.page_offset += self.page_size
-        self.scan_offset = 0

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -40,7 +40,7 @@ import pathlib
 import tempfile
 import time
 import urllib.parse
-from collections.abc import Collection, Iterator, Mapping
+from collections.abc import Collection, Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import override
@@ -57,6 +57,7 @@ from wandb.apis.internal import Api as InternalApi
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import SizedPaginator
 from wandb.apis.public.const import RETRY_TIMEDELTA
+from wandb.apis.public.service_api import ServiceApi
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.sdk import wandb_setup
 from wandb.sdk.lib import ipython, json_util
@@ -69,7 +70,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from wandb.apis.public import RetryingClient
-    from wandb.apis.public.service_api import ServiceApi
     from wandb.old.summary import HTTPSummary
 
 WANDB_INTERNAL_KEYS = {"_wandb", "wandb_version"}
@@ -1224,64 +1224,48 @@ class Run(Attrs):
         self,
         keys: list[str] | None = None,
         page_size: int = 1_000,
-        min_step: int | None = None,
+        min_step: int = 0,
         max_step: int | None = None,
-    ) -> Iterator[dict[str, Any]]:
+        use_cache: bool = True,
+    ) -> public.HistoryScan:
         """Returns an iterable collection of all history records for a run.
 
         Args:
-            keys ([str], optional): only fetch these keys, and only fetch rows that have all of keys defined.
-            page_size (int, optional): size of pages to fetch from the api.
-            min_step (int, optional): the minimum number of pages to scan at a time.
-            max_step (int, optional): the maximum number of pages to scan at a time.
+            keys: list of metrics to read from the run's history.
+                if no keys are provided then all metrics will be returned.
+            page_size: the number of history records to read at a time.
+            min_step: The minimum step to start reading history from (inclusive).
+            max_step: The maximum step to read history up to (exclusive).
+            use_cache: When set to True, checks the WANDB_CACHE_DIR for a run history.
+                If the run history is not found in the cache, it will be downloaded from the server.
+                If set to False, the run history will be downloaded every time.
 
         Returns:
-            An iterable collection over history records (dict).
-
-        Example:
-        Export all the loss values for an example run
-
-        ```python
-        run = api.run("entity/project-name/run-id")
-        history = run.scan_history(keys=["Loss"])
-        losses = [row["Loss"] for row in history]
-        ```
+            A BetaHistoryScan object,
+            which can be iterator over to get history records.
         """
         if keys is not None and not isinstance(keys, list):
-            wandb.termerror("keys must be specified in a list")
-            return []
-        if keys is not None and len(keys) > 0 and not isinstance(keys[0], str):
-            wandb.termerror("keys argument must be a list of strings")
-            return []
+            raise ValueError("keys must be specified in a list")
+        if (
+            keys is not None
+            and len(keys) > 0
+            and not all(isinstance(key, str) for key in keys)
+        ):
+            raise ValueError("keys argument must be a list of strings")
 
-        last_step = self.lastHistoryStep
-        # set defaults for min/max step
-        if min_step is None:
-            min_step = 0
-        if max_step is None:
-            max_step = last_step + 1
-        # if the max step is past the actual last step, clamp it down
-        if max_step > last_step:
-            max_step = last_step + 1
-        if keys is None:
-            return public.HistoryScan(
-                run=self,
-                client=self.client,
-                service_api=self._service_api,
-                page_size=page_size,
-                min_step=min_step,
-                max_step=max_step,
-            )
-        else:
-            return public.SampledHistoryScan(
-                run=self,
-                client=self.client,
-                service_api=self._service_api,
-                keys=keys,
-                page_size=page_size,
-                min_step=min_step,
-                max_step=max_step,
-            )
+        if self._service_api is None:
+            settings = wandb_setup.singleton().settings.model_copy()
+            self._service_api = ServiceApi(settings=settings)
+
+        return public.HistoryScan(
+            service_api=self._service_api,
+            run=self,
+            min_step=min_step,
+            max_step=max_step or self.lastHistoryStep + 1,
+            keys=keys,
+            page_size=page_size,
+            use_cache=use_cache,
+        )
 
     @normalize_exceptions
     def logged_artifacts(self, per_page: int = 100) -> public.RunArtifacts:
@@ -1637,45 +1621,6 @@ class Run(Attrs):
     def _string_representation(self) -> str:
         return f"<{nameof(type(self))} {'/'.join(self.path)} ({self.state})>"
 
-    def beta_scan_history(
-        self,
-        keys: list[str] | None = None,
-        page_size: int = 1_000,
-        min_step: int = 0,
-        max_step: int | None = None,
-        use_cache: bool = True,
-    ) -> public.BetaHistoryScan:
-        """Returns an iterable collection of all history records for a run.
-
-        This function is still in development and may not work as expected.
-        It uses wandb-core to read history from a run's exported
-        parquet history locally.
-
-        Args:
-            keys: list of metrics to read from the run's history.
-                if no keys are provided then all metrics will be returned.
-            page_size: the number of history records to read at a time.
-            min_step: The minimum step to start reading history from (inclusive).
-            max_step: The maximum step to read history up to (exclusive).
-            use_cache: When set to True, checks the WANDB_CACHE_DIR for a run history.
-                If the run history is not found in the cache, it will be downloaded from the server.
-                If set to False, the run history will be downloaded every time.
-
-        Returns:
-            A BetaHistoryScan object,
-            which can be iterator over to get history records.
-        """
-        beta_history_scan = public.BetaHistoryScan(
-            run=self,
-            service_api=self._service_api,
-            min_step=min_step,
-            max_step=max_step or self.lastHistoryStep + 1,
-            keys=keys,
-            page_size=page_size,
-            use_cache=use_cache,
-        )
-        return beta_history_scan
-
     def download_history_exports(
         self,
         download_dir: pathlib.Path | str,
@@ -1733,4 +1678,26 @@ class Run(Attrs):
                 request_id,
                 contains_live_data,
             )
+        )
+
+    def beta_scan_history(
+        self,
+        keys: list[str] | None = None,
+        page_size: int = 1_000,
+        min_step: int = 0,
+        max_step: int | None = None,
+        use_cache: bool = True,
+    ) -> public.HistoryScan:
+        wandb.termwarn(
+            "`beta_scan_history` is deprecated and will be removed in a future release. "
+            + "Use `scan_history` instead.",
+            repeat=False,
+        )
+
+        return self.scan_history(
+            keys=keys,
+            page_size=page_size,
+            min_step=min_step,
+            max_step=max_step,
+            use_cache=use_cache,
         )

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1257,11 +1257,17 @@ class Run(Attrs):
             settings = wandb_setup.singleton().settings.model_copy()
             self._service_api = ServiceApi(settings=settings)
 
+        last_step = self.lastHistoryStep
+        if max_step is None:
+            max_step = last_step + 1
+        elif max_step > last_step:
+            max_step = last_step + 1
+
         return public.HistoryScan(
             service_api=self._service_api,
             run=self,
             min_step=min_step,
-            max_step=max_step or self.lastHistoryStep + 1,
+            max_step=max_step,
             keys=keys,
             page_size=page_size,
             use_cache=use_cache,

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1241,7 +1241,7 @@ class Run(Attrs):
                 If set to False, the run history will be downloaded every time.
 
         Returns:
-            A BetaHistoryScan object,
+            A HistoryScan object,
             which can be iterator over to get history records.
         """
         if keys is not None and not isinstance(keys, list):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

This PR replaces the underlying implementation of the current `api.Run::scan_history` function with the `beta_scan_history` implementation which utilizes reading parquet history locally for improved throughput. The current `beta_scan_history` now simply points to `scan_history` so it can be removed on the next minor version bump.

Additionally, because this PR removes the legacy `scan_history` implementation this PR also removes some classes in `history.py` which is no longer used anywhere.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


