### PR TITLE
chore: fix windows unit tests for git_root

### DIFF
--- a/tests/unit_tests/test_wandb_settings.py
+++ b/tests/unit_tests/test_wandb_settings.py
@@ -705,7 +705,7 @@ def test_infer_git_root_finds_repo(tmp_path):
     s = Settings(root_dir=str(subdir))
     s.infer_git_root()
 
-    assert s.git_root == str(git_root)
+    assert pathlib.Path(s.git_root) == git_root
 
 
 def test_infer_git_root_no_repo(tmp_path):


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Windows unit tests are failing with

```bash
FAILED tests/unit_tests/test_wandb_settings.py::test_infer_git_root_finds_repo - AssertionError: assert 'C:/Users/circleci/AppData/Local/Temp/pytest-of-circleci/pytest-0/popen-gw3/test_infer_git_root_finds_repo0/repo' == 'C:\\Users\\circleci\\AppData\\Local\\Temp\\pytest-of-circleci\\pytest-0\\popen-gw3\\test_infer_git_root_finds_repo0\\repo'
  
  - C:\Users\circleci\AppData\Local\Temp\pytest-of-circleci\pytest-0\popen-gw3\test_infer_git_root_finds_repo0\repo
  ?   ^     ^        ^       ^     ^    ^                  ^        ^         ^                               ^
  + C:/Users/circleci/AppData/Local/Temp/pytest-of-circleci/pytest-0/popen-gw3/test_infer_git_root_finds_repo0/repo
  ?   ^     ^        ^       ^     ^    ^                  ^        ^         ^                               ^
```

This occurs because the path returned from `GitRepo.root` returns the path with forward slashes (`/`), but windows expects back slashes (`\`) for paths. This PR fixes the test by normalizing the path with pathlib.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

unit tests pass on windows.

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->