### PR TITLE
refactor: use ratelimit.Cooldown() and looptime

### DIFF
--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -4,7 +4,9 @@ import asyncio
 import pathlib
 import re
 from collections.abc import Callable
+from typing import cast
 
+import looptime
 import pytest
 import wandb
 from click.testing import CliRunner
@@ -165,14 +167,6 @@ class _Tester:
             self._cond.notify_all()
 
         return handle.map(to_response)
-
-
-@pytest.fixture
-def skip_asyncio_sleep(monkeypatch: pytest.MonkeyPatch):
-    async def do_nothing(duration: float) -> None:
-        _ = duration
-
-    monkeypatch.setattr(beta_sync, "_SLEEP", do_nothing)
 
 
 def _unauthenticate_for_test() -> None:
@@ -463,7 +457,6 @@ def test_prints_relative_paths(
     ]
 
 
-@pytest.mark.usefixtures("skip_asyncio_sleep")
 def test_prints_status_updates(
     tmp_path: pathlib.Path,
     emulated_terminal: EmulatedTerminal,
@@ -498,6 +491,10 @@ def test_prints_status_updates(
         await tester.respond_sync_status(new_infos=[], new_errors=[])
 
     async def do_test():
+        # Enable looptime to fast-forward any sleeping.
+        loop = asyncio.get_running_loop()
+        looptime.patch_event_loop(cast(asyncio.BaseEventLoop, loop))
+
         tester: Any = _Tester(mailbox=mailbox)
 
         async with asyncio_compat.open_task_group(exit_timeout=5) as group:

--- a/tests/unit_tests/test_lib/test_run_messages.py
+++ b/tests/unit_tests/test_lib/test_run_messages.py
@@ -1,48 +1,32 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+import pytest_asyncio
+from looptime import LoopTimeProxy
 from wandb.proto import wandb_internal_pb2 as pb
-from wandb.sdk.lib import asyncio_manager, run_messages
+from wandb.sdk.lib import asyncio_compat, run_messages
 
 from tests.fixtures.mock_wandb_log import MockWandbLog
 
 
-@pytest.fixture(autouse=True)
-def fake_now(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Patched time.monotonic() that returns 0 by default."""
-    now = MagicMock()
-    now.return_value = 0
-    monkeypatch.setattr(run_messages, "_NOW", now)
-    return now
+@pytest_asyncio.fixture
+async def fake_messages() -> asyncio.Queue[pb.Result]:
+    """The queue of internal message responses to return in tests."""
+    return asyncio.Queue()
 
 
-@pytest.fixture(autouse=True)
-def fake_sleep(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
-    """Patched asyncio.sleep() that blocks forever by default."""
-
-    async def block(duration: float) -> None:
-        _ = duration
-        await asyncio.Event().wait()
-
-    sleep = AsyncMock()
-    sleep.side_effect = block
-    monkeypatch.setattr(run_messages, "_SLEEP", sleep)
-
-    return sleep
-
-
-@pytest.fixture
-def fake_messages() -> AsyncMock:
-    """Patched MailboxHandle.wait_async() that returns an empty Result."""
-    return AsyncMock(return_value=pb.Result())
-
-
-@pytest.fixture
-def fake_interface(fake_messages: AsyncMock) -> Mock:
+@pytest_asyncio.fixture
+async def fake_interface(fake_messages: asyncio.Queue[pb.Result]) -> Mock:
     """Mock interface that returns fake_messages from deliver_async."""
+
+    async def next_message(*, timeout: float) -> pb.Result:
+        result = await asyncio.wait_for(fake_messages.get(), timeout=timeout)
+        fake_messages.task_done()  # needed for join() in tests
+        return result
+
     handle = Mock()
-    handle.wait_async = fake_messages
+    handle.wait_async = next_message
 
     interface = Mock()
     interface.deliver_async = AsyncMock(return_value=handle)
@@ -50,113 +34,85 @@ def fake_interface(fake_messages: AsyncMock) -> Mock:
     return interface
 
 
-@pytest.fixture(scope="module")
-def asyncer():
-    asyncer = asyncio_manager.AsyncioManager()
-    asyncer.start()
-
-    try:
-        yield asyncer
-    finally:
-        asyncer.join()
-
-
-def _make_messages_result(*warnings: str) -> pb.Result:
+def _result(*warnings: str) -> pb.Result:
     result = pb.Result()
     result.response.internal_messages_response.messages.warning.extend(warnings)
     return result
 
 
-def test_prints_warnings(
-    asyncer: asyncio_manager.AsyncioManager,
-    fake_messages: AsyncMock,
+@pytest.mark.looptime
+async def test_prints_warnings(
+    looptime: LoopTimeProxy,
+    fake_messages: asyncio.Queue[pb.Result],
     fake_interface: Mock,
     mock_wandb_log: MockWandbLog,
 ):
-    fake_messages.side_effect = [
-        _make_messages_result("warning 1", "warning 2", "warning 3"),
-        _make_messages_result(),
-    ]
+    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
 
-    rm = run_messages.RunMessages(asyncer, fake_interface)
-    rm.start()
-    rm.stop(timeout=5)
+    async with asyncio_compat.open_task_group() as group:
+        group.start_soon(rm.loop())
+
+        # Let loop() process one message:
+        fake_messages.put_nowait(_result("warning 1", "warning 2", "warning 3"))
+        await fake_messages.join()
+
+        # This message gets processed by stop():
+        fake_messages.put_nowait(_result("final warning"))
+        await rm.stop(timeout=5)
 
     mock_wandb_log.assert_warned("warning 1")
     mock_wandb_log.assert_warned("warning 2")
     mock_wandb_log.assert_warned("warning 3")
-
-
-def test_stop_does_final_poll(
-    asyncer: asyncio_manager.AsyncioManager,
-    fake_messages: AsyncMock,
-    fake_interface: Mock,
-    mock_wandb_log: MockWandbLog,
-):
-    fake_messages.side_effect = [
-        _make_messages_result(),
-        _make_messages_result("final warning"),
-    ]
-
-    rm = run_messages.RunMessages(asyncer, fake_interface)
-    rm.start()
-    rm.stop(timeout=5)
-
     mock_wandb_log.assert_warned("final warning")
+    assert looptime == 0  # No sleeping should have happened.
 
 
-def test_stop_warns_on_loop_timeout(
-    asyncer: asyncio_manager.AsyncioManager,
-    fake_messages: AsyncMock,
+@pytest.mark.looptime
+async def test_stop_warns_on_loop_timeout(
     fake_interface: Mock,
     wandb_caplog: pytest.LogCaptureFixture,
 ):
-    fake_messages.side_effect = [
-        _make_messages_result(),
-        _make_messages_result(),
-    ]
+    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
 
-    rm = run_messages.RunMessages(asyncer, fake_interface)
-    rm.start()
-    rm.stop(timeout=-1)  # time out immediately
+    async with asyncio_compat.open_task_group() as group:
+        group.start_soon(rm.loop())
+        await rm.stop(timeout=-1)  # time out immediately
 
     assert "Timed out waiting for messages" in wandb_caplog.text
 
 
-def test_stop_warns_on_handle_timeout(
-    asyncer: asyncio_manager.AsyncioManager,
-    fake_messages: AsyncMock,
+@pytest.mark.looptime
+async def test_stop_warns_on_handle_timeout(
     fake_interface: Mock,
     wandb_caplog: pytest.LogCaptureFixture,
 ):
-    fake_messages.side_effect = [
-        _make_messages_result(),
-        TimeoutError(),
-    ]
+    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
 
-    rm = run_messages.RunMessages(asyncer, fake_interface)
-    rm.start()
-    rm.stop(timeout=5)
+    async with asyncio_compat.open_task_group() as group:
+        group.start_soon(rm.loop())
+        await rm.stop(timeout=7)  # times out waiting on fake_messages
 
     assert "Timed out waiting for messages" in wandb_caplog.text
 
 
-def test_sleeps_for_remaining_interval(
-    asyncer: asyncio_manager.AsyncioManager,
-    fake_sleep: AsyncMock,
-    fake_now: MagicMock,
-    fake_messages: AsyncMock,
+@pytest.mark.looptime
+async def test_rate_limits(
+    looptime: LoopTimeProxy,
+    fake_messages: asyncio.Queue[pb.Result],
     fake_interface: Mock,
 ):
-    fake_now.side_effect = [0, 3]  # pretend 3 seconds pass waiting for messages
-    fake_messages.side_effect = [
-        _make_messages_result(),
-        _make_messages_result(),
-    ]
+    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
 
-    rm = run_messages.RunMessages(asyncer, fake_interface, poll_interval=10)
-    rm.start()
-    rm.stop(timeout=5)
+    async with asyncio_compat.open_task_group() as group:
+        group.start_soon(rm.loop())
 
-    # Polling interval is 10, and 3 seconds passed, so 7 remain.
-    fake_sleep.assert_called_once_with(7)
+        fake_messages.put_nowait(_result())  # immediate
+        fake_messages.put_nowait(_result())  # at 10s
+        fake_messages.put_nowait(_result())  # at 20s
+        await fake_messages.join()  # let the loop process everything
+
+        fake_messages.put_nowait(_result())  # last loop() iteration
+        fake_messages.put_nowait(_result())  # for stop()
+        await rm.stop(timeout=5)
+
+    assert looptime == 20

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import pathlib
-import time
 from collections.abc import Iterable, Iterator
 from itertools import filterfalse
 
@@ -13,7 +12,7 @@ import wandb
 from wandb.errors import term
 from wandb.proto.wandb_sync_pb2 import ServerSyncResponse
 from wandb.sdk import wandb_setup
-from wandb.sdk.lib import asyncio_compat, wbauth
+from wandb.sdk.lib import asyncio_compat, ratelimit, wbauth
 from wandb.sdk.lib.printer import Printer, new_printer
 from wandb.sdk.lib.progress import progress_printer
 from wandb.sdk.lib.service.service_connection import ServiceConnection
@@ -21,7 +20,6 @@ from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
 
 _MAX_LIST_LINES = 20
 _POLL_WAIT_SECONDS = 0.1
-_SLEEP = asyncio.sleep  # patched in tests
 
 
 def sync(
@@ -227,7 +225,7 @@ class _SyncStatusLoop:
         self._service = service
         self._printer = printer
 
-        self._rate_limit_last_time: float | None = None
+        self._rate_limit = ratelimit.Cooldown(_POLL_WAIT_SECONDS)
         self._done = asyncio.Event()
 
     async def wait_with_progress(
@@ -261,15 +259,10 @@ class _SyncStatusLoop:
 
     async def _rate_limit_check_done(self) -> bool:
         """Wait for rate limit and return whether _done is set."""
-        now = time.monotonic()
-        last_time = self._rate_limit_last_time
-        self._rate_limit_last_time = now
-
-        if last_time and (time_since_last := now - last_time) < _POLL_WAIT_SECONDS:
-            await asyncio_compat.race(
-                _SLEEP(_POLL_WAIT_SECONDS - time_since_last),
-                self._done.wait(),
-            )
+        await asyncio_compat.race(
+            self._rate_limit.wait(),
+            self._done.wait(),
+        )
 
         return self._done.is_set()
 

--- a/wandb/sdk/lib/run_messages.py
+++ b/wandb/sdk/lib/run_messages.py
@@ -5,17 +5,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import time
 
 from wandb.errors import term
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.interface.interface import InterfaceBase
-from wandb.sdk.lib import asyncio_compat, asyncio_manager
-
-# Patched in tests.
-_NOW = time.monotonic
-_SLEEP = asyncio.sleep
-
+from wandb.sdk.lib import asyncio_compat, asyncio_manager, ratelimit
 
 _logger = logging.getLogger(__name__)
 
@@ -70,7 +64,7 @@ class _RunMessagesImpl:
         poll_interval: float,
     ) -> None:
         self._interface = interface
-        self._poll_interval = poll_interval
+        self._rate_limit = ratelimit.Cooldown(poll_interval)
 
         self._stop_event = asyncio.Event()  # stop requested
         self._done_event = asyncio.Event()  # loop() done
@@ -85,12 +79,12 @@ class _RunMessagesImpl:
                 On timeout, some messages may be missed or may print
                 asynchronously.
         """
-        timeout_at = time.monotonic() + timeout
+        timeout_at = asyncio_compat.now() + timeout
 
         self._stop_event.set()
         try:
             await asyncio.wait_for(self._done_event.wait(), timeout)
-            await self._poll_and_print(timeout=timeout_at - time.monotonic())
+            await self._poll_and_print(timeout=timeout_at - asyncio_compat.now())
 
         # NOTE: asyncio.TimeoutError is different from TimeoutError
         #   until Python 3.11.
@@ -100,17 +94,16 @@ class _RunMessagesImpl:
     async def loop(self) -> None:
         """Print messages until asked to stop."""
         try:
-            while not self._stop_event.is_set():
-                start_time = _NOW()
-                await self._poll_and_print(timeout=None)
-                end_time = _NOW()
+            await self._rate_limit.wait()
 
-                remaining = self._poll_interval - (end_time - start_time)
-                if remaining > 0:
-                    await asyncio_compat.race(
-                        self._stop_event.wait(),  # wake up if stopping
-                        _SLEEP(remaining),
-                    )
+            while not self._stop_event.is_set():
+                await self._poll_and_print(timeout=None)
+
+                await asyncio_compat.race(
+                    self._stop_event.wait(),  # wake up if stopping
+                    self._rate_limit.wait(),
+                )
+
         finally:
             self._done_event.set()
 


### PR DESCRIPTION
Replaces explicit time tracking and sleeping by the new `ratelimit.Cooldown()` class from PR #11920, and updates the corresponding tests to use `looptime` instead of monkeypatching `asyncio.sleep()` and `time.monotonic()`.

I rewrote `test_run_messages.py` in terms of the async implementation class to avoid using `AsyncioManager` because it is more readable and easier to debug (having no multithreading). The (unchanged) `test_run_messages_full.py` system test still exercises the main class's code.