### PR TITLE
fix(sdk): sdk Docs + Don't catch errors with string matching

### DIFF
--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -336,45 +336,34 @@ def test_run_update_state_success(wandb_backend_spy):
 
     wandb_backend_spy.stub_gql(
         gql.Matcher(operation="UpdateRunState"),
-        gql.Constant(content={"data": {"updateRunState": {"success": True}}}),
-    )
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="UpdateRunState"),
         update_state_spy,
     )
 
     seed_run = Api().create_run()
     run = Api().run(f"{seed_run.entity}/{seed_run.project}/{seed_run.id}")
-    run._attrs["state"] = "failed"
-    run._state = "failed"
 
-    result = run.update_state("pending")
+    # A freshly created run is "running"; "running" -> "pending" is allowed.
+    result = run.update_state("failed")
 
     assert result is True
-    assert run.state == "pending"
+    assert run.state == "failed"
     assert update_state_spy.total_calls == 1
-    assert update_state_spy.requests[0].variables["input"]["state"] == "pending"
+    assert update_state_spy.requests[0].variables["input"]["state"] == "failed"
     assert update_state_spy.requests[0].variables["input"]["id"] == run.storage_id
 
 
 def test_run_update_state_failure(wandb_backend_spy):
-    """Test that update_state returns False when server rejects transition."""
-    gql = wandb_backend_spy.gql
-
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="UpdateRunState"),
-        gql.Constant(content={"data": {"updateRunState": {"success": False}}}),
-    )
-
+    """Test that update_state raises when the server rejects the transition."""
     seed_run = Api().create_run()
     run = Api().run(f"{seed_run.entity}/{seed_run.project}/{seed_run.id}")
-    run._attrs["state"] = "running"
-    run._state = "running"
 
-    result = run.update_state("pending")
+    # A freshly created run is "running"; mark it "failed" (an allowed transition).
+    assert run.update_state("failed") is True
+    assert run.state == "failed"
 
-    assert result is False
-    assert run.state == "running"
+    # "failed" -> "failed" is not a supported transition, so the server rejects it.
+    with pytest.raises(wandb.Error):
+        run.update_state("failed")
 
 
 def test_run_file_direct(

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -342,7 +342,6 @@ def test_run_update_state_success(wandb_backend_spy):
     seed_run = Api().create_run()
     run = Api().run(f"{seed_run.entity}/{seed_run.project}/{seed_run.id}")
 
-    # A freshly created run is "running"; "running" -> "pending" is allowed.
     result = run.update_state("failed")
 
     assert result is True
@@ -357,11 +356,9 @@ def test_run_update_state_failure(wandb_backend_spy):
     seed_run = Api().create_run()
     run = Api().run(f"{seed_run.entity}/{seed_run.project}/{seed_run.id}")
 
-    # A freshly created run is "running"; mark it "failed" (an allowed transition).
     assert run.update_state("failed") is True
     assert run.state == "failed"
 
-    # "failed" -> "failed" is not a supported transition, so the server rejects it.
     with pytest.raises(wandb.Error):
         run.update_state("failed")
 

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -335,8 +335,7 @@ def test_run_update_state_success(wandb_backend_spy):
     update_state_spy = gql.Capture()
 
     wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="UpdateRunState"),
-        update_state_spy,
+        gql.Matcher(operation="UpdateRunState"), update_state_spy
     )
 
     seed_run = Api().create_run()
@@ -351,7 +350,8 @@ def test_run_update_state_success(wandb_backend_spy):
     assert update_state_spy.requests[0].variables["input"]["id"] == run.storage_id
 
 
-def test_run_update_state_failure(wandb_backend_spy):
+@pytest.mark.usefixtures("user")
+def test_run_update_state_failure():
     """Test that update_state raises when the server rejects the transition."""
     seed_run = Api().create_run()
     run = Api().run(f"{seed_run.entity}/{seed_run.project}/{seed_run.id}")
@@ -359,7 +359,7 @@ def test_run_update_state_failure(wandb_backend_spy):
     assert run.update_state("failed") is True
     assert run.state == "failed"
 
-    with pytest.raises(wandb.Error):
+    with pytest.raises(wandb.Error, match="invalid state transition"):
         run.update_state("failed")
 
 

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1004,9 +1004,9 @@ class Run(Attrs):
         """Update the state of a run.
 
         Supported transitions:
-            - to `"pending"` from `running`, `failed`, `crashed`, or `preempted`
+            - to `pending` from `running`, `failed`, `crashed`, or `preempted`
               (e.g. to requeue a terminated or in-progress run)
-            - to `"failed"` from `pending` or `running`
+            - to `failed` from `pending` or `running`
               (e.g. to mark a preempted or lost run as failed)
 
         Sweep runs cannot have their state updated.

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -670,7 +670,19 @@ class Run(Attrs):
 
     @property
     def state(self) -> str:
-        """The state of the run. Can be one of: Finished, Failed, Crashed, or Running."""
+        """The state of the run.
+
+        The following table describes the possible states a run can be in:
+
+        | State    | Description |
+        | -------- | ----------- |
+        | Crashed  | Run stopped sending heartbeats in the internal process, which can happen if the machine crashes. |
+        | Failed   | Run ended with a non-zero exit status. |
+        | Finished | Run ended and fully synced data, or called `wandb.Run.finish()`. |
+        | Killed   | Run was forcibly stopped before it could finish. |
+        | Running  | Run is still running and has recently sent a heartbeat. |
+        | Pending  | Run is scheduled but not yet started (common in sweeps and Launch jobs). |
+        """
         return self._state
 
     @property
@@ -988,13 +1000,21 @@ class Run(Attrs):
         self.update()
 
     @normalize_exceptions
-    def update_state(self, state: Literal["pending"]) -> bool:
+    def update_state(self, state: str) -> bool:
         """Update the state of a run.
 
-        Allows transitioning runs from 'failed' or 'crashed' to 'pending'.
+        Supported transitions:
+            - to `"pending"` from `running`, `failed`, `crashed`, or `preempted`
+              (e.g. to requeue a terminated or in-progress run)
+            - to `"failed"` from `pending` or `running`
+              (e.g. to mark a preempted or lost run as failed)
+
+        Sweep runs cannot have their state updated.
+
+        See `Run.state` for the list of possible run states.
 
         Args:
-            state: The target run state. Only `"pending"` is supported.
+            state: The target run state. One of `"pending"` or `"failed"`.
 
         Returns:
             `True` if the state was successfully updated.
@@ -1011,31 +1031,15 @@ class Run(Attrs):
             }
             """
 
-        try:
-            result = self._service_api.execute_graphql(
-                mutation,
-                {
-                    "input": {
-                        "id": self.storage_id,
-                        "state": state,
-                    }
-                },
-            )
-        except Exception as e:
-            error_msg = str(e)
-            if "UpdateRunStateInput" in error_msg or "updateRunState" in error_msg:
-                raise wandb.Error(
-                    "The server does not support the update_state operation. "
-                    "Please ensure your W&B server is updated to a version that "
-                    "supports run state transitions."
-                ) from e
-            if "invalid state transition" in error_msg.lower():
-                raise wandb.Error(
-                    f"Invalid state transition: cannot change run from '{self.state}' "
-                    f"to '{state}'. Only runs in 'failed' or 'crashed' state can be "
-                    "transitioned to 'pending'."
-                ) from e
-            raise
+        result = self._service_api.execute_graphql(
+            mutation,
+            {
+                "input": {
+                    "id": self.storage_id,
+                    "state": state,
+                }
+            },
+        )
 
         if result.get("updateRunState", {}).get("success"):
             self._attrs["state"] = state


### PR DESCRIPTION
## Description

Document allowed state transitions and state definitions
Throw error with backend string, I am adding the valid transitions in the error message so we dont have to keep updating the sdk

## Testing

Make tests not stub the backend
Change tests to not disallow running to pending because i will be allowing it soon

- [x] I updated CHANGELOG.unreleased.md