### PR TITLE
fix: send "W&B Public Client" User-Agent for Public API requests

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,3 +13,7 @@ sections:
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- `wandb.Api().viewer` (and `Api().user()` / `Api().users()`) no longer fail with `WandbApiFailedError: relogin required` for some API keys, a regression in `0.27.1` (@dmitryduev in https://github.com/wandb/wandb/pull/12009)

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -160,109 +160,19 @@ def test_direct_specification_of_api_key():
     # test_settings has a different API key
     api = Api(api_key="abcd" * 10)
     assert api.api_key == "abcd" * 10
+    # The key must reach the settings wandb-core receives, not just the Api.
     assert api._service_api._settings.api_key == "abcd" * 10
     assert api._service_api._settings.to_proto().api_key.value == "abcd" * 10
 
 
-@pytest.mark.usefixtures("skip_verify_login")
-def test_viewer_retries_without_api_keys_on_unauthorized_api_keys(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from wandb.apis._generated import GET_VIEWER_GQL
-
-    monkeypatch.setattr(Api, "_configure_sentry", lambda self: None)
-
-    error_response = apb.ApiErrorResponse(
-        message="relogin required",
-        http_status=401,
-    )
-    execute_graphql = MagicMock(
-        side_effect=[
-            WandbApiFailedError(error_response.message, error_response),
-            {
-                "viewer": {
-                    "id": "test-id",
-                    "name": "Test User",
-                    "username": "test-user",
-                    "email": "test@example.com",
-                    "admin": False,
-                    "flags": "",
-                    "entity": "test-entity",
-                    "deletedAt": None,
-                    "teams": None,
-                }
-            },
-        ]
-    )
-    monkeypatch.setattr(
-        wandb.apis.public.api.ServiceApi,
-        "execute_graphql",
-        execute_graphql,
-    )
-
-    api = Api(api_key="abcd" * 10)
-
-    assert api.viewer.entity == "test-entity"
-    assert api.viewer.api_keys == []
-    assert execute_graphql.call_args_list == [
-        mock.call(GET_VIEWER_GQL),
-        mock.call(GET_VIEWER_GQL, omit_fields={"apiKeys"}),
-    ]
-
-
-@pytest.mark.parametrize("method_name", ["user", "users"])
-@pytest.mark.usefixtures("skip_verify_login")
-def test_user_search_retries_without_api_keys_on_unauthorized_api_keys(
-    monkeypatch: pytest.MonkeyPatch,
-    method_name: str,
-):
-    from wandb.apis._generated import SEARCH_USERS_GQL
-
-    monkeypatch.setattr(Api, "_configure_sentry", lambda self: None)
-
-    error_response = apb.ApiErrorResponse(
-        message="relogin required",
-        http_status=401,
-    )
-    execute_graphql = MagicMock(
-        side_effect=[
-            WandbApiFailedError(error_response.message, error_response),
-            {
-                "users": {
-                    "edges": [
-                        {
-                            "node": {
-                                "id": "test-id",
-                                "name": "Test User",
-                                "username": "test-user",
-                                "email": "test@example.com",
-                                "admin": False,
-                                "flags": "",
-                                "entity": "test-entity",
-                                "deletedAt": None,
-                                "teams": None,
-                            }
-                        }
-                    ]
-                }
-            },
-        ]
-    )
-    monkeypatch.setattr(
-        wandb.apis.public.api.ServiceApi,
-        "execute_graphql",
-        execute_graphql,
-    )
-
-    result = getattr(Api(api_key="abcd" * 10), method_name)("test-user")
-
-    user = result[0] if method_name == "users" else result
-    assert user.entity == "test-entity"
-    assert user.api_keys == []
-    assert execute_graphql.call_args_list == [
-        mock.call(SEARCH_USERS_GQL, {"query": "test-user"}),
-        mock.call(SEARCH_USERS_GQL, {"query": "test-user"}, omit_fields={"apiKeys"}),
-    ]
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_public_api_sends_first_party_user_agent():
+    # The backend gates first-party fields (e.g. a user's apiKeys) on a
+    # recognized W&B client User-Agent, so the Public API must set it when
+    # routing GraphQL through wandb-core (whose default User-Agent is rejected).
+    headers = Api()._service_api._settings.x_extra_http_headers
+    assert headers["User-Agent"] == f"W&B Public Client {wandb.__version__}"
+    assert headers["Use-Admin-Privileges"] == "true"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -160,6 +160,109 @@ def test_direct_specification_of_api_key():
     # test_settings has a different API key
     api = Api(api_key="abcd" * 10)
     assert api.api_key == "abcd" * 10
+    assert api._service_api._settings.api_key == "abcd" * 10
+    assert api._service_api._settings.to_proto().api_key.value == "abcd" * 10
+
+
+@pytest.mark.usefixtures("skip_verify_login")
+def test_viewer_retries_without_api_keys_on_unauthorized_api_keys(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from wandb.apis._generated import GET_VIEWER_GQL
+
+    monkeypatch.setattr(Api, "_configure_sentry", lambda self: None)
+
+    error_response = apb.ApiErrorResponse(
+        message="relogin required",
+        http_status=401,
+    )
+    execute_graphql = MagicMock(
+        side_effect=[
+            WandbApiFailedError(error_response.message, error_response),
+            {
+                "viewer": {
+                    "id": "test-id",
+                    "name": "Test User",
+                    "username": "test-user",
+                    "email": "test@example.com",
+                    "admin": False,
+                    "flags": "",
+                    "entity": "test-entity",
+                    "deletedAt": None,
+                    "teams": None,
+                }
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        wandb.apis.public.api.ServiceApi,
+        "execute_graphql",
+        execute_graphql,
+    )
+
+    api = Api(api_key="abcd" * 10)
+
+    assert api.viewer.entity == "test-entity"
+    assert api.viewer.api_keys == []
+    assert execute_graphql.call_args_list == [
+        mock.call(GET_VIEWER_GQL),
+        mock.call(GET_VIEWER_GQL, omit_fields={"apiKeys"}),
+    ]
+
+
+@pytest.mark.parametrize("method_name", ["user", "users"])
+@pytest.mark.usefixtures("skip_verify_login")
+def test_user_search_retries_without_api_keys_on_unauthorized_api_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+):
+    from wandb.apis._generated import SEARCH_USERS_GQL
+
+    monkeypatch.setattr(Api, "_configure_sentry", lambda self: None)
+
+    error_response = apb.ApiErrorResponse(
+        message="relogin required",
+        http_status=401,
+    )
+    execute_graphql = MagicMock(
+        side_effect=[
+            WandbApiFailedError(error_response.message, error_response),
+            {
+                "users": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "test-id",
+                                "name": "Test User",
+                                "username": "test-user",
+                                "email": "test@example.com",
+                                "admin": False,
+                                "flags": "",
+                                "entity": "test-entity",
+                                "deletedAt": None,
+                                "teams": None,
+                            }
+                        }
+                    ]
+                }
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        wandb.apis.public.api.ServiceApi,
+        "execute_graphql",
+        execute_graphql,
+    )
+
+    result = getattr(Api(api_key="abcd" * 10), method_name)("test-user")
+
+    user = result[0] if method_name == "users" else result
+    assert user.entity == "test-entity"
+    assert user.api_keys == []
+    assert execute_graphql.call_args_list == [
+        mock.call(SEARCH_USERS_GQL, {"query": "test-user"}),
+        mock.call(SEARCH_USERS_GQL, {"query": "test-user"}, omit_fields={"apiKeys"}),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -169,9 +169,13 @@ class Api:
         wbauth.set_auth_settings(settings, self._auth)
         settings.base_url = base_url
         extra_headers = dict(settings.x_extra_http_headers or {})
-        # Preserve the legacy admin-capable Public API transport behavior while
-        # routing GraphQL through wandb-core.
+        # Preserve the legacy Public API transport behavior while routing
+        # GraphQL through wandb-core. The backend gates admin-capable access
+        # and first-party fields (e.g. a user's `apiKeys`) on a recognized
+        # "W&B Public Client" User-Agent; wandb-core's default "wandb-core"
+        # User-Agent would otherwise be rejected with "relogin required".
         extra_headers["Use-Admin-Privileges"] = "true"
+        extra_headers["User-Agent"] = f"W&B Public Client {wandb.__version__}"
         settings.x_extra_http_headers = extra_headers
         if http_proxy := proxies.get("http"):
             settings.http_proxy = http_proxy
@@ -692,24 +696,7 @@ class Api:
         from .users import User
 
         if self._viewer is None:
-            try:
-                data = self._service_api.execute_graphql(GET_VIEWER_GQL)
-            except WandbApiFailedError as e:
-                if _api_error_status(e) != HTTPStatus.UNAUTHORIZED.value:
-                    raise
-
-                # Service-account keys can read viewer data but cannot list
-                # apiKeys. SaaS returns partial data with HTTP 401 for that
-                # field, which wandb-core treats as an error.
-                data = self._service_api.execute_graphql(
-                    GET_VIEWER_GQL,
-                    omit_fields={"apiKeys"},
-                )
-                if isinstance(data, dict) and isinstance(
-                    viewer := data.get("viewer"),
-                    dict,
-                ):
-                    viewer["apiKeys"] = None
+            data = self._service_api.execute_graphql(GET_VIEWER_GQL)
             result = GetViewer.model_validate(data)
             if (viewer := result.viewer) is None:
                 msg = "Unable to fetch user data from W&B, please verify your API key is valid."
@@ -1045,11 +1032,14 @@ class Api:
         Returns:
             A `User` object or None if a user is not found.
         """
-        from wandb.apis._generated import SearchUsers
+        from wandb.apis._generated import SEARCH_USERS_GQL, SearchUsers
 
         from .users import User
 
-        data = self._search_users_data(username_or_email)
+        data = self._service_api.execute_graphql(
+            SEARCH_USERS_GQL,
+            {"query": username_or_email},
+        )
         result = SearchUsers.model_validate(data)
         if not (conn := result.users) or not (edges := conn.edges):
             return None
@@ -1070,11 +1060,14 @@ class Api:
         Returns:
             An array of `User` objects.
         """
-        from wandb.apis._generated import SearchUsers
+        from wandb.apis._generated import SEARCH_USERS_GQL, SearchUsers
 
         from .users import User
 
-        data = self._search_users_data(username_or_email)
+        data = self._service_api.execute_graphql(
+            SEARCH_USERS_GQL,
+            {"query": username_or_email},
+        )
         result = SearchUsers.model_validate(data)
         if not ((conn := result.users) and (edges := conn.edges)):
             return []
@@ -1082,40 +1075,6 @@ class Api:
             User(self._service_api, edge.node.model_dump(), api_key=self.api_key)
             for edge in edges
         ]
-
-    def _search_users_data(self, query: str) -> Any:
-        from wandb.apis._generated import SEARCH_USERS_GQL
-
-        variables = {"query": query}
-        try:
-            return self._service_api.execute_graphql(SEARCH_USERS_GQL, variables)
-        except WandbApiFailedError as e:
-            if _api_error_status(e) != HTTPStatus.UNAUTHORIZED.value:
-                raise
-
-            # Service-account keys can search users but cannot list apiKeys.
-            # SaaS returns partial data with HTTP 401 for that field, which
-            # wandb-core treats as an error.
-            data = self._service_api.execute_graphql(
-                SEARCH_USERS_GQL,
-                variables,
-                omit_fields={"apiKeys"},
-            )
-            if not isinstance(data, dict):
-                return data
-            users = data.get("users")
-            if not isinstance(users, dict):
-                return data
-            edges = users.get("edges")
-            if not isinstance(edges, list):
-                return data
-            for edge in edges:
-                if isinstance(edge, dict) and isinstance(
-                    node := edge.get("node"),
-                    dict,
-                ):
-                    node["apiKeys"] = None
-            return data
 
     def runs(
         self,

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -692,7 +692,24 @@ class Api:
         from .users import User
 
         if self._viewer is None:
-            data = self._service_api.execute_graphql(GET_VIEWER_GQL)
+            try:
+                data = self._service_api.execute_graphql(GET_VIEWER_GQL)
+            except WandbApiFailedError as e:
+                if _api_error_status(e) != HTTPStatus.UNAUTHORIZED.value:
+                    raise
+
+                # Service-account keys can read viewer data but cannot list
+                # apiKeys. SaaS returns partial data with HTTP 401 for that
+                # field, which wandb-core treats as an error.
+                data = self._service_api.execute_graphql(
+                    GET_VIEWER_GQL,
+                    omit_fields={"apiKeys"},
+                )
+                if isinstance(data, dict) and isinstance(
+                    viewer := data.get("viewer"),
+                    dict,
+                ):
+                    viewer["apiKeys"] = None
             result = GetViewer.model_validate(data)
             if (viewer := result.viewer) is None:
                 msg = "Unable to fetch user data from W&B, please verify your API key is valid."
@@ -1028,14 +1045,11 @@ class Api:
         Returns:
             A `User` object or None if a user is not found.
         """
-        from wandb.apis._generated import SEARCH_USERS_GQL, SearchUsers
+        from wandb.apis._generated import SearchUsers
 
         from .users import User
 
-        data = self._service_api.execute_graphql(
-            SEARCH_USERS_GQL,
-            {"query": username_or_email},
-        )
+        data = self._search_users_data(username_or_email)
         result = SearchUsers.model_validate(data)
         if not (conn := result.users) or not (edges := conn.edges):
             return None
@@ -1056,14 +1070,11 @@ class Api:
         Returns:
             An array of `User` objects.
         """
-        from wandb.apis._generated import SEARCH_USERS_GQL, SearchUsers
+        from wandb.apis._generated import SearchUsers
 
         from .users import User
 
-        data = self._service_api.execute_graphql(
-            SEARCH_USERS_GQL,
-            {"query": username_or_email},
-        )
+        data = self._search_users_data(username_or_email)
         result = SearchUsers.model_validate(data)
         if not ((conn := result.users) and (edges := conn.edges)):
             return []
@@ -1071,6 +1082,40 @@ class Api:
             User(self._service_api, edge.node.model_dump(), api_key=self.api_key)
             for edge in edges
         ]
+
+    def _search_users_data(self, query: str) -> Any:
+        from wandb.apis._generated import SEARCH_USERS_GQL
+
+        variables = {"query": query}
+        try:
+            return self._service_api.execute_graphql(SEARCH_USERS_GQL, variables)
+        except WandbApiFailedError as e:
+            if _api_error_status(e) != HTTPStatus.UNAUTHORIZED.value:
+                raise
+
+            # Service-account keys can search users but cannot list apiKeys.
+            # SaaS returns partial data with HTTP 401 for that field, which
+            # wandb-core treats as an error.
+            data = self._service_api.execute_graphql(
+                SEARCH_USERS_GQL,
+                variables,
+                omit_fields={"apiKeys"},
+            )
+            if not isinstance(data, dict):
+                return data
+            users = data.get("users")
+            if not isinstance(users, dict):
+                return data
+            edges = users.get("edges")
+            if not isinstance(edges, list):
+                return data
+            for edge in edges:
+                if isinstance(edge, dict) and isinstance(
+                    node := edge.get("node"),
+                    dict,
+                ):
+                    node["apiKeys"] = None
+            return data
 
     def runs(
         self,


### PR DESCRIPTION
Description
-----------
`wandb.Api(api_key=...).viewer` (and `.user/.users`) regressed in 0.27.1, failing with `WandbApiFailedError: relogin required`. The same keys work in 0.27.0.


#11818 routed the Public API through wandb-core, which sends `User-Agent: wandb-core`. The backend gates first-party fields (e.g. a user's `apiKeys`) on a recognized client (User-Agent the legacy transport sent "W&B Public Client <version>") and rejects the whole request otherwise. (The key does reach wandb-core, and the query is unchanged from 0.27.0; only the User-Agent differs.)

Testing
-------

Verified live against MT SaaS (api.viewer.api_keys returns real keys; user/users work) and added unit tests for key propagation and the User-Agent.