### PR TITLE
feat(sdk): do not send admin header by default

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,3 +13,7 @@ sections:
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Changed
+
+- `wandb.Api()` no longer sends the `Use-Admin-Privileges` header by default. Pass `admin_privileges=True` when constructing `Api` if you need it (admin-only deployments and admin-only methods). This unblocks non-admin keys on deployments that reject the header (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/11877)

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -160,6 +160,23 @@ def test_direct_specification_of_api_key():
     assert api.api_key == "abcd" * 10
 
 
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_admin_privileges_header_absent_by_default():
+    # The Use-Admin-Privileges header should not be sent by default, since
+    # some W&B deployments reject it for non-admin keys and would otherwise
+    # break `Api()` construction.
+    api = Api()
+    headers = api._base_client.transport.headers
+    assert "Use-Admin-Privileges" not in headers
+
+
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_admin_privileges_header_present_when_opted_in():
+    api = Api(admin_privileges=True)
+    headers = api._base_client.transport.headers
+    assert headers.get("Use-Admin-Privileges") == "true"
+
+
 @pytest.mark.parametrize(
     "path",
     [

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -175,6 +175,8 @@ class Api:
         overrides: dict[str, Any] | None = None,
         timeout: int | None = None,
         api_key: str | None = None,
+        *,
+        admin_privileges: bool = False,
     ) -> None:
         """Initialize the API.
 
@@ -188,6 +190,13 @@ class Api:
                 the API key from the current environment or configuration will be used.
                 Prompts for an API key if none is provided
                 or configured in the environment.
+            admin_privileges: If `True`, send the `Use-Admin-Privileges` header
+                on GraphQL requests issued by this `Api` instance. Only set this
+                when authenticated with an admin API key and you intend to call
+                admin-only endpoints (for example, `create_user`, `user`,
+                `users`). Defaults to `False`; some W&B deployments reject the
+                header for non-admin keys, which would otherwise cause every
+                `Api()` call to fail at construction time.
         """
         self.settings = InternalApi().settings()
         self.settings.update(overrides or {})
@@ -229,12 +238,13 @@ class Api:
         settings.api_key = self.api_key or ""
         self._service_api: ServiceApi = ServiceApi(settings=settings)
 
+        client_headers: dict[str, str] = {"User-Agent": self.user_agent}
+        if admin_privileges:
+            client_headers["Use-Admin-Privileges"] = "true"
+
         self._base_client = Client(
             transport=GraphQLSession(
-                headers={
-                    "User-Agent": self.user_agent,
-                    "Use-Admin-Privileges": "true",
-                },
+                headers=client_headers,
                 use_json=True,
                 # this timeout won't apply when the DNS lookup fails. in that case, it will be 60s
                 # https://bugs.python.org/issue22889


### PR DESCRIPTION
## Description

- [https://coreweave.atlassian.net/browse/WB-34338](https://coreweave.atlassian.net/browse/WB-34338)

New option to Api() to use admin_privileges, which sends the Use-Admin-Privileges header. This will be off by default which may cause some Api() calls to fail for existing workflows. Without this change, users with an API key would not be able to access the wandb api on dedicated environments

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

Used against qa-azure environment

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->