### PR TITLE
fix(xpu): unlink unix socket on shutdown

### DIFF
--- a/xpu/src/main.rs
+++ b/xpu/src/main.rs
@@ -343,11 +343,19 @@ async fn create_listener(args: &Args) -> Result<ListenerType, Box<dyn std::error
                 std::fs::write(&args.portfile, token)?;
                 debug!("System metrics service listening on {}", path_str);
 
-                // Store path for cleanup
-                let cleanup_path = socket_path.clone();
+                // `UnixListener` does not unlink its socket file on drop;
+                // a Drop guard parked in a tokio task cleans it up when the
+                // runtime shuts down (or on SIGINT).
+                struct SocketCleanup(std::path::PathBuf);
+                impl Drop for SocketCleanup {
+                    fn drop(&mut self) {
+                        let _ = std::fs::remove_file(&self.0);
+                    }
+                }
+                let cleanup = SocketCleanup(socket_path.clone());
                 tokio::spawn(async move {
+                    let _cleanup = cleanup;
                     tokio::signal::ctrl_c().await.ok();
-                    let _ = std::fs::remove_file(&cleanup_path);
                 });
             } else {
                 return Err("Invalid UTF-8 sequence in socket path".into());


### PR DESCRIPTION
## Summary

`UnixListener` does not unlink its on-disk inode when dropped, and the previous cleanup only ran on `ctrl_c` (SIGINT). The normal shutdown path is a gRPC `TearDown` request from wandb-core, which never triggers the SIGINT handler, so `/tmp/wandb_xpu-*.sock` files accumulated on every run.

This wraps the socket path in a `Drop` guard moved into the existing tokio task. When the runtime shuts down after `main` returns (TearDown, parent-pid watchdog exit, panic) the task is cancelled, the future is dropped, and the guard removes the file. The existing `ctrl_c` await keeps SIGINT-path cleanup working as before.

Related to #11518 (addresses the `wandb_xpu-*.sock` portion of the leak; the wandb-core service tempdir is a separate code path).

## Test plan

- [x] `cargo build --release` in `xpu/`
- [x] Verified `tokio` runtime drop drops pending task futures and runs captured `Drop` impls (standalone reproducer)
- [x] End-to-end repro from the issue:
  ```python
  import wandb, os, tempfile
  run = wandb.init(project='test', mode='offline')
  run.finish()
  wandb.teardown()
  os.system(f'find {tempfile.gettempdir()} -maxdepth 1 -name "wandb_xpu*" -ls')
  ```
  Before patch: `/tmp/wandb_xpu-*.sock` remains. 
  After patch: no match.
