### PR TITLE
docs(wandb_init): add valid string values and deprecation note to reinit docstring

### DIFF
--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -332,7 +332,15 @@ def init(
             proceed. If `False` (default), the script can proceed without a login,
             switching to offline mode if the user is not logged in.
         reinit: Shorthand for the "reinit" setting. Determines the behavior of
-            `wandb.init()` when a run is active.
+            `wandb.init()` when a run is active. Valid string values are:
+        - `"default"`: Use `"finish_previous"` in notebooks and `"return_previous"`
+            otherwise.
+        - `"return_previous"`: Return the most recently created run that is not
+            yet finished.
+        - `"finish_previous"`: Finish all active runs, then return a new run.
+        - `"create_new"`: Create a new run without modifying other active runs.
+        - `True`: Deprecated. Use `"finish_previous"` instead.
+        - `False`: Deprecated. Use `"return_previous"` instead.
         resume: Controls the behavior when resuming a run with the specified `id`.
             Available options are:
         - `"allow"`: If a run with the specified `id` exists, it will resume

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1394,7 +1394,15 @@ def init(  # noqa: C901
             proceed. If `False` (default), the script can proceed without a login,
             switching to offline mode if the user is not logged in.
         reinit: Shorthand for the "reinit" setting. Determines the behavior of
-            `wandb.init()` when a run is active.
+            `wandb.init()` when a run is active. Valid string values are:
+        - `"default"`: Use `"finish_previous"` in notebooks and `"return_previous"`
+            otherwise.
+        - `"return_previous"`: Return the most recently created run that is not
+            yet finished.
+        - `"finish_previous"`: Finish all active runs, then return a new run.
+        - `"create_new"`: Create a new run without modifying other active runs.
+        - `True`: Deprecated. Use `"finish_previous"` instead.
+        - `False`: Deprecated. Use `"return_previous"` instead.
         resume: Controls the behavior when resuming a run with the specified `id`.
             Available options are:
         - `"allow"`: If a run with the specified `id` exists, it will resume


### PR DESCRIPTION
The reinit docstring just says 'Determines the behavior of wandb.init() when a run is active' — no mention of what values are actually valid or that passing True/False is deprecated. Ran into this while reading the docs and noticed resume lists its valid values right there in the docstring, but reinit doesn't.

Updated the docstring to list the four valid string values and add a deprecation note for boolean usage, matching the resume parameter style.

Closes #11833