### PR TITLE
chore(sdk): fix `unit-tests-macos-*` with `brew install --no-ask` and temp disable codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,8 @@ commands:
           command: >
             nox -s "<<parameters.session>>" --python <<parameters.python>> --verbose
 
-      - codecov/upload: { flags: <<parameters.codecov_flags>> }
+      # TODO[WB-35582]: Temporarily disable codecov because brew install broke it.
+      # - codecov/upload: { flags: <<parameters.codecov_flags>> }
       - save-test-results
 
   local-wandb-server-deps:
@@ -485,7 +486,8 @@ jobs:
             cd core
             go test -count=1 -race -coverprofile=coverage.txt -covermode=atomic ./...
       - save-go-cache
-      - codecov/upload: { flags: unit }
+      # TODO[WB-35582]: Temporarily disable codecov because brew install broke it.
+      # - codecov/upload: { flags: unit }
 
   unit-tests-rust:
     resource_class: wandb/docker-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
       - checkout
       - run:
           name: Install system deps
-          command: brew install ffmpeg python@<<parameters.python>>
+          command: brew install --no-ask ffmpeg python@<<parameters.python>>
       - install_go
       - install_rust
 


### PR DESCRIPTION
Description
-----------
`unit-tests-macos-*` runs `brew install ffmpeg python@3.10` which now stalls out on:

```
==> Do you want to proceed with the installation? [y/n]
```
Example: https://app.circleci.com/pipelines/github/wandb/wandb/64719/workflows/948f4fe6-9c59-46cf-a6ff-b4423dbf8d74/jobs/1678812

Adding `--no-ask` flag.

This is because Homebrew changed the default behavior for install: https://brew.sh/2026/06/11/homebrew-6.0.0/

> ... The most notable is [making ask mode the default for developers](https://github.com/Homebrew/brew/pull/22369), so brew install and brew upgrade show a dependency summary and confirmation prompt before making changes.

Also disabling codecov because it's broken for the same reason: https://app.circleci.com/pipelines/github/wandb/wandb/64725/workflows/a6c1c6a7-9bda-4f9a-ba31-cee83d491635/jobs/1678891

Filed https://coreweave.atlassian.net/browse/WB-35582 to track re-enabling codecov

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
  - No changelog needed; just fixing unit test harness


Testing
-------
How was this PR tested?

- [x] `unit-tests-macos-*` can brew install now.

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
