### PR TITLE
chore: mark legacy-only and beta-only sync options

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -566,7 +566,7 @@ def init(ctx, project, entity, reset, mode):
     "--view",
     is_flag=True,
     default=False,
-    help="View runs.",
+    help="(legacy only) View runs. Try `wandb leet` instead!",
     hidden=True,
 )
 @click.option(
@@ -575,6 +575,13 @@ def init(ctx, project, entity, reset, mode):
     default=False,
     help="Enable verbose output.",
     hidden=True,
+)
+@click.option(
+    "--yes",
+    "skip_confirmation",
+    is_flag=True,
+    default=False,
+    help="(beta only) Don't prompt for confirmation.",
 )
 @click.option("--id", "run_id", help="Upload to an existing run ID.")
 @click.option("--project", "-p", help="Set the project to upload the run to.")
@@ -588,17 +595,23 @@ def init(ctx, project, entity, reset, mode):
     "--sync-tensorboard/--no-sync-tensorboard",
     is_flag=True,
     default=None,
-    help="""Sync TensorBoard tfevent files.
+    help="""(legacy only) Sync TensorBoard tfevent files.
     On by default for specific paths,
     off for --sync-all.""",
 )
 @click.option(
     "--include-globs",
-    help="Include only runs matching these glob patterns (comma-separated).",
+    help="""
+        (legacy only) Include only runs matching these glob patterns
+        (comma-separated).
+    """,
 )
 @click.option(
     "--exclude-globs",
-    help="Exclude runs matching these glob patterns (comma-separated).",
+    help="""
+        (legacy only) Exclude runs matching these glob patterns
+        (comma-separated).
+    """,
 )
 @click.option(
     "--include-online/--no-include-online",
@@ -610,7 +623,7 @@ def init(ctx, project, entity, reset, mode):
     "--include-offline/--no-include-offline",
     is_flag=True,
     default=None,
-    help="Include runs created in offline mode.",
+    help="""(legacy only) Include runs created in offline mode.""",
 )
 @click.option(
     "--include-synced/--no-include-synced",
@@ -622,19 +635,19 @@ def init(ctx, project, entity, reset, mode):
     "--mark-synced/--no-mark-synced",
     is_flag=True,
     default=True,
-    help="Mark runs as synced after upload.",
+    help="(legacy only) Mark runs as synced after upload.",
 )
 @click.option(
     "--sync-all",
     is_flag=True,
     default=False,
-    help="Sync all unsynced runs in the local wandb directory.",
+    help="(legacy only) Sync all unsynced runs in the local wandb directory.",
 )
 @click.option(
     "--clean",
     is_flag=True,
     default=False,
-    help="Delete local data for runs that are already synced.",
+    help="(legacy only) Delete local data for runs that are already synced.",
 )
 @click.option(
     "--clean-old-hours",
@@ -651,19 +664,24 @@ def init(ctx, project, entity, reset, mode):
 )
 @click.option("--ignore", hidden=True)
 @click.option(
-    "--show", default=5, help="Set the number of runs to show in the summary."
+    "--show",
+    default=5,
+    help="Set the number of runs to show in the summary.",
 )
 @click.option(
     "--append",
     is_flag=True,
     default=False,
-    help="Append data to an existing run instead of creating a new run.",
+    help="""
+        (legacy only) Append data to an existing run instead of creating
+        a new run.
+    """,
 )
 @click.option(
     "--skip-console",
     is_flag=True,
     default=False,
-    help="Skip uploading console logs.",
+    help="(legacy only) Skip uploading console logs.",
 )
 @click.option(
     "--replace-tags",
@@ -680,6 +698,7 @@ def sync(
     path: tuple[str, ...],
     view: bool,
     verbose: bool,
+    skip_confirmation: bool,
     run_id: str | None,
     project: str | None,
     entity: str | None,
@@ -703,6 +722,10 @@ def sync(
     legacy: bool,
 ):
     """Upload existing local W&B run data to the cloud.
+
+    MIGRATION NOTE: This command is being gradually rerouted to
+    `wandb beta sync`. Some options are only allowed in legacy mode, and others
+    only in beta mode. See option descriptions for info.
 
     Sync offline or incomplete runs from the local `wandb` directory to
     the W&B server. If PATH is provided, sync runs at that path. If no
@@ -754,7 +777,6 @@ def sync(
     """
     if (
         not legacy
-        and len(path) >= 1  # slightly different behavior when no paths
         and not any(TFEVENT_SUBSTRING in p for p in path)  # no tfevents support
         and not view
         # verbose, run_id, project, entity, job_type OK
@@ -783,13 +805,26 @@ def sync(
             job_type=job_type or "",
             replace_tags=replace_tags or "",
             dry_run=False,
-            skip_confirmation=False,
+            skip_confirmation=skip_confirmation,
             skip_synced=not include_synced,
             skip_online=not include_online,
             verbose=verbose,
             parallelism=5,  # same default as wandb beta sync
         )
         return
+
+    bad_options: list[str] = []
+    if skip_confirmation:
+        bad_options.append("--yes")
+    if bad_options:
+        if not legacy:
+            wandb.termlog(
+                "Legacy mode was selected due to presence of legacy options."
+                + " See --help for more info or use `wandb beta sync` directly."
+            )
+
+        bad_opts_str = ", ".join(bad_options)
+        raise ClickException(f"Not allowed in legacy mode: {bad_opts_str}")
 
     api = _get_cling_api()
     if not api.is_authenticated:


### PR DESCRIPTION
Mark which `wandb sync` options are legacy-only and beta-only, and add the first beta-only option `--yes`. Using a legacy option forces legacy mode, and using a beta option in legacy mode causes the command to fail.

```
❯ wandb sync --legacy --yes  
Error: Not allowed in legacy mode: --yes

❯ wandb sync --sync-all --yes
wandb: Legacy mode was selected due to presence of legacy options. See --help for more info or use `wandb beta sync` directly.
Error: Not allowed in legacy mode: --yes
```

For `path`, I decided to remove the `len(path) >= 1` condition. The slight difference is that `wandb sync` used to be roughly the same as `wandb beta sync --dry-run --no-skip-online`, but now it prints out the runs it finds and prompts for confirmation. If prompting is not available (try with `TERM=dumb`), it raises a `NotATerminalError`, but using `wandb sync` in a non-interactive environment doesn't seem useful, so I don't think this is a breaking change.

 I didn't add docs about `tfevents` paths being legacy because that seems too in-depth, and the feature doesn't appear to be documented; someone who really wants to use a beta option can always use `wandb beta sync` directly.