### PR TITLE
feat(leet): display wandb.Image lists in the media pane

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,9 +18,11 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb beta leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)
 - Basic remote-run support in W&B LEET TUI (`wandb beta leet <run-url>` command) (@jacobromero in https://github.com/wandb/wandb/pull/11261)
+- Synced scrubbing in the W&B LEET media pane: press `l` to link scrubbing, then the scrub keys (`←/→/↑/↓/home/end`) move a shared cursor over the union step timeline and every image tile follows it (@dmitryduev in https://github.com/wandb/wandb/pull/12033)
 
 ### Fixed
 
+- Lists of images logged under a single key are now displayed in the W&B LEET media pane, one tile per image (@dmitryduev in https://github.com/wandb/wandb/pull/12033)
 - `wandb.Api().viewer` (and `Api().user()` / `Api().users()`) no longer fail with `WandbApiFailedError: relogin required` for some API keys, a regression in `0.27.1` (@dmitryduev in https://github.com/wandb/wandb/pull/12009)
 - When a `wandb.Image` carrying multiple `box` or `mask` layers with distinct `class_labels` is logged inside a `wandb.Table`, each layer's labels are now preserved in new `box_class_maps` / `mask_class_maps` fields in the `table.json`. Previously, there was only as single `class_map` that got incorrectly clobbered by each set of class labels. The next server release will contain a corresponding frontend fix that reads these per-layer fields. Legacy servers will retain the current behavior. (@kelu-wandb in https://github.com/wandb/wandb/pull/11901)
 - Artifact file operations now consistently require normalized relative paths (@tonyyli-wandb in https://github.com/wandb/wandb/pull/11735)

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -195,6 +195,10 @@ func RunKeyBindings() []BindingCategory[Run] {
 					Handler:     (*Run).handleSidebarPageNav,
 				},
 				{
+					Keys:        []string{"alt+↑/↓/←/→", "alt+home/end"},
+					Description: "Scrub all media series in sync (media pane focused)",
+				},
+				{
 					Keys:        []string{"k"},
 					Description: "Toggle media image renderer: ANSI ↔ full-res (media pane focused)",
 				},
@@ -412,6 +416,10 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 					Keys:        []string{"p"},
 					Description: "Pin/unpin selected run",
 					Handler:     (*Workspace).handlePinRunKey,
+				},
+				{
+					Keys:        []string{"alt+↑/↓/←/→", "alt+home/end"},
+					Description: "Scrub all media series in sync (media pane focused)",
 				},
 				{
 					Keys:        []string{"k"},

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -195,8 +195,8 @@ func RunKeyBindings() []BindingCategory[Run] {
 					Handler:     (*Run).handleSidebarPageNav,
 				},
 				{
-					Keys:        []string{"alt+↑/↓/←/→", "alt+home/end"},
-					Description: "Scrub all media series in sync (media pane focused)",
+					Keys:        []string{"l"},
+					Description: "Link scrubbing: arrow keys scrub all media series in sync (media pane focused)",
 				},
 				{
 					Keys:        []string{"k"},
@@ -418,8 +418,8 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 					Handler:     (*Workspace).handlePinRunKey,
 				},
 				{
-					Keys:        []string{"alt+↑/↓/←/→", "alt+home/end"},
-					Description: "Scrub all media series in sync (media pane focused)",
+					Keys:        []string{"l"},
+					Description: "Link scrubbing: arrow keys scrub all media series in sync (media pane focused)",
 				},
 				{
 					Keys:        []string{"k"},

--- a/core/internal/leet/leveldbhistorysource.go
+++ b/core/internal/leet/leveldbhistorysource.go
@@ -1,6 +1,7 @@
 package leet
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -252,23 +253,45 @@ func ParseHistory(runPath string, history *spb.HistoryRecord) tea.Msg {
 
 	media := make(map[string][]MediaPoint)
 	for mediaKey, fields := range mediaFieldsByKey {
-		if fields["_type"] != "image-file" {
-			continue
+		switch fields["_type"] {
+		case "image-file":
+			relPath := fields["path"]
+			if relPath == "" {
+				continue
+			}
+			media[mediaKey] = append(media[mediaKey], MediaPoint{
+				X:            float64(step),
+				FilePath:     resolveMediaPath(runPath, relPath),
+				RelativePath: relPath,
+				Caption:      fields["caption"],
+				Format:       fields["format"],
+				Width:        parseHistoryInt(fields["width"]),
+				Height:       parseHistoryInt(fields["height"]),
+				SHA256:       fields["sha256"],
+			})
+		case "images/separated":
+			// A list of wandb.Image logged under one key: fan each image
+			// out into its own "key[i]" series so every image gets a tile.
+			captions := parseJSONStringArray(fields["captions"])
+			for i, relPath := range parseJSONStringArray(fields["filenames"]) {
+				if relPath == "" {
+					continue
+				}
+				point := MediaPoint{
+					X:            float64(step),
+					FilePath:     resolveMediaPath(runPath, relPath),
+					RelativePath: relPath,
+					Format:       fields["format"],
+					Width:        parseHistoryInt(fields["width"]),
+					Height:       parseHistoryInt(fields["height"]),
+				}
+				if i < len(captions) {
+					point.Caption = captions[i]
+				}
+				indexedKey := fmt.Sprintf("%s[%d]", mediaKey, i)
+				media[indexedKey] = append(media[indexedKey], point)
+			}
 		}
-		relPath := fields["path"]
-		if relPath == "" {
-			continue
-		}
-		media[mediaKey] = append(media[mediaKey], MediaPoint{
-			X:            float64(step),
-			FilePath:     resolveMediaPath(runPath, relPath),
-			RelativePath: relPath,
-			Caption:      fields["caption"],
-			Format:       fields["format"],
-			Width:        parseHistoryInt(fields["width"]),
-			Height:       parseHistoryInt(fields["height"]),
-			SHA256:       fields["sha256"],
-		})
 	}
 
 	if len(metrics) == 0 && len(media) == 0 {
@@ -295,6 +318,16 @@ func trimJSONString(v string) string {
 	return v
 }
 
+// parseJSONStringArray decodes a JSON array of strings, returning nil on
+// malformed input.
+func parseJSONStringArray(v string) []string {
+	var out []string
+	if json.Unmarshal([]byte(v), &out) != nil {
+		return nil
+	}
+	return out
+}
+
 func parseHistoryInt(v string) int {
 	i, err := strconv.Atoi(v)
 	if err == nil {
@@ -310,7 +343,8 @@ func historyMediaField(item *spb.HistoryItem) (mediaKey, field string, ok bool) 
 	}
 	field = parts[len(parts)-1]
 	switch field {
-	case "_type", "path", "caption", "format", "width", "height", "sha256", "size":
+	case "_type", "path", "caption", "format", "width", "height", "sha256", "size",
+		"count", "filenames", "captions":
 	default:
 		return "", "", false
 	}

--- a/core/internal/leet/leveldbhistorysource.go
+++ b/core/internal/leet/leveldbhistorysource.go
@@ -251,6 +251,39 @@ func ParseHistory(runPath string, history *spb.HistoryRecord) tea.Msg {
 		}
 	}
 
+	media := parseHistoryMedia(runPath, step, mediaFieldsByKey)
+
+	if len(metrics) == 0 && len(media) == 0 {
+		return nil
+	}
+
+	msg := HistoryMsg{RunPath: runPath}
+	if len(metrics) > 0 {
+		msg.Metrics = metrics
+	}
+	if len(media) > 0 {
+		msg.Media = media
+	}
+	return msg
+}
+
+func trimJSONString(v string) string {
+	if v == "" {
+		return ""
+	}
+	if unquoted, err := strconv.Unquote(v); err == nil {
+		return unquoted
+	}
+	return v
+}
+
+// parseHistoryMedia builds media series from the per-key media fields of a
+// history record.
+func parseHistoryMedia(
+	runPath string,
+	step int,
+	mediaFieldsByKey map[string]map[string]string,
+) map[string][]MediaPoint {
 	media := make(map[string][]MediaPoint)
 	for mediaKey, fields := range mediaFieldsByKey {
 		switch fields["_type"] {
@@ -293,29 +326,7 @@ func ParseHistory(runPath string, history *spb.HistoryRecord) tea.Msg {
 			}
 		}
 	}
-
-	if len(metrics) == 0 && len(media) == 0 {
-		return nil
-	}
-
-	msg := HistoryMsg{RunPath: runPath}
-	if len(metrics) > 0 {
-		msg.Metrics = metrics
-	}
-	if len(media) > 0 {
-		msg.Media = media
-	}
-	return msg
-}
-
-func trimJSONString(v string) string {
-	if v == "" {
-		return ""
-	}
-	if unquoted, err := strconv.Unquote(v); err == nil {
-		return unquoted
-	}
-	return v
+	return media
 }
 
 // parseJSONStringArray decodes a JSON array of strings, returning nil on

--- a/core/internal/leet/media.go
+++ b/core/internal/leet/media.go
@@ -59,7 +59,7 @@ func (s *MediaStore) ProcessHistory(msg HistoryMsg) bool {
 
 		if _, ok := s.series[key]; !ok {
 			s.keys = append(s.keys, key)
-			sort.Strings(s.keys)
+			slices.SortFunc(s.keys, compareNatural)
 			changed = true
 		}
 
@@ -170,6 +170,41 @@ func (s *MediaStore) Empty() bool {
 	defer s.mu.RUnlock()
 	return len(s.keys) == 0
 }
+
+// compareNatural orders strings lexicographically, except that runs of ASCII
+// digits compare numerically, so "key[2]" sorts before "key[10]".
+func compareNatural(a, b string) int {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if isASCIIDigit(a[i]) && isASCIIDigit(b[j]) {
+			aEnd, bEnd := i, j
+			for aEnd < len(a) && isASCIIDigit(a[aEnd]) {
+				aEnd++
+			}
+			for bEnd < len(b) && isASCIIDigit(b[bEnd]) {
+				bEnd++
+			}
+			aNum := strings.TrimLeft(a[i:aEnd], "0")
+			bNum := strings.TrimLeft(b[j:bEnd], "0")
+			if c := len(aNum) - len(bNum); c != 0 {
+				return c
+			}
+			if c := strings.Compare(aNum, bNum); c != 0 {
+				return c
+			}
+			i, j = aEnd, bEnd
+			continue
+		}
+		if a[i] != b[j] {
+			return int(a[i]) - int(b[j])
+		}
+		i++
+		j++
+	}
+	return (len(a) - i) - (len(b) - j)
+}
+
+func isASCIIDigit(c byte) bool { return '0' <= c && c <= '9' }
 
 // resolveMediaPath resolves a media file path from a history record to the file
 // on disk for the given run.

--- a/core/internal/leet/media_test.go
+++ b/core/internal/leet/media_test.go
@@ -69,6 +69,81 @@ func TestParseHistory_ImageFile_NormalizesRelativePathWithinFilesDir(t *testing.
 	)
 }
 
+func TestParseHistory_ImagesSeparated(t *testing.T) {
+	runPath := filepath.Join("tmp", "offline-run-123", "run-123.wandb")
+
+	history := &spb.HistoryRecord{
+		Item: []*spb.HistoryItem{
+			{NestedKey: []string{"_step"}, ValueJson: "7"},
+			{NestedKey: []string{"attention_maps", "_type"}, ValueJson: `"images/separated"`},
+			{
+				NestedKey: []string{"attention_maps", "filenames"},
+				ValueJson: `["media/images/maps_7_0.png","media/images/maps_7_1.png"]`,
+			},
+			{NestedKey: []string{"attention_maps", "captions"}, ValueJson: `["head 0","head 1"]`},
+			{NestedKey: []string{"attention_maps", "format"}, ValueJson: `"png"`},
+			{NestedKey: []string{"attention_maps", "width"}, ValueJson: "64"},
+			{NestedKey: []string{"attention_maps", "height"}, ValueJson: "64"},
+			{NestedKey: []string{"attention_maps", "count"}, ValueJson: "2"},
+		},
+	}
+
+	msg, ok := leet.ParseHistory(runPath, history).(leet.HistoryMsg)
+	require.True(t, ok)
+	require.Len(t, msg.Media, 2)
+	require.Contains(t, msg.Media, "attention_maps[0]")
+	require.Contains(t, msg.Media, "attention_maps[1]")
+
+	point := msg.Media["attention_maps[1]"][0]
+	require.Equal(t, 7.0, point.X)
+	require.Equal(
+		t,
+		filepath.Join(filepath.Dir(runPath), "files", "media", "images", "maps_7_1.png"),
+		point.FilePath,
+	)
+	require.Equal(t, "media/images/maps_7_1.png", point.RelativePath)
+	require.Equal(t, "head 1", point.Caption)
+	require.Equal(t, "png", point.Format)
+	require.Equal(t, 64, point.Width)
+	require.Equal(t, 64, point.Height)
+
+	// Media metadata must not leak into scalar metrics.
+	require.NotContains(t, msg.Metrics, "attention_maps.count")
+}
+
+func TestParseHistory_ImagesSeparated_NoCaptions(t *testing.T) {
+	runPath := filepath.Join("tmp", "offline-run-123", "run-123.wandb")
+
+	history := &spb.HistoryRecord{
+		Item: []*spb.HistoryItem{
+			{NestedKey: []string{"_step"}, ValueJson: "3"},
+			{NestedKey: []string{"samples", "_type"}, ValueJson: `"images/separated"`},
+			{NestedKey: []string{"samples", "filenames"}, ValueJson: `["media/images/s_3_0.png"]`},
+			{NestedKey: []string{"samples", "format"}, ValueJson: `"png"`},
+		},
+	}
+
+	msg, ok := leet.ParseHistory(runPath, history).(leet.HistoryMsg)
+	require.True(t, ok)
+	require.Len(t, msg.Media, 1)
+	require.Contains(t, msg.Media, "samples[0]")
+	require.Empty(t, msg.Media["samples[0]"][0].Caption)
+}
+
+func TestMediaStoreSeriesKeys_NaturalOrder(t *testing.T) {
+	store := leet.NewMediaStore()
+	for _, key := range []string{"maps[10]", "maps[2]", "maps[0]", "loss", "zmap"} {
+		store.ProcessHistory(leet.HistoryMsg{
+			Media: map[string][]leet.MediaPoint{key: {{X: 1, FilePath: "/img.png"}}},
+		})
+	}
+	require.Equal(
+		t,
+		[]string{"loss", "maps[0]", "maps[2]", "maps[10]", "zmap"},
+		store.SeriesKeys(),
+	)
+}
+
 func TestMediaStoreResolveAt(t *testing.T) {
 	store := leet.NewMediaStore()
 

--- a/core/internal/leet/mediapane.go
+++ b/core/internal/leet/mediapane.go
@@ -438,6 +438,24 @@ func (p *MediaPane) HandleKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	case "end":
 		p.ScrubToEnd()
 		return true, nil
+	case "alt+left":
+		p.ScrubAll(-1)
+		return true, nil
+	case "alt+right":
+		p.ScrubAll(1)
+		return true, nil
+	case "alt+up":
+		p.ScrubAll(-10)
+		return true, nil
+	case "alt+down":
+		p.ScrubAll(10)
+		return true, nil
+	case "alt+home":
+		p.ScrubAllToStart()
+		return true, nil
+	case "alt+end":
+		p.ScrubAllToEnd()
+		return true, nil
 	case "a":
 		p.MoveSelection(-1, 0)
 		return true, nil
@@ -552,6 +570,66 @@ func (p *MediaPane) ScrubToEnd() {
 	}
 	p.xIndices[key] = len(xs) - 1
 	p.autoFollows[key] = true
+}
+
+// ScrubAll scrubs every media series in sync: it moves a shared cursor along
+// the union X timeline and aligns each series to it.
+func (p *MediaPane) ScrubAll(delta int) {
+	if p.store == nil {
+		return
+	}
+	union := p.store.XValues()
+	if len(union) == 0 {
+		return
+	}
+
+	// The most advanced series defines the cursor on the union timeline.
+	cursor := 0
+	for _, key := range p.seriesKeys() {
+		if x, ok := p.currentXForSeries(key); ok {
+			if idx, found := slices.BinarySearch(union, x); found {
+				cursor = max(cursor, idx)
+			}
+		}
+	}
+
+	target := union[clamp(cursor+delta, 0, len(union)-1)]
+	for _, key := range p.seriesKeys() {
+		p.alignSeriesTo(key, target)
+	}
+}
+
+// alignSeriesTo moves a series' scrub position to its latest sample at or
+// before x, or to its first sample when none exists yet.
+func (p *MediaPane) alignSeriesTo(key string, x float64) {
+	xs := p.seriesXValues(key)
+	if len(xs) == 0 {
+		return
+	}
+	idx, found := slices.BinarySearch(xs, x)
+	if !found {
+		idx = max(idx-1, 0)
+	}
+	p.xIndices[key] = idx
+	p.autoFollows[key] = idx == len(xs)-1
+}
+
+func (p *MediaPane) ScrubAllToStart() {
+	for _, key := range p.seriesKeys() {
+		p.xIndices[key] = 0
+		p.autoFollows[key] = false
+	}
+}
+
+func (p *MediaPane) ScrubAllToEnd() {
+	for _, key := range p.seriesKeys() {
+		xs := p.seriesXValues(key)
+		if len(xs) == 0 {
+			continue
+		}
+		p.xIndices[key] = len(xs) - 1
+		p.autoFollows[key] = true
+	}
 }
 
 func (p *MediaPane) syncGridLayoutForViewport(width, height int) {

--- a/core/internal/leet/mediapane.go
+++ b/core/internal/leet/mediapane.go
@@ -112,6 +112,13 @@ type MediaPane struct {
 	active bool
 	// fullscreen expands the selected image inside the pane and keeps keys local.
 	fullscreen bool
+	// linkedScrub makes the scrub keys move all media series in sync by
+	// driving a single shared cursor over the union X timeline.
+	linkedScrub bool
+	// linkedXIndex is the shared cursor's index into store.XValues().
+	linkedXIndex int
+	// linkedAutoFollow keeps the shared cursor pinned to the latest X value.
+	linkedAutoFollow bool
 
 	// selectedIndex is the selected series index within store.SeriesKeys().
 	selectedIndex int
@@ -246,6 +253,8 @@ type MediaPaneViewState struct {
 	SelectedIndex int
 	XIndices      map[string]int
 	AutoFollows   map[string]bool
+	LinkedScrub   bool
+	LinkedXIndex  int
 }
 
 func (p *MediaPane) SaveViewState() MediaPaneViewState {
@@ -257,6 +266,8 @@ func (p *MediaPane) SaveViewState() MediaPaneViewState {
 		SelectedIndex: p.selectedIndex,
 		XIndices:      xi,
 		AutoFollows:   af,
+		LinkedScrub:   p.linkedScrub,
+		LinkedXIndex:  p.linkedXIndex,
 	}
 }
 
@@ -266,6 +277,10 @@ func (p *MediaPane) RestoreViewState(s MediaPaneViewState) {
 	maps.Copy(p.xIndices, s.XIndices)
 	clear(p.autoFollows)
 	maps.Copy(p.autoFollows, s.AutoFollows)
+	p.linkedScrub = s.LinkedScrub
+	p.linkedXIndex = s.LinkedXIndex
+	xs := p.unionXValues()
+	p.linkedAutoFollow = len(xs) > 0 && s.LinkedXIndex >= len(xs)-1
 	p.fullscreen = false
 	p.syncState()
 }
@@ -274,6 +289,9 @@ func (p *MediaPane) ResetViewState() {
 	p.selectedIndex = 0
 	clear(p.xIndices)
 	clear(p.autoFollows)
+	p.linkedScrub = false
+	p.linkedXIndex = 0
+	p.linkedAutoFollow = false
 	p.nav.currentPage = 0
 	p.fullscreen = false
 	p.syncState()
@@ -309,6 +327,16 @@ func (p *MediaPane) syncState() {
 		default:
 			p.xIndices[key] = clamp(p.xIndices[key], 0, len(xs)-1)
 		}
+	}
+
+	// Maintain the shared linked cursor against the union timeline.
+	switch xs := p.unionXValues(); {
+	case len(xs) == 0:
+		p.linkedXIndex = 0
+	case p.linkedAutoFollow:
+		p.linkedXIndex = len(xs) - 1
+	default:
+		p.linkedXIndex = clamp(p.linkedXIndex, 0, len(xs)-1)
 	}
 
 	itemsPerPage := p.itemsPerPage()
@@ -362,7 +390,7 @@ func (p *MediaPane) currentSelection() (string, MediaPoint, bool) {
 	}
 	idx := clamp(p.selectedIndex, 0, len(keys)-1)
 	key := keys[idx]
-	x, ok := p.currentXForSeries(key)
+	x, ok := p.scrubX(key)
 	if !ok || p.store == nil {
 		return key, MediaPoint{}, false
 	}
@@ -380,13 +408,21 @@ func (p *MediaPane) StatusLabel() string {
 		return ""
 	}
 
-	x, hasX := p.currentXForSeries(key)
+	// Show the resolved sample's step; fall back to the scrub position when
+	// the series has no sample there yet.
+	x, hasX := p.scrubX(key)
+	if ok {
+		x, hasX = point.X, true
+	}
 	parts := []string{fmt.Sprintf("Media: %s", key)}
 	if hasX {
 		parts = append(parts, fmt.Sprintf("X=_step %s", formatMediaAxisValue(x)))
 	}
 	if ok && point.Caption != "" {
 		parts = append(parts, truncateValue(point.Caption, 48))
+	}
+	if p.linkedScrub {
+		parts = append(parts, "sync")
 	}
 	if p.fullscreen {
 		parts = append(parts, "fullscreen")
@@ -396,6 +432,8 @@ func (p *MediaPane) StatusLabel() string {
 
 // HandleKey handles media-pane-local navigation. It returns whether the key
 // was consumed and any command needed to render media.
+//
+//gocyclo:ignore
 func (p *MediaPane) HandleKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	if !p.active && !p.fullscreen {
 		return false, nil
@@ -420,6 +458,11 @@ func (p *MediaPane) HandleKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 			p.requestRenderedMediaPrepare()
 		}
 		return true, cmd
+	case "l":
+		if p.HasData() {
+			p.toggleLinkedScrub()
+		}
+		return true, nil
 	case "left":
 		p.Scrub(-1)
 		return true, nil
@@ -437,24 +480,6 @@ func (p *MediaPane) HandleKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 		return true, nil
 	case "end":
 		p.ScrubToEnd()
-		return true, nil
-	case "alt+left":
-		p.ScrubAll(-1)
-		return true, nil
-	case "alt+right":
-		p.ScrubAll(1)
-		return true, nil
-	case "alt+up":
-		p.ScrubAll(-10)
-		return true, nil
-	case "alt+down":
-		p.ScrubAll(10)
-		return true, nil
-	case "alt+home":
-		p.ScrubAllToStart()
-		return true, nil
-	case "alt+end":
-		p.ScrubAllToEnd()
 		return true, nil
 	case "a":
 		p.MoveSelection(-1, 0)
@@ -537,7 +562,19 @@ func (p *MediaPane) selectedKey() string {
 	return keys[clamp(p.selectedIndex, 0, len(keys)-1)]
 }
 
+// Scrub moves the scrub position by delta samples: the shared cursor over
+// the union timeline when scrubbing is linked, the selected series otherwise.
 func (p *MediaPane) Scrub(delta int) {
+	if p.linkedScrub {
+		xs := p.unionXValues()
+		if len(xs) == 0 {
+			return
+		}
+		p.linkedXIndex = clamp(p.linkedXIndex+delta, 0, len(xs)-1)
+		p.linkedAutoFollow = p.linkedXIndex == len(xs)-1
+		return
+	}
+
 	key := p.selectedKey()
 	if key == "" {
 		return
@@ -551,6 +588,12 @@ func (p *MediaPane) Scrub(delta int) {
 }
 
 func (p *MediaPane) ScrubToStart() {
+	if p.linkedScrub {
+		p.linkedXIndex = 0
+		p.linkedAutoFollow = false
+		return
+	}
+
 	key := p.selectedKey()
 	if key == "" {
 		return
@@ -560,6 +603,14 @@ func (p *MediaPane) ScrubToStart() {
 }
 
 func (p *MediaPane) ScrubToEnd() {
+	if p.linkedScrub {
+		if xs := p.unionXValues(); len(xs) > 0 {
+			p.linkedXIndex = len(xs) - 1
+		}
+		p.linkedAutoFollow = true
+		return
+	}
+
 	key := p.selectedKey()
 	if key == "" {
 		return
@@ -572,18 +623,23 @@ func (p *MediaPane) ScrubToEnd() {
 	p.autoFollows[key] = true
 }
 
-// ScrubAll scrubs every media series in sync: it moves a shared cursor along
-// the union X timeline and aligns each series to it.
-func (p *MediaPane) ScrubAll(delta int) {
-	if p.store == nil {
-		return
-	}
-	union := p.store.XValues()
-	if len(union) == 0 {
+// toggleLinkedScrub switches between linked and per-series scrubbing.
+//
+// Linking starts the shared cursor at the most advanced series position so
+// the view doesn't jump; unlinking writes the cursor back into each series'
+// own scrub position so tiles keep showing the same samples.
+func (p *MediaPane) toggleLinkedScrub() {
+	if p.linkedScrub {
+		if x, ok := p.linkedX(); ok {
+			for _, key := range p.seriesKeys() {
+				p.alignSeriesTo(key, x)
+			}
+		}
+		p.linkedScrub = false
 		return
 	}
 
-	// The most advanced series defines the cursor on the union timeline.
+	union := p.unionXValues()
 	cursor := 0
 	for _, key := range p.seriesKeys() {
 		if x, ok := p.currentXForSeries(key); ok {
@@ -592,11 +648,9 @@ func (p *MediaPane) ScrubAll(delta int) {
 			}
 		}
 	}
-
-	target := union[clamp(cursor+delta, 0, len(union)-1)]
-	for _, key := range p.seriesKeys() {
-		p.alignSeriesTo(key, target)
-	}
+	p.linkedXIndex = cursor
+	p.linkedAutoFollow = cursor == len(union)-1
+	p.linkedScrub = true
 }
 
 // alignSeriesTo moves a series' scrub position to its latest sample at or
@@ -614,22 +668,29 @@ func (p *MediaPane) alignSeriesTo(key string, x float64) {
 	p.autoFollows[key] = idx == len(xs)-1
 }
 
-func (p *MediaPane) ScrubAllToStart() {
-	for _, key := range p.seriesKeys() {
-		p.xIndices[key] = 0
-		p.autoFollows[key] = false
+func (p *MediaPane) unionXValues() []float64 {
+	if p.store == nil {
+		return nil
 	}
+	return p.store.XValues()
 }
 
-func (p *MediaPane) ScrubAllToEnd() {
-	for _, key := range p.seriesKeys() {
-		xs := p.seriesXValues(key)
-		if len(xs) == 0 {
-			continue
-		}
-		p.xIndices[key] = len(xs) - 1
-		p.autoFollows[key] = true
+// linkedX returns the shared cursor's X value on the union timeline.
+func (p *MediaPane) linkedX() (float64, bool) {
+	xs := p.unionXValues()
+	if len(xs) == 0 {
+		return 0, false
 	}
+	return xs[clamp(p.linkedXIndex, 0, len(xs)-1)], true
+}
+
+// scrubX returns the X position a series' tile resolves against: the shared
+// cursor when scrubbing is linked, the series' own position otherwise.
+func (p *MediaPane) scrubX(key string) (float64, bool) {
+	if p.linkedScrub {
+		return p.linkedX()
+	}
+	return p.currentXForSeries(key)
 }
 
 func (p *MediaPane) syncGridLayoutForViewport(width, height int) {
@@ -798,16 +859,11 @@ func (p *MediaPane) renderHeader(width int, runLabel string, fullscreen bool) st
 }
 
 func (p *MediaPane) renderSlider(width int) string {
-	key := p.selectedKey()
-	if key == "" {
-		return mediaPaneSliderStyle.Width(width).Render("X: _step —")
-	}
-	xs := p.seriesXValues(key)
+	xs, idx := p.sliderPosition()
 	if len(xs) == 0 {
 		return mediaPaneSliderStyle.Width(width).Render("X: _step —")
 	}
 
-	idx := clamp(p.xIndices[key], 0, len(xs)-1)
 	barWidth := clamp(width-24, 8, 48)
 	pos := 0
 	if len(xs) > 1 {
@@ -833,7 +889,25 @@ func (p *MediaPane) renderSlider(width int) string {
 		idx+1,
 		len(xs),
 	)
+	if p.linkedScrub {
+		text += "  [sync]"
+	}
 	return mediaPaneSliderStyle.Width(width).Render(truncateValue(text, width))
+}
+
+// sliderPosition returns the timeline and cursor index the slider displays:
+// the union timeline when scrubbing is linked, the selected series otherwise.
+func (p *MediaPane) sliderPosition() ([]float64, int) {
+	if p.linkedScrub {
+		xs := p.unionXValues()
+		return xs, clamp(p.linkedXIndex, 0, max(len(xs)-1, 0))
+	}
+	key := p.selectedKey()
+	if key == "" {
+		return nil, 0
+	}
+	xs := p.seriesXValues(key)
+	return xs, clamp(p.xIndices[key], 0, max(len(xs)-1, 0))
 }
 
 func (p *MediaPane) renderGrid(width, height int, hint string) string {
@@ -857,7 +931,7 @@ func (p *MediaPane) renderGrid(width, height int, hint string) string {
 	renderKeys := make([]mediaRenderKey, 0, endIdx-startIdx)
 	for idx := startIdx; idx < endIdx; idx++ {
 		key := keys[idx]
-		x, hasX := p.currentXForSeries(key)
+		x, hasX := p.scrubX(key)
 		point, ok := MediaPoint{}, false
 		if hasX && p.store != nil {
 			point, ok = p.store.ResolveAt(key, x)
@@ -971,7 +1045,12 @@ func mediaTileLayout(slotW, slotH int) (innerW, innerH, imageH, footerLines int)
 }
 
 func (p *MediaPane) tileFooter(key string, point MediaPoint, ok bool, width int) string {
-	x, hasX := p.currentXForSeries(key)
+	// Show the resolved sample's step; fall back to the scrub position when
+	// the series has no sample there yet.
+	x, hasX := p.scrubX(key)
+	if ok {
+		x, hasX = point.X, true
+	}
 	stepLabel := ""
 	if hasX {
 		stepLabel = "X=_step " + formatMediaAxisValue(x)
@@ -1006,9 +1085,7 @@ func (p *MediaPane) fullscreenFooter(point MediaPoint, width int) string {
 	if point.Format != "" {
 		parts = append(parts, strings.ToUpper(point.Format))
 	}
-	if x, ok := p.currentXForSeries(p.selectedKey()); ok {
-		parts = append(parts, "X=_step "+formatMediaAxisValue(x))
-	}
+	parts = append(parts, "X=_step "+formatMediaAxisValue(point.X))
 	if len(parts) == 0 {
 		return ""
 	}

--- a/core/internal/leet/mediapane_test.go
+++ b/core/internal/leet/mediapane_test.go
@@ -271,6 +271,95 @@ func TestMediaPane_HandleKeyScrubBindings(t *testing.T) {
 	require.Contains(t, pane.StatusLabel(), "X=_step 0")
 }
 
+func TestMediaPane_ScrubAll(t *testing.T) {
+	pane, store := testMediaPane(t)
+	feedImages(store, "a", 0, 1, 2, 3, 4)
+	feedImages(store, "b", 0, 2, 4)
+	pane.SetStore(store)
+
+	// Auto-follow starts both series at their last sample (X=4). Scrubbing
+	// back one step on the union timeline aligns "b" to its sample at 2.
+	pane.ScrubAll(-1)
+	require.Contains(t, pane.StatusLabel(), "Media: a")
+	require.Contains(t, pane.StatusLabel(), "X=_step 3")
+	pane.NavigatePage(1) // select "b"
+	require.Contains(t, pane.StatusLabel(), "Media: b")
+	require.Contains(t, pane.StatusLabel(), "X=_step 2")
+	pane.NavigatePage(-1)
+
+	// The most advanced series ("a" at 3) carries the cursor: 3 → 2.
+	pane.ScrubAll(-1)
+	require.Contains(t, pane.StatusLabel(), "X=_step 2")
+
+	// Scrubbing past the start clamps every series to its first sample.
+	pane.ScrubAll(-100)
+	require.Contains(t, pane.StatusLabel(), "X=_step 0")
+
+	pane.ScrubAllToEnd()
+	require.Contains(t, pane.StatusLabel(), "X=_step 4")
+	pane.NavigatePage(1)
+	require.Contains(t, pane.StatusLabel(), "X=_step 4")
+
+	pane.ScrubAllToStart()
+	require.Contains(t, pane.StatusLabel(), "X=_step 0")
+	pane.NavigatePage(-1)
+	require.Contains(t, pane.StatusLabel(), "X=_step 0")
+}
+
+func TestMediaPane_ScrubAll_EmptyStore(t *testing.T) {
+	pane, _ := testMediaPane(t)
+	// Should not panic on empty store.
+	pane.ScrubAll(1)
+	pane.ScrubAllToStart()
+	pane.ScrubAllToEnd()
+}
+
+func TestMediaPane_HandleKeySyncScrubBindings(t *testing.T) {
+	pane, store := testMediaPane(t)
+	feedImages(store, "a", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+	feedImages(store, "b", 0, 10)
+	pane.SetStore(store)
+	pane.SetActive(true)
+
+	altKey := func(code rune) tea.KeyPressMsg {
+		return tea.KeyPressMsg{Code: code, Mod: tea.ModAlt}
+	}
+
+	handled, cmd := pane.HandleKey(altKey(tea.KeyHome))
+	require.True(t, handled)
+	require.Nil(t, cmd)
+	require.Contains(t, pane.StatusLabel(), "X=_step 0")
+
+	handled, cmd = pane.HandleKey(altKey(tea.KeyRight))
+	require.True(t, handled)
+	require.Nil(t, cmd)
+	require.Contains(t, pane.StatusLabel(), "X=_step 1")
+
+	handled, cmd = pane.HandleKey(altKey(tea.KeyDown))
+	require.True(t, handled)
+	require.Nil(t, cmd)
+	require.Contains(t, pane.StatusLabel(), "X=_step 11")
+	pane.NavigatePage(1) // "b" aligned to its latest sample ≤ 11
+	require.Contains(t, pane.StatusLabel(), "Media: b")
+	require.Contains(t, pane.StatusLabel(), "X=_step 10")
+	pane.NavigatePage(-1)
+
+	handled, cmd = pane.HandleKey(altKey(tea.KeyUp))
+	require.True(t, handled)
+	require.Nil(t, cmd)
+	require.Contains(t, pane.StatusLabel(), "X=_step 1")
+
+	handled, cmd = pane.HandleKey(altKey(tea.KeyLeft))
+	require.True(t, handled)
+	require.Nil(t, cmd)
+	require.Contains(t, pane.StatusLabel(), "X=_step 0")
+
+	handled, cmd = pane.HandleKey(altKey(tea.KeyEnd))
+	require.True(t, handled)
+	require.Nil(t, cmd)
+	require.Contains(t, pane.StatusLabel(), "X=_step 11")
+}
+
 // --- MediaPane view state save/restore ---
 
 func TestMediaPane_ViewState_SaveRestore(t *testing.T) {

--- a/core/internal/leet/mediapane_test.go
+++ b/core/internal/leet/mediapane_test.go
@@ -271,71 +271,95 @@ func TestMediaPane_HandleKeyScrubBindings(t *testing.T) {
 	require.Contains(t, pane.StatusLabel(), "X=_step 0")
 }
 
-func TestMediaPane_ScrubAll(t *testing.T) {
+func TestMediaPane_LinkedScrub_SharedCursor(t *testing.T) {
 	pane, store := testMediaPane(t)
 	feedImages(store, "a", 0, 1, 2, 3, 4)
 	feedImages(store, "b", 0, 2, 4)
 	pane.SetStore(store)
+	pane.SetActive(true)
 
-	// Auto-follow starts both series at their last sample (X=4). Scrubbing
-	// back one step on the union timeline aligns "b" to its sample at 2.
-	pane.ScrubAll(-1)
+	// Linking starts the shared cursor at the most advanced position (X=4).
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "l"))
+	require.Contains(t, pane.StatusLabel(), "X=_step 4")
+
+	// One press moves the cursor by one union step; each tile resolves to
+	// its latest sample at or before the cursor.
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "left"))
 	require.Contains(t, pane.StatusLabel(), "Media: a")
 	require.Contains(t, pane.StatusLabel(), "X=_step 3")
-	pane.NavigatePage(1) // select "b"
+	pane.NavigatePage(1) // select "b": latest sample ≤ 3 is 2
 	require.Contains(t, pane.StatusLabel(), "Media: b")
 	require.Contains(t, pane.StatusLabel(), "X=_step 2")
 	pane.NavigatePage(-1)
 
-	// The most advanced series ("a" at 3) carries the cursor: 3 → 2.
-	pane.ScrubAll(-1)
-	require.Contains(t, pane.StatusLabel(), "X=_step 2")
-
-	// Scrubbing past the start clamps every series to its first sample.
-	pane.ScrubAll(-100)
+	// Scrubbing past the start clamps the cursor to the first union step.
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "up"))
 	require.Contains(t, pane.StatusLabel(), "X=_step 0")
 
-	pane.ScrubAllToEnd()
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "end"))
 	require.Contains(t, pane.StatusLabel(), "X=_step 4")
 	pane.NavigatePage(1)
 	require.Contains(t, pane.StatusLabel(), "X=_step 4")
 
-	pane.ScrubAllToStart()
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "home"))
 	require.Contains(t, pane.StatusLabel(), "X=_step 0")
 	pane.NavigatePage(-1)
 	require.Contains(t, pane.StatusLabel(), "X=_step 0")
 }
 
-func TestMediaPane_ScrubAll_EmptyStore(t *testing.T) {
-	pane, _ := testMediaPane(t)
-	// Should not panic on empty store.
-	pane.ScrubAll(1)
-	pane.ScrubAllToStart()
-	pane.ScrubAllToEnd()
+func TestMediaPane_LinkedScrub_MixedCadence(t *testing.T) {
+	pane, store := testMediaPane(t)
+	feedImages(store, "a", 0, 1, 2, 3, 4)
+	feedImages(store, "b", 3, 4) // starts later
+	pane.SetStore(store)
+	pane.SetActive(true)
+
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "l"))
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "home"))
+	require.Contains(t, pane.StatusLabel(), "X=_step 0")
+
+	// One press moves the shared cursor by exactly one union step, even
+	// though "b" has no sample there.
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "right"))
+	require.Contains(t, pane.StatusLabel(), "X=_step 1")
+
+	// "b" has no sample at or before the cursor: its tile shows a
+	// placeholder rather than a "future" image.
+	pane.NavigatePage(1)
+	require.Contains(t, pane.StatusLabel(), "Media: b")
+	require.Contains(t, pane.StatusLabel(), "X=_step 1")
+	require.Contains(t, pane.View(40, 14, "", ""), "No image at X")
+
+	// Once the cursor reaches b's first sample, the tile resolves.
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "right"))
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "right"))
+	require.Contains(t, pane.StatusLabel(), "X=_step 3")
 }
 
-func TestMediaPane_HandleKeySyncScrubBindings(t *testing.T) {
+func TestMediaPane_HandleKeyLinkedScrubBindings(t *testing.T) {
 	pane, store := testMediaPane(t)
 	feedImages(store, "a", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
 	feedImages(store, "b", 0, 10)
 	pane.SetStore(store)
 	pane.SetActive(true)
 
-	altKey := func(code rune) tea.KeyPressMsg {
-		return tea.KeyPressMsg{Code: code, Mod: tea.ModAlt}
-	}
+	// "l" links scrubbing across all series.
+	handled, cmd := pane.HandleKey(mediaKeyMsg(t, "l"))
+	require.True(t, handled)
+	require.Nil(t, cmd)
+	require.Contains(t, pane.StatusLabel(), "sync")
 
-	handled, cmd := pane.HandleKey(altKey(tea.KeyHome))
+	handled, cmd = pane.HandleKey(mediaKeyMsg(t, "home"))
 	require.True(t, handled)
 	require.Nil(t, cmd)
 	require.Contains(t, pane.StatusLabel(), "X=_step 0")
 
-	handled, cmd = pane.HandleKey(altKey(tea.KeyRight))
+	handled, cmd = pane.HandleKey(mediaKeyMsg(t, "right"))
 	require.True(t, handled)
 	require.Nil(t, cmd)
 	require.Contains(t, pane.StatusLabel(), "X=_step 1")
 
-	handled, cmd = pane.HandleKey(altKey(tea.KeyDown))
+	handled, cmd = pane.HandleKey(mediaKeyMsg(t, "down"))
 	require.True(t, handled)
 	require.Nil(t, cmd)
 	require.Contains(t, pane.StatusLabel(), "X=_step 11")
@@ -344,20 +368,36 @@ func TestMediaPane_HandleKeySyncScrubBindings(t *testing.T) {
 	require.Contains(t, pane.StatusLabel(), "X=_step 10")
 	pane.NavigatePage(-1)
 
-	handled, cmd = pane.HandleKey(altKey(tea.KeyUp))
+	handled, cmd = pane.HandleKey(mediaKeyMsg(t, "up"))
 	require.True(t, handled)
 	require.Nil(t, cmd)
 	require.Contains(t, pane.StatusLabel(), "X=_step 1")
 
-	handled, cmd = pane.HandleKey(altKey(tea.KeyLeft))
+	handled, cmd = pane.HandleKey(mediaKeyMsg(t, "left"))
 	require.True(t, handled)
 	require.Nil(t, cmd)
 	require.Contains(t, pane.StatusLabel(), "X=_step 0")
 
-	handled, cmd = pane.HandleKey(altKey(tea.KeyEnd))
+	handled, cmd = pane.HandleKey(mediaKeyMsg(t, "end"))
 	require.True(t, handled)
 	require.Nil(t, cmd)
 	require.Contains(t, pane.StatusLabel(), "X=_step 11")
+	pane.NavigatePage(1)
+	require.Contains(t, pane.StatusLabel(), "X=_step 10")
+	pane.NavigatePage(-1)
+
+	// "l" again unlinks: plain scrubbing only moves the selected series.
+	handled, _ = pane.HandleKey(mediaKeyMsg(t, "l"))
+	require.True(t, handled)
+	require.NotContains(t, pane.StatusLabel(), "sync")
+
+	handled, _ = pane.HandleKey(mediaKeyMsg(t, "left"))
+	require.True(t, handled)
+	require.Contains(t, pane.StatusLabel(), "X=_step 10")
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "left"))
+	require.Contains(t, pane.StatusLabel(), "X=_step 9")
+	pane.NavigatePage(1) // "b" stays at its last sample
+	require.Contains(t, pane.StatusLabel(), "X=_step 10")
 }
 
 // --- MediaPane view state save/restore ---
@@ -381,6 +421,33 @@ func TestMediaPane_ViewState_SaveRestore(t *testing.T) {
 
 	// Restore brings it back.
 	pane.RestoreViewState(state)
+	require.Contains(t, pane.StatusLabel(), "X=_step 1")
+}
+
+func TestMediaPane_ViewState_LinkedScrub(t *testing.T) {
+	pane, store := testMediaPane(t)
+	feedImages(store, "a", 0, 1, 2, 3)
+	feedImages(store, "b", 0, 1, 2)
+	pane.SetStore(store)
+	pane.SetActive(true)
+
+	// Link and move the shared cursor to X=1.
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "l"))
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "home"))
+	_, _ = pane.HandleKey(mediaKeyMsg(t, "right"))
+	require.Contains(t, pane.StatusLabel(), "sync")
+	require.Contains(t, pane.StatusLabel(), "X=_step 1")
+
+	state := pane.SaveViewState()
+
+	// Reset unlinks and destroys the cursor.
+	pane.ResetViewState()
+	require.NotContains(t, pane.StatusLabel(), "sync")
+	require.Contains(t, pane.StatusLabel(), "X=_step 3")
+
+	// Restore brings both back.
+	pane.RestoreViewState(state)
+	require.Contains(t, pane.StatusLabel(), "sync")
 	require.Contains(t, pane.StatusLabel(), "X=_step 1")
 }
 


### PR DESCRIPTION
Description
-----------

`wandb leet` showed an empty media pane for runs that log a **list** of images under one key, e.g. `run.log({"attention_maps": [wandb.Image(...), ...]})`. Lists serialize to history as `_type: "images/separated"` with a `filenames` array, while the media parser only accepted the single-image `image-file` shape and silently dropped everything else. A side effect was a phantom `<key>.count` scalar metric appearing in the charts.

  - Each image in a list now becomes its own `key[i]` media series with its paired caption, so every image gets a tile in the media grid; series keys sort naturally (`key[2]` before `key[10]`).
  - New: `alt+←/→/↑/↓/home/end` (media pane focused) scrubs **all** media series in sync along the union step timeline — series logged at different frequencies stay step-aligned, matching the web UI's per-panel slider semantics. Follows the existing `alt+right-click+drag` "inspect all charts in sync" convention.
  - The `images/separated` metadata fields no longer leak into scalar metrics.

  - [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Verified end-to-end against real offline runs logging 4- and 3-image lists per step: all series parse with correct captions and resolvable file paths, and render in the TUI.