### PR TITLE
fix(launch): harden kubernetes additional services

### DIFF
--- a/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
+++ b/tests/unit_tests/test_launch/test_runner/test_kubernetes.py
@@ -1583,6 +1583,15 @@ async def test_launch_additional_services(
         .get("name")
         == expected_pod_name
     )
+    assert (
+        additional_service_call[0][1]
+        .get("spec")
+        .get("template")
+        .get("spec")
+        .get("containers")[0]
+        .get("securityContext")
+        == K8S_RESTRICTED_SECURITY_CONTEXT
+    )
 
     labels = additional_service_call[0][1].get("metadata").get("labels")
     assert "wandb.ai/label" in labels
@@ -1591,6 +1600,102 @@ async def test_launch_additional_services(
     assert (
         labels[WANDB_K8S_LABEL_AUXILIARY_RESOURCE] == expected_auxiliary_resource_label
     )
+
+
+@pytest.mark.asyncio
+async def test_launch_additional_services_rejects_unsafe_config(
+    mock_event_streams,
+    mock_batch_api,
+    mock_kube_context_and_api_client,
+    mock_maybe_create_image_pullsecret,
+    mock_create_from_dict,
+    test_api,
+    manifest,
+    clean_monitor,
+    clean_agent,
+):
+    unsafe_additional_service = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "unsafe-pod"},
+        "spec": {
+            "hostPID": True,
+            "containers": [{"name": "unsafe", "image": "test_image"}],
+        },
+    }
+
+    project = LaunchProject(
+        docker_config={"docker_image": "test_image"},
+        target_entity="test_entity",
+        target_project="test_project",
+        resource_args={"kubernetes": manifest},
+        launch_spec={
+            "additional_services": [
+                {
+                    "config": unsafe_additional_service,
+                    "name": "unsafe_additional_service",
+                }
+            ]
+        },
+        overrides={},
+        resource="kubernetes",
+        api=test_api,
+        git_info={},
+        job="",
+        uri="https://wandb.ai/test_entity/test_project/runs/test_run_id",
+        run_id="test_run_id",
+        name="test_run",
+    )
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    with pytest.raises(
+        LaunchError,
+        match="Unsafe resource_args.kubernetes option 'hostPID'",
+    ):
+        await runner.run(project, "test_image")
+
+    mock_create_from_dict.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_launch_without_additional_services_still_creates_job(
+    mock_event_streams,
+    mock_batch_api,
+    mock_kube_context_and_api_client,
+    mock_maybe_create_image_pullsecret,
+    mock_create_from_dict,
+    test_api,
+    manifest,
+    clean_monitor,
+    clean_agent,
+):
+    project = LaunchProject(
+        docker_config={"docker_image": "test_image"},
+        target_entity="test_entity",
+        target_project="test_project",
+        resource_args={"kubernetes": manifest},
+        launch_spec={},
+        overrides={},
+        resource="kubernetes",
+        api=test_api,
+        git_info={},
+        job="",
+        uri="https://wandb.ai/test_entity/test_project/runs/test_run_id",
+        run_id="test_run_id",
+        name="test_run",
+    )
+    runner = KubernetesRunner(
+        test_api, {"SYNCHRONOUS": False}, MagicMock(), MagicMock()
+    )
+
+    submitted_run = await runner.run(project, "test_image")
+
+    assert submitted_run.id == "test-job"
+    assert mock_create_from_dict.call_count == 1
+    submitted_manifest = mock_create_from_dict.call_args_list[0][0][1]
+    assert submitted_manifest.get("kind") == "Job"
 
 
 def _make_emptydir_manifest(

--- a/wandb/sdk/launch/runner/kubernetes_runner.py
+++ b/wandb/sdk/launch/runner/kubernetes_runner.py
@@ -13,9 +13,8 @@ import time
 from collections.abc import Iterator
 from typing import Any
 
-import yaml
-
 import wandb
+import yaml
 from wandb.apis.internal import Api
 from wandb.sdk.launch.agent.agent import LaunchAgent
 from wandb.sdk.launch.environment.abstract import AbstractEnvironment
@@ -776,6 +775,9 @@ class KubernetesRunner(AbstractRunner):
                     }
                 )
                 cont["env"] = env
+
+        validate_kubernetes_resource_args(config)
+        inject_restricted_security_context(config)
 
         try:
             sanitize_identifiers_for_k8s(config)


### PR DESCRIPTION
## Summary
- Harden Kubernetes `additional_services` configs by running `validate_kubernetes_resource_args(config)` before creation.
- Inject the restricted Kubernetes `securityContext` into additional-service pod specs via `inject_restricted_security_context(config)`.
- Add unit coverage for unsafe additional-service rejection, benign injection, and normal launches with no `additional_services`.

## Security context
This completes the VULNMGMT-2137 objective stacked on PR #12103. PR #12103 hardened launch-agent Kubernetes `resource_args`, but `additional_services` was a parallel create path for non-public Kubernetes queues that could reach `create_from_dict` without the resource-args validator or restricted security context injection. A queue submitter could use that bypass to request privileged Kubernetes objects such as pods with `hostPID`, `hostPath`, or privileged container contexts. This PR fails that path closed before Kubernetes creation.

## Test / lint results
- `uv run pytest tests/unit_tests/test_launch/test_runner/test_kubernetes.py -k "additional_services or without_additional_services_still_creates_job"` -> did not run tests; uv dependency resolution failed for the optional `wandb[sandbox]` / `cwsandbox[cli]` requirement across Python 3.10 markers.
- `.venv/bin/python -m pytest tests/unit_tests/test_launch/test_runner/test_kubernetes.py -k "additional_services or without_additional_services_still_creates_job"` -> 3 passed, 65 deselected.
- `.venv/bin/python -m pytest tests/unit_tests/test_launch/test_runner/test_kubernetes.py` -> 66 passed, 1 skipped, 1 xpassed.
- `.venv/bin/python -m pytest tests/unit_tests/test_launch/test_util.py -k "kubernetes_resource_args"` -> 22 passed, 52 deselected.
- `uvx ruff format --check wandb/sdk/launch/runner/kubernetes_runner.py tests/unit_tests/test_launch/test_runner/test_kubernetes.py && uvx ruff check wandb/sdk/launch/runner/kubernetes_runner.py tests/unit_tests/test_launch/test_runner/test_kubernetes.py` -> 2 files already formatted; all checks passed.
- `git push -u origin fix/vulnmgmt-2137-additional-services` -> pre-push hooks passed, including ruff check, ruff format, generate-stubs, and go-mod-tidy.