### PR TITLE
fix: error instead of deadlocking in AsyncioManager in a forked process

### DIFF
--- a/wandb/sdk/lib/asyncio_manager.py
+++ b/wandb/sdk/lib/asyncio_manager.py
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import contextlib
 import logging
+import os
 import threading
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
@@ -23,6 +24,10 @@ class RunCancelledError(Exception):
 
 class AlreadyJoinedError(Exception):
     """AsyncioManager.run() used after join()."""
+
+
+class ForkedError(Exception):
+    """AsyncioManager used in a forked process where it's not valid."""
 
 
 class AsyncioManager:
@@ -54,6 +59,7 @@ class AsyncioManager:
             name="wandb-AsyncioManager-main",
             daemon=True,
         )
+        self._pid = os.getpid()
         self._lock = threading.Lock()
 
         self._ready_event = threading.Event()
@@ -80,6 +86,8 @@ class AsyncioManager:
 
     def join(self) -> None:
         """Stop accepting new asyncio tasks and wait for the remaining ones."""
+        self._ensure_not_in_fork()
+
         try:
             with self._lock:
                 # If join() was already called, block until the thread completes
@@ -196,6 +204,8 @@ class AsyncioManager:
         daemon: bool,
         name: str | None = None,
     ) -> concurrent.futures.Future[_T]:
+        self._ensure_not_in_fork()
+
         # Wait for _loop to be initialized.
         self._ready_event.wait()
 
@@ -232,6 +242,24 @@ class AsyncioManager:
                     with self._lock:
                         self._remaining_tasks -= 1
                     self._task_finished_cond.notify_all()
+
+    def _ensure_not_in_fork(self) -> None:
+        """Raise an error if we're in a forked process.
+
+        Forks do not inherit threads, so submitting tasks will deadlock in
+        a forked process as these tasks will never run.
+
+        Forking a multithreaded process is generally not valid, and recent
+        Python versions warn about it, but in some cases it is hard to avoid,
+        so this check at least prevents a deadlock.
+        """
+        if (pid := os.getpid()) != self._pid:
+            raise ForkedError(
+                "This operation is not valid in a forked process."
+                + f" Original PID={self._pid}, current PID={pid}."
+                + " Avoid using os.fork() and make sure your multiprocessing"
+                + " start method is 'forkserver' or 'spawn'."
+            )
 
     def _main(self) -> None:
         """Run the asyncio loop until join() is called and all tasks finish."""


### PR DESCRIPTION
Makes `AsyncioManager` detect forks and raise an error. It's still not valid to use in a fork, but it's more helpful to error out immediately than deadlock.

See issue #12079 for an example of a deadlock: forks inherit finalizers, so a forked process that inherits a `ServiceApi` will get stuck in its finalizer when trying to garbage collect it because the finalizer submits an asyncio task.

One might consider using `os.register_at_fork()` to re-create the thread in a forked process, but it's sort of a useless thing to support considering that (1) other objects are still likely to break (like `ServiceConnection`), (2) forking is generally discouraged, and (3) there are workarounds, like using `multiprocessing`'s "forkserver" method which is the default on all POSIX systems from Python 3.14. I'd rather not spread this PID check everywhere (we already have it in `wandb_setup.py` for the singleton object).