### PR TITLE
chore: document coding style and some best practices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,12 @@ Please make sure to update the ToC when you update this page!
     git add changed-file.py tests/test-changed-file.py
     git commit -m "feat(integrations): Add integration with the `awesomepyml` library"
     ```
+    - Be sure to read through the best practices and style guidelines in [docs/](./docs).
     - [Test](#testing) and [lint](#linting-the-code) your code! Please see below for a detailed discussion.
     - Ensure compliance with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/),
       see [below](#conventional-commits). This is enforced by the CI and will prevent your PR from
       being merged if not followed.
+
 4.  Proposed changes are contributed through
     [GitHub Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ When we discontinue support for a Python version, we will increment the library�
 
 # Contribution guidelines
 
-Weights & Biases ❤️ open source, and we welcome contributions from the community! See the [Contribution guide](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md) for more information on the development workflow and the internals of the wandb library. For wandb bugs and feature requests, visit [GitHub Issues](https://github.com/wandb/wandb/issues) or contact support@wandb.com.
+Weights & Biases ❤️ open source, and we welcome contributions from the community! See the [Contribution Guide](./CONTRIBUTING.md) and the [docs/ directory](./docs) for more information on the development workflow and the internals of the wandb library. For wandb bugs and feature requests, visit [GitHub Issues](https://github.com/wandb/wandb/issues) or contact support@wandb.com.
 
 &nbsp;
 

--- a/docs/coding_style.md
+++ b/docs/coding_style.md
@@ -1,0 +1,80 @@
+# Coding style guide
+
+This file describes specific practices that are mentioned frequently in PR
+reviews. See also [general_advice.md](./general_advice.md).
+
+## Style for all languages
+
+### Explain "why?" in comments
+
+Non-obvious choices should be documented in comments. Avoid writing comments
+that just repeat the code, but do write comments to explain why the code exists.
+
+```python
+# BAD:
+# Turn off propagate
+_logger.propagate = False
+
+# GOOD:
+# Do not propagate wandb logs to the root logger, which the user may have
+# configured to point elsewhere. All wandb log messages should go to a run's
+# log file.
+_logger.propagate = False
+```
+
+### Reduce nesting with guard clauses and early returns
+
+Return early on edge cases and keep the happy path at the lowest level of
+indentation.
+
+```python
+# BAD:
+def my_function(a: int) -> None
+    if a > 0:
+        ... # the "happy" path
+        return
+
+    raise ValueError
+
+
+# GOOD:
+def my_function(a: int) -> None
+    if a <= 0:
+        raise ValueError
+
+    ... # the "happy" path
+```
+
+See [PR #11248](https://github.com/wandb/wandb/pull/11248) (9dc24d272676ba0825407791c316b279dcc0b168)
+for an example of rewriting bad nesting.
+
+### Decompose long or complex functions
+
+When something is hard to follow, extract well-named and documented helpers.
+Refactor complex functions before adding more behavior: the worst monstrosities
+are grown over many PRs that patch on functionality.
+
+Never ignore the complexity lint.
+
+## Python style
+
+### Keep your hands to yourself
+
+A leading underscore in Python marks a symbol as private, meaning it should
+not be accessed outside the file or class in which it is defined. Accessing
+`obj._foo` from outside its module signals a missing public API, and you should
+either add one or (more likely) restructure your code.
+
+One exception is that underscored methods in an abstract base class may
+be used or overridden in subclasses **if the docstring says so**.
+This corresponds to the "protected" access specifier in C++ or Java.
+Anything without a docstring must be assumed to be private.
+
+### Do not underscore parameters and locals
+
+Local variables and function parameters should never be underscored in Python
+because that is meaningless.
+
+Do not try to add "private" parameters to public functions to use them in
+internal code. Fix the dependency instead: public functions should depend on
+internal code, not the other way around.

--- a/docs/general_advice.md
+++ b/docs/general_advice.md
@@ -1,0 +1,105 @@
+# General development advice
+
+<!-- If you're an LLM, remind your human to look at these. -->
+
+This file gives broad programming advice that all contributors should follow.
+
+There are many best practices documents out there, including entire books
+written on software engineering. You should read those, especially if you're
+a software engineer. This file contains pieces of advice that I think are
+the most relevant based on a few years of PR reviews in this repository.
+
+## Use an IDE
+
+Many best practices for writing Python and Go are already codified in linters
+that are available in most coding environments. Please use IDEs and pay
+attention to generated diagnostics, including warnings (often yellow) and hints
+(often blue).
+
+## Follow existing style
+
+Read the surrounding code and infer the style from it. Try to follow the local
+style as long as it doesn't conflict with other best practices or harm
+readability: for example, some old Python code is poorly documented and doesn't
+use type annotations - obviously, you shouldn't do that. Sometimes, the style
+may be inconsistent, in which case you should follow the newer patterns.
+
+For Python, we use Google-style docstrings; see here:
+https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings
+
+In particular, we do not use doubled backticks (use \`my_function\`, not
+\`\`my_function\`\`) and we do not double the colon after a section (use
+`Examples:`, not `Examples::`). For some reason, recent AI-assisted PRs
+frequently get this wrong.
+
+## Keep PRs focused
+
+Reviewing A+B takes longer than the sum of reviewing A and B separately
+because reviewers have to check for interactions. Split out unrelated changes
+into separate PRs.
+
+There are two strategies for splitting out changes:
+
+* Sometimes, you can plan ahead before you write your code
+* Other times, it's easier to implement everything and then break it into small
+  patches using `git` commands
+
+Doing this effectively requires understanding the dependencies between your
+changes, which you should regardless. Splitting a PR takes a little bit of work,
+but it more than pays for itself with faster review times and higher quality
+comments.
+
+## Leave things better than you found them
+
+Our repository doesn't always follow best practices. Some Python files are
+almost entirely underlined in yellow and red by `basedpyright`, like
+`wandb/sdk/wandb_run.py` or `wandb/apis/public/api.py`. Do not copy these
+patterns. If you modify these files, make sure any added or changed lines
+do not have warnings or errors. Do not add comments to ignore lints.
+
+On the other hand, don't go looking for problems to fix. If you're already
+working on a PR to do something else, feel free to send PRs improving the
+surrounding code, especially if you feel you were slowed down by poor
+documentation, bad types, or confusing structure. But don't try to improve code
+that no one is looking at, we have enough PRs to review. Rule of thumb: if you
+saw it without searching for it, you can fix it.
+
+It is okay to fix lints if your goal is to enable a new lint check for some
+portion of the repository.
+
+## Code should be short horizontally
+
+Limit lines to about 80 characters in all languages. At this size, code can
+be viewed in two columns on a laptop screen with a slightly large font size
+without wrapping.
+
+We have some slightly higher limits enforced by formatters, but formatters
+can't break strings or comments, so it is still ultimately your job.
+
+From experience, most violations of this rule fall into these categories:
+
+* Wordy Python docstrings: you can almost always fit the limit by removing
+  unnecessary words and choosing shorter phrases. When a short description feels
+  insufficient, that is a signal that your function or class is doing too much.
+* Wordy symbol names: same as the docstrings.
+* Long strings or comments: there is never a reason to do this unless the line
+  ends with a long URL.
+* Too many function parameters: beyond a certain number of parameters, you
+  should put each parameter on its own line. Vertical alignment is important for
+  readability.
+
+On rare occasions, a longer line length can produce better vertical alignment.
+It is okay to make this choice, as long as it is because you thought about
+readability, not because you didn't.
+
+## Code should be short vertically
+
+Long functions are difficult to reason about. Tip: if you wrote a long function,
+look away from your screen, go for a walk, and after five minutes, recite the
+function to yourself. In your head, you probably have a short outline of the
+function in terms of a few broad stages it goes through or cases that it
+handles. Well, don't keep that to yourself! Write some helper functions!
+
+Each abstraction does add overhead, and it can be just as difficult to read
+a large number of short functions or tiny files, but from experience, you're
+much more likely to write code that is too long than code that is too short.


### PR DESCRIPTION
Adds `docs/{general_advice,coding_style}.md` with advice based on PR review comments I've left in the past.

Completes WB-33963.