### PR TITLE
fix(sdk): build vendored orjson on Windows 32-bit

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -167,6 +167,12 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             rustup target add x86_64-apple-darwin
 
+          # cp*-win32 builds run a 32-bit Python on the 64-bit Windows host;
+          # the wandb_orjson hatch script passes --target i686-pc-windows-msvc
+          # to cargo to match, which needs the std lib for that triple.
+          CIBW_BEFORE_ALL_WINDOWS: >
+            rustup target add i686-pc-windows-msvc
+
           # Work around https://github.com/matthew-brett/delocate/issues/204
           # by adding `--ignore-missing-dependencies` to cibuildwheel's default
           # repair wheel command.

--- a/wandb/vendor/wandb_orjson/hatch.py
+++ b/wandb/vendor/wandb_orjson/hatch.py
@@ -7,7 +7,8 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from typing import List
+import sysconfig
+from typing import List, Optional
 
 
 class OrjsonBuildError(Exception):
@@ -59,6 +60,8 @@ def build_orjson(
         "--message-format=json",
         "--lib",
     ]
+    if cargo_target := _cargo_target():
+        cmd.extend(["--target", cargo_target])
 
     # On Linux, libpython may not be available as a shared library
     # (musl bundles it statically; manylinux may not have it on the
@@ -158,3 +161,19 @@ def _cargo_env() -> dict[str, str]:
         rustflags = env.get("RUSTFLAGS", "")
         env["RUSTFLAGS"] = f"{rustflags} -C target-feature=-crt-static".strip()
     return env
+
+
+def _cargo_target() -> Optional[str]:
+    """Returns a Rust target triple to pass via --target, or None.
+
+    cibuildwheel builds cp*-win32 wheels by running a 32-bit Python on a
+    64-bit Windows runner. Cargo's default target follows the host
+    (x86_64-pc-windows-msvc), so pyo3-ffi's build script aborts with
+    "your Rust target architecture (64-bit) does not match your python
+    interpreter (32-bit)". Returning i686-pc-windows-msvc keeps the two
+    aligned. CI must `rustup target add i686-pc-windows-msvc` first.
+    """
+    if sysconfig.get_platform() == "win32":
+        return "i686-pc-windows-msvc"
+
+    return None


### PR DESCRIPTION
Description
-----------
The 0.27.0 release pipeline failed on cp310-win32 with "your Rust target architecture (64-bit) does not match your python interpreter (32-bit)" — cibuildwheel runs a 32-bit Python on the 64-bit Windows runner, but cargo defaults to the host target so pyo3-ffi's build script aborts.

Fix is to pass --target i686-pc-windows-msvc to cargo when sysconfig.get_platform() == "win32" and install the matching std lib via CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc (mirrors the existing macOS pattern).