### PR TITLE
chore: use ty for python type checking

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,5 +21,4 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv tool install prek
-          prek run --hook-stage pre-commit --all-files
           prek run --hook-stage pre-push --all-files --skip go-generate-graphql

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,4 +21,5 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv tool install prek
+          prek run --hook-stage pre-commit --all-files
           prek run --hook-stage pre-push --all-files --skip go-generate-graphql

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,13 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: "v0.0.56"
+    hooks:
+      # Type-check with ty on every commit.
+      # ty's coverage and rule config live in [tool.ty] in pyproject.toml.
+      - id: ty
+        stages: [pre-commit]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v22.1.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       # Type-check with ty on every commit.
       # ty's coverage and rule config live in [tool.ty] in pyproject.toml.
       - id: ty
+        args: ["--isolated"] # --isolated stops `uv check` from writing a uv.lock.
         stages: [pre-commit]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v22.1.5

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["astral-sh.ty"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,7 +360,7 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["wandb"]
-exclude = ["wandb/vendor"]
+exclude = ["wandb/vendor", "wandb/proto"]
 
 [tool.ty.rules]
 unresolved-attribute = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,9 @@ launch = [
 ]
 models = ["cloudpickle"]
 workspaces = ["wandb-workspaces"]
-sandbox = ["cwsandbox[cli]>=0.20.0"]
-eval-table = [  # wandb.EvalTable support (private testing only)
+# cwsandbox requires Python >=3.11, so this extra is unavailable on 3.10.
+sandbox = ["cwsandbox[cli]>=0.20.0; python_version >= '3.11'"]
+eval-table = [ # wandb.EvalTable support (private testing only)
     "weave>=0.52.41",
 ]
 
@@ -112,9 +113,7 @@ eval-table = [  # wandb.EvalTable support (private testing only)
 # TODO: Currently, wandb[media] requires moviepy>=1.0.0, while
 # weave[video_support] requires moviepy<=1.0.3. We should reconcile these
 # dependencies (and probably make weave support moviepy>=2).
-eval-table-video-support = [
-    "weave[video_support]>=0.52.41",
-]
+eval-table-video-support = ["weave[video_support]>=0.52.41"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -355,6 +354,41 @@ ignore-decorators = [
 
 # TODO: Remove the landfill/ directory.
 "landfill/**" = ["F405", "N806", "D415"]
+
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.src]
+include = ["wandb"]
+exclude = ["wandb/vendor"]
+
+[tool.ty.rules]
+unresolved-attribute = "ignore"
+invalid-argument-type = "ignore"
+unused-type-ignore-comment = "ignore"
+possibly-missing-submodule = "ignore"
+unknown-argument = "ignore"
+unresolved-import = "ignore"
+invalid-assignment = "ignore"
+invalid-method-override = "ignore"
+invalid-return-type = "ignore"
+missing-argument = "ignore"
+call-non-callable = "ignore"
+not-subscriptable = "ignore"
+deprecated = "ignore"
+no-matching-overload = "ignore"
+invalid-attribute-override = "ignore"
+invalid-type-form = "ignore"
+invalid-key = "ignore"
+not-iterable = "ignore"
+unresolved-reference = "ignore"
+unsupported-operator = "ignore"
+invalid-frozen-dataclass-subclass = "ignore"
+call-top-callable = "ignore"
+invalid-explicit-override = "ignore"
+redundant-cast = "ignore"
+subclass-of-final-class = "ignore"
+invalid-parameter-default = "ignore"
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]


### PR DESCRIPTION
Description
-----------
`ty` (by Astral) is the fast rust-backed python type checker I think we should migrate to. 

With this PR, it will run on every commit via the `ty` prek hook. The first invocation locally will take a moment, but should be blazing fast™️ from then on.

This is the first of a series: mypy stays in CI as a safety net for now, the silenced rules will get lifted incrementally in follow-up PRs, and the final PR will likely remove mypy entirely.

Coverage is scoped to match mypy today (the `wandb` package, minus vendored code), and every rule that currently fires is set to "ignore" so the check is green from day one.
