### PR TITLE
fix(sandbox): reject invalid placement overrides for serverless sandboxes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,4 +31,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Fixed
 
-- `wandb.sandbox` now rejects unsupported placement overrides
+- `wandb.sandbox` now rejects invalid argument values for placement, gpu, and egress

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,3 +28,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `Run.scan_history()` now reads from exported parquet history when available, which can significantly improve throughput for runs with large history (@jacobromero in https://github.com/wandb/wandb/pull/11797)
     - This was introduced under `beta_scan_history` in `v0.23.1`
+
+### Fixed
+
+- `wandb.sandbox` now rejects unsupported placement overrides

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -53,7 +53,7 @@ def test_sandbox_wrapper_uses_wandb_secret_override() -> None:
 
 @pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
 def test_sandbox_wrapper_rejects_placement_overrides(field: str) -> None:
-    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+    with pytest.raises(UsageError, match=f"selects the runner and profile.*{field}"):
         wandb_sandbox.Sandbox(**{field: []})
 
 
@@ -61,13 +61,13 @@ def test_sandbox_wrapper_rejects_placement_overrides(field: str) -> None:
 def test_sandbox_wrapper_rejects_default_placement_overrides(field: str) -> None:
     defaults = cwsandbox.SandboxDefaults(**{field: ("placement-1",)})
 
-    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+    with pytest.raises(UsageError, match=f"selects the runner and profile.*{field}"):
         wandb_sandbox.Sandbox(defaults=defaults)
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
 def test_sandbox_wrapper_rejects_gpu_resources(resources) -> None:
-    with pytest.raises(UsageError, match="GPU resources"):
+    with pytest.raises(UsageError, match="CPU and memory resources"):
         wandb_sandbox.Sandbox(resources=resources)
 
 
@@ -75,7 +75,7 @@ def test_sandbox_wrapper_rejects_gpu_resources(resources) -> None:
 def test_sandbox_wrapper_rejects_default_gpu_resources(resources) -> None:
     defaults = cwsandbox.SandboxDefaults(resources=resources)
 
-    with pytest.raises(UsageError, match="GPU resources"):
+    with pytest.raises(UsageError, match="CPU and memory resources"):
         wandb_sandbox.Sandbox(defaults=defaults)
 
 
@@ -102,13 +102,13 @@ def test_sandbox_wrapper_allows_supported_network_options(network) -> None:
 def test_sandbox_session_rejects_placement_overrides(field: str) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+    with pytest.raises(UsageError, match=f"selects the runner and profile.*{field}"):
         session.sandbox(**{field: ["placement-1"]})
 
 
 @pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
 def test_sandbox_session_rejects_default_placement_overrides(field: str) -> None:
-    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+    with pytest.raises(UsageError, match=f"selects the runner and profile.*{field}"):
         wandb_sandbox.Session(defaults={field: ["placement-1"]})
 
 
@@ -116,7 +116,7 @@ def test_sandbox_session_rejects_default_placement_overrides(field: str) -> None
 def test_sandbox_session_rejects_positional_default_placement_overrides(
     field: str,
 ) -> None:
-    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+    with pytest.raises(UsageError, match=f"selects the runner and profile.*{field}"):
         wandb_sandbox.Session({field: ["placement-1"]})
 
 
@@ -124,13 +124,13 @@ def test_sandbox_session_rejects_positional_default_placement_overrides(
 def test_sandbox_session_rejects_gpu_resources(resources) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match="GPU resources"):
+    with pytest.raises(UsageError, match="CPU and memory resources"):
         session.sandbox(resources=resources)
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
 def test_sandbox_session_rejects_default_gpu_resources(resources) -> None:
-    with pytest.raises(UsageError, match="GPU resources"):
+    with pytest.raises(UsageError, match="CPU and memory resources"):
         wandb_sandbox.Session(defaults={"resources": resources})
 
 
@@ -152,7 +152,7 @@ def test_sandbox_session_rejects_default_unsupported_egress_modes(network) -> No
 def test_sandbox_session_function_rejects_placement_overrides(field: str) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+    with pytest.raises(UsageError, match=f"selects the runner and profile.*{field}"):
         session.function(**{field: ["placement-1"]})
 
 
@@ -160,7 +160,7 @@ def test_sandbox_session_function_rejects_placement_overrides(field: str) -> Non
 def test_sandbox_session_function_rejects_gpu_resources(resources) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match="GPU resources"):
+    with pytest.raises(UsageError, match="CPU and memory resources"):
         session.function(resources=resources)
 
 

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -1,10 +1,30 @@
 import cwsandbox
+import pytest
 import wandb.sandbox as wandb_sandbox
+import wandb.sandbox._sandbox as sandbox_module
+from wandb.errors import UsageError
 from wandb.sandbox import Secret
 from wandb.sandbox._secret import WANDB_SECRET_STORE
 
 _HIDDEN_EXPORT_NAMES = {"AuthHeaders", "set_auth_mode"}
-_OVERRIDDEN_EXPORT_NAMES = {"Secret"}
+_OVERRIDDEN_EXPORT_NAMES = {"Sandbox", "Secret", "Session"}
+_PLACEMENT_OVERRIDE_FIELDS = ("profile_ids", "profile_names", "runner_ids")
+_GPU_RESOURCE_VALUES = (
+    cwsandbox.ResourceOptions(gpu={"count": 1}),
+    {"gpu": 1},
+    {"requests": {"cpu": "1"}, "gpu": {"count": 1}},
+)
+_UNSUPPORTED_EGRESS_NETWORK_VALUES = (
+    cwsandbox.NetworkOptions(egress_mode="private"),
+    {"egress_mode": "private"},
+)
+_SUPPORTED_NETWORK_VALUES = (
+    cwsandbox.NetworkOptions(egress_mode="internet"),
+    cwsandbox.NetworkOptions(egress_mode="none"),
+    cwsandbox.NetworkOptions(ingress_mode="public", exposed_ports=(8080,)),
+    {"egress_mode": "internet"},
+    {"egress_mode": "none"},
+)
 
 
 def test_sandbox_wrapper_reexports_cwsandbox_public_api() -> None:
@@ -29,3 +49,127 @@ def test_sandbox_wrapper_uses_wandb_secret_override() -> None:
 
     secret = Secret(store="not-default-store", name="MY_SECRET")
     assert secret.store == "not-default-store"
+
+
+@pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
+def test_sandbox_wrapper_rejects_placement_overrides(field: str) -> None:
+    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+        wandb_sandbox.Sandbox(**{field: []})
+
+
+@pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
+def test_sandbox_wrapper_rejects_default_placement_overrides(field: str) -> None:
+    defaults = cwsandbox.SandboxDefaults(**{field: ("placement-1",)})
+
+    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+        wandb_sandbox.Sandbox(defaults=defaults)
+
+
+@pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
+def test_sandbox_wrapper_rejects_gpu_resources(resources) -> None:
+    with pytest.raises(UsageError, match="GPU resources"):
+        wandb_sandbox.Sandbox(resources=resources)
+
+
+@pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
+def test_sandbox_wrapper_rejects_default_gpu_resources(resources) -> None:
+    defaults = cwsandbox.SandboxDefaults(resources=resources)
+
+    with pytest.raises(UsageError, match="GPU resources"):
+        wandb_sandbox.Sandbox(defaults=defaults)
+
+
+@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
+def test_sandbox_wrapper_rejects_unsupported_egress_modes(network) -> None:
+    with pytest.raises(UsageError, match="egress modes.*private"):
+        wandb_sandbox.Sandbox(network=network)
+
+
+@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
+def test_sandbox_wrapper_rejects_default_unsupported_egress_modes(network) -> None:
+    defaults = cwsandbox.SandboxDefaults(network=network)
+
+    with pytest.raises(UsageError, match="egress modes.*private"):
+        wandb_sandbox.Sandbox(defaults=defaults)
+
+
+@pytest.mark.parametrize("network", _SUPPORTED_NETWORK_VALUES)
+def test_sandbox_wrapper_allows_supported_network_options(network) -> None:
+    wandb_sandbox.Sandbox(network=network)
+
+
+@pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
+def test_sandbox_session_rejects_placement_overrides(field: str) -> None:
+    session = wandb_sandbox.Session()
+
+    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+        session.sandbox(**{field: ["placement-1"]})
+
+
+@pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
+def test_sandbox_session_rejects_default_placement_overrides(field: str) -> None:
+    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+        wandb_sandbox.Session(defaults={field: ["placement-1"]})
+
+
+@pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
+def test_sandbox_session_rejects_positional_default_placement_overrides(
+    field: str,
+) -> None:
+    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+        wandb_sandbox.Session({field: ["placement-1"]})
+
+
+@pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
+def test_sandbox_session_rejects_gpu_resources(resources) -> None:
+    session = wandb_sandbox.Session()
+
+    with pytest.raises(UsageError, match="GPU resources"):
+        session.sandbox(resources=resources)
+
+
+@pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
+def test_sandbox_session_rejects_default_gpu_resources(resources) -> None:
+    with pytest.raises(UsageError, match="GPU resources"):
+        wandb_sandbox.Session(defaults={"resources": resources})
+
+
+@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
+def test_sandbox_session_rejects_unsupported_egress_modes(network) -> None:
+    session = wandb_sandbox.Session()
+
+    with pytest.raises(UsageError, match="egress modes.*private"):
+        session.sandbox(network=network)
+
+
+@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
+def test_sandbox_session_rejects_default_unsupported_egress_modes(network) -> None:
+    with pytest.raises(UsageError, match="egress modes.*private"):
+        wandb_sandbox.Session(defaults={"network": network})
+
+
+def test_sandbox_session_forwards_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    sandbox = object()
+
+    def fake_base_sandbox(self, **kwargs):
+        calls.append((self, kwargs))
+        return sandbox
+
+    monkeypatch.setattr(sandbox_module._BaseSession, "sandbox", fake_base_sandbox)
+
+    session = wandb_sandbox.Session()
+    result = session.sandbox(command="sleep", future_option={"enabled": True})
+
+    assert result is sandbox
+    assert calls == [
+        (session, {"command": "sleep", "future_option": {"enabled": True}})
+    ]
+
+
+def test_sandbox_classmethod_session_uses_wandb_session_wrapper() -> None:
+    session = wandb_sandbox.Sandbox.session()
+
+    assert isinstance(session, wandb_sandbox.Session)

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -148,6 +148,30 @@ def test_sandbox_session_rejects_default_unsupported_egress_modes(network) -> No
         wandb_sandbox.Session(defaults={"network": network})
 
 
+@pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
+def test_sandbox_session_function_rejects_placement_overrides(field: str) -> None:
+    session = wandb_sandbox.Session()
+
+    with pytest.raises(UsageError, match=f"placement overrides.*{field}"):
+        session.function(**{field: ["placement-1"]})
+
+
+@pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
+def test_sandbox_session_function_rejects_gpu_resources(resources) -> None:
+    session = wandb_sandbox.Session()
+
+    with pytest.raises(UsageError, match="GPU resources"):
+        session.function(resources=resources)
+
+
+@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
+def test_sandbox_session_function_rejects_unsupported_egress_modes(network) -> None:
+    session = wandb_sandbox.Session()
+
+    with pytest.raises(UsageError, match="egress modes.*private"):
+        session.function(network=network)
+
+
 def test_sandbox_session_forwards_kwargs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -166,6 +190,27 @@ def test_sandbox_session_forwards_kwargs(
     assert result is sandbox
     assert calls == [
         (session, {"command": "sleep", "future_option": {"enabled": True}})
+    ]
+
+
+def test_sandbox_session_function_forwards_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    decorator = object()
+
+    def fake_base_function(self, **kwargs):
+        calls.append((self, kwargs))
+        return decorator
+
+    monkeypatch.setattr(sandbox_module._BaseSession, "function", fake_base_function)
+
+    session = wandb_sandbox.Session()
+    result = session.function(container_image="python:3.11", future_option=True)
+
+    assert result is decorator
+    assert calls == [
+        (session, {"container_image": "python:3.11", "future_option": True})
     ]
 
 

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -12,6 +12,7 @@ from cwsandbox import __all__ as cwsandbox_all
 
 # wandb specific overrides
 from ._auth import _set_wandb_auth_mode
+from ._sandbox import Sandbox, Session
 from ._secret import Secret
 
 _set_wandb_auth_mode()

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -18,23 +18,8 @@ R = TypeVar("R")
 def _placement_override_error(fields: Sequence[str]) -> UsageError:
     fields_display = ", ".join(fields)
     return UsageError(
-        "wandb.sandbox does not support placement overrides "
-        f"({fields_display}). Omit these arguments; W&B Serverless selects the runner and profile."
-    )
-
-
-def _gpu_resources_error() -> UsageError:
-    return UsageError(
-        "wandb.sandbox does not support GPU resources. "
-        "Omit resources.gpu; W&B Serverless currently supports CPU and memory resources."
-    )
-
-
-def _egress_mode_error(egress_mode: Any) -> UsageError:
-    modes_display = ", ".join(_SUPPORTED_EGRESS_MODES)
-    return UsageError(
-        "wandb.sandbox supports only egress modes "
-        f"({modes_display}). Got {egress_mode!r}."
+        "W&B Serverless automatically selects the runner and profile. "
+        f"Remove ({fields_display})."
     )
 
 
@@ -68,7 +53,10 @@ def _reject_gpu_resources(
     resources: ResourceOptions | Mapping[str, Any] | None,
 ) -> None:
     if _resources_include_gpu(resources):
-        raise _gpu_resources_error()
+        raise UsageError(
+            "W&B Serverless currently supports only CPU and memory resources. "
+            "Remove resources.gpu."
+        )
 
 
 def _reject_unsupported_egress_mode(
@@ -85,7 +73,11 @@ def _reject_unsupported_egress_mode(
         return
 
     if egress_mode is not None and egress_mode not in _SUPPORTED_EGRESS_MODES:
-        raise _egress_mode_error(egress_mode)
+        modes_display = ", ".join(_SUPPORTED_EGRESS_MODES)
+        raise UsageError(
+            "wandb.sandbox supports only egress modes "
+            f"({modes_display}). Got {egress_mode!r}."
+        )
 
 
 def _reject_invalid_kwargs(kwargs: Mapping[str, Any]) -> None:

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import Any
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, ParamSpec, TypeVar
 
-from cwsandbox import NetworkOptions, ResourceOptions, SandboxDefaults
+from cwsandbox import NetworkOptions, RemoteFunction, ResourceOptions, SandboxDefaults
 from cwsandbox import Sandbox as _BaseSandbox
 from cwsandbox import Session as _BaseSession
 
@@ -11,6 +11,8 @@ from wandb.errors import UsageError
 
 _PLACEMENT_OVERRIDE_FIELDS = ("profile_ids", "profile_names", "runner_ids")
 _SUPPORTED_EGRESS_MODES = ("internet", "none")
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def _placement_override_error(fields: Sequence[str]) -> UsageError:
@@ -56,7 +58,10 @@ def _resources_include_gpu(
         gpu = resources.get("gpu")
         return gpu is not None and gpu != {}
 
-    return getattr(resources, "gpu", None) is not None
+    if isinstance(resources, ResourceOptions):
+        return resources.gpu is not None
+
+    return False
 
 
 def _reject_gpu_resources(
@@ -72,13 +77,21 @@ def _reject_unsupported_egress_mode(
     if network is None:
         return
 
-    egress_mode = (
-        network.get("egress_mode")
-        if isinstance(network, Mapping)
-        else getattr(network, "egress_mode", None)
-    )
+    if isinstance(network, Mapping):
+        egress_mode = network.get("egress_mode")
+    elif isinstance(network, NetworkOptions):
+        egress_mode = network.egress_mode
+    else:
+        return
+
     if egress_mode is not None and egress_mode not in _SUPPORTED_EGRESS_MODES:
         raise _egress_mode_error(egress_mode)
+
+
+def _reject_invalid_kwargs(kwargs: Mapping[str, Any]) -> None:
+    _reject_placement_override_kwargs(kwargs)
+    _reject_gpu_resources(kwargs.get("resources"))
+    _reject_unsupported_egress_mode(kwargs.get("network"))
 
 
 def _reject_invalid_defaults(
@@ -122,9 +135,7 @@ class Sandbox(_BaseSandbox):
     """W&B sandbox wrapper with W&B Serverless policy guardrails."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        _reject_placement_override_kwargs(kwargs)
-        _reject_gpu_resources(kwargs.get("resources"))
-        _reject_unsupported_egress_mode(kwargs.get("network"))
+        _reject_invalid_kwargs(kwargs)
         _reject_invalid_defaults(kwargs.get("defaults"))
         super().__init__(*args, **kwargs)
 
@@ -154,7 +165,12 @@ class Session(_BaseSession):
         self,
         **kwargs: Any,
     ) -> _BaseSandbox:
-        _reject_placement_override_kwargs(kwargs)
-        _reject_gpu_resources(kwargs.get("resources"))
-        _reject_unsupported_egress_mode(kwargs.get("network"))
+        _reject_invalid_kwargs(kwargs)
         return super().sandbox(**kwargs)
+
+    def function(
+        self,
+        **kwargs: Any,
+    ) -> Callable[[Callable[P, R]], RemoteFunction[P, R]]:
+        _reject_invalid_kwargs(kwargs)
+        return super().function(**kwargs)

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from cwsandbox import NetworkOptions, RemoteFunction, ResourceOptions, SandboxDefaults
 from cwsandbox import Sandbox as _BaseSandbox
@@ -134,43 +134,45 @@ def _reject_invalid_defaults(
 class Sandbox(_BaseSandbox):
     """W&B sandbox wrapper with W&B Serverless policy guardrails."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        _reject_invalid_kwargs(kwargs)
-        _reject_invalid_defaults(kwargs.get("defaults"))
-        super().__init__(*args, **kwargs)
+    if TYPE_CHECKING:
+        __init__ = _BaseSandbox.__init__
+    else:
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _reject_invalid_kwargs(kwargs)
+            _reject_invalid_defaults(kwargs.get("defaults"))
+            super().__init__(*args, **kwargs)
 
     @classmethod
-    def session(
-        cls,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Session:
+    def session(cls, *args: Any, **kwargs: Any) -> Session:
         return Session(*args, **kwargs)
 
 
 class Session(_BaseSession):
     """W&B sandbox session wrapper with W&B Serverless policy guardrails."""
 
-    def __init__(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ) -> None:
-        if args:
-            _reject_invalid_defaults(args[0])
-        _reject_invalid_defaults(kwargs.get("defaults"))
-        super().__init__(*args, **kwargs)
+    if TYPE_CHECKING:
+        __init__ = _BaseSession.__init__
+        sandbox = _BaseSession.sandbox
+        function = _BaseSession.function
+    else:
 
-    def sandbox(
-        self,
-        **kwargs: Any,
-    ) -> _BaseSandbox:
-        _reject_invalid_kwargs(kwargs)
-        return super().sandbox(**kwargs)
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            if args:
+                _reject_invalid_defaults(args[0])
+            _reject_invalid_defaults(kwargs.get("defaults"))
+            super().__init__(*args, **kwargs)
 
-    def function(
-        self,
-        **kwargs: Any,
-    ) -> Callable[[Callable[P, R]], RemoteFunction[P, R]]:
-        _reject_invalid_kwargs(kwargs)
-        return super().function(**kwargs)
+        def sandbox(
+            self,
+            **kwargs: Any,
+        ) -> _BaseSandbox:
+            _reject_invalid_kwargs(kwargs)
+            return super().sandbox(**kwargs)
+
+        def function(
+            self,
+            **kwargs: Any,
+        ) -> Callable[[Callable[P, R]], RemoteFunction[P, R]]:
+            _reject_invalid_kwargs(kwargs)
+            return super().function(**kwargs)

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from cwsandbox import NetworkOptions, ResourceOptions, SandboxDefaults
+from cwsandbox import Sandbox as _BaseSandbox
+from cwsandbox import Session as _BaseSession
+
+from wandb.errors import UsageError
+
+_PLACEMENT_OVERRIDE_FIELDS = ("profile_ids", "profile_names", "runner_ids")
+_SUPPORTED_EGRESS_MODES = ("internet", "none")
+
+
+def _placement_override_error(fields: Sequence[str]) -> UsageError:
+    fields_display = ", ".join(fields)
+    return UsageError(
+        "wandb.sandbox does not support placement overrides "
+        f"({fields_display}). Omit these arguments; W&B Serverless selects the runner and profile."
+    )
+
+
+def _gpu_resources_error() -> UsageError:
+    return UsageError(
+        "wandb.sandbox does not support GPU resources. "
+        "Omit resources.gpu; W&B Serverless currently supports CPU and memory resources."
+    )
+
+
+def _egress_mode_error(egress_mode: Any) -> UsageError:
+    modes_display = ", ".join(_SUPPORTED_EGRESS_MODES)
+    return UsageError(
+        "wandb.sandbox supports only egress modes "
+        f"({modes_display}). Got {egress_mode!r}."
+    )
+
+
+def _reject_placement_override_kwargs(kwargs: Mapping[str, Any]) -> None:
+    blocked = [
+        field
+        for field in _PLACEMENT_OVERRIDE_FIELDS
+        if field in kwargs and kwargs[field] is not None
+    ]
+    if blocked:
+        raise _placement_override_error(blocked)
+
+
+def _resources_include_gpu(
+    resources: ResourceOptions | Mapping[str, Any] | None,
+) -> bool:
+    if resources is None:
+        return False
+
+    if isinstance(resources, Mapping):
+        gpu = resources.get("gpu")
+        return gpu is not None and gpu != {}
+
+    return getattr(resources, "gpu", None) is not None
+
+
+def _reject_gpu_resources(
+    resources: ResourceOptions | Mapping[str, Any] | None,
+) -> None:
+    if _resources_include_gpu(resources):
+        raise _gpu_resources_error()
+
+
+def _reject_unsupported_egress_mode(
+    network: NetworkOptions | Mapping[str, Any] | None,
+) -> None:
+    if network is None:
+        return
+
+    egress_mode = (
+        network.get("egress_mode")
+        if isinstance(network, Mapping)
+        else getattr(network, "egress_mode", None)
+    )
+    if egress_mode is not None and egress_mode not in _SUPPORTED_EGRESS_MODES:
+        raise _egress_mode_error(egress_mode)
+
+
+def _reject_invalid_defaults(
+    defaults: SandboxDefaults | Mapping[str, Any] | None,
+) -> None:
+    if defaults is None:
+        return
+
+    if isinstance(defaults, Mapping):
+        blocked = [
+            field
+            for field in _PLACEMENT_OVERRIDE_FIELDS
+            if field in defaults and defaults[field] is not None
+        ]
+    else:
+        blocked = [
+            field
+            for field in _PLACEMENT_OVERRIDE_FIELDS
+            if getattr(defaults, field, None) is not None
+        ]
+
+    if blocked:
+        raise _placement_override_error(blocked)
+
+    resources = (
+        defaults.get("resources")
+        if isinstance(defaults, Mapping)
+        else getattr(defaults, "resources", None)
+    )
+    _reject_gpu_resources(resources)
+
+    network = (
+        defaults.get("network")
+        if isinstance(defaults, Mapping)
+        else getattr(defaults, "network", None)
+    )
+    _reject_unsupported_egress_mode(network)
+
+
+class Sandbox(_BaseSandbox):
+    """W&B sandbox wrapper with W&B Serverless policy guardrails."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        _reject_placement_override_kwargs(kwargs)
+        _reject_gpu_resources(kwargs.get("resources"))
+        _reject_unsupported_egress_mode(kwargs.get("network"))
+        _reject_invalid_defaults(kwargs.get("defaults"))
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def session(
+        cls,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Session:
+        return Session(*args, **kwargs)
+
+
+class Session(_BaseSession):
+    """W&B sandbox session wrapper with W&B Serverless policy guardrails."""
+
+    def __init__(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        if args:
+            _reject_invalid_defaults(args[0])
+        _reject_invalid_defaults(kwargs.get("defaults"))
+        super().__init__(*args, **kwargs)
+
+    def sandbox(
+        self,
+        **kwargs: Any,
+    ) -> _BaseSandbox:
+        _reject_placement_override_kwargs(kwargs)
+        _reject_gpu_resources(kwargs.get("resources"))
+        _reject_unsupported_egress_mode(kwargs.get("network"))
+        return super().sandbox(**kwargs)


### PR DESCRIPTION
Description
-----------
https://coreweave.atlassian.net/browse/WB-34571

Adds guardrails to serverless sandboxes so that users can't make invalid requests. In particular, we don't have:
* GPU support
* Only two egress profiles, internet and none
* No profile or runner selection

The GPU support restriction will raise a new error that breaks e2e tests, fix here: https://github.com/wandb/wb-sandboxes-tests-e2e/pull/3

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
- [x] updated unit tests
- [x] ran smoke tests
```
PYTHONPATH=/Users/nicholaspun/Documents/sdk-repo \
  /Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/.venv/bin/python -c 'import wandb; print(wandb.__version__, wandb.__file__)'
0.27.1.dev1 /Users/nicholaspun/Documents/sdk-repo/wandb/__init__.py

WANDB_API_KEY="$(python3 -c 'import netrc; print(netrc.netrc().authenticators("api.wandb.ai")[2])')" \
  WANDB_ENTITY="$(grep '^WANDB_ENTITY=' .env | cut -d= -f2-)" \
  DD_API_KEY= \
  DD_REPORT_EVENTS=0 \
  DD_REPORT_SLACK_FAILURE_EVENTS=0 \
  PYTHONPATH=/Users/nicholaspun/Documents/sdk-repo \
  PATH="/Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/.venv/bin:$PATH" \
  scripts/run_e2e.sh smoke
Running Sandboxes E2E suite: smoke
Command: pytest -m smoke tests/test_phase1_00_environment_contract.py tests/test_phase1_01_normal_auth_lifecycle.py tests/test_phase1_02_exec_streams_files.py tests/test_phase1_03_network_images_resources.py tests/test_phase1_04_secrets_wandb_weave_artifacts.py tests/test_phase1_05_sessions_remote_async.py tests/test_phase1_06_cli_docs_ui_smoke.py tests/test_phase1_07_normal_scale_and_longrun.py tests/test_phase1_08_edge_cases.py 
============================================================== test session starts ==============================================================
platform darwin -- Python 3.11.11, pytest-9.0.3, pluggy-1.6.0 -- /Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/.venv/bin/python3
rootdir: /Users/nicholaspun/Documents/wb-sandboxes-tests-e2e
configfile: pytest.ini
plugins: timeout-2.4.0
timeout: 300.0s
timeout method: signal
timeout func_only: False
collected 84 items / 62 deselected / 22 selected                                                                                                

tests/test_phase1_00_environment_contract.py::test_fresh_process_can_import_wandb_sandbox PASSED                                          [  4%]
tests/test_phase1_00_environment_contract.py::test_public_api_surface_matches_current_contract PASSED                                     [  9%]
tests/test_phase1_00_environment_contract.py::test_import_succeeds_without_credentials PASSED                                             [ 13%]
tests/test_phase1_00_environment_contract.py::test_private_grpc_base_url_parser_contract PASSED                                           [ 18%]
tests/test_phase1_00_environment_contract.py::test_sdk_version_drift_guard PASSED                                                         [ 22%]
tests/test_phase1_01_normal_auth_lifecycle.py::test_wandb_api_key_auth_create_exec_stop PASSED                                            [ 27%]
tests/test_phase1_01_normal_auth_lifecycle.py::test_netrc_auth_create_list_without_wandb_api_key_env PASSED                               [ 31%]
tests/test_phase1_01_normal_auth_lifecycle.py::test_missing_credentials_fail_cleanly_before_sandbox_create PASSED                         [ 36%]
tests/test_phase1_01_normal_auth_lifecycle.py::test_wandb_sandbox_import_overrides_cwsandbox_api_key_auth PASSED                          [ 40%]
tests/test_phase1_01_normal_auth_lifecycle.py::test_context_manager_stops_sandbox_on_exit PASSED                                          [ 45%]
tests/test_phase1_01_normal_auth_lifecycle.py::test_stop_and_delete_are_idempotent_with_missing_ok PASSED                                 [ 50%]
tests/test_phase1_01_normal_auth_lifecycle.py::test_from_id_and_list_find_running_sandbox PASSED                                          [ 54%]
tests/test_phase1_02_exec_streams_files.py::test_exec_result_shape_and_check_behavior PASSED                                              [ 59%]
tests/test_phase1_02_exec_streams_files.py::test_exec_timeout_does_not_poison_sandbox PASSED                                              [ 63%]
tests/test_phase1_02_exec_streams_files.py::test_file_write_read_round_trip_with_binary_payload PASSED                                    [ 68%]
tests/test_phase1_03_network_images_resources.py::test_internet_egress_reaches_wandb_api PASSED                                           [ 72%]
tests/test_phase1_03_network_images_resources.py::test_invalid_resource_shapes_fail_client_side PASSED                                    [ 77%]
tests/test_phase1_04_secrets_wandb_weave_artifacts.py::test_wandb_secret_injection_optional_fixture SKIPPED (Set SANDBOX_E2E_SECRET_N...) [ 81%]
tests/test_phase1_05_sessions_remote_async.py::test_sandbox_defaults_utilities_and_immutability PASSED                                    [ 86%]
tests/test_phase1_06_cli_docs_ui_smoke.py::test_wandb_beta_sandbox_help_exposes_expected_commands PASSED                                  [ 90%]
tests/test_phase1_06_cli_docs_ui_smoke.py::test_cli_exec_and_logs_separate_exec_output_from_main_logs PASSED                              [ 95%]
tests/test_phase1_06_cli_docs_ui_smoke.py::test_quickstart_style_python_snippet_create_exec_stop PASSED                                   [100%]

============================================ 21 passed, 1 skipped, 62 deselected in 83.53s (0:01:23) ============================================

Sandboxes E2E Result Summary
================================
file: /Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/results/e2e-a1c3a1ace358.jsonl
records: 22
pass: 21
skip: 1

Skipped / Expected
- SBX-SEC-001: skip: ('/Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/tests/test_phase1_04_secrets_wandb_weave_artifacts.py', 53, 'Skipped: Set SANDBOX_E2E_SECRET_NAME to run secret injection smoke')
```
- [x] ran targeted `Session` tests
```
  WANDB_API_KEY="$(python3 -c 'import netrc; print(netrc.netrc().authenticators("api.wandb.ai")[2])')" \
  WANDB_ENTITY="$(grep '^WANDB_ENTITY=' .env | cut -d= -f2-)" \
  DD_API_KEY= \
  DD_REPORT_EVENTS=0 \
  DD_REPORT_SLACK_FAILURE_EVENTS=0 \
  PYTHONPATH=/Users/nicholaspun/Documents/sdk-repo \
  PATH="/Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/.venv/bin:$PATH" \
  scripts/run_e2e.sh nightly -k "test_deferred_start_and_construction_patterns or test_sandbox_session_classmethod_matches_session_constructor"
Running Sandboxes E2E suite: nightly
Command: pytest -m nightly tests/test_phase1_00_environment_contract.py tests/test_phase1_01_normal_auth_lifecycle.py tests/test_phase1_02_exec_streams_files.py tests/test_phase1_03_network_images_resources.py tests/test_phase1_04_secrets_wandb_weave_artifacts.py tests/test_phase1_05_sessions_remote_async.py tests/test_phase1_06_cli_docs_ui_smoke.py tests/test_phase1_07_normal_scale_and_longrun.py tests/test_phase1_08_edge_cases.py -k test_deferred_start_and_construction_patterns or test_sandbox_session_classmethod_matches_session_constructor
============================================================== test session starts ==============================================================
platform darwin -- Python 3.11.11, pytest-9.0.3, pluggy-1.6.0 -- /Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/.venv/bin/python3
rootdir: /Users/nicholaspun/Documents/wb-sandboxes-tests-e2e
configfile: pytest.ini
plugins: timeout-2.4.0
timeout: 300.0s
timeout method: signal
timeout func_only: False
collected 84 items / 82 deselected / 2 selected                                                                                                 

tests/test_phase1_01_normal_auth_lifecycle.py::test_deferred_start_and_construction_patterns PASSED                                       [ 50%]
tests/test_phase1_05_sessions_remote_async.py::test_sandbox_session_classmethod_matches_session_constructor PASSED                        [100%]

======================================================= 2 passed, 82 deselected in 27.95s =======================================================

Sandboxes E2E Result Summary
================================
file: /Users/nicholaspun/Documents/wb-sandboxes-tests-e2e/results/e2e-0e7fb258032d.jsonl
records: 2
pass: 2
``` 
