### PR TITLE
docs: document settings source precedence order

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -74,6 +74,20 @@ class Settings(BaseModel, validate_assignment=True):
        versions.
     3. Computed settings: Read-only settings that are automatically derived from other settings or
        the environment.
+
+    Settings are loaded from multiple sources. When the same setting is supplied
+    by more than one source, the source listed later wins. From lowest to highest
+    precedence:
+
+    1. Default values defined on this `Settings` model.
+    2. Configuration files (`~/.config/wandb/settings`, or the `settings` file in
+       the directory named by the `WANDB_CONFIG_DIR` environment variable).
+    3. Environment variables (those prefixed with `WANDB_`, e.g. `WANDB_MODE`).
+    4. Settings inferred from the system environment.
+    5. SageMaker settings, when running in an Amazon SageMaker environment.
+    6. Settings passed programmatically, such as the `settings` argument to
+       `wandb.setup()` and `wandb.init()`, and the explicit keyword arguments to
+       `wandb.init()` (for example `mode=`).
     """
 
     # Pydantic Model configuration.

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -83,11 +83,14 @@ class Settings(BaseModel, validate_assignment=True):
     2. Configuration files (`~/.config/wandb/settings`, or the `settings` file in
        the directory named by the `WANDB_CONFIG_DIR` environment variable).
     3. Environment variables (those prefixed with `WANDB_`, e.g. `WANDB_MODE`).
-    4. Settings inferred from the system environment.
+    4. Values detected from the runtime environment, such as the hostname, the
+       running program/script path, the Python executable, the Docker image, and
+       Jupyter notebook details.
     5. SageMaker settings, when running in an Amazon SageMaker environment.
-    6. Settings passed programmatically, such as the `settings` argument to
-       `wandb.setup()` and `wandb.init()`, and the explicit keyword arguments to
-       `wandb.init()` (for example `mode=`).
+    6. The `settings` parameter of `wandb.setup()`.
+    7. The `settings` parameter of `wandb.init()`.
+    8. Certain `wandb.init()` parameters (for example, `mode=` overrides the
+       `mode` setting).
     """
 
     # Pydantic Model configuration.


### PR DESCRIPTION
Description
-----------
Spell out the order in which Settings sources are applied (defaults < config files < `WANDB_` env vars < system env < SageMaker < programmatic args) in the `Settings` class docstring as it is user-facing.

Clarifies that precedence is determined by the source of a setting, not its value, so, for example, `wandb.init(mode=...)` intentionally overrides `WANDB_MODE`.

Addresses a user report that disabled mode should beat shared mode: WB-26585.