### PR TITLE
chore: type DefaultTask.Headers as http.Header

### DIFF
--- a/core/internal/filetransfer/file_transfer_azure.go
+++ b/core/internal/filetransfer/file_transfer_azure.go
@@ -277,22 +277,15 @@ func (ft *AzureFileTransfer) uploadBlob(
 		HTTPHeaders: &blob.HTTPHeaders{},
 	}
 
-	for _, header := range task.Headers {
-		parts := strings.SplitN(header, ":", 2)
-		if len(parts) != 2 {
-			ft.logger.Error("file transfer: upload: invalid header", "header", header)
-			continue
+	if md5b64 := task.Headers.Get("Content-MD5"); md5b64 != "" {
+		md5, err := base64.StdEncoding.DecodeString(md5b64)
+		if err != nil {
+			return nil, err
 		}
-		switch parts[0] {
-		case "Content-MD5":
-			md5, err := base64.StdEncoding.DecodeString(parts[1])
-			if err != nil {
-				return nil, err
-			}
-			uploadOptions.HTTPHeaders.BlobContentMD5 = md5
-		case "Content-Type":
-			uploadOptions.HTTPHeaders.BlobContentType = &parts[1]
-		}
+		uploadOptions.HTTPHeaders.BlobContentMD5 = md5
+	}
+	if contentType := task.Headers.Get("Content-Type"); contentType != "" {
+		uploadOptions.HTTPHeaders.BlobContentType = &contentType
 	}
 
 	resp, err := blockBlobClient.UploadStream(context.Background(), requestBody, &uploadOptions)

--- a/core/internal/filetransfer/file_transfer_azure_test.go
+++ b/core/internal/filetransfer/file_transfer_azure_test.go
@@ -323,10 +323,9 @@ func TestAzureFileTransfer_Upload(t *testing.T) {
 
 	// Headers to be tested
 	contentMD5 := base64.StdEncoding.EncodeToString([]byte("test"))
-	headers := []string{
-		"Content-MD5:" + contentMD5,
-		"Content-Type:text/plain",
-	}
+	headers := http.Header{}
+	headers.Set("Content-MD5", contentMD5)
+	headers.Set("Content-Type", "text/plain")
 
 	mockAzureBlockBlobClient := mockAzureBlockBlobClient{
 		t:               t,
@@ -408,7 +407,7 @@ func TestAzureFileTransfer_UploadClientError(t *testing.T) {
 	// According to Azure docs, `uploadStream` returns an error if the connection is closed
 	// or the context is cancelled.
 	contentExpected := []byte("")
-	headers := []string{}
+	headers := http.Header{}
 
 	mockAzureBlockBlobClient := mockAzureBlockBlobClient{
 		t:               t,

--- a/core/internal/filetransfer/file_transfer_default.go
+++ b/core/internal/filetransfer/file_transfer_default.go
@@ -3,11 +3,11 @@ package filetransfer
 import (
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
 
@@ -76,17 +76,7 @@ func (ft *DefaultFileTransfer) Upload(task *DefaultUploadTask) error {
 	if err != nil {
 		return err
 	}
-	for _, header := range task.Headers {
-		parts := strings.SplitN(header, ":", 2)
-		if len(parts) != 2 {
-			ft.logger.Error(
-				"file transfer: upload: invalid header",
-				"header", header,
-			)
-			continue
-		}
-		req.Header.Set(parts[0], parts[1])
-	}
+	maps.Copy(req.Header, task.Headers)
 	if task.Context != nil {
 		req = req.WithContext(task.Context)
 	}

--- a/core/internal/filetransfer/file_transfer_default_test.go
+++ b/core/internal/filetransfer/file_transfer_default_test.go
@@ -135,28 +135,23 @@ func TestDefaultFileTransfer_DownloadHTTPError(t *testing.T) {
 func TestDefaultFileTransfer_Upload(t *testing.T) {
 	expectedContent := []byte("test content for upload")
 	path := writeTempFile(t, expectedContent)
-	expectedHeaders := []string{
-		"X-Test-1:x:: test",
-		"X-Test-2:",
-		"X-Test-3",
-		"X-Test-4: test",
-	}
 	testURL := runServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedContent, body)
 		assert.Equal(t, r.Method, http.MethodPut)
-		assert.Equal(t, r.Header.Get("X-Test-1"), "x:: test")
-		assert.Equal(t, r.Header.Get("X-Test-2"), "")
-		assert.Equal(t, r.Header.Get("X-Test-3"), "")
-		assert.Equal(t, r.Header.Get("X-Test-4"), "test")
+		assert.Equal(t, r.Header.Get("X-Test-1"), "value-with:colon")
+		assert.Equal(t, r.Header.Get("X-Test-2"), "value")
 	})
 
 	task := &filetransfer.DefaultUploadTask{
-		Path:    path,
-		Url:     testURL,
-		Headers: expectedHeaders,
+		Path: path,
+		Url:  testURL,
+		Headers: http.Header{
+			"X-Test-1": {"value-with:colon"},
+			"X-Test-2": {"value"},
+		},
 	}
 	err := newFileTransfer(t).Upload(task)
 

--- a/core/internal/filetransfer/task_default.go
+++ b/core/internal/filetransfer/task_default.go
@@ -24,7 +24,7 @@ type DefaultTask struct {
 	Url string
 
 	// Headers to send on the upload
-	Headers []string
+	Headers http.Header
 
 	// Size is the number of bytes to upload
 	//
@@ -94,10 +94,28 @@ func (t *DefaultDownloadTask) String() string {
 func (t *DefaultDownloadTask) SetError(err error) { t.Err = err }
 
 func (t *DefaultUploadTask) RequiresAzureUpload() bool {
-	for _, header := range t.Headers {
-		if strings.Contains(header, "x-ms-blob-type") {
-			return true
+	return t.Headers.Get("x-ms-blob-type") != ""
+}
+
+// ParseHeaders converts a list of "Key: Value" header strings, as returned by
+// the W&B backend, into an http.Header.
+//
+// It returns the successfully parsed headers along with an error naming any
+// entries that lacked a colon separator and were skipped, so callers can log
+// the anomaly without aborting an otherwise-valid transfer.
+func ParseHeaders(headers []string) (http.Header, error) {
+	parsed := make(http.Header, len(headers))
+	var malformed []string
+	for _, header := range headers {
+		key, value, found := strings.Cut(header, ":")
+		if !found {
+			malformed = append(malformed, header)
+			continue
 		}
+		parsed.Add(key, strings.TrimSpace(value))
 	}
-	return false
+	if len(malformed) > 0 {
+		return parsed, fmt.Errorf("skipped malformed headers: %q", malformed)
+	}
+	return parsed, nil
 }

--- a/core/internal/filetransfer/task_default_test.go
+++ b/core/internal/filetransfer/task_default_test.go
@@ -1,0 +1,34 @@
+package filetransfer_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wandb/wandb/core/internal/filetransfer"
+)
+
+func TestParseHeaders(t *testing.T) {
+	t.Run("parses valid headers", func(t *testing.T) {
+		headers, err := filetransfer.ParseHeaders([]string{
+			"Content-Type: text/plain", // leading whitespace is trimmed
+			"X-Empty:",                 // empty values are kept
+			"X-Colon:a:b",              // only the first colon separates
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.Header{
+			"Content-Type": {"text/plain"},
+			"X-Empty":      {""},
+			"X-Colon":      {"a:b"},
+		}, headers)
+	})
+
+	t.Run("reports and skips entries without a colon", func(t *testing.T) {
+		headers, err := filetransfer.ParseHeaders([]string{"Good:1", "no-colon", "also bad"})
+
+		assert.Equal(t, http.Header{"Good": {"1"}}, headers)
+		assert.ErrorContains(t, err, `["no-colon" "also bad"]`)
+	})
+}

--- a/core/internal/runfiles/runfiles_test.go
+++ b/core/internal/runfiles/runfiles_test.go
@@ -2,6 +2,7 @@ package runfiles_test
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -398,7 +399,7 @@ func TestUploader(t *testing.T) {
 			assert.Equal(t, "test-file1", task.Name)
 			assert.Equal(t, "URL1", task.Url)
 			assert.Equal(t,
-				[]string{"Header1:Value1", "Header2:Value2"},
+				http.Header{"Header1": {"Value1"}, "Header2": {"Value2"}},
 				task.Headers)
 
 			task, ok = uploadTasks[1].(*filetransfer.DefaultUploadTask)
@@ -409,7 +410,7 @@ func TestUploader(t *testing.T) {
 			assert.Equal(t, "subdir/test-file2", task.Name)
 			assert.Equal(t, "URL2", task.Url)
 			assert.Equal(t,
-				[]string{"Header1:Value1", "Header2:Value2"},
+				http.Header{"Header1": {"Value1"}, "Header2": {"Value2"}},
 				task.Headers)
 		})
 

--- a/core/internal/runfiles/saved_file.go
+++ b/core/internal/runfiles/saved_file.go
@@ -3,6 +3,7 @@ package runfiles
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"sync"
 
@@ -50,7 +51,7 @@ type savedFile struct {
 
 	// HTTP headers to set on the reupload request for the file if
 	// `reuploadScheduled`.
-	reuploadHeaders []string
+	reuploadHeaders http.Header
 
 	// Hash of the last successfully uploaded content (base64 MD5).
 	lastUploadedB64MD5 string
@@ -91,7 +92,7 @@ func (f *savedFile) SetCategory(category filetransfer.RunFileKind) {
 // the file bytes differ from the last successful upload.
 func (f *savedFile) Upload(
 	url string,
-	headers []string,
+	headers http.Header,
 ) {
 	f.Lock()
 	defer f.Unlock()
@@ -113,7 +114,7 @@ func (f *savedFile) Upload(
 // doUpload sends an upload Task to the FileTransferManager.
 //
 // It must be called while a lock is held. It temporarily releases the lock.
-func (f *savedFile) doUpload(uploadURL string, uploadHeaders []string) {
+func (f *savedFile) doUpload(uploadURL string, uploadHeaders http.Header) {
 	// Mark as uploading first so concurrent f.Upload calls defer and queue.
 	f.isUploading = true
 

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -418,6 +418,10 @@ func (u *uploader) scheduleUploadTask(
 	u.stateMu.Lock()
 	defer u.stateMu.Unlock()
 
-	u.knownFile(runPath).Upload(uploadURL, headers)
+	parsedHeaders, err := filetransfer.ParseHeaders(headers)
+	if err != nil {
+		u.logger.Warn("runfiles: upload: skipping malformed header(s)", "error", err)
+	}
+	u.knownFile(runPath).Upload(uploadURL, parsedHeaders)
 	u.uploadWG.Done()
 }

--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -420,7 +420,7 @@ func (u *uploader) scheduleUploadTask(
 
 	parsedHeaders, err := filetransfer.ParseHeaders(headers)
 	if err != nil {
-		u.logger.Warn("runfiles: upload: skipping malformed header(s)", "error", err)
+		u.logger.Warn("runfiles: upload: error parsing headers", "error", err)
 	}
 	u.knownFile(runPath).Upload(uploadURL, parsedHeaders)
 	u.uploadWG.Done()

--- a/core/internal/wbapi/filetransferhandler.go
+++ b/core/internal/wbapi/filetransferhandler.go
@@ -2,7 +2,7 @@ package wbapi
 
 import (
 	"context"
-	"fmt"
+	"net/http"
 
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -61,9 +61,9 @@ func (h *FileTransferHandler) HandleUploadFile(
 	ctx context.Context,
 	request *spb.UploadFileRequest,
 ) *spb.ApiResponse {
-	headers := make([]string, 0, len(request.GetHeaders()))
+	headers := make(http.Header, len(request.GetHeaders()))
 	for key, value := range request.GetHeaders() {
-		headers = append(headers, fmt.Sprintf("%s:%s", key, value))
+		headers.Set(key, value)
 	}
 
 	done := make(chan struct{})

--- a/core/internal/wbapi/filetransferhandler_test.go
+++ b/core/internal/wbapi/filetransferhandler_test.go
@@ -105,7 +105,7 @@ func TestUploadFileSendsTask(t *testing.T) {
 	task := manager.tasks[0].(*filetransfer.DefaultUploadTask)
 	assert.Equal(t, "/tmp/model.bin", task.Path)
 	assert.Equal(t, "https://files.example/model.bin", task.Url)
-	assert.Equal(t, []string{"X-Test:value"}, task.Headers)
+	assert.Equal(t, http.Header{"X-Test": {"value"}}, task.Headers)
 }
 
 func TestUploadFileReturnsTaskHTTPError(t *testing.T) {

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -618,8 +618,8 @@ func (as *ArtifactSaver) uploadMultipart(
 
 func getContentType(headers []string) string {
 	for _, h := range headers {
-		if strings.HasPrefix(h, "Content-Type:") {
-			return strings.TrimPrefix(h, "Content-Type:")
+		if after, ok := strings.CutPrefix(h, "Content-Type:"); ok {
+			return after
 		}
 	}
 	return ""

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -401,7 +402,11 @@ func (as *ArtifactSaver) processFiles(
 				}()
 			} else {
 				suboperation := wboperation.Get(as.ctx).Subtask(fileInfo.name)
-				task := newUploadTask(fileInfo, *entry.LocalPath)
+				headers, err := filetransfer.ParseHeaders(fileInfo.uploadHeaders)
+				if err != nil {
+					as.logger.Warn("artifacts: upload: skipping malformed header(s)", "error", err)
+				}
+				task := newUploadTask(fileInfo, *entry.LocalPath, headers)
 				task.Context = suboperation.Context(as.ctx)
 				task.OnComplete = func() {
 					suboperation.Finish()
@@ -484,13 +489,14 @@ func (as *ArtifactSaver) batchSize() int {
 func newUploadTask(
 	fileInfo serverFileResponse,
 	localPath string,
+	headers http.Header,
 ) *filetransfer.DefaultUploadTask {
 	return &filetransfer.DefaultUploadTask{
 		FileKind: filetransfer.RunFileKindArtifact,
 		Path:     localPath,
 		Name:     fileInfo.name,
 		Url:      *fileInfo.uploadUrl,
-		Headers:  fileInfo.uploadHeaders,
+		Headers:  headers,
 	}
 }
 
@@ -526,7 +532,8 @@ func (as *ArtifactSaver) uploadMultipart(
 				"%s (%d/%d)",
 				fileInfo.name, i+1, len(partInfo),
 			))
-		task := newUploadTask(fileInfo, path)
+		// Headers are set per-part below, so none are passed here.
+		task := newUploadTask(fileInfo, path, nil)
 		task.Context = suboperation.Context(as.ctx)
 		task.Url = part.UploadUrl
 		task.Offset = int64(i) * chunkSize
@@ -536,10 +543,10 @@ func (as *ArtifactSaver) uploadMultipart(
 		if err != nil {
 			return uploadResult{name: fileInfo.name, err: err}
 		}
-		task.Headers = []string{
-			"Content-Md5:" + b64md5,
-			"Content-Length:" + strconv.FormatInt(task.Size, 10),
-			"Content-Type:" + contentType,
+		task.Headers = http.Header{
+			"Content-Md5":    {b64md5},
+			"Content-Length": {strconv.FormatInt(task.Size, 10)},
+			"Content-Type":   {contentType},
 		}
 		task.OnComplete = func() {
 			suboperation.Finish()
@@ -675,12 +682,17 @@ func (as *ArtifactSaver) uploadManifest(
 		return errors.New("nil uploadURL")
 	}
 
+	parsedHeaders, err := filetransfer.ParseHeaders(uploadHeaders)
+	if err != nil {
+		as.logger.Warn("artifacts: upload: skipping malformed manifest header(s)", "error", err)
+	}
+
 	resultChan := make(chan *filetransfer.DefaultUploadTask, 1)
 	task := &filetransfer.DefaultUploadTask{
 		FileKind: filetransfer.RunFileKindArtifact,
 		Path:     manifestFile,
 		Url:      *uploadURL,
-		Headers:  uploadHeaders,
+		Headers:  parsedHeaders,
 	}
 	task.OnComplete = func() { resultChan <- task }
 

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -404,7 +404,7 @@ func (as *ArtifactSaver) processFiles(
 				suboperation := wboperation.Get(as.ctx).Subtask(fileInfo.name)
 				headers, err := filetransfer.ParseHeaders(fileInfo.uploadHeaders)
 				if err != nil {
-					as.logger.Warn("artifacts: upload: skipping malformed header(s)", "error", err)
+					as.logger.Warn("artifacts: upload: error parsing headers", "error", err)
 				}
 				task := newUploadTask(fileInfo, *entry.LocalPath, headers)
 				task.Context = suboperation.Context(as.ctx)
@@ -684,7 +684,7 @@ func (as *ArtifactSaver) uploadManifest(
 
 	parsedHeaders, err := filetransfer.ParseHeaders(uploadHeaders)
 	if err != nil {
-		as.logger.Warn("artifacts: upload: skipping malformed manifest header(s)", "error", err)
+		as.logger.Warn("artifacts: upload: error parsing headers", "error", err)
 	}
 
 	resultChan := make(chan *filetransfer.DefaultUploadTask, 1)


### PR DESCRIPTION
Description
-----------
Follow-up to https://github.com/wandb/wandb/pull/12083. Changes `filetransfer.DefaultTask.Headers` from `[]string` of "Key: Value" strings to a typed `http.Header`, so producers no longer hand-format header strings and consumers no longer split on the first colon.
