### PR TITLE
fix(sweeps): agent heartbeat should allow in-progress runs to finish on 404

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -51,8 +51,7 @@ This version drops compatibility with server versions older than 0.70.0.
 
 ### Fixed
 
-- `wandb.Api().viewer` (and `Api().user()` / `Api().users()`) no longer fail with `WandbApiFailedError: relogin required` for some API keys, a regression in `0.27.1` (@dmitryduev in https://github.com/wandb/wandb/pull/12009)
 - Saving a linked registry artifact (for example, when adding an alias) no longer fails when the caller lacks write access to the source project (@ibindlish in https://github.com/wandb/wandb/pull/12075)
 - `np.float16`/`np.float32` NaN values logged with `Run.log()` are now recorded as `NaN` instead of being silently dropped, matching `np.float64` and native `float` (@dmitryduev in https://github.com/wandb/wandb/pull/12116)
 - `Run.upload_file()` (via `wandb.Api().run(...)`) now registers the uploaded file with the run on self-hosted servers. Previously the file's bytes were uploaded but never committed, so the file did not appear on the run on deployments without object-store notifications (@dmitryduev in https://github.com/wandb/wandb/pull/12121)
-- sweep agents will now allow the in-progress run to complete before exiting when the sweep is deleted or Api() returns 404 (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/11880)
+- Sweep agents will now allow the in-progress run to complete before exiting when the sweep is deleted or Api() returns 404 (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/11880)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -51,6 +51,8 @@ This version drops compatibility with server versions older than 0.70.0.
 
 ### Fixed
 
+- `wandb.Api().viewer` (and `Api().user()` / `Api().users()`) no longer fail with `WandbApiFailedError: relogin required` for some API keys, a regression in `0.27.1` (@dmitryduev in https://github.com/wandb/wandb/pull/12009)
 - Saving a linked registry artifact (for example, when adding an alias) no longer fails when the caller lacks write access to the source project (@ibindlish in https://github.com/wandb/wandb/pull/12075)
 - `np.float16`/`np.float32` NaN values logged with `Run.log()` are now recorded as `NaN` instead of being silently dropped, matching `np.float64` and native `float` (@dmitryduev in https://github.com/wandb/wandb/pull/12116)
 - `Run.upload_file()` (via `wandb.Api().run(...)`) now registers the uploaded file with the run on self-hosted servers. Previously the file's bytes were uploaded but never committed, so the file did not appear on the run on deployments without object-store notifications (@dmitryduev in https://github.com/wandb/wandb/pull/12121)
+- sweep agents will now allow the in-progress run to complete before exiting when the sweep is deleted or Api() returns 404 (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/11880)

--- a/tests/system_tests/test_sweep/test_wandb_agent_full.py
+++ b/tests/system_tests/test_sweep/test_wandb_agent_full.py
@@ -267,7 +267,7 @@ def test_agent_sweep_deleted_waits_for_in_flight_run(user, monkeypatch):
     """A 404 on heartbeat must not stop the agent while a trial thread is still running.
 
     The trial deliberately stays in user code until the agent has handled the 404
-    and logged the "Waiting for the in-process run to finish" message. That message
+    and logged the "in-process run will be allowed to finish" message. That message
     is emitted (from the heartbeat thread) only after the agent confirms a trial
     thread is still alive, so the trial is provably in flight across the 404 check.
 
@@ -285,7 +285,7 @@ def test_agent_sweep_deleted_waits_for_in_flight_run(user, monkeypatch):
     }
     sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
 
-    wait_msg = "Waiting for the in-process run to finish"
+    wait_msg = "in-process run will be allowed to finish"
 
     first_heartbeat_done = threading.Event()
     trial_in_user_code = threading.Event()

--- a/tests/system_tests/test_sweep/test_wandb_agent_full.py
+++ b/tests/system_tests/test_sweep/test_wandb_agent_full.py
@@ -264,49 +264,84 @@ def test_agent_sweep_deleted(user):
 
 
 def test_agent_sweep_deleted_waits_for_in_flight_run(user, monkeypatch):
-    """404 on heartbeat does not stop the agent while a trial thread is still running."""
+    """A 404 on heartbeat must not stop the agent while a trial thread is still running.
+
+    The trial deliberately stays in user code until the agent has handled the 404
+    and logged the "Waiting for the in-process run to finish" message. That message
+    is emitted (from the heartbeat thread) only after the agent confirms a trial
+    thread is still alive, so the trial is provably in flight across the 404 check.
+
+    The trial does not call ``wandb.init()``: the agent's 404 handling only checks
+    whether the trial thread is alive (``_has_running_thread``), so a real run is
+    unnecessary, and creating one is racy under the agent's concurrent teardown and
+    heartbeat (it intermittently failed with "user is not logged in" on CI).
+    Coordination uses a ``wandb.termerror`` spy rather than capturing stderr.
+    """
+    project = "test-agent-sweep-deleted-waits-for-in-flight-run"
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-sweep-deleted-waits-for-in-flight-run",
         "method": "grid",
         "parameters": {"a": {"values": [1, 2, 3]}},
     }
-    sweep_id = wandb.sweep(sweep_config)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
+
+    wait_msg = "Waiting for the in-process run to finish"
 
     first_heartbeat_done = threading.Event()
     trial_in_user_code = threading.Event()
+    waited_for_in_flight_run = threading.Event()
+    termerrors: list[str] = []
 
-    monkeypatch.setattr(pyagent.Agent, "HEARTBEAT_SLEEP_SECONDS", 0)
+    # Use a short (non-zero) heartbeat interval: fast enough to keep the test
+    # snappy, but without a hot spin that hammers the shared API lock.
+    monkeypatch.setattr(pyagent.Agent, "HEARTBEAT_SLEEP_SECONDS", 0.05)
+
+    real_termerror = wandb.termerror
+
+    def termerror_spy(message, *args, **kwargs):
+        termerrors.append(message)
+        if wait_msg in message:
+            waited_for_in_flight_run.set()
+        return real_termerror(message, *args, **kwargs)
+
+    monkeypatch.setattr(wandb, "termerror", termerror_spy)
 
     def train():
-        run = wandb.init()
+        # Announce that the trial is in user code, then stay here until the
+        # agent has logged that it is waiting for the in-flight run. The agent
+        # only logs that after confirming this thread is still alive, so the
+        # trial stays provably in flight across the 404 check.
         trial_in_user_code.set()
-        run.finish()
+        assert waited_for_in_flight_run.wait(timeout=30), (
+            "agent did not log the in-flight wait message before timeout"
+        )
 
     def agent_heartbeat_mock(agent_id, metrics, run_states):
-        if first_heartbeat_done.is_set():
-            trial_in_user_code.wait()
-            raise SweepNotFoundError("Sweep not found")
-        first_heartbeat_done.set()
-        return [
-            {
-                "type": "run",
-                "run_id": "sweep-deleted-wait-run",
-                "args": {"a": {"value": 1}},
-                "program": "train.py",
-            }
-        ]
+        if not first_heartbeat_done.is_set():
+            first_heartbeat_done.set()
+            return [
+                {
+                    "type": "run",
+                    "run_id": "sweep-deleted-wait-run",
+                    "args": {"a": {"value": 1}},
+                    "program": "train.py",
+                }
+            ]
+        # Only raise the 404 once the trial is actually executing user code.
+        # Return an empty command list (rather than blocking) until then: the
+        # agent calls this under `Agent._api_lock`, and the run thread needs that
+        # same lock to start the trial, so blocking here would deadlock.
+        if not trial_in_user_code.is_set():
+            return []
+        raise SweepNotFoundError("Sweep not found")
 
-    captured_stderr = io.StringIO()
-    with contextlib.redirect_stderr(captured_stderr):
-        with mock.patch(
-            "wandb.sdk.internal.internal_api.Api.agent_heartbeat",
-            side_effect=agent_heartbeat_mock,
-        ):
-            wandb.agent(sweep_id, function=train, count=1)
+    with mock.patch(
+        "wandb.sdk.internal.internal_api.Api.agent_heartbeat",
+        side_effect=agent_heartbeat_mock,
+    ):
+        wandb.agent(sweep_id, function=train, count=1, entity=user, project=project)
 
-    stderr_output = captured_stderr.getvalue()
-    assert "Sweep was deleted or agent was not found" in stderr_output
-    assert "Waiting for the in-process run to finish" in stderr_output
+    assert any(wait_msg in message for message in termerrors)
 
 
 def test_public_api_sweep_agent_retrieves_running_agent(user):

--- a/tests/system_tests/test_sweep/test_wandb_agent_full.py
+++ b/tests/system_tests/test_sweep/test_wandb_agent_full.py
@@ -5,6 +5,7 @@ import io
 import pathlib
 import queue
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
@@ -262,6 +263,52 @@ def test_agent_sweep_deleted(user):
     assert "Sweep was deleted or agent was not found" in stderr_output
 
 
+def test_agent_sweep_deleted_waits_for_in_flight_run(user, monkeypatch):
+    """404 on heartbeat does not stop the agent while a trial thread is still running."""
+    sweep_config = {
+        "name": "My Sweep",
+        "method": "grid",
+        "parameters": {"a": {"values": [1, 2, 3]}},
+    }
+    sweep_id = wandb.sweep(sweep_config)
+
+    first_heartbeat_done = threading.Event()
+    trial_in_user_code = threading.Event()
+
+    monkeypatch.setattr(pyagent.Agent, "HEARTBEAT_SLEEP_SECONDS", 0)
+
+    def train():
+        run = wandb.init()
+        trial_in_user_code.set()
+        run.finish()
+
+    def agent_heartbeat_mock(agent_id, metrics, run_states):
+        if first_heartbeat_done.is_set():
+            trial_in_user_code.wait()
+            raise SweepNotFoundError("Sweep not found")
+        first_heartbeat_done.set()
+        return [
+            {
+                "type": "run",
+                "run_id": "sweep-deleted-wait-run",
+                "args": {"a": {"value": 1}},
+                "program": "train.py",
+            }
+        ]
+
+    captured_stderr = io.StringIO()
+    with contextlib.redirect_stderr(captured_stderr):
+        with mock.patch(
+            "wandb.sdk.internal.internal_api.Api.agent_heartbeat",
+            side_effect=agent_heartbeat_mock,
+        ):
+            wandb.agent(sweep_id, function=train, count=1)
+
+    stderr_output = captured_stderr.getvalue()
+    assert "Sweep was deleted or agent was not found" in stderr_output
+    assert "Waiting for the in-process run to finish" in stderr_output
+
+
 def test_public_api_sweep_agent_retrieves_running_agent(user):
     """While a sweep agent is blocked in user code, Api().sweep().agent() returns it."""
     project = "test-public-api-sweep-agent-retrieves-running-agent"
@@ -334,7 +381,6 @@ def test_normal_run_after_agent_does_not_overwrite_sweep_run(user, runner, monke
     with an explicit id. The normal run must be separate and must not overwrite
     the sweep run.
     """
-    import time
 
     with runner.isolated_filesystem():
         project_name = "test-normal-run-after-agent"

--- a/tests/unit_tests/test_wandb_agent_cli_sweep_not_found.py
+++ b/tests/unit_tests/test_wandb_agent_cli_sweep_not_found.py
@@ -1,0 +1,95 @@
+"""Sweep-not-found behavior for wandb_agent.Agent (CLI subprocess agent)."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import multiprocessing
+from unittest import mock
+
+import pytest
+import wandb
+from wandb.sdk.launch.sweeps import SweepNotFoundError
+from wandb.wandb_agent import Agent
+
+
+def _patch_cli_agent_loop(monkeypatch, tmp_path):
+    """Avoid slow queue reads and noisy teardown when unit-testing wandb_agent.Agent."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(wandb.env.SWEEP_ID, "sweep-cli-test")
+    monkeypatch.setenv(wandb.env.DIR, str(tmp_path))
+    monkeypatch.setattr(
+        "wandb.wandb_agent.util.read_many_from_queue",
+        lambda q, max_items, queue_timeout: [],
+    )
+    monkeypatch.setattr(wandb, "teardown", lambda *args, **kwargs: None)
+
+
+def _mock_api_for_cli_agent():
+    api = mock.MagicMock()
+    api.sweep.return_value = None
+    api.register_agent.return_value = {"id": "agent-test-id"}
+    return api
+
+
+class _AgentWithFakeChildProcess(Agent):
+    """Injects a mock subprocess so CLI agent tests do not spawn real training jobs."""
+
+    def _command_run(self, command):
+        proc = mock.MagicMock()
+        proc.last_sigterm_time = None
+        proc.poll = mock.Mock(side_effect=[None, 0])
+        self._run_processes[command["run_id"]] = proc
+
+
+def test_cli_agent_sweep_not_found_no_running_raises(monkeypatch, tmp_path):
+    """404 on heartbeat with no child runs re-raises SweepNotFoundError (CLI subprocess agent)."""
+    _patch_cli_agent_loop(monkeypatch, tmp_path)
+    api = _mock_api_for_cli_agent()
+    api.agent_heartbeat.side_effect = SweepNotFoundError("Sweep not found")
+
+    agent = Agent(
+        api,
+        multiprocessing.Queue(),
+        sweep_id="sweep-cli-test",
+        function=None,
+        in_jupyter=False,
+        count=None,
+    )
+
+    with pytest.raises(SweepNotFoundError):
+        agent.run()
+
+
+def test_cli_agent_sweep_not_found_waits_for_active_run(monkeypatch, tmp_path):
+    """404 does not raise while a mock child process is still reported running."""
+    _patch_cli_agent_loop(monkeypatch, tmp_path)
+    api = _mock_api_for_cli_agent()
+    api.agent_heartbeat.side_effect = [
+        [
+            {
+                "type": "run",
+                "run_id": "cli-sweep-deleted-run",
+                "args": {"a": {"value": 1}},
+                "program": "train.py",
+            }
+        ],
+        SweepNotFoundError("Sweep not found"),
+    ]
+
+    agent = _AgentWithFakeChildProcess(
+        api,
+        multiprocessing.Queue(),
+        sweep_id="sweep-cli-test",
+        function=None,
+        in_jupyter=False,
+        count=None,
+    )
+
+    captured = io.StringIO()
+    with contextlib.redirect_stderr(captured):
+        agent.run()
+
+    err = captured.getvalue()
+    assert "Sweep was deleted or agent was not found" in err
+    assert "Waiting for active runs to finish" in err

--- a/tests/unit_tests/test_wandb_agent_cli_sweep_not_found.py
+++ b/tests/unit_tests/test_wandb_agent_cli_sweep_not_found.py
@@ -92,4 +92,4 @@ def test_cli_agent_sweep_not_found_waits_for_active_run(monkeypatch, tmp_path):
 
     err = captured.getvalue()
     assert "Sweep was deleted or agent was not found" in err
-    assert "Waiting for active runs to finish" in err
+    assert "Active runs will be allowed to finish before the agent exits" in err

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -79,6 +79,8 @@ class Agent:
     FLAPPING_MAX_SECONDS = 60
     FLAPPING_MAX_FAILURES = 3
     MAX_INITIAL_FAILURES = 5
+    # Delay between sweep heartbeats (seconds). Tests may set to 0 to avoid wall-clock waits.
+    HEARTBEAT_SLEEP_SECONDS = 5
 
     def __init__(
         self, sweep_id=None, project=None, entity=None, function=None, count=None
@@ -108,6 +110,7 @@ class Agent:
         self._run_status = {}
         self._queue = queue.Queue()
         self._exit_flag = False
+        self._sweep_not_found = False
         self._exceptions = {}
         self._start_time = time.time()
 
@@ -155,6 +158,10 @@ class Agent:
         self._exit_flag = True
         # _terminate_thread(self._main_thread)
 
+    def _has_in_flight_work_after_sweep_removed(self) -> bool:
+        """True while an in-process trial thread is still running."""
+        return any(t.is_alive() for t in self._run_threads.values())
+
     def _heartbeat(self):
         while True:
             if self._exit_flag:
@@ -166,19 +173,26 @@ class Agent:
                 for run, status in self._run_status.items()
                 if status in (RunStatus.QUEUED, RunStatus.RUNNING)
             }
-            try:
-                with self._api_lock:
-                    commands = self._api.agent_heartbeat(
-                        self._agent_id,
-                        {},
-                        run_status,
-                    )
-            except SweepNotFoundError:
-                wandb.termerror(
-                    "Sweep was deleted or agent was not found. Stopping sweep."
-                )
-                self._exit()
-                return
+            if self._sweep_not_found:
+                # avoid sending heartbeat if the sweep was deleted
+                # allow the agent to finish the in-process run
+                commands = []
+            else:
+                try:
+                    with self._api_lock:
+                        commands = self._api.agent_heartbeat(
+                            self._agent_id,
+                            {},
+                            run_status,
+                        )
+                except SweepNotFoundError:
+                    self._sweep_not_found = True
+                    commands = []
+                    if self._has_in_flight_work_after_sweep_removed():
+                        wandb.termerror(
+                            "Sweep was deleted or agent was not found. "
+                            "Waiting for the in-process run to finish."
+                        )
             if commands:
                 job = Job(commands[0])
                 logger.debug(f"Job received: {job}")
@@ -190,7 +204,16 @@ class Agent:
                 elif job.type == "exit":
                     self._exit()
                     return
-            time.sleep(5)
+            if (
+                self._sweep_not_found
+                and not self._has_in_flight_work_after_sweep_removed()
+            ):
+                wandb.termerror(
+                    "Sweep was deleted or agent was not found. Stopping sweep."
+                )
+                self._exit_flag = True
+                continue  # skip sleep
+            time.sleep(self.HEARTBEAT_SLEEP_SECONDS)
 
     def _run_jobs_from_queue(self):
         global _INSTANCES

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -178,7 +178,8 @@ class Agent:
             if self._has_running_thread():
                 wandb.termerror(
                     "Sweep was deleted or agent was not found. "
-                    "Waiting for the in-process run to finish."
+                    "The in-process run will be allowed to finish before the "
+                    "agent exits."
                 )
             return []
 

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -13,6 +13,7 @@ import sys
 import threading
 import time
 import traceback
+from typing import Any
 
 import wandb
 from wandb.apis import InternalApi
@@ -158,9 +159,37 @@ class Agent:
         self._exit_flag = True
         # _terminate_thread(self._main_thread)
 
-    def _has_in_flight_work_after_sweep_removed(self) -> bool:
+    def _has_running_thread(self) -> bool:
         """True while an in-process trial thread is still running."""
         return any(t.is_alive() for t in self._run_threads.values())
+
+    def _heartbeat_commands(self, run_status: dict) -> list[dict[str, Any]]:
+        """Fetch the next batch of agent commands from the server."""
+        if self._sweep_not_found:
+            # The sweep was deleted; stop heartbeating but let the in-process
+            # run finish before we shut the agent down.
+            return []
+
+        try:
+            with self._api_lock:
+                return self._api.agent_heartbeat(self._agent_id, {}, run_status)
+        except SweepNotFoundError:
+            self._sweep_not_found = True
+            if self._has_running_thread():
+                wandb.termerror(
+                    "Sweep was deleted or agent was not found. "
+                    "Waiting for the in-process run to finish."
+                )
+            return []
+
+    def _stop_if_deleted_sweep_drained(self) -> bool:
+        """Stop the agent once a deleted sweep has no in-process run left."""
+        if not self._sweep_not_found or self._has_running_thread():
+            return False
+
+        wandb.termerror("Sweep was deleted or agent was not found. Stopping sweep.")
+        self._exit_flag = True
+        return True
 
     def _heartbeat(self):
         while True:
@@ -173,26 +202,7 @@ class Agent:
                 for run, status in self._run_status.items()
                 if status in (RunStatus.QUEUED, RunStatus.RUNNING)
             }
-            if self._sweep_not_found:
-                # avoid sending heartbeat if the sweep was deleted
-                # allow the agent to finish the in-process run
-                commands = []
-            else:
-                try:
-                    with self._api_lock:
-                        commands = self._api.agent_heartbeat(
-                            self._agent_id,
-                            {},
-                            run_status,
-                        )
-                except SweepNotFoundError:
-                    self._sweep_not_found = True
-                    commands = []
-                    if self._has_in_flight_work_after_sweep_removed():
-                        wandb.termerror(
-                            "Sweep was deleted or agent was not found. "
-                            "Waiting for the in-process run to finish."
-                        )
+            commands = self._heartbeat_commands(run_status)
             if commands:
                 job = Job(commands[0])
                 logger.debug(f"Job received: {job}")
@@ -204,14 +214,7 @@ class Agent:
                 elif job.type == "exit":
                     self._exit()
                     return
-            if (
-                self._sweep_not_found
-                and not self._has_in_flight_work_after_sweep_removed()
-            ):
-                wandb.termerror(
-                    "Sweep was deleted or agent was not found. Stopping sweep."
-                )
-                self._exit_flag = True
+            if self._stop_if_deleted_sweep_drained():
                 continue  # skip sleep
             time.sleep(self.HEARTBEAT_SLEEP_SECONDS)
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2194,6 +2194,9 @@ def agent(ctx, project, entity, count, forward_signals, sweep_id):
         )
     # TODO: handle other errors with correct exit codes
     except SweepNotFoundError:
+        # The agent loop has already printed the "Sweep was deleted or agent was
+        # not found" error to the terminal before re-raising, so here we only
+        # need to translate it into a non-zero exit code.
         sys.exit(1)
 
     # you can send local commands like so:

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2194,7 +2194,6 @@ def agent(ctx, project, entity, count, forward_signals, sweep_id):
         )
     # TODO: handle other errors with correct exit codes
     except SweepNotFoundError:
-        wandb.termerror("Sweep was deleted or agent was not found. Stopping agent.")
         sys.exit(1)
 
     # you can send local commands like so:

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2196,7 +2196,9 @@ def agent(ctx, project, entity, count, forward_signals, sweep_id):
     except SweepNotFoundError:
         # The agent loop has already printed the "Sweep was deleted or agent was
         # not found" error to the terminal before re-raising, so here we only
-        # need to translate it into a non-zero exit code.
+        # need to report that we're stopping and translate it into a non-zero
+        # exit code.
+        wandb.termerror("Stopping agent.")
         sys.exit(1)
 
     # you can send local commands like so:

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -19,6 +19,7 @@ from typing import Any
 import wandb
 from wandb import util
 from wandb.sdk import wandb_login, wandb_setup
+from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib import config_util, ipython
 
 logger = logging.getLogger(__name__)
@@ -283,6 +284,7 @@ class Agent:
             self.MAX_INITIAL_FAILURES
         )
         self._forward_signals = forward_signals
+        self._sweep_not_found = False
         if self._report_interval is None:
             raise AgentError("Invalid agent report interval")
         if self._kill_delay is None:
@@ -406,6 +408,9 @@ class Agent:
                         self._last_report_time = None
                         self._finished += 1
 
+                    if self._stop_if_deleted_sweep_drained():
+                        continue
+
                     if (
                         self._count
                         and self._finished >= self._count
@@ -414,7 +419,7 @@ class Agent:
                         self._running = False
                         continue
 
-                    commands = self._api.agent_heartbeat(agent_id, {}, run_status)
+                    commands = self._heartbeat_commands(agent_id, run_status)
 
                     # TODO: send _server_responses
                     self._server_responses = []
@@ -470,6 +475,38 @@ class Agent:
                         run_process.kill()
                     except OSError:
                         pass  # if process is already dead
+
+    def _heartbeat_commands(
+        self, agent_id: str, run_status: dict
+    ) -> list[dict[str, Any]]:
+        """Fetch the next batch of agent commands from the server."""
+        if self._sweep_not_found:
+            # The sweep was deleted; stop heartbeating but let the in-process
+            # run finish before we shut the agent down.
+            return []
+
+        try:
+            return self._api.agent_heartbeat(agent_id, {}, run_status)
+        except SweepNotFoundError:
+            if not self._run_processes:
+                wandb.termerror(
+                    "Sweep was deleted or agent was not found. Stopping agent."
+                )
+                raise
+            wandb.termerror(
+                "Sweep was deleted or agent was not found. "
+                "Waiting for active runs to finish."
+            )
+            self._sweep_not_found = True
+            return []
+
+    def _stop_if_deleted_sweep_drained(self) -> bool:
+        """Stop the run loop once a deleted sweep has no active child runs left."""
+        if not self._sweep_not_found or self._run_processes:
+            return False
+
+        self._running = False
+        return True
 
     def _process_command(self, command):
         logger.info("Agent received command: {}".format(command.get("type", "Unknown")))

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -489,13 +489,11 @@ class Agent:
             return self._api.agent_heartbeat(agent_id, {}, run_status)
         except SweepNotFoundError:
             if not self._run_processes:
-                wandb.termerror(
-                    "Sweep was deleted or agent was not found. Stopping agent."
-                )
+                wandb.termerror("Sweep was deleted or agent was not found.")
                 raise
             wandb.termerror(
                 "Sweep was deleted or agent was not found. "
-                "Waiting for active runs to finish."
+                "Active runs will be allowed to finish before the agent exits."
             )
             self._sweep_not_found = True
             return []


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-34332

Customer was seeing 404 instead of 500 errors when MySQL could not connect. When this happens it looks to the agent that the sweep was deleted. In https://github.com/wandb/wandb/pull/11226 we automatically shut down the agent when the sweep appears deleted to avoid agent_heartbeat repeated noise.

In this PR, we allow the currently running run to complete before shutting down the agent. This avoids calling _exit(), which can cause customers with training scripts that call torch DDP to shut down their entire cluster.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

Added a new unit tests that checks agent heartbeat allows the running run to exit first

Manually ran a sweep and then deleted it, the agent finished its existing work https://wandb.ai/wandb/sweep-delete-manual-test?nw=nwuserkmikowicz

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->