### PR TITLE
fix(sweeps): do not load sweeps by default in run response

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Basic remote-run support in W&B LEET TUI (`wandb beta leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
 
 ### Fixed
-
+- `wandb.runs()` no longer loads Sweeps for each run to improve query performance. Use include_sweeps=True to re-enable (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/12019)
 - `wandb.Api().viewer` (and `Api().user()` / `Api().users()`) no longer fail with `WandbApiFailedError: relogin required` for some API keys, a regression in `0.27.1` (@dmitryduev in https://github.com/wandb/wandb/pull/12009)
 - When a `wandb.Image` carrying multiple `box` or `mask` layers with distinct `class_labels` is logged inside a `wandb.Table`, each layer's labels are now preserved in new `box_class_maps` / `mask_class_maps` fields in the `table.json`. Previously, there was only as single `class_map` that got incorrectly clobbered by each set of class labels. The next server release will contain a corresponding frontend fix that reads these per-layer fields. Legacy servers will retain the current behavior. (@kelu-wandb in https://github.com/wandb/wandb/pull/11901)
 - Artifact file operations now consistently require normalized relative paths (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11735)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,8 +19,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 - High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb beta leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)
 - Basic remote-run support in W&B LEET TUI (`wandb beta leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
 
+### Changed
+- `wandb.Api().runs()` no longer loads Sweeps for each run by default to improve query performance. Sweep data is loaded on first access of the `sweep` property (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/12019)
+
 ### Fixed
-- `wandb.runs()` no longer loads Sweeps for each run to improve query performance. Use include_sweeps=True to re-enable (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/12019)
 - `wandb.Api().viewer` (and `Api().user()` / `Api().users()`) no longer fail with `WandbApiFailedError: relogin required` for some API keys, a regression in `0.27.1` (@dmitryduev in https://github.com/wandb/wandb/pull/12009)
 - When a `wandb.Image` carrying multiple `box` or `mask` layers with distinct `class_labels` is logged inside a `wandb.Table`, each layer's labels are now preserved in new `box_class_maps` / `mask_class_maps` fields in the `table.json`. Previously, there was only as single `class_map` that got incorrectly clobbered by each set of class labels. The next server release will contain a corresponding frontend fix that reads these per-layer fields. Legacy servers will retain the current behavior. (@kelu-wandb in https://github.com/wandb/wandb/pull/11901)
 - Artifact file operations now consistently require normalized relative paths (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11735)

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 import wandb
 from wandb.apis.public.runs import Run
+from wandb.apis.public.sweeps import Sweep
 
 
 @pytest.mark.parametrize(
@@ -204,3 +205,47 @@ def test_run_url_encodes_spaces_in_project_name():
     )
 
     assert run.url == "https://wandb.ai/my-entity/My%20Project/runs/12345"
+
+
+def _make_sweep_graphql_response(sweep_name: str) -> dict:
+    return {
+        "project": {
+            "sweep": {
+                "name": sweep_name,
+                "state": "RUNNING",
+                "config": "method: grid\n",
+            }
+        }
+    }
+
+
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_sweep_property_loads_from_api():
+    """Accessing run.sweep should fetch and return a Sweep from the API."""
+    service_api = mock.MagicMock()
+    lightweight = _make_lightweight_attrs()
+    sweep_name = "test-sweep"
+    lightweight["sweepName"] = sweep_name
+    service_api.execute_graphql.return_value = _make_sweep_graphql_response(sweep_name)
+
+    run = Run(
+        service_api=service_api,
+        entity="test-entity",
+        project="test-project",
+        run_id="run-abc123",
+        attrs=dict(lightweight),
+        lazy=True,
+    )
+
+    service_api.execute_graphql.assert_not_called()
+
+    sweep = run.sweep
+
+    assert isinstance(sweep, Sweep)
+    assert sweep.name == sweep_name
+    assert sweep.entity == "test-entity"
+    assert sweep.project == "test-project"
+    service_api.execute_graphql.assert_called_once()
+    assert (
+        service_api.execute_graphql.call_args.kwargs["variables"]["name"] == sweep_name
+    )

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1082,7 +1082,7 @@ class Api:
         filters: dict[str, Any] | None = None,
         order: str = "+created_at",
         per_page: int = 50,
-        include_sweeps: bool = True,
+        include_sweeps: bool = False,
         lazy: bool = True,
     ):
         """Returns a `Runs` object, which lazily iterates over `Run` objects.
@@ -1132,7 +1132,7 @@ class Api:
                 If you prepend order with a - order is descending.
                 The default order is run.created_at from oldest to newest.
             per_page: (int) Sets the page size for query pagination.
-            include_sweeps: (bool) Whether to include the sweep runs in the results.
+            include_sweeps: (bool) Whether to fetch the sweep object in each run result.
             lazy: (bool) Whether to use lazy loading for faster performance.
                 When True (default), only essential run metadata is loaded initially.
                 Heavy fields like config, summaryMetrics, and systemMetrics are loaded

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1132,7 +1132,7 @@ class Api:
                 If you prepend order with a - order is descending.
                 The default order is run.created_at from oldest to newest.
             per_page: (int) Sets the page size for query pagination.
-            include_sweeps: (bool) Whether to fetch the sweep object in each run result.
+            include_sweeps: (bool) Whether to eagerly fetch the sweep object in each run result.
             lazy: (bool) Whether to use lazy loading for faster performance.
                 When True (default), only essential run metadata is loaded initially.
                 Heavy fields like config, summaryMetrics, and systemMetrics are loaded

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -333,7 +333,7 @@ class Runs(SizedPaginator["Run"]):
 
                 if sweep is None:
                     continue
-                run.sweep = sweep
+                run._sweep = sweep
 
         return objs
 
@@ -649,7 +649,7 @@ class Run(Attrs):
         self._files = {}
         self._base_dir = env.get_dir(tempfile.gettempdir())
         self.id = run_id
-        self.sweep = None
+        self._sweep: public.Sweep | None = None
         self._include_sweeps = include_sweeps
         self._lazy = lazy
         self._full_data_loaded = False  # Track if we've loaded full data
@@ -667,6 +667,9 @@ class Run(Attrs):
         self._api_key = api_key
 
         self.load(force=not _attrs)
+
+        if self._include_sweeps:
+            self._load_sweep()
 
     @property
     def state(self) -> str:
@@ -813,19 +816,6 @@ class Run(Attrs):
             if self._attrs.get("user"):
                 self.user = public.User(self._service_api, self._attrs["user"])
 
-            if self._include_sweeps and self.sweep_name and not self.sweep:
-                # There may be a lot of runs. Don't bother pulling them all
-                # just for the sake of this one.
-                from wandb.apis.public.sweeps import _get_sweep
-
-                self.sweep = _get_sweep(
-                    self._service_api,
-                    self.entity,
-                    self.project,
-                    self.sweep_name,
-                    withRuns=False,
-                )
-
         if not self._is_loaded or force:
             # Always set _project_internal_id if projectId is available, regardless of fragment type
             if "projectId" in self._attrs:
@@ -863,19 +853,6 @@ class Run(Attrs):
         if "systemMetrics" in self._attrs:
             self._attrs["systemMetrics"] = _convert_to_dict(
                 self._attrs.get("systemMetrics")
-            )
-
-        # Only check for sweeps if sweep_name is available (not in lazy mode or if it exists)
-        if self._include_sweeps and self._attrs.get("sweepName") and not self.sweep:
-            # There may be a lot of runs. Don't bother pulling them all
-            from wandb.apis.public.sweeps import _get_sweep
-
-            self.sweep = _get_sweep(
-                self._service_api,
-                self.entity,
-                self.project,
-                self._attrs["sweepName"],
-                withRuns=False,
             )
 
         config_user, config_raw = {}, {}
@@ -1536,6 +1513,29 @@ class Run(Attrs):
         """Get sweep name. Always available since sweepName is in lightweight fragment."""
         # sweepName is included in lightweight fragment, so no need to load full data
         return self._attrs.get("sweepName")
+
+    @property
+    def sweep(self) -> public.Sweep | None:
+        """The sweep associated with this run. Loads sweep data if include_sweeps is False."""
+        if self._sweep is None and self.sweep_name:
+            self._load_sweep()
+        return self._sweep
+
+    def _load_sweep(self) -> None:
+        """Load sweep metadata for this run without fetching all sweep runs."""
+        if not self.sweep_name:
+            return
+
+        # There may be a lot of runs. Don't bother pulling them all.
+        from wandb.apis.public.sweeps import _get_sweep
+
+        self._sweep = _get_sweep(
+            self._service_api,
+            self.entity,
+            self.project,
+            self.sweep_name,
+            withRuns=False,
+        )
 
     @property
     def path(self) -> list[str]:

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -210,7 +210,7 @@ class Runs(SizedPaginator["Run"]):
         filters: dict[str, Any] | None = None,
         order: str = "+created_at",
         per_page: int = 50,
-        include_sweeps: bool = True,
+        include_sweeps: bool = False,
         lazy: bool = True,
         api_key: str | None = None,
     ):
@@ -633,7 +633,7 @@ class Run(Attrs):
         project: str,
         run_id: str,
         attrs: Mapping | None = None,
-        include_sweeps: bool = True,
+        include_sweeps: bool = False,
         lazy: bool = True,
         api_key: str | None = None,
     ):


### PR DESCRIPTION
## Description

- Fixes WB-35156

Customers reported very slow .runs() calls. This was investigated and mitigated by setting include_sweeps=False as an argument to .runs(), since in projects with many sweep runs, the Sweep() GQL is called N times across the entire project, making the API run in O(N).

We are making include_sweeps=False by default, but .sweep is now a @property which will load the sweep on frst access.

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

I used .runs() to read sweeps from my personal project. The sweep class was not loaded for each object, but the sweep_name was still available.