### PR TITLE
feat(artifacts): generalize non-AWS S3 endpoint detection, recognize Backblaze B2, and tag boto3 requests with W&B user-agent

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ This version drops compatibility with server versions older than 0.70.0.
 
 - New filters parameter to `Api().project().sweeps()` matching the runs filter format (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/12059)
 - Added `Run.stop()` to the public API (`wandb.Api().run(...).stop()`) to programmatically request that an active run stop gracefully, like the "Stop run" button in the W&B App UI (@dmitryduev in https://github.com/wandb/wandb/pull/12159)
+- Recognize Backblaze B2 S3-compatible endpoints (`s3.<region>.backblazeb2.com`) and enforce virtual-hosted-style addressing for them, mirroring the existing CoreWeave handling. Also set `user_agent_extra="wandb/<version>"` on every boto3 `Config` built by the S3 storage handler (AWS or otherwise) so server-side request logs can identify the W&B SDK as the caller (@goanpeca in https://github.com/wandb/wandb/pull/11938)
 
 ### Changed
 

--- a/tests/unit_tests/test_artifacts/test_s3_handler.py
+++ b/tests/unit_tests/test_artifacts/test_s3_handler.py
@@ -41,13 +41,16 @@ BACKBLAZE_ENDPOINT_TEST_CASES = [
     ("https://s3.us-west-004.backblazeb2.com/", True),
     ("https://s3.eu-central-003.backblazeb2.com", True),
     ("s3.us-west-004.backblazeb2.com", True),  # missing scheme defaults to https
+    ("https://s3.us-west-004.backblazeb2.com:443", True),
     # Virtual-hosted-style: "<bucket>.s3.<region>.backblazeb2.com".
     ("https://my-bucket.s3.us-west-004.backblazeb2.com", True),
     ("https://my.dotted.bucket.s3.us-west-004.backblazeb2.com", True),
+    ("https://my-bucket.s3.us-west-004.backblazeb2.com:443", True),
     # Case-insensitive: hostnames + schemes must match regardless of case.
     ("HTTPS://S3.US-WEST-004.BACKBLAZEB2.COM", True),
     ("HTTPS://MY-BUCKET.S3.US-WEST-004.BACKBLAZEB2.COM", True),
     # Negatives: native b2 API, AWS, lookalikes, empty.
+    ("http://s3.us-west-004.backblazeb2.com", False),
     ("https://api.backblazeb2.com", False),
     ("https://f004.backblazeb2.com", False),
     ("https://backblazeb2.com", False),

--- a/tests/unit_tests/test_artifacts/test_s3_handler.py
+++ b/tests/unit_tests/test_artifacts/test_s3_handler.py
@@ -1,4 +1,5 @@
 import pytest
+import wandb
 from wandb.sdk.artifacts.storage_handlers.s3_handler import S3Handler
 
 COREWEAVE_ENDPOINT_TEST_CASES = [
@@ -10,6 +11,10 @@ COREWEAVE_ENDPOINT_TEST_CASES = [
     ("https://object.lga1.coreweave.com/", True),
     ("cwobject.com", True),  # No scheme, https should be added
     ("https://accel-object.lga1.coreweave.com", True),
+    # Case-insensitive: hostnames + schemes must match regardless of case.
+    ("HTTPS://CWOBJECT.COM", True),
+    ("HTTPS://OBJECT.LGA1.COREWEAVE.COM", True),
+    ("HTTP://CWLOTA.COM", True),
     ("cwlota.com", False),  # This will default to https://cwlota.com
     ("http://object.lga1.coreweave.com", False),  # invalid http scheme
     ("https://s3.amazonaws.com", False),
@@ -28,3 +33,115 @@ def test_is_coreweave_endpoint(endpoint_url, expected):
     """Tests the S3Handler._is_coreweave_endpoint method with various URLs."""
     handler = S3Handler()
     assert handler._is_coreweave_endpoint(endpoint_url) == expected
+
+
+BACKBLAZE_ENDPOINT_TEST_CASES = [
+    # Canonical path-style S3 endpoints (one per region shape).
+    ("https://s3.us-west-004.backblazeb2.com", True),
+    ("https://s3.us-west-004.backblazeb2.com/", True),
+    ("https://s3.eu-central-003.backblazeb2.com", True),
+    ("s3.us-west-004.backblazeb2.com", True),  # missing scheme defaults to https
+    # Virtual-hosted-style: "<bucket>.s3.<region>.backblazeb2.com".
+    ("https://my-bucket.s3.us-west-004.backblazeb2.com", True),
+    ("https://my.dotted.bucket.s3.us-west-004.backblazeb2.com", True),
+    # Case-insensitive: hostnames + schemes must match regardless of case.
+    ("HTTPS://S3.US-WEST-004.BACKBLAZEB2.COM", True),
+    ("HTTPS://MY-BUCKET.S3.US-WEST-004.BACKBLAZEB2.COM", True),
+    # Negatives: native b2 API, AWS, lookalikes, empty.
+    ("https://api.backblazeb2.com", False),
+    ("https://f004.backblazeb2.com", False),
+    ("https://backblazeb2.com", False),
+    ("https://s3.amazonaws.com", False),
+    ("https://s3.us-west-004.backblazeb2.com.malicious.com", False),
+    ("https://cwobject.com", False),
+    ("", False),
+]
+
+
+@pytest.mark.parametrize(
+    "endpoint_url, expected",
+    BACKBLAZE_ENDPOINT_TEST_CASES,
+)
+def test_is_backblaze_endpoint(endpoint_url, expected):
+    """Tests the S3Handler._is_backblaze_endpoint method with various URLs."""
+    handler = S3Handler()
+    assert handler._is_backblaze_endpoint(endpoint_url) == expected
+
+
+# One representative URL per registered S3-compatible provider, plus a few
+# unrecognized ones. The dispatcher should return the provider name (or None).
+S3_COMPATIBLE_PROVIDER_TEST_CASES = [
+    ("https://cwobject.com", "coreweave"),
+    ("https://object.lga1.coreweave.com/", "coreweave"),
+    ("http://cwlota.com", "coreweave"),
+    ("https://s3.us-west-004.backblazeb2.com", "backblaze"),
+    ("https://my-bucket.s3.us-west-004.backblazeb2.com", "backblaze"),
+    ("https://s3.amazonaws.com", None),
+    ("https://example.com", None),
+    ("", None),
+]
+
+
+@pytest.mark.parametrize(
+    "endpoint_url, expected_provider",
+    S3_COMPATIBLE_PROVIDER_TEST_CASES,
+)
+def test_resolve_s3_provider(endpoint_url, expected_provider):
+    """Tests the dispatcher returns the right provider name (or None)."""
+    handler = S3Handler()
+    assert handler._resolve_s3_provider(endpoint_url) == expected_provider
+
+
+# Per-endpoint expectation for the boto3 ``Config`` that ``init_boto`` builds.
+# ``user_agent_extra`` must always be ``wandb/<version>``; the virtual-hosted
+# ``addressing_style`` switch only fires for recognized S3-compatible non-AWS
+# endpoints.
+INIT_BOTO_CONFIG_CASES = [
+    # AWS S3 (no endpoint override): UA tagged, no addressing-style override.
+    (None, False),
+    # AWS-hosted S3 endpoint: UA tagged, no addressing-style override.
+    ("https://s3.amazonaws.com", False),
+    # Recognized non-AWS providers: UA tagged + virtual-hosted addressing.
+    ("https://cwobject.com", True),
+    ("https://s3.us-west-004.backblazeb2.com", True),
+    ("https://my-bucket.s3.us-west-004.backblazeb2.com", True),
+]
+
+
+@pytest.mark.parametrize(
+    "endpoint_url, expect_virtual_addressing",
+    INIT_BOTO_CONFIG_CASES,
+)
+def test_init_boto_config(monkeypatch, endpoint_url, expect_virtual_addressing):
+    """Tests that ``init_boto`` builds a boto3 ``Config`` with the right shape.
+
+    Two invariants are checked:
+
+    1. ``user_agent_extra`` is set to ``wandb/<version>`` for *every* endpoint
+       (AWS or otherwise) so server-side request logs can identify the W&B SDK
+       as the caller regardless of S3 backend.
+    2. ``addressing_style="virtual"`` is set only for endpoints the dispatcher
+       recognizes as S3-compatible non-AWS providers.
+    """
+    # ``init_boto`` requires boto3/botocore (the optional ``wandb[aws]`` extra);
+    # skip cleanly if they are not installed in the test environment.
+    pytest.importorskip("boto3")
+    pytest.importorskip("botocore")
+
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    if endpoint_url is None:
+        monkeypatch.delenv("AWS_S3_ENDPOINT_URL", raising=False)
+    else:
+        monkeypatch.setenv("AWS_S3_ENDPOINT_URL", endpoint_url)
+
+    handler = S3Handler()
+    s3 = handler.init_boto()
+    config = s3.meta.client.meta.config
+
+    assert config.user_agent_extra == f"wandb/{wandb.__version__}"
+
+    s3_config = config.s3 or {}
+    if expect_virtual_addressing:
+        assert s3_config.get("addressing_style") == "virtual"
+    else:
+        assert "addressing_style" not in s3_config

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -369,11 +369,17 @@ class S3Handler(StorageHandler):
         if not (url := endpoint_url.strip().rstrip("/")):
             return False
 
-        # B2's S3 endpoints are HTTPS-only. Hostnames are case-insensitive, so
-        # lowercase before matching.
-        https_url = ensureprefix(url.lower(), "https://")
-        netloc = urlparse(https_url).netloc
-        return bool(self._B2_NETLOC_REGEX.fullmatch(netloc))
+        # B2's S3 endpoints are HTTPS-only. If no scheme is given, match the
+        # CoreWeave precedent and treat it as HTTPS.
+        if "://" not in url:
+            url = f"https://{url}"
+
+        parsed = urlparse(url)
+        if parsed.scheme.lower() != "https":
+            return False
+
+        hostname = parsed.hostname
+        return bool(hostname and self._B2_NETLOC_REGEX.fullmatch(hostname))
 
     # Registry of supported S3-compatible non-AWS providers. To add a new one:
     # (1) define ``_is_<provider>_endpoint`` above with its matching logic;

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Callable
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import parse_qsl, urlparse
 
+from wandb import __version__ as _wandb_version
 from wandb import util
 from wandb._strutils import ensureprefix
 from wandb.errors import CommError
@@ -61,11 +63,12 @@ class S3Handler(StorageHandler):
         from botocore.client import Config  # type: ignore
 
         s3_endpoint = os.getenv("AWS_S3_ENDPOINT_URL")
-        config = (
-            Config(s3={"addressing_style": "virtual"})
-            if s3_endpoint and self._is_coreweave_endpoint(s3_endpoint)
-            else None
-        )
+        config_kwargs: dict[str, Any] = {
+            "user_agent_extra": f"wandb/{_wandb_version}",
+        }
+        if s3_endpoint and self._resolve_s3_provider(s3_endpoint):
+            config_kwargs["s3"] = {"addressing_style": "virtual"}
+        config = Config(**config_kwargs)
         self._s3 = boto.session.Session().resource(
             "s3",
             endpoint_url=s3_endpoint,
@@ -326,6 +329,10 @@ class S3Handler(StorageHandler):
         if not (url := endpoint_url.strip().rstrip("/")):
             return False
 
+        # URL schemes and hostnames are case-insensitive; lowercase before
+        # comparing so e.g. ``HTTPS://CWOBJECT.COM`` still matches.
+        url = url.lower()
+
         # Only http://cwlota.com is supported using HTTP
         if url == "http://cwlota.com":
             return True
@@ -340,3 +347,53 @@ class S3Handler(StorageHandler):
             # Check for legacy endpoints
             self._CW_LEGACY_NETLOC_REGEX.fullmatch(netloc)
         )
+
+    _B2_NETLOC_REGEX: re.Pattern[str] = re.compile(
+        r"""
+        # Path-style S3 endpoint: "s3.<region>.backblazeb2.com"
+        s3\.[a-z0-9-]+\.backblazeb2\.com
+        |
+        # Virtual-hosted-style: "<bucket>.s3.<region>.backblazeb2.com"
+        [a-z0-9][a-z0-9.-]*\.s3\.[a-z0-9-]+\.backblazeb2\.com
+        """,
+        flags=re.VERBOSE,
+    )
+
+    def _is_backblaze_endpoint(self, endpoint_url: str) -> bool:
+        """Return True if ``endpoint_url`` points at a Backblaze B2 S3 endpoint.
+
+        B2's S3-compatible API supports virtual-hosted-style addressing, which
+        is what AWS now treats as the default; we set that explicitly so wandb
+        artifact references work without per-bucket DNS surprises.
+        """
+        if not (url := endpoint_url.strip().rstrip("/")):
+            return False
+
+        # B2's S3 endpoints are HTTPS-only. Hostnames are case-insensitive, so
+        # lowercase before matching.
+        https_url = ensureprefix(url.lower(), "https://")
+        netloc = urlparse(https_url).netloc
+        return bool(self._B2_NETLOC_REGEX.fullmatch(netloc))
+
+    # Registry of supported S3-compatible non-AWS providers. To add a new one:
+    # (1) define ``_is_<provider>_endpoint`` above with its matching logic;
+    # (2) add the (name, detector) entry below. Call sites that need to
+    # branch on "is this any S3-compatible non-AWS endpoint?" should call
+    # ``_resolve_s3_provider`` and check that the return value is not ``None``.
+    _S3_COMPATIBLE_PROVIDER_DETECTORS: ClassVar[
+        dict[str, Callable[[S3Handler, str], bool]]
+    ] = {
+        "coreweave": _is_coreweave_endpoint,
+        "backblaze": _is_backblaze_endpoint,
+    }
+
+    def _resolve_s3_provider(self, endpoint_url: str) -> str | None:
+        """Return the matching S3-compatible provider name (or ``None``).
+
+        ``None`` means the URL is not a recognized S3-compatible non-AWS
+        endpoint (i.e. it is either AWS S3 itself or an unrecognized host).
+        """
+        for name, detector in self._S3_COMPATIBLE_PROVIDER_DETECTORS.items():
+            if detector(self, endpoint_url):
+                return name
+        return None


### PR DESCRIPTION
Mirrors the existing `_is_coreweave_endpoint()` precedent (#9979) for Backblaze B2 and generalizes the surrounding detection so future S3-compatible providers can be added with one entry.

**What changed**

- New `_is_backblaze_endpoint()` matching `s3.<region>.backblazeb2.com` (path-style) and `<bucket>.s3.<region>.backblazeb2.com` (virtual-hosted-style). It parses the endpoint URL, rejects explicit non-HTTPS schemes, and matches against `urlparse(...).hostname` so case-insensitive hosts and explicit ports are handled while suffix-injection lookalikes (e.g. `s3.us-west-004.backblazeb2.com.malicious.com`) are rejected.
- Provider detection consolidated behind a `_S3_COMPATIBLE_PROVIDER_DETECTORS` registry and a single `_resolve_s3_provider(url) -> str | None` dispatcher. CoreWeave + B2 both route through it. Adding a future provider is one helper + one registry entry.
- `init_boto()` now sets `user_agent_extra=f"wandb/{_wandb_version}"` on the boto3 `Config` unconditionally, so server-side request logs can identify the W&B SDK as the caller for any S3 backend (not just B2/CoreWeave). The `addressing_style="virtual"` switch is still scoped to recognized S3-compatible non-AWS endpoints.

**Testing**

- 48 parametrized cases in `tests/unit_tests/test_artifacts/test_s3_handler.py`:
  - 17 CoreWeave + 18 B2 + 8 dispatcher cases for the provider-detection helpers.
  - 5 `test_init_boto_config` cases that drive `init_boto()` end-to-end and assert (via real boto3 `Config` introspection) that `user_agent_extra == "wandb/<version>"` lands on the client for every endpoint, and that `addressing_style="virtual"` is set only for recognized S3-compatible non-AWS endpoints.
- The `init_boto()` config test uses `pytest.importorskip("boto3")` and `pytest.importorskip("botocore")` so environments without the optional `wandb[aws]` dependencies skip cleanly.
- Review follow-up checks: `git diff --check` and `python -m py_compile wandb/sdk/artifacts/storage_handlers/s3_handler.py tests/unit_tests/test_artifacts/test_s3_handler.py` passed locally.
- `CHANGELOG.unreleased.md` updated under `### Added`.

**Notes for reviewers**

- B2 docs ref: https://www.backblaze.com/docs/cloud-storage-s3-compatible-api
- CodeQL may flag the `backblazeb2.com` literal as "incomplete URL substring sanitization", same as it did on #9979. Matching is performed on the parsed hostname with `re.fullmatch`, so substring-injection attacks (`...backblazeb2.com.attacker.com`) are rejected. Explicit negative cases are in the test table.
- No new runtime dependencies. `boto3` is already required by `wandb[aws]`.

Companion docs PR: https://github.com/wandb/docs/pull/2661