### PR TITLE
chore: fix failing mypy check in wandb/util.py

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -62,7 +62,7 @@ T = TypeVar("T")
 
 
 logger = logging.getLogger(__name__)
-_not_importable = set()
+_not_importable: set[str] = set()
 
 LAUNCH_JOB_ARTIFACT_SLOT_NAME = "_wandb_job"
 


### PR DESCRIPTION
Fixes a check that started failing with the 2.0 release of MyPy.