### PR TITLE
fix: better online run detection in wandb beta sync

### DIFF
--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -399,7 +399,7 @@ def test_merges_symlinks(
 
     assert result.output.splitlines() == [
         "wandb: Would sync 1 run(s):",
-        "wandb:   offline-actual-run/run.wandb",
+        "wandb:   latest-run/run.wandb",
     ]
 
 

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -319,7 +319,10 @@ def _is_online(path: pathlib.Path) -> bool:
     Online run directories are named like "run-..." and offline runs
     are named like "offline-run-...".
     """
-    return not path.parent.name.startswith("offline-")
+    try:
+        return not path.parent.resolve().name.startswith("offline-")
+    except OSError:
+        return False
 
 
 def _print_sorted_paths(


### PR DESCRIPTION
Follow-up to #12087 to correctly detect online runs in the presence of symlinks (like `latest-run`).