### PR TITLE
Some TypeErrors are declared but never raised

### DIFF
--- a/tests/unit_tests/test_dtypes.py
+++ b/tests/unit_tests/test_dtypes.py
@@ -960,3 +960,23 @@ def test_artifact_type():
         == nested_target_type
     )
     assert type_of_nested_artifact_string.assign(nested_artifact) == nested_target_type
+
+
+def test_type_from_dict_missing_wb_type():
+    with pytest.raises(TypeError):
+        TypeRegistry.type_from_dict({})
+
+
+def test_type_from_dict_unknown_wb_type():
+    with pytest.raises(TypeError):
+        TypeRegistry.type_from_dict({"wb_type": "nonexistent_type_xyz"})
+
+
+def test_const_type_rejects_unsupported_type():
+    with pytest.raises(TypeError):
+        ConstType(object())
+
+
+def test_typed_dict_type_from_obj_rejects_non_dict():
+    with pytest.raises(TypeError):
+        TypedDictType.from_obj("not a dict")

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -79,10 +79,10 @@ class TypeRegistry:
     ) -> Type:
         wb_type = json_dict.get("wb_type")
         if wb_type is None:
-            TypeError("json_dict must contain `wb_type` key")
+            raise TypeError("json_dict must contain `wb_type` key")
         _type = TypeRegistry.types_by_name().get(wb_type)
         if _type is None:
-            TypeError(f"missing type handler for {wb_type}")
+            raise TypeError(f"missing type handler for {wb_type}")
         return _type.from_json(json_dict, artifact)
 
     @staticmethod
@@ -440,7 +440,7 @@ class ConstType(Type):
 
     def __init__(self, val: t.Any | None = None, is_set: bool | None = False):
         if val.__class__ not in [str, int, float, bool, set, list, None.__class__]:
-            TypeError(
+            raise TypeError(
                 f"ConstType only supports str, int, float, bool, set, list, and None types. Found {val}"
             )
         if is_set or isinstance(val, set):
@@ -795,7 +795,7 @@ class TypedDictType(Type):
     @classmethod
     def from_obj(cls, py_obj: t.Any | None = None) -> TypedDictType:
         if not isinstance(py_obj, dict):
-            TypeError("TypedDictType.from_obj expects a dictionary")
+            raise TypeError("TypedDictType.from_obj expects a dictionary")
 
         assert isinstance(py_obj, dict)  # helps mypy type checker
         return cls({key: TypeRegistry.type_of(py_obj[key]) for key in py_obj})


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes #11890

This PR raises some TypeErrors in `_dtypes.py` that look like they were intended to be raised but never were.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

1. The first commit introduces four failing tests.
2. The second commit adds four counts of `raise`, one for each test.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

Note for reviewer
-----------------

The change to `ConstType.__init__()` causes some other tests to fail.
It looks as though there may be a presumption that you can have a `ConstType(dict())` (at least in the tests), even though `ConstType` says in its docstring that it only supports primatives (though it also does support sets and lists).

I'm not sure what the solution ought to be. It might be one of:

1. Allow `ConstType` to be passed other objects (I'm not sure how safe it is to allow mutable types like Dict though) and remove the `raise`.
2. Issue a warning from `ConstType` that non-primitive types could result in runtime issues and/or that they will be deprecated in a future release.
3. Do not allow non-primitive types and amend/remove the tests that rely on them (such as https://github.com/wandb/wandb/blob/bb98bc3a7a30953f5a48863b1f91a4b949158ae8/tests/unit_tests/test_dtypes.py#L435).
