### PR TITLE
fix: don't mutate Run class when making disabled run

### DIFF
--- a/wandb/sdk/lib/noop_run.py
+++ b/wandb/sdk/lib/noop_run.py
@@ -1,0 +1,137 @@
+"""Implementation for WANDB_MODE=disabled."""
+
+import time
+from typing import cast
+
+from typing_extensions import Self, override
+
+import wandb
+from wandb.sdk import wandb_config, wandb_metric, wandb_run, wandb_settings
+from wandb.sdk.artifacts import artifact
+from wandb.sdk.lib import module
+from wandb.sdk.lib.disabled import SummaryDisabled
+
+
+def init_noop_run(
+    settings: wandb_settings.Settings,
+    config: dict[str, object],
+) -> wandb_run.Run:
+    """Create a mode=disabled run and set it as the global run."""
+    noop_run = NoopRun(settings, config)
+
+    module.set_global(
+        run=noop_run,
+        config=noop_run.config,
+        log=noop_run.log,
+        summary=noop_run.summary,
+        save=noop_run.save,
+        use_artifact=noop_run.use_artifact,
+        log_artifact=noop_run.log_artifact,
+        define_metric=noop_run.define_metric,
+        alert=noop_run.alert,
+        watch=noop_run.watch,
+        unwatch=noop_run.unwatch,
+    )
+
+    return noop_run
+
+
+class _Noop:
+    """A callable object for which every attribute is self."""
+
+    def __getattr__(self, _: str) -> Self:
+        return self
+
+    def __call__(self, *args, **kwargs) -> Self:
+        return self
+
+
+class NoopRun(wandb_run.Run):
+    """A subclass of Run that generally does nothing.
+
+    This is a very bad implementation because any new method on Run is
+    automatically inherited here, so there's always a chance of NoopRun
+    accidentally doing something. A better way is possible, but requires
+    some restructuring: we can make `wandb.Run` an ABC subclassed by both
+    `NoopRun` and the real implementation.
+    """
+
+    def __init__(
+        self,
+        settings: wandb_settings.Settings,
+        config: dict[str, object],
+    ) -> None:
+        super().__init__(settings=settings)
+
+        self._config = wandb_config.Config()
+        self._config.update(config)
+
+        self.summary = SummaryDisabled()  # type: ignore
+
+        self._start_time = time.time()
+        self._starting_step = 0
+        self._step = 0
+        self._attach_id = None
+        self._interface = None
+
+    # Replace all of these symbols with functions that return None.
+    for __symbol in (
+        "alert",
+        "finish_artifact",
+        "get_project_url",
+        "get_sweep_url",
+        "get_url",
+        "link_artifact",
+        "link_model",
+        "use_artifact",
+        "log_code",
+        "log_model",
+        "use_model",
+        "mark_preempting",
+        "restore",
+        "status",
+        "watch",
+        "write_logs",
+        "unwatch",
+        "upsert_artifact",
+        "_finish",
+    ):
+        locals()[__symbol] = lambda *args, **kwargs: None
+
+    @override
+    def log(self, data, *args, **kwargs) -> None:
+        self.summary.update(data)
+
+    @override
+    def finish(self, *args, **kwargs) -> None:
+        if wandb.run is self:
+            module.unset_globals()
+
+    @override
+    def define_metric(self, *args, **kwargs) -> wandb_metric.Metric:
+        return wandb_metric.Metric("dummy")
+
+    @override
+    def save(self, *args, **kwargs) -> bool:
+        return False
+
+    @property
+    @override
+    def url(self) -> None:
+        return None
+
+    @property
+    @override
+    def project_url(self) -> None:
+        return None
+
+    @property
+    @override
+    def sweep_url(self) -> None:
+        return None
+
+    @override
+    def log_artifact(self, *args, **kwargs) -> artifact.Artifact:
+        # Cast to object first to tell the type-checker this is intentional.
+        noop = cast(object, _Noop())
+        return cast(artifact.Artifact, noop)

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -24,7 +24,7 @@ import time
 from collections.abc import Generator, Iterable, Sequence
 from typing import TYPE_CHECKING, Literal
 
-from typing_extensions import Any, Protocol, Self
+from typing_extensions import Any, Protocol
 
 import wandb
 import wandb.env
@@ -36,12 +36,12 @@ from wandb.errors.util import ProtobufErrorHandler
 from wandb.integration import sagemaker, weave
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
 from wandb.sdk.lib import ipython as wb_ipython
-from wandb.sdk.lib import progress, runid, wb_logging
+from wandb.sdk.lib import noop_run, progress, runid, wb_logging
 from wandb.sdk.lib.paths import StrPath
 from wandb.util import _is_artifact_representation
 
 from . import wandb_login, wandb_setup
-from .lib import SummaryDisabled, filesystem, module, paths, printer, telemetry
+from .lib import filesystem, module, paths, printer, telemetry
 from .lib.deprecation import UNSET, DoNotSet, warn_and_record_deprecation
 from .mailbox import wait_with_progress
 from .wandb_helper import parse_config
@@ -742,7 +742,7 @@ class _WandbInit:
         are no-op versions that don't perform any actual logging or communication.
         """
         run_id = runid.generate_id()
-        drun = Run(
+        return noop_run.init_noop_run(
             settings=Settings(
                 mode="disabled",
                 root_dir=tempfile.gettempdir(),
@@ -753,94 +753,9 @@ class _WandbInit:
                 run_name=f"dummy-{run_id}",
                 project="dummy",
                 entity="dummy",
-            )
+            ),
+            config={**config.base_no_artifacts, **config.sweep_no_artifacts},
         )
-        # config, summary, and metadata objects
-        drun._config = wandb.sdk.wandb_config.Config()
-        drun._config.update(config.sweep_no_artifacts)
-        drun._config.update(config.base_no_artifacts)
-        drun.summary = SummaryDisabled()  # type: ignore
-
-        # methods
-        drun.log = lambda data, *_, **__: drun.summary.update(data)  # type: ignore[method-assign]
-        drun.finish = lambda *_, **__: module.unset_globals()  # type: ignore[method-assign]
-        drun.join = drun.finish  # type: ignore[method-assign]
-        drun.define_metric = lambda *_, **__: wandb.sdk.wandb_metric.Metric("dummy")  # type: ignore[method-assign]
-        drun.save = lambda *_, **__: False  # type: ignore[method-assign]
-        for symbol in (
-            "alert",
-            "finish_artifact",
-            "get_project_url",
-            "get_sweep_url",
-            "get_url",
-            "link_artifact",
-            "link_model",
-            "use_artifact",
-            "log_code",
-            "log_model",
-            "use_model",
-            "mark_preempting",
-            "restore",
-            "status",
-            "watch",
-            "write_logs",
-            "unwatch",
-            "upsert_artifact",
-            "_finish",
-        ):
-            setattr(drun, symbol, lambda *_, **__: None)  # type: ignore
-
-        # set properties to None
-        for attr in ("url", "project_url", "sweep_url"):
-            setattr(type(drun), attr, property(lambda _: None))
-
-        class _ChainableNoOp:
-            """An object that allows chaining arbitrary attributes and method calls."""
-
-            def __getattr__(self, _: str) -> Self:
-                return self
-
-            def __call__(self, *_: Any, **__: Any) -> Self:
-                return self
-
-        class _ChainableNoOpField:
-            # This is used to chain arbitrary attributes and method calls.
-            # For example, `run.log_artifact().state` will work in disabled mode.
-            def __init__(self) -> None:
-                self._value = None
-
-            def __set__(self, instance: Any, value: Any) -> None:
-                self._value = value
-
-            def __get__(self, instance: Any, owner: type) -> Any:
-                return _ChainableNoOp() if (self._value is None) else self._value
-
-            def __call__(self, *args: Any, **kwargs: Any) -> _ChainableNoOp:
-                return _ChainableNoOp()
-
-        drun.log_artifact = _ChainableNoOpField()  # type: ignore
-        # attributes
-        drun._start_time = time.time()
-        drun._starting_step = 0
-        drun._step = 0
-        drun._attach_id = None
-        drun._interface = None
-
-        # set the disabled run as the global run
-        module.set_global(
-            run=drun,
-            config=drun.config,
-            log=drun.log,
-            summary=drun.summary,
-            save=drun.save,
-            use_artifact=drun.use_artifact,
-            log_artifact=drun.log_artifact,
-            define_metric=drun.define_metric,
-            alert=drun.alert,
-            watch=drun.watch,
-            unwatch=drun.unwatch,
-        )
-        return drun
 
     def init(  # noqa: C901
         self,


### PR DESCRIPTION
Moves the `WANDB_MODE=disabled` logic out of `wandb_init.py` and into its own file, mostly copying it over, but changing it to subclass `wandb.Run` instead of monkeypatching an instance of it. Subclassing works exactly the same, but avoids this horrible code in the original implementation:

```python
for attr in ("url", "project_url", "sweep_url"):
    setattr(type(drun), attr, property(lambda _: None))
```

`type(drun)` is `wandb.Run`, so this snippet changes how `wandb.Run` works after `wandb.init(mode="disabled")`. This shows up in test flakes like [this one](https://app.circleci.com/pipelines/github/wandb/wandb/64307/workflows/cdb8c0a4-ec07-4b38-9d14-e82c652830a0/jobs/1672741/tests).

The other horrible code is ported over as-is.

I spent a while trying to do this properly but gave up after too many edge cases. The least intrusive approach (not involving changes to `wandb_run.py`) is to semi-dynamically construct `NoopRun` (using reflection + hand-written overrides) and then write tests that inspect `wandb.Run` and ensure `NoopRun` has the desired interface: same public methods, dunders, properties, and attributes (like `run.summary`). But while writing it, I realized I'm not sure what guarantees we want to provide. The entire thing is sort of patched together from a series of bug reports (like how `log_artifact` is patched to return a `_Noop` object, so that people can write `run.log_artifact().wait()`; but the other Artifact-returning methods still return None). Does `log()` really need to update the `summary` for disabled runs? Hyrum's law says someone would have found a way to rely on this.

We could use a more thoughtful design, but that will take a lot more work than just fixing this bug.