### PR TITLE
chore: use thread-based pytest-timeout in tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -157,6 +157,11 @@ def run_pytest(
     # (pytest-timeout) Per-test timeout.
     pytest_opts.append(f"--timeout={opts.get('timeout', 60)}")
 
+    # (pytest-timeout) Use the thread watchdog, not the default "signal" method:
+    # SIGALRM can't interrupt a main thread parked on a threading primitive (as
+    # in e.g. a deadlocked wandb.teardown()), so the timeout would silently never fire.
+    pytest_opts.append(f"--timeout-method={opts.get('timeout_method', 'thread')}")
+
     # (pytest-xdist) Run tests in parallel.
     pytest_opts.append(f"-n={opts.get('n', 'auto')}")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -157,9 +157,8 @@ def run_pytest(
     # (pytest-timeout) Per-test timeout.
     pytest_opts.append(f"--timeout={opts.get('timeout', 60)}")
 
-    # (pytest-timeout) Use the thread watchdog, not the default "signal" method:
-    # SIGALRM can't interrupt a main thread parked on a threading primitive (as
-    # in e.g. a deadlocked wandb.teardown()), so the timeout would silently never fire.
+    # (pytest-timeout) Use the 'thread' method to shut down more reliably
+    # to help debug hangs.
     pytest_opts.append(f"--timeout-method={opts.get('timeout_method', 'thread')}")
 
     # (pytest-xdist) Run tests in parallel.


### PR DESCRIPTION
Description
-----------
system-tests-linux-3.13 randomly gets stuck and is killed by CircleCI's no_output_timeout: 10m with no diagnostics. A scan of the last 800 failed builds found 160 such hangs in ~4 weeks, 96% on Python 3.13 (154 vs 6 on 3.10, at equal run frequency), spread across 17+ test files, so it's not like a single flaky test.

Logs show the stall is always at the end of the run with 0–1 tests in-flight, suggesting the pytest-xdist signature of a test hanging in its teardown phase. The hang could be in wandb.teardown() (run after every test by the autouse clean_up fixture), which has unbounded waits (Future.result(), Thread.join(), subprocess.wait()). We set --timeout=60, but the default signal method's SIGALRM can't interrupt a main thread parked on a threading primitive, so the timeout silently never fires. I think :)

This one switches pytest-timeout to --timeout-method=thread. Its watchdog runs independently of the deadlocked main thread, dumping all thread stacks and force-exiting — turning a 10-min silent job-killer into a fast failure with a traceback. No behavior change on green runs.