### PR TITLE
fix: wandb.api would drop or duplicate history steps

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,3 +13,7 @@ sections:
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- `Run.scan_history()` no longer returns duplicate or missing steps when getting run history (@jacobromero in https://github.com/wandb/wandb/pull/12010)

--- a/core/internal/runhistoryreader/livedata.go
+++ b/core/internal/runhistoryreader/livedata.go
@@ -96,7 +96,7 @@ func (h *HistoryReader) getLiveDataForSpecificKeys(
 	spec := map[string]any{
 		"keys":    keys,
 		"minStep": minStep,
-		"maxStep": maxStep,
+		"maxStep": maxStep - 1,
 		"samples": maxStep - minStep,
 	}
 	specJSON, err := simplejsonext.MarshalToString(spec)

--- a/core/internal/runhistoryreader/livedata.go
+++ b/core/internal/runhistoryreader/livedata.go
@@ -96,8 +96,13 @@ func (h *HistoryReader) getLiveDataForSpecificKeys(
 	spec := map[string]any{
 		"keys":    keys,
 		"minStep": minStep,
-		"maxStep": maxStep - 1,
 		"samples": maxStep - minStep,
+
+		// SampledHistory marks the max step as inclusive,
+		// This affects the sample window size, causing 1 data point to be dropped.
+		// To keep this inline with the HistoryPage query,
+		// we subtract 1 from the max step to make it exclusive.
+		"maxStep": maxStep - 1,
 	}
 	specJSON, err := simplejsonext.MarshalToString(spec)
 	if err != nil {

--- a/tests/system_tests/test_api/test_public_api_history.py
+++ b/tests/system_tests/test_api/test_public_api_history.py
@@ -415,3 +415,25 @@ def test_run_download_history_exports__require_complete_history_raises_error(
             download_dir=download_dir,
             require_complete_history=True,
         )
+
+
+def test_run_scan_history__with_live_data(
+    wandb_backend_spy,
+    parquet_file_server,
+    monkeypatch,
+):
+    monkeypatch.setenv("WANDB_CACHE_DIR", tempfile.mkdtemp())
+
+    with wandb.init() as run:
+        for i in range(10):
+            run.log({"acc": i})
+
+    run = wandb.Api().run(
+        f"{run.entity}/{run.project}/{run.id}",
+    )
+
+    scan = run.scan_history(page_size=2, keys=["acc"])
+    history = [row for row in scan]
+    expected_history = [{"_step": i, "acc": i} for i in range(10)]
+    assert len(history) == len(expected_history)
+    assert history == expected_history


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

## Summary

Fixes an issue where `Run.scan_history(page_size=..., keys=[...])` could drop or
duplicate history items.
The fix queries `max_step - 1` instead of `max_step` for these requests, which
restores the intended exclusive `[min_step, max_step)` window so adjacent pages no
longer overlap and no rows are downsampled.

## Background

When `keys` are specified, the live-history path queries the backend's
`sampledHistory` endpoint, paging through the run in half-open windows of
`[min_step, max_step)`. For each page we requested `samples = max_step - min_step`.
The backend, however:

1. Rewrites the query as `max_step = max_step + 1`, making `max_step` **inclusive**.
2. Downsamples the result whenever the number of **fetched rows** exceeds the
requested number of **samples**.

This results in some dropped items, because the backend would downsample some history rows, and duplicate other rows because the our `max_step`would be included as the upper bound of the first query, and the lower bound on the second query.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [ ] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

- Added a system test
- Manual verification

```python
import wandb

NUM_STEPS = 10

with wandb.init() as run:
    for step in range(NUM_STEPS):
        run.log({"validation-rmse": 0.9 - 0.06 * step}, step=step)

api_run = wandb.Api().run(f"{run.entity}/{run.project}/{run.id}")
steps = [r["_step"] for r in api_run.scan_history(keys=["validation-rmse", "_step"], page_size=2)]
assert steps == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->