### PR TITLE
chore: bump ariadne-codegen to 0.17.1

### DIFF
--- a/requirements/requirements_dev.3.10.darwin.txt
+++ b/requirements/requirements_dev.3.10.darwin.txt
@@ -34,7 +34,7 @@ argon2-cffi==25.1.0
     # via jupyter-server
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-ariadne-codegen==0.16.0
+ariadne-codegen==0.17.1
     # via -r requirements/requirements_dev.txt
 arrow==1.4.0
     # via isoduration
@@ -72,7 +72,7 @@ backports-asyncio-runner==1.2.0
     # via pytest-asyncio
 beautifulsoup4==4.14.3
     # via nbconvert
-black==26.3.1
+black==26.5.1
     # via ariadne-codegen
 bleach==6.3.0
     # via nbconvert
@@ -351,7 +351,7 @@ hf-xet==1.5.0
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -r requirements/requirements_test.txt
     #   ariadne-codegen
@@ -1015,9 +1015,7 @@ skops==0.14.0
 smmap==5.0.3
     # via gitdb
 sniffio==1.3.1
-    # via
-    #   httpx
-    #   openai
+    # via openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.13.1

--- a/requirements/requirements_dev.3.10.linux.txt
+++ b/requirements/requirements_dev.3.10.linux.txt
@@ -35,7 +35,7 @@ argon2-cffi==25.1.0
     # via jupyter-server
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-ariadne-codegen==0.16.0
+ariadne-codegen==0.17.1
     # via -r requirements/requirements_dev.txt
 arrow==1.4.0
     # via isoduration
@@ -75,7 +75,7 @@ backports-asyncio-runner==1.2.0
     # via pytest-asyncio
 beautifulsoup4==4.14.3
     # via nbconvert
-black==26.3.1
+black==26.5.1
     # via ariadne-codegen
 bleach==6.3.0
     # via nbconvert
@@ -373,7 +373,7 @@ hf-xet==1.5.0
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -r requirements/requirements_test.txt
     #   ariadne-codegen
@@ -1112,9 +1112,7 @@ skops==0.14.0
 smmap==5.0.3
     # via gitdb
 sniffio==1.3.1
-    # via
-    #   httpx
-    #   openai
+    # via openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.13.1

--- a/requirements/requirements_dev.3.10.windows.txt
+++ b/requirements/requirements_dev.3.10.windows.txt
@@ -35,7 +35,7 @@ argon2-cffi==25.1.0
     # via jupyter-server
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-ariadne-codegen==0.16.0
+ariadne-codegen==0.17.1
     # via -r requirements/requirements_dev.txt
 arrow==1.4.0
     # via isoduration
@@ -77,7 +77,7 @@ backports-asyncio-runner==1.2.0
     # via pytest-asyncio
 beautifulsoup4==4.14.3
     # via nbconvert
-black==26.3.1
+black==26.5.1
     # via ariadne-codegen
 bleach==6.3.0
     # via nbconvert
@@ -373,7 +373,7 @@ hf-xet==1.5.0
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -r requirements/requirements_test.txt
     #   ariadne-codegen
@@ -1071,9 +1071,7 @@ skops==0.14.0
 smmap==5.0.3
     # via gitdb
 sniffio==1.3.1
-    # via
-    #   httpx
-    #   openai
+    # via openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.13.1

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -33,7 +33,7 @@ argon2-cffi==25.1.0
     # via jupyter-server
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-ariadne-codegen==0.16.0
+ariadne-codegen==0.17.1
     # via -r requirements/requirements_dev.txt
 arrow==1.4.0
     # via isoduration
@@ -67,7 +67,7 @@ babel==2.18.0
     # via jupyterlab-server
 beautifulsoup4==4.14.3
     # via nbconvert
-black==26.3.1
+black==26.5.1
     # via ariadne-codegen
 bleach==6.3.0
     # via nbconvert
@@ -343,7 +343,7 @@ hf-xet==1.4.2
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -r requirements/requirements_test.txt
     #   ariadne-codegen
@@ -709,7 +709,7 @@ parameterized==0.9.0
     # via -r requirements/requirements_test.txt
 parso==0.8.6
     # via jedi
-pathspec==1.0.4
+pathspec==1.1.1
     # via black
 pexpect==4.9.0
     # via ipython
@@ -1012,9 +1012,7 @@ skops==0.13.0
 smmap==5.0.3
     # via gitdb
 sniffio==1.3.1
-    # via
-    #   httpx
-    #   openai
+    # via openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.13.1

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -34,7 +34,7 @@ argon2-cffi==25.1.0
     # via jupyter-server
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-ariadne-codegen==0.16.0
+ariadne-codegen==0.17.1
     # via -r requirements/requirements_dev.txt
 arrow==1.4.0
     # via isoduration
@@ -70,7 +70,7 @@ babel==2.18.0
     # via jupyterlab-server
 beautifulsoup4==4.14.3
     # via nbconvert
-black==26.3.1
+black==26.5.1
     # via ariadne-codegen
 bleach==6.3.0
     # via nbconvert
@@ -365,7 +365,7 @@ hf-xet==1.4.2
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -r requirements/requirements_test.txt
     #   ariadne-codegen
@@ -794,7 +794,7 @@ parameterized==0.9.0
     # via -r requirements/requirements_test.txt
 parso==0.8.6
     # via jedi
-pathspec==1.0.4
+pathspec==1.1.1
     # via black
 pexpect==4.9.0
     # via ipython
@@ -1109,9 +1109,7 @@ skops==0.13.0
 smmap==5.0.3
     # via gitdb
 sniffio==1.3.1
-    # via
-    #   httpx
-    #   openai
+    # via openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.13.1

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -34,7 +34,7 @@ argon2-cffi==25.1.0
     # via jupyter-server
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-ariadne-codegen==0.16.0
+ariadne-codegen==0.17.1
     # via -r requirements/requirements_dev.txt
 arrow==1.4.0
     # via isoduration
@@ -72,7 +72,7 @@ babel==2.18.0
     # via jupyterlab-server
 beautifulsoup4==4.14.3
     # via nbconvert
-black==26.3.1
+black==26.5.1
     # via ariadne-codegen
 bleach==6.3.0
     # via nbconvert
@@ -365,7 +365,7 @@ hf-xet==1.4.2
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -r requirements/requirements_test.txt
     #   ariadne-codegen
@@ -752,7 +752,7 @@ parameterized==0.9.0
     # via -r requirements/requirements_test.txt
 parso==0.8.6
     # via jedi
-pathspec==1.0.4
+pathspec==1.1.1
     # via black
 pillow==12.1.1
     # via
@@ -1068,9 +1068,7 @@ skops==0.13.0
 smmap==5.0.3
     # via gitdb
 sniffio==1.3.1
-    # via
-    #   httpx
-    #   openai
+    # via openai
 sortedcontainers==2.4.0
     # via hypothesis
 soundfile==0.13.1

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -66,7 +66,11 @@ boto3
 botocore>=1.5.76
 
 # `ariadne-codegen` is a dev-only dependency used for GraphQL codegen.
-ariadne-codegen
+# Restricting to `<0.17.2` is deliberate for now. See: https://github.com/mirumee/ariadne-codegen/pull/403,
+# which renames generated fields shadowing Python builtin types
+# (e.g. `filter`/`type` -> `filter_`/`type_` via `alias=...`) and would break
+# handwritten subclasses and callers of generated types.
+ariadne-codegen==0.17.1
 
 awscli; sys_platform == 'win32'
 .[launch]

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -11,7 +11,7 @@ parameterized~=0.9.0
 
 flask~=2.2
 fastapi~=0.115.3
-httpx~=0.27.0
+httpx~=0.28.0
 responses~=0.23.3
 uvicorn~=0.32.0
 


### PR DESCRIPTION
Description
-----------

- Fixes [WB-34454](https://coreweave.atlassian.net/browse/WB-34454)

PR bumps `ariadne-codegen` to 0.17.1 and updates the `httpx` test pin so `ariadne-codegen` 0.17 can be installed.

- Relaxes `httpx` from `~=0.27.0` to `~=0.28.0` in `requirements/requirements_test.txt`.
- Adds `ariadne-codegen<0.17.2` in `requirements/requirements_dev.txt` so we stay below [0.17.2](https://github.com/mirumee/ariadne-codegen/releases/tag/0.17.2). That release renames generated fields when GraphQL names shadow Python builtins (`filter`, `type`, and similar), which would need coordinated updates to generated code and its call sites.

No intended functional changes. Existing tests must continue to pass.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

[WB-34454]: https://coreweave.atlassian.net/browse/WB-34454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ