### PR TITLE
fix(sdk): skip public API cleanup finalizer in forked children

### DIFF
--- a/tests/unit_tests/test_public_api/test_service_api.py
+++ b/tests/unit_tests/test_public_api/test_service_api.py
@@ -1,6 +1,11 @@
+import gc
+import os
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
+from wandb.apis.public import service_api
 from wandb.apis.public.service_api import ServiceApi
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
@@ -48,3 +53,45 @@ def test_execute_graphql_propagates_core_api_error_response():
         api.execute_graphql("query Viewer { viewer { id } }")
 
     assert exc_info.value.response is error_response
+
+
+def _mock_service(monkeypatch) -> Mock:
+    """Back _get_api_session() with a mock connection and return it."""
+    connection = Mock()
+    connection.api_init_request.return_value = SimpleNamespace(api_id="api-1")
+    monkeypatch.setattr(
+        service_api.wandb_setup,
+        "singleton",
+        lambda: SimpleNamespace(ensure_service=lambda: connection),
+    )
+    return connection
+
+
+def test_cleanup_finalizer_runs_in_owner_process(monkeypatch):
+    connection = _mock_service(monkeypatch)
+
+    api = ServiceApi(Settings())
+    api._get_api_session()
+
+    del api
+    gc.collect()
+
+    connection.api_cleanup_request.assert_called_once_with("api-1")
+
+
+def test_cleanup_finalizer_skips_forked_child(monkeypatch):
+    connection = _mock_service(monkeypatch)
+
+    api = ServiceApi(Settings())
+    api._get_api_session()  # the finalizer records this process's pid
+
+    # Simulate cyclic GC collecting the inherited ServiceApi in a forked child,
+    # where the owning asyncio thread is gone and the cleanup request would
+    # otherwise block forever.
+    child_pid = os.getpid() + 1
+    monkeypatch.setattr(os, "getpid", lambda: child_pid)
+
+    del api
+    gc.collect()
+
+    connection.api_cleanup_request.assert_not_called()

--- a/wandb/apis/public/service_api.py
+++ b/wandb/apis/public/service_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 import weakref
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -25,8 +26,15 @@ from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
 _logger = logging.getLogger(__name__)
 
 
-def _cleanup(connection: ServiceConnection, api_id: str) -> None:
+def _cleanup(connection: ServiceConnection, api_id: str, owner_pid: int) -> None:
     """Clean up the api resources associated with the api id."""
+    # Skip cleanup in a forked child: it inherits this finalizer but not the
+    # asyncio thread that the cleanup request blocks on, so running it here
+    # would deadlock the child. See
+    # https://github.com/wandb/wandb/issues/12079.
+    if os.getpid() != owner_pid:
+        return
+
     with contextlib.suppress(Exception):
         connection.api_cleanup_request(api_id)
 
@@ -71,6 +79,7 @@ class ServiceApi:
             _cleanup,
             session.connection,
             session.api_id,
+            os.getpid(),
         )
 
         return session


### PR DESCRIPTION
Description
-----------
Fixes #12079.
`ServiceApi` registers a `weakref.finalize` that, on GC, calls `api_cleanup_request → AsyncioManager.run → future.result()`. That future is only fulfilled by the asyncio loop **thread**, which is not copied across `fork()`. When a forked child's cyclic GC collects the inherited `ServiceApi`, the finalizer fires and blocks forever — there is no loop thread in the child to complete the request. `contextlib.suppress(Exception)` doesn't help: it's a
hang, not an exception.

The most common real-world trigger is `wandb.Api()` (or any public-API use) together with a PyTorch `DataLoader(num_workers>0)` on Linux (default `fork`): a worker wedges inside GC, batches stop, and training hangs at a random step.

Regressed in 0.25.1 when the public API was (partially) routed through wandb-core.

## Fix

Capture the owning PID when registering the finalizer and skip cleanup if it
runs in a different process. This mirrors the existing fork guards in the SDK
(`Sentry._pid`, `wandb_run._init_pid`). The owning process still performs the
cleanup; the forked child correctly does nothing.



## Minimal repro (no torch needed)

```python
import gc, os, sys, time
from wandb.apis.public.service_api import ServiceApi
from wandb.sdk.wandb_settings import Settings

api = ServiceApi(Settings(mode="offline"))
api._get_api_session()          # registers the finalizer in the parent

if os.fork() == 0:              # child: inherits the object but not the loop thread
    del api; gc.collect()       # collect it -> finalizer fires
    print("child survived"); os._exit(0)

_, status = os.waitpid(0, 0) if False else (None, None)
deadline = time.time() + 5
while time.time() < deadline:
    if os.waitpid(-1, os.WNOHANG)[0]:
        sys.exit(0)
    time.sleep(0.05)
print("DEADLOCK: child stuck in finalizer"); sys.exit(1)
```
Before the fix the child hangs (exit 1); after it, the child prints
`child survived` and exits 0.


- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Adds two unit tests in `test_service_api.py`. The forked-child test fails on
`main` (cleanup is wrongly invoked) and passes with this change; the
owner-process test ensures normal cleanup is unaffected.