### PR TITLE
chore: fix CODEOWNERS path for wandb_agent.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,7 +80,7 @@
 /tests/unit_tests/test_sandbox/       @wandb/launch-reviewers @wandb/sdk-team
 
 # Sweeps
-/wandb/sdk/wandb_agent.py                        @wandb/sweeps-launch-team @wandb/sdk-team
+/wandb/wandb_agent.py                            @wandb/sweeps-launch-team @wandb/sdk-team
 /tests/system_tests/test_sweep/                  @wandb/sweeps-launch-team @wandb/sdk-team
 /tests/unit_tests/test_wandb_agent_teardown.py   @wandb/sweeps-launch-team @wandb/sdk-team
 /tests/unit_tests/test_wandb_agent_signals.py    @wandb/sweeps-launch-team @wandb/sdk-team


### PR DESCRIPTION
## Summary
The Sweeps section of `.github/CODEOWNERS` points at `/wandb/sdk/wandb_agent.py`, but the agent module actually lives at `/wandb/wandb_agent.py`. The mismatched path means @wandb/sweeps-launch-team and @wandb/sdk-team don't get auto-assigned as reviewers when the agent file changes (e.g. #11950).

## Change
One-line path fix in `.github/CODEOWNERS`. No code or test changes.

## Test plan
- [x] Confirmed `/wandb/sdk/wandb_agent.py` does not exist on `main`
- [x] Confirmed `/wandb/wandb_agent.py` exists and is the file modified by recent sweep agent PRs
- [ ] After merge, verify a PR touching `wandb/wandb_agent.py` auto-requests review from the two teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)