### PR TITLE
refactor: don't change global logger in test

### DIFF
--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -119,7 +119,7 @@ func NewConnection(
 	return &Connection{
 		connLifetimeCtx:    connLifetimeCtx,
 		stopConnection:     stopConnection,
-		requestCanceller:   NewRequestCanceller(connLifetimeCtx),
+		requestCanceller:   NewRequestCanceller(connLifetimeCtx, slog.Default()),
 		stopServer:         stopServer,
 		streamMux:          params.StreamMux,
 		runSyncManager:     params.RunSyncManager,

--- a/core/pkg/server/requestcanceller.go
+++ b/core/pkg/server/requestcanceller.go
@@ -14,7 +14,8 @@ const requestCountWarnInterval = 100
 
 // RequestCanceller manages contexts for cancellable requests to wandb-core.
 type RequestCanceller struct {
-	mu sync.Mutex
+	mu     sync.Mutex
+	logger *slog.Logger
 
 	// ctx is the parent context for all requests.
 	ctx context.Context
@@ -30,8 +31,12 @@ type RequestCanceller struct {
 	warnInterval, lastWarnCount int
 }
 
-func NewRequestCanceller(ctx context.Context) *RequestCanceller {
+func NewRequestCanceller(
+	ctx context.Context,
+	logger *slog.Logger,
+) *RequestCanceller {
 	return &RequestCanceller{
+		logger:           logger,
 		ctx:              ctx,
 		requestCtxCancel: make(map[string]func()),
 		warnInterval:     requestCountWarnInterval,
@@ -66,7 +71,7 @@ func (rc *RequestCanceller) Context(id string) (context.Context, func()) {
 	defer rc.mu.Unlock()
 
 	if _, exists := rc.requestCtxCancel[id]; exists {
-		slog.Error("requestcanceller: request ID already exists", "id", id)
+		rc.logger.Error("requestcanceller: request ID already exists", "id", id)
 		return rc.ctx, func() {}
 	}
 
@@ -86,7 +91,7 @@ func (rc *RequestCanceller) Context(id string) (context.Context, func()) {
 		rc.lastWarnCount = count
 
 		message := "server: requestcanceller: many unfinished requests"
-		slog.Warn(message, "count", count)
+		rc.logger.Warn(message, "count", count)
 
 		sentry.WithScope(func(scope *sentry.Scope) {
 			scope.SetTag("count", fmt.Sprintf("%d", count))

--- a/core/pkg/server/requestcanceller_test.go
+++ b/core/pkg/server/requestcanceller_test.go
@@ -14,26 +14,20 @@ import (
 	"github.com/wandb/wandb/core/pkg/server"
 )
 
-// captureSlog redirects slog to a buffer for the duration of the test.
-func captureSlog(t *testing.T) *bytes.Buffer {
+// capturingLogger returns a buffer and a logger that writes to it.
+func capturingLogger(t *testing.T) (*bytes.Buffer, *slog.Logger) {
 	t.Helper()
 
-	prev := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(prev) })
-
-	var logs bytes.Buffer
-	slog.SetDefault(slog.New(
-		slog.NewTextHandler(&logs, &slog.HandlerOptions{}),
-	))
-
-	return &logs
+	logs := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{}))
+	return logs, logger
 }
 
 func TestRequestCanceller_WarnsAtEachThreshold(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		logs := captureSlog(t)
+		logs, logger := capturingLogger(t)
 
-		rc := server.NewRequestCanceller(t.Context())
+		rc := server.NewRequestCanceller(t.Context(), logger)
 		rc.SetWarnInterval(2)
 
 		_, cancel1 := rc.Context("1")


### PR DESCRIPTION
Uses an explicit logger in `requestcanceller.go` instead of changing the `slog` default to avoid this rare conflict between concurrent tests: https://github.com/wandb/wandb/actions/runs/28267172802/job/83756538881?pr=11573#step:5:142