### PR TITLE
fix(launch): address security vuln via override args

### DIFF
--- a/tests/unit_tests/test_launch/test_runner/test_local_container.py
+++ b/tests/unit_tests/test_launch/test_runner/test_local_container.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import shlex
 from unittest.mock import MagicMock
 
 import pytest
@@ -133,6 +134,21 @@ def test_shell_command_uses_cmd_on_windows(mocker):
 
     assert local_container._shell_command("echo hello") == ["cmd", "/C", "echo hello"]
     mock_which.assert_not_called()
+
+
+def test_get_docker_command_quotes_user_controlled_args_for_shell():
+    payload = "; echo HACKED > /tmp/wandb-poc-cmd-injection; #"
+
+    command = local_container.get_docker_command(
+        "test-image",
+        {},
+        entry_cmd=[payload, payload],
+        additional_args=[payload],
+    )
+
+    split_command = shlex.split(" ".join(command))
+    assert split_command[split_command.index("--entrypoint") + 1] == payload
+    assert split_command[-2:] == [payload, payload]
 
 
 @pytest.mark.asyncio

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -303,12 +303,12 @@ def get_docker_command(
                 cmd += [prefix, shlex.quote(str(value))]
 
     if entry_cmd:
-        cmd += ["--entrypoint", entry_cmd[0]]
+        cmd += ["--entrypoint", shlex.quote(str(entry_cmd[0]))]
     cmd += [shlex.quote(image)]
     if entry_cmd and len(entry_cmd) > 1:
-        cmd += entry_cmd[1:]
+        cmd += [shlex.quote(str(arg)) for arg in entry_cmd[1:]]
     if additional_args:
-        cmd += additional_args
+        cmd += [shlex.quote(str(arg)) for arg in additional_args]
     return cmd
 
 


### PR DESCRIPTION
Description
-----------
https://coreweave.atlassian.net/browse/VULNMGMT-1773
https://coreweave.atlassian.net/browse/WB-34158

Addresses a command injection security vulnerability on launch agent by wrapping the docker command and override args with `shlex.quote`


- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

1. Added unit test. 

2. [Built a launch agent](https://github.com/wandb/wandb/actions/runs/25688705850) off this branch and started it to poll off `nicpun-test-docker-queue`. Queued a job to run with override args `'{"overrides":{"args":["; echo PROOF > /proof/proof-patched-vulnmgmt-1773.txt; #"]}}'`, which now [fails](https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6NjgxNTY=/logs). The same test off `wandb/launch-agent:latest` [queues the job](https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6NjgxNTc=/logs) and we can verify that the "proof" file is created, i.e. the command below prints `PROOF`:
```
docker exec launch-agent-latest-proof-1773 sh -c 'printf "proof file: "; cat /proof/proof-latest-vulnmgmt-1773.txt 2>/dev/null || printf "<missing>\n"'
```