### PR TITLE
refactor: cancel AsyncioManager.run() future on any exception

### DIFF
--- a/wandb/sdk/lib/asyncio_manager.py
+++ b/wandb/sdk/lib/asyncio_manager.py
@@ -139,7 +139,12 @@ class AsyncioManager:
         except concurrent.futures.CancelledError:
             raise RunCancelledError from None
 
-        except KeyboardInterrupt:
+        except:
+            # This is primarily for KeyboardInterrupt and any other exception
+            # that can be raised "out of thin air". For instance, pytest-timeout
+            # calls `pytest.fail()` inside a SIGALRM handler, which raises
+            # a special exception that pytest catches.
+            #
             # If we're interrupted here, we only cancel this task rather than
             # cancelling all tasks like in join(). This only matters if the
             # interrupt is then suppressed (or delayed) in which case we


### PR DESCRIPTION
Improves some cancellation behavior in `AsyncioManager`, but doesn't fix the CI hangs.

I had written `AsyncioManager` under the assumption that `KeyboardInterrupt` is the only exception that can reasonably get raised out of thin air, but really that's true for any exception raised from a signal handler. `pytest-timeout` with the `signal` method uses `pytest.fail()` in a SIGALRM handler which raises a special exception, and that should cancel the future like a `KeyboardInterrupt`.

Unfortunately, this does not explain the CI hangs. Not cancelling futures means not cancelling ServerRequests on timeout, and so I thought we were getting stuck on `wandb.teardown()`. But `Connection::handleInformTeardown` calls `stopServer`, which cancels the server context and all of its child contexts, including the contexts used by API operations, so the process should be able to exit fairly quickly.