### PR TITLE
docs(sdk): fix parameter name mismatches in docstrings

### DIFF
--- a/wandb/sdk/launch/registry/elastic_container_registry.py
+++ b/wandb/sdk/launch/registry/elastic_container_registry.py
@@ -41,7 +41,7 @@ class ElasticContainerRegistry(AbstractRegistry):
             uri: The uri of the repository.
             account_id: The AWS account id.
             region: The AWS region of the container registry.
-            repository: The name of the repository.
+            repo_name: The name of the repository.
 
         Raises:
             LaunchError: If there is an error initializing the Elastic Container Registry helper.

--- a/wandb/sdk/lib/filesystem.py
+++ b/wandb/sdk/lib/filesystem.py
@@ -506,9 +506,9 @@ def link_or_copy(
     Tries strategies in order: symlink -> hardlink -> copy.
 
     Args:
+        settings: Settings used to decide whether symlinks may be attempted.
         src: Source file path (should be resolved/absolute).
         dst: Destination file path.
-        allow_symlink: Whether to attempt symlinks before hardlinks.
 
     Returns:
         The strategy that succeeded.

--- a/wandb/sdk/lib/wb_logging.py
+++ b/wandb/sdk/lib/wb_logging.py
@@ -74,7 +74,7 @@ def log_to_run(run_id: str | None) -> Generator[None]:
     """Direct all wandb log messages to the given run.
 
     Args:
-        id: The current run ID, or None if actions in the context manager are
+        run_id: The current run ID, or None if actions in the context manager are
             not associated to a specific run. In the latter case, log messages
             will go to all runs.
 


### PR DESCRIPTION
### Description

Fixes three SDK docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `wandb/sdk/lib/wb_logging.py` | `log_to_run` | `id` | `run_id` |
| `wandb/sdk/lib/filesystem.py` | `link_or_copy` | stale `allow_symlink`; `settings` undocumented | `settings`, `src`, `dst` |
| `wandb/sdk/launch/registry/elastic_container_registry.py` | `ElasticContainerRegistry.__init__` | `repository` | `repo_name` |

Doc-only change; no behavior modified.

### Testing

N/A - docstring-only edits, verified against the function signatures.