### PR TITLE
feat: lazily load sweep info on Run.sweep access

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1057,7 +1057,7 @@ class Api:
         filters: dict[str, Any] | None = None,
         order: str = "+created_at",
         per_page: int = 50,
-        include_sweeps: bool = True,
+        include_sweeps: bool = False,
         lazy: bool = True,
     ):
         """Returns a `Runs` object, which lazily iterates over `Run` objects.
@@ -1107,7 +1107,10 @@ class Api:
                 If you prepend order with a - order is descending.
                 The default order is run.created_at from oldest to newest.
             per_page: (int) Sets the page size for query pagination.
-            include_sweeps: (bool) Whether to include the sweep runs in the results.
+            include_sweeps: (bool) Whether to eagerly fetch sweep information
+                for each run. Defaults to False, in which case `Run.sweep` is
+                fetched lazily on first access. Set to True to fetch sweeps
+                upfront and share them across runs in the same sweep.
             lazy: (bool) Whether to use lazy loading for faster performance.
                 When True (default), only essential run metadata is loaded initially.
                 Heavy fields like config, summaryMetrics, and systemMetrics are loaded

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -205,8 +205,10 @@ class Runs(SizedPaginator["Run"]):
             If you prepend order with a - order is descending.
             The default order is run.created_at from oldest to newest.
         per_page: (int) The number of runs to fetch per request (default is 50).
-        include_sweeps: (bool) Whether to include sweep information in the
-            runs. Defaults to True.
+        include_sweeps: (bool) Whether to eagerly fetch sweep information for
+            each run. Defaults to False. When False, accessing `Run.sweep`
+            lazily fetches the sweep on first access. When True, sweeps are
+            fetched upfront and shared across runs in the same sweep.
     """
 
     def __init__(
@@ -217,7 +219,7 @@ class Runs(SizedPaginator["Run"]):
         filters: dict[str, Any] | None = None,
         order: str = "+created_at",
         per_page: int = 50,
-        include_sweeps: bool = True,
+        include_sweeps: bool = False,
         lazy: bool = True,
         service_api: ServiceApi | None = None,
     ):
@@ -593,7 +595,9 @@ class Run(Attrs):
         project: The project associated with the run.
         run_id: The unique identifier for the run.
         attrs: The attributes of the run.
-        include_sweeps: Whether to include sweeps in the run.
+        include_sweeps: Whether to eagerly fetch sweep information at load
+            time. Defaults to False. When False, accessing `Run.sweep`
+            lazily fetches the sweep on first access.
 
     Attributes:
         tags ([str]): a list of tags associated with the run
@@ -624,7 +628,7 @@ class Run(Attrs):
         project: str,
         run_id: str,
         attrs: Mapping | None = None,
-        include_sweeps: bool = True,
+        include_sweeps: bool = False,
         lazy: bool = True,
         service_api: ServiceApi | None = None,
     ):
@@ -641,7 +645,8 @@ class Run(Attrs):
         self._files = {}
         self._base_dir = env.get_dir(tempfile.gettempdir())
         self.id = run_id
-        self.sweep = None
+        self._sweep: public.Sweep | None = None
+        self._sweep_loaded = False
         self._include_sweeps = include_sweeps
         self._lazy = lazy
         self._full_data_loaded = False  # Track if we've loaded full data
@@ -833,7 +838,7 @@ class Run(Attrs):
             if self._attrs.get("user"):
                 self.user = public.User(self.client, self._attrs["user"])
 
-            if self._include_sweeps and self.sweep_name and not self.sweep:
+            if self._include_sweeps and self.sweep_name and not self._sweep_loaded:
                 # There may be a lot of runs. Don't bother pulling them all
                 # just for the sake of this one.
                 self.sweep = public.Sweep.get(
@@ -884,7 +889,11 @@ class Run(Attrs):
             )
 
         # Only check for sweeps if sweep_name is available (not in lazy mode or if it exists)
-        if self._include_sweeps and self._attrs.get("sweepName") and not self.sweep:
+        if (
+            self._include_sweeps
+            and self._attrs.get("sweepName")
+            and not self._sweep_loaded
+        ):
             # There may be a lot of runs. Don't bother pulling them all
             self.sweep = public.Sweep.get(
                 self.client,
@@ -1572,6 +1581,29 @@ class Run(Attrs):
         """Get sweep name. Always available since sweepName is in lightweight fragment."""
         # sweepName is included in lightweight fragment, so no need to load full data
         return self._attrs.get("sweepName")
+
+    @property
+    def sweep(self) -> public.Sweep | None:
+        """The sweep associated with the run, or None if the run is not part of a sweep.
+
+        If the run was loaded with `include_sweeps=False`, the sweep is
+        fetched lazily on first access and cached for subsequent accesses.
+        """
+        if not self._sweep_loaded and self.sweep_name:
+            self._sweep = public.Sweep.get(
+                self.client,
+                self.entity,
+                self.project,
+                self.sweep_name,
+                withRuns=False,
+            )
+            self._sweep_loaded = True
+        return self._sweep
+
+    @sweep.setter
+    def sweep(self, value: public.Sweep | None) -> None:
+        self._sweep = value
+        self._sweep_loaded = True
 
     @property
     def path(self) -> list[str]:


### PR DESCRIPTION
## Summary
- Change `include_sweeps` default from `True` to `False` on `Run`, `Runs`, and `Api.runs`.
- Make `Run.sweep` a property that fetches the sweep on first access when `include_sweeps=False`, using `sweepName` already returned by the lightweight run fragment. Result is cached on `_sweep` / `_sweep_loaded` so subsequent accesses don't re-fetch.
- Keep the existing eager-fetch path for `include_sweeps=True`, which is still preferable when iterating many runs in the same sweep (the `Runs` collection shares one fetched `Sweep` across all runs).
- The existing `run.sweep = sweep` write path (used by `Runs.convert_objects` to inject the shared sweep) continues to work through the new setter.

## Test plan
- [ ] Run `tests/system_tests/test_sweep/test_sweep_public_api.py` — confirms `run.sweep.id == sweep_id` still works through the lazy property
- [ ] Manually: call `api.runs(...)` with default args and confirm no sweep queries fire until `.sweep` is touched
- [ ] Manually: call `api.runs(..., include_sweeps=True)` and confirm sweeps are fetched upfront and shared
- [ ] Manually: `api.run(...)` then `.sweep` — confirm single lazy fetch and cached on second access

🤖 Generated with [Claude Code](https://claude.com/claude-code)