### PR TITLE
fix(artifacts): enforce max_objects in S3Handler.store_path

### DIFF
--- a/tests/unit_tests/test_artifacts/test_references_s3.py
+++ b/tests/unit_tests/test_artifacts/test_references_s3.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import boto3
 from moto import mock_aws
-from pytest import MonkeyPatch, fixture, mark, raises
+from pytest import MonkeyPatch, fixture, raises
 from wandb import Artifact
 
 if TYPE_CHECKING:
@@ -259,13 +259,6 @@ def test_add_s3_reference_path_with_content_type(
     assert "Generating checksum" in capsys.readouterr().err
 
 
-@mark.xfail(
-    reason=(
-        "S3Handler.store_path fetches only max_objects objects, so an over-limit "
-        "reference is silently truncated instead of raising ValueError."
-    ),
-    strict=True,
-)
 def test_add_s3_max_objects(s3, bucket, mock_body, artifact):
     s3.put_object(Bucket=bucket, Key="my_dir/my_object.pb", Body=mock_body)
     s3.put_object(Bucket=bucket, Key="my_dir/my_other_object.pb", Body=mock_body)

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -214,14 +214,16 @@ class S3Handler(StorageHandler):
                     f'Generating checksum for up to {max_objects} objects in "{bucket}/{key}"... ',
                     newline=False,
                 )
+                # Fetch one more than the cap so we can detect (and reject)
+                # references that exceed it, rather than silently truncating.
                 if key != "":
                     objs = (
                         self._s3.Bucket(bucket)
                         .objects.filter(Prefix=key)
-                        .limit(max_objects)
+                        .limit(max_objects + 1)
                     )
                 else:
-                    objs = self._s3.Bucket(bucket).objects.limit(max_objects)
+                    objs = self._s3.Bucket(bucket).objects.limit(max_objects + 1)
             # Weird iterator scoping makes us assign this to a local function
             size = self._size_from_obj
             entries = [


### PR DESCRIPTION
## What

Make `S3Handler.store_path` actually enforce the `max_objects` cap on a directory/prefix reference, and re-enable `test_add_s3_max_objects` as a real assertion.

## Why

`store_path` fetched at most `max_objects` objects:

```python
objs = self._s3.Bucket(bucket).objects.filter(Prefix=key).limit(max_objects)
...
if len(entries) > max_objects:
    raise ValueError("Exceeded ...")
```

Because `.limit(max_objects)` already caps the result, `len(entries)` can never exceed `max_objects` against a real client — so the guard was dead code and an over-large reference was **silently truncated** to the first `max_objects` objects instead of being rejected. (The old hand-rolled test mock only "caught" this because its `.limit()` ignored the argument and always returned 2 objects.)

## Fix

Fetch `max_objects + 1` so the existing guard can see the overflow and raise. No change to the success path or the `termlog` wording.

This is the second half of the stack: the previous PR (#12090) converted the S3 reference tests to `moto` and marked `test_add_s3_max_objects` as `xfail` to document the broken behavior. This PR removes that `xfail` so the test asserts the `ValueError` for real.

## Verification

`tests/unit_tests/test_artifacts/test_references_s3.py` → **9 passed** against real `moto` + `boto3` (was 8 passed / 1 xfailed before this change). `ruff check` / `ruff format --check` clean.

Stacked on #12090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiFnDX4duBZbesmcYMrf88

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiFnDX4duBZbesmcYMrf88)_