### PR TITLE
fix(artifacts): verify files with sha256 integrity digest

### DIFF
--- a/tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
+++ b/tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py
@@ -8,6 +8,10 @@ from pytest_mock import MockerFixture
 from wandb.sdk.artifacts._validators import validate_fspath
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
+from wandb.sdk.artifacts.artifact_manifests.artifact_manifest_v1 import (
+    ArtifactManifestV1,
+)
+from wandb.sdk.lib.hashutil import sha256_file_b64
 
 
 @mark.parametrize(
@@ -67,6 +71,56 @@ def test_manifest_download(mocker: MockerFixture, tmp_path: Path, cache_path: Pa
     entry.path = cache_path
     fpath = PurePath(entry.download(root=tmp_path, skip_cache=True))
     assert Path(fpath) == tmp_path / cache_path
+
+
+def test_manifest_download_rejects_sha256_mismatch(
+    mocker: MockerFixture,
+    tmp_path: Path,
+):
+    expected_path = tmp_path / "expected.bin"
+    artifact_path = tmp_path / "artifact.bin"
+    cache_path = tmp_path / "cache.bin"
+    expected_path.write_text("expected")
+    artifact_path.write_text("substituted")
+    cache_path.write_text("substituted")
+
+    artifact = Artifact("mnist", type="dataset")
+    entry = ArtifactManifestEntry(
+        path=artifact_path.name,
+        digest="legacy-digest",
+        extra={"sha256": sha256_file_b64(expected_path)},
+    )
+    entry._parent_artifact = artifact
+
+    mocker.patch.object(
+        artifact.manifest.storage_policy,
+        "load_file",
+        return_value=cache_path,
+    )
+
+    with raises(ValueError, match="Digest mismatch"):
+        entry.download(root=tmp_path)
+
+
+def test_manifest_digest_includes_sha256_when_available(tmp_path: Path):
+    first_manifest = ArtifactManifestV1()
+    first_manifest.add_entry(
+        ArtifactManifestEntry(
+            path="artifact.bin",
+            digest="legacy-digest",
+            extra={"sha256": "first-sha256"},
+        )
+    )
+    second_manifest = ArtifactManifestV1()
+    second_manifest.add_entry(
+        ArtifactManifestEntry(
+            path="artifact.bin",
+            digest="legacy-digest",
+            extra={"sha256": "second-sha256"},
+        )
+    )
+
+    assert first_manifest.digest() != second_manifest.digest()
 
 
 @mark.parametrize(

--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -20,7 +20,7 @@ from wandb.sdk.artifacts.storage_handlers.local_file_handler import LocalFileHan
 from wandb.sdk.artifacts.storage_handlers.s3_handler import S3Handler
 from wandb.sdk.artifacts.storage_handlers.wb_artifact_handler import WBArtifactHandler
 from wandb.sdk.artifacts.storage_policy import StoragePolicy
-from wandb.sdk.lib.hashutil import ETag, md5_string
+from wandb.sdk.lib.hashutil import ETag, md5_file_b64, md5_string, sha256_file_b64
 
 example_digest = md5_string("example")
 
@@ -339,6 +339,40 @@ def test_local_file_handler_load_path_uses_cache(artifact_file_cache, tmp_path):
         local=True,
     )
     assert local_path == path
+
+
+def test_local_file_handler_rejects_sha256_mismatched_cache(
+    artifact_file_cache,
+    tmp_path,
+):
+    source = tmp_path / "source.txt"
+    source.write_text("expected")
+    poisoned = tmp_path / "poisoned.txt"
+    poisoned.write_text("poisoned")
+    uri = source.as_uri()
+    digest = md5_file_b64(source)
+
+    path, _, opener = artifact_file_cache.check_md5_obj_path(
+        b64_md5=digest,
+        size=source.stat().st_size,
+    )
+    with opener() as f:
+        f.write(poisoned.read_text())
+
+    handler = LocalFileHandler()
+
+    local_path = handler.load_path(
+        ArtifactManifestEntry(
+            path="foo/bar",
+            ref=uri,
+            digest=digest,
+            size=source.stat().st_size,
+            extra={"sha256": sha256_file_b64(source)},
+        ),
+        local=True,
+    )
+    assert local_path == path
+    assert Path(local_path).read_text() == source.read_text()
 
 
 def test_s3_storage_handler_load_path_uses_cache(artifact_file_cache):

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -30,6 +30,7 @@ from wandb.sdk.artifacts.storage_policies._multipart import (
     should_multipart_download,
 )
 from wandb.sdk.artifacts.storage_policies.wandb_storage_policy import WandbStoragePolicy
+from wandb.sdk.lib.hashutil import md5_file_b64, sha256_file_b64
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -520,6 +521,17 @@ def test_add_file_rejects_invalid_artifact_path(tmp_path, invalid_name):
         artifact.add_file(str(local_file), name=invalid_name)
 
 
+def test_add_file_records_sha256_digest(tmp_path):
+    artifact = Artifact("test-artifact", "test-type")
+    local_file = tmp_path / "test.txt"
+    local_file.write_text("hello")
+
+    entry = artifact.add_file(str(local_file))
+
+    assert entry.digest == md5_file_b64(local_file)
+    assert entry.extra["sha256"] == sha256_file_b64(local_file)
+
+
 @mark.parametrize("invalid_name", ["../test.txt", "/test.txt", r"C:\test.txt"])
 def test_new_file_rejects_invalid_artifact_path(invalid_name):
     artifact = Artifact("test-artifact", "test-type")
@@ -557,6 +569,25 @@ def test_verify_rejects_invalid_artifact_path(tmp_path):
     artifact.manifest.entries[bad_entry.path] = bad_entry
 
     with raises(ValueError, match="Invalid artifact path"):
+        artifact.verify(root=str(tmp_path))
+
+
+def test_verify_uses_sha256_when_available(tmp_path):
+    artifact = Artifact("test-artifact", "test-type")
+    artifact._state = ArtifactState.COMMITTED
+    local_file = tmp_path / "test.txt"
+    local_file.write_text("expected")
+    artifact.manifest.add_entry(
+        ArtifactManifestEntry(
+            path=local_file.name,
+            digest=md5_file_b64(local_file),
+            extra={"sha256": sha256_file_b64(local_file)},
+        )
+    )
+
+    local_file.write_text("different")
+
+    with raises(ValueError, match="Digest mismatch"):
         artifact.verify(root=str(tmp_path))
 
 

--- a/tests/unit_tests/test_lib/test_hashutil.py
+++ b/tests/unit_tests/test_lib/test_hashutil.py
@@ -73,6 +73,11 @@ def test_md5_file_b64_no_files():
     assert b64hash == hashutil.md5_file_b64()
 
 
+def test_sha256_file_b64_no_files():
+    b64hash = base64.b64encode(hashlib.sha256(b"").digest()).decode("ascii")
+    assert b64hash == hashutil.sha256_file_b64()
+
+
 def test_md5_file_hex_single_file(bin_data):
     fpath = Path("binfile")
     fpath.write_bytes(bin_data)
@@ -95,6 +100,22 @@ def test_md5_file_hashes_on_three_files(bin_data, txt_data, bin_data2):
     # Intentionally provide the paths out of order (check sorting).
     assert expected_b64_hash == hashutil.md5_file_b64(fpath_c, fpath_a, fpath_b)
     assert expected_hex_hash == hashutil.md5_file_hex(fpath_c, fpath_a, fpath_b)
+
+
+def test_sha256_file_hashes_on_three_files(bin_data, txt_data, bin_data2):
+    fpath_a = Path("a.bin")
+    fpath_b = Path("b.txt")
+    fpath_c = Path("c.bin")
+
+    fpath_a.write_bytes(bin_data)
+    fpath_b.write_text(txt_data, encoding="utf-8")
+    fpath_c.write_bytes(bin_data2)
+
+    data = bin_data + fpath_b.read_bytes() + bin_data2
+    expected_b64_hash = base64.b64encode(hashlib.sha256(data).digest()).decode("ascii")
+
+    # Intentionally provide the paths out of order (check sorting).
+    assert expected_b64_hash == hashutil.sha256_file_b64(fpath_c, fpath_a, fpath_b)
 
 
 @pytest.mark.skipif(

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -53,7 +53,7 @@ from wandb.sdk.data_types._dtypes import TypeRegistry
 from wandb.sdk.lib import retry, telemetry
 from wandb.sdk.lib.deprecation import warn_and_record_deprecation
 from wandb.sdk.lib.filesystem import check_exists, system_preferred_path
-from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64
+from wandb.sdk.lib.hashutil import B64MD5, b64_to_hex_id, md5_file_b64, sha256_file_b64
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, URIStr
 from wandb.sdk.lib.runid import generate_fast_id, generate_id
 from wandb.sdk.mailbox import MailboxHandle
@@ -1515,6 +1515,7 @@ class Artifact:
 
         name = LogicalPath(name or os.path.basename(local_path))
         digest = md5_file_b64(local_path)
+        sha256_digest = sha256_file_b64(local_path)
 
         if is_tmp:
             file_path, file_name = os.path.split(name)
@@ -1526,6 +1527,7 @@ class Artifact:
             name,
             local_path,
             digest=digest,
+            extra={"sha256": sha256_digest},
             skip_cache=skip_cache,
             policy=policy,
             overwrite=overwrite,
@@ -1790,6 +1792,7 @@ class Artifact:
         name: StrPath,
         path: StrPath,
         digest: B64MD5 | None = None,
+        extra: dict[str, Any] | None = None,
         skip_cache: bool | None = False,
         policy: Literal["mutable", "immutable"] | None = "mutable",
         overwrite: bool = False,
@@ -1812,6 +1815,9 @@ class Artifact:
             path=name,
             digest=digest or md5_file_b64(upload_path),
             size=os.path.getsize(upload_path),
+            extra=extra
+            if extra is not None
+            else {"sha256": sha256_file_b64(upload_path)},
             local_path=upload_path,
             skip_cache=skip_cache,
         )
@@ -2311,7 +2317,9 @@ class Artifact:
         ref_count = 0
         for entry in self.manifest.entries.values():
             if entry.ref is None:
-                if md5_file_b64(validate_fspath(root, entry.path)) != entry.digest:
+                if not entry._local_file_digest_matches(
+                    validate_fspath(root, entry.path)
+                ):
                     raise ValueError(f"Digest mismatch for file: {entry.path}")
             else:
                 ref_count += 1

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -5,13 +5,15 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import concurrent.futures
 import hashlib
 import logging
 import os
 from contextlib import suppress
 from os.path import getsize
-from typing import TYPE_CHECKING, Annotated, Any, Dict, Final, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Dict, Final, Literal, Optional, Union
 from urllib.parse import urlparse
 
 from pydantic import Field, NonNegativeInt, field_validator, model_validator
@@ -23,10 +25,12 @@ from wandb.sdk.lib.deprecation import warn_and_record_deprecation
 from wandb.sdk.lib.filesystem import copy_or_overwrite_changed
 from wandb.sdk.lib.hashutil import (
     B64MD5,
+    B64SHA256,
     ETag,
     b64_to_hex_id,
     hex_to_b64_id,
     md5_file_b64,
+    sha256_file_b64,
 )
 from wandb.sdk.lib.paths import FilePathStr, LogicalPath, URIStr
 
@@ -41,6 +45,42 @@ logger = logging.getLogger(__name__)
 
 
 _WB_ARTIFACT_SCHEME: Final[str] = "wandb-artifact"
+_SHA256_DIGEST_KEY: Final[str] = "sha256"
+_MD5_DIGEST_BYTES: Final[int] = 16
+_LocalDigestAlgorithm = Literal["md5", "sha256"]
+
+
+def _format_cached_checksum(algorithm: _LocalDigestAlgorithm, digest: str) -> str:
+    return f"{algorithm}:{digest}"
+
+
+def _cached_checksum_matches(
+    cached_checksum: str | None,
+    algorithm: _LocalDigestAlgorithm,
+    digest: str,
+) -> bool:
+    if cached_checksum is None:
+        return False
+
+    if cached_checksum == _format_cached_checksum(algorithm, digest):
+        return True
+
+    # Backward compatibility with checksum cache entries written before the
+    # algorithm was included in the cache value.
+    return algorithm == "md5" and cached_checksum == digest
+
+
+def _is_b64_md5_digest(digest: str) -> bool:
+    try:
+        return len(base64.b64decode(digest, validate=True)) == _MD5_DIGEST_BYTES
+    except (binascii.Error, ValueError):
+        return False
+
+
+def _file_digest_b64(file_path: str, algorithm: _LocalDigestAlgorithm) -> str:
+    if algorithm == "sha256":
+        return sha256_file_b64(file_path)
+    return md5_file_b64(file_path)
 
 
 def _checksum_cache_path(file_path: str) -> str:
@@ -153,6 +193,36 @@ class ArtifactManifestEntry(ArtifactsBase):
             raise NotImplementedError
         return self._parent_artifact
 
+    def _local_integrity_digest(self) -> tuple[_LocalDigestAlgorithm, str] | None:
+        """Return the strongest available content digest for local file checks."""
+        sha256_digest = self.extra.get(_SHA256_DIGEST_KEY)
+        if isinstance(sha256_digest, str):
+            return "sha256", B64SHA256(sha256_digest)
+
+        if isinstance(self.digest, str) and _is_b64_md5_digest(self.digest):
+            return "md5", B64MD5(self.digest)
+
+        return None
+
+    def _local_file_digest_matches(self, file_path: str) -> bool:
+        integrity_digest = self._local_integrity_digest()
+        if integrity_digest is None:
+            return False
+
+        algorithm, expected_digest = integrity_digest
+        return _file_digest_b64(file_path, algorithm) == expected_digest
+
+    def _cache_hit_integrity_matches(self, file_path: str) -> bool:
+        integrity_digest = self._local_integrity_digest()
+        if integrity_digest is None:
+            return True
+
+        algorithm, expected_digest = integrity_digest
+        if algorithm != "sha256":
+            return True
+
+        return _file_digest_b64(file_path, algorithm) == expected_digest
+
     def download(
         self,
         root: str | None = None,
@@ -174,21 +244,35 @@ class ArtifactManifestEntry(ArtifactsBase):
 
         # Skip checking the cache (and possibly downloading) if the file already exists
         # and has the digest we're expecting.
+        dest_path_integrity_mismatch = False
+        integrity_digest = self._local_integrity_digest()
+        if integrity_digest is not None:
+            algorithm, expected_digest = integrity_digest
 
-        # Fast integrity check using cached checksum from persistent cache
-        with suppress(OSError):
-            if self.digest == _read_cached_checksum(dest_path):
-                return FilePathStr(dest_path)
+            if algorithm == "md5":
+                # Fast integrity check using cached checksum from persistent cache
+                with suppress(OSError):
+                    if _cached_checksum_matches(
+                        _read_cached_checksum(dest_path),
+                        algorithm,
+                        expected_digest,
+                    ):
+                        return FilePathStr(dest_path)
 
-        # Fallback to computing/caching the checksum hash
-        try:
-            md5_hash = md5_file_b64(dest_path)
-        except (FileNotFoundError, IsADirectoryError):
-            logger.debug(f"unable to find {dest_path!r}, skip searching for file")
-        else:
-            _write_cached_checksum(dest_path, md5_hash)
-            if self.digest == md5_hash:
-                return FilePathStr(dest_path)
+            # Fallback to computing/caching the checksum hash
+            try:
+                file_digest = _file_digest_b64(dest_path, algorithm)
+            except (FileNotFoundError, IsADirectoryError):
+                logger.debug(f"unable to find {dest_path!r}, skip searching for file")
+            else:
+                if algorithm == "md5":
+                    _write_cached_checksum(
+                        dest_path,
+                        _format_cached_checksum(algorithm, file_digest),
+                    )
+                if expected_digest == file_digest:
+                    return FilePathStr(dest_path)
+                dest_path_integrity_mismatch = True
 
         # Override the target cache path IF we're skipping the cache.
         # Note that `override_cache_path is None` <=> `skip_cache is False`.
@@ -204,12 +288,26 @@ class ArtifactManifestEntry(ArtifactsBase):
             )
 
         # Determine the final path
-        final_path = FilePathStr(
-            override_cache_path or copy_or_overwrite_changed(cache_path, dest_path)
-        )
+        if override_cache_path:
+            final_path = FilePathStr(override_cache_path)
+        else:
+            if dest_path_integrity_mismatch:
+                with suppress(FileNotFoundError):
+                    os.remove(dest_path)
+            final_path = FilePathStr(copy_or_overwrite_changed(cache_path, dest_path))
 
-        # Cache the checksum for future downloads
-        _write_cached_checksum(final_path, self.digest)
+        if integrity_digest is not None:
+            algorithm, expected_digest = integrity_digest
+            actual_digest = _file_digest_b64(final_path, algorithm)
+            if actual_digest != expected_digest:
+                raise ValueError(f"Digest mismatch for file: {self.path}")
+
+            if algorithm == "md5":
+                # Cache the checksum for future downloads
+                _write_cached_checksum(
+                    final_path,
+                    _format_cached_checksum(algorithm, actual_digest),
+                )
 
         return final_path
 

--- a/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
+++ b/wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py
@@ -66,6 +66,8 @@ class ArtifactManifestV1(ArtifactManifest):
         # sort by key (path)
         for path, entry in sorted(self.entries.items(), key=itemgetter(0)):
             hasher.update(f"{path}:{entry.digest}\n".encode())
+            if sha256_digest := entry.extra.get("sha256"):
+                hasher.update(f"{path}:sha256:{sha256_digest}\n".encode())
         return hasher.hexdigest()
 
     def size(self) -> int:

--- a/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
@@ -14,7 +14,13 @@ from wandb.errors.term import termlog
 from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.storage_handler import DEFAULT_MAX_OBJECTS, StorageHandler
-from wandb.sdk.lib.hashutil import B64MD5, md5_file_b64, md5_string
+from wandb.sdk.lib.hashutil import (
+    B64MD5,
+    B64SHA256,
+    md5_file_b64,
+    md5_string,
+    sha256_file_b64,
+)
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 from wandb.util import local_file_uri_to_path
 
@@ -31,6 +37,10 @@ def _md5_content(path: str) -> B64MD5:
 
 def _md5_path(path: str) -> B64MD5:
     return md5_string(Path(path).resolve().as_uri())
+
+
+def _sha256_content(path: str) -> B64SHA256:
+    return sha256_file_b64(path)
 
 
 class LocalFileHandler(StorageHandler):
@@ -68,7 +78,7 @@ class LocalFileHandler(StorageHandler):
         path, hit, cache_open = self._cache.check_md5_obj_path(
             b64_md5=expected_digest, size=manifest_entry.size or 0
         )
-        if hit:
+        if hit and manifest_entry._cache_hit_integrity_matches(path):
             return path
 
         if (digest := md5_file_b64(local_path)) != expected_digest:
@@ -81,6 +91,10 @@ class LocalFileHandler(StorageHandler):
 
         with cache_open() as f:
             shutil.copy(local_path, f.name)
+        if not manifest_entry._local_file_digest_matches(path):
+            raise ValueError(
+                f"Local file reference: Digest mismatch for path {local_path!r}"
+            )
         return path
 
     def store_path(
@@ -99,6 +113,9 @@ class LocalFileHandler(StorageHandler):
 
         # Closure func for calculating the file hash from its path
         check_md5: Callable[[str], B64MD5] = _md5_content if checksum else _md5_path
+        check_sha256: Callable[[str], B64SHA256] | None = (
+            _sha256_content if checksum else None
+        )
 
         # We have a single file or directory
         # Note, we follow symlinks for files contained within the directory
@@ -132,6 +149,11 @@ class LocalFileHandler(StorageHandler):
                         ref=os.path.join(path, file_path),
                         size=os.path.getsize(physical_path),
                         digest=check_md5(physical_path),
+                        extra=(
+                            {"sha256": check_sha256(physical_path)}
+                            if check_sha256
+                            else {}
+                        ),
                     )
                     entries.append(entry)
             return list(entries)
@@ -143,6 +165,7 @@ class LocalFileHandler(StorageHandler):
                     ref=path,
                     size=os.path.getsize(local_path),
                     digest=check_md5(local_path),
+                    extra={"sha256": check_sha256(local_path)} if check_sha256 else {},
                 )
             ]
         else:

--- a/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
@@ -126,5 +126,6 @@ class WBArtifactHandler(StorageHandler):
                 ref=path,
                 size=0,
                 digest=entry.digest,
+                extra=entry.extra,
             )
         ]

--- a/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
@@ -78,5 +78,6 @@ class WBLocalArtifactHandler(StorageHandler):
                 ref=path,
                 size=0,
                 digest=target_entry.digest,
+                extra=target_entry.extra,
             )
         ]

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -135,7 +135,7 @@ class WandbStoragePolicy(StoragePolicy):
             manifest_entry.digest,
             size=manifest_entry.size or 0,
         )
-        if hit:
+        if hit and manifest_entry._cache_hit_integrity_matches(path):
             return path
 
         if url := manifest_entry._download_url:
@@ -195,6 +195,8 @@ class WandbStoragePolicy(StoragePolicy):
         with cache_open(mode="wb") as file:
             for data in response.iter_content(chunk_size=16 * KiB):
                 file.write(data)
+        if not manifest_entry._local_file_digest_matches(path):
+            raise ValueError(f"Digest mismatch for file: {manifest_entry.path}")
         return path
 
     def store_reference(

--- a/wandb/sdk/lib/hashutil.py
+++ b/wandb/sdk/lib/hashutil.py
@@ -22,11 +22,16 @@ logger = logging.getLogger(__name__)
 ETag: TypeAlias = str
 HexMD5: TypeAlias = str
 B64MD5: TypeAlias = str
+B64SHA256: TypeAlias = str
 
 
 def _md5(data: bytes = b"") -> _hashlib.HASH:
     """Allow FIPS-compliant md5 hash when supported."""
     return hashlib.md5(data, usedforsecurity=False)
+
+
+def _sha256(data: bytes = b"") -> _hashlib.HASH:
+    return hashlib.sha256(data)
 
 
 def md5_string(string: str) -> B64MD5:
@@ -65,20 +70,39 @@ def md5_file_hex(*paths: StrPath) -> HexMD5:
     return HexMD5(_md5_file_hasher(*paths).hexdigest())
 
 
+def sha256_file_b64(*paths: StrPath) -> B64SHA256:
+    start_time = time.monotonic()
+    digest = _b64_from_hasher(_sha256_file_hasher(*paths))
+    hash_time_seconds = time.monotonic() - start_time
+    if hash_time_seconds > 1.0:
+        logger.debug(
+            "Computed SHA-256 hash for file. paths=%s, hashTimeMs=%d",
+            paths,
+            int(hash_time_seconds * 1000),
+        )
+    return digest
+
+
 _KB: int = 1_024
 _CHUNKSIZE: int = 128 * _KB
 """Chunk size (in bytes) for iteratively reading from file, if needed."""
 
 
 def _md5_file_hasher(*paths: StrPath) -> _hashlib.HASH:
-    md5_hash = _md5()
+    return _file_hasher(_md5(), *paths)
 
+
+def _sha256_file_hasher(*paths: StrPath) -> _hashlib.HASH:
+    return _file_hasher(_sha256(), *paths)
+
+
+def _file_hasher(hasher: _hashlib.HASH, *paths: StrPath) -> _hashlib.HASH:
     # Note: We use str paths (instead of pathlib.Path objs) for minor perf improvements.
     for path in sorted(map(str, paths)):
         with open(path, "rb") as f:
             try:
                 with mmap.mmap(f.fileno(), length=0, access=mmap.ACCESS_READ) as mview:
-                    md5_hash.update(mview)
+                    hasher.update(mview)
             except OSError:
                 # This occurs if the mmap-ed file is on a different/mounted filesystem,
                 # so we'll fall back on a less performant implementation.
@@ -88,11 +112,11 @@ def _md5_file_hasher(*paths: StrPath) -> _hashlib.HASH:
                 # Consider revisiting once 3.7 support is no longer needed.
                 chunk = f.read(_CHUNKSIZE)
                 while chunk:
-                    md5_hash.update(chunk)
+                    hasher.update(chunk)
                     chunk = f.read(_CHUNKSIZE)
             except ValueError:
                 # This occurs when mmap-ing an empty file, which can be skipped.
                 # See: https://github.com/python/cpython/blob/986a4e1b6fcae7fe7a1d0a26aea446107dd58dd2/Modules/mmapmodule.c#L1589
                 pass
 
-    return md5_hash
+    return hasher


### PR DESCRIPTION
## Summary
- store a SHA-256 content digest alongside the existing artifact entry digest for newly added files and checksum-enabled local file references
- prefer SHA-256 for local artifact download, cache-hit, and verify integrity checks while preserving legacy MD5 compatibility for older entries
- include SHA-256 metadata in artifact manifest digests when available and propagate it through artifact references

Closes #12030

## Testing
- pytest -q tests/unit_tests/test_lib/test_hashutil.py tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py tests/unit_tests/test_artifacts/test_storage.py::test_local_file_handler_load_path_uses_cache tests/unit_tests/test_artifacts/test_storage.py::test_local_file_handler_rejects_sha256_mismatched_cache tests/unit_tests/test_artifacts/test_wandb_artifacts.py::test_add_file_records_sha256_digest tests/unit_tests/test_artifacts/test_wandb_artifacts.py::test_verify_uses_sha256_when_available
- uvx ruff check wandb/sdk/lib/hashutil.py wandb/sdk/artifacts/artifact.py wandb/sdk/artifacts/artifact_manifest_entry.py wandb/sdk/artifacts/artifact_manifests/artifact_manifest_v1.py wandb/sdk/artifacts/storage_handlers/local_file_handler.py wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py tests/unit_tests/test_lib/test_hashutil.py tests/unit_tests/test_artifacts/test_artifact_manifest_entry.py tests/unit_tests/test_artifacts/test_storage.py tests/unit_tests/test_artifacts/test_wandb_artifacts.py
- git diff --check

Note: I attempted a targeted system artifact digest test, but the local environment is missing additional system-test fixture dependencies such as fastapi.