### PR TITLE
fix(artifacts): improve error messages on invalid or missing data in artifact responses

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - W&B LEET, the terminal UI for viewing W&B runs, is now generally available as `wandb leet`; `wandb beta leet` is kept as an alias (@dmitryduev in https://github.com/wandb/wandb/pull/12028)
 - `wandb.Api().runs()` no longer loads Sweeps for each run by default to improve query performance. Sweep data is loaded on first access of the `sweep` property (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/12019)
 - Lists of images logged under a single key are now displayed in the W&B LEET media pane, one tile per image (@dmitryduev in https://github.com/wandb/wandb/pull/12033)
+- More informative errors are raised from `Api.artifacts()` and related artifact paginators when the artifact path is invalid or inaccessible (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11813)
 
 ### Fixed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Changed
+
+- More informative errors are raised from `Api.artifacts()` and related artifact paginators when the artifact path is invalid or inaccessible (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11813)
+
 ### Fixed
 
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
@@ -668,3 +668,53 @@ def test_artifact_download_http_headers(user, monkeypatch, tmp_path):
         # Expect all requests to have been populated with the custom headers
         for req in storage_requests:
             assert custom_headers.items() <= req.headers.items()
+
+
+# ------------------------------------------------------------------------------
+# Test for error messages on invalid path / inaccessible resource.
+#
+# `Api.artifacts(...)` and other paginators in `wandb.apis.public.artifacts`
+# previously raised a generic `Unable to parse '<Class>' response data` ValueError
+# whenever the GraphQL response had a `null` at any level (which the server
+# returns with HTTP 200 for invalid path or access-denied). These tests pin down
+# specific, user-actionable messages identifying the missing path component.
+
+
+def test_artifacts_invalid_project(logged_artifact: Artifact, api: Api):
+    artifact_type = logged_artifact.type
+
+    entity = logged_artifact.entity
+    invalid_project = "nonexistent_project"
+    collection = logged_artifact.name.split(":")[0]
+    path = f"{entity}/{invalid_project}/{collection}"
+
+    expected_message = rf"{invalid_project}.*not found"
+
+    with raises(ValueError, match=expected_message):
+        list(api.artifacts(type_name=artifact_type, name=path))
+
+
+def test_artifacts_invalid_type(logged_artifact: Artifact, api: Api):
+    invalid_artifact_type = "nonexistent_type"
+
+    entity = logged_artifact.entity
+    project = logged_artifact.project
+    collection = logged_artifact.name.split(":")[0]
+    path = f"{entity}/{project}/{collection}"
+
+    expected_message = rf"{invalid_artifact_type}.*not found"
+
+    with raises(ValueError, match=expected_message):
+        list(api.artifacts(type_name=invalid_artifact_type, name=path))
+
+
+def test_project_collections_invalid_project(logged_artifact: Artifact, api: Api):
+    invalid_project_name = "nonexistent_project"
+
+    # This doesn't error because the data for the returned Project is fetched lazily.
+    project = api.project(name=invalid_project_name, entity=logged_artifact.entity)
+
+    expected_message = rf"{invalid_project_name}.*not found"
+
+    with raises(ValueError, match=expected_message):
+        list(project.collections())

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
@@ -629,3 +629,53 @@ def test_artifact_download_http_headers(user, monkeypatch, tmp_path):
         # Expect all requests to have been populated with the custom headers
         for req in storage_requests:
             assert custom_headers.items() <= req.headers.items()
+
+
+# ------------------------------------------------------------------------------
+# Test for error messages on invalid path / inaccessible resource.
+#
+# `Api.artifacts(...)` and other paginators in `wandb.apis.public.artifacts`
+# previously raised a generic `Unable to parse '<Class>' response data` ValueError
+# whenever the GraphQL response had a `null` at any level (which the server
+# returns with HTTP 200 for invalid path or access-denied). These tests pin down
+# specific, user-actionable messages identifying the missing path component.
+
+
+def test_artifacts_invalid_project(logged_artifact: Artifact, api: Api):
+    artifact_type = logged_artifact.type
+
+    entity = logged_artifact.entity
+    invalid_project = "nonexistent_project"
+    collection = logged_artifact.name.split(":")[0]
+    path = f"{entity}/{invalid_project}/{collection}"
+
+    expected_message = rf"{invalid_project}.*not found"
+
+    with raises(ValueError, match=expected_message):
+        list(api.artifacts(type_name=artifact_type, name=path))
+
+
+def test_artifacts_invalid_type(logged_artifact: Artifact, api: Api):
+    invalid_artifact_type = "nonexistent_type"
+
+    entity = logged_artifact.entity
+    project = logged_artifact.project
+    collection = logged_artifact.name.split(":")[0]
+    path = f"{entity}/{project}/{collection}"
+
+    expected_message = rf"{invalid_artifact_type}.*not found"
+
+    with raises(ValueError, match=expected_message):
+        list(api.artifacts(type_name=invalid_artifact_type, name=path))
+
+
+def test_project_collections_invalid_project(logged_artifact: Artifact, api: Api):
+    invalid_project_name = "nonexistent_project"
+
+    # This doesn't error because the data for the returned Project is fetched lazily.
+    project = api.project(name=invalid_project_name, entity=logged_artifact.entity)
+
+    expected_message = rf"{invalid_project_name}.*not found"
+
+    with raises(ValueError, match=expected_message):
+        list(project.collections())

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_api.py
@@ -5,6 +5,7 @@ import os
 import re
 import time
 from pathlib import Path
+from typing import Any
 
 import responses
 import wandb
@@ -12,6 +13,8 @@ from pytest import mark, raises
 from wandb import Api
 from wandb.errors import CommError
 from wandb.sdk.artifacts.artifact import Artifact
+
+from tests.fixtures.wandb_backend_spy import WandbBackendSpy
 
 
 def _fetch_artifact_with_tags(
@@ -631,42 +634,48 @@ def test_artifact_download_http_headers(user, monkeypatch, tmp_path):
             assert custom_headers.items() <= req.headers.items()
 
 
-# ------------------------------------------------------------------------------
-# Test for error messages on invalid path / inaccessible resource.
-#
-# `Api.artifacts(...)` and other paginators in `wandb.apis.public.artifacts`
-# previously raised a generic `Unable to parse '<Class>' response data` ValueError
-# whenever the GraphQL response had a `null` at any level (which the server
-# returns with HTTP 200 for invalid path or access-denied). These tests pin down
-# specific, user-actionable messages identifying the missing path component.
+@mark.parametrize(
+    ("data", "expected_message"),
+    [
+        (
+            {"project": None},
+            "Project 'project' not found in entity 'entity'",
+        ),
+        (
+            {"project": {"artifactType": None}},
+            "Artifact type 'type' not found in 'entity/project'",
+        ),
+        (
+            {"project": {"artifactType": {"artifactCollection": None}}},
+            "Artifact collection 'collection' not found in 'entity/project'",
+        ),
+        (
+            {
+                "project": {
+                    "artifactType": {
+                        "artifactCollection": {"artifacts": None},
+                    }
+                }
+            },
+            "Unable to parse 'Artifacts' response data",
+        ),
+    ],
+    ids=("project", "type", "collection", "connection"),
+)
+def test_artifacts_invalid_response(
+    wandb_backend_spy: WandbBackendSpy,
+    api: Api,
+    data: dict[str, Any],
+    expected_message: str,
+):
+    gql = wandb_backend_spy.gql
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="ProjectArtifacts"),
+        gql.Constant(content={"data": data}),
+    )
 
-
-def test_artifacts_invalid_project(logged_artifact: Artifact, api: Api):
-    artifact_type = logged_artifact.type
-
-    entity = logged_artifact.entity
-    invalid_project = "nonexistent_project"
-    collection = logged_artifact.name.split(":")[0]
-    path = f"{entity}/{invalid_project}/{collection}"
-
-    expected_message = rf"{invalid_project}.*not found"
-
-    with raises(ValueError, match=expected_message):
-        list(api.artifacts(type_name=artifact_type, name=path))
-
-
-def test_artifacts_invalid_type(logged_artifact: Artifact, api: Api):
-    invalid_artifact_type = "nonexistent_type"
-
-    entity = logged_artifact.entity
-    project = logged_artifact.project
-    collection = logged_artifact.name.split(":")[0]
-    path = f"{entity}/{project}/{collection}"
-
-    expected_message = rf"{invalid_artifact_type}.*not found"
-
-    with raises(ValueError, match=expected_message):
-        list(api.artifacts(type_name=invalid_artifact_type, name=path))
+    with raises(ValueError, match=re.escape(expected_message)):
+        list(api.artifacts(type_name="type", name="entity/project/collection"))
 
 
 def test_project_collections_invalid_project(logged_artifact: Artifact, api: Api):

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -151,8 +151,13 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
         result = ProjectArtifactTypes.model_validate(data)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        if not ((proj := result.project) and (conn := proj.artifact_types)):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (conn := proj.artifact_types) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"unexpected empty response for artifact types in {err_path!r}"
+            raise ValueError(msg)
 
         self.last_response = ArtifactTypeConnection.model_validate(conn)
 
@@ -357,12 +362,17 @@ class ArtifactCollections(
         result = ArtifactTypeArtifactCollections.model_validate(data)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        if not (
-            (proj := result.project)
-            and (artifact_type := proj.artifact_type)
-            and (conn := artifact_type.artifact_collections)
-        ):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (artifact_type := proj.artifact_type) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (conn := artifact_type.artifact_collections) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"
+            raise ValueError(msg)
 
         self.last_response = ArtifactCollectionConnection.model_validate(conn)
 
@@ -457,8 +467,13 @@ class ProjectArtifactCollections(
         result = ProjectArtifactCollections.model_validate(data)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        if not ((proj := result.project) and (conn := proj.artifact_collections)):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (conn := proj.artifact_collections) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"unexpected empty response for artifact collections in {err_path!r}"
+            raise ValueError(msg)
 
         self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
 
@@ -913,13 +928,24 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
         result = ProjectArtifacts.model_validate(data)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        if not (
-            (proj := result.project)
-            and (type_ := proj.artifact_type)
-            and (collection := type_.artifact_collection)
-            and (conn := collection.artifacts)
-        ):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        # At the time of writing, the server returns HTTP 200 with `null` at
+        # any level for an invalid path or access-denied, so provide a specific
+        # message at the first missing level.
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (type_ := proj.artifact_type) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"artifact type {self.type!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (collection := type_.artifact_collection) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"artifact collection {self.collection_name!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (conn := collection.artifacts) is None:
+            err_path = f"{self.entity}/{self.project}/{self.collection_name}"
+            msg = f"unexpected empty response for artifacts in {err_path!r}"
+            raise ValueError(msg)
 
         self.last_response = _ArtifactConnectionGeneric[
             ArtifactFragment
@@ -1090,15 +1116,45 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
         data = self._execute_query()
 
         # Extract the inner `*Connection` result for faster/easier access.
+        # At the time of writing, the server returns HTTP 200 with `null` at
+        # any level for an invalid path or access-denied, so provide a specific
+        # message at the first missing level.
+        art = self.artifact
         if self.query_via_membership:
             result = GetArtifactMembershipFiles.model_validate(data)
-            conn = result.project.artifact_collection.artifact_membership.files
+            if (proj := result.project) is None:
+                msg = f"project {art.project!r} not found in entity {art.entity!r}"
+                raise ValueError(msg)
+            if (coll := proj.artifact_collection) is None:
+                coll_name = art.name.split(":")[0]
+                err_path = f"{art.entity}/{art.project}"
+                msg = f"artifact collection {coll_name!r} not found in {err_path!r}"
+                raise ValueError(msg)
+            if (membership := coll.artifact_membership) is None:
+                err_path = f"{art.entity}/{art.project}"
+                msg = f"member artifact {art.name!r} not found in {err_path!r}"
+                raise ValueError(msg)
+            if (conn := membership.files) is None:
+                err_path = f"{art.entity}/{art.project}"
+                msg = f"unexpected empty response for files of artifact {art.name!r} in {err_path!r}"
+                raise ValueError(msg)
         else:
             result = GetArtifactFiles.model_validate(data)
-            conn = result.project.artifact_type.artifact.files
-
-        if conn is None:
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+            if (proj := result.project) is None:
+                msg = f"project {art.source_project!r} not found in entity {art.source_entity!r}"
+                raise ValueError(msg)
+            if (atype := proj.artifact_type) is None:
+                err_path = f"{art.source_entity}/{art.source_project}"
+                msg = f"artifact type {art.type!r} not found in {err_path!r}"
+                raise ValueError(msg)
+            if (artifact := atype.artifact) is None:
+                err_path = f"{art.source_entity}/{art.source_project}"
+                msg = f"artifact {art.source_name!r} not found in {err_path!r}"
+                raise ValueError(msg)
+            if (conn := artifact.files) is None:
+                err_path = f"{art.source_entity}/{art.source_project}"
+                msg = f"unexpected empty response for files of artifact {art.source_name!r} in {err_path!r}"
+                raise ValueError(msg)
 
         self.last_response = ArtifactFileConnection.model_validate(conn)
 

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -12,6 +12,7 @@ from copy import copy
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, List, Literal, TypeVar  # noqa: UP035
 
+from pydantic import ValidationError
 from typing_extensions import override
 
 from wandb._iterutils import always_list
@@ -144,22 +145,38 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
-        from wandb.sdk.artifacts._generated import ProjectArtifactTypes
-        from wandb.sdk.artifacts._models.pagination import ArtifactTypeConnection
+        from wandb.sdk.artifacts._models.pagination import ProjectArtifactTypesResult
 
         data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = ProjectArtifactTypes.model_validate(data)
+        try:
+            result = ProjectArtifactTypesResult.model_validate(data)
+        except ValidationError as e:
+            entity, project = self.entity, self.project
+            entity_project = f"{entity}/{project}"
+            match data:
+                case {"project": None}:
+                    msg = f"project {project!r} not found in entity {entity!r}"
+                case {"project": {"artifactTypes": None}}:
+                    msg = f"unexpected empty response for artifact types in {entity_project!r}"
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
-            raise ValueError(msg)
-        if (conn := proj.artifact_types) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"unexpected empty response for artifact types in {err_path!r}"
             raise ValueError(msg)
 
-        self.last_response = ArtifactTypeConnection.model_validate(conn)
+        self.last_response = result.connection
+
+        # result = ProjectArtifactTypes.model_validate(data)
+
+        # # Extract the inner `*Connection` result for faster/easier access.
+        # if (proj := result.project) is None:
+        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
+        #     raise ValueError(msg)
+        # if (conn := proj.artifact_types) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"unexpected empty response for artifact types in {err_path!r}"
+        #     raise ValueError(msg)
+
+        # self.last_response = ArtifactTypeConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactTypeFragment) -> ArtifactType:
         return ArtifactType(
@@ -355,26 +372,51 @@ class ArtifactCollections(
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
-        from wandb.sdk.artifacts._generated import ArtifactTypeArtifactCollections
-        from wandb.sdk.artifacts._models.pagination import ArtifactCollectionConnection
+        from wandb.sdk.artifacts._models.pagination import (
+            ProjectArtifactTypeArtifactCollectionsResult,
+        )
 
         data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = ArtifactTypeArtifactCollections.model_validate(data)
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
-            raise ValueError(msg)
-        if (artifact_type := proj.artifact_type) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (conn := artifact_type.artifact_collections) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"
+        try:
+            result = ProjectArtifactTypeArtifactCollectionsResult.model_validate(data)
+        except ValidationError as e:
+            entity, project, type_name = self.entity, self.project, self.type_name
+            entity_project = f"{entity}/{project}"
+
+            match data:
+                case {"project": None}:
+                    msg = f"project {project!r} not found in entity {entity!r}"
+
+                case {"project": {"artifactType": None}}:
+                    msg = f"artifact type {type_name!r} not found in {entity_project!r}"
+
+                case {"project": {"artifactType": {"artifactCollections": None}}}:
+                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {type_name!r}"
+
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+
             raise ValueError(msg)
 
-        self.last_response = ArtifactCollectionConnection.model_validate(conn)
+        self.last_response = result.connection
+
+        # result = ArtifactTypeArtifactCollections.model_validate(data)
+
+        # # Extract the inner `*Connection` result for faster/easier access.
+        # if (proj := result.project) is None:
+        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
+        #     raise ValueError(msg)
+        # if (artifact_type := proj.artifact_type) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
+        #     raise ValueError(msg)
+        # if (conn := artifact_type.artifact_collections) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"  # noqa: W505
+        #     raise ValueError(msg)
+
+        # self.last_response = ArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:
@@ -458,24 +500,41 @@ class ProjectArtifactCollections(
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
-        from wandb.sdk.artifacts._generated import ProjectArtifactCollections
         from wandb.sdk.artifacts._models.pagination import (
-            ProjectArtifactCollectionConnection,
+            ProjectArtifactCollectionsResult,
         )
 
         data = self._execute_query()
-        result = ProjectArtifactCollections.model_validate(data)
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
-            raise ValueError(msg)
-        if (conn := proj.artifact_collections) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"unexpected empty response for artifact collections in {err_path!r}"
+        try:
+            result = ProjectArtifactCollectionsResult.model_validate(data)
+        except ValidationError as e:
+            entity, project = self.entity, self.project
+            entity_project = f"{entity}/{project}"
+
+            match data:
+                case {"project": None}:
+                    msg = f"project {project!r} not found in entity {entity!r}"
+                case {"project": {"artifactCollections": None}}:
+                    msg = f"unexpected empty response for artifact collections in {entity_project!r}"
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
-        self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
+        self.last_response = result.connection
+
+        # result = ProjectArtifactCollections.model_validate(data)
+
+        # # Extract the inner `*Connection` result for faster/easier access.
+        # if (proj := result.project) is None:
+        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
+        #     raise ValueError(msg)
+        # if (conn := proj.artifact_collections) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"unexpected empty response for artifact collections in {err_path!r}"
+        #     raise ValueError(msg)
+
+        # self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -10,13 +10,12 @@ import json
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from copy import copy
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, ClassVar, List, Literal, TypeVar  # noqa: UP035
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import ValidationError
 from typing_extensions import override
 
 from wandb._iterutils import always_list
-from wandb._pydantic import Connection, ConnectionWithTotal, Edge
 from wandb._strutils import nameof
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import RelayPaginator, SizedRelayPaginator
@@ -31,6 +30,7 @@ from wandb.sdk.lib.deprecation import warn_and_record_deprecation
 from .files import File
 
 if TYPE_CHECKING:
+    from wandb._pydantic import Connection, ConnectionWithTotal
     from wandb.apis.public.service_api import ServiceApi
     from wandb.sdk.artifacts._generated import (
         ArtifactAliasFragment,
@@ -40,16 +40,13 @@ if TYPE_CHECKING:
         FileFragment,
     )
     from wandb.sdk.artifacts._models.pagination import (
-        ArtifactCollectionConnection,
         ArtifactFileConnection,
-        ArtifactTypeConnection,
+        ProjectArtifactConnection,
+        VersionedArtifactEdge,
     )
     from wandb.sdk.artifacts.artifact import Artifact
 
     from . import Run
-
-
-TNode = TypeVar("TNode")
 
 
 @lru_cache(maxsize=1)
@@ -94,6 +91,7 @@ class _ArtifactCollectionAliases(RelayPaginator["ArtifactAliasFragment", str]):
         )
 
     def _update_response(self) -> None:
+        from wandb._pydantic import Connection
         from wandb.sdk.artifacts._generated import (
             ArtifactAliasFragment,
             ArtifactCollectionAliases,
@@ -119,7 +117,7 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
     """
 
     QUERY: ClassVar[str | None] = None
-    last_response: ArtifactTypeConnection | None
+    last_response: Connection[ArtifactTypeFragment] | None
 
     def __init__(
         self,
@@ -151,13 +149,13 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
         try:
             result = ProjectArtifactTypesResult.model_validate(data)
         except ValidationError as e:
-            entity, project = self.entity, self.project
-            entity_project = f"{entity}/{project}"
+            project, entity = self.project, self.entity
             match data:
                 case {"project": None}:
-                    msg = f"project {project!r} not found in entity {entity!r}"
+                    msg = f"Project {project!r} not found in entity {entity!r}"
                 case {"project": {"artifactTypes": None}}:
-                    msg = f"unexpected empty response for artifact types in {entity_project!r}"
+                    path = f"{entity}/{project}"
+                    msg = f"Unexpected empty response for artifact types in {path!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
 
@@ -311,7 +309,7 @@ class ArtifactCollections(
     """
 
     QUERY: ClassVar[str | None] = None
-    last_response: ArtifactCollectionConnection | None
+    last_response: ConnectionWithTotal[ArtifactCollectionFragment] | None
 
     def __init__(
         self,
@@ -369,15 +367,15 @@ class ArtifactCollections(
             result = ProjectArtifactTypeArtifactCollectionsResult.model_validate(data)
         except ValidationError as e:
             entity, project, art_type = self.entity, self.project, self.type_name
-            entity_project = f"{entity}/{project}"
+            proj_path = f"{entity}/{project}"
 
             match data:
                 case {"project": None}:
-                    msg = f"project {project!r} not found in entity {entity!r}"
+                    msg = f"Project {project!r} not found in entity {entity!r}"
                 case {"project": {"artifactType": None}}:
-                    msg = f"artifact type {art_type!r} not found in {entity_project!r}"
+                    msg = f"Artifact type {art_type!r} not found in {proj_path!r}"
                 case {"project": {"artifactType": {"artifactCollections": None}}}:
-                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {art_type!r}"
+                    msg = f"Unexpected empty response for artifact collections in {proj_path!r}, type {art_type!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
@@ -417,7 +415,7 @@ class ProjectArtifactCollections(
     """
 
     QUERY: str | None
-    last_response: ArtifactCollectionConnection | None
+    last_response: ConnectionWithTotal[ArtifactCollectionFragment] | None
 
     def __init__(
         self,
@@ -476,13 +474,13 @@ class ProjectArtifactCollections(
             result = ProjectArtifactCollectionsResult.model_validate(data)
         except ValidationError as e:
             entity, project = self.entity, self.project
-            entity_project = f"{entity}/{project}"
+            proj_path = f"{entity}/{project}"
 
             match data:
                 case {"project": None}:
-                    msg = f"project {project!r} not found in entity {entity!r}"
+                    msg = f"Project {project!r} not found in entity {entity!r}"
                 case {"project": {"artifactCollections": None}}:
-                    msg = f"unexpected empty response for artifact collections in {entity_project!r}"
+                    msg = f"Unexpected empty response for artifact collections in {proj_path!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
@@ -861,14 +859,6 @@ class ArtifactCollection:
         return f"<ArtifactCollection {self.name} ({self.type})>"
 
 
-class _ArtifactEdgeGeneric(Edge[TNode]):
-    version: str  # Extra field defined only on VersionedArtifactEdge
-
-
-class _ArtifactConnectionGeneric(ConnectionWithTotal[TNode]):
-    edges: List[_ArtifactEdgeGeneric]  # noqa: UP006
-
-
 class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     """An iterable collection of artifact versions associated with a project.
 
@@ -892,8 +882,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
 
     QUERY: str  # Must be set per-instance
 
-    # Loosely-annotated to avoid importing heavy types at module import time.
-    last_response: _ArtifactConnectionGeneric | None
+    last_response: ProjectArtifactConnection | None
 
     def __init__(
         self,
@@ -934,34 +923,36 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
 
     @override
     def _update_response(self) -> None:
-        from wandb.sdk.artifacts._generated import ArtifactFragment, ProjectArtifacts
+        from wandb.sdk.artifacts._models.pagination import ProjectArtifactsResult
 
         data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = ProjectArtifacts.model_validate(data)
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        # At the time of writing, the server returns HTTP 200 with `null` at
-        # any level for an invalid path or access-denied, so provide a specific
-        # message at the first missing level.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
-            raise ValueError(msg)
-        if (type_ := proj.artifact_type) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"artifact type {self.type!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (collection := type_.artifact_collection) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"artifact collection {self.collection_name!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (conn := collection.artifacts) is None:
-            err_path = f"{self.entity}/{self.project}/{self.collection_name}"
-            msg = f"unexpected empty response for artifacts in {err_path!r}"
+        try:
+            result = ProjectArtifactsResult.model_validate(data)
+        except ValidationError as e:
+            entity, project = self.entity, self.project
+            coll, art_type = self.collection_name, self.type
+            proj_path = f"{entity}/{project}"
+
+            match data:
+                case {"project": None}:
+                    msg = f"Project {project!r} not found in entity {entity!r}"
+                case {"project": {"artifactType": None}}:
+                    msg = f"Artifact type {art_type!r} not found in {proj_path!r}"
+                case {"project": {"artifactType": {"artifactCollection": None}}}:
+                    msg = f"Artifact collection {coll!r} not found in {proj_path!r}"
+                case {
+                    "project": {
+                        "artifactType": {"artifactCollection": {"artifacts": None}}
+                    }
+                }:
+                    coll_path = f"{proj_path}/{coll}"
+                    msg = f"Unexpected empty response for artifacts in {coll_path!r}"
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
-        self.last_response = _ArtifactConnectionGeneric[
-            ArtifactFragment
-        ].model_validate(conn)
+        self.last_response = result.connection
 
     # FIXME: For now, we deliberately override the signatures of:
     # - `_convert()`
@@ -972,7 +963,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     # In the future, we should move to fetching artifacts via (GQL) artifactMemberships,
     # not (GQL) artifacts, so we don't have to deal with this hack.
     @override
-    def _convert(self, edge: _ArtifactEdgeGeneric[ArtifactFragment]) -> Artifact:
+    def _convert(self, edge: VersionedArtifactEdge) -> Artifact:
         from wandb.sdk.artifacts._validators import FullArtifactPath
         from wandb.sdk.artifacts.artifact import Artifact
 
@@ -1119,56 +1110,67 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
 
     @override
     def _update_response(self) -> None:
-        from wandb.sdk.artifacts._generated import (
-            GetArtifactFiles,
-            GetArtifactMembershipFiles,
+        from wandb.sdk.artifacts._models.pagination import (
+            ProjectArtifactFilesResult,
+            ProjectArtifactMembershipFilesResult,
         )
-        from wandb.sdk.artifacts._models.pagination import ArtifactFileConnection
 
         data = self._execute_query()
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        # At the time of writing, the server returns HTTP 200 with `null` at
-        # any level for an invalid path or access-denied, so provide a specific
-        # message at the first missing level.
         art = self.artifact
         if self.query_via_membership:
-            result = GetArtifactMembershipFiles.model_validate(data)
-            if (proj := result.project) is None:
-                msg = f"project {art.project!r} not found in entity {art.entity!r}"
-                raise ValueError(msg)
-            if (coll := proj.artifact_collection) is None:
+            try:
+                result = ProjectArtifactMembershipFilesResult.model_validate(data)
+            except ValidationError as e:
+                entity, project = art.entity, art.project
+                proj_path = f"{entity}/{project}"
                 coll_name = art.name.split(":")[0]
-                err_path = f"{art.entity}/{art.project}"
-                msg = f"artifact collection {coll_name!r} not found in {err_path!r}"
-                raise ValueError(msg)
-            if (membership := coll.artifact_membership) is None:
-                err_path = f"{art.entity}/{art.project}"
-                msg = f"member artifact {art.name!r} not found in {err_path!r}"
-                raise ValueError(msg)
-            if (conn := membership.files) is None:
-                err_path = f"{art.entity}/{art.project}"
-                msg = f"unexpected empty response for files of artifact {art.name!r} in {err_path!r}"
+
+                match data:
+                    case {"project": None}:
+                        msg = f"Project {project!r} not found in entity {entity!r}"
+                    case {"project": {"artifactCollection": None}}:
+                        msg = f"Artifact collection {coll_name!r} not found in {proj_path!r}"
+                    case {
+                        "project": {"artifactCollection": {"artifactMembership": None}}
+                    }:
+                        msg = f"Member artifact {art.name!r} not found in {proj_path!r}"
+                    case {
+                        "project": {
+                            "artifactCollection": {
+                                "artifactMembership": {"files": None}
+                            }
+                        }
+                    }:
+                        msg = f"Unexpected empty response for files of artifact {art.name!r} in {proj_path!r}"
+                    case _:
+                        msg = (
+                            f"Unable to parse {nameof(type(self))!r} response data: {e}"
+                        )
                 raise ValueError(msg)
         else:
-            result = GetArtifactFiles.model_validate(data)
-            if (proj := result.project) is None:
-                msg = f"project {art.source_project!r} not found in entity {art.source_entity!r}"
-                raise ValueError(msg)
-            if (atype := proj.artifact_type) is None:
-                err_path = f"{art.source_entity}/{art.source_project}"
-                msg = f"artifact type {art.type!r} not found in {err_path!r}"
-                raise ValueError(msg)
-            if (artifact := atype.artifact) is None:
-                err_path = f"{art.source_entity}/{art.source_project}"
-                msg = f"artifact {art.source_name!r} not found in {err_path!r}"
-                raise ValueError(msg)
-            if (conn := artifact.files) is None:
-                err_path = f"{art.source_entity}/{art.source_project}"
-                msg = f"unexpected empty response for files of artifact {art.source_name!r} in {err_path!r}"
+            try:
+                result = ProjectArtifactFilesResult.model_validate(data)
+            except ValidationError as e:
+                entity, project = art.source_entity, art.source_project
+                proj_path = f"{entity}/{project}"
+
+                match data:
+                    case {"project": None}:
+                        msg = f"Project {project!r} not found in entity {entity!r}"
+                    case {"project": {"artifactType": None}}:
+                        msg = f"Artifact type {art.type!r} not found in {proj_path!r}"
+                    case {"project": {"artifactType": {"artifact": None}}}:
+                        msg = f"Artifact {art.source_name!r} not found in {proj_path!r}"
+                    case {"project": {"artifactType": {"artifact": {"files": None}}}}:
+                        msg = f"Unexpected empty response for files of artifact {art.source_name!r} in {proj_path!r}"
+                    case _:
+                        msg = (
+                            f"Unable to parse {nameof(type(self))!r} response data: {e}"
+                        )
                 raise ValueError(msg)
 
-        self.last_response = ArtifactFileConnection.model_validate(conn)
+        self.last_response = result.connection
 
     @property
     def path(self) -> list[str]:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts._models.pagination import (
         ArtifactFileConnection,
         ProjectArtifactConnection,
-        VersionedArtifactEdge,
+        _VersionedEdge,
     )
     from wandb.sdk.artifacts.artifact import Artifact
 
@@ -963,7 +963,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     # In the future, we should move to fetching artifacts via (GQL) artifactMemberships,
     # not (GQL) artifacts, so we don't have to deal with this hack.
     @override
-    def _convert(self, edge: VersionedArtifactEdge) -> Artifact:
+    def _convert(self, edge: _VersionedEdge) -> Artifact:
         from wandb.sdk.artifacts._validators import FullArtifactPath
         from wandb.sdk.artifacts.artifact import Artifact
 

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -165,19 +165,6 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
 
         self.last_response = result.connection
 
-        # result = ProjectArtifactTypes.model_validate(data)
-
-        # # Extract the inner `*Connection` result for faster/easier access.
-        # if (proj := result.project) is None:
-        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
-        #     raise ValueError(msg)
-        # if (conn := proj.artifact_types) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"unexpected empty response for artifact types in {err_path!r}"
-        #     raise ValueError(msg)
-
-        # self.last_response = ArtifactTypeConnection.model_validate(conn)
-
     def _convert(self, node: ArtifactTypeFragment) -> ArtifactType:
         return ArtifactType(
             service_api=self._service_api,
@@ -381,42 +368,21 @@ class ArtifactCollections(
         try:
             result = ProjectArtifactTypeArtifactCollectionsResult.model_validate(data)
         except ValidationError as e:
-            entity, project, type_name = self.entity, self.project, self.type_name
+            entity, project, art_type = self.entity, self.project, self.type_name
             entity_project = f"{entity}/{project}"
 
             match data:
                 case {"project": None}:
                     msg = f"project {project!r} not found in entity {entity!r}"
-
                 case {"project": {"artifactType": None}}:
-                    msg = f"artifact type {type_name!r} not found in {entity_project!r}"
-
+                    msg = f"artifact type {art_type!r} not found in {entity_project!r}"
                 case {"project": {"artifactType": {"artifactCollections": None}}}:
-                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {type_name!r}"
-
+                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {art_type!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
-
             raise ValueError(msg)
 
         self.last_response = result.connection
-
-        # result = ArtifactTypeArtifactCollections.model_validate(data)
-
-        # # Extract the inner `*Connection` result for faster/easier access.
-        # if (proj := result.project) is None:
-        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
-        #     raise ValueError(msg)
-        # if (artifact_type := proj.artifact_type) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
-        #     raise ValueError(msg)
-        # if (conn := artifact_type.artifact_collections) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"  # noqa: W505
-        #     raise ValueError(msg)
-
-        # self.last_response = ArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:
@@ -522,19 +488,6 @@ class ProjectArtifactCollections(
             raise ValueError(msg)
 
         self.last_response = result.connection
-
-        # result = ProjectArtifactCollections.model_validate(data)
-
-        # # Extract the inner `*Connection` result for faster/easier access.
-        # if (proj := result.project) is None:
-        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
-        #     raise ValueError(msg)
-        # if (conn := proj.artifact_collections) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"unexpected empty response for artifact collections in {err_path!r}"
-        #     raise ValueError(msg)
-
-        # self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -19,7 +19,7 @@ from typing import (  # noqa: UP035
     TypeVar,
 )
 
-from pydantic import Field, PositiveInt
+from pydantic import Field, PositiveInt, ValidationError
 from typing_extensions import override
 
 from wandb._iterutils import always_list
@@ -180,21 +180,38 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
-        from wandb.sdk.artifacts._generated import ProjectArtifactTypes
-        from wandb.sdk.artifacts._models.pagination import ArtifactTypeConnection
+        from wandb.sdk.artifacts._models.pagination import ProjectArtifactTypesResult
 
-        result = self._execute_query(parse=ProjectArtifactTypes.model_validate_json)
+        data = self._execute_query()
+        try:
+            result = ProjectArtifactTypesResult.model_validate(data)
+        except ValidationError as e:
+            entity, project = self.entity, self.project
+            entity_project = f"{entity}/{project}"
+            match data:
+                case {"project": None}:
+                    msg = f"project {project!r} not found in entity {entity!r}"
+                case {"project": {"artifactTypes": None}}:
+                    msg = f"unexpected empty response for artifact types in {entity_project!r}"
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
             raise ValueError(msg)
-        if (conn := proj.artifact_types) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"unexpected empty response for artifact types in {err_path!r}"
-            raise ValueError(msg)
 
-        self.last_response = ArtifactTypeConnection.model_validate(conn)
+        self.last_response = result.connection
+
+        # result = ProjectArtifactTypes.model_validate(data)
+
+        # # Extract the inner `*Connection` result for faster/easier access.
+        # if (proj := result.project) is None:
+        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
+        #     raise ValueError(msg)
+        # if (conn := proj.artifact_types) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"unexpected empty response for artifact types in {err_path!r}"
+        #     raise ValueError(msg)
+
+        # self.last_response = ArtifactTypeConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactTypeFragment) -> ArtifactType:
         return ArtifactType(
@@ -408,27 +425,51 @@ class ArtifactCollections(
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
-        from wandb.sdk.artifacts._generated import ArtifactTypeArtifactCollections
-        from wandb.sdk.artifacts._models.pagination import ArtifactCollectionConnection
-
-        result = self._execute_query(
-            parse=ArtifactTypeArtifactCollections.model_validate_json
+        from wandb.sdk.artifacts._models.pagination import (
+            ProjectArtifactTypeArtifactCollectionsResult,
         )
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
-            raise ValueError(msg)
-        if (artifact_type := proj.artifact_type) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (conn := artifact_type.artifact_collections) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"
+        data = self._execute_query()
+
+        try:
+            result = ProjectArtifactTypeArtifactCollectionsResult.model_validate(data)
+        except ValidationError as e:
+            entity, project, type_name = self.entity, self.project, self.type_name
+            entity_project = f"{entity}/{project}"
+
+            match data:
+                case {"project": None}:
+                    msg = f"project {project!r} not found in entity {entity!r}"
+
+                case {"project": {"artifactType": None}}:
+                    msg = f"artifact type {type_name!r} not found in {entity_project!r}"
+
+                case {"project": {"artifactType": {"artifactCollections": None}}}:
+                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {type_name!r}"
+
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+
             raise ValueError(msg)
 
-        self.last_response = ArtifactCollectionConnection.model_validate(conn)
+        self.last_response = result.connection
+
+        # result = ArtifactTypeArtifactCollections.model_validate(data)
+
+        # # Extract the inner `*Connection` result for faster/easier access.
+        # if (proj := result.project) is None:
+        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
+        #     raise ValueError(msg)
+        # if (artifact_type := proj.artifact_type) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
+        #     raise ValueError(msg)
+        # if (conn := artifact_type.artifact_collections) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"  # noqa: W505
+        #     raise ValueError(msg)
+
+        # self.last_response = ArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:
@@ -521,24 +562,41 @@ class ProjectArtifactCollections(
     @override
     def _update_response(self) -> None:
         """Fetch and validate the response data for the current page."""
-        from wandb.sdk.artifacts._generated import ProjectArtifactCollections
         from wandb.sdk.artifacts._models.pagination import (
-            ProjectArtifactCollectionConnection,
+            ProjectArtifactCollectionsResult,
         )
 
-        result = self._execute_query(
-            parse=ProjectArtifactCollections.model_validate_json
-        )
-        # Extract the inner `*Connection` result for faster/easier access.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
-            raise ValueError(msg)
-        if (conn := proj.artifact_collections) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"unexpected empty response for artifact collections in {err_path!r}"
+        data = self._execute_query()
+
+        try:
+            result = ProjectArtifactCollectionsResult.model_validate(data)
+        except ValidationError as e:
+            entity, project = self.entity, self.project
+            entity_project = f"{entity}/{project}"
+
+            match data:
+                case {"project": None}:
+                    msg = f"project {project!r} not found in entity {entity!r}"
+                case {"project": {"artifactCollections": None}}:
+                    msg = f"unexpected empty response for artifact collections in {entity_project!r}"
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
-        self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
+        self.last_response = result.connection
+
+        # result = ProjectArtifactCollections.model_validate(data)
+
+        # # Extract the inner `*Connection` result for faster/easier access.
+        # if (proj := result.project) is None:
+        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
+        #     raise ValueError(msg)
+        # if (conn := proj.artifact_collections) is None:
+        #     err_path = f"{self.entity}/{self.project}"
+        #     msg = f"unexpected empty response for artifact collections in {err_path!r}"
+        #     raise ValueError(msg)
+
+        # self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -200,19 +200,6 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
 
         self.last_response = result.connection
 
-        # result = ProjectArtifactTypes.model_validate(data)
-
-        # # Extract the inner `*Connection` result for faster/easier access.
-        # if (proj := result.project) is None:
-        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
-        #     raise ValueError(msg)
-        # if (conn := proj.artifact_types) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"unexpected empty response for artifact types in {err_path!r}"
-        #     raise ValueError(msg)
-
-        # self.last_response = ArtifactTypeConnection.model_validate(conn)
-
     def _convert(self, node: ArtifactTypeFragment) -> ArtifactType:
         return ArtifactType(
             service_api=self._service_api,
@@ -434,42 +421,21 @@ class ArtifactCollections(
         try:
             result = ProjectArtifactTypeArtifactCollectionsResult.model_validate(data)
         except ValidationError as e:
-            entity, project, type_name = self.entity, self.project, self.type_name
+            entity, project, art_type = self.entity, self.project, self.type_name
             entity_project = f"{entity}/{project}"
 
             match data:
                 case {"project": None}:
                     msg = f"project {project!r} not found in entity {entity!r}"
-
                 case {"project": {"artifactType": None}}:
-                    msg = f"artifact type {type_name!r} not found in {entity_project!r}"
-
+                    msg = f"artifact type {art_type!r} not found in {entity_project!r}"
                 case {"project": {"artifactType": {"artifactCollections": None}}}:
-                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {type_name!r}"
-
+                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {art_type!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
-
             raise ValueError(msg)
 
         self.last_response = result.connection
-
-        # result = ArtifactTypeArtifactCollections.model_validate(data)
-
-        # # Extract the inner `*Connection` result for faster/easier access.
-        # if (proj := result.project) is None:
-        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
-        #     raise ValueError(msg)
-        # if (artifact_type := proj.artifact_type) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
-        #     raise ValueError(msg)
-        # if (conn := artifact_type.artifact_collections) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"  # noqa: W505
-        #     raise ValueError(msg)
-
-        # self.last_response = ArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:
@@ -584,19 +550,6 @@ class ProjectArtifactCollections(
             raise ValueError(msg)
 
         self.last_response = result.connection
-
-        # result = ProjectArtifactCollections.model_validate(data)
-
-        # # Extract the inner `*Connection` result for faster/easier access.
-        # if (proj := result.project) is None:
-        #     msg = f"project {self.project!r} not found in entity {self.entity!r}"
-        #     raise ValueError(msg)
-        # if (conn := proj.artifact_collections) is None:
-        #     err_path = f"{self.entity}/{self.project}"
-        #     msg = f"unexpected empty response for artifact collections in {err_path!r}"
-        #     raise ValueError(msg)
-
-        # self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
         if not node.project:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -9,24 +9,13 @@ from __future__ import annotations
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from copy import copy
 from functools import lru_cache
-from typing import (  # noqa: UP035
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    ClassVar,
-    List,
-    Literal,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal
 
 from pydantic import Field, PositiveInt, ValidationError
 from typing_extensions import override
 
 from wandb._iterutils import always_list
 from wandb._pydantic import (
-    Connection,
-    ConnectionWithTotal,
-    Edge,
     FilterDict,
     OrderValidator,
     PaginatorVars,
@@ -45,6 +34,7 @@ from wandb.sdk.lib.deprecation import warn_and_record_deprecation
 from .files import File
 
 if TYPE_CHECKING:
+    from wandb._pydantic import Connection, ConnectionWithTotal
     from wandb.apis.public.service_api import ServiceApi
     from wandb.sdk.artifacts._generated import (
         ArtifactAliasFragment,
@@ -54,16 +44,13 @@ if TYPE_CHECKING:
         FileFragment,
     )
     from wandb.sdk.artifacts._models.pagination import (
-        ArtifactCollectionConnection,
         ArtifactFileConnection,
-        ArtifactTypeConnection,
+        ProjectArtifactConnection,
+        VersionedArtifactEdge,
     )
     from wandb.sdk.artifacts.artifact import Artifact
 
     from . import Run
-
-
-TNode = TypeVar("TNode")
 
 
 @lru_cache(maxsize=1)
@@ -116,6 +103,7 @@ class _ArtifactCollectionAliases(RelayPaginator["ArtifactAliasFragment", str]):
         )
 
     def _update_response(self) -> None:
+        from wandb._pydantic import Connection
         from wandb.sdk.artifacts._generated import (
             ArtifactAliasFragment,
             ArtifactCollectionAliases,
@@ -148,7 +136,7 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
     """
 
     QUERY: ClassVar[str | None] = None
-    last_response: ArtifactTypeConnection | None
+    last_response: Connection[ArtifactTypeFragment] | None
 
     def __init__(
         self,
@@ -186,13 +174,13 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
         try:
             result = ProjectArtifactTypesResult.model_validate(data)
         except ValidationError as e:
-            entity, project = self.entity, self.project
-            entity_project = f"{entity}/{project}"
+            project, entity = self.project, self.entity
             match data:
                 case {"project": None}:
-                    msg = f"project {project!r} not found in entity {entity!r}"
+                    msg = f"Project {project!r} not found in entity {entity!r}"
                 case {"project": {"artifactTypes": None}}:
-                    msg = f"unexpected empty response for artifact types in {entity_project!r}"
+                    path = f"{entity}/{project}"
+                    msg = f"Unexpected empty response for artifact types in {path!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
 
@@ -357,7 +345,7 @@ class ArtifactCollections(
     """
 
     QUERY: ClassVar[str | None] = None
-    last_response: ArtifactCollectionConnection | None
+    last_response: ConnectionWithTotal[ArtifactCollectionFragment] | None
 
     def __init__(
         self,
@@ -422,15 +410,15 @@ class ArtifactCollections(
             result = ProjectArtifactTypeArtifactCollectionsResult.model_validate(data)
         except ValidationError as e:
             entity, project, art_type = self.entity, self.project, self.type_name
-            entity_project = f"{entity}/{project}"
+            proj_path = f"{entity}/{project}"
 
             match data:
                 case {"project": None}:
-                    msg = f"project {project!r} not found in entity {entity!r}"
+                    msg = f"Project {project!r} not found in entity {entity!r}"
                 case {"project": {"artifactType": None}}:
-                    msg = f"artifact type {art_type!r} not found in {entity_project!r}"
+                    msg = f"Artifact type {art_type!r} not found in {proj_path!r}"
                 case {"project": {"artifactType": {"artifactCollections": None}}}:
-                    msg = f"unexpected empty response for artifact collections in {entity_project!r}, type {art_type!r}"
+                    msg = f"Unexpected empty response for artifact collections in {proj_path!r}, type {art_type!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
@@ -478,7 +466,7 @@ class ProjectArtifactCollections(
     """
 
     QUERY: ClassVar[str | None] = None
-    last_response: ArtifactCollectionConnection | None
+    last_response: Connection[ArtifactCollectionFragment] | None
 
     def __init__(
         self,
@@ -538,13 +526,13 @@ class ProjectArtifactCollections(
             result = ProjectArtifactCollectionsResult.model_validate(data)
         except ValidationError as e:
             entity, project = self.entity, self.project
-            entity_project = f"{entity}/{project}"
+            proj_path = f"{entity}/{project}"
 
             match data:
                 case {"project": None}:
-                    msg = f"project {project!r} not found in entity {entity!r}"
+                    msg = f"Project {project!r} not found in entity {entity!r}"
                 case {"project": {"artifactCollections": None}}:
-                    msg = f"unexpected empty response for artifact collections in {entity_project!r}"
+                    msg = f"Unexpected empty response for artifact collections in {proj_path!r}"
                 case _:
                     msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
@@ -938,14 +926,6 @@ class ArtifactCollection:
         return f"<ArtifactCollection {self.name} ({self.type})>"
 
 
-class _ArtifactEdgeGeneric(Edge[TNode]):
-    version: str  # Extra field defined only on VersionedArtifactEdge
-
-
-class _ArtifactConnectionGeneric(ConnectionWithTotal[TNode]):
-    edges: List[_ArtifactEdgeGeneric]  # noqa: UP006
-
-
 class _ArtifactsVars(PaginatorVars):
     entity: str
     project: str
@@ -981,8 +961,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
 
     QUERY: ClassVar[str | None] = None
 
-    # Loosely-annotated to avoid importing heavy types at module import time.
-    last_response: _ArtifactConnectionGeneric | None
+    last_response: ProjectArtifactConnection | None
 
     def __init__(
         self,
@@ -1030,33 +1009,36 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
 
     @override
     def _update_response(self) -> None:
-        from wandb.sdk.artifacts._generated import ArtifactFragment, ProjectArtifacts
+        from wandb.sdk.artifacts._models.pagination import ProjectArtifactsResult
 
-        result = self._execute_query(parse=ProjectArtifacts.model_validate_json)
+        data = self._execute_query()
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        # At the time of writing, the server returns HTTP 200 with `null` at
-        # any level for an invalid path or access-denied, so provide a specific
-        # message at the first missing level.
-        if (proj := result.project) is None:
-            msg = f"project {self.project!r} not found in entity {self.entity!r}"
-            raise ValueError(msg)
-        if (type_ := proj.artifact_type) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"artifact type {self.type!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (collection := type_.artifact_collection) is None:
-            err_path = f"{self.entity}/{self.project}"
-            msg = f"artifact collection {self.collection_name!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (conn := collection.artifacts) is None:
-            err_path = f"{self.entity}/{self.project}/{self.collection_name}"
-            msg = f"unexpected empty response for artifacts in {err_path!r}"
+        try:
+            result = ProjectArtifactsResult.model_validate(data)
+        except ValidationError as e:
+            entity, project = self.entity, self.project
+            coll, art_type = self.collection_name, self.type
+            proj_path = f"{entity}/{project}"
+
+            match data:
+                case {"project": None}:
+                    msg = f"Project {project!r} not found in entity {entity!r}"
+                case {"project": {"artifactType": None}}:
+                    msg = f"Artifact type {art_type!r} not found in {proj_path!r}"
+                case {"project": {"artifactType": {"artifactCollection": None}}}:
+                    msg = f"Artifact collection {coll!r} not found in {proj_path!r}"
+                case {
+                    "project": {
+                        "artifactType": {"artifactCollection": {"artifacts": None}}
+                    }
+                }:
+                    coll_path = f"{proj_path}/{coll}"
+                    msg = f"Unexpected empty response for artifacts in {coll_path!r}"
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
-        self.last_response = _ArtifactConnectionGeneric[
-            ArtifactFragment
-        ].model_validate(conn)
+        self.last_response = result.connection
 
     # FIXME: For now, we deliberately override the signatures of:
     # - `_convert()`
@@ -1067,7 +1049,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     # In the future, we should move to fetching artifacts via (GQL) artifactMemberships,
     # not (GQL) artifacts, so we don't have to deal with this hack.
     @override
-    def _convert(self, edge: _ArtifactEdgeGeneric[ArtifactFragment]) -> Artifact:
+    def _convert(self, edge: VersionedArtifactEdge) -> Artifact:
         from wandb.sdk.artifacts._validators import FullArtifactPath
         from wandb.sdk.artifacts.artifact import Artifact
 
@@ -1226,34 +1208,38 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
 
     @override
     def _update_response(self) -> None:
-        from wandb.sdk.artifacts._generated import ArtifactMembershipFiles
-        from wandb.sdk.artifacts._models.pagination import ArtifactFileConnection
+        from wandb.sdk.artifacts._models.pagination import (
+            ProjectArtifactMembershipFilesResult,
+        )
 
-        result = self._execute_query(parse=ArtifactMembershipFiles.model_validate_json)
+        data = self._execute_query()
 
-        # Extract the inner `*Connection` result for faster/easier access.
-        # At the time of writing, the server returns HTTP 200 with `null` at
-        # any level for an invalid path or access-denied, so provide a specific
-        # message at the first missing level.
         art = self.artifact
-        if (proj := result.project) is None:
-            msg = f"project {art.project!r} not found in entity {art.entity!r}"
-            raise ValueError(msg)
-        if (coll := proj.artifact_collection) is None:
+        try:
+            result = ProjectArtifactMembershipFilesResult.model_validate(data)
+        except ValidationError as e:
+            entity, project = art.entity, art.project
+            proj_path = f"{entity}/{project}"
             coll_name = art.name.split(":")[0]
-            err_path = f"{art.entity}/{art.project}"
-            msg = f"artifact collection {coll_name!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (membership := coll.artifact_membership) is None:
-            err_path = f"{art.entity}/{art.project}"
-            msg = f"member artifact {art.name!r} not found in {err_path!r}"
-            raise ValueError(msg)
-        if (conn := membership.files) is None:
-            err_path = f"{art.entity}/{art.project}"
-            msg = f"unexpected empty response for files of artifact {art.name!r} in {err_path!r}"
+
+            match data:
+                case {"project": None}:
+                    msg = f"Project {project!r} not found in entity {entity!r}"
+                case {"project": {"artifactCollection": None}}:
+                    msg = f"Artifact collection {coll_name!r} not found in {proj_path!r}"
+                case {"project": {"artifactCollection": {"artifactMembership": None}}}:
+                    msg = f"Member artifact {art.name!r} not found in {proj_path!r}"
+                case {
+                    "project": {
+                        "artifactCollection": {"artifactMembership": {"files": None}}
+                    }
+                }:
+                    msg = f"Unexpected empty response for files of artifact {art.name!r} in {proj_path!r}"
+                case _:
+                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
-        self.last_response = ArtifactFileConnection.model_validate(conn)
+        self.last_response = result.connection
 
     @property
     def path(self) -> list[str]:

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -15,11 +15,7 @@ from pydantic import Field, PositiveInt, ValidationError
 from typing_extensions import override
 
 from wandb._iterutils import always_list
-from wandb._pydantic import (
-    FilterDict,
-    OrderValidator,
-    PaginatorVars,
-)
+from wandb._pydantic import FilterDict, OrderValidator, PaginatorVars
 from wandb._strutils import nameof
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import RelayPaginator, SizedRelayPaginator
@@ -44,9 +40,8 @@ if TYPE_CHECKING:
         FileFragment,
     )
     from wandb.sdk.artifacts._models.pagination import (
-        ArtifactFileConnection,
         ProjectArtifactConnection,
-        VersionedArtifactEdge,
+        _VersionedEdge,
     )
     from wandb.sdk.artifacts.artifact import Artifact
 
@@ -170,19 +165,16 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
         """Fetch and validate the response data for the current page."""
         from wandb.sdk.artifacts._models.pagination import ProjectArtifactTypesResult
 
-        data = self._execute_query()
         try:
-            result = ProjectArtifactTypesResult.model_validate(data)
+            result = self._execute_query(
+                parse=ProjectArtifactTypesResult.model_validate_json
+            )
         except ValidationError as e:
             project, entity = self.project, self.entity
-            match data:
-                case {"project": None}:
+            msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+            match e.errors():
+                case [{"input": {"project": None}}]:
                     msg = f"Project {project!r} not found in entity {entity!r}"
-                case {"project": {"artifactTypes": None}}:
-                    path = f"{entity}/{project}"
-                    msg = f"Unexpected empty response for artifact types in {path!r}"
-                case _:
-                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
 
             raise ValueError(msg)
 
@@ -404,23 +396,20 @@ class ArtifactCollections(
             ProjectArtifactTypeArtifactCollectionsResult,
         )
 
-        data = self._execute_query()
-
         try:
-            result = ProjectArtifactTypeArtifactCollectionsResult.model_validate(data)
+            result = self._execute_query(
+                parse=ProjectArtifactTypeArtifactCollectionsResult.model_validate_json
+            )
         except ValidationError as e:
             entity, project, art_type = self.entity, self.project, self.type_name
             proj_path = f"{entity}/{project}"
 
-            match data:
-                case {"project": None}:
+            msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+            match e.errors():
+                case [{"input": {"project": None}}]:
                     msg = f"Project {project!r} not found in entity {entity!r}"
-                case {"project": {"artifactType": None}}:
+                case [{"input": {"project": {"artifactType": None}}}]:
                     msg = f"Artifact type {art_type!r} not found in {proj_path!r}"
-                case {"project": {"artifactType": {"artifactCollections": None}}}:
-                    msg = f"Unexpected empty response for artifact collections in {proj_path!r}, type {art_type!r}"
-                case _:
-                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
         self.last_response = result.connection
@@ -520,21 +509,25 @@ class ProjectArtifactCollections(
             ProjectArtifactCollectionsResult,
         )
 
-        data = self._execute_query()
-
         try:
-            result = ProjectArtifactCollectionsResult.model_validate(data)
+            result = self._execute_query(
+                parse=ProjectArtifactCollectionsResult.model_validate_json
+            )
         except ValidationError as e:
             entity, project = self.entity, self.project
             proj_path = f"{entity}/{project}"
 
-            match data:
-                case {"project": None}:
+            msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+            match e.errors():
+                case [{"input": {"project": None}}]:
                     msg = f"Project {project!r} not found in entity {entity!r}"
-                case {"project": {"artifactCollections": None}}:
+                case [
+                    {
+                        "input": None,
+                        "loc": ("project", "artifactCollections"),
+                    }
+                ]:
                     msg = f"Unexpected empty response for artifact collections in {proj_path!r}"
-                case _:
-                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
         self.last_response = result.connection
@@ -1011,31 +1004,29 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     def _update_response(self) -> None:
         from wandb.sdk.artifacts._models.pagination import ProjectArtifactsResult
 
-        data = self._execute_query()
-
         try:
-            result = ProjectArtifactsResult.model_validate(data)
+            result = self._execute_query(
+                parse=ProjectArtifactsResult.model_validate_json
+            )
         except ValidationError as e:
             entity, project = self.entity, self.project
             coll, art_type = self.collection_name, self.type
             proj_path = f"{entity}/{project}"
 
-            match data:
-                case {"project": None}:
+            msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+            match e.errors():
+                case [{"input": {"project": None}}]:
                     msg = f"Project {project!r} not found in entity {entity!r}"
-                case {"project": {"artifactType": None}}:
+                case [{"input": {"project": {"artifactType": None}}}]:
                     msg = f"Artifact type {art_type!r} not found in {proj_path!r}"
-                case {"project": {"artifactType": {"artifactCollection": None}}}:
-                    msg = f"Artifact collection {coll!r} not found in {proj_path!r}"
-                case {
-                    "project": {
-                        "artifactType": {"artifactCollection": {"artifacts": None}}
+                case [
+                    {
+                        "input": {
+                            "project": {"artifactType": {"artifactCollection": None}}
+                        }
                     }
-                }:
-                    coll_path = f"{proj_path}/{coll}"
-                    msg = f"Unexpected empty response for artifacts in {coll_path!r}"
-                case _:
-                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+                ]:
+                    msg = f"Artifact collection {coll!r} not found in {proj_path!r}"
             raise ValueError(msg)
 
         self.last_response = result.connection
@@ -1049,7 +1040,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     # In the future, we should move to fetching artifacts via (GQL) artifactMemberships,
     # not (GQL) artifacts, so we don't have to deal with this hack.
     @override
-    def _convert(self, edge: VersionedArtifactEdge) -> Artifact:
+    def _convert(self, edge: _VersionedEdge) -> Artifact:
         from wandb.sdk.artifacts._validators import FullArtifactPath
         from wandb.sdk.artifacts.artifact import Artifact
 
@@ -1168,7 +1159,7 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
     """
 
     QUERY: ClassVar[str | None] = None
-    last_response: ArtifactFileConnection | None
+    last_response: Connection[FileFragment] | None
 
     def __init__(
         self,
@@ -1212,31 +1203,46 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
             ProjectArtifactMembershipFilesResult,
         )
 
-        data = self._execute_query()
-
         art = self.artifact
         try:
-            result = ProjectArtifactMembershipFilesResult.model_validate(data)
+            result = self._execute_query(
+                parse=ProjectArtifactMembershipFilesResult.model_validate_json
+            )
         except ValidationError as e:
             entity, project = art.entity, art.project
             proj_path = f"{entity}/{project}"
             coll_name = art.name.split(":")[0]
 
-            match data:
-                case {"project": None}:
+            msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
+            match e.errors():
+                case [{"input": {"project": None}}]:
                     msg = f"Project {project!r} not found in entity {entity!r}"
-                case {"project": {"artifactCollection": None}}:
-                    msg = f"Artifact collection {coll_name!r} not found in {proj_path!r}"
-                case {"project": {"artifactCollection": {"artifactMembership": None}}}:
-                    msg = f"Member artifact {art.name!r} not found in {proj_path!r}"
-                case {
-                    "project": {
-                        "artifactCollection": {"artifactMembership": {"files": None}}
+                case [{"input": {"project": {"artifactCollection": None}}}]:
+                    msg = (
+                        f"Artifact collection {coll_name!r} not found in {proj_path!r}"
+                    )
+                case [
+                    {
+                        "input": {
+                            "project": {
+                                "artifactCollection": {"artifactMembership": None}
+                            }
+                        }
                     }
-                }:
+                ]:
+                    msg = f"Member artifact {art.name!r} not found in {proj_path!r}"
+                case [
+                    {
+                        "input": None,
+                        "loc": (
+                            "project",
+                            "artifactCollection",
+                            "artifactMembership",
+                            "files",
+                        ),
+                    }
+                ]:
                     msg = f"Unexpected empty response for files of artifact {art.name!r} in {proj_path!r}"
-                case _:
-                    msg = f"Unable to parse {nameof(type(self))!r} response data: {e}"
             raise ValueError(msg)
 
         self.last_response = result.connection

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -186,8 +186,13 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
         result = self._execute_query(parse=ProjectArtifactTypes.model_validate_json)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        if not ((proj := result.project) and (conn := proj.artifact_types)):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (conn := proj.artifact_types) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"unexpected empty response for artifact types in {err_path!r}"
+            raise ValueError(msg)
 
         self.last_response = ArtifactTypeConnection.model_validate(conn)
 
@@ -411,12 +416,17 @@ class ArtifactCollections(
         )
 
         # Extract the inner `*Connection` result for faster/easier access.
-        if not (
-            (proj := result.project)
-            and (artifact_type := proj.artifact_type)
-            and (conn := artifact_type.artifact_collections)
-        ):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (artifact_type := proj.artifact_type) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"artifact type {self.type_name!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (conn := artifact_type.artifact_collections) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"unexpected empty response for artifact collections in {err_path!r}, type {self.type_name!r}"
+            raise ValueError(msg)
 
         self.last_response = ArtifactCollectionConnection.model_validate(conn)
 
@@ -520,8 +530,14 @@ class ProjectArtifactCollections(
             parse=ProjectArtifactCollections.model_validate_json
         )
         # Extract the inner `*Connection` result for faster/easier access.
-        if not ((proj := result.project) and (conn := proj.artifact_collections)):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (conn := proj.artifact_collections) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"unexpected empty response for artifact collections in {err_path!r}"
+            raise ValueError(msg)
+
         self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
@@ -1008,13 +1024,24 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
         result = self._execute_query(parse=ProjectArtifacts.model_validate_json)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        if not (
-            (proj := result.project)
-            and (type_ := proj.artifact_type)
-            and (collection := type_.artifact_collection)
-            and (conn := collection.artifacts)
-        ):
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        # At the time of writing, the server returns HTTP 200 with `null` at
+        # any level for an invalid path or access-denied, so provide a specific
+        # message at the first missing level.
+        if (proj := result.project) is None:
+            msg = f"project {self.project!r} not found in entity {self.entity!r}"
+            raise ValueError(msg)
+        if (type_ := proj.artifact_type) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"artifact type {self.type!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (collection := type_.artifact_collection) is None:
+            err_path = f"{self.entity}/{self.project}"
+            msg = f"artifact collection {self.collection_name!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (conn := collection.artifacts) is None:
+            err_path = f"{self.entity}/{self.project}/{self.collection_name}"
+            msg = f"unexpected empty response for artifacts in {err_path!r}"
+            raise ValueError(msg)
 
         self.last_response = _ArtifactConnectionGeneric[
             ArtifactFragment
@@ -1194,10 +1221,26 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
         result = self._execute_query(parse=ArtifactMembershipFiles.model_validate_json)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        conn = result.project.artifact_collection.artifact_membership.files
-
-        if conn is None:
-            raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
+        # At the time of writing, the server returns HTTP 200 with `null` at
+        # any level for an invalid path or access-denied, so provide a specific
+        # message at the first missing level.
+        art = self.artifact
+        if (proj := result.project) is None:
+            msg = f"project {art.project!r} not found in entity {art.entity!r}"
+            raise ValueError(msg)
+        if (coll := proj.artifact_collection) is None:
+            coll_name = art.name.split(":")[0]
+            err_path = f"{art.entity}/{art.project}"
+            msg = f"artifact collection {coll_name!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (membership := coll.artifact_membership) is None:
+            err_path = f"{art.entity}/{art.project}"
+            msg = f"member artifact {art.name!r} not found in {err_path!r}"
+            raise ValueError(msg)
+        if (conn := membership.files) is None:
+            err_path = f"{art.entity}/{art.project}"
+            msg = f"unexpected empty response for files of artifact {art.name!r} in {err_path!r}"
+            raise ValueError(msg)
 
         self.last_response = ArtifactFileConnection.model_validate(conn)
 

--- a/wandb/sdk/artifacts/_models/pagination.py
+++ b/wandb/sdk/artifacts/_models/pagination.py
@@ -1,6 +1,10 @@
 """Artifacts-specific data models for handling paginated results from GraphQL queries."""
 
-from wandb._pydantic import Connection, ConnectionWithTotal
+from typing import Annotated
+
+from pydantic import AliasPath, Field
+
+from wandb._pydantic import Connection, ConnectionWithTotal, GQLResult
 
 from .._generated.fragments import (
     ArtifactCollectionFragment,
@@ -14,14 +18,45 @@ from .._generated.fragments import (
 )
 
 ArtifactTypeConnection = Connection[ArtifactTypeFragment]
+
+
+class ProjectArtifactTypesResult(GQLResult):
+    connection: Annotated[
+        ArtifactTypeConnection,
+        Field(validation_alias=AliasPath("project", "artifactTypes")),
+    ]
+
+
 ArtifactCollectionConnection = ConnectionWithTotal[ArtifactCollectionFragment]
+
+
+class ProjectArtifactTypeArtifactCollectionsResult(GQLResult):
+    connection: Annotated[
+        ArtifactCollectionConnection,
+        Field(
+            validation_alias=AliasPath("project", "artifactType", "artifactCollections")
+        ),
+    ]
+
+
 ProjectArtifactCollectionConnection = Connection[ArtifactCollectionFragment]
+
+
+class ProjectArtifactCollectionsResult(GQLResult):
+    connection: Annotated[
+        ProjectArtifactCollectionConnection,
+        Field(validation_alias=AliasPath("project", "artifactCollections")),
+    ]
+
+
 ArtifactMembershipConnection = Connection[ArtifactMembershipFragment]
 
 FileWithUrlConnection = Connection[FileWithUrlFragment]
+
 ArtifactFileConnection = Connection[FileFragment]
 
 RunArtifactConnection = ConnectionWithTotal[ArtifactFragment]
 
 RegistryConnection = Connection[RegistryFragment]
+
 RegistryCollectionConnection = ConnectionWithTotal[RegistryCollectionFragment]

--- a/wandb/sdk/artifacts/_models/pagination.py
+++ b/wandb/sdk/artifacts/_models/pagination.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 from pydantic import AliasPath, Field
 
-from wandb._pydantic import Connection, ConnectionWithTotal, GQLResult
+from wandb._pydantic import Connection, ConnectionWithTotal, Edge, GQLResult
 
 from .._generated.fragments import (
     ArtifactCollectionFragment,
@@ -17,35 +17,47 @@ from .._generated.fragments import (
     RegistryFragment,
 )
 
-ArtifactTypeConnection = Connection[ArtifactTypeFragment]
-
 
 class ProjectArtifactTypesResult(GQLResult):
     connection: Annotated[
-        ArtifactTypeConnection,
+        Connection[ArtifactTypeFragment],
         Field(validation_alias=AliasPath("project", "artifactTypes")),
     ]
 
 
-ArtifactCollectionConnection = ConnectionWithTotal[ArtifactCollectionFragment]
-
-
 class ProjectArtifactTypeArtifactCollectionsResult(GQLResult):
     connection: Annotated[
-        ArtifactCollectionConnection,
+        ConnectionWithTotal[ArtifactCollectionFragment],
         Field(
             validation_alias=AliasPath("project", "artifactType", "artifactCollections")
         ),
     ]
 
 
-ProjectArtifactCollectionConnection = Connection[ArtifactCollectionFragment]
-
-
 class ProjectArtifactCollectionsResult(GQLResult):
     connection: Annotated[
-        ProjectArtifactCollectionConnection,
+        Connection[ArtifactCollectionFragment],
         Field(validation_alias=AliasPath("project", "artifactCollections")),
+    ]
+
+
+class VersionedArtifactEdge(Edge[ArtifactFragment]):
+    # The artifact `version` is read from the GraphQL edge, not the node.
+    version: str
+
+
+class ProjectArtifactConnection(ConnectionWithTotal[ArtifactFragment]):
+    edges: list[VersionedArtifactEdge]
+
+
+class ProjectArtifactsResult(GQLResult):
+    connection: Annotated[
+        ProjectArtifactConnection,
+        Field(
+            validation_alias=AliasPath(
+                "project", "artifactType", "artifactCollection", "artifacts"
+            )
+        ),
     ]
 
 
@@ -54,6 +66,27 @@ ArtifactMembershipConnection = Connection[ArtifactMembershipFragment]
 FileWithUrlConnection = Connection[FileWithUrlFragment]
 
 ArtifactFileConnection = Connection[FileFragment]
+
+
+class ProjectArtifactFilesResult(GQLResult):
+    connection: Annotated[
+        ArtifactFileConnection,
+        Field(
+            validation_alias=AliasPath("project", "artifactType", "artifact", "files")
+        ),
+    ]
+
+
+class ProjectArtifactMembershipFilesResult(GQLResult):
+    connection: Annotated[
+        ArtifactFileConnection,
+        Field(
+            validation_alias=AliasPath(
+                "project", "artifactCollection", "artifactMembership", "files"
+            )
+        ),
+    ]
+
 
 RunArtifactConnection = ConnectionWithTotal[ArtifactFragment]
 

--- a/wandb/sdk/artifacts/_models/pagination.py
+++ b/wandb/sdk/artifacts/_models/pagination.py
@@ -1,6 +1,6 @@
 """Artifacts-specific data models for handling paginated results from GraphQL queries."""
 
-from typing import Annotated
+from typing import Annotated, TypeVar
 
 from pydantic import AliasPath, Field
 
@@ -16,6 +16,8 @@ from .._generated.fragments import (
     RegistryCollectionFragment,
     RegistryFragment,
 )
+
+NodeT = TypeVar("NodeT")
 
 
 class ProjectArtifactTypesResult(GQLResult):
@@ -41,13 +43,12 @@ class ProjectArtifactCollectionsResult(GQLResult):
     ]
 
 
-class VersionedArtifactEdge(Edge[ArtifactFragment]):
-    # The artifact `version` is read from the GraphQL edge, not the node.
-    version: str
+class _VersionedEdge(Edge[NodeT]):
+    version: str  # The artifact `version` is on the GraphQL edge, not node.
 
 
-class ProjectArtifactConnection(ConnectionWithTotal[ArtifactFragment]):
-    edges: list[VersionedArtifactEdge]
+class ProjectArtifactConnection(ConnectionWithTotal[NodeT]):
+    edges: list[_VersionedEdge[ArtifactFragment]]  # type: ignore[assignment]
 
 
 class ProjectArtifactsResult(GQLResult):

--- a/wandb/sdk/artifacts/_models/pagination.py
+++ b/wandb/sdk/artifacts/_models/pagination.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 from pydantic import AliasPath, Field
 
-from wandb._pydantic import Connection, ConnectionWithTotal, GQLResult
+from wandb._pydantic import Connection, ConnectionWithTotal, Edge, GQLResult
 
 from .._generated.fragments import (
     ArtifactCollectionFragment,
@@ -17,35 +17,47 @@ from .._generated.fragments import (
     RegistryFragment,
 )
 
-ArtifactTypeConnection = Connection[ArtifactTypeFragment]
-
 
 class ProjectArtifactTypesResult(GQLResult):
     connection: Annotated[
-        ArtifactTypeConnection,
+        Connection[ArtifactTypeFragment],
         Field(validation_alias=AliasPath("project", "artifactTypes")),
     ]
 
 
-ArtifactCollectionConnection = ConnectionWithTotal[ArtifactCollectionFragment]
-
-
 class ProjectArtifactTypeArtifactCollectionsResult(GQLResult):
     connection: Annotated[
-        ArtifactCollectionConnection,
+        ConnectionWithTotal[ArtifactCollectionFragment],
         Field(
             validation_alias=AliasPath("project", "artifactType", "artifactCollections")
         ),
     ]
 
 
-ProjectArtifactCollectionConnection = Connection[ArtifactCollectionFragment]
-
-
 class ProjectArtifactCollectionsResult(GQLResult):
     connection: Annotated[
-        ProjectArtifactCollectionConnection,
+        Connection[ArtifactCollectionFragment],
         Field(validation_alias=AliasPath("project", "artifactCollections")),
+    ]
+
+
+class VersionedArtifactEdge(Edge[ArtifactFragment]):
+    # The artifact `version` is read from the GraphQL edge, not the node.
+    version: str
+
+
+class ProjectArtifactConnection(ConnectionWithTotal[ArtifactFragment]):
+    edges: list[VersionedArtifactEdge]
+
+
+class ProjectArtifactsResult(GQLResult):
+    connection: Annotated[
+        ProjectArtifactConnection,
+        Field(
+            validation_alias=AliasPath(
+                "project", "artifactType", "artifactCollection", "artifacts"
+            )
+        ),
     ]
 
 
@@ -54,6 +66,18 @@ ArtifactMembershipConnection = Connection[ArtifactMembershipFragment]
 FileWithUrlConnection = Connection[FileWithUrlFragment]
 
 ArtifactFileConnection = Connection[FileFragment]
+
+
+class ProjectArtifactMembershipFilesResult(GQLResult):
+    connection: Annotated[
+        ArtifactFileConnection,
+        Field(
+            validation_alias=AliasPath(
+                "project", "artifactCollection", "artifactMembership", "files"
+            )
+        ),
+    ]
+
 
 RunArtifactConnection = ConnectionWithTotal[ArtifactFragment]
 

--- a/wandb/sdk/artifacts/_models/pagination.py
+++ b/wandb/sdk/artifacts/_models/pagination.py
@@ -1,8 +1,9 @@
 """Artifacts-specific data models for handling paginated results from GraphQL queries."""
 
-from typing import Annotated
+from typing import Annotated, TypeVar
 
 from pydantic import AliasPath, Field
+from pydantic.fields import FieldInfo
 
 from wandb._pydantic import Connection, ConnectionWithTotal, Edge, GQLResult
 
@@ -17,47 +18,51 @@ from .._generated.fragments import (
     RegistryFragment,
 )
 
+NodeT = TypeVar("NodeT")
+
+
+def GQLPath(first_arg: str, *args: str | int) -> FieldInfo:  # noqa: N802
+    """Create Pydantic field metadata for a nested GraphQL response path."""
+    return Field(validation_alias=AliasPath(first_arg, *args))
+
+
+# An intermediate `null` in an `AliasPath` leaves the root response in the
+# validation error's `input`; a terminal `null` has `input=None` and the path in `loc`.
+
 
 class ProjectArtifactTypesResult(GQLResult):
     connection: Annotated[
         Connection[ArtifactTypeFragment],
-        Field(validation_alias=AliasPath("project", "artifactTypes")),
+        GQLPath("project", "artifactTypes"),
     ]
 
 
 class ProjectArtifactTypeArtifactCollectionsResult(GQLResult):
     connection: Annotated[
         ConnectionWithTotal[ArtifactCollectionFragment],
-        Field(
-            validation_alias=AliasPath("project", "artifactType", "artifactCollections")
-        ),
+        GQLPath("project", "artifactType", "artifactCollections"),
     ]
 
 
 class ProjectArtifactCollectionsResult(GQLResult):
     connection: Annotated[
         Connection[ArtifactCollectionFragment],
-        Field(validation_alias=AliasPath("project", "artifactCollections")),
+        GQLPath("project", "artifactCollections"),
     ]
 
 
-class VersionedArtifactEdge(Edge[ArtifactFragment]):
-    # The artifact `version` is read from the GraphQL edge, not the node.
-    version: str
+class _VersionedEdge(Edge[NodeT]):
+    version: str  # The artifact `version` is on the GraphQL edge, not node.
 
 
-class ProjectArtifactConnection(ConnectionWithTotal[ArtifactFragment]):
-    edges: list[VersionedArtifactEdge]
+class ProjectArtifactConnection(ConnectionWithTotal[NodeT]):
+    edges: list[_VersionedEdge[ArtifactFragment]]  # type: ignore[assignment]
 
 
 class ProjectArtifactsResult(GQLResult):
     connection: Annotated[
         ProjectArtifactConnection,
-        Field(
-            validation_alias=AliasPath(
-                "project", "artifactType", "artifactCollection", "artifacts"
-            )
-        ),
+        GQLPath("project", "artifactType", "artifactCollection", "artifacts"),
     ]
 
 
@@ -65,17 +70,11 @@ ArtifactMembershipConnection = Connection[ArtifactMembershipFragment]
 
 FileWithUrlConnection = Connection[FileWithUrlFragment]
 
-ArtifactFileConnection = Connection[FileFragment]
-
 
 class ProjectArtifactMembershipFilesResult(GQLResult):
     connection: Annotated[
-        ArtifactFileConnection,
-        Field(
-            validation_alias=AliasPath(
-                "project", "artifactCollection", "artifactMembership", "files"
-            )
-        ),
+        Connection[FileFragment],
+        GQLPath("project", "artifactCollection", "artifactMembership", "files"),
     ]
 
 


### PR DESCRIPTION
Description
-----------

- Fixes https://coreweave.atlassian.net/browse/WB-27432

When `Api.artifacts()` (or a related paginator) is called with an invalid or inaccessible artifact path, the SDK previously raised this unhelpful error:

```
ValueError: Unable to parse 'Artifacts' response data
```

Root cause: the server returns HTTP 200 with `null` at one of the inner levels of the GraphQL response (e.g. `project: null` for a missing or inaccessible project), and the SDK collapsed every such case into one generic message.

This PR replaces that with a specific error naming the first missing path component, for example:

```
ValueError: project 'foo' not found in entity 'bar'
ValueError: artifact type 'baz' not found in bar/foo
ValueError: artifact collection 'qux' not found in bar/foo
```

Five paginators in wandb/apis/public/artifacts.py share the same response shape and are all fixed: `Artifacts`, `ArtifactTypes`, `ArtifactCollections`, `ProjectArtifactCollections`, `ArtifactFiles`.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added system tests in tests/system_tests/test_artifacts/test_wandb_artifacts_api.py.