### PR TITLE
fix: scan_history returning empty for active runs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,3 +42,4 @@ This version drops compatibility with server versions older than 0.65.0.
 - `git_root` setting is now preferred for creating the `diff.patch` file, the `root_dir` setting is now used as a fallback (@TomSiegl in https://github.com/wandb/wandb/pull/11967)
 - Apple system metrics (GPU, CPU, power, and temperature) are now collected on Apple M5 Macs (@dmitryduev in https://github.com/wandb/wandb/pull/12061)
 - file download progress is now shown when using `wandb.Api().run(...).download_history_exports` (@jacobromero in https://github.com/wandb/wandb/pull/12063)
+- `Run.scan_history()` no longer returns no rows for a run whose history exists but has not been exported to parquet (e.g. an active run; a regression in `0.27.1`) (@dmitryduev in https://github.com/wandb/wandb/issues/12073)

--- a/core/internal/runhistoryreader/livedata.go
+++ b/core/internal/runhistoryreader/livedata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"slices"
 
 	"github.com/wandb/simplejsonext"
@@ -20,7 +21,15 @@ func (h *HistoryReader) getLiveData(
 	maxStep int64,
 	selectAllKeys bool,
 ) ([]parquet.KeyValueList, error) {
-	requireLiveDataQuery := minStep >= h.minLiveStep || maxStep > h.minLiveStep
+	// A page must be served from the live endpoints when it extends past the
+	// boundary where exported parquet data ends. The fallback case covers runs
+	// whose history exists but the backend reported neither a live-step boundary
+	// nor any exported parquet files: the data is then only reachable live, so
+	// query it instead of silently returning no rows.
+	hasLiveRangeBoundary := h.minLiveStep != math.MaxInt64
+	hasExportedData := len(h.parquetReaders) > 0
+	requireLiveDataQuery := maxStep > h.minLiveStep ||
+		(!hasLiveRangeBoundary && !hasExportedData)
 	if !requireLiveDataQuery {
 		return []parquet.KeyValueList{}, nil
 	}

--- a/core/internal/runhistoryreader/reader.go
+++ b/core/internal/runhistoryreader/reader.go
@@ -193,14 +193,6 @@ func (h *HistoryReader) getParquetFilePaths(
 
 	if len(liveData) > 0 {
 		h.minLiveStep = slices.Min(liveData)
-	} else if len(signedUrls) == 0 {
-		// The backend returned neither exported parquet files nor live-step
-		// markers. This happens for runs whose history has not been exported to
-		// parquet (e.g. backends that don't populate parquetHistory.liveData).
-		// The full history is then only reachable through the live
-		// history/sampledHistory endpoints, so treat every step as live instead
-		// of silently returning no rows.
-		h.minLiveStep = 0
 	}
 
 	dir, err := getUserRunHistoryCacheDir()

--- a/core/internal/runhistoryreader/reader.go
+++ b/core/internal/runhistoryreader/reader.go
@@ -193,6 +193,14 @@ func (h *HistoryReader) getParquetFilePaths(
 
 	if len(liveData) > 0 {
 		h.minLiveStep = slices.Min(liveData)
+	} else if len(signedUrls) == 0 {
+		// The backend returned neither exported parquet files nor live-step
+		// markers. This happens for runs whose history has not been exported to
+		// parquet (e.g. backends that don't populate parquetHistory.liveData).
+		// The full history is then only reachable through the live
+		// history/sampledHistory endpoints, so treat every step as live instead
+		// of silently returning no rows.
+		h.minLiveStep = 0
 	}
 
 	dir, err := getUserRunHistoryCacheDir()

--- a/core/internal/runhistoryreader/reader_test.go
+++ b/core/internal/runhistoryreader/reader_test.go
@@ -676,6 +676,71 @@ func TestHistoryReader_GetHistorySteps_AllLiveData_WithKeys(t *testing.T) {
 	})
 }
 
+// When the backend reports no parquet files and no live-step markers, the
+// reader must still fall back to the live history endpoint rather than
+// returning nothing. This guards against scan_history() yielding 0 rows for
+// runs whose history exists but hasn't been exported to parquet.
+func TestHistoryReader_GetHistorySteps_NoParquetEmptyLiveData(t *testing.T) {
+	ctx := t.Context()
+	mockGQL := gqlmock.NewMockClient()
+
+	// No parquet files and an empty liveData list.
+	mockGQL.StubMatchOnce(
+		gqlmock.WithOpName("RunParquetHistory"),
+		`{
+			"project": {
+				"run": {
+					"parquetHistory": {
+						"parquetUrls": [],
+						"liveData": []
+					}
+				}
+			}
+		}`,
+	)
+
+	// The live history is still served by the history endpoint.
+	mockGQL.StubMatchOnce(
+		gqlmock.WithOpName("HistoryPage"),
+		`{
+			"project": {
+				"run": {
+					"history": [
+						"{\"_step\":0,\"metric1\":1.0}",
+						"{\"_step\":1,\"metric1\":2.0}"
+					]
+				}
+			}
+		}`,
+	)
+
+	reader, err := New(
+		ctx,
+		"test-entity",
+		"test-project",
+		"test-run-id",
+		mockGQL,
+		retryablehttp.NewClient(),
+		[]string{},
+		true,
+		createMockRustArrowWrapper(nil, nil, nil),
+	)
+	require.NoError(t, err)
+
+	results, err := reader.GetHistorySteps(ctx, 0, 10)
+
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.ElementsMatch(t, results[0], parquet.KeyValueList{
+		{Key: "_step", Value: int64(0)},
+		{Key: "metric1", Value: 1.0},
+	})
+	assert.ElementsMatch(t, results[1], parquet.KeyValueList{
+		{Key: "_step", Value: int64(1)},
+		{Key: "metric1", Value: 2.0},
+	})
+}
+
 func TestHistoryReader_GetHistorySteps_MixedParquetAndLiveData(t *testing.T) {
 	ctx := t.Context()
 	tempDir := t.TempDir()

--- a/tests/unit_tests/test_public_api/test_history.py
+++ b/tests/unit_tests/test_public_api/test_history.py
@@ -1,0 +1,72 @@
+import json
+from types import SimpleNamespace
+
+from wandb.apis.public.history import HistoryScan
+from wandb.proto import wandb_api_pb2 as apb
+
+
+class FakeServiceApi:
+    def __init__(self, pages):
+        self.pages = list(pages)
+        self.scan_ranges = []
+
+    def send_api_request(self, request):
+        read_request = request.read_run_history_request
+
+        if read_request.HasField("scan_run_history_init"):
+            return apb.ApiResponse(
+                read_run_history_response=apb.ReadRunHistoryResponse(
+                    scan_run_history_init=apb.ScanRunHistoryInitResponse(request_id=1)
+                )
+            )
+
+        if read_request.HasField("scan_run_history"):
+            scan_request = read_request.scan_run_history
+            self.scan_ranges.append((scan_request.min_step, scan_request.max_step))
+            return apb.ApiResponse(
+                read_run_history_response=apb.ReadRunHistoryResponse(
+                    run_history=apb.RunHistoryResponse(history_rows=self.pages.pop(0))
+                )
+            )
+
+        return apb.ApiResponse(
+            read_run_history_response=apb.ReadRunHistoryResponse(
+                scan_run_history_cleanup=apb.ScanRunHistoryCleanupResponse()
+            )
+        )
+
+
+def history_row(**items):
+    return apb.HistoryRow(
+        history_items=[
+            apb.ParquetHistoryItem(key=key, value_json=json.dumps(value))
+            for key, value in items.items()
+        ]
+    )
+
+
+def test_scan_history_skips_empty_pages_before_later_history():
+    service_api = FakeServiceApi(
+        pages=[
+            [],
+            [
+                history_row(_step=2, acc=0.5),
+                history_row(_step=3, acc=0.75),
+            ],
+        ]
+    )
+    run = SimpleNamespace(entity="entity", project="project", id="run-id")
+
+    scan = HistoryScan(
+        service_api=service_api,
+        run=run,
+        min_step=0,
+        max_step=4,
+        page_size=2,
+    )
+
+    assert list(scan) == [
+        {"_step": 2, "acc": 0.5},
+        {"_step": 3, "acc": 0.75},
+    ]
+    assert service_api.scan_ranges == [(0, 2), (2, 4)]

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -111,11 +111,11 @@ class HistoryScan(Iterator[_RowDict]):
                 return row
             if self.page_offset >= self._stop_step:
                 raise StopIteration()
-            # Load the next page
-            previous_page_offset = self.page_offset
+            # Load the next page. An empty page does not terminate the scan: a
+            # step range may have no rows while later steps do (e.g. a gap
+            # between exported parquet data and the live tail). Iteration ends
+            # only once page_offset reaches _stop_step (checked above).
             self._load_next()
-            if len(self.rows) == 0 and self.page_offset <= previous_page_offset:
-                raise StopIteration()
 
     def _load_next(self) -> None:
         from wandb.proto import wandb_api_pb2 as pb

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -112,9 +112,9 @@ class HistoryScan(Iterator[_RowDict]):
             if self.page_offset >= self._stop_step:
                 raise StopIteration()
             # Load the next page
+            previous_page_offset = self.page_offset
             self._load_next()
-            # If no rows were returned, we've reached the end of the data
-            if len(self.rows) == 0:
+            if len(self.rows) == 0 and self.page_offset <= previous_page_offset:
                 raise StopIteration()
 
     def _load_next(self) -> None:


### PR DESCRIPTION
Description
-----------
Fixes #12067.

`Run.scan_history()` returned `[]` for runs whose history exists (`lastHistoryStep` and sampled history show data) but isn't available as exported parquet — e.g. active runs, or backends that don't populate `parquetHistory.liveData`.

Two regressions from the parquet-based scan introduced in 0.27.1:

1. **wandb-core (primary):** `getLiveData` only queried the live history/sampledHistory endpoints when a page extended past `minLiveStep`. When the backend reports neither a      live-step boundary nor any exported parquet, `minLiveStep` stayed `MaxInt64` and the      live path was never hit, so every page came back empty. The `requireLiveDataQuery`      gate now falls back to the live endpoints in that case.

2. **Python iterator:** `HistoryScan` stopped as soon as any page returned no rows. The      legacy GraphQL scan never did this; an early/sparse range can be empty while later      ranges have data. It now scans until `page_offset` reaches the requested range end.
