### PR TITLE
fix: ban-graphql-introspection check does not break on deleted files

### DIFF
--- a/.github/scripts/ban-graphql-introspection-test.sh
+++ b/.github/scripts/ban-graphql-introspection-test.sh
@@ -20,15 +20,20 @@ git config user.email "<>"
 
 # Set up a test file and add GQL introspection to it.
 TEST_FILE=ban-graphql-introspection.txt
+# Also test deletions, since they have special handling.
+# Must be alphabetically before the other file.
+TEST_DELETED_FILE="a.txt"
 
 # Initial content:
+echo "content" >"$TEST_DELETED_FILE"
 cat >"$TEST_FILE" <<EOF
 Line 1 contains __type but is unchanged.
 Line 2 contains __type but will be deleted.
 EOF
-git add "$TEST_FILE" && git commit -m initial
+git add "$TEST_FILE" "$TEST_DELETED_FILE" && git commit -m initial
 
 # Updated content:
+rm "$TEST_DELETED_FILE"
 cat >"$TEST_FILE" <<EOF
 Line 1 contains __type but is unchanged.
 Line 2 had GQL introspection that got removed.
@@ -36,7 +41,7 @@ Line 3 uses __schema, which is not allowed.
 Line 4 uses __type, also not allowed.
 Line 5 uses __typename, which is OK.
 EOF
-git add "$TEST_FILE" && git commit -m initial
+git add "$TEST_FILE" "$TEST_DELETED_FILE" && git commit -m updated
 
 
 # Check that the expected output is produced.

--- a/.github/scripts/ban-graphql-introspection.py
+++ b/.github/scripts/ban-graphql-introspection.py
@@ -30,6 +30,11 @@ while True:
         file_context = file
         context.clear()
         continue
+    if text.startswith("+++ /dev/null"):  # different format for deletions
+        file = None
+        file_context = ""
+        context.clear()
+        continue
     if match := re.match(r"^@@ \S+ \+(\d+)", text):
         line = int(match.group(1))
         continue


### PR DESCRIPTION
Fixes the AssertionError that can happen when diff output starts with a deleted file: https://github.com/wandb/wandb/runs/78189600582?pr=11953

The script assumed the patch header always includes a line starting with `+++ b/`, but the header for a deleted file includes `+++ /dev/null` instead (no `b/`).