### PR TITLE
refactor: fix ratelimit.py clock precision issue that can happen in tests

### DIFF
--- a/wandb/sdk/lib/ratelimit.py
+++ b/wandb/sdk/lib/ratelimit.py
@@ -36,9 +36,14 @@ class Cooldown:
 
         Does not affect the cooldown if cancelled.
         """
-        # Loop in case tasks call wait() concurrently.
-        # This is exactly like using a condvar.
-        while (remaining := (self._unblock_at - asyncio_compat.now())) > 0:
-            await asyncio.sleep(remaining)
+        now = asyncio_compat.now()
+        remaining = self._unblock_at - now
 
-        self._unblock_at = asyncio_compat.now() + self._cooldown
+        if remaining <= 0:
+            self._unblock_at = now + self._cooldown
+            return
+
+        # Set the unblock time for the next `wait()` before sleeping,
+        # in case `wait()` is called again concurrently.
+        self._unblock_at += self._cooldown
+        await asyncio.sleep(remaining)


### PR DESCRIPTION
Replaces the `while` loop with a single sleep to avoid floating point precision problems when time is patched by `looptime`.

The `while` loop assumed

```python
await asyncio.sleep(unblock_at - asyncio_compat.now())
assert asyncio_compat.now() >= unblock_at
```

But due to `looptime`'s [internal rounding](https://looptime.readthedocs.io/nuances/#time-resolution-floating-point-precision-errors), it's possible for `asyncio.sleep(<small number>)` to not advance the clock, causing an infinite loop. I ran into this when writing a test that used a cooldown of `0.1` a few times. At some point, `unblock_at` becomes `0.2 + 0.1 == 0.30000000000000004` but `asyncio_compat.now()` gets stuck at `0.3`.

I like it better without a loop anyway!