### PR TITLE
feat: add sandbox integration metadata header

### DIFF
--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -33,11 +33,13 @@ def _singleton(
     }
     return Mock(spec_set=tuple(singleton), **singleton)
 
+
 @pytest.fixture(autouse=True)
 def reset_integration_metadata():
     sandbox_auth.set_integration_metadata("")
     yield
     sandbox_auth.set_integration_metadata("")
+
 
 def test_override_sandbox_entity_restores_after_exit(
     monkeypatch,
@@ -213,4 +215,3 @@ def test_client_version_headers_includes_integration_when_set() -> None:
     sandbox_auth.set_integration_metadata("some-integration")
     headers = dict(sandbox_auth._client_version_headers())
     assert headers[sandbox_auth._INTEGRATION_METADATA_KEY] == "some-integration"
-

--- a/tests/unit_tests/test_sandbox/test_sandbox_auth.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_auth.py
@@ -33,6 +33,11 @@ def _singleton(
     }
     return Mock(spec_set=tuple(singleton), **singleton)
 
+@pytest.fixture(autouse=True)
+def reset_integration_metadata():
+    sandbox_auth.set_integration_metadata("")
+    yield
+    sandbox_auth.set_integration_metadata("")
 
 def test_override_sandbox_entity_restores_after_exit(
     monkeypatch,
@@ -196,3 +201,16 @@ def test_resolve_wandb_sdk_auth_raises_when_login_does_not_resolve_credentials(
         match="wandb.sandbox could not resolve W&B credentials for sandbox auth.",
     ):
         sandbox_auth._resolve_wandb_sdk_auth()
+
+
+def test_client_version_headers_omits_integration_by_default() -> None:
+    headers = dict(sandbox_auth._client_version_headers())
+
+    assert sandbox_auth._INTEGRATION_METADATA_KEY not in headers
+
+
+def test_client_version_headers_includes_integration_when_set() -> None:
+    sandbox_auth.set_integration_metadata("some-integration")
+    headers = dict(sandbox_auth._client_version_headers())
+    assert headers[sandbox_auth._INTEGRATION_METADATA_KEY] == "some-integration"
+

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -15,7 +15,6 @@ from ._auth import _set_wandb_auth_mode, set_integration_metadata
 from ._sandbox import Sandbox, Session
 from ._secret import Secret
 
-
 _set_wandb_auth_mode()
 
 _HIDDEN = {"AuthHeaders", "set_auth_mode"}

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -11,9 +11,10 @@ from cwsandbox import *  # noqa: F403
 from cwsandbox import __all__ as cwsandbox_all
 
 # wandb specific overrides
-from ._auth import _set_wandb_auth_mode
+from ._auth import _set_wandb_auth_mode, set_integration_metadata
 from ._sandbox import Sandbox, Session
 from ._secret import Secret
+
 
 _set_wandb_auth_mode()
 

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -21,9 +21,11 @@ _entity_override: ContextVar[object | str] = ContextVar(
     default=_OVERRIDE_UNSET,
 )
 
+
 def set_integration_metadata(integration: str) -> None:
     global _INTEGRATION_METADATA_VALUE
     _INTEGRATION_METADATA_VALUE = integration
+
 
 def _set_wandb_auth_mode() -> None:
     """Install W&B as the active cwsandbox auth mode for this process.
@@ -58,7 +60,7 @@ def _client_version_headers() -> list[tuple[str, str]]:
 
     The gateway records these for SDK-adoption tracking.
     """
-    headers =  [
+    headers = [
         ("x-wandb-sdk-version", wandb.__version__),
         # Included in case the cwsandbox transport doesn't report its own version.
         ("x-cwsandbox-client-version", cwsandbox.__version__),
@@ -66,6 +68,7 @@ def _client_version_headers() -> list[tuple[str, str]]:
     if _INTEGRATION_METADATA_VALUE:
         headers.append((_INTEGRATION_METADATA_KEY, _INTEGRATION_METADATA_VALUE))
     return headers
+
 
 def _resolve_wandb_sdk_auth() -> AuthHeaders:
     settings = wandb_setup.singleton().settings

--- a/wandb/sandbox/_auth.py
+++ b/wandb/sandbox/_auth.py
@@ -13,12 +13,17 @@ from wandb.sdk import wandb_setup
 from wandb.sdk.lib import wbauth
 
 _AUTH_MODE_NAME = "wandb"
+_INTEGRATION_METADATA_KEY = "x-sandbox-integration"
+_INTEGRATION_METADATA_VALUE = ""
 _OVERRIDE_UNSET = object()
 _entity_override: ContextVar[object | str] = ContextVar(
     "wandb_sandbox_entity_override",
     default=_OVERRIDE_UNSET,
 )
 
+def set_integration_metadata(integration: str) -> None:
+    global _INTEGRATION_METADATA_VALUE
+    _INTEGRATION_METADATA_VALUE = integration
 
 def _set_wandb_auth_mode() -> None:
     """Install W&B as the active cwsandbox auth mode for this process.
@@ -53,12 +58,14 @@ def _client_version_headers() -> list[tuple[str, str]]:
 
     The gateway records these for SDK-adoption tracking.
     """
-    return [
+    headers =  [
         ("x-wandb-sdk-version", wandb.__version__),
         # Included in case the cwsandbox transport doesn't report its own version.
         ("x-cwsandbox-client-version", cwsandbox.__version__),
     ]
-
+    if _INTEGRATION_METADATA_VALUE:
+        headers.append((_INTEGRATION_METADATA_KEY, _INTEGRATION_METADATA_VALUE))
+    return headers
 
 def _resolve_wandb_sdk_auth() -> AuthHeaders:
     settings = wandb_setup.singleton().settings


### PR DESCRIPTION
Description
-----------
🥅 Goal: Attribute W&B Serverless sandbox usage to the originating integration.

Why: Today we only see the SDK and cwsandbox client versions. For integrations like Harbor that use wandb.sandbox under the hood, we need a low-cardinality way to identify which integration initiated the request.


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- [x] Unit Test
