### PR TITLE
refactor: use Generator instead of Iterator in type hints

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 import time
 import unittest.mock
-from collections.abc import Callable, Generator, Iterator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from queue import Queue
 from typing import Any
@@ -39,7 +39,7 @@ pytest_plugins = [
 
 
 @pytest.fixture(autouse=True, scope="session")
-def setup_wandb_env_variables() -> Iterator[None]:
+def setup_wandb_env_variables() -> Generator[None]:
     """Configures wandb env variables to suitable defaults for tests."""
     with pytest.MonkeyPatch().context() as monkeypatch:
         # Override the base URL, which otherwise defaults to https://api.wandb.ai
@@ -92,7 +92,7 @@ def copy_asset(
 @pytest.fixture()
 def wandb_caplog(
     caplog: pytest.LogCaptureFixture,
-) -> Iterator[pytest.LogCaptureFixture]:
+) -> Generator[pytest.LogCaptureFixture]:
     """Modified caplog fixture that detect wandb log messages.
 
     The wandb logger is configured to not propagate messages to the root logger,

--- a/tests/fixtures/wandb_backend_spy/proxy.py
+++ b/tests/fixtures/wandb_backend_spy/proxy.py
@@ -5,7 +5,7 @@ import contextlib
 import socket
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Generator
 
 import fastapi
 import httpx
@@ -18,7 +18,7 @@ from .spy import WandbBackendSpy
 def spy_proxy(
     target_host: str,
     target_port: int,
-) -> Iterator[WandbBackendProxy]:
+) -> Generator[WandbBackendProxy]:
     """A context manager that proxies a W&B backend.
 
     The proxy server will be available at 127.0.0.1 on a port chosen by the
@@ -119,7 +119,7 @@ class WandbBackendProxy:
         self.port = local_port
 
     @contextlib.contextmanager
-    def spy(self) -> Iterator[WandbBackendSpy]:
+    def spy(self) -> Generator[WandbBackendSpy]:
         """A context manager for intercepting W&B requests.
 
         Args:

--- a/tests/fixtures/wandb_backend_spy/spy.py
+++ b/tests/fixtures/wandb_backend_spy/spy.py
@@ -4,7 +4,7 @@ import contextlib
 import dataclasses
 import json
 import threading
-from collections.abc import Iterator
+from collections.abc import Generator
 from typing import Any
 
 import fastapi
@@ -23,7 +23,7 @@ class WandbBackendSpy:
         self._filestream_stubs: list[_FileStreamResponse] = []
 
     @contextlib.contextmanager
-    def freeze(self) -> Iterator[WandbBackendSnapshot]:
+    def freeze(self) -> Generator[WandbBackendSnapshot]:
         """A context manager in which the spied state can be queried.
 
         Usage:

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Callable, Generator, Iterator
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 
 import pytest
@@ -97,7 +97,7 @@ def wandb_verbose(request):
 def user(
     request: pytest.FixtureRequest,
     backend_fixture_factory: BackendFixtureFactory,
-) -> Iterator[str]:
+) -> Generator[str]:
     """A user created for the duration of a test.
 
     This cannot be used together with module_user. If module_user is also
@@ -116,7 +116,7 @@ def user(
 @pytest.fixture(scope="module")
 def module_user(
     backend_fixture_factory: BackendFixtureFactory,
-) -> Iterator[str]:
+) -> Generator[str]:
     """A new user shared by all tests in a module.
 
     Just like `user`, but is shared by multiple tests.
@@ -130,7 +130,7 @@ def module_user(
 
 
 @contextlib.contextmanager
-def _user(backend_fixture_factory: BackendFixtureFactory) -> Iterator[str]:
+def _user(backend_fixture_factory: BackendFixtureFactory) -> Generator[str]:
     username = backend_fixture_factory.make_user()
 
     with pytest.MonkeyPatch.context() as monkeypatch:
@@ -185,7 +185,7 @@ class UserOrg:
 def user_in_orgs_factory(
     backend_fixture_factory: BackendFixtureFactory,
     user: str,
-) -> Iterator[Callable[[int], UserOrg]]:
+) -> Generator[Callable[[int], UserOrg]]:
     """Fixture that provides a factory function to create a user and associated orgs.
 
     Usage in a test:

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -4,7 +4,7 @@ import filecmp
 import os
 import shutil
 import unittest.mock
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Generator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
@@ -476,7 +476,7 @@ def test_add_reference_local_file_no_checksum(tmp_path, artifact):
 
 class TestAddReferenceLocalFileNoChecksumTwice:
     @fixture
-    def run(self, user) -> Iterator[wandb.Run]:
+    def run(self, user) -> Generator[wandb.Run]:
         with wandb.init() as run:
             yield run
 

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import secrets
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from functools import lru_cache
 from string import ascii_lowercase, digits
 from typing import TypeAlias
@@ -129,7 +129,7 @@ def webhook(
     make_module_api: Callable[[], wandb.Api],
     make_webhook_integration: Callable[[str, str, str], WebhookIntegration],
     make_name: Callable[[str], str],
-) -> Iterator[WebhookIntegration]:
+) -> Generator[WebhookIntegration]:
     """A "registered" webhook integration for automation system tests."""
     name = make_name("test-webhook")
     entity = make_module_api().default_entity

--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from unittest.mock import patch
 
 import wandb
@@ -12,7 +12,7 @@ from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 
 
 @fixture
-def default_organization(user_in_orgs_factory) -> Iterator[str]:
+def default_organization(user_in_orgs_factory) -> Generator[str]:
     """Provides the name of the single default organization."""
     user_in_orgs = user_in_orgs_factory()
     yield user_in_orgs.organization_names[0]

--- a/tests/system_tests/test_registries/test_registry_members.py
+++ b/tests/system_tests/test_registries/test_registry_members.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING
 
 from pytest import fixture, mark
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 @fixture(scope="module")
 def user(
     module_mocker, backend_fixture_factory: BackendFixtureFactory
-) -> Iterator[str]:
+) -> Generator[str]:
     """Module-scoped admin user that deliberately overrides the default user fixture.
 
     We need admin privileges to perform some of the setup steps via the public API.

--- a/tests/unit_tests/test_lib/test_printer_asyncio.py
+++ b/tests/unit_tests/test_lib/test_printer_asyncio.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
-from collections.abc import Iterator
+from collections.abc import Generator
 from unittest.mock import Mock
 
 import pytest
@@ -26,7 +26,7 @@ class _Tester:
         self._mock_printer.loading_symbol.return_value = loading_symbol
 
     @contextlib.contextmanager
-    def _dynamic_text(self) -> Iterator[printer.DynamicText]:
+    def _dynamic_text(self) -> Generator[printer.DynamicText]:
         """Fake implementation of Printer.dynamic_text."""
         yield self._mock_dynamic_text
 

--- a/tests/unit_tests/test_lib/test_progress.py
+++ b/tests/unit_tests/test_lib/test_progress.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Generator
 
 import pytest
 from wandb.proto import wandb_internal_pb2 as pb
@@ -12,7 +12,7 @@ from tests.fixtures.mock_wandb_log import MockWandbLog
 @pytest.fixture()
 def dynamic_progress_printer(
     emulated_terminal: EmulatedTerminal,
-) -> Iterator[progress.ProgressPrinter]:
+) -> Generator[progress.ProgressPrinter]:
     """A ProgressPrinter writing to an emulated terminal."""
     # Ensure dynamic text is supported.
     _ = emulated_terminal
@@ -25,7 +25,7 @@ def dynamic_progress_printer(
 
 
 @pytest.fixture()
-def static_progress_printer() -> Iterator[progress.ProgressPrinter]:
+def static_progress_printer() -> Generator[progress.ProgressPrinter]:
     """A ProgressPrinter that writes to a file or dumb terminal."""
     with progress.progress_printer(
         p.new_printer(),

--- a/tests/unit_tests/test_retry.py
+++ b/tests/unit_tests/test_retry.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import datetime
-from collections.abc import Iterator
+from collections.abc import Generator
 from unittest import mock
 
 import pytest
@@ -16,7 +16,7 @@ class MockTime:
 
 
 @pytest.fixture(autouse=True)
-def mock_time() -> Iterator[MockTime]:
+def mock_time() -> Generator[MockTime]:
     """Mock out the now()/sleep() funcs used by the retry logic."""
     now = datetime.datetime.now()
 

--- a/tests/unit_tests/test_ssl.py
+++ b/tests/unit_tests/test_ssl.py
@@ -3,7 +3,7 @@ import dataclasses
 import http.server
 import ssl
 import threading
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Generator, Mapping
 from pathlib import Path
 from unittest.mock import patch
 
@@ -35,7 +35,7 @@ def ssl_creds(assets_path: Callable[[str], Path]) -> SSLCredPaths:
 
 
 @pytest.fixture(scope="session")
-def ssl_server(ssl_creds: SSLCredPaths) -> Iterator[http.server.HTTPServer]:
+def ssl_server(ssl_creds: SSLCredPaths) -> Generator[http.server.HTTPServer]:
     class MyServer(http.server.BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
 

--- a/tests/unit_tests/test_wb_logging.py
+++ b/tests/unit_tests/test_wb_logging.py
@@ -1,7 +1,7 @@
 import contextlib
 import logging
 import pathlib
-from collections.abc import Iterator
+from collections.abc import Generator
 
 from wandb.sdk.lib import wb_logging
 
@@ -12,7 +12,7 @@ wb_logging.configure_wandb_logger()
 def _wandb_file_handler(
     run_id: str,
     path: pathlib.Path,
-) -> Iterator[None]:
+) -> Generator[None]:
     handler = wb_logging.add_file_handler(run_id, path)
     try:
         yield

--- a/tools/generate-tool.py
+++ b/tools/generate-tool.py
@@ -14,7 +14,7 @@ import filecmp
 import os
 import subprocess
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Generator
 from pathlib import Path, PurePath
 
 parser = argparse.ArgumentParser()
@@ -81,7 +81,7 @@ def format_files(paths: list[PurePath]) -> None:
 
 
 @contextlib.contextmanager
-def temp_fname() -> Iterator[PurePath]:
+def temp_fname() -> Generator[PurePath]:
     try:
         f = tempfile.NamedTemporaryFile(delete=False)
         tmp_name = f.name

--- a/tools/local_wandb_server.py
+++ b/tools/local_wandb_server.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import time
 import traceback
-from collections.abc import Iterator
+from collections.abc import Generator
 
 import click
 import filelock
@@ -252,7 +252,7 @@ def _resources(suffix: str) -> pathlib.Path:
 
 
 @contextlib.contextmanager
-def _info_file() -> Iterator[_InfoFile]:
+def _info_file() -> Generator[_InfoFile]:
     with filelock.FileLock(_resources(".state.lock")):
         with open(_resources(".state"), "a+") as f:
             f.seek(0)

--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -18,7 +18,7 @@ import re
 import shutil
 import sys
 import threading
-from collections.abc import Iterator
+from collections.abc import Generator
 from typing import TYPE_CHECKING, Protocol
 
 import click
@@ -93,7 +93,7 @@ def termsetup(
 
 
 @contextlib.contextmanager
-def dynamic_text() -> Iterator[DynamicBlock | None]:
+def dynamic_text() -> Generator[DynamicBlock | None]:
     """A context manager that provides a handle to a new dynamic text area.
 
     The text goes to stderr. Returns None if dynamic text is not supported.

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 
@@ -29,7 +29,7 @@ def _set_wandb_auth_mode() -> None:
 @contextmanager
 def override_sandbox_entity(
     entity: str | None = None,
-) -> Iterator[None]:
+) -> Generator[None]:
     """Temporarily override the sandbox entity for sandbox auth.
 
     Passing `None` means using the default resolve logic from run

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -14,7 +14,7 @@ import stat
 import tempfile
 import time
 from collections import deque
-from collections.abc import Iterator, Sequence
+from collections.abc import Generator, Sequence
 from concurrent.futures import Executor, ThreadPoolExecutor, as_completed
 from copy import copy
 from dataclasses import asdict, replace
@@ -1452,7 +1452,7 @@ class Artifact:
     @ensure_not_finalized
     def new_file(
         self, name: str, mode: str = "x", encoding: str | None = None
-    ) -> Iterator[IO]:
+    ) -> Generator[IO]:
         """Open a new temporary file and add it to the artifact.
 
         Args:

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import AbstractContextManager
 from functools import lru_cache
 from pathlib import Path
@@ -203,7 +203,7 @@ class ArtifactFileCache:
 
     def _opener(self, path: Path, size: int, skip_cache: bool = False) -> Opener:
         @contextlib.contextmanager
-        def atomic_open(mode: str = "w") -> Iterator[IO]:
+        def atomic_open(mode: str = "w") -> Generator[IO]:
             if "a" in mode:
                 raise ValueError("Appending to cache files is not supported")
 

--- a/wandb/sdk/lib/console_capture.py
+++ b/wandb/sdk/lib/console_capture.py
@@ -30,7 +30,7 @@ import contextvars
 import logging
 import sys
 import threading
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from typing import IO, AnyStr, Protocol
 
 from . import wb_logging
@@ -204,7 +204,7 @@ def _patch(
 @contextlib.contextmanager
 def _enter_callbacks(
     callbacks: dict[int, _WriteCallback],
-) -> Iterator[list[_WriteCallback]]:
+) -> Generator[list[_WriteCallback]]:
     """Returns a list of callbacks to invoke.
 
     This prevents deadlocks and some infinite loops by returning an empty list
@@ -272,7 +272,7 @@ def _enter_callbacks(
 
 
 @contextlib.contextmanager
-def _reset_on_exception() -> Iterator[None]:
+def _reset_on_exception() -> Generator[None]:
     """Clear all callbacks on any exception, suppressing it.
 
     This prevents infinite loops:

--- a/wandb/sdk/lib/printer.py
+++ b/wandb/sdk/lib/printer.py
@@ -7,7 +7,7 @@ import contextlib
 import itertools
 import platform
 import sys
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 
 import click
 from typing_extensions import override
@@ -116,7 +116,7 @@ class Printer(abc.ABC):
 
     @contextlib.contextmanager
     @abc.abstractmethod
-    def dynamic_text(self) -> Iterator[DynamicText | None]:
+    def dynamic_text(self) -> Generator[DynamicText | None]:
         """A context manager providing a handle to a block of changeable text.
 
         Since `wandb` may be outputting to a terminal, it's important to only
@@ -289,7 +289,7 @@ class _PrinterTerm(Printer):
 
     @override
     @contextlib.contextmanager
-    def dynamic_text(self) -> Iterator[DynamicText | None]:
+    def dynamic_text(self) -> Generator[DynamicText | None]:
         if self._settings and self._settings.silent:
             yield None
             return
@@ -445,7 +445,7 @@ class _PrinterJupyter(Printer):
 
     @override
     @contextlib.contextmanager
-    def dynamic_text(self) -> Iterator[DynamicText | None]:
+    def dynamic_text(self) -> Generator[DynamicText | None]:
         if self._settings and self._settings.silent:
             yield None
             return

--- a/wandb/sdk/lib/progress.py
+++ b/wandb/sdk/lib/progress.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections.abc import Iterator
+from collections.abc import Generator
 from typing import NoReturn
 
 from wandb.proto import wandb_internal_pb2 as pb
@@ -71,7 +71,7 @@ async def loop_printing_operation_stats(
 def progress_printer(
     printer: p.Printer,
     default_text: str,
-) -> Iterator[ProgressPrinter]:
+) -> Generator[ProgressPrinter]:
     """Context manager providing an object for printing run progress.
 
     Args:

--- a/wandb/sdk/lib/wb_logging.py
+++ b/wandb/sdk/lib/wb_logging.py
@@ -18,7 +18,7 @@ import contextlib
 import contextvars
 import logging
 import pathlib
-from collections.abc import Iterator
+from collections.abc import Generator
 
 
 class _NotRunSpecific:
@@ -70,7 +70,7 @@ def configure_wandb_logger() -> None:
 
 
 @contextlib.contextmanager
-def log_to_run(run_id: str | None) -> Iterator[None]:
+def log_to_run(run_id: str | None) -> Generator[None]:
     """Direct all wandb log messages to the given run.
 
     Args:
@@ -91,7 +91,7 @@ def log_to_run(run_id: str | None) -> Iterator[None]:
 
 
 @contextlib.contextmanager
-def log_to_all_runs() -> Iterator[None]:
+def log_to_all_runs() -> Generator[None]:
     """Direct wandb log messages to all runs.
 
     Unlike `log_to_run(None)`, this indicates an intentional choice.

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -21,7 +21,7 @@ import platform
 import sys
 import tempfile
 import time
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from typing import TYPE_CHECKING, Literal
 
 from typing_extensions import Any, Protocol, Self
@@ -659,7 +659,7 @@ class _WandbInit:
         ipython.display_pub.publish = publish
 
     @contextlib.contextmanager
-    def setup_run_log_directory(self, settings: Settings) -> Iterator[None]:
+    def setup_run_log_directory(self, settings: Settings) -> Generator[None]:
         """Set up the run's log directory.
 
         This is a context manager that closes and unregisters the log handler


### PR DESCRIPTION
Changes `@pytest.fixture` and `@contextlib.contextmanager` functions to use `Generator` rather than `Iterator` in their type hints, for the same reason as in PR #11881, which is that using `Iterator` with `@contextlib.contextmanager` emits a deprecation diagnostic. There's no deprecation for `@pytest.fixture`, but I thought we might as well set the right precedent.

A `Generator` is created by a function that uses `yield`, and `Generator[T]` is a subtype of `Iterator[T]`. A `Generator[T]` is different because it [has additional `send()` and `throw()` methods](https://docs.python.org/3/reference/expressions.html#generator-iterator-methods).

I didn't update other functions that return `Iterator[T]` because returning a supertype puts fewer constraints on the implementation (in theory, those functions could be rewritten using a class with just `__iter__` and `__next__` methods). But `@pytest.fixture` and `@contextlib.contextmanager` should always be used with generators (specifically, generator functions).