### PR TITLE
fix(artifacts): restore Api._artifact method name

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1599,7 +1599,7 @@ class Api:
         )
 
     @normalize_exceptions
-    def _artifact_from_name(self, name: str, type: str | None = None) -> Artifact:
+    def _artifact(self, name: str, type: str | None = None) -> Artifact:
         from wandb.sdk.artifacts._validators import (
             FullArtifactPath,
             is_artifact_registry_project,
@@ -1701,7 +1701,7 @@ class Api:
         ```
 
         """
-        return self._artifact_from_name(name=name, type=type)
+        return self._artifact(name=name, type=type)
 
     @normalize_exceptions
     def job(self, name: str | None, path: str | None = None) -> public.Job:
@@ -1829,7 +1829,7 @@ class Api:
 
         """
         try:
-            self._artifact_from_name(name, type)
+            self._artifact(name, type)
         except wandb.errors.CommError as e:
             if _is_service_api_transport_error(e.exc):
                 raise

--- a/wandb/apis/public/jobs.py
+++ b/wandb/apis/public/jobs.py
@@ -52,7 +52,7 @@ class Job:
         service_api: ServiceApi | None = None,
     ) -> None:
         try:
-            self._job_artifact = api._artifact_from_name(name, type="job")
+            self._job_artifact = api._artifact(name, type="job")
         except CommError:
             raise CommError(f"Job artifact {name} not found")
         if path:
@@ -105,9 +105,7 @@ class Job:
         if is_id:
             code_artifact = self._api._artifact_from_id(artifact_string)
         else:
-            code_artifact = self._api._artifact_from_name(
-                name=artifact_string, type="code"
-            )
+            code_artifact = self._api._artifact(name=artifact_string, type="code")
         if code_artifact is None:
             raise LaunchError("No code artifact found")
         if code_artifact.state == ArtifactState.DELETED:

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2489,9 +2489,7 @@ class Artifact:
             raise ValueError("Unable to parse linked artifact version from response")
 
         link_name = f"{target.to_str()}:v{version_idx}"
-        return Api(overrides={"entity": self.source_entity})._artifact_from_name(
-            link_name
-        )
+        return Api(overrides={"entity": self.source_entity})._artifact(link_name)
 
     @ensure_logged
     def unlink(self) -> None:

--- a/wandb/sdk/launch/_launch_add.py
+++ b/wandb/sdk/launch/_launch_add.py
@@ -242,7 +242,7 @@ def _launch_add(
     public_api = public.Api()
     if job is not None:
         try:
-            public_api._artifact_from_name(job, type="job")
+            public_api._artifact(job, type="job")
         except (ValueError, CommError) as e:
             raise LaunchError(f"Unable to fetch job with name {job}: {e}")
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1376,7 +1376,7 @@ class Run:
             if is_id:
                 artifact = public_api._artifact_from_id(artifact_string)
             else:
-                artifact = public_api._artifact_from_name(name=artifact_string)
+                artifact = public_api._artifact(name=artifact_string)
             # in the future we'll need to support using artifacts from
             # different instances of wandb.
 
@@ -3117,7 +3117,7 @@ class Run:
         if isinstance(artifact_or_name, str):
             name = artifact_or_name
             public_api = self._public_api()
-            artifact = public_api._artifact_from_name(type=type, name=name)
+            artifact = public_api._artifact(type=type, name=name)
             if type is not None and type != artifact.type:
                 raise ValueError(
                     f"Supplied type {type} does not match type {artifact.type} of artifact {artifact.name}"
@@ -3606,7 +3606,7 @@ class Run:
 
         public_api = self._public_api()
         try:
-            artifact = public_api._artifact_from_name(name=f"{name}:latest")
+            artifact = public_api._artifact(name=f"{name}:latest")
             if "model" not in str(artifact.type.lower()):
                 raise AssertionError(
                     "You can only use this method for 'model' artifacts."


### PR DESCRIPTION
Description
-----------

Stacked on top of #12112.

#12112 renamed `Api._artifact` → `Api._artifact_from_name`. The rename was applied to the source callers but not to the unit test `tests/unit_tests/test_launch/test_job.py`, which still stubs `mock_api._artifact.return_value`. Because the code now called `_artifact_from_name`, the mock no longer intercepted the call and the CircleCI `main` workflow failed.

This PR restores the original method name `_artifact` across all call sites, which realigns the code with the existing tests. The EOL cleanup from #12112 (dropping the `ArtifactByName` fallback query, the `PROJECT_ARTIFACT_COLLECTION_MEMBERSHIP` check, and the `enable_tracking` argument) is left intact — only the method name is reverted.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable — not applicable (internal method rename only)

Testing
-------

`ruff format` clean. Restores alignment with the existing `test_launch/test_job.py` unit tests that mock `Api._artifact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMzNwUJJdnZXB2YUHhqZUb)_