### PR TITLE
chore: use otel proxy to capture existing sentry data

### DIFF
--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -495,7 +495,10 @@ func runSymon(opts *leetOptions, logger *observability.CoreLogger) int {
 		finalModel, err := program.Run()
 		m.Cleanup()
 		if err != nil {
-			logger.CaptureError(fmt.Errorf("wandb-symon: %v", err))
+			logger.CaptureError(
+				"main",
+				fmt.Errorf("wandb-symon: %v", err),
+			)
 			return exitCodeErrorInternal
 		}
 
@@ -524,7 +527,10 @@ func runLeetWorkspace(opts *leetOptions, logger *observability.CoreLogger) int {
 
 		finalModel, err := program.Run()
 		if err != nil {
-			logger.CaptureError(fmt.Errorf("wandb-leet: %v", err))
+			logger.CaptureError(
+				"main",
+				fmt.Errorf("wandb-leet: %v", err),
+			)
 			return exitCodeErrorInternal
 		}
 

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -459,6 +459,7 @@ func newLeetLogger(logLevel int) (*observability.CoreLogger, func(), error) {
 			&slog.HandlerOptions{Level: slog.Level(logLevel)},
 		)),
 		observability.NewSentryContext(sentry.CurrentHub()),
+		nil,
 	)
 	return logger, closeLogWriter, nil
 }

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -459,7 +459,7 @@ func newLeetLogger(logLevel int) (*observability.CoreLogger, func(), error) {
 			&slog.HandlerOptions{Level: slog.Level(logLevel)},
 		)),
 		observability.NewSentryContext(sentry.CurrentHub()),
-		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 	)
 	return logger, closeLogWriter, nil
 }

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -131,6 +131,8 @@ func serviceMain() int {
 	var sentryDSN string
 	if !*disableAnalytics {
 		sentryDSN = observability.WandbCoreDSN
+	} else {
+		analytics.Disable()
 	}
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              sentryDSN,

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -212,7 +212,7 @@ func (r *TelemetryRecorder) With(
 // It additionally records a log record with the telemetry
 // context's attributes plus the caller-supplied attributes under the same
 // name
-func (r TelemetryRecorder) IncrementCounterAndLogEvent(
+func (r *TelemetryRecorder) IncrementCounterAndLogEvent(
 	ctx context.Context,
 	name string,
 	attributes map[string]string,
@@ -242,7 +242,7 @@ func (r TelemetryRecorder) IncrementCounterAndLogEvent(
 //
 // The log record contains the telemetry context's attributes,
 // in addition to the caller-supplied attributes
-func (r TelemetryRecorder) Log(
+func (r *TelemetryRecorder) Log(
 	ctx context.Context,
 	message string,
 	attributes map[string]string,
@@ -276,7 +276,7 @@ func (r TelemetryRecorder) Log(
 // "error.originator". The stack trace is captured at the point Error is called.
 //
 // errorOriginator is a caller-supplied hint about where the error originated.
-func (r TelemetryRecorder) Error(
+func (r *TelemetryRecorder) Error(
 	ctx context.Context,
 	message string,
 	err error,

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -142,7 +142,8 @@ func (s *TelemetryContext) with(
 	low := s.lowCardinalityAttributes
 	low.merge(lowCardinalityAttributes)
 
-	high := maps.Clone(s.highCardinalityAttributes)
+	high := make(map[string]string, len(s.highCardinalityAttributes))
+	maps.Copy(high, s.highCardinalityAttributes)
 	maps.Copy(high, highCardinalityAttributes)
 
 	return TelemetryContext{
@@ -211,7 +212,7 @@ func (r *TelemetryRecorder) With(
 // It additionally records a log record with the telemetry
 // context's attributes plus the caller-supplied attributes under the same
 // name
-func (r *TelemetryRecorder) IncrementCounterAndLogEvent(
+func (r TelemetryRecorder) IncrementCounterAndLogEvent(
 	ctx context.Context,
 	name string,
 	attributes map[string]string,
@@ -241,7 +242,7 @@ func (r *TelemetryRecorder) IncrementCounterAndLogEvent(
 //
 // The log record contains the telemetry context's attributes,
 // in addition to the caller-supplied attributes
-func (r *TelemetryRecorder) Log(
+func (r TelemetryRecorder) Log(
 	ctx context.Context,
 	message string,
 	attributes map[string]string,
@@ -275,7 +276,7 @@ func (r *TelemetryRecorder) Log(
 // "error.originator". The stack trace is captured at the point Error is called.
 //
 // errorOriginator is a caller-supplied hint about where the error originated.
-func (r *TelemetryRecorder) Error(
+func (r TelemetryRecorder) Error(
 	ctx context.Context,
 	message string,
 	err error,
@@ -336,9 +337,6 @@ type OpenTelemetryProxy struct {
 }
 
 // NewOpenTelemetryProxy returns an OpenTelemetryProxy for the given endpoint.
-//
-// When analytics is disabled or no API key is available, a no-op proxy is
-// returned so no providers are created and nothing is recorded.
 func NewOpenTelemetryProxy(
 	ctx context.Context,
 	wandbSettings *settings.Settings,

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -340,19 +340,31 @@ type OpenTelemetryProxy struct {
 
 // NewOpenTelemetryProxy returns an OpenTelemetryProxy for the given endpoint.
 //
-// When analytics is disabled, the wandbSettings are offline, or the api key is not set,
-// a nil pointer is returned, making calls to the proxy a no-op.
+// When analytics is disabled, the wandbSettings are offline, or no credentials
+// are available, a nil pointer is returned, making calls to the proxy a no-op.
 func NewOpenTelemetryProxy(
 	ctx context.Context,
 	wandbSettings *settings.Settings,
 ) *OpenTelemetryProxy {
-	if disabled.Load() || wandbSettings.IsOffline() || wandbSettings.GetAPIKey() == "" {
+	if disabled.Load() || wandbSettings.IsOffline() {
+		return nil
+	}
+
+	httpClient, err := newOTLPHTTPClient(wandbSettings)
+	if err != nil {
+		slog.Debug(
+			"analytics: failed to configure telemetry authentication",
+			"error", err,
+		)
+		return nil
+	}
+	if httpClient == nil {
 		return nil
 	}
 
 	proxy := &OpenTelemetryProxy{
 		endpoint:   wandbSettings.GetBaseURL(),
-		httpClient: newOTLPHTTPClient(wandbSettings),
+		httpClient: httpClient,
 	}
 	if err := proxy.initializeOTelResources(ctx); err != nil {
 		return nil
@@ -360,7 +372,20 @@ func NewOpenTelemetryProxy(
 	return proxy
 }
 
-func newOTLPHTTPClient(wandbSettings *settings.Settings) *http.Client {
+func newOTLPHTTPClient(
+	wandbSettings *settings.Settings,
+) (*http.Client, error) {
+	credentialProvider, err := api.NewCredentialProvider(
+		wandbSettings,
+		slog.Default(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := credentialProvider.(api.NoopCredentialProvider); ok {
+		return nil, nil
+	}
+
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.Proxy = clients.ProxyFn(
 		wandbSettings.GetHTTPProxy(),
@@ -389,10 +414,10 @@ func newOTLPHTTPClient(wandbSettings *settings.Settings) *http.Client {
 		transport,
 		httplayers.Concat(
 			httplayers.ExtraHeaders(extraHeaders),
-			api.NewAPIKeyCredentialProvider(wandbSettings.GetAPIKey()),
+			credentialProvider,
 		),
 	)
-	return client
+	return client, nil
 }
 
 // initializeOTelResources initializes the OpenTelemetry meter and log providers.

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -276,6 +276,8 @@ func (r *TelemetryRecorder) Log(
 // "error.originator". The stack trace is captured at the point Error is called.
 //
 // errorOriginator is a caller-supplied hint about where the error originated.
+// The errorOriginator is recorded as a means of aggregating errors by related
+// sections of the code.
 func (r *TelemetryRecorder) Error(
 	ctx context.Context,
 	message string,
@@ -341,6 +343,10 @@ func NewOpenTelemetryProxy(
 	ctx context.Context,
 	wandbSettings *settings.Settings,
 ) *OpenTelemetryProxy {
+	if disabled.Load() {
+		return nil
+	}
+
 	proxy := &OpenTelemetryProxy{
 		endpoint:   wandbSettings.GetBaseURL(),
 		httpClient: newOTLPHTTPClient(wandbSettings),

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -276,8 +276,8 @@ func (r *TelemetryRecorder) Log(
 // "error.originator". The stack trace is captured at the point Error is called.
 //
 // errorOriginator is a caller-supplied hint about where the error originated.
-// The errorOriginator is recorded as a means of aggregating errors by related
-// sections of the code.
+// Callers pass the declared package name of the calling file, so
+// errorOriginator aggregates errors by package.
 func (r *TelemetryRecorder) Error(
 	ctx context.Context,
 	message string,

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -206,6 +206,22 @@ func (r *TelemetryRecorder) With(
 	}
 }
 
+// IncrementCounter increments a counter metric by 1
+// with the telemetry context's low-cardinality attributes
+func (r *TelemetryRecorder) IncrementCounter(
+	ctx context.Context,
+	name string,
+	lowCardinalityAttributes LowCardinalityAttributes,
+) {
+	if r == nil {
+		return
+	}
+
+	mergedLowCardinalityAttributes := r.telemetryContext.lowCardinalityAttributes
+	mergedLowCardinalityAttributes.merge(lowCardinalityAttributes)
+	r.root.incrementCounter(ctx, name, mergedLowCardinalityAttributes)
+}
+
 // IncrementCounterAndLogEvent increments a counter metric by 1
 // with the telemetry context's low-cardinality attributes
 //
@@ -222,9 +238,7 @@ func (r *TelemetryRecorder) IncrementCounterAndLogEvent(
 		return
 	}
 
-	mergedLowCardinalityAttributes := r.telemetryContext.lowCardinalityAttributes
-	mergedLowCardinalityAttributes.merge(lowCardinalityAttributes)
-	r.root.incrementCounter(ctx, name, mergedLowCardinalityAttributes)
+	r.IncrementCounter(ctx, name, lowCardinalityAttributes)
 
 	recordAttributes := make(map[string]string)
 	maps.Copy(recordAttributes, r.telemetryContext.highCardinalityAttributes)
@@ -264,21 +278,13 @@ func (r *TelemetryRecorder) Log(
 	r.root.log(ctx, message, logAttributes, severity)
 }
 
-// Error records an error as both a counter metric and an error log.
+// ErrorMetric records an error as a counter metric.
 //
 // The counter metric has the name "error" and contains
 // the low-cardinality attributes from the current telemetry context plus an
 // "error.type" attribute (the caller-supplied error type) so the
 // rate of each error type can be aggregated and graphed.
-//
-// The log record contains the attributes from the current telemetry context,
-// plus "error.type", "error.message", "error.stacktrace", and
-// "error.originator". The stack trace is captured at the point Error is called.
-//
-// errorOriginator is a caller-supplied hint about where the error originated.
-// Callers pass the declared package name of the calling file, so
-// errorOriginator aggregates errors by package.
-func (r *TelemetryRecorder) Error(
+func (r *TelemetryRecorder) ErrorMetric(
 	ctx context.Context,
 	message string,
 	err error,
@@ -288,25 +294,42 @@ func (r *TelemetryRecorder) Error(
 		return
 	}
 
+	r.IncrementCounter(
+		ctx,
+		"error",
+		LowCardinalityAttributes{
+			ErrorOriginator: errorOriginator,
+		},
+	)
+}
+
+// ErrorLog emits an OpenTelemetry log record with the specified severity level.
+//
+// The log record contains the attributes from the current telemetry context,
+// plus "error.type", "error.message", "error.stacktrace", and
+// "error.originator". The stack trace is captured at the point Error is called.
+func (r *TelemetryRecorder) ErrorLog(
+	ctx context.Context,
+	message string,
+	err error,
+	errorOriginator string,
+) {
+	if r == nil {
+		return
+	}
+
+	mergedLowCardinalityAttributes := r.telemetryContext.lowCardinalityAttributes
+	mergedLowCardinalityAttributes.merge(LowCardinalityAttributes{
+		ErrorOriginator: errorOriginator,
+	})
+
 	errorMessage := ""
 	if err != nil {
 		errorMessage = err.Error()
 	}
-
-	lowCardinalityAttributes := r.telemetryContext.lowCardinalityAttributes
-	lowCardinalityAttributes.merge(LowCardinalityAttributes{
-		ErrorOriginator: errorOriginator,
-	})
-
-	r.root.incrementCounter(
-		ctx,
-		"error",
-		lowCardinalityAttributes,
-	)
-
 	logAttributes := make(map[string]string)
 	maps.Copy(logAttributes, r.telemetryContext.highCardinalityAttributes)
-	maps.Copy(logAttributes, lowCardinalityAttributes.toMap())
+	maps.Copy(logAttributes, mergedLowCardinalityAttributes.toMap())
 	maps.Copy(logAttributes, map[string]string{
 		"error.message":    errorMessage,
 		"error.stacktrace": captureStacktrace(),

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -339,11 +339,14 @@ type OpenTelemetryProxy struct {
 }
 
 // NewOpenTelemetryProxy returns an OpenTelemetryProxy for the given endpoint.
+//
+// When analytics is disabled, the wandbSettings are offline, or the api key is not set,
+// a nil pointer is returned, making calls to the proxy a no-op.
 func NewOpenTelemetryProxy(
 	ctx context.Context,
 	wandbSettings *settings.Settings,
 ) *OpenTelemetryProxy {
-	if disabled.Load() {
+	if disabled.Load() || wandbSettings.IsOffline() || wandbSettings.GetAPIKey() == "" {
 		return nil
 	}
 

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -306,13 +306,16 @@ func (r *TelemetryRecorder) ErrorMetric(
 // ErrorLog emits an OpenTelemetry log record with the specified severity level.
 //
 // The log record contains the attributes from the current telemetry context,
-// plus "error.type", "error.message", "error.stacktrace", and
-// "error.originator". The stack trace is captured at the point Error is called.
+// plus "error.type", "error.message", "error.stacktrace", "error.originator",
+// and the caller-supplied attributes.
+//
+// The stack trace is captured at the point Error is called.
 func (r *TelemetryRecorder) ErrorLog(
 	ctx context.Context,
 	message string,
 	err error,
 	errorOriginator string,
+	attributes map[string]string,
 ) {
 	if r == nil {
 		return
@@ -330,6 +333,7 @@ func (r *TelemetryRecorder) ErrorLog(
 	logAttributes := make(map[string]string)
 	maps.Copy(logAttributes, r.telemetryContext.highCardinalityAttributes)
 	maps.Copy(logAttributes, mergedLowCardinalityAttributes.toMap())
+	maps.Copy(logAttributes, attributes)
 	maps.Copy(logAttributes, map[string]string{
 		"error.message":    errorMessage,
 		"error.stacktrace": captureStacktrace(),

--- a/core/internal/analytics/opentelemetryproxy_test.go
+++ b/core/internal/analytics/opentelemetryproxy_test.go
@@ -331,7 +331,7 @@ func TestTelemetryRecorder_SendsAPIKeyAuth(t *testing.T) {
 	}
 }
 
-func TestTelemetryRecorder_Error(t *testing.T) {
+func TestTelemetryRecorder_ErrorLog(t *testing.T) {
 	proxy := analyticstest.NewOpenTelemetryProxyTest(t)
 	recorder := analytics.NewTelemetryRecorder(
 		proxy.OpenTelemetryProxy,
@@ -343,24 +343,13 @@ func TestTelemetryRecorder_Error(t *testing.T) {
 	)
 
 	const wantErrorOriginator = "TestTelemetryRecorder_Error"
-	recorder.Error(
+	recorder.ErrorLog(
 		t.Context(),
 		"error-message",
 		assert.AnError,
 		wantErrorOriginator,
 	)
 	require.NoError(t, proxy.Shutdown(context.Background()))
-
-	metric, ok := proxy.FindMetric("error")
-	require.True(t, ok, "expected an error metric")
-	assert.Equal(t, int64(1), metric.Value)
-	assert.Equal(
-		t,
-		wantErrorOriginator,
-		metric.Attributes["error.originator"],
-	)
-	assert.Equal(t, "custom-version", metric.Attributes["wandb_version"])
-	assert.NotContains(t, metric.Attributes, "request_id")
 
 	// verify log emitted
 	log, ok := proxy.FindLog("error-message")
@@ -373,6 +362,30 @@ func TestTelemetryRecorder_Error(t *testing.T) {
 	assert.NotEmpty(t, log.Attributes["error.stacktrace"])
 }
 
+func TestTelemetryRecorder_ErrorMetric(t *testing.T) {
+	proxy := analyticstest.NewOpenTelemetryProxyTest(t)
+	recorder := analytics.NewTelemetryRecorder(
+		proxy.OpenTelemetryProxy,
+		analytics.NewTelemetryContext(),
+	)
+
+	recorder.ErrorMetric(
+		t.Context(),
+		"error-message",
+		assert.AnError,
+		"TestTelemetryRecorder_ErrorMetric",
+	)
+	require.NoError(t, proxy.Shutdown(context.Background()))
+
+	metric, ok := proxy.FindMetric("error")
+	require.True(t, ok, "expected an error metric")
+	assert.Equal(t, int64(1), metric.Value)
+	assert.Equal(
+		t,
+		"TestTelemetryRecorder_ErrorMetric",
+		metric.Attributes["error.originator"],
+	)
+}
 func TestOpenTelemetryProxy_Shutdown_CalledMultipleTimes(t *testing.T) {
 	proxy := analyticstest.NewOpenTelemetryProxyTest(t)
 

--- a/core/internal/analytics/opentelemetryproxy_test.go
+++ b/core/internal/analytics/opentelemetryproxy_test.go
@@ -348,6 +348,7 @@ func TestTelemetryRecorder_ErrorLog(t *testing.T) {
 		"error-message",
 		assert.AnError,
 		wantErrorOriginator,
+		map[string]string{"custom-attribute": "test-attribute"},
 	)
 	require.NoError(t, proxy.Shutdown(context.Background()))
 
@@ -358,6 +359,7 @@ func TestTelemetryRecorder_ErrorLog(t *testing.T) {
 	assert.Equal(t, wantErrorOriginator, log.Attributes["error.originator"])
 	assert.Equal(t, "custom-version", log.Attributes["wandb_version"])
 	assert.Equal(t, "test-request", log.Attributes["request_id"])
+	assert.Equal(t, "test-attribute", log.Attributes["custom-attribute"])
 	assert.Equal(t, assert.AnError.Error(), log.Attributes["error.message"])
 	assert.NotEmpty(t, log.Attributes["error.stacktrace"])
 }

--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -226,7 +226,10 @@ func (fs *fileStream) StreamUpdate(update Update) {
 	defer fs.mu.Unlock()
 
 	if fs.isFinished {
-		fs.logger.CaptureError(fmt.Errorf("filestream: StreamUpdate after Finish"))
+		fs.logger.CaptureError(
+			"filestream",
+			fmt.Errorf("filestream: StreamUpdate after Finish"),
+		)
 		return
 	}
 
@@ -270,7 +273,10 @@ func (fs *fileStream) logFatalAndStopWorking(err error) {
 		fs.stopState.Store(true)
 	}
 
-	fs.logger.CaptureFatal(fmt.Errorf("filestream: fatal error: %v", err))
+	fs.logger.CaptureFatal(
+		"filestream",
+		fmt.Errorf("filestream: fatal error: %v", err),
+	)
 	fs.deadChanOnce.Do(func() {
 		close(fs.deadChan)
 		fs.printer.Errorf(

--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -211,7 +211,9 @@ func (fs *fileStream) send(
 	defer func(Body io.ReadCloser) {
 		if err = Body.Close(); err != nil {
 			fs.logger.CaptureError(
-				fmt.Errorf("filestream: error closing response body: %v", err))
+				"filestream",
+				fmt.Errorf("filestream: error closing response body: %v", err),
+			)
 		}
 	}(resp.Body)
 
@@ -219,7 +221,9 @@ func (fs *fileStream) send(
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
 		fs.logger.CaptureError(
-			fmt.Errorf("filestream: json decode error: %v", err))
+			"filestream",
+			fmt.Errorf("filestream: json decode error: %v", err),
+		)
 	}
 	feedbackChan <- res
 	fs.logger.Debug("filestream: post response", "response", res)

--- a/core/internal/filestream/filestreamstate.go
+++ b/core/internal/filestream/filestreamstate.go
@@ -200,7 +200,9 @@ func (s *FileStreamState) popSummary(
 		if err != nil {
 			// A partial success is possible, so we log and continue.
 			logger.CaptureError(
-				fmt.Errorf("filestream: error applying summary updates: %v", err))
+				"filestream",
+				fmt.Errorf("filestream: error applying summary updates: %v", err),
+			)
 		}
 
 		summaryJSON, err := s.RunSummary.Serialize()
@@ -208,7 +210,9 @@ func (s *FileStreamState) popSummary(
 			// On error, we don't modify UnsentSummary so that we still upload
 			// a previous successfully-serialized value.
 			logger.CaptureError(
-				fmt.Errorf("filestream: failed to serialize summary: %v", err))
+				"filestream",
+				fmt.Errorf("filestream: failed to serialize summary: %v", err),
+			)
 		} else {
 			s.UnsentSummary = string(summaryJSON)
 			s.LastRunSummarySize = len(summaryJSON)

--- a/core/internal/filestream/updatehistory.go
+++ b/core/internal/filestream/updatehistory.go
@@ -21,6 +21,7 @@ func (u *HistoryUpdate) Apply(ctx UpdateContext) error {
 		if err != nil {
 
 			ctx.Logger.CaptureError(
+				"filestream",
 				fmt.Errorf(
 					"filestream: failed to apply history record: %v",
 					err,

--- a/core/internal/filestream/updatestats.go
+++ b/core/internal/filestream/updatestats.go
@@ -28,6 +28,7 @@ func (u *StatsUpdate) Apply(ctx UpdateContext) error {
 		val, err := simplejsonext.UnmarshalString(item.ValueJson)
 		if err != nil {
 			ctx.Logger.CaptureError(
+				"filestream",
 				fmt.Errorf("filestream: failed to marshal StatsItem: %v", err),
 				"key", item.Key,
 			)
@@ -49,10 +50,12 @@ func (u *StatsUpdate) Apply(ctx UpdateContext) error {
 	case err != nil:
 		// This is a non-blocking failure, so we don't return an error.
 		ctx.Logger.CaptureError(
+			"filestream",
 			fmt.Errorf(
 				"filestream: failed to marshal system metrics: %v",
 				err,
-			))
+			),
+		)
 	case len(line) > int(maxLineBytes):
 		// This is a non-blocking failure as well.
 		ctx.Logger.CaptureWarn(

--- a/core/internal/filetransfer/file_transfer_azure.go
+++ b/core/internal/filetransfer/file_transfer_azure.go
@@ -228,6 +228,7 @@ func (ft *AzureFileTransfer) Upload(task *DefaultUploadTask) error {
 		err := file.Close()
 		if err != nil {
 			ft.logger.CaptureError(
+				"AzureFileTransfer",
 				fmt.Errorf(
 					"azure file transfer: upload: error closing file %s: %v",
 					task.Path,

--- a/core/internal/filetransfer/file_transfer_azure.go
+++ b/core/internal/filetransfer/file_transfer_azure.go
@@ -228,7 +228,7 @@ func (ft *AzureFileTransfer) Upload(task *DefaultUploadTask) error {
 		err := file.Close()
 		if err != nil {
 			ft.logger.CaptureError(
-				"AzureFileTransfer",
+				"filetransfer",
 				fmt.Errorf(
 					"azure file transfer: upload: error closing file %s: %v",
 					task.Path,

--- a/core/internal/filetransfer/file_transfer_default.go
+++ b/core/internal/filetransfer/file_transfer_default.go
@@ -59,6 +59,7 @@ func (ft *DefaultFileTransfer) Upload(task *DefaultUploadTask) error {
 		err := file.Close()
 		if err != nil {
 			ft.logger.CaptureError(
+				"DefaultFileTransfer",
 				fmt.Errorf(
 					"file transfer: upload: error closing file %s: %v",
 					task.Path,
@@ -161,6 +162,7 @@ func (ft *DefaultFileTransfer) Download(task *DefaultDownloadTask) error {
 	defer func(file *os.File) {
 		if err := file.Close(); err != nil {
 			ft.logger.CaptureError(
+				"DefaultFileTransfer",
 				fmt.Errorf(
 					"file transfer: download: error closing file %s: %v",
 					task.Path,
@@ -171,7 +173,10 @@ func (ft *DefaultFileTransfer) Download(task *DefaultDownloadTask) error {
 
 	progress, err := wboperation.Get(task.Context).NewProgress()
 	if err != nil {
-		ft.logger.CaptureError(fmt.Errorf("file transfer: download: %v", err))
+		ft.logger.CaptureError(
+			"DefaultFileTransfer",
+			fmt.Errorf("file transfer: download: %v", err),
+		)
 	}
 
 	// If Size is not set, try to get it from Content-Length header
@@ -250,7 +255,10 @@ func getUploadRequestBody(
 
 		progress, err := wboperation.Get(task.Context).NewProgress()
 		if err != nil {
-			logger.CaptureError(fmt.Errorf("file transfer: %v", err))
+			logger.CaptureError(
+				"DefaultFileTransfer",
+				fmt.Errorf("file transfer: %v", err),
+			)
 		}
 
 		requestBody = NewProgressReader(

--- a/core/internal/filetransfer/file_transfer_default.go
+++ b/core/internal/filetransfer/file_transfer_default.go
@@ -59,7 +59,7 @@ func (ft *DefaultFileTransfer) Upload(task *DefaultUploadTask) error {
 		err := file.Close()
 		if err != nil {
 			ft.logger.CaptureError(
-				"DefaultFileTransfer",
+				"filetransfer",
 				fmt.Errorf(
 					"file transfer: upload: error closing file %s: %v",
 					task.Path,
@@ -162,7 +162,7 @@ func (ft *DefaultFileTransfer) Download(task *DefaultDownloadTask) error {
 	defer func(file *os.File) {
 		if err := file.Close(); err != nil {
 			ft.logger.CaptureError(
-				"DefaultFileTransfer",
+				"filetransfer",
 				fmt.Errorf(
 					"file transfer: download: error closing file %s: %v",
 					task.Path,
@@ -174,7 +174,7 @@ func (ft *DefaultFileTransfer) Download(task *DefaultDownloadTask) error {
 	progress, err := wboperation.Get(task.Context).NewProgress()
 	if err != nil {
 		ft.logger.CaptureError(
-			"DefaultFileTransfer",
+			"filetransfer",
 			fmt.Errorf("file transfer: download: %v", err),
 		)
 	}
@@ -256,7 +256,7 @@ func getUploadRequestBody(
 		progress, err := wboperation.Get(task.Context).NewProgress()
 		if err != nil {
 			logger.CaptureError(
-				"DefaultFileTransfer",
+				"filetransfer",
 				fmt.Errorf("file transfer: %v", err),
 			)
 		}

--- a/core/internal/filetransfer/file_transfer_manager.go
+++ b/core/internal/filetransfer/file_transfer_manager.go
@@ -87,7 +87,12 @@ func (fm *fileTransferManager) AddTask(task Task) {
 		<-fm.semaphore
 
 		if err != nil {
-			fm.logger.CaptureError(err, "task", task.String())
+			fm.logger.CaptureError(
+				"FileTransferManager",
+				err,
+				"task",
+				task.String(),
+			)
 		}
 
 		// Execute the callback.

--- a/core/internal/filetransfer/file_transfer_manager.go
+++ b/core/internal/filetransfer/file_transfer_manager.go
@@ -88,7 +88,7 @@ func (fm *fileTransferManager) AddTask(task Task) {
 
 		if err != nil {
 			fm.logger.CaptureError(
-				"FileTransferManager",
+				"filetransfer",
 				err,
 				"task",
 				task.String(),

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -422,6 +422,7 @@ func (m *Run) logPanic(ctx string) {
 	if r := recover(); r != nil {
 		stackTrace := string(debug.Stack())
 		m.logger.CaptureError(
+			"leet.run",
 			fmt.Errorf("PANIC in %s: %v\nStack trace:\n%s", ctx, r, stackTrace),
 		)
 		panic(r)

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -422,7 +422,7 @@ func (m *Run) logPanic(ctx string) {
 	if r := recover(); r != nil {
 		stackTrace := string(debug.Stack())
 		m.logger.CaptureError(
-			"leet.run",
+			"leet",
 			fmt.Errorf("PANIC in %s: %v\nStack trace:\n%s", ctx, r, stackTrace),
 		)
 		panic(r)

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -901,7 +901,10 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 	// heartbeat can produce messages; WatcherManager.Finish unblocks it.
 	if !r.IsRemote() && r.runState == RunStateRunning && !r.watcherMgr.IsStarted() {
 		if err := r.watcherMgr.Start(r.runParams.RunFile); err != nil {
-			r.logger.CaptureError(fmt.Errorf("model: error starting watcher: %v", err))
+			r.logger.CaptureError(
+				"leet.run",
+				fmt.Errorf("model: error starting watcher: %v", err),
+			)
 		} else {
 			r.logger.Info("model: watcher started successfully")
 			r.heartbeatMgr.Start(r.isRunning)

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -902,7 +902,7 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 	if !r.IsRemote() && r.runState == RunStateRunning && !r.watcherMgr.IsStarted() {
 		if err := r.watcherMgr.Start(r.runParams.RunFile); err != nil {
 			r.logger.CaptureError(
-				"leet.run",
+				"leet",
 				fmt.Errorf("model: error starting watcher: %v", err),
 			)
 		} else {

--- a/core/internal/leet/symonsampler.go
+++ b/core/internal/leet/symonsampler.go
@@ -100,7 +100,9 @@ func (s *SymonSampler) Sample() StatsMsg {
 			defer func() {
 				if r := recover(); r != nil {
 					s.logger.CaptureError(
-						fmt.Errorf("symon: panic sampling resource: %v", r))
+						"leet.SymonSampler",
+						fmt.Errorf("symon: panic sampling resource: %v", r),
+					)
 				}
 			}()
 
@@ -146,7 +148,10 @@ func (s *SymonSampler) Cleanup() {
 // depending on whether the monitor package considers them expected.
 func (s *SymonSampler) logSamplingError(err error) {
 	if monitor.ShouldCaptureSamplingError(err) {
-		s.logger.CaptureError(fmt.Errorf("symon: sampling error: %v", err))
+		s.logger.CaptureError(
+			"leet.SymonSampler",
+			fmt.Errorf("symon: sampling error: %v", err),
+		)
 		return
 	}
 	s.logger.Debug(fmt.Sprintf("symon: benign sampling error: %v", err))

--- a/core/internal/leet/symonsampler.go
+++ b/core/internal/leet/symonsampler.go
@@ -100,7 +100,7 @@ func (s *SymonSampler) Sample() StatsMsg {
 			defer func() {
 				if r := recover(); r != nil {
 					s.logger.CaptureError(
-						"leet.SymonSampler",
+						"leet",
 						fmt.Errorf("symon: panic sampling resource: %v", r),
 					)
 				}
@@ -149,7 +149,7 @@ func (s *SymonSampler) Cleanup() {
 func (s *SymonSampler) logSamplingError(err error) {
 	if monitor.ShouldCaptureSamplingError(err) {
 		s.logger.CaptureError(
-			"leet.SymonSampler",
+			"leet",
 			fmt.Errorf("symon: sampling error: %v", err),
 		)
 		return

--- a/core/internal/leet/watchermanager.go
+++ b/core/internal/leet/watchermanager.go
@@ -48,7 +48,10 @@ func (wm *WatcherManager) Start(runPath string) error {
 	})
 
 	if err != nil {
-		wm.logger.CaptureError(fmt.Errorf("watcher: error starting: %v", err))
+		wm.logger.CaptureError(
+			"leet.WatcherManager",
+			fmt.Errorf("watcher: error starting: %v", err),
+		)
 		return err
 	}
 

--- a/core/internal/leet/watchermanager.go
+++ b/core/internal/leet/watchermanager.go
@@ -49,7 +49,7 @@ func (wm *WatcherManager) Start(runPath string) error {
 
 	if err != nil {
 		wm.logger.CaptureError(
-			"leet.WatcherManager",
+			"leet",
 			fmt.Errorf("watcher: error starting: %v", err),
 		)
 		return err

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -277,7 +277,10 @@ func (w *Workspace) Update(msg tea.Msg) tea.Cmd {
 	case ErrorMsg:
 		// Read errors from per-run commands; the affected run simply stops
 		// streaming, so surface the error in the logs.
-		w.logger.CaptureError(fmt.Errorf("workspace: run read failed: %v", t.Err))
+		w.logger.CaptureError(
+			"leet.Workspace",
+			fmt.Errorf("workspace: run read failed: %v", t.Err),
+		)
 	}
 
 	return nil

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -278,7 +278,7 @@ func (w *Workspace) Update(msg tea.Msg) tea.Cmd {
 		// Read errors from per-run commands; the affected run simply stops
 		// streaming, so surface the error in the logs.
 		w.logger.CaptureError(
-			"leet.Workspace",
+			"leet",
 			fmt.Errorf("workspace: run read failed: %v", t.Err),
 		)
 	}

--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -169,7 +169,10 @@ func (w *Workspace) handleWorkspaceRunDirs(msg WorkspaceRunDirsMsg) tea.Cmd {
 	pollCmd := w.pollWandbDirCmd(wandbDirPollInterval)
 
 	if msg.Err != nil {
-		w.logger.CaptureError(fmt.Errorf("workspace: wandb dir scan: %v", msg.Err))
+		w.logger.CaptureError(
+			"leet.Workspace",
+			fmt.Errorf("workspace: wandb dir scan: %v", msg.Err),
+		)
 		return pollCmd
 	}
 
@@ -294,7 +297,10 @@ func (w *Workspace) handleWorkspaceRunOverviewPreloaded(
 		// Best-effort logging for unexpected failures; avoid spamming for
 		// "file not ready yet" or missing run records.
 		err := fmt.Errorf("workspace: preload run overview for %s: %v", msg.RunKey, msg.Err)
-		w.logger.CaptureError(err)
+		w.logger.CaptureError(
+			"leet.Workspace",
+			err,
+		)
 	}
 
 	// Keep draining the queue.

--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -170,7 +170,7 @@ func (w *Workspace) handleWorkspaceRunDirs(msg WorkspaceRunDirsMsg) tea.Cmd {
 
 	if msg.Err != nil {
 		w.logger.CaptureError(
-			"leet.Workspace",
+			"leet",
 			fmt.Errorf("workspace: wandb dir scan: %v", msg.Err),
 		)
 		return pollCmd
@@ -298,7 +298,7 @@ func (w *Workspace) handleWorkspaceRunOverviewPreloaded(
 		// "file not ready yet" or missing run records.
 		err := fmt.Errorf("workspace: preload run overview for %s: %v", msg.RunKey, msg.Err)
 		w.logger.CaptureError(
-			"leet.Workspace",
+			"leet",
 			err,
 		)
 	}

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -542,8 +542,14 @@ func (w *Workspace) ensureLiveStreaming(run *WorkspaceRun) tea.Cmd {
 		run.watcher = NewWatcherManager(ch, w.logger)
 
 		if err := run.watcher.Start(run.wandbPath); err != nil {
-			w.logger.CaptureError(fmt.Errorf(
-				"workspace: failed to start watcher for %s: %v", run.Key, err))
+			w.logger.CaptureError(
+				"leet.Workspace",
+				fmt.Errorf(
+					"workspace: failed to start watcher for %s: %v",
+					run.Key,
+					err,
+				),
+			)
 			run.watcher = nil
 		} else {
 			watcherCmd = w.waitForWatcher(run.Key)
@@ -601,10 +607,15 @@ func (w *Workspace) handleWorkspaceInitErr(msg WorkspaceInitErrMsg) tea.Cmd {
 	}
 
 	if msg.Err != nil && !os.IsNotExist(msg.Err) {
-		w.logger.CaptureError(fmt.Errorf(
-			"workspace: init reader for %s (%s): %v",
-			msg.RunKey, msg.RunPath, msg.Err,
-		))
+		w.logger.CaptureError(
+			"leet.Workspace",
+			fmt.Errorf(
+				"workspace: init reader for %s (%s): %v",
+				msg.RunKey,
+				msg.RunPath,
+				msg.Err,
+			),
+		)
 	}
 	return nil
 }
@@ -1070,7 +1081,10 @@ func (w *Workspace) toggleRunSelected(runKey string) tea.Cmd {
 	wandbFile := runWandbFile(w.wandbDir, runKey)
 	if wandbFile == "" {
 		err := fmt.Errorf("workspace: unable to resolve .wandb file for run key %q", runKey)
-		w.logger.CaptureError(err)
+		w.logger.CaptureError(
+			"leet.Workspace",
+			err,
+		)
 		return nil
 	}
 

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -543,7 +543,7 @@ func (w *Workspace) ensureLiveStreaming(run *WorkspaceRun) tea.Cmd {
 
 		if err := run.watcher.Start(run.wandbPath); err != nil {
 			w.logger.CaptureError(
-				"leet.Workspace",
+				"leet",
 				fmt.Errorf(
 					"workspace: failed to start watcher for %s: %v",
 					run.Key,
@@ -608,7 +608,7 @@ func (w *Workspace) handleWorkspaceInitErr(msg WorkspaceInitErrMsg) tea.Cmd {
 
 	if msg.Err != nil && !os.IsNotExist(msg.Err) {
 		w.logger.CaptureError(
-			"leet.Workspace",
+			"leet",
 			fmt.Errorf(
 				"workspace: init reader for %s (%s): %v",
 				msg.RunKey,
@@ -1082,7 +1082,7 @@ func (w *Workspace) toggleRunSelected(runKey string) tea.Cmd {
 	if wandbFile == "" {
 		err := fmt.Errorf("workspace: unable to resolve .wandb file for run key %q", runKey)
 		w.logger.CaptureError(
-			"leet.Workspace",
+			"leet",
 			err,
 		)
 		return nil

--- a/core/internal/monitor/cwmetadata.go
+++ b/core/internal/monitor/cwmetadata.go
@@ -126,7 +126,10 @@ func (cwm *CoreWeaveMetadata) Probe(ctx context.Context) *spb.EnvironmentRecord 
 
 	upserter, err := cwm.runHandle.Upserter()
 	if err != nil {
-		cwm.logger.CaptureError(fmt.Errorf("cwmetadata: %v", err))
+		cwm.logger.CaptureError(
+			"cwmetadata",
+			fmt.Errorf("cwmetadata: %v", err),
+		)
 		return nil
 	}
 	entity := upserter.RunPath().Entity

--- a/core/internal/monitor/cwmetadata.go
+++ b/core/internal/monitor/cwmetadata.go
@@ -127,7 +127,7 @@ func (cwm *CoreWeaveMetadata) Probe(ctx context.Context) *spb.EnvironmentRecord 
 	upserter, err := cwm.runHandle.Upserter()
 	if err != nil {
 		cwm.logger.CaptureError(
-			"cwmetadata",
+			"monitor",
 			fmt.Errorf("cwmetadata: %v", err),
 		)
 		return nil

--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -179,7 +179,9 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 		sm.resources = append(sm.resources, xpu)
 	} else if err != nil {
 		sm.logger.CaptureError(
-			fmt.Errorf("monitor: failed to initialize xpu resource: %v", err))
+			"SystemMonitor",
+			fmt.Errorf("monitor: failed to initialize xpu resource: %v", err),
+		)
 	}
 
 	if trainium := NewTrainium(
@@ -203,7 +205,12 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 		sm.resources = append(sm.resources, cwm)
 	} else if err != nil {
 		sm.logger.CaptureError(
-			fmt.Errorf("monitor: failed to initialize CoreWeave metadata resource: %v", err))
+			"SystemMonitor",
+			fmt.Errorf(
+				"monitor: failed to initialize CoreWeave metadata resource: %v",
+				err,
+			),
+		)
 	}
 
 	// DCGM Exporter.
@@ -298,7 +305,10 @@ func (sm *SystemMonitor) probeResources() *spb.Record {
 		g.Go(func() error {
 			defer func() {
 				if err := recover(); err != nil {
-					sm.logger.CaptureError(fmt.Errorf("monitor: panic probing resource: %v", err))
+					sm.logger.CaptureError(
+						"SystemMonitor",
+						fmt.Errorf("monitor: panic probing resource: %v", err),
+					)
 				}
 			}()
 
@@ -419,7 +429,10 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 	defer func() {
 		if err := recover(); err != nil {
 			if resource != nil {
-				sm.logger.CaptureError(fmt.Errorf("monitor: panic: %v", err))
+				sm.logger.CaptureError(
+					"SystemMonitor",
+					fmt.Errorf("monitor: panic: %v", err),
+				)
 			}
 		}
 	}()
@@ -440,7 +453,10 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 			metrics, err := resource.Sample()
 			if err != nil {
 				if ShouldCaptureSamplingError(err) {
-					sm.logger.CaptureError(fmt.Errorf("monitor: error sampling metrics: %v", err))
+					sm.logger.CaptureError(
+						"SystemMonitor",
+						fmt.Errorf("monitor: error sampling metrics: %v", err),
+					)
 				} else {
 					sm.logger.Debug(fmt.Sprintf("monitor: benign sampling error: %v", err))
 				}

--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -179,7 +179,7 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 		sm.resources = append(sm.resources, xpu)
 	} else if err != nil {
 		sm.logger.CaptureError(
-			"SystemMonitor",
+			"monitor",
 			fmt.Errorf("monitor: failed to initialize xpu resource: %v", err),
 		)
 	}
@@ -205,7 +205,7 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 		sm.resources = append(sm.resources, cwm)
 	} else if err != nil {
 		sm.logger.CaptureError(
-			"SystemMonitor",
+			"monitor",
 			fmt.Errorf(
 				"monitor: failed to initialize CoreWeave metadata resource: %v",
 				err,
@@ -306,7 +306,7 @@ func (sm *SystemMonitor) probeResources() *spb.Record {
 			defer func() {
 				if err := recover(); err != nil {
 					sm.logger.CaptureError(
-						"SystemMonitor",
+						"monitor",
 						fmt.Errorf("monitor: panic probing resource: %v", err),
 					)
 				}
@@ -430,7 +430,7 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 		if err := recover(); err != nil {
 			if resource != nil {
 				sm.logger.CaptureError(
-					"SystemMonitor",
+					"monitor",
 					fmt.Errorf("monitor: panic: %v", err),
 				)
 			}
@@ -454,7 +454,7 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 			if err != nil {
 				if ShouldCaptureSamplingError(err) {
 					sm.logger.CaptureError(
-						"SystemMonitor",
+						"monitor",
 						fmt.Errorf("monitor: error sampling metrics: %v", err),
 					)
 				} else {

--- a/core/internal/monitor/trainium.go
+++ b/core/internal/monitor/trainium.go
@@ -224,7 +224,10 @@ func (t *Trainium) Start() error {
 				if scanner.Scan() {
 					rawStats := make(map[string]any)
 					if err := json.Unmarshal(scanner.Bytes(), &rawStats); err != nil {
-						t.logger.CaptureError("Trainium", fmt.Errorf("trainium: failed to parse JSON: %v", err))
+						t.logger.CaptureError(
+							"Trainium",
+							fmt.Errorf("trainium: failed to parse JSON: %v", err),
+						)
 						continue
 					}
 					t.SetRawStats(rawStats)
@@ -416,7 +419,10 @@ func (t *Trainium) flattenStats(sample TrainiumStats) map[string]any {
 			var subMap map[string]any
 			err := json.Unmarshal(jsonBytes, &subMap)
 			if err != nil {
-				t.logger.CaptureError("Trainium", fmt.Errorf("trainium: failed to unmarshal submap: %v", err))
+				t.logger.CaptureError(
+					"Trainium",
+					fmt.Errorf("trainium: failed to unmarshal submap: %v", err),
+				)
 				return
 			}
 			for subKey, subValue := range subMap {
@@ -451,7 +457,10 @@ func (t *Trainium) Close() {
 	if t.cmd != nil && t.cmd.Process != nil {
 		err := t.cmd.Process.Kill()
 		if err != nil {
-			t.logger.CaptureError("Trainium", fmt.Errorf("trainium: failed to kill process: %v", err))
+			t.logger.CaptureError(
+				"Trainium",
+				fmt.Errorf("trainium: failed to kill process: %v", err),
+			)
 		}
 	}
 	t.SetRunningState(false)

--- a/core/internal/monitor/trainium.go
+++ b/core/internal/monitor/trainium.go
@@ -224,7 +224,7 @@ func (t *Trainium) Start() error {
 				if scanner.Scan() {
 					rawStats := make(map[string]any)
 					if err := json.Unmarshal(scanner.Bytes(), &rawStats); err != nil {
-						t.logger.CaptureError(fmt.Errorf("trainium: failed to parse JSON: %v", err))
+						t.logger.CaptureError("Trainium", fmt.Errorf("trainium: failed to parse JSON: %v", err))
 						continue
 					}
 					t.SetRawStats(rawStats)
@@ -335,6 +335,7 @@ func (t *Trainium) Sample() (*spb.StatsRecord, error) {
 		}
 		if err != nil {
 			t.logger.CaptureError(
+				"Trainium",
 				fmt.Errorf(
 					"trainium: failed to unmarshal host memory usage: %v",
 					err))
@@ -355,6 +356,7 @@ func (t *Trainium) Sample() (*spb.StatsRecord, error) {
 			}
 			if err != nil {
 				t.logger.CaptureError(
+					"Trainium",
 					fmt.Errorf("trainium: failed to unmarshal neuroncore memory usage: %v", err))
 			}
 		}
@@ -414,7 +416,7 @@ func (t *Trainium) flattenStats(sample TrainiumStats) map[string]any {
 			var subMap map[string]any
 			err := json.Unmarshal(jsonBytes, &subMap)
 			if err != nil {
-				t.logger.CaptureError(fmt.Errorf("trainium: failed to unmarshal submap: %v", err))
+				t.logger.CaptureError("Trainium", fmt.Errorf("trainium: failed to unmarshal submap: %v", err))
 				return
 			}
 			for subKey, subValue := range subMap {
@@ -449,7 +451,7 @@ func (t *Trainium) Close() {
 	if t.cmd != nil && t.cmd.Process != nil {
 		err := t.cmd.Process.Kill()
 		if err != nil {
-			t.logger.CaptureError(fmt.Errorf("trainium: failed to kill process: %v", err))
+			t.logger.CaptureError("Trainium", fmt.Errorf("trainium: failed to kill process: %v", err))
 		}
 	}
 	t.SetRunningState(false)

--- a/core/internal/monitor/trainium.go
+++ b/core/internal/monitor/trainium.go
@@ -225,7 +225,7 @@ func (t *Trainium) Start() error {
 					rawStats := make(map[string]any)
 					if err := json.Unmarshal(scanner.Bytes(), &rawStats); err != nil {
 						t.logger.CaptureError(
-							"Trainium",
+							"monitor",
 							fmt.Errorf("trainium: failed to parse JSON: %v", err),
 						)
 						continue
@@ -338,7 +338,7 @@ func (t *Trainium) Sample() (*spb.StatsRecord, error) {
 		}
 		if err != nil {
 			t.logger.CaptureError(
-				"Trainium",
+				"monitor",
 				fmt.Errorf(
 					"trainium: failed to unmarshal host memory usage: %v",
 					err))
@@ -359,7 +359,7 @@ func (t *Trainium) Sample() (*spb.StatsRecord, error) {
 			}
 			if err != nil {
 				t.logger.CaptureError(
-					"Trainium",
+					"monitor",
 					fmt.Errorf("trainium: failed to unmarshal neuroncore memory usage: %v", err))
 			}
 		}
@@ -420,7 +420,7 @@ func (t *Trainium) flattenStats(sample TrainiumStats) map[string]any {
 			err := json.Unmarshal(jsonBytes, &subMap)
 			if err != nil {
 				t.logger.CaptureError(
-					"Trainium",
+					"monitor",
 					fmt.Errorf("trainium: failed to unmarshal submap: %v", err),
 				)
 				return
@@ -458,7 +458,7 @@ func (t *Trainium) Close() {
 		err := t.cmd.Process.Kill()
 		if err != nil {
 			t.logger.CaptureError(
-				"Trainium",
+				"monitor",
 				fmt.Errorf("trainium: failed to kill process: %v", err),
 			)
 		}
@@ -469,7 +469,7 @@ func (t *Trainium) Close() {
 func (t *Trainium) Probe(_ context.Context) *spb.EnvironmentRecord {
 	info := &spb.EnvironmentRecord{
 		Trainium: &spb.TrainiumInfo{
-			Name:   "Trainium",
+			Name:   "monitor",
 			Vendor: "AWS",
 		},
 	}

--- a/core/internal/monitor/trainium.go
+++ b/core/internal/monitor/trainium.go
@@ -469,7 +469,7 @@ func (t *Trainium) Close() {
 func (t *Trainium) Probe(_ context.Context) *spb.EnvironmentRecord {
 	info := &spb.EnvironmentRecord{
 		Trainium: &spb.TrainiumInfo{
-			Name:   "monitor",
+			Name:   "Trainium",
 			Vendor: "AWS",
 		},
 	}

--- a/core/internal/observability/captureratelimiter.go
+++ b/core/internal/observability/captureratelimiter.go
@@ -7,7 +7,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 )
 
-// CaptureRateLimiter limits the rate at which messages are uploaded to Sentry.
+// CaptureRateLimiter limits the rate at which messages are captured.
 //
 // It maps message hashes to timestamps. The last capture time of every message
 // is tracked and capturing is skipped for messages seen too recently.

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -49,7 +49,7 @@ type CoreLogger struct {
 	*slog.Logger
 	sentryCtx *SentryContext // nil if Sentry is disabled
 
-	telemetryProxy analytics.OpenTelemetryProxy // nil if telemetry is disabled
+	telemetryProxy analytics.TelemetryRecorder // nil if telemetry is disabled
 
 	extraSentryTags Tags // extra Sentry tags for just this logger
 
@@ -63,7 +63,7 @@ type CoreLogger struct {
 func NewCoreLogger(
 	logger *slog.Logger,
 	sentryCtx *SentryContext,
-	telemetryProxy analytics.OpenTelemetryProxy,
+	telemetryProxy analytics.TelemetryRecorder,
 ) *CoreLogger {
 	const captureRateLimiterCacheSize = 100
 	const captureMinDuration = 5 * time.Minute
@@ -109,14 +109,26 @@ func (cl *CoreLogger) With(
 	attrs []any,
 	tags map[string]string,
 ) *CoreLogger {
+	newTags := NewTags(attrs...)
+	maps.Copy(newTags, tags)
+
 	extraSentryTags := maps.Clone(cl.extraSentryTags)
-	maps.Copy(extraSentryTags, NewTags(attrs...))
-	maps.Copy(extraSentryTags, tags)
+	maps.Copy(extraSentryTags, newTags)
+
+	// Derive a child telemetry context so the new attributes are attached
+	// to telemetry emitted through the derived logger only.
+	telemetryProxy := cl.telemetryProxy
+	if telemetryProxy != nil {
+		telemetryProxy = telemetryProxy.With(
+			newTags,
+			analytics.LowCardinalityAttributes{},
+		)
+	}
 
 	return &CoreLogger{
 		Logger:             cl.Logger.With(attrs...),
 		sentryCtx:          cl.sentryCtx,
-		telemetryProxy:     cl.telemetryProxy,
+		telemetryProxy:     telemetryProxy,
 		extraSentryTags:    extraSentryTags,
 		captureRateLimiter: cl.captureRateLimiter,
 	}
@@ -175,7 +187,7 @@ func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 // captureException uploads an error to Sentry if possible and allowed.
 func (cl *CoreLogger) captureException(err error, args ...any) {
 	if cl.telemetryProxy != nil {
-		cl.telemetryProxy.Exception(context.Background(), err.Error(), err)
+		cl.telemetryProxy.Error(context.Background(), err.Error(), err, "error")
 	}
 
 	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(err.Error()) {
@@ -199,7 +211,7 @@ func (cl *CoreLogger) captureMessage(
 			context.Background(),
 			msg,
 			argsToAttributes(args...),
-			nil,
+			analytics.LowCardinalityAttributes{},
 			severity,
 		)
 	}
@@ -242,11 +254,11 @@ func (cl *CoreLogger) RecordTelemetry(
 		return
 	}
 
-	cl.telemetryProxy.RecordMetricAndLogEvent(
+	cl.telemetryProxy.IncrementCounterAndLogEvent(
 		context.Background(),
 		event,
 		attributes,
-		nil,
+		analytics.LowCardinalityAttributes{},
 	)
 }
 

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -175,7 +175,7 @@ func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 // captureException uploads an error to Sentry if possible and allowed.
 func (cl *CoreLogger) captureException(err error, args ...any) {
 	if cl.telemetryProxy != nil {
-		cl.telemetryProxy.Exception(err.Error(), err)
+		cl.telemetryProxy.Exception(context.Background(), err.Error(), err)
 	}
 
 	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(err.Error()) {
@@ -196,8 +196,10 @@ func (cl *CoreLogger) captureMessage(
 ) {
 	if cl.telemetryProxy != nil {
 		cl.telemetryProxy.RecordLog(
+			context.Background(),
 			msg,
 			argsToAttributes(args...),
+			nil,
 			severity,
 		)
 	}
@@ -240,7 +242,12 @@ func (cl *CoreLogger) RecordTelemetry(
 		return
 	}
 
-	cl.telemetryProxy.RecordMetricAndLogEvent(event, attributes)
+	cl.telemetryProxy.RecordMetricAndLogEvent(
+		context.Background(),
+		event,
+		attributes,
+		nil,
+	)
 }
 
 // NewNoOpLogger returns a logger that discards all messages.

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"runtime"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -137,13 +138,25 @@ func (cl *CoreLogger) With(
 // CaptureError logs an error and sends it to Sentry.
 func (cl *CoreLogger) CaptureError(err error, args ...any) {
 	cl.Error(err.Error(), args...)
-	cl.captureException(err, args...)
+	cl.captureException(err, callerName(1), args...)
 }
 
 // CaptureFatal logs a fatal error and sends it to Sentry.
 func (cl *CoreLogger) CaptureFatal(err error, args ...any) {
+	cl.captureFatal(err, callerName(1), args...)
+}
+
+// captureFatal logs a fatal error and records a corresponding telemetry event.
+//
+// codeFunctionName is the fully-qualified name of the function the error is
+// attributed to, recorded as the telemetry "code.function.name" attribute.
+func (cl *CoreLogger) captureFatal(
+	err error,
+	codeFunctionName string,
+	args ...any,
+) {
 	cl.Log(context.Background(), LevelFatal, err.Error(), args...)
-	cl.captureException(err, args...)
+	cl.captureException(err, codeFunctionName, args...)
 }
 
 // CaptureFatalAndPanic logs a fatal error, sends it to Sentry and panics.
@@ -152,7 +165,7 @@ func (cl *CoreLogger) CaptureFatalAndPanic(err error, args ...any) {
 		err = errors.New("observability: panicked with nil error")
 	}
 
-	cl.CaptureFatal(err, args...)
+	cl.captureFatal(err, callerName(1), args...)
 
 	// Log panics to debug-core.log as well. This helps debugging if there are
 	// multiple active debug files.
@@ -185,9 +198,21 @@ func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 }
 
 // captureException uploads an error to Sentry if possible and allowed.
-func (cl *CoreLogger) captureException(err error, args ...any) {
+//
+// codeFunctionName is the fully-qualified name of the function the error is
+// attributed to, recorded as the telemetry "code.function.name" attribute.
+func (cl *CoreLogger) captureException(
+	err error,
+	codeFunctionName string,
+	args ...any,
+) {
 	if cl.telemetryProxy != nil {
-		cl.telemetryProxy.Error(context.Background(), err.Error(), err, "error")
+		cl.telemetryProxy.Error(
+			context.Background(),
+			err.Error(),
+			err,
+			codeFunctionName,
+		)
 	}
 
 	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(err.Error()) {
@@ -271,6 +296,24 @@ func NewNoOpLogger() *CoreLogger {
 		nil,
 		nil,
 	)
+}
+
+// callerName returns the fully-qualified name of the function `skip` levels above
+// the immediate caller or "" if unknown.
+//
+// if skip == 0, the immediate caller is returned.
+//
+// "go:noinline" ensures this function's own frame is stable for the skip count.
+//
+//go:noinline
+func callerName(skip int) string {
+	var pcs [1]uintptr
+	// +2 skips runtime.Callers and callerName itself.
+	if runtime.Callers(skip+2, pcs[:]) == 0 {
+		return ""
+	}
+	frame, _ := runtime.CallersFrames(pcs[:]).Next()
+	return frame.Function
 }
 
 func argsToAttributes(args ...any) map[string]string {

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -49,7 +49,7 @@ type CoreLogger struct {
 	*slog.Logger
 	sentryCtx *SentryContext // nil if Sentry is disabled
 
-	telemetryProxy analytics.TelemetryRecorder // nil if telemetry is disabled
+	telemetryRecorder analytics.TelemetryRecorder
 
 	extraSentryTags Tags // extra Sentry tags for just this logger
 
@@ -63,7 +63,7 @@ type CoreLogger struct {
 func NewCoreLogger(
 	logger *slog.Logger,
 	sentryCtx *SentryContext,
-	telemetryProxy analytics.TelemetryRecorder,
+	telemetryRecorder analytics.TelemetryRecorder,
 ) *CoreLogger {
 	const captureRateLimiterCacheSize = 100
 	const captureMinDuration = 5 * time.Minute
@@ -82,7 +82,7 @@ func NewCoreLogger(
 	return &CoreLogger{
 		Logger:             logger,
 		sentryCtx:          sentryCtx,
-		telemetryProxy:     telemetryProxy,
+		telemetryRecorder:  telemetryRecorder,
 		extraSentryTags:    make(Tags),
 		captureRateLimiter: captureRateLimiter,
 	}
@@ -117,18 +117,15 @@ func (cl *CoreLogger) With(
 
 	// Derive a child telemetry context so the new attributes are attached
 	// to telemetry emitted through the derived logger only.
-	telemetryProxy := cl.telemetryProxy
-	if telemetryProxy != nil {
-		telemetryProxy = telemetryProxy.With(
-			newTags,
-			analytics.LowCardinalityAttributes{},
-		)
-	}
+	telemetryRecorder := cl.telemetryRecorder.With(
+		analytics.LowCardinalityAttributes{},
+		map[string]string(newTags),
+	)
 
 	return &CoreLogger{
 		Logger:             cl.Logger.With(attrs...),
 		sentryCtx:          cl.sentryCtx,
-		telemetryProxy:     telemetryProxy,
+		telemetryRecorder:  telemetryRecorder,
 		extraSentryTags:    extraSentryTags,
 		captureRateLimiter: cl.captureRateLimiter,
 	}
@@ -205,13 +202,12 @@ func (cl *CoreLogger) captureException(
 	err error,
 	args ...any,
 ) {
-	if cl.telemetryProxy != nil {
-		cl.telemetryProxy.Error(
-			context.Background(),
-			errorOriginator,
-			err.Error(),
-		)
-	}
+	cl.telemetryRecorder.Error(
+		context.Background(),
+		err.Error(),
+		err,
+		errorOriginator,
+	)
 
 	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(err.Error()) {
 		return
@@ -229,15 +225,12 @@ func (cl *CoreLogger) captureMessage(
 	severity otellogapi.Severity,
 	args ...any,
 ) {
-	if cl.telemetryProxy != nil {
-		cl.telemetryProxy.RecordLog(
-			context.Background(),
-			msg,
-			argsToAttributes(args...),
-			analytics.LowCardinalityAttributes{},
-			severity,
-		)
-	}
+	cl.telemetryRecorder.Log(
+		context.Background(),
+		msg,
+		argsToAttributes(args...),
+		severity,
+	)
 
 	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(msg) {
 		return
@@ -277,11 +270,7 @@ func (cl *CoreLogger) RecordTelemetry(
 	event string,
 	attributes map[string]string,
 ) {
-	if cl.telemetryProxy == nil {
-		return
-	}
-
-	cl.telemetryProxy.IncrementCounterAndLogEvent(
+	cl.telemetryRecorder.IncrementCounterAndLogEvent(
 		context.Background(),
 		event,
 		attributes,
@@ -296,7 +285,7 @@ func NewNoOpLogger() *CoreLogger {
 	return NewCoreLogger(
 		slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		nil,
-		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 	)
 }
 

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"maps"
-	"runtime"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -136,36 +135,36 @@ func (cl *CoreLogger) With(
 }
 
 // CaptureError logs an error and sends it to Sentry.
-func (cl *CoreLogger) CaptureError(err error, args ...any) {
-	cl.Error(err.Error(), args...)
-	cl.captureException(err, callerName(1), args...)
-}
-
-// CaptureFatal logs a fatal error and sends it to Sentry.
-func (cl *CoreLogger) CaptureFatal(err error, args ...any) {
-	cl.captureFatal(err, callerName(1), args...)
-}
-
-// captureFatal logs a fatal error and records a corresponding telemetry event.
-//
-// codeFunctionName is the fully-qualified name of the function the error is
-// attributed to, recorded as the telemetry "code.function.name" attribute.
-func (cl *CoreLogger) captureFatal(
+func (cl *CoreLogger) CaptureError(
+	errorOriginator string,
 	err error,
-	codeFunctionName string,
+	args ...any,
+) {
+	cl.Error(err.Error(), args...)
+	cl.captureException(errorOriginator, err, args...)
+}
+
+// CaptureFatal logs a fatal error and records a corresponding telemetry event.
+func (cl *CoreLogger) CaptureFatal(
+	errorOriginator string,
+	err error,
 	args ...any,
 ) {
 	cl.Log(context.Background(), LevelFatal, err.Error(), args...)
-	cl.captureException(err, codeFunctionName, args...)
+	cl.captureException(errorOriginator, err, args...)
 }
 
 // CaptureFatalAndPanic logs a fatal error, sends it to Sentry and panics.
-func (cl *CoreLogger) CaptureFatalAndPanic(err error, args ...any) {
+func (cl *CoreLogger) CaptureFatalAndPanic(
+	errorOriginator string,
+	err error,
+	args ...any,
+) {
 	if err == nil {
 		err = errors.New("observability: panicked with nil error")
 	}
 
-	cl.captureFatal(err, callerName(1), args...)
+	cl.CaptureFatal(errorOriginator, err, args...)
 
 	// Log panics to debug-core.log as well. This helps debugging if there are
 	// multiple active debug files.
@@ -202,16 +201,15 @@ func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 // codeFunctionName is the fully-qualified name of the function the error is
 // attributed to, recorded as the telemetry "code.function.name" attribute.
 func (cl *CoreLogger) captureException(
+	errorOriginator string,
 	err error,
-	codeFunctionName string,
 	args ...any,
 ) {
 	if cl.telemetryProxy != nil {
 		cl.telemetryProxy.Error(
 			context.Background(),
+			errorOriginator,
 			err.Error(),
-			err,
-			codeFunctionName,
 		)
 	}
 
@@ -254,16 +252,20 @@ func (cl *CoreLogger) captureMessage(
 // Reraise logs a panic, uploads it to Sentry, and re-panics.
 //
 // It is meant to be used in a `defer` statement.
-func (cl *CoreLogger) Reraise(args ...any) {
+func (cl *CoreLogger) Reraise(errorOriginator string, args ...any) {
 	panicErr := recover()
 	if panicErr == nil { // if NO error, return
 		return
 	}
 
 	if err, ok := panicErr.(error); ok {
-		cl.CaptureFatalAndPanic(err, args...)
+		cl.CaptureFatalAndPanic(errorOriginator, err, args...)
 	} else {
-		cl.CaptureFatalAndPanic(fmt.Errorf("%v", panicErr), args...)
+		cl.CaptureFatalAndPanic(
+			errorOriginator,
+			fmt.Errorf("%v", panicErr),
+			args...,
+		)
 	}
 }
 
@@ -296,24 +298,6 @@ func NewNoOpLogger() *CoreLogger {
 		nil,
 		nil,
 	)
-}
-
-// callerName returns the fully-qualified name of the function `skip` levels above
-// the immediate caller or "" if unknown.
-//
-// if skip == 0, the immediate caller is returned.
-//
-// "go:noinline" ensures this function's own frame is stable for the skip count.
-//
-//go:noinline
-func callerName(skip int) string {
-	var pcs [1]uintptr
-	// +2 skips runtime.Callers and callerName itself.
-	if runtime.Callers(skip+2, pcs[:]) == 0 {
-		return ""
-	}
-	frame, _ := runtime.CallersFrames(pcs[:]).Next()
-	return frame.Function
 }
 
 func argsToAttributes(args ...any) map[string]string {

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -49,7 +49,7 @@ type CoreLogger struct {
 	*slog.Logger
 	sentryCtx *SentryContext // nil if Sentry is disabled
 
-	telemetryRecorder analytics.TelemetryRecorder
+	telemetryRecorder *analytics.TelemetryRecorder
 
 	extraSentryTags Tags // extra Sentry tags for just this logger
 
@@ -63,7 +63,7 @@ type CoreLogger struct {
 func NewCoreLogger(
 	logger *slog.Logger,
 	sentryCtx *SentryContext,
-	telemetryRecorder analytics.TelemetryRecorder,
+	telemetryRecorder *analytics.TelemetryRecorder,
 ) *CoreLogger {
 	const captureRateLimiterCacheSize = 100
 	const captureMinDuration = 5 * time.Minute

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	otellogapi "go.opentelemetry.io/otel/log"
+
+	"github.com/wandb/wandb/core/internal/analytics"
 )
 
 type Tags map[string]string
@@ -46,6 +49,8 @@ type CoreLogger struct {
 	*slog.Logger
 	sentryCtx *SentryContext // nil if Sentry is disabled
 
+	telemetryProxy analytics.OpenTelemetryProxy // nil if telemetry is disabled
+
 	extraSentryTags Tags // extra Sentry tags for just this logger
 
 	captureRateLimiter *CaptureRateLimiter
@@ -58,6 +63,7 @@ type CoreLogger struct {
 func NewCoreLogger(
 	logger *slog.Logger,
 	sentryCtx *SentryContext,
+	telemetryProxy analytics.OpenTelemetryProxy,
 ) *CoreLogger {
 	const captureRateLimiterCacheSize = 100
 	const captureMinDuration = 5 * time.Minute
@@ -76,6 +82,7 @@ func NewCoreLogger(
 	return &CoreLogger{
 		Logger:             logger,
 		sentryCtx:          sentryCtx,
+		telemetryProxy:     telemetryProxy,
 		extraSentryTags:    make(Tags),
 		captureRateLimiter: captureRateLimiter,
 	}
@@ -109,6 +116,7 @@ func (cl *CoreLogger) With(
 	return &CoreLogger{
 		Logger:             cl.Logger.With(attrs...),
 		sentryCtx:          cl.sentryCtx,
+		telemetryProxy:     cl.telemetryProxy,
 		extraSentryTags:    extraSentryTags,
 		captureRateLimiter: cl.captureRateLimiter,
 	}
@@ -155,17 +163,21 @@ func (cl *CoreLogger) CaptureFatalAndPanic(err error, args ...any) {
 // CaptureWarn logs a warning and sends it to Sentry.
 func (cl *CoreLogger) CaptureWarn(msg string, args ...any) {
 	cl.Warn(msg, args...)
-	cl.captureMessage(msg, args...)
+	cl.captureMessage(msg, otellogapi.SeverityWarn, args...)
 }
 
 // CaptureInfo logs an info message and sends it to Sentry.
 func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 	cl.Info(msg, args...)
-	cl.captureMessage(msg, args...)
+	cl.captureMessage(msg, otellogapi.SeverityInfo, args...)
 }
 
 // captureException uploads an error to Sentry if possible and allowed.
 func (cl *CoreLogger) captureException(err error, args ...any) {
+	if cl.telemetryProxy != nil {
+		cl.telemetryProxy.Exception(err.Error(), err)
+	}
+
 	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(err.Error()) {
 		return
 	}
@@ -177,7 +189,19 @@ func (cl *CoreLogger) captureException(err error, args ...any) {
 }
 
 // captureException uploads a message to Sentry if possible and allowed.
-func (cl *CoreLogger) captureMessage(msg string, args ...any) {
+func (cl *CoreLogger) captureMessage(
+	msg string,
+	severity otellogapi.Severity,
+	args ...any,
+) {
+	if cl.telemetryProxy != nil {
+		cl.telemetryProxy.RecordLog(
+			msg,
+			argsToAttributes(args...),
+			severity,
+		)
+	}
+
 	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(msg) {
 		return
 	}
@@ -204,9 +228,38 @@ func (cl *CoreLogger) Reraise(args ...any) {
 	}
 }
 
+// RecordTelemetry records an event as both a counter metric and a log record.
+//
+// The counter metric aggregates over a low-cardinality attribute space, while
+// the log record captures the full, possibly high-cardinality, attributes.
+func (cl *CoreLogger) RecordTelemetry(
+	event string,
+	attributes map[string]string,
+) {
+	if cl.telemetryProxy == nil {
+		return
+	}
+
+	cl.telemetryProxy.RecordMetricAndLogEvent(event, attributes)
+}
+
 // NewNoOpLogger returns a logger that discards all messages.
 //
 // Used for testing.
 func NewNoOpLogger() *CoreLogger {
-	return NewCoreLogger(slog.New(slog.NewJSONHandler(io.Discard, nil)), nil)
+	return NewCoreLogger(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		nil,
+		nil,
+	)
+}
+
+func argsToAttributes(args ...any) map[string]string {
+	attributes := make(map[string]string)
+	for _, arg := range args {
+		if attr, ok := arg.(slog.Attr); ok {
+			attributes[attr.Key] = attr.Value.String()
+		}
+	}
+	return attributes
 }

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -132,6 +132,8 @@ func (cl *CoreLogger) With(
 }
 
 // CaptureError logs an error and records a corresponding telemetry event.
+//
+// errorOriginator must be the declared package name of the calling file.
 func (cl *CoreLogger) CaptureError(
 	errorOriginator string,
 	err error,
@@ -142,6 +144,8 @@ func (cl *CoreLogger) CaptureError(
 }
 
 // CaptureFatal logs a fatal error and records a corresponding telemetry event.
+//
+// errorOriginator must be the declared package name of the calling file.
 func (cl *CoreLogger) CaptureFatal(
 	errorOriginator string,
 	err error,
@@ -151,8 +155,10 @@ func (cl *CoreLogger) CaptureFatal(
 	cl.captureException(errorOriginator, err, args...)
 }
 
-// CaptureFatalAndPanic logs a fatal error, records a corresponding telemetry event,
-// and panics.
+// CaptureFatalAndPanic logs a fatal error, records a corresponding telemetry
+// event, and panics.
+//
+// errorOriginator must be the declared package name of the calling file.
 func (cl *CoreLogger) CaptureFatalAndPanic(
 	errorOriginator string,
 	err error,
@@ -254,6 +260,7 @@ func (cl *CoreLogger) captureMessage(
 // Reraise logs a panic, records a telemetry error event, and re-panics.
 //
 // It is meant to be used in a `defer` statement.
+// errorOriginator must be the declared package name of the calling file.
 func (cl *CoreLogger) Reraise(errorOriginator string, args ...any) {
 	panicErr := recover()
 	if panicErr == nil { // if NO error, return

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -209,11 +209,21 @@ func (cl *CoreLogger) captureException(
 	err error,
 	args ...any,
 ) {
+	// Always record the error as a counter metric.
+	// Since it will allow us to still see all errors,
+	// without flooding our logs.
+	cl.telemetryRecorder.ErrorMetric(
+		context.Background(),
+		err.Error(),
+		err,
+		errorOriginator,
+	)
+
 	if !cl.captureRateLimiter.AllowCapture(err.Error()) {
 		return
 	}
 
-	cl.telemetryRecorder.Error(
+	cl.telemetryRecorder.ErrorLog(
 		context.Background(),
 		err.Error(),
 		err,

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -228,6 +228,7 @@ func (cl *CoreLogger) captureException(
 		err.Error(),
 		err,
 		errorOriginator,
+		cl.withArgs(args...),
 	)
 
 	if cl.sentryCtx == nil {

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -203,6 +203,10 @@ func (cl *CoreLogger) captureException(
 	err error,
 	args ...any,
 ) {
+	if !cl.captureRateLimiter.AllowCapture(err.Error()) {
+		return
+	}
+
 	cl.telemetryRecorder.Error(
 		context.Background(),
 		err.Error(),
@@ -210,7 +214,7 @@ func (cl *CoreLogger) captureException(
 		errorOriginator,
 	)
 
-	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(err.Error()) {
+	if cl.sentryCtx == nil {
 		return
 	}
 
@@ -226,6 +230,10 @@ func (cl *CoreLogger) captureMessage(
 	severity otellogapi.Severity,
 	args ...any,
 ) {
+	if !cl.captureRateLimiter.AllowCapture(msg) {
+		return
+	}
+
 	cl.telemetryRecorder.Log(
 		context.Background(),
 		msg,
@@ -233,7 +241,7 @@ func (cl *CoreLogger) captureMessage(
 		severity,
 	)
 
-	if cl.sentryCtx == nil || !cl.captureRateLimiter.AllowCapture(msg) {
+	if cl.sentryCtx == nil {
 		return
 	}
 

--- a/core/internal/observability/logging.go
+++ b/core/internal/observability/logging.go
@@ -57,9 +57,9 @@ type CoreLogger struct {
 }
 
 // NewCoreLogger returns a new logger that writes messages to the slog Logger
-// and uploads captured messages using a clone of the sentryHub.
+// and uploads captured messages to Sentry and Datadog.
 //
-// sentryHub can be set to nil to disable Sentry.
+// Sentry events are captured with a clone of the sentryHub.
 func NewCoreLogger(
 	logger *slog.Logger,
 	sentryCtx *SentryContext,
@@ -98,13 +98,13 @@ func (cl *CoreLogger) withArgs(args ...any) Tags {
 	return tags
 }
 
-// With returns a derived logger with additional slog attrs and Sentry tags.
+// With returns a derived logger with additional slog attrs and telemetry tags.
 //
 // The returned logger inherits the attrs and tags of this logger.
 //
 // The additional attrs are logged with every message and included as tags on
-// every Sentry event. The tags are only uploaded to Sentry, so they can
-// be more verbose.
+// every Sentry+OpenTelemetry event.
+// The tags are captured in Sentry and OpenTelemetry, so they can be more verbose.
 func (cl *CoreLogger) With(
 	attrs []any,
 	tags map[string]string,
@@ -131,7 +131,7 @@ func (cl *CoreLogger) With(
 	}
 }
 
-// CaptureError logs an error and sends it to Sentry.
+// CaptureError logs an error and records a corresponding telemetry event.
 func (cl *CoreLogger) CaptureError(
 	errorOriginator string,
 	err error,
@@ -151,7 +151,8 @@ func (cl *CoreLogger) CaptureFatal(
 	cl.captureException(errorOriginator, err, args...)
 }
 
-// CaptureFatalAndPanic logs a fatal error, sends it to Sentry and panics.
+// CaptureFatalAndPanic logs a fatal error, records a corresponding telemetry event,
+// and panics.
 func (cl *CoreLogger) CaptureFatalAndPanic(
 	errorOriginator string,
 	err error,
@@ -181,22 +182,22 @@ func (cl *CoreLogger) CaptureFatalAndPanic(
 	panic(err)
 }
 
-// CaptureWarn logs a warning and sends it to Sentry.
+// CaptureWarn logs a warning and records a corresponding telemetry event.
 func (cl *CoreLogger) CaptureWarn(msg string, args ...any) {
 	cl.Warn(msg, args...)
 	cl.captureMessage(msg, otellogapi.SeverityWarn, args...)
 }
 
-// CaptureInfo logs an info message and sends it to Sentry.
+// CaptureInfo logs an info message and records a corresponding telemetry event.
 func (cl *CoreLogger) CaptureInfo(msg string, args ...any) {
 	cl.Info(msg, args...)
 	cl.captureMessage(msg, otellogapi.SeverityInfo, args...)
 }
 
-// captureException uploads an error to Sentry if possible and allowed.
+// captureException captures a telemetry error event if possible and allowed.
 //
-// codeFunctionName is the fully-qualified name of the function the error is
-// attributed to, recorded as the telemetry "code.function.name" attribute.
+// errorOriginator is a telemetry tag that attributes where the
+// error was captured.
 func (cl *CoreLogger) captureException(
 	errorOriginator string,
 	err error,
@@ -219,7 +220,7 @@ func (cl *CoreLogger) captureException(
 	})
 }
 
-// captureException uploads a message to Sentry if possible and allowed.
+// captureMessage captures a telemetry event if possible and allowed.
 func (cl *CoreLogger) captureMessage(
 	msg string,
 	severity otellogapi.Severity,
@@ -228,7 +229,7 @@ func (cl *CoreLogger) captureMessage(
 	cl.telemetryRecorder.Log(
 		context.Background(),
 		msg,
-		argsToAttributes(args...),
+		NewTags(args...),
 		severity,
 	)
 
@@ -242,7 +243,7 @@ func (cl *CoreLogger) captureMessage(
 	})
 }
 
-// Reraise logs a panic, uploads it to Sentry, and re-panics.
+// Reraise logs a panic, records a telemetry error event, and re-panics.
 //
 // It is meant to be used in a `defer` statement.
 func (cl *CoreLogger) Reraise(errorOriginator string, args ...any) {
@@ -287,14 +288,4 @@ func NewNoOpLogger() *CoreLogger {
 		nil,
 		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 	)
-}
-
-func argsToAttributes(args ...any) map[string]string {
-	attributes := make(map[string]string)
-	for _, arg := range args {
-		if attr, ok := arg.(slog.Attr); ok {
-			attributes[attr.Key] = attr.Value.String()
-		}
-	}
-	return attributes
 }

--- a/core/internal/observability/logging_test.go
+++ b/core/internal/observability/logging_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,7 +91,7 @@ func TestReraise(t *testing.T) {
 			assert.Empty(t, logs)
 		}()
 
-		defer logger.Reraise()
+		defer logger.Reraise("logging_test")
 	})
 
 	t.Run("panic with error", func(t *testing.T) {
@@ -104,7 +103,7 @@ func TestReraise(t *testing.T) {
 			assert.Contains(t, logs.String(), "test error")
 		}()
 
-		defer logger.Reraise()
+		defer logger.Reraise("logging_test")
 		panic(testErr)
 	})
 
@@ -116,7 +115,7 @@ func TestReraise(t *testing.T) {
 			assert.Contains(t, logs.String(), "test error string")
 		}()
 
-		defer logger.Reraise()
+		defer logger.Reraise("logging_test")
 		panic("test error string")
 	})
 }
@@ -128,7 +127,7 @@ func TestCaptureFatalAndPanic_Nil(t *testing.T) {
 		assert.ErrorContains(t, recover().(error), "panicked with nil error")
 	}()
 
-	logger.CaptureFatalAndPanic(nil)
+	logger.CaptureFatalAndPanic("logging_test", nil)
 }
 
 func TestLoggerHierarchy(t *testing.T) {
@@ -191,12 +190,11 @@ func (f *fakeTelemetryRecorder) IncrementCounterAndLogEvent(
 
 func (f *fakeTelemetryRecorder) Error(
 	_ context.Context,
-	_ string,
-	_ error,
-	codeFunctionName string,
+	errorOriginator string,
+	message string,
 ) {
 	f.errorCalled = true
-	f.lastCodeFunctionName = codeFunctionName
+	f.lastCodeFunctionName = errorOriginator
 }
 
 func (f *fakeTelemetryRecorder) With(
@@ -220,22 +218,18 @@ func TestCaptureError_AttributesCaller(t *testing.T) {
 	rec := &fakeTelemetryRecorder{}
 	logger := newTelemetryTestLogger(rec)
 
-	logger.CaptureError(errors.New("boom"))
-	pc, _, _, _ := runtime.Caller(0)
-	want := runtime.FuncForPC(pc).Name()
+	logger.CaptureError("logging_test", errors.New("boom"))
 
 	require.True(t, rec.errorCalled, "expected Error to be recorded")
-	assert.Equal(t, want, rec.lastCodeFunctionName)
+	assert.Equal(t, "logging_test", rec.lastCodeFunctionName)
 }
 
 func TestCaptureFatal_AttributesCaller(t *testing.T) {
 	rec := &fakeTelemetryRecorder{}
 	logger := newTelemetryTestLogger(rec)
 
-	logger.CaptureFatal(errors.New("boom"))
-	pc, _, _, _ := runtime.Caller(0)
-	want := runtime.FuncForPC(pc).Name()
+	logger.CaptureFatal("logging_test", errors.New("boom"))
 
 	require.True(t, rec.errorCalled, "expected Error to be recorded")
-	assert.Equal(t, want, rec.lastCodeFunctionName)
+	assert.Equal(t, "logging_test", rec.lastCodeFunctionName)
 }

--- a/core/internal/observability/logging_test.go
+++ b/core/internal/observability/logging_test.go
@@ -6,15 +6,21 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	otellogapi "go.opentelemetry.io/otel/log"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
+	wbsettings "github.com/wandb/wandb/core/internal/settings"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
 func TestNewTags(t *testing.T) {
@@ -164,72 +170,104 @@ func TestLoggerHierarchy(t *testing.T) {
 	}, logRecords[1])
 }
 
-// fakeTelemetryRecorder records the codeFunctionName passed to Error so tests
-// can assert how the caller is attributed.
-type fakeTelemetryRecorder struct {
-	errorCalled          bool
-	lastCodeFunctionName string
-}
+func captureTelemetryLog(
+	t *testing.T,
+	record func(*observability.CoreLogger),
+) map[string]string {
+	t.Helper()
 
-func (f *fakeTelemetryRecorder) RecordLog(
-	context.Context,
-	string,
-	map[string]string,
-	analytics.LowCardinalityAttributes,
-	otellogapi.Severity,
-) {
-}
+	type exportResult struct {
+		request *collogspb.ExportLogsServiceRequest
+		err     error
+	}
+	exported := make(chan exportResult, 1)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/sdk/otel/v1/logs" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
 
-func (f *fakeTelemetryRecorder) IncrementCounterAndLogEvent(
-	context.Context,
-	string,
-	map[string]string,
-	analytics.LowCardinalityAttributes,
-) {
-}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				exported <- exportResult{err: err}
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 
-func (f *fakeTelemetryRecorder) Error(
-	_ context.Context,
-	errorOriginator string,
-	message string,
-) {
-	f.errorCalled = true
-	f.lastCodeFunctionName = errorOriginator
-}
+			request := &collogspb.ExportLogsServiceRequest{}
+			err = proto.Unmarshal(body, request)
+			exported <- exportResult{request: request, err: err}
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	t.Cleanup(server.Close)
 
-func (f *fakeTelemetryRecorder) With(
-	map[string]string,
-	analytics.LowCardinalityAttributes,
-) analytics.TelemetryRecorder {
-	return f
-}
-
-func newTelemetryTestLogger(
-	rec analytics.TelemetryRecorder,
-) *observability.CoreLogger {
-	return observability.NewCoreLogger(
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl: wrapperspb.String(server.URL),
+		ApiKey:  wrapperspb.String("test-api-key"),
+	})
+	proxy := analytics.NewOpenTelemetryProxy(t.Context(), settings)
+	require.NotNil(t, proxy)
+	recorder := analytics.NewTelemetryRecorder(
+		proxy,
+		analytics.NewTelemetryContext(),
+	)
+	logger := observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		nil,
-		rec,
+		recorder,
 	)
+
+	record(logger)
+	require.NoError(t, proxy.Shutdown(context.Background()))
+
+	result := <-exported
+	require.NoError(t, result.err)
+	resourceLogs := result.request.GetResourceLogs()
+	require.Len(t, resourceLogs, 1)
+	scopeLogs := resourceLogs[0].GetScopeLogs()
+	require.Len(t, scopeLogs, 1)
+	records := scopeLogs[0].GetLogRecords()
+	require.Len(t, records, 1)
+
+	attributes := make(map[string]string)
+	for _, attribute := range records[0].GetAttributes() {
+		attributes[attribute.GetKey()] = attribute.GetValue().GetStringValue()
+	}
+	return attributes
+}
+
+func TestCaptureInfo_IncludesDerivedTelemetryTags(t *testing.T) {
+	attributes := captureTelemetryLog(t, func(logger *observability.CoreLogger) {
+		logger.With(
+			[]any{"logger-attr", "attr-value"},
+			map[string]string{"logger-tag": "tag-value"},
+		).CaptureInfo(
+			"test message",
+			slog.String("call-attr", "call-value"),
+			slog.Int("call-int", 123),
+		)
+	})
+
+	assert.Equal(t, "attr-value", attributes["logger-attr"])
+	assert.Equal(t, "tag-value", attributes["logger-tag"])
+	assert.Equal(t, "call-value", attributes["call-attr"])
+	assert.Equal(t, "123", attributes["call-int"])
 }
 
 func TestCaptureError_AttributesCaller(t *testing.T) {
-	rec := &fakeTelemetryRecorder{}
-	logger := newTelemetryTestLogger(rec)
+	attributes := captureTelemetryLog(t, func(logger *observability.CoreLogger) {
+		logger.CaptureError("logging_test", assert.AnError)
+	})
 
-	logger.CaptureError("logging_test", errors.New("boom"))
-
-	require.True(t, rec.errorCalled, "expected Error to be recorded")
-	assert.Equal(t, "logging_test", rec.lastCodeFunctionName)
+	assert.Equal(t, "logging_test", attributes["error.originator"])
 }
 
 func TestCaptureFatal_AttributesCaller(t *testing.T) {
-	rec := &fakeTelemetryRecorder{}
-	logger := newTelemetryTestLogger(rec)
+	attributes := captureTelemetryLog(t, func(logger *observability.CoreLogger) {
+		logger.CaptureFatal("logging_test", assert.AnError)
+	})
 
-	logger.CaptureFatal("logging_test", errors.New("boom"))
-
-	require.True(t, rec.errorCalled, "expected Error to be recorded")
-	assert.Equal(t, "logging_test", rec.lastCodeFunctionName)
+	assert.Equal(t, "logging_test", attributes["error.originator"])
 }

--- a/core/internal/observability/logging_test.go
+++ b/core/internal/observability/logging_test.go
@@ -1,14 +1,19 @@
 package observability_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	otellogapi "go.opentelemetry.io/otel/log"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
@@ -158,4 +163,79 @@ func TestLoggerHierarchy(t *testing.T) {
 		// slog only includes the attrs passed to With().
 		"attr": "attr-value",
 	}, logRecords[1])
+}
+
+// fakeTelemetryRecorder records the codeFunctionName passed to Error so tests
+// can assert how the caller is attributed.
+type fakeTelemetryRecorder struct {
+	errorCalled          bool
+	lastCodeFunctionName string
+}
+
+func (f *fakeTelemetryRecorder) RecordLog(
+	context.Context,
+	string,
+	map[string]string,
+	analytics.LowCardinalityAttributes,
+	otellogapi.Severity,
+) {
+}
+
+func (f *fakeTelemetryRecorder) IncrementCounterAndLogEvent(
+	context.Context,
+	string,
+	map[string]string,
+	analytics.LowCardinalityAttributes,
+) {
+}
+
+func (f *fakeTelemetryRecorder) Error(
+	_ context.Context,
+	_ string,
+	_ error,
+	codeFunctionName string,
+) {
+	f.errorCalled = true
+	f.lastCodeFunctionName = codeFunctionName
+}
+
+func (f *fakeTelemetryRecorder) With(
+	map[string]string,
+	analytics.LowCardinalityAttributes,
+) analytics.TelemetryRecorder {
+	return f
+}
+
+func newTelemetryTestLogger(
+	rec analytics.TelemetryRecorder,
+) *observability.CoreLogger {
+	return observability.NewCoreLogger(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		nil,
+		rec,
+	)
+}
+
+func TestCaptureError_AttributesCaller(t *testing.T) {
+	rec := &fakeTelemetryRecorder{}
+	logger := newTelemetryTestLogger(rec)
+
+	logger.CaptureError(errors.New("boom"))
+	pc, _, _, _ := runtime.Caller(0)
+	want := runtime.FuncForPC(pc).Name()
+
+	require.True(t, rec.errorCalled, "expected Error to be recorded")
+	assert.Equal(t, want, rec.lastCodeFunctionName)
+}
+
+func TestCaptureFatal_AttributesCaller(t *testing.T) {
+	rec := &fakeTelemetryRecorder{}
+	logger := newTelemetryTestLogger(rec)
+
+	logger.CaptureFatal(errors.New("boom"))
+	pc, _, _, _ := runtime.Caller(0)
+	want := runtime.FuncForPC(pc).Name()
+
+	require.True(t, rec.errorCalled, "expected Error to be recorded")
+	assert.Equal(t, want, rec.lastCodeFunctionName)
 }

--- a/core/internal/observabilitytest/logging.go
+++ b/core/internal/observabilitytest/logging.go
@@ -10,6 +10,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/observability"
 )
 
@@ -22,7 +23,7 @@ func NewTestLogger(t *testing.T) *observability.CoreLogger {
 	return observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(t.Output(), &slog.HandlerOptions{})),
 		nil,
-		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 	)
 }
 
@@ -40,7 +41,7 @@ func NewRecordingTestLogger(t *testing.T) (
 	return observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
 		nil,
-		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 	), recordedLogs
 }
 
@@ -64,7 +65,7 @@ func NewSentryTestLogger(t *testing.T) (
 	return observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
 		observability.NewSentryContext(hub),
-		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 	), recordedLogs, transport
 }
 

--- a/core/internal/observabilitytest/logging.go
+++ b/core/internal/observabilitytest/logging.go
@@ -22,6 +22,7 @@ func NewTestLogger(t *testing.T) *observability.CoreLogger {
 	return observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(t.Output(), &slog.HandlerOptions{})),
 		nil,
+		nil,
 	)
 }
 
@@ -38,6 +39,7 @@ func NewRecordingTestLogger(t *testing.T) (
 
 	return observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
+		nil,
 		nil,
 	), recordedLogs
 }
@@ -62,6 +64,7 @@ func NewSentryTestLogger(t *testing.T) (
 	return observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
 		observability.NewSentryContext(hub),
+		nil,
 	), recordedLogs, transport
 }
 

--- a/core/internal/runconsolelogs/outputfilewriter.go
+++ b/core/internal/runconsolelogs/outputfilewriter.go
@@ -137,7 +137,9 @@ func (w *outputFileWriter) writeToFile(
 		if err := w.createNewChunk(); err != nil {
 			w.broken = true
 			w.logger.CaptureError(
-				fmt.Errorf("runconsolelogs: failed to create chunk: %v", err))
+				"runconsolelogs",
+				fmt.Errorf("runconsolelogs: failed to create chunk: %v", err),
+			)
 			return
 		}
 	}
@@ -160,7 +162,10 @@ func (w *outputFileWriter) writeToFile(
 
 	if err := w.currentChunk.UpdateLines(lines); err != nil {
 		w.broken = true
-		w.logger.CaptureError(fmt.Errorf("failed to write to chunk: %v", err))
+		w.logger.CaptureError(
+			"runconsolelogs",
+			fmt.Errorf("failed to write to chunk: %v", err),
+		)
 		return
 	}
 

--- a/core/internal/runconsolelogs/runconsolelogs.go
+++ b/core/internal/runconsolelogs/runconsolelogs.go
@@ -240,8 +240,10 @@ func (s *Sender) StreamLogs(record *spb.OutputRawRecord) {
 
 	default:
 		s.logger.CaptureError(
+			"runconsolelogs",
 			errors.New("runconsolelogs: invalid OutputRawRecord type"),
-			"type", record.OutputType,
+			"type",
+			record.OutputType,
 		)
 	}
 }

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -110,7 +110,12 @@ func newUploader(
 
 func (u *uploader) Process(record *spb.FilesRecord) {
 	if err := u.lockForOperation("Process"); err != nil {
-		u.logger.CaptureError(err, "record", record)
+		u.logger.CaptureError(
+			"runfiles",
+			err,
+			"record",
+			record,
+		)
 		return
 	}
 	defer u.stateMu.Unlock()
@@ -121,10 +126,9 @@ func (u *uploader) Process(record *spb.FilesRecord) {
 		maybeRunPath, err := paths.Relative(file.GetPath())
 		if err != nil {
 			u.logger.CaptureError(
-				fmt.Errorf(
-					"runfiles: file path is not relative: %v",
-					err,
-				))
+				"runfiles",
+				fmt.Errorf("runfiles: file path is not relative: %v", err),
+			)
 			continue
 		}
 		runPath := *maybeRunPath
@@ -151,11 +155,13 @@ func (u *uploader) Process(record *spb.FilesRecord) {
 				u.uploadBatcher.Add([]paths.RelativePath{runPath})
 			}); err != nil {
 				u.logger.CaptureError(
+					"runfiles",
 					fmt.Errorf(
 						"runfiles: error watching file: %v",
 						err,
 					),
-					"path", file.GetPath())
+					"path", file.GetPath(),
+				)
 			}
 
 		case spb.FilesItem_END:
@@ -182,7 +188,7 @@ func (u *uploader) UploadNow(
 	category filetransfer.RunFileKind,
 ) {
 	if err := u.lockForOperation("UploadNow"); err != nil {
-		u.logger.CaptureError(err, "path", string(path))
+		u.logger.CaptureError("runfiles", err, "path", string(path))
 		return
 	}
 	defer u.stateMu.Unlock()
@@ -196,7 +202,7 @@ func (u *uploader) UploadAtEnd(
 	category filetransfer.RunFileKind,
 ) {
 	if err := u.lockForOperation("UploadAtEnd"); err != nil {
-		u.logger.CaptureError(err, "path", string(path))
+		u.logger.CaptureError("runfiles", err, "path", string(path))
 		return
 	}
 	defer u.stateMu.Unlock()
@@ -207,7 +213,7 @@ func (u *uploader) UploadAtEnd(
 
 func (u *uploader) UploadRemaining() {
 	if err := u.lockForOperation("UploadRemaining"); err != nil {
-		u.logger.CaptureError(err)
+		u.logger.CaptureError("runfiles", err)
 		return
 	}
 	defer u.stateMu.Unlock()
@@ -298,7 +304,7 @@ func (u *uploader) upload(runPaths []paths.RelativePath) {
 
 	runUpserter, err := u.runHandle.Upserter()
 	if err != nil {
-		u.logger.CaptureError(fmt.Errorf("runfiles: %v", err))
+		u.logger.CaptureError("runfiles", fmt.Errorf("runfiles: %v", err))
 		return
 	}
 	runFullID := runUpserter.RunPath()
@@ -323,13 +329,16 @@ func (u *uploader) upload(runPaths []paths.RelativePath) {
 		)
 		if err != nil {
 			u.logger.CaptureError(
-				fmt.Errorf("runfiles: CreateRunFiles returned error: %v", err))
+				"runfiles",
+				fmt.Errorf("runfiles: CreateRunFiles returned error: %v", err),
+			)
 			u.uploadWG.Add(-len(runPaths))
 			return
 		}
 
 		if len(createRunFilesResponse.CreateRunFiles.Files) != len(runPaths) {
 			u.logger.CaptureError(
+				"runfiles",
 				errors.New(
 					"runfiles: CreateRunFiles returned"+
 						" unexpected number of files"),
@@ -352,11 +361,13 @@ func (u *uploader) upload(runPaths []paths.RelativePath) {
 			maybeRunPath, err := paths.Relative(filepath.FromSlash(f.Name))
 			if err != nil || !maybeRunPath.IsLocal() {
 				u.logger.CaptureError(
+					"runfiles",
 					fmt.Errorf(
 						"runfiles: CreateRunFiles returned unexpected file name: %v",
 						err,
 					),
-					"response", createRunFilesResponse)
+					"response", createRunFilesResponse,
+				)
 				u.uploadWG.Done()
 				continue
 			}

--- a/core/internal/runsync/errors.go
+++ b/core/internal/runsync/errors.go
@@ -79,7 +79,7 @@ func LogSyncFailure(logger *observability.CoreLogger, err error) {
 	// If you're here from Sentry, please figure out where
 	// the error happens and wrap it in a SyncError with
 	// proper UserText. Or fix it so it can't happen.
-	logger.CaptureError(err)
+	logger.CaptureError("runsync", err)
 }
 
 // ToUserText returns user-facing text for the error, which may be a SyncError.

--- a/core/internal/runsync/logging.go
+++ b/core/internal/runsync/logging.go
@@ -76,7 +76,7 @@ func OpenDebugSyncLogFile(
 func NewSyncLogger(
 	logFile *DebugSyncLogFile,
 	logLevel slog.Level,
-	telemetryRecorder analytics.TelemetryRecorder,
+	telemetryRecorder *analytics.TelemetryRecorder,
 ) *observability.CoreLogger {
 	return observability.NewCoreLogger(
 		slog.New(

--- a/core/internal/runsync/logging.go
+++ b/core/internal/runsync/logging.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/fileutil"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
@@ -75,6 +76,7 @@ func OpenDebugSyncLogFile(
 func NewSyncLogger(
 	logFile *DebugSyncLogFile,
 	logLevel slog.Level,
+	telemetryProxy analytics.OpenTelemetryProxy,
 ) *observability.CoreLogger {
 	return observability.NewCoreLogger(
 		slog.New(
@@ -83,5 +85,6 @@ func NewSyncLogger(
 				&slog.HandlerOptions{Level: logLevel},
 			)),
 		observability.NewSentryContext(sentry.CurrentHub()),
+		telemetryProxy,
 	)
 }

--- a/core/internal/runsync/logging.go
+++ b/core/internal/runsync/logging.go
@@ -76,7 +76,7 @@ func OpenDebugSyncLogFile(
 func NewSyncLogger(
 	logFile *DebugSyncLogFile,
 	logLevel slog.Level,
-	telemetryProxy analytics.OpenTelemetryProxy,
+	telemetryRecorder analytics.TelemetryRecorder,
 ) *observability.CoreLogger {
 	return observability.NewCoreLogger(
 		slog.New(
@@ -85,6 +85,6 @@ func NewSyncLogger(
 				&slog.HandlerOptions{Level: logLevel},
 			)),
 		observability.NewSentryContext(sentry.CurrentHub()),
-		telemetryProxy,
+		telemetryRecorder,
 	)
 }

--- a/core/internal/runsync/runsyncer.go
+++ b/core/internal/runsync/runsyncer.go
@@ -184,13 +184,13 @@ func (rs *RunSyncer) markSynced() {
 func (rs *RunSyncer) printRunURL() {
 	upserter, err := rs.runHandle.Upserter()
 	if err != nil {
-		rs.logger.CaptureError(fmt.Errorf("runsync: printRunURL: %v", err))
+		rs.logger.CaptureError("runsync", fmt.Errorf("runsync: printRunURL: %v", err))
 		return
 	}
 
 	url, err := upserter.RunPath().URL(rs.settings.GetAppURL())
 	if err != nil {
-		rs.logger.CaptureError(fmt.Errorf("runsync: printRunURL: %v", err))
+		rs.logger.CaptureError("runsync", fmt.Errorf("runsync: printRunURL: %v", err))
 		return
 	}
 

--- a/core/internal/runsync/runsyncmanager.go
+++ b/core/internal/runsync/runsyncmanager.go
@@ -41,6 +41,7 @@ func (m *RunSyncManager) InitSync(
 
 	m.telemetryProxy = analytics.NewOpenTelemetryProxy(
 		settings.From(request.Settings).GetBaseURL(),
+		settings.From(request.Settings).GetAPIKey(),
 	)
 	if err := m.telemetryProxy.Start(context.Background()); err != nil {
 		slog.Error("runsync: failed to start telemetry proxy", "error", err)

--- a/core/internal/runsync/runsyncmanager.go
+++ b/core/internal/runsync/runsyncmanager.go
@@ -3,11 +3,8 @@ package runsync
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sync"
 
-	"github.com/wandb/wandb/core/internal/analytics"
-	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -20,8 +17,6 @@ type RunSyncManager struct {
 	ongoingSyncOps map[string]*RunSyncOperation
 
 	runSyncOperationFactory *RunSyncOperationFactory
-
-	telemetryProxy analytics.OpenTelemetryProxy
 }
 
 func NewRunSyncManager() *RunSyncManager {
@@ -38,11 +33,6 @@ func (m *RunSyncManager) InitSync(
 ) *spb.ServerInitSyncResponse {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	m.telemetryProxy = analytics.NewOpenTelemetryProxy(
-		context.Background(),
-		settings.From(request.Settings),
-	)
 
 	id := fmt.Sprintf("sync-%d", m.nextID)
 	m.nextID++
@@ -85,10 +75,6 @@ func (m *RunSyncManager) DoSync(
 	m.mu.Lock()
 	delete(m.ongoingSyncOps, request.Id)
 	m.mu.Unlock()
-
-	if err := m.telemetryProxy.Shutdown(context.Background()); err != nil {
-		slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
-	}
 
 	return response
 }

--- a/core/internal/runsync/runsyncmanager.go
+++ b/core/internal/runsync/runsyncmanager.go
@@ -40,8 +40,7 @@ func (m *RunSyncManager) InitSync(
 	defer m.mu.Unlock()
 
 	m.telemetryProxy = analytics.NewOpenTelemetryProxy(
-		settings.From(request.Settings).GetBaseURL(),
-		settings.From(request.Settings).GetAPIKey(),
+		settings.From(request.Settings),
 	)
 	if err := m.telemetryProxy.Start(context.Background()); err != nil {
 		slog.Error("runsync: failed to start telemetry proxy", "error", err)

--- a/core/internal/runsync/runsyncmanager.go
+++ b/core/internal/runsync/runsyncmanager.go
@@ -3,8 +3,11 @@ package runsync
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
+	"github.com/wandb/wandb/core/internal/analytics"
+	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -17,6 +20,8 @@ type RunSyncManager struct {
 	ongoingSyncOps map[string]*RunSyncOperation
 
 	runSyncOperationFactory *RunSyncOperationFactory
+
+	telemetryProxy analytics.OpenTelemetryProxy
 }
 
 func NewRunSyncManager() *RunSyncManager {
@@ -33,6 +38,13 @@ func (m *RunSyncManager) InitSync(
 ) *spb.ServerInitSyncResponse {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	m.telemetryProxy = analytics.NewOpenTelemetryProxy(
+		settings.From(request.Settings).GetBaseURL(),
+	)
+	if err := m.telemetryProxy.Start(context.Background()); err != nil {
+		slog.Error("runsync: failed to start telemetry proxy", "error", err)
+	}
 
 	id := fmt.Sprintf("sync-%d", m.nextID)
 	m.nextID++
@@ -75,6 +87,10 @@ func (m *RunSyncManager) DoSync(
 	m.mu.Lock()
 	delete(m.ongoingSyncOps, request.Id)
 	m.mu.Unlock()
+
+	if err := m.telemetryProxy.Shutdown(context.Background()); err != nil {
+		slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
+	}
 
 	return response
 }

--- a/core/internal/runsync/runsyncmanager.go
+++ b/core/internal/runsync/runsyncmanager.go
@@ -40,11 +40,9 @@ func (m *RunSyncManager) InitSync(
 	defer m.mu.Unlock()
 
 	m.telemetryProxy = analytics.NewOpenTelemetryProxy(
+		context.Background(),
 		settings.From(request.Settings),
 	)
-	if err := m.telemetryProxy.Start(context.Background()); err != nil {
-		slog.Error("runsync: failed to start telemetry proxy", "error", err)
-	}
 
 	id := fmt.Sprintf("sync-%d", m.nextID)
 	m.nextID++

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -40,12 +41,18 @@ func (f *RunSyncOperationFactory) New(
 		printer: observability.NewPrinter(printerBufferSize),
 	}
 
-	logFile, err := OpenDebugSyncLogFile(settings.From(globalSettings))
+	wandbSettings := settings.From(globalSettings)
+	telemetryProxy := analytics.NewOpenTelemetryProxy(wandbSettings.GetBaseURL())
+	if err := telemetryProxy.Start(context.Background()); err != nil {
+		slog.Error("runsync: failed to start telemetry proxy", "error", err)
+	}
+
+	logFile, err := OpenDebugSyncLogFile(wandbSettings)
 	if err != nil {
 		slog.Error("runsync: couldn't create log file", "error", err)
 	}
 	op.logFile = logFile
-	op.logger = NewSyncLogger(logFile, slog.LevelInfo)
+	op.logger = NewSyncLogger(logFile, slog.LevelInfo, telemetryProxy)
 
 	for _, userPath := range paths {
 		var path string

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -42,7 +42,10 @@ func (f *RunSyncOperationFactory) New(
 	}
 
 	wandbSettings := settings.From(globalSettings)
-	telemetryProxy := analytics.NewOpenTelemetryProxy(wandbSettings.GetBaseURL())
+	telemetryProxy := analytics.NewOpenTelemetryProxy(
+		wandbSettings.GetBaseURL(),
+		wandbSettings.GetAPIKey(),
+	)
 	if err := telemetryProxy.Start(context.Background()); err != nil {
 		slog.Error("runsync: failed to start telemetry proxy", "error", err)
 	}

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -28,6 +28,8 @@ type RunSyncOperation struct {
 
 	logFile *DebugSyncLogFile
 	logger  *observability.CoreLogger
+
+	telemetryProxy analytics.OpenTelemetryProxy
 }
 
 func (f *RunSyncOperationFactory) New(
@@ -37,15 +39,16 @@ func (f *RunSyncOperationFactory) New(
 	live bool,
 	globalSettings *spb.Settings,
 ) *RunSyncOperation {
-	op := &RunSyncOperation{
-		printer: observability.NewPrinter(printerBufferSize),
-	}
-
 	wandbSettings := settings.From(globalSettings)
 	telemetryProxy := analytics.NewOpenTelemetryProxy(
 		context.Background(),
 		wandbSettings,
 	)
+
+	op := &RunSyncOperation{
+		printer:        observability.NewPrinter(printerBufferSize),
+		telemetryProxy: telemetryProxy,
+	}
 
 	logFile, err := OpenDebugSyncLogFile(wandbSettings)
 	if err != nil {
@@ -116,6 +119,10 @@ func (op *RunSyncOperation) Do(
 	}
 
 	_ = group.Wait()
+
+	if err := op.telemetryProxy.Shutdown(ctx); err != nil {
+		slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
+	}
 
 	return &spb.ServerSyncResponse{
 		Messages: op.popMessages(),

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -29,7 +29,7 @@ type RunSyncOperation struct {
 	logFile *DebugSyncLogFile
 	logger  *observability.CoreLogger
 
-	telemetryProxy analytics.OpenTelemetryProxy
+	telemetryProxy *analytics.OpenTelemetryProxy
 }
 
 func (f *RunSyncOperationFactory) New(
@@ -44,6 +44,10 @@ func (f *RunSyncOperationFactory) New(
 		context.Background(),
 		wandbSettings,
 	)
+	telemetryRecorder := analytics.NewTelemetryRecorder(
+		telemetryProxy,
+		analytics.NewTelemetryContext(),
+	)
 
 	op := &RunSyncOperation{
 		printer:        observability.NewPrinter(printerBufferSize),
@@ -55,7 +59,7 @@ func (f *RunSyncOperationFactory) New(
 		slog.Error("runsync: couldn't create log file", "error", err)
 	}
 	op.logFile = logFile
-	op.logger = NewSyncLogger(logFile, slog.LevelInfo, telemetryProxy)
+	op.logger = NewSyncLogger(logFile, slog.LevelInfo, telemetryRecorder)
 
 	for _, userPath := range paths {
 		var path string
@@ -120,8 +124,10 @@ func (op *RunSyncOperation) Do(
 
 	_ = group.Wait()
 
-	if err := op.telemetryProxy.Shutdown(ctx); err != nil {
-		slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
+	if op.telemetryProxy != nil {
+		if err := op.telemetryProxy.Shutdown(ctx); err != nil {
+			slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
+		}
 	}
 
 	return &spb.ServerSyncResponse{

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -42,10 +42,10 @@ func (f *RunSyncOperationFactory) New(
 	}
 
 	wandbSettings := settings.From(globalSettings)
-	telemetryProxy := analytics.NewOpenTelemetryProxy(wandbSettings)
-	if err := telemetryProxy.Start(context.Background()); err != nil {
-		slog.Error("runsync: failed to start telemetry proxy", "error", err)
-	}
+	telemetryProxy := analytics.NewOpenTelemetryProxy(
+		context.Background(),
+		wandbSettings,
+	)
 
 	logFile, err := OpenDebugSyncLogFile(wandbSettings)
 	if err != nil {

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -42,10 +42,7 @@ func (f *RunSyncOperationFactory) New(
 	}
 
 	wandbSettings := settings.From(globalSettings)
-	telemetryProxy := analytics.NewOpenTelemetryProxy(
-		wandbSettings.GetBaseURL(),
-		wandbSettings.GetAPIKey(),
-	)
+	telemetryProxy := analytics.NewOpenTelemetryProxy(wandbSettings)
 	if err := telemetryProxy.Start(context.Background()); err != nil {
 		slog.Error("runsync: failed to start telemetry proxy", "error", err)
 	}

--- a/core/internal/runupserter/runupdatework.go
+++ b/core/internal/runupserter/runupdatework.go
@@ -116,9 +116,12 @@ func (w *RunUpdateWork) initRun(request *runwork.Request) {
 	err = w.RunHandle.Init(upserter)
 	if err != nil {
 		w.Logger.CaptureError(
+			"runupserter",
 			fmt.Errorf(
 				"runupserter: failed to set run after initializing: %v",
-				err))
+				err,
+			),
+		)
 
 		if w.Record.Control.GetMailboxSlot() != "" {
 			respondRunUpdate(request, runInitErrorResult(err))

--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -278,7 +278,9 @@ func (upserter *RunUpserter) UpdateConfig(config *spb.ConfigRecord) {
 	upserter.config.ApplyChangeRecord(config,
 		func(err error) {
 			upserter.logger.CaptureError(
-				fmt.Errorf("runupserter: error updating config: %v", err))
+				"runupserter",
+				fmt.Errorf("runupserter: error updating config: %v", err),
+			)
 		})
 
 	upserter.isConfigDirty = true
@@ -333,7 +335,9 @@ func (upserter *RunUpserter) UpdateMetrics(metric *spb.MetricRecord) {
 	err := upserter.metrics.ProcessRecord(metric)
 	if err != nil {
 		upserter.logger.CaptureError(
-			fmt.Errorf("runupserter: failed to process metric: %v", err))
+			"runupserter",
+			fmt.Errorf("runupserter: failed to process metric: %v", err),
+		)
 		return
 	}
 

--- a/core/internal/runwork/runwork.go
+++ b/core/internal/runwork/runwork.go
@@ -169,7 +169,7 @@ func (rw *runWork) AddWorkOrCancel(
 
 		case <-rw.closed:
 			// Here, Close() must have been called, so we should drop the record.
-			rw.logger.CaptureError(errRecordAfterClose, "work", work)
+			rw.logger.CaptureError("runwork", errRecordAfterClose, "work", work)
 			work.Request.WillNotRespond()
 			return
 

--- a/core/internal/runwork/runwork_test.go
+++ b/core/internal/runwork/runwork_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runwork"
@@ -76,7 +77,11 @@ func TestAddWorkConcurrent(t *testing.T) {
 func TestAddWorkAfterClose(t *testing.T) {
 	logs := bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{}))
-	rw := runwork.New(0, observability.NewCoreLogger(logger, nil, nil))
+	rw := runwork.New(0, observability.NewCoreLogger(
+		logger,
+		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
+	))
 	req := newTestRequest(t)
 
 	rw.Close()
@@ -92,7 +97,11 @@ func TestAddWorkAfterClose(t *testing.T) {
 func TestCloseDuringAddWork(t *testing.T) {
 	logs := bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{}))
-	rw := runwork.New(0, observability.NewCoreLogger(logger, nil, nil))
+	rw := runwork.New(0, observability.NewCoreLogger(
+		logger,
+		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
+	))
 	req := newTestRequest(t)
 
 	go func() {

--- a/core/internal/runwork/runwork_test.go
+++ b/core/internal/runwork/runwork_test.go
@@ -76,7 +76,7 @@ func TestAddWorkConcurrent(t *testing.T) {
 func TestAddWorkAfterClose(t *testing.T) {
 	logs := bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{}))
-	rw := runwork.New(0, observability.NewCoreLogger(logger, nil))
+	rw := runwork.New(0, observability.NewCoreLogger(logger, nil, nil))
 	req := newTestRequest(t)
 
 	rw.Close()
@@ -92,7 +92,7 @@ func TestAddWorkAfterClose(t *testing.T) {
 func TestCloseDuringAddWork(t *testing.T) {
 	logs := bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{}))
-	rw := runwork.New(0, observability.NewCoreLogger(logger, nil))
+	rw := runwork.New(0, observability.NewCoreLogger(logger, nil, nil))
 	req := newTestRequest(t)
 
 	go func() {

--- a/core/internal/stream/flowcontrol.go
+++ b/core/internal/stream/flowcontrol.go
@@ -57,7 +57,7 @@ func (f *FlowControlFactory) New(
 // Closes the output channel and the transaction log reader after completing.
 func (fc *FlowControl) Do(savedWork <-chan runwork.MaybeSavedWork) {
 	go func() {
-		defer fc.logger.Reraise()
+		defer fc.logger.Reraise("flowcontrol")
 
 		for work := range savedWork {
 			fc.buffer.Add(work)
@@ -93,7 +93,7 @@ func (fc *FlowControl) loopFlushBuffer() {
 				err := fc.readSavedChunk(chunk)
 
 				if err != nil {
-					fc.logger.CaptureError(err, "chunk", chunk)
+					fc.logger.CaptureError("flowcontrol", err, "chunk", chunk)
 					fc.buffer.StopOffloading()
 				}
 			},

--- a/core/internal/stream/flowcontrol.go
+++ b/core/internal/stream/flowcontrol.go
@@ -57,7 +57,7 @@ func (f *FlowControlFactory) New(
 // Closes the output channel and the transaction log reader after completing.
 func (fc *FlowControl) Do(savedWork <-chan runwork.MaybeSavedWork) {
 	go func() {
-		defer fc.logger.Reraise("flowcontrol")
+		defer fc.logger.Reraise("stream")
 
 		for work := range savedWork {
 			fc.buffer.Add(work)
@@ -93,7 +93,7 @@ func (fc *FlowControl) loopFlushBuffer() {
 				err := fc.readSavedChunk(chunk)
 
 				if err != nil {
-					fc.logger.CaptureError("flowcontrol", err, "chunk", chunk)
+					fc.logger.CaptureError("stream", err, "chunk", chunk)
 					fc.buffer.StopOffloading()
 				}
 			},

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -154,7 +154,7 @@ func (h *Handler) OutChan() <-chan runwork.Work {
 //
 //gocyclo:ignore
 func (h *Handler) Do(allWork <-chan runwork.Work) {
-	defer h.logger.Reraise()
+	defer h.logger.Reraise("handler")
 	h.logger.Info("handler: started")
 	for work := range allWork {
 		h.logger.Debug("handler: got work", "work", work)
@@ -237,10 +237,14 @@ func (h *Handler) handleRecord(record *spb.Record, request *runwork.Request) {
 		h.handleSummary(x.Summary)
 	case nil:
 		h.logger.CaptureFatalAndPanic(
-			errors.New("handler: handleRecord: record type is nil"))
+			"handler",
+			errors.New("handler: handleRecord: record type is nil"),
+		)
 	default:
 		h.logger.CaptureFatalAndPanic(
-			fmt.Errorf("handler: handleRecord: unknown record type %T", x))
+			"handler",
+			fmt.Errorf("handler: handleRecord: unknown record type %T", x),
+		)
 	}
 }
 
@@ -325,10 +329,14 @@ func (h *Handler) handleRequest(
 		h.handleRequestProbeSystemInfo(record)
 	case nil:
 		h.logger.CaptureFatalAndPanic(
-			errors.New("handler: handleRequest: request type is nil"))
+			"handler.handleRequest",
+			errors.New("handler: handleRequest: request type is nil"),
+		)
 	default:
 		h.logger.CaptureFatalAndPanic(
-			fmt.Errorf("handler: handleRequest: unknown request type %T", x))
+			"handler.handleRequest",
+			fmt.Errorf("handler: handleRequest: unknown request type %T", x),
+		)
 	}
 }
 
@@ -370,14 +378,18 @@ func (h *Handler) handleMetric(record *spb.Record) {
 	metric := record.GetMetric()
 	if metric == nil {
 		h.logger.CaptureError(
-			errors.New("handler: bad record type for handleMetric"))
+			"handler",
+			errors.New("handler: bad record type for handleMetric"),
+		)
 		return
 	}
 
 	if err := h.metricHandler.ProcessRecord(metric); err != nil {
 		h.logger.CaptureError(
+			"handler",
 			fmt.Errorf("handler: cannot add metric: %v", err),
-			"metric", metric)
+			"metric", metric,
+		)
 		return
 	}
 
@@ -492,7 +504,9 @@ func (h *Handler) handleRequestRunStart(
 
 	if h.runRecord, ok = proto.Clone(run).(*spb.RunRecord); !ok {
 		h.logger.CaptureFatalAndPanic(
-			errors.New("handleRunStart: failed to clone run"))
+			"handler.handleRequestRunStart",
+			errors.New("handleRunStart: failed to clone run"),
+		)
 	}
 	h.fwdRecord(record, request)
 
@@ -743,7 +757,9 @@ func (h *Handler) handleRequestGetSummary(
 	// able to produce.
 	if err != nil {
 		h.logger.CaptureError(
-			fmt.Errorf("handler: error flattening run summary: %v", err))
+			"handler",
+			fmt.Errorf("handler: error flattening run summary: %v", err),
+		)
 	}
 
 	response.ResponseType = &spb.Response_GetSummaryResponse{
@@ -853,7 +869,9 @@ func (h *Handler) handleRequestJobInput(
 func (h *Handler) handleSummary(summary *spb.SummaryRecord) {
 	if err := runsummary.FromProto(summary).Apply(h.runSummary); err != nil {
 		h.logger.CaptureError(
-			fmt.Errorf("handler: error processing summary: %v", err))
+			"handler",
+			fmt.Errorf("handler: error processing summary: %v", err),
+		)
 	}
 }
 
@@ -948,8 +966,10 @@ func (h *Handler) handlePartialHistoryAsync(request *spb.PartialHistoryRequest) 
 
 		if err != nil {
 			h.logger.CaptureError(
+				"handler",
 				fmt.Errorf("handler: failed to set history metric: %v", err),
-				"item", item)
+				"item", item,
+			)
 		}
 	}
 
@@ -997,8 +1017,10 @@ func (h *Handler) handlePartialHistorySync(request *spb.PartialHistoryRequest) {
 		err := h.partialHistory.SetFromRecord(item)
 		if err != nil {
 			h.logger.CaptureError(
+				"handler",
 				fmt.Errorf("handler: failed to set history metric: %v", err),
-				"item", item)
+				"item", item,
+			)
 		}
 	}
 
@@ -1075,7 +1097,9 @@ func (h *Handler) flushPartialHistory(useStep bool, nextStep int64) {
 	// Report errors, but continue anyway to drop as little data as possible.
 	if err != nil {
 		h.logger.CaptureError(
-			fmt.Errorf("handler: error flattening run history: %v", err))
+			"handler",
+			fmt.Errorf("handler: error flattening run history: %v", err),
+		)
 		h.terminalPrinter.Warnf(
 			"There was an issue processing run metrics in step %d;"+
 				" some data may be missing.",
@@ -1103,7 +1127,9 @@ func (h *Handler) updateSummary() {
 	// We continue despite errors to update as much of the summary as we can.
 	if err != nil {
 		h.logger.CaptureError(
-			fmt.Errorf("handler: error updating summary: %v", err))
+			"handler",
+			fmt.Errorf("handler: error updating summary: %v", err),
+		)
 	}
 
 	if len(updates) == 0 {

--- a/core/internal/stream/handler.go
+++ b/core/internal/stream/handler.go
@@ -154,7 +154,7 @@ func (h *Handler) OutChan() <-chan runwork.Work {
 //
 //gocyclo:ignore
 func (h *Handler) Do(allWork <-chan runwork.Work) {
-	defer h.logger.Reraise("handler")
+	defer h.logger.Reraise("stream")
 	h.logger.Info("handler: started")
 	for work := range allWork {
 		h.logger.Debug("handler: got work", "work", work)
@@ -237,12 +237,12 @@ func (h *Handler) handleRecord(record *spb.Record, request *runwork.Request) {
 		h.handleSummary(x.Summary)
 	case nil:
 		h.logger.CaptureFatalAndPanic(
-			"handler",
+			"stream",
 			errors.New("handler: handleRecord: record type is nil"),
 		)
 	default:
 		h.logger.CaptureFatalAndPanic(
-			"handler",
+			"stream",
 			fmt.Errorf("handler: handleRecord: unknown record type %T", x),
 		)
 	}
@@ -329,12 +329,12 @@ func (h *Handler) handleRequest(
 		h.handleRequestProbeSystemInfo(record)
 	case nil:
 		h.logger.CaptureFatalAndPanic(
-			"handler.handleRequest",
+			"stream",
 			errors.New("handler: handleRequest: request type is nil"),
 		)
 	default:
 		h.logger.CaptureFatalAndPanic(
-			"handler.handleRequest",
+			"stream",
 			fmt.Errorf("handler: handleRequest: unknown request type %T", x),
 		)
 	}
@@ -378,7 +378,7 @@ func (h *Handler) handleMetric(record *spb.Record) {
 	metric := record.GetMetric()
 	if metric == nil {
 		h.logger.CaptureError(
-			"handler",
+			"stream",
 			errors.New("handler: bad record type for handleMetric"),
 		)
 		return
@@ -386,7 +386,7 @@ func (h *Handler) handleMetric(record *spb.Record) {
 
 	if err := h.metricHandler.ProcessRecord(metric); err != nil {
 		h.logger.CaptureError(
-			"handler",
+			"stream",
 			fmt.Errorf("handler: cannot add metric: %v", err),
 			"metric", metric,
 		)
@@ -504,7 +504,7 @@ func (h *Handler) handleRequestRunStart(
 
 	if h.runRecord, ok = proto.Clone(run).(*spb.RunRecord); !ok {
 		h.logger.CaptureFatalAndPanic(
-			"handler.handleRequestRunStart",
+			"stream",
 			errors.New("handleRunStart: failed to clone run"),
 		)
 	}
@@ -757,7 +757,7 @@ func (h *Handler) handleRequestGetSummary(
 	// able to produce.
 	if err != nil {
 		h.logger.CaptureError(
-			"handler",
+			"stream",
 			fmt.Errorf("handler: error flattening run summary: %v", err),
 		)
 	}
@@ -869,7 +869,7 @@ func (h *Handler) handleRequestJobInput(
 func (h *Handler) handleSummary(summary *spb.SummaryRecord) {
 	if err := runsummary.FromProto(summary).Apply(h.runSummary); err != nil {
 		h.logger.CaptureError(
-			"handler",
+			"stream",
 			fmt.Errorf("handler: error processing summary: %v", err),
 		)
 	}
@@ -966,7 +966,7 @@ func (h *Handler) handlePartialHistoryAsync(request *spb.PartialHistoryRequest) 
 
 		if err != nil {
 			h.logger.CaptureError(
-				"handler",
+				"stream",
 				fmt.Errorf("handler: failed to set history metric: %v", err),
 				"item", item,
 			)
@@ -1017,7 +1017,7 @@ func (h *Handler) handlePartialHistorySync(request *spb.PartialHistoryRequest) {
 		err := h.partialHistory.SetFromRecord(item)
 		if err != nil {
 			h.logger.CaptureError(
-				"handler",
+				"stream",
 				fmt.Errorf("handler: failed to set history metric: %v", err),
 				"item", item,
 			)
@@ -1097,7 +1097,7 @@ func (h *Handler) flushPartialHistory(useStep bool, nextStep int64) {
 	// Report errors, but continue anyway to drop as little data as possible.
 	if err != nil {
 		h.logger.CaptureError(
-			"handler",
+			"stream",
 			fmt.Errorf("handler: error flattening run history: %v", err),
 		)
 		h.terminalPrinter.Warnf(
@@ -1127,7 +1127,7 @@ func (h *Handler) updateSummary() {
 	// We continue despite errors to update as much of the summary as we can.
 	if err != nil {
 		h.logger.CaptureError(
-			"handler",
+			"stream",
 			fmt.Errorf("handler: error updating summary: %v", err),
 		)
 	}

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -221,7 +221,7 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 
 // Do processes all work on the input channel.
 func (s *Sender) Do(allWork <-chan runwork.Work) {
-	defer s.logger.Reraise()
+	defer s.logger.Reraise("sender")
 	s.logger.Info("sender: started")
 
 	hangDetectionInChan := make(chan runwork.Work, 32)
@@ -351,14 +351,21 @@ func (s *Sender) sendRecord(record *spb.Record, request *runwork.Request) {
 		s.sendArtifact(record, x.Artifact)
 	case nil:
 		s.logger.CaptureFatalAndPanic(
+			"sender",
 			fmt.Errorf(
 				"sender: sendRecord: nil RecordType, number %d",
-				record.GetNum()))
+				record.GetNum(),
+			),
+		)
 	default:
 		s.logger.CaptureFatalAndPanic(
+			"sender",
 			fmt.Errorf(
 				"sender: sendRecord: unexpected type %T, number %d",
-				x, record.GetNum()))
+				x,
+				record.GetNum(),
+			),
+		)
 	}
 }
 
@@ -391,10 +398,14 @@ func (s *Sender) sendRequest(
 		s.sendRequestJobInput(x.JobInput)
 	case nil:
 		s.logger.CaptureFatalAndPanic(
-			errors.New("sender: sendRequest: nil RequestType"))
+			"sender",
+			errors.New("sender: sendRequest: nil RequestType"),
+		)
 	default:
 		s.logger.CaptureFatalAndPanic(
-			fmt.Errorf("sender: sendRequest: unexpected type %T", x))
+			"sender",
+			fmt.Errorf("sender: sendRequest: unexpected type %T", x),
+		)
 	}
 }
 
@@ -433,7 +444,9 @@ func (s *Sender) sendRequestRunStart(_ *spb.RunStartRequest) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: sendRequestRunStart: %v", err))
+			"sender",
+			fmt.Errorf("sender: sendRequestRunStart: %v", err),
+		)
 		return
 	}
 
@@ -481,7 +494,10 @@ func (s *Sender) sendJobFlush() {
 
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: sendJobFlush: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: sendJobFlush: %v", err),
+		)
 		return
 	}
 
@@ -515,7 +531,9 @@ func (s *Sender) sendJobFlush() {
 	)
 	if result.Err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to save job artifact: %v", result.Err))
+			"sender",
+			fmt.Errorf("sender: failed to save job artifact: %v", result.Err),
+		)
 	}
 }
 
@@ -529,7 +547,7 @@ func (s *Sender) startFinishRun(
 	exitRequest *runwork.Request,
 ) {
 	go func() {
-		defer s.logger.Reraise()
+		defer s.logger.Reraise("sender")
 		s.finishRunSync(exitRecord, exitRequest)
 	}()
 }
@@ -662,7 +680,10 @@ func (s *Sender) respondExit(
 func (s *Sender) sendTelemetry(_ *spb.Record, telemetry *spb.TelemetryRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: sendTelemetry: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: sendTelemetry: %v", err),
+		)
 		return
 	}
 
@@ -672,7 +693,10 @@ func (s *Sender) sendTelemetry(_ *spb.Record, telemetry *spb.TelemetryRecord) {
 func (s *Sender) sendEnvironment(environment *spb.EnvironmentRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: sendMetadata: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: sendMetadata: %v", err),
+		)
 		return
 	}
 
@@ -694,14 +718,22 @@ func (s *Sender) uploadMetadataFile() {
 
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: uploadMetadataFile: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: uploadMetadataFile: %v", err),
+		)
 		return
 	}
 
 	environment, err := upserter.EnvironmentJSON()
 	if err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to serialize run environment info: %v", err))
+			"sender",
+			fmt.Errorf(
+				"sender: failed to serialize run environment info: %v",
+				err,
+			),
+		)
 		return
 	}
 
@@ -711,7 +743,13 @@ func (s *Sender) uploadMetadataFile() {
 		filetransfer.RunFileKindWandb,
 	); err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to upload run's %s file: %v", MetaFileName, err))
+			"sender",
+			fmt.Errorf(
+				"sender: failed to upload run's %s file: %v",
+				MetaFileName,
+				err,
+			),
+		)
 	}
 }
 
@@ -791,7 +829,9 @@ func (s *Sender) sendSummary(_ *spb.Record, summary *spb.SummaryRecord) {
 	updates := runsummary.FromProto(summary)
 	if err := updates.Apply(s.runSummary); err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: error updating summary: %v", err))
+			"sender",
+			fmt.Errorf("sender: error updating summary: %v", err),
+		)
 	}
 
 	if s.fileStream != nil {
@@ -811,7 +851,9 @@ func (s *Sender) uploadSummaryFile() {
 	summary, err := s.runSummary.Serialize()
 	if err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to serialize run summary: %v", err))
+			"sender",
+			fmt.Errorf("sender: failed to serialize run summary: %v", err),
+		)
 		return
 	}
 
@@ -821,7 +863,9 @@ func (s *Sender) uploadSummaryFile() {
 		filetransfer.RunFileKindWandb,
 	); err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to upload run summary: %v", err))
+			"sender",
+			fmt.Errorf("sender: failed to upload run summary: %v", err),
+		)
 	}
 }
 
@@ -836,14 +880,19 @@ func (s *Sender) uploadConfigFile() {
 
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: uploadConfigFile: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: uploadConfigFile: %v", err),
+		)
 		return
 	}
 
 	config, err := upserter.ConfigYAML()
 	if err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to serialize run config: %v", err))
+			"sender",
+			fmt.Errorf("sender: failed to serialize run config: %v", err),
+		)
 		return
 	}
 
@@ -853,7 +902,9 @@ func (s *Sender) uploadConfigFile() {
 		filetransfer.RunFileKindWandb,
 	); err != nil {
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to upload run config: %v", err))
+			"sender",
+			fmt.Errorf("sender: failed to upload run config: %v", err),
+		)
 	}
 }
 
@@ -895,7 +946,10 @@ func (s *Sender) scheduleFileUpload(
 func (s *Sender) sendConfig(_ *spb.Record, configRecord *spb.ConfigRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: sendConfig: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: sendConfig: %v", err),
+		)
 		return
 	}
 
@@ -915,7 +969,10 @@ func (s *Sender) sendSystemMetrics(record *spb.StatsRecord) {
 
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: sendSystemMetrics: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: sendSystemMetrics: %v", err),
+		)
 		return
 	}
 
@@ -926,7 +983,9 @@ func (s *Sender) sendSystemMetrics(record *spb.StatsRecord) {
 	startTime := upserter.StartTime()
 	if startTime.IsZero() {
 		s.logger.CaptureError(
-			errors.New("sender: sendSystemMetrics: start time not set"))
+			"sender",
+			errors.New("sender: sendSystemMetrics: start time not set"),
+		)
 		return
 	}
 
@@ -970,7 +1029,10 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureFatalAndPanic(fmt.Errorf("sender: sendAlert: %v", err))
+		s.logger.CaptureFatalAndPanic(
+			"sender",
+			fmt.Errorf("sender: sendAlert: %v", err),
+		)
 		return
 	}
 	runPath := upserter.RunPath()
@@ -991,10 +1053,12 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 	)
 	if err != nil {
 		s.logger.CaptureError(
+			"sender",
 			fmt.Errorf(
 				"sender: sendAlert: failed to notify scriptable run alert: %v",
 				err,
-			))
+			),
+		)
 	} else {
 		s.logger.Info("sender: sendAlert: notified scriptable run alert", "data", data)
 	}
@@ -1009,7 +1073,9 @@ func (s *Sender) sendExit(
 ) {
 	if s.receivedExit {
 		s.logger.CaptureError(
-			errors.New("sender: received exit more than once, ignoring"))
+			"sender",
+			errors.New("sender: received exit more than once, ignoring"),
+		)
 		request.WillNotRespond()
 		return
 	}
@@ -1023,7 +1089,10 @@ func (s *Sender) sendExit(
 func (s *Sender) sendMetric(_ *spb.Record, metrics *spb.MetricRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
-		s.logger.CaptureError(fmt.Errorf("sender: sendMetric: %v", err))
+		s.logger.CaptureError(
+			"sender",
+			fmt.Errorf("sender: sendMetric: %v", err),
+		)
 		return
 	}
 
@@ -1062,8 +1131,10 @@ func (s *Sender) sendArtifact(_ *spb.Record, msg *spb.ArtifactRecord) {
 		op.Finish()
 		if result.Err != nil {
 			s.logger.CaptureError(
+				"sender",
 				fmt.Errorf("sender: failed to log artifact: %v", result.Err),
-				"artifactID", result.ArtifactID)
+				"artifactID", result.ArtifactID,
+			)
 		}
 	}()
 }
@@ -1097,6 +1168,7 @@ func (s *Sender) sendRequestLogArtifact(
 			response.ErrorMessage = result.Err.Error()
 			// TODO: it will send error to sentry, do we want it?
 			s.logger.CaptureError(
+				"sender",
 				fmt.Errorf("sender: failed to log artifact: %v", result.Err),
 				"artifactID", result.ArtifactID,
 			)
@@ -1146,7 +1218,9 @@ func (s *Sender) sendRequestDownloadArtifact(
 	).Download(); err != nil {
 		// Online mode handling: error during download
 		s.logger.CaptureError(
-			fmt.Errorf("sender: failed to download artifact: %v", err))
+			"sender",
+			fmt.Errorf("sender: failed to download artifact: %v", err),
+		)
 		response.ErrorMessage = err.Error()
 	}
 
@@ -1179,5 +1253,8 @@ func (s *Sender) sendRequestJobInput(request *spb.JobInputRequest) {
 // logCalledAfterExit logs an error for a method wrongly called after an Exit
 // record has been received.
 func (s *Sender) logCalledAfterExit(method string) {
-	s.logger.CaptureError(fmt.Errorf("sender: %s called after exit", method))
+	s.logger.CaptureError(
+		"sender",
+		fmt.Errorf("sender: %s called after exit", method),
+	)
 }

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -221,7 +221,7 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 
 // Do processes all work on the input channel.
 func (s *Sender) Do(allWork <-chan runwork.Work) {
-	defer s.logger.Reraise("sender")
+	defer s.logger.Reraise("stream")
 	s.logger.Info("sender: started")
 
 	hangDetectionInChan := make(chan runwork.Work, 32)
@@ -351,7 +351,7 @@ func (s *Sender) sendRecord(record *spb.Record, request *runwork.Request) {
 		s.sendArtifact(record, x.Artifact)
 	case nil:
 		s.logger.CaptureFatalAndPanic(
-			"sender",
+			"stream",
 			fmt.Errorf(
 				"sender: sendRecord: nil RecordType, number %d",
 				record.GetNum(),
@@ -359,7 +359,7 @@ func (s *Sender) sendRecord(record *spb.Record, request *runwork.Request) {
 		)
 	default:
 		s.logger.CaptureFatalAndPanic(
-			"sender",
+			"stream",
 			fmt.Errorf(
 				"sender: sendRecord: unexpected type %T, number %d",
 				x,
@@ -398,12 +398,12 @@ func (s *Sender) sendRequest(
 		s.sendRequestJobInput(x.JobInput)
 	case nil:
 		s.logger.CaptureFatalAndPanic(
-			"sender",
+			"stream",
 			errors.New("sender: sendRequest: nil RequestType"),
 		)
 	default:
 		s.logger.CaptureFatalAndPanic(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendRequest: unexpected type %T", x),
 		)
 	}
@@ -444,7 +444,7 @@ func (s *Sender) sendRequestRunStart(_ *spb.RunStartRequest) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendRequestRunStart: %v", err),
 		)
 		return
@@ -495,7 +495,7 @@ func (s *Sender) sendJobFlush() {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendJobFlush: %v", err),
 		)
 		return
@@ -531,7 +531,7 @@ func (s *Sender) sendJobFlush() {
 	)
 	if result.Err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: failed to save job artifact: %v", result.Err),
 		)
 	}
@@ -547,7 +547,7 @@ func (s *Sender) startFinishRun(
 	exitRequest *runwork.Request,
 ) {
 	go func() {
-		defer s.logger.Reraise("sender")
+		defer s.logger.Reraise("stream")
 		s.finishRunSync(exitRecord, exitRequest)
 	}()
 }
@@ -681,7 +681,7 @@ func (s *Sender) sendTelemetry(_ *spb.Record, telemetry *spb.TelemetryRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendTelemetry: %v", err),
 		)
 		return
@@ -694,7 +694,7 @@ func (s *Sender) sendEnvironment(environment *spb.EnvironmentRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendMetadata: %v", err),
 		)
 		return
@@ -719,7 +719,7 @@ func (s *Sender) uploadMetadataFile() {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: uploadMetadataFile: %v", err),
 		)
 		return
@@ -728,7 +728,7 @@ func (s *Sender) uploadMetadataFile() {
 	environment, err := upserter.EnvironmentJSON()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf(
 				"sender: failed to serialize run environment info: %v",
 				err,
@@ -743,7 +743,7 @@ func (s *Sender) uploadMetadataFile() {
 		filetransfer.RunFileKindWandb,
 	); err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf(
 				"sender: failed to upload run's %s file: %v",
 				MetaFileName,
@@ -829,7 +829,7 @@ func (s *Sender) sendSummary(_ *spb.Record, summary *spb.SummaryRecord) {
 	updates := runsummary.FromProto(summary)
 	if err := updates.Apply(s.runSummary); err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: error updating summary: %v", err),
 		)
 	}
@@ -851,7 +851,7 @@ func (s *Sender) uploadSummaryFile() {
 	summary, err := s.runSummary.Serialize()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: failed to serialize run summary: %v", err),
 		)
 		return
@@ -863,7 +863,7 @@ func (s *Sender) uploadSummaryFile() {
 		filetransfer.RunFileKindWandb,
 	); err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: failed to upload run summary: %v", err),
 		)
 	}
@@ -881,7 +881,7 @@ func (s *Sender) uploadConfigFile() {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: uploadConfigFile: %v", err),
 		)
 		return
@@ -890,7 +890,7 @@ func (s *Sender) uploadConfigFile() {
 	config, err := upserter.ConfigYAML()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: failed to serialize run config: %v", err),
 		)
 		return
@@ -902,7 +902,7 @@ func (s *Sender) uploadConfigFile() {
 		filetransfer.RunFileKindWandb,
 	); err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: failed to upload run config: %v", err),
 		)
 	}
@@ -947,7 +947,7 @@ func (s *Sender) sendConfig(_ *spb.Record, configRecord *spb.ConfigRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendConfig: %v", err),
 		)
 		return
@@ -970,7 +970,7 @@ func (s *Sender) sendSystemMetrics(record *spb.StatsRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendSystemMetrics: %v", err),
 		)
 		return
@@ -983,7 +983,7 @@ func (s *Sender) sendSystemMetrics(record *spb.StatsRecord) {
 	startTime := upserter.StartTime()
 	if startTime.IsZero() {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			errors.New("sender: sendSystemMetrics: start time not set"),
 		)
 		return
@@ -1030,7 +1030,7 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureFatalAndPanic(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendAlert: %v", err),
 		)
 		return
@@ -1053,7 +1053,7 @@ func (s *Sender) sendAlert(_ *spb.Record, alert *spb.AlertRecord) {
 	)
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf(
 				"sender: sendAlert: failed to notify scriptable run alert: %v",
 				err,
@@ -1073,7 +1073,7 @@ func (s *Sender) sendExit(
 ) {
 	if s.receivedExit {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			errors.New("sender: received exit more than once, ignoring"),
 		)
 		request.WillNotRespond()
@@ -1090,7 +1090,7 @@ func (s *Sender) sendMetric(_ *spb.Record, metrics *spb.MetricRecord) {
 	upserter, err := s.runHandle.Upserter()
 	if err != nil {
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: sendMetric: %v", err),
 		)
 		return
@@ -1131,7 +1131,7 @@ func (s *Sender) sendArtifact(_ *spb.Record, msg *spb.ArtifactRecord) {
 		op.Finish()
 		if result.Err != nil {
 			s.logger.CaptureError(
-				"sender",
+				"stream",
 				fmt.Errorf("sender: failed to log artifact: %v", result.Err),
 				"artifactID", result.ArtifactID,
 			)
@@ -1168,7 +1168,7 @@ func (s *Sender) sendRequestLogArtifact(
 			response.ErrorMessage = result.Err.Error()
 			// TODO: it will send error to sentry, do we want it?
 			s.logger.CaptureError(
-				"sender",
+				"stream",
 				fmt.Errorf("sender: failed to log artifact: %v", result.Err),
 				"artifactID", result.ArtifactID,
 			)
@@ -1218,7 +1218,7 @@ func (s *Sender) sendRequestDownloadArtifact(
 	).Download(); err != nil {
 		// Online mode handling: error during download
 		s.logger.CaptureError(
-			"sender",
+			"stream",
 			fmt.Errorf("sender: failed to download artifact: %v", err),
 		)
 		response.ErrorMessage = err.Error()
@@ -1254,7 +1254,7 @@ func (s *Sender) sendRequestJobInput(request *spb.JobInputRequest) {
 // record has been received.
 func (s *Sender) logCalledAfterExit(method string) {
 	s.logger.CaptureError(
-		"sender",
+		"stream",
 		fmt.Errorf("sender: %s called after exit", method),
 	)
 }

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -204,8 +204,13 @@ func (s *Stream) maybeSavingToTransactionLog(
 	if err != nil {
 		// Capture the error because if we can open for writing,
 		// why can't we open for reading?
-		s.logger.CaptureError(fmt.Errorf(
-			"stream: error opening transaction log for reading: %v", err))
+		s.logger.CaptureError(
+			"stream",
+			fmt.Errorf(
+				"stream: error opening transaction log for reading: %v",
+				err,
+			),
+		)
 		return work
 	}
 
@@ -331,7 +336,10 @@ func (s *Stream) printFooter() {
 			),
 		)
 	} else if runURL, err := s.runURL(); err != nil {
-		s.logger.CaptureError(fmt.Errorf("stream: runURL: %v", err))
+		s.logger.CaptureError(
+			"stream",
+			fmt.Errorf("stream: runURL: %v", err),
+		)
 	} else {
 		formatter.Println(
 			fmt.Sprintf(

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -62,12 +62,11 @@ type Stream struct {
 	// logger writes debug logs for the run.
 	logger *observability.CoreLogger
 
-	// telemetryProxy sends metrics and logs to the W&B backend's
-	// OpenTelemetry proxy API.
-	telemetryProxy analytics.OpenTelemetryProxy
-
 	// loggerFile is the file (if any) to which the logger writes.
 	loggerFile *os.File
+
+	// otelProxy records open telemetry analytics for the run.
+	otelProxy analytics.OpenTelemetryProxy
 
 	// wg is the WaitGroup for the stream
 	wg sync.WaitGroup
@@ -107,7 +106,7 @@ func NewStream(
 	handlerFactory *HandlerFactory,
 	loggerFile streamLoggerFile,
 	logger *observability.CoreLogger,
-	telemetryProxy analytics.OpenTelemetryProxy,
+	otelProxy analytics.OpenTelemetryProxy,
 	operations *wboperation.WandbOperations,
 	recordParserFactory *RecordParserFactory,
 	senderFactory *SenderFactory,
@@ -140,8 +139,8 @@ func NewStream(
 		featureProvider:    featureProvider,
 		graphqlClientOrNil: graphqlClientOrNil,
 		logger:             logger,
-		telemetryProxy:     telemetryProxy,
 		loggerFile:         loggerFile,
+		otelProxy:          otelProxy,
 		settings:           s,
 		recordParser:       recordParser,
 		handler:            handlerFactory.New(runWork),
@@ -162,15 +161,6 @@ func (s *Stream) GetSettings() *settings.Settings {
 
 // Start begins processing the stream's input records and producing outputs.
 func (s *Stream) Start() {
-	if s.telemetryProxy != nil {
-		if err := s.telemetryProxy.Start(context.Background()); err != nil {
-			s.logger.Error(
-				"stream: failed to start telemetry proxy",
-				"error", err,
-			)
-		}
-	}
-
 	s.wg.Add(1)
 	go func() {
 		s.handler.Do(s.runWork.Chan())
@@ -267,19 +257,18 @@ func (s *Stream) Close() {
 	s.wg.Wait()
 	s.logger.Info("stream: all finished")
 
-	// Flush any pending telemetry and shut the proxy down.
-	if s.telemetryProxy != nil {
-		shutdownCtx, cancel := context.WithTimeout(
-			context.Background(),
-			5*time.Second,
+	// All of the stream's goroutines have finished, so no more analytics
+	// will be recorded; flush what's pending.
+	shutdownCtx, cancel := context.WithTimeout(
+		context.Background(),
+		2*time.Second,
+	)
+	defer cancel()
+	if err := s.otelProxy.Shutdown(shutdownCtx); err != nil {
+		s.logger.Error(
+			"stream: failed to shut down analytics",
+			"error", err,
 		)
-		defer cancel()
-		if err := s.telemetryProxy.Shutdown(shutdownCtx); err != nil {
-			s.logger.Error(
-				"stream: failed to shut down telemetry proxy",
-				"error", err,
-			)
-		}
 	}
 
 	if s.loggerFile != nil {

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -66,7 +66,7 @@ type Stream struct {
 	loggerFile *os.File
 
 	// otelProxy records open telemetry analytics for the run.
-	otelProxy analytics.OpenTelemetryProxy
+	otelProxy *analytics.OpenTelemetryProxy
 
 	// wg is the WaitGroup for the stream
 	wg sync.WaitGroup
@@ -106,7 +106,7 @@ func NewStream(
 	handlerFactory *HandlerFactory,
 	loggerFile streamLoggerFile,
 	logger *observability.CoreLogger,
-	otelProxy analytics.OpenTelemetryProxy,
+	otelProxy *analytics.OpenTelemetryProxy,
 	operations *wboperation.WandbOperations,
 	recordParserFactory *RecordParserFactory,
 	senderFactory *SenderFactory,
@@ -269,11 +269,14 @@ func (s *Stream) Close() {
 		2*time.Second,
 	)
 	defer cancel()
-	if err := s.otelProxy.Shutdown(shutdownCtx); err != nil {
-		s.logger.Error(
-			"stream: failed to shut down analytics",
-			"error", err,
-		)
+	if s.otelProxy != nil {
+		err := s.otelProxy.Shutdown(shutdownCtx)
+		if err != nil {
+			s.logger.Error(
+				"stream: failed to shut down analytics",
+				"error", err,
+			)
+		}
 	}
 
 	if s.loggerFile != nil {

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/featurechecker"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/pfxout"
@@ -61,6 +62,10 @@ type Stream struct {
 	// logger writes debug logs for the run.
 	logger *observability.CoreLogger
 
+	// telemetryProxy sends metrics and logs to the W&B backend's
+	// OpenTelemetry proxy API.
+	telemetryProxy analytics.OpenTelemetryProxy
+
 	// loggerFile is the file (if any) to which the logger writes.
 	loggerFile *os.File
 
@@ -102,6 +107,7 @@ func NewStream(
 	handlerFactory *HandlerFactory,
 	loggerFile streamLoggerFile,
 	logger *observability.CoreLogger,
+	telemetryProxy analytics.OpenTelemetryProxy,
 	operations *wboperation.WandbOperations,
 	recordParserFactory *RecordParserFactory,
 	senderFactory *SenderFactory,
@@ -134,6 +140,7 @@ func NewStream(
 		featureProvider:    featureProvider,
 		graphqlClientOrNil: graphqlClientOrNil,
 		logger:             logger,
+		telemetryProxy:     telemetryProxy,
 		loggerFile:         loggerFile,
 		settings:           s,
 		recordParser:       recordParser,
@@ -155,6 +162,15 @@ func (s *Stream) GetSettings() *settings.Settings {
 
 // Start begins processing the stream's input records and producing outputs.
 func (s *Stream) Start() {
+	if s.telemetryProxy != nil {
+		if err := s.telemetryProxy.Start(context.Background()); err != nil {
+			s.logger.Error(
+				"stream: failed to start telemetry proxy",
+				"error", err,
+			)
+		}
+	}
+
 	s.wg.Add(1)
 	go func() {
 		s.handler.Do(s.runWork.Chan())
@@ -250,6 +266,21 @@ func (s *Stream) Close() {
 	s.runWork.Close()
 	s.wg.Wait()
 	s.logger.Info("stream: all finished")
+
+	// Flush any pending telemetry and shut the proxy down.
+	if s.telemetryProxy != nil {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer cancel()
+		if err := s.telemetryProxy.Shutdown(shutdownCtx); err != nil {
+			s.logger.Error(
+				"stream: failed to shut down telemetry proxy",
+				"error", err,
+			)
+		}
+	}
 
 	if s.loggerFile != nil {
 		// Sync the file instead of closing it, in case we keep writing to it.

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -34,7 +34,9 @@ func BaseURLFromSettings(
 	baseURL, err := url.Parse(s.GetBaseURL())
 	if err != nil {
 		logger.CaptureFatalAndPanic(
-			fmt.Errorf("stream_init: BaseURLFromSettings: %v", err))
+			"stream_init",
+			fmt.Errorf("stream_init: BaseURLFromSettings: %v", err),
+		)
 	}
 
 	return baseURL
@@ -49,7 +51,9 @@ func CredentialsFromSettings(
 
 	if err != nil {
 		logger.CaptureFatalAndPanic(
-			fmt.Errorf("stream_init: NewCredentialProvider: %v", err))
+			"stream_init",
+			fmt.Errorf("stream_init: NewCredentialProvider: %v", err),
+		)
 	}
 
 	return credentialProvider

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -34,7 +34,7 @@ func BaseURLFromSettings(
 	baseURL, err := url.Parse(s.GetBaseURL())
 	if err != nil {
 		logger.CaptureFatalAndPanic(
-			"stream_init",
+			"stream",
 			fmt.Errorf("stream_init: BaseURLFromSettings: %v", err),
 		)
 	}
@@ -51,7 +51,7 @@ func CredentialsFromSettings(
 
 	if err != nil {
 		logger.CaptureFatalAndPanic(
-			"stream_init",
+			"stream",
 			fmt.Errorf("stream_init: NewCredentialProvider: %v", err),
 		)
 	}

--- a/core/internal/stream/streamlogger.go
+++ b/core/internal/stream/streamlogger.go
@@ -31,7 +31,7 @@ var streamLoggerProviders = wire.NewSet(
 //
 // The stream owns the proxy's lifecycle: it is shut down in Stream.Close
 // after all of the stream's work is processed.
-func streamOTelProxy(s *settings.Settings) analytics.OpenTelemetryProxy {
+func streamOTelProxy(s *settings.Settings) *analytics.OpenTelemetryProxy {
 	return analytics.NewOpenTelemetryProxy(context.Background(), s)
 }
 
@@ -77,7 +77,7 @@ func streamSentryContext(s *settings.Settings) *observability.SentryContext {
 func streamLogger(
 	loggerFile streamLoggerFile,
 	sentryCtx *observability.SentryContext,
-	telemetryProxy analytics.OpenTelemetryProxy,
+	telemetryProxy *analytics.OpenTelemetryProxy,
 	s *settings.Settings,
 	logLevel slog.Level,
 ) *observability.CoreLogger {
@@ -98,6 +98,11 @@ func streamLogger(
 		sentryOnlyTags["sweep_url"] = s.GetSweepURL()
 	}
 
+	telemetryRecorder := analytics.NewTelemetryRecorder(
+		telemetryProxy,
+		analytics.NewTelemetryContext(),
+	)
+
 	logger := observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(
 			writer,
@@ -107,7 +112,7 @@ func streamLogger(
 			},
 		)),
 		sentryCtx,
-		telemetryProxy,
+		telemetryRecorder,
 	).With(nil, sentryOnlyTags)
 
 	logger.CaptureInfo("wandb-core")

--- a/core/internal/stream/streamlogger.go
+++ b/core/internal/stream/streamlogger.go
@@ -38,7 +38,10 @@ func streamTelemetryProxy(s *settings.Settings) analytics.OpenTelemetryProxy {
 		return analytics.NoopOpenTelemetryProxy{}
 	}
 
-	return analytics.NewOpenTelemetryProxy(s.GetBaseURL())
+	return analytics.NewOpenTelemetryProxy(
+		s.GetBaseURL(),
+		s.GetAPIKey(),
+	)
 }
 
 // symlinkDebugCore symlinks the debug-core.log file to the run's directory.

--- a/core/internal/stream/streamlogger.go
+++ b/core/internal/stream/streamlogger.go
@@ -38,10 +38,7 @@ func streamTelemetryProxy(s *settings.Settings) analytics.OpenTelemetryProxy {
 		return analytics.NoopOpenTelemetryProxy{}
 	}
 
-	return analytics.NewOpenTelemetryProxy(
-		s.GetBaseURL(),
-		s.GetAPIKey(),
-	)
+	return analytics.NewOpenTelemetryProxy(s)
 }
 
 // symlinkDebugCore symlinks the debug-core.log file to the run's directory.

--- a/core/internal/stream/streamlogger.go
+++ b/core/internal/stream/streamlogger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/google/wire"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/version"
@@ -21,8 +22,24 @@ type streamLoggerFile *os.File
 var streamLoggerProviders = wire.NewSet(
 	openStreamLoggerFile,
 	streamSentryContext,
+	streamTelemetryProxy,
 	streamLogger,
 )
+
+// streamTelemetryProxy creates the OpenTelemetry proxy for the stream.
+//
+// Telemetry is sent to the W&B backend's OpenTelemetry proxy API at the run's
+// base URL. The endpoint is only known once the client's settings arrive, so
+// the proxy is constructed per-stream here rather than at server startup.
+//
+// Offline runs get a no-op proxy since there is no backend to send to.
+func streamTelemetryProxy(s *settings.Settings) analytics.OpenTelemetryProxy {
+	if s.IsOffline() {
+		return analytics.NoopOpenTelemetryProxy{}
+	}
+
+	return analytics.NewOpenTelemetryProxy(s.GetBaseURL())
+}
 
 // symlinkDebugCore symlinks the debug-core.log file to the run's directory.
 func symlinkDebugCore(
@@ -66,6 +83,7 @@ func streamSentryContext(s *settings.Settings) *observability.SentryContext {
 func streamLogger(
 	loggerFile streamLoggerFile,
 	sentryCtx *observability.SentryContext,
+	telemetryProxy analytics.OpenTelemetryProxy,
 	s *settings.Settings,
 	logLevel slog.Level,
 ) *observability.CoreLogger {
@@ -95,6 +113,7 @@ func streamLogger(
 			},
 		)),
 		sentryCtx,
+		telemetryProxy,
 	).With(nil, sentryOnlyTags)
 
 	logger.CaptureInfo("wandb-core")

--- a/core/internal/stream/streamlogger.go
+++ b/core/internal/stream/streamlogger.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"os"
@@ -22,23 +23,16 @@ type streamLoggerFile *os.File
 var streamLoggerProviders = wire.NewSet(
 	openStreamLoggerFile,
 	streamSentryContext,
-	streamTelemetryProxy,
 	streamLogger,
+	streamOTelProxy,
 )
 
-// streamTelemetryProxy creates the OpenTelemetry proxy for the stream.
+// streamOTelProxy returns the OpenTelemetry proxy for the stream.
 //
-// Telemetry is sent to the W&B backend's OpenTelemetry proxy API at the run's
-// base URL. The endpoint is only known once the client's settings arrive, so
-// the proxy is constructed per-stream here rather than at server startup.
-//
-// Offline runs get a no-op proxy since there is no backend to send to.
-func streamTelemetryProxy(s *settings.Settings) analytics.OpenTelemetryProxy {
-	if s.IsOffline() {
-		return analytics.NoopOpenTelemetryProxy{}
-	}
-
-	return analytics.NewOpenTelemetryProxy(s)
+// The stream owns the proxy's lifecycle: it is shut down in Stream.Close
+// after all of the stream's work is processed.
+func streamOTelProxy(s *settings.Settings) analytics.OpenTelemetryProxy {
+	return analytics.NewOpenTelemetryProxy(context.Background(), s)
 }
 
 // symlinkDebugCore symlinks the debug-core.log file to the run's directory.

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -32,7 +32,7 @@ func InjectStream(commit GitCommitHash, xpuResourceManager *monitor.XPUResourceM
 	clientID := sharedmode.RandomClientID()
 	streamStreamLoggerFile := openStreamLoggerFile(settings2)
 	sentryContext := streamSentryContext(settings2)
-	openTelemetryProxy := streamTelemetryProxy(settings2)
+	openTelemetryProxy := streamOTelProxy(settings2)
 	coreLogger := streamLogger(streamStreamLoggerFile, sentryContext, openTelemetryProxy, settings2, logLevel)
 	wbBaseURL := BaseURLFromSettings(coreLogger, settings2)
 	credentialProvider := CredentialsFromSettings(coreLogger, settings2)

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -32,7 +32,8 @@ func InjectStream(commit GitCommitHash, xpuResourceManager *monitor.XPUResourceM
 	clientID := sharedmode.RandomClientID()
 	streamStreamLoggerFile := openStreamLoggerFile(settings2)
 	sentryContext := streamSentryContext(settings2)
-	coreLogger := streamLogger(streamStreamLoggerFile, sentryContext, settings2, logLevel)
+	openTelemetryProxy := streamTelemetryProxy(settings2)
+	coreLogger := streamLogger(streamStreamLoggerFile, sentryContext, openTelemetryProxy, settings2, logLevel)
 	wbBaseURL := BaseURLFromSettings(coreLogger, settings2)
 	credentialProvider := CredentialsFromSettings(coreLogger, settings2)
 	peeker := &observability.Peeker{}
@@ -120,7 +121,7 @@ func InjectStream(commit GitCommitHash, xpuResourceManager *monitor.XPUResourceM
 		Logger:   coreLogger,
 		Settings: settings2,
 	}
-	stream := NewStream(clientID, debugCorePath, featureProvider, flowControlFactory, client, handlerFactory, streamStreamLoggerFile, coreLogger, wandbOperations, recordParserFactory, senderFactory, settings2, runHandle, tbHandlerFactory, writerFactory)
+	stream := NewStream(clientID, debugCorePath, featureProvider, flowControlFactory, client, handlerFactory, streamStreamLoggerFile, coreLogger, openTelemetryProxy, wandbOperations, recordParserFactory, senderFactory, settings2, runHandle, tbHandlerFactory, writerFactory)
 	return stream
 }
 

--- a/core/internal/stream/writer.go
+++ b/core/internal/stream/writer.go
@@ -64,7 +64,7 @@ func (w *Writer) Chan() <-chan runwork.MaybeSavedWork {
 // Do saves all input Work and pushes it to the output channel,
 // closing it and the transaction log writer at the end.
 func (w *Writer) Do(allWork <-chan runwork.Work) {
-	defer w.logger.Reraise()
+	defer w.logger.Reraise("writer")
 	defer close(w.out)
 	w.logger.Info("writer: started", "stream_id", w.settings.GetRunID())
 
@@ -84,7 +84,9 @@ func (w *Writer) Do(allWork <-chan runwork.Work) {
 
 			if err != nil {
 				w.logger.CaptureError(
-					fmt.Errorf("writer: failed to save record: %v", err))
+					"writer",
+					fmt.Errorf("writer: failed to save record: %v", err),
+				)
 			} else {
 				savedWork.IsSaved = true
 				savedWork.SavedOffset = offset
@@ -105,7 +107,9 @@ func (w *Writer) Do(allWork <-chan runwork.Work) {
 
 	if err := w.writer.Close(); err != nil {
 		w.logger.CaptureError(
-			fmt.Errorf("writer: failed closing store: %v", err))
+			"writer",
+			fmt.Errorf("writer: failed closing store: %v", err),
+		)
 	}
 }
 

--- a/core/internal/stream/writer.go
+++ b/core/internal/stream/writer.go
@@ -64,7 +64,7 @@ func (w *Writer) Chan() <-chan runwork.MaybeSavedWork {
 // Do saves all input Work and pushes it to the output channel,
 // closing it and the transaction log writer at the end.
 func (w *Writer) Do(allWork <-chan runwork.Work) {
-	defer w.logger.Reraise("writer")
+	defer w.logger.Reraise("stream")
 	defer close(w.out)
 	w.logger.Info("writer: started", "stream_id", w.settings.GetRunID())
 
@@ -84,7 +84,7 @@ func (w *Writer) Do(allWork <-chan runwork.Work) {
 
 			if err != nil {
 				w.logger.CaptureError(
-					"writer",
+					"stream",
 					fmt.Errorf("writer: failed to save record: %v", err),
 				)
 			} else {
@@ -107,7 +107,7 @@ func (w *Writer) Do(allWork <-chan runwork.Work) {
 
 	if err := w.writer.Close(); err != nil {
 		w.logger.CaptureError(
-			"writer",
+			"stream",
 			fmt.Errorf("writer: failed closing store: %v", err),
 		)
 	}

--- a/core/internal/tensorboard/tbwork.go
+++ b/core/internal/tensorboard/tbwork.go
@@ -33,7 +33,10 @@ type TBWork struct {
 func (w *TBWork) Schedule(wg *sync.WaitGroup, proceed func()) {
 	err := w.TBHandler.Handle(w.Record.GetTbrecord())
 	if err != nil {
-		w.Logger.CaptureError(err)
+		w.Logger.CaptureError(
+			"tensorboard",
+			err,
+		)
 	}
 	proceed()
 }

--- a/core/internal/tensorboard/tfeventconverter.go
+++ b/core/internal/tensorboard/tfeventconverter.go
@@ -34,7 +34,10 @@ func (h *TFEventConverter) ConvertNext(
 ) {
 	stepKey, err := h.withNamespace("global_step")
 	if err != nil {
-		logger.CaptureError(fmt.Errorf("tensorboard: global_step: %v", err))
+		logger.CaptureError(
+			"tensorboard",
+			fmt.Errorf("tensorboard: global_step: %v", err),
+		)
 	} else {
 		emitter.SetTFStep(pathtree.PathOf(stepKey), event.Step)
 		emitter.SetTFWallTime(event.WallTime)
@@ -44,7 +47,9 @@ func (h *TFEventConverter) ConvertNext(
 		tag, err := h.withNamespace(value.GetTag())
 		if err != nil {
 			logger.CaptureError(
-				fmt.Errorf("tensorboard: invalid tag: %v", err))
+				"tensorboard",
+				fmt.Errorf("tensorboard: invalid tag: %v", err),
+			)
 			continue
 		}
 

--- a/core/internal/tensorboard/tfeventconverter_test.go
+++ b/core/internal/tensorboard/tfeventconverter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/pathtree"
@@ -532,7 +533,7 @@ func TestConvertImage_NotPNG(t *testing.T) {
 		observability.NewCoreLogger(
 			slog.New(slog.NewTextHandler(&logs, nil)),
 			nil,
-			nil,
+			analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 		),
 	)
 
@@ -553,7 +554,7 @@ func TestConvertImage_BadDims(t *testing.T) {
 		observability.NewCoreLogger(
 			slog.New(slog.NewTextHandler(&logs, nil)),
 			nil,
-			nil,
+			analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 		),
 	)
 
@@ -575,7 +576,7 @@ func TestConvertImage_UnknownTBFormat(t *testing.T) {
 		observability.NewCoreLogger(
 			slog.New(slog.NewTextHandler(&logs, nil)),
 			nil,
-			nil,
+			analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
 		),
 	)
 

--- a/core/internal/tensorboard/tfeventconverter_test.go
+++ b/core/internal/tensorboard/tfeventconverter_test.go
@@ -529,7 +529,11 @@ func TestConvertImage_NotPNG(t *testing.T) {
 		summaryEvent(123, 0.345,
 			tensorValueStrings("my_img", "images",
 				"2", "4", "not a PNG")),
-		observability.NewCoreLogger(slog.New(slog.NewTextHandler(&logs, nil)), nil),
+		observability.NewCoreLogger(
+			slog.New(slog.NewTextHandler(&logs, nil)),
+			nil,
+			nil,
+		),
 	)
 
 	assert.Empty(t, emitter.EmitImagesCalls)
@@ -546,7 +550,11 @@ func TestConvertImage_BadDims(t *testing.T) {
 		summaryEvent(123, 0.345,
 			tensorValueStrings("my_img", "images",
 				"2a", "4x", "\x89PNG\x0D\x0A\x1A\x0Acontent")),
-		observability.NewCoreLogger(slog.New(slog.NewTextHandler(&logs, nil)), nil),
+		observability.NewCoreLogger(
+			slog.New(slog.NewTextHandler(&logs, nil)),
+			nil,
+			nil,
+		),
 	)
 
 	assert.Empty(t, emitter.EmitImagesCalls)
@@ -564,7 +572,11 @@ func TestConvertImage_UnknownTBFormat(t *testing.T) {
 		emitter,
 		summaryEvent(123, 0.345,
 			tensorValueStrings("my_img", "images", "not enough strings")),
-		observability.NewCoreLogger(slog.New(slog.NewTextHandler(&logs, nil)), nil),
+		observability.NewCoreLogger(
+			slog.New(slog.NewTextHandler(&logs, nil)),
+			nil,
+			nil,
+		),
 	)
 
 	assert.Empty(t, emitter.EmitImagesCalls)

--- a/core/internal/tensorboard/tfeventconverterhistograms.go
+++ b/core/internal/tensorboard/tfeventconverterhistograms.go
@@ -27,10 +27,12 @@ func processHistograms(
 
 	default:
 		logger.CaptureError(
+			"tensorboard",
 			fmt.Errorf(
 				"tensorboard: expected histograms value to be a Tensor"+
 					" or HistogramProto but its type is %T",
-				value))
+				value),
+		)
 	}
 }
 
@@ -44,7 +46,9 @@ func processHistogramsTensor(
 	tensor, err := tensorFromProto(tensorValue)
 	if err != nil {
 		logger.CaptureError(
-			fmt.Errorf("tensorboard: failed to parse tensor: %v", err))
+			"tensorboard",
+			fmt.Errorf("tensorboard: failed to parse tensor: %v", err),
+		)
 		return
 	}
 
@@ -53,8 +57,12 @@ func processHistogramsTensor(
 	weights, err3 := tensor.Col(2)
 	if err1 != nil || err2 != nil || err3 != nil {
 		logger.CaptureError(
-			fmt.Errorf("tensorboard: couldn't read histograms row: %v",
-				errors.Join(err1, err2, err3)))
+			"tensorboard",
+			fmt.Errorf(
+				"tensorboard: couldn't read histograms row: %v",
+				errors.Join(err1, err2, err3),
+			),
+		)
 		return
 	}
 
@@ -84,12 +92,16 @@ func processHistogramsProto(
 
 	if len(rightEdges) == 0 {
 		logger.CaptureError(
-			errors.New("tensorboard: invalid histogram: empty BucketLimit"))
+			"tensorboard",
+			errors.New("tensorboard: invalid histogram: empty BucketLimit"),
+		)
 		return
 	}
 	if len(rightEdges) != len(binWeights) {
 		logger.CaptureError(
-			errors.New("tensorboard: invalid histogram: len(BucketLimit) != len(Bucket)"))
+			"tensorboard",
+			errors.New("tensorboard: invalid histogram: len(BucketLimit) != len(Bucket)"),
+		)
 		return
 	}
 
@@ -111,7 +123,11 @@ func processHistogramsProto(
 
 	default:
 		logger.CaptureError(
-			errors.New("tensorboard: invalid histogram: histo.Min >= rightEdges[0]"))
+			"tensorboard",
+			errors.New(
+				"tensorboard: invalid histogram: histo.Min >= rightEdges[0]",
+			),
+		)
 		return
 	}
 
@@ -127,9 +143,11 @@ func emitHistogram(
 ) {
 	if len(binEdges) != 1+len(binWeights) {
 		logger.CaptureError(
+			"tensorboard",
 			errors.New("tensorboard: invalid histogram"),
 			"len(binEdges)", len(binEdges),
-			"len(binWeights)", len(binWeights))
+			"len(binWeights)", len(binWeights),
+		)
 		return
 	}
 
@@ -143,7 +161,9 @@ func emitHistogram(
 
 		if err != nil {
 			logger.CaptureError(
-				fmt.Errorf("tensorboard: error rebinning histogram: %v", err))
+				"tensorboard",
+				fmt.Errorf("tensorboard: error rebinning histogram: %v", err),
+			)
 			return
 		}
 	}
@@ -154,7 +174,9 @@ func emitHistogram(
 	}.HistoryValueJSON()
 	if err != nil {
 		logger.CaptureError(
-			fmt.Errorf("tensorboard: error serializing histogram: %v", err))
+			"tensorboard",
+			fmt.Errorf("tensorboard: error serializing histogram: %v", err),
+		)
 		return
 	}
 

--- a/core/internal/tensorboard/tfeventconverterimages.go
+++ b/core/internal/tensorboard/tfeventconverterimages.go
@@ -27,10 +27,13 @@ func processImages(
 
 	default:
 		logger.CaptureError(
+			"tensorboard",
 			fmt.Errorf(
 				"tensorboard: expected images summary to use 'image'"+
 					" or 'tensor' field but its type is %T",
-				value.GetValue()))
+				value.GetValue(),
+			),
+		)
 	}
 }
 
@@ -43,10 +46,13 @@ func processImagesTensor(
 ) {
 	if len(tensorValue.StringVal) < 3 {
 		logger.CaptureError(
+			"tensorboard",
 			fmt.Errorf(
 				"tensorboard: expected images tensor string_val"+
 					" to have at least 3 values, but it has %d",
-				len(tensorValue.StringVal)))
+				len(tensorValue.StringVal),
+			),
+		)
 		return
 	}
 
@@ -55,9 +61,12 @@ func processImagesTensor(
 	height, err2 := strconv.Atoi(string(tensorValue.StringVal[1]))
 	if err1 != nil || err2 != nil {
 		logger.CaptureError(
+			"tensorboard",
 			fmt.Errorf(
 				"tensorboard: couldn't parse image dimensions: %v",
-				errors.Join(err1, err2)))
+				errors.Join(err1, err2),
+			),
+		)
 		return
 	}
 
@@ -97,7 +106,9 @@ func emitImages(
 		image, err := wbvalue.ImageFromData(width, height, encodedData)
 		if err != nil {
 			logger.CaptureError(
-				fmt.Errorf("tensorboard: failed to read image: %v", err))
+				"tensorboard",
+				fmt.Errorf("tensorboard: failed to read image: %v", err),
+			)
 		} else {
 			wbImages = append(wbImages, image)
 		}
@@ -107,7 +118,9 @@ func emitImages(
 		err := emitter.EmitImages(pathtree.PathOf(tag), wbImages)
 		if err != nil {
 			logger.CaptureError(
-				fmt.Errorf("tensorboard: couldn't emit image: %v", err))
+				"tensorboard",
+				fmt.Errorf("tensorboard: couldn't emit image: %v", err),
+			)
 		}
 	}
 }

--- a/core/internal/tensorboard/tfeventconverterprcurves.go
+++ b/core/internal/tensorboard/tfeventconverterprcurves.go
@@ -36,17 +36,22 @@ func processPRCurves(
 	tensorValue, ok := value.GetValue().(*tbproto.Summary_Value_Tensor)
 	if !ok {
 		logger.CaptureError(
+			"tensorboard",
 			fmt.Errorf(
 				"tensorboard: expected pr_curves value to be a Tensor"+
 					" but its type is %T",
-				value.GetValue()))
+				value.GetValue(),
+			),
+		)
 		return
 	}
 
 	tensor, err := tensorFromProto(tensorValue.Tensor)
 	if err != nil {
 		logger.CaptureError(
-			fmt.Errorf("tensorboard: failed to parse tensor: %v", err))
+			"tensorboard",
+			fmt.Errorf("tensorboard: failed to parse tensor: %v", err),
+		)
 		return
 	}
 
@@ -54,16 +59,21 @@ func processPRCurves(
 	recall, err2 := tensor.Row(-1)
 	if err1 != nil || err2 != nil {
 		logger.CaptureError(
+			"tensorboard",
 			fmt.Errorf(
 				"tensorboard: couldn't read pr_curves row: %v",
-				errors.Join(err1, err2)))
+				errors.Join(err1, err2),
+			),
+		)
 		return
 	}
 
 	if len(precision) != len(recall) {
 		// Shouldn't happen since it's a 2D array.
 		logger.CaptureError(
-			errors.New("tensorboard: len(precision) != len(recall)"))
+			"tensorboard",
+			errors.New("tensorboard: len(precision) != len(recall)"),
+		)
 		return
 	}
 
@@ -79,7 +89,9 @@ func processPRCurves(
 	err = emitter.EmitTable(pathtree.PathOf(tag), table)
 	if err != nil {
 		logger.CaptureError(
-			fmt.Errorf("tensorboard: failed to emit pr_curves table: %v", err))
+			"tensorboard",
+			fmt.Errorf("tensorboard: failed to emit pr_curves table: %v", err),
+		)
 	}
 
 	err = emitter.EmitChart(
@@ -92,6 +104,8 @@ func processPRCurves(
 		})
 	if err != nil {
 		logger.CaptureError(
-			fmt.Errorf("tensorboard: failed to emit pr_curves chart: %v", err))
+			"tensorboard",
+			fmt.Errorf("tensorboard: failed to emit pr_curves chart: %v", err),
+		)
 	}
 }

--- a/core/internal/tensorboard/tfeventconverterscalars.go
+++ b/core/internal/tensorboard/tfeventconverterscalars.go
@@ -25,21 +25,27 @@ func processScalars(
 		tensor, err := tensorFromProto(value.Tensor)
 		if err != nil {
 			logger.CaptureError(
-				fmt.Errorf("tensorboard: error parsing tensor: %v", err))
+				"tensorboard",
+				fmt.Errorf("tensorboard: error parsing tensor: %v", err),
+			)
 			return
 		}
 
 		scalar, err := tensor.Scalar()
 		if err != nil {
 			logger.CaptureError(
-				fmt.Errorf("tensorboard: error getting scalar: %v", err))
+				"tensorboard",
+				fmt.Errorf("tensorboard: error getting scalar: %v", err),
+			)
 			return
 		}
 
 		floatJSON, err := simplejsonext.MarshalToString(scalar)
 		if err != nil {
 			logger.CaptureError(
-				fmt.Errorf("tensorboard: error encoding scalar: %v", err))
+				"tensorboard",
+				fmt.Errorf("tensorboard: error encoding scalar: %v", err),
+			)
 			return
 		}
 
@@ -47,9 +53,12 @@ func processScalars(
 
 	default:
 		logger.CaptureError(
+			"tensorboard",
 			fmt.Errorf(
 				"tensorboard: unexpected scalars value type: %T",
-				value))
+				value,
+			),
+		)
 	}
 }
 
@@ -63,7 +72,9 @@ func processScalarsSimpleValue(
 	floatJSON, err := simplejsonext.MarshalToString(value)
 	if err != nil {
 		logger.CaptureError(
-			fmt.Errorf("tensorboard: error encoding scalar: %v", err))
+			"tensorboard",
+			fmt.Errorf("tensorboard: error encoding scalar: %v", err),
+		)
 		return
 	}
 

--- a/core/internal/tensorboard/tfeventstream.go
+++ b/core/internal/tensorboard/tfeventstream.go
@@ -99,10 +99,12 @@ func (s *tfEventStream) loop() {
 		event, err := s.reader.NextEvent(s.ctx, s.emitFilePath /*onNewFile*/)
 		if err != nil {
 			s.logger.CaptureError(
+				"tensorboard",
 				fmt.Errorf(
 					"tensorboard: failed reading next event: %v",
 					err,
-				))
+				),
+			)
 			return
 		}
 

--- a/core/internal/watcher/impl.go
+++ b/core/internal/watcher/impl.go
@@ -160,10 +160,12 @@ func (w *watcher) loopWatchFiles(ctx context.Context) {
 
 		case err := <-w.delegate.Error:
 			w.logger.CaptureError(
+				"watcher",
 				fmt.Errorf(
 					"watcher: error in file watcher: %v",
 					err,
-				))
+				),
+			)
 
 		case <-w.delegate.Closed:
 			return

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/simplejsonext"
 
+	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runhistoryreader"
 	"github.com/wandb/wandb/core/internal/runhistoryreader/parquet"
 	"github.com/wandb/wandb/core/internal/runhistoryreader/parquet/ffi"
@@ -24,6 +25,7 @@ import (
 type RunHistoryAPIHandler struct {
 	graphqlClient graphql.Client
 	httpClient    *retryablehttp.Client
+	logger        *observability.CoreLogger
 
 	// mu protects scanHistoryReaders and downloadOperations from
 	// concurrent access by goroutines spawned in handleApi.
@@ -61,11 +63,13 @@ type RunHistoryAPIHandler struct {
 func NewRunHistoryAPIHandler(
 	graphqlClient graphql.Client,
 	httpClient *retryablehttp.Client,
+	logger *observability.CoreLogger,
 ) *RunHistoryAPIHandler {
 
 	return &RunHistoryAPIHandler{
 		graphqlClient:      graphqlClient,
 		httpClient:         httpClient,
+		logger:             logger,
 		currentRequestId:   atomic.Int32{},
 		scanHistoryReaders: make(map[int32]*runhistoryreader.HistoryReader),
 		downloadOperations: make(map[int32]*parquet.RunHistoryDownloadOperation),
@@ -105,6 +109,15 @@ func (f *RunHistoryAPIHandler) handleScanRunHistoryInit(
 	ctx context.Context,
 	request *spb.ScanRunHistoryInit,
 ) *spb.ApiResponse {
+	f.logger.RecordTelemetry(
+		"scan_run_history_init",
+		map[string]string{
+			"entity":  request.Entity,
+			"project": request.Project,
+			"runId":   request.RunId,
+		},
+	)
+
 	f.rustArrowOnce.Do(func() {
 		f.rustArrowWrapper, f.rustArrowInitializationErr = ffi.NewRustArrowWrapper()
 	})

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -102,15 +102,19 @@ func New(
 		semaphore: make(chan struct{}, maxConcurrency),
 		settings:  s,
 
-		authHandler:          NewAuthHandler(graphqlClient),
-		featuresHandler:      NewFeaturesHandler(featureProvider),
-		fileTransferHandler:  NewFileTransferHandler(fileTransferManager),
-		graphqlHandler:       NewGraphQLHandler(graphqlClient),
-		customChartHandler:   NewCustomChartHandler(graphqlClient),
-		runFilesHandler:      NewRunFilesHandler(graphqlClient),
-		runHandler:           NewRunHandler(graphqlClient),
-		runQueueHandler:      NewRunQueueHandler(graphqlClient),
-		runHistoryApiHandler: NewRunHistoryAPIHandler(graphqlClient, httpClient),
+		authHandler:         NewAuthHandler(graphqlClient),
+		featuresHandler:     NewFeaturesHandler(featureProvider),
+		fileTransferHandler: NewFileTransferHandler(fileTransferManager),
+		graphqlHandler:      NewGraphQLHandler(graphqlClient),
+		customChartHandler:  NewCustomChartHandler(graphqlClient),
+		runFilesHandler:     NewRunFilesHandler(graphqlClient),
+		runHandler:          NewRunHandler(graphqlClient),
+		runQueueHandler:     NewRunQueueHandler(graphqlClient),
+		runHistoryApiHandler: NewRunHistoryAPIHandler(
+			graphqlClient,
+			httpClient,
+			logger,
+		),
 	}, nil
 }
 

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -680,15 +680,25 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	telemetryProxy := analytics.NewOpenTelemetryProxy(context.Background(), s)
 	go func() {
 		<-nc.connLifetimeCtx.Done()
-		if err := telemetryProxy.Shutdown(context.Background()); err != nil {
-			slog.Error("connection: failed to shutdown telemetry proxy", "error", err)
+		if telemetryProxy != nil {
+			err := telemetryProxy.Shutdown(context.Background())
+			if err != nil {
+				slog.Error(
+					"connection: failed to shut down telemetry proxy",
+					"error",
+					err,
+				)
+			}
 		}
 	}()
 
 	logger := observability.NewCoreLogger(
 		slog.Default(),
 		nil,
-		telemetryProxy,
+		analytics.NewTelemetryRecorder(
+			telemetryProxy,
+			analytics.NewTelemetryContext(),
+		),
 	)
 	wbapiInstance, err := wbapi.New(s, logger)
 	if err != nil {

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 
+	"github.com/wandb/wandb/core/internal/analytics"
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/gql"
@@ -675,7 +676,23 @@ func (nc *Connection) handleSyncStatus(
 // handleApiInit sets up a new wandbAPI instance.
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	s := settings.From(request.GetSettings())
-	logger := observability.NewCoreLogger(slog.Default(), nil)
+
+	telemetryProxy := analytics.NewOpenTelemetryProxy(s.GetBaseURL())
+	if err := telemetryProxy.Start(context.Background()); err != nil {
+		slog.Error("connection: failed to start telemetry proxy", "error", err)
+	}
+	go func() {
+		<-nc.connLifetimeCtx.Done()
+		if err := telemetryProxy.Shutdown(context.Background()); err != nil {
+			slog.Error("connection: failed to shutdown telemetry proxy", "error", err)
+		}
+	}()
+
+	logger := observability.NewCoreLogger(
+		slog.Default(),
+		nil,
+		telemetryProxy,
+	)
 	wbapiInstance, err := wbapi.New(s, logger)
 	if err != nil {
 		nc.Respond(&spb.ServerResponse{

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -677,10 +677,7 @@ func (nc *Connection) handleSyncStatus(
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	s := settings.From(request.GetSettings())
 
-	telemetryProxy := analytics.NewOpenTelemetryProxy(s)
-	if err := telemetryProxy.Start(context.Background()); err != nil {
-		slog.Error("connection: failed to start telemetry proxy", "error", err)
-	}
+	telemetryProxy := analytics.NewOpenTelemetryProxy(context.Background(), s)
 	go func() {
 		<-nc.connLifetimeCtx.Done()
 		if err := telemetryProxy.Shutdown(context.Background()); err != nil {

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -681,7 +682,13 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	go func() {
 		<-nc.connLifetimeCtx.Done()
 		if telemetryProxy != nil {
-			err := telemetryProxy.Shutdown(context.Background())
+			shutdownCtx, cancel := context.WithTimeout(
+				context.Background(),
+				2*time.Second,
+			)
+			defer cancel()
+
+			err := telemetryProxy.Shutdown(shutdownCtx)
 			if err != nil {
 				slog.Error(
 					"connection: failed to shut down telemetry proxy",

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -677,7 +677,10 @@ func (nc *Connection) handleSyncStatus(
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	s := settings.From(request.GetSettings())
 
-	telemetryProxy := analytics.NewOpenTelemetryProxy(s.GetBaseURL())
+	telemetryProxy := analytics.NewOpenTelemetryProxy(
+		s.GetBaseURL(),
+		s.GetAPIKey(),
+	)
 	if err := telemetryProxy.Start(context.Background()); err != nil {
 		slog.Error("connection: failed to start telemetry proxy", "error", err)
 	}

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -677,10 +677,7 @@ func (nc *Connection) handleSyncStatus(
 func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest) {
 	s := settings.From(request.GetSettings())
 
-	telemetryProxy := analytics.NewOpenTelemetryProxy(
-		s.GetBaseURL(),
-		s.GetAPIKey(),
-	)
+	telemetryProxy := analytics.NewOpenTelemetryProxy(s)
 	if err := telemetryProxy.Start(context.Background()); err != nil {
 		slog.Error("connection: failed to start telemetry proxy", "error", err)
 	}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

implements the OpenTelemetry proxy added in https://github.com/wandb/wandb/pull/12000 as part of the core_logger.  
Where ever sentry messages/exceptions were captured currently, a similar OpenTelemetry event (metric and/or log) is sent as well.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

- a beta_scan_history emits a sentry event

```python
import wandb

api = wandb.Api()
run = api.run("jacobromerotest/uncategorized/2f444zmt")
scan = run.beta_scan_history(
    page_size=2,
)

for row in scan:
    continue
```

  
![image.png](https://app.graphite.com/user-attachments/assets/77a34c17-bb4d-4eb7-bea3-197849ca8865.png)



<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->