### PR TITLE
fix: preserve numpy float NaN (np.float16/32) in logged metrics

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,3 +24,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Saving a linked registry artifact (for example, when adding an alias) no longer fails when the caller lacks write access to the source project (@ibindlish in https://github.com/wandb/wandb/pull/12075)
+- `np.float16`/`np.float32` NaN values logged with `Run.log()` are now recorded as `NaN` instead of being silently dropped, matching `np.float64` and native `float` (@dmitryduev in https://github.com/wandb/wandb/pull/12116)

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -258,6 +258,24 @@ def test_json_dumps_safer_preserves_nonfinite_floats():
     assert "null" not in encoded
 
 
+@pytest.mark.parametrize(
+    "dumps", [util.json_dumps_safer, util.json_dumps_safer_history]
+)
+@pytest.mark.parametrize("dtype", [np.float16, np.float32])
+def test_json_dumps_safer_preserves_numpy_float_nan(dumps, dtype):
+    # numpy floats narrower than float64 are not float subclasses, so they reach
+    # the encoder's default(); they must serialize to "NaN" like native float and
+    # np.float64 do (WB-32475).
+    assert dumps({"nan": dtype("nan")}) == '{"nan":NaN}'
+
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32])
+def test_json_friendly_val_drops_numpy_float_nan(dtype):
+    # json_friendly_val pre-sanitizes values (no JSON serializer involved), so it
+    # keeps dropping NaN to None as it does for native float NaN.
+    assert util.json_friendly_val(dtype("nan")) is None
+
+
 def test_json_dumps_safer_supports_non_string_keys():
     assert util.json_dumps_safer({1: "one"}) == '{"1":"one"}'
 

--- a/tests/unit_tests/test_wandb_run.py
+++ b/tests/unit_tests/test_wandb_run.py
@@ -157,6 +157,20 @@ def test_run_publish_history(mock_run, parse_records, record_q):
     assert history[1]["that"] == "2"
 
 
+def test_run_publish_history_preserves_numpy_float_nan(
+    mock_run, parse_records, record_q
+):
+    run = mock_run()
+    run.log(dict(float16=np.float16("nan"), float32=np.float32("nan")))
+
+    parsed = parse_records(record_q)
+
+    history = parsed.history or parsed.partial_history
+    assert len(history) == 1
+    assert history[0]["float16"] == "NaN"
+    assert history[0]["float32"] == "NaN"
+
+
 @pytest.mark.skipif(
     platform.system() == "Windows",
     reason="numpy.float128 does not exist on windows",

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -542,9 +542,12 @@ def matplotlib_contains_images(obj: Any) -> bool:
     return any(len(ax.images) > 0 for ax in obj.axes)
 
 
-def _numpy_generic_convert(obj: Any) -> Any:
+def _numpy_generic_convert(obj: Any, *, preserve_nan: bool = False) -> Any:
     obj = obj.item()
-    if isinstance(obj, float) and math.isnan(obj):
+    # JSON encoders pass preserve_nan=True so NaN stays a float and the JSON
+    # serializer emits "NaN" for it, matching how native floats and np.float64 (a
+    # float subclass that bypasses this conversion) are serialized (WB-32475).
+    if isinstance(obj, float) and math.isnan(obj) and not preserve_nan:
         obj = None
     elif isinstance(obj, np.generic) and (
         obj.dtype.kind == "f" or obj.dtype == "bfloat16"
@@ -597,6 +600,8 @@ def _sanitize_numpy_keys(
 
 def json_friendly(  # noqa: C901
     obj: Any,
+    *,
+    preserve_numpy_nan: bool = False,
 ) -> tuple[Any, bool] | tuple[None | str | float, bool]:
     """Convert an object into something that's more becoming of JSON."""
     converted = True
@@ -634,7 +639,7 @@ def json_friendly(  # noqa: C901
         elif obj.size <= 32:
             obj = obj.tolist()
     elif np and isinstance(obj, np.generic):
-        obj = _numpy_generic_convert(obj)
+        obj = _numpy_generic_convert(obj, preserve_nan=preserve_numpy_nan)
     elif isinstance(obj, bytes):
         obj = obj.decode("utf-8")
     elif isinstance(obj, (datetime, date)):
@@ -788,7 +793,7 @@ class WandBJSONEncoder(json.JSONEncoder):
             return obj.json_encode()
         # if hasattr(obj, 'to_json'):
         #     return obj.to_json()
-        tmp_obj, converted = json_friendly(obj)
+        tmp_obj, converted = json_friendly(obj, preserve_numpy_nan=True)
         if converted:
             return tmp_obj
         return json.JSONEncoder.default(self, obj)
@@ -812,7 +817,7 @@ class WandBHistoryJSONEncoder(json.JSONEncoder):
     """
 
     def default(self, obj: Any) -> Any:
-        obj, converted = json_friendly(obj)
+        obj, converted = json_friendly(obj, preserve_numpy_nan=True)
         obj, compressed = maybe_compress_history(obj)
         if converted:
             return obj


### PR DESCRIPTION
Description
-----------
Fixes [WB-32475](https://coreweave.atlassian.net/browse/WB-32475).

`np.float16/np.float32` NaN values were silently dropped from logged metrics (serialized as null), while `np.float64` and native float NaN were preserved.
This made NaN points — and their steps — disappear from charts (e.g. x-axis jumping 9 → 13).

Root cause: np.float16/float32 are not `float` subclasses, so the JSON serializer can't encode them directly and falls back to the W&B JSON encoders' `default()` → `json_friendly` → `_numpy_generic_convert`, which converted any float NaN to None. Native float and np.float64 (a float subclass) are encoded directly by the serializer (inf_nan_mode="constants") and emit "NaN", so they were never affected, hence the inconsistency.

Fix: thread a `preserve_numpy_nan` flag through `json_friendly` / `_numpy_generic_convert` and set it in `WandBJSONEncoder` and `WandBHistoryJSONEncoder`, so `numpy` float NaN stays a float and the serializer emits "NaN", matching native/np.float64.

Why a flag instead of preserving everywhere: `json_friendly` has callers with conflicting needs. The encoders want NaN preserved, but `json_friendly_val` feeds artifact-metadata validation via json.dumps(..., allow_nan=False), which RAISES on NaN and relies on the existing NaN→None conversion (see _validators.py). Config/summary paths likewise expect the legacy behavior. So the default stays NaN→None (unchanged for every existing caller) and only the two encoder paths, where the serializer safely renders "NaN", opt in.


[WB-32475]: https://coreweave.atlassian.net/browse/WB-32475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ