### PR TITLE
feat: print skipped count in wandb beta sync

### DIFF
--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -191,7 +191,7 @@ def test_syncs_run(
     result = runner.invoke(cli.beta, f"sync {run.settings.sync_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Syncing 1 run(s):"
+    assert lines[0] == "wandb: Syncing 1 run(s) (0 skipped):"
     assert lines[1].endswith(f"run-{run.id}.wandb")
     # More lines possible depending on status updates. Not deterministic.
     assert lines[-1].startswith(f"wandb: [{run.path}] Finished syncing")
@@ -240,7 +240,7 @@ def test_sync_defaults_to_wandb_dir(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, "sync", input="n")
 
     assert result.output.splitlines() == [
-        "wandb: Syncing 5 run(s):",
+        "wandb: Syncing 5 run(s) (0 skipped):",
         f"wandb:   {paths[0]}",
         f"wandb:   {paths[1]}",
         f"wandb:   {paths[2]}",
@@ -354,8 +354,10 @@ def test_skip_synced(
     assert "run-3.wandb" in result.output
 
     if skip_synced:
+        assert "Would sync 2 run(s) (1 skipped)" in result.output
         assert "run-2.wandb" not in result.output
     else:
+        assert "Would sync 3 run(s) (0 skipped)" in result.output
         assert "run-2.wandb" in result.output
 
 
@@ -380,8 +382,10 @@ def test_skip_online(
     assert "run-def.wandb" in result.output
 
     if skip_online:
+        assert "Would sync 2 run(s) (1 skipped)" in result.output
         assert "run-xyz.wandb" not in result.output
     else:
+        assert "Would sync 3 run(s) (0 skipped)" in result.output
         assert "run-xyz.wandb" in result.output
 
 
@@ -398,7 +402,7 @@ def test_merges_symlinks(
     result = runner.invoke(cli.beta, "sync --dry-run .")
 
     assert result.output.splitlines() == [
-        "wandb: Would sync 1 run(s):",
+        "wandb: Would sync 1 run(s) (0 skipped):",
         "wandb:   latest-run/run.wandb",
     ]
 
@@ -411,7 +415,7 @@ def test_sync_wandb_file(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {file}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 1 run(s):"
+    assert lines[0] == "wandb: Would sync 1 run(s) (0 skipped):"
     assert lines[1].endswith("run-abc.wandb")
 
 
@@ -423,7 +427,7 @@ def test_sync_run_directory(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {run_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 1 run(s):"
+    assert lines[0] == "wandb: Would sync 1 run(s) (0 skipped):"
     assert lines[1].endswith("run.wandb")
 
 
@@ -441,7 +445,7 @@ def test_sync_wandb_directory(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {wandb_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 2 run(s):"
+    assert lines[0] == "wandb: Would sync 2 run(s) (0 skipped):"
     assert lines[1].endswith("run-1.wandb")
     assert lines[2].endswith("run-2.wandb")
 
@@ -460,7 +464,7 @@ def test_truncates_printed_paths(
     result = runner.invoke(cli.beta, f"sync --dry-run {tmp_path}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 20 run(s):"
+    assert lines[0] == "wandb: Would sync 20 run(s) (0 skipped):"
     for line in lines[1:6]:
         assert re.fullmatch(r"wandb:   .+/offline-run-\d+/run\.wandb", line)
     assert lines[6] == "wandb:   +15 more (pass --verbose to see all)"
@@ -487,7 +491,7 @@ def test_prints_relative_paths(
     result = runner.invoke(cli.beta, f"sync --dry-run {dir1_cwd} {dir2_not}")
 
     assert result.output.splitlines() == [
-        "wandb: Would sync 2 run(s):",
+        "wandb: Would sync 2 run(s) (0 skipped):",
         *sorted(
             [
                 "wandb:   offline-run-1/run-relative.wandb",

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -70,29 +70,24 @@ def sync(
         paths = [pathlib.Path(singleton.settings.wandb_dir)]
         ask_for_confirmation = True
 
-    wandb_files = _to_unique_files(
-        (
-            wandb_file
-            for path in paths
-            for wandb_file in _find_wandb_files(
-                path,
-                skip_synced=skip_synced,
-                skip_online=skip_online,
-            )
-        ),
+    wandb_files, skipped = _find_wandb_files(
+        paths,
+        skip_synced=skip_synced,
+        skip_online=skip_online,
         verbose=verbose,
     )
+    skipped_str = f"({skipped} skipped)"
 
     if not wandb_files:
-        term.termlog("No runs to sync.")
+        term.termlog(f"No runs to sync {skipped_str}.")
         return
 
     if dry_run:
-        term.termlog(f"Would sync {len(wandb_files)} run(s):")
+        term.termlog(f"Would sync {len(wandb_files)} run(s) {skipped_str}:")
         _print_sorted_paths(wandb_files, verbose=verbose, root=cwd)
         return
 
-    term.termlog(f"Syncing {len(wandb_files)} run(s):")
+    term.termlog(f"Syncing {len(wandb_files)} run(s) {skipped_str}:")
     _print_sorted_paths(wandb_files, verbose=verbose, root=cwd)
 
     if ask_for_confirmation and not term.confirm("Sync the listed runs?"):
@@ -144,36 +139,6 @@ def _parse_replace_tags(replace_tags: str) -> dict[str, str]:
         tag_replacements[old_tag.strip()] = new_tag.strip()
 
     return tag_replacements
-
-
-def _to_unique_files(
-    paths: Iterator[pathlib.Path],
-    *,
-    verbose: bool,
-) -> set[pathlib.Path]:
-    """Returns paths with duplicates removed.
-
-    Determines file equality the same way as os.path.samefile().
-    """
-    id_to_path: dict[tuple[int, int], pathlib.Path] = dict()
-
-    # Sort in reverse so that the last path written to the map is
-    # alphabetically earliest.
-    for path in sorted(paths, reverse=True):
-        try:
-            stat = path.stat()
-        except OSError as e:
-            term.termerror(f"Failed to stat {path}: {e}")
-            continue
-
-        id = (stat.st_ino, stat.st_dev)
-
-        if verbose and (other_path := id_to_path.get(id)):
-            term.termlog(f"{path} is the same as {other_path}")
-
-        id_to_path[id] = path
-
-    return set(id_to_path.values())
 
 
 async def _do_sync(
@@ -273,18 +238,66 @@ class _SyncStatusLoop:
 
 
 def _find_wandb_files(
-    path: pathlib.Path,
+    paths: Iterable[pathlib.Path],
     *,
     skip_synced: bool,
     skip_online: bool,
-) -> Iterator[pathlib.Path]:
-    """Returns paths to the .wandb files to sync."""
-    for file in _expand_wandb_files(path):
+    verbose: bool,
+) -> tuple[set[pathlib.Path], int]:
+    """Finds all unique .wandb files selected by the paths.
+
+    Returns:
+        The .wandb files to sync and the number of files that were filtered out.
+    """
+    unique_files = _to_unique_files(
+        [file for path in paths for file in _expand_wandb_files(path)],
+        verbose=verbose,
+    )
+
+    filtered_files: set[pathlib.Path] = set()
+    skipped = 0
+
+    for file in unique_files:
         if skip_synced and _is_synced(file):
+            skipped += 1
             continue
         if skip_online and _is_online(file):
+            skipped += 1
             continue
-        yield file
+
+        filtered_files.add(file)
+
+    return filtered_files, skipped
+
+
+def _to_unique_files(
+    paths: list[pathlib.Path],
+    *,
+    verbose: bool,
+) -> set[pathlib.Path]:
+    """Returns paths with duplicates removed.
+
+    Determines file equality the same way as os.path.samefile().
+    """
+    id_to_path: dict[tuple[int, int], pathlib.Path] = dict()
+
+    # Sort in reverse so that the last path written to the map is
+    # alphabetically earliest.
+    for path in sorted(paths, reverse=True):
+        try:
+            stat = path.stat()
+        except OSError as e:
+            term.termerror(f"Failed to stat {path}: {e}")
+            continue
+
+        id = (stat.st_ino, stat.st_dev)
+
+        if verbose and (other_path := id_to_path.get(id)):
+            term.termlog(f"{path} is the same as {other_path}")
+
+        id_to_path[id] = path
+
+    return set(id_to_path.values())
 
 
 def _expand_wandb_files(


### PR DESCRIPTION
Prints the number of paths filtered out due to `--skip-synced` and `--skip-online` (which are the default).

For example, if all paths are filtered out, the message now says "No runs to sync (N skipped)" instead of just "No runs to sync," which is less confusing.