### PR TITLE
fix: error on non-2xx HTTP status when downloading a file

### DIFF
--- a/core/internal/filetransfer/file_transfer_default.go
+++ b/core/internal/filetransfer/file_transfer_default.go
@@ -152,22 +152,16 @@ func (ft *DefaultFileTransfer) Download(task *DefaultDownloadTask) error {
 		return err
 	}
 	task.Response = resp
+
+	// Close the body on every return path, including the non-2xx case below.
+	defer resp.Body.Close()
+
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return attachErrorResponseBody(
 			"file transfer: download: failed to download: status: "+resp.Status,
 			resp,
 		)
 	}
-
-	defer func(file io.ReadCloser) {
-		if err := file.Close(); err != nil {
-			ft.logger.CaptureError(
-				fmt.Errorf(
-					"file transfer: download: error closing response reader: %v",
-					err,
-				))
-		}
-	}(resp.Body)
 
 	// open the file for writing and defer closing it
 	file, err := os.Create(task.Path)

--- a/core/internal/filetransfer/file_transfer_default.go
+++ b/core/internal/filetransfer/file_transfer_default.go
@@ -144,11 +144,30 @@ func (ft *DefaultFileTransfer) Download(task *DefaultDownloadTask) error {
 	if err != nil {
 		return err
 	}
+	if task.Context != nil {
+		req = req.WithContext(task.Context)
+	}
 	resp, err := ft.client.Do(req)
 	if err != nil {
 		return err
 	}
 	task.Response = resp
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return attachErrorResponseBody(
+			"file transfer: download: failed to download: status: "+resp.Status,
+			resp,
+		)
+	}
+
+	defer func(file io.ReadCloser) {
+		if err := file.Close(); err != nil {
+			ft.logger.CaptureError(
+				fmt.Errorf(
+					"file transfer: download: error closing response reader: %v",
+					err,
+				))
+		}
+	}(resp.Body)
 
 	// open the file for writing and defer closing it
 	file, err := os.Create(task.Path)
@@ -165,16 +184,6 @@ func (ft *DefaultFileTransfer) Download(task *DefaultDownloadTask) error {
 				))
 		}
 	}(file)
-
-	defer func(file io.ReadCloser) {
-		if err := file.Close(); err != nil {
-			ft.logger.CaptureError(
-				fmt.Errorf(
-					"file transfer: download: error closing response reader: %v",
-					err,
-				))
-		}
-	}(resp.Body)
 
 	progress, err := wboperation.Get(task.Context).NewProgress()
 	if err != nil {

--- a/core/internal/filetransfer/file_transfer_default_test.go
+++ b/core/internal/filetransfer/file_transfer_default_test.go
@@ -86,6 +86,28 @@ func TestDefaultFileTransfer_Download(t *testing.T) {
 	assert.Equal(t, task.Response.StatusCode, http.StatusOK)
 }
 
+func TestDefaultFileTransfer_DownloadHTTPError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test-file.txt")
+	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, err := w.Write([]byte("missing"))
+		assert.NoError(t, err)
+	})
+
+	task := &filetransfer.DefaultDownloadTask{
+		Path: path,
+		Url:  testURL,
+	}
+	err := newFileTransfer(t).Download(task)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to download: status: 404 Not Found")
+	assert.Contains(t, err.Error(), "body: missing")
+	assert.Equal(t, http.StatusNotFound, task.Response.StatusCode)
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
 func TestDefaultFileTransfer_Upload(t *testing.T) {
 	expectedContent := []byte("test content for upload")
 	path := writeTempFile(t, expectedContent)


### PR DESCRIPTION
Description
-----------
DefaultFileTransfer.Download previously wrote the response body to the destination file and reported success regardless of the HTTP status, so a 404 (or any error page) would be saved to disk as if it were the file.

Testing
-------
The added test fails on main (and the file gets created):
```
Running tool: /opt/homebrew/bin/go test -test.fullpath=true -timeout 30s -run ^TestDefaultFileTransfer_DownloadHTTPError$ github.com/wandb/wandb/core/internal/filetransfer -race -covermode=atomic

=== RUN   TestDefaultFileTransfer_DownloadHTTPError
2026/06/16 13:36:01 [DEBUG] GET http://127.0.0.1:58769
    /Users/dduev/code/wandb/core/internal/filetransfer/file_transfer_default_test.go:103:
                Error Trace:    /Users/dduev/code/wandb/core/internal/filetransfer/file_transfer_default_test.go:103
                Error:          An error is expected but got nil.
                Test:           TestDefaultFileTransfer_DownloadHTTPError
--- FAIL: TestDefaultFileTransfer_DownloadHTTPError (0.00s)
FAIL
coverage: 5.8% of statements
FAIL    github.com/wandb/wandb/core/internal/filetransfer 0.961s

```