### PR TITLE
feat: route wandb sync to wandb beta sync sometimes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,3 +18,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - remove temporary unix socket files and directories on shutdown (@geoffhardy in https://github.com/wandb/wandb/pull/12058)
 - `wandb beta sync` now skips online runs by default like `wandb sync` (@timoffex in https://github.com/wandb/wandb/pull/12087)
+- `wandb sync` now routes to `wandb beta sync` for supported parameter sets (@timoffex in https://github.com/wandb/wandb/pull/12093)
+  - Restore original behavior with `--legacy`

--- a/tests/system_tests/test_core/test_cli_full.py
+++ b/tests/system_tests/test_core/test_cli_full.py
@@ -184,8 +184,9 @@ def test_sync_wandb_run_and_tensorboard(runner, wandb_backend_spy, user, copy_as
             uploaded_files = snapshot.uploaded_files(run_id="g9dvvkua")
             assert "code/standalone_tests/code-toad.py" in uploaded_files
 
-        # Check we marked the run as synced
-        result = runner.invoke(cli.sync, [run_dir])
+        # Check we marked the run as synced.
+        # Pass --legacy for the warning below.
+        result = runner.invoke(cli.sync, [run_dir, "--legacy"])
         assert result.exit_code == 0
         assert (
             "WARNING Found .wandb file, not streaming tensorboard metrics"

--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -145,9 +145,8 @@ def sync(
 ) -> None:
     """Upload .wandb files specified by PATHS.
 
-    This is a beta re-implementation of `wandb sync`.
-    It is not feature complete, not guaranteed to work, and may change
-    in backward-incompatible ways in any release of wandb.
+    This is an improvement on `wandb sync` with additional features and better
+    UX and performance. It will eventually be absorbed into `wandb sync`.
 
     PATHS can include .wandb files, run directories containing .wandb files,
     and "wandb" directories containing run directories.

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -28,6 +28,7 @@ import wandb.sdk.verify.verify as wandb_verify
 from wandb import Config, Error, env, util, wandb_agent
 from wandb.analytics import get_sentry
 from wandb.apis import InternalApi, PublicApi
+from wandb.cli import beta_sync
 from wandb.errors.links import url_registry
 from wandb.sdk import wandb_setup, wandb_sweep
 from wandb.sdk.artifacts._validators import is_artifact_registry_project
@@ -40,7 +41,7 @@ from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.launch.sweeps.scheduler import Scheduler
 from wandb.sdk.lib import filesystem, settings_file
-from wandb.sync import SyncManager, get_run_from_path, get_runs
+from wandb.sync import TFEVENT_SUBSTRING, SyncManager, get_run_from_path, get_runs
 
 from .beta import beta
 from .leet import leet
@@ -668,6 +669,11 @@ def init(ctx, project, entity, reset, mode):
     "--replace-tags",
     help="Rename tags during sync. Use 'old=new' pairs separated by commas.",
 )
+@click.option(
+    "--legacy",
+    is_flag=True,
+    help="Force legacy behavior instead of rerouting to `wandb beta sync`.",
+)
 @display_error
 def sync(
     ctx: click.Context,
@@ -694,6 +700,7 @@ def sync(
     append: bool,
     skip_console: bool,
     replace_tags: str | None,
+    legacy: bool,
 ):
     """Upload existing local W&B run data to the cloud.
 
@@ -745,6 +752,44 @@ def sync(
 
         $ wandb sync --clean --clean-old-hours 48 --clean-force
     """
+    if (
+        not legacy
+        and len(path) >= 1  # slightly different behavior when no paths
+        and not any(TFEVENT_SUBSTRING in p for p in path)  # no tfevents support
+        and not view
+        # verbose, run_id, project, entity, job_type OK
+        and not sync_tensorboard
+        and not include_globs
+        and not exclude_globs
+        # include_online OK
+        and include_offline is not False  # True and None OK
+        # include_synced OK
+        and mark_synced
+        and not sync_all
+        # ignore, show OK (unused)
+        and not clean
+        # clean_old_hours, clean_force OK (no-op without clean)
+        and not append
+        and not skip_console
+        # replace_tags OK
+    ):
+        wandb.termlog("Using wandb beta sync. Turn this off with --legacy.")
+        beta_sync.sync(
+            [pathlib.Path(p) for p in path],
+            live=False,
+            entity=entity or "",
+            project=project or "",
+            run_id=run_id or "",
+            job_type=job_type or "",
+            replace_tags=replace_tags or "",
+            dry_run=False,
+            skip_synced=not include_synced,
+            skip_online=not include_online,
+            verbose=verbose,
+            parallelism=5,  # same default as wandb beta sync
+        )
+        return
+
     api = _get_cling_api()
     if not api.is_authenticated:
         wandb.termlog("Login to W&B to sync runs")

--- a/wandb/sync/__init__.py
+++ b/wandb/sync/__init__.py
@@ -1,3 +1,3 @@
 """module sync."""
 
-from .sync import SyncManager, get_run_from_path, get_runs
+from .sync import TFEVENT_SUBSTRING, SyncManager, get_run_from_path, get_runs


### PR DESCRIPTION
Makes `wandb sync` route to `wandb beta sync` for supported parameter choices.

I went down the parameter list and for each one, either added a condition for it or added a comment and used it in the `beta_sync.sync()` call. The `path` parameter is the trickiest, and I only discovered the `tfevents` condition because of `wandb sync` tests. I spot-tested the other combinations and didn't run into any regressions.