### PR TITLE
chore: harden wbapi request handling

### DIFF
--- a/core/internal/runhistoryreader/parquet/downloader.go
+++ b/core/internal/runhistoryreader/parquet/downloader.go
@@ -126,10 +126,21 @@ func extractStepValuesFromLiveData(liveData []any) ([]int64, error) {
 }
 
 func GetFileSize(
+	ctx context.Context,
 	fileUrl string,
 	httpClient *retryablehttp.Client,
 ) (int64, error) {
-	resp, err := httpClient.Head(fileUrl)
+	req, err := retryablehttp.NewRequestWithContext(
+		ctx,
+		http.MethodHead,
+		fileUrl,
+		nil,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return 0, err
 	}
@@ -215,7 +226,7 @@ func (d *RunHistoryDownloadOperation) createDownloadTasks(
 			i,
 		)
 		filePath := filepath.Join(d.downloadDir, fileName)
-		fileSize, err := GetFileSize(url, d.httpClient)
+		fileSize, err := GetFileSize(ctx, url, d.httpClient)
 		if err != nil {
 			return nil, err
 		}
@@ -250,9 +261,11 @@ func (d *RunHistoryDownloadOperation) createDownloadTasks(
 }
 
 // StartDownloads begins all the download tasks for the files.
-func (d *RunHistoryDownloadOperation) StartDownloads() ([]string, map[string]error) {
+func (d *RunHistoryDownloadOperation) StartDownloads(
+	ctx context.Context,
+) ([]string, map[string]error) {
 	parentOperation := d.operations.New("Downloading run history")
-	operationCtx := parentOperation.Context(context.Background())
+	operationCtx := parentOperation.Context(ctx)
 	defer parentOperation.Finish()
 
 	fileTransferStats := filetransfer.NewFileTransferStats()

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -73,19 +73,20 @@ func NewRunHistoryAPIHandler(
 }
 
 func (f *RunHistoryAPIHandler) HandleRequest(
+	ctx context.Context,
 	request *spb.ReadRunHistoryRequest,
 ) *spb.ApiResponse {
 	switch request.Request.(type) {
 	case *spb.ReadRunHistoryRequest_ScanRunHistoryInit:
-		return f.handleScanRunHistoryInit(request.GetScanRunHistoryInit())
+		return f.handleScanRunHistoryInit(ctx, request.GetScanRunHistoryInit())
 	case *spb.ReadRunHistoryRequest_ScanRunHistory:
-		return f.handleScanRunHistoryRead(request.GetScanRunHistory())
+		return f.handleScanRunHistoryRead(ctx, request.GetScanRunHistory())
 	case *spb.ReadRunHistoryRequest_ScanRunHistoryCleanup:
 		return f.handleScanRunHistoryCleanup(request.GetScanRunHistoryCleanup())
 	case *spb.ReadRunHistoryRequest_DownloadRunHistoryInit:
-		return f.handleDownloadRunHistoryInit(request.GetDownloadRunHistoryInit())
+		return f.handleDownloadRunHistoryInit(ctx, request.GetDownloadRunHistoryInit())
 	case *spb.ReadRunHistoryRequest_DownloadRunHistory:
-		return f.handleDownloadRunHistory(request.GetDownloadRunHistory())
+		return f.handleDownloadRunHistory(ctx, request.GetDownloadRunHistory())
 	case *spb.ReadRunHistoryRequest_DownloadRunHistoryStatus:
 		return f.handleDownloadRunHistoryStatus(request.GetDownloadRunHistoryStatus())
 	}
@@ -101,6 +102,7 @@ func (f *RunHistoryAPIHandler) HandleRequest(
 // It returns an Id correlating subsequent scan requests
 // with the history reader.
 func (f *RunHistoryAPIHandler) handleScanRunHistoryInit(
+	ctx context.Context,
 	request *spb.ScanRunHistoryInit,
 ) *spb.ApiResponse {
 	f.rustArrowOnce.Do(func() {
@@ -133,7 +135,7 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryInit(
 	requestKeys := request.GetKeys()
 
 	historyReader, err := runhistoryreader.New(
-		context.Background(),
+		ctx,
 		request.Entity,
 		request.Project,
 		request.RunId,
@@ -173,6 +175,7 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryInit(
 // handleScanRunHistoryRead handles a request to scan
 // over a portion of a run's history.
 func (f *RunHistoryAPIHandler) handleScanRunHistoryRead(
+	ctx context.Context,
 	request *spb.ScanRunHistory,
 ) *spb.ApiResponse {
 	requestId := request.GetRequestId()
@@ -196,7 +199,7 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryRead(
 
 	getHistoryStepsStart := time.Now()
 	historySteps, err := historyReader.GetHistorySteps(
-		context.Background(),
+		ctx,
 		minStep,
 		maxStep,
 	)
@@ -294,10 +297,11 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryCleanup(
 }
 
 func (f *RunHistoryAPIHandler) handleDownloadRunHistoryInit(
+	ctx context.Context,
 	request *spb.DownloadRunHistoryInit,
 ) *spb.ApiResponse {
 	signedUrls, liveData, err := parquet.GetSignedUrlsWithLiveSteps(
-		context.Background(),
+		ctx,
 		f.graphqlClient,
 		request.Entity,
 		request.Project,
@@ -336,7 +340,7 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistoryInit(
 		}
 	}
 	downloadOperation, err := parquet.NewRunHistoryDownloadOperation(
-		context.Background(),
+		ctx,
 		f.httpClient,
 		request.Entity,
 		request.Project,
@@ -376,6 +380,7 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistoryInit(
 
 // handleDownloadRunHistory handles a request to download a run's history.
 func (f *RunHistoryAPIHandler) handleDownloadRunHistory(
+	ctx context.Context,
 	request *spb.DownloadRunHistory,
 ) *spb.ApiResponse {
 	f.mu.Lock()
@@ -395,7 +400,7 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistory(
 		}
 	}
 
-	downloadedFiles, errors := downloadOperation.StartDownloads()
+	downloadedFiles, errors := downloadOperation.StartDownloads(ctx)
 	errorsMap := make(map[string]string, len(errors))
 	for file, err := range errors {
 		errorsMap[file] = err.Error()

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -90,8 +90,17 @@ func (p *WandbAPI) HandleRequest(
 	id string,
 	request *spb.ApiRequest,
 ) *spb.ApiResponse {
-	// block until until we are able to process more requests
-	p.semaphore <- struct{}{}
+	if err := ctx.Err(); err != nil {
+		return apiErrorResponse(err.Error(), 0)
+	}
+
+	// Block until we are able to process more requests, unless the client is
+	// tearing down and the request context is cancelled first.
+	select {
+	case p.semaphore <- struct{}{}:
+	case <-ctx.Done():
+		return apiErrorResponse(ctx.Err().Error(), 0)
+	}
 	defer func() { <-p.semaphore }()
 
 	switch req := request.Request.(type) {
@@ -100,8 +109,7 @@ func (p *WandbAPI) HandleRequest(
 	case *spb.ApiRequest_GraphqlRequest:
 		return p.graphqlHandler.HandleRequest(ctx, req.GraphqlRequest)
 	case *spb.ApiRequest_ReadRunHistoryRequest:
-		// TODO: Propagate ctx here.
-		return p.runHistoryApiHandler.HandleRequest(req.ReadRunHistoryRequest)
+		return p.runHistoryApiHandler.HandleRequest(ctx, req.ReadRunHistoryRequest)
 	}
 
 	return nil


### PR DESCRIPTION
Description
-----------
I added a couple things to harden request handling by `wbapi`:
- Ensure requests do not block forever waiting on the semaphore during teardown.
- Fixed parent context propagation in RunHistoryAPIHandler and parquet downloader.
