### PR TITLE
refactor: use AsyncGenerator instead of AsyncIterator in type hints

### DIFF
--- a/wandb/sdk/lib/asyncio_compat.py
+++ b/wandb/sdk/lib/asyncio_compat.py
@@ -7,7 +7,7 @@ import concurrent
 import concurrent.futures
 import contextlib
 import threading
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncGenerator, Callable, Coroutine
 from typing import Any, TypeVar
 
 _T = TypeVar("_T")
@@ -208,7 +208,7 @@ async def open_task_group(
     *,
     exit_timeout: float | None = None,
     race: bool = False,
-) -> AsyncIterator[TaskGroup]:
+) -> AsyncGenerator[TaskGroup]:
     """Create a task group.
 
     `asyncio` gained task groups in Python 3.11.
@@ -244,7 +244,9 @@ async def open_task_group(
 
 
 @contextlib.asynccontextmanager
-async def cancel_on_exit(coro: Coroutine[Any, Any, Any]) -> AsyncIterator[None]:
+async def cancel_on_exit(
+    coro: Coroutine[Any, Any, Any],
+) -> AsyncGenerator[None]:
     """Schedule a task, cancelling it when exiting the context manager.
 
     If the context manager exits successfully but the given coroutine raises


### PR DESCRIPTION
Fixes all type hints that use `AsyncIterator` for `@contextlib.asynccontextmanager` to use `AsyncGenerator` instead. The former is marked deprecated starting in Python 3.10:

```
@deprecated(
    "Annotating the return type as `-> AsyncIterator[Foo]` with `@asynccontextmanager` is deprecated. "
    "Use `-> AsyncGenerator[Foo]` instead."
)
def asynccontextmanager(func: Callable[_P, AsyncIterator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
```