### PR TITLE
fix(sdk): percent-encode run URL path segments

### DIFF
--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -197,3 +197,19 @@ def test_lazy_run_user_accessible_without_full_load():
     user = run.user
     assert user.name == "testuser"
     assert run._full_data_loaded is False
+
+
+def test_run_url_encodes_spaces_in_project_name():
+    client = mock.MagicMock()
+    client.app_url = "https://wandb.ai/"
+
+    run = Run(
+        client=client,
+        entity="my-entity",
+        project="My Project",
+        run_id="12345",
+        attrs={"name": "test"},
+        service_api=mock.MagicMock(),
+    )
+
+    assert run.url == "https://wandb.ai/my-entity/My%20Project/runs/12345"

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -39,7 +39,7 @@ import os
 import pathlib
 import tempfile
 import time
-from urllib.parse import quote
+import urllib.parse
 from collections.abc import Collection, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -1556,9 +1556,9 @@ class Run(Attrs):
     def path(self) -> list[str]:
         """The path of the run. The path is a list containing the entity, project, and run_id."""
         return [
-            quote(str(self.entity), safe=""),
-            quote(str(self.project), safe=""),
-            quote(str(self.id), safe=""),
+            urllib.parse.quote(str(self.entity), safe=""),
+            urllib.parse.quote(str(self.project), safe=""),
+            urllib.parse.quote(str(self.id), safe=""),
         ]
 
     @property

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -39,7 +39,7 @@ import os
 import pathlib
 import tempfile
 import time
-import urllib
+from urllib.parse import quote
 from collections.abc import Collection, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -1556,9 +1556,9 @@ class Run(Attrs):
     def path(self) -> list[str]:
         """The path of the run. The path is a list containing the entity, project, and run_id."""
         return [
-            urllib.parse.quote_plus(str(self.entity)),
-            urllib.parse.quote_plus(str(self.project)),
-            urllib.parse.quote_plus(str(self.id)),
+            quote(str(self.entity), safe=""),
+            quote(str(self.project), safe=""),
+            quote(str(self.id), safe=""),
         ]
 
     @property


### PR DESCRIPTION
## Summary
Fixes #11793.

`Run.url` in the public API was building URLs from `Run.path` using `quote_plus`, which converts spaces to `+`.
For URL path segments, spaces should be encoded as `%20`, not `+`.

This change switches path-segment encoding to `urllib.parse.quote(..., safe="")` for:
- entity
- project
- run id

## What changed
- `wandb/apis/public/runs.py`
  - use `from urllib.parse import quote`
  - replace `quote_plus(...)` with `quote(..., safe="")` in `Run.path`

## Tests
Added unit regression test:
- `tests/unit_tests/test_public_api/test_runs.py`
  - `test_run_url_encodes_spaces_in_project_name`

This verifies:
- `run.url == "https://wandb.ai/my-entity/My%20Project/runs/12345"`
- URL does not contain `+Project`

## Validation
Ran:
```bash
pytest tests/unit_tests/test_public_api/test_runs.py -k run_url_encodes_spaces_in_project_name
```
Passed.
