### PR TITLE
chore(sdk): try to make `test_data_types` and `test_wandb_agent_full` less flaky

### DIFF
--- a/tests/system_tests/test_artifacts/test_data_types.py
+++ b/tests/system_tests/test_artifacts/test_data_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeAlias
 
@@ -36,6 +37,27 @@ def filter_artifacts_by_type(run, *artifact_types):
         List of artifacts matching the specified type(s).
     """
     return [art for art in run.logged_artifacts() if art.type in artifact_types]
+
+
+def wait_for_artifacts_by_type(
+    api: Api,
+    run_path: str,
+    *artifact_types: str,
+    expected_count: int,
+    timeout_seconds: float = 10,
+):
+    deadline = time.monotonic() + timeout_seconds
+    artifacts = []
+
+    while time.monotonic() < deadline:
+        api.flush()
+        api_run = api.run(run_path)
+        artifacts = filter_artifacts_by_type(api_run, *artifact_types)
+        if len(artifacts) == expected_count:
+            break
+        time.sleep(0.5)
+
+    return artifacts
 
 
 @fixture
@@ -88,8 +110,12 @@ def test_log_dataframe(user: str, api: Api, test_settings: SettingsFactory):
         cv_results = pd.DataFrame(data={"test_col": [1, 2, 3], "test_col2": [4, 5, 6]})
         run.log({"results_df": cv_results})
 
-    api_run = api.run(f"uncategorized/{run.id}")
-    table_artifacts = filter_artifacts_by_type(api_run, "run_table")
+    table_artifacts = wait_for_artifacts_by_type(
+        api,
+        f"uncategorized/{run.id}",
+        "run_table",
+        expected_count=1,
+    )
     assert len(table_artifacts) == 1
 
 

--- a/tests/system_tests/test_sweep/test_wandb_agent_full.py
+++ b/tests/system_tests/test_sweep/test_wandb_agent_full.py
@@ -21,11 +21,12 @@ def test_agent_basic(user):
     sweep_ids = []
     sweep_configs = []
     sweep_resumed = []
+    project = "test-agent-basic"
 
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-basic",
         "method": "grid",
-        "parameters": {"a": {"values": [1, 2, 3]}},
+        "parameters": {"a": {"values": [1]}},
     }
 
     def train():
@@ -35,9 +36,9 @@ def test_agent_basic(user):
         sweep_resumed.append(run.resumed)
         run.finish()
 
-    sweep_id = wandb.sweep(sweep_config)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
 
-    wandb.agent(sweep_id, function=train, count=1)
+    wandb.agent(sweep_id, function=train, count=1, entity=user, project=project)
 
     assert len(sweep_ids) == len(sweep_configs) == 1
     assert sweep_ids[0] == sweep_id
@@ -47,6 +48,7 @@ def test_agent_basic(user):
 
 def test_agent_config_merge(user, monkeypatch):
     sweep_configs = []
+    project = "test-agent-config-merge"
 
     def train():
         run = wandb.init(config={"extra": 2})
@@ -54,14 +56,14 @@ def test_agent_config_merge(user, monkeypatch):
         run.finish()
 
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-config-merge",
         "method": "grid",
-        "parameters": {"a": {"values": [1, 2, 3]}},
+        "parameters": {"a": {"values": [1]}},
     }
 
     monkeypatch.setenv("WANDB_CONSOLE", "off")
-    sweep_id = wandb.sweep(sweep_config)
-    wandb.agent(sweep_id, function=train, count=1)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
+    wandb.agent(sweep_id, function=train, count=1, entity=user, project=project)
 
     assert len(sweep_configs) == 1
     assert sweep_configs[0] == {"a": 1, "extra": 2}
@@ -69,6 +71,7 @@ def test_agent_config_merge(user, monkeypatch):
 
 def test_agent_config_whitespace_py_agent(user, monkeypatch):
     ran = False
+    project = "test-agent-config-whitespace-py-agent"
 
     def train():
         nonlocal ran
@@ -80,7 +83,7 @@ def test_agent_config_whitespace_py_agent(user, monkeypatch):
         ran = True
 
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-config-whitespace-py-agent",
         "method": "grid",
         "parameters": {
             "a": {"values": ["one two"]},
@@ -90,8 +93,8 @@ def test_agent_config_whitespace_py_agent(user, monkeypatch):
     }
 
     monkeypatch.setenv("WANDB_CONSOLE", "off")
-    sweep_id = wandb.sweep(sweep_config)
-    wandb.agent(sweep_id, function=train, count=1)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
+    wandb.agent(sweep_id, function=train, count=1, entity=user, project=project)
     assert ran
 
 
@@ -124,6 +127,7 @@ def test_agent_config_whitespace_cli_agent(runner, user):
 
 def test_agent_config_ignore(user):
     sweep_configs = []
+    project = "test-agent-config-ignore"
 
     def train():
         run = wandb.init(config={"a": "ignored", "extra": 2})
@@ -131,13 +135,13 @@ def test_agent_config_ignore(user):
         run.finish()
 
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-config-ignore",
         "method": "grid",
-        "parameters": {"a": {"values": [1, 2, 3]}},
+        "parameters": {"a": {"values": [1]}},
     }
 
-    sweep_id = wandb.sweep(sweep_config)
-    wandb.agent(sweep_id, function=train, count=1)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
+    wandb.agent(sweep_id, function=train, count=1, entity=user, project=project)
 
     assert len(sweep_configs) == 1
     assert sweep_configs[0] == {"a": 1, "extra": 2}
@@ -148,7 +152,7 @@ def test_agent_ignore_project_entity_run_id(user):
     sweep_projects = []
     sweep_run_ids = []
 
-    project_name = "actual"
+    project_name = "test-agent-ignore-project-entity-run-id"
     public_api = Api()
     public_api.create_project(project_name, user)
 
@@ -160,22 +164,23 @@ def test_agent_ignore_project_entity_run_id(user):
         run.finish()
 
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-ignore-project-entity-run-id",
         "method": "grid",
         "parameters": {"a": {"values": [1, 2, 3]}},
     }
-    sweep_id = wandb.sweep(sweep_config, project=project_name)
-    wandb.agent(sweep_id, function=train, count=1, project=project_name)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project_name)
+    wandb.agent(sweep_id, function=train, count=1, entity=user, project=project_name)
 
     assert len(sweep_projects) == len(sweep_entities) == 1
-    assert sweep_projects[0] == "actual"
+    assert sweep_projects[0] == project_name
     assert sweep_entities[0] == user
     assert sweep_run_ids[0] != "also_ignored"
 
 
 def test_agent_exception(user):
+    project = "test-agent-exception"
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-exception",
         "method": "grid",
         "parameters": {"a": {"values": [1, 2, 3]}},
     }
@@ -184,11 +189,11 @@ def test_agent_exception(user):
         wandb.init()
         raise Exception("Unexpected error")
 
-    sweep_id = wandb.sweep(sweep_config)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
 
     captured_stderr = io.StringIO()
     with contextlib.redirect_stderr(captured_stderr):
-        wandb.agent(sweep_id, function=train, count=1)
+        wandb.agent(sweep_id, function=train, count=1, entity=user, project=project)
 
     stderr_lines = captured_stderr.getvalue().splitlines()
 
@@ -234,13 +239,14 @@ def test_agent_subprocess_with_import_readline(user, monkeypatch):
 
 def test_agent_sweep_deleted(user):
     """Test that agent exits gracefully when sweep is deleted (404)."""
+    project = "test-agent-sweep-deleted"
     sweep_config = {
-        "name": "My Sweep",
+        "name": "test-agent-sweep-deleted",
         "method": "grid",
         "parameters": {"a": {"values": [1, 2, 3]}},
     }
 
-    sweep_id = wandb.sweep(sweep_config)
+    sweep_id = wandb.sweep(sweep_config, entity=user, project=project)
 
     captured_stderr = io.StringIO()
     with contextlib.redirect_stderr(captured_stderr):
@@ -248,7 +254,9 @@ def test_agent_sweep_deleted(user):
             "wandb.sdk.internal.internal_api.Api.agent_heartbeat",
             side_effect=SweepNotFoundError("Sweep not found"),
         ):
-            wandb.agent(sweep_id, function=lambda: None, count=1)
+            wandb.agent(
+                sweep_id, function=lambda: None, count=1, entity=user, project=project
+            )
 
     stderr_output = captured_stderr.getvalue()
     assert "Sweep was deleted or agent was not found" in stderr_output
@@ -256,7 +264,7 @@ def test_agent_sweep_deleted(user):
 
 def test_public_api_sweep_agent_retrieves_running_agent(user):
     """While a sweep agent is blocked in user code, Api().sweep().agent() returns it."""
-    project = "test"
+    project = "test-public-api-sweep-agent-retrieves-running-agent"
     sweep_id = wandb.sweep(SWEEP_CONFIG_GRID, entity=user, project=project)
 
     agent_id_queue = queue.Queue()
@@ -293,7 +301,7 @@ def test_public_api_sweep_agent_retrieves_running_agent(user):
 
 def test_public_api_sweep_agent_runs_lists_finished_run(user):
     """After three sweep runs finish, Agent.runs(per_page=2) returns all three (paginated)."""
-    project = "test"
+    project = "test-public-api-sweep-agent-runs-lists-finished-run"
     sweep_id = wandb.sweep(SWEEP_CONFIG_GRID, entity=user, project=project)
 
     def train():


### PR DESCRIPTION
Description
-----------

Try to make a couplee of tests less flaky.

- Add retry to `test_data_types.py::test_log_dataframe` in case new artifact can't be read right away.

- In `test_wandb_agent_full ` ensure cross-test isolation by using a separate project name in each test.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
  - No CHANGELOG update needed.

Flake Logs
-------

### `tests/system_tests/test_artifacts/test_data_types.py::test_log_dataframe`

```log
[235/243] FAILED tests/system_tests/test_artifacts/test_data_types.py::test_log_dataframe 
Too long with no output (exceeded 10m0s): context deadline exceeded
```

### `tests/system_tests/test_sweep/test_wandb_agent_full.py::test_agent_config_merge`

```log
FAILED tests/system_tests/test_sweep/test_wandb_agent_full.py::test_agent_config_merge - AssertionError: assert {'extra': 2, 'a': 2} == {'a': 1, 'extra': 2}
  
  Common items:
  {'extra': 2}
  Differing items:
  {'a': 2} != {'a': 1}
  
  Full diff:
    {
  -     'a': 1,
  ?          ^
  +     'a': 2,
  ?          ^
        'extra': 2,
    }
======= 1 failed, 235 passed, 3 skipped, 13 warnings in 94.83s (0:01:34) =======
nox > Command pytest --durations=20 --junitxml=.nox-wandb/pytest-results/system_tests-3_13/junit.xml --timeout=60 -n=8 --maxprocesses=10 --splits=8 --group=8 --cov-report= --no-cov-on-fail --cov=wandb tests/system_tests --ignore=tests/system_tests/test_notebooks --ignore=tests/system_tests/test_functional --ignore=tests/system_tests/test_experimental failed with exit code 1
```

Testing
-------
Hopefully tests are less flaky now?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
