### PR TITLE
chore(sdk): ci: bump codecov orb to v6.0.0 to fix GPG download bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,9 +149,7 @@ commands:
           command: >
             nox -s "<<parameters.session>>" --python <<parameters.python>> --verbose
 
-      - codecov/upload:
-          flags: <<parameters.codecov_flags>>
-          use_pypi: true
+      - codecov/upload: { flags: <<parameters.codecov_flags>> }
       - save-test-results
 
   local-wandb-server-deps:
@@ -479,7 +477,6 @@ jobs:
           name: Install system deps
           command: |
             sudo apt-get update
-            sudo apt-get install -y python3-pip
       - install_go
       - load-go-cache
       - run:
@@ -488,9 +485,7 @@ jobs:
             cd core
             go test -count=1 -race -coverprofile=coverage.txt -covermode=atomic ./...
       - save-go-cache
-      - codecov/upload:
-          flags: unit
-          use_pypi: true
+      - codecov/upload: { flags: unit }
 
   unit-tests-rust:
     resource_class: wandb/docker-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ orbs:
   codecov: codecov/codecov@6.0.0
 
 parameters:
-  codecov_cli_version:
-    type: string
-    default: "11.2.8"
   go_version:
     type: string
     default: "1.26.4"
@@ -155,7 +152,6 @@ commands:
       - codecov/upload:
           flags: <<parameters.codecov_flags>>
           use_pypi: true
-          version: << pipeline.parameters.codecov_cli_version >>
       - save-test-results
 
   local-wandb-server-deps:
@@ -495,7 +491,6 @@ jobs:
       - codecov/upload:
           flags: unit
           use_pypi: true
-          version: << pipeline.parameters.codecov_cli_version >>
 
   unit-tests-rust:
     resource_class: wandb/docker-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,12 @@ orbs:
   go: circleci/go@3.0.4
   slack: circleci/slack@4.12.5
   gcloud: circleci/gcp-cli@3.1.1
-  codecov: codecov/codecov@5.0.0
+  codecov: codecov/codecov@6.0.0
 
 parameters:
+  codecov_cli_version:
+    type: string
+    default: "11.2.8"
   go_version:
     type: string
     default: "1.26.4"
@@ -149,7 +152,10 @@ commands:
           command: >
             nox -s "<<parameters.session>>" --python <<parameters.python>> --verbose
 
-      - codecov/upload: { flags: <<parameters.codecov_flags>> }
+      - codecov/upload:
+          flags: <<parameters.codecov_flags>>
+          use_pypi: true
+          version: << pipeline.parameters.codecov_cli_version >>
       - save-test-results
 
   local-wandb-server-deps:
@@ -477,6 +483,7 @@ jobs:
           name: Install system deps
           command: |
             sudo apt-get update
+            sudo apt-get install -y python3-pip
       - install_go
       - load-go-cache
       - run:
@@ -485,7 +492,10 @@ jobs:
             cd core
             go test -count=1 -race -coverprofile=coverage.txt -covermode=atomic ./...
       - save-go-cache
-      - codecov/upload: { flags: unit }
+      - codecov/upload:
+          flags: unit
+          use_pypi: true
+          version: << pipeline.parameters.codecov_cli_version >>
 
   unit-tests-rust:
     resource_class: wandb/docker-builder


### PR DESCRIPTION
Description
-----------

Bump codecov orb to [v6.0.0](https://github.com/codecov/codecov-circleci-orb/compare/v5.4.3...v6.0.0), which includes [codecov wrapper v0.2.9](https://github.com/codecov/wrapper/releases/tag/v0.2.9), which fixes [GPG key issue](https://github.com/codecov/wrapper/issues/71).

Currently codecov is breaking all tests, e.g.: https://app.circleci.com/pipelines/github/wandb/wandb/64556/workflows/c98bb9cd-8782-4296-8b8a-8ab3d7b544a1/jobs/1676450

```
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
```

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
  - No CHANGELOG needed; CI impact only

Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->

- [x] CI now passes
