### PR TITLE
chore: fix test_asyncio_compat_run test flake

### DIFF
--- a/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
+++ b/tests/system_tests/test_functional/asyncio_compat_run/pass_if_cancelled.py
@@ -5,8 +5,7 @@ import time
 
 from wandb.sdk.lib import asyncio_compat
 
-_got_cancelled_lock = threading.Lock()
-_got_cancelled = False
+_got_cancelled = threading.Event()
 
 
 async def pass_if_cancelled() -> None:
@@ -24,8 +23,7 @@ async def pass_if_cancelled() -> None:
         # The test sends a SIGINT to the process, which we expect
         # asyncio_compat.run() to turn into task cancellation.
         print(f"CancelledError caught at {time.monotonic()}", file=sys.stderr)
-        with _got_cancelled_lock:
-            _got_cancelled = True
+        _got_cancelled.set()
         raise
 
 
@@ -33,8 +31,11 @@ if __name__ == "__main__":
     try:
         asyncio_compat.run(pass_if_cancelled)
     except KeyboardInterrupt:
-        with _got_cancelled_lock:
-            cancelled = _got_cancelled
+        # If the interrupt is sent at an unlucky time, it is possible for
+        # the thread started by run() to "leak" and continue running after
+        # it returns. However, run() guarantees that that thread will
+        # get a CancelledError if it successfully entered the asyncio loop.
+        cancelled = _got_cancelled.wait(timeout=2)
 
         if cancelled:
             print(

--- a/wandb/sdk/lib/asyncio_compat.py
+++ b/wandb/sdk/lib/asyncio_compat.py
@@ -25,10 +25,9 @@ def run(fn: Callable[[], Coroutine[Any, Any, _T]]) -> _T:
     """
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         runner = CancellableRunner()
-        future = executor.submit(runner.run, fn)
 
         try:
-            return future.result()
+            return executor.submit(runner.run, fn).result()
 
         finally:
             runner.cancel()


### PR DESCRIPTION
Concludes the debugging saga that started with PR #9660. In that PR's description, this statement was wrong:

> the `__exit__` of the ThreadPoolExecutor used by `asyncio_compat.run` blocks until the future completes

---

I added extra debugging in #11781 and those messages appear [in this flake](https://app.circleci.com/pipelines/github/wandb/wandb/64472/workflows/c8b47ac0-c5db-44a1-be53-73f1b7f9aa3e/jobs/1675183/parallel-runs/0/steps/0-112?invite=true#step-112-25424_23):

```
Ready at 2780.565030025
FAIL: Interrupted but not cancelled (2780.566072269)
Finished sleeping at 2785.570137139
```

This means that the asyncio thread ran for five seconds after its ThreadPoolExecutor shut down, which should not be possible, since the ThreadPoolExecutor joins its threads. In the CPython 3.13 implementation, `submit()` [starts a thread and adds it](https://github.com/python/cpython/blob/01104ce1beb3135c2e0c01ec835b994c1f55a1c0/Lib/concurrent/futures/thread.py#L203-L204) to `self._threads` while holding a lock. A KeyboardInterrupt that occurs between `t.start()` and `self._threads.add(t)` seems like the only way to get this to happen! That sort of matches up with how rare the flake is, although I'm amazed I ever observed it at all.

With this in mind, it is more correct to `submit()` inside the `try-finally`. If `submit()` is interrupted, we cancel the runner before shutting down the thread pool. If the thread was not joined and the `Runner.cancel()` happened before it could call `Runner.run()`, it will hit a `RunnerCancelledError`; otherwise, `cancel()` will cancel the async work in the thread.

`asyncio_compat.run()` is not used directly anymore, but the test checks the correctness of `CancellableRunner`, which is used by `AsyncioManager`. The `AsyncioManager` tests don't have this problem because they don't rely on `ThreadPoolExecutor`'s semantics.