### PR TITLE
fix(artifacts): surface errors from artifact saver even when wait() isnt used

### DIFF
--- a/core/pkg/artifacts/builder.go
+++ b/core/pkg/artifacts/builder.go
@@ -17,12 +17,20 @@ import (
 type ArtifactBuilder struct {
 	artifactRecord   *spb.ArtifactRecord
 	isDigestUpToDate bool
+
+	// fallbackTempDir is used by AddData when the OS default temp dir
+	// (os.TempDir() / $TMPDIR) fails. Pass a wandb-controlled directory so
+	// AddData doesn't silently fail in HPC environments where $TMPDIR points
+	// to a path the job never created. Empty disables the fallback (legacy
+	// behavior).
+	fallbackTempDir string
 }
 
-func NewArtifactBuilder(artifactRecord *spb.ArtifactRecord) *ArtifactBuilder {
+func NewArtifactBuilder(artifactRecord *spb.ArtifactRecord, fallbackTempDir string) *ArtifactBuilder {
 	artifactClone := proto.Clone(artifactRecord).(*spb.ArtifactRecord)
 	builder := &ArtifactBuilder{
-		artifactRecord: artifactClone,
+		artifactRecord:  artifactClone,
+		fallbackTempDir: fallbackTempDir,
 	}
 	builder.initDefaultManifest()
 	return builder
@@ -43,7 +51,7 @@ func (b *ArtifactBuilder) initDefaultManifest() {
 }
 
 func (b *ArtifactBuilder) AddData(name string, data any) error {
-	filename, digest, size, err := WriteJSONToTempFileWithMetadata(data)
+	filename, digest, size, err := WriteJSONToTempFileWithMetadata(data, b.fallbackTempDir)
 	if err != nil {
 		return err
 	}

--- a/core/pkg/artifacts/builder_test.go
+++ b/core/pkg/artifacts/builder_test.go
@@ -54,7 +54,7 @@ func TestArtifactBuilder(t *testing.T) {
 		SequenceClientId: sequenceClientId,
 	}
 
-	builder := NewArtifactBuilder(baseArtifact)
+	builder := NewArtifactBuilder(baseArtifact, "")
 	err = builder.AddData("obj.object.json", weaveObjectData)
 	assert.Nil(t, err)
 	err = builder.AddData("obj.type.json", weaveTypeData)

--- a/core/pkg/artifacts/file_helper.go
+++ b/core/pkg/artifacts/file_helper.go
@@ -10,13 +10,26 @@ import (
 
 // WriteJSONToTempFileWithMetadata writes the provided data as JSON to a temporary file.
 //
+// The OS default temp directory (typically $TMPDIR) is tried first to preserve
+// legacy behavior. If that fails — e.g. because $TMPDIR points to a missing
+// path on HPC setups where the job script never created it — and fallbackDir
+// is non-empty, the call is retried with fallbackDir. Pass a wandb-controlled
+// location (e.g. an artifact's stagingDir) so manifest writes don't silently
+// fail when the host $TMPDIR is broken. An empty fallbackDir disables the
+// retry and preserves the original legacy semantics.
+//
 // Returns the path to the temporary file, the Base64-encoded MD5 digest of the JSON data,
 // the size of the file, and an error if something goes wrong during the process.
 func WriteJSONToTempFileWithMetadata(
 	data any,
+	fallbackDir string,
 ) (filename, digest string, size int64, err error) {
-	// Create a temporary file
+	// Try the OS default temp dir first (legacy behavior). If that errors and
+	// the caller supplied a wandb-controlled fallback, retry there.
 	f, err := os.CreateTemp("", "tmpfile-")
+	if err != nil && fallbackDir != "" {
+		f, err = os.CreateTemp(fallbackDir, "tmpfile-")
+	}
 	if err != nil {
 		return "", "", 0, fmt.Errorf("unable to create temporary file: %w", err)
 	}

--- a/core/pkg/artifacts/file_helper_test.go
+++ b/core/pkg/artifacts/file_helper_test.go
@@ -15,7 +15,7 @@ type Marshallable struct {
 
 func TestUtilFiles(t *testing.T) {
 	data := Marshallable{"junk"}
-	filename, digest, size, err := artifacts.WriteJSONToTempFileWithMetadata(data)
+	filename, digest, size, err := artifacts.WriteJSONToTempFileWithMetadata(data, "")
 	defer func() {
 		_ = os.Remove(filename)
 	}()
@@ -23,4 +23,47 @@ func TestUtilFiles(t *testing.T) {
 	assert.Equal(t, int64(15), size)
 	assert.FileExists(t, filename)
 	assert.Nil(t, err)
+}
+
+// TestUtilFiles_FallbackOnBrokenTMPDIR exercises the $TMPDIR-broken recovery
+// path: when the OS default temp dir is unwritable, the call should retry
+// with the supplied fallbackDir rather than fail.
+func TestUtilFiles_FallbackOnBrokenTMPDIR(t *testing.T) {
+	missing := t.TempDir() + "/never-created"
+	t.Setenv("TMPDIR", missing)
+	t.Setenv("TMP", missing)
+	t.Setenv("TEMP", missing)
+
+	fallback := t.TempDir()
+	data := Marshallable{"junk"}
+	filename, _, _, err := artifacts.WriteJSONToTempFileWithMetadata(data, fallback)
+	defer func() {
+		if filename != "" {
+			_ = os.Remove(filename)
+		}
+	}()
+
+	assert.NoError(t, err)
+	assert.FileExists(t, filename)
+	assert.True(
+		t,
+		len(filename) > len(fallback) && filename[:len(fallback)] == fallback,
+		"expected temp file under fallback dir %q, got %q",
+		fallback,
+		filename,
+	)
+}
+
+// TestUtilFiles_NoFallbackPreservesLegacyError confirms that an empty
+// fallbackDir does NOT trigger a retry — preserves the legacy error so we
+// don't quietly succeed in a different location than the caller intended.
+func TestUtilFiles_NoFallbackPreservesLegacyError(t *testing.T) {
+	missing := t.TempDir() + "/never-created"
+	t.Setenv("TMPDIR", missing)
+	t.Setenv("TMP", missing)
+	t.Setenv("TEMP", missing)
+
+	data := Marshallable{"junk"}
+	_, _, _, err := artifacts.WriteJSONToTempFileWithMetadata(data, "")
+	assert.Error(t, err)
 }

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -180,8 +180,13 @@ func ManifestContentsFromFile(path string) (map[string]ManifestEntry, error) {
 	return contents, nil
 }
 
-func (m *Manifest) WriteToFile() (filename, digest string, size int64, rerr error) {
-	return WriteJSONToTempFileWithMetadata(m)
+// WriteToFile serializes the manifest to a temporary file. The OS default
+// temp directory is tried first; fallbackDir is used only if that fails
+// (e.g. host $TMPDIR points to a missing path). Pass a wandb-controlled
+// directory like the artifact's stagingDir so manifest writes don't silently
+// fail. See WriteJSONToTempFileWithMetadata for the rationale.
+func (m *Manifest) WriteToFile(fallbackDir string) (filename, digest string, size int64, rerr error) {
+	return WriteJSONToTempFileWithMetadata(m, fallbackDir)
 }
 
 func (m *Manifest) GetManifestEntryFromArtifactFilePath(path string) (ManifestEntry, error) {

--- a/core/pkg/artifacts/manifest_test.go
+++ b/core/pkg/artifacts/manifest_test.go
@@ -186,7 +186,7 @@ func TestManifest_WriteToFile(t *testing.T) {
 		},
 	}
 
-	filename, digest, size, err := manifest.WriteToFile()
+	filename, digest, size, err := manifest.WriteToFile("")
 	defer func() {
 		_ = os.Remove(filename)
 	}()

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -786,7 +786,11 @@ func (as *ArtifactSaver) Save() (artifactID string, rerr error) {
 		return "", fmt.Errorf("ArtifactSaver.resolveClientIDReferences: %w", err)
 	}
 	// TODO: check if size is needed
-	manifestFile, manifestDigest, _, err := manifest.WriteToFile()
+	// stagingDir is the wandb-controlled fallback for the manifest temp file
+	// when the host's default temp dir ($TMPDIR / os.TempDir()) is missing or
+	// unwritable. The Python SDK guarantees stagingDir exists before sending
+	// the LogArtifactRequest, so it's a safe last-resort write location.
+	manifestFile, manifestDigest, _, err := manifest.WriteToFile(as.stagingDir)
 	if err != nil {
 		return "", fmt.Errorf("ArtifactSaver.writeManifest: %w", err)
 	}

--- a/core/pkg/launch/job_builder.go
+++ b/core/pkg/launch/job_builder.go
@@ -693,7 +693,10 @@ func (j *JobBuilder) buildArtifact(
 	fileDir string,
 	sourceType SourceType,
 ) (*spb.ArtifactRecord, error) {
-	artifactBuilder := artifacts.NewArtifactBuilder(baseArtifact)
+	// fileDir is the run's files directory — guaranteed to exist and be
+	// writable by the SDK contract. Used as a fallback for temp-file writes
+	// when the host's $TMPDIR is missing.
+	artifactBuilder := artifacts.NewArtifactBuilder(baseArtifact, fileDir)
 
 	err := artifactBuilder.AddFile(
 		filepath.Join(fileDir, REQUIREMENTS_FNAME),

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1225,6 +1225,40 @@ class Artifact:
         self._save_handle = save_handle
         self._client = client
 
+        # Schedule a watcher coroutine on the asyncer that already runs the
+        # mailbox loop. When wandb-core delivers the LogArtifactResponse, the
+        # watcher inspects its error_message field and surfaces it as a
+        # termwarn so failures are visible even when the caller never calls
+        # .wait(). The watcher runs on the existing asyncio event loop — no
+        # new thread is spawned.
+        #
+        # Note: if the caller does call .wait(), they'll see the existing
+        # ValueError on error AND this warning. Same message twice, on
+        # different channels. We accept the minor noise because suppressing
+        # it requires racy flag bookkeeping; the silent-failure path
+        # (no-wait callers, e.g. WandbLogger) is the actual bug we're
+        # fixing here.
+        artifact_name = self.name
+
+        async def _surface_error_if_any() -> None:
+            try:
+                result = await save_handle.wait_async(timeout=None)
+            except Exception:
+                # Mailbox was shut down or the handle abandoned. Nothing to
+                # surface; don't crash the asyncer loop.
+                return
+            response = result.response.log_artifact_response
+            if response.error_message:
+                wandb.termwarn(
+                    f"Artifact '{artifact_name}' failed to upload: "
+                    f"{response.error_message}"
+                )
+
+        save_handle.asyncer.run_soon(
+            _surface_error_if_any,
+            name=f"surface-artifact-error/{artifact_name}",
+        )
+
     def wait(self, timeout: int | None = None) -> Artifact:
         """If needed, wait for this artifact to finish logging.
 


### PR DESCRIPTION
Description
-----------
Follow up from https://github.com/wandb/wandb/pull/11958

When we use `WandbLogger` to log an artifact, an errors returned in the saver response are silently ignored. This PR adds a new watcher which parses the error field and prints a warning for it. However, this comes with the drawback that in cases where users use `wait()`, the error is displayed twice, once as a warning and the next time as an error. Still trying to find a way around that.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
