### PR TITLE
fix: actually raise errors in `_dtypes.py`

### DIFF
--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -79,10 +79,10 @@ class TypeRegistry:
     ) -> Type:
         wb_type = json_dict.get("wb_type")
         if wb_type is None:
-            TypeError("json_dict must contain `wb_type` key")
+            raise TypeError("json_dict must contain `wb_type` key")
         _type = TypeRegistry.types_by_name().get(wb_type)
         if _type is None:
-            TypeError(f"missing type handler for {wb_type}")
+            raise TypeError(f"missing type handler for {wb_type}")
         return _type.from_json(json_dict, artifact)
 
     @staticmethod
@@ -439,10 +439,6 @@ class ConstType(Type):
     types: t.ClassVar[list[type]] = []
 
     def __init__(self, val: t.Any | None = None, is_set: bool | None = False):
-        if val.__class__ not in [str, int, float, bool, set, list, None.__class__]:
-            TypeError(
-                f"ConstType only supports str, int, float, bool, set, list, and None types. Found {val}"
-            )
         if is_set or isinstance(val, set):
             is_set = True
             assert isinstance(val, (set, list))
@@ -795,7 +791,7 @@ class TypedDictType(Type):
     @classmethod
     def from_obj(cls, py_obj: t.Any | None = None) -> TypedDictType:
         if not isinstance(py_obj, dict):
-            TypeError("TypedDictType.from_obj expects a dictionary")
+            raise TypeError("TypedDictType.from_obj expects a dictionary")
 
         assert isinstance(py_obj, dict)  # helps mypy type checker
         return cls({key: TypeRegistry.type_of(py_obj[key]) for key in py_obj})


### PR DESCRIPTION
Fixes https://coreweave.atlassian.net/browse/WB-34507.

I did a quick search for `(?<!raise|except) TypeError` and `^\s+\w+Error\(` to see if we have any other instances of this... pattern.

I removed the check in `ConstType` because it appears to be wrong based on our own code. The checks in `TypeRegistry.type_from_dict()` look right (if they're skipped, other errors happen). The check in `TypedDictType.from_obj()` is a little sketchy because any dict-like object would technically work *if* asserts were disabled, but asserts are often not disabled.

Helpfully reported in #11890.