### PR TITLE
fix: reduce system_tests xdist parallelism to curb OOM worker kills

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -247,8 +247,15 @@ def system_tests(session: nox.Session) -> None:
     run_pytest(
         session,
         paths=paths,
-        # TODO: consider relaxing this once the test memory usage is under control.
-        opts={"n": "8"},
+        # Run with fewer workers than the box has CPUs. Each worker imports
+        # heavy deps (tensorflow, torch) and holds 700MB+ resident, so at n=8
+        # the memory-capped CI pods OOM-kill workers mid-test. xdist then
+        # reports the killed worker as "node down: Not properly terminated" and
+        # fails whatever test it was running -- surfacing as flaky, unrelated
+        # failures spread across the suite. n=4 matches functional_tests, which
+        # dropped to 4 for the same reason.
+        # TODO: raise back toward n=8 once per-worker memory is under control.
+        opts={"n": "4"},
     )
 
 


### PR DESCRIPTION
## Root cause (confirmed from CI logs)

System-test flakiness is dominated by **`pytest-xdist` worker crashes**, not test logic. Evidence from the raw CircleCI job logs (public v1.1 API) across my branch **and** `main`:

- ~**13 of 45 recent `main` system-test jobs (~29%)** have a worker die. The signature is always:
  ```
  [gwN] node down: Not properly terminated
  replacing crashed worker gwN
  worker 'gwN' crashed while running <whatever test it happened to be on>
  ```
- There is **no Python traceback, no `+++ Timeout +++` dump, and no `MemoryError`** before the death — the worker just vanishes. That's the signature of an **abrupt `SIGKILL` (OOM killer)**, not a per-test timeout or a Python exception.
- The reported "failing tests" are just whatever was running on the killed worker — **victims, not causes**. This is why the failures looked like ~40 unrelated flaky tests with no dominant offender.

Each xdist worker imports heavy deps (tensorflow, torch) and holds **700MB+ resident**; at `-n=8` in the memory-capped CI pods this exhausts RAM. `functional_tests` already dropped to `-n=4` for exactly this reason (see its noxfile comment).

## Fix

Drop `system_tests` from `-n=8` to `-n=4`, matching `functional_tests`. This reduces peak memory to keep workers under the pod limit.

## Honesty about verification

- I **cannot** fully prove OOM-elimination in a single CI run — worker kills are probabilistic (~1 per affected job), so this needs to be watched over several runs.
- Definitive confirmation of the OOM killer (pod `dmesg` / Datadog pod-memory metrics) needs **cluster access** (`ci-cluster`), which I can't reach from a sandbox. That's the one remaining "SSH into the cluster" step.
- Tradeoff: `-n=4` roughly doubles system-test wall-clock. If that's too costly, alternatives are raising the CI pod memory limit or trimming per-worker imports.

## Superseded

An earlier version of this PR tried to (a) harden `backend_fixtures._send()` retries and (b) activate `@pytest.mark.flaky` via the `flaky` plugin. Both were **backed out**: the `flaky` plugin crashed xdist workers, and the retry change targeted a near-nonexistent failure mode while *worsening* teardown (it retried best-effort cleanup, correlating with more worker kills). See history.
