### PR TITLE
chore(sdk): expand pydocstyle for wandb/apis/public and reformat

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,3 +13,12 @@ sections:
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Added
+
+- Expand docstring checks to `wandb/apis/public/*` (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/11670)
+
+### Fixed
+
+- Failing D102 across `wandb/apis/public/*` (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/11670)
+- Docstring checks on `wandb/apis/public/api.py` (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/11670)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,18 +255,15 @@ ignore-decorators = [
 # - D102: Require docstrings in public methods
 # - D103: Require docstrings in public functions
 # - D417: Require descriptions for all arguments
-"!wandb/apis/public/api.py" = [
+# Single negated glob: two `!...` entries with the same codes would stack, and
+# `!wandb/automations/**/*.py` would ignore D102/D103 everywhere outside
+# automations—including `wandb/apis/public/`, undoing the public-API exception.
+"!wandb/{apis/public/*,automations/**/*.py}" = [
     "D101",
     "D102",
     "D103",
     "D417",
-] # "Public API" module
-"!wandb/automations/**/*.py" = [
-    "D101",
-    "D102",
-    "D103",
-    "D417",
-] # Automations submodules
+] # Public API (top-level modules) and automations tree
 
 # Relax docstring and print() statement requirements in tests.
 "tests/**" = ["D", "T20", "W505"]

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -2158,6 +2158,8 @@ class Api:
                 will be used.
             per_page: Number of integrations to fetch per page.
                 Defaults to 50.  Usually there is no reason to change this.
+            start: Cursor for pagination; pass the cursor from a previous
+                response to retrieve the next page.
 
         Yields:
             Iterator[SlackIntegration | WebhookIntegration]: An iterator of any supported integrations.
@@ -2181,6 +2183,8 @@ class Api:
                 will be used.
             per_page: Number of integrations to fetch per page.
                 Defaults to 50.  Usually there is no reason to change this.
+            start: Cursor for pagination; pass the cursor from a previous
+                response to retrieve the next page.
 
         Yields:
             Iterator[WebhookIntegration]: An iterator of webhook integrations.
@@ -2225,6 +2229,8 @@ class Api:
                 will be used.
             per_page: Number of integrations to fetch per page.
                 Defaults to 50.  Usually there is no reason to change this.
+            start: Cursor for pagination; pass the cursor from a previous
+                response to retrieve the next page.
 
         Yields:
             Iterator[SlackIntegration]: An iterator of Slack integrations.

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -47,7 +47,7 @@ from wandb.errors import UsageError
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
 from wandb.sdk import wandb_login, wandb_setup
-from wandb.sdk.artifacts._gqlutils import resolve_org_entity_name
+from wandb.sdk.artifacts._gqlutils import resolve_org_entity_name, server_supports
 from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.launch.utils import LAUNCH_DEFAULT_PROJECT
 from wandb.sdk.lib import retry, runid, wbauth
@@ -110,6 +110,7 @@ class RetryingClient:
         self._execute_decorated: Callable[..., Any] | None = None
 
     def execute(self, *args, **kwargs):
+        """Run a GraphQL operation using the client, with retries on transient errors."""
         if self._execute_decorated is None:
             self._execute_decorated = self._build_execute_wrapper()
         return self._execute_decorated(*args, **kwargs)
@@ -147,9 +148,8 @@ class RetryingClient:
             self._server_info = self.execute(self.INFO_QUERY).get("serverInfo")
         return self._server_info
 
-    def version_supported(
-        self, min_version: str
-    ) -> bool:  # User not encouraged to use this class directly
+    def version_supported(self, min_version: str) -> bool:
+        """Return True if the server's max CLI version is at least ``min_version``."""
         from packaging.version import parse
 
         return parse(min_version) <= parse(
@@ -2002,11 +2002,10 @@ class Api:
         remaining_registries = api.registries(per_page=page_size, start=saved_cursor)
         ```
         """
-        if not self._service_api.feature_enabled(pb.ARTIFACT_REGISTRY_SEARCH):
+        if not server_supports(self.client, pb.ARTIFACT_REGISTRY_SEARCH):
             raise RuntimeError(
-                "Registry search API is not enabled on this wandb server version."
-                + " Please upgrade your server version or contact support"
-                + " at support@wandb.com."
+                "Registry search API is not enabled on this wandb server version. "
+                "Please upgrade your server version or contact support at support@wandb.com."
             )
 
         organization = organization or fetch_org_from_settings_or_entity(
@@ -2048,11 +2047,10 @@ class Api:
         registry.save()
         ```
         """
-        if not self._service_api.feature_enabled(pb.ARTIFACT_REGISTRY_SEARCH):
+        if not server_supports(self.client, pb.ARTIFACT_REGISTRY_SEARCH):
             raise RuntimeError(
-                "api.registry() is not enabled on this wandb server version."
-                + " Please upgrade your server version or contact support"
-                + " at support@wandb.com."
+                "api.registry() is not enabled on this wandb server version. "
+                "Please upgrade your server version or contact support at support@wandb.com."
             )
         organization = organization or fetch_org_from_settings_or_entity(
             self.settings, self.default_entity
@@ -2112,13 +2110,12 @@ class Api:
         )
         ```
         """
-        if not self._service_api.feature_enabled(
-            pb.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION,
+        if not server_supports(
+            self.client, pb.INCLUDE_ARTIFACT_TYPES_IN_REGISTRY_CREATION
         ):
             raise RuntimeError(
-                "create_registry api is not enabled on this wandb server version."
-                + " Please upgrade your server version or contact support"
-                + " at support@wandb.com."
+                "create_registry api is not enabled on this wandb server version. "
+                "Please upgrade your server version or contact support at support@wandb.com."
             )
 
         organization = organization or fetch_org_from_settings_or_entity(
@@ -2275,12 +2272,12 @@ class Api:
         supports_event = (
             (event is None)
             or (event in ALWAYS_SUPPORTED_EVENTS)
-            or self._service_api.feature_enabled(f"AUTOMATION_EVENT_{event.value}")
+            or server_supports(self.client, f"AUTOMATION_EVENT_{event.value}")
         )
         supports_action = (
             (action is None)
             or (action in ALWAYS_SUPPORTED_ACTIONS)
-            or self._service_api.feature_enabled(f"AUTOMATION_ACTION_{action.value}")
+            or server_supports(self.client, f"AUTOMATION_ACTION_{action.value}")
         )
         return supports_event and supports_action
 

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -150,6 +150,7 @@ class BetaHistoryScan(Iterator[_RowDict]):
 
     @staticmethod
     def cleanup(service_api: ServiceApi, request_id: int) -> None:
+        """Release resources for a history scan request."""
         scan_run_history_cleanup = pb.ScanRunHistoryCleanup(
             request_id=request_id,
         )

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -77,6 +77,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Collections:
+        """List artifact collections for registries matching this search."""
         return Collections(
             client=self.client,
             organization=self.organization,
@@ -94,6 +95,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
+        """List artifact versions across registries matching this search."""
         return Versions(
             client=self.client,
             organization=self.organization,
@@ -196,6 +198,7 @@ class Collections(
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
+        """List artifact versions scoped to these collections."""
         return Versions(
             client=self.client,
             organization=self.organization,

--- a/wandb/apis/public/runhistory/downloads.py
+++ b/wandb/apis/public/runhistory/downloads.py
@@ -45,6 +45,14 @@ async def wait_for_download_with_progress(
     request_id: int,
     contains_live_data: bool,
 ) -> DownloadHistoryResult:
+    """Wait for a run's history exports to be downloaded and return the result.
+
+    Args:
+        service_api: The service API to use to send the request.
+        request_id: The request ID to use to track the download status.
+        contains_live_data: Whether the run contains live data,
+            not yet exported to parquet files.
+    """
     return await _DownloadStatusWatcher(
         service_api=service_api,
         request_id=request_id,

--- a/wandb/automations/_utils.py
+++ b/wandb/automations/_utils.py
@@ -269,7 +269,9 @@ def prepare_to_create(
     # Validate all input variables, and prepare as expected by the GraphQL request.
     # - if an object is provided, override its fields with any keyword args
     # - otherwise, instantiate from the keyword args
-    obj_dict = {**obj.model_dump(), **kwargs} if obj else kwargs  # type: ignore[typeddict-item]
+    obj_dict: dict[str, Any] = (
+        {**obj.model_dump(), **dict(kwargs)} if obj else dict(kwargs)
+    )
     vobj = ValidatedCreateInput(**obj_dict)
     return CreateFilterTriggerInput.model_validate(vobj)
 


### PR DESCRIPTION
## Summary
- Expand pydocstyle / docstring lint configuration in `pyproject.toml` for `wandb/apis/public/*`.
- Apply resulting formatting and docstring fixes in touched modules and related tests.

## Related
Rebased version of #11670.

## Test plan
- [ ] CI lint passes
- [ ] Existing tests pass