### PR TITLE
chore: gate live scan history by server feature

### DIFF
--- a/tests/system_tests/test_api/test_public_api_history.py
+++ b/tests/system_tests/test_api/test_public_api_history.py
@@ -8,6 +8,7 @@ import pytest
 import wandb
 from wandb.apis.public import DownloadHistoryResult, IncompleteRunHistoryError, Run
 from wandb.errors import CommError
+from wandb.sdk.artifacts._gqlutils import server_supports
 
 
 def stub_run_parquet_history(
@@ -428,7 +429,11 @@ def test_run_scan_history__with_live_data(
         for i in range(10):
             run.log({"acc": i})
 
-    run = wandb.Api().run(
+    api = wandb.Api()
+    if not server_supports(api._service_api, "RUN_SCAN_HISTORY_LIVE_DATA"):
+        pytest.skip("Server doesn't support live data in run scan_history")
+
+    run = api.run(
         f"{run.entity}/{run.project}/{run.id}",
     )
 


### PR DESCRIPTION
Summary
-------
Gate `test_run_scan_history__with_live_data` on the explicit `RUN_SCAN_HISTORY_LIVE_DATA` server feature.

The min-server job can run against older server images that do not include the final live row in `run.scan_history`. This keeps the test active on servers that advertise the capability while avoiding a broad job-level skip.

Related backend flag
--------------------
- https://github.com/wandb/core/pull/45915
