### PR TITLE
docs(init): document reinit valid string values and deprecate boolean usage

### DIFF
--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -331,8 +331,19 @@ def init(
             the user must be logged in to W&B; otherwise, the script will not
             proceed. If `False` (default), the script can proceed without a login,
             switching to offline mode if the user is not logged in.
-        reinit: Shorthand for the "reinit" setting. Determines the behavior of
-            `wandb.init()` when a run is active.
+        reinit: Controls the behavior of `wandb.init()` when a run is already
+            active. Available options are:
+        - `"default"`: (default) In interactive notebook environments, finishes
+            the active run and starts a new one. In non-interactive scripts,
+            returns the active run without starting a new one.
+        - `"return_previous"`: Returns the active run without starting a new
+            one.
+        - `"finish_previous"`: Finishes the active run and starts a new one.
+        - `"create_new"`: Starts a new run without finishing the active run.
+            Both runs remain active concurrently.
+        - `True`: Deprecated. Use `"finish_previous"` instead.
+        - `False`: Deprecated. Use the default behavior (leaving `reinit`
+            unset) to return the active run in non-notebook environments.
         resume: Controls the behavior when resuming a run with the specified `id`.
             Available options are:
         - `"allow"`: If a run with the specified `id` exists, it will resume

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1393,8 +1393,19 @@ def init(  # noqa: C901
             the user must be logged in to W&B; otherwise, the script will not
             proceed. If `False` (default), the script can proceed without a login,
             switching to offline mode if the user is not logged in.
-        reinit: Shorthand for the "reinit" setting. Determines the behavior of
-            `wandb.init()` when a run is active.
+        reinit: Controls the behavior of `wandb.init()` when a run is already
+            active. Available options are:
+        - `"default"`: (default) In interactive notebook environments, finishes
+            the active run and starts a new one. In non-interactive scripts,
+            returns the active run without starting a new one.
+        - `"return_previous"`: Returns the active run without starting a new
+            one.
+        - `"finish_previous"`: Finishes the active run and starts a new one.
+        - `"create_new"`: Starts a new run without finishing the active run.
+            Both runs remain active concurrently.
+        - `True`: Deprecated. Use `"finish_previous"` instead.
+        - `False`: Deprecated. Use the default behavior (leaving `reinit`
+            unset) to return the active run in non-notebook environments.
         resume: Controls the behavior when resuming a run with the specified `id`.
             Available options are:
         - `"allow"`: If a run with the specified `id` exists, it will resume


### PR DESCRIPTION
## Summary

- Expands the `reinit` parameter docstring in `wandb.init()` to list all valid string values (`"default"`, `"return_previous"`, `"finish_previous"`, `"create_new"`) with a description of each behavior
- Documents that boolean values `True` and `False` are deprecated and provides migration guidance
- Regenerates `wandb/__init__.pyi` stub via `tools/generate_stubs.py` so the stub reflects the updated docstring

## Related Issue

Closes #11833

## Local verification

```
=== LOCAL_TEST_PASSED ===
$ python3 tools/generate_stubs.py
Docstring updated for 'require'.
Docstring updated for 'setup'.
Docstring updated for 'teardown'.
Docstring updated for 'init'.
...
All updates completed.
1 file reformatted
Found 1 error (1 fixed, 0 remaining).
Signature match for 'init'
... (all signatures match)

$ ruff check wandb/sdk/wandb_init.py wandb/__init__.pyi
All checks passed!

$ ruff format --check wandb/sdk/wandb_init.py wandb/__init__.pyi
2 files already formatted

$ python3 -m pytest tests/unit_tests/test_wandb_init.py -v
tests/unit_tests/test_wandb_init.py::test_no_root_dir_access__uses_temp_dir PASSED
tests/unit_tests/test_wandb_init.py::test_no_temp_dir_access__throws_error PASSED
tests/unit_tests/test_wandb_init.py::test_makedirs_raises_oserror__uses_temp_dir PASSED
tests/unit_tests/test_wandb_init.py::test_avoids_sync_dir_conflict PASSED
4 passed in 1.49s
```

## Risk

Documentation-only change. No logic is modified; only the docstring for the `reinit` parameter is updated to enumerate valid values and deprecation notices. The generated `__init__.pyi` stub is also updated to match.
