### PR TITLE
fix: display download stats for wandb.Api.Run.download_history_exports

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,3 +39,4 @@ This version drops compatibility with server versions older than 0.65.0.
 - Logging artifacts in shared mode works again, and in particular, `wandb.init(mode="shared")` with code-saving enabled no longer raises an error (@timoffex in https://github.com/wandb/wandb/pull/12017)
 - `git_root` setting is now preferred for creating the `diff.patch` file, the `root_dir` setting is now used as a fallback (@TomSiegl in https://github.com/wandb/wandb/pull/11967)
 - Apple system metrics (GPU, CPU, power, and temperature) are now collected on Apple M5 Macs (@dmitryduev in https://github.com/wandb/wandb/pull/12061)
+- file download progress is now shown when using `wandb.Api().run(...).download_history_exports` (@jacobromero in https://github.com/wandb/wandb/pull/12063)

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -383,11 +383,15 @@ func (f *RunHistoryAPIHandler) handleDownloadRunHistory(
 	ctx context.Context,
 	request *spb.DownloadRunHistory,
 ) *spb.ApiResponse {
+	// Cleanup the download operation after the request is handled.
+	defer func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		delete(f.downloadOperations, request.GetRequestId())
+	}()
+
 	f.mu.Lock()
 	downloadOperation, ok := f.downloadOperations[request.GetRequestId()]
-	if ok {
-		delete(f.downloadOperations, request.GetRequestId())
-	}
 	f.mu.Unlock()
 
 	if !ok || downloadOperation == nil {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

When downloading a run's parquet history using the public API, no stats for the downloaded file were being shown. This occurred due to a bug where the download operation containing the stats was removed from the map of existing operations. So subsequent status requests wouldn't return anything.

This is fixed by wrapping the deletion of the download operation in a `defer` function. Since the `handleDownloadRunHistory` is a sync operation. Once the download completes there will be no futher updates to the operation.

- [x] I updated [CHANGELOG.unreleased.md](http://CHANGELOG.unreleased.md), or it's not applicable

## Testing

How was this PR tested?

- Test script

```python
import wandb

api = wandb.Api()

api_run = api.run("jacobromerotest/perf-run-depth/runs/c8a350wi")
result = api_run.download_history_exports(
    "./parquet/pqfiles",
    require_complete_history=True,
)
print(f"downloaded: {result}")
```

  
[Screen Recording 2026-06-17 at 3.04.45 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/caac3628-a38c-41cf-a736-228c7038d68c.mov" />](https://app.graphite.com/user-attachments/video/caac3628-a38c-41cf-a736-228c7038d68c.mov)



<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->