### PR TITLE
refactor: simple ratelimiter for asyncio sleep(remaining) pattern

### DIFF
--- a/requirements/requirements_dev.3.10.darwin.txt
+++ b/requirements/requirements_dev.3.10.darwin.txt
@@ -527,6 +527,8 @@ lightning-utilities==0.15.3
     #   torchmetrics
 litellm==1.83.0
     # via dspy
+looptime==0.7
+    # via -r requirements/requirements_test.txt
 mako==1.3.12
     # via alembic
 markdown==3.10.2

--- a/requirements/requirements_dev.3.10.linux.txt
+++ b/requirements/requirements_dev.3.10.linux.txt
@@ -556,6 +556,8 @@ lightning-utilities==0.15.3
     #   torchmetrics
 litellm==1.83.0
     # via dspy
+looptime==0.7
+    # via -r requirements/requirements_test.txt
 mako==1.3.12
     # via alembic
 markdown==3.10.2

--- a/requirements/requirements_dev.3.10.windows.txt
+++ b/requirements/requirements_dev.3.10.windows.txt
@@ -556,6 +556,8 @@ lightning-utilities==0.15.3
     #   torchmetrics
 litellm==1.83.0
     # via dspy
+looptime==0.7
+    # via -r requirements/requirements_test.txt
 mako==1.3.12
     # via alembic
 markdown==3.10.2

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -522,6 +522,8 @@ lightning-utilities==0.15.3
     #   torchmetrics
 litellm==1.82.6
     # via dspy
+looptime==0.7
+    # via -r requirements/requirements_test.txt
 mako==1.3.10
     # via alembic
 markdown==3.10.2

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -551,6 +551,8 @@ lightning-utilities==0.15.3
     #   torchmetrics
 litellm==1.82.6
     # via dspy
+looptime==0.7
+    # via -r requirements/requirements_test.txt
 mako==1.3.10
     # via alembic
 markdown==3.10.2

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -551,6 +551,8 @@ lightning-utilities==0.15.3
     #   torchmetrics
 litellm==1.82.6
     # via dspy
+looptime==0.7
+    # via -r requirements/requirements_test.txt
 mako==1.3.10
     # via alembic
 markdown==3.10.2

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -8,6 +8,7 @@ pytest-timeout~=2.4
 pytest-flakefinder~=1.1
 pyfakefs~=5.9
 parameterized~=0.9.0
+looptime
 
 flask~=2.2
 fastapi~=0.115.3

--- a/tests/unit_tests/test_lib/test_ratelimit.py
+++ b/tests/unit_tests/test_lib/test_ratelimit.py
@@ -1,0 +1,50 @@
+import asyncio
+
+import pytest
+from looptime import LoopTimeProxy
+from wandb.sdk.lib import asyncio_compat, ratelimit
+
+
+@pytest.mark.asyncio
+@pytest.mark.looptime
+async def test_allows_first_event(looptime: LoopTimeProxy):
+    cooldown = ratelimit.Cooldown(13)
+
+    await cooldown.wait()
+
+    # Should not sleep, so no time should pass.
+    assert looptime == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.looptime
+async def test_waits_for_cooldown(looptime: LoopTimeProxy):
+    cooldown = ratelimit.Cooldown(10)
+
+    # First event allowed immediately.
+    await cooldown.wait()
+    assert looptime == 0
+
+    # No sleeping after the cooldown passes.
+    await asyncio.sleep(11)
+    await cooldown.wait()
+    assert looptime == 11
+
+    # The next event must wait the cooldown (10s) after the last event,
+    # not from the last unblock time. This rate limiter does not adjust
+    # for drift.
+    await cooldown.wait()
+    assert looptime == 21
+
+
+@pytest.mark.asyncio
+@pytest.mark.looptime
+async def test_concurrent_wait(looptime: LoopTimeProxy):
+    cooldown = ratelimit.Cooldown(3)
+
+    async with asyncio_compat.open_task_group() as group:
+        group.start_soon(cooldown.wait())  # Completes immediately (time = 0)
+        group.start_soon(cooldown.wait())  # Completes at time = 3
+        group.start_soon(cooldown.wait())  # Completes at time = 6
+
+    assert looptime == 6

--- a/wandb/sdk/lib/asyncio_compat.py
+++ b/wandb/sdk/lib/asyncio_compat.py
@@ -279,3 +279,14 @@ async def race(*coros: Coroutine[Any, Any, Any]) -> None:
     async with open_task_group(race=True) as tg:
         for coro in coros:
             tg.start_soon(coro)
+
+
+def now() -> float:
+    """Returns the current time according to the running event loop.
+
+    This is normally `time.monotonic()`, but using this allows a custom
+    event loop implementation to override how time works during tests.
+
+    This raises an error if called outside of an asyncio loop.
+    """
+    return asyncio.get_running_loop().time()

--- a/wandb/sdk/lib/ratelimit.py
+++ b/wandb/sdk/lib/ratelimit.py
@@ -1,0 +1,44 @@
+"""A small asyncio rate limiter."""
+
+import asyncio
+
+from wandb.sdk.lib import asyncio_compat
+
+
+class Cooldown:
+    """A very simple rate limiter for asyncio loops.
+
+    Implemented by sleeping until the next unblock time.
+
+    Use the `looptime` package to test code that uses this.
+    """
+
+    def __init__(self, cooldown: float, /) -> None:
+        """Initialize the rate limiter.
+
+        The first `wait` will return immediately.
+
+        Args:
+            cooldown: The number of seconds that must pass between consecutive
+                events. The reciprocal of the frequency (events per second).
+        """
+        self._cooldown = cooldown
+
+        # Allow the next event immediately.
+        self._unblock_at = asyncio_compat.now()
+
+    async def wait(self) -> None:
+        """Wait for the cooldown, then reset it.
+
+        This can be called from multiple tasks at the same time,
+        in which case an arbitrary task will win, and the others will
+        continue waiting for the new cooldown.
+
+        Does not affect the cooldown if cancelled.
+        """
+        # Loop in case tasks call wait() concurrently.
+        # This is exactly like using a condvar.
+        while (remaining := (self._unblock_at - asyncio_compat.now())) > 0:
+            await asyncio.sleep(remaining)
+
+        self._unblock_at = asyncio_compat.now() + self._cooldown


### PR DESCRIPTION
Defines a `ratelimit.Cooldown()` class that implements a simple rate-limiting pattern we have in a couple spots in the codebase:

```python
start_time = time.monotonic()
await something()
end_time = time.monotonic()

remaining = _PERIOD - (end_time - start_time)
if remaining > 0:
    await asyncio.sleep(remaining)
```

This PR also adds `looptime` to our test dependencies. `looptime` patches the `pytest-asyncio` event loop to use a fake time that fast-forwards whenever the loop would block to sleep. I read through its source code and really liked its approach. I had initially written a simple fixture to directly patch `asyncio.sleep()` and `time.monotonic()`, but dropped that idea upon realizing I'd also have to patch `asyncio.wait_for()` and other waiting operations to work for our tests. The `looptime` package replaces a low-level event loop method instead, which works more generally.

Follow-up PR rewrites other tests to use `looptime` and `ratelimit.Cooldown()`.