### PR TITLE
docs: pr template: change conventional commits link from markdown to raw url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,6 @@ Testing
 How was this PR tested?
 
 <!--
-Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits)
+Ensure PR title compliance with the conventional commits standards:
+https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
 -->


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Change the URL in the conventional commit PR template message from markdown to a raw URL since it's in a comment, so the markdown never gets rendered.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
  - n/a


Testing
-------
I don't think it's testable as I don't think it gets used until it's merged, so I've manually put it in this PR description to demo.

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
