### PR TITLE
fix(sdk): handle missing file edges in run.files

### DIFF
--- a/tests/unit_tests/test_file/test_file_public_api.py
+++ b/tests/unit_tests/test_file/test_file_public_api.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import wandb
 from pytest import fixture
-from wandb.apis.public.files import File
+from wandb.apis.public.files import File, Files
 
 
 @fixture
@@ -82,3 +82,47 @@ def test_path_uri_with_reference_file(mock_client, termwarn_spy):
 
     assert file.path_uri == "s3://my-bucket/wandb-artifacts/my-artifact.txt"
     termwarn_spy.assert_not_called()
+
+
+def test_files_convert_objects_skips_invalid_edges(mock_client, mocker):
+    run = mocker.MagicMock(project="project", entity="entity", id="run")
+    files = Files(mock_client, run)
+    files.last_response = {
+        "project": {
+            "run": {
+                "files": {
+                    "edges": [
+                        None,
+                        {"node": None},
+                        {"node": {"id": "file-id", "name": "metrics.json"}},
+                    ]
+                }
+            }
+        }
+    }
+
+    objects = files.convert_objects()
+
+    assert len(objects) == 1
+    assert isinstance(objects[0], File)
+    assert objects[0].name == "metrics.json"
+
+
+def test_files_cursor_skips_invalid_edges(mock_client, mocker):
+    run = mocker.MagicMock(project="project", entity="entity", id="run")
+    files = Files(mock_client, run)
+    files.last_response = {
+        "project": {
+            "run": {
+                "files": {
+                    "edges": [
+                        None,
+                        {"node": {"id": "file-id"}},
+                        {"cursor": "next-cursor", "node": {"id": "file-id-2"}},
+                    ]
+                }
+            }
+        }
+    }
+
+    assert files.cursor == "next-cursor"

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -222,7 +222,10 @@ class Files(SizedPaginator["File"]):
         if not edges:
             return None
 
-        return edges[-1].get("cursor")
+        for edge in reversed(edges):
+            if edge and (cursor := edge.get("cursor")) is not None:
+                return cursor
+        return None
 
     def update_variables(self) -> None:
         """Updates the GraphQL query variables for pagination.
@@ -243,7 +246,12 @@ class Files(SizedPaginator["File"]):
         run_data = project.get("run") or {}
         files_data = run_data.get("files") or {}
         edges = files_data.get("edges") or []
-        return [File(self.client, r["node"], self.run) for r in edges]
+        objects = []
+        for edge in edges:
+            if not edge or not (node := edge.get("node")):
+                continue
+            objects.append(File(self.client, node, self.run))
+        return objects
 
     def __repr__(self) -> str:
         return f"<{nameof(type(self))} {'/'.join(self.run.path)} ({len(self)})>"


### PR DESCRIPTION
## Summary
Fixes #11422.

This hardens Public API file pagination against malformed/partial GraphQL data where file edges or nodes can be `null`.
It also addresses the same crash pattern reported in #11351.

## What changed
- `wandb/apis/public/files.py`
  - `Files.cursor` now skips invalid edges instead of assuming every edge is a dict.
  - `Files.convert_objects` now skips `None` edges and `None` nodes.

## Why
Some runs can return file connections with non-standard edge payloads (e.g. `None` entries), causing:
- `TypeError: 'NoneType' object is not subscriptable`

## Tests
Added unit regression tests in:
- `tests/unit_tests/test_file/test_file_public_api.py`
  - `test_files_convert_objects_skips_invalid_edges`
  - `test_files_cursor_skips_invalid_edges`

## Validation
Ran:
```bash
pytest tests/unit_tests/test_file/test_file_public_api.py
```
Result: 9 passed.
