### PR TITLE
chore: bump min server test version to resolve test failures with older server versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,7 @@ workflows:
                 [
                   "us-central1-docker.pkg.dev/wandb-client-cicd/images/local-testcontainer",
                 ]
-              server_image_tag: ["0.63.0"]
+              server_image_tag: ["0.65.0"]
 
       - nox-tests-linux:
           name: notebook-tests-linux-<<matrix.python>>

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Notable Changes
+
+This version drops compatibility with server versions older than 0.65.0.
+
 ### Added
 
 - High-resolution image rendering in terminals supporting the Kitty protocol with ANSI fallback in the W&B LEET TUI media pane (`wandb leet` command) (@dmitryduev in https://github.com/wandb/wandb/pull/11806)

--- a/core/internal/version/version.go
+++ b/core/internal/version/version.go
@@ -4,7 +4,7 @@ import "strings"
 
 const Version = "0.27.3.dev1"
 
-const MinServerVersion = "0.63.0"
+const MinServerVersion = "0.65.0"
 
 var Environment string
 


### PR DESCRIPTION
Description
-----------

Bumps the min server version to fix failing tests.

https://github.com/wandb/wandb/pull/12010 fixed a bug where `scan_history` would return duplicate or missing keys. This was caused by the fact that the backend server makes the max_step inclusive (see PR for more details). In server versions <0.65.0, max_step was exclusive, resulting in the missing data for  older server versions.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

```python
nox -s "system_tests" --python 3.13 --verbose -- tests/system_tests/test_api/test_public_api_history.py::test_run_scan_history__with_live_data
```
- against the server version 0.63.0 - `FAILED`
- against the server version 0.64.0 - `FAILED`
- against the server version 0.65.0 - `PASSED`

<!--
Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
-->
