### PR TITLE
fix(launch): ensure docker image for accelerator base image

### DIFF
--- a/tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/unit_tests/test_launch/test_builder/test_build.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -114,21 +115,46 @@ def test_get_base_setup_accepts_accelerator_base_image_refs(base_image):
 
 
 @pytest.mark.parametrize(
-    "base_image",
+    "base_image,expected_error",
     [
-        "ubuntu:22.04\nRUN echo PROOF > /proof.txt\n#",
-        "ubuntu:22.04 # comment",
-        "ubuntu:22.04 as base",
-        "ubuntu:22.04\n",
-        "ubuntu:22.04@sha256:not-a-digest",
-        1,
+        (
+            "ubuntu:22.04\nRUN echo PROOF > /proof.txt\n#",
+            "Docker image references cannot contain whitespace or '#'.",
+        ),
+        (
+            "ubuntu:22.04 # comment",
+            "Docker image references cannot contain whitespace or '#'.",
+        ),
+        (
+            "ubuntu:22.04 as base",
+            "Docker image references cannot contain whitespace or '#'.",
+        ),
+        (
+            "ubuntu:22.04\n",
+            "Docker image references cannot contain whitespace or '#'.",
+        ),
+        (
+            "ubuntu:22.04@sha256:not-a-digest",
+            "Expected digest to match sha256:<64 hex characters>.",
+        ),
+        (
+            "Ubuntu:22.04",
+            "Expected a valid Docker image reference name.",
+        ),
+        (
+            1,
+            "Expected builder.accelerator.base_image to be a string Docker image "
+            "reference, got int.",
+        ),
     ],
 )
-def test_get_base_setup_rejects_invalid_accelerator_base_image_refs(base_image):
+def test_get_base_setup_rejects_invalid_accelerator_base_image_refs(
+    base_image, expected_error
+):
     launch_project = MagicMock()
     launch_project.accelerator_base_image = base_image
 
-    with pytest.raises(LaunchError, match="Invalid accelerator base image"):
+    with pytest.raises(LaunchError, match=re.escape(expected_error)):
         build.get_base_setup(launch_project, "3.10", "3")
 
 

--- a/tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/unit_tests/test_launch/test_builder/test_build.py
@@ -141,11 +141,6 @@ def test_get_base_setup_accepts_accelerator_base_image_refs(base_image):
             "Ubuntu:22.04",
             "Expected a valid Docker image reference name.",
         ),
-        (
-            1,
-            "Expected builder.accelerator.base_image to be a string Docker image "
-            "reference, got int.",
-        ),
     ],
 )
 def test_get_base_setup_rejects_invalid_accelerator_base_image_refs(

--- a/tests/unit_tests/test_launch/test_builder/test_build.py
+++ b/tests/unit_tests/test_launch/test_builder/test_build.py
@@ -10,6 +10,7 @@ from wandb.sdk.launch.builder.abstract import registry_from_uri
 from wandb.sdk.launch.builder.context_manager import get_requirements_section
 from wandb.sdk.launch.builder.templates.dockerfile import PIP_TEMPLATE
 from wandb.sdk.launch.create_job import _configure_job_builder_for_partial
+from wandb.sdk.launch.errors import LaunchError
 
 
 def _read_wandb_job_json_from_artifact(artifact: Artifact) -> dict:
@@ -92,6 +93,43 @@ def mock_launch_project(mocker):
     )
     launch_project.get_job_entry_point = lambda: launch_project.entry_point
     return launch_project
+
+
+@pytest.mark.parametrize(
+    "base_image",
+    [
+        "ubuntu:22.04",
+        "nvidia/cuda:12.4.1-runtime-ubuntu22.04",
+        "registry.example.com:5000/team/image:tag",
+        f"ubuntu@sha256:{'a' * 64}",
+    ],
+)
+def test_get_base_setup_accepts_accelerator_base_image_refs(base_image):
+    launch_project = MagicMock()
+    launch_project.accelerator_base_image = base_image
+
+    dockerfile = build.get_base_setup(launch_project, "3.10", "3")
+
+    assert f"FROM {base_image} as base" in dockerfile
+
+
+@pytest.mark.parametrize(
+    "base_image",
+    [
+        "ubuntu:22.04\nRUN echo PROOF > /proof.txt\n#",
+        "ubuntu:22.04 # comment",
+        "ubuntu:22.04 as base",
+        "ubuntu:22.04\n",
+        "ubuntu:22.04@sha256:not-a-digest",
+        1,
+    ],
+)
+def test_get_base_setup_rejects_invalid_accelerator_base_image_refs(base_image):
+    launch_project = MagicMock()
+    launch_project.accelerator_base_image = base_image
+
+    with pytest.raises(LaunchError, match="Invalid accelerator base image"):
+        build.get_base_setup(launch_project, "3.10", "3")
 
 
 def _setup(mocker):

--- a/tests/unit_tests/test_launch/test_project/test_project.py
+++ b/tests/unit_tests/test_launch/test_project/test_project.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from wandb.sdk.launch._project_spec import LaunchProject, LaunchSource
+from wandb.sdk.launch.errors import LaunchError
 
 
 def test_project_build_required():
@@ -197,6 +198,44 @@ def mock_project_args():
         "run_id": None,
         "sweep_id": "mock-sweep-id",
     }
+
+
+@pytest.mark.parametrize("accelerator_key", ["accelerator", "cuda"])
+def test_project_rejects_non_string_accelerator_base_image(
+    mock_project_args, accelerator_key
+):
+    mock_project_args["resource_args"] = {
+        "local-container": {
+            "builder": {
+                accelerator_key: {"base_image": 123},
+            }
+        }
+    }
+
+    with pytest.raises(
+        LaunchError,
+        match=(
+            "Expected builder\\."
+            f"{accelerator_key}\\.base_image to be a string Docker image "
+            "reference, got int\\."
+        ),
+    ):
+        LaunchProject(**mock_project_args)
+
+
+@pytest.mark.parametrize("accelerator_key", ["accelerator", "cuda"])
+def test_project_sets_string_accelerator_base_image(mock_project_args, accelerator_key):
+    mock_project_args["resource_args"] = {
+        "local-container": {
+            "builder": {
+                accelerator_key: {"base_image": "ubuntu:22.04"},
+            }
+        }
+    }
+
+    project = LaunchProject(**mock_project_args)
+
+    assert project.accelerator_base_image == "ubuntu:22.04"
 
 
 def test_project_parse_existing_requirements_invalid_requirement(

--- a/tools/launch_release/build/Dockerfile
+++ b/tools/launch_release/build/Dockerfile
@@ -6,7 +6,7 @@ ARG TARGETARCH
 RUN apk add --no-cache python3 git py3-pip gcc python3-dev curl openssl-dev pkgconf \
     && ln -sf /usr/bin/pkgconf /usr/bin/pkg-config
 
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
     curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -; \
     elif [ "$TARGETARCH" = "arm64" ]; then \

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -36,6 +36,27 @@ RESOURCE_UID_MAP = {"local": 1000, "sagemaker": 0}
 IMAGE_TAG_MAX_LENGTH = 32
 
 
+def _get_accelerator_base_image(
+    resource_args_build: dict[str, Any],
+) -> str | None:
+    """Return configured accelerator base image from raw builder resource args."""
+    for accelerator_key in ("accelerator", "cuda"):
+        base_image = resource_args_build.get(accelerator_key, {}).get("base_image")
+        if base_image is None or base_image == "":
+            continue
+
+        if not isinstance(base_image, str):
+            raise LaunchError(
+                "Invalid accelerator base image. Expected "
+                f"builder.{accelerator_key}.base_image to be a string Docker "
+                f"image reference, got {type(base_image).__name__}."
+            )
+
+        return base_image
+
+    return None
+
+
 class LaunchSource(enum.IntEnum):
     """Enumeration of possible sources for a launch project.
 
@@ -119,10 +140,8 @@ class LaunchProject:
         self._job_dockerfile: str | None = None
         self._job_build_context: str | None = None
         self._job_base_image: str | None = None
-        self.accelerator_base_image: str | None = self._resource_args_build.get(
-            "accelerator", {}
-        ).get("base_image") or self._resource_args_build.get("cuda", {}).get(
-            "base_image"
+        self.accelerator_base_image: str | None = _get_accelerator_base_image(
+            self._resource_args_build
         )
         self.docker_image: str | None = docker_config.get(
             "docker_image"

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -38,27 +38,32 @@ _DOCKER_IMAGE_REF_UNSAFE_CHARS = re.compile(r"[\s#]")
 _DOCKER_IMAGE_SHA256_DIGEST = re.compile(r"sha256:[0-9a-fA-F]{64}")
 
 
-def _validate_accelerator_base_image(base_image: str) -> str:
+def _validate_accelerator_base_image(base_image: Any) -> str:
     """Validate accelerator base image before inserting it into a Dockerfile."""
     if not isinstance(base_image, str):
         raise LaunchError(
-            "Invalid accelerator base image. Expected a Docker image reference."
+            "Invalid accelerator base image. Expected "
+            "builder.accelerator.base_image to be a string Docker image "
+            f"reference, got {type(base_image).__name__}."
         )
 
     if _DOCKER_IMAGE_REF_UNSAFE_CHARS.search(base_image):
         raise LaunchError(
-            "Invalid accelerator base image. Expected a Docker image reference."
+            "Invalid accelerator base image. Docker image references cannot "
+            "contain whitespace or '#'."
         )
 
     image_name, digest_sep, digest = base_image.partition("@")
     if digest_sep and not _DOCKER_IMAGE_SHA256_DIGEST.fullmatch(digest):
         raise LaunchError(
-            "Invalid accelerator base image. Expected a Docker image reference."
+            "Invalid accelerator base image. Expected digest to match "
+            "sha256:<64 hex characters>."
         )
 
     if not image_name or not docker_image_regex(image_name):
         raise LaunchError(
-            "Invalid accelerator base image. Expected a Docker image reference."
+            "Invalid accelerator base image. Expected a valid Docker image "
+            "reference name."
         )
 
     return base_image

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -38,15 +38,8 @@ _DOCKER_IMAGE_REF_UNSAFE_CHARS = re.compile(r"[\s#]")
 _DOCKER_IMAGE_SHA256_DIGEST = re.compile(r"sha256:[0-9a-fA-F]{64}")
 
 
-def _validate_accelerator_base_image(base_image: Any) -> str:
+def _validate_accelerator_base_image(base_image: str) -> str:
     """Validate accelerator base image before inserting it into a Dockerfile."""
-    if not isinstance(base_image, str):
-        raise LaunchError(
-            "Invalid accelerator base image. Expected "
-            "builder.accelerator.base_image to be a string Docker image "
-            f"reference, got {type(base_image).__name__}."
-        )
-
     if _DOCKER_IMAGE_REF_UNSAFE_CHARS.search(base_image):
         raise LaunchError(
             "Invalid accelerator base image. Docker image references cannot "

--- a/wandb/sdk/launch/builder/build.py
+++ b/wandb/sdk/launch/builder/build.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import shlex
 import shutil
 from typing import Any
@@ -16,7 +17,7 @@ from wandb.sdk.launch.loader import (
     environment_from_config,
     registry_from_config,
 )
-from wandb.util import get_module
+from wandb.util import docker_image_regex, get_module
 
 from .._project_spec import EntryPoint, LaunchProject
 from ..errors import ExecutionError, LaunchError
@@ -33,6 +34,34 @@ _logger = logging.getLogger(__name__)
 
 
 _WANDB_DOCKERFILE_NAME = "Dockerfile.wandb"
+_DOCKER_IMAGE_REF_UNSAFE_CHARS = re.compile(r"[\s#]")
+_DOCKER_IMAGE_SHA256_DIGEST = re.compile(r"sha256:[0-9a-fA-F]{64}")
+
+
+def _validate_accelerator_base_image(base_image: str) -> str:
+    """Validate accelerator base image before inserting it into a Dockerfile."""
+    if not isinstance(base_image, str):
+        raise LaunchError(
+            "Invalid accelerator base image. Expected a Docker image reference."
+        )
+
+    if _DOCKER_IMAGE_REF_UNSAFE_CHARS.search(base_image):
+        raise LaunchError(
+            "Invalid accelerator base image. Expected a Docker image reference."
+        )
+
+    image_name, digest_sep, digest = base_image.partition("@")
+    if digest_sep and not _DOCKER_IMAGE_SHA256_DIGEST.fullmatch(digest):
+        raise LaunchError(
+            "Invalid accelerator base image. Expected a Docker image reference."
+        )
+
+    if not image_name or not docker_image_regex(image_name):
+        raise LaunchError(
+            "Invalid accelerator base image. Expected a Docker image reference."
+        )
+
+    return base_image
 
 
 async def validate_docker_installation() -> None:
@@ -152,9 +181,10 @@ def get_base_setup(
     else:
         python_base_image = f"python:{py_version}-bookworm"
     if launch_project.accelerator_base_image:
-        _logger.info(
-            f"Using accelerator base image: {launch_project.accelerator_base_image}"
+        accelerator_base_image = _validate_accelerator_base_image(
+            launch_project.accelerator_base_image
         )
+        _logger.info("Using accelerator base image: %s", accelerator_base_image)
         python_packages = [
             f"python{py_version}",
             f"libpython{py_version}",
@@ -162,7 +192,7 @@ def get_base_setup(
             "python3-setuptools",
         ]
         base_setup = ACCELERATOR_SETUP_TEMPLATE.format(
-            accelerator_base_image=launch_project.accelerator_base_image,
+            accelerator_base_image=accelerator_base_image,
             python_packages=" \\\n".join(python_packages),
             py_version=py_version,
         )


### PR DESCRIPTION
Description
-----------
https://coreweave.atlassian.net/browse/VULNMGMT-1774
https://coreweave.atlassian.net/browse/WB-34160

A vulnerability exists where users can inject arbitrary dockerfile instructions via `resource_args.kubernetes.builder.accelerator.base_image` since we do not verify that the argument is a valid docker image. This PR adds validation and also bumps the golang version from `1.26.2` to `1.26.3` (which was just updated earlier https://github.com/wandb/wandb/pull/11851)

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
* Updated unit test
* Ran the agent locally and then attempted to launch a hello world job with the base image modified:
```
uv run wandb launch \
    --job wandb/launch-agent-vulnmgmt-test/job-https___github.com_wandb_launch-jobs-py310:latest \
    --queue nicpun-test-k8s-queue \
    --entity wandb \
    --project launch-agent-vulnmgmt-test \
    --resource kubernetes \
    --config '{"overrides":{"working_dir":"jobs/hello_world"}}' \
    --resource-args '{"kubernetes":{"builder":{"accelerator":{"base_image":"ubuntu:22.04\nRUN echo PROOF > /proof.txt\n#"}}}}'
```

Before the fix, we would see the `RUN echo PROOF > /proof.txt` as a step in the build process, like in https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6NjgxNTg=/logs:
```
2026-05-11 18:06:16
Step 8/22 : RUN echo PROOF > /proof.txt
2026-05-11 18:06:16
 ---> Using cache
2026-05-11 18:06:16
 ---> c7f752d35693
```

After the fix, we see an invalid image error instead, like in https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6NjgxNjI=/logs
