### PR TITLE
fix(launch): harden launch agent resource_args handling  

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Security
+
+- harden launch agent `resource_args` handling so queue submitters can no longer request privileged containers, host mounts, or host/cluster access (VULNMGMT-2137)
+
 ### Changed
 
 - Remove temporary Unix socket files and directories on shutdown (@geoffhardy in https://github.com/wandb/wandb/pull/12058)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,10 +14,6 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
-### Security
-
-- harden launch agent `resource_args` handling so queue submitters can no longer request privileged containers, host mounts, or host/cluster access (VULNMGMT-2137)
-
 ### Changed
 
 - Remove temporary Unix socket files and directories on shutdown (@geoffhardy in https://github.com/wandb/wandb/pull/12058)

--- a/tests/system_tests/test_launch/test_launch_local_container.py
+++ b/tests/system_tests/test_launch/test_launch_local_container.py
@@ -42,7 +42,11 @@ async def test_local_container_entrypoint(use_local_wandb_backend, monkeypatch):
     # test with user provided image
     project = MagicMock()
     entrypoint = EntryPoint("blah", entry_command)
-    project.resource_args = {"local_container": {}}
+    project.resource_args = {"local-container": {}}
+    # Stub fill_macros like the sibling system tests so resource_args flow
+    # through as a real dict (the runner reads the "local-container" key).
+    project.fill_macros = lambda _: project.resource_args
+    project.job_base_image = None
     project.target_entity = entity_name
     project.target_project = project_name
     project.name = None

--- a/tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -81,7 +81,57 @@ async def test_loop_capture_stack_trace(mocker, clean_agent):
 
 
 @pytest.mark.asyncio
-async def test_run_job_secure_mode(mocker, clean_agent):
+@pytest.mark.parametrize(
+    "job,exception_type,error",
+    [
+        pytest.param(
+            {
+                "runSpec": {
+                    "resource_args": {
+                        "kubernetes": {
+                            "spec": {"template": {"spec": {"hostPID": True}}}
+                        }
+                    }
+                }
+            },
+            LaunchError,
+            "Unsafe resource_args.kubernetes option 'hostPID' is not allowed",
+            id="reject-host-pid",
+        ),
+        pytest.param(
+            {
+                "runSpec": {
+                    "resource_args": {
+                        "kubernetes": {
+                            "spec": {
+                                "template": {
+                                    "spec": {
+                                        "containers": [
+                                            {},
+                                            {"command": ["some", "code"]},
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            ValueError,
+            'This agent is configured to lock "command" in container spec '
+            "but the job specification attempts to override it.",
+            id="reject-container-command",
+        ),
+        pytest.param(
+            {"runSpec": {"overrides": {"entry_point": ["some", "code"]}}},
+            ValueError,
+            'This agent is configured to lock the "entrypoint" override '
+            "but the job specification attempts to override it.",
+            id="reject-entrypoint-override",
+        ),
+    ],
+)
+async def test_run_job_secure_mode(mocker, clean_agent, job, exception_type, error):
     _setup(mocker)
     mock_config = {
         "entity": "test-entity",
@@ -90,51 +140,9 @@ async def test_run_job_secure_mode(mocker, clean_agent):
     }
     agent = LaunchAgent(api=mocker.api, config=mock_config)
 
-    jobs = [
-        {
-            "runSpec": {
-                "resource_args": {
-                    "kubernetes": {"spec": {"template": {"spec": {"hostPID": True}}}}
-                }
-            }
-        },
-        {
-            "runSpec": {
-                "resource_args": {
-                    "kubernetes": {
-                        "spec": {
-                            "template": {
-                                "spec": {
-                                    "containers": [{}, {"command": ["some", "code"]}]
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        {"runSpec": {"overrides": {"entry_point": ["some", "code"]}}},
-    ]
-    errors = [
-        (
-            LaunchError,
-            "Unsafe resource_args.kubernetes option 'hostPID' is not allowed",
-        ),
-        (
-            ValueError,
-            'This agent is configured to lock "command" in container spec '
-            "but the job specification attempts to override it.",
-        ),
-        (
-            ValueError,
-            'This agent is configured to lock the "entrypoint" override '
-            "but the job specification attempts to override it.",
-        ),
-    ]
     mock_file_saver = MagicMock()
-    for job, (exception_type, error) in zip(jobs, errors, strict=False):
-        with pytest.raises(exception_type, match=error):
-            await agent.run_job(job, "test-queue", mock_file_saver)
+    with pytest.raises(exception_type, match=error):
+        await agent.run_job(job, "test-queue", mock_file_saver)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_launch/test_agent/test_agent.py
+++ b/tests/unit_tests/test_launch/test_agent/test_agent.py
@@ -116,14 +116,73 @@ async def test_run_job_secure_mode(mocker, clean_agent):
         {"runSpec": {"overrides": {"entry_point": ["some", "code"]}}},
     ]
     errors = [
-        'This agent is configured to lock "hostPID" in pod spec but the job specification attempts to override it.',
-        'This agent is configured to lock "command" in container spec but the job specification attempts to override it.',
-        'This agent is configured to lock the "entrypoint" override but the job specification attempts to override it.',
+        (
+            LaunchError,
+            "Unsafe resource_args.kubernetes option 'hostPID' is not allowed",
+        ),
+        (
+            ValueError,
+            'This agent is configured to lock "command" in container spec '
+            "but the job specification attempts to override it.",
+        ),
+        (
+            ValueError,
+            'This agent is configured to lock the "entrypoint" override '
+            "but the job specification attempts to override it.",
+        ),
     ]
     mock_file_saver = MagicMock()
-    for job, error in zip(jobs, errors, strict=False):
-        with pytest.raises(ValueError, match=error):
+    for job, (exception_type, error) in zip(jobs, errors, strict=False):
+        with pytest.raises(exception_type, match=error):
             await agent.run_job(job, "test-queue", mock_file_saver)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resource_args,expected_field",
+    [
+        (
+            {"local-container": {"privileged": True}},
+            "Unsupported resource_args.local-container option 'privileged'",
+        ),
+        (
+            {
+                "kubernetes": {
+                    "spec": {
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {"securityContext": {"privileged": True}}
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "Unsafe resource_args.kubernetes option 'securityContext'",
+        ),
+    ],
+)
+async def test_run_job_rejects_unsafe_resource_args_without_secure_mode(
+    mocker, clean_agent, resource_args, expected_field
+):
+    _setup(mocker)
+    mock_config = {
+        "entity": "test-entity",
+        "project": "test-project",
+    }
+    agent = LaunchAgent(api=mocker.api, config=mock_config)
+    mock_file_saver = MagicMock()
+
+    with pytest.raises(
+        LaunchError,
+        match=expected_field,
+    ):
+        await agent.run_job(
+            {"runSpec": {"resource_args": resource_args}},
+            "test-queue",
+            mock_file_saver,
+        )
 
 
 def _setup_requeue(mocker):

--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -649,6 +649,75 @@ async def test_launch_crd_injects_restricted_security_context(
 
 
 @pytest.mark.asyncio
+async def test_launch_cronjob_injects_restricted_security_context(
+    monkeypatch,
+    mock_event_streams,
+    mock_batch_api,
+    mock_kube_context_and_api_client,
+    mock_maybe_create_image_pullsecret,
+    mock_create_from_dict,
+    test_api,
+    clean_monitor,
+    clean_agent,
+):
+    """A batch/v1 CronJob's jobTemplate pod containers must get the context."""
+    cronjob = {
+        "apiVersion": "batch/v1",
+        "kind": "CronJob",
+        "metadata": {"name": "test-job"},
+        "spec": {
+            "schedule": "* * * * *",
+            "jobTemplate": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {"name": "main", "image": "test-image"},
+                            ],
+                            "restartPolicy": "Never",
+                        }
+                    }
+                }
+            },
+        },
+    }
+    project = LaunchProject(
+        docker_config={"docker_image": "test_image"},
+        target_entity="test_entity",
+        target_project="test_project",
+        resource_args={"kubernetes": cronjob},
+        launch_spec={},
+        overrides={},
+        resource="kubernetes",
+        api=test_api,
+        git_info={},
+        job="",
+        uri="https://wandb.ai/test_entity/test_project/runs/test_run",
+        run_id="test_run_id",
+        name="test_run",
+    )
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+    await runner.run(project, "test-image")
+
+    # The CronJob flows through the standard Job path (batch/v1) and is submitted
+    # via create_from_dict.
+    submitted_job = mock_create_from_dict.call_args_list[0][0][1]
+    expected = {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+        "runAsNonRoot": True,
+    }
+    pod_spec = submitted_job["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+    containers = pod_spec["containers"]
+    assert containers, "expected the CronJob jobTemplate to expose containers"
+    for cont in containers:
+        assert cont["securityContext"] == expected
+
+
+@pytest.mark.asyncio
 async def test_launch_crd_pod_schedule_warning(
     monkeypatch,
     mock_event_streams,

--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -3,7 +3,7 @@ import base64
 import json
 import platform
 import shlex
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import wandb
@@ -84,6 +84,141 @@ def test_add_entrypoint_args_overrides(manifest):
     assert manifest["spec"]["template"]["spec"]["containers"][1]["command"] == [
         "test_entry"
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pod_spec_patch,expected_field",
+    [
+        ({"hostPID": True}, "hostPID"),
+        ({"hostIPC": True}, "hostIPC"),
+        ({"hostNetwork": True}, "hostNetwork"),
+        (
+            {"volumes": [{"name": "host-root", "hostPath": {"path": "/"}}]},
+            "hostPath",
+        ),
+        ({"serviceAccountName": "cluster-admin"}, "serviceAccountName"),
+        ({"serviceAccount": "cluster-admin"}, "serviceAccount"),
+        ({"automountServiceAccountToken": True}, "automountServiceAccountToken"),
+        (
+            {"containers": [{"securityContext": {"privileged": True}}]},
+            "securityContext",
+        ),
+        (
+            {
+                "containers": [
+                    {"securityContext": {"capabilities": {"add": ["SYS_ADMIN"]}}}
+                ]
+            },
+            "securityContext",
+        ),
+        (
+            {"containers": [{"ports": [{"hostPort": 8080}]}]},
+            "hostPort",
+        ),
+        (
+            {
+                "volumes": [
+                    {
+                        "name": "kube-api",
+                        "projected": {
+                            "sources": [{"serviceAccountToken": {"path": "token"}}]
+                        },
+                    }
+                ]
+            },
+            "serviceAccountToken",
+        ),
+    ],
+)
+async def test_kubernetes_runner_rejects_unsafe_resource_args(
+    test_api, pod_spec_patch, expected_field
+):
+    manifest = {
+        "kind": "Job",
+        "spec": {
+            "template": {
+                "spec": {
+                    "restartPolicy": "Never",
+                    **pod_spec_patch,
+                }
+            }
+        },
+    }
+    project = MagicMock()
+    project.fill_macros.return_value = {"kubernetes": manifest}
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    with pytest.raises(
+        LaunchError,
+        match=f"Unsafe resource_args.kubernetes option '{expected_field}'",
+    ):
+        await runner.run(project, "test-image")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "submitted_security_context",
+    [
+        None,  # submitter supplies nothing
+        {},  # submitter supplies an empty securityContext
+        {"runAsUser": 1234},  # submitter supplies a partial securityContext
+    ],
+)
+async def test_kubernetes_runner_injects_restricted_security_context(
+    test_api, submitted_security_context
+):
+    container = {"name": "main", "image": "test-image"}
+    # A submitter-supplied securityContext is refused by validation, but
+    # _inject_defaults must always set the restricted context regardless of what
+    # arrives, so we exercise it directly here.
+    if submitted_security_context is not None:
+        container["securityContext"] = submitted_security_context
+    resource_args = {
+        "spec": {"template": {"spec": {"containers": [container]}}},
+    }
+
+    project = MagicMock()
+    project.fill_macros.return_value = {"kubernetes": resource_args}
+    project.run_id = "test-run-id"
+    project.target_entity = "test-entity"
+    project.target_project = "test-project"
+    project.override_args = []
+    project.override_entrypoint = None
+    project.job_base_image = None
+    project.docker_image = "test-image"
+    project.get_job_entry_point.return_value = MagicMock(command=["echo", "hi"])
+    project.get_env_vars_dict.return_value = {}
+
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    async def _no_secret(*args, **kwargs):
+        return None
+
+    with patch(
+        "wandb.sdk.launch.runner.kubernetes_runner.maybe_create_imagepull_secret",
+        new=_no_secret,
+    ):
+        job, _ = await runner._inject_defaults(
+            resource_args,
+            project,
+            "test-image",
+            "wandb",
+            MagicMock(),
+        )
+
+    containers = job["spec"]["template"]["spec"]["containers"]
+    for cont in containers:
+        assert cont["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "seccompProfile": {"type": "RuntimeDefault"},
+            "runAsNonRoot": True,
+        }
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -597,6 +597,58 @@ async def test_launch_crd_works(
 
 
 @pytest.mark.asyncio
+async def test_launch_crd_injects_restricted_security_context(
+    monkeypatch,
+    mock_event_streams,
+    mock_batch_api,
+    mock_custom_api,
+    mock_kube_context_and_api_client,
+    mock_create_from_dict,
+    test_api,
+    volcano_spec,
+    clean_monitor,
+    clean_agent,
+):
+    """The custom-resource path must inject the restricted securityContext."""
+    monkeypatch.setattr(
+        "wandb.sdk.launch.runner.kubernetes_runner.maybe_create_imagepull_secret",
+        lambda *args, **kwargs: None,
+    )
+    mock_batch_api.jobs = {"test-job": MockDict(volcano_spec)}
+    project = LaunchProject(
+        docker_config={"docker_image": "test_image"},
+        target_entity="test_entity",
+        target_project="test_project",
+        resource_args={"kubernetes": volcano_spec},
+        launch_spec={},
+        overrides={},
+        resource="kubernetes",
+        api=test_api,
+        git_info={},
+        job="",
+        uri="https://wandb.ai/test_entity/test_project/runs/test_run",
+        run_id="test_run_id",
+        name="test_run",
+    )
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+    await runner.run(project, MagicMock())
+
+    submitted_body = mock_custom_api.jobs["test-job"]
+    expected = {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+        "runAsNonRoot": True,
+    }
+    containers = submitted_body["tasks"][0]["template"]["spec"]["containers"]
+    assert containers, "expected the custom resource to expose a pod spec"
+    for cont in containers:
+        assert cont["securityContext"] == expected
+
+
+@pytest.mark.asyncio
 async def test_launch_crd_pod_schedule_warning(
     monkeypatch,
     mock_event_streams,

--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -87,60 +87,14 @@ def test_add_entrypoint_args_overrides(manifest):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "pod_spec_patch,expected_field",
-    [
-        ({"hostPID": True}, "hostPID"),
-        ({"hostIPC": True}, "hostIPC"),
-        ({"hostNetwork": True}, "hostNetwork"),
-        (
-            {"volumes": [{"name": "host-root", "hostPath": {"path": "/"}}]},
-            "hostPath",
-        ),
-        ({"serviceAccountName": "cluster-admin"}, "serviceAccountName"),
-        ({"serviceAccount": "cluster-admin"}, "serviceAccount"),
-        ({"automountServiceAccountToken": True}, "automountServiceAccountToken"),
-        (
-            {"containers": [{"securityContext": {"privileged": True}}]},
-            "securityContext",
-        ),
-        (
-            {
-                "containers": [
-                    {"securityContext": {"capabilities": {"add": ["SYS_ADMIN"]}}}
-                ]
-            },
-            "securityContext",
-        ),
-        (
-            {"containers": [{"ports": [{"hostPort": 8080}]}]},
-            "hostPort",
-        ),
-        (
-            {
-                "volumes": [
-                    {
-                        "name": "kube-api",
-                        "projected": {
-                            "sources": [{"serviceAccountToken": {"path": "token"}}]
-                        },
-                    }
-                ]
-            },
-            "serviceAccountToken",
-        ),
-    ],
-)
-async def test_kubernetes_runner_rejects_unsafe_resource_args(
-    test_api, pod_spec_patch, expected_field
-):
+async def test_kubernetes_runner_rejects_unsafe_resource_args(test_api):
     manifest = {
         "kind": "Job",
         "spec": {
             "template": {
                 "spec": {
                     "restartPolicy": "Never",
-                    **pod_spec_patch,
+                    "hostPID": True,
                 }
             }
         },
@@ -153,7 +107,7 @@ async def test_kubernetes_runner_rejects_unsafe_resource_args(
 
     with pytest.raises(
         LaunchError,
-        match=f"Unsafe resource_args.kubernetes option '{expected_field}'",
+        match="Unsafe resource_args.kubernetes option 'hostPID'",
     ):
         await runner.run(project, "test-image")
 
@@ -674,6 +628,9 @@ async def test_launch_cronjob_injects_restricted_security_context(
                             "containers": [
                                 {"name": "main", "image": "test-image"},
                             ],
+                            "initContainers": [
+                                {"name": "init", "image": "busybox"},
+                            ],
                             "restartPolicy": "Never",
                         }
                     }
@@ -714,6 +671,10 @@ async def test_launch_cronjob_injects_restricted_security_context(
     containers = pod_spec["containers"]
     assert containers, "expected the CronJob jobTemplate to expose containers"
     for cont in containers:
+        assert cont["securityContext"] == expected
+    init_containers = pod_spec["initContainers"]
+    assert init_containers, "expected the CronJob jobTemplate to expose initContainers"
+    for cont in init_containers:
         assert cont["securityContext"] == expected
 
 

--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -33,6 +33,7 @@ from wandb.sdk.launch.runner.kubernetes_runner import (
     ensure_api_key_secret,
     maybe_create_imagepull_secret,
 )
+from wandb.sdk.launch.utils import K8S_RESTRICTED_SECURITY_CONTEXT
 
 from .conftest import MockDict
 
@@ -167,12 +168,7 @@ async def test_kubernetes_runner_injects_restricted_security_context(
 
     containers = job["spec"]["template"]["spec"]["containers"]
     for cont in containers:
-        assert cont["securityContext"] == {
-            "allowPrivilegeEscalation": False,
-            "capabilities": {"drop": ["ALL"]},
-            "seccompProfile": {"type": "RuntimeDefault"},
-            "runAsNonRoot": True,
-        }
+        assert cont["securityContext"] == K8S_RESTRICTED_SECURITY_CONTEXT
 
 
 @pytest.fixture
@@ -590,12 +586,7 @@ async def test_launch_crd_injects_restricted_security_context(
     await runner.run(project, MagicMock())
 
     submitted_body = mock_custom_api.jobs["test-job"]
-    expected = {
-        "allowPrivilegeEscalation": False,
-        "capabilities": {"drop": ["ALL"]},
-        "seccompProfile": {"type": "RuntimeDefault"},
-        "runAsNonRoot": True,
-    }
+    expected = K8S_RESTRICTED_SECURITY_CONTEXT
     containers = submitted_body["tasks"][0]["template"]["spec"]["containers"]
     assert containers, "expected the custom resource to expose a pod spec"
     for cont in containers:
@@ -661,12 +652,7 @@ async def test_launch_cronjob_injects_restricted_security_context(
     # The CronJob flows through the standard Job path (batch/v1) and is submitted
     # via create_from_dict.
     submitted_job = mock_create_from_dict.call_args_list[0][0][1]
-    expected = {
-        "allowPrivilegeEscalation": False,
-        "capabilities": {"drop": ["ALL"]},
-        "seccompProfile": {"type": "RuntimeDefault"},
-        "runAsNonRoot": True,
-    }
+    expected = K8S_RESTRICTED_SECURITY_CONTEXT
     pod_spec = submitted_job["spec"]["jobTemplate"]["spec"]["template"]["spec"]
     containers = pod_spec["containers"]
     assert containers, "expected the CronJob jobTemplate to expose containers"

--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -1583,6 +1583,15 @@ async def test_launch_additional_services(
         .get("name")
         == expected_pod_name
     )
+    assert (
+        additional_service_call[0][1]
+        .get("spec")
+        .get("template")
+        .get("spec")
+        .get("containers")[0]
+        .get("securityContext")
+        == K8S_RESTRICTED_SECURITY_CONTEXT
+    )
 
     labels = additional_service_call[0][1].get("metadata").get("labels")
     assert "wandb.ai/label" in labels
@@ -1591,6 +1600,102 @@ async def test_launch_additional_services(
     assert (
         labels[WANDB_K8S_LABEL_AUXILIARY_RESOURCE] == expected_auxiliary_resource_label
     )
+
+
+@pytest.mark.asyncio
+async def test_launch_additional_services_rejects_unsafe_config(
+    mock_event_streams,
+    mock_batch_api,
+    mock_kube_context_and_api_client,
+    mock_maybe_create_image_pullsecret,
+    mock_create_from_dict,
+    test_api,
+    manifest,
+    clean_monitor,
+    clean_agent,
+):
+    unsafe_additional_service = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "unsafe-pod"},
+        "spec": {
+            "hostPID": True,
+            "containers": [{"name": "unsafe", "image": "test_image"}],
+        },
+    }
+
+    project = LaunchProject(
+        docker_config={"docker_image": "test_image"},
+        target_entity="test_entity",
+        target_project="test_project",
+        resource_args={"kubernetes": manifest},
+        launch_spec={
+            "additional_services": [
+                {
+                    "config": unsafe_additional_service,
+                    "name": "unsafe_additional_service",
+                }
+            ]
+        },
+        overrides={},
+        resource="kubernetes",
+        api=test_api,
+        git_info={},
+        job="",
+        uri="https://wandb.ai/test_entity/test_project/runs/test_run_id",
+        run_id="test_run_id",
+        name="test_run",
+    )
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    with pytest.raises(
+        LaunchError,
+        match="Unsafe resource_args.kubernetes option 'hostPID'",
+    ):
+        await runner.run(project, "test_image")
+
+    mock_create_from_dict.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_launch_without_additional_services_still_creates_job(
+    mock_event_streams,
+    mock_batch_api,
+    mock_kube_context_and_api_client,
+    mock_maybe_create_image_pullsecret,
+    mock_create_from_dict,
+    test_api,
+    manifest,
+    clean_monitor,
+    clean_agent,
+):
+    project = LaunchProject(
+        docker_config={"docker_image": "test_image"},
+        target_entity="test_entity",
+        target_project="test_project",
+        resource_args={"kubernetes": manifest},
+        launch_spec={},
+        overrides={},
+        resource="kubernetes",
+        api=test_api,
+        git_info={},
+        job="",
+        uri="https://wandb.ai/test_entity/test_project/runs/test_run_id",
+        run_id="test_run_id",
+        name="test_run",
+    )
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    submitted_run = await runner.run(project, "test_image")
+
+    assert submitted_run.id == "test-job"
+    assert mock_create_from_dict.call_count == 1
+    submitted_manifest = mock_create_from_dict.call_args_list[0][0][1]
+    assert submitted_manifest.get("kind") == "Job"
 
 
 def _make_emptydir_manifest(

--- a/tests/unit_tests/test_launch/test_runner/test_local_container.py
+++ b/tests/unit_tests/test_launch/test_runner/test_local_container.py
@@ -151,22 +151,8 @@ def test_get_docker_command_quotes_user_controlled_args_for_shell():
     assert split_command[-2:] == [payload, payload]
 
 
-@pytest.mark.parametrize(
-    "docker_args,expected_field",
-    [
-        ({"privileged": True}, "privileged"),
-        ({"volume": ["/:/host:rw"]}, "volume"),
-        ({"mount": "type=bind,source=/,target=/host"}, "mount"),
-        ({"pid": "host"}, "pid"),
-        ({"userns": "host"}, "userns"),
-        ({"cap-add": ["SYS_ADMIN"]}, "cap-add"),
-        ({"device": ["/dev/kmsg"]}, "device"),
-        ({"security-opt": ["apparmor=unconfined"]}, "security-opt"),
-    ],
-)
-def test_local_container_rejects_unsafe_resource_args(
-    mock_launch_project, test_api, docker_args, expected_field
-):
+def test_local_container_rejects_unsafe_resource_args(mock_launch_project, test_api):
+    docker_args = {"privileged": True}
     mock_launch_project.fill_macros.return_value = {"local-container": docker_args}
     mock_launch_project.job_base_image = None
     runner = LocalContainerRunner(
@@ -175,56 +161,20 @@ def test_local_container_rejects_unsafe_resource_args(
 
     with pytest.raises(
         LaunchError,
-        match=f"Unsupported resource_args.local-container option '{expected_field}'",
+        match="Unsupported resource_args.local-container option 'privileged'",
     ):
         runner._populate_docker_args(mock_launch_project, "test-image")
 
 
-@pytest.mark.parametrize(
-    "raw_name",
-    [
-        "v",  # short alias for --volume
-        "p",  # short alias for --publish
-        "Privileged",  # case variant
-        "cap_add",  # underscore variant
-        "security_opt",
-        "privileged=true",  # equals form
-    ],
-)
-def test_local_container_rejects_alias_and_equals_forms(
-    mock_launch_project, test_api, raw_name
-):
-    mock_launch_project.fill_macros.return_value = {"local-container": {raw_name: "x"}}
-    mock_launch_project.job_base_image = None
-    runner = LocalContainerRunner(
-        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
-    )
-
-    with pytest.raises(
-        LaunchError,
-        match="Unsupported resource_args.local-container option",
-    ):
-        runner._populate_docker_args(mock_launch_project, "test-image")
-
-
-@pytest.mark.parametrize(
-    "docker_args",
-    [
-        {"cpus": ["2", "--privileged"]},  # arity smuggling via list
-        {"memory": {"x": "y"}},  # mapping value
-        {"cpu": True},  # bare boolean for a value-taking flag
-    ],
-)
-def test_local_container_rejects_value_smuggling(
-    mock_launch_project, test_api, docker_args
-):
+def test_local_container_rejects_value_smuggling(mock_launch_project, test_api):
+    docker_args = {"memory": {"x": "y"}}
     mock_launch_project.fill_macros.return_value = {"local-container": docker_args}
     mock_launch_project.job_base_image = None
     runner = LocalContainerRunner(
         test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
     )
 
-    with pytest.raises(LaunchError):
+    with pytest.raises(LaunchError, match="must be a single string or numeric value"):
         runner._populate_docker_args(mock_launch_project, "test-image")
 
 

--- a/tests/unit_tests/test_launch/test_runner/test_local_container.py
+++ b/tests/unit_tests/test_launch/test_runner/test_local_container.py
@@ -151,6 +151,123 @@ def test_get_docker_command_quotes_user_controlled_args_for_shell():
     assert split_command[-2:] == [payload, payload]
 
 
+@pytest.mark.parametrize(
+    "docker_args,expected_field",
+    [
+        ({"privileged": True}, "privileged"),
+        ({"volume": ["/:/host:rw"]}, "volume"),
+        ({"mount": "type=bind,source=/,target=/host"}, "mount"),
+        ({"pid": "host"}, "pid"),
+        ({"userns": "host"}, "userns"),
+        ({"cap-add": ["SYS_ADMIN"]}, "cap-add"),
+        ({"device": ["/dev/kmsg"]}, "device"),
+        ({"security-opt": ["apparmor=unconfined"]}, "security-opt"),
+    ],
+)
+def test_local_container_rejects_unsafe_resource_args(
+    mock_launch_project, test_api, docker_args, expected_field
+):
+    mock_launch_project.fill_macros.return_value = {"local-container": docker_args}
+    mock_launch_project.job_base_image = None
+    runner = LocalContainerRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    with pytest.raises(
+        LaunchError,
+        match=f"Unsupported resource_args.local-container option '{expected_field}'",
+    ):
+        runner._populate_docker_args(mock_launch_project, "test-image")
+
+
+@pytest.mark.parametrize(
+    "raw_name",
+    [
+        "v",  # short alias for --volume
+        "p",  # short alias for --publish
+        "Privileged",  # case variant
+        "cap_add",  # underscore variant
+        "security_opt",
+        "privileged=true",  # equals form
+    ],
+)
+def test_local_container_rejects_alias_and_equals_forms(
+    mock_launch_project, test_api, raw_name
+):
+    mock_launch_project.fill_macros.return_value = {"local-container": {raw_name: "x"}}
+    mock_launch_project.job_base_image = None
+    runner = LocalContainerRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    with pytest.raises(
+        LaunchError,
+        match="Unsupported resource_args.local-container option",
+    ):
+        runner._populate_docker_args(mock_launch_project, "test-image")
+
+
+@pytest.mark.parametrize(
+    "docker_args",
+    [
+        {"cpus": ["2", "--privileged"]},  # arity smuggling via list
+        {"memory": {"x": "y"}},  # mapping value
+        {"cpu": True},  # bare boolean for a value-taking flag
+    ],
+)
+def test_local_container_rejects_value_smuggling(
+    mock_launch_project, test_api, docker_args
+):
+    mock_launch_project.fill_macros.return_value = {"local-container": docker_args}
+    mock_launch_project.job_base_image = None
+    runner = LocalContainerRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    with pytest.raises(LaunchError):
+        runner._populate_docker_args(mock_launch_project, "test-image")
+
+
+def test_local_container_allows_safe_resource_args(mock_launch_project, test_api):
+    docker_args = {
+        "cpu": 2,
+        "env": ["FOO=bar"],
+        "memory": "2g",
+        "workdir": "/workspace",
+    }
+    mock_launch_project.fill_macros.return_value = {"local-container": docker_args}
+    mock_launch_project.job_base_image = None
+    runner = LocalContainerRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    assert (
+        runner._populate_docker_args(mock_launch_project, "test-image") == docker_args
+    )
+
+
+def test_get_docker_command_serializes_allowed_values():
+    command = local_container.get_docker_command(
+        "test-image",
+        {},
+        docker_args={"cpu": 2, "memory": "2g", "env": ["FOO=bar", "BAZ=qux"]},
+    )
+    joined = " ".join(command)
+    assert "--cpu 2" in joined
+    assert "--memory 2g" in joined
+    # Each list item becomes its own `--env value`; no item is dropped or merged.
+    assert joined.count("--env") == 2
+    assert "--env FOO=bar" in joined
+    assert "--env BAZ=qux" in joined
+
+
+def test_get_docker_command_rejects_mapping_values():
+    with pytest.raises(LaunchError, match="mapping values are not supported"):
+        local_container.get_docker_command(
+            "test-image", {}, docker_args={"label": {"a": "b"}}
+        )
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(os.name == "nt", reason="POSIX shell selection test")
 async def test_local_container_runner_uses_sh_when_bash_missing(

--- a/tests/unit_tests/test_launch/test_runner/test_local_container.py
+++ b/tests/unit_tests/test_launch/test_runner/test_local_container.py
@@ -196,6 +196,37 @@ def test_local_container_allows_safe_resource_args(mock_launch_project, test_api
     )
 
 
+def test_populate_docker_args_does_not_mutate_submitter_resource_args(
+    mock_launch_project, test_api
+):
+    docker_args = {"command": "echo hello world"}
+    mock_launch_project.fill_macros.return_value = {"local-container": docker_args}
+    mock_launch_project.job_base_image = "test-base-image"
+    mock_launch_project.resolved_working_dir = "/mnt/wandb"
+    test_api.settings = MagicMock(return_value="http://localhost:8080")
+    runner = LocalContainerRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    first = runner._populate_docker_args(mock_launch_project, "test-image")
+    second = runner._populate_docker_args(mock_launch_project, "test-image")
+
+    network_arg = "net" if local_container.sys.platform == "win32" else "network"
+    mount_string = f"{mock_launch_project.project_dir}:{local_container.CODE_MOUNT_DIR}"
+    for populated_args in (first, second):
+        assert populated_args["command"] == "echo hello world"
+        assert populated_args[network_arg] == "host"
+        if local_container.sys.platform in ("linux", "linux2"):
+            assert populated_args["add-host"] == "host.docker.internal:host-gateway"
+        assert populated_args["volume"] == [mount_string]
+        assert populated_args["workdir"] == "/mnt/wandb"
+
+    assert first["volume"] is not second["volume"]
+    assert docker_args == {"command": "echo hello world"}
+    for injected_arg in ("network", "net", "add-host", "volume", "workdir"):
+        assert injected_arg not in docker_args
+
+
 def test_get_docker_command_serializes_allowed_values():
     command = local_container.get_docker_command(
         "test-image",

--- a/tests/unit_tests/test_launch/test_util.py
+++ b/tests/unit_tests/test_launch/test_util.py
@@ -12,7 +12,9 @@ from wandb.sdk.launch.utils import (
     pull_docker_image,
     recursive_macro_sub,
     sanitize_identifiers_for_k8s,
+    validate_kubernetes_resource_args,
     validate_launch_spec_source,
+    validate_local_container_resource_args,
     yield_containers,
 )
 
@@ -203,6 +205,214 @@ def test_validate_launch_spec_source(spec, valid):
     else:
         with pytest.raises(LaunchError):
             validate_launch_spec_source(spec)
+
+
+@pytest.mark.parametrize(
+    "pod_spec_patch,expected_field",
+    [
+        ({"hostPID": True}, "hostPID"),
+        ({"hostIPC": True}, "hostIPC"),
+        ({"hostNetwork": True}, "hostNetwork"),
+        ({"shareProcessNamespace": True}, "shareProcessNamespace"),
+        ({"hostUsers": True}, "hostUsers"),
+        (
+            {"volumes": [{"name": "host-root", "hostPath": {"path": "/"}}]},
+            "hostPath",
+        ),
+        ({"serviceAccountName": "cluster-admin"}, "serviceAccountName"),
+        # A submitter cannot use the deprecated alias to dodge the refusal.
+        ({"serviceAccount": "cluster-admin"}, "serviceAccount"),
+        ({"automountServiceAccountToken": True}, "automountServiceAccountToken"),
+        # Pod-level securityContext is refused outright (agent injects its own).
+        ({"securityContext": {"runAsUser": 0}}, "securityContext"),
+        # Container-level securityContext is refused outright too, no matter the
+        # value (privileged, capabilities, ...).
+        (
+            {"containers": [{"securityContext": {"privileged": True}}]},
+            "securityContext",
+        ),
+        (
+            {
+                "containers": [
+                    {"securityContext": {"capabilities": {"add": ["SYS_ADMIN"]}}}
+                ]
+            },
+            "securityContext",
+        ),
+        # initContainers / ephemeralContainers are covered too.
+        (
+            {"initContainers": [{"securityContext": {"privileged": True}}]},
+            "securityContext",
+        ),
+        (
+            {"ephemeralContainers": [{"securityContext": {"privileged": True}}]},
+            "securityContext",
+        ),
+        # hostPort binding is refused.
+        (
+            {"containers": [{"ports": [{"hostPort": 8080}]}]},
+            "hostPort",
+        ),
+        # Bidirectional mount propagation can escape to the host mount namespace.
+        (
+            {
+                "containers": [
+                    {
+                        "volumeMounts": [
+                            {
+                                "name": "x",
+                                "mountPath": "/x",
+                                "mountPropagation": "Bidirectional",
+                            }
+                        ]
+                    }
+                ]
+            },
+            "mountPropagation",
+        ),
+        # A projected service-account-token volume is refused.
+        (
+            {
+                "volumes": [
+                    {
+                        "name": "kube-api",
+                        "projected": {
+                            "sources": [{"serviceAccountToken": {"path": "token"}}]
+                        },
+                    }
+                ]
+            },
+            "serviceAccountToken",
+        ),
+    ],
+)
+def test_validate_kubernetes_resource_args_rejects_unsafe_pod_specs(
+    pod_spec_patch, expected_field
+):
+    manifest = {
+        "kind": "Job",
+        "spec": {"template": {"spec": {"restartPolicy": "Never", **pod_spec_patch}}},
+    }
+
+    with pytest.raises(
+        LaunchError,
+        match=f"Unsafe resource_args.kubernetes option '{expected_field}'",
+    ):
+        validate_kubernetes_resource_args(manifest)
+
+
+@pytest.mark.parametrize(
+    "annotation_key",
+    [
+        "container.apparmor.security.beta.kubernetes.io/launch",
+        "seccomp.security.alpha.kubernetes.io/pod",
+    ],
+)
+def test_validate_kubernetes_resource_args_rejects_unconfined_annotations(
+    annotation_key,
+):
+    manifest = {
+        "spec": {
+            "template": {
+                "metadata": {"annotations": {annotation_key: "unconfined"}},
+                "spec": {"containers": [{}]},
+            }
+        }
+    }
+
+    with pytest.raises(
+        LaunchError,
+        match="metadata.annotations",
+    ):
+        validate_kubernetes_resource_args(manifest)
+
+
+def test_validate_kubernetes_resource_args_allows_benign_pod_spec():
+    # A benign manifest with no submitter-managed security keys passes. The agent
+    # injects the restricted securityContext itself, so submitters omit it.
+    validate_kubernetes_resource_args(
+        {
+            "kind": "Job",
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "main",
+                                "resources": {"limits": {"cpu": "2"}},
+                            }
+                        ],
+                        "volumes": [{"name": "scratch", "emptyDir": {}}],
+                    }
+                }
+            },
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "raw_name",
+    [
+        "privileged",
+        "privileged=true",
+        "v",  # short alias for --volume
+        "volume",
+        "Volume",
+        "p",  # short alias for --publish
+        "pid",
+        "userns",
+        "cap-add",
+        "cap_add",
+        "capAdd",
+        "device",
+        "security-opt",
+        "security_opt",
+        "network",
+        "net",
+        "ipc",
+        "sysctl",
+        "add-host",
+    ],
+)
+def test_validate_local_container_resource_args_rejects_unsafe_flags(raw_name):
+    with pytest.raises(
+        LaunchError,
+        match="Unsupported resource_args.local-container option",
+    ):
+        validate_local_container_resource_args({raw_name: "anything"})
+
+
+@pytest.mark.parametrize(
+    "docker_args",
+    [
+        # Non-repeatable flag may not be a list (arity smuggling).
+        {"cpus": ["2", "--privileged"]},
+        # Mapping values are never allowed.
+        {"memory": {"x": "y"}},
+        # Bare boolean for a value-taking flag is rejected.
+        {"cpu": True},
+        # Repeatable flag with a non-scalar item is rejected.
+        {"env": ["FOO=bar", {"x": "y"}]},
+        # Repeatable flag with an empty list is rejected.
+        {"env": []},
+    ],
+)
+def test_validate_local_container_resource_args_rejects_bad_values(docker_args):
+    with pytest.raises(LaunchError):
+        validate_local_container_resource_args(docker_args)
+
+
+def test_validate_local_container_resource_args_allows_safe_flags():
+    validate_local_container_resource_args(
+        {
+            "cpu": 2,
+            "memory": "2g",
+            "gpus": "all",
+            "env": ["FOO=bar", "BAZ=qux"],
+            "ulimit": "nofile=1024:1024",
+            "workdir": "/workspace",
+        }
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_launch/test_util.py
+++ b/tests/unit_tests/test_launch/test_util.py
@@ -6,7 +6,6 @@ from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.runner.local_container import get_docker_command
 from wandb.sdk.launch.utils import (
     diff_pip_requirements,
-    inject_restricted_security_context,
     load_wandb_config,
     macro_sub,
     make_k8s_label_safe,
@@ -435,73 +434,6 @@ def test_validate_kubernetes_resource_args_allows_non_dangerous_values(pod_spec_
             },
         }
     )
-
-
-RESTRICTED_SECURITY_CONTEXT = {
-    "allowPrivilegeEscalation": False,
-    "capabilities": {"drop": ["ALL"]},
-    "seccompProfile": {"type": "RuntimeDefault"},
-    "runAsNonRoot": True,
-}
-
-
-def test_inject_restricted_security_context_covers_cronjob():
-    # CronJob workload pod template lives under spec.jobTemplate.spec.template.spec.
-    manifest = {
-        "apiVersion": "batch/v1",
-        "kind": "CronJob",
-        "spec": {
-            "jobTemplate": {
-                "spec": {
-                    "template": {
-                        "spec": {
-                            "containers": [{"name": "main"}],
-                            "initContainers": [{"name": "init"}],
-                        }
-                    }
-                }
-            }
-        },
-    }
-    inject_restricted_security_context(manifest)
-    pod_spec = manifest["spec"]["jobTemplate"]["spec"]["template"]["spec"]
-    assert pod_spec["containers"][0]["securityContext"] == RESTRICTED_SECURITY_CONTEXT
-    assert (
-        pod_spec["initContainers"][0]["securityContext"] == RESTRICTED_SECURITY_CONTEXT
-    )
-
-
-def test_inject_restricted_security_context_covers_custom_resource():
-    # A CRD (e.g. volcano) exposes pod specs under tasks[].template.spec.
-    manifest = {
-        "apiVersion": "batch.volcano.sh/v1alpha1",
-        "kind": "Job",
-        "tasks": [
-            {"template": {"spec": {"containers": [{"name": "master"}]}}},
-            {"template": {"spec": {"containers": [{"name": "worker"}]}}},
-        ],
-    }
-    inject_restricted_security_context(manifest)
-    for task in manifest["tasks"]:
-        cont = task["template"]["spec"]["containers"][0]
-        assert cont["securityContext"] == RESTRICTED_SECURITY_CONTEXT
-
-
-def test_inject_restricted_security_context_overrides_submitter_values():
-    manifest = {
-        "spec": {
-            "template": {
-                "spec": {
-                    "containers": [
-                        {"name": "main", "securityContext": {"privileged": True}}
-                    ]
-                }
-            }
-        }
-    }
-    inject_restricted_security_context(manifest)
-    cont = manifest["spec"]["template"]["spec"]["containers"][0]
-    assert cont["securityContext"] == RESTRICTED_SECURITY_CONTEXT
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_launch/test_util.py
+++ b/tests/unit_tests/test_launch/test_util.py
@@ -3,8 +3,10 @@ import random
 import pytest
 from wandb.docker import DockerError
 from wandb.sdk.launch.errors import LaunchError
+from wandb.sdk.launch.runner.local_container import get_docker_command
 from wandb.sdk.launch.utils import (
     diff_pip_requirements,
+    inject_restricted_security_context,
     load_wandb_config,
     macro_sub,
     make_k8s_label_safe,
@@ -413,6 +415,112 @@ def test_validate_local_container_resource_args_allows_safe_flags():
             "workdir": "/workspace",
         }
     )
+
+
+@pytest.mark.parametrize(
+    "pod_spec_patch",
+    [
+        # Only the dangerous (truthy) forms are refused; these benign forms must
+        # not be over-blocked.
+        {"hostUsers": False},
+        {"containers": [{"ports": [{"hostPort": 0}]}]},
+    ],
+)
+def test_validate_kubernetes_resource_args_allows_non_dangerous_values(pod_spec_patch):
+    validate_kubernetes_resource_args(
+        {
+            "kind": "Job",
+            "spec": {
+                "template": {"spec": {"restartPolicy": "Never", **pod_spec_patch}}
+            },
+        }
+    )
+
+
+RESTRICTED_SECURITY_CONTEXT = {
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+    "seccompProfile": {"type": "RuntimeDefault"},
+    "runAsNonRoot": True,
+}
+
+
+def test_inject_restricted_security_context_covers_cronjob():
+    # CronJob workload pod template lives under spec.jobTemplate.spec.template.spec.
+    manifest = {
+        "apiVersion": "batch/v1",
+        "kind": "CronJob",
+        "spec": {
+            "jobTemplate": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{"name": "main"}],
+                            "initContainers": [{"name": "init"}],
+                        }
+                    }
+                }
+            }
+        },
+    }
+    inject_restricted_security_context(manifest)
+    pod_spec = manifest["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+    assert pod_spec["containers"][0]["securityContext"] == RESTRICTED_SECURITY_CONTEXT
+    assert (
+        pod_spec["initContainers"][0]["securityContext"] == RESTRICTED_SECURITY_CONTEXT
+    )
+
+
+def test_inject_restricted_security_context_covers_custom_resource():
+    # A CRD (e.g. volcano) exposes pod specs under tasks[].template.spec.
+    manifest = {
+        "apiVersion": "batch.volcano.sh/v1alpha1",
+        "kind": "Job",
+        "tasks": [
+            {"template": {"spec": {"containers": [{"name": "master"}]}}},
+            {"template": {"spec": {"containers": [{"name": "worker"}]}}},
+        ],
+    }
+    inject_restricted_security_context(manifest)
+    for task in manifest["tasks"]:
+        cont = task["template"]["spec"]["containers"][0]
+        assert cont["securityContext"] == RESTRICTED_SECURITY_CONTEXT
+
+
+def test_inject_restricted_security_context_overrides_submitter_values():
+    manifest = {
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {"name": "main", "securityContext": {"privileged": True}}
+                    ]
+                }
+            }
+        }
+    }
+    inject_restricted_security_context(manifest)
+    cont = manifest["spec"]["template"]["spec"]["containers"][0]
+    assert cont["securityContext"] == RESTRICTED_SECURITY_CONTEXT
+
+
+@pytest.mark.parametrize(
+    "docker_args,flag,value",
+    [
+        ({"cpus": "--privileged"}, "--cpus", "--privileged"),
+        ({"env": ["--privileged"]}, "--env", "--privileged"),
+    ],
+)
+def test_get_docker_command_dash_token_is_consumed_as_value(docker_args, flag, value):
+    # A dash-prefixed value token must be emitted as the VALUE of its allowed
+    # flag (a single flag+value pair), never as a standalone docker option.
+    validate_local_container_resource_args(docker_args)
+    command = get_docker_command("test-image", {}, docker_args=docker_args)
+    # The token only ever appears immediately after its flag.
+    indices = [i for i, tok in enumerate(command) if tok == value]
+    assert indices, f"{value} not found in {command}"
+    for i in indices:
+        assert command[i - 1] == flag
 
 
 @pytest.mark.parametrize(

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -33,6 +33,7 @@ from ..utils import (
     LOG_PREFIX,
     PROJECT_SYNCHRONOUS,
     event_loop_thread_exec,
+    validate_launch_resource_args,
 )
 from .job_status_tracker import JobAndRunStatusTracker
 from .run_queue_item_file_saver import RunQueueItemFileSaver
@@ -534,7 +535,8 @@ class LaunchAgent:
         )
 
     def _assert_secure(self, launch_spec: dict[str, Any]) -> None:
-        """If secure mode is set, make sure no vulnerable keys are overridden."""
+        """Reject unsafe resource args and enforce secure-mode-only locks."""
+        validate_launch_resource_args(launch_spec.get("resource_args", {}))
         if not self._secure_mode:
             return
         k8s_config = launch_spec.get("resource_args", {}).get("kubernetes", {})

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -777,6 +777,9 @@ class KubernetesRunner(AbstractRunner):
                 )
                 cont["env"] = env
 
+        validate_kubernetes_resource_args(config)
+        inject_restricted_security_context(config)
+
         try:
             sanitize_identifiers_for_k8s(config)
 

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import copy
 import datetime
 import json
 import logging
@@ -44,11 +43,11 @@ from .._project_spec import EntryPoint, LaunchProject
 from ..errors import LaunchError
 from ..utils import (
     CODE_MOUNT_DIR,
-    K8S_RESTRICTED_SECURITY_CONTEXT,
     LOG_PREFIX,
     MAX_ENV_LENGTHS,
     PROJECT_SYNCHRONOUS,
     get_kube_context_and_api_client,
+    inject_restricted_security_context,
     make_k8s_label_safe,
     make_name_dns_safe,
     validate_kubernetes_resource_args,
@@ -345,27 +344,6 @@ class CrdSubmittedRun(AbstractRun):
             await asyncio.sleep(5)
 
 
-def _enforce_restricted_security_context(
-    pod_spec: dict[str, Any], containers: list[dict[str, Any]]
-) -> None:
-    """Always set the agent's restricted securityContext on every container.
-
-    Submitter-supplied securityContext is refused upstream by
-    ``validate_kubernetes_resource_args``, so the agent's safe values always win.
-    ``initContainers``/``ephemeralContainers`` are covered too for defense in
-    depth.
-    """
-    for container_key in ("containers", "initContainers", "ephemeralContainers"):
-        container_list = (
-            containers
-            if container_key == "containers"
-            else pod_spec.get(container_key, [])
-        )
-        for cont in container_list:
-            if isinstance(cont, dict):
-                cont["securityContext"] = copy.deepcopy(K8S_RESTRICTED_SECURITY_CONTEXT)
-
-
 class KubernetesRunner(AbstractRunner):
     """Launches runs onto kubernetes."""
 
@@ -464,8 +442,6 @@ class KubernetesRunner(AbstractRunner):
         for i, cont in enumerate(containers):
             if "name" not in cont:
                 cont["name"] = cont.get("name", "launch" + str(i))
-
-        _enforce_restricted_security_context(pod_spec, containers)
 
         entry_point = (
             launch_project.override_entrypoint or launch_project.get_job_entry_point()
@@ -583,6 +559,12 @@ class KubernetesRunner(AbstractRunner):
                 WANDB_K8S_LABEL_AGENT,
                 LaunchAgent.name(),
             )
+
+        # Force the restricted securityContext onto every pod spec in the
+        # assembled job (standard template, and any CronJob jobTemplate). This
+        # is symmetric with validate_kubernetes_resource_args, which refuses
+        # submitter-supplied securityContext anywhere in the manifest.
+        inject_restricted_security_context(job)
 
         return job, api_key_secret
 
@@ -903,6 +885,12 @@ class KubernetesRunner(AbstractRunner):
                 resource_args,
                 overrides,
             )
+
+            # Custom resources never go through _inject_defaults, so harden any
+            # pod spec they expose here. Matches the standard Job path and is
+            # symmetric with validate_kubernetes_resource_args.
+            inject_restricted_security_context(resource_args)
+
             api = client.CustomObjectsApi(api_client)
             # Infer the attributes of a custom object from the apiVersion and/or
             # a kind: attribute in the resource args.

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 import datetime
 import json
 import logging
@@ -43,12 +44,14 @@ from .._project_spec import EntryPoint, LaunchProject
 from ..errors import LaunchError
 from ..utils import (
     CODE_MOUNT_DIR,
+    K8S_RESTRICTED_SECURITY_CONTEXT,
     LOG_PREFIX,
     MAX_ENV_LENGTHS,
     PROJECT_SYNCHRONOUS,
     get_kube_context_and_api_client,
     make_k8s_label_safe,
     make_name_dns_safe,
+    validate_kubernetes_resource_args,
 )
 from .abstract import AbstractRun, AbstractRunner
 
@@ -342,6 +345,27 @@ class CrdSubmittedRun(AbstractRun):
             await asyncio.sleep(5)
 
 
+def _enforce_restricted_security_context(
+    pod_spec: dict[str, Any], containers: list[dict[str, Any]]
+) -> None:
+    """Always set the agent's restricted securityContext on every container.
+
+    Submitter-supplied securityContext is refused upstream by
+    ``validate_kubernetes_resource_args``, so the agent's safe values always win.
+    ``initContainers``/``ephemeralContainers`` are covered too for defense in
+    depth.
+    """
+    for container_key in ("containers", "initContainers", "ephemeralContainers"):
+        container_list = (
+            containers
+            if container_key == "containers"
+            else pod_spec.get(container_key, [])
+        )
+        for cont in container_list:
+            if isinstance(cont, dict):
+                cont["securityContext"] = copy.deepcopy(K8S_RESTRICTED_SECURITY_CONTEXT)
+
+
 class KubernetesRunner(AbstractRunner):
     """Launches runs onto kubernetes."""
 
@@ -440,12 +464,8 @@ class KubernetesRunner(AbstractRunner):
         for i, cont in enumerate(containers):
             if "name" not in cont:
                 cont["name"] = cont.get("name", "launch" + str(i))
-            if "securityContext" not in cont:
-                cont["securityContext"] = {
-                    "allowPrivilegeEscalation": False,
-                    "capabilities": {"drop": ["ALL"]},
-                    "seccompProfile": {"type": "RuntimeDefault"},
-                }
+
+        _enforce_restricted_security_context(pod_spec, containers)
 
         entry_point = (
             launch_project.override_entrypoint or launch_project.get_job_entry_point()
@@ -802,8 +822,9 @@ class KubernetesRunner(AbstractRunner):
         Returns:
             The run object if the run was successful, otherwise None.
         """
-        await LaunchKubernetesMonitor.ensure_initialized()
         resource_args = launch_project.fill_macros(image_uri).get("kubernetes", {})
+        validate_kubernetes_resource_args(resource_args)
+        await LaunchKubernetesMonitor.ensure_initialized()
         if not resource_args:
             wandb.termlog(
                 f"{LOG_PREFIX}Note: no resource args specified. Add a "

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -27,6 +27,7 @@ from ..utils import (
     event_loop_thread_exec,
     pull_docker_image,
     sanitize_wandb_api_key,
+    validate_local_container_resource_args,
 )
 from .abstract import AbstractRun, AbstractRunner, Status
 
@@ -118,6 +119,7 @@ class LocalContainerRunner(AbstractRunner):
         docker_args: dict[str, Any] = launch_project.fill_macros(image_uri).get(
             "local-container", {}
         )
+        validate_local_container_resource_args(docker_args)
         if _is_wandb_local_uri(self._api.settings("base_url")):
             if sys.platform == "win32":
                 docker_args["net"] = "host"
@@ -294,7 +296,16 @@ def get_docker_command(
                 prefix = "-" + shlex.quote(name)
             else:
                 prefix = "--" + shlex.quote(name)
-            if isinstance(value, list):
+            # Submitter-supplied flags are validated upstream by
+            # validate_local_container_resource_args; this is a defense-in-depth
+            # guard so a value can never smuggle a second option or an unexpected
+            # shape into the command. Each flag emits exactly `--flag value`
+            # (repeated once per item for list-valued flags).
+            if isinstance(value, dict):
+                raise LaunchError(
+                    f"Invalid docker argument '{name}': mapping values are not supported."
+                )
+            if isinstance(value, (list, tuple)):
                 for v in value:
                     cmd += [prefix, shlex.quote(str(v))]
             elif isinstance(value, bool) and value:

--- a/wandb/sdk/launch/runner/local_container.py
+++ b/wandb/sdk/launch/runner/local_container.py
@@ -116,10 +116,11 @@ class LocalContainerRunner(AbstractRunner):
     def _populate_docker_args(
         self, launch_project: LaunchProject, image_uri: str
     ) -> dict[str, Any]:
-        docker_args: dict[str, Any] = launch_project.fill_macros(image_uri).get(
-            "local-container", {}
-        )
-        validate_local_container_resource_args(docker_args)
+        submitter_docker_args: dict[str, Any] = launch_project.fill_macros(
+            image_uri
+        ).get("local-container", {})
+        validate_local_container_resource_args(submitter_docker_args)
+        docker_args = dict(submitter_docker_args)
         if _is_wandb_local_uri(self._api.settings("base_url")):
             if sys.platform == "win32":
                 docker_args["net"] = "host"
@@ -132,6 +133,8 @@ class LocalContainerRunner(AbstractRunner):
             # Mount code into the container and set the working directory.
             if "volume" not in docker_args:
                 docker_args["volume"] = []
+            else:
+                docker_args["volume"] = list(docker_args["volume"])
             docker_args["volume"].append(
                 f"{launch_project.project_dir}:{CODE_MOUNT_DIR}"
             )

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -358,15 +358,15 @@ _DOCKER_ALLOWED_RESOURCE_ARGS = {
 # may arrive as a list of scalar values (e.g. ``--env A=1 --env B=2``).
 _DOCKER_REPEATABLE_RESOURCE_ARGS = {"e", "env", "ulimit"}
 
-# Restricted securityContext the Kubernetes runner always injects. Submitters
-# cannot override it (see ``validate_kubernetes_resource_args`` which refuses any
-# submitter-supplied securityContext, and ``_inject_defaults`` which always sets
-# this on every container).
+# SecurityContext the Kubernetes runner always injects. This preserves the
+# existing launch defaults while making sure submitters cannot override them
+# (see ``validate_kubernetes_resource_args`` which refuses any submitter-supplied
+# securityContext, and ``_inject_defaults`` which always sets this on every
+# container).
 K8S_RESTRICTED_SECURITY_CONTEXT: dict[str, Any] = {
     "allowPrivilegeEscalation": False,
     "capabilities": {"drop": ["ALL"]},
     "seccompProfile": {"type": "RuntimeDefault"},
-    "runAsNonRoot": True,
 }
 
 # Submitter-supplied keys we refuse anywhere in a Kubernetes manifest because

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -558,6 +559,48 @@ def validate_kubernetes_resource_args(resource_args: dict[str, Any]) -> None:
 
     _scan_kubernetes_annotations(resource_args)
     _scan_kubernetes_node(resource_args)
+
+
+# Keys whose value is a list of containers within a pod spec.
+_K8S_CONTAINER_KEYS = ("containers", "initContainers", "ephemeralContainers")
+
+
+def yield_kubernetes_pod_specs(manifest: Any) -> Iterator[dict[str, Any]]:
+    """Yield every pod spec found anywhere in a Kubernetes manifest.
+
+    A pod spec is recognized by carrying a container list (``containers``,
+    ``initContainers`` or ``ephemeralContainers``). This locates the workload
+    pod template no matter where it lives — Job ``spec.template.spec``, CronJob
+    ``spec.jobTemplate.spec.template.spec``, or a custom resource that exposes a
+    recognizable pod spec — so security hardening can be applied symmetrically
+    with ``validate_kubernetes_resource_args`` (which scans the whole manifest).
+    """
+    if isinstance(manifest, dict):
+        if any(isinstance(manifest.get(key), list) for key in _K8S_CONTAINER_KEYS):
+            yield manifest
+        for value in manifest.values():
+            yield from yield_kubernetes_pod_specs(value)
+    elif isinstance(manifest, list):
+        for item in manifest:
+            yield from yield_kubernetes_pod_specs(item)
+
+
+def inject_restricted_security_context(manifest: Any) -> None:
+    """Force the agent's restricted securityContext onto every container.
+
+    Applied to every container/initContainer/ephemeralContainer in every pod
+    spec found anywhere in ``manifest``. Submitter-supplied securityContext is
+    already refused by ``validate_kubernetes_resource_args``, so always setting
+    the restricted context here is safe and guarantees the agent's values win,
+    regardless of the workload shape (Job, CronJob, or custom resource).
+    """
+    for pod_spec in yield_kubernetes_pod_specs(manifest):
+        for container_key in _K8S_CONTAINER_KEYS:
+            for container in pod_spec.get(container_key) or []:
+                if isinstance(container, dict):
+                    container["securityContext"] = copy.deepcopy(
+                        K8S_RESTRICTED_SECURITY_CONTEXT
+                    )
 
 
 def validate_launch_resource_args(resource_args: dict[str, Any]) -> None:

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -328,6 +328,253 @@ def validate_launch_spec_source(launch_spec: dict[str, Any]) -> None:
         )
 
 
+_DOCKER_ALLOWED_RESOURCE_ARGS = {
+    "command",
+    "cpu",
+    "cpu-period",
+    "cpu-quota",
+    "cpu-shares",
+    "cpus",
+    "cpuset-cpus",
+    "cpuset-mems",
+    "e",
+    "env",
+    "gpus",
+    "m",
+    "memory",
+    "memory-reservation",
+    "memory-swap",
+    "name",
+    "pids-limit",
+    "platform",
+    "shm-size",
+    "ulimit",
+    "w",
+    "workdir",
+}
+
+# Allowed Docker flags that may legitimately be supplied more than once and so
+# may arrive as a list of scalar values (e.g. ``--env A=1 --env B=2``).
+_DOCKER_REPEATABLE_RESOURCE_ARGS = {"e", "env", "ulimit"}
+
+# Restricted securityContext the Kubernetes runner always injects. Submitters
+# cannot override it (see ``validate_kubernetes_resource_args`` which refuses any
+# submitter-supplied securityContext, and ``_inject_defaults`` which always sets
+# this on every container).
+K8S_RESTRICTED_SECURITY_CONTEXT: dict[str, Any] = {
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+    "seccompProfile": {"type": "RuntimeDefault"},
+    "runAsNonRoot": True,
+}
+
+# Submitter-supplied keys we refuse anywhere in a Kubernetes manifest because
+# they grant host or cluster privileges. This list fails CLOSED: rather than
+# enumerating every dangerous *value*, we reject the security-relevant *keys*
+# outright and always inject our own restricted securityContext.
+#
+# Keys whose mere presence is refused (the agent owns these):
+_K8S_REFUSED_PRESENT_KEYS = {
+    "securityContext": "the agent manages the pod/container security context "
+    "and it cannot be overridden",
+    "hostPath": "hostPath volumes are not permitted",
+    "serviceAccountToken": "projected service account tokens are not permitted",
+}
+# Keys refused only when they carry a host/cluster-privilege-granting value:
+_K8S_REFUSED_HOST_NAMESPACE_KEYS = (
+    "hostPID",
+    "hostIPC",
+    "hostNetwork",
+    "shareProcessNamespace",
+    "hostUsers",
+)
+_K8S_REFUSED_SERVICE_ACCOUNT_KEYS = ("serviceAccountName", "serviceAccount")
+
+
+def _is_present_resource_value(value: Any) -> bool:
+    if isinstance(value, (list, tuple, set)):
+        return any(_is_present_resource_value(item) for item in value)
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _is_truthy_resource_value(value: Any) -> bool:
+    if value is True:
+        return True
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return False
+
+
+def _raise_unsafe_resource_arg(resource: str, field: str, reason: str) -> None:
+    raise LaunchError(
+        f"Unsafe resource_args.{resource} option '{field}' is not allowed: {reason}"
+    )
+
+
+def _docker_arg_name(name: Any) -> str:
+    return str(name).strip().lstrip("-").replace("_", "-").lower()
+
+
+def _is_safe_docker_value(value: Any) -> bool:
+    """A docker flag value must be a single, non-boolean scalar."""
+    return isinstance(value, (str, int, float)) and not isinstance(value, bool)
+
+
+def _validate_local_container_resource_value(name: str, value: Any) -> None:
+    """Enforce fixed arity/typing for an allowed docker flag value.
+
+    Every flag in ``_DOCKER_ALLOWED_RESOURCE_ARGS`` takes a value, so we reject
+    bare booleans (which would serialize to a lone ``--flag``), dicts, and—for
+    non-repeatable flags—lists. Repeatable flags may be a list of scalars.
+    """
+    if name in _DOCKER_REPEATABLE_RESOURCE_ARGS and isinstance(value, (list, tuple)):
+        if not value:
+            raise LaunchError(
+                f"resource_args.local-container option '{name}' requires a value."
+            )
+        for item in value:
+            if not _is_safe_docker_value(item):
+                raise LaunchError(
+                    f"resource_args.local-container option '{name}' only accepts "
+                    "string or numeric values."
+                )
+        return
+    if not _is_safe_docker_value(value):
+        raise LaunchError(
+            f"resource_args.local-container option '{name}' must be a single "
+            "string or numeric value."
+        )
+
+
+def validate_local_container_resource_args(docker_args: dict[str, Any]) -> None:
+    """Accept only Docker flags W&B intentionally supports for queue submitters.
+
+    This is an allow-list of non-isolation, resource-shaping flags. Anything that
+    can affect container isolation (``--privileged``, ``--volume``, ``--pid``,
+    ``--cap-add``, ``--device``, ``--security-opt``, ...) is rejected. Flag names
+    are normalized (dashes/underscores/case, short aliases, ``=`` forms) before
+    the allow-list check, and each allowed flag's value is arity/type checked so
+    a value token cannot smuggle a second option.
+    """
+    if not isinstance(docker_args, dict):
+        raise LaunchError("resource_args.local-container must be a dictionary")
+
+    for raw_name, value in docker_args.items():
+        name = _docker_arg_name(raw_name)
+        if name not in _DOCKER_ALLOWED_RESOURCE_ARGS:
+            supported = ", ".join(sorted(_DOCKER_ALLOWED_RESOURCE_ARGS))
+            raise LaunchError(
+                f"Unsupported resource_args.local-container option '{name}'. "
+                f"Supported options are: {supported}"
+            )
+        _validate_local_container_resource_value(name, value)
+
+
+def _scan_kubernetes_annotations(node: Any) -> None:
+    """Refuse apparmor/seccomp ``=unconfined`` annotations anywhere in a manifest."""
+    if isinstance(node, dict):
+        annotations = node.get("annotations")
+        if isinstance(annotations, dict):
+            for key, value in annotations.items():
+                normalized_key = str(key).lower()
+                normalized_value = str(value).lower()
+                if (
+                    "apparmor" in normalized_key or "seccomp" in normalized_key
+                ) and "unconfined" in normalized_value:
+                    _raise_unsafe_resource_arg(
+                        "kubernetes",
+                        f"metadata.annotations.{key}",
+                        "unconfined apparmor/seccomp profiles are not permitted",
+                    )
+        for value in node.values():
+            _scan_kubernetes_annotations(value)
+    elif isinstance(node, list):
+        for item in node:
+            _scan_kubernetes_annotations(item)
+
+
+def _scan_kubernetes_node(node: Any) -> None:
+    """Recursively refuse security-relevant submitter keys anywhere in a manifest.
+
+    Failing closed on a short refuse-list (instead of enumerating dangerous
+    values) keeps maintenance bounded and covers ``initContainers`` /
+    ``ephemeralContainers`` and creative nesting for free.
+    """
+    if isinstance(node, dict):
+        for key, reason in _K8S_REFUSED_PRESENT_KEYS.items():
+            if key in node:
+                _raise_unsafe_resource_arg("kubernetes", key, reason)
+        for key in _K8S_REFUSED_HOST_NAMESPACE_KEYS:
+            if _is_truthy_resource_value(node.get(key)):
+                _raise_unsafe_resource_arg(
+                    "kubernetes", key, "host namespace sharing is not permitted"
+                )
+        for key in _K8S_REFUSED_SERVICE_ACCOUNT_KEYS:
+            if _is_present_resource_value(node.get(key)):
+                _raise_unsafe_resource_arg(
+                    "kubernetes",
+                    key,
+                    "overriding the pod service account is not permitted",
+                )
+        if _is_truthy_resource_value(node.get("automountServiceAccountToken")):
+            _raise_unsafe_resource_arg(
+                "kubernetes",
+                "automountServiceAccountToken",
+                "mounting service account tokens is not permitted",
+            )
+        if _is_truthy_resource_value(node.get("hostPort")):
+            _raise_unsafe_resource_arg(
+                "kubernetes", "hostPort", "binding host ports is not permitted"
+            )
+        if str(node.get("mountPropagation", "")).strip() == "Bidirectional":
+            _raise_unsafe_resource_arg(
+                "kubernetes",
+                "mountPropagation",
+                "bidirectional mount propagation is not permitted",
+            )
+        for value in node.values():
+            _scan_kubernetes_node(value)
+    elif isinstance(node, list):
+        for item in node:
+            _scan_kubernetes_node(item)
+
+
+def validate_kubernetes_resource_args(resource_args: dict[str, Any]) -> None:
+    """Refuse Kubernetes resource args that grant host or cluster privileges.
+
+    Rather than enumerating dangerous values, we refuse a short list of
+    security-relevant submitter keys outright (failing closed) and rely on the
+    agent always injecting a restricted securityContext that the submitter
+    cannot override (``KubernetesRunner._inject_defaults``).
+    """
+    if not isinstance(resource_args, dict):
+        raise LaunchError("resource_args.kubernetes must be a dictionary")
+
+    _scan_kubernetes_annotations(resource_args)
+    _scan_kubernetes_node(resource_args)
+
+
+def validate_launch_resource_args(resource_args: dict[str, Any]) -> None:
+    if not resource_args:
+        return
+    if not isinstance(resource_args, dict):
+        raise LaunchError("resource_args must be a dictionary")
+
+    local_container_args = resource_args.get("local-container")
+    if local_container_args is not None:
+        validate_local_container_resource_args(local_container_args)
+
+    kubernetes_args = resource_args.get("kubernetes")
+    if kubernetes_args is not None:
+        validate_kubernetes_resource_args(kubernetes_args)
+
+
 def parse_wandb_uri(uri: str) -> tuple[str, str, str]:
     """Parse wandb uri to retrieve entity, project and run name."""
     ref = WandbReference.parse(uri)


### PR DESCRIPTION
# Description

https://coreweave.atlassian.net/browse/VULNMGMT-2137

A queue submitter is able to pass privileged container settings through resource_args into the launch agent's Docker and Kubernetes backends. This PR hardens resource_args handling by validating the incoming keys. For docker (local-container), we will maintain an allowlist of acceptable Docker args. For Kubernetes, we are further rejecting security-relevant keys, like: `serviceAccountToken`, `hostPath`, etc.  and also enforcing an agent-managed `securityContext`. Present users _may_ be using these keys for valid reasons, but we've chosen to restrict these for now and we can open it up if anyone writes in for access.

Edit: commit [e0d174e93fbb30154265c9f0b4be678015d08fc7](https://github.com/wandb/wandb/pull/12103/changes/e0d174e93fbb30154265c9f0b4be678015d08fc7) additionally hardens the k8s configs for `additional_services`. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


# Testing
- [x] Added unit tests

## E2E Testing

Built `wandb/launch-agent-dev:vulnmgmt-2137-02` (https://github.com/wandb/wandb/actions/runs/28205258243) and launched real jobs against the agent

### Docker smoke test
Agent: https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6Njg4MTk=/logs
Run: https://wandb.ai/wandb/launch-agent-smoke/runs/lgt7hzrc
Run Spec:
```
{'runQueueItemId': 'UnVuUXVldWVJdGVtOjgwODY1MDMxMg==',
 'runSpec': {'_wandb_job_collection_id': 'QXJ0aWZhY3RDb2xsZWN0aW9uOjExMjkyNjg2MzE=',
             'author': 'nicholas-pun',
             'docker': {},
             'entity': 'wandb',
             'git': {},
             'job': 'wandb/launch-agent-smoke/hello-world-vulnmgmt-2137:v0',
             'overrides': {},
             'project': 'launch-agent-smoke',
             'resource': 'local-container',
             'resource_args': {'local-container': {}}}}
```

### Docker w/ vulnerability test
Agent: https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6Njg4MTk=/logs
Logs:
```
{'runQueueItemId': 'UnVuUXVldWVJdGVtOjgwODY1MTQ0Ng==',
 'runSpec': {'_wandb_job_collection_id': 'QXJ0aWZhY3RDb2xsZWN0aW9uOjExMjkyNjg2MzE=',
             'author': 'nicholas-pun',
             'docker': {},
             'entity': 'wandb',
             'git': {},
             'job': 'wandb/launch-agent-smoke/hello-world-vulnmgmt-2137:v0',
             'overrides': {},
             'project': 'launch-agent-smoke',
             'resource': 'local-container',
             'resource_args': {'local-container': {'cap-add': ['SYS_ADMIN'],
                                                   'pid': 'host',
                                                   'privileged': True,
                                                   'security-opt': ['apparmor=unconfined'],
                                                   'userns': 'host',
                                                   'volume': ['/:/host:rw']}}}}

INFO    MainThread:1 [agent.py:info():134] launch: Parsing launch spec

ERROR launch: Error running job: Traceback (most recent call last):
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/agent/agent.py", line 609, in loop
ERROR     await self.run_job(job, queue, file_saver)
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/agent/agent.py", line 524, in run_job
ERROR     self._assert_secure(launch_spec)
ERROR     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/agent/agent.py", line 539, in _assert_secure
ERROR     validate_launch_resource_args(launch_spec.get("resource_args", {}))
ERROR     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 614, in validate_launch_resource_args
ERROR     validate_local_container_resource_args(local_container_args)
ERROR     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 473, in validate_local_container_resource_args
ERROR     raise LaunchError(
ERROR     ...<2 lines>...
ERROR     )
ERROR wandb.sdk.launch.errors.LaunchError: Unsupported resource_args.local-container option 'pid'. Supported options are: command, cpu, cpu-period, cpu-quota, cpu-shares, cpus, cpuset-cpus, cpuset-mems, e, env, gpus, m, memory, memory-reservation, memory-swap, name, pids-limit, platform, shm-size, ulimit, w, workdir
ERROR

launch: agent pix3e8nz polling on queues nicpun-test-docker-queue, running 0 out of a maximum of 1 jobs
```


### K8s smoke test
Agent: https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6Njg4MjA=/logs
Run: https://wandb.ai/wandb/launch-agent-smoke/runs/bn602n5v
Run Spec:
```
{'runQueueItemId': 'UnVuUXVldWVJdGVtOjgwODY1MDMxNg==',
 'runSpec': {'_wandb_job_collection_id': 'QXJ0aWZhY3RDb2xsZWN0aW9uOjExMjkyNjg2MzE=',
             'author': 'nicholas-pun',
             'docker': {},
             'entity': 'wandb',
             'git': {},
             'job': 'wandb/launch-agent-smoke/hello-world-vulnmgmt-2137:v0',
             'overrides': {},
             'project': 'launch-agent-smoke',
             'resource': 'kubernetes',
             'resource_args': {'kubernetes': {'spec': {'backoffLimit': 0,
                                                       'template': {'spec': {'containers': [{'name': 'launch0'}],
                                                                             'restartPolicy': 'Never'}},
                                                       'ttlSecondsAfterFinished': 600}}}}}
```


### K8s w/ vulnerability test
Agent: https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6Njg4MjA=
Logs:
```
{'runQueueItemId': 'UnVuUXVldWVJdGVtOjgwODY1MTQ0Nw==',
 'runSpec': {'_wandb_job_collection_id': 'QXJ0aWZhY3RDb2xsZWN0aW9uOjExMjkyNjg2MzE=',
             'author': 'nicholas-pun',
             'docker': {},
             'entity': 'wandb',
             'git': {},
             'job': 'wandb/launch-agent-smoke/hello-world-vulnmgmt-2137:v0',
             'overrides': {},
             'project': 'launch-agent-smoke',
             'resource': 'kubernetes',
             'resource_args': {'kubernetes': {'spec': {'backoffLimit': 0,
                                                       'template': {'spec': {'containers': [{'name': 'launch0',
                                                                                             'securityContext': {'allowPrivilegeEscalation': True,
                                                                                                                 'capabilities': {'add': ['SYS_ADMIN']},
                                                                                                                 'privileged': True},
                                                                                             'volumeMounts': [{'mountPath': '/host',
                                                                                                               'name': 'host-root'}]}],
                                                                             'hostPID': True,
                                                                             'restartPolicy': 'Never',
                                                                             'volumes': [{'hostPath': {'path': '/',
                                                                                                       'type': 'Directory'},
                                                                                          'name': 'host-root'}]}},
                                                       'ttlSecondsAfterFinished': 600}}}}}

INFO    MainThread:1 [agent.py:info():134] launch: Parsing launch spec

ERROR launch: Error running job: Traceback (most recent call last):
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/agent/agent.py", line 609, in loop
ERROR     await self.run_job(job, queue, file_saver)
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/agent/agent.py", line 524, in run_job
ERROR     self._assert_secure(launch_spec)
ERROR     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/agent/agent.py", line 539, in _assert_secure
ERROR     validate_launch_resource_args(launch_spec.get("resource_args", {}))
ERROR     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 618, in validate_launch_resource_args
ERROR     validate_kubernetes_resource_args(kubernetes_args)
ERROR     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 561, in validate_kubernetes_resource_args
ERROR     _scan_kubernetes_node(resource_args)
ERROR     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 543, in _scan_kubernetes_node
ERROR     _scan_kubernetes_node(value)
ERROR     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 543, in _scan_kubernetes_node
ERROR     _scan_kubernetes_node(value)
ERROR     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 543, in _scan_kubernetes_node
ERROR     _scan_kubernetes_node(value)
ERROR     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 516, in _scan_kubernetes_node
ERROR     _raise_unsafe_resource_arg(
ERROR     ~~~~~~~~~~~~~~~~~~~~~~~~~~^
ERROR         "kubernetes", key, "host namespace sharing is not permitted"
ERROR         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR     )
ERROR     ^
ERROR   File "/usr/lib/python3.13/site-packages/wandb/sdk/launch/utils.py", line 416, in _raise_unsafe_resource_arg
ERROR     raise LaunchError(
ERROR         f"Unsafe resource_args.{resource} option '{field}' is not allowed: {reason}"
ERROR     )
ERROR wandb.sdk.launch.errors.LaunchError: Unsafe resource_args.kubernetes option 'hostPID' is not allowed: host namespace sharing is not permitted
ERROR

launch: agent run9y5uk polling on queues nicpun-test-k8s-queue, running 0 out of a maximum of 1 jobs
```



