### PR TITLE
chore(automations): make create/delete system tests additive

### DIFF
--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -18,6 +18,7 @@ from wandb.automations import (
     MetricChangeFilter,
     MetricThresholdFilter,
     MetricZScoreFilter,
+    NewAutomation,
     OnAddArtifactAlias,
     OnCreateArtifact,
     OnLinkArtifact,
@@ -40,6 +41,16 @@ from wandb.errors.errors import CommError
 @fixture
 def automation_name(make_name: Callable[[str], str]) -> str:
     return make_name(prefix="test-automation")
+
+
+@fixture
+def webhook_automation(project: Project, webhook: WebhookIntegration) -> NewAutomation:
+    """A simple valid automation for tests that don't vary the event, action, or scope."""
+    event = OnLinkArtifact(
+        scope=project,
+        filter=ArtifactEvent.alias.matches_regex("^my-artifact.*"),
+    )
+    return event >> SendWebhook.from_integration(webhook)
 
 
 @fixture
@@ -120,6 +131,9 @@ def test_fetch_slack_integrations(
     assert len(fetched_slack_integrations) == 0
 
 
+# Pin the action to a webhook so this exercises every event type and scope once
+# (a no-op action is covered separately below), instead of once per action type.
+@mark.parametrize("action_type", [ActionType.GENERIC_WEBHOOK], indirect=True)
 @mark.usefixtures(reset_automations.__name__)
 def test_create_automation(
     module_user: str,
@@ -158,18 +172,33 @@ def test_create_automation(
 
 
 @mark.usefixtures(reset_automations.__name__)
-def test_create_existing_automation_raises_by_default_if_existing(
+def test_create_automation_with_no_op_action(
     module_api: wandb.Api,
-    event,
-    action,
+    webhook_automation: NewAutomation,
     automation_name: str,
 ):
+    """The no-op action round-trips through the server, like the webhook action above."""
+    if not module_api._supports_automation(action=ActionType.NO_OP):
+        skip("Server does not support the no-op action")
+
     created = module_api.create_automation(
-        (event >> action),
-        name=automation_name,
+        (webhook_automation.event >> DoNothing()), name=automation_name
     )
+
+    refetched = module_api.automation(name=created.name)
+    assert isinstance(refetched.action, SavedNoOpAction)
+
+
+# Duplicate-name detection is independent of the event, action, and scope.
+@mark.usefixtures(reset_automations.__name__)
+def test_create_existing_automation_raises_by_default_if_existing(
+    module_api: wandb.Api,
+    webhook_automation: NewAutomation,
+    automation_name: str,
+):
+    created = module_api.create_automation(webhook_automation, name=automation_name)
     with raises(CommError):
-        module_api.create_automation((event >> action), name=created.name)
+        module_api.create_automation(webhook_automation, name=created.name)
 
     # Fetching the automation by name should return the original automation,
     # unchanged.
@@ -189,19 +218,15 @@ def test_create_existing_automation_raises_by_default_if_existing(
 @mark.usefixtures(reset_automations.__name__)
 def test_create_existing_automation_fetches_existing_if_requested(
     module_api: wandb.Api,
-    event,
-    action,
+    webhook_automation: NewAutomation,
     automation_name: str,
 ):
-    created = module_api.create_automation(
-        (event >> action),
-        name=automation_name,
-    )
+    created = module_api.create_automation(webhook_automation, name=automation_name)
 
     # Since we request the prior automation if it exists, any extra values
     # that would normally be set on the created object will be ignored.
     existing = module_api.create_automation(
-        (event >> action),
+        webhook_automation,
         name=created.name,
         description="ignored description",
         fetch_existing=True,
@@ -476,15 +501,11 @@ def test_create_automation_for_run_metric_zscore_event(
 def created_automation(
     module_api: wandb.Api,
     reset_automations,
-    event,
-    action,
+    webhook_automation: NewAutomation,
     automation_name: str,
 ) -> Automation:
-    """An already-created automation that we can use for testing."""
-    created = module_api.create_automation(
-        (event >> action),
-        name=automation_name,
-    )
+    """An already-created automation for tests of deletion, which is event/action/scope-independent."""
+    created = module_api.create_automation(webhook_automation, name=automation_name)
 
     # Fetch the automation by name (avoids the off-by-1 index issue on older servers)
     fetched = module_api.automation(name=created.name)


### PR DESCRIPTION
Description
-----------
Second PR in the stack streamlining the automations **system** tests (stacked on #12130). The create and delete tests inherited the full `event × action × scope` product (~38 cases each) via the shared `event`/`action` fixtures, even though duplicate-name detection and deletion are independent of all three axes, and create only needs each event/action/scope round-tripped through the server once.

Changes:
- **`test_create_automation`** now pins the action to a webhook (`@mark.parametrize("action_type", [GENERIC_WEBHOOK], indirect=True)`), so it exercises each event type and scope **once** (19 cases) instead of once per action type. It still parametrizes over the conftest `event` fixture, so **new `EventType`s are auto-covered**.
- New **`test_create_automation_with_no_op_action`** covers the other testable action (NO_OP) on create, so both actions still round-trip.
- The two **`test_create_existing_*`** tests and the **`created_automation`** fixture (which drives the three `test_delete_*` tests) now build a single canonical automation via a shared `webhook_automation` fixture, since their behavior doesn't depend on the event/action/scope.
- Kept as-is: the four `test_create_automation_for_run_*` tests, `TestPaginatedAutomations`, `test_fetch_*_integrations`, `test_no_initial_*`, and `test_delete_automation_raises_on_invalid_id`.

Effect (verified via `--collect-only`, no backend):
- Create/delete cases: **~228 → 25**.
- Full `tests/system_tests/test_automations` module: **274 → 71** (831 → 71 cumulatively with #12130).

Coverage at the system level is preserved: every valid event type, both testable actions (webhook + no-op), and both scope types still round-trip through the real server at least once. Combination correctness remains covered by the no-backend unit tests in `tests/unit_tests/test_automations`.

Note: the original plan suggested 12 cases for `test_create_automation` (event-only, natural scope); this keeps 19 (each valid event × scope once) because collapsing the scope cleanly would mean hardcoded pairs (losing auto-coverage of new event types) or importing conftest internals. Pinning the action removes the dominant multiplier while keeping auto-coverage. Easy to switch to explicit pairs if preferred.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable (test-only change; not applicable)

Testing
-------
- `pytest tests/system_tests/test_automations --collect-only -q` confirms the counts above and the per-test distribution (`test_create_automation` ×19; all other create/delete tests ×1).
- `ruff check` / `ruff format --check` pass.
- Full system-test run against `local-testcontainer` exercises the behavior in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_015gmpnpsqDD65xLA8KCdy87)_