### PR TITLE
refactor: wbauth.set_auth_settings()

### DIFF
--- a/wandb/sdk/lib/wbauth/__init__.py
+++ b/wandb/sdk/lib/wbauth/__init__.py
@@ -7,6 +7,7 @@ __all__ = (
     "authenticate_session",
     "unauthenticate_session",
     "use_explicit_auth",
+    "set_auth_settings",
     "check_api_key",
     "prompt_and_save_api_key",
     "read_netrc_auth",
@@ -23,5 +24,6 @@ from .authenticate import (
 )
 from .host_url import HostUrl
 from .prompt import prompt_and_save_api_key
+from .settings import set_auth_settings
 from .validation import check_api_key
 from .wbnetrc import WriteNetrcError, read_netrc_auth, write_netrc_auth

--- a/wandb/sdk/lib/wbauth/authenticate.py
+++ b/wandb/sdk/lib/wbauth/authenticate.py
@@ -10,6 +10,7 @@ from wandb.sdk import wandb_setup
 from . import prompt, wbnetrc
 from .auth import Auth, AuthApiKey, AuthIdentityTokenFile, AuthWithSource
 from .host_url import HostUrl
+from .settings import set_auth_settings
 
 _session_auth_lock = threading.Lock()
 _session_auth: Auth | None = None
@@ -44,28 +45,8 @@ def _locked_set_session_auth(
     global _session_auth
     _session_auth = auth
 
-    if not update_settings:
-        return
-
-    settings = wandb_setup.singleton().settings
-
-    if auth is None:
-        settings.api_key = None
-        settings.identity_token_file = None
-
-    elif isinstance(auth, AuthApiKey):
-        settings.api_key = auth.api_key
-        settings.identity_token_file = None
-        settings.base_url = str(auth.host)
-
-    elif isinstance(auth, AuthIdentityTokenFile):
-        settings.api_key = None
-        settings.identity_token_file = str(auth.path)
-        settings.credentials_file = str(auth.credentials_path)
-        settings.base_url = str(auth.host)
-
-    else:
-        raise NotImplementedError(str(auth))
+    if update_settings:
+        set_auth_settings(wandb_setup.singleton().settings, auth)
 
 
 def unauthenticate_session(*, update_settings: bool = True) -> Auth | None:

--- a/wandb/sdk/lib/wbauth/settings.py
+++ b/wandb/sdk/lib/wbauth/settings.py
@@ -1,0 +1,43 @@
+"""Logic for setting auth-related parts of wandb.Settings."""
+
+from wandb.sdk.wandb_settings import Settings
+
+from .auth import Auth, AuthApiKey, AuthIdentityTokenFile
+
+
+def set_auth_settings(settings: Settings, auth: Auth | None) -> None:
+    """Set auth-related settings based on the given credentials.
+
+    Auth settings fall into two categories:
+    - Mutually exclusive settings used to determine the auth method to use,
+      like api_key and identity_token file.
+    - Additional data needed for the chosen auth method,
+      like base_url and credentials_file.
+
+    This function always updates the first kind, but only updates relevant
+    settings of the second kind: in particular, auth=None does not clear
+    base_url, and using an API key auth does not clear the credentials_file used
+    for JWT auth. This may be important in legacy code that expects to store
+    this information in settings even when logged out.
+
+    Args:
+        settings: The settings to update.
+        auth: The credentials, or possibly None to clear auth-related settings.
+    """
+    if auth is None:
+        settings.api_key = None
+        settings.identity_token_file = None
+
+    elif isinstance(auth, AuthApiKey):
+        settings.api_key = auth.api_key
+        settings.identity_token_file = None
+        settings.base_url = auth.host.url
+
+    elif isinstance(auth, AuthIdentityTokenFile):
+        settings.api_key = None
+        settings.identity_token_file = str(auth.path)
+        settings.credentials_file = str(auth.credentials_path)
+        settings.base_url = auth.host.url
+
+    else:
+        raise NotImplementedError(str(auth))


### PR DESCRIPTION
Defines `wbauth.set_auth_settings()` to propagate auth to local `wandb.Settings` values, like in `wandb.Api`.