### PR TITLE
feat: wandb beta sync --yes

### DIFF
--- a/wandb/cli/beta.py
+++ b/wandb/cli/beta.py
@@ -112,6 +112,13 @@ beta.add_command(leet)
     help="Print what would happen without uploading anything.",
 )
 @click.option(
+    "--yes",
+    "skip_confirmation",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation.",
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -140,6 +147,7 @@ def sync(
     skip_synced: bool,
     skip_online: bool,
     dry_run: bool,
+    skip_confirmation: bool,
     verbose: bool,
     n: int,
 ) -> None:
@@ -174,6 +182,7 @@ def sync(
         job_type=job_type,
         replace_tags=replace_tags,
         dry_run=dry_run,
+        skip_confirmation=skip_confirmation,
         skip_synced=skip_synced,
         skip_online=skip_online,
         verbose=verbose,

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -31,6 +31,7 @@ def sync(
     job_type: str,
     replace_tags: str,
     dry_run: bool,
+    skip_confirmation: bool,
     skip_synced: bool,
     skip_online: bool,
     verbose: bool,
@@ -51,6 +52,7 @@ def sync(
         replace_tags: A string in the form 'old1=new1,old2=new2' that defines
             how to rename run tags.
         dry_run: If true, just prints what it would do and exits.
+        skip_confirmation: If true, don't ask for confirmation.
         skip_synced: If true, skips files that have already been synced
             as indicated by a .wandb.synced marker file in the same directory.
         skip_online: If true, skips online runs (determined by folder name).
@@ -69,7 +71,7 @@ def sync(
     ask_for_confirmation = False
     if not paths:
         paths = [pathlib.Path(singleton.settings.wandb_dir)]
-        ask_for_confirmation = True
+        ask_for_confirmation = not skip_confirmation
 
     wandb_files, skipped = _find_wandb_files(
         paths,

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -783,6 +783,7 @@ def sync(
             job_type=job_type or "",
             replace_tags=replace_tags or "",
             dry_run=False,
+            skip_confirmation=False,
             skip_synced=not include_synced,
             skip_online=not include_online,
             verbose=verbose,


### PR DESCRIPTION
Adds the `--yes` flag to skip prompts.

When no paths are given, `wandb beta sync` shows which paths would be synced and asks for confirmation, whereas `wandb sync` shows the paths and suggests using either `--sync-all` or `--clean`. `wandb sync --sync-all` is the same as `wandb beta sync --yes --no-skip-online`.

I don't like the `--sync-all` flag because it ignores explicitly given paths, so it doesn't play well with other arguments. Like, what does `wandb sync --sync-all wandb/offline-run-*` mean? Not what you think it does. So my plan is to deprecate `--sync-all`.