### PR TITLE
fix: pass valid `resume` value to `SettingsStatic` in `WandbImporter`

### DIFF
--- a/wandb/apis/importers/wandb.py
+++ b/wandb/apis/importers/wandb.py
@@ -402,7 +402,7 @@ class WandbImporter:
         settings_override = {
             "api_key": self.dst_api_key,
             "base_url": self.dst_base_url,
-            "resume": "true",
+            "resume": "allow",
             "resumed": True,
         }
 
@@ -490,7 +490,7 @@ class WandbImporter:
         settings_override = {
             "api_key": self.dst_api_key,
             "base_url": self.dst_base_url,
-            "resume": "true",
+            "resume": "allow",
             "resumed": True,
         }
 
@@ -769,7 +769,7 @@ class WandbImporter:
         settings_override = {
             "api_key": self.dst_api_key,
             "base_url": self.dst_base_url,
-            "resume": "true",
+            "resume": "allow",
             "resumed": True,
         }
         logger.debug(f"Using artifact sequence with {settings_override=}, {namespace=}")


### PR DESCRIPTION
Fixes #11838

Note: A grep of the importer codebase shows no other occurrences of the legacy string, so the three above appear to be the complete fix.