### PR TITLE
chore(sdk): modernize annotations and trim pydantic-v1 compat holdovers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,10 +227,8 @@ split-on-trailing-comma = false
 
 [tool.ruff.lint.pep8-naming]
 classmethod-decorators = [
-    # Allow Pydantic's `@field_validator` to trigger classmethod treatment,
-    # as well as the internal compat implementation.
+    # Allow Pydantic's `@field_validator` to trigger classmethod treatment.
     "pydantic.field_validator",
-    "wandb._pydantic.field_validator",
 ]
 
 [tool.ruff.lint.pycodestyle]
@@ -278,17 +276,9 @@ ignore-decorators = [
 # TODO: Unignore this lint and add symbols to __all__ instead.
 "**/__init__.py" = ["F401"]
 
-# TODO: Fix UP006, UP007, UP045 in wandb_run.py, then remove ignores here.
 "wandb/__init__.py" = ["I001"]
-"wandb/__init__.pyi" = ["UP006", "UP007", "UP035", "UP045", "W505"]
-"wandb/__init__.template.pyi" = [
-    "UP006",
-    "UP007",
-    "UP035",
-    "UP045",
-    "D415",
-    "N999",
-]
+"wandb/__init__.pyi" = ["W505"]
+"wandb/__init__.template.pyi" = ["D415", "N999"]
 
 # TODO: Use f-strings in wandb/apis/public/ for GraphQL statements.
 #   To preserve GraphQL syntax highlighting, add #graphql at the start of
@@ -351,30 +341,8 @@ ignore-decorators = [
 # See: https://docs.python.org/3/library/ast.html#ast.NodeTransformer
 "tools/graphql_codegen/**" = ["N802"]
 
-# Ignore lints on generated code.
-"wandb/**/_generated/**/*.py" = [
-    # Generated code names may not respect PEP8.
-    "N8",
-
-    # TODO: These ignores were originally needed for Pydantic v1, where
-    # `list[...]` / `X | Y` could trip up runtime type introspection
-    # (especially without `eval_type_backport` on Python < 3.10). With
-    # Pydantic v1 dropped and Python >= 3.10 required, the annotations can
-    # be modernized and these ignores lifted.
-    "UP006",
-    "UP007",
-    "UP035",
-    "UP045",
-]
-
-# TODO: Same as above — kept for Pydantic v1 compatibility, can be modernized
-# now that v2 is required.
-"wandb/sdk/wandb_settings.py" = ["UP006", "UP007", "UP035", "UP045"]
-"wandb/sdk/wandb_metadata.py" = ["UP006", "UP007", "UP035", "UP045"]
-"wandb/sdk/lib/run_moment.py" = ["UP006", "UP007", "UP035", "UP045"]
-"wandb/automations/**" = ["UP006", "UP007", "UP035", "UP045"]
-"wandb/sdk/artifacts/_models/**" = ["UP006", "UP007", "UP035", "UP045"]
-"wandb/_pydantic/**" = ["UP006", "UP007", "UP035", "UP045"]
+# Generated code names may not respect PEP8.
+"wandb/**/_generated/**/*.py" = ["N8"]
 
 # TODO: Remove the landfill/ directory.
 "landfill/**" = ["F405", "N806", "D415"]

--- a/tests/unit_tests/test_automations/test_scopes.py
+++ b/tests/unit_tests/test_automations/test_scopes.py
@@ -1,11 +1,11 @@
-from wandb._pydantic import CompatBaseModel
+from pydantic import BaseModel
 from wandb.apis.public import ArtifactCollection, Project
 from wandb.automations import ArtifactCollectionScope, ProjectScope, ScopeType
 from wandb.automations._generated import TriggerScopeType
 from wandb.automations.scopes import ArtifactCollectionScopeTypes, AutomationScope
 
 
-class HasScope(CompatBaseModel):
+class HasScope(BaseModel):
     scope: AutomationScope
 
 

--- a/tests/unit_tests/test_pydantic_helpers.py
+++ b/tests/unit_tests/test_pydantic_helpers.py
@@ -1,17 +1,9 @@
 """Basic tests for W&B's Pydantic helper layer."""
 
-# TODO: These noqa entries were originally needed for Pydantic v1, where
-# modern annotation forms (`list[X]`, `X | None`) could trip up runtime type
-# introspection. v1 is dropped, so the annotations below can be modernized
-# and these ignores removed.
-# ruff: noqa: UP006  # allow e.g. `List[X]` instead of `list[X]`
-# ruff: noqa: UP035  # allow deprecated typing module imports
-# ruff: noqa: UP045  # allow e.g. `Optional[X]` instead of `X | None`
-
 from __future__ import annotations
 
 import json
-from typing import Any, List, Optional
+from typing import Any
 
 from pydantic import ConfigDict, Field, Json, ValidationError
 from pytest import raises
@@ -135,7 +127,7 @@ def test_model_fields_class_property():
 def test_model_fields_set_property():
     class Model(CompatBaseModel):
         x: int
-        y: Optional[str] = None
+        y: str | None = None
 
     obj = Model(x=1)
     assert obj.model_fields_set == {"x"}
@@ -197,9 +189,9 @@ def test_model_config_conversion():
 def test_model_dump_methods_with_json_fields():
     class Model(CompatBaseModel):
         x: int
-        req_json_field: Json[List[int]]
-        opt_json_field: Optional[Json[List[int]]] = None
-        unset_opt_json_field: Optional[Json[List[int]]] = None
+        req_json_field: Json[list[int]]
+        opt_json_field: Json[list[int]] | None = None
+        unset_opt_json_field: Json[list[int]] | None = None
 
     obj = Model(
         x=1,
@@ -239,10 +231,8 @@ class Item(CompatBaseModel):
 
 
 class ListFields(CompatBaseModel):
-    required_list: List[Item] = Field(min_length=1, max_length=3)
-    optional_list: Optional[List[Item]] = Field(
-        default=None, min_length=1, max_length=3
-    )
+    required_list: list[Item] = Field(min_length=1, max_length=3)
+    optional_list: list[Item] | None = Field(default=None, min_length=1, max_length=3)
 
 
 def test_field_constraints_on_list_fields():
@@ -274,7 +264,7 @@ def test_field_constraints_on_list_fields():
 def test_field_constraints_on_str_fields():
     class StringFields(CompatBaseModel):
         required_str: str = Field(min_length=1, max_length=3, pattern=r"^[a-z]+$")
-        optional_str: Optional[str] = Field(
+        optional_str: str | None = Field(
             default=None, min_length=1, max_length=3, pattern=r"^[a-z]+$"
         )
 
@@ -358,15 +348,15 @@ def test_generated_pydantic_fragment_validates_response_data():
 
 # ------------------------------------------------------------------------------
 class NestedInput(GQLInput):
-    inner_str: Optional[str] = None
-    inner_int: Optional[int] = None
+    inner_str: str | None = None
+    inner_int: int | None = None
 
 
 class CreateThingInput(GQLInput):
     required_value: int
-    optional_str: Optional[str] = None
-    optional_int: Optional[int] = None
-    nested: Optional[NestedInput] = None
+    optional_str: str | None = None
+    optional_int: int | None = None
+    nested: NestedInput | None = None
 
 
 NestedInput.model_rebuild()

--- a/tools/graphql_codegen/plugin.py
+++ b/tools/graphql_codegen/plugin.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import ast
 import subprocess
 import sys
-from collections import deque
 from contextlib import suppress
 from itertools import chain
 from pathlib import Path
@@ -189,47 +188,6 @@ class GraphQLCodegenPlugin(Plugin):
                 # Keep only imported names that aren't being dropped
                 kept_names = sorted(set(imported_names(imp)) - omit_names)
                 yield make_import_from(imp.module, kept_names, level=imp.level)
-
-    def _ensure_all_model_rebuilds(self, module: ast.Module) -> ast.Module:
-        """Ensure that all generated classes call `model_rebuild()` after being defined.
-
-        TODO: This was originally a workaround for Pydantic v1, where forward
-        references between sibling classes required explicit
-        `.update_forward_refs()` (i.e. `.model_rebuild()` in v2) calls that v2
-        normally resolves automatically. Now that v1 is no longer supported,
-        this codegen pass — and the resulting `model_rebuild()` boilerplate in
-        the generated files — should be removable.
-        """
-        import_stmts = deque()  # e.g. `from typing import ...`
-        classdef_stmts = deque()  # e.g. `class MyFragmentFields(BaseModel): ...`
-
-        for stmt in module.body:
-            match stmt:
-                case ast.ImportFrom() | ast.Import():
-                    import_stmts.append(stmt)
-                case ast.ClassDef():
-                    classdef_stmts.append(stmt)
-                case ast.Expr(value=ast.Call(func=ast.Attribute(attr="model_rebuild"))):
-                    # e.g. `MyFragmentFields.model_rebuild()`
-                    # We'll regenerate these from scratch
-                    pass
-                case _:
-                    msg = f"Unexpected AST statement in module: {ast.dump(stmt)}"
-                    raise ValueError(msg)
-
-        rebuild_stmts = [
-            ast.Expr(
-                value=ast.Call(
-                    func=ast.Attribute(value=ast.Name(cl.name), attr="model_rebuild"),
-                    args=[],
-                    keywords=[],
-                )
-            )
-            for cl in classdef_stmts
-        ]
-
-        module.body = [*import_stmts, *classdef_stmts, *rebuild_stmts]
-        return module
 
     def process_schema(self, schema: GraphQLSchema) -> GraphQLSchema:
         # `ariadne-codegen` 0.16 misses standard GraphQL meta fields in the schema model.
@@ -451,7 +409,6 @@ class GraphQLCodegenPlugin(Plugin):
                     # - omit default: Fragment defined on a GQL interface with multiple impls.
                     stmt.value = ast.Constant(names[0]) if len(names) == 1 else None
 
-        module = self._ensure_all_model_rebuilds(module)
         return self._rewrite_generated_module(module)
 
     def _rewrite_generated_module(self, module: ast.Module) -> ast.Module:

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -62,8 +62,8 @@ __all__ = (
 )
 
 import os
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Callable, Literal, TextIO
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Literal, TextIO
 
 import wandb.plot as plot
 from wandb.apis import InternalApi

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -62,8 +62,8 @@ __all__ = (
 )
 
 import os
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Callable, Literal, TextIO
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Literal, TextIO
 
 import wandb.plot as plot
 from wandb.apis import InternalApi

--- a/wandb/_pydantic/base.py
+++ b/wandb/_pydantic/base.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Literal, overload
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
@@ -83,7 +84,7 @@ class JsonableModel(CompatBaseModel, ABC):
     # - by_alias: Convert keys to JSON-ready names and objects to JSON-ready
     #   dicts.
     # - round_trip: Ensure the result can round-trip.
-    __DUMP_DEFAULTS: ClassVar[Dict[str, Any]] = dict(by_alias=True, round_trip=True)
+    __DUMP_DEFAULTS: ClassVar[dict[str, Any]] = dict(by_alias=True, round_trip=True)
 
     @overload  # Actual signature
     def model_dump(
@@ -132,7 +133,7 @@ class GQLResult(GQLBase, ABC):
 class GQLInput(GQLBase, ABC):
     # For GraphQL inputs, exclude null values when preparing JSON-able request
     # data.
-    __DUMP_DEFAULTS: ClassVar[Dict[str, Any]] = dict(exclude_none=True)
+    __DUMP_DEFAULTS: ClassVar[dict[str, Any]] = dict(exclude_none=True)
 
     @override
     def model_dump(self, *, mode: str = "json", **kwargs: Any) -> dict[str, Any]:

--- a/wandb/_pydantic/pagination.py
+++ b/wandb/_pydantic/pagination.py
@@ -6,7 +6,7 @@ For formal specs and definitions, see https://relay.dev/graphql/connections.htm.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Generic, Literal, Optional, TypeVar
+from typing import Generic, Literal, TypeVar
 
 from pydantic import NonNegativeInt
 
@@ -21,7 +21,7 @@ class PageInfo(GQLResult):
 
     typename__: Literal["PageInfo"] = "PageInfo"
 
-    end_cursor: Optional[str]
+    end_cursor: str | None
     """Opaque token marking the end of this page and the start of the next page."""
 
     has_next_page: bool
@@ -59,7 +59,7 @@ class Connection(GQLResult, Generic[NodeT]):
     page_info: PageInfo
     """Pagination metadata, e.g. `end_cursor`, `has_next_page`."""
 
-    total_count: Optional[NonNegativeInt] = None
+    total_count: NonNegativeInt | None = None
     """Total number of results across all pages, if available."""
 
     def nodes(self) -> Iterator[NodeT]:
@@ -72,7 +72,7 @@ class Connection(GQLResult, Generic[NodeT]):
         return self.page_info.has_next_page
 
     @property
-    def next_cursor(self) -> Optional[str]:
+    def next_cursor(self) -> str | None:
         """The cursor value to pass as the `after` arg in the next page request."""
         return self.page_info.end_cursor
 

--- a/wandb/apis/_generated/create_invite.py
+++ b/wandb/apis/_generated/create_invite.py
@@ -3,27 +3,25 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLId, GQLResult
 
 
 class CreateInvite(GQLResult):
-    result: Optional[CreateInviteResult]
+    result: CreateInviteResult | None
 
 
 class CreateInviteResult(GQLResult):
-    invite: Optional[CreateInviteResultInvite]
+    invite: CreateInviteResultInvite | None
 
 
 class CreateInviteResultInvite(GQLResult):
     id: GQLId
     name: str
-    email: Optional[str]
-    created_at: Optional[str] = Field(alias="createdAt")
-    to_user: Optional[CreateInviteResultInviteToUser] = Field(alias="toUser")
+    email: str | None
+    created_at: str | None = Field(alias="createdAt")
+    to_user: CreateInviteResultInviteToUser | None = Field(alias="toUser")
 
 
 class CreateInviteResultInviteToUser(GQLResult):

--- a/wandb/apis/_generated/create_project.py
+++ b/wandb/apis/_generated/create_project.py
@@ -3,21 +3,19 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import CreatedProjectFragment
 
 
 class CreateProject(GQLResult):
-    result: Optional[CreateProjectResult]
+    result: CreateProjectResult | None
 
 
 class CreateProjectResult(GQLResult):
-    project: Optional[CreatedProjectFragment]
-    model: Optional[CreatedProjectFragment]
-    inserted: Optional[bool]
+    project: CreatedProjectFragment | None
+    model: CreatedProjectFragment | None
+    inserted: bool | None
 
 
 CreateProject.model_rebuild()

--- a/wandb/apis/_generated/create_service_account.py
+++ b/wandb/apis/_generated/create_service_account.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLId, GQLResult
 
 
 class CreateServiceAccount(GQLResult):
-    result: Optional[CreateServiceAccountResult]
+    result: CreateServiceAccountResult | None
 
 
 class CreateServiceAccountResult(GQLResult):
-    user: Optional[CreateServiceAccountResultUser]
+    user: CreateServiceAccountResultUser | None
 
 
 class CreateServiceAccountResultUser(GQLResult):

--- a/wandb/apis/_generated/create_team.py
+++ b/wandb/apis/_generated/create_team.py
@@ -3,27 +3,25 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLId, GQLResult
 
 
 class CreateTeam(GQLResult):
-    result: Optional[CreateTeamResult]
+    result: CreateTeamResult | None
 
 
 class CreateTeamResult(GQLResult):
-    entity: Optional[CreateTeamResultEntity]
+    entity: CreateTeamResultEntity | None
 
 
 class CreateTeamResultEntity(GQLResult):
     id: GQLId
     name: str
-    available: Optional[bool]
-    photo_url: Optional[str] = Field(alias="photoUrl")
-    limits: Optional[str]
+    available: bool | None
+    photo_url: str | None = Field(alias="photoUrl")
+    limits: str | None
 
 
 CreateTeam.model_rebuild()

--- a/wandb/apis/_generated/create_user_from_admin.py
+++ b/wandb/apis/_generated/create_user_from_admin.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import UserInfoFragment
 
 
 class CreateUserFromAdmin(GQLResult):
-    result: Optional[CreateUserFromAdminResult]
+    result: CreateUserFromAdminResult | None
 
 
 class CreateUserFromAdminResult(GQLResult):
-    user: Optional[UserInfoFragment]
+    user: UserInfoFragment | None
 
 
 CreateUserFromAdmin.model_rebuild()

--- a/wandb/apis/_generated/delete_api_key.py
+++ b/wandb/apis/_generated/delete_api_key.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class DeleteApiKey(GQLResult):
-    result: Optional[DeleteApiKeyResult]
+    result: DeleteApiKeyResult | None
 
 
 class DeleteApiKeyResult(GQLResult):
-    success: Optional[bool]
+    success: bool | None
 
 
 DeleteApiKey.model_rebuild()

--- a/wandb/apis/_generated/delete_invite.py
+++ b/wandb/apis/_generated/delete_invite.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class DeleteInvite(GQLResult):
-    result: Optional[DeleteInviteResult]
+    result: DeleteInviteResult | None
 
 
 class DeleteInviteResult(GQLResult):
-    success: Optional[bool]
+    success: bool | None
 
 
 DeleteInvite.model_rebuild()

--- a/wandb/apis/_generated/fragments.py
+++ b/wandb/apis/_generated/fragments.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -14,25 +14,25 @@ class AgentFragment(GQLResult):
     id: GQLId
     name: str
     host: str
-    state: Optional[str]
+    state: str | None
     total_runs: int = Field(alias="totalRuns")
     created_at: str = Field(alias="createdAt")
-    heartbeat_at: Optional[str] = Field(alias="heartbeatAt")
+    heartbeat_at: str | None = Field(alias="heartbeatAt")
 
 
 class ApiKeyFragment(GQLResult):
     id: GQLId
     name: str
-    description: Optional[str]
+    description: str | None
 
 
 class CreatedProjectFragment(GQLResult):
     id: GQLId
     name: str
     entity_name: str = Field(alias="entityName")
-    description: Optional[str]
-    access: Optional[str]
-    views: Optional[str]
+    description: str | None
+    access: str | None
+    views: str | None
 
 
 class LegacySweepFragment(GQLResult):
@@ -40,67 +40,67 @@ class LegacySweepFragment(GQLResult):
     id: GQLId
     name: str
     state: str
-    best_loss: Optional[float] = Field(alias="bestLoss")
+    best_loss: float | None = Field(alias="bestLoss")
     config: str
 
 
 class LightweightRunFragment(GQLResult):
     id: GQLId
-    tags: Optional[List[str]]
+    tags: list[str] | None
     name: str
-    display_name: Optional[str] = Field(alias="displayName")
-    sweep_name: Optional[str] = Field(alias="sweepName")
-    state: Optional[str]
-    group: Optional[str]
-    job_type: Optional[str] = Field(alias="jobType")
-    commit: Optional[str]
-    read_only: Optional[bool] = Field(alias="readOnly")
+    display_name: str | None = Field(alias="displayName")
+    sweep_name: str | None = Field(alias="sweepName")
+    state: str | None
+    group: str | None
+    job_type: str | None = Field(alias="jobType")
+    commit: str | None
+    read_only: bool | None = Field(alias="readOnly")
     created_at: str = Field(alias="createdAt")
-    heartbeat_at: Optional[str] = Field(alias="heartbeatAt")
-    description: Optional[str]
-    notes: Optional[str]
-    history_line_count: Optional[int] = Field(alias="historyLineCount")
-    user: Optional[LightweightRunFragmentUser]
+    heartbeat_at: str | None = Field(alias="heartbeatAt")
+    description: str | None
+    notes: str | None
+    history_line_count: int | None = Field(alias="historyLineCount")
+    user: LightweightRunFragmentUser | None
 
 
 class LightweightRunFragmentUser(GQLResult):
     name: str
-    username: Optional[str]
+    username: str | None
 
 
 class PageInfoFragment(GQLResult):
     typename__: Typename[Literal["PageInfo"]] = "PageInfo"
-    end_cursor: Optional[str] = Field(alias="endCursor")
+    end_cursor: str | None = Field(alias="endCursor")
     has_next_page: bool = Field(alias="hasNextPage")
 
 
 class UserFragment(GQLResult):
     id: GQLId
     name: str
-    username: Optional[str]
-    email: Optional[str]
-    admin: Optional[bool]
-    flags: Optional[str]
-    entity: Optional[str]
-    deleted_at: Optional[str] = Field(alias="deletedAt")
-    api_keys: Optional[UserFragmentApiKeys] = Field(alias="apiKeys")
-    teams: Optional[UserFragmentTeams]
+    username: str | None
+    email: str | None
+    admin: bool | None
+    flags: str | None
+    entity: str | None
+    deleted_at: str | None = Field(alias="deletedAt")
+    api_keys: UserFragmentApiKeys | None = Field(alias="apiKeys")
+    teams: UserFragmentTeams | None
 
 
 class UserFragmentApiKeys(GQLResult):
-    edges: List[UserFragmentApiKeysEdges]
+    edges: list[UserFragmentApiKeysEdges]
 
 
 class UserFragmentApiKeysEdges(GQLResult):
-    node: Optional[ApiKeyFragment]
+    node: ApiKeyFragment | None
 
 
 class UserFragmentTeams(GQLResult):
-    edges: List[UserFragmentTeamsEdges]
+    edges: list[UserFragmentTeamsEdges]
 
 
 class UserFragmentTeamsEdges(GQLResult):
-    node: Optional[UserFragmentTeamsEdgesNode]
+    node: UserFragmentTeamsEdgesNode | None
 
 
 class UserFragmentTeamsEdgesNode(GQLResult):
@@ -114,31 +114,31 @@ class ProjectFragment(GQLResult):
     entity_name: str = Field(alias="entityName")
     created_at: str = Field(alias="createdAt")
     is_benchmark: bool = Field(alias="isBenchmark")
-    user: Optional[UserFragment]
+    user: UserFragment | None
 
 
 class SweepFragment(GQLResult):
     typename__: Typename[Literal["Sweep"]] = "Sweep"
     id: GQLId
     name: str
-    display_name: Optional[str] = Field(alias="displayName")
+    display_name: str | None = Field(alias="displayName")
     method: str
     state: str
-    description: Optional[str]
-    best_loss: Optional[float] = Field(alias="bestLoss")
+    description: str | None
+    best_loss: float | None = Field(alias="bestLoss")
     config: str
     created_at: str = Field(alias="createdAt")
-    updated_at: Optional[str] = Field(alias="updatedAt")
+    updated_at: str | None = Field(alias="updatedAt")
     run_count: int = Field(alias="runCount")
-    run_count_expected: Optional[int] = Field(alias="runCountExpected")
+    run_count_expected: int | None = Field(alias="runCountExpected")
 
 
 class UserInfoFragment(GQLResult):
     id: GQLId
     name: str
-    username: Optional[str]
-    email: Optional[str]
-    admin: Optional[bool]
+    username: str | None
+    email: str | None
+    admin: bool | None
 
 
 AgentFragment.model_rebuild()
@@ -146,16 +146,8 @@ ApiKeyFragment.model_rebuild()
 CreatedProjectFragment.model_rebuild()
 LegacySweepFragment.model_rebuild()
 LightweightRunFragment.model_rebuild()
-LightweightRunFragmentUser.model_rebuild()
 PageInfoFragment.model_rebuild()
 UserFragment.model_rebuild()
-UserFragmentApiKeys.model_rebuild()
-UserFragmentApiKeysEdges.model_rebuild()
-ApiKeyFragment.model_rebuild()
-UserFragmentTeams.model_rebuild()
-UserFragmentTeamsEdges.model_rebuild()
-UserFragmentTeamsEdgesNode.model_rebuild()
 ProjectFragment.model_rebuild()
-UserFragment.model_rebuild()
 SweepFragment.model_rebuild()
 UserInfoFragment.model_rebuild()

--- a/wandb/apis/_generated/generate_api_key.py
+++ b/wandb/apis/_generated/generate_api_key.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,11 +11,11 @@ from .fragments import ApiKeyFragment
 
 
 class GenerateApiKey(GQLResult):
-    result: Optional[GenerateApiKeyResult]
+    result: GenerateApiKeyResult | None
 
 
 class GenerateApiKeyResult(GQLResult):
-    api_key: Optional[ApiKeyFragment] = Field(alias="apiKey")
+    api_key: ApiKeyFragment | None = Field(alias="apiKey")
 
 
 GenerateApiKey.model_rebuild()

--- a/wandb/apis/_generated/get_agent_runs.py
+++ b/wandb/apis/_generated/get_agent_runs.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,15 +11,15 @@ from .fragments import LightweightRunFragment, PageInfoFragment
 
 
 class GetAgentRuns(GQLResult):
-    project: Optional[GetAgentRunsProject]
+    project: GetAgentRunsProject | None
 
 
 class GetAgentRunsProject(GQLResult):
-    sweep: Optional[GetAgentRunsProjectSweep]
+    sweep: GetAgentRunsProjectSweep | None
 
 
 class GetAgentRunsProjectSweep(GQLResult):
-    agent: Optional[GetAgentRunsProjectSweepAgent]
+    agent: GetAgentRunsProjectSweepAgent | None
 
 
 class GetAgentRunsProjectSweepAgent(GQLResult):
@@ -30,7 +28,7 @@ class GetAgentRunsProjectSweepAgent(GQLResult):
 
 class GetAgentRunsProjectSweepAgentRuns(GQLResult):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[GetAgentRunsProjectSweepAgentRunsEdges]
+    edges: list[GetAgentRunsProjectSweepAgentRunsEdges]
 
 
 class GetAgentRunsProjectSweepAgentRunsEdges(GQLResult):

--- a/wandb/apis/_generated/get_default_entity.py
+++ b/wandb/apis/_generated/get_default_entity.py
@@ -3,18 +3,16 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLId, GQLResult
 
 
 class GetDefaultEntity(GQLResult):
-    viewer: Optional[GetDefaultEntityViewer]
+    viewer: GetDefaultEntityViewer | None
 
 
 class GetDefaultEntityViewer(GQLResult):
     id: GQLId
-    entity: Optional[str]
+    entity: str | None
 
 
 GetDefaultEntity.model_rebuild()

--- a/wandb/apis/_generated/get_project.py
+++ b/wandb/apis/_generated/get_project.py
@@ -3,15 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import ProjectFragment
 
 
 class GetProject(GQLResult):
-    project: Optional[ProjectFragment]
+    project: ProjectFragment | None
 
 
 GetProject.model_rebuild()

--- a/wandb/apis/_generated/get_projects.py
+++ b/wandb/apis/_generated/get_projects.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,16 +11,16 @@ from .fragments import PageInfoFragment, ProjectFragment
 
 
 class GetProjects(GQLResult):
-    models: Optional[GetProjectsModels]
+    models: GetProjectsModels | None
 
 
 class GetProjectsModels(GQLResult):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[GetProjectsModelsEdges]
+    edges: list[GetProjectsModelsEdges]
 
 
 class GetProjectsModelsEdges(GQLResult):
-    node: Optional[ProjectFragment]
+    node: ProjectFragment | None
 
 
 GetProjects.model_rebuild()

--- a/wandb/apis/_generated/get_sweep.py
+++ b/wandb/apis/_generated/get_sweep.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import SweepFragment
 
 
 class GetSweep(GQLResult):
-    project: Optional[GetSweepProject]
+    project: GetSweepProject | None
 
 
 class GetSweepProject(GQLResult):
-    sweep: Optional[SweepFragment]
+    sweep: SweepFragment | None
 
 
 GetSweep.model_rebuild()

--- a/wandb/apis/_generated/get_sweep_agent.py
+++ b/wandb/apis/_generated/get_sweep_agent.py
@@ -3,23 +3,21 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import AgentFragment
 
 
 class GetSweepAgent(GQLResult):
-    project: Optional[GetSweepAgentProject]
+    project: GetSweepAgentProject | None
 
 
 class GetSweepAgentProject(GQLResult):
-    sweep: Optional[GetSweepAgentProjectSweep]
+    sweep: GetSweepAgentProjectSweep | None
 
 
 class GetSweepAgentProjectSweep(GQLResult):
-    agent: Optional[AgentFragment]
+    agent: AgentFragment | None
 
 
 GetSweepAgent.model_rebuild()

--- a/wandb/apis/_generated/get_sweep_agents.py
+++ b/wandb/apis/_generated/get_sweep_agents.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import AgentFragment
 
 
 class GetSweepAgents(GQLResult):
-    project: Optional[GetSweepAgentsProject]
+    project: GetSweepAgentsProject | None
 
 
 class GetSweepAgentsProject(GQLResult):
-    sweep: Optional[GetSweepAgentsProjectSweep]
+    sweep: GetSweepAgentsProjectSweep | None
 
 
 class GetSweepAgentsProjectSweep(GQLResult):
@@ -23,7 +21,7 @@ class GetSweepAgentsProjectSweep(GQLResult):
 
 
 class GetSweepAgentsProjectSweepAgents(GQLResult):
-    edges: List[GetSweepAgentsProjectSweepAgentsEdges]
+    edges: list[GetSweepAgentsProjectSweepAgentsEdges]
 
 
 class GetSweepAgentsProjectSweepAgentsEdges(GQLResult):

--- a/wandb/apis/_generated/get_sweep_legacy.py
+++ b/wandb/apis/_generated/get_sweep_legacy.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import LegacySweepFragment
 
 
 class GetSweepLegacy(GQLResult):
-    project: Optional[GetSweepLegacyProject]
+    project: GetSweepLegacyProject | None
 
 
 class GetSweepLegacyProject(GQLResult):
-    sweep: Optional[LegacySweepFragment]
+    sweep: LegacySweepFragment | None
 
 
 GetSweepLegacy.model_rebuild()

--- a/wandb/apis/_generated/get_sweeps.py
+++ b/wandb/apis/_generated/get_sweeps.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,17 +11,17 @@ from .fragments import PageInfoFragment, SweepFragment
 
 
 class GetSweeps(GQLResult):
-    project: Optional[GetSweepsProject]
+    project: GetSweepsProject | None
 
 
 class GetSweepsProject(GQLResult):
     total_sweeps: int = Field(alias="totalSweeps")
-    sweeps: Optional[GetSweepsProjectSweeps]
+    sweeps: GetSweepsProjectSweeps | None
 
 
 class GetSweepsProjectSweeps(GQLResult):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[GetSweepsProjectSweepsEdges]
+    edges: list[GetSweepsProjectSweepsEdges]
 
 
 class GetSweepsProjectSweepsEdges(GQLResult):

--- a/wandb/apis/_generated/get_team_entity.py
+++ b/wandb/apis/_generated/get_team_entity.py
@@ -3,43 +3,41 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLId, GQLResult
 
 
 class GetTeamEntity(GQLResult):
-    entity: Optional[GetTeamEntityEntity]
+    entity: GetTeamEntityEntity | None
 
 
 class GetTeamEntityEntity(GQLResult):
     id: GQLId
     name: str
-    available: Optional[bool]
-    photo_url: Optional[str] = Field(alias="photoUrl")
-    read_only: Optional[bool] = Field(alias="readOnly")
+    available: bool | None
+    photo_url: str | None = Field(alias="photoUrl")
+    read_only: bool | None = Field(alias="readOnly")
     read_only_admin: bool = Field(alias="readOnlyAdmin")
     is_team: bool = Field(alias="isTeam")
     private_only: bool = Field(alias="privateOnly")
     storage_bytes: int = Field(alias="storageBytes")
     code_saving_enabled: bool = Field(alias="codeSavingEnabled")
     default_access: str = Field(alias="defaultAccess")
-    is_paid: Optional[bool] = Field(alias="isPaid")
-    members: List[GetTeamEntityEntityMembers]
+    is_paid: bool | None = Field(alias="isPaid")
+    members: list[GetTeamEntityEntityMembers]
 
 
 class GetTeamEntityEntityMembers(GQLResult):
-    id: Optional[str]
-    admin: Optional[bool]
-    pending: Optional[bool]
-    email: Optional[str]
-    username: Optional[str]
+    id: str | None
+    admin: bool | None
+    pending: bool | None
+    email: str | None
+    username: str | None
     name: str
-    photo_url: Optional[str] = Field(alias="photoUrl")
-    account_type: Optional[str] = Field(alias="accountType")
-    api_key: Optional[str] = Field(alias="apiKey")
+    photo_url: str | None = Field(alias="photoUrl")
+    account_type: str | None = Field(alias="accountType")
+    api_key: str | None = Field(alias="apiKey")
 
 
 GetTeamEntity.model_rebuild()

--- a/wandb/apis/_generated/get_viewer.py
+++ b/wandb/apis/_generated/get_viewer.py
@@ -3,15 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import UserFragment
 
 
 class GetViewer(GQLResult):
-    viewer: Optional[UserFragment]
+    viewer: UserFragment | None
 
 
 GetViewer.model_rebuild()

--- a/wandb/apis/_generated/input_types.py
+++ b/wandb/apis/_generated/input_types.py
@@ -3,15 +3,13 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLId, GQLInput
 
 
 class ArtifactTypeInput(GQLInput):
-    description: Optional[str] = None
+    description: str | None = None
     name: str = Field(max_length=128, pattern="^[-\\w]+([ ]*[-.\\w]+)*$")
 
 
@@ -21,48 +19,46 @@ class ProjectIconInput(GQLInput):
 
 
 class RateLimitsInput(GQLInput):
-    create_artifacts: Optional[int] = Field(alias="createArtifacts", default=None)
-    create_artifacts_time_window: Optional[int] = Field(
+    create_artifacts: int | None = Field(alias="createArtifacts", default=None)
+    create_artifacts_time_window: int | None = Field(
         alias="createArtifactsTimeWindow", default=None
     )
-    filestream_count: Optional[float] = Field(alias="filestreamCount", default=None)
-    filestream_per_run_count: Optional[float] = Field(
+    filestream_count: float | None = Field(alias="filestreamCount", default=None)
+    filestream_per_run_count: float | None = Field(
         alias="filestreamPerRunCount", default=None
     )
-    filestream_size: Optional[int] = Field(alias="filestreamSize", default=None)
-    graphql: Optional[int] = None
-    run_update_count: Optional[float] = Field(alias="runUpdateCount", default=None)
-    sdk_graphql: Optional[int] = Field(alias="sdkGraphql", default=None)
-    sdk_graphql_query_seconds: Optional[float] = Field(
+    filestream_size: int | None = Field(alias="filestreamSize", default=None)
+    graphql: int | None = None
+    run_update_count: float | None = Field(alias="runUpdateCount", default=None)
+    sdk_graphql: int | None = Field(alias="sdkGraphql", default=None)
+    sdk_graphql_query_seconds: float | None = Field(
         alias="sdkGraphqlQuerySeconds", default=None
     )
 
 
 class UpsertModelInput(GQLInput):
-    access: Optional[str] = None
-    allow_all_artifact_types_in_registry: Optional[bool] = Field(
+    access: str | None = None
+    allow_all_artifact_types_in_registry: bool | None = Field(
         alias="allowAllArtifactTypesInRegistry", default=None
     )
-    artifact_types: Optional[List[ArtifactTypeInput]] = Field(
+    artifact_types: list[ArtifactTypeInput] | None = Field(
         alias="artifactTypes", default=None
     )
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    description: Optional[str] = None
-    docker_image: Optional[str] = Field(
-        alias="dockerImage", default=None, max_length=512
-    )
-    entity_name: Optional[str] = Field(alias="entityName", default=None)
-    framework: Optional[str] = None
-    icon: Optional[ProjectIconInput] = None
-    id: Optional[str] = None
-    is_benchmark: Optional[bool] = Field(alias="isBenchmark", default=None)
-    is_published: Optional[bool] = Field(alias="isPublished", default=None)
-    linked_benchmark: Optional[GQLId] = Field(alias="linkedBenchmark", default=None)
-    name: Optional[str] = Field(default=None, max_length=128)
-    owner: Optional[GQLId] = None
-    rate_limits: Optional[RateLimitsInput] = Field(alias="rateLimits", default=None)
-    repo: Optional[str] = Field(default=None, max_length=256)
-    views: Optional[str] = None
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    description: str | None = None
+    docker_image: str | None = Field(alias="dockerImage", default=None, max_length=512)
+    entity_name: str | None = Field(alias="entityName", default=None)
+    framework: str | None = None
+    icon: ProjectIconInput | None = None
+    id: str | None = None
+    is_benchmark: bool | None = Field(alias="isBenchmark", default=None)
+    is_published: bool | None = Field(alias="isPublished", default=None)
+    linked_benchmark: GQLId | None = Field(alias="linkedBenchmark", default=None)
+    name: str | None = Field(default=None, max_length=128)
+    owner: GQLId | None = None
+    rate_limits: RateLimitsInput | None = Field(alias="rateLimits", default=None)
+    repo: str | None = Field(default=None, max_length=256)
+    views: str | None = None
 
 
 UpsertModelInput.model_rebuild()

--- a/wandb/apis/_generated/search_users.py
+++ b/wandb/apis/_generated/search_users.py
@@ -3,23 +3,21 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import UserFragment
 
 
 class SearchUsers(GQLResult):
-    users: Optional[SearchUsersUsers]
+    users: SearchUsersUsers | None
 
 
 class SearchUsersUsers(GQLResult):
-    edges: List[SearchUsersUsersEdges]
+    edges: list[SearchUsersUsersEdges]
 
 
 class SearchUsersUsersEdges(GQLResult):
-    node: Optional[UserFragment]
+    node: UserFragment | None
 
 
 SearchUsers.model_rebuild()

--- a/wandb/automations/_filters/expressions.py
+++ b/wandb/automations/_filters/expressions.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, Dict, Union
+from typing import Any, TypeAlias
 
 from pydantic import ConfigDict, model_serializer
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self
 
 from wandb._pydantic import CompatBaseModel, model_validator
 from wandb._strutils import nameof
@@ -136,7 +136,7 @@ class FilterExpr(CompatBaseModel, SupportsBitwiseLogicalOps):
     )
 
     field: str
-    op: Union[Op, Dict[str, Any]]
+    op: Op | dict[str, Any]
 
     def __repr__(self) -> str:
         return f"{nameof(type(self))}({self.field!s}: {self.op!r})"
@@ -177,4 +177,4 @@ Nor.model_rebuild()
 Not.model_rebuild()
 
 # for type annotations
-MongoLikeFilter: TypeAlias = Union[Op, FilterExpr, Dict[str, Any]]
+MongoLikeFilter: TypeAlias = Op | FilterExpr | dict[str, Any]

--- a/wandb/automations/_filters/operators.py
+++ b/wandb/automations/_filters/operators.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, get_args
 
 from pydantic import ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
-from typing_extensions import Self, TypeAlias, get_args, override
+from typing_extensions import Self, override
 
 from wandb._pydantic import GQLBase
 from wandb._strutils import nameof
@@ -16,22 +16,17 @@ if TYPE_CHECKING:
     from .expressions import FilterExpr
 
 # for type annotations
-Scalar = Union[StrictStr, StrictInt, StrictFloat, StrictBool]
+Scalar = StrictStr | StrictInt | StrictFloat | StrictBool
 # for runtime type checks
 ScalarTypes: tuple[type, ...] = tuple(t.__origin__ for t in get_args(Scalar))
 
 # See: https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol
 RichReprResult: TypeAlias = Iterable[
-    Union[
-        Any,
-        Tuple[Any],
-        Tuple[str, Any],
-        Tuple[str, Any, Any],
-    ]
+    Any | tuple[Any] | tuple[str, Any] | tuple[str, Any, Any]
 ]
 
 T = TypeVar("T")
-TupleOf: TypeAlias = Tuple[T, ...]
+TupleOf: TypeAlias = tuple[T, ...]
 
 
 # NOTE: Wherever class descriptions that are not docstrings, this is deliberate.
@@ -91,7 +86,7 @@ class BaseOp(GQLBase, SupportsBitwiseLogicalOps, ABC):
 
 # Base type for logical operators that take a variable number of expressions.
 class BaseVariadicLogicalOp(BaseOp, ABC):
-    exprs: TupleOf[Union[FilterExpr, Op]]
+    exprs: TupleOf[FilterExpr | Op]
 
     @classmethod
     def wrap(cls, expr: Any) -> Self:
@@ -104,11 +99,11 @@ class BaseVariadicLogicalOp(BaseOp, ABC):
 # https://www.mongodb.com/docs/manual/reference/operator/query/nor/
 # https://www.mongodb.com/docs/manual/reference/operator/query/not/
 class And(BaseVariadicLogicalOp):
-    exprs: TupleOf[Union[FilterExpr, Op]] = Field(default=(), alias="$and")
+    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$and")
 
 
 class Or(BaseVariadicLogicalOp):
-    exprs: TupleOf[Union[FilterExpr, Op]] = Field(default=(), alias="$or")
+    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$or")
 
     @override
     def __invert__(self) -> Nor:
@@ -117,7 +112,7 @@ class Or(BaseVariadicLogicalOp):
 
 
 class Nor(BaseVariadicLogicalOp):
-    exprs: TupleOf[Union[FilterExpr, Op]] = Field(default=(), alias="$nor")
+    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$nor")
 
     @override
     def __invert__(self) -> Or:
@@ -126,10 +121,10 @@ class Nor(BaseVariadicLogicalOp):
 
 
 class Not(BaseOp):
-    expr: Union[FilterExpr, Op] = Field(alias="$not")
+    expr: FilterExpr | Op = Field(alias="$not")
 
     @override
-    def __invert__(self) -> Union[FilterExpr, Op]:
+    def __invert__(self) -> FilterExpr | Op:
         """Implements `~Not(a) -> a`."""
         return self.expr
 
@@ -262,20 +257,20 @@ KEY_TO_OP: dict[str, type[BaseOp]] = {
 
 
 # Known, implemented MongoDB operators for type annotations.
-Op = Union[
-    And,
-    Or,
-    Nor,
-    Not,
-    Lt,
-    Gt,
-    Lte,
-    Gte,
-    Eq,
-    Ne,
-    In,
-    NotIn,
-    Exists,
-    Regex,
-    Contains,
-]
+Op = (
+    And
+    | Or
+    | Nor
+    | Not
+    | Lt
+    | Gt
+    | Lte
+    | Gte
+    | Eq
+    | Ne
+    | In
+    | NotIn
+    | Exists
+    | Regex
+    | Contains
+)

--- a/wandb/automations/_filters/run_metrics.py
+++ b/wandb/automations/_filters/run_metrics.py
@@ -1,16 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    Final,
-    Literal,
-    Optional,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Annotated, Any, Final, Literal, TypeAlias, overload
 
 from pydantic import (
     Field,
@@ -20,7 +11,7 @@ from pydantic import (
     StrictInt,
     field_validator,
 )
-from typing_extensions import TypeAlias, override
+from typing_extensions import override
 
 from wandb._pydantic import GQLBase
 from wandb.automations._validators import LenientStrEnum
@@ -44,7 +35,7 @@ MONGO2PY_OPS: Final[dict[str, str]] = {
 PY2MONGO_OPS: Final[dict[str, str]] = {v: k for k, v in MONGO2PY_OPS.items()}
 
 # Type hint for positive numbers (int or float)
-PosNum: TypeAlias = Union[PositiveInt, PositiveFloat]
+PosNum: TypeAlias = PositiveInt | PositiveFloat
 
 
 class Agg(LenientStrEnum):  # from: Aggregation
@@ -89,18 +80,18 @@ class BaseMetricFilter(GQLBase, ABC, extra="forbid"):
     name: str
     """Name of the observed metric."""
 
-    agg: Optional[Agg]
+    agg: Agg | None
     """Aggregate operation, if any, to apply over the window size."""
 
     window: PositiveInt
     """Size of the metric aggregation window (ignored if `agg` is ``None``)."""
 
     # ------------------------------------------------------------------------------
-    cmp: Optional[str]
+    cmp: str | None
     """Comparison operator between the metric expression (left) vs. the threshold or target (right)."""  # noqa: W505
 
     # ------------------------------------------------------------------------------
-    threshold: Union[StrictInt, StrictFloat]
+    threshold: StrictInt | StrictFloat
     """Threshold value to compare against."""
 
     def __and__(self, other: Any) -> RunMetricFilter:
@@ -140,13 +131,13 @@ class MetricThresholdFilter(BaseMetricFilter):  # from: RunMetricThresholdFilter
     """
 
     name: str
-    agg: Annotated[Optional[Agg], Field(alias="agg_op")] = None
+    agg: Annotated[Agg | None, Field(alias="agg_op")] = None
     window: Annotated[PositiveInt, Field(alias="window_size")] = 1
 
     cmp: Annotated[Literal["$gte", "$gt", "$lt", "$lte"], Field(alias="cmp_op")]
     """Comparison operator between the metric value (left) vs. the threshold (right)."""
 
-    threshold: Union[StrictInt, StrictFloat]
+    threshold: StrictInt | StrictFloat
 
     @field_validator("cmp", mode="before")
     def _validate_cmp(cls, v: Any) -> Any:
@@ -167,7 +158,7 @@ class MetricChangeFilter(BaseMetricFilter):  # from: RunMetricChangeFilter
     """
 
     name: str
-    agg: Annotated[Optional[Agg], Field(alias="agg_op")] = None
+    agg: Annotated[Agg | None, Field(alias="agg_op")] = None
     window: Annotated[PositiveInt, Field(alias="current_window_size")] = 1
 
     # `prior_window` is only for `RUN_METRIC_CHANGE` events

--- a/wandb/automations/_filters/run_states.py
+++ b/wandb/automations/_filters/run_states.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Annotated, Any
 
-from pydantic import BeforeValidator
+from pydantic import BeforeValidator, field_validator
 
 from wandb._iterutils import always_list
-from wandb._pydantic import GQLBase, field_validator
+from wandb._pydantic import GQLBase
 from wandb.automations._validators import LenientStrEnum
 
 from .expressions import FilterExpr

--- a/wandb/automations/_generated/create_automation.py
+++ b/wandb/automations/_generated/create_automation.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import TriggerFields
 
 
 class CreateAutomation(GQLResult):
-    result: Optional[CreateAutomationResult]
+    result: CreateAutomationResult | None
 
 
 class CreateAutomationResult(GQLResult):
-    trigger: Optional[TriggerFields]
+    trigger: TriggerFields | None
 
 
 CreateAutomation.model_rebuild()

--- a/wandb/automations/_generated/create_generic_webhook_integration.py
+++ b/wandb/automations/_generated/create_generic_webhook_integration.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from pydantic import Field
 
@@ -13,16 +13,16 @@ from .fragments import WebhookIntegrationFields
 
 
 class CreateGenericWebhookIntegration(GQLResult):
-    create_generic_webhook_integration: Optional[
-        CreateGenericWebhookIntegrationCreateGenericWebhookIntegration
-    ] = Field(alias="createGenericWebhookIntegration")
+    create_generic_webhook_integration: (
+        CreateGenericWebhookIntegrationCreateGenericWebhookIntegration | None
+    ) = Field(alias="createGenericWebhookIntegration")
 
 
 class CreateGenericWebhookIntegrationCreateGenericWebhookIntegration(GQLResult):
-    integration: Union[
-        CreateGenericWebhookIntegrationCreateGenericWebhookIntegrationIntegrationIntegration,
-        WebhookIntegrationFields,
-    ] = Field(discriminator="typename__")
+    integration: (
+        CreateGenericWebhookIntegrationCreateGenericWebhookIntegrationIntegrationIntegration
+        | WebhookIntegrationFields
+    ) = Field(discriminator="typename__")
 
 
 class CreateGenericWebhookIntegrationCreateGenericWebhookIntegrationIntegrationIntegration(

--- a/wandb/automations/_generated/fragments.py
+++ b/wandb/automations/_generated/fragments.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Literal, Optional, Union
+from typing import Literal
 
 from pydantic import Field
 
@@ -46,10 +46,10 @@ class GenericWebhookActionFields(GQLResult):
     typename__: Typename[Literal["GenericWebhookTriggeredAction"]] = (
         "GenericWebhookTriggeredAction"
     )
-    integration: Union[
-        GenericWebhookActionFieldsIntegrationIntegration, WebhookIntegrationFields
-    ] = Field(discriminator="typename__")
-    request_payload: Optional[str] = Field(alias="requestPayload")
+    integration: (
+        GenericWebhookActionFieldsIntegrationIntegration | WebhookIntegrationFields
+    ) = Field(discriminator="typename__")
+    request_payload: str | None = Field(alias="requestPayload")
 
 
 class GenericWebhookActionFieldsIntegrationIntegration(GQLResult):
@@ -60,7 +60,7 @@ class GenericWebhookActionFieldsIntegrationIntegration(GQLResult):
 
 class NoOpActionFields(GQLResult):
     typename__: Typename[Literal["NoOpTriggeredAction"]] = "NoOpTriggeredAction"
-    no_op: Optional[bool] = Field(alias="noOp")
+    no_op: bool | None = Field(alias="noOp")
 
 
 class SlackIntegrationFields(GQLResult):
@@ -74,12 +74,12 @@ class NotificationActionFields(GQLResult):
     typename__: Typename[Literal["NotificationTriggeredAction"]] = (
         "NotificationTriggeredAction"
     )
-    integration: Union[
-        NotificationActionFieldsIntegrationIntegration, SlackIntegrationFields
-    ] = Field(discriminator="typename__")
-    title: Optional[str]
-    message: Optional[str]
-    severity: Optional[AlertSeverity]
+    integration: (
+        NotificationActionFieldsIntegrationIntegration | SlackIntegrationFields
+    ) = Field(discriminator="typename__")
+    title: str | None
+    message: str | None
+    severity: AlertSeverity | None
 
 
 class NotificationActionFieldsIntegrationIntegration(GQLResult):
@@ -89,7 +89,7 @@ class NotificationActionFieldsIntegrationIntegration(GQLResult):
 
 
 class PageInfoFields(GQLResult):
-    end_cursor: Optional[str] = Field(alias="endCursor")
+    end_cursor: str | None = Field(alias="endCursor")
     has_next_page: bool = Field(alias="hasNextPage")
 
 
@@ -101,7 +101,7 @@ class ProjectScopeFields(GQLResult):
 
 class QueueJobActionFields(GQLResult):
     typename__: Typename[Literal["QueueJobTriggeredAction"]] = "QueueJobTriggeredAction"
-    queue: Optional[QueueJobActionFieldsQueue]
+    queue: QueueJobActionFieldsQueue | None
     template: str
 
 
@@ -114,21 +114,21 @@ class TriggerFields(GQLResult):
     typename__: Typename[Literal["Trigger"]] = "Trigger"
     id: GQLId
     created_at: datetime = Field(alias="createdAt")
-    updated_at: Optional[datetime] = Field(alias="updatedAt")
+    updated_at: datetime | None = Field(alias="updatedAt")
     name: str
-    description: Optional[str]
+    description: str | None
     enabled: bool
-    scope: Union[
-        ArtifactPortfolioScopeFields, ArtifactSequenceScopeFields, ProjectScopeFields
-    ] = Field(discriminator="typename__")
+    scope: (
+        ArtifactPortfolioScopeFields | ArtifactSequenceScopeFields | ProjectScopeFields
+    ) = Field(discriminator="typename__")
     event: FilterEventFields
-    action: Union[
-        GenericWebhookActionFields,
-        NoOpActionFields,
-        NotificationActionFields,
-        TriggerFieldsActionPushNotificationTriggeredAction,
-        QueueJobActionFields,
-    ] = Field(discriminator="typename__")
+    action: (
+        GenericWebhookActionFields
+        | NoOpActionFields
+        | NotificationActionFields
+        | TriggerFieldsActionPushNotificationTriggeredAction
+        | QueueJobActionFields
+    ) = Field(discriminator="typename__")
 
 
 class TriggerFieldsActionPushNotificationTriggeredAction(GQLResult):
@@ -137,7 +137,7 @@ class TriggerFieldsActionPushNotificationTriggeredAction(GQLResult):
 
 class ProjectTriggersFields(GQLResult):
     typename__: Typename[Literal["Project"]] = "Project"
-    triggers: List[TriggerFields]
+    triggers: list[TriggerFields]
 
 
 ArtifactPortfolioScopeFields.model_rebuild()
@@ -145,26 +145,11 @@ ArtifactSequenceScopeFields.model_rebuild()
 FilterEventFields.model_rebuild()
 WebhookIntegrationFields.model_rebuild()
 GenericWebhookActionFields.model_rebuild()
-GenericWebhookActionFieldsIntegrationIntegration.model_rebuild()
-WebhookIntegrationFields.model_rebuild()
 NoOpActionFields.model_rebuild()
 SlackIntegrationFields.model_rebuild()
 NotificationActionFields.model_rebuild()
-NotificationActionFieldsIntegrationIntegration.model_rebuild()
-SlackIntegrationFields.model_rebuild()
 PageInfoFields.model_rebuild()
 ProjectScopeFields.model_rebuild()
 QueueJobActionFields.model_rebuild()
-QueueJobActionFieldsQueue.model_rebuild()
 TriggerFields.model_rebuild()
-ArtifactPortfolioScopeFields.model_rebuild()
-ArtifactSequenceScopeFields.model_rebuild()
-ProjectScopeFields.model_rebuild()
-FilterEventFields.model_rebuild()
-GenericWebhookActionFields.model_rebuild()
-NoOpActionFields.model_rebuild()
-NotificationActionFields.model_rebuild()
-TriggerFieldsActionPushNotificationTriggeredAction.model_rebuild()
-QueueJobActionFields.model_rebuild()
 ProjectTriggersFields.model_rebuild()
-TriggerFields.model_rebuild()

--- a/wandb/automations/_generated/get_automations.py
+++ b/wandb/automations/_generated/get_automations.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,20 +11,20 @@ from .fragments import PageInfoFields, ProjectTriggersFields
 
 
 class GetAutomations(GQLResult):
-    scope: Optional[GetAutomationsScope]
+    scope: GetAutomationsScope | None
 
 
 class GetAutomationsScope(GQLResult):
-    projects: Optional[GetAutomationsScopeProjects]
+    projects: GetAutomationsScopeProjects | None
 
 
 class GetAutomationsScopeProjects(GQLResult):
     page_info: PageInfoFields = Field(alias="pageInfo")
-    edges: List[GetAutomationsScopeProjectsEdges]
+    edges: list[GetAutomationsScopeProjectsEdges]
 
 
 class GetAutomationsScopeProjectsEdges(GQLResult):
-    node: Optional[ProjectTriggersFields]
+    node: ProjectTriggersFields | None
 
 
 GetAutomations.model_rebuild()

--- a/wandb/automations/_generated/get_automations_by_entity.py
+++ b/wandb/automations/_generated/get_automations_by_entity.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,20 +11,20 @@ from .fragments import PageInfoFields, ProjectTriggersFields
 
 
 class GetAutomationsByEntity(GQLResult):
-    scope: Optional[GetAutomationsByEntityScope]
+    scope: GetAutomationsByEntityScope | None
 
 
 class GetAutomationsByEntityScope(GQLResult):
-    projects: Optional[GetAutomationsByEntityScopeProjects]
+    projects: GetAutomationsByEntityScopeProjects | None
 
 
 class GetAutomationsByEntityScopeProjects(GQLResult):
     page_info: PageInfoFields = Field(alias="pageInfo")
-    edges: List[GetAutomationsByEntityScopeProjectsEdges]
+    edges: list[GetAutomationsByEntityScopeProjectsEdges]
 
 
 class GetAutomationsByEntityScopeProjectsEdges(GQLResult):
-    node: Optional[ProjectTriggersFields]
+    node: ProjectTriggersFields | None
 
 
 GetAutomationsByEntity.model_rebuild()

--- a/wandb/automations/_generated/input_types.py
+++ b/wandb/automations/_generated/input_types.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLId, GQLInput
@@ -18,8 +16,8 @@ from .enums import (
 
 
 class CreateFilterTriggerInput(GQLInput):
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    description: Optional[str] = None
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    description: str | None = None
     enabled: bool
     event_filter: str = Field(alias="eventFilter")
     name: str = Field(max_length=255)
@@ -35,33 +33,33 @@ class CreateFilterTriggerInput(GQLInput):
 
 
 class CreateGenericWebhookIntegrationInput(GQLInput):
-    access_token_ref: Optional[str] = Field(alias="accessTokenRef", default=None)
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    access_token_ref: str | None = Field(alias="accessTokenRef", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
     entity_name: str = Field(alias="entityName")
     name: str = Field(max_length=64, pattern="^[-\\w]+([ ]+[-\\w]+)*$")
-    secret_ref: Optional[str] = Field(alias="secretRef", default=None)
+    secret_ref: str | None = Field(alias="secretRef", default=None)
     url_endpoint: str = Field(alias="urlEndpoint")
 
 
 class GenericWebhookActionInput(GQLInput):
     integration_id: GQLId = Field(alias="integrationID")
-    request_payload: Optional[str] = Field(alias="requestPayload", default=None)
+    request_payload: str | None = Field(alias="requestPayload", default=None)
 
 
 class NoOpTriggeredActionInput(GQLInput):
-    no_op: Optional[bool] = Field(alias="noOp", default=None)
+    no_op: bool | None = Field(alias="noOp", default=None)
 
 
 class NotificationActionInput(GQLInput):
     integration_id: GQLId = Field(alias="integrationID")
-    message: Optional[str] = None
-    severity: Optional[AlertSeverity] = None
-    title: Optional[str] = None
+    message: str | None = None
+    severity: AlertSeverity | None = None
+    title: str | None = None
 
 
 class PushNotificationActionInput(GQLInput):
-    body: Optional[str] = None
-    title: Optional[str] = None
+    body: str | None = None
+    title: str | None = None
     user_id: GQLId = Field(alias="userID")
 
 
@@ -71,39 +69,39 @@ class QueueJobActionInput(GQLInput):
 
 
 class TriggeredActionConfig(GQLInput):
-    generic_webhook_action_input: Optional[GenericWebhookActionInput] = Field(
+    generic_webhook_action_input: GenericWebhookActionInput | None = Field(
         alias="genericWebhookActionInput", default=None
     )
-    no_op_action_input: Optional[NoOpTriggeredActionInput] = Field(
+    no_op_action_input: NoOpTriggeredActionInput | None = Field(
         alias="noOpActionInput", default=None
     )
-    notification_action_input: Optional[NotificationActionInput] = Field(
+    notification_action_input: NotificationActionInput | None = Field(
         alias="notificationActionInput", default=None
     )
-    push_notification_action_input: Optional[PushNotificationActionInput] = Field(
+    push_notification_action_input: PushNotificationActionInput | None = Field(
         alias="pushNotificationActionInput", default=None
     )
-    queue_job_action_input: Optional[QueueJobActionInput] = Field(
+    queue_job_action_input: QueueJobActionInput | None = Field(
         alias="queueJobActionInput", default=None
     )
 
 
 class UpdateFilterTriggerInput(GQLInput):
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    description: Optional[str] = None
-    enabled: Optional[bool] = None
-    event_filter: Optional[str] = Field(alias="eventFilter", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    description: str | None = None
+    enabled: bool | None = None
+    event_filter: str | None = Field(alias="eventFilter", default=None)
     id: GQLId
-    name: Optional[str] = Field(default=None, max_length=255)
-    scope_id: Optional[GQLId] = Field(alias="scopeID", default=None)
-    scope_type: Optional[TriggerScopeType] = Field(alias="scopeType", default=None)
-    triggered_action_config: Optional[TriggeredActionConfig] = Field(
+    name: str | None = Field(default=None, max_length=255)
+    scope_id: GQLId | None = Field(alias="scopeID", default=None)
+    scope_type: TriggerScopeType | None = Field(alias="scopeType", default=None)
+    triggered_action_config: TriggeredActionConfig | None = Field(
         alias="triggeredActionConfig", default=None
     )
-    triggered_action_type: Optional[TriggeredActionType] = Field(
+    triggered_action_type: TriggeredActionType | None = Field(
         alias="triggeredActionType", default=None
     )
-    triggering_event_type: Optional[EventTriggeringConditionType] = Field(
+    triggering_event_type: EventTriggeringConditionType | None = Field(
         alias="triggeringEventType", default=None
     )
 

--- a/wandb/automations/_generated/integrations_by_entity.py
+++ b/wandb/automations/_generated/integrations_by_entity.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, List, Literal, Optional, Union
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -13,29 +13,28 @@ from .fragments import PageInfoFields, SlackIntegrationFields, WebhookIntegratio
 
 
 class IntegrationsByEntity(GQLResult):
-    entity: Optional[IntegrationsByEntityEntity]
+    entity: IntegrationsByEntityEntity | None
 
 
 class IntegrationsByEntityEntity(GQLResult):
-    integrations: Optional[IntegrationsByEntityEntityIntegrations]
+    integrations: IntegrationsByEntityEntityIntegrations | None
 
 
 class IntegrationsByEntityEntityIntegrations(GQLResult):
     page_info: PageInfoFields = Field(alias="pageInfo")
-    edges: List[IntegrationsByEntityEntityIntegrationsEdges]
+    edges: list[IntegrationsByEntityEntityIntegrationsEdges]
 
 
 class IntegrationsByEntityEntityIntegrationsEdges(GQLResult):
-    node: Optional[
+    node: (
         Annotated[
-            Union[
-                IntegrationsByEntityEntityIntegrationsEdgesNodeIntegration,
-                WebhookIntegrationFields,
-                SlackIntegrationFields,
-            ],
+            IntegrationsByEntityEntityIntegrationsEdgesNodeIntegration
+            | WebhookIntegrationFields
+            | SlackIntegrationFields,
             Field(discriminator="typename__"),
         ]
-    ]
+        | None
+    )
 
 
 class IntegrationsByEntityEntityIntegrationsEdgesNodeIntegration(GQLResult):

--- a/wandb/automations/_generated/update_automation.py
+++ b/wandb/automations/_generated/update_automation.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import TriggerFields
 
 
 class UpdateAutomation(GQLResult):
-    result: Optional[UpdateAutomationResult]
+    result: UpdateAutomationResult | None
 
 
 class UpdateAutomationResult(GQLResult):
-    trigger: Optional[TriggerFields]
+    trigger: TriggerFields | None
 
 
 UpdateAutomation.model_rebuild()

--- a/wandb/automations/_utils.py
+++ b/wandb/automations/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection
-from typing import Annotated, Any, Final, Optional, Protocol, TypedDict, Union
+from typing import Annotated, Any, Final, Protocol, TypedDict
 
 from pydantic import Field
 from typing_extensions import Self, Unpack
@@ -90,11 +90,11 @@ class InputActionConfig(TriggeredActionConfig):
     # NOTE: `QueueJobActionInput` for defining a Launch job is deprecated,
     # so while it's allowed here to update EXISTING mutations, we don't
     # currently expose it through the public API to create NEW automations.
-    queue_job_action_input: Optional[QueueJobActionInput] = None
+    queue_job_action_input: QueueJobActionInput | None = None
 
-    notification_action_input: Optional[SendNotification] = None
-    generic_webhook_action_input: Optional[SendWebhook] = None
-    no_op_action_input: Optional[DoNothing] = None
+    notification_action_input: SendNotification | None = None
+    generic_webhook_action_input: SendWebhook | None = None
+    no_op_action_input: DoNothing | None = None
 
 
 def prepare_action_config_input(obj: SavedAction | InputAction) -> dict[str, Any]:
@@ -146,7 +146,7 @@ class ValidatedCreateInput(GQLInput, extra="forbid", frozen=True):
     """
 
     name: str
-    description: Optional[str] = None
+    description: str | None = None
     enabled: bool = True
 
     # ------------------------------------------------------------------------------
@@ -211,12 +211,12 @@ class ValidatedUpdateInput(GQLInput, extra="ignore", frozen=True):
 
     id: GQLId
 
-    name: Optional[str] = None
-    description: Optional[str] = None
-    enabled: Optional[bool] = None
+    name: str | None = None
+    description: str | None = None
+    enabled: bool | None = None
 
-    event: Annotated[Union[InputEvent, SavedEvent], Field(exclude=True)]
-    action: Annotated[Union[InputAction, SavedAction], Field(exclude=True)]
+    event: Annotated[InputEvent | SavedEvent, Field(exclude=True)]
+    action: Annotated[InputAction | SavedAction, Field(exclude=True)]
     scope: Annotated[AutomationScope, Field(exclude=True)]
 
     # --------------------------------------------------------------------------

--- a/wandb/automations/actions.py
+++ b/wandb/automations/actions.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, get_args
 
 from pydantic import BeforeValidator, Field
-from typing_extensions import Self, TypeVar, get_args
+from typing_extensions import Self, TypeVar
 
 from wandb._pydantic import GQLBase, GQLId
 from wandb._strutils import nameof
@@ -86,9 +86,9 @@ class SavedNotificationAction(NotificationActionFields, frozen=False):
     # always come back tagged with the SlackIntegration stub typename.
     integration: _SlackIntegrationStub  # type: ignore[assignment]
 
-    title: Optional[str]
-    message: Optional[str]
-    severity: Optional[AlertSeverity]
+    title: str | None
+    message: str | None
+    severity: AlertSeverity | None
 
 
 class SavedWebhookAction(GenericWebhookActionFields, frozen=False):
@@ -100,7 +100,7 @@ class SavedWebhookAction(GenericWebhookActionFields, frozen=False):
     # We override the type of the `requestPayload` field since the original GraphQL
     # schema (and generated class) effectively defines it as a string, when we know
     # and need to anticipate the expected structure of the JSON-serialized data.
-    request_payload: Optional[JsonEncoded[dict[str, Any]]] = None  # type: ignore[assignment]
+    request_payload: JsonEncoded[dict[str, Any]] | None = None  # type: ignore[assignment]
 
 
 class SavedNoOpAction(NoOpActionFields, frozen=False):
@@ -119,12 +119,10 @@ class SavedNoOpAction(NoOpActionFields, frozen=False):
 
 # for type annotations
 SavedAction = Annotated[
-    Union[
-        SavedLaunchJobAction,
-        SavedNotificationAction,
-        SavedWebhookAction,
-        SavedNoOpAction,
-    ],
+    SavedLaunchJobAction
+    | SavedNotificationAction
+    | SavedWebhookAction
+    | SavedNoOpAction,
     BeforeValidator(parse_saved_action),
     Field(discriminator="typename__"),
 ]
@@ -185,7 +183,7 @@ class SendWebhook(_BaseActionInput, GenericWebhookActionInput):
     """The ID of the webhook integration that will be used to send the request."""
 
     # overrides the generated field type to parse/serialize JSON strings
-    request_payload: Optional[JsonEncoded[dict[str, Any]]] = Field(  # type: ignore[assignment]
+    request_payload: JsonEncoded[dict[str, Any]] | None = Field(  # type: ignore[assignment]
         default=None, alias="requestPayload"
     )
     """The payload, possibly with template variables, to send in the webhook request."""
@@ -195,7 +193,7 @@ class SendWebhook(_BaseActionInput, GenericWebhookActionInput):
         cls,
         integration: WebhookIntegration,
         *,
-        payload: Optional[JsonEncoded[dict[str, Any]]] = None,
+        payload: JsonEncoded[dict[str, Any]] | None = None,
     ) -> Self:
         """Define a webhook action that sends to the given (webhook) integration."""
         return cls(integration_id=integration.id, request_payload=payload)
@@ -215,11 +213,7 @@ class DoNothing(_BaseActionInput, NoOpTriggeredActionInput, frozen=True):
 
 # for type annotations
 InputAction = Annotated[
-    Union[
-        SendNotification,
-        SendWebhook,
-        DoNothing,
-    ],
+    SendNotification | SendWebhook | DoNothing,
     BeforeValidator(parse_input_action),
     Field(discriminator="action_type"),
 ]

--- a/wandb/automations/automations.py
+++ b/wandb/automations/automations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Optional
+from typing import Annotated
 
 from pydantic import Field
 
@@ -25,14 +25,14 @@ class Automation(TriggerFields, frozen=False):
     """The date and time when this automation was created."""
 
     updated_at: Annotated[
-        Optional[datetime], Field(repr=False, frozen=True, alias="updatedAt")
+        datetime | None, Field(repr=False, frozen=True, alias="updatedAt")
     ] = None
     """The date and time when this automation was last updated, if applicable."""
 
     name: str
     """The name of this automation."""
 
-    description: Optional[str]
+    description: str | None
     """An optional description of this automation."""
 
     enabled: bool
@@ -51,21 +51,21 @@ class Automation(TriggerFields, frozen=False):
 class NewAutomation(GQLInput, extra="forbid", validate_default=False):
     """A new automation to be created."""
 
-    name: Optional[str] = None
+    name: str | None = None
     """The name of this automation."""
 
-    description: Optional[str] = None
+    description: str | None = None
     """An optional description of this automation."""
 
-    enabled: Optional[bool] = None
+    enabled: bool | None = None
     """Whether this automation is enabled.  Only enabled automations will trigger."""
 
-    event: Optional[InputEvent] = None
+    event: InputEvent | None = None
     """The event that will trigger this automation."""
 
     # Ensure that the event and its scope are always consistent, if the event is set.
     @property
-    def scope(self) -> Optional[AutomationScope]:
+    def scope(self) -> AutomationScope | None:
         """The scope in which the triggering event must occur."""
         return self.event.scope if self.event else None
 
@@ -75,7 +75,7 @@ class NewAutomation(GQLInput, extra="forbid", validate_default=False):
             raise ValueError("Cannot set `scope` for an automation with no `event`")
         self.event.scope = value
 
-    action: Optional[InputAction] = None
+    action: InputAction | None = None
     """The action that will execute when this automation is triggered."""
 
 

--- a/wandb/automations/events.py
+++ b/wandb/automations/events.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args
 
 from pydantic import AfterValidator, Field
-from typing_extensions import get_args
 
 from wandb._pydantic import GQLBase, model_validator, pydantic_isinstance
 from wandb._strutils import nameof
@@ -125,18 +124,16 @@ class RunMetricFilter(GQLBase):  # from: TriggeringRunMetricEvent
     """Filters that must match any runs that will trigger this event."""
 
     metric: Annotated[
-        Union[
-            _WrappedMetricThresholdFilter,
-            _WrappedMetricChangeFilter,
-            _WrappedMetricZScoreFilter,
-        ],
+        _WrappedMetricThresholdFilter
+        | _WrappedMetricChangeFilter
+        | _WrappedMetricZScoreFilter,
         Field(alias="run_metric_filter"),
     ]
     """Metric condition(s) that must be satisfied for this event to trigger."""
 
     # ------------------------------------------------------------------------------
     legacy_metric_filter: Annotated[
-        Optional[JsonEncoded[MetricThresholdFilter]],
+        JsonEncoded[MetricThresholdFilter] | None,
         Field(alias="metric_filter", deprecated=True),
     ] = None
     """Deprecated legacy field for defining run metric threshold events.
@@ -187,7 +184,7 @@ class SavedEvent(FilterEventFields):  # from: FilterEventTriggeringCondition
     # We override the type of the `filter` field in order to enforce the expected
     # structure for the JSON data when validating and serializing.
     filter: JsonEncoded[  # type: ignore[assignment]
-        Union[_WrappedSavedEventFilter, RunMetricFilter, RunStateFilter]
+        _WrappedSavedEventFilter | RunMetricFilter | RunStateFilter
     ]
     """The condition(s) under which this event triggers an automation."""
 
@@ -384,13 +381,7 @@ class OnRunState(_BaseRunEventInput):
 
 # for type annotations
 InputEvent = Annotated[
-    Union[
-        OnLinkArtifact,
-        OnAddArtifactAlias,
-        OnCreateArtifact,
-        OnRunMetric,
-        OnRunState,
-    ],
+    OnLinkArtifact | OnAddArtifactAlias | OnCreateArtifact | OnRunMetric | OnRunState,
     Field(discriminator="event_type"),
 ]
 # for runtime type checks

--- a/wandb/automations/integrations.py
+++ b/wandb/automations/integrations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Union
+from typing import Annotated
 
 from pydantic import Field, TypeAdapter
 
@@ -24,7 +24,7 @@ class WebhookIntegration(WebhookIntegrationFields):
 
 
 Integration = Annotated[
-    Union[SlackIntegration, WebhookIntegration],
+    SlackIntegration | WebhookIntegration,
     Field(discriminator="typename__"),
 ]
 

--- a/wandb/automations/scopes.py
+++ b/wandb/automations/scopes.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal, TypeAlias, get_args
 
 from pydantic import BeforeValidator, Field
-from typing_extensions import TypeAlias, get_args
 
 from wandb._pydantic import GQLBase
 
@@ -43,7 +42,7 @@ class _ArtifactPortfolioScope(_BaseScope, ArtifactPortfolioScopeFields):
 
 # for type annotations
 ArtifactCollectionScope = Annotated[
-    Union[_ArtifactSequenceScope, _ArtifactPortfolioScope],
+    _ArtifactSequenceScope | _ArtifactPortfolioScope,
     BeforeValidator(parse_scope),
     Field(discriminator="typename__"),
 ]
@@ -63,7 +62,7 @@ class ProjectScope(_BaseScope, ProjectScopeFields):
 
 # for type annotations
 AutomationScope: TypeAlias = Annotated[
-    Union[_ArtifactSequenceScope, _ArtifactPortfolioScope, ProjectScope],
+    _ArtifactSequenceScope | _ArtifactPortfolioScope | ProjectScope,
     BeforeValidator(parse_scope),
     Field(discriminator="typename__"),
 ]

--- a/wandb/sdk/artifacts/_generated/add_aliases.py
+++ b/wandb/sdk/artifacts/_generated/add_aliases.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class AddAliases(GQLResult):
-    result: Optional[AddAliasesResult]
+    result: AddAliasesResult | None
 
 
 class AddAliasesResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/add_artifact_collection_tags.py
+++ b/wandb/sdk/artifacts/_generated/add_artifact_collection_tags.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import TagFragment
 
 
 class AddArtifactCollectionTags(GQLResult):
-    result: Optional[AddArtifactCollectionTagsResult]
+    result: AddArtifactCollectionTagsResult | None
 
 
 class AddArtifactCollectionTagsResult(GQLResult):
-    tags: List[TagFragment]
+    tags: list[TagFragment]
 
 
 AddArtifactCollectionTags.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/artifact_by_id.py
+++ b/wandb/sdk/artifacts/_generated/artifact_by_id.py
@@ -3,15 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import ArtifactFragment
 
 
 class ArtifactByID(GQLResult):
-    artifact: Optional[ArtifactFragment]
+    artifact: ArtifactFragment | None
 
 
 ArtifactByID.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/artifact_by_name.py
+++ b/wandb/sdk/artifacts/_generated/artifact_by_name.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import ArtifactFragment
 
 
 class ArtifactByName(GQLResult):
-    project: Optional[ArtifactByNameProject]
+    project: ArtifactByNameProject | None
 
 
 class ArtifactByNameProject(GQLResult):
-    artifact: Optional[ArtifactFragment]
+    artifact: ArtifactFragment | None
 
 
 ArtifactByName.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/artifact_collection_aliases.py
+++ b/wandb/sdk/artifacts/_generated/artifact_collection_aliases.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -13,7 +13,7 @@ from .fragments import ArtifactAliasFragment, PageInfoFragment
 
 
 class ArtifactCollectionAliases(GQLResult):
-    artifact_collection: Optional[ArtifactCollectionAliasesArtifactCollection] = Field(
+    artifact_collection: ArtifactCollectionAliasesArtifactCollection | None = Field(
         alias="artifactCollection"
     )
 
@@ -27,11 +27,11 @@ class ArtifactCollectionAliasesArtifactCollection(GQLResult):
 
 class ArtifactCollectionAliasesArtifactCollectionAliases(GQLResult):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[ArtifactCollectionAliasesArtifactCollectionAliasesEdges]
+    edges: list[ArtifactCollectionAliasesArtifactCollectionAliasesEdges]
 
 
 class ArtifactCollectionAliasesArtifactCollectionAliasesEdges(GQLResult):
-    node: Optional[ArtifactAliasFragment]
+    node: ArtifactAliasFragment | None
 
 
 ArtifactCollectionAliases.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/artifact_created_by.py
+++ b/wandb/sdk/artifacts/_generated/artifact_created_by.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -13,16 +13,17 @@ from .fragments import RunInfoFragment
 
 
 class ArtifactCreatedBy(GQLResult):
-    artifact: Optional[ArtifactCreatedByArtifact]
+    artifact: ArtifactCreatedByArtifact | None
 
 
 class ArtifactCreatedByArtifact(GQLResult):
-    created_by: Optional[
+    created_by: (
         Annotated[
-            Union[RunInfoFragment, ArtifactCreatedByArtifactCreatedByUser],
+            RunInfoFragment | ArtifactCreatedByArtifactCreatedByUser,
             Field(discriminator="typename__"),
         ]
-    ] = Field(alias="createdBy")
+        | None
+    ) = Field(alias="createdBy")
 
 
 class ArtifactCreatedByArtifactCreatedByUser(GQLResult):

--- a/wandb/sdk/artifacts/_generated/artifact_membership_by_name.py
+++ b/wandb/sdk/artifacts/_generated/artifact_membership_by_name.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,11 +11,11 @@ from .fragments import ArtifactMembershipFragment
 
 
 class ArtifactMembershipByName(GQLResult):
-    project: Optional[ArtifactMembershipByNameProject]
+    project: ArtifactMembershipByNameProject | None
 
 
 class ArtifactMembershipByNameProject(GQLResult):
-    artifact_collection_membership: Optional[ArtifactMembershipFragment] = Field(
+    artifact_collection_membership: ArtifactMembershipFragment | None = Field(
         alias="artifactCollectionMembership"
     )
 

--- a/wandb/sdk/artifacts/_generated/artifact_type.py
+++ b/wandb/sdk/artifacts/_generated/artifact_type.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
 
 
 class ArtifactType(GQLResult):
-    project: Optional[ArtifactTypeProject]
+    project: ArtifactTypeProject | None
 
 
 class ArtifactTypeProject(GQLResult):
-    artifact: Optional[ArtifactTypeProjectArtifact]
+    artifact: ArtifactTypeProjectArtifact | None
 
 
 class ArtifactTypeProjectArtifact(GQLResult):

--- a/wandb/sdk/artifacts/_generated/artifact_type_artifact_collections.py
+++ b/wandb/sdk/artifacts/_generated/artifact_type_artifact_collections.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,25 +11,25 @@ from .fragments import ArtifactCollectionFragment, PageInfoFragment
 
 
 class ArtifactTypeArtifactCollections(GQLResult):
-    project: Optional[ArtifactTypeArtifactCollectionsProject]
+    project: ArtifactTypeArtifactCollectionsProject | None
 
 
 class ArtifactTypeArtifactCollectionsProject(GQLResult):
-    artifact_type: Optional[ArtifactTypeArtifactCollectionsProjectArtifactType] = Field(
+    artifact_type: ArtifactTypeArtifactCollectionsProjectArtifactType | None = Field(
         alias="artifactType"
     )
 
 
 class ArtifactTypeArtifactCollectionsProjectArtifactType(GQLResult):
-    artifact_collections: Optional[
-        ArtifactTypeArtifactCollectionsProjectArtifactTypeArtifactCollections
-    ] = Field(alias="artifactCollections")
+    artifact_collections: (
+        ArtifactTypeArtifactCollectionsProjectArtifactTypeArtifactCollections | None
+    ) = Field(alias="artifactCollections")
 
 
 class ArtifactTypeArtifactCollectionsProjectArtifactTypeArtifactCollections(GQLResult):
     total_count: int = Field(alias="totalCount")
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[
+    edges: list[
         ArtifactTypeArtifactCollectionsProjectArtifactTypeArtifactCollectionsEdges
     ]
 
@@ -39,7 +37,7 @@ class ArtifactTypeArtifactCollectionsProjectArtifactTypeArtifactCollections(GQLR
 class ArtifactTypeArtifactCollectionsProjectArtifactTypeArtifactCollectionsEdges(
     GQLResult
 ):
-    node: Optional[ArtifactCollectionFragment]
+    node: ArtifactCollectionFragment | None
 
 
 ArtifactTypeArtifactCollections.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/artifact_used_by.py
+++ b/wandb/sdk/artifacts/_generated/artifact_used_by.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,7 +11,7 @@ from .fragments import RunInfoFragment
 
 
 class ArtifactUsedBy(GQLResult):
-    artifact: Optional[ArtifactUsedByArtifact]
+    artifact: ArtifactUsedByArtifact | None
 
 
 class ArtifactUsedByArtifact(GQLResult):
@@ -21,7 +19,7 @@ class ArtifactUsedByArtifact(GQLResult):
 
 
 class ArtifactUsedByArtifactUsedBy(GQLResult):
-    edges: List[ArtifactUsedByArtifactUsedByEdges]
+    edges: list[ArtifactUsedByArtifactUsedByEdges]
 
 
 class ArtifactUsedByArtifactUsedByEdges(GQLResult):

--- a/wandb/sdk/artifacts/_generated/create_registry_members.py
+++ b/wandb/sdk/artifacts/_generated/create_registry_members.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class CreateRegistryMembers(GQLResult):
-    result: Optional[CreateRegistryMembersResult]
+    result: CreateRegistryMembersResult | None
 
 
 class CreateRegistryMembersResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/delete_aliases.py
+++ b/wandb/sdk/artifacts/_generated/delete_aliases.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class DeleteAliases(GQLResult):
-    result: Optional[DeleteAliasesResult]
+    result: DeleteAliasesResult | None
 
 
 class DeleteAliasesResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/delete_artifact.py
+++ b/wandb/sdk/artifacts/_generated/delete_artifact.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLId, GQLResult
 
 
 class DeleteArtifact(GQLResult):
-    result: Optional[DeleteArtifactResult]
+    result: DeleteArtifactResult | None
 
 
 class DeleteArtifactResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/delete_artifact_collection_tags.py
+++ b/wandb/sdk/artifacts/_generated/delete_artifact_collection_tags.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class DeleteArtifactCollectionTags(GQLResult):
-    result: Optional[DeleteArtifactCollectionTagsResult]
+    result: DeleteArtifactCollectionTagsResult | None
 
 
 class DeleteArtifactCollectionTagsResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/delete_artifact_portfolio.py
+++ b/wandb/sdk/artifacts/_generated/delete_artifact_portfolio.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -13,7 +13,7 @@ from .enums import ArtifactCollectionState
 
 
 class DeleteArtifactPortfolio(GQLResult):
-    result: Optional[DeleteArtifactPortfolioResult]
+    result: DeleteArtifactPortfolioResult | None
 
 
 class DeleteArtifactPortfolioResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/delete_artifact_sequence.py
+++ b/wandb/sdk/artifacts/_generated/delete_artifact_sequence.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -13,7 +13,7 @@ from .enums import ArtifactCollectionState
 
 
 class DeleteArtifactSequence(GQLResult):
-    result: Optional[DeleteArtifactSequenceResult]
+    result: DeleteArtifactSequenceResult | None
 
 
 class DeleteArtifactSequenceResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/delete_registry.py
+++ b/wandb/sdk/artifacts/_generated/delete_registry.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
 
 
 class DeleteRegistry(GQLResult):
-    delete_model: Optional[DeleteRegistryDeleteModel] = Field(alias="deleteModel")
+    delete_model: DeleteRegistryDeleteModel | None = Field(alias="deleteModel")
 
 
 class DeleteRegistryDeleteModel(GQLResult):
-    success: Optional[bool]
+    success: bool | None
 
 
 DeleteRegistry.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/delete_registry_members.py
+++ b/wandb/sdk/artifacts/_generated/delete_registry_members.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class DeleteRegistryMembers(GQLResult):
-    result: Optional[DeleteRegistryMembersResult]
+    result: DeleteRegistryMembersResult | None
 
 
 class DeleteRegistryMembersResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/fetch_artifact_manifest.py
+++ b/wandb/sdk/artifacts/_generated/fetch_artifact_manifest.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,13 +11,11 @@ from .fragments import DeferredManifestFragment
 
 
 class FetchArtifactManifest(GQLResult):
-    artifact: Optional[FetchArtifactManifestArtifact]
+    artifact: FetchArtifactManifestArtifact | None
 
 
 class FetchArtifactManifestArtifact(GQLResult):
-    current_manifest: Optional[DeferredManifestFragment] = Field(
-        alias="currentManifest"
-    )
+    current_manifest: DeferredManifestFragment | None = Field(alias="currentManifest")
 
 
 FetchArtifactManifest.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/fetch_linked_artifacts.py
+++ b/wandb/sdk/artifacts/_generated/fetch_linked_artifacts.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,7 +11,7 @@ from .fragments import ArtifactAliasFragment, CollectionInfoFragment
 
 
 class FetchLinkedArtifacts(GQLResult):
-    artifact: Optional[FetchLinkedArtifactsArtifact]
+    artifact: FetchLinkedArtifactsArtifact | None
 
 
 class FetchLinkedArtifactsArtifact(GQLResult):
@@ -23,17 +21,17 @@ class FetchLinkedArtifactsArtifact(GQLResult):
 
 
 class FetchLinkedArtifactsArtifactArtifactMemberships(GQLResult):
-    edges: List[FetchLinkedArtifactsArtifactArtifactMembershipsEdges]
+    edges: list[FetchLinkedArtifactsArtifactArtifactMembershipsEdges]
 
 
 class FetchLinkedArtifactsArtifactArtifactMembershipsEdges(GQLResult):
-    node: Optional[FetchLinkedArtifactsArtifactArtifactMembershipsEdgesNode]
+    node: FetchLinkedArtifactsArtifactArtifactMembershipsEdgesNode | None
 
 
 class FetchLinkedArtifactsArtifactArtifactMembershipsEdgesNode(GQLResult):
-    version_index: Optional[int] = Field(alias="versionIndex")
-    aliases: List[ArtifactAliasFragment]
-    artifact_collection: Optional[CollectionInfoFragment] = Field(
+    version_index: int | None = Field(alias="versionIndex")
+    aliases: list[ArtifactAliasFragment]
+    artifact_collection: CollectionInfoFragment | None = Field(
         alias="artifactCollection"
     )
 

--- a/wandb/sdk/artifacts/_generated/fetch_org_entity_from_organization.py
+++ b/wandb/sdk/artifacts/_generated/fetch_org_entity_from_organization.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
 
 
 class FetchOrgEntityFromOrganization(GQLResult):
-    organization: Optional[FetchOrgEntityFromOrganizationOrganization]
+    organization: FetchOrgEntityFromOrganizationOrganization | None
 
 
 class FetchOrgEntityFromOrganizationOrganization(GQLResult):
-    org_entity: Optional[FetchOrgEntityFromOrganizationOrganizationOrgEntity] = Field(
+    org_entity: FetchOrgEntityFromOrganizationOrganizationOrgEntity | None = Field(
         alias="orgEntity"
     )
 

--- a/wandb/sdk/artifacts/_generated/fetch_org_info_from_entity.py
+++ b/wandb/sdk/artifacts/_generated/fetch_org_info_from_entity.py
@@ -3,24 +3,22 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import OrgInfoFragment
 
 
 class FetchOrgInfoFromEntity(GQLResult):
-    entity: Optional[FetchOrgInfoFromEntityEntity]
+    entity: FetchOrgInfoFromEntityEntity | None
 
 
 class FetchOrgInfoFromEntityEntity(GQLResult):
-    organization: Optional[OrgInfoFragment]
-    user: Optional[FetchOrgInfoFromEntityEntityUser]
+    organization: OrgInfoFragment | None
+    user: FetchOrgInfoFromEntityEntityUser | None
 
 
 class FetchOrgInfoFromEntityEntityUser(GQLResult):
-    organizations: List[OrgInfoFragment]
+    organizations: list[OrgInfoFragment]
 
 
 FetchOrgInfoFromEntity.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/fetch_registries.py
+++ b/wandb/sdk/artifacts/_generated/fetch_registries.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,26 +11,24 @@ from .fragments import PageInfoFragment, RegistryFragment
 
 
 class FetchRegistries(GQLResult):
-    organization: Optional[FetchRegistriesOrganization]
+    organization: FetchRegistriesOrganization | None
 
 
 class FetchRegistriesOrganization(GQLResult):
-    org_entity: Optional[FetchRegistriesOrganizationOrgEntity] = Field(
-        alias="orgEntity"
-    )
+    org_entity: FetchRegistriesOrganizationOrgEntity | None = Field(alias="orgEntity")
 
 
 class FetchRegistriesOrganizationOrgEntity(GQLResult):
-    projects: Optional[FetchRegistriesOrganizationOrgEntityProjects]
+    projects: FetchRegistriesOrganizationOrgEntityProjects | None
 
 
 class FetchRegistriesOrganizationOrgEntityProjects(GQLResult):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[FetchRegistriesOrganizationOrgEntityProjectsEdges]
+    edges: list[FetchRegistriesOrganizationOrgEntityProjectsEdges]
 
 
 class FetchRegistriesOrganizationOrgEntityProjectsEdges(GQLResult):
-    node: Optional[RegistryFragment]
+    node: RegistryFragment | None
 
 
 FetchRegistries.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/fetch_registry.py
+++ b/wandb/sdk/artifacts/_generated/fetch_registry.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import RegistryFragment
 
 
 class FetchRegistry(GQLResult):
-    entity: Optional[FetchRegistryEntity]
+    entity: FetchRegistryEntity | None
 
 
 class FetchRegistryEntity(GQLResult):
-    project: Optional[RegistryFragment]
+    project: RegistryFragment | None
 
 
 FetchRegistry.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/fragments.py
+++ b/wandb/sdk/artifacts/_generated/fragments.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -37,10 +37,10 @@ class ArtifactCollectionFragment(GQLResult):
     typename__: Typename[Literal["ArtifactPortfolio", "ArtifactSequence"]]
     id: GQLId
     name: str
-    description: Optional[str]
+    description: str | None
     created_at: str = Field(alias="createdAt")
-    updated_at: Optional[str] = Field(alias="updatedAt")
-    project: Optional[ProjectInfoFragment]
+    updated_at: str | None = Field(alias="updatedAt")
+    project: ProjectInfoFragment | None
     type: ArtifactCollectionFragmentType
     tags: ArtifactCollectionFragmentTags
 
@@ -50,7 +50,7 @@ class ArtifactCollectionFragmentType(GQLResult):
 
 
 class ArtifactCollectionFragmentTags(GQLResult):
-    edges: List[ArtifactCollectionFragmentTagsEdges]
+    edges: list[ArtifactCollectionFragmentTagsEdges]
 
 
 class ArtifactCollectionFragmentTagsEdges(GQLResult):
@@ -60,35 +60,35 @@ class ArtifactCollectionFragmentTagsEdges(GQLResult):
 class CollectionInfoFragment(GQLResult):
     typename__: Typename[Literal["ArtifactPortfolio", "ArtifactSequence"]]
     name: str
-    project: Optional[ProjectInfoFragment]
+    project: ProjectInfoFragment | None
 
 
 class SourceCollectionInfoFragment(GQLResult):
     typename__: Typename[Literal["ArtifactSequence"]] = "ArtifactSequence"
     name: str
-    project: Optional[ProjectInfoFragment]
+    project: ProjectInfoFragment | None
 
 
 class ArtifactFragment(GQLResult):
     typename__: Typename[Literal["Artifact"]] = "Artifact"
     id: GQLId
     artifact_sequence: SourceCollectionInfoFragment = Field(alias="artifactSequence")
-    version_index: Optional[int] = Field(alias="versionIndex")
+    version_index: int | None = Field(alias="versionIndex")
     artifact_type: ArtifactFragmentArtifactType = Field(alias="artifactType")
-    description: Optional[str]
-    metadata: Optional[str]
+    description: str | None
+    metadata: str | None
     ttl_duration_seconds: int = Field(alias="ttlDurationSeconds")
     ttl_is_inherited: bool = Field(alias="ttlIsInherited")
-    tags: List[TagFragment]
-    history_step: Optional[int] = Field(alias="historyStep")
+    tags: list[TagFragment]
+    history_step: int | None = Field(alias="historyStep")
     state: ArtifactState
     size: int
     digest: str
-    commit_hash: Optional[str] = Field(alias="commitHash")
+    commit_hash: str | None = Field(alias="commitHash")
     file_count: int = Field(alias="fileCount")
     created_at: str = Field(alias="createdAt")
-    updated_at: Optional[str] = Field(alias="updatedAt")
-    aliases: Optional[List[ArtifactFragmentAliases]] = None
+    updated_at: str | None = Field(alias="updatedAt")
+    aliases: list[ArtifactFragmentAliases] | None = None
 
 
 class ArtifactFragmentArtifactType(GQLResult):
@@ -96,7 +96,7 @@ class ArtifactFragmentArtifactType(GQLResult):
 
 
 class ArtifactFragmentAliases(ArtifactAliasFragment):
-    artifact_collection: Optional[CollectionInfoFragment] = Field(
+    artifact_collection: CollectionInfoFragment | None = Field(
         alias="artifactCollection"
     )
 
@@ -106,12 +106,12 @@ class ArtifactMembershipFragment(GQLResult):
         "ArtifactCollectionMembership"
     )
     id: GQLId
-    version_index: Optional[int] = Field(alias="versionIndex")
-    aliases: List[ArtifactAliasFragment]
-    artifact_collection: Optional[CollectionInfoFragment] = Field(
+    version_index: int | None = Field(alias="versionIndex")
+    aliases: list[ArtifactAliasFragment]
+    artifact_collection: CollectionInfoFragment | None = Field(
         alias="artifactCollection"
     )
-    artifact: Optional[ArtifactFragment]
+    artifact: ArtifactFragment | None
 
 
 class ArtifactPortfolioTypeFields(GQLResult):
@@ -130,7 +130,7 @@ class ArtifactTypeFragment(GQLResult):
     typename__: Typename[Literal["ArtifactType"]] = "ArtifactType"
     id: GQLId
     name: str
-    description: Optional[str]
+    description: str | None
     created_at: str = Field(alias="createdAt")
 
 
@@ -146,13 +146,13 @@ class FileFragment(GQLResult):
     typename__: Typename[Literal["File"]] = "File"
     id: GQLId
     name: str
-    url: Optional[str]
+    url: str | None
     size_bytes: int = Field(alias="sizeBytes")
-    storage_path: Optional[str] = Field(alias="storagePath")
-    mimetype: Optional[str]
-    updated_at: Optional[str] = Field(alias="updatedAt")
-    digest: Optional[str]
-    md_5: Optional[str] = Field(alias="md5")
+    storage_path: str | None = Field(alias="storagePath")
+    mimetype: str | None
+    updated_at: str | None = Field(alias="updatedAt")
+    digest: str | None
+    md_5: str | None = Field(alias="md5")
     direct_url: str = Field(alias="directUrl")
 
 
@@ -164,7 +164,7 @@ class FileWithUrlFragment(GQLResult):
 
 class OrgInfoFragment(GQLResult):
     name: str
-    org_entity: Optional[OrgInfoFragmentOrgEntity] = Field(alias="orgEntity")
+    org_entity: OrgInfoFragmentOrgEntity | None = Field(alias="orgEntity")
 
 
 class OrgInfoFragmentOrgEntity(GQLResult):
@@ -173,7 +173,7 @@ class OrgInfoFragmentOrgEntity(GQLResult):
 
 class PageInfoFragment(GQLResult):
     typename__: Typename[Literal["PageInfo"]] = "PageInfo"
-    end_cursor: Optional[str] = Field(alias="endCursor")
+    end_cursor: str | None = Field(alias="endCursor")
     has_next_page: bool = Field(alias="hasNextPage")
 
 
@@ -181,10 +181,10 @@ class RegistryCollectionFragment(GQLResult):
     typename__: Typename[Literal["ArtifactPortfolio", "ArtifactSequence"]]
     id: GQLId
     name: str
-    description: Optional[str]
+    description: str | None
     created_at: str = Field(alias="createdAt")
-    updated_at: Optional[str] = Field(alias="updatedAt")
-    project: Optional[ProjectInfoFragment]
+    updated_at: str | None = Field(alias="updatedAt")
+    project: ProjectInfoFragment | None
     type: RegistryCollectionFragmentType
     tags: RegistryCollectionFragmentTags
 
@@ -194,7 +194,7 @@ class RegistryCollectionFragmentType(GQLResult):
 
 
 class RegistryCollectionFragmentTags(GQLResult):
-    edges: List[RegistryCollectionFragmentTagsEdges]
+    edges: list[RegistryCollectionFragmentTagsEdges]
 
 
 class RegistryCollectionFragmentTagsEdges(GQLResult):
@@ -206,17 +206,17 @@ class RegistryFragment(GQLResult):
     id: GQLId
     name: str
     entity: RegistryFragmentEntity
-    description: Optional[str]
+    description: str | None
     created_at: str = Field(alias="createdAt")
-    updated_at: Optional[str] = Field(alias="updatedAt")
-    access: Optional[str]
+    updated_at: str | None = Field(alias="updatedAt")
+    access: str | None
     allow_all_artifact_types: bool = Field(alias="allowAllArtifactTypes")
     artifact_types: RegistryFragmentArtifactTypes = Field(alias="artifactTypes")
 
 
 class RegistryFragmentEntity(GQLResult):
     name: str
-    organization: Optional[RegistryFragmentEntityOrganization]
+    organization: RegistryFragmentEntityOrganization | None
 
 
 class RegistryFragmentEntityOrganization(GQLResult):
@@ -224,11 +224,11 @@ class RegistryFragmentEntityOrganization(GQLResult):
 
 
 class RegistryFragmentArtifactTypes(GQLResult):
-    edges: List[RegistryFragmentArtifactTypesEdges]
+    edges: list[RegistryFragmentArtifactTypesEdges]
 
 
 class RegistryFragmentArtifactTypesEdges(GQLResult):
-    node: Optional[RegistryFragmentArtifactTypesEdgesNode]
+    node: RegistryFragmentArtifactTypesEdgesNode | None
 
 
 class RegistryFragmentArtifactTypesEdgesNode(GQLResult):
@@ -243,37 +243,37 @@ class RunInfoFragment(GQLResult):
     typename__: Typename[Literal["Run"]] = "Run"
     id: GQLId
     name: str
-    project: Optional[ProjectInfoFragment]
+    project: ProjectInfoFragment | None
 
 
 class TeamMemberFragment(GQLResult):
     typename__: Typename[Literal["Member"]] = "Member"
-    id: Optional[str]
-    role: Optional[str]
-    pending: Optional[bool]
-    email: Optional[str]
-    username: Optional[str]
+    id: str | None
+    role: str | None
+    pending: bool | None
+    email: str | None
+    username: str | None
     name: str
-    photo_url: Optional[str] = Field(alias="photoUrl")
-    account_type: Optional[str] = Field(alias="accountType")
-    api_key: Optional[str] = Field(alias="apiKey")
+    photo_url: str | None = Field(alias="photoUrl")
+    account_type: str | None = Field(alias="accountType")
+    api_key: str | None = Field(alias="apiKey")
 
 
 class TeamFragment(GQLResult):
     typename__: Typename[Literal["Entity"]] = "Entity"
     id: GQLId
     name: str
-    available: Optional[bool]
-    photo_url: Optional[str] = Field(alias="photoUrl")
-    read_only: Optional[bool] = Field(alias="readOnly")
+    available: bool | None
+    photo_url: str | None = Field(alias="photoUrl")
+    read_only: bool | None = Field(alias="readOnly")
     read_only_admin: bool = Field(alias="readOnlyAdmin")
     is_team: bool = Field(alias="isTeam")
     private_only: bool = Field(alias="privateOnly")
     storage_bytes: int = Field(alias="storageBytes")
     code_saving_enabled: bool = Field(alias="codeSavingEnabled")
     default_access: str = Field(alias="defaultAccess")
-    is_paid: Optional[bool] = Field(alias="isPaid")
-    members: List[TeamMemberFragment]
+    is_paid: bool | None = Field(alias="isPaid")
+    members: list[TeamMemberFragment]
 
 
 class TeamRegistryMemberFragment(GQLResult):
@@ -283,66 +283,33 @@ class TeamRegistryMemberFragment(GQLResult):
 
 class UserRegistryMemberFragment(GQLResult):
     id: GQLId
-    name: Optional[str]
-    username: Optional[str]
-    email: Optional[str]
+    name: str | None
+    username: str | None
+    email: str | None
     role: RegistryRoleFragment
 
 
 ArtifactAliasFragment.model_rebuild()
 ProjectInfoFragment.model_rebuild()
-ProjectInfoFragmentEntity.model_rebuild()
 TagFragment.model_rebuild()
 ArtifactCollectionFragment.model_rebuild()
-ProjectInfoFragment.model_rebuild()
-ArtifactCollectionFragmentType.model_rebuild()
-ArtifactCollectionFragmentTags.model_rebuild()
-ArtifactCollectionFragmentTagsEdges.model_rebuild()
-TagFragment.model_rebuild()
 CollectionInfoFragment.model_rebuild()
-ProjectInfoFragment.model_rebuild()
 SourceCollectionInfoFragment.model_rebuild()
-ProjectInfoFragment.model_rebuild()
 ArtifactFragment.model_rebuild()
-SourceCollectionInfoFragment.model_rebuild()
-ArtifactFragmentArtifactType.model_rebuild()
-TagFragment.model_rebuild()
-ArtifactFragmentAliases.model_rebuild()
-CollectionInfoFragment.model_rebuild()
 ArtifactMembershipFragment.model_rebuild()
-ArtifactAliasFragment.model_rebuild()
-CollectionInfoFragment.model_rebuild()
-ArtifactFragment.model_rebuild()
 ArtifactPortfolioTypeFields.model_rebuild()
 ArtifactSequenceTypeFields.model_rebuild()
 ArtifactTypeFragment.model_rebuild()
 DeferredManifestFragment.model_rebuild()
-DeferredManifestFragmentFile.model_rebuild()
 FileFragment.model_rebuild()
 FileWithUrlFragment.model_rebuild()
 OrgInfoFragment.model_rebuild()
-OrgInfoFragmentOrgEntity.model_rebuild()
 PageInfoFragment.model_rebuild()
 RegistryCollectionFragment.model_rebuild()
-ProjectInfoFragment.model_rebuild()
-RegistryCollectionFragmentType.model_rebuild()
-RegistryCollectionFragmentTags.model_rebuild()
-RegistryCollectionFragmentTagsEdges.model_rebuild()
-TagFragment.model_rebuild()
 RegistryFragment.model_rebuild()
-RegistryFragmentEntity.model_rebuild()
-RegistryFragmentEntityOrganization.model_rebuild()
-RegistryFragmentArtifactTypes.model_rebuild()
-RegistryFragmentArtifactTypesEdges.model_rebuild()
-RegistryFragmentArtifactTypesEdgesNode.model_rebuild()
 RegistryRoleFragment.model_rebuild()
 RunInfoFragment.model_rebuild()
-ProjectInfoFragment.model_rebuild()
 TeamMemberFragment.model_rebuild()
 TeamFragment.model_rebuild()
-TeamMemberFragment.model_rebuild()
 TeamRegistryMemberFragment.model_rebuild()
-TeamFragment.model_rebuild()
-RegistryRoleFragment.model_rebuild()
 UserRegistryMemberFragment.model_rebuild()
-RegistryRoleFragment.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/get_artifact_file_urls.py
+++ b/wandb/sdk/artifacts/_generated/get_artifact_file_urls.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,20 +11,20 @@ from .fragments import FileWithUrlFragment, PageInfoFragment
 
 
 class GetArtifactFileUrls(GQLResult):
-    artifact: Optional[GetArtifactFileUrlsArtifact]
+    artifact: GetArtifactFileUrlsArtifact | None
 
 
 class GetArtifactFileUrlsArtifact(GQLResult):
-    files: Optional[GetArtifactFileUrlsArtifactFiles]
+    files: GetArtifactFileUrlsArtifactFiles | None
 
 
 class GetArtifactFileUrlsArtifactFiles(GQLResult):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[GetArtifactFileUrlsArtifactFilesEdges]
+    edges: list[GetArtifactFileUrlsArtifactFilesEdges]
 
 
 class GetArtifactFileUrlsArtifactFilesEdges(GQLResult):
-    node: Optional[FileWithUrlFragment]
+    node: FileWithUrlFragment | None
 
 
 GetArtifactFileUrls.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/get_artifact_files.py
+++ b/wandb/sdk/artifacts/_generated/get_artifact_files.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,31 +11,31 @@ from .fragments import FileFragment, PageInfoFragment
 
 
 class GetArtifactFiles(GQLResult):
-    project: Optional[GetArtifactFilesProject]
+    project: GetArtifactFilesProject | None
 
 
 class GetArtifactFilesProject(GQLResult):
-    artifact_type: Optional[GetArtifactFilesProjectArtifactType] = Field(
+    artifact_type: GetArtifactFilesProjectArtifactType | None = Field(
         alias="artifactType"
     )
 
 
 class GetArtifactFilesProjectArtifactType(GQLResult):
-    artifact: Optional[GetArtifactFilesProjectArtifactTypeArtifact]
+    artifact: GetArtifactFilesProjectArtifactTypeArtifact | None
 
 
 class GetArtifactFilesProjectArtifactTypeArtifact(GQLResult):
-    files: Optional[GetArtifactFilesProjectArtifactTypeArtifactFiles]
+    files: GetArtifactFilesProjectArtifactTypeArtifactFiles | None
 
 
 class GetArtifactFilesProjectArtifactTypeArtifactFiles(GQLResult):
-    total_count: Optional[int] = Field(alias="totalCount", default=None)
+    total_count: int | None = Field(alias="totalCount", default=None)
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[GetArtifactFilesProjectArtifactTypeArtifactFilesEdges]
+    edges: list[GetArtifactFilesProjectArtifactTypeArtifactFilesEdges]
 
 
 class GetArtifactFilesProjectArtifactTypeArtifactFilesEdges(GQLResult):
-    node: Optional[FileFragment]
+    node: FileFragment | None
 
 
 GetArtifactFiles.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/get_artifact_membership_file_urls.py
+++ b/wandb/sdk/artifacts/_generated/get_artifact_membership_file_urls.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -13,37 +13,38 @@ from .fragments import FileWithUrlFragment, PageInfoFragment
 
 
 class GetArtifactMembershipFileUrls(GQLResult):
-    project: Optional[GetArtifactMembershipFileUrlsProject]
+    project: GetArtifactMembershipFileUrlsProject | None
 
 
 class GetArtifactMembershipFileUrlsProject(GQLResult):
-    artifact_collection: Optional[
-        GetArtifactMembershipFileUrlsProjectArtifactCollection
-    ] = Field(alias="artifactCollection")
+    artifact_collection: (
+        GetArtifactMembershipFileUrlsProjectArtifactCollection | None
+    ) = Field(alias="artifactCollection")
 
 
 class GetArtifactMembershipFileUrlsProjectArtifactCollection(GQLResult):
     typename__: Typename[
         Literal["ArtifactCollection", "ArtifactPortfolio", "ArtifactSequence"]
     ]
-    artifact_membership: Optional[
-        GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembership
-    ] = Field(alias="artifactMembership")
+    artifact_membership: (
+        GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembership | None
+    ) = Field(alias="artifactMembership")
 
 
 class GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembership(
     GQLResult
 ):
-    files: Optional[
+    files: (
         GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembershipFiles
-    ]
+        | None
+    )
 
 
 class GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembershipFiles(
     GQLResult
 ):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[
+    edges: list[
         GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembershipFilesEdges
     ]
 
@@ -51,7 +52,7 @@ class GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembershipFi
 class GetArtifactMembershipFileUrlsProjectArtifactCollectionArtifactMembershipFilesEdges(
     GQLResult
 ):
-    node: Optional[FileWithUrlFragment]
+    node: FileWithUrlFragment | None
 
 
 GetArtifactMembershipFileUrls.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/get_artifact_membership_files.py
+++ b/wandb/sdk/artifacts/_generated/get_artifact_membership_files.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -13,36 +13,37 @@ from .fragments import FileFragment, PageInfoFragment
 
 
 class GetArtifactMembershipFiles(GQLResult):
-    project: Optional[GetArtifactMembershipFilesProject]
+    project: GetArtifactMembershipFilesProject | None
 
 
 class GetArtifactMembershipFilesProject(GQLResult):
-    artifact_collection: Optional[
-        GetArtifactMembershipFilesProjectArtifactCollection
-    ] = Field(alias="artifactCollection")
+    artifact_collection: GetArtifactMembershipFilesProjectArtifactCollection | None = (
+        Field(alias="artifactCollection")
+    )
 
 
 class GetArtifactMembershipFilesProjectArtifactCollection(GQLResult):
     typename__: Typename[
         Literal["ArtifactCollection", "ArtifactPortfolio", "ArtifactSequence"]
     ]
-    artifact_membership: Optional[
-        GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembership
-    ] = Field(alias="artifactMembership")
+    artifact_membership: (
+        GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembership | None
+    ) = Field(alias="artifactMembership")
 
 
 class GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembership(GQLResult):
-    files: Optional[
+    files: (
         GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembershipFiles
-    ]
+        | None
+    )
 
 
 class GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembershipFiles(
     GQLResult
 ):
-    total_count: Optional[int] = Field(alias="totalCount", default=None)
+    total_count: int | None = Field(alias="totalCount", default=None)
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[
+    edges: list[
         GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembershipFilesEdges
     ]
 
@@ -50,7 +51,7 @@ class GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembershipFiles
 class GetArtifactMembershipFilesProjectArtifactCollectionArtifactMembershipFilesEdges(
     GQLResult
 ):
-    node: Optional[FileFragment]
+    node: FileFragment | None
 
 
 GetArtifactMembershipFiles.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/input_types.py
+++ b/wandb/sdk/artifacts/_generated/input_types.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLId, GQLInput
 
 
 class AddAliasesInput(GQLInput):
-    aliases: List[ArtifactCollectionAliasInput]
+    aliases: list[ArtifactCollectionAliasInput]
     artifact_id: GQLId = Field(alias="artifactID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
 
 
 class ArtifactAliasInput(GQLInput):
@@ -29,68 +27,68 @@ class ArtifactCollectionAliasInput(GQLInput):
 
 
 class ArtifactTypeInput(GQLInput):
-    description: Optional[str] = None
+    description: str | None = None
     name: str = Field(max_length=128, pattern="^[-\\w]+([ ]*[-.\\w]+)*$")
 
 
 class CreateArtifactCollectionTagAssignmentsInput(GQLInput):
     artifact_collection_name: str = Field(alias="artifactCollectionName")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationID", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationID", default=None)
     entity_name: str = Field(alias="entityName")
     project_name: str = Field(alias="projectName")
-    tags: List[TagInput] = Field(max_length=20)
+    tags: list[TagInput] = Field(max_length=20)
 
 
 class CreateProjectMembersInput(GQLInput):
     project_id: GQLId = Field(alias="projectId")
-    team_ids: Optional[List[GQLId]] = Field(alias="teamIds", default=None)
-    user_ids: Optional[List[GQLId]] = Field(alias="userIds", default=None)
+    team_ids: list[GQLId] | None = Field(alias="teamIds", default=None)
+    user_ids: list[GQLId] | None = Field(alias="userIds", default=None)
 
 
 class DeleteAliasesInput(GQLInput):
-    aliases: List[ArtifactCollectionAliasInput]
+    aliases: list[ArtifactCollectionAliasInput]
     artifact_id: GQLId = Field(alias="artifactID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
 
 
 class DeleteArtifactCollectionTagAssignmentsInput(GQLInput):
     artifact_collection_name: str = Field(alias="artifactCollectionName")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationID", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationID", default=None)
     entity_name: str = Field(alias="entityName")
     project_name: str = Field(alias="projectName")
-    tags: List[TagInput] = Field(max_length=20)
+    tags: list[TagInput] = Field(max_length=20)
 
 
 class DeleteArtifactInput(GQLInput):
     artifact_id: GQLId = Field(alias="artifactID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    delete_aliases: Optional[bool] = Field(alias="deleteAliases", default=False)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    delete_aliases: bool | None = Field(alias="deleteAliases", default=False)
 
 
 class DeleteProjectMembersInput(GQLInput):
     project_id: GQLId = Field(alias="projectId")
-    team_ids: Optional[List[GQLId]] = Field(alias="teamIds", default=None)
-    user_ids: Optional[List[GQLId]] = Field(alias="userIds", default=None)
+    team_ids: list[GQLId] | None = Field(alias="teamIds", default=None)
+    user_ids: list[GQLId] | None = Field(alias="userIds", default=None)
 
 
 class LinkArtifactInput(GQLInput):
-    aliases: Optional[List[ArtifactAliasInput]] = None
-    artifact_id: Optional[GQLId] = Field(alias="artifactID", default=None)
-    artifact_portfolio_id: Optional[GQLId] = Field(
+    aliases: list[ArtifactAliasInput] | None = None
+    artifact_id: GQLId | None = Field(alias="artifactID", default=None)
+    artifact_portfolio_id: GQLId | None = Field(
         alias="artifactPortfolioID", default=None
     )
-    artifact_portfolio_name: Optional[str] = Field(
+    artifact_portfolio_name: str | None = Field(
         alias="artifactPortfolioName", default=None
     )
-    client_id: Optional[GQLId] = Field(alias="clientID", default=None)
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    entity_name: Optional[str] = Field(alias="entityName", default=None)
-    project_name: Optional[str] = Field(alias="projectName", default=None)
+    client_id: GQLId | None = Field(alias="clientID", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    entity_name: str | None = Field(alias="entityName", default=None)
+    project_name: str | None = Field(alias="projectName", default=None)
 
 
 class MoveArtifactSequenceInput(GQLInput):
     artifact_sequence_id: GQLId = Field(alias="artifactSequenceID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
     destination_artifact_type_name: str = Field(alias="destinationArtifactTypeName")
 
 
@@ -100,33 +98,33 @@ class ProjectIconInput(GQLInput):
 
 
 class RateLimitsInput(GQLInput):
-    create_artifacts: Optional[int] = Field(alias="createArtifacts", default=None)
-    create_artifacts_time_window: Optional[int] = Field(
+    create_artifacts: int | None = Field(alias="createArtifacts", default=None)
+    create_artifacts_time_window: int | None = Field(
         alias="createArtifactsTimeWindow", default=None
     )
-    filestream_count: Optional[float] = Field(alias="filestreamCount", default=None)
-    filestream_per_run_count: Optional[float] = Field(
+    filestream_count: float | None = Field(alias="filestreamCount", default=None)
+    filestream_per_run_count: float | None = Field(
         alias="filestreamPerRunCount", default=None
     )
-    filestream_size: Optional[int] = Field(alias="filestreamSize", default=None)
-    graphql: Optional[int] = None
-    run_update_count: Optional[float] = Field(alias="runUpdateCount", default=None)
-    sdk_graphql: Optional[int] = Field(alias="sdkGraphql", default=None)
-    sdk_graphql_query_seconds: Optional[float] = Field(
+    filestream_size: int | None = Field(alias="filestreamSize", default=None)
+    graphql: int | None = None
+    run_update_count: float | None = Field(alias="runUpdateCount", default=None)
+    sdk_graphql: int | None = Field(alias="sdkGraphql", default=None)
+    sdk_graphql_query_seconds: float | None = Field(
         alias="sdkGraphqlQuerySeconds", default=None
     )
 
 
 class RenameProjectInput(GQLInput):
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
     entity_name: str = Field(alias="entityName")
     new_project_name: str = Field(alias="newProjectName")
     old_project_name: str = Field(alias="oldProjectName")
 
 
 class TagInput(GQLInput):
-    attributes: Optional[str] = None
-    tag_category_name: Optional[str] = Field(
+    attributes: str | None = None
+    tag_category_name: str | None = Field(
         alias="tagCategoryName",
         default=None,
         max_length=128,
@@ -140,76 +138,72 @@ class TagInput(GQLInput):
 class UnlinkArtifactInput(GQLInput):
     artifact_id: GQLId = Field(alias="artifactID")
     artifact_portfolio_id: GQLId = Field(alias="artifactPortfolioID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
 
 
 class UpdateArtifactInput(GQLInput):
-    aliases: Optional[List[ArtifactAliasInput]] = None
+    aliases: list[ArtifactAliasInput] | None = None
     artifact_id: GQLId = Field(alias="artifactID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    description: Optional[str] = None
-    labels: Optional[str] = None
-    metadata: Optional[str] = None
-    tags_to_add: Optional[List[TagInput]] = Field(alias="tagsToAdd", default=None)
-    tags_to_delete: Optional[List[TagInput]] = Field(alias="tagsToDelete", default=None)
-    ttl_duration_seconds: Optional[int] = Field(
-        alias="ttlDurationSeconds", default=None
-    )
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    description: str | None = None
+    labels: str | None = None
+    metadata: str | None = None
+    tags_to_add: list[TagInput] | None = Field(alias="tagsToAdd", default=None)
+    tags_to_delete: list[TagInput] | None = Field(alias="tagsToDelete", default=None)
+    ttl_duration_seconds: int | None = Field(alias="ttlDurationSeconds", default=None)
 
 
 class UpdateArtifactPortfolioInput(GQLInput):
     artifact_portfolio_id: GQLId = Field(alias="artifactPortfolioID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    description: Optional[str] = None
-    name: Optional[str] = Field(default=None, max_length=128)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    description: str | None = None
+    name: str | None = Field(default=None, max_length=128)
 
 
 class UpdateArtifactSequenceInput(GQLInput):
     artifact_sequence_id: GQLId = Field(alias="artifactSequenceID")
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    description: Optional[str] = None
-    name: Optional[str] = Field(default=None, max_length=128)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    description: str | None = None
+    name: str | None = Field(default=None, max_length=128)
 
 
 class UpdateProjectMemberInput(GQLInput):
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
     project_id: GQLId = Field(alias="projectId")
     user_id: GQLId = Field(alias="userId")
     user_project_role: str = Field(alias="userProjectRole")
 
 
 class UpdateProjectTeamMemberInput(GQLInput):
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
     project_id: GQLId = Field(alias="projectId")
     team_id: GQLId = Field(alias="teamId")
     team_project_role: str = Field(alias="teamProjectRole")
 
 
 class UpsertModelInput(GQLInput):
-    access: Optional[str] = None
-    allow_all_artifact_types_in_registry: Optional[bool] = Field(
+    access: str | None = None
+    allow_all_artifact_types_in_registry: bool | None = Field(
         alias="allowAllArtifactTypesInRegistry", default=None
     )
-    artifact_types: Optional[List[ArtifactTypeInput]] = Field(
+    artifact_types: list[ArtifactTypeInput] | None = Field(
         alias="artifactTypes", default=None
     )
-    client_mutation_id: Optional[str] = Field(alias="clientMutationId", default=None)
-    description: Optional[str] = None
-    docker_image: Optional[str] = Field(
-        alias="dockerImage", default=None, max_length=512
-    )
-    entity_name: Optional[str] = Field(alias="entityName", default=None)
-    framework: Optional[str] = None
-    icon: Optional[ProjectIconInput] = None
-    id: Optional[str] = None
-    is_benchmark: Optional[bool] = Field(alias="isBenchmark", default=None)
-    is_published: Optional[bool] = Field(alias="isPublished", default=None)
-    linked_benchmark: Optional[GQLId] = Field(alias="linkedBenchmark", default=None)
-    name: Optional[str] = Field(default=None, max_length=128)
-    owner: Optional[GQLId] = None
-    rate_limits: Optional[RateLimitsInput] = Field(alias="rateLimits", default=None)
-    repo: Optional[str] = Field(default=None, max_length=256)
-    views: Optional[str] = None
+    client_mutation_id: str | None = Field(alias="clientMutationId", default=None)
+    description: str | None = None
+    docker_image: str | None = Field(alias="dockerImage", default=None, max_length=512)
+    entity_name: str | None = Field(alias="entityName", default=None)
+    framework: str | None = None
+    icon: ProjectIconInput | None = None
+    id: str | None = None
+    is_benchmark: bool | None = Field(alias="isBenchmark", default=None)
+    is_published: bool | None = Field(alias="isPublished", default=None)
+    linked_benchmark: GQLId | None = Field(alias="linkedBenchmark", default=None)
+    name: str | None = Field(default=None, max_length=128)
+    owner: GQLId | None = None
+    rate_limits: RateLimitsInput | None = Field(alias="rateLimits", default=None)
+    repo: str | None = Field(default=None, max_length=256)
+    views: str | None = None
 
 
 AddAliasesInput.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/link_artifact.py
+++ b/wandb/sdk/artifacts/_generated/link_artifact.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,12 +11,12 @@ from .fragments import ArtifactMembershipFragment
 
 
 class LinkArtifact(GQLResult):
-    result: Optional[LinkArtifactResult]
+    result: LinkArtifactResult | None
 
 
 class LinkArtifactResult(GQLResult):
-    version_index: Optional[int] = Field(alias="versionIndex")
-    artifact_membership: Optional[ArtifactMembershipFragment] = Field(
+    version_index: int | None = Field(alias="versionIndex")
+    artifact_membership: ArtifactMembershipFragment | None = Field(
         alias="artifactMembership", default=None
     )
 

--- a/wandb/sdk/artifacts/_generated/project_artifact_collection.py
+++ b/wandb/sdk/artifacts/_generated/project_artifact_collection.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,17 +11,17 @@ from .fragments import ArtifactCollectionFragment
 
 
 class ProjectArtifactCollection(GQLResult):
-    project: Optional[ProjectArtifactCollectionProject]
+    project: ProjectArtifactCollectionProject | None
 
 
 class ProjectArtifactCollectionProject(GQLResult):
-    artifact_type: Optional[ProjectArtifactCollectionProjectArtifactType] = Field(
+    artifact_type: ProjectArtifactCollectionProjectArtifactType | None = Field(
         alias="artifactType"
     )
 
 
 class ProjectArtifactCollectionProjectArtifactType(GQLResult):
-    artifact_collection: Optional[ArtifactCollectionFragment] = Field(
+    artifact_collection: ArtifactCollectionFragment | None = Field(
         alias="artifactCollection"
     )
 

--- a/wandb/sdk/artifacts/_generated/project_artifact_collections.py
+++ b/wandb/sdk/artifacts/_generated/project_artifact_collections.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,23 +11,23 @@ from .fragments import ArtifactCollectionFragment, PageInfoFragment
 
 
 class ProjectArtifactCollections(GQLResult):
-    project: Optional[ProjectArtifactCollectionsProject]
+    project: ProjectArtifactCollectionsProject | None
 
 
 class ProjectArtifactCollectionsProject(GQLResult):
-    artifact_collections: Optional[
-        ProjectArtifactCollectionsProjectArtifactCollections
-    ] = Field(alias="artifactCollections")
+    artifact_collections: (
+        ProjectArtifactCollectionsProjectArtifactCollections | None
+    ) = Field(alias="artifactCollections")
 
 
 class ProjectArtifactCollectionsProjectArtifactCollections(GQLResult):
-    total_count: Optional[int] = Field(alias="totalCount", default=None)
+    total_count: int | None = Field(alias="totalCount", default=None)
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[ProjectArtifactCollectionsProjectArtifactCollectionsEdges]
+    edges: list[ProjectArtifactCollectionsProjectArtifactCollectionsEdges]
 
 
 class ProjectArtifactCollectionsProjectArtifactCollectionsEdges(GQLResult):
-    node: Optional[ArtifactCollectionFragment]
+    node: ArtifactCollectionFragment | None
 
 
 ProjectArtifactCollections.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/project_artifact_type.py
+++ b/wandb/sdk/artifacts/_generated/project_artifact_type.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,11 +11,11 @@ from .fragments import ArtifactTypeFragment
 
 
 class ProjectArtifactType(GQLResult):
-    project: Optional[ProjectArtifactTypeProject]
+    project: ProjectArtifactTypeProject | None
 
 
 class ProjectArtifactTypeProject(GQLResult):
-    artifact_type: Optional[ArtifactTypeFragment] = Field(alias="artifactType")
+    artifact_type: ArtifactTypeFragment | None = Field(alias="artifactType")
 
 
 ProjectArtifactType.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/project_artifact_types.py
+++ b/wandb/sdk/artifacts/_generated/project_artifact_types.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,7 +11,7 @@ from .fragments import ArtifactTypeFragment, PageInfoFragment
 
 
 class ProjectArtifactTypes(GQLResult):
-    project: Optional[ProjectArtifactTypesProject]
+    project: ProjectArtifactTypesProject | None
 
 
 class ProjectArtifactTypesProject(GQLResult):
@@ -23,12 +21,12 @@ class ProjectArtifactTypesProject(GQLResult):
 
 
 class ProjectArtifactTypesProjectArtifactTypes(GQLResult):
-    edges: List[ProjectArtifactTypesProjectArtifactTypesEdges]
+    edges: list[ProjectArtifactTypesProjectArtifactTypesEdges]
     page_info: PageInfoFragment = Field(alias="pageInfo")
 
 
 class ProjectArtifactTypesProjectArtifactTypesEdges(GQLResult):
-    node: Optional[ArtifactTypeFragment]
+    node: ArtifactTypeFragment | None
 
 
 ProjectArtifactTypes.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/project_artifacts.py
+++ b/wandb/sdk/artifacts/_generated/project_artifacts.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -13,32 +13,32 @@ from .fragments import ArtifactFragment, PageInfoFragment
 
 
 class ProjectArtifacts(GQLResult):
-    project: Optional[ProjectArtifactsProject]
+    project: ProjectArtifactsProject | None
 
 
 class ProjectArtifactsProject(GQLResult):
-    artifact_type: Optional[ProjectArtifactsProjectArtifactType] = Field(
+    artifact_type: ProjectArtifactsProjectArtifactType | None = Field(
         alias="artifactType"
     )
 
 
 class ProjectArtifactsProjectArtifactType(GQLResult):
-    artifact_collection: Optional[
-        ProjectArtifactsProjectArtifactTypeArtifactCollection
-    ] = Field(alias="artifactCollection")
+    artifact_collection: (
+        ProjectArtifactsProjectArtifactTypeArtifactCollection | None
+    ) = Field(alias="artifactCollection")
 
 
 class ProjectArtifactsProjectArtifactTypeArtifactCollection(GQLResult):
     typename__: Typename[
         Literal["ArtifactCollection", "ArtifactPortfolio", "ArtifactSequence"]
     ]
-    artifacts: Optional[ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifacts]
+    artifacts: ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifacts | None
 
 
 class ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifacts(GQLResult):
     total_count: int = Field(alias="totalCount")
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactsEdges]
+    edges: list[ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactsEdges]
 
 
 class ProjectArtifactsProjectArtifactTypeArtifactCollectionArtifactsEdges(GQLResult):

--- a/wandb/sdk/artifacts/_generated/registry_collections.py
+++ b/wandb/sdk/artifacts/_generated/registry_collections.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,30 +11,30 @@ from .fragments import PageInfoFragment, RegistryCollectionFragment
 
 
 class RegistryCollections(GQLResult):
-    organization: Optional[RegistryCollectionsOrganization]
+    organization: RegistryCollectionsOrganization | None
 
 
 class RegistryCollectionsOrganization(GQLResult):
-    org_entity: Optional[RegistryCollectionsOrganizationOrgEntity] = Field(
+    org_entity: RegistryCollectionsOrganizationOrgEntity | None = Field(
         alias="orgEntity"
     )
 
 
 class RegistryCollectionsOrganizationOrgEntity(GQLResult):
     name: str
-    artifact_collections: Optional[
-        RegistryCollectionsOrganizationOrgEntityArtifactCollections
-    ] = Field(alias="artifactCollections")
+    artifact_collections: (
+        RegistryCollectionsOrganizationOrgEntityArtifactCollections | None
+    ) = Field(alias="artifactCollections")
 
 
 class RegistryCollectionsOrganizationOrgEntityArtifactCollections(GQLResult):
     total_count: int = Field(alias="totalCount")
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[RegistryCollectionsOrganizationOrgEntityArtifactCollectionsEdges]
+    edges: list[RegistryCollectionsOrganizationOrgEntityArtifactCollectionsEdges]
 
 
 class RegistryCollectionsOrganizationOrgEntityArtifactCollectionsEdges(GQLResult):
-    node: Optional[RegistryCollectionFragment]
+    node: RegistryCollectionFragment | None
 
 
 RegistryCollections.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/registry_team_members.py
+++ b/wandb/sdk/artifacts/_generated/registry_team_members.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,11 +11,11 @@ from .fragments import TeamRegistryMemberFragment
 
 
 class RegistryTeamMembers(GQLResult):
-    project: Optional[RegistryTeamMembersProject]
+    project: RegistryTeamMembersProject | None
 
 
 class RegistryTeamMembersProject(GQLResult):
-    team_members: List[TeamRegistryMemberFragment] = Field(alias="teamMembers")
+    team_members: list[TeamRegistryMemberFragment] = Field(alias="teamMembers")
 
 
 RegistryTeamMembers.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/registry_user_members.py
+++ b/wandb/sdk/artifacts/_generated/registry_user_members.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import UserRegistryMemberFragment
 
 
 class RegistryUserMembers(GQLResult):
-    project: Optional[RegistryUserMembersProject]
+    project: RegistryUserMembersProject | None
 
 
 class RegistryUserMembersProject(GQLResult):
-    members: List[UserRegistryMemberFragment]
+    members: list[UserRegistryMemberFragment]
 
 
 RegistryUserMembers.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/registry_versions.py
+++ b/wandb/sdk/artifacts/_generated/registry_versions.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,29 +11,27 @@ from .fragments import ArtifactMembershipFragment, PageInfoFragment
 
 
 class RegistryVersions(GQLResult):
-    organization: Optional[RegistryVersionsOrganization]
+    organization: RegistryVersionsOrganization | None
 
 
 class RegistryVersionsOrganization(GQLResult):
-    org_entity: Optional[RegistryVersionsOrganizationOrgEntity] = Field(
-        alias="orgEntity"
-    )
+    org_entity: RegistryVersionsOrganizationOrgEntity | None = Field(alias="orgEntity")
 
 
 class RegistryVersionsOrganizationOrgEntity(GQLResult):
     name: str
-    artifact_memberships: Optional[
-        RegistryVersionsOrganizationOrgEntityArtifactMemberships
-    ] = Field(alias="artifactMemberships")
+    artifact_memberships: (
+        RegistryVersionsOrganizationOrgEntityArtifactMemberships | None
+    ) = Field(alias="artifactMemberships")
 
 
 class RegistryVersionsOrganizationOrgEntityArtifactMemberships(GQLResult):
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[RegistryVersionsOrganizationOrgEntityArtifactMembershipsEdges]
+    edges: list[RegistryVersionsOrganizationOrgEntityArtifactMembershipsEdges]
 
 
 class RegistryVersionsOrganizationOrgEntityArtifactMembershipsEdges(GQLResult):
-    node: Optional[ArtifactMembershipFragment]
+    node: ArtifactMembershipFragment | None
 
 
 RegistryVersions.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/rename_registry.py
+++ b/wandb/sdk/artifacts/_generated/rename_registry.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,12 +11,12 @@ from .fragments import RegistryFragment
 
 
 class RenameRegistry(GQLResult):
-    rename_project: Optional[RenameRegistryRenameProject] = Field(alias="renameProject")
+    rename_project: RenameRegistryRenameProject | None = Field(alias="renameProject")
 
 
 class RenameRegistryRenameProject(GQLResult):
-    inserted: Optional[bool]
-    project: Optional[RegistryFragment]
+    inserted: bool | None
+    project: RegistryFragment | None
 
 
 RenameRegistry.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/run_input_artifacts.py
+++ b/wandb/sdk/artifacts/_generated/run_input_artifacts.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,25 +11,25 @@ from .fragments import ArtifactFragment, PageInfoFragment
 
 
 class RunInputArtifacts(GQLResult):
-    project: Optional[RunInputArtifactsProject]
+    project: RunInputArtifactsProject | None
 
 
 class RunInputArtifactsProject(GQLResult):
-    run: Optional[RunInputArtifactsProjectRun]
+    run: RunInputArtifactsProjectRun | None
 
 
 class RunInputArtifactsProjectRun(GQLResult):
-    artifacts: Optional[RunInputArtifactsProjectRunArtifacts]
+    artifacts: RunInputArtifactsProjectRunArtifacts | None
 
 
 class RunInputArtifactsProjectRunArtifacts(GQLResult):
     total_count: int = Field(alias="totalCount")
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[RunInputArtifactsProjectRunArtifactsEdges]
+    edges: list[RunInputArtifactsProjectRunArtifactsEdges]
 
 
 class RunInputArtifactsProjectRunArtifactsEdges(GQLResult):
-    node: Optional[ArtifactFragment]
+    node: ArtifactFragment | None
 
 
 RunInputArtifacts.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/run_output_artifacts.py
+++ b/wandb/sdk/artifacts/_generated/run_output_artifacts.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,25 +11,25 @@ from .fragments import ArtifactFragment, PageInfoFragment
 
 
 class RunOutputArtifacts(GQLResult):
-    project: Optional[RunOutputArtifactsProject]
+    project: RunOutputArtifactsProject | None
 
 
 class RunOutputArtifactsProject(GQLResult):
-    run: Optional[RunOutputArtifactsProjectRun]
+    run: RunOutputArtifactsProjectRun | None
 
 
 class RunOutputArtifactsProjectRun(GQLResult):
-    artifacts: Optional[RunOutputArtifactsProjectRunArtifacts]
+    artifacts: RunOutputArtifactsProjectRunArtifacts | None
 
 
 class RunOutputArtifactsProjectRunArtifacts(GQLResult):
     total_count: int = Field(alias="totalCount")
     page_info: PageInfoFragment = Field(alias="pageInfo")
-    edges: List[RunOutputArtifactsProjectRunArtifactsEdges]
+    edges: list[RunOutputArtifactsProjectRunArtifactsEdges]
 
 
 class RunOutputArtifactsProjectRunArtifactsEdges(GQLResult):
-    node: Optional[ArtifactFragment]
+    node: ArtifactFragment | None
 
 
 RunOutputArtifacts.model_rebuild()

--- a/wandb/sdk/artifacts/_generated/unlink_artifact.py
+++ b/wandb/sdk/artifacts/_generated/unlink_artifact.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class UnlinkArtifact(GQLResult):
-    result: Optional[UnlinkArtifactResult]
+    result: UnlinkArtifactResult | None
 
 
 class UnlinkArtifactResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/update_artifact.py
+++ b/wandb/sdk/artifacts/_generated/update_artifact.py
@@ -3,15 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 from .fragments import ArtifactFragment
 
 
 class UpdateArtifact(GQLResult):
-    result: Optional[UpdateArtifactResult]
+    result: UpdateArtifactResult | None
 
 
 class UpdateArtifactResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/update_artifact_portfolio.py
+++ b/wandb/sdk/artifacts/_generated/update_artifact_portfolio.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,7 +11,7 @@ from .fragments import ArtifactCollectionFragment
 
 
 class UpdateArtifactPortfolio(GQLResult):
-    result: Optional[UpdateArtifactPortfolioResult]
+    result: UpdateArtifactPortfolioResult | None
 
 
 class UpdateArtifactPortfolioResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/update_artifact_sequence.py
+++ b/wandb/sdk/artifacts/_generated/update_artifact_sequence.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,7 +11,7 @@ from .fragments import ArtifactCollectionFragment
 
 
 class UpdateArtifactSequence(GQLResult):
-    result: Optional[UpdateArtifactSequenceResult]
+    result: UpdateArtifactSequenceResult | None
 
 
 class UpdateArtifactSequenceResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/update_artifact_sequence_type.py
+++ b/wandb/sdk/artifacts/_generated/update_artifact_sequence_type.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,11 +11,11 @@ from .fragments import ArtifactCollectionFragment
 
 
 class UpdateArtifactSequenceType(GQLResult):
-    result: Optional[UpdateArtifactSequenceTypeResult]
+    result: UpdateArtifactSequenceTypeResult | None
 
 
 class UpdateArtifactSequenceTypeResult(GQLResult):
-    artifact_collection: Optional[ArtifactCollectionFragment] = Field(
+    artifact_collection: ArtifactCollectionFragment | None = Field(
         alias="artifactCollection"
     )
 

--- a/wandb/sdk/artifacts/_generated/update_team_registry_role.py
+++ b/wandb/sdk/artifacts/_generated/update_team_registry_role.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class UpdateTeamRegistryRole(GQLResult):
-    result: Optional[UpdateTeamRegistryRoleResult]
+    result: UpdateTeamRegistryRoleResult | None
 
 
 class UpdateTeamRegistryRoleResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/update_user_registry_role.py
+++ b/wandb/sdk/artifacts/_generated/update_user_registry_role.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from wandb._pydantic import GQLResult
 
 
 class UpdateUserRegistryRole(GQLResult):
-    result: Optional[UpdateUserRegistryRoleResult]
+    result: UpdateUserRegistryRoleResult | None
 
 
 class UpdateUserRegistryRoleResult(GQLResult):

--- a/wandb/sdk/artifacts/_generated/upsert_registry.py
+++ b/wandb/sdk/artifacts/_generated/upsert_registry.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
@@ -13,12 +11,12 @@ from .fragments import RegistryFragment
 
 
 class UpsertRegistry(GQLResult):
-    upsert_model: Optional[UpsertRegistryUpsertModel] = Field(alias="upsertModel")
+    upsert_model: UpsertRegistryUpsertModel | None = Field(alias="upsertModel")
 
 
 class UpsertRegistryUpsertModel(GQLResult):
-    inserted: Optional[bool]
-    project: Optional[RegistryFragment]
+    inserted: bool | None
+    project: RegistryFragment | None
 
 
 UpsertRegistry.model_rebuild()

--- a/wandb/sdk/artifacts/_models/artifact_collection.py
+++ b/wandb/sdk/artifacts/_models/artifact_collection.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from typing_extensions import Self
-
-from wandb._pydantic import field_validator
 
 from .base_model import ArtifactsBase
 
@@ -38,13 +36,13 @@ class ArtifactCollectionData(ArtifactsBase):
     type: str
     """The artifact type of this collection."""
 
-    description: Optional[str] = None
+    description: str | None = None
     """The description, if any, for this collection."""
 
     created_at: str = Field(frozen=True)
     """When this collection was created."""
 
-    updated_at: Optional[str] = None
+    updated_at: str | None = None
     """When this collection was last updated."""
 
     project: str = Field(frozen=True)
@@ -53,7 +51,7 @@ class ArtifactCollectionData(ArtifactsBase):
     entity: str = Field(frozen=True)
     """The name of the entity that owns this collection's project."""
 
-    aliases: Optional[Tuple[str, ...]] = Field(default=None, frozen=True)
+    aliases: tuple[str, ...] | None = Field(default=None, frozen=True)
     """All aliases assigned to artifact versions within this collection.
 
     Deliberately immutable since this should be a read-only attribute.
@@ -65,7 +63,7 @@ class ArtifactCollectionData(ArtifactsBase):
         any reason, NOT that aliases are absent in this collection.
     """
 
-    tags: List[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
     """The tags assigned to this collection.
 
     Note that this is distinct from tags assigned to individual artifact

--- a/wandb/sdk/artifacts/_models/manifest.py
+++ b/wandb/sdk/artifacts/_models/manifest.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, Literal, final
+from typing import Any, Literal, final
 
-from wandb._pydantic import field_validator, to_camel
+from pydantic import field_validator
+from pydantic.alias_generators import to_camel
+
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 
 from .base_model import ArtifactsBase
@@ -13,7 +15,7 @@ class ArtifactManifestV1Data(ArtifactsBase, alias_generator=to_camel):
 
     version: Literal[1]
 
-    contents: Dict[str, ArtifactManifestEntry]
+    contents: dict[str, ArtifactManifestEntry]
 
     storage_policy: str
     storage_policy_config: StoragePolicyConfig

--- a/wandb/sdk/artifacts/_models/registry.py
+++ b/wandb/sdk/artifacts/_models/registry.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from typing_extensions import Self
 
-from wandb._pydantic import GQLId, field_validator
+from wandb._pydantic import GQLId
 from wandb._strutils import nameof
 from wandb.apis.public.registries._freezable_list import AddOnlyArtifactTypesList
 from wandb.apis.public.registries._utils import Visibility
@@ -29,7 +29,7 @@ class RegistryData(ArtifactsBase):
     created_at: str = Field(frozen=True)
     """When this registry was created."""
 
-    updated_at: Optional[str] = Field(frozen=True)
+    updated_at: str | None = Field(frozen=True)
     """When this registry was last updated."""
 
     organization: str = Field(frozen=True)
@@ -41,7 +41,7 @@ class RegistryData(ArtifactsBase):
     name: str = Field(min_length=1)  # Disallow empty strings
     """The name of the registry without the `wandb-registry-` project prefix."""
 
-    description: Optional[str] = None
+    description: str | None = None
     """The description, if any, of the registry."""
 
     allow_all_artifact_types: bool

--- a/wandb/sdk/artifacts/_models/storage.py
+++ b/wandb/sdk/artifacts/_models/storage.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import ConfigDict, StrictStr
+from pydantic.alias_generators import to_camel
 from typing_extensions import Self
 
-from wandb._pydantic import to_camel
 from wandb.sdk.artifacts.storage_layout import StorageLayout
 
 from .base_model import ArtifactsBase
@@ -19,8 +17,8 @@ class StoragePolicyConfig(ArtifactsBase):
         str_strip_whitespace=True,
     )
 
-    storage_layout: Optional[StorageLayout] = None
-    storage_region: Optional[StrictStr] = None
+    storage_layout: StorageLayout | None = None
+    storage_region: StrictStr | None = None
 
     @classmethod
     def from_env(

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -14,10 +14,9 @@ from os.path import getsize
 from typing import TYPE_CHECKING, Annotated, Any, Dict, Final, Optional, Union
 from urllib.parse import urlparse
 
-from pydantic import Field, NonNegativeInt
+from pydantic import Field, NonNegativeInt, field_validator, model_validator
 from typing_extensions import Self
 
-from wandb._pydantic import field_validator, model_validator
 from wandb._strutils import nameof
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
 from wandb.sdk.lib.deprecation import warn_and_record_deprecation

--- a/wandb/sdk/internal/_generated/server_features_query.py
+++ b/wandb/sdk/internal/_generated/server_features_query.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import Field
 
 from wandb._pydantic import GQLResult
 
 
 class ServerFeaturesQuery(GQLResult):
-    server_info: Optional[ServerFeaturesQueryServerInfo] = Field(alias="serverInfo")
+    server_info: ServerFeaturesQueryServerInfo | None = Field(alias="serverInfo")
 
 
 class ServerFeaturesQueryServerInfo(GQLResult):
-    features: List[Optional[ServerFeaturesQueryServerInfoFeatures]]
+    features: list[ServerFeaturesQueryServerInfoFeatures | None]
 
 
 class ServerFeaturesQueryServerInfoFeatures(GQLResult):

--- a/wandb/sdk/lib/run_moment.py
+++ b/wandb/sdk/lib/run_moment.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 from urllib import parse
 
 
@@ -17,7 +16,7 @@ class RunMoment:
     run: str
     """run ID"""
 
-    value: Union[int, float]
+    value: int | float
     """Value of the metric."""
 
     metric: str = "_step"

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -10,14 +10,14 @@ import shutil
 import socket
 import sys
 import traceback
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Literal
 from urllib.parse import quote, unquote
 
 from google.protobuf.wrappers_pb2 import BoolValue, DoubleValue, Int32Value, StringValue
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Callable, Self
+from typing_extensions import Self
 
 import wandb
 from wandb import env, util
@@ -111,13 +111,13 @@ class Settings(BaseModel, validate_assignment=True):
     )
     """Deprecated and will be removed."""
 
-    api_key: Optional[str] = None
+    api_key: str | None = None
     """The W&B API key."""
 
-    azure_account_url_to_access_key: Optional[Dict[str, str]] = None
+    azure_account_url_to_access_key: dict[str, str] | None = None
     """Mapping of Azure account URLs to their corresponding access keys for Azure integration."""
 
-    app_url_override: Optional[str] = None
+    app_url_override: str | None = None
     """Override for the 'app' URL for the W&B UI.
 
     The `app_url` is normally computed based on `base_url`, but this can be
@@ -129,10 +129,10 @@ class Settings(BaseModel, validate_assignment=True):
     base_url: str = "https://api.wandb.ai"
     """The URL of the W&B backend for data synchronization."""
 
-    code_dir: Optional[str] = None
+    code_dir: str | None = None
     """Directory containing the code to be tracked by W&B."""
 
-    config_paths: Optional[Sequence[str]] = None
+    config_paths: Sequence[str] | None = None
     """Paths to files to load configuration from into the `Config` object."""
 
     console: Literal["auto", "off", "wrap", "redirect", "wrap_raw", "wrap_emu"] = Field(
@@ -190,7 +190,7 @@ class Settings(BaseModel, validate_assignment=True):
     limit.
     """
 
-    capture_loggers: Optional[dict[str, str]] = None
+    capture_loggers: dict[str, str] | None = None
     """Names of Python loggers to capture into the run's Logs tab.
 
     A mapping of logger name to minimum log level. When set, wandb installs a
@@ -246,38 +246,38 @@ class Settings(BaseModel, validate_assignment=True):
     disable_job_creation: bool = True
     """Whether to disable the creation of a job artifact for W&B Launch."""
 
-    docker: Optional[str] = None
+    docker: str | None = None
     """The Docker image used to execute the script."""
 
-    email: Optional[str] = None
+    email: str | None = None
     """The email address of the user."""
 
-    entity: Optional[str] = None
+    entity: str | None = None
     """The W&B entity, such as a user or a team."""
 
-    organization: Optional[str] = None
+    organization: str | None = None
     """The W&B organization."""
 
     force: bool = False
     """Whether to pass the `force` flag to `wandb.login()`."""
 
-    fork_from: Optional[RunMoment] = None
+    fork_from: RunMoment | None = None
     """Specifies a point in a previous execution of a run to fork from.
 
     The point is defined by the run ID, a metric, and its value.
     Currently, only the metric '_step' is supported.
     """
 
-    git_commit: Optional[str] = None
+    git_commit: str | None = None
     """The git commit hash to associate with the run."""
 
     git_remote: str = "origin"
     """The git remote to associate with the run."""
 
-    git_remote_url: Optional[str] = None
+    git_remote_url: str | None = None
     """The URL of the git remote repository."""
 
-    git_root: Optional[str] = None
+    git_root: str | None = None
     """Root directory of the git repository."""
 
     heartbeat_seconds: int = 30
@@ -286,16 +286,16 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    host: Optional[str] = None
+    host: str | None = None
     """Hostname of the machine running the script."""
 
-    http_proxy: Optional[str] = None
+    http_proxy: str | None = None
     """Custom proxy servers for http requests to W&B."""
 
-    https_proxy: Optional[str] = None
+    https_proxy: str | None = None
     """Custom proxy servers for https requests to W&B."""
 
-    identity_token_file: Optional[str] = None
+    identity_token_file: str | None = None
     """Path to file containing an identity token (JWT) for authentication."""
 
     ignore_globs: Sequence[str] = ()
@@ -344,10 +344,10 @@ class Settings(BaseModel, validate_assignment=True):
     insecure_disable_ssl: bool = False
     """Whether to insecurely disable SSL verification."""
 
-    job_name: Optional[str] = None
+    job_name: str | None = None
     """Name of the Launch job running the script."""
 
-    job_source: Optional[Literal["repo", "artifact", "image"]] = None
+    job_source: Literal["repo", "artifact", "image"] | None = None
     """Source type for Launch."""
 
     label_disable: bool = False
@@ -359,10 +359,10 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    launch_config_path: Optional[str] = None
+    launch_config_path: str | None = None
     """Path to the launch configuration file."""
 
-    login_timeout: Optional[float] = None
+    login_timeout: float | None = None
     """Time in seconds to wait for login operations before timing out."""
 
     mode: Literal["online", "offline", "shared", "disabled", "dryrun", "run"] = Field(
@@ -371,13 +371,13 @@ class Settings(BaseModel, validate_assignment=True):
     )
     """The operating mode for W&B logging and synchronization."""
 
-    notebook_name: Optional[str] = None
+    notebook_name: str | None = None
     """Name of the notebook if running in a Jupyter-like environment."""
 
-    program: Optional[str] = None
+    program: str | None = None
     """Path to the script that created the run, if available."""
 
-    program_abspath: Optional[str] = None
+    program_abspath: str | None = None
     """The absolute path from the root repository directory to the script that
     created the run.
 
@@ -385,24 +385,18 @@ class Settings(BaseModel, validate_assignment=True):
     .git directory, if it exists. Otherwise, it's the current working directory.
     """
 
-    program_relpath: Optional[str] = None
+    program_relpath: str | None = None
     """The relative path to the script that created the run."""
 
-    project: Optional[str] = None
+    project: str | None = None
     """The W&B project ID."""
 
     quiet: bool = False
     """Flag to suppress non-essential output."""
 
-    reinit: Union[
-        Literal[
-            "default",
-            "return_previous",
-            "finish_previous",
-            "create_new",
-        ],
-        bool,
-    ] = "default"
+    reinit: (
+        Literal["default", "return_previous", "finish_previous", "create_new"] | bool
+    ) = "default"
     """What to do when `wandb.init()` is called while a run is active.
 
     Options:
@@ -424,7 +418,7 @@ class Settings(BaseModel, validate_assignment=True):
     relogin: bool = False
     """Flag to force a new login attempt."""
 
-    resume: Optional[Literal["allow", "must", "never", "auto"]] = None
+    resume: Literal["allow", "must", "never", "auto"] | None = None
     """Specifies the resume behavior for the run.
 
     Options:
@@ -438,7 +432,7 @@ class Settings(BaseModel, validate_assignment=True):
        machine.
     """
 
-    resume_from: Optional[RunMoment] = None
+    resume_from: RunMoment | None = None
     """Specifies a point in a previous execution of a run to resume from.
 
     The point is defined by the run ID, a metric, and its value.
@@ -458,37 +452,37 @@ class Settings(BaseModel, validate_assignment=True):
     In particular, this is used to derive the wandb directory and the run directory.
     """
 
-    run_group: Optional[str] = None
+    run_group: str | None = None
     """Group identifier for related runs.
 
     Used for grouping runs in the UI.
     """
 
-    run_id: Optional[str] = None
+    run_id: str | None = None
     """The ID of the run."""
 
-    run_job_type: Optional[str] = None
+    run_job_type: str | None = None
     """Type of job being run (e.g., training, evaluation)."""
 
-    run_name: Optional[str] = None
+    run_name: str | None = None
     """Human-readable name for the run."""
 
-    run_notes: Optional[str] = None
+    run_notes: str | None = None
     """Additional notes or description for the run."""
 
-    run_tags: Optional[Tuple[str, ...]] = None
+    run_tags: tuple[str, ...] | None = None
     """Tags to associate with the run for organization and filtering."""
 
     sagemaker_disable: bool = False
     """Flag to disable SageMaker-specific functionality."""
 
-    save_code: Optional[bool] = None
+    save_code: bool | None = None
     """Whether to save the code associated with the run."""
 
-    settings_system: Optional[str] = None
+    settings_system: str | None = None
     """Path to the system-wide settings file."""
 
-    stop_fn: Optional[Callable[[], None]] = None
+    stop_fn: Callable[[], None] | None = None
     """A callback to execute to stop the run.
 
     A run can be stopped through the web UI, or after a fatal error
@@ -508,13 +502,13 @@ class Settings(BaseModel, validate_assignment=True):
     max_end_of_run_summary_metrics: int = 10
     """Maximum number of summary metrics to display at the end of a run."""
 
-    show_colors: Optional[bool] = None
+    show_colors: bool | None = None
     """Whether to use colored output in the console.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    show_emoji: Optional[bool] = None
+    show_emoji: bool | None = None
     """Whether to show emoji in the console output.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -532,7 +526,7 @@ class Settings(BaseModel, validate_assignment=True):
     silent: bool = False
     """Flag to suppress all output."""
 
-    start_method: Optional[str] = None
+    start_method: str | None = None
     """Method to use for starting subprocesses.
 
     This is deprecated and will be removed in a future release.
@@ -552,7 +546,7 @@ class Settings(BaseModel, validate_assignment=True):
     as if the stop button was pressed in the web UI.
     """
 
-    strict: Optional[bool] = None
+    strict: bool | None = None
     """Whether to enable strict mode for validation and error checking."""
 
     summary_timeout: int = 60
@@ -564,29 +558,29 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    sweep_id: Optional[str] = None
+    sweep_id: str | None = None
     """Identifier of the sweep this run belongs to."""
 
-    sweep_param_path: Optional[str] = None
+    sweep_param_path: str | None = None
     """Path to the sweep parameters configuration."""
 
     symlink: bool = Field(default_factory=lambda: platform.system() != "Windows")
     """Whether to use symlinks (True by default except on Windows)."""
 
-    sync_tensorboard: Optional[bool] = None
+    sync_tensorboard: bool | None = None
     """Whether to synchronize TensorBoard logs with W&B."""
 
     table_raise_on_max_row_limit_exceeded: bool = False
     """Whether to raise an exception when table row limits are exceeded."""
 
-    use_dot_wandb: Optional[bool] = None
+    use_dot_wandb: bool | None = None
     """Whether to use a hidden `.wandb` or visible `wandb` directory for run data.
 
     If True, the SDK uses `.wandb`. If False, `wandb`.
     If not set, defaults to `.wandb` if it already exists, otherwise `wandb`.
     """
 
-    username: Optional[str] = None
+    username: str | None = None
     """Username."""
 
     # Internal settings.
@@ -618,16 +612,16 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_executable: Optional[str] = None
+    x_executable: str | None = None
     """Path to the Python executable.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_extra_http_headers: Optional[Dict[str, str]] = None
+    x_extra_http_headers: dict[str, str] | None = None
     """Additional headers to add to all outgoing HTTP requests."""
 
-    x_file_stream_max_bytes: Optional[int] = None
+    x_file_stream_max_bytes: int | None = None
     """An approximate maximum request size for the filestream API.
 
     Its purpose is to prevent HTTP requests from failing due to
@@ -636,13 +630,13 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_stream_max_line_bytes: Optional[int] = None
+    x_file_stream_max_line_bytes: int | None = None
     """Maximum line length for filestream JSONL files.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_stream_transmit_interval: Optional[float] = None
+    x_file_stream_transmit_interval: float | None = None
     """Interval in seconds between filestream transmissions.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -650,25 +644,25 @@ class Settings(BaseModel, validate_assignment=True):
 
     # Filestream retry client configuration.
 
-    x_file_stream_retry_max: Optional[int] = None
+    x_file_stream_retry_max: int | None = None
     """Max number of retries for filestream operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_stream_retry_wait_min_seconds: Optional[float] = None
+    x_file_stream_retry_wait_min_seconds: float | None = None
     """Minimum wait time between retries for filestream operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_stream_retry_wait_max_seconds: Optional[float] = None
+    x_file_stream_retry_wait_max_seconds: float | None = None
     """Maximum wait time between retries for filestream operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_stream_timeout_seconds: Optional[float] = None
+    x_file_stream_timeout_seconds: float | None = None
     """Timeout in seconds for individual filestream HTTP requests.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -676,31 +670,31 @@ class Settings(BaseModel, validate_assignment=True):
 
     # file transfer retry client configuration
 
-    x_file_transfer_retry_max: Optional[int] = None
+    x_file_transfer_retry_max: int | None = None
     """Max number of retries for file transfer operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_transfer_retry_wait_min_seconds: Optional[float] = None
+    x_file_transfer_retry_wait_min_seconds: float | None = None
     """Minimum wait time between retries for file transfer operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_transfer_retry_wait_max_seconds: Optional[float] = None
+    x_file_transfer_retry_wait_max_seconds: float | None = None
     """Maximum wait time between retries for file transfer operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_file_transfer_timeout_seconds: Optional[float] = None
+    x_file_transfer_timeout_seconds: float | None = None
     """Timeout in seconds for individual file transfer HTTP requests.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_files_dir: Optional[str] = None
+    x_files_dir: str | None = None
     """Override setting for the computed files_dir.
 
     DEPRECATED, DO NOT USE. This private setting is not respected by wandb-core
@@ -709,14 +703,14 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_flow_control_custom: Optional[bool] = None
+    x_flow_control_custom: bool | None = None
     """Flag indicating custom flow control for filestream.
 
     TODO: Not implemented in wandb-core.
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_flow_control_disabled: Optional[bool] = None
+    x_flow_control_disabled: bool | None = None
     """Flag indicating flow control is disabled for filestream.
 
     TODO: Not implemented in wandb-core.
@@ -725,25 +719,25 @@ class Settings(BaseModel, validate_assignment=True):
 
     # graphql retry client configuration
 
-    x_graphql_retry_max: Optional[int] = None
+    x_graphql_retry_max: int | None = None
     """Max number of retries for GraphQL operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_graphql_retry_wait_min_seconds: Optional[float] = None
+    x_graphql_retry_wait_min_seconds: float | None = None
     """Minimum wait time between retries for GraphQL operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_graphql_retry_wait_max_seconds: Optional[float] = None
+    x_graphql_retry_wait_max_seconds: float | None = None
     """Maximum wait time between retries for GraphQL operations.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_graphql_timeout_seconds: Optional[float] = None
+    x_graphql_timeout_seconds: float | None = None
     """Timeout in seconds for individual GraphQL requests.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -755,38 +749,38 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_jupyter_name: Optional[str] = None
+    x_jupyter_name: str | None = None
     """Name of the Jupyter notebook.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_jupyter_path: Optional[str] = None
+    x_jupyter_path: str | None = None
     """Path to the Jupyter notebook.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_jupyter_root: Optional[str] = None
+    x_jupyter_root: str | None = None
     """Root directory of the Jupyter notebook.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_label: Optional[str] = None
+    x_label: str | None = None
     """Label to assign to system metrics and console logs collected for the run.
 
     This is used to group data by on the frontend and can be used to distinguish data
     from different processes in a distributed training job.
     """
 
-    x_live_policy_rate_limit: Optional[int] = None
+    x_live_policy_rate_limit: int | None = None
     """Rate limit for live policy updates in seconds.
 
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_live_policy_wait_time: Optional[int] = None
+    x_live_policy_wait_time: int | None = None
     """Wait time between live policy updates in seconds.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -798,7 +792,7 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_network_buffer: Optional[int] = None
+    x_network_buffer: int | None = None
     """Size of the network buffer used in flow control.
 
     TODO: Not implemented in wandb-core.
@@ -815,7 +809,7 @@ class Settings(BaseModel, validate_assignment=True):
     as the primary process handles the main logging.
     """
 
-    x_proxies: Optional[Dict[str, str]] = None
+    x_proxies: dict[str, str] | None = None
     """Custom proxy servers for requests to W&B.
 
     This is deprecated and will be removed in a future release.
@@ -823,7 +817,7 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_runqueue_item_id: Optional[str] = None
+    x_runqueue_item_id: str | None = None
     """ID of the Launch run queue item being processed.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -845,7 +839,7 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_service_transport: Optional[str] = None
+    x_service_transport: str | None = None
     """Transport method for communication with the wandb service.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -864,7 +858,7 @@ class Settings(BaseModel, validate_assignment=True):
     recoverability.
     """
 
-    x_start_time: Optional[float] = None
+    x_start_time: float | None = None
     """The start time of the run in seconds since the Unix epoch.
 
     <!-- lazydoc-ignore-class-attributes -->
@@ -879,14 +873,14 @@ class Settings(BaseModel, validate_assignment=True):
     x_stats_sampling_interval: float = Field(default=15.0)
     """Sampling interval for the system monitor in seconds."""
 
-    x_stats_neuron_monitor_config_path: Optional[str] = None
+    x_stats_neuron_monitor_config_path: str | None = None
     """Path to the default config file for the neuron-monitor tool.
 
     This is used to monitor AWS Trainium devices.
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_stats_dcgm_exporter: Optional[str] = None
+    x_stats_dcgm_exporter: str | None = None
     """Endpoint to extract Nvidia DCGM metrics from.
 
     Options:
@@ -901,12 +895,12 @@ class Settings(BaseModel, validate_assignment=True):
     <!-- lazydoc-ignore-class-attributes -->
     """
 
-    x_stats_open_metrics_endpoints: Optional[Dict[str, str]] = None
+    x_stats_open_metrics_endpoints: dict[str, str] | None = None
     """OpenMetrics `/metrics` endpoints to monitor for system metrics."""
 
-    x_stats_open_metrics_filters: Union[
-        Dict[str, Dict[str, str]], Sequence[str], None
-    ] = None
+    x_stats_open_metrics_filters: dict[str, dict[str, str]] | Sequence[str] | None = (
+        None
+    )
     """Filter to apply to metrics collected from OpenMetrics `/metrics` endpoints.
 
     Supports two formats:
@@ -914,37 +908,37 @@ class Settings(BaseModel, validate_assignment=True):
      - `("metric regex pattern 1", "metric regex pattern 2", ...)`
     """
 
-    x_stats_open_metrics_http_headers: Optional[Dict[str, str]] = None
+    x_stats_open_metrics_http_headers: dict[str, str] | None = None
     """HTTP headers to add to OpenMetrics requests."""
 
-    x_stats_disk_paths: Optional[Sequence[str]] = ("/",)
+    x_stats_disk_paths: Sequence[str] | None = ("/",)
     """System paths to monitor for disk usage."""
 
-    x_stats_cpu_count: Optional[int] = None
+    x_stats_cpu_count: int | None = None
     """System CPU count.
 
     If set, overrides the auto-detected value in the run metadata.
     """
 
-    x_stats_cpu_logical_count: Optional[int] = None
+    x_stats_cpu_logical_count: int | None = None
     """Logical CPU count.
 
     If set, overrides the auto-detected value in the run metadata.
     """
 
-    x_stats_gpu_count: Optional[int] = None
+    x_stats_gpu_count: int | None = None
     """GPU device count.
 
     If set, overrides the auto-detected value in the run metadata.
     """
 
-    x_stats_gpu_type: Optional[str] = None
+    x_stats_gpu_type: str | None = None
     """GPU device type.
 
     If set, overrides the auto-detected value in the run metadata.
     """
 
-    x_stats_gpu_device_ids: Optional[Sequence[int]] = None
+    x_stats_gpu_device_ids: Sequence[int] | None = None
     """GPU device indices to monitor.
 
     If not set, the system monitor captures metrics for all GPUs.
@@ -1183,7 +1177,7 @@ class Settings(BaseModel, validate_assignment=True):
 
     @field_validator("fork_from", mode="before")
     @classmethod
-    def validate_fork_from(cls, value, values) -> Optional[RunMoment]:
+    def validate_fork_from(cls, value, values) -> RunMoment | None:
         """Validate the fork_from field.
 
         <!-- lazydoc-ignore-classmethod: internal -->
@@ -1309,7 +1303,7 @@ class Settings(BaseModel, validate_assignment=True):
 
     @field_validator("resume_from", mode="before")
     @classmethod
-    def validate_resume_from(cls, value, values) -> Optional[RunMoment]:
+    def validate_resume_from(cls, value, values) -> RunMoment | None:
         """Validate the resume_from field.
 
         <!-- lazydoc-ignore-classmethod: internal -->
@@ -1565,7 +1559,7 @@ class Settings(BaseModel, validate_assignment=True):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def _args(self) -> List[str]:
+    def _args(self) -> list[str]:
         if not self._jupyter:
             return sys.argv[1:]
         return []
@@ -1586,7 +1580,7 @@ class Settings(BaseModel, validate_assignment=True):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def _code_path_local(self) -> Optional[str]:
+    def _code_path_local(self) -> str | None:
         """The relative path from the current working directory to the code path.
 
         For example, if the code path is /home/user/project/example.py, and the
@@ -1688,7 +1682,7 @@ class Settings(BaseModel, validate_assignment=True):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def colab_url(self) -> Optional[str]:
+    def colab_url(self) -> str | None:
         """The URL to the Colab notebook, if running in Colab."""
         if not self._colab:
             return None
@@ -1922,7 +1916,7 @@ class Settings(BaseModel, validate_assignment=True):
         # them to succeed.
         self.update_from_settings(parsed_settings)
 
-    def update_from_env_vars(self, environ: Dict[str, Any]):
+    def update_from_env_vars(self, environ: dict[str, Any]):
         """Update settings from environment variables.
 
         <!-- lazydoc-ignore: internal -->
@@ -2031,7 +2025,7 @@ class Settings(BaseModel, validate_assignment=True):
 
         self.program = program
 
-    def update_from_dict(self, settings: Dict[str, Any]) -> None:
+    def update_from_dict(self, settings: dict[str, Any]) -> None:
         """Update settings from a dictionary.
 
         <!-- lazydoc-ignore: internal -->
@@ -2120,7 +2114,7 @@ class Settings(BaseModel, validate_assignment=True):
 
         return settings_proto
 
-    def _get_program(self) -> Optional[str]:
+    def _get_program(self) -> str | None:
         """Get the program that started the current process."""
         if self._jupyter:
             # If in a notebook, try to get the program from the notebook metadata.
@@ -2157,7 +2151,7 @@ class Settings(BaseModel, validate_assignment=True):
         return python_args
 
     @staticmethod
-    def _get_program_relpath(program: str, root: Optional[str] = None) -> Optional[str]:
+    def _get_program_relpath(program: str, root: str | None = None) -> str | None:
         """Get the relative path to the program from the root directory."""
         if not program:
             return None
@@ -2193,8 +2187,8 @@ class Settings(BaseModel, validate_assignment=True):
 
     @staticmethod
     def _runmoment_preprocessor(
-        val: Union[RunMoment, str, None],
-    ) -> Optional[RunMoment]:
+        val: RunMoment | str | None,
+    ) -> RunMoment | None:
         """Preprocess the setting for forking or resuming a run."""
         if isinstance(val, RunMoment) or val is None:
             return val


### PR DESCRIPTION
## Description

Follow-up to #11869 (which dropped Pydantic v1 support); salvages the cleanup #11165 would have shipped. Pure code-style refactor, no behavior change.

- Codegen: Removed the _ensure_all_model_rebuilds AST pass in tools/graphql_codegen/plugin.py; it existed to paper over Pydantic v1's forward-ref handling, which v2 resolves on its own.
- Hand-written annotations: Lifted per-file UP006/UP007/UP035/UP045 ignores.
- Compat surface trim: Dropped wandb.\_pydantic.field_validator from ruff's classmethod-decorators (the bare pydantic.field_validator entry covers everything now). Rerouted field_validator / to_camel imports in wandb/sdk/artifacts/_models/* straight from pydantic / pydantic.alias_generators.