### PR TITLE
feat(artifacts): accept order kwarg in artifacts and registries paginators + related methods

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@ This version drops compatibility with server versions older than 0.65.0.
 - High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)
 - Synced scrubbing in the W&B LEET media pane: press `l` to link scrubbing, then the scrub keys (`←/→/↑/↓/home/end`) move a shared cursor over the union step timeline and every image tile follows it (@dmitryduev in https://github.com/wandb/wandb/pull/12033)
 - Basic remote-run support in W&B LEET TUI (`wandb leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
-- Paginated artifacts and registry API methods (e.g. `Api.artifacts()`, `Api.artifact_collections()`, `Api.registries()`, `Registry.collections()`) now accept an optional `order` string as a keyword arg (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11990)
+- The following paginated artifacts and registry API methods now accept an optional `order` string as a keyword argument: `Api.artifacts()`, `Api.artifact_collections()`, `Api.registries()`, `Api.registries().collections()`, `Registry.collections()` (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11990)
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ This version drops compatibility with server versions older than 0.65.0.
 - High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)
 - Synced scrubbing in the W&B LEET media pane: press `l` to link scrubbing, then the scrub keys (`←/→/↑/↓/home/end`) move a shared cursor over the union step timeline and every image tile follows it (@dmitryduev in https://github.com/wandb/wandb/pull/12033)
 - Basic remote-run support in W&B LEET TUI (`wandb leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
+- Paginated artifacts and registry API methods (e.g. `Api.artifacts()`, `Api.artifact_collections()`, `Api.registries()`, `Registry.collections()`) now accept an optional `order` string as a keyword arg (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11990)
 
 ### Changed
 

--- a/tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -90,6 +90,32 @@ def test_artifact_versions_start(api: Api):
 
 
 @mark.usefixtures("sample_data")
+@mark.parametrize(
+    ("order", "expected_names"),
+    (
+        (
+            # ascending (implicit default)
+            "version_index",
+            ["mnist:v0", "mnist:v1"],
+        ),
+        (
+            # ascending
+            "+version_index",
+            ["mnist:v0", "mnist:v1"],
+        ),
+        (
+            # descending
+            "-version_index",
+            ["mnist:v1", "mnist:v0"],
+        ),
+    ),
+)
+def test_artifacts_order(api: Api, order: str, expected_names: list[str]):
+    names = [a.name for a in api.artifacts("dataset", "mnist", order=order)]
+    assert names == expected_names
+
+
+@mark.usefixtures("sample_data")
 def test_artifact_type(api: Api):
     atype = api.artifact_type("dataset")
     assert atype.name == "dataset"
@@ -108,7 +134,7 @@ def test_artifact_type_collections(api: Api):
         f.write("test")
     artifact.save()
     artifact.wait()
-    project_path = f"{artifact.entity}/{artifact.project}"
+    proj_path = f"{artifact.entity}/{artifact.project}"
 
     cols = atype.collections()
     assert len(cols) == 2
@@ -128,7 +154,7 @@ def test_artifact_type_collections(api: Api):
     remaining_names_via_api = [
         coll.name
         for coll in api.artifact_collections(
-            project_path,
+            proj_path,
             atype.name,
             per_page=1,
             start=saved_cursor,
@@ -139,22 +165,28 @@ def test_artifact_type_collections(api: Api):
     assert all_collection_names == [first_name, *remaining_names_via_api]
 
     if server_supports(api._service_api, pb.ARTIFACT_COLLECTIONS_FILTERING_SORTING):
-        cols = atype.collections(filters={"name": "mnist"})
-        assert len(cols) == 1 and cols[0].name == "mnist"
-        cols = atype.collections(order="name")
-        assert len(cols) == 2
-        assert cols[0].name == "another-collection" and cols[1].name == "mnist"
+        filtered_collections = atype.collections(filters={"name": "mnist"})
+        assert len(filtered_collections) == 1
+        assert [c.name for c in filtered_collections] == ["mnist"]
+
+        ordered_collections = atype.collections(order="name")
+        assert len(ordered_collections) == 2
+        assert [c.name for c in ordered_collections] == ["another-collection", "mnist"]
+
+        # The same ordering is reachable through the top-level Api method.
+        api_collections = api.artifact_collections(proj_path, atype.name, order="name")
+        assert [c.name for c in api_collections] == ["another-collection", "mnist"]
     else:
-        with raises(
-            UnsupportedError,
-            match="Filtering and ordering of artifact collections is not supported on this wandb server version.",
-        ):
+        err_msg = "Filtering and ordering of artifact collections is not supported on this wandb server version."
+
+        with raises(UnsupportedError, match=err_msg):
             atype.collections(filters={"name": "mnist"})
-        with raises(
-            UnsupportedError,
-            match="Filtering and ordering of artifact collections is not supported on this wandb server version.",
-        ):
+
+        with raises(UnsupportedError, match=err_msg):
             atype.collections(order="name")
+
+        with raises(UnsupportedError, match=err_msg):
+            api.artifact_collections(proj_path, atype.name, order="name")
 
 
 @mark.usefixtures("sample_data")

--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -398,6 +398,15 @@ def test_fetch_registries(team: str, org: str, org_entity: str, api: Api):
         assert registry.full_name == f"{REGISTRY_PREFIX}test-{i}"
         assert registry.visibility == "organization"
 
+    # `order` sorts server-side rather than relying on the Python sort above.
+    expected_asc_names = ["test-0", "test-1", "test-2"]
+    expected_desc_names = expected_asc_names[::-1]
+
+    ascending = [r.name for r in api.registries(organization=org, order="name")]
+    descending = [r.name for r in api.registries(organization=org, order="-name")]
+    assert ascending == expected_asc_names
+    assert descending == expected_desc_names
+
 
 @fixture
 def source_artifacts(team: str):
@@ -429,9 +438,7 @@ def test_registries_collections(
         filter={"name": target_registry.full_name},
     )
 
-    all_collection_names = [
-        collection.name for collection in registries.collections(per_page=1)
-    ]
+    all_collection_names = [c.name for c in registries.collections(per_page=1)]
     paged_collections = registries.collections(per_page=1)
     first_page_name = next(paged_collections).name
     saved_cursor = paged_collections.cursor
@@ -439,12 +446,10 @@ def test_registries_collections(
     assert saved_cursor is not None
 
     remaining_names_via_registry = [
-        collection.name
-        for collection in target_registry.collections(per_page=1, start=saved_cursor)
+        c.name for c in target_registry.collections(per_page=1, start=saved_cursor)
     ]
     remaining_names_via_search = [
-        collection.name
-        for collection in registries.collections(per_page=1, start=saved_cursor)
+        c.name for c in registries.collections(per_page=1, start=saved_cursor)
     ]
 
     assert remaining_names_via_search == remaining_names_via_registry
@@ -454,9 +459,24 @@ def test_registries_collections(
     assert len(collections) == len(source_artifacts)
 
     # Check that we have the correct registry collections
-    for i, collection in enumerate(collections):
-        assert collection.name == f"reg-collection-{i}"
-        assert collection.type == "test-type"
+    expected_ordered_names = [f"reg-collection-{i}" for i in range(len(collections))]
+    assert [c.name for c in collections] == expected_ordered_names
+    assert [c.type for c in collections] == ["test-type"] * len(collections)
+
+    # `order` sorts server-side rather than relying on the Python sort above.
+    expected_asc_names = expected_ordered_names
+    expected_desc_names = expected_ordered_names[::-1]
+
+    ascending = [c.name for c in registries.collections(order="name")]
+    descending = [c.name for c in registries.collections(order="-name")]
+    assert ascending == expected_asc_names
+    assert descending == expected_desc_names
+
+    # `order` is also honored when accessed directly from a single Registry.
+    asc_via_registry = [c.name for c in target_registry.collections(order="name")]
+    desc_via_registry = [c.name for c in target_registry.collections(order="-name")]
+    assert asc_via_registry == expected_asc_names
+    assert desc_via_registry == expected_desc_names
 
 
 def test_registries_versions(

--- a/tools/graphql_codegen/artifacts/registries.graphql
+++ b/tools/graphql_codegen/artifacts/registries.graphql
@@ -5,6 +5,7 @@ query RegistryVersions(
   $artifactFilter: JSONString
   $cursor: String
   $perPage: Int
+  $order: String
   $includeAliases: Boolean = false
 ) {
   organization(name: $organization) {
@@ -16,6 +17,7 @@ query RegistryVersions(
         filters: $artifactFilter
         after: $cursor
         first: $perPage
+        order: $order
       ) {
         pageInfo {
           ...PageInfoFragment
@@ -37,6 +39,7 @@ query RegistryCollections(
   $collectionTypes: [ArtifactCollectionType!] = [PORTFOLIO]
   $cursor: String
   $perPage: Int
+  $order: String
 ) {
   organization(name: $organization) {
     orgEntity {
@@ -47,6 +50,7 @@ query RegistryCollections(
         collectionTypes: $collectionTypes
         after: $cursor
         first: $perPage
+        order: $order
       ) {
         totalCount
         pageInfo {
@@ -92,15 +96,10 @@ query FetchRegistry($name: String, $entity: String) {
   }
 }
 
-query FetchRegistries(
-  $organization: String!
-  $filters: JSONString
-  $cursor: String
-  $perPage: Int
-) {
+query FetchRegistries($organization: String!, $filters: JSONString, $cursor: String, $perPage: Int, $order: String) {
   organization(name: $organization) {
     orgEntity {
-      projects(filters: $filters, after: $cursor, first: $perPage) {
+      projects(filters: $filters, after: $cursor, first: $perPage, order: $order) {
         pageInfo {
           ...PageInfoFragment
         }

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1393,6 +1393,9 @@ class Api:
         Args:
             project_name: The name of the project to filter on.
             type_name: The name of the artifact type to filter on.
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
             per_page: Sets the page size for query pagination.
                 Usually there is no reason to change this.
             start: Pagination cursor for resuming a past query, captured
@@ -1516,6 +1519,9 @@ class Api:
             name: The artifact's collection name. Optionally append the
                 entity that logged the artifact as a prefix followed by
                 a forward slash.
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
             per_page: Sets the page size for query pagination. Usually
                 there is no reason to change this.
             tags: Only return artifacts with all of these tags.
@@ -1889,15 +1895,18 @@ class Api:
         or artifact versions across your organization's registry.
 
         Args:
-            organization: (str, optional) The organization of the registry to fetch.
+            organization: The organization of the registry to fetch.
                 If not specified, use the organization specified in the user's settings.
-            filter: (dict, optional) MongoDB-style filter to apply to each object in the lazy registry iterator.
+            filter: Optional MongoDB-style filter to apply to each object in the lazy registry iterator.
                 Fields available to filter for registries are
                     `name`, `description`, `created_at`, `updated_at`.
                 Fields available to filter for collections are
                     `name`, `tag`, `description`, `created_at`, `updated_at`
                 Fields available to filter for versions are
                     `tag`, `alias`, `created_at`, `updated_at`, `metadata`
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
             per_page: Sets the page size for query pagination.
             start: Pagination cursor for resuming a past query, captured
                 from a previous paginator's `.cursor` attribute.

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1384,6 +1384,7 @@ class Api:
         self,
         project_name: str,
         type_name: str,
+        order: str | None = None,
         per_page: int = 50,
         start: str | None = None,
     ) -> ArtifactCollections:
@@ -1418,6 +1419,7 @@ class Api:
             entity,
             project,
             type_name,
+            order=order,
             per_page=per_page,
             start=start,
         )
@@ -1502,6 +1504,7 @@ class Api:
         self,
         type_name: str,
         name: str,
+        order: str | None = None,
         per_page: int = 50,
         tags: list[str] | None = None,
         start: str | None = None,
@@ -1583,6 +1586,7 @@ class Api:
             project,
             collection_name,
             type_name,
+            order=order,
             per_page=per_page,
             tags=tags,
             start=start,
@@ -1875,6 +1879,7 @@ class Api:
         self,
         organization: str | None = None,
         filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: int = 100,
         start: str | None = None,
     ) -> Registries:
@@ -1967,6 +1972,7 @@ class Api:
             self._service_api,
             organization=organization,
             filter=filter,
+            order=order,
             per_page=per_page,
             start=start,
         )

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -244,8 +244,8 @@ class ArtifactType:
         Args:
             filters (dict): Optional mapping of filters to apply to the query.
             order (str): Optional string to specify the order of the results.
-                If you prepend order with a + order is ascending (default).
-                If you prepend order with a - order is descending.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
                 The default order is the collection ID in descending order.
             per_page (int): The number of artifact collections to fetch per page.
                 Default is 50.
@@ -294,8 +294,8 @@ class ArtifactCollections(
         type_name: The name of the artifact type for which to fetch collections.
         filters: Optional mapping of filters to apply to the query.
         order: Optional string to specify the order of the results.
-            If you prepend order with a + order is ascending (default).
-            If you prepend order with a - order is descending.
+            If prefixed with '+', sorts ascending (default).
+            If prefixed with '-', sorts descending.
         per_page: The number of artifact collections to fetch per page. Default is 50.
 
     <!-- lazydoc-ignore-init: internal -->
@@ -391,8 +391,8 @@ class ProjectArtifactCollections(
         project: The name of the project to query for artifact collections.
         filters: Optional mapping of filters to apply to the query.
         order: Optional string to specify the order of the results.
-            If you prepend order with a + order is ascending (default).
-            If you prepend order with a - order is descending.
+            If prefixed with '+', sorts ascending (default).
+            If prefixed with '-', sorts descending.
         per_page: The number of artifact collections to fetch per page. Default is 50.
 
     <!-- lazydoc-ignore-init: internal -->
@@ -857,6 +857,8 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
             "dataset" or "model".
         filters: Optional mapping of filters to apply to the query.
         order: Optional string to specify the order of the results.
+            If prefixed with '+', sorts ascending (default).
+            If prefixed with '-', sorts descending.
         per_page: The number of artifact versions to fetch per page. Default is 50.
         tags: Optional string or list of strings to filter artifacts by tags.
 

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from collections.abc import Collection
 from enum import Enum
 from functools import lru_cache, partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from wandb._strutils import ensureprefix
 
 if TYPE_CHECKING:
     from wandb.apis.public.service_api import ServiceApi
+
+
+T = TypeVar("T")
 
 
 class Visibility(str, Enum):
@@ -63,8 +66,22 @@ def prepare_artifact_types_input(
     return None
 
 
+@overload
+def ensure_registry_prefix_on_names(query: str, in_name: bool = ...) -> str: ...
+@overload
+def ensure_registry_prefix_on_names(
+    query: dict[str, Any], in_name: bool = ...
+) -> dict[str, Any]: ...
+@overload
+def ensure_registry_prefix_on_names(
+    query: list[T] | tuple[T], in_name: bool = ...
+) -> list[T]: ...
+@overload
+def ensure_registry_prefix_on_names(query: T, in_name: bool = ...) -> T: ...
+
+
 def ensure_registry_prefix_on_names(query: Any, in_name: bool = False) -> Any:
-    """Recursively the registry prefix to values under "name" keys, excluding regex ops.
+    """Recursively prepend the registry prefix under "name" keys, excluding regex ops.
 
     - in_name: True if we are under a "name" key (or propagating from one).
 
@@ -72,23 +89,27 @@ def ensure_registry_prefix_on_names(query: Any, in_name: bool = False) -> Any:
     """
     from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 
-    if isinstance((txt := query), str):
-        return ensureprefix(txt, REGISTRY_PREFIX) if in_name else txt
-    if isinstance((dct := query), dict):
-        new_dict = {}
-        for key, obj in dct.items():
-            if key == "$regex":
-                # For regex operator, we skip transformation of its value.
-                new_dict[key] = obj
-            elif key == "name":
-                new_dict[key] = ensure_registry_prefix_on_names(obj, in_name=True)
-            else:
-                # For any other key, propagate flags as-is.
-                new_dict[key] = ensure_registry_prefix_on_names(obj, in_name=in_name)
-        return new_dict
-    if isinstance((seq := query), (list, tuple)):
-        return list(map(partial(ensure_registry_prefix_on_names, in_name=in_name), seq))
-    return query
+    match query:
+        case str() as txt:
+            return ensureprefix(txt, REGISTRY_PREFIX) if in_name else txt
+        case dict() as dct:
+            new_dict = {}
+            for k, v in dct.items():
+                if k == "$regex":
+                    # For regex operator, we skip transformation of its value.
+                    new_dict[k] = v
+                else:
+                    # Enforce prefix on "name" keys, otherwise propagate flags as-is.
+                    new_dict[k] = ensure_registry_prefix_on_names(
+                        v, in_name=(k == "name") or in_name
+                    )
+            return new_dict
+        case list() | tuple() as seq:
+            return list(
+                map(partial(ensure_registry_prefix_on_names, in_name=in_name), seq)
+            )
+        case _:
+            return query
 
 
 @lru_cache(maxsize=10)

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -105,7 +105,6 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
     def versions(
         self,
         filter: dict[str, Any] | None = None,
-        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
@@ -113,9 +112,6 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
 
         Args:
             filter: Optional mapping of filters to apply to the artifact versions query.
-            order: Optional string to specify the order of the results.
-                If prefixed with '+', sorts ascending (default).
-                If prefixed with '-', sorts descending.
             per_page: The number of results to fetch per page.
                 Usually there is no reason to change this.
             start: Pagination cursor for resuming a past query, captured
@@ -127,7 +123,6 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
             registry_filter=self.filter,
             collection_filter=None,
             artifact_filter=filter,
-            order=order,
             per_page=per_page,
             start=start,
         )
@@ -220,7 +215,6 @@ class Collections(
     def versions(
         self,
         filter: dict[str, Any] | None = None,
-        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
@@ -228,9 +222,6 @@ class Collections(
 
         Args:
             filter: Optional mapping of filters to apply to the artifact versions query.
-            order: Optional string to specify the order of the results.
-                If prefixed with '+', sorts ascending (default).
-                If prefixed with '-', sorts descending.
             per_page: The number of results to fetch per page.
                 Usually there is no reason to change this.
             start: Pagination cursor for resuming a past query, captured
@@ -242,7 +233,6 @@ class Collections(
             registry_filter=self.registry_filter,
             collection_filter=self.collection_filter,
             artifact_filter=filter,
-            order=order,
             per_page=per_page,
             start=start,
         )
@@ -301,7 +291,6 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
         registry_filter: dict[str, Any] | None = None,
         collection_filter: dict[str, Any] | None = None,
         artifact_filter: dict[str, Any] | None = None,
-        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ):
@@ -320,7 +309,6 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
             "collectionFilter": json.dumps(f) if (f := collection_filter) else None,
             "artifactFilter": json.dumps(f) if (f := artifact_filter) else None,
             "organization": organization,
-            "order": order,
         }
         super().__init__(
             service_api, variables=variables, per_page=per_page, start=start

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -79,6 +79,18 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Collections:
+        """Returns the collections belonging to these registries.
+
+        Args:
+            filter: Optional mapping of filters to apply to the collections query.
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
+            per_page: The number of results to fetch per page.
+                Usually there is no reason to change this.
+            start: Pagination cursor for resuming a past query, captured
+                from a previous paginator's `.cursor` attribute.
+        """
         return Collections(
             service_api=self._service_api,
             organization=self.organization,
@@ -97,6 +109,18 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
+        """Returns the artifact versions belonging to these registries.
+
+        Args:
+            filter: Optional mapping of filters to apply to the artifact versions query.
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
+            per_page: The number of results to fetch per page.
+                Usually there is no reason to change this.
+            start: Pagination cursor for resuming a past query, captured
+                from a previous paginator's `.cursor` attribute.
+        """
         return Versions(
             service_api=self._service_api,
             organization=self.organization,
@@ -200,6 +224,18 @@ class Collections(
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
+        """Returns the artifact versions belonging to these collections.
+
+        Args:
+            filter: Optional mapping of filters to apply to the artifact versions query.
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
+            per_page: The number of results to fetch per page.
+                Usually there is no reason to change this.
+            start: Pagination cursor for resuming a past query, captured
+                from a previous paginator's `.cursor` attribute.
+        """
         return Versions(
             service_api=self._service_api,
             organization=self.organization,

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -41,6 +41,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         service_api: ServiceApi,
         organization: str,
         filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ):
@@ -53,7 +54,11 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         self.filter = ensure_registry_prefix_on_names(filter or {})
         self._service_api = service_api
 
-        variables = {"organization": organization, "filters": json.dumps(self.filter)}
+        variables = {
+            "organization": organization,
+            "filters": json.dumps(self.filter),
+            "order": order,
+        }
         super().__init__(
             service_api, variables=variables, per_page=per_page, start=start
         )
@@ -70,6 +75,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
     def collections(
         self,
         filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Collections:
@@ -78,6 +84,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
             organization=self.organization,
             registry_filter=self.filter,
             collection_filter=filter,
+            order=order,
             per_page=per_page,
             start=start,
         )
@@ -86,6 +93,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
     def versions(
         self,
         filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
@@ -95,6 +103,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
             registry_filter=self.filter,
             collection_filter=None,
             artifact_filter=filter,
+            order=order,
             per_page=per_page,
             start=start,
         )
@@ -150,6 +159,7 @@ class Collections(
         organization: str,
         registry_filter: dict[str, Any] | None = None,
         collection_filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ):
@@ -167,6 +177,7 @@ class Collections(
             "registryFilter": json.dumps(f) if (f := registry_filter) else None,
             "collectionFilter": json.dumps(f) if (f := collection_filter) else None,
             "organization": organization,
+            "order": order,
             "perPage": per_page,
         }
         super().__init__(
@@ -185,6 +196,7 @@ class Collections(
     def versions(
         self,
         filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
@@ -194,6 +206,7 @@ class Collections(
             registry_filter=self.registry_filter,
             collection_filter=self.collection_filter,
             artifact_filter=filter,
+            order=order,
             per_page=per_page,
             start=start,
         )
@@ -252,6 +265,7 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
         registry_filter: dict[str, Any] | None = None,
         collection_filter: dict[str, Any] | None = None,
         artifact_filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ):
@@ -270,6 +284,7 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
             "collectionFilter": json.dumps(f) if (f := collection_filter) else None,
             "artifactFilter": json.dumps(f) if (f := artifact_filter) else None,
             "organization": organization,
+            "order": order,
         }
         super().__init__(
             service_api, variables=variables, per_page=per_page, start=start

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -195,6 +195,7 @@ class Registry:
     def collections(
         self,
         filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Collections:
@@ -204,6 +205,7 @@ class Registry:
             organization=self.organization,
             registry_filter={"name": self.full_name},
             collection_filter=filter,
+            order=order,
             per_page=per_page,
             start=start,
         )
@@ -212,6 +214,7 @@ class Registry:
     def versions(
         self,
         filter: dict[str, Any] | None = None,
+        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
@@ -221,6 +224,7 @@ class Registry:
             organization=self.organization,
             registry_filter={"name": self.full_name},
             collection_filter=None,
+            order=order,
             artifact_filter=filter,
             per_page=per_page,
             start=start,

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -225,7 +225,6 @@ class Registry:
     def versions(
         self,
         filter: dict[str, Any] | None = None,
-        order: str | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
@@ -233,9 +232,6 @@ class Registry:
 
         Args:
             filter: Optional mapping of filters to apply to the artifact versions query.
-            order: Optional string to specify the order of the results.
-                If prefixed with '+', sorts ascending (default).
-                If prefixed with '-', sorts descending.
             per_page: The number of results to fetch per page.
                 Usually there is no reason to change this.
             start: Pagination cursor for resuming a past query, captured
@@ -246,7 +242,6 @@ class Registry:
             organization=self.organization,
             registry_filter={"name": self.full_name},
             collection_filter=None,
-            order=order,
             artifact_filter=filter,
             per_page=per_page,
             start=start,

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -199,7 +199,18 @@ class Registry:
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Collections:
-        """Returns the collections belonging to the registry."""
+        """Returns the collections belonging to this registry.
+
+        Args:
+            filter: Optional mapping of filters to apply to the collections query.
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
+            per_page: The number of results to fetch per page.
+                Usually there is no reason to change this.
+            start: Pagination cursor for resuming a past query, captured
+                from a previous paginator's `.cursor` attribute.
+        """
         return Collections(
             service_api=self._service_api,
             organization=self.organization,
@@ -218,7 +229,18 @@ class Registry:
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> Versions:
-        """Returns the versions belonging to the registry."""
+        """Returns the artifact versions belonging to this registry.
+
+        Args:
+            filter: Optional mapping of filters to apply to the artifact versions query.
+            order: Optional string to specify the order of the results.
+                If prefixed with '+', sorts ascending (default).
+                If prefixed with '-', sorts descending.
+            per_page: The number of results to fetch per page.
+                Usually there is no reason to change this.
+            start: Pagination cursor for resuming a past query, captured
+                from a previous paginator's `.cursor` attribute.
+        """
         return Versions(
             service_api=self._service_api,
             organization=self.organization,

--- a/wandb/sdk/artifacts/_generated/operations.py
+++ b/wandb/sdk/artifacts/_generated/operations.py
@@ -1545,7 +1545,7 @@ query FetchOrgEntityFromOrganization($organization: String!) {
 """
 
 REGISTRY_VERSIONS_GQL = """
-query RegistryVersions($organization: String!, $registryFilter: JSONString, $collectionFilter: JSONString, $artifactFilter: JSONString, $cursor: String, $perPage: Int, $includeAliases: Boolean = false) {
+query RegistryVersions($organization: String!, $registryFilter: JSONString, $collectionFilter: JSONString, $artifactFilter: JSONString, $cursor: String, $perPage: Int, $order: String, $includeAliases: Boolean = false) {
   organization(name: $organization) {
     orgEntity {
       name
@@ -1555,6 +1555,7 @@ query RegistryVersions($organization: String!, $registryFilter: JSONString, $col
         filters: $artifactFilter
         after: $cursor
         first: $perPage
+        order: $order
       ) {
         pageInfo {
           ...PageInfoFragment
@@ -1660,7 +1661,7 @@ fragment TagFragment on Tag {
 """
 
 REGISTRY_COLLECTIONS_GQL = """
-query RegistryCollections($organization: String!, $registryFilter: JSONString, $collectionFilter: JSONString, $collectionTypes: [ArtifactCollectionType!] = [PORTFOLIO], $cursor: String, $perPage: Int) {
+query RegistryCollections($organization: String!, $registryFilter: JSONString, $collectionFilter: JSONString, $collectionTypes: [ArtifactCollectionType!] = [PORTFOLIO], $cursor: String, $perPage: Int, $order: String) {
   organization(name: $organization) {
     orgEntity {
       name
@@ -1670,6 +1671,7 @@ query RegistryCollections($organization: String!, $registryFilter: JSONString, $
         collectionTypes: $collectionTypes
         after: $cursor
         first: $perPage
+        order: $order
       ) {
         totalCount
         pageInfo {
@@ -1763,10 +1765,10 @@ fragment RegistryFragment on Project {
 """
 
 FETCH_REGISTRIES_GQL = """
-query FetchRegistries($organization: String!, $filters: JSONString, $cursor: String, $perPage: Int) {
+query FetchRegistries($organization: String!, $filters: JSONString, $cursor: String, $perPage: Int, $order: String) {
   organization(name: $organization) {
     orgEntity {
-      projects(filters: $filters, after: $cursor, first: $perPage) {
+      projects(filters: $filters, after: $cursor, first: $perPage, order: $order) {
         pageInfo {
           ...PageInfoFragment
         }


### PR DESCRIPTION
## Description

- https://coreweave.atlassian.net/browse/WB-35086

PR adds an `order` keyword arg to paginated artifacts and registries APIs (i.e. internal paginator types and related methods).
- `Api.artifacts`, `Api.artifact_collections`, and `Api.registries` accept an optional `order` kwarg and pass it through to their instantiated paginators.
- Registry search paginators (`Registries`, `Collections`) and their corresponding nested methods `api.registries().collections()` / helpers accept `order` as well.

- `Versions` / `.versions()` is intentionally deferred for a separate PR.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


## Testing
