### PR TITLE
chore: fix cibuildwheel hardcodes for universal wheels when building orjson

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -54,14 +54,26 @@ class CustomBuildHook(BuildHookInterface):
             self._prepare_wheel(build_data)
 
     def _prepare_wheel(self, build_data: dict[str, Any]) -> None:
-        build_data["tag"] = f"py3-none-{self._get_platform_tag()}"
+        platform_tag = self._get_platform_tag()
+        include_orjson = self._include_orjson()
+
+        if include_orjson:
+            # orjson uses CPython ABI, so the wheel tag must be version-specific.
+            version_info = sys.version_info
+            build_data["tag"] = (
+                f"cp{version_info.major}{version_info.minor}"
+                f"-cp{version_info.major}{version_info.minor}"
+                f"-{platform_tag}"
+            )
+        else:
+            build_data["tag"] = f"py3-none-{platform_tag}"
 
         artifacts: list[str] = build_data["artifacts"]
         artifacts.extend(self._build_wandb_core())
         artifacts.extend(self._build_arrow_rs_wrapper())
         if self._include_wandb_xpu():
             artifacts.extend(self._build_wandb_xpu())
-        if self._include_orjson():
+        if include_orjson:
             artifacts.extend(self._build_orjson())
 
     def _get_platform_tag(self) -> str:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Since we have started building Orjson, the build process was hardcoding the wheel tag to `py3-non-{platform}` indicating it is a universal wheel, and was not building the wheel against the required CPython ABI.

Cibuildwheel would reuse the first compatible wheel across version. Meaning while supporting python 3.9 orjson was not built in any of the wheels. In python 3.10 trying to import wandb_orjson would fail the import with a SIGSEGV. This PR adds the build tags so that orjson can be built against the correct Python ABI version.

## Testing

How was this PR tested?

```bash
python3.12 -m hatchling build -t wheel -d dist-test

pip install dist-test/wandb-0.26.2.dev1-cp312-cp312-macosx_15_0_arm64.whl

ipython
> In [1]: import wandb.vendor.wandb_orjson as orjson
> In [2]: print('orjson version:', orjson.__version__)
orjson version: 3.11.7
> In [3]: print('dumps:', orjson.dumps({'hello': 'world'}))
dumps: b'{"hello":"world"}'

```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->