### PR TITLE
refactor: asyncio run messages

### DIFF
--- a/tests/system_tests/test_core/test_run_messages_full.py
+++ b/tests/system_tests/test_core/test_run_messages_full.py
@@ -1,0 +1,22 @@
+"""Integration tests for the run_messages mechanism."""
+
+import pytest
+import wandb
+
+from tests.fixtures.mock_wandb_log import MockWandbLog
+
+
+@pytest.mark.usefixtures("user")  # test requires an online run
+def test_prints_run_messages(mock_wandb_log: MockWandbLog):
+    # This test may need to be rewritten if the message changes
+    # or if the setting is updated.
+    #
+    # Any way to make wandb-core reliably print works here.
+    settings = wandb.Settings(x_file_stream_max_line_bytes=10)
+
+    with wandb.init(settings=settings) as run:
+        run.log({"x": "too many bytes in this line"})
+
+    mock_wandb_log.assert_warned(
+        "Skipped uploading run.log() data that exceeded size limit",
+    )

--- a/tests/unit_tests/test_lib/test_run_messages.py
+++ b/tests/unit_tests/test_lib/test_run_messages.py
@@ -1,0 +1,162 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.lib import asyncio_manager, run_messages
+
+from tests.fixtures.mock_wandb_log import MockWandbLog
+
+
+@pytest.fixture(autouse=True)
+def fake_now(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patched time.monotonic() that returns 0 by default."""
+    now = MagicMock()
+    now.return_value = 0
+    monkeypatch.setattr(run_messages, "_NOW", now)
+    return now
+
+
+@pytest.fixture(autouse=True)
+def fake_sleep(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Patched asyncio.sleep() that blocks forever by default."""
+
+    async def block(duration: float) -> None:
+        _ = duration
+        await asyncio.Event().wait()
+
+    sleep = AsyncMock()
+    sleep.side_effect = block
+    monkeypatch.setattr(run_messages, "_SLEEP", sleep)
+
+    return sleep
+
+
+@pytest.fixture
+def fake_messages() -> AsyncMock:
+    """Patched MailboxHandle.wait_async() that returns an empty Result."""
+    return AsyncMock(return_value=pb.Result())
+
+
+@pytest.fixture
+def fake_interface(fake_messages: AsyncMock) -> Mock:
+    """Mock interface that returns fake_messages from deliver_async."""
+    handle = Mock()
+    handle.wait_async = fake_messages
+
+    interface = Mock()
+    interface.deliver_async = AsyncMock(return_value=handle)
+
+    return interface
+
+
+@pytest.fixture(scope="module")
+def asyncer():
+    asyncer = asyncio_manager.AsyncioManager()
+    asyncer.start()
+
+    try:
+        yield asyncer
+    finally:
+        asyncer.join()
+
+
+def _make_messages_result(*warnings: str) -> pb.Result:
+    result = pb.Result()
+    result.response.internal_messages_response.messages.warning.extend(warnings)
+    return result
+
+
+def test_prints_warnings(
+    asyncer: asyncio_manager.AsyncioManager,
+    fake_messages: AsyncMock,
+    fake_interface: Mock,
+    mock_wandb_log: MockWandbLog,
+):
+    fake_messages.side_effect = [
+        _make_messages_result("warning 1", "warning 2", "warning 3"),
+        _make_messages_result(),
+    ]
+
+    rm = run_messages.RunMessages(asyncer, fake_interface)
+    rm.start()
+    rm.stop(timeout=5)
+
+    mock_wandb_log.assert_warned("warning 1")
+    mock_wandb_log.assert_warned("warning 2")
+    mock_wandb_log.assert_warned("warning 3")
+
+
+def test_stop_does_final_poll(
+    asyncer: asyncio_manager.AsyncioManager,
+    fake_messages: AsyncMock,
+    fake_interface: Mock,
+    mock_wandb_log: MockWandbLog,
+):
+    fake_messages.side_effect = [
+        _make_messages_result(),
+        _make_messages_result("final warning"),
+    ]
+
+    rm = run_messages.RunMessages(asyncer, fake_interface)
+    rm.start()
+    rm.stop(timeout=5)
+
+    mock_wandb_log.assert_warned("final warning")
+
+
+def test_stop_warns_on_loop_timeout(
+    asyncer: asyncio_manager.AsyncioManager,
+    fake_messages: AsyncMock,
+    fake_interface: Mock,
+    wandb_caplog: pytest.LogCaptureFixture,
+):
+    fake_messages.side_effect = [
+        _make_messages_result(),
+        _make_messages_result(),
+    ]
+
+    rm = run_messages.RunMessages(asyncer, fake_interface)
+    rm.start()
+    rm.stop(timeout=-1)  # time out immediately
+
+    assert "Timed out waiting for messages" in wandb_caplog.text
+
+
+def test_stop_warns_on_handle_timeout(
+    asyncer: asyncio_manager.AsyncioManager,
+    fake_messages: AsyncMock,
+    fake_interface: Mock,
+    wandb_caplog: pytest.LogCaptureFixture,
+):
+    fake_messages.side_effect = [
+        _make_messages_result(),
+        TimeoutError(),
+    ]
+
+    rm = run_messages.RunMessages(asyncer, fake_interface)
+    rm.start()
+    rm.stop(timeout=5)
+
+    assert "Timed out waiting for messages" in wandb_caplog.text
+
+
+def test_sleeps_for_remaining_interval(
+    asyncer: asyncio_manager.AsyncioManager,
+    fake_sleep: AsyncMock,
+    fake_now: MagicMock,
+    fake_messages: AsyncMock,
+    fake_interface: Mock,
+):
+    fake_now.side_effect = [0, 3]  # pretend 3 seconds pass waiting for messages
+    fake_messages.side_effect = [
+        _make_messages_result(),
+        _make_messages_result(),
+    ]
+
+    rm = run_messages.RunMessages(asyncer, fake_interface, poll_interval=10)
+    rm.start()
+    rm.stop(timeout=5)
+
+    # Polling interval is 10, and 3 seconds passed, so 7 remain.
+    fake_sleep.assert_called_once_with(7)

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -995,16 +995,6 @@ class InterfaceBase(abc.ABC):
     ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_internal_messages(self) -> MailboxHandle[pb.Result]:
-        internal_message = pb.InternalMessagesRequest()
-        return self._deliver_internal_messages(internal_message)
-
-    @abc.abstractmethod
-    def _deliver_internal_messages(
-        self, internal_message: pb.InternalMessagesRequest
-    ) -> MailboxHandle[pb.Result]:
-        raise NotImplementedError
-
     def deliver_get_summary(self) -> MailboxHandle[pb.Result]:
         get_summary = pb.GetSummaryRequest()
         return self._deliver_get_summary(get_summary)

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -131,7 +131,6 @@ class InterfaceShared(InterfaceBase, abc.ABC):
         resume: pb.ResumeRequest | None = None,
         status: pb.StatusRequest | None = None,
         stop_status: pb.StopStatusRequest | None = None,
-        internal_messages: pb.InternalMessagesRequest | None = None,
         network_status: pb.NetworkStatusRequest | None = None,
         poll_exit: pb.PollExitRequest | None = None,
         partial_history: pb.PartialHistoryRequest | None = None,
@@ -169,8 +168,6 @@ class InterfaceShared(InterfaceBase, abc.ABC):
             request.status.CopyFrom(status)
         elif stop_status:
             request.stop_status.CopyFrom(stop_status)
-        elif internal_messages:
-            request.internal_messages.CopyFrom(internal_messages)
         elif network_status:
             request.network_status.CopyFrom(network_status)
         elif poll_exit:
@@ -479,12 +476,6 @@ class InterfaceShared(InterfaceBase, abc.ABC):
         self, network_status: pb.NetworkStatusRequest
     ) -> MailboxHandle[pb.Result]:
         record = self._make_request(network_status=network_status)
-        return self._deliver(record)
-
-    def _deliver_internal_messages(
-        self, internal_message: pb.InternalMessagesRequest
-    ) -> MailboxHandle[pb.Result]:
-        record = self._make_request(internal_messages=internal_message)
         return self._deliver(record)
 
     def _deliver_request_sampled_history(

--- a/wandb/sdk/lib/run_messages.py
+++ b/wandb/sdk/lib/run_messages.py
@@ -1,0 +1,138 @@
+"""Echoing messages from wandb-core to the terminal."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+
+from wandb.errors import term
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.interface.interface import InterfaceBase
+from wandb.sdk.lib import asyncio_compat, asyncio_manager
+
+# Patched in tests.
+_NOW = time.monotonic
+_SLEEP = asyncio.sleep
+
+
+_logger = logging.getLogger(__name__)
+
+
+class RunMessages:
+    """Polls and prints run messages from wandb-core.
+
+    Messages are scoped to a run. In the future, we may want to switch to
+    connection-level messages to allow `ServiceApi` operations to print
+    and replace this by a new ServiceMessages class.
+    """
+
+    def __init__(
+        self,
+        asyncer: asyncio_manager.AsyncioManager,
+        interface: InterfaceBase,
+        *,
+        poll_interval: float = 10,
+    ) -> None:
+        self._asyncer = asyncer
+
+        async def async_init() -> _RunMessagesImpl:
+            return _RunMessagesImpl(interface, poll_interval=poll_interval)
+
+        self._impl = asyncer.run(async_init)
+
+    def start(self) -> None:
+        """Start polling for and printing generated messages."""
+        self._asyncer.run_soon(
+            self._impl.loop,
+            daemon=True,
+            name="RunMessages.loop",
+        )
+
+    def stop(self, *, timeout: float) -> None:
+        """Stop the polling loop and print any final messages.
+
+        Args:
+            timeout: How long to wait, in seconds, before giving up.
+                A warning is printed on timeout; some messages may get
+                asynchronously printed in the future.
+        """
+        with contextlib.suppress(asyncio_manager.AlreadyJoinedError):
+            self._asyncer.run(lambda: self._impl.stop(timeout=timeout))
+
+
+class _RunMessagesImpl:
+    def __init__(
+        self,
+        interface: InterfaceBase,
+        *,
+        poll_interval: float,
+    ) -> None:
+        self._interface = interface
+        self._poll_interval = poll_interval
+
+        self._stop_event = asyncio.Event()  # stop requested
+        self._done_event = asyncio.Event()  # loop() done
+
+    async def stop(self, *, timeout: float) -> None:
+        """Stop looping and print any final messages.
+
+        Assumes that `loop` has been or will be called.
+
+        Args:
+            timeout: How long to wait, in seconds, before giving up.
+                On timeout, some messages may be missed or may print
+                asynchronously.
+        """
+        timeout_at = time.monotonic() + timeout
+
+        self._stop_event.set()
+        try:
+            await asyncio.wait_for(self._done_event.wait(), timeout)
+            await self._poll_and_print(timeout=timeout_at - time.monotonic())
+
+        # NOTE: asyncio.TimeoutError is different from TimeoutError
+        #   until Python 3.11.
+        except (asyncio.TimeoutError, TimeoutError):
+            _logger.exception("Timed out waiting for messages.")
+
+    async def loop(self) -> None:
+        """Print messages until asked to stop."""
+        try:
+            while not self._stop_event.is_set():
+                start_time = _NOW()
+                await self._poll_and_print(timeout=None)
+                end_time = _NOW()
+
+                remaining = self._poll_interval - (end_time - start_time)
+                if remaining > 0:
+                    await asyncio_compat.race(
+                        self._stop_event.wait(),  # wake up if stopping
+                        _SLEEP(remaining),
+                    )
+        finally:
+            self._done_event.set()
+
+    async def _poll_and_print(self, *, timeout: float | None) -> None:
+        """Fetch and print messages.
+
+        Args:
+            timeout: How long to wait for wandb-core to respond.
+
+        Raises:
+            TimeoutError: if timeout was specified and was exceeded.
+                If a timeout occurs, some messages may be lost.
+        """
+        request = pb.Record(
+            request=pb.Request(
+                internal_messages=pb.InternalMessagesRequest(),
+            )
+        )
+
+        handle = await self._interface.deliver_async(request)
+        result = await handle.wait_async(timeout=timeout)
+
+        warnings = result.response.internal_messages_response.messages.warning
+        for msg in warnings:
+            term.termwarn(msg)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -38,7 +38,7 @@ from wandb.proto.wandb_internal_pb2 import (
     RunRecord,
 )
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
-from wandb.sdk.lib import wb_logging
+from wandb.sdk.lib import asyncio_manager, run_messages, wb_logging
 from wandb.sdk.lib.filesystem import (
     FilesDict,
     GlobStr,
@@ -99,7 +99,6 @@ if TYPE_CHECKING:
     from wandb.apis.public import Api as PublicApi
     from wandb.proto.wandb_internal_pb2 import (
         GetSummaryResponse,
-        InternalMessagesResponse,
         SampledHistoryResponse,
     )
 
@@ -161,12 +160,11 @@ class RunStatusChecker:
     _stop_status_handle: MailboxHandle[Result] | None
     _network_status_lock: threading.Lock
     _network_status_handle: MailboxHandle[Result] | None
-    _internal_messages_lock: threading.Lock
-    _internal_messages_handle: MailboxHandle[Result] | None
 
     def __init__(
         self,
         run_id: str,
+        asyncer: asyncio_manager.AsyncioManager,
         interface: InterfaceBase,
         settings: Settings,
         retry_polling_interval: int = 5,
@@ -196,18 +194,12 @@ class RunStatusChecker:
             daemon=True,
         )
 
-        self._internal_messages_lock = threading.Lock()
-        self._internal_messages_handle = None
-        self._internal_messages_thread = threading.Thread(
-            target=self.check_internal_messages,
-            name="IntMsgThr",
-            daemon=True,
-        )
+        self._internal_messages = run_messages.RunMessages(asyncer, interface)
 
     def start(self) -> None:
         self._stop_thread.start()
         self._network_status_thread.start()
-        self._internal_messages_thread.start()
+        self._internal_messages.start()
 
     @staticmethod
     def _abandon_status_check(
@@ -330,33 +322,6 @@ class RunStatusChecker:
                     self._stop_status_handle,
                 )
 
-    def check_internal_messages(self) -> None:
-        def _process_internal_messages(result: Result) -> None:
-            if (
-                not self._settings.show_warnings
-                or self._settings.quiet
-                or self._settings.silent
-            ):
-                return
-            internal_messages = result.response.internal_messages_response
-            for msg in internal_messages.messages.warning:
-                wandb.termwarn(msg, repeat=False)
-
-        with wb_logging.log_to_run(self._run_id):
-            try:
-                self._loop_check_status(
-                    lock=self._internal_messages_lock,
-                    set_handle=lambda x: setattr(self, "_internal_messages_handle", x),
-                    timeout=self._internal_messages_polling_interval,
-                    request=self._interface.deliver_internal_messages,
-                    process=_process_internal_messages,
-                )
-            except BrokenPipeError:
-                self._abandon_status_check(
-                    self._internal_messages_lock,
-                    self._internal_messages_handle,
-                )
-
     def stop(self) -> None:
         self._join_event.set()
         self._abandon_status_check(
@@ -367,16 +332,12 @@ class RunStatusChecker:
             self._network_status_lock,
             self._network_status_handle,
         )
-        self._abandon_status_check(
-            self._internal_messages_lock,
-            self._internal_messages_handle,
-        )
 
     def join(self) -> None:
         self.stop()
         self._stop_thread.join()
         self._network_status_thread.join()
-        self._internal_messages_thread.join()
+        self._internal_messages.stop(timeout=5)  # TODO: use finish timeout
 
 
 _P = ParamSpec("_P")
@@ -557,7 +518,6 @@ class Run:
     _final_summary: GetSummaryResponse | None
     _poll_exit_handle: MailboxHandle[Result] | None
     _poll_exit_response: PollExitResponse | None
-    _internal_messages_response: InternalMessagesResponse | None
 
     _stdout_slave_fd: int | None
     _stderr_slave_fd: int | None
@@ -662,7 +622,6 @@ class Run:
         self._sampled_history = None
         self._final_summary = None
         self._poll_exit_response = None
-        self._internal_messages_response = None
         self._poll_exit_handle = None
         self._finish_timed_out = False
 
@@ -2558,7 +2517,6 @@ class Run:
             sampled_history=self._sampled_history,
             final_summary=self._final_summary,
             poll_exit_response=self._poll_exit_response,
-            internal_messages_response=self._internal_messages_response,
             settings=self._settings,
             printer=self._printer,
         )
@@ -2576,6 +2534,8 @@ class Run:
             self._output_writer = None
 
     def _on_start(self) -> None:
+        assert self._wl
+
         self._header()
 
         if self._settings.save_code and self._settings.code_dir is not None:
@@ -2593,6 +2553,7 @@ class Run:
             assert self._settings.run_id
             self._run_status_checker = RunStatusChecker(
                 self._settings.run_id,
+                asyncer=self._wl.asyncer,
                 interface=self._interface,
                 settings=self._settings,
             )
@@ -2786,10 +2747,6 @@ class Run:
         poll_exit_handle = self._interface.deliver_poll_exit()
         result = poll_exit_handle.wait_or(timeout=None)
         self._poll_exit_response = result.response.poll_exit_response
-
-        internal_messages_handle = self._interface.deliver_internal_messages()
-        result = internal_messages_handle.wait_or(timeout=None)
-        self._internal_messages_response = result.response.internal_messages_response
 
         # dispatch all our final requests
 
@@ -3860,7 +3817,6 @@ class Run:
         sampled_history: SampledHistoryResponse | None = None,
         final_summary: GetSummaryResponse | None = None,
         poll_exit_response: PollExitResponse | None = None,
-        internal_messages_response: InternalMessagesResponse | None = None,
         *,
         settings: Settings,
         printer: printer.Printer,
@@ -3878,11 +3834,6 @@ class Run:
             printer=printer,
         )
         Run._footer_log_dir_info(settings=settings, printer=printer)
-        Run._footer_internal_messages(
-            internal_messages_response=internal_messages_response,
-            settings=settings,
-            printer=printer,
-        )
 
     @staticmethod
     def _footer_sync_info(
@@ -4044,22 +3995,6 @@ class Run:
             summary_rows.append([f"+{remaining:,d}", "..."])
 
         return printer.grid(summary_rows, "Run summary:")
-
-    @staticmethod
-    def _footer_internal_messages(
-        internal_messages_response: InternalMessagesResponse | None = None,
-        *,
-        settings: Settings,
-        printer: printer.Printer,
-    ) -> None:
-        if settings.quiet or settings.silent:
-            return
-
-        if not internal_messages_response:
-            return
-
-        for message in internal_messages_response.messages.warning:
-            printer.display(message, level="warn")
 
 
 # We define this outside of the run context to support restoring before init


### PR DESCRIPTION
Replaces the "internal messages" thread with an asyncio task.

## Testing

This logic was previously untested!

`test_run_messages.py` has detailed unit tests, and `test_run_messages_full.py` has a single integration test that also works as a manual check:

```bash
❯ python -c '
import wandb

settings = wandb.Settings(x_file_stream_max_line_bytes=10)
with wandb.init(settings=settings) as run:
    run.log({"x": "too many bytes here"})
'
```

The integration test is necessary because the unit tests mock out `Interface` and don't catch some bugs, like using `deliver_internal_messages()` instead of `deliver_async()`.

`pytest` technically requires test modules to have unique names, which is why the system test has a `_full` suffix, but we often break this rule.