### PR TITLE
chore: temporarily remove lightning from dev requirements

### DIFF
--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -6,7 +6,6 @@ aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.4
     # via
-    #   fsspec
     #   kubernetes-asyncio
     #   litellm
 aiosignal==1.4.0
@@ -228,8 +227,6 @@ frozenlist==1.8.0
 fsspec==2026.3.0
     # via
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
     #   torch
 gepa==0.0.26
     # via dspy
@@ -513,13 +510,6 @@ lark==1.3.1
     # via rfc3987-syntax
 lightgbm==4.6.0
     # via -r requirements/requirements_dev.txt
-lightning==2.6.1
-    # via -r requirements/requirements_dev.txt
-lightning-utilities==0.15.3
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 litellm==1.82.6
     # via dspy
 mako==1.3.10
@@ -633,7 +623,6 @@ numpy==2.3.5
     #   stable-baselines3
     #   tensorboard
     #   tensorboardx
-    #   torchmetrics
     #   torchvision
     #   xgboost
 oauthlib==3.3.1
@@ -682,8 +671,6 @@ packaging==26.0
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
-    #   lightning
-    #   lightning-utilities
     #   matplotlib
     #   mlflow-skinny
     #   mlflow-tracing
@@ -691,11 +678,9 @@ packaging==26.0
     #   optuna
     #   plotly
     #   pytest
-    #   pytorch-lightning
     #   skops
     #   tensorboard
     #   tensorboardx
-    #   torchmetrics
     #   wandb
 pandas==2.3.3
     # via
@@ -883,8 +868,6 @@ python-json-logger==4.1.0
     # via jupyter-events
 pytokens==0.4.1
     # via black
-pytorch-lightning==2.6.1
-    # via lightning
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
@@ -896,10 +879,8 @@ pyyaml==6.0.3
     #   kfp
     #   kubernetes
     #   kubernetes-asyncio
-    #   lightning
     #   mlflow-skinny
     #   optuna
-    #   pytorch-lightning
     #   responses
     #   wandb
 pyzmq==27.1.0
@@ -1067,15 +1048,8 @@ tomli==2.4.1
 torch==2.11.0
     # via
     #   -r requirements/requirements_dev.txt
-    #   lightning
-    #   pytorch-lightning
     #   stable-baselines3
-    #   torchmetrics
     #   torchvision
-torchmetrics==1.9.0
-    # via
-    #   lightning
-    #   pytorch-lightning
 torchvision==0.26.0
     # via -r requirements/requirements_dev.txt
 tornado==6.5.5
@@ -1093,12 +1067,10 @@ tqdm==4.67.3
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   huggingface-hub
-    #   lightning
     #   moviepy
     #   openai
     #   optuna
     #   proglog
-    #   pytorch-lightning
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -1132,8 +1104,6 @@ typing-extensions==4.15.0
     #   grpcio
     #   gymnasium
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
     #   mlflow-skinny
     #   openai
     #   opentelemetry-api
@@ -1141,7 +1111,6 @@ typing-extensions==4.15.0
     #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
-    #   pytorch-lightning
     #   sqlalchemy
     #   torch
     #   typing-inspection

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -9,7 +9,6 @@ aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.4
     # via
-    #   fsspec
     #   kubernetes-asyncio
     #   litellm
 aiosignal==1.4.0
@@ -239,8 +238,6 @@ frozenlist==1.8.0
 fsspec==2026.3.0
     # via
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
     #   torch
 gast==0.7.0
     # via tensorflow
@@ -542,13 +539,6 @@ libclang==18.1.1
     # via tensorflow
 lightgbm==4.6.0
     # via -r requirements/requirements_dev.txt
-lightning==2.6.1
-    # via -r requirements/requirements_dev.txt
-lightning-utilities==0.15.3
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 litellm==1.82.6
     # via dspy
 mako==1.3.10
@@ -670,7 +660,6 @@ numpy==2.3.5
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   torchvision
     #   xgboost
 nvidia-cublas==13.1.0.3
@@ -765,8 +754,6 @@ packaging==26.0
     #   jupyterlab
     #   jupyterlab-server
     #   keras
-    #   lightning
-    #   lightning-utilities
     #   matplotlib
     #   mlflow-skinny
     #   mlflow-tracing
@@ -774,12 +761,10 @@ packaging==26.0
     #   optuna
     #   plotly
     #   pytest
-    #   pytorch-lightning
     #   skops
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   wandb
     #   wheel
 pandas==2.3.3
@@ -970,8 +955,6 @@ python-json-logger==4.1.0
     # via jupyter-events
 pytokens==0.4.1
     # via black
-pytorch-lightning==2.6.1
-    # via lightning
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
@@ -983,10 +966,8 @@ pyyaml==6.0.3
     #   kfp
     #   kubernetes
     #   kubernetes-asyncio
-    #   lightning
     #   mlflow-skinny
     #   optuna
-    #   pytorch-lightning
     #   responses
     #   sweeps
     #   wandb
@@ -1170,15 +1151,8 @@ tomli==2.4.1
 torch==2.11.0
     # via
     #   -r requirements/requirements_dev.txt
-    #   lightning
-    #   pytorch-lightning
     #   stable-baselines3
-    #   torchmetrics
     #   torchvision
-torchmetrics==1.9.0
-    # via
-    #   lightning
-    #   pytorch-lightning
 torchvision==0.26.0
     # via -r requirements/requirements_dev.txt
 tornado==6.5.5
@@ -1196,12 +1170,10 @@ tqdm==4.67.3
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   huggingface-hub
-    #   lightning
     #   moviepy
     #   openai
     #   optuna
     #   proglog
-    #   pytorch-lightning
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -1237,8 +1209,6 @@ typing-extensions==4.15.0
     #   grpcio
     #   gymnasium
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
     #   mlflow-skinny
     #   openai
     #   opentelemetry-api
@@ -1247,7 +1217,6 @@ typing-extensions==4.15.0
     #   optree
     #   pydantic
     #   pydantic-core
-    #   pytorch-lightning
     #   sqlalchemy
     #   tensorflow
     #   torch

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -9,7 +9,6 @@ aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.4
     # via
-    #   fsspec
     #   kubernetes-asyncio
     #   litellm
 aiosignal==1.4.0
@@ -241,8 +240,6 @@ frozenlist==1.8.0
 fsspec==2026.3.0
     # via
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
     #   torch
 gast==0.7.0
     # via tensorflow
@@ -542,13 +539,6 @@ libclang==18.1.1
     # via tensorflow
 lightgbm==4.6.0
     # via -r requirements/requirements_dev.txt
-lightning==2.6.1
-    # via -r requirements/requirements_dev.txt
-lightning-utilities==0.15.3
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 litellm==1.82.6
     # via dspy
 mako==1.3.10
@@ -670,7 +660,6 @@ numpy==2.3.5
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   torchvision
     #   xgboost
 oauthlib==3.3.1
@@ -723,8 +712,6 @@ packaging==26.0
     #   jupyterlab
     #   jupyterlab-server
     #   keras
-    #   lightning
-    #   lightning-utilities
     #   matplotlib
     #   mlflow-skinny
     #   mlflow-tracing
@@ -732,12 +719,10 @@ packaging==26.0
     #   optuna
     #   plotly
     #   pytest
-    #   pytorch-lightning
     #   skops
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   wandb
     #   wheel
 pandas==2.3.3
@@ -922,8 +907,6 @@ python-json-logger==4.1.0
     # via jupyter-events
 pytokens==0.4.1
     # via black
-pytorch-lightning==2.6.1
-    # via lightning
 pytz==2026.1.post1
     # via pandas
 pywin32==311
@@ -942,10 +925,8 @@ pyyaml==6.0.3
     #   kfp
     #   kubernetes
     #   kubernetes-asyncio
-    #   lightning
     #   mlflow-skinny
     #   optuna
-    #   pytorch-lightning
     #   responses
     #   sweeps
     #   wandb
@@ -1129,15 +1110,8 @@ tomli==2.4.1
 torch==2.11.0
     # via
     #   -r requirements/requirements_dev.txt
-    #   lightning
-    #   pytorch-lightning
     #   stable-baselines3
-    #   torchmetrics
     #   torchvision
-torchmetrics==1.9.0
-    # via
-    #   lightning
-    #   pytorch-lightning
 torchvision==0.26.0
     # via -r requirements/requirements_dev.txt
 tornado==6.5.5
@@ -1155,12 +1129,10 @@ tqdm==4.67.3
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   huggingface-hub
-    #   lightning
     #   moviepy
     #   openai
     #   optuna
     #   proglog
-    #   pytorch-lightning
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -1194,8 +1166,6 @@ typing-extensions==4.15.0
     #   grpcio
     #   gymnasium
     #   huggingface-hub
-    #   lightning
-    #   lightning-utilities
     #   mlflow-skinny
     #   openai
     #   opentelemetry-api
@@ -1204,7 +1174,6 @@ typing-extensions==4.15.0
     #   optree
     #   pydantic
     #   pydantic-core
-    #   pytorch-lightning
     #   sqlalchemy
     #   tensorflow
     #   torch

--- a/requirements/requirements_dev.3.9.darwin.txt
+++ b/requirements/requirements_dev.3.9.darwin.txt
@@ -243,8 +243,6 @@ fsspec==2025.3.0
     # via
     #   datasets
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
     #   torch
 gitdb==4.0.12
     # via gitpython
@@ -536,13 +534,6 @@ lark==1.3.1
     # via rfc3987-syntax
 lightgbm==4.6.0
     # via -r requirements/requirements_dev.txt
-lightning==2.6.0
-    # via -r requirements/requirements_dev.txt
-lightning-utilities==0.15.2
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 litellm==1.82.6
     # via dspy
 magicattr==0.1.6
@@ -655,7 +646,6 @@ numpy==1.26.4
     #   stable-baselines3
     #   tensorboard
     #   tensorboardx
-    #   torchmetrics
     #   torchvision
     #   xgboost
 oauthlib==3.3.1
@@ -698,18 +688,14 @@ packaging==25.0
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
-    #   lightning
-    #   lightning-utilities
     #   matplotlib
     #   mlflow-skinny
     #   nbconvert
     #   optuna
     #   plotly
     #   pytest
-    #   pytorch-lightning
     #   tensorboard
     #   tensorboardx
-    #   torchmetrics
     #   wandb
 pandas==1.5.3
     # via
@@ -891,8 +877,6 @@ python-json-logger==4.0.0
     # via jupyter-events
 pytokens==0.4.1
     # via black
-pytorch-lightning==2.6.0
-    # via lightning
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
@@ -905,10 +889,8 @@ pyyaml==6.0.3
     #   kfp
     #   kubernetes
     #   kubernetes-asyncio
-    #   lightning
     #   mlflow-skinny
     #   optuna
-    #   pytorch-lightning
     #   responses
     #   wandb
 pyzmq==27.1.0
@@ -1001,7 +983,6 @@ sentry-sdk==2.56.0
 setuptools==82.0.1
     # via
     #   jupyterlab
-    #   lightning-utilities
     #   tensorboard
 shapely==2.0.7
     # via google-cloud-aiplatform
@@ -1080,15 +1061,8 @@ tomli==2.4.1
 torch==2.8.0
     # via
     #   -r requirements/requirements_dev.txt
-    #   lightning
-    #   pytorch-lightning
     #   stable-baselines3
-    #   torchmetrics
     #   torchvision
-torchmetrics==1.8.2
-    # via
-    #   lightning
-    #   pytorch-lightning
 torchvision==0.23.0
     # via -r requirements/requirements_dev.txt
 tornado==6.5.5
@@ -1107,12 +1081,10 @@ tqdm==4.67.3
     #   datasets
     #   dspy
     #   huggingface-hub
-    #   lightning
     #   moviepy
     #   openai
     #   optuna
     #   proglog
-    #   pytorch-lightning
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -1156,8 +1128,6 @@ typing-extensions==4.15.0
     #   gymnasium
     #   huggingface-hub
     #   ipython
-    #   lightning
-    #   lightning-utilities
     #   mistune
     #   mlflow-skinny
     #   multidict
@@ -1170,7 +1140,6 @@ typing-extensions==4.15.0
     #   pyjwt
     #   pytest-asyncio
     #   python-json-logger
-    #   pytorch-lightning
     #   referencing
     #   sqlalchemy
     #   starlette

--- a/requirements/requirements_dev.3.9.linux.txt
+++ b/requirements/requirements_dev.3.9.linux.txt
@@ -248,8 +248,6 @@ fsspec==2025.3.0
     # via
     #   datasets
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
     #   torch
 gast==0.7.0
     # via tensorflow
@@ -560,13 +558,6 @@ libclang==18.1.1
     # via tensorflow
 lightgbm==4.6.0
     # via -r requirements/requirements_dev.txt
-lightning==2.6.0
-    # via -r requirements/requirements_dev.txt
-lightning-utilities==0.15.2
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 litellm==1.82.6
     # via dspy
 magicattr==0.1.6
@@ -687,7 +678,6 @@ numpy==1.26.4
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   torchvision
     #   xgboost
 nvidia-cublas-cu12==12.8.4.1
@@ -774,19 +764,15 @@ packaging==25.0
     #   jupyterlab
     #   jupyterlab-server
     #   keras
-    #   lightning
-    #   lightning-utilities
     #   matplotlib
     #   mlflow-skinny
     #   nbconvert
     #   optuna
     #   plotly
     #   pytest
-    #   pytorch-lightning
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   wandb
     #   wheel
 pandas==1.5.3
@@ -971,8 +957,6 @@ python-json-logger==4.0.0
     # via jupyter-events
 pytokens==0.4.1
     # via black
-pytorch-lightning==2.6.0
-    # via lightning
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
@@ -985,10 +969,8 @@ pyyaml==6.0.3
     #   kfp
     #   kubernetes
     #   kubernetes-asyncio
-    #   lightning
     #   mlflow-skinny
     #   optuna
-    #   pytorch-lightning
     #   responses
     #   sweeps
     #   wandb
@@ -1087,7 +1069,6 @@ sentry-sdk==2.56.0
 setuptools==82.0.1
     # via
     #   jupyterlab
-    #   lightning-utilities
     #   tensorboard
     #   tensorflow
     #   triton
@@ -1179,15 +1160,8 @@ tomli==2.4.1
 torch==2.8.0
     # via
     #   -r requirements/requirements_dev.txt
-    #   lightning
-    #   pytorch-lightning
     #   stable-baselines3
-    #   torchmetrics
     #   torchvision
-torchmetrics==1.8.2
-    # via
-    #   lightning
-    #   pytorch-lightning
 torchvision==0.23.0
     # via -r requirements/requirements_dev.txt
 tornado==6.5.5
@@ -1206,12 +1180,10 @@ tqdm==4.67.3
     #   datasets
     #   dspy
     #   huggingface-hub
-    #   lightning
     #   moviepy
     #   openai
     #   optuna
     #   proglog
-    #   pytorch-lightning
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -1257,8 +1229,6 @@ typing-extensions==4.15.0
     #   gymnasium
     #   huggingface-hub
     #   ipython
-    #   lightning
-    #   lightning-utilities
     #   mistune
     #   mlflow-skinny
     #   multidict
@@ -1272,7 +1242,6 @@ typing-extensions==4.15.0
     #   pyjwt
     #   pytest-asyncio
     #   python-json-logger
-    #   pytorch-lightning
     #   referencing
     #   sqlalchemy
     #   starlette

--- a/requirements/requirements_dev.3.9.windows.txt
+++ b/requirements/requirements_dev.3.9.windows.txt
@@ -256,8 +256,6 @@ fsspec==2025.3.0
     # via
     #   datasets
     #   huggingface-hub
-    #   lightning
-    #   pytorch-lightning
     #   torch
 gast==0.7.0
     # via tensorflow
@@ -565,13 +563,6 @@ libclang==18.1.1
     # via tensorflow
 lightgbm==4.6.0
     # via -r requirements/requirements_dev.txt
-lightning==2.6.0
-    # via -r requirements/requirements_dev.txt
-lightning-utilities==0.15.2
-    # via
-    #   lightning
-    #   pytorch-lightning
-    #   torchmetrics
 litellm==1.82.6
     # via dspy
 magicattr==0.1.6
@@ -692,7 +683,6 @@ numpy==1.26.4
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   torchvision
     #   xgboost
 oauthlib==3.3.1
@@ -739,19 +729,15 @@ packaging==25.0
     #   jupyterlab
     #   jupyterlab-server
     #   keras
-    #   lightning
-    #   lightning-utilities
     #   matplotlib
     #   mlflow-skinny
     #   nbconvert
     #   optuna
     #   plotly
     #   pytest
-    #   pytorch-lightning
     #   tensorboard
     #   tensorboardx
     #   tensorflow
-    #   torchmetrics
     #   wandb
     #   wheel
 pandas==1.5.3
@@ -930,8 +916,6 @@ python-json-logger==4.0.0
     # via jupyter-events
 pytokens==0.4.1
     # via black
-pytorch-lightning==2.6.0
-    # via lightning
 pytz==2026.1.post1
     # via pandas
 pywin32==311
@@ -953,10 +937,8 @@ pyyaml==6.0.3
     #   kfp
     #   kubernetes
     #   kubernetes-asyncio
-    #   lightning
     #   mlflow-skinny
     #   optuna
-    #   pytorch-lightning
     #   responses
     #   sweeps
     #   wandb
@@ -1055,7 +1037,6 @@ sentry-sdk==2.56.0
 setuptools==82.0.1
     # via
     #   jupyterlab
-    #   lightning-utilities
     #   tensorboard
     #   tensorflow
 shapely==2.0.7
@@ -1146,15 +1127,8 @@ tomli==2.4.1
 torch==2.8.0
     # via
     #   -r requirements/requirements_dev.txt
-    #   lightning
-    #   pytorch-lightning
     #   stable-baselines3
-    #   torchmetrics
     #   torchvision
-torchmetrics==1.8.2
-    # via
-    #   lightning
-    #   pytorch-lightning
 torchvision==0.23.0
     # via -r requirements/requirements_dev.txt
 tornado==6.5.5
@@ -1173,12 +1147,10 @@ tqdm==4.67.3
     #   datasets
     #   dspy
     #   huggingface-hub
-    #   lightning
     #   moviepy
     #   openai
     #   optuna
     #   proglog
-    #   pytorch-lightning
 traitlets==5.14.3
     # via
     #   ipykernel
@@ -1222,8 +1194,6 @@ typing-extensions==4.15.0
     #   gymnasium
     #   huggingface-hub
     #   ipython
-    #   lightning
-    #   lightning-utilities
     #   mistune
     #   mlflow-skinny
     #   multidict
@@ -1237,7 +1207,6 @@ typing-extensions==4.15.0
     #   pyjwt
     #   pytest-asyncio
     #   python-json-logger
-    #   pytorch-lightning
     #   referencing
     #   sqlalchemy
     #   starlette

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -37,7 +37,7 @@ scikit-learn
 torch
 torchvision
 jax[cpu]
-lightning==2.6.1
+# lightning==2.6.1  # lightning==2.6.{2,3} were compromised. package is quarantined as of 4/30/2026.
 
 pyarrow
 kfp

--- a/tests/system_tests/test_functional/lightning/test_lightning.py
+++ b/tests/system_tests/test_functional/lightning/test_lightning.py
@@ -1,6 +1,12 @@
 import pathlib
 
+import pytest
 
+
+@pytest.mark.skip(
+    reason="lightning v2.6.2 and 2.6.3 were compromised. "
+    "the package is quarantined on PyPI until that is fixed.",
+)
 def test_strategy_ddp_spawn(wandb_backend_spy, execute_script):
     script_path = pathlib.Path(__file__).parent / "strategy_ddp_spawn.py"
     execute_script(script_path)
@@ -20,6 +26,10 @@ def test_strategy_ddp_spawn(wandb_backend_spy, execute_script):
         assert 106 in telemetry["2"]  # import=lightning
 
 
+@pytest.mark.skip(
+    reason="lightning v2.6.2 and 2.6.3 were compromised. "
+    "the package is quarantined on PyPI until that is fixed.",
+)
 def test_strategy_ddp(wandb_backend_spy, execute_script):
     script_path = pathlib.Path(__file__).parent / "strategy_ddp.py"
     execute_script(script_path)


### PR DESCRIPTION
Description
-----------
Unblock the CI while `lightning` is fixing the 2.6.2 & 2.6.3 problem.

Revert once it is fixed. See https://github.com/Lightning-AI/pytorch-lightning/issues/21691