### PR TITLE
chore(sdk): temporarily disable `system-tests-min-server-version-linux-3.13` due to auth issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -631,26 +631,27 @@ workflows:
             parameters:
               python: ["3.10", "3.13"]
 
-      - nox-tests-linux:
-          name: system-tests-min-server-version-linux-<<matrix.python>>
-          session: system_tests
-          codecov_flags: system
-          parallelism: 8
-          executor_name: local-testcontainer
+      # TODO[WB-35584]: Temporarily disable due to auth issues
+      # - nox-tests-linux:
+      #     name: system-tests-min-server-version-linux-<<matrix.python>>
+      #     session: system_tests
+      #     codecov_flags: system
+      #     parallelism: 8
+      #     executor_name: local-testcontainer
 
-          filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
+      #     filters:
+      #       branches:
+      #         # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      #         ignore: /pull\/[0-9]+/
 
-          matrix:
-            parameters:
-              python: ["3.13"]
-              server_image:
-                [
-                  "us-central1-docker.pkg.dev/wandb-client-cicd/images/local-testcontainer",
-                ]
-              server_image_tag: ["0.63.0"]
+      #     matrix:
+      #       parameters:
+      #         python: ["3.13"]
+      #         server_image:
+      #           [
+      #             "us-central1-docker.pkg.dev/wandb-client-cicd/images/local-testcontainer",
+      #           ]
+      #         server_image_tag: ["0.63.0"]
 
       - nox-tests-linux:
           name: notebook-tests-linux-<<matrix.python>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -631,7 +631,8 @@ workflows:
             parameters:
               python: ["3.10", "3.13"]
 
-      # TODO[WB-35584]: Temporarily disable due to auth issues
+      # TODO[WB-35584]: Temporarily disable due to auth issues. Re-enable when
+      # we figure that out.
       # - nox-tests-linux:
       #     name: system-tests-min-server-version-linux-<<matrix.python>>
       #     session: system_tests


### PR DESCRIPTION
Description
-----------
Temporarily disable `system-tests-min-server-version-linux-3.13` due to auth issues.

Example: https://app.circleci.com/pipelines/gh/wandb/wandb/64751/workflows/bad1df7d-4c2f-42e2-84cd-9fd26b66c09a/jobs/1679292/parallel-runs/0?filterBy=ALL

Thread: https://weightsandbiases.slack.com/archives/C0108SLEP6K/p1780017213939359

Filed ticket to track followup:
- https://coreweave.atlassian.net/browse/WB-35584

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
  - No changelog needed


Testing
-------
How was this PR tested?

- [x] No longer slowing down CI