### PR TITLE
fix(leet): assign run colors lazily at workspace startup

### DIFF
--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -370,12 +370,6 @@ func (w *Workspace) applyRunKeys(runKeys []string) {
 
 	w.setRunItems(runKeys)
 
-	if w.runColors != nil {
-		for _, runKey := range runKeys {
-			w.runColors.Assign(w.runPathForKey(runKey))
-		}
-	}
-
 	if prevCursorKey != "" {
 		w.restoreRunCursor(prevCursorKey)
 	}


### PR DESCRIPTION
Description
-----------
`applyRunKeys` eagerly colored every run on the update goroutine; collision resolution is superlinear, so a large .wandb dir froze startup (~6.2k runs: 1.1s).
Colors are already assigned lazily and cached for the rows we render and series we plot, so drop the eager loop. A local test showed: 1.12s → 447µs.