### PR TITLE
feat(leet): promote W&B LEET to GA as `wandb leet`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,8 +16,13 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Added
 
-- High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb beta leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)
-- Basic remote-run support in W&B LEET TUI (`wandb beta leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
+- High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)
+- Basic remote-run support in W&B LEET TUI (`wandb leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
+- Runs in offline mode now display a hint about viewing the run in the terminal with `wandb leet` (@dmitryduev in https://github.com/wandb/wandb/pull/XXXXX)
+
+### Changed
+
+- W&B LEET, the terminal UI for viewing W&B runs, is now generally available as `wandb leet`; `wandb beta leet` is kept as an alias (@dmitryduev in https://github.com/wandb/wandb/pull/XXXXX)
 
 ### Fixed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,11 +18,11 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)
 - Basic remote-run support in W&B LEET TUI (`wandb leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
-- Runs in offline mode now display a hint about viewing the run in the terminal with `wandb leet` (@dmitryduev in https://github.com/wandb/wandb/pull/XXXXX)
+- Runs in offline mode now display a hint about viewing the run in the terminal with `wandb leet` (@dmitryduev in https://github.com/wandb/wandb/pull/12028)
 
 ### Changed
 
-- W&B LEET, the terminal UI for viewing W&B runs, is now generally available as `wandb leet`; `wandb beta leet` is kept as an alias (@dmitryduev in https://github.com/wandb/wandb/pull/XXXXX)
+- W&B LEET, the terminal UI for viewing W&B runs, is now generally available as `wandb leet`; `wandb beta leet` is kept as an alias (@dmitryduev in https://github.com/wandb/wandb/pull/12028)
 
 ### Fixed
 

--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -61,7 +61,7 @@ const (
 	DefaultWorkspaceMediaGridCols = 2
 
 	// Startup modes control what LEET does when launched without a specified run path
-	// (i.e. `wandb beta leet` with no PATH).
+	// (i.e. `wandb leet` with no PATH).
 	StartupModeWorkspaceLatest = "workspace_latest"  // Load workspace view and select latest run
 	StartupModeSingleRunLatest = "single_run_latest" // Load latest run in the single-run view
 	DefaultStartupMode         = StartupModeWorkspaceLatest

--- a/core/internal/leet/configeditor.go
+++ b/core/internal/leet/configeditor.go
@@ -34,7 +34,7 @@ type ConfigEditorParams struct {
 // ConfigEditor is a standalone Bubble Tea model for interactively editing
 // LEET's persisted configuration.
 //
-// Launch it with `wandb beta leet config`. It reads the current config from
+// Launch it with `wandb leet config`. It reads the current config from
 // disk, presents every editable field in a navigable table, and writes changes
 // back atomically on save.
 //

--- a/core/internal/leet/help.go
+++ b/core/internal/leet/help.go
@@ -103,7 +103,7 @@ func (h *HelpModel) entriesForMode() []HelpEntry {
 func tipsEntries() []HelpEntry {
 	return []HelpEntry{
 		{Key: "Tips", Description: ""},
-		{Key: "wandb beta leet config", Description: "Open the interactive config editor"},
+		{Key: "wandb leet config", Description: "Open the interactive config editor"},
 		{Key: "Runs filter", Description: "Bare terms search run key/name/id/project/tags/notes. " +
 			"Qualifiers: project:, name:, id:, tag:, note:, config:, cfg.<path>:, has:. " +
 			"Boolean: space/AND, OR or |, -/!/NOT."},
@@ -116,7 +116,7 @@ func tipsEntries() []HelpEntry {
 func symonTipsEntries() []HelpEntry {
 	return []HelpEntry{
 		{Key: "Tips", Description: ""},
-		{Key: "wandb beta leet config", Description: "Open the interactive config editor"},
+		{Key: "wandb leet config", Description: "Open the interactive config editor"},
 		{Key: "SYMON", Description: "Live system monitor"},
 		blankLine,
 	}

--- a/tests/unit_tests/test_cli_leet.py
+++ b/tests/unit_tests/test_cli_leet.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from wandb.cli import cli, leet
+
+
+@pytest.fixture
+def core_calls(monkeypatch) -> list[list[str]]:
+    """Stub out wandb-core and record the arguments it would be invoked with."""
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(leet, "get_core_path", lambda: "wandb-core")
+    monkeypatch.setattr(leet, "error_reporting_enabled", lambda: True)
+    monkeypatch.setattr(leet, "is_debug", lambda default: False)
+    monkeypatch.setattr(leet, "_run_core", lambda args, env=None: calls.append(args))
+
+    return calls
+
+
+def test_leet_help_shows_run_command(runner):
+    result = runner.invoke(cli.cli, ["leet", "--help"])
+
+    assert result.exit_code == 0
+    assert "Launch the LEET TUI" in result.output
+
+
+def test_leet_defaults_to_run_command(runner, core_calls, tmp_path: pathlib.Path):
+    wandb_dir = tmp_path / "wandb"
+    wandb_dir.mkdir()
+
+    result = runner.invoke(cli.cli, ["leet", str(wandb_dir)])
+
+    assert result.exit_code == 0
+    assert core_calls == [["wandb-core", "leet", str(wandb_dir.resolve())]]
+
+
+def test_leet_resolves_run_directory(runner, core_calls, tmp_path: pathlib.Path):
+    run_dir = tmp_path / "wandb" / "run-20250101_000000-abc123"
+    run_dir.mkdir(parents=True)
+    run_file = run_dir / "run-abc123.wandb"
+    run_file.touch()
+
+    result = runner.invoke(cli.cli, ["leet", str(run_dir)])
+
+    assert result.exit_code == 0
+    assert core_calls == [
+        [
+            "wandb-core",
+            "leet",
+            "--run-file",
+            str(run_file.resolve()),
+            str((tmp_path / "wandb").resolve()),
+        ]
+    ]
+
+
+def test_beta_leet_is_an_alias(runner, core_calls, tmp_path: pathlib.Path):
+    wandb_dir = tmp_path / "wandb"
+    wandb_dir.mkdir()
+
+    result = runner.invoke(cli.cli, ["beta", "leet", str(wandb_dir)])
+
+    assert result.exit_code == 0
+    assert "generally available as `wandb leet`" in result.stderr
+    assert core_calls == [["wandb-core", "leet", str(wandb_dir.resolve())]]

--- a/tests/unit_tests/test_cli_leet.py
+++ b/tests/unit_tests/test_cli_leet.py
@@ -4,6 +4,7 @@ import pathlib
 
 import pytest
 from wandb.cli import cli, leet
+from wandb.errors import WandbCoreNotAvailableError
 
 
 @pytest.fixture
@@ -19,11 +20,44 @@ def core_calls(monkeypatch) -> list[list[str]]:
     return calls
 
 
-def test_leet_help_shows_run_command(runner):
-    result = runner.invoke(cli.cli, ["leet", "--help"])
+@pytest.fixture
+def core_unavailable(monkeypatch) -> None:
+    """Make wandb-core resolution fail as on an unsupported platform."""
+
+    def raise_unavailable() -> str:
+        raise WandbCoreNotAvailableError("wandb-core not found")
+
+    monkeypatch.setattr(leet, "get_core_path", raise_unavailable)
+
+
+@pytest.mark.parametrize("help_flag", ["--help", "-h"])
+def test_leet_help_shows_group_help(runner, core_unavailable, help_flag):
+    """Group help lists all subcommands and works without wandb-core."""
+    result = runner.invoke(cli.cli, ["leet", help_flag])
+
+    assert result.exit_code == 0
+    assert "Lightweight Experiment Exploration Tool" in result.output
+    assert "Launch the LEET TUI" in result.output
+    assert "Launch the standalone system monitor" in result.output
+    assert "Edit LEET configuration" in result.output
+    assert "wandb-core not found" not in result.output
+
+
+def test_leet_run_help_shows_run_command(runner):
+    result = runner.invoke(cli.cli, ["leet", "run", "--help"])
 
     assert result.exit_code == 0
     assert "Launch the LEET TUI" in result.output
+
+
+def test_leet_fails_cleanly_without_core(runner, core_unavailable, tmp_path):
+    wandb_dir = tmp_path / "wandb"
+    wandb_dir.mkdir()
+
+    result = runner.invoke(cli.cli, ["leet", str(wandb_dir)])
+
+    assert result.exit_code == 1
+    assert "Error: wandb-core not found" in result.stderr
 
 
 def test_leet_defaults_to_run_command(runner, core_calls, tmp_path: pathlib.Path):

--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -6,7 +6,6 @@ These commands are experimental and may change or be removed in future versions.
 from __future__ import annotations
 
 import pathlib
-from typing import Any
 
 import click
 
@@ -14,31 +13,12 @@ from wandb.analytics import get_sentry
 from wandb.errors import WandbCoreNotAvailableError
 from wandb.util import get_core_path
 
-
-class DefaultCommandGroup(click.Group):
-    """A click Group that falls through to a default command.
-
-    If the first argument isn't a recognized subcommand, the default
-    command is invoked with all arguments passed through. This allows
-    backward-compatible CLIs where `cmd [path]` and `cmd run [path]`
-    are equivalent.
-    """
-
-    def __init__(self, *args: Any, default_cmd: str = "run", **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.default_cmd = default_cmd
-
-    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        if not args or args[0].startswith("-") or args[0] not in self.commands:
-            args = [self.default_cmd, *args]
-        return super().parse_args(ctx, args)
-
-    def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        formatter.write_usage(ctx.command_path, "[PATH] | COMMAND [ARGS]...")
+from .leet import leet
 
 
 @click.group()
-def beta() -> None:
+@click.pass_context
+def beta(ctx: click.Context) -> None:
     """Beta versions of wandb CLI commands.
 
     These commands may change or even completely break in any release of wandb.
@@ -54,73 +34,18 @@ def beta() -> None:
             err=True,
         )
 
-
-@beta.group(cls=DefaultCommandGroup, default_cmd="run", invoke_without_command=True)
-@click.pass_context
-def leet(ctx: click.Context) -> None:
-    """W&B LEET: the Lightweight Experiment Exploration Tool.
-
-    A terminal UI for viewing your W&B runs locally.
-
-    Examples:
-        wandb beta leet                    View the latest run
-        wandb beta leet ./wandb            Browse runs in a wandb directory
-        wandb beta leet <run-url>          View a remote W&B run
-        wandb beta leet symon              View live local system metrics
-    """
-    pass
+    if ctx.invoked_subcommand == "leet":
+        click.secho(
+            "LEET is now generally available as `wandb leet`;"
+            " `wandb beta leet` is kept as an alias.",
+            fg="yellow",
+            err=True,
+        )
 
 
-@leet.command()
-@click.argument("path", nargs=1, type=click.STRING, required=False)
-@click.option(
-    "--pprof",
-    default="",
-    hidden=True,
-    help="Serve /debug/pprof/* on this address (e.g. 127.0.0.1:6060).",
-)
-@click.help_option("-h", "--help")
-def run(path: str | None = None, pprof: str = "") -> None:
-    """Launch the LEET TUI.
-
-    LEET is a terminal UI for viewing a W&B run specified by an optional PATH.
-
-    PATH can include a .wandb file, a run directory containing a .wandb file,
-    or a W&B run URL.
-    If PATH is not provided, the command will look for the latest run.
-    """
-    from . import beta_leet
-
-    beta_leet.launch(path, pprof)
-
-
-@leet.command()
-@click.option(
-    "--pprof",
-    default="",
-    hidden=True,
-    help="Serve /debug/pprof/* on this address (e.g. 127.0.0.1:6060).",
-)
-@click.option(
-    "--interval",
-    default="",
-    metavar="DURATION",
-    help="Sampling interval for system metrics (e.g. 500ms, 2s, 1m).",
-)
-@click.help_option("-h", "--help")
-def symon(pprof: str = "", interval: str = "") -> None:
-    """Launch the standalone system monitor."""
-    from . import beta_leet
-
-    beta_leet.launch_symon(pprof=pprof, interval=interval)
-
-
-@leet.command()
-def config() -> None:
-    """Edit LEET configuration."""
-    from . import beta_leet
-
-    beta_leet.launch_config()
+# LEET graduated from beta; `wandb beta leet` is kept as an alias for
+# `wandb leet` to avoid breaking existing users.
+beta.add_command(leet)
 
 
 @beta.command()

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -43,6 +43,7 @@ from wandb.sdk.lib import filesystem, settings_file
 from wandb.sync import SyncManager, get_run_from_path, get_runs
 
 from .beta import beta
+from .leet import leet
 
 
 def _get_wandb_dir(root_dir: str | None = None) -> str:
@@ -3684,3 +3685,4 @@ def purge_cache(
 
 
 cli.add_command(beta)
+cli.add_command(leet)

--- a/wandb/cli/leet.py
+++ b/wandb/cli/leet.py
@@ -1,3 +1,9 @@
+"""The `wandb leet` command.
+
+W&B LEET, the Lightweight Experiment Exploration Tool, is a terminal UI
+for viewing W&B runs.
+"""
+
 from __future__ import annotations
 
 import dataclasses
@@ -6,15 +12,104 @@ import pathlib
 import subprocess
 import sys
 import urllib.parse
+from typing import Any
 
 import click
 from typing_extensions import Never
 
 from wandb.analytics import get_sentry
 from wandb.env import error_reporting_enabled, is_debug
+from wandb.errors import WandbCoreNotAvailableError
 from wandb.sdk import wandb_setup
 from wandb.sdk.lib import wbauth
 from wandb.util import get_core_path
+
+
+class DefaultCommandGroup(click.Group):
+    """A click Group that falls through to a default command.
+
+    If the first argument isn't a recognized subcommand, the default
+    command is invoked with all arguments passed through. This allows
+    backward-compatible CLIs where `cmd [path]` and `cmd run [path]`
+    are equivalent.
+    """
+
+    def __init__(self, *args: Any, default_cmd: str = "run", **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.default_cmd = default_cmd
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not args or args[0].startswith("-") or args[0] not in self.commands:
+            args = [self.default_cmd, *args]
+        return super().parse_args(ctx, args)
+
+    def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        formatter.write_usage(ctx.command_path, "[PATH] | COMMAND [ARGS]...")
+
+
+@click.group(cls=DefaultCommandGroup, default_cmd="run", invoke_without_command=True)
+def leet() -> None:
+    """W&B LEET: the Lightweight Experiment Exploration Tool.
+
+    A terminal UI for viewing your W&B runs locally.
+
+    Examples:
+        wandb leet                    View the latest run
+        wandb leet ./wandb            Browse runs in a wandb directory
+        wandb leet <run-url>          View a remote W&B run
+        wandb leet symon              View live local system metrics
+    """
+    try:
+        get_core_path()
+    except WandbCoreNotAvailableError as e:
+        get_sentry().exception(f"using `wandb leet`. failed with {e}")
+        click.secho(str(e), fg="red", err=True)
+
+
+@leet.command()
+@click.argument("path", nargs=1, type=click.STRING, required=False)
+@click.option(
+    "--pprof",
+    default="",
+    hidden=True,
+    help="Serve /debug/pprof/* on this address (e.g. 127.0.0.1:6060).",
+)
+@click.help_option("-h", "--help")
+def run(path: str | None = None, pprof: str = "") -> None:
+    """Launch the LEET TUI.
+
+    LEET is a terminal UI for viewing a W&B run specified by an optional PATH.
+
+    PATH can include a .wandb file, a run directory containing a .wandb file,
+    or a W&B run URL.
+    If PATH is not provided, the command will look for the latest run.
+    """
+    launch(path, pprof)
+
+
+@leet.command()
+@click.option(
+    "--pprof",
+    default="",
+    hidden=True,
+    help="Serve /debug/pprof/* on this address (e.g. 127.0.0.1:6060).",
+)
+@click.option(
+    "--interval",
+    default="",
+    metavar="DURATION",
+    help="Sampling interval for system metrics (e.g. 500ms, 2s, 1m).",
+)
+@click.help_option("-h", "--help")
+def symon(pprof: str = "", interval: str = "") -> None:
+    """Launch the standalone system monitor."""
+    launch_symon(pprof=pprof, interval=interval)
+
+
+@leet.command()
+def config() -> None:
+    """Edit LEET configuration."""
+    launch_config()
 
 
 class LaunchConfig:

--- a/wandb/cli/leet.py
+++ b/wandb/cli/leet.py
@@ -28,10 +28,10 @@ from wandb.util import get_core_path
 class DefaultCommandGroup(click.Group):
     """A click Group that falls through to a default command.
 
-    If the first argument isn't a recognized subcommand, the default
-    command is invoked with all arguments passed through. This allows
-    backward-compatible CLIs where `cmd [path]` and `cmd run [path]`
-    are equivalent.
+    If the first argument isn't a recognized subcommand or a help flag,
+    the default command is invoked with all arguments passed through.
+    This allows backward-compatible CLIs where `cmd [path]` and
+    `cmd run [path]` are equivalent.
     """
 
     def __init__(self, *args: Any, default_cmd: str = "run", **kwargs: Any) -> None:
@@ -39,6 +39,8 @@ class DefaultCommandGroup(click.Group):
         self.default_cmd = default_cmd
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if args and args[0] in ctx.help_option_names:
+            return super().parse_args(ctx, args)
         if not args or args[0].startswith("-") or args[0] not in self.commands:
             args = [self.default_cmd, *args]
         return super().parse_args(ctx, args)
@@ -47,23 +49,24 @@ class DefaultCommandGroup(click.Group):
         formatter.write_usage(ctx.command_path, "[PATH] | COMMAND [ARGS]...")
 
 
-@click.group(cls=DefaultCommandGroup, default_cmd="run", invoke_without_command=True)
+@click.group(
+    cls=DefaultCommandGroup,
+    default_cmd="run",
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 def leet() -> None:
     """W&B LEET: the Lightweight Experiment Exploration Tool.
 
     A terminal UI for viewing your W&B runs locally.
 
+    \b
     Examples:
         wandb leet                    View the latest run
         wandb leet ./wandb            Browse runs in a wandb directory
         wandb leet <run-url>          View a remote W&B run
         wandb leet symon              View live local system metrics
-    """
-    try:
-        get_core_path()
-    except WandbCoreNotAvailableError as e:
-        get_sentry().exception(f"using `wandb leet`. failed with {e}")
-        click.secho(str(e), fg="red", err=True)
+    """  # noqa: D301 -- the \b escape is click's marker to not rewrap Examples.
 
 
 @leet.command()
@@ -190,7 +193,13 @@ def _resolve_path(path: str | None) -> LaunchConfig:
 
 def _base_args() -> list[str]:
     """Build the common base arguments for wandb-core leet commands."""
-    args = [get_core_path(), "leet"]
+    try:
+        core_path = get_core_path()
+    except WandbCoreNotAvailableError as e:
+        get_sentry().exception(f"using `wandb leet`. failed with {e}")
+        _fatal(str(e))
+
+    args = [core_path, "leet"]
 
     if not error_reporting_enabled():
         args.append("--no-observability")

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3762,7 +3762,11 @@ class Run:
                 f"or set {self._printer.code('WANDB_MODE=online')} "
                 "to enable cloud syncing."
             )
-            self._printer.display([offline_warning, sync_location_msg])
+            leet_hint = (
+                "View this run in the terminal with "
+                f"{self._printer.code('`wandb leet`')}"
+            )
+            self._printer.display([offline_warning, sync_location_msg, leet_hint])
         else:
             messages = [sync_location_msg]
 


### PR DESCRIPTION
Description
-----------

LEET, the terminal UI for viewing W&B runs, graduates from beta:

- Move the `leet` command group out of `wandb beta` to the top-level CLI. The command definitions and the launch logic now live together in `wandb/cli/leet.py` (renamed from `beta_leet.py`).
- Keep `wandb beta leet` working as an alias that points at the same command group and prints a notice about the GA command.
- Display a hint about viewing the run with `wandb leet` in the run header when running in offline mode.
- Update Go-side help and docs strings to reference `wandb leet`.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
