### PR TITLE
fix(sdk): use git_root instead of root_dir setting for git diff

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,4 +37,4 @@ This version drops compatibility with server versions older than 0.65.0.
 - Artifact file operations now consistently require normalized relative paths (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11735)
 - Logging an artifact (whether via `WandbLogger` or `run.log_artifact`) now writes the manifest file to the artifact's staging directory instead of the OS temp dir (`$TMPDIR`), avoiding silent failures when `$TMPDIR` is missing or unwritable (@ibindlish in https://github.com/wandb/wandb/pull/11958)
 - Logging artifacts in shared mode works again, and in particular, `wandb.init(mode="shared")` with code-saving enabled no longer raises an error (@timoffex in https://github.com/wandb/wandb/pull/12017)
-- `git_root` setting is now respected for creating the `diff.patch` file. Previously, the `root_dir` setting determined where the git diff was performed.
+- `git_root` setting is now preferred for creating the `diff.patch` file, the `root_dir` setting is now used as a fallback (@TomSiegl in https://github.com/wandb/wandb/pull/11967)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,3 +37,4 @@ This version drops compatibility with server versions older than 0.65.0.
 - Artifact file operations now consistently require normalized relative paths (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11735)
 - Logging an artifact (whether via `WandbLogger` or `run.log_artifact`) now writes the manifest file to the artifact's staging directory instead of the OS temp dir (`$TMPDIR`), avoiding silent failures when `$TMPDIR` is missing or unwritable (@ibindlish in https://github.com/wandb/wandb/pull/11958)
 - Logging artifacts in shared mode works again, and in particular, `wandb.init(mode="shared")` with code-saving enabled no longer raises an error (@timoffex in https://github.com/wandb/wandb/pull/12017)
+- `git_root` setting is now respected for creating the `diff.patch` file. Previously, the `root_dir` setting determined where the git diff was performed.

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -171,6 +171,11 @@ func (s *Settings) GetFilesDir() string {
 	return filepath.Join(s.GetSyncDir(), "files")
 }
 
+// The root directory of the Git repository.
+func (s *Settings) GetGitRoot() string {
+	return s.Proto.GitRoot.GetValue()
+}
+
 // Unix glob patterns relative to `files_dir` to not upload.
 func (s *Settings) GetIgnoreGlobs() []string {
 	return s.Proto.IgnoreGlobs.GetValue()

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -618,7 +618,7 @@ func (h *Handler) handlePatchSave() {
 		return
 	}
 
-	git := gitops.New(h.settings.GetRootDir(), h.logger)
+	git := gitops.New(h.settings.GetGitRoot(), h.logger)
 	if !git.IsAvailable() {
 		return
 	}

--- a/tests/unit_tests/test_wandb_settings.py
+++ b/tests/unit_tests/test_wandb_settings.py
@@ -693,3 +693,46 @@ def test_reports_invalid_system_settings(
         mock_wandb_log.assert_errored_re(
             rf"^Failed to load settings from {re.escape(str(settings_file))}$",
         )
+
+
+def test_infer_git_root_finds_repo(tmp_path):
+    git_root = tmp_path / "repo"
+    git_root.mkdir()
+    subprocess.run(["git", "init", str(git_root)], check=True, capture_output=True)
+    subdir = git_root / "subdir"
+    subdir.mkdir()
+
+    s = Settings(root_dir=str(subdir))
+    s.infer_git_root()
+
+    assert s.git_root == str(git_root)
+
+
+def test_infer_git_root_no_repo(tmp_path):
+    s = Settings(root_dir=str(tmp_path))
+    s.infer_git_root()
+
+    assert s.git_root is None
+
+
+def test_infer_git_root_skips_if_already_set(tmp_path):
+    git_root = tmp_path / "repo"
+    git_root.mkdir()
+    subprocess.run(["git", "init", str(git_root)], check=True, capture_output=True)
+
+    preset = "/some/other/path"
+    s = Settings(root_dir=str(git_root), git_root=preset)
+    s.infer_git_root()
+
+    assert s.git_root == preset
+
+
+def test_infer_git_root_skips_if_disable_git(tmp_path):
+    git_root = tmp_path / "repo"
+    git_root.mkdir()
+    subprocess.run(["git", "init", str(git_root)], check=True, capture_output=True)
+
+    s = Settings(root_dir=str(git_root), disable_git=True)
+    s.infer_git_root()
+
+    assert s.git_root is None

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -311,6 +311,8 @@ class _WandbInit:
         if save_code_pre_user_settings is False:
             settings.save_code = False
 
+        settings.infer_git_root()
+
         # TODO: remove this once we refactor the client. This is a temporary
         # fix to make sure that we use the same project name for wandb-core.
         # The reason this is not going through the settings object is to

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -2023,13 +2023,25 @@ class Settings(BaseModel, validate_assignment=True):
         else:
             program = "<python with no main file>"
 
-        if self.git_root is None:
-            if self.program_abspath is not None:
-                self.git_root = os.path.dirname(self.program_abspath)
-            else:
-                self.git_root = self.root_dir
-
         self.program = program
+
+    def infer_git_root(self) -> None:
+        """Infer the git root from the root_dir setting using GitRepo.
+
+        <!-- lazydoc-ignore: internal -->
+        """
+        if self.git_root is not None or self.disable_git:
+            return
+
+        from .lib.gitlib import GitRepo
+
+        try:
+            git_root = GitRepo(root=self.root_dir).root
+        except Exception:
+            return
+
+        if git_root is not None:
+            self.git_root = str(git_root)
 
     def update_from_dict(self, settings: dict[str, Any]) -> None:
         """Update settings from a dictionary.

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -2014,6 +2014,9 @@ class Settings(BaseModel, validate_assignment=True):
 
         # proceed if not in CLI mode
         if self.x_cli_only_mode:
+            if self.git_root is None:
+                self.git_root = self.root_dir
+
             return
 
         program = self.program or self._get_program()
@@ -2022,6 +2025,12 @@ class Settings(BaseModel, validate_assignment=True):
             self._setup_code_paths(program)
         else:
             program = "<python with no main file>"
+
+        if self.git_root is None:
+            if self.program_abspath is not None:
+                self.git_root = os.path.dirname(self.program_abspath)
+            else:
+                self.git_root = self.root_dir
 
         self.program = program
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -2014,9 +2014,6 @@ class Settings(BaseModel, validate_assignment=True):
 
         # proceed if not in CLI mode
         if self.x_cli_only_mode:
-            if self.git_root is None:
-                self.git_root = self.root_dir
-
             return
 
         program = self.program or self._get_program()


### PR DESCRIPTION
Description
---

- Fixes #11966 

Accesses the `git_root` setting in `handler.go:handlePatchSave()` to set the path from where git operations are executed. Previously the `root_dir` setting was used at that point.

- [x] I updated CHANGELOG.unreleased.md

**Caveats**:
- When `git_root` is not set, it seems to be an empty string at the moment. We might want to consider falling back to `root_dir` in that case.
- The comment next to `Settings.Proto` in `settings.go` says "DO NOT ADD USAGES.", but this adds a new usage. I do not know how else to get the `git_root` on the Go side.

Testing
-------
Testing would require a system test, which I cannot run as an external.