### PR TITLE
chore: deprecate some legacy sync options

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -130,3 +130,8 @@ When preparing a release that can include breaking changes, consider applying ch
 - Use `.wandb` staging directory unconditionally in `wandb.Settings.wandb_dir` and deprecate + remove `wandb.Settings.use_dot_wandb`.
     - Owner: @dmitryduev
     - Can do in >= 0.24
+
+- Remove deprecated `wandb sync` options:
+  - Owner: @timoffex
+  - Deprecated after 0.28.0 (https://github.com/wandb/wandb/pull/12098)
+  - Can do a few releases after 0.28.1 or 0.29.0 (whichever comes first)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -775,6 +775,7 @@ def sync(
 
         $ wandb sync --clean --clean-old-hours 48 --clean-force
     """
+    # Use `wandb beta sync` if possible.
     if (
         not legacy
         and not any(TFEVENT_SUBSTRING in p for p in path)  # no tfevents support
@@ -813,6 +814,28 @@ def sync(
         )
         return
 
+    # Print out deprecations for legacy options, especially if they prevent
+    # us from rerouting through `wandb beta sync`.
+    if view:
+        wandb.termwarn("--view is deprecated. Consider using `wandb leet`.")
+    if include_globs or exclude_globs:
+        wandb.termwarn(
+            "--include-globs and --exclude-globs are deprecated."
+            + " Provide explicit paths instead."
+        )
+    if include_offline is False:
+        wandb.termwarn("--no-include-offline is deprecated and will be removed.")
+    if not mark_synced:
+        wandb.termwarn("--no-mark-synced is deprecated and will be removed.")
+    if sync_all:
+        wandb.termwarn(
+            "--sync-all is deprecated. It is equivalent to"
+            + " `wandb sync --yes --include-online`."
+        )
+    if skip_console:
+        wandb.termwarn("--skip-console is deprecated and will be removed.")
+
+    # Fail if any beta options are provided in legacy mode.
     bad_options: list[str] = []
     if skip_confirmation:
         bad_options.append("--yes")


### PR DESCRIPTION
Prints deprecation warnings for `--view`, `--include-globs`, `--exclude-globs`, `--no-include-offline`, `--no-mark-synced`, `--sync-all` and `--skip-console`. These options won't be migrated to `wandb beta sync` either because they're not useful (like `--no-include-offline`) and/or because they have alternatives. The filtering options in particular are replaced by passing explicit paths.

I didn't deprecate `--clean`, `--sync-tensorboard` or `--append` since we may want to keep their functionality and they don't have useful analogs yet.

I also didn't add messages for `--ignore` (a hidden, unused option) and `--show` (safe to ignore, but useful for legacy).