### PR TITLE
feat(sdk): add Run.log_lines() to read console logs

### DIFF
--- a/tests/unit_tests/test_public_api/test_log_lines.py
+++ b/tests/unit_tests/test_public_api/test_log_lines.py
@@ -87,7 +87,9 @@ def test_log_line_exposes_all_fields():
 def test_len_is_log_line_count():
     service_api = mock.MagicMock()
     run = _run(service_api)
-    service_api.execute_graphql.return_value = _page(42, [_node(0, "x")], has_next=False)
+    service_api.execute_graphql.return_value = _page(
+        42, [_node(0, "x")], has_next=False
+    )
 
     assert len(run.log_lines()) == 42
 

--- a/tests/unit_tests/test_public_api/test_log_lines.py
+++ b/tests/unit_tests/test_public_api/test_log_lines.py
@@ -1,0 +1,154 @@
+from unittest import mock
+
+import pytest
+from wandb.apis.public.log_lines import LogLine, LogLines
+from wandb.apis.public.runs import Run
+
+
+def _run(service_api):
+    return Run(
+        service_api=service_api,
+        entity="entity",
+        project="project",
+        run_id="run-id",
+        attrs={"name": "run-id", "state": "finished"},
+    )
+
+
+def _node(number, line, **overrides):
+    node = {
+        "number": number,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "level": "info",
+        "label": "",
+        "line": line,
+    }
+    node.update(overrides)
+    return {"node": node, "cursor": f"c{number}"}
+
+
+def _page(log_line_count, edges, has_next, end_cursor="c"):
+    return {
+        "project": {
+            "run": {
+                "logLineCount": log_line_count,
+                "logLines": {
+                    "edges": edges,
+                    "pageInfo": {"endCursor": end_cursor, "hasNextPage": has_next},
+                },
+            }
+        }
+    }
+
+
+def test_run_log_lines_returns_paginator():
+    service_api = mock.MagicMock()
+    run = _run(service_api)
+    assert isinstance(run.log_lines(), LogLines)
+
+
+def test_tail_is_a_single_request():
+    service_api = mock.MagicMock()
+    run = _run(service_api)
+    service_api.execute_graphql.return_value = _page(
+        1512, [_node(1510, "second to last"), _node(1511, "last")], has_next=False
+    )
+
+    lines = list(run.log_lines(last=2))
+
+    assert [line.line for line in lines] == ["second to last", "last"]
+    assert isinstance(lines[0], LogLine)
+    # tail = exactly one request, carrying `last`, not forward-pagination args
+    assert service_api.execute_graphql.call_count == 1
+    variables = service_api.execute_graphql.call_args.kwargs["variables"]
+    assert variables["last"] == 2
+    assert variables["first"] is None
+    assert variables["after"] is None
+
+
+def test_log_line_exposes_all_fields():
+    service_api = mock.MagicMock()
+    run = _run(service_api)
+    service_api.execute_graphql.return_value = _page(
+        1,
+        [_node(7, "boom", level="error", label="rank-1")],
+        has_next=False,
+    )
+
+    (line,) = list(run.log_lines())
+
+    assert line.number == 7
+    assert line.line == "boom"
+    assert line.level == "error"
+    assert line.label == "rank-1"
+    assert line.timestamp == "2026-01-01T00:00:00Z"
+
+
+def test_len_is_log_line_count():
+    service_api = mock.MagicMock()
+    run = _run(service_api)
+    service_api.execute_graphql.return_value = _page(42, [_node(0, "x")], has_next=False)
+
+    assert len(run.log_lines()) == 42
+
+
+def test_tail_len_is_tail_size_not_run_total():
+    service_api = mock.MagicMock()
+    run = _run(service_api)
+    service_api.execute_graphql.return_value = _page(
+        1512, [_node(1510, "a"), _node(1511, "b")], has_next=False
+    )
+
+    tail = run.log_lines(last=2)
+
+    # tail reports the fetched tail (2), not the run's total logLineCount (1512)
+    assert len(tail) == 2
+    assert [line.number for line in tail] == [1510, 1511]
+
+
+def test_unsupported_server_raises_before_querying():
+    service_api = mock.MagicMock()
+    service_api.feature_enabled.return_value = False
+    run = _run(service_api)
+
+    with pytest.raises(ValueError, match="structured console logs"):
+        run.log_lines()
+
+    service_api.execute_graphql.assert_not_called()
+
+
+def test_forward_pagination_advances_cursor():
+    service_api = mock.MagicMock()
+    run = _run(service_api)
+    pages = [
+        _page(3, [_node(0, "l0"), _node(1, "l1")], has_next=True, end_cursor="cA"),
+        _page(3, [_node(2, "l2")], has_next=False, end_cursor="cB"),
+    ]
+    # The paginator reuses one `variables` dict (like `Files`), so snapshot each
+    # call's variables here rather than reading the shared, mutated reference.
+    seen = []
+
+    def fake_execute(query, variables=None, **kwargs):
+        seen.append(dict(variables))
+        return pages[len(seen) - 1]
+
+    service_api.execute_graphql.side_effect = fake_execute
+
+    numbers = [line.number for line in run.log_lines(per_page=2)]
+
+    assert numbers == [0, 1, 2]
+    assert len(seen) == 2
+    assert seen[0]["first"] == 2
+    assert seen[0]["after"] is None
+    assert seen[0]["last"] is None
+    # second page resumes from the last edge cursor of the first page
+    assert seen[1]["after"] == "c1"
+
+
+def test_empty_log():
+    service_api = mock.MagicMock()
+    run = _run(service_api)
+    service_api.execute_graphql.return_value = _page(0, [], has_next=False)
+
+    assert list(run.log_lines()) == []
+    assert len(run.log_lines()) == 0

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -13,6 +13,8 @@ __all__ = (
     "Automations",
     "File",
     "Files",
+    "LogLine",
+    "LogLines",
     "HistoryScan",  # doc:exclude
     "IncompleteRunHistoryError",
     "SlackIntegrations",  # doc:exclude
@@ -57,6 +59,7 @@ from wandb.apis.public.artifacts import (
 from wandb.apis.public.automations import Automations
 from wandb.apis.public.files import FILE_FRAGMENT, File, Files
 from wandb.apis.public.history import HistoryScan
+from wandb.apis.public.log_lines import LOG_LINES_FRAGMENT, LogLine, LogLines
 from wandb.apis.public.integrations import SlackIntegrations, WebhookIntegrations
 from wandb.apis.public.jobs import (
     Job,

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -59,7 +59,6 @@ from wandb.apis.public.artifacts import (
 from wandb.apis.public.automations import Automations
 from wandb.apis.public.files import FILE_FRAGMENT, File, Files
 from wandb.apis.public.history import HistoryScan
-from wandb.apis.public.log_lines import LOG_LINES_FRAGMENT, LogLine, LogLines
 from wandb.apis.public.integrations import SlackIntegrations, WebhookIntegrations
 from wandb.apis.public.jobs import (
     Job,
@@ -69,6 +68,7 @@ from wandb.apis.public.jobs import (
     RunQueuePrioritizationMode,
     RunQueueResourceType,
 )
+from wandb.apis.public.log_lines import LOG_LINES_FRAGMENT, LogLine, LogLines
 from wandb.apis.public.projects import Project, Projects, Sweeps
 from wandb.apis.public.query_generator import QueryGenerator
 from wandb.apis.public.registries import Registries, Registry

--- a/wandb/apis/public/log_lines.py
+++ b/wandb/apis/public/log_lines.py
@@ -1,0 +1,188 @@
+"""W&B Public API for run console log lines.
+
+This module exposes a run's streamed console log (`logLines`) through the public
+API.
+
+Example:
+```python
+from wandb.apis.public import Api
+
+run = Api().run("entity/project/run_id")
+
+# Tail (single request) — good for crash diagnosis of a running run.
+for line in run.log_lines(last=200):
+    print(line.line)
+
+# Full forward pagination.
+for line in run.log_lines():
+    print(line.number, line.line)
+```
+
+Note:
+    For a finished or crashed run, downloading `output.log` via `run.files()`
+    is usually faster (one static file). Prefer `log_lines()` for a run that is
+    still running (no file yet) or for a cheap tail.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from wandb.apis.attrs import Attrs
+from wandb.apis.paginator import SizedPaginator
+
+if TYPE_CHECKING:
+    from wandb.apis.public.runs import Run
+    from wandb.apis.public.service_api import ServiceApi
+
+LOG_LINES_FRAGMENT = """fragment RunLogLinesFragment on Run {
+    logLines(first: $first, after: $after, last: $last) {
+        edges {
+            node {
+                number
+                timestamp
+                level
+                label
+                line
+            }
+            cursor
+        }
+        pageInfo {
+            endCursor
+            hasNextPage
+        }
+    }
+}"""
+
+
+class LogLines(SizedPaginator["LogLine"]):
+    """A lazy iterator over a run's console log lines.
+
+    Backed by the `logLines` connection, fetched page-by-page. Length is the
+    run's `logLineCount`.
+    """
+
+    def _get_query(self) -> str:
+        return f"""#graphql
+            query RunLogLines($project: String!, $entity: String!, $name: String!,
+                $first: Int, $after: String, $last: Int) {{
+                project(name: $project, entityName: $entity) {{
+                    run(name: $name) {{
+                        logLineCount
+                        ...RunLogLinesFragment
+                    }}
+                }}
+            }}
+            {LOG_LINES_FRAGMENT}
+            """
+
+    def __init__(
+        self,
+        service_api: ServiceApi,
+        run: Run,
+        per_page: int = 1000,
+        last: int | None = None,
+    ):
+        """Initialize a lazy iterator over a run's console log lines.
+
+        Args:
+            service_api: The service API instance used to query W&B.
+            run: The run whose console log is read.
+            per_page (int): Number of lines to fetch per page during forward
+                pagination.
+            last (int, optional): If set, fetch only the last N lines in a single
+                request (a tail) instead of paginating from the start.
+        """
+        self.run = run
+        self._tail = last
+        variables = {
+            "project": run.project,
+            "entity": run.entity,
+            "name": run.id,
+            "last": last,
+        }
+        super().__init__(service_api, variables, per_page)
+
+    def _update_response(self) -> None:
+        """Fetch and store the response data for the next page."""
+        self.last_response = self._service_api.execute_graphql(
+            self._get_query(), variables=self.variables
+        )
+
+    def _run_node(self) -> dict:
+        if not self.last_response:
+            return {}
+        return (self.last_response.get("project") or {}).get("run") or {}
+
+    @property
+    def _length(self) -> int:
+        """Number of log lines this iterator yields.
+
+        Forward pagination reports the run's total `logLineCount`; tail mode
+        (`last=N`) reports only the size of the fetched tail, matching what
+        iteration returns.
+        """
+        if not self.last_response:
+            self._load_page()
+        run_node = self._run_node()
+        if self._tail is not None:
+            conn = run_node.get("logLines") or {}
+            return len(conn.get("edges") or [])
+        return run_node.get("logLineCount", 0)
+
+    @property
+    def more(self) -> bool:
+        """Whether there are more log lines to fetch."""
+        # Tail mode is a single request: fetch once, then stop.
+        if self._tail is not None:
+            return self.last_response is None
+        if not self.last_response:
+            return True
+        conn = self._run_node().get("logLines") or {}
+        return (conn.get("pageInfo") or {}).get("hasNextPage", False)
+
+    @property
+    def cursor(self) -> str | None:
+        """The end cursor of the last fetched page."""
+        conn = self._run_node().get("logLines") or {}
+        edges = conn.get("edges") or []
+        return edges[-1].get("cursor") if edges else None
+
+    def update_variables(self) -> None:
+        """Update the GraphQL variables for the next page fetch."""
+        if self._tail is not None:
+            self.variables.update({"first": None, "after": None, "last": self._tail})
+        else:
+            self.variables.update(
+                {"first": self.per_page, "after": self.cursor, "last": None}
+            )
+
+    def convert_objects(self) -> list[LogLine]:
+        """Convert GraphQL edges to `LogLine` objects."""
+        conn = self._run_node().get("logLines") or {}
+        edges = conn.get("edges") or []
+        return [LogLine(edge["node"]) for edge in edges]
+
+    def __repr__(self) -> str:
+        return f"<LogLines {'/'.join(self.run.path)} ({len(self)})>"
+
+
+class LogLine(Attrs):
+    """A single console log line from a run.
+
+    Attributes (via `Attrs`):
+        number (int): Line number (0-indexed).
+        timestamp (str): ISO timestamp.
+        level (str): Log level (`info`, `error`, ...).
+        label (str): Writer label distinguishing concurrent writers to the same
+            run in shared mode — not the stdout/stderr stream (usually empty for
+            single-writer runs).
+        line (str): The log line content.
+    """
+
+    def __init__(self, attrs: dict):
+        super().__init__(dict(attrs))
+
+    def __repr__(self) -> str:
+        line = (self._attrs.get("line") or "")[:60]
+        return f"<LogLine {self._attrs.get('number')}: {line!r}>"

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -1110,6 +1110,46 @@ class Run(Attrs):
             per_page=per_page,
         )
 
+    def log_lines(
+        self,
+        per_page: int = 1000,
+        last: int | None = None,
+    ) -> public.LogLines:
+        """Return the run's console log lines.
+
+        For a finished or crashed run, downloading `output.log` via `files()` is
+        usually faster (a single static file). Prefer `log_lines()` for a run
+        that is still running (no file yet) or for a cheap tail.
+
+        Args:
+            per_page (int): Number of lines to fetch per page during forward
+                pagination.
+            last (int, optional): If set, fetch only the last N lines in a single
+                request (a tail) — useful for crash diagnosis or quick checks.
+
+        Returns:
+            A `LogLines` object, an iterator over `LogLine` objects
+            (fields: `number`, `timestamp`, `level`, `label`, `line`).
+
+        Raises:
+            ValueError: If the W&B server does not support structured console
+                logs. In that case read the log from files instead
+                (`run.file("output.log")` or the multipart `logs/` parts).
+        """
+        if not self._service_api.feature_enabled(pb.STRUCTURED_CONSOLE_LOGS):
+            raise ValueError(
+                "This W&B server does not support structured console logs, which "
+                "`run.log_lines()` requires. Read the run's console log from files "
+                "instead: `run.file('output.log')` (or the multipart "
+                "`logs/output_*.log` parts via `run.files()`)."
+            )
+        return public.LogLines(
+            self._service_api,
+            self,
+            per_page=per_page,
+            last=last,
+        )
+
     @normalize_exceptions
     def file(self, name: str) -> public.File:
         """Return the path of a file with a given name in the artifact.


### PR DESCRIPTION
Description
-----------

Adds a public `Run.log_lines()` accessor for a run's console log. The log data (the `logLines`) has been served by the backend and used by the web UI, but the Python SDK exposed no public method — so programmatic callers had to hit the internal GraphQL client directly (`api.client.execute` /`_service_api`), an anti-pattern that also broke across SDK versions. 

This gives console-log access parity with the UI over a supported public API.


## Implementation
- **`wandb/apis/public/log_lines.py`**: `LogLines(SizedPaginator)` +  `LogLine(Attrs)`
- **`wandb/apis/public/runs.py`**: `Forward pagination by default; `last=N` fetches only the tail in a single request. 
- Gated on `feature_enabled(STRUCTURED_CONSOLE_LOGS)` raises a clear error directing users to `output.log` when unsupported.


<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

- `run-log-lines-returns-paginator`: `run.log_lines()` returns a `LogLines`.
- `tail-is-a-single-request`: `last=N` issues one request carrying `last`.
- `log-line-exposes-all-fields`: number/timestamp/level/label/line accessible.
- `len-is-log-line-count `/ `tail-len-is-tail-size`: `len()` semantics per mode.
- `forward-pagination-advances-cursor`: multi-page iteration, cursor advance, order.
- `empty-log`: empty result iterates to `[]`.
- `unsupported-server-raises-before-querying`: clear error, no GraphQL call.
