### PR TITLE
fix(sandbox): add SDK versions to headers

### DIFF
--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import cwsandbox
 import cwsandbox._sandbox as cwsandbox_sandbox
 import pytest
 import wandb
@@ -77,6 +78,18 @@ def _patch_sandbox_stub(
     return calls
 
 
+def _client_version_headers() -> dict[str, str]:
+    """The client-version headers every request carries, with live versions.
+
+    Derived from the installed package versions (the same source the client
+    reads) so the assertions stay exact without breaking on version bumps.
+    """
+    return {
+        "x-wandb-sdk-version": wandb.__version__,
+        "x-cwsandbox-client-version": cwsandbox.__version__,
+    }
+
+
 def test_sandbox_run_uses_settings_entity_project(
     user,
     monkeypatch,
@@ -93,6 +106,7 @@ def test_sandbox_run_uses_settings_entity_project(
         "x-wandb-api-key": user,
         "x-entity-id": "entity-from-settings",
         "x-project-name": "project-from-settings",
+        **_client_version_headers(),
     }
     assert len(calls.start) == 1
     assert dict(calls.start[0]["metadata"]) == expected_headers
@@ -113,6 +127,7 @@ def test_sandbox_run_ignore_run_override(
     expected_headers = {
         "x-wandb-api-key": user,
         "x-entity-id": user,
+        **_client_version_headers(),
     }
     assert len(calls.start) == 1
     assert dict(calls.start[0]["metadata"]) == expected_headers
@@ -132,7 +147,8 @@ def test_sandbox_run_without_entity_or_project(
     with Sandbox.run("sleep", "infinity") as sandbox:
         assert sandbox.sandbox_id == "sb-system-test"
 
+    expected_headers = {"x-wandb-api-key": user, **_client_version_headers()}
     assert len(calls.start) == 1
-    assert dict(calls.start[0]["metadata"]) == {"x-wandb-api-key": user}
+    assert dict(calls.start[0]["metadata"]) == expected_headers
     assert len(calls.stop) == 1
-    assert dict(calls.stop[0]["metadata"]) == {"x-wandb-api-key": user}
+    assert dict(calls.stop[0]["metadata"]) == expected_headers

--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -39,6 +39,7 @@ def test_override_sandbox_entity_restores_after_exit(
 ) -> None:
     singleton = _singleton()
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth, "_client_version_headers", list)
     monkeypatch.setattr(
         sandbox_auth.wbauth,
         "authenticate_session",
@@ -68,6 +69,7 @@ def test_resolve_wandb_sdk_auth_delegates_to_authenticate_session(
     singleton = _singleton(api_key=_SETTINGS_API_KEY)
     auth_calls: list[dict[str, object]] = []
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth, "_client_version_headers", list)
     monkeypatch.setattr(
         sandbox_auth.wbauth,
         "authenticate_session",
@@ -101,6 +103,7 @@ def test_resolve_wandb_sdk_auth_omits_optional_metadata_when_unset(
 ) -> None:
     singleton = _singleton(entity=None, project=None)
     monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(sandbox_auth, "_client_version_headers", list)
     monkeypatch.setattr(
         sandbox_auth.wbauth,
         "authenticate_session",
@@ -113,6 +116,46 @@ def test_resolve_wandb_sdk_auth_omits_optional_metadata_when_unset(
     headers = sandbox_auth._resolve_wandb_sdk_auth()
 
     assert headers.headers == {"x-wandb-api-key": _VALID_API_KEY}
+
+
+def test_resolve_wandb_sdk_auth_appends_client_version_headers(
+    monkeypatch,
+) -> None:
+    singleton = _singleton()
+    monkeypatch.setattr(sandbox_auth.wandb_setup, "singleton", lambda: singleton)
+    monkeypatch.setattr(
+        sandbox_auth,
+        "_client_version_headers",
+        lambda: [
+            ("x-wandb-sdk-version", "1.2.3"),
+            ("x-cwsandbox-client-version", "0.20.0"),
+        ],
+    )
+    monkeypatch.setattr(
+        sandbox_auth.wbauth,
+        "authenticate_session",
+        lambda **kwargs: sandbox_auth.wbauth.AuthApiKey(
+            host=kwargs["host"],
+            api_key=_VALID_API_KEY,
+        ),
+    )
+
+    headers = sandbox_auth._resolve_wandb_sdk_auth().headers
+
+    assert headers["x-wandb-sdk-version"] == "1.2.3"
+    assert headers["x-cwsandbox-client-version"] == "0.20.0"
+    # Existing auth headers are unaffected.
+    assert headers["x-wandb-api-key"] == _VALID_API_KEY
+
+
+def test_client_version_headers_includes_sdk_versions() -> None:
+    headers = dict(sandbox_auth._client_version_headers())
+
+    # wandb is always importable in the test env; cwsandbox is a hard dependency.
+    assert "x-wandb-sdk-version" in headers
+    assert headers["x-wandb-sdk-version"]
+    assert "x-cwsandbox-client-version" in headers
+    assert headers["x-cwsandbox-client-version"]
 
 
 def test_resolve_wandb_sdk_auth_rejects_non_api_key_credentials(

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -46,6 +46,29 @@ def override_sandbox_entity(
         _entity_override.reset(entity_token)
 
 
+def _client_version_headers() -> list[tuple[str, str]]:
+    """Version headers identifying this client to the sandbox gateway (WB-34958).
+
+    The gateway records these for SDK-adoption tracking. Best-effort: a failure to
+    resolve a version must never break sandbox auth, so each lookup is guarded.
+    """
+    headers: list[tuple[str, str]] = []
+    try:
+        import wandb
+
+        headers.append(("x-wandb-sdk-version", str(wandb.__version__)))
+    except Exception:
+        pass
+    try:
+        import cwsandbox
+
+        # Including in case cwsandbox doesn't add it.
+        headers.append(("x-cwsandbox-client-version", str(cwsandbox.__version__)))
+    except Exception:
+        pass
+    return headers
+
+
 def _resolve_wandb_sdk_auth() -> AuthHeaders:
     settings = wandb_setup.singleton().settings
     host = wbauth.HostUrl(settings.base_url, app_url=settings.app_url)
@@ -70,6 +93,8 @@ def _resolve_wandb_sdk_auth() -> AuthHeaders:
         metadata.append(("x-entity-id", entity))
     if settings.project:
         metadata.append(("x-project-name", settings.project))
+
+    metadata.extend(_client_version_headers())
 
     return AuthHeaders(
         headers={key: value for key, value in metadata},

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -4,8 +4,10 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 
+import cwsandbox
 from cwsandbox import AuthHeaders, CWSandboxAuthenticationError, set_auth_mode
 
+import wandb
 from wandb.errors import UsageError
 from wandb.sdk import wandb_setup
 from wandb.sdk.lib import wbauth
@@ -49,24 +51,13 @@ def override_sandbox_entity(
 def _client_version_headers() -> list[tuple[str, str]]:
     """Version headers identifying this client to the sandbox gateway (WB-34958).
 
-    The gateway records these for SDK-adoption tracking. Best-effort: a failure to
-    resolve a version must never break sandbox auth, so each lookup is guarded.
+    The gateway records these for SDK-adoption tracking.
     """
-    headers: list[tuple[str, str]] = []
-    try:
-        import wandb
-
-        headers.append(("x-wandb-sdk-version", str(wandb.__version__)))
-    except Exception:
-        pass
-    try:
-        import cwsandbox
-
-        # Including in case cwsandbox doesn't add it.
-        headers.append(("x-cwsandbox-client-version", str(cwsandbox.__version__)))
-    except Exception:
-        pass
-    return headers
+    return [
+        ("x-wandb-sdk-version", wandb.__version__),
+        # Included in case the cwsandbox transport doesn't report its own version.
+        ("x-cwsandbox-client-version", cwsandbox.__version__),
+    ]
 
 
 def _resolve_wandb_sdk_auth() -> AuthHeaders:


### PR DESCRIPTION
Description
-----------

Adds SDK versions to the gRPC headers so that we have better debugging info in the BE.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Added unit tests, also ran e2e with local sandboxes setup
