### PR TITLE
fix: error when calling beta_scan_history for a subset of keys without providing the '_step' key

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,3 +17,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Removed
 
 - Removed the unsupported `wandb.apis.importers` API (@dmitryduev in https://github.com/wandb/wandb/pull/11923)
+
+### Fixed
+
+- `api.Run.beta_scan_history` no longer throws `Step column '_step' not found in schema` error when called with a `keys` list that does not include `_step` (@jacobromero in https://github.com/wandb/wandb/pull/11924)

--- a/core/internal/runhistoryreader/reader.go
+++ b/core/internal/runhistoryreader/reader.go
@@ -61,6 +61,10 @@ func New(
 	useCache bool,
 	rustArrowWrapper *ffi.RustArrowWrapper,
 ) (*HistoryReader, error) {
+	if len(keys) > 0 && !slices.Contains(keys, parquet.StepKey) {
+		keys = append(keys, parquet.StepKey)
+	}
+
 	historyReader := &HistoryReader{
 		entity:        entity,
 		graphqlClient: graphqlClient,

--- a/core/internal/runhistoryreader/reader_test.go
+++ b/core/internal/runhistoryreader/reader_test.go
@@ -549,6 +549,92 @@ func TestHistoryReader_GetHistorySteps_WithKeys(t *testing.T) {
 	}
 }
 
+func TestHistoryReader_New_AddsStepKeyWhenMissing(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	t.Setenv("WANDB_CACHE_DIR", tempDir)
+
+	columns := []columnDef{
+		{name: "_step", colType: "int64"},
+		{name: "metric1", colType: "float64"},
+	}
+	data := []map[string]any{
+		{"_step": int64(0), "metric1": 1.0},
+	}
+
+	dummyContent := createDummyFileContent()
+	server := createHttpServer(t, respondWithContent(t, dummyContent))
+	mockGQL := mockGraphQLWithParquetUrls([]string{
+		server.URL + "/test.parquet",
+	})
+	rustWrapper := createMockRustArrowWrapper(
+		t,
+		columns,
+		map[uintptr][]map[string]any{1: data},
+	)
+
+	reader, err := New(
+		ctx,
+		"test-entity",
+		"test-project",
+		"test-run-id",
+		mockGQL,
+		retryablehttp.NewClient(),
+		[]string{"metric1"},
+		true,
+		rustWrapper,
+	)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t,
+		[]string{"metric1", parquet.StepKey},
+		reader.keys,
+	)
+}
+
+func TestHistoryReader_New_DoesNotDuplicateStepKey(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+	t.Setenv("WANDB_CACHE_DIR", tempDir)
+
+	columns := []columnDef{
+		{name: "_step", colType: "int64"},
+		{name: "metric1", colType: "float64"},
+	}
+	data := []map[string]any{
+		{"_step": int64(0), "metric1": 1.0},
+	}
+
+	dummyContent := createDummyFileContent()
+	server := createHttpServer(t, respondWithContent(t, dummyContent))
+	mockGQL := mockGraphQLWithParquetUrls([]string{
+		server.URL + "/test.parquet",
+	})
+	rustWrapper := createMockRustArrowWrapper(
+		t,
+		columns,
+		map[uintptr][]map[string]any{1: data},
+	)
+
+	reader, err := New(
+		ctx,
+		"test-entity",
+		"test-project",
+		"test-run-id",
+		mockGQL,
+		retryablehttp.NewClient(),
+		[]string{parquet.StepKey, "metric1"},
+		true,
+		rustWrapper,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{parquet.StepKey, "metric1"},
+		reader.keys,
+	)
+}
+
 func TestHistoryReader_GetHistorySteps_AllLiveData(t *testing.T) {
 	ctx := t.Context()
 	mockGQL := gqlmock.NewMockClient()

--- a/tests/system_tests/test_api/conftest.py
+++ b/tests/system_tests/test_api/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.server
 import io
+import re
 import socket
 import socketserver
 import threading
@@ -19,19 +20,66 @@ class ParquetFileHandler(http.server.SimpleHTTPRequestHandler):
 
     parquet_files: dict[str, bytes] = {}
 
+    def do_HEAD(self):
+        path = self.path.lstrip("/")
+
+        if path not in self.parquet_files:
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            return
+
+        content = self.parquet_files[path]
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(content)))
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+
     def do_GET(self):
         path = self.path.lstrip("/")
 
-        if path in self.parquet_files:
-            content = self.parquet_files[path]
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(content)
-        else:
+        if path not in self.parquet_files:
             self.send_response(404)
             self.send_header("Content-Type", "text/plain")
             self.end_headers()
             self.wfile.write(b"File not found")
+            return
+
+        content = self.parquet_files[path]
+        range_header = self.headers.get("Range")
+
+        if range_header is None:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(content)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            self.wfile.write(content)
+            return
+
+        match = re.fullmatch(r"bytes=(\d+)-(\d*)", range_header.strip())
+        if not match:
+            self.send_response(416)
+            self.send_header("Content-Range", f"bytes */{len(content)}")
+            self.end_headers()
+            return
+
+        start = int(match.group(1))
+        end = int(match.group(2)) if match.group(2) else len(content) - 1
+        end = min(end, len(content) - 1)
+
+        if start > end or start >= len(content):
+            self.send_response(416)
+            self.send_header("Content-Range", f"bytes */{len(content)}")
+            self.end_headers()
+            return
+
+        partial = content[start : end + 1]
+        self.send_response(206)
+        self.send_header("Content-Length", str(len(partial)))
+        self.send_header("Content-Range", f"bytes {start}-{end}/{len(content)}")
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+        self.wfile.write(partial)
 
 
 class ParquetHTTPServer:

--- a/tests/system_tests/test_api/test_public_api_history.py
+++ b/tests/system_tests/test_api/test_public_api_history.py
@@ -98,6 +98,46 @@ def test_run_beta_scan_history(
     ]
 
 
+def test_run_beta_scan_history__keys_subset(
+    wandb_backend_spy,
+    parquet_file_server,
+    monkeypatch,
+):
+    """Scanning with a key list that omits _step should still succeed.
+
+    The Rust parquet reader requires _step to filter rows by step range,
+    so the Go HistoryReader is expected to add it to the user-supplied
+    key list automatically.
+    """
+    monkeypatch.setenv("WANDB_CACHE_DIR", tempfile.mkdtemp())
+
+    parquet_data_path = "parquet/1.parquet"
+    run_data = {
+        "_step": [0, 1, 2],
+        "acc": [0.5, 0.75, 0.9],
+        "loss": [1.0, 0.5, 0.1],
+    }
+    parquet_file_server.serve_data_as_parquet_file(parquet_data_path, run_data)
+    stub_run_parquet_history(
+        wandb_backend_spy, parquet_file_server, [parquet_data_path]
+    )
+    stub_api_run_history_keys(wandb_backend_spy, 2)
+    with wandb.init() as run:
+        pass
+    run = wandb.Api().run(
+        f"{run.entity}/{run.project}/{run.id}",
+    )
+
+    scan = run.beta_scan_history(keys=["acc"])
+
+    history = [row for row in scan]
+    assert history == [
+        {"_step": 0, "acc": 0.5},
+        {"_step": 1, "acc": 0.75},
+        {"_step": 2, "acc": 0.9},
+    ]
+
+
 def test_run_beta_scan_history__iter_resets(
     wandb_backend_spy,
     parquet_file_server,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Calling _Run.beta_scan_history(keys=[...])_ with a subset of history keys that does not include __step_ would cause error scanning step range: Step. This PR fixes that issue, by including the `_step key if not provided.`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

```python
import wandb

api = wandb.Api()
run = api.run("jacobromerotest/uncategorized/2f444zmt")

start_time = time.time()
scan = run.beta_scan_history(
    keys=["a", "b"],
)

for row in scan:
    print(row)

```

#### Before this change

```
❯ python scantest.py
Traceback (most recent call last):
  File "/Users/jacob.romero/workspace/test/benchmark/scantest.py", line 31, in <module>
    for row in scan:
               ^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/apis/public/history.py", line 116, in __next__
    self._load_next()
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/apis/public/history.py", line 135, in _load_next
    response: pb.ApiResponse = self._service_api.send_api_request(api_request)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/apis/public/service_api.py", line 75, in send_api_request
    return conn.api_request(request, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/sdk/lib/service/service_connection.py", line 246, in api_request
    raise WandbApiFailedError(
wandb.sdk.lib.service.service_connection.WandbApiFailedError: error scanning step range: Step column '_step' not found in schema

```

#### After this change

```
❯ python scantest.py
{'a': 1, 'b': 0.5, '_step': 0}
{'a': 2, 'b': 1.5, '_step': 1}
{'a': 3, 'b': 2.5, '_step': 2}
{'a': 4, 'b': None, '_step': 3}
{'a': 5, 'b': 3.5, '_step': 4}

```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->