### PR TITLE
chore: pin lighting==2.6.0 for Python < 3.10

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -37,7 +37,8 @@ scikit-learn
 torch
 torchvision
 jax[cpu]
-lightning==2.6.1
+lightning==2.6.0; python_version < '3.10'
+lightning==2.6.1; python_version >= '3.10'
 
 pyarrow
 kfp


### PR DESCRIPTION
The 'Regenerate Python Requirements' workflow [failed](https://github.com/wandb/wandb/actions/runs/25333443641/job/74272605296) because of the `lightning==2.6.1` constraint added in PR #11810 cannot be satisfied for Python 3.9.