### PR TITLE
refactor: resolve feature flags lazily

### DIFF
--- a/core/internal/featurechecker/features.go
+++ b/core/internal/featurechecker/features.go
@@ -2,6 +2,7 @@ package featurechecker
 
 import (
 	"context"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -9,6 +10,17 @@ import (
 	"github.com/wandb/wandb/core/internal/observability"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+// featureLoadTimeout bounds the server feature-flags query.
+//
+// The query is made synchronously from wandb-core's connection request loop
+// during stream creation (handleInformInit). With an unbounded context it can
+// retry against a slow or overloaded server for minutes (the GraphQL client
+// allows up to ~20 retries at 30s each), wedging the loop so it never gets to
+// the queued inform_teardown. That stalls the connection's shutdown and hangs
+// the client's wandb.teardown() indefinitely. Feature checks fail open, so cap
+// the query rather than letting it block the loop.
+const featureLoadTimeout = 30 * time.Second
 
 // FeatureProvider fetches the values of server features.
 //
@@ -77,7 +89,13 @@ func (fp *FeatureProvider) lockedLoadFeatures(ctx context.Context) {
 		return
 	}
 
-	resp, err := gql.ServerFeaturesQuery(ctx, fp.graphqlClient)
+	// Bound the query so a slow/unresponsive server can't block the caller
+	// (notably wandb-core's connection request loop) for minutes. Derived from
+	// ctx, so caller cancellation still applies.
+	queryCtx, cancel := context.WithTimeout(ctx, featureLoadTimeout)
+	defer cancel()
+
+	resp, err := gql.ServerFeaturesQuery(queryCtx, fp.graphqlClient)
 	if err != nil {
 		fp.logger.Error(
 			"featurechecker: failed to load features, all will be disabled",

--- a/core/internal/featurechecker/features.go
+++ b/core/internal/featurechecker/features.go
@@ -2,7 +2,6 @@ package featurechecker
 
 import (
 	"context"
-	"time"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -10,17 +9,6 @@ import (
 	"github.com/wandb/wandb/core/internal/observability"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
-
-// featureLoadTimeout bounds the server feature-flags query.
-//
-// The query is made synchronously from wandb-core's connection request loop
-// during stream creation (handleInformInit). With an unbounded context it can
-// retry against a slow or overloaded server for minutes (the GraphQL client
-// allows up to ~20 retries at 30s each), wedging the loop so it never gets to
-// the queued inform_teardown. That stalls the connection's shutdown and hangs
-// the client's wandb.teardown() indefinitely. Feature checks fail open, so cap
-// the query rather than letting it block the loop.
-const featureLoadTimeout = 30 * time.Second
 
 // FeatureProvider fetches the values of server features.
 //
@@ -89,13 +77,7 @@ func (fp *FeatureProvider) lockedLoadFeatures(ctx context.Context) {
 		return
 	}
 
-	// Bound the query so a slow/unresponsive server can't block the caller
-	// (notably wandb-core's connection request loop) for minutes. Derived from
-	// ctx, so caller cancellation still applies.
-	queryCtx, cancel := context.WithTimeout(ctx, featureLoadTimeout)
-	defer cancel()
-
-	resp, err := gql.ServerFeaturesQuery(queryCtx, fp.graphqlClient)
+	resp, err := gql.ServerFeaturesQuery(ctx, fp.graphqlClient)
 	if err != nil {
 		fp.logger.Error(
 			"featurechecker: failed to load features, all will be disabled",

--- a/core/internal/runconsolelogs/filestreamwriter.go
+++ b/core/internal/runconsolelogs/filestreamwriter.go
@@ -14,9 +14,12 @@ type filestreamWriter struct {
 	debouncer  *debouncedWriter
 	FileStream filestream.FileStream
 
-	// Structured controls the format of uploaded lines.
+	// Structured reports whether to use the structured (JSON) line format.
 	//
-	// If false, then the legacy plain text format is used:
+	// It is a function so the underlying server feature check is
+	// evaluated lazily here, off the hot path that creates the writer.
+	//
+	// If false, the legacy plain text format is used:
 	//
 	// ERROR 2023-04-05T10:15:30.000000 [node-1-rank-0] Critical error occurred
 	//
@@ -28,13 +31,18 @@ type filestreamWriter struct {
 	//    "label":"node-1-rank-0",
 	//    "content":"Division by zero",
 	//  }
-	Structured bool
+	Structured func() bool
 }
 
 func NewFileStreamWriter(
-	structured bool,
+	structured func() bool,
 	fileStream filestream.FileStream,
 ) *filestreamWriter {
+	if structured == nil {
+		// Default to the legacy format.
+		structured = func() bool { return false }
+	}
+
 	w := &filestreamWriter{
 		FileStream: fileStream,
 		Structured: structured,
@@ -60,7 +68,7 @@ func (w *filestreamWriter) sendBatch(
 ) {
 	w.FileStream.StreamUpdate(&filestream.LogsUpdate{
 		Lines: sparselist.Map(lines, func(line *RunLogsLine) string {
-			if w.Structured {
+			if w.Structured() {
 				if s, err := line.StructuredFormat(); err == nil {
 					return s
 				} else {

--- a/core/internal/runconsolelogs/filestreamwriter_test.go
+++ b/core/internal/runconsolelogs/filestreamwriter_test.go
@@ -15,7 +15,7 @@ import (
 func TestWritesStructuredFormat(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		fileStream := filestreamtest.NewFakeFileStream()
-		w := NewFileStreamWriter(true, fileStream)
+		w := NewFileStreamWriter(func() bool { return true }, fileStream)
 
 		line1 := RunLogsLineForTest("content 1")
 		line1Str, err := line1.StructuredFormat()
@@ -41,7 +41,7 @@ func TestWritesStructuredFormat(t *testing.T) {
 func TestWritesLegacyFormat(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		fileStream := filestreamtest.NewFakeFileStream()
-		w := NewFileStreamWriter(false, fileStream)
+		w := NewFileStreamWriter(func() bool { return false }, fileStream)
 
 		line1 := RunLogsLineForTest("content 1")
 		line1Str := line1.LegacyFormat()

--- a/core/internal/runconsolelogs/runconsolelogs.go
+++ b/core/internal/runconsolelogs/runconsolelogs.go
@@ -89,8 +89,10 @@ type Params struct {
 	// It is used for testing.
 	GetNow func() time.Time
 
-	// Structured indicates whether to send the console output in structured format.
-	Structured bool
+	// Structured reports whether to send console output in structured format.
+	//
+	// It is a function so the underlying server feature check is evaluated lazily.
+	Structured func() bool
 
 	// Label is an optional prefix for the console output lines.
 	Label string

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -155,6 +155,24 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 		)
 	}
 
+	// Resolve server feature flags lazily, off the connection's request loop.
+	//
+	// SenderFactory.New runs synchronously in that loop (via handleInformInit),
+	// so querying features here would block the loop on a network round-trip.
+	featureCtx := runWork.BeforeEndCtx()
+	structuredConsoleLogs := sync.OnceValue(func() bool {
+		return f.FeatureProvider.Enabled(
+			featureCtx,
+			spb.ServerFeature_STRUCTURED_CONSOLE_LOGS,
+		)
+	})
+	useArtifactProjectEntityInfo := sync.OnceValue(func() bool {
+		return f.FeatureProvider.Enabled(
+			featureCtx,
+			spb.ServerFeature_USE_ARTIFACT_WITH_ENTITY_AND_PROJECT_INFORMATION,
+		)
+	})
+
 	consoleLogsSenderParams := runconsolelogs.Params{
 		FilesDir:              f.Settings.GetFilesDir(),
 		EnableCapture:         f.Settings.IsConsoleCaptureEnabled(),
@@ -165,10 +183,7 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 		Multipart:             f.Settings.IsConsoleMultipart(),
 		ChunkMaxBytes:         f.Settings.GetConsoleChunkMaxBytes(),
 		ChunkMaxSeconds:       f.Settings.GetConsoleChunkMaxSeconds(),
-		Structured: f.FeatureProvider.Enabled(
-			context.Background(),
-			spb.ServerFeature_STRUCTURED_CONSOLE_LOGS,
-		),
+		Structured:            structuredConsoleLogs,
 	}
 
 	s := &Sender{
@@ -186,10 +201,7 @@ func (f *SenderFactory) New(runWork runwork.RunWork) *Sender {
 			f.FileStreamFactory.Printer,
 			f.GraphqlClient,
 			f.FileTransferManager,
-			f.FeatureProvider.Enabled(
-				context.Background(),
-				spb.ServerFeature_USE_ARTIFACT_WITH_ENTITY_AND_PROJECT_INFORMATION,
-			),
+			useArtifactProjectEntityInfo,
 		),
 		networkPeeker:     f.Peeker,
 		printer:           f.Printer,

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -44,7 +44,7 @@ type ArtifactSaveManager struct {
 	graphqlClient                graphql.Client
 	fileTransferManager          filetransfer.FileTransferManager
 	fileCache                    Cache
-	useArtifactProjectEntityInfo bool
+	useArtifactProjectEntityInfo func() bool
 
 	// uploadsByName ensures that uploads for the same artifact name happen
 	// serially, so that version numbers are assigned deterministically.
@@ -56,7 +56,7 @@ func NewArtifactSaveManager(
 	printer *observability.Printer,
 	graphqlClient graphql.Client,
 	fileTransferManager filetransfer.FileTransferManager,
-	useArtifactProjectEntityInfo bool,
+	useArtifactProjectEntityInfo func() bool,
 ) *ArtifactSaveManager {
 	workerPool := &errgroup.Group{}
 	workerPool.SetLimit(maxSimultaneousUploads)
@@ -115,7 +115,7 @@ func (as *ArtifactSaveManager) Save(
 			stagingDir:                   stagingDir,
 			maxActiveBatches:             5,
 			resultChan:                   resultChan,
-			useArtifactProjectEntityInfo: as.useArtifactProjectEntityInfo,
+			useArtifactProjectEntityInfo: as.useArtifactProjectEntityInfo(),
 		},
 	)
 

--- a/core/pkg/artifacts/saver_test.go
+++ b/core/pkg/artifacts/saver_test.go
@@ -51,7 +51,7 @@ func TestSaveGraphQLRequest(t *testing.T) {
 		observability.NewPrinter(0),
 		mockGQL,
 		ftm,
-		true,
+		func() bool { return true },
 	)
 
 	result := <-saver.Save(
@@ -114,7 +114,7 @@ func TestSave_CleansUpManifestFileInStagingDir(t *testing.T) {
 		observability.NewPrinter(0),
 		mockGQL,
 		ftm,
-		true,
+		func() bool { return true },
 	)
 
 	stagingDir := t.TempDir()


### PR DESCRIPTION
Description
-----------
I've been trying to repro the flakiness of system tests in CI locally and after about 43,000 attempts managed to do so -- it stuck for me on `FeatureProvider.Enabled`. Probably something was up with the local-testcontainer. Regardless, this is a regular GraphQL query that sits on the connection path (when creating the sender), so it would retry for quite sometime, potentially longer than our default 60-second test timeout, (and would not get cancelled by teardown I think?). Feels like it is not absolutely necessary to have it in this path, so I changed it to a lazy loading model.