### PR TITLE
fix(sandbox): set default lifetime to 12h for serverless sandboxes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ This version drops compatibility with server versions older than 0.67.0.
 - `wandb sync` now routes to `wandb beta sync` for supported parameter sets (@timoffex in https://github.com/wandb/wandb/pull/12093)
   - Restore original behavior with `--legacy`
 - Dropped support for protobuf v4 (@jacobromero in https://github.com/wandb/wandb/pull/12115)
+- `wandb.sandbox` now defaults serverless sandboxes to a 12-hour max lifetime (`max_lifetime_seconds=43200`); override per sandbox with `max_lifetime_seconds` or via `SandboxDefaults` (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12136)
 
 ### Removed
 

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import cwsandbox
 import pytest
 import wandb.sandbox as wandb_sandbox
@@ -218,3 +220,71 @@ def test_sandbox_classmethod_session_uses_wandb_session_wrapper() -> None:
     session = wandb_sandbox.Sandbox.session()
 
     assert isinstance(session, wandb_sandbox.Session)
+
+
+def test_sandbox_applies_default_max_lifetime_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_init(self, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(sandbox_module._BaseSandbox, "__init__", fake_init)
+
+    wandb_sandbox.Sandbox()
+
+    assert (
+        calls[0]["defaults"].max_lifetime_seconds
+        == sandbox_module._SERVERLESS_DEFAULT_MAX_LIFETIME_SECONDS
+    )
+
+
+def test_sandbox_explicit_max_lifetime_seconds_skips_default_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_init(self, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(sandbox_module._BaseSandbox, "__init__", fake_init)
+
+    wandb_sandbox.Sandbox(max_lifetime_seconds=60)
+
+    assert calls[0]["max_lifetime_seconds"] == 60
+    assert "defaults" not in calls[0]
+
+
+def test_sandbox_respects_explicit_default_max_lifetime_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_init(self, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(sandbox_module._BaseSandbox, "__init__", fake_init)
+
+    defaults = cwsandbox.SandboxDefaults(max_lifetime_seconds=7200)
+    wandb_sandbox.Sandbox(defaults=defaults)
+
+    assert calls[0]["defaults"].max_lifetime_seconds == 7200
+
+
+def test_sandbox_session_applies_default_max_lifetime_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[Any] = []
+
+    def fake_init(self, defaults=None, report_to=None):
+        calls.append(defaults)
+
+    monkeypatch.setattr(sandbox_module._BaseSession, "__init__", fake_init)
+
+    wandb_sandbox.Session()
+
+    assert (
+        calls[0].max_lifetime_seconds
+        == sandbox_module._SERVERLESS_DEFAULT_MAX_LIFETIME_SECONDS
+    )

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -11,6 +11,7 @@ from wandb.errors import UsageError
 
 _PLACEMENT_OVERRIDE_FIELDS = ("profile_ids", "profile_names", "runner_ids")
 _SUPPORTED_EGRESS_MODES = ("internet", "none")
+_SERVERLESS_DEFAULT_MAX_LIFETIME_SECONDS = 12 * 60 * 60
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -86,6 +87,36 @@ def _reject_invalid_kwargs(kwargs: Mapping[str, Any]) -> None:
     _reject_unsupported_egress_mode(kwargs.get("network"))
 
 
+def _with_serverless_max_lifetime_default(
+    defaults: SandboxDefaults | Mapping[str, Any] | None,
+) -> SandboxDefaults:
+    if defaults is None:
+        return SandboxDefaults(
+            max_lifetime_seconds=_SERVERLESS_DEFAULT_MAX_LIFETIME_SECONDS
+        )
+
+    if isinstance(defaults, Mapping):
+        coerced = SandboxDefaults.from_dict(defaults)
+        if coerced.max_lifetime_seconds is not None:
+            return coerced
+        return coerced.with_overrides(
+            max_lifetime_seconds=_SERVERLESS_DEFAULT_MAX_LIFETIME_SECONDS
+        )
+
+    if defaults.max_lifetime_seconds is not None:
+        return defaults
+
+    return defaults.with_overrides(
+        max_lifetime_seconds=_SERVERLESS_DEFAULT_MAX_LIFETIME_SECONDS
+    )
+
+
+def _apply_serverless_defaults_kwargs(kwargs: dict[str, Any]) -> None:
+    if kwargs.get("max_lifetime_seconds") is not None:
+        return
+    kwargs["defaults"] = _with_serverless_max_lifetime_default(kwargs.get("defaults"))
+
+
 def _reject_invalid_defaults(
     defaults: SandboxDefaults | Mapping[str, Any] | None,
 ) -> None:
@@ -133,6 +164,7 @@ class Sandbox(_BaseSandbox):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             _reject_invalid_kwargs(kwargs)
             _reject_invalid_defaults(kwargs.get("defaults"))
+            _apply_serverless_defaults_kwargs(kwargs)
             super().__init__(*args, **kwargs)
 
     @classmethod
@@ -152,7 +184,10 @@ class Session(_BaseSession):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             if args:
                 _reject_invalid_defaults(args[0])
-            _reject_invalid_defaults(kwargs.get("defaults"))
+                args = (_with_serverless_max_lifetime_default(args[0]), *args[1:])
+            else:
+                _reject_invalid_defaults(kwargs.get("defaults"))
+                _apply_serverless_defaults_kwargs(kwargs)
             super().__init__(*args, **kwargs)
 
         def sandbox(


### PR DESCRIPTION
Description
-----------
Set default on serverless sandboxes to 12h so that users don't rack up cost if they forget about sandboxes in response to https://coreweave.slack.com/archives/C0ANRC5A7RN/p1782841383864069. Users can still override this if they set the TTL manually.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Added unit tests