### PR TITLE
refactor: remove platformdirs dependency

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -589,7 +589,6 @@ def mypy_report(session: nox.Session) -> None:
         "packaging",
         "pandas-stubs",
         "pip",
-        "platformdirs",
         "pydantic",
         "pycobertura",
         "types-jsonschema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "sentry-sdk>=2.0.0",
     "protobuf>4.21.0,!=5.28.0,!=5.29.0,<8",
     "PyYAML",
-    "platformdirs",
     "typing_extensions>=4.8,<5",
     "pydantic>=2.6,<3",
     "packaging",

--- a/requirements/requirements_dev.3.10.darwin.txt
+++ b/requirements/requirements_dev.3.10.darwin.txt
@@ -732,7 +732,6 @@ platformdirs==4.9.6
     # via
     #   black
     #   jupyter-core
-    #   wandb
 plotly==6.7.0
     # via
     #   -r requirements/requirements_dev.txt

--- a/requirements/requirements_dev.3.10.linux.txt
+++ b/requirements/requirements_dev.3.10.linux.txt
@@ -817,7 +817,6 @@ platformdirs==4.9.6
     # via
     #   black
     #   jupyter-core
-    #   wandb
 plotly==6.7.0
     # via
     #   -r requirements/requirements_dev.txt

--- a/requirements/requirements_dev.3.10.windows.txt
+++ b/requirements/requirements_dev.3.10.windows.txt
@@ -773,7 +773,6 @@ platformdirs==4.9.6
     # via
     #   black
     #   jupyter-core
-    #   wandb
 plotly==6.7.0
     # via
     #   -r requirements/requirements_dev.txt

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -728,7 +728,6 @@ platformdirs==4.9.4
     # via
     #   black
     #   jupyter-core
-    #   wandb
 plotly==6.6.0
     # via
     #   -r requirements/requirements_dev.txt

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -813,7 +813,6 @@ platformdirs==4.9.4
     # via
     #   black
     #   jupyter-core
-    #   wandb
 plotly==6.6.0
     # via
     #   -r requirements/requirements_dev.txt

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -769,7 +769,6 @@ platformdirs==4.9.4
     # via
     #   black
     #   jupyter-core
-    #   wandb
 plotly==6.6.0
     # via
     #   -r requirements/requirements_dev.txt

--- a/tests/unit_tests/test_platformdirs.py
+++ b/tests/unit_tests/test_platformdirs.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+from wandb import _platformdirs
+
+
+def _clear_dir_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "HOME",
+        "USERPROFILE",
+        "LOCALAPPDATA",
+        "WIN_PD_OVERRIDE_LOCAL_APPDATA",
+        "XDG_CACHE_HOME",
+        "XDG_DATA_HOME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("platform", "environ", "expected_data_dir", "expected_cache_dir"),
+    [
+        (
+            "linux",
+            {"HOME": "/home/alice"},
+            "/home/alice/.local/share/wandb",
+            "/home/alice/.cache/wandb",
+        ),
+        (
+            "linux",
+            {
+                "HOME": "/home/alice",
+                "XDG_DATA_HOME": "/data",
+                "XDG_CACHE_HOME": "/cache",
+            },
+            "/data/wandb",
+            "/cache/wandb",
+        ),
+        (
+            "darwin",
+            {"HOME": "/Users/alice"},
+            "/Users/alice/Library/Application Support/wandb",
+            "/Users/alice/Library/Caches/wandb",
+        ),
+        (
+            "darwin",
+            {
+                "HOME": "/Users/alice",
+                "XDG_DATA_HOME": "/data",
+                "XDG_CACHE_HOME": "/cache",
+            },
+            "/data/wandb",
+            "/cache/wandb",
+        ),
+        (
+            "win32",
+            {
+                "LOCALAPPDATA": r"C:\Users\Alice\AppData\Local",
+                "XDG_DATA_HOME": "/ignored",
+                "XDG_CACHE_HOME": "/ignored",
+            },
+            r"C:\Users\Alice\AppData\Local\wandb\wandb",
+            r"C:\Users\Alice\AppData\Local\wandb\wandb\Cache",
+        ),
+        (
+            "win32",
+            {"WIN_PD_OVERRIDE_LOCAL_APPDATA": r"D:\LocalAppData"},
+            r"D:\LocalAppData\wandb\wandb",
+            r"D:\LocalAppData\wandb\wandb\Cache",
+        ),
+    ],
+)
+def test_user_data_and_cache_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    environ: dict[str, str],
+    expected_data_dir: str,
+    expected_cache_dir: str,
+) -> None:
+    monkeypatch.setattr(_platformdirs.sys, "platform", platform)
+    _clear_dir_env(monkeypatch)
+    for name, value in environ.items():
+        monkeypatch.setenv(name, value)
+
+    assert _platformdirs.user_data_dir("wandb") == expected_data_dir
+    assert _platformdirs.user_cache_dir("wandb") == expected_cache_dir
+
+
+def test_windows_local_app_data_prefers_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail() -> str:
+        raise AssertionError("fallback should not be called")
+
+    monkeypatch.setenv("WIN_PD_OVERRIDE_LOCAL_APPDATA", r"D:\Override")
+    monkeypatch.setattr(_platformdirs, "_windows_known_folder_local_app_data", fail)
+    monkeypatch.setattr(_platformdirs, "_windows_registry_local_app_data", fail)
+    monkeypatch.setattr(_platformdirs, "_windows_env_local_app_data", fail)
+
+    assert _platformdirs._windows_local_app_data() == r"D:\Override"
+
+
+def test_windows_local_app_data_prefers_known_folder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("WIN_PD_OVERRIDE_LOCAL_APPDATA", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Env")
+    monkeypatch.setattr(
+        _platformdirs, "_windows_known_folder_local_app_data", lambda: r"D:\Known"
+    )
+    monkeypatch.setattr(
+        _platformdirs, "_windows_registry_local_app_data", lambda: r"E:\Registry"
+    )
+
+    assert _platformdirs._windows_local_app_data() == r"D:\Known"
+
+
+def test_windows_local_app_data_falls_back_to_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable() -> str:
+        raise OSError("unavailable")
+
+    monkeypatch.delenv("WIN_PD_OVERRIDE_LOCAL_APPDATA", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Env")
+    monkeypatch.setattr(
+        _platformdirs, "_windows_known_folder_local_app_data", unavailable
+    )
+    monkeypatch.setattr(
+        _platformdirs, "_windows_registry_local_app_data", lambda: r"D:\Registry"
+    )
+
+    assert _platformdirs._windows_local_app_data() == r"D:\Registry"
+
+
+def test_windows_local_app_data_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable() -> str:
+        raise OSError("unavailable")
+
+    monkeypatch.delenv("WIN_PD_OVERRIDE_LOCAL_APPDATA", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Env")
+    monkeypatch.setattr(
+        _platformdirs, "_windows_known_folder_local_app_data", unavailable
+    )
+    monkeypatch.setattr(_platformdirs, "_windows_registry_local_app_data", unavailable)
+
+    assert _platformdirs._windows_local_app_data() == r"C:\Env"

--- a/wandb/_platformdirs.py
+++ b/wandb/_platformdirs.py
@@ -1,0 +1,178 @@
+"""Small platform directory helpers for W&B.
+
+Portions of the Windows LocalAppData resolution are adapted from platformdirs
+4.10.0, `platformdirs/windows.py`: https://github.com/tox-dev/platformdirs
+
+MIT License
+
+Copyright (c) 2010-202x The platformdirs developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import annotations
+
+import ntpath
+import os
+import sys
+
+_WINDOWS_LOCAL_APPDATA_GUID = "{F1B32785-6FBA-4FCF-9D55-7B8E7F157091}"
+_KF_FLAG_DONT_VERIFY = 0x00004000
+
+
+def user_data_dir(app_name: str) -> str:
+    if sys.platform == "win32":
+        return ntpath.join(_windows_local_app_data(), app_name, app_name)
+
+    if xdg_dir := _xdg_dir("XDG_DATA_HOME", app_name):
+        return xdg_dir
+
+    if sys.platform == "darwin":
+        return os.path.expanduser(f"~/Library/Application Support/{app_name}")
+
+    return os.path.join(os.path.expanduser("~/.local/share"), app_name)
+
+
+def user_cache_dir(app_name: str) -> str:
+    if sys.platform == "win32":
+        return ntpath.join(_windows_local_app_data(), app_name, app_name, "Cache")
+
+    if xdg_dir := _xdg_dir("XDG_CACHE_HOME", app_name):
+        return xdg_dir
+
+    if sys.platform == "darwin":
+        return os.path.expanduser(f"~/Library/Caches/{app_name}")
+
+    return os.path.join(os.path.expanduser("~/.cache"), app_name)
+
+
+def _xdg_dir(env_var: str, app_name: str) -> str | None:
+    path = os.environ.get(env_var, "").strip()
+    if path:
+        return os.path.join(path, app_name)
+    return None
+
+
+def _windows_local_app_data() -> str:
+    override = os.environ.get("WIN_PD_OVERRIDE_LOCAL_APPDATA", "").strip()
+    if override:
+        return ntpath.normpath(override)
+
+    for get_dir in (
+        _windows_known_folder_local_app_data,
+        _windows_registry_local_app_data,
+        _windows_env_local_app_data,
+    ):
+        try:
+            path = get_dir()
+            if path:
+                return ntpath.normpath(path)
+        except (AttributeError, ImportError, OSError, ValueError):
+            pass
+
+    raise ValueError("Unable to find Windows LocalAppData directory.")
+
+
+def _windows_known_folder_local_app_data() -> str:
+    if sys.platform != "win32":
+        raise OSError("Windows known folders are only available on Windows.")
+
+    from ctypes import (
+        HRESULT,
+        POINTER,
+        Structure,
+        WinDLL,
+        byref,
+        create_unicode_buffer,
+        wintypes,
+    )
+
+    class _GUID(Structure):
+        _fields_ = [
+            ("Data1", wintypes.DWORD),
+            ("Data2", wintypes.WORD),
+            ("Data3", wintypes.WORD),
+            ("Data4", wintypes.BYTE * 8),
+        ]
+
+    ole32 = WinDLL("ole32")
+    ole32.CLSIDFromString.restype = HRESULT
+    ole32.CLSIDFromString.argtypes = [wintypes.LPCOLESTR, POINTER(_GUID)]
+    ole32.CoTaskMemFree.restype = None
+    ole32.CoTaskMemFree.argtypes = [wintypes.LPVOID]
+
+    shell32 = WinDLL("shell32")
+    shell32.SHGetKnownFolderPath.restype = HRESULT
+    shell32.SHGetKnownFolderPath.argtypes = [
+        POINTER(_GUID),
+        wintypes.DWORD,
+        wintypes.HANDLE,
+        POINTER(wintypes.LPWSTR),
+    ]
+
+    guid = _GUID()
+    if ole32.CLSIDFromString(_WINDOWS_LOCAL_APPDATA_GUID, byref(guid)) != 0:
+        raise OSError("Unable to resolve LocalAppData GUID.")
+
+    path_ptr = wintypes.LPWSTR()
+    result = shell32.SHGetKnownFolderPath(
+        byref(guid), _KF_FLAG_DONT_VERIFY, None, byref(path_ptr)
+    )
+    try:
+        if result != 0 or path_ptr.value is None:
+            raise OSError("Unable to resolve LocalAppData known folder.")
+        path = path_ptr.value
+    finally:
+        if path_ptr:
+            ole32.CoTaskMemFree(path_ptr)
+
+    if any(ord(char) > 255 for char in path):
+        kernel32 = WinDLL("kernel32")
+        kernel32.GetShortPathNameW.restype = wintypes.DWORD
+        kernel32.GetShortPathNameW.argtypes = [
+            wintypes.LPWSTR,
+            wintypes.LPWSTR,
+            wintypes.DWORD,
+        ]
+        buf = create_unicode_buffer(1024)
+        if kernel32.GetShortPathNameW(path, buf, 1024):
+            path = buf.value
+
+    return path
+
+
+def _windows_registry_local_app_data() -> str:
+    if sys.platform != "win32":
+        raise OSError("Windows registry is only available on Windows.")
+
+    import winreg
+
+    with winreg.OpenKey(
+        winreg.HKEY_CURRENT_USER,
+        r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
+    ) as key:
+        path, _ = winreg.QueryValueEx(key, "Local AppData")
+    return str(path)
+
+
+def _windows_env_local_app_data() -> str:
+    path = os.environ.get("LOCALAPPDATA")
+    if not path:
+        raise ValueError("Unset environment variable: LOCALAPPDATA")
+    return path

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -15,7 +15,7 @@ import sys
 from collections.abc import MutableMapping
 from pathlib import Path
 
-import platformdirs
+from . import _platformdirs
 
 CONFIG_PATHS = "WANDB_CONFIG_PATHS"
 SWEEP_PARAM_PATH = "WANDB_SWEEP_PARAM_PATH"
@@ -412,11 +412,11 @@ def get_magic(
 
 
 def get_data_dir(env: MutableMapping | None = None) -> str:
-    default_dir = platformdirs.user_data_dir("wandb")
     if env is None:
         env = os.environ
-    val = env.get(DATA_DIR, default_dir)
-    return val
+    if DATA_DIR in env:
+        return env[DATA_DIR]
+    return _platformdirs.user_data_dir("wandb")
 
 
 def get_artifact_dir(env: MutableMapping | None = None) -> str:
@@ -436,8 +436,11 @@ def get_artifact_fetch_file_url_batch_size(env: MutableMapping | None = None) ->
 
 
 def get_cache_dir(env: MutableMapping | None = None) -> Path:
-    env = env or os.environ
-    return Path(env.get(CACHE_DIR, platformdirs.user_cache_dir("wandb")))
+    if env is None:
+        env = os.environ
+    if CACHE_DIR in env:
+        return Path(env[CACHE_DIR])
+    return Path(_platformdirs.user_cache_dir("wandb"))
 
 
 def get_use_v1_artifacts(env: MutableMapping | None = None) -> bool:


### PR DESCRIPTION
Description
-----------
platformdirs was only used for two defaults: WANDB_DATA_DIR and WANDB_CACHE_DIR. This replaces that dependency with a focused resolver for W&B's actual needs while preserving the important platform behavior:

- honors WANDB_DATA_DIR / WANDB_CACHE_DIR before any platform probing
- supports XDG defaults on Linux/macOS
- preserves macOS ~/Library/... defaults
- preserves Windows LocalAppData\wandb\wandb behavior using SHGetKnownFolderPath, with registry and %LOCALAPPDATA% fallbacks
