### PR TITLE
chore(sandbox): modify API key header for targeted auth

### DIFF
--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -90,7 +90,7 @@ def test_sandbox_run_uses_settings_entity_project(
         assert sandbox.sandbox_id == "sb-system-test"
 
     expected_headers = {
-        "x-api-key": user,
+        "x-wandb-api-key": user,
         "x-entity-id": "entity-from-settings",
         "x-project-name": "project-from-settings",
     }
@@ -111,7 +111,7 @@ def test_sandbox_run_ignore_run_override(
             assert sandbox.sandbox_id == "sb-system-test"
 
     expected_headers = {
-        "x-api-key": user,
+        "x-wandb-api-key": user,
         "x-entity-id": user,
     }
     assert len(calls.start) == 1
@@ -133,6 +133,6 @@ def test_sandbox_run_without_entity_or_project(
         assert sandbox.sandbox_id == "sb-system-test"
 
     assert len(calls.start) == 1
-    assert dict(calls.start[0]["metadata"]) == {"x-api-key": user}
+    assert dict(calls.start[0]["metadata"]) == {"x-wandb-api-key": user}
     assert len(calls.stop) == 1
-    assert dict(calls.stop[0]["metadata"]) == {"x-api-key": user}
+    assert dict(calls.stop[0]["metadata"]) == {"x-wandb-api-key": user}

--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -50,13 +50,13 @@ def test_override_sandbox_entity_restores_after_exit(
 
     with sandbox_auth.override_sandbox_entity(entity="override-entity"):
         assert sandbox_auth._resolve_wandb_sdk_auth().headers == {
-            "x-api-key": _VALID_API_KEY,
+            "x-wandb-api-key": _VALID_API_KEY,
             "x-entity-id": "override-entity",
             "x-project-name": "default-project",
         }
 
     assert sandbox_auth._resolve_wandb_sdk_auth().headers == {
-        "x-api-key": _VALID_API_KEY,
+        "x-wandb-api-key": _VALID_API_KEY,
         "x-entity-id": "default-entity",
         "x-project-name": "default-project",
     }
@@ -90,7 +90,7 @@ def test_resolve_wandb_sdk_auth_delegates_to_authenticate_session(
     assert auth_calls[0]["no_offline"] is True
     assert headers.strategy == "wandb_api_key"
     assert headers.headers == {
-        "x-api-key": _VALID_API_KEY,
+        "x-wandb-api-key": _VALID_API_KEY,
         "x-entity-id": "default-entity",
         "x-project-name": "default-project",
     }
@@ -112,7 +112,7 @@ def test_resolve_wandb_sdk_auth_omits_optional_metadata_when_unset(
 
     headers = sandbox_auth._resolve_wandb_sdk_auth()
 
-    assert headers.headers == {"x-api-key": _VALID_API_KEY}
+    assert headers.headers == {"x-wandb-api-key": _VALID_API_KEY}
 
 
 def test_resolve_wandb_sdk_auth_rejects_non_api_key_credentials(

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -57,7 +57,7 @@ def _resolve_wandb_sdk_auth() -> AuthHeaders:
     if not isinstance(auth, wbauth.AuthApiKey):
         raise UsageError("wandb.sandbox currently supports only W&B user API-key auth.")
 
-    metadata: list[tuple[str, str]] = [("x-api-key", auth.api_key)]
+    metadata: list[tuple[str, str]] = [("x-wandb-api-key", auth.api_key)]
     # Both entity and project are optional.
     # entity will use the default entity user set in web UI.
     # project will use/create 'sandbox' project automatically.


### PR DESCRIPTION
Description
-----------
https://coreweave.atlassian.net/browse/WB-33713

Changing the header key when using W&B auth for sandboxes so that we can select and short-circuit on our module at the sandbox gateway. Otherwise, the auth is multi-module and falls through a chain so W&B users can only receive generic unauthorized messages