### PR TITLE
feat: push-based run messages

### DIFF
--- a/tests/unit_tests/test_lib/test_run_messages.py
+++ b/tests/unit_tests/test_lib/test_run_messages.py
@@ -47,52 +47,39 @@ async def test_prints_warnings(
     fake_interface: Mock,
     mock_wandb_log: MockWandbLog,
 ):
-    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
+    rm = run_messages._RunMessagesImpl(fake_interface)
 
     async with asyncio_compat.open_task_group() as group:
         group.start_soon(rm.loop())
 
-        # Let loop() process one message:
+        # Pretend first message batch happens at 1 second,
+        # then the run exits immediately after.
+        await asyncio.sleep(1)
         fake_messages.put_nowait(_result("warning 1", "warning 2", "warning 3"))
-        await fake_messages.join()
+        fake_messages.put_nowait(_result())
 
-        # This message gets processed by stop():
-        fake_messages.put_nowait(_result("final warning"))
         await rm.stop(timeout=5)
 
     mock_wandb_log.assert_warned("warning 1")
     mock_wandb_log.assert_warned("warning 2")
     mock_wandb_log.assert_warned("warning 3")
-    mock_wandb_log.assert_warned("final warning")
-    assert looptime == 0  # No sleeping should have happened.
+    assert looptime == 1  # no extra sleeping
 
 
 @pytest.mark.looptime
-async def test_stop_warns_on_loop_timeout(
+async def test_stop_warns_on_timeout(
+    looptime: LoopTimeProxy,
     fake_interface: Mock,
     wandb_caplog: pytest.LogCaptureFixture,
 ):
-    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
+    rm = run_messages._RunMessagesImpl(fake_interface)
 
     async with asyncio_compat.open_task_group() as group:
         group.start_soon(rm.loop())
-        await rm.stop(timeout=-1)  # time out immediately
+        await rm.stop(timeout=10)
 
     assert "Timed out waiting for messages" in wandb_caplog.text
-
-
-@pytest.mark.looptime
-async def test_stop_warns_on_handle_timeout(
-    fake_interface: Mock,
-    wandb_caplog: pytest.LogCaptureFixture,
-):
-    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
-
-    async with asyncio_compat.open_task_group() as group:
-        group.start_soon(rm.loop())
-        await rm.stop(timeout=7)  # times out waiting on fake_messages
-
-    assert "Timed out waiting for messages" in wandb_caplog.text
+    assert looptime == 10
 
 
 @pytest.mark.looptime
@@ -101,18 +88,16 @@ async def test_rate_limits(
     fake_messages: asyncio.Queue[pb.Result],
     fake_interface: Mock,
 ):
-    rm = run_messages._RunMessagesImpl(fake_interface, poll_interval=10)
+    rm = run_messages._RunMessagesImpl(fake_interface)
 
     async with asyncio_compat.open_task_group() as group:
         group.start_soon(rm.loop())
 
-        fake_messages.put_nowait(_result())  # immediate
-        fake_messages.put_nowait(_result())  # at 10s
-        fake_messages.put_nowait(_result())  # at 20s
-        await fake_messages.join()  # let the loop process everything
+        fake_messages.put_nowait(_result("message 1"))  # immediate
+        fake_messages.put_nowait(_result("message 2"))  # after 0.1s
+        fake_messages.put_nowait(_result("message 3"))  # after 0.2s
+        fake_messages.put_nowait(_result())  # after 0.3s
 
-        fake_messages.put_nowait(_result())  # last loop() iteration
-        fake_messages.put_nowait(_result())  # for stop()
         await rm.stop(timeout=5)
 
-    assert looptime == 20
+    assert looptime == 0.3

--- a/wandb/sdk/lib/run_messages.py
+++ b/wandb/sdk/lib/run_messages.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 
 
 class RunMessages:
-    """Polls and prints run messages from wandb-core.
+    """Prints run messages from wandb-core.
 
     Messages are scoped to a run. In the future, we may want to switch to
     connection-level messages to allow `ServiceApi` operations to print
@@ -26,18 +26,16 @@ class RunMessages:
         self,
         asyncer: asyncio_manager.AsyncioManager,
         interface: InterfaceBase,
-        *,
-        poll_interval: float = 10,
     ) -> None:
         self._asyncer = asyncer
 
         async def async_init() -> _RunMessagesImpl:
-            return _RunMessagesImpl(interface, poll_interval=poll_interval)
+            return _RunMessagesImpl(interface)
 
         self._impl = asyncer.run(async_init)
 
     def start(self) -> None:
-        """Start polling for and printing generated messages."""
+        """Start waiting for and printing generated messages."""
         self._asyncer.run_soon(
             self._impl.loop,
             daemon=True,
@@ -45,7 +43,10 @@ class RunMessages:
         )
 
     def stop(self, *, timeout: float) -> None:
-        """Stop the polling loop and print any final messages.
+        """Stop the message loop after the run has exited.
+
+        This should be called after wandb-core responds to the Exit record,
+        after which it won't output more messages.
 
         Args:
             timeout: How long to wait, in seconds, before giving up.
@@ -57,20 +58,14 @@ class RunMessages:
 
 
 class _RunMessagesImpl:
-    def __init__(
-        self,
-        interface: InterfaceBase,
-        *,
-        poll_interval: float,
-    ) -> None:
+    def __init__(self, interface: InterfaceBase) -> None:
         self._interface = interface
-        self._rate_limit = ratelimit.Cooldown(poll_interval)
 
-        self._stop_event = asyncio.Event()  # stop requested
+        self._force_stop_event = asyncio.Event()  # timeout during stop()
         self._done_event = asyncio.Event()  # loop() done
 
     async def stop(self, *, timeout: float) -> None:
-        """Stop looping and print any final messages.
+        """Stop the message loop after the run has exited.
 
         Assumes that `loop` has been or will be called.
 
@@ -79,53 +74,48 @@ class _RunMessagesImpl:
                 On timeout, some messages may be missed or may print
                 asynchronously.
         """
-        timeout_at = asyncio_compat.now() + timeout
-
-        self._stop_event.set()
+        # Since the run has exited, the loop will receive an empty response
+        # from wandb-core and exit automatically.
+        #
+        # In case of a bug, we force-stop the loop after a timeout.
         try:
-            await asyncio.wait_for(self._done_event.wait(), timeout)
-            await self._poll_and_print(timeout=timeout_at - asyncio_compat.now())
-
-        # NOTE: asyncio.TimeoutError is different from TimeoutError
-        #   until Python 3.11.
-        except (asyncio.TimeoutError, TimeoutError):
+            await asyncio.wait_for(self._done_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
             _logger.exception("Timed out waiting for messages.")
+            self._force_stop_event.set()
 
     async def loop(self) -> None:
-        """Print messages until asked to stop."""
+        """Print messages until forced to stop or the run exits."""
         try:
-            await self._rate_limit.wait()
-
-            while not self._stop_event.is_set():
-                await self._poll_and_print(timeout=None)
-
-                await asyncio_compat.race(
-                    self._stop_event.wait(),  # wake up if stopping
-                    self._rate_limit.wait(),
-                )
+            await asyncio_compat.race(
+                self._print_all(),
+                self._force_stop_event.wait(),
+            )
 
         finally:
             self._done_event.set()
 
-    async def _poll_and_print(self, *, timeout: float | None) -> None:
-        """Fetch and print messages.
+    async def _print_all(self) -> None:
+        """Print all of a run's messages until it exits."""
+        # Rate limit to avoid busy-looping in case of a bug.
+        # We won't need to print more than once every 100ms.
+        rate_limit = ratelimit.Cooldown(0.1)
+        while True:
+            await rate_limit.wait()
 
-        Args:
-            timeout: How long to wait for wandb-core to respond.
-
-        Raises:
-            TimeoutError: if timeout was specified and was exceeded.
-                If a timeout occurs, some messages may be lost.
-        """
-        request = pb.Record(
-            request=pb.Request(
-                internal_messages=pb.InternalMessagesRequest(),
+            request = pb.Record(
+                request=pb.Request(
+                    internal_messages=pb.InternalMessagesRequest(wait=True),
+                )
             )
-        )
 
-        handle = await self._interface.deliver_async(request)
-        result = await handle.wait_async(timeout=timeout)
+            handle = await self._interface.deliver_async(request)
+            result = await handle.wait_async(timeout=None)
+            warnings = result.response.internal_messages_response.messages.warning
 
-        warnings = result.response.internal_messages_response.messages.warning
-        for msg in warnings:
-            term.termwarn(msg)
+            # Since wait=True, no messages means the run exited.
+            if not warnings:
+                return
+
+            for msg in warnings:
+                term.termwarn(msg)


### PR DESCRIPTION
Instead of polling for run messages every 10 seconds, uses the new push-based mechanism. Messages like "Skipped uploading run.log() data that exceeded size limit" are now printed almost immediately.

The implementation is simpler because the message-reading loop can detect when it has seen the final message, so `stop()` doesn't need to read one last time.

## Try it out

```
❯ python     
>>> import wandb
>>> settings = wandb.Settings(x_file_stream_max_line_bytes=10)
>>> run = wandb.init(settings=settings)
[...]
>>> run.log({"x": "abcdefghijklmnop"})
>>> wandb: WARNING Skipped uploading run.log() data that exceeded size limit (94 > 10).

```

The message is printed immediately when you use `log()`. Unfortunately, since these messages are printed in a separate thread, it also probably messes up the `>>>` prompt, but that has always been a possibility.