### PR TITLE
refactor: asyncio run stopping

### DIFF
--- a/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
+++ b/tests/system_tests/test_functional/interrupt/pass_if_interrupted.py
@@ -6,7 +6,7 @@ import sys
 import time
 
 import wandb
-import wandb.sdk.wandb_run
+import wandb.sdk.lib.run_stopping
 
 if __name__ == "__main__":
     # The stop status is delivered via a FileStream response.
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     start_time: float | None = None
 
     # Use a faster polling interval to speed up the test.
-    wandb.sdk.wandb_run._STOP_POLLING_INTERVAL = 0.1
+    wandb.sdk.lib.run_stopping._POLL_INTERVAL = 0.1
 
     try:
         with wandb.init(settings=settings):

--- a/tests/system_tests/test_functional/interrupt/test_interrupt.py
+++ b/tests/system_tests/test_functional/interrupt/test_interrupt.py
@@ -10,7 +10,7 @@ from tests.fixtures.wandb_backend_spy import WandbBackendSpy
 
 @pytest.fixture(autouse=True)
 def fast_stop_polling_interval(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("wandb.sdk.wandb_run._STOP_POLLING_INTERVAL", 0.1)
+    monkeypatch.setattr("wandb.sdk.lib.run_stopping._POLL_INTERVAL", 0.1)
 
 
 def test_run_stop_interrupts(wandb_backend_spy: WandbBackendSpy):

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -973,17 +973,6 @@ class InterfaceBase(abc.ABC):
     ) -> MailboxHandle[pb.Result]:
         raise NotImplementedError
 
-    def deliver_stop_status(self) -> MailboxHandle[pb.Result]:
-        status = pb.StopStatusRequest()
-        return self._deliver_stop_status(status)
-
-    @abc.abstractmethod
-    def _deliver_stop_status(
-        self,
-        status: pb.StopStatusRequest,
-    ) -> MailboxHandle[pb.Result]:
-        raise NotImplementedError
-
     def deliver_network_status(self) -> MailboxHandle[pb.Result]:
         status = pb.NetworkStatusRequest()
         return self._deliver_network_status(status)

--- a/wandb/sdk/interface/interface_shared.py
+++ b/wandb/sdk/interface/interface_shared.py
@@ -130,7 +130,6 @@ class InterfaceShared(InterfaceBase, abc.ABC):
         pause: pb.PauseRequest | None = None,
         resume: pb.ResumeRequest | None = None,
         status: pb.StatusRequest | None = None,
-        stop_status: pb.StopStatusRequest | None = None,
         network_status: pb.NetworkStatusRequest | None = None,
         poll_exit: pb.PollExitRequest | None = None,
         partial_history: pb.PartialHistoryRequest | None = None,
@@ -166,8 +165,6 @@ class InterfaceShared(InterfaceBase, abc.ABC):
             request.resume.CopyFrom(resume)
         elif status:
             request.status.CopyFrom(status)
-        elif stop_status:
-            request.stop_status.CopyFrom(stop_status)
         elif network_status:
             request.network_status.CopyFrom(network_status)
         elif poll_exit:
@@ -456,13 +453,6 @@ class InterfaceShared(InterfaceBase, abc.ABC):
         poll_exit: pb.PollExitRequest,
     ) -> MailboxHandle[pb.Result]:
         record = self._make_request(poll_exit=poll_exit)
-        return self._deliver(record)
-
-    def _deliver_stop_status(
-        self,
-        stop_status: pb.StopStatusRequest,
-    ) -> MailboxHandle[pb.Result]:
-        record = self._make_request(stop_status=stop_status)
         return self._deliver(record)
 
     def _deliver_attach(

--- a/wandb/sdk/lib/run_stopping.py
+++ b/wandb/sdk/lib/run_stopping.py
@@ -1,0 +1,117 @@
+"""Stopping a run if requested by wandb-core.
+
+A run can be stopped manually through the UI or automatically after
+a fatal upload error (if configured). "Stopping" a run means killing
+its script.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import Callable
+
+from wandb.agents import pyagent
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.interface.interface import InterfaceBase
+from wandb.sdk.lib import asyncio_compat, asyncio_manager
+
+# Patched in tests.
+_NOW = time.monotonic
+_SLEEP = asyncio.sleep
+_POLL_INTERVAL = 15
+
+
+class RunStopChecker:
+    """Kills the script if requested by wandb-core."""
+
+    def __init__(
+        self,
+        asyncer: asyncio_manager.AsyncioManager,
+        interface: InterfaceBase,
+        stop_fn: Callable[[], None],
+        *,
+        poll_interval: float = _POLL_INTERVAL,
+    ) -> None:
+        self._asyncer = asyncer
+
+        async def async_init() -> _RunStopCheckerImpl:
+            return _RunStopCheckerImpl(
+                interface,
+                stop_fn,
+                poll_interval=poll_interval,
+            )
+
+        self._impl = asyncer.run(async_init)
+
+    def start(self) -> None:
+        """Start checking for whether the run is stopped."""
+        self._asyncer.run_soon(
+            self._impl.loop,
+            daemon=True,
+            name="RunStopChecker.loop",
+        )
+
+    def stop_soon(self) -> None:
+        """Stop the polling loop.
+
+        This is best-effort. It is still possible for the status checker to
+        kill the script for a short time after this function returns.
+        """
+        with contextlib.suppress(asyncio_manager.AlreadyJoinedError):
+            self._asyncer.run(lambda: self._impl.stop_soon())
+
+
+class _RunStopCheckerImpl:
+    def __init__(
+        self,
+        interface: InterfaceBase,
+        stop_fn: Callable[[], None],
+        *,
+        poll_interval: float,
+    ) -> None:
+        self._interface = interface
+        self._stop_fn = stop_fn
+        self._poll_interval = poll_interval
+        self._stop_event = asyncio.Event()  # stop requested
+
+    async def stop_soon(self) -> None:
+        """Stop looping."""
+        self._stop_event.set()
+
+    async def loop(self) -> None:
+        """Check the run's stop status until we are done."""
+        while not self._stop_event.is_set():
+            start_time = _NOW()
+            should_stop = await self._check_should_stop()
+            end_time = _NOW()
+
+            # Only stop once.
+            if should_stop:
+                self._stop_fn()
+                return
+
+            remaining = self._poll_interval - (end_time - start_time)
+            if remaining > 0:
+                await asyncio_compat.race(
+                    self._stop_event.wait(),  # wake up if stopping
+                    _SLEEP(remaining),
+                )
+
+    async def _check_should_stop(self) -> bool:
+        """Check whether the run should stop."""
+        # TODO: Remove the pyagent.is_running() check if safe to do so.
+        # See WB-3606.
+        if pyagent.is_running():
+            return False
+
+        request = pb.Record(
+            request=pb.Request(
+                stop_status=pb.StopStatusRequest(),
+            ),
+        )
+
+        handle = await self._interface.deliver_async(request)
+        result = await handle.wait_async(timeout=None)
+        return result.response.stop_status_response.run_should_stop

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -38,7 +38,7 @@ from wandb.proto.wandb_internal_pb2 import (
     RunRecord,
 )
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
-from wandb.sdk.lib import asyncio_manager, run_messages, wb_logging
+from wandb.sdk.lib import asyncio_manager, run_messages, run_stopping, wb_logging
 from wandb.sdk.lib.filesystem import (
     FilesDict,
     GlobStr,
@@ -135,8 +135,6 @@ logger = logging.getLogger("wandb")
 EXIT_TIMEOUT = 60
 RE_LABEL = re.compile(r"[a-zA-Z0-9_-]+$")
 
-_STOP_POLLING_INTERVAL = 15
-
 
 class TeardownStage(IntEnum):
     EARLY = 1
@@ -156,8 +154,6 @@ class RunStatusChecker:
     - check the run sync status.
     """
 
-    _stop_status_lock: threading.Lock
-    _stop_status_handle: MailboxHandle[Result] | None
     _network_status_lock: threading.Lock
     _network_status_handle: MailboxHandle[Result] | None
 
@@ -178,14 +174,6 @@ class RunStatusChecker:
 
         self._join_event = threading.Event()
 
-        self._stop_status_lock = threading.Lock()
-        self._stop_status_handle = None
-        self._stop_thread = threading.Thread(
-            target=self.check_stop_status,
-            name="ChkStopThr",
-            daemon=True,
-        )
-
         self._network_status_lock = threading.Lock()
         self._network_status_handle = None
         self._network_status_thread = threading.Thread(
@@ -194,10 +182,15 @@ class RunStatusChecker:
             daemon=True,
         )
 
+        self._stop_checker = run_stopping.RunStopChecker(
+            asyncer,
+            interface,
+            settings.stop_fn or interrupt.interrupt_main,
+        )
         self._internal_messages = run_messages.RunMessages(asyncer, interface)
 
     def start(self) -> None:
-        self._stop_thread.start()
+        self._stop_checker.start()
         self._network_status_thread.start()
         self._internal_messages.start()
 
@@ -283,51 +276,8 @@ class RunStatusChecker:
                     self._network_status_handle,
                 )
 
-    def check_stop_status(self) -> None:
-        def _process_stop_status(result: Result) -> None:
-            from wandb.agents import pyagent
-
-            # TODO: Remove the pyagent.is_running() check if safe to do so.
-            # See WB-3606.
-            if pyagent.is_running():
-                return
-
-            stop_status = result.response.stop_status_response
-            if not stop_status.run_should_stop:
-                return
-
-            if stop_fn := self._settings.stop_fn:
-                stop_fn()
-            else:
-                interrupt.interrupt_main()
-
-            # Only stop once.
-            self._abandon_status_check(
-                self._stop_status_lock,
-                self._stop_status_handle,
-            )
-
-        with wb_logging.log_to_run(self._run_id):
-            try:
-                self._loop_check_status(
-                    lock=self._stop_status_lock,
-                    set_handle=lambda x: setattr(self, "_stop_status_handle", x),
-                    timeout=_STOP_POLLING_INTERVAL,
-                    request=self._interface.deliver_stop_status,
-                    process=_process_stop_status,
-                )
-            except BrokenPipeError:
-                self._abandon_status_check(
-                    self._stop_status_lock,
-                    self._stop_status_handle,
-                )
-
     def stop(self) -> None:
         self._join_event.set()
-        self._abandon_status_check(
-            self._stop_status_lock,
-            self._stop_status_handle,
-        )
         self._abandon_status_check(
             self._network_status_lock,
             self._network_status_handle,
@@ -335,7 +285,8 @@ class RunStatusChecker:
 
     def join(self) -> None:
         self.stop()
-        self._stop_thread.join()
+
+        self._stop_checker.stop_soon()
         self._network_status_thread.join()
         self._internal_messages.stop(timeout=5)  # TODO: use finish timeout
 


### PR DESCRIPTION
Replaces the run stop detection thread with an asyncio loop, similar to PR #11816.

The implementation is similar to `run_messages.py` in that PR, with a small difference that simplifies things: the loop is stopped on a best-effort basis because there's no harm if we accidentally miss a stop event at the very end of a run.

It might be worth merging `interrupt.py` into this new `run_stopping.py` file, and I might do that in a later PR. It was separate before because it is too subtle for the monolithic `wandb_run.py` file.

## Testing

There are already integration tests in `tests/system_tests/test_functional/interrupt/test_interrupt.py`, so the test strategy is a lot simpler than the mock-heavy unit tests in PR #11816.