### PR TITLE
chore: pin pypi package lightning to version 2.6.1

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -37,7 +37,7 @@ scikit-learn
 torch
 torchvision
 jax[cpu]
-lightning
+lightning==2.6.1
 
 pyarrow
 kfp


### PR DESCRIPTION
Description
-----------
Pinned lightning to version 2.6.1 as part of mitigating https://socket.dev/blog/lightning-pypi-package-compromised


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [X] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

Not tested. The pypi package `lightning` is currently under quarantine and cannot be tested. Pinned the version to be safe whenever quarantine is lifted.
