### PR TITLE
chore(sdk): post release notifications to wandb-c1-shared

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -449,7 +449,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        channel: [C0108SLEP6K, C01KQ5KTDC3]
+        channel: [C0108SLEP6K, C01KQ5KTDC3, C080Q7GLKRR]
     steps:
       - name: Post to Slack
         uses: slackapi/slack-github-action@v3.0.3


### PR DESCRIPTION
## Summary
- Adds the `wandb-c1-shared` Slack channel (`C080Q7GLKRR`) to the SDK release notification matrix in `.github/workflows/release-sdk.yml` so customer receives SDK release notes alongside the existing internal channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)