### PR TITLE
fix: rare 'send on closed channel' panic when the client exits

### DIFF
--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/url"
 	"sync"
-	"sync/atomic"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -88,12 +87,12 @@ type Connection struct {
 	// inChan is the channel for incoming messages
 	inChan chan *spb.ServerRequest
 
-	// outChan is the channel for outgoing messages
+	// outChan is the channel for outgoing messages.
+	//
+	// Messages are processed until connLifetimeCtx ends, after which further
+	// writes will deadlock. The channel is never closed. All writes should be
+	// guarded by a fallback case that runs if connLifetimeCtx is done.
 	outChan chan *spb.ServerResponse
-
-	// An atomic flag indicating whether the `outChan` has been closed, ensuring
-	// thread-safe checking and updating of the connection’s closure state.
-	closed *atomic.Bool
 
 	// The current W&B Git commit hash, identifying the specific version of the binary.
 	commit string
@@ -118,7 +117,7 @@ func NewConnection(
 	return &Connection{
 		connLifetimeCtx:    connLifetimeCtx,
 		stopConnection:     stopConnection,
-		requestCanceller:   NewRequestCanceller(),
+		requestCanceller:   NewRequestCanceller(connLifetimeCtx),
 		stopServer:         stopServer,
 		streamMux:          params.StreamMux,
 		runSyncManager:     params.RunSyncManager,
@@ -128,7 +127,6 @@ func NewConnection(
 		id:                 params.ID,
 		inChan:             make(chan *spb.ServerRequest, BufferSize),
 		outChan:            make(chan *spb.ServerResponse, BufferSize),
-		closed:             &atomic.Bool{},
 		loggerPath:         params.LoggerPath,
 		logLevel:           params.LogLevel,
 		apiManager:         wbapi.NewManager(),
@@ -146,11 +144,11 @@ func (nc *Connection) ManageConnectionData() {
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		defer nc.stopConnection()
 		nc.processIncomingData()
 	})
 
 	wg.Go(func() {
+		defer nc.stopConnection()
 		nc.handleIncomingRequests()
 	})
 
@@ -172,16 +170,21 @@ func (nc *Connection) ManageConnectionData() {
 	slog.Info("connection: ManageConnectionData: connection closed", "id", nc.id)
 }
 
-// processOutgoingData processes and sends outgoing messages from the server to the client.
-//
-// It reads protobuf messages from the `outChan`, serializes them, and writes the serialized
-// data to the network connection. The client is responsible for reading and parsing the messages.
-// If any error occurs during serialization or writing, the function logs the error and terminates
-// early to prevent further message processing.
+// processOutgoingData processes outChan until connLifetimeCtx ends.
 func (nc *Connection) processOutgoingData() {
 	slog.Debug("processOutgoingData: started", "id", nc.id)
 
-	for msg := range nc.outChan {
+	for {
+		var msg *spb.ServerResponse
+
+		select {
+		case <-nc.connLifetimeCtx.Done():
+			slog.Info("processOutgoingData: finished", "id", nc.id)
+			return
+
+		case msg = <-nc.outChan:
+		}
+
 		// Marshal the message to protobuf format
 		out, err := proto.Marshal(msg)
 		if err != nil {
@@ -212,8 +215,6 @@ func (nc *Connection) processOutgoingData() {
 			return
 		}
 	}
-
-	slog.Debug("processOutgoingData: finished", "id", nc.id)
 }
 
 // processIncomingData reads and processes messages from a network connection.
@@ -356,11 +357,6 @@ func (nc *Connection) handleIncomingRequests() {
 
 	// Wait to complete any asynchronous requests.
 	wg.Wait()
-
-	// Ensure outChan is closed if connection isn't already marked as closed
-	if !nc.closed.Swap(true) {
-		close(nc.outChan)
-	}
 
 	slog.Debug("handleIncomingRequests: finished", "id", nc.id)
 }
@@ -557,6 +553,8 @@ func (nc *Connection) handleInformRecord(requestID string, msg *spb.Record) {
 	// by the presence of a request ID.
 	var request *runwork.Request
 	if requestID != "" {
+		// NOTE: The request is cancelled when connLifetimeCtx ends,
+		// so it will not deadlock trying to write to outChan.
 		ctx, cancelCtx := nc.requestCanceller.Context(requestID)
 		request = runwork.NewRequest(requestID, ctx, cancelCtx, nc.outChan)
 	}
@@ -745,19 +743,16 @@ func (nc *Connection) Close() {
 	}
 }
 
-// Respond impplements the Responder interface to send a response to the client.
+// Respond implements the Responder interface to send a response to the client.
 //
-// This is used to send a response to the outgoing message channel for the connection.
-// The response is then processed and sent to the client by the `processOutgoingData`
-// function.
+// If the connection is closed or becomes closed, the response is ignored
+// and a warning is logged.
 func (nc *Connection) Respond(resp *spb.ServerResponse) {
-	// Check if the connection has already been closed
-	if nc.closed.Load() {
-		// TODO: this is a bit of a hack, we should probably handle this better
-		//       and not send responses to closed connections
-		slog.Warn("connection: Respond: attempt to send response on closed connection", "id", nc.id)
-		return
+	select {
+	case nc.outChan <- resp:
+	case <-nc.connLifetimeCtx.Done():
+		slog.Warn(
+			"connection: tried to respond on closed connection",
+			"id", nc.id)
 	}
-
-	nc.outChan <- resp
 }

--- a/core/pkg/server/requestcanceller.go
+++ b/core/pkg/server/requestcanceller.go
@@ -16,6 +16,9 @@ const requestCountWarnInterval = 100
 type RequestCanceller struct {
 	mu sync.Mutex
 
+	// ctx is the parent context for all requests.
+	ctx context.Context
+
 	// requestCtxCancel maps some active server request IDs to functions
 	// that can be used to cancel their operations.
 	requestCtxCancel map[string]func()
@@ -27,8 +30,9 @@ type RequestCanceller struct {
 	warnInterval, lastWarnCount int
 }
 
-func NewRequestCanceller() *RequestCanceller {
+func NewRequestCanceller(ctx context.Context) *RequestCanceller {
 	return &RequestCanceller{
+		ctx:              ctx,
 		requestCtxCancel: make(map[string]func()),
 		warnInterval:     requestCountWarnInterval,
 	}
@@ -50,12 +54,12 @@ func (rc *RequestCanceller) SetWarnInterval(warnInterval int) {
 // A context leak is a goroutine leak; enough of these can crash the program,
 // so it's important to make designs that support a `defer cancel()`.
 //
-// If the request ID is empty, this returns a background context and a no-op
+// If the request ID is empty, this returns the root context and a no-op
 // cancellation function. If a previous request's ID is given, an error is
-// logged and a background context is returned.
+// logged and the root context is returned.
 func (rc *RequestCanceller) Context(id string) (context.Context, func()) {
 	if id == "" {
-		return context.Background(), func() {}
+		return rc.ctx, func() {}
 	}
 
 	rc.mu.Lock()
@@ -63,10 +67,10 @@ func (rc *RequestCanceller) Context(id string) (context.Context, func()) {
 
 	if _, exists := rc.requestCtxCancel[id]; exists {
 		slog.Error("requestcanceller: request ID already exists", "id", id)
-		return context.Background(), func() {}
+		return rc.ctx, func() {}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(rc.ctx)
 	rc.requestCtxCancel[id] = cancel
 
 	// Clear the map once the context is cancelled.

--- a/core/pkg/server/requestcanceller_test.go
+++ b/core/pkg/server/requestcanceller_test.go
@@ -33,7 +33,7 @@ func TestRequestCanceller_WarnsAtEachThreshold(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		logs := captureSlog(t)
 
-		rc := server.NewRequestCanceller()
+		rc := server.NewRequestCanceller(t.Context())
 		rc.SetWarnInterval(2)
 
 		_, cancel1 := rc.Context("1")


### PR DESCRIPTION
Fixes a rare "send on closed channel" panic that can happen if the client ends the connection early ([Sentry](https://weights-biases.sentry.io/issues/7440184044/events/bf5ef916258949da90a78ba750c50349/)).

### When it happens

After `Connection` processes all incoming data, it closes `outChan`. `Stream` is independent of `Connection` and may still be processing requests and attempting to respond to them, which panics.

This is a low severity bug because it can only happen if the client process dies, not in normal operation. In particular, it cannot happen during `wandb.teardown()` because `wandb.teardown()` blocks until all `Streams` end before closing `outChan` (I initially thought it happened during `wandb.teardown()`).

### Solution

A `Connection` doesn't own a `Stream`, so it can't wait for all streams to which it passed messages to stop before closing `outChan`, and that means that closing `outChan` was never safe. There was an incorrect attempt to guard it with an atomic boolean in PR #7243, but that only worked by luck: it could panic if `Connection.Respond()` was blocked on writing to `outChan` while simultaneously the connection became closed.

Instead, the solution is to guard `outChan` usage by a separate "done" channel, which in this case is `connLifetimeCtx.Done()`.