### PR TITLE
feat(leet): mouse-drag pane resizing + predictable focus navigation

### DIFF
--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -40,6 +40,9 @@ const (
 	// Chart grid size constraints.
 	MinGridSize, MaxGridSize = 1, 9
 
+	// Layout override fractions are clamped to this range when set.
+	MinLayoutFrac, MaxLayoutFrac = 0.05, 0.9
+
 	ColorModePerPlot   = "per_plot"   // Each chart gets next color
 	ColorModePerSeries = "per_series" // All charts use base color, multi-series differentiate
 
@@ -90,6 +93,11 @@ type Config struct {
 
 	// SymonGrid is the dimensions for the standalone system monitor chart grid.
 	SymonGrid GridConfig `json:"symon_grid" leet:"desc=standalone system metrics grid"`
+
+	// Mouse-dragged pane proportions per view. Managed by drag-resize and
+	// the "0" reset key, not the config editor.
+	RunLayout       LayoutOverrides `json:"run_layout,omitzero"       leet:"-"`
+	WorkspaceLayout LayoutOverrides `json:"workspace_layout,omitzero" leet:"-"`
 
 	// ColorScheme is the color scheme to display the main metrics.
 	ColorScheme string `json:"color_scheme" leet:"desc=Palette for main run metrics charts (and run list colors).,options=colorSchemes"`
@@ -147,6 +155,20 @@ type Config struct {
 type GridConfig struct {
 	Rows int `json:"rows" leet:"min=1,max=9"`
 	Cols int `json:"cols" leet:"min=1,max=9"`
+}
+
+// LayoutOverrides stores user-adjusted pane proportions for one view,
+// set by dragging pane boundaries with the mouse.
+//
+// Each value is a fraction of the terminal width (sidebars) or height
+// (stacked panes). Zero means "use the built-in default". The JSON schema
+// matches leet-rs so both implementations can share wandb-leet.json.
+type LayoutOverrides struct {
+	LeftSidebar  float64 `json:"left_sidebar,omitempty"`
+	RightSidebar float64 `json:"right_sidebar,omitempty"`
+	System       float64 `json:"system,omitempty"`
+	Media        float64 `json:"media,omitempty"`
+	Logs         float64 `json:"logs,omitempty"`
 }
 
 // ConfigManager manages application configuration with thread-safe access
@@ -316,6 +338,20 @@ func (cm *ConfigManager) normalizeConfig() {
 	if cm.config.StartupMode != StartupModeWorkspaceLatest &&
 		cm.config.StartupMode != StartupModeSingleRunLatest {
 		cm.config.StartupMode = DefaultStartupMode
+	}
+
+	normalizeLayoutOverrides(&cm.config.RunLayout)
+	normalizeLayoutOverrides(&cm.config.WorkspaceLayout)
+}
+
+// normalizeLayoutOverrides clamps set (non-zero) fractions to a sane range.
+func normalizeLayoutOverrides(o *LayoutOverrides) {
+	for _, f := range []*float64{
+		&o.LeftSidebar, &o.RightSidebar, &o.System, &o.Media, &o.Logs,
+	} {
+		if *f != 0 {
+			*f = min(max(*f, MinLayoutFrac), MaxLayoutFrac)
+		}
 	}
 }
 
@@ -558,6 +594,38 @@ func (cm *ConfigManager) SetSymonCols(cols int) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config.SymonGrid.Cols = cols
+	return cm.save()
+}
+
+// RunLayout returns the single-run view's layout overrides.
+func (cm *ConfigManager) RunLayout() LayoutOverrides {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.config.RunLayout
+}
+
+// SetRunLayout sets and persists the single-run view's layout overrides.
+func (cm *ConfigManager) SetRunLayout(o LayoutOverrides) error {
+	normalizeLayoutOverrides(&o)
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.config.RunLayout = o
+	return cm.save()
+}
+
+// WorkspaceLayout returns the workspace view's layout overrides.
+func (cm *ConfigManager) WorkspaceLayout() LayoutOverrides {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.config.WorkspaceLayout
+}
+
+// SetWorkspaceLayout sets and persists the workspace view's layout overrides.
+func (cm *ConfigManager) SetWorkspaceLayout(o LayoutOverrides) error {
+	normalizeLayoutOverrides(&o)
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.config.WorkspaceLayout = o
 	return cm.save()
 }
 

--- a/core/internal/leet/config_test.go
+++ b/core/internal/leet/config_test.go
@@ -83,6 +83,46 @@ func TestConfig_SetLeftSidebarVisible_AffectsModelOnStartup(t *testing.T) {
 	require.True(t, model.TestLeftSidebarVisible())
 }
 
+func TestConfig_SetRunLayout_PersistsAndReloads(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	path := filepath.Join(t.TempDir(), "config.json")
+	cfg := leet.NewConfigManager(path, logger)
+
+	want := leet.LayoutOverrides{LeftSidebar: 0.3, Media: 0.25}
+	require.NoError(t, cfg.SetRunLayout(want))
+	require.Equal(t, want, cfg.RunLayout())
+
+	// A fresh manager reads the same overrides back from disk.
+	reloaded := leet.NewConfigManager(path, logger)
+	require.Equal(t, want, reloaded.RunLayout())
+	require.Equal(t, leet.LayoutOverrides{}, reloaded.WorkspaceLayout())
+}
+
+func TestConfig_SetWorkspaceLayout_ClampsFractions(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	require.NoError(t, cfg.SetWorkspaceLayout(leet.LayoutOverrides{
+		LeftSidebar: 0.001, // below the minimum
+		Logs:        1.5,   // above the maximum
+	}))
+
+	got := cfg.WorkspaceLayout()
+	require.Equal(t, leet.MinLayoutFrac, got.LeftSidebar)
+	require.Equal(t, leet.MaxLayoutFrac, got.Logs)
+	// Unset fractions stay zero ("use default") rather than being clamped.
+	require.Zero(t, got.Media)
+}
+
+func TestConfig_SetRunLayout_ZeroValueResets(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{RightSidebar: 0.4}))
+	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{}))
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
+}
+
 func TestConfig_SetTagColorScheme_Persists(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	path := filepath.Join(t.TempDir(), "config.json")

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -1,0 +1,163 @@
+package leet
+
+import "math"
+
+// Mouse-drag pane resizing.
+//
+// A left-click exactly on a sidebar's border column or on the separator row
+// above a stacked pane latches a drag. Mouse motion resizes the pane live;
+// release persists the new proportion (a fraction of the terminal dimension)
+// to the per-view LayoutOverrides in wandb-leet.json. The "0" key resets a
+// view's overrides to the golden-ratio defaults.
+
+const (
+	// sidebarDragMinWidth is the narrowest a sidebar can be dragged to.
+	// Deliberately smaller than SidebarMinWidth so users can shrink
+	// sidebars below the default clamp.
+	sidebarDragMinWidth = 20
+
+	// mainDragMinWidth is the narrowest the main content column can be
+	// squeezed to by dragging a sidebar border.
+	mainDragMinWidth = 24
+
+	// minFlexMetricsHeight is the shortest the flex metrics section can be
+	// squeezed to by dragging the separator below it.
+	minFlexMetricsHeight = 5
+)
+
+// dragBoundary identifies a draggable layout boundary.
+type dragBoundary int
+
+const (
+	dragBoundaryNone dragBoundary = iota
+	dragBoundaryLeftSidebar
+	dragBoundaryRightSidebar
+	dragBoundarySeparator
+)
+
+// layoutDrag tracks an in-progress boundary drag.
+//
+// frac holds the latest proportion produced by the drag and is persisted
+// on mouse release. section is set for separator drags.
+type layoutDrag struct {
+	boundary dragBoundary
+	section  stackSectionID
+	frac     float64
+}
+
+func (d layoutDrag) active() bool { return d.boundary != dragBoundaryNone }
+
+// stackGeom describes one visible section of the central vertical stack.
+type stackGeom struct {
+	id   stackSectionID
+	y    int
+	h    int
+	minH int
+}
+
+// stackGeometry returns the visible central-column sections in top-to-bottom
+// order. Sections with zero height (hidden, or absent in this view) are
+// omitted, so the same code serves both the run and workspace layouts.
+func stackGeometry(layout Layout) []stackGeom {
+	all := []stackGeom{
+		{stackSectionMetrics, 0, layout.height, minFlexMetricsHeight},
+		{stackSectionSystemMetrics, layout.systemMetricsY,
+			layout.systemMetricsHeight, systemMetricsPaneMinHeight},
+		{stackSectionMedia, layout.mediaY, layout.mediaHeight, mediaPaneMinHeight},
+		{stackSectionConsoleLogs, layout.consoleLogsY,
+			layout.consoleLogsHeight, ConsoleLogsPaneMinHeight},
+	}
+	visible := all[:0]
+	for _, g := range all {
+		if g.h > 0 {
+			visible = append(visible, g)
+		}
+	}
+	return visible
+}
+
+// boundaryAt hit-tests a mouse position against the draggable boundaries:
+// the sidebars' border columns and the separator rows of the central stack.
+//
+// Sidebar borders are only draggable when the sidebar is stably expanded so
+// a drag never fights an animation.
+func boundaryAt(
+	x, y, width int,
+	layout Layout,
+	leftExpanded, rightExpanded bool,
+) (layoutDrag, bool) {
+	if y >= layout.totalContentAreaHeight {
+		return layoutDrag{}, false
+	}
+
+	if layout.leftSidebarWidth > 0 && leftExpanded &&
+		x == layout.leftSidebarWidth-1 {
+		return layoutDrag{boundary: dragBoundaryLeftSidebar}, true
+	}
+	if layout.rightSidebarWidth > 0 && rightExpanded &&
+		x == width-layout.rightSidebarWidth {
+		return layoutDrag{boundary: dragBoundaryRightSidebar}, true
+	}
+
+	// Separator rows span the central column only.
+	if x < layout.leftSidebarWidth || x >= width-layout.rightSidebarWidth {
+		return layoutDrag{}, false
+	}
+	sections := stackGeometry(layout)
+	for i := 1; i < len(sections); i++ {
+		if y == sections[i].y-1 {
+			return layoutDrag{
+				boundary: dragBoundarySeparator,
+				section:  sections[i].id,
+			}, true
+		}
+	}
+	return layoutDrag{}, false
+}
+
+// dragSeparatorHeight computes the new height for the section below the
+// separator being dragged to row y.
+//
+// The section is bottom-anchored (the flex metrics section absorbs the
+// difference), so only its own height changes. The row is clamped so both
+// the section and its upstairs neighbor keep their minimum heights.
+func dragSeparatorHeight(
+	layout Layout,
+	section stackSectionID,
+	y, terminalHeight int,
+) (newHeight int, frac float64, ok bool) {
+	sections := stackGeometry(layout)
+	for i := 1; i < len(sections); i++ {
+		if sections[i].id != section {
+			continue
+		}
+		prev, sec := sections[i-1], sections[i]
+		bottom := sec.y + sec.h
+		y = clamp(y, prev.y+prev.minH, bottom-1-sec.minH)
+		newHeight = bottom - y - 1
+		return newHeight, float64(newHeight) / float64(terminalHeight), true
+	}
+	return 0, 0, false
+}
+
+// paneHeightFor returns a stacked pane's expanded height for the given
+// override fraction of the terminal height, or the fallback default when no
+// override is set. The pane's own SetExpandedHeight enforces its minimum.
+func paneHeightFor(frac float64, terminalHeight, fallback int) int {
+	if frac <= 0 {
+		return fallback
+	}
+	return int(math.Round(float64(terminalHeight) * frac))
+}
+
+// sidebarWidthFor returns the expanded sidebar width for the given override
+// fraction of the terminal width. A zero fraction falls back to the
+// golden-ratio default.
+func sidebarWidthFor(terminalWidth int, frac float64, oppositeVisible bool) int {
+	if frac <= 0 {
+		return expandedSidebarWidth(terminalWidth, oppositeVisible)
+	}
+	maxW := max(terminalWidth-mainDragMinWidth, sidebarDragMinWidth)
+	w := int(math.Round(float64(terminalWidth) * frac))
+	return clamp(w, sidebarDragMinWidth, maxW)
+}

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -129,26 +129,20 @@ func boundaryAt(
 	return layoutDrag{}, false
 }
 
-// separatorResize is one pane's new extent produced by a separator drag.
-type separatorResize struct {
-	section stackSectionID
-	height  int
-	frac    float64
-}
-
-// dragSeparator computes the pane resizes for dragging the separator above
-// section to row y. The row is clamped so both neighbors keep their minimum
-// heights.
+// dragSeparator records in o the pane fractions for dragging the separator
+// above section to row y, clamped so both neighbors keep their minimum
+// heights. It reports whether o was updated.
 //
 // The pane below the separator keeps its bottom anchored. When the pane
-// above is another fixed pane, it is resized too so the boundary lands
-// exactly on the mouse row; when it is the flex metrics section, the flex
-// absorbs the change instead.
+// above is another fixed pane, its fraction is updated too so the boundary
+// lands exactly on the mouse row; when it is the flex metrics section, the
+// flex absorbs the change instead.
 func dragSeparator(
+	o *LayoutOverrides,
 	layout Layout,
 	section stackSectionID,
 	y, terminalHeight int,
-) []separatorResize {
+) bool {
 	sections := stackGeometry(layout)
 	for i := 1; i < len(sections); i++ {
 		if sections[i].id != section {
@@ -158,25 +152,17 @@ func dragSeparator(
 		bottom := sec.y + sec.h
 		lo, hi := prev.y+prev.minH, bottom-1-sec.minH
 		if lo > hi {
-			return nil
+			return false
 		}
 		y = clamp(y, lo, hi)
 
-		resizes := []separatorResize{{
-			section: sec.id,
-			height:  bottom - y - 1,
-			frac:    float64(bottom-y-1) / float64(terminalHeight),
-		}}
+		o.setSection(sec.id, float64(bottom-y-1)/float64(terminalHeight))
 		if prev.id != stackSectionMetrics {
-			resizes = append(resizes, separatorResize{
-				section: prev.id,
-				height:  y - prev.y,
-				frac:    float64(y-prev.y) / float64(terminalHeight),
-			})
+			o.setSection(prev.id, float64(y-prev.y)/float64(terminalHeight))
 		}
-		return resizes
+		return true
 	}
-	return nil
+	return false
 }
 
 // paneHeightFor returns a stacked pane's expanded height for the given
@@ -187,16 +173,4 @@ func paneHeightFor(frac float64, terminalHeight, fallback int) int {
 		return fallback
 	}
 	return int(math.Round(float64(terminalHeight) * frac))
-}
-
-// sidebarWidthFor returns the expanded sidebar width for the given override
-// fraction of the terminal width. A zero fraction falls back to the
-// golden-ratio default.
-func sidebarWidthFor(terminalWidth int, frac float64, oppositeVisible bool) int {
-	if frac <= 0 {
-		return expandedSidebarWidth(terminalWidth, oppositeVisible)
-	}
-	maxW := max(terminalWidth-mainDragMinWidth, sidebarDragMinWidth)
-	w := int(math.Round(float64(terminalWidth) * frac))
-	return clamp(w, sidebarDragMinWidth, maxW)
 }

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -37,15 +37,29 @@ const (
 
 // layoutDrag tracks an in-progress boundary drag.
 //
-// frac holds the latest proportion produced by the drag and is persisted
-// on mouse release. section is set for separator drags.
+// overrides accumulates the view's pending layout fractions as the mouse
+// moves (a separator drag between two fixed panes updates two of them) and
+// is persisted once on mouse release. section is set for separator drags.
 type layoutDrag struct {
-	boundary dragBoundary
-	section  stackSectionID
-	frac     float64
+	boundary  dragBoundary
+	section   stackSectionID
+	overrides LayoutOverrides
+	dirty     bool
 }
 
 func (d layoutDrag) active() bool { return d.boundary != dragBoundaryNone }
+
+// setSection records a stacked pane's height fraction.
+func (o *LayoutOverrides) setSection(id stackSectionID, frac float64) {
+	switch id {
+	case stackSectionSystemMetrics:
+		o.System = frac
+	case stackSectionMedia:
+		o.Media = frac
+	case stackSectionConsoleLogs:
+		o.Logs = frac
+	}
+}
 
 // stackGeom describes one visible section of the central vertical stack.
 type stackGeom struct {
@@ -115,17 +129,26 @@ func boundaryAt(
 	return layoutDrag{}, false
 }
 
-// dragSeparatorHeight computes the new height for the section below the
-// separator being dragged to row y.
+// separatorResize is one pane's new extent produced by a separator drag.
+type separatorResize struct {
+	section stackSectionID
+	height  int
+	frac    float64
+}
+
+// dragSeparator computes the pane resizes for dragging the separator above
+// section to row y. The row is clamped so both neighbors keep their minimum
+// heights.
 //
-// The section is bottom-anchored (the flex metrics section absorbs the
-// difference), so only its own height changes. The row is clamped so both
-// the section and its upstairs neighbor keep their minimum heights.
-func dragSeparatorHeight(
+// The pane below the separator keeps its bottom anchored. When the pane
+// above is another fixed pane, it is resized too so the boundary lands
+// exactly on the mouse row; when it is the flex metrics section, the flex
+// absorbs the change instead.
+func dragSeparator(
 	layout Layout,
 	section stackSectionID,
 	y, terminalHeight int,
-) (newHeight int, frac float64, ok bool) {
+) []separatorResize {
 	sections := stackGeometry(layout)
 	for i := 1; i < len(sections); i++ {
 		if sections[i].id != section {
@@ -133,11 +156,27 @@ func dragSeparatorHeight(
 		}
 		prev, sec := sections[i-1], sections[i]
 		bottom := sec.y + sec.h
-		y = clamp(y, prev.y+prev.minH, bottom-1-sec.minH)
-		newHeight = bottom - y - 1
-		return newHeight, float64(newHeight) / float64(terminalHeight), true
+		lo, hi := prev.y+prev.minH, bottom-1-sec.minH
+		if lo > hi {
+			return nil
+		}
+		y = clamp(y, lo, hi)
+
+		resizes := []separatorResize{{
+			section: sec.id,
+			height:  bottom - y - 1,
+			frac:    float64(bottom-y-1) / float64(terminalHeight),
+		}}
+		if prev.id != stackSectionMetrics {
+			resizes = append(resizes, separatorResize{
+				section: prev.id,
+				height:  y - prev.y,
+				frac:    float64(y-prev.y) / float64(terminalHeight),
+			})
+		}
+		return resizes
 	}
-	return 0, 0, false
+	return nil
 }
 
 // paneHeightFor returns a stacked pane's expanded height for the given

--- a/core/internal/leet/dragresize_test.go
+++ b/core/internal/leet/dragresize_test.go
@@ -84,22 +84,25 @@ func TestBoundaryAtStackSeparators(t *testing.T) {
 	require.False(t, ok)
 }
 
+// frac converts a pane height to its terminal-height fraction.
+func frac(height, terminalHeight int) float64 {
+	return float64(height) / float64(terminalHeight)
+}
+
 func TestDragSeparatorBelowFlexResizesOnePane(t *testing.T) {
 	layout := testRunLayout()
 	const termH = 63 // content + status bar
 
 	// The pane above the media separator is the flex metrics grid, so only
 	// media resizes; dragging up by 5 rows grows it by 5.
-	resizes := dragSeparator(layout, stackSectionMedia, layout.mediaY-1-5, termH)
-	require.Len(t, resizes, 1)
-	require.Equal(t, stackSectionMedia, resizes[0].section)
-	require.Equal(t, layout.mediaHeight+5, resizes[0].height)
-	require.InDelta(t, float64(resizes[0].height)/float64(termH), resizes[0].frac, 1e-9)
+	var o LayoutOverrides
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, layout.mediaY-1-5, termH))
+	require.Equal(t, LayoutOverrides{Media: frac(layout.mediaHeight+5, termH)}, o)
 
 	// Dragging down by 5 shrinks media by 5.
-	resizes = dragSeparator(layout, stackSectionMedia, layout.mediaY-1+5, termH)
-	require.Len(t, resizes, 1)
-	require.Equal(t, layout.mediaHeight-5, resizes[0].height)
+	o = LayoutOverrides{}
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, layout.mediaY-1+5, termH))
+	require.Equal(t, LayoutOverrides{Media: frac(layout.mediaHeight-5, termH)}, o)
 }
 
 func TestDragSeparatorBetweenFixedPanesResizesBoth(t *testing.T) {
@@ -108,12 +111,13 @@ func TestDragSeparatorBetweenFixedPanesResizesBoth(t *testing.T) {
 
 	// Media (fixed) sits above the console logs separator: dragging down by
 	// 3 rows grows media by 3 and shrinks logs by 3.
-	resizes := dragSeparator(layout, stackSectionConsoleLogs, layout.consoleLogsY-1+3, termH)
-	require.Len(t, resizes, 2)
-	require.Equal(t, stackSectionConsoleLogs, resizes[0].section)
-	require.Equal(t, layout.consoleLogsHeight-3, resizes[0].height)
-	require.Equal(t, stackSectionMedia, resizes[1].section)
-	require.Equal(t, layout.mediaHeight+3, resizes[1].height)
+	var o LayoutOverrides
+	require.True(t,
+		dragSeparator(&o, layout, stackSectionConsoleLogs, layout.consoleLogsY-1+3, termH))
+	require.Equal(t, LayoutOverrides{
+		Media: frac(layout.mediaHeight+3, termH),
+		Logs:  frac(layout.consoleLogsHeight-3, termH),
+	}, o)
 }
 
 func TestDragSeparatorClamps(t *testing.T) {
@@ -121,34 +125,37 @@ func TestDragSeparatorClamps(t *testing.T) {
 	const termH = 63
 
 	// Dragging far down clamps at the pane's min height.
-	resizes := dragSeparator(layout, stackSectionMedia, 1000, termH)
-	require.Len(t, resizes, 1)
-	require.Equal(t, mediaPaneMinHeight, resizes[0].height)
+	var o LayoutOverrides
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, 1000, termH))
+	require.Equal(t, LayoutOverrides{Media: frac(mediaPaneMinHeight, termH)}, o)
 
 	// Dragging far up clamps so the section above keeps its min height.
-	resizes = dragSeparator(layout, stackSectionMedia, 0, termH)
-	require.Len(t, resizes, 1)
+	o = LayoutOverrides{}
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, 0, termH))
 	mediaBottom := layout.mediaY + layout.mediaHeight
-	require.Equal(t, mediaBottom-minFlexMetricsHeight-1, resizes[0].height)
+	require.Equal(t,
+		LayoutOverrides{Media: frac(mediaBottom-minFlexMetricsHeight-1, termH)}, o)
 
 	// Unknown or top-most sections are not draggable.
-	require.Empty(t, dragSeparator(layout, stackSectionMetrics, 10, termH))
-	require.Empty(t, dragSeparator(layout, stackSectionSystemMetrics, 10, termH))
+	o = LayoutOverrides{}
+	require.False(t, dragSeparator(&o, layout, stackSectionMetrics, 10, termH))
+	require.False(t, dragSeparator(&o, layout, stackSectionSystemMetrics, 10, termH))
+	require.Equal(t, LayoutOverrides{}, o)
 }
 
-func TestSidebarWidthFor(t *testing.T) {
+func TestExpandedSidebarWidth(t *testing.T) {
 	// No override: golden-ratio default.
-	require.Equal(t, expandedSidebarWidth(200, false), sidebarWidthFor(200, 0, false))
-	require.Equal(t, expandedSidebarWidth(200, true), sidebarWidthFor(200, 0, true))
+	require.Equal(t, 76, expandedSidebarWidth(200, false, 0)) // 200 * 0.382
+	require.Equal(t, 47, expandedSidebarWidth(200, true, 0))  // 200 * 0.236
 
 	// Override fraction of terminal width.
-	require.Equal(t, 50, sidebarWidthFor(200, 0.25, false))
+	require.Equal(t, 50, expandedSidebarWidth(200, false, 0.25))
 
 	// Overrides can go below the default minimum, but not the drag minimum.
-	require.Equal(t, sidebarDragMinWidth, sidebarWidthFor(200, 0.05, false))
+	require.Equal(t, sidebarDragMinWidth, expandedSidebarWidth(200, false, 0.05))
 
 	// The main content column keeps its minimum width.
-	require.Equal(t, 200-mainDragMinWidth, sidebarWidthFor(200, 0.99, false))
+	require.Equal(t, 200-mainDragMinWidth, expandedSidebarWidth(200, false, 0.99))
 }
 
 func TestPaneHeightFor(t *testing.T) {

--- a/core/internal/leet/dragresize_test.go
+++ b/core/internal/leet/dragresize_test.go
@@ -84,42 +84,56 @@ func TestBoundaryAtStackSeparators(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestDragSeparatorHeightTracksMouse(t *testing.T) {
+func TestDragSeparatorBelowFlexResizesOnePane(t *testing.T) {
 	layout := testRunLayout()
 	const termH = 63 // content + status bar
 
-	// Dragging the media separator up by 5 rows grows media by 5.
-	newH, frac, ok := dragSeparatorHeight(layout, stackSectionMedia, layout.mediaY-1-5, termH)
-	require.True(t, ok)
-	require.Equal(t, layout.mediaHeight+5, newH)
-	require.InDelta(t, float64(newH)/float64(termH), frac, 1e-9)
+	// The pane above the media separator is the flex metrics grid, so only
+	// media resizes; dragging up by 5 rows grows it by 5.
+	resizes := dragSeparator(layout, stackSectionMedia, layout.mediaY-1-5, termH)
+	require.Len(t, resizes, 1)
+	require.Equal(t, stackSectionMedia, resizes[0].section)
+	require.Equal(t, layout.mediaHeight+5, resizes[0].height)
+	require.InDelta(t, float64(resizes[0].height)/float64(termH), resizes[0].frac, 1e-9)
 
 	// Dragging down by 5 shrinks media by 5.
-	newH, _, ok = dragSeparatorHeight(layout, stackSectionMedia, layout.mediaY-1+5, termH)
-	require.True(t, ok)
-	require.Equal(t, layout.mediaHeight-5, newH)
+	resizes = dragSeparator(layout, stackSectionMedia, layout.mediaY-1+5, termH)
+	require.Len(t, resizes, 1)
+	require.Equal(t, layout.mediaHeight-5, resizes[0].height)
 }
 
-func TestDragSeparatorHeightClamps(t *testing.T) {
+func TestDragSeparatorBetweenFixedPanesResizesBoth(t *testing.T) {
+	layout := testRunLayout()
+	const termH = 63
+
+	// Media (fixed) sits above the console logs separator: dragging down by
+	// 3 rows grows media by 3 and shrinks logs by 3.
+	resizes := dragSeparator(layout, stackSectionConsoleLogs, layout.consoleLogsY-1+3, termH)
+	require.Len(t, resizes, 2)
+	require.Equal(t, stackSectionConsoleLogs, resizes[0].section)
+	require.Equal(t, layout.consoleLogsHeight-3, resizes[0].height)
+	require.Equal(t, stackSectionMedia, resizes[1].section)
+	require.Equal(t, layout.mediaHeight+3, resizes[1].height)
+}
+
+func TestDragSeparatorClamps(t *testing.T) {
 	layout := testRunLayout()
 	const termH = 63
 
 	// Dragging far down clamps at the pane's min height.
-	newH, _, ok := dragSeparatorHeight(layout, stackSectionMedia, 1000, termH)
-	require.True(t, ok)
-	require.Equal(t, mediaPaneMinHeight, newH)
+	resizes := dragSeparator(layout, stackSectionMedia, 1000, termH)
+	require.Len(t, resizes, 1)
+	require.Equal(t, mediaPaneMinHeight, resizes[0].height)
 
 	// Dragging far up clamps so the section above keeps its min height.
-	newH, _, ok = dragSeparatorHeight(layout, stackSectionMedia, 0, termH)
-	require.True(t, ok)
+	resizes = dragSeparator(layout, stackSectionMedia, 0, termH)
+	require.Len(t, resizes, 1)
 	mediaBottom := layout.mediaY + layout.mediaHeight
-	require.Equal(t, mediaBottom-minFlexMetricsHeight-1, newH)
+	require.Equal(t, mediaBottom-minFlexMetricsHeight-1, resizes[0].height)
 
 	// Unknown or top-most sections are not draggable.
-	_, _, ok = dragSeparatorHeight(layout, stackSectionMetrics, 10, termH)
-	require.False(t, ok)
-	_, _, ok = dragSeparatorHeight(layout, stackSectionSystemMetrics, 10, termH)
-	require.False(t, ok)
+	require.Empty(t, dragSeparator(layout, stackSectionMetrics, 10, termH))
+	require.Empty(t, dragSeparator(layout, stackSectionSystemMetrics, 10, termH))
 }
 
 func TestSidebarWidthFor(t *testing.T) {

--- a/core/internal/leet/dragresize_test.go
+++ b/core/internal/leet/dragresize_test.go
@@ -1,0 +1,143 @@
+package leet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testRunLayout mirrors a single-run view: metrics (flex) on top, media and
+// console logs stacked below, one separator row above each fixed pane.
+//
+//	y 0..29  metrics (30)
+//	y 30     separator
+//	y 31..50 media (20)
+//	y 51     separator
+//	y 52..61 logs (10)
+func testRunLayout() Layout {
+	return Layout{
+		leftSidebarWidth:       40,
+		mainContentAreaWidth:   100,
+		rightSidebarWidth:      60,
+		totalContentAreaHeight: 62,
+		height:                 30,
+		mediaY:                 31,
+		mediaHeight:            20,
+		consoleLogsY:           52,
+		consoleLogsHeight:      10,
+	}
+}
+
+func TestBoundaryAtSidebarBorders(t *testing.T) {
+	layout := testRunLayout()
+	const width = 200
+
+	// Left sidebar border column is the sidebar's last column.
+	drag, ok := boundaryAt(39, 5, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundaryLeftSidebar, drag.boundary)
+
+	// Right sidebar border column is its first column.
+	drag, ok = boundaryAt(width-60, 5, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundaryRightSidebar, drag.boundary)
+
+	// One column off is a miss.
+	_, ok = boundaryAt(38, 5, width, layout, true, true)
+	require.False(t, ok)
+	_, ok = boundaryAt(width-59, 5, width, layout, true, true)
+	require.False(t, ok)
+
+	// A collapsed/animating sidebar is not draggable.
+	_, ok = boundaryAt(39, 5, width, layout, false, true)
+	require.False(t, ok)
+
+	// The status bar area is off limits.
+	_, ok = boundaryAt(39, layout.totalContentAreaHeight, width, layout, true, true)
+	require.False(t, ok)
+}
+
+func TestBoundaryAtStackSeparators(t *testing.T) {
+	layout := testRunLayout()
+	const width = 200
+
+	// Separator above media.
+	drag, ok := boundaryAt(100, layout.mediaY-1, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundarySeparator, drag.boundary)
+	require.Equal(t, stackSectionMedia, drag.section)
+
+	// Separator above console logs.
+	drag, ok = boundaryAt(100, layout.consoleLogsY-1, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundarySeparator, drag.boundary)
+	require.Equal(t, stackSectionConsoleLogs, drag.section)
+
+	// Separator rows are only draggable within the central column.
+	_, ok = boundaryAt(10, layout.mediaY-1, width, layout, true, true)
+	require.False(t, ok)
+	_, ok = boundaryAt(width-30, layout.mediaY-1, width, layout, true, true)
+	require.False(t, ok)
+
+	// Non-separator rows in the central column are misses.
+	_, ok = boundaryAt(100, layout.mediaY, width, layout, true, true)
+	require.False(t, ok)
+}
+
+func TestDragSeparatorHeightTracksMouse(t *testing.T) {
+	layout := testRunLayout()
+	const termH = 63 // content + status bar
+
+	// Dragging the media separator up by 5 rows grows media by 5.
+	newH, frac, ok := dragSeparatorHeight(layout, stackSectionMedia, layout.mediaY-1-5, termH)
+	require.True(t, ok)
+	require.Equal(t, layout.mediaHeight+5, newH)
+	require.InDelta(t, float64(newH)/float64(termH), frac, 1e-9)
+
+	// Dragging down by 5 shrinks media by 5.
+	newH, _, ok = dragSeparatorHeight(layout, stackSectionMedia, layout.mediaY-1+5, termH)
+	require.True(t, ok)
+	require.Equal(t, layout.mediaHeight-5, newH)
+}
+
+func TestDragSeparatorHeightClamps(t *testing.T) {
+	layout := testRunLayout()
+	const termH = 63
+
+	// Dragging far down clamps at the pane's min height.
+	newH, _, ok := dragSeparatorHeight(layout, stackSectionMedia, 1000, termH)
+	require.True(t, ok)
+	require.Equal(t, mediaPaneMinHeight, newH)
+
+	// Dragging far up clamps so the section above keeps its min height.
+	newH, _, ok = dragSeparatorHeight(layout, stackSectionMedia, 0, termH)
+	require.True(t, ok)
+	mediaBottom := layout.mediaY + layout.mediaHeight
+	require.Equal(t, mediaBottom-minFlexMetricsHeight-1, newH)
+
+	// Unknown or top-most sections are not draggable.
+	_, _, ok = dragSeparatorHeight(layout, stackSectionMetrics, 10, termH)
+	require.False(t, ok)
+	_, _, ok = dragSeparatorHeight(layout, stackSectionSystemMetrics, 10, termH)
+	require.False(t, ok)
+}
+
+func TestSidebarWidthFor(t *testing.T) {
+	// No override: golden-ratio default.
+	require.Equal(t, expandedSidebarWidth(200, false), sidebarWidthFor(200, 0, false))
+	require.Equal(t, expandedSidebarWidth(200, true), sidebarWidthFor(200, 0, true))
+
+	// Override fraction of terminal width.
+	require.Equal(t, 50, sidebarWidthFor(200, 0.25, false))
+
+	// Overrides can go below the default minimum, but not the drag minimum.
+	require.Equal(t, sidebarDragMinWidth, sidebarWidthFor(200, 0.05, false))
+
+	// The main content column keeps its minimum width.
+	require.Equal(t, 200-mainDragMinWidth, sidebarWidthFor(200, 0.99, false))
+}
+
+func TestPaneHeightFor(t *testing.T) {
+	require.Equal(t, 17, paneHeightFor(0, 60, 17))
+	require.Equal(t, 30, paneHeightFor(0.5, 60, 17))
+}

--- a/core/internal/leet/flexlayout.go
+++ b/core/internal/leet/flexlayout.go
@@ -135,3 +135,18 @@ func placeMainColumn(width, height int, content string) string {
 	}
 	return lipgloss.Place(width, height, lipgloss.Left, lipgloss.Top, content)
 }
+
+// padStackSection pads a rendered central-column section to the height the
+// vertical stack layout reserved for it.
+//
+// Mouse hit-testing (chart cells, separator drags) maps screen rows to
+// sections via computeVerticalStackLayout, so each rendered section must
+// occupy exactly its reserved rows. The metrics grid in particular renders
+// header + rows*cellHeight lines, which integer division leaves short of
+// the section height.
+func padStackSection(content string, width, height int) string {
+	if width <= 0 || height <= 0 {
+		return content
+	}
+	return lipgloss.Place(width, height, lipgloss.Left, lipgloss.Top, content)
+}

--- a/core/internal/leet/flexlayout.go
+++ b/core/internal/leet/flexlayout.go
@@ -1,6 +1,10 @@
 package leet
 
-import "charm.land/lipgloss/v2"
+import (
+	"math"
+
+	"charm.land/lipgloss/v2"
+)
 
 // stackSectionID identifies a vertically stacked pane in the main content area.
 type stackSectionID int
@@ -98,7 +102,17 @@ func (l verticalStackLayout) Y(id stackSectionID) int {
 	return l.Sections[id].Y
 }
 
-func expandedSidebarWidth(terminalWidth int, oppositeVisible bool) int {
+// expandedSidebarWidth returns a sidebar's expanded width: a user-dragged
+// fraction of the terminal width when set (non-zero), or the golden-ratio
+// default. Dragged widths may go below the default minimum but always leave
+// room for the main content column.
+func expandedSidebarWidth(terminalWidth int, oppositeVisible bool, frac float64) int {
+	if frac > 0 {
+		maxW := max(terminalWidth-mainDragMinWidth, sidebarDragMinWidth)
+		w := int(math.Round(float64(terminalWidth) * frac))
+		return clamp(w, sidebarDragMinWidth, maxW)
+	}
+
 	ratio := SidebarWidthRatio
 	if oppositeVisible {
 		ratio = SidebarWidthRatioBoth

--- a/core/internal/leet/focusmanager.go
+++ b/core/internal/leet/focusmanager.go
@@ -17,13 +17,10 @@ const (
 type FocusRegionDef struct {
 	Target FocusTarget
 
-	// Available reports whether the region is currently focusable for normal
-	// navigation.
+	// Available reports whether the region is currently focusable: its pane
+	// is logically visible (target state, so an expanding pane counts and a
+	// collapsing one does not) and has content to interact with.
 	Available func() bool
-
-	// AvailableTarget reports whether the region should be considered focusable
-	// immediately after a visibility toggle. When nil, Available is used.
-	AvailableTarget func() bool
 
 	Activate   func(direction int)
 	Deactivate func()
@@ -31,9 +28,10 @@ type FocusRegionDef struct {
 
 // FocusManager is the single source of truth for which UI component holds focus.
 //
-// It tracks one FocusTarget at a time, supports Tab cycling through available
-// regions, and resolves focus after visibility changes. All focus state changes
-// flow through this manager.
+// It tracks one FocusTarget at a time and supports Tab cycling through
+// available regions. Focus never moves on its own: it changes only through
+// Tab, mouse adoption, or explicit SetTarget calls, and Resolve clears it
+// when the focused region disappears.
 type FocusManager struct {
 	current FocusTarget
 	regions []FocusRegionDef
@@ -143,56 +141,22 @@ func (fm *FocusManager) TabWithinOrAdvance(direction int, withinFn func(int) boo
 	fm.Tab(direction)
 }
 
-// ResolveAfterAvailabilityChange keeps the current focus when it is still
-// available. Otherwise, it activates the first currently available region.
-// If none are available, it clears focus.
-func (fm *FocusManager) ResolveAfterAvailabilityChange() {
-	fm.resolve(fm.regionAvailable)
-}
-
-// ResolveAfterVisibilityChange checks whether the current target is still
-// available under the target visibility state after a toggle. If not, it
-// activates the first region that will be available in the target state. If
-// none are available, it clears focus.
-func (fm *FocusManager) ResolveAfterVisibilityChange() {
-	fm.resolve(fm.regionAvailableForResolve)
+// Resolve clears focus when the focused region is no longer available
+// (its pane was closed, emptied, or squeezed out). It never moves focus
+// to another region.
+func (fm *FocusManager) Resolve() {
+	if fm.current == FocusTargetNone {
+		return
+	}
+	idx := fm.indexOf(fm.current)
+	if idx != -1 && fm.regionAvailable(&fm.regions[idx]) {
+		return
+	}
+	fm.ClearAll()
 }
 
 func (fm *FocusManager) regionAvailable(r *FocusRegionDef) bool {
 	return r.Available != nil && r.Available()
-}
-
-func (fm *FocusManager) regionAvailableForResolve(r *FocusRegionDef) bool {
-	if r.AvailableTarget != nil {
-		return r.AvailableTarget()
-	}
-	return fm.regionAvailable(r)
-}
-
-func (fm *FocusManager) resolve(isAvailable func(*FocusRegionDef) bool) {
-	if fm.current != FocusTargetNone {
-		for i := range fm.regions {
-			if fm.regions[i].Target != fm.current {
-				continue
-			}
-			if isAvailable(&fm.regions[i]) {
-				return
-			}
-			break
-		}
-	}
-
-	for i := range fm.regions {
-		if !isAvailable(&fm.regions[i]) {
-			continue
-		}
-		fm.deactivateAll()
-		fm.current = fm.regions[i].Target
-		fm.regions[i].Activate(1)
-		return
-	}
-
-	fm.ClearAll()
 }
 
 func (fm *FocusManager) deactivateAll() {

--- a/core/internal/leet/focusmanager_test.go
+++ b/core/internal/leet/focusmanager_test.go
@@ -8,37 +8,82 @@ import (
 	"github.com/wandb/wandb/core/internal/leet"
 )
 
-func TestFocusManagerResolveAfterVisibilityChangeUsesTargetAvailability(t *testing.T) {
-	currentOverviewVisible := true
-	targetOverviewVisible := true
-	overviewActive := false
-	logsActive := false
-
-	fm := leet.NewFocusManager([]leet.FocusRegionDef{
+// newTwoRegionFocusManager builds a manager with an overview and a logs
+// region whose availability is controlled by the returned pointers.
+func newTwoRegionFocusManager(
+	overviewAvailable, logsAvailable *bool,
+	overviewActive, logsActive *bool,
+) *leet.FocusManager {
+	return leet.NewFocusManager([]leet.FocusRegionDef{
 		{
-			Target:          leet.FocusTargetOverview,
-			Available:       func() bool { return currentOverviewVisible },
-			AvailableTarget: func() bool { return targetOverviewVisible },
-			Activate:        func(int) { overviewActive = true },
-			Deactivate:      func() { overviewActive = false },
+			Target:     leet.FocusTargetOverview,
+			Available:  func() bool { return *overviewAvailable },
+			Activate:   func(int) { *overviewActive = true },
+			Deactivate: func() { *overviewActive = false },
 		},
 		{
-			Target:          leet.FocusTargetConsoleLogs,
-			Available:       func() bool { return true },
-			AvailableTarget: func() bool { return true },
-			Activate:        func(int) { logsActive = true },
-			Deactivate:      func() { logsActive = false },
+			Target:     leet.FocusTargetConsoleLogs,
+			Available:  func() bool { return *logsAvailable },
+			Activate:   func(int) { *logsActive = true },
+			Deactivate: func() { *logsActive = false },
 		},
 	})
+}
+
+func TestFocusManagerResolveKeepsAvailableFocus(t *testing.T) {
+	overviewAvailable, logsAvailable := true, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
 
 	fm.SetTarget(leet.FocusTargetOverview, 1)
+	fm.Resolve()
+
 	require.True(t, fm.IsTarget(leet.FocusTargetOverview))
 	require.True(t, overviewActive)
+}
 
-	targetOverviewVisible = false
-	fm.ResolveAfterVisibilityChange()
+func TestFocusManagerResolveClearsUnavailableFocus(t *testing.T) {
+	overviewAvailable, logsAvailable := true, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
+
+	fm.SetTarget(leet.FocusTargetOverview, 1)
+	require.True(t, overviewActive)
+
+	// The focused region disappears: focus clears rather than jumping to
+	// another region.
+	overviewAvailable = false
+	fm.Resolve()
+
+	require.True(t, fm.IsTarget(leet.FocusTargetNone))
+	require.False(t, overviewActive)
+	require.False(t, logsActive)
+}
+
+func TestFocusManagerResolveIsNoOpWhenNothingFocused(t *testing.T) {
+	overviewAvailable, logsAvailable := true, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
+
+	fm.Resolve()
+
+	require.True(t, fm.IsTarget(leet.FocusTargetNone))
+	require.False(t, overviewActive)
+	require.False(t, logsActive)
+}
+
+func TestFocusManagerTabSkipsUnavailableRegions(t *testing.T) {
+	overviewAvailable, logsAvailable := false, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
+
+	fm.Tab(1)
 
 	require.True(t, fm.IsTarget(leet.FocusTargetConsoleLogs))
-	require.False(t, overviewActive)
 	require.True(t, logsActive)
+	require.False(t, overviewActive)
 }

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -76,6 +76,10 @@ func RunKeyBindings() []BindingCategory[Run] {
 					Handler:     (*Run).handleToggleConsoleLogsPane,
 				},
 				{
+					Keys:        []string{"drag border/separator"},
+					Description: "Resize panes with the mouse",
+				},
+				{
 					Keys:        []string{"0"},
 					Description: "Reset pane sizes to defaults",
 					Handler:     (*Run).handleResetLayout,
@@ -211,7 +215,7 @@ func RunKeyBindings() []BindingCategory[Run] {
 			},
 		},
 
-		mouseCategory(paneResizeBinding[Run]()),
+		mouseCategory[Run](),
 	}
 }
 
@@ -277,6 +281,10 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 					Keys:        []string{"4"},
 					Description: "Toggle console logs panel",
 					Handler:     (*Workspace).handleToggleConsoleLogsPane,
+				},
+				{
+					Keys:        []string{"drag border/separator"},
+					Description: "Resize panes with the mouse",
 				},
 				{
 					Keys:        []string{"0"},
@@ -439,7 +447,7 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 			},
 		},
 
-		mouseCategory(paneResizeBinding[Workspace]()),
+		mouseCategory[Workspace](),
 	}
 }
 
@@ -565,10 +573,10 @@ func normalizeKey(key string) string {
 	return key
 }
 
-func mouseCategory[T any](extra ...KeyBinding[T]) BindingCategory[T] {
+func mouseCategory[T any]() BindingCategory[T] {
 	return BindingCategory[T]{
 		Name: "Mouse",
-		Bindings: append([]KeyBinding[T]{
+		Bindings: []KeyBinding[T]{
 			{
 				Keys:        []string{"wheel"},
 				Description: "Zoom in/out on focused chart",
@@ -585,15 +593,6 @@ func mouseCategory[T any](extra ...KeyBinding[T]) BindingCategory[T] {
 				Keys:        []string{"shift+drag"},
 				Description: "Select text",
 			},
-		}, extra...),
-	}
-}
-
-// paneResizeBinding documents mouse-drag pane resizing for views that
-// support it (run and workspace).
-func paneResizeBinding[T any]() KeyBinding[T] {
-	return KeyBinding[T]{
-		Keys:        []string{"drag border/separator"},
-		Description: "Resize panes (press 0 to reset)",
+		},
 	}
 }

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -42,7 +42,8 @@ func RunKeyBindings() []BindingCategory[Run] {
 				},
 				{
 					Keys:        []string{"esc"},
-					Description: "Back to workspace (when not filtering/configuring)",
+					Description: "Unfocus pane, then back to workspace",
+					Handler:     (*Run).handleEscape,
 				},
 			},
 		},
@@ -73,6 +74,11 @@ func RunKeyBindings() []BindingCategory[Run] {
 					Keys:        []string{"4"},
 					Description: "Toggle console logs panel",
 					Handler:     (*Run).handleToggleConsoleLogsPane,
+				},
+				{
+					Keys:        []string{"0"},
+					Description: "Reset pane sizes to defaults",
+					Handler:     (*Run).handleResetLayout,
 				},
 			},
 		},
@@ -205,7 +211,7 @@ func RunKeyBindings() []BindingCategory[Run] {
 			},
 		},
 
-		mouseCategory[Run](),
+		mouseCategory(paneResizeBinding[Run]()),
 	}
 }
 
@@ -271,6 +277,11 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 					Keys:        []string{"4"},
 					Description: "Toggle console logs panel",
 					Handler:     (*Workspace).handleToggleConsoleLogsPane,
+				},
+				{
+					Keys:        []string{"0"},
+					Description: "Reset pane sizes to defaults",
+					Handler:     (*Workspace).handleResetLayout,
 				},
 			},
 		},
@@ -428,7 +439,7 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 			},
 		},
 
-		mouseCategory[Workspace](),
+		mouseCategory(paneResizeBinding[Workspace]()),
 	}
 }
 
@@ -554,10 +565,10 @@ func normalizeKey(key string) string {
 	return key
 }
 
-func mouseCategory[T any]() BindingCategory[T] {
+func mouseCategory[T any](extra ...KeyBinding[T]) BindingCategory[T] {
 	return BindingCategory[T]{
 		Name: "Mouse",
-		Bindings: []KeyBinding[T]{
+		Bindings: append([]KeyBinding[T]{
 			{
 				Keys:        []string{"wheel"},
 				Description: "Zoom in/out on focused chart",
@@ -574,6 +585,15 @@ func mouseCategory[T any]() BindingCategory[T] {
 				Keys:        []string{"shift+drag"},
 				Description: "Select text",
 			},
-		},
+		}, extra...),
+	}
+}
+
+// paneResizeBinding documents mouse-drag pane resizing for views that
+// support it (run and workspace).
+func paneResizeBinding[T any]() KeyBinding[T] {
+	return KeyBinding[T]{
+		Keys:        []string{"drag border/separator"},
+		Description: "Resize panes (press 0 to reset)",
 	}
 }

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -159,13 +159,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	// Snapshot before sub-models consume the key — a filter's Enter
-	// exits filter mode, so checking after would miss it.
+	// Snapshot before sub-models consume the key — a filter's Enter exits
+	// filter mode and the run's Esc clears pane focus, so checking after
+	// would miss them.
 	awaitingInput := m.isAwaitingUserInput()
+	runHadPaneFocus := m.mode == viewModeRun && m.run != nil && m.run.HasPaneFocus()
 
 	cmds := m.updateSubComponents(msg)
 
-	if cmd := m.handleModeSwitch(msg, awaitingInput); cmd != nil {
+	if cmd := m.handleModeSwitch(msg, awaitingInput, runHadPaneFocus); cmd != nil {
 		return m, cmd
 	}
 
@@ -197,10 +199,11 @@ func (m *Model) updateSubComponents(msg tea.Msg) []tea.Cmd {
 
 // handleModeSwitch checks for Enter/Esc and transitions between views.
 //
-// awaitingInput must be snapshotted before sub-components process the
-// message, because an Enter in filter mode exits the filter and would
-// otherwise fall through to a view switch.
-func (m *Model) handleModeSwitch(msg tea.Msg, awaitingInput bool) tea.Cmd {
+// awaitingInput and runHadPaneFocus must be snapshotted before sub-components
+// process the message: an Enter in filter mode exits the filter, and an Esc
+// with a focused pane clears that focus. Either would otherwise fall through
+// to a view switch on the same key press.
+func (m *Model) handleModeSwitch(msg tea.Msg, awaitingInput, runHadPaneFocus bool) tea.Cmd {
 	keyMsg, ok := msg.(tea.KeyPressMsg)
 	if !ok {
 		return nil
@@ -214,7 +217,8 @@ func (m *Model) handleModeSwitch(msg tea.Msg, awaitingInput bool) tea.Cmd {
 			return m.enterRunView()
 		}
 	case viewModeRun:
-		runCapturesEsc := m.run != nil && m.run.MediaFullscreen()
+		runCapturesEsc := runHadPaneFocus ||
+			(m.run != nil && m.run.MediaFullscreen())
 		if keyMsg.Code == tea.KeyEsc &&
 			!awaitingInput && !runCapturesEsc {
 			return m.exitRunView()

--- a/core/internal/leet/rightsidebar.go
+++ b/core/internal/leet/rightsidebar.go
@@ -54,7 +54,7 @@ func (rs *RightSidebar) UpdateDimensions(
 	leftSidebarVisible bool,
 	widthFrac float64,
 ) {
-	rs.animState.SetExpanded(sidebarWidthFor(terminalWidth, widthFrac, leftSidebarVisible))
+	rs.animState.SetExpanded(expandedSidebarWidth(terminalWidth, leftSidebarVisible, widthFrac))
 
 	if gridWidth := sidebarContentWidth(rs.animState.Value()); gridWidth > 0 {
 		rs.metricsGrid.Resize(gridWidth, defaultSystemMetricsGridHeight)

--- a/core/internal/leet/rightsidebar.go
+++ b/core/internal/leet/rightsidebar.go
@@ -46,10 +46,15 @@ func NewRightSidebar(
 	}
 }
 
-// UpdateDimensions updates the right sidebar dimensions based on terminal width
-// and the visibility of the left sidebar.
-func (rs *RightSidebar) UpdateDimensions(terminalWidth int, leftSidebarVisible bool) {
-	rs.animState.SetExpanded(expandedSidebarWidth(terminalWidth, leftSidebarVisible))
+// UpdateDimensions updates the right sidebar dimensions based on terminal
+// width, the visibility of the left sidebar, and an optional user-dragged
+// width fraction (0 = default).
+func (rs *RightSidebar) UpdateDimensions(
+	terminalWidth int,
+	leftSidebarVisible bool,
+	widthFrac float64,
+) {
+	rs.animState.SetExpanded(sidebarWidthFor(terminalWidth, widthFrac, leftSidebarVisible))
 
 	if gridWidth := sidebarContentWidth(rs.animState.Value()); gridWidth > 0 {
 		rs.metricsGrid.Resize(gridWidth, defaultSystemMetricsGridHeight)

--- a/core/internal/leet/rightsidebar_test.go
+++ b/core/internal/leet/rightsidebar_test.go
@@ -13,7 +13,7 @@ import (
 
 func expandRightSidebar(t *testing.T, rs *leet.RightSidebar, termWidth int, leftVisible bool) {
 	t.Helper()
-	rs.UpdateDimensions(termWidth, leftVisible)
+	rs.UpdateDimensions(termWidth, leftVisible, 0)
 	rs.Toggle()
 	time.Sleep(leet.AnimationDuration + 20*time.Millisecond)
 	rs.Update(leet.RightSidebarAnimationMsg{})
@@ -110,7 +110,7 @@ func TestRightSidebar_Update_ReturnsAnimationCmdWhileAnimating(t *testing.T) {
 	rs := leet.NewRightSidebar(cfg, &leet.Focus{}, logger)
 
 	// Start expansion; immediately update -> should get a continuation command.
-	rs.UpdateDimensions(120, false)
+	rs.UpdateDimensions(120, false, 0)
 	rs.Toggle()
 	_, cmd := rs.Update(leet.RightSidebarAnimationMsg{})
 	require.NotNil(t, cmd, "expected a continuation command while animating")

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -81,6 +81,13 @@ type Run struct {
 	focusMgr *FocusManager
 	focus    *Focus
 
+	// focusSeeded is set once initial focus lands on the first pane that
+	// receives data. After that, focus only ever changes on user action.
+	focusSeeded bool
+
+	// In-progress pane-boundary drag (mouse resize).
+	drag layoutDrag
+
 	// UI components.
 	metricsGridAnimState *AnimatedValue
 	metricsGrid          *MetricsGrid
@@ -254,15 +261,31 @@ func (r *Run) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // handleWindowResize handles window resize messages.
 func (r *Run) handleWindowResize(msg tea.WindowSizeMsg) {
 	r.width, r.height = msg.Width, msg.Height
+	r.applyLayoutConfig()
+	r.focusMgr.Resolve()
+}
 
-	r.leftSidebar.UpdateDimensions(msg.Width, r.rightSidebar.animState.TargetVisible())
-	r.rightSidebar.UpdateDimensions(msg.Width, r.leftSidebar.animState.TargetVisible())
+// applyLayoutConfig re-derives all pane extents from the terminal size and
+// any saved layout overrides.
+func (r *Run) applyLayoutConfig() {
+	r.updateSidebarDimensions(
+		r.leftSidebar.animState.TargetVisible(),
+		r.rightSidebar.animState.TargetVisible(),
+	)
 	r.updateBottomPaneHeights(
 		r.mediaPane.animState.TargetVisible(), r.consoleLogsPane.animState.TargetVisible())
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
-	r.focusMgr.ResolveAfterAvailabilityChange()
+}
+
+// updateSidebarDimensions re-derives both sidebars' expanded widths from the
+// terminal width, the given post-toggle visibility of each side, and any
+// saved layout overrides.
+func (r *Run) updateSidebarDimensions(leftVisible, rightVisible bool) {
+	o := r.config.RunLayout()
+	r.leftSidebar.UpdateDimensions(r.width, rightVisible, o.LeftSidebar)
+	r.rightSidebar.UpdateDimensions(r.width, leftVisible, o.RightSidebar)
 }
 
 // isUIMsg returns true for messages that should flow to child view models.
@@ -683,12 +706,13 @@ func (r *Run) updateBottomPaneHeights(mediaVisible, logsVisible bool) {
 		lowerTierH = maxH
 	}
 
+	o := r.config.RunLayout()
 	each := lowerTierH / lowerCount
 	if mediaVisible {
-		r.mediaPane.SetExpandedHeight(each)
+		r.mediaPane.SetExpandedHeight(paneHeightFor(o.Media, r.height, each))
 	}
 	if logsVisible {
-		r.consoleLogsPane.SetExpandedHeight(each)
+		r.consoleLogsPane.SetExpandedHeight(paneHeightFor(o.Logs, r.height, each))
 	}
 }
 

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -279,11 +279,20 @@ func (r *Run) applyLayoutConfig() {
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
 }
 
+// layoutOverrides returns the live pane proportions: the in-progress drag's
+// pending values, or the persisted config.
+func (r *Run) layoutOverrides() LayoutOverrides {
+	if r.drag.active() {
+		return r.drag.overrides
+	}
+	return r.config.RunLayout()
+}
+
 // updateSidebarDimensions re-derives both sidebars' expanded widths from the
-// terminal width, the given post-toggle visibility of each side, and any
-// saved layout overrides.
+// terminal width, the given post-toggle visibility of each side, and the
+// live layout overrides.
 func (r *Run) updateSidebarDimensions(leftVisible, rightVisible bool) {
-	o := r.config.RunLayout()
+	o := r.layoutOverrides()
 	r.leftSidebar.UpdateDimensions(r.width, rightVisible, o.LeftSidebar)
 	r.rightSidebar.UpdateDimensions(r.width, leftVisible, o.RightSidebar)
 }
@@ -707,7 +716,7 @@ func (r *Run) updateBottomPaneHeights(mediaVisible, logsVisible bool) {
 		lowerTierH = maxH
 	}
 
-	o := r.config.RunLayout()
+	o := r.layoutOverrides()
 	each := lowerTierH / lowerCount
 	if mediaVisible {
 		r.mediaPane.SetExpandedHeight(paneHeightFor(o.Media, r.height, each))

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -378,7 +378,8 @@ func (r *Run) renderMainView() string {
 					renderMetricsEmptyState(w, layout.height, "No scalar metrics logged."))
 			} else {
 				dims := r.metricsGrid.CalculateChartDimensions(w, layout.height)
-				sections = append(sections, r.metricsGrid.View(dims))
+				sections = append(sections,
+					padStackSection(r.metricsGrid.View(dims), w, layout.height))
 			}
 		}
 

--- a/core/internal/leet/runfocus.go
+++ b/core/internal/leet/runfocus.go
@@ -1,5 +1,7 @@
 package leet
 
+import tea "charm.land/bubbletea/v2"
+
 // buildRunFocusManager constructs the FocusManager for the single-run view.
 //
 // The region order follows the spatial layout so Tab flows naturally:
@@ -11,86 +13,63 @@ package leet
 func (r *Run) buildRunFocusManager() *FocusManager {
 	return NewFocusManager([]FocusRegionDef{
 		{
-			Target:          FocusTargetOverview,
-			Available:       r.overviewFocusAvailable,
-			AvailableTarget: r.overviewFocusTargetAvailable,
-			Activate:        r.activateOverviewFocus,
-			Deactivate:      r.deactivateOverviewFocus,
+			Target:     FocusTargetOverview,
+			Available:  r.overviewFocusAvailable,
+			Activate:   r.activateOverviewFocus,
+			Deactivate: r.deactivateOverviewFocus,
 		},
 		{
-			Target:          FocusTargetMetricsGrid,
-			Available:       r.metricsGridFocusAvailable,
-			AvailableTarget: r.metricsGridFocusTargetAvailable,
-			Activate:        r.activateMetricsGridFocus,
-			Deactivate:      r.deactivateMetricsGridFocus,
+			Target:     FocusTargetMetricsGrid,
+			Available:  r.metricsGridFocusAvailable,
+			Activate:   r.activateMetricsGridFocus,
+			Deactivate: r.deactivateMetricsGridFocus,
 		},
 		{
-			Target:          FocusTargetMedia,
-			Available:       r.mediaFocusAvailable,
-			AvailableTarget: r.mediaFocusTargetAvailable,
-			Activate:        r.activateMediaFocus,
-			Deactivate:      r.deactivateMediaFocus,
+			Target:     FocusTargetMedia,
+			Available:  r.mediaFocusAvailable,
+			Activate:   r.activateMediaFocus,
+			Deactivate: r.deactivateMediaFocus,
 		},
 		{
-			Target:          FocusTargetConsoleLogs,
-			Available:       r.logsFocusAvailable,
-			AvailableTarget: r.logsFocusTargetAvailable,
-			Activate:        r.activateLogsFocus,
-			Deactivate:      r.deactivateLogsFocus,
+			Target:     FocusTargetConsoleLogs,
+			Available:  r.logsFocusAvailable,
+			Activate:   r.activateLogsFocus,
+			Deactivate: r.deactivateLogsFocus,
 		},
 		{
-			Target:          FocusTargetSystemMetrics,
-			Available:       r.systemMetricsFocusAvailable,
-			AvailableTarget: r.systemMetricsFocusTargetAvailable,
-			Activate:        r.activateSystemMetricsFocus,
-			Deactivate:      r.deactivateSystemMetricsFocus,
+			Target:     FocusTargetSystemMetrics,
+			Available:  r.systemMetricsFocusAvailable,
+			Activate:   r.activateSystemMetricsFocus,
+			Deactivate: r.deactivateSystemMetricsFocus,
 		},
 	})
 }
 
 // ---- Availability ----
+//
+// A region is available when its pane's target state is visible and it has
+// content to interact with. Empty panes are skipped by Tab navigation.
 
 func (r *Run) overviewFocusAvailable() bool {
-	firstSec, _ := r.leftSidebar.focusableSectionBounds()
-	return r.leftSidebar.animState.IsExpanded() && firstSec != -1
-}
-
-func (r *Run) overviewFocusTargetAvailable() bool {
 	firstSec, _ := r.leftSidebar.focusableSectionBounds()
 	return r.leftSidebar.animState.TargetVisible() && firstSec != -1
 }
 
 func (r *Run) metricsGridFocusAvailable() bool {
-	return r.metricsGridAnimState.IsExpanded() && r.metricsGrid.ChartCount() > 0
-}
-
-func (r *Run) metricsGridFocusTargetAvailable() bool {
 	return r.metricsGridAnimState.TargetVisible() && r.metricsGrid.ChartCount() > 0
 }
 
 func (r *Run) systemMetricsFocusAvailable() bool {
-	return r.rightSidebar.IsVisible() && r.rightSidebar.metricsGrid.ChartCount() > 0
-}
-
-func (r *Run) systemMetricsFocusTargetAvailable() bool {
 	return r.rightSidebar.animState.TargetVisible() &&
 		r.rightSidebar.metricsGrid.ChartCount() > 0
 }
 
 func (r *Run) mediaFocusAvailable() bool {
-	return r.mediaPane.IsExpanded() && r.mediaPane.HasData()
-}
-
-func (r *Run) mediaFocusTargetAvailable() bool {
 	return r.mediaPane.animState.TargetVisible() && r.mediaPane.HasData()
 }
 
 func (r *Run) logsFocusAvailable() bool {
-	return r.consoleLogsPane.IsExpanded()
-}
-
-func (r *Run) logsFocusTargetAvailable() bool {
-	return r.consoleLogsPane.animState.TargetVisible()
+	return r.consoleLogsPane.animState.TargetVisible() && r.consoleLogsPane.HasData()
 }
 
 // ---- Activate ----
@@ -156,13 +135,41 @@ func (r *Run) deactivateLogsFocus() {
 	r.consoleLogsPane.SetActive(false)
 }
 
+// resolveFocusAfterData keeps focus consistent as data streams in.
+//
+// The first time any region becomes available, focus is seeded there so
+// keyboard navigation works immediately after load. From then on, incoming
+// data never moves focus; it is only cleared if the focused pane disappears.
+func (r *Run) resolveFocusAfterData() {
+	if r.focusSeeded {
+		r.focusMgr.Resolve()
+		return
+	}
+	if r.focusMgr.Current() == FocusTargetNone {
+		r.focusMgr.Tab(1)
+	}
+	r.focusSeeded = r.focusMgr.Current() != FocusTargetNone
+}
+
+// HasPaneFocus reports whether any pane currently holds focus.
+func (r *Run) HasPaneFocus() bool {
+	return r.focusMgr.Current() != FocusTargetNone
+}
+
+// handleEscape clears pane focus. When nothing is focused, the parent model
+// handles Esc by exiting back to the workspace.
+func (r *Run) handleEscape(tea.KeyPressMsg) tea.Cmd {
+	r.focusMgr.ClearAll()
+	return nil
+}
+
 // ---- Within-region cycling ----
 
 // cycleRunOverviewSection tries to move within overview sections.
 // Returns true if the navigation was handled (i.e. we're not at a boundary).
 func (r *Run) cycleRunOverviewSection(direction int) bool {
 	firstSec, lastSec := r.leftSidebar.focusableSectionBounds()
-	if !r.leftSidebar.animState.IsExpanded() || firstSec == -1 {
+	if !r.overviewFocusAvailable() {
 		return false
 	}
 

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -142,6 +142,7 @@ func (r *Run) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
 		if !ok || (drag.boundary == dragBoundarySeparator && r.mediaPane.IsFullscreen()) {
 			return false
 		}
+		drag.overrides = r.config.RunLayout()
 		r.drag = drag
 		return true
 
@@ -162,32 +163,35 @@ func (r *Run) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
 	return false
 }
 
-// applyLayoutDrag resizes the dragged pane to follow the mouse.
+// applyLayoutDrag resizes the dragged pane(s) to follow the mouse.
 func (r *Run) applyLayoutDrag(x, y int, layout Layout) {
 	switch r.drag.boundary {
 	case dragBoundaryLeftSidebar:
-		r.drag.frac = float64(x+1) / float64(r.width)
+		r.drag.overrides.LeftSidebar = float64(x+1) / float64(r.width)
 		r.leftSidebar.UpdateDimensions(
-			r.width, r.rightSidebar.animState.TargetVisible(), r.drag.frac)
+			r.width, r.rightSidebar.animState.TargetVisible(), r.drag.overrides.LeftSidebar)
 
 	case dragBoundaryRightSidebar:
-		r.drag.frac = float64(r.width-x) / float64(r.width)
+		r.drag.overrides.RightSidebar = float64(r.width-x) / float64(r.width)
 		r.rightSidebar.UpdateDimensions(
-			r.width, r.leftSidebar.animState.TargetVisible(), r.drag.frac)
+			r.width, r.leftSidebar.animState.TargetVisible(), r.drag.overrides.RightSidebar)
 
 	case dragBoundarySeparator:
-		newH, frac, ok := dragSeparatorHeight(layout, r.drag.section, y, r.height)
-		if !ok {
+		resizes := dragSeparator(layout, r.drag.section, y, r.height)
+		if len(resizes) == 0 {
 			return
 		}
-		r.drag.frac = frac
-		switch r.drag.section {
-		case stackSectionMedia:
-			r.mediaPane.SetExpandedHeight(newH)
-		case stackSectionConsoleLogs:
-			r.consoleLogsPane.SetExpandedHeight(newH)
+		for _, rz := range resizes {
+			switch rz.section {
+			case stackSectionMedia:
+				r.mediaPane.SetExpandedHeight(rz.height)
+			case stackSectionConsoleLogs:
+				r.consoleLogsPane.SetExpandedHeight(rz.height)
+			}
+			r.drag.overrides.setSection(rz.section, rz.frac)
 		}
 	}
+	r.drag.dirty = true
 
 	resized := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(resized.mainContentAreaWidth, resized.height)
@@ -202,29 +206,14 @@ func (r *Run) handleResetLayout(tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
-// finishLayoutDrag persists the dragged proportion and ends the drag.
+// finishLayoutDrag persists the dragged proportions and ends the drag.
 func (r *Run) finishLayoutDrag() {
 	drag := r.drag
 	r.drag = layoutDrag{}
-	if drag.frac == 0 {
+	if !drag.dirty {
 		return // Click without motion: nothing changed.
 	}
-
-	o := r.config.RunLayout()
-	switch drag.boundary {
-	case dragBoundaryLeftSidebar:
-		o.LeftSidebar = drag.frac
-	case dragBoundaryRightSidebar:
-		o.RightSidebar = drag.frac
-	case dragBoundarySeparator:
-		switch drag.section {
-		case stackSectionMedia:
-			o.Media = drag.frac
-		case stackSectionConsoleLogs:
-			o.Logs = drag.frac
-		}
-	}
-	if err := r.config.SetRunLayout(o); err != nil {
+	if err := r.config.SetRunLayout(drag.overrides); err != nil {
 		r.logger.Error(fmt.Sprintf("model: failed to save layout: %v", err))
 	}
 }

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -17,7 +17,7 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 	defer func() {
 		r.logger.Debug(fmt.Sprintf("perf: processRecordMsg(%T) took %s", msg, time.Since(start)))
 	}()
-	defer r.focusMgr.ResolveAfterAvailabilityChange()
+	defer r.resolveFocusAfterData()
 
 	switch msg := msg.(type) {
 	case RunMsg:
@@ -56,6 +56,9 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 	case ConsoleLogMsg:
 		r.logger.Debug("model: processing ConsoleLogMsg")
 		r.consoleLogs.ProcessRaw(msg.Text, msg.IsStderr, msg.Time)
+		// Keep the pane's data (and thus focus availability) current
+		// without waiting for the next render.
+		r.consoleLogsPane.SetConsoleLogs(r.consoleLogs.Items())
 
 	case FileCompleteMsg:
 		r.logger.Debug("model: processing FileCompleteMsg - file is complete!")
@@ -110,6 +113,11 @@ func (r *Run) handleMouseMsg(msg tea.MouseMsg) tea.Cmd {
 
 	layout := r.computeViewports()
 
+	// Pane resizing wins over pane-local mouse handling.
+	if r.handleLayoutDrag(msg, layout) {
+		return nil
+	}
+
 	if r.isInLeftSidebar(msg, layout) {
 		return r.handleLeftSidebarMouse()
 	}
@@ -119,6 +127,106 @@ func (r *Run) handleMouseMsg(msg tea.MouseMsg) tea.Cmd {
 	}
 
 	return r.handleMainContentMouse(msg, layout)
+}
+
+// handleLayoutDrag processes mouse events for pane-boundary resizing.
+// It returns true when the event was consumed by an active or new drag.
+func (r *Run) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
+	switch m := msg.(type) {
+	case tea.MouseClickMsg:
+		if m.Button != tea.MouseLeft {
+			return false
+		}
+		drag, ok := boundaryAt(m.X, m.Y, r.width, layout,
+			r.leftSidebar.IsExpanded(), r.rightSidebar.animState.IsExpanded())
+		if !ok || (drag.boundary == dragBoundarySeparator && r.mediaPane.IsFullscreen()) {
+			return false
+		}
+		r.drag = drag
+		return true
+
+	case tea.MouseMotionMsg:
+		if !r.drag.active() || m.Button != tea.MouseLeft {
+			return false
+		}
+		r.applyLayoutDrag(m.X, m.Y, layout)
+		return true
+
+	case tea.MouseReleaseMsg:
+		if !r.drag.active() {
+			return false
+		}
+		r.finishLayoutDrag()
+		return true
+	}
+	return false
+}
+
+// applyLayoutDrag resizes the dragged pane to follow the mouse.
+func (r *Run) applyLayoutDrag(x, y int, layout Layout) {
+	switch r.drag.boundary {
+	case dragBoundaryLeftSidebar:
+		r.drag.frac = float64(x+1) / float64(r.width)
+		r.leftSidebar.UpdateDimensions(
+			r.width, r.rightSidebar.animState.TargetVisible(), r.drag.frac)
+
+	case dragBoundaryRightSidebar:
+		r.drag.frac = float64(r.width-x) / float64(r.width)
+		r.rightSidebar.UpdateDimensions(
+			r.width, r.leftSidebar.animState.TargetVisible(), r.drag.frac)
+
+	case dragBoundarySeparator:
+		newH, frac, ok := dragSeparatorHeight(layout, r.drag.section, y, r.height)
+		if !ok {
+			return
+		}
+		r.drag.frac = frac
+		switch r.drag.section {
+		case stackSectionMedia:
+			r.mediaPane.SetExpandedHeight(newH)
+		case stackSectionConsoleLogs:
+			r.consoleLogsPane.SetExpandedHeight(newH)
+		}
+	}
+
+	resized := r.computeViewports()
+	r.metricsGrid.UpdateDimensions(resized.mainContentAreaWidth, resized.height)
+}
+
+// handleResetLayout resets the view's pane proportions to the defaults.
+func (r *Run) handleResetLayout(tea.KeyPressMsg) tea.Cmd {
+	if err := r.config.SetRunLayout(LayoutOverrides{}); err != nil {
+		r.logger.Error(fmt.Sprintf("model: failed to save layout: %v", err))
+	}
+	r.applyLayoutConfig()
+	return nil
+}
+
+// finishLayoutDrag persists the dragged proportion and ends the drag.
+func (r *Run) finishLayoutDrag() {
+	drag := r.drag
+	r.drag = layoutDrag{}
+	if drag.frac == 0 {
+		return // Click without motion: nothing changed.
+	}
+
+	o := r.config.RunLayout()
+	switch drag.boundary {
+	case dragBoundaryLeftSidebar:
+		o.LeftSidebar = drag.frac
+	case dragBoundaryRightSidebar:
+		o.RightSidebar = drag.frac
+	case dragBoundarySeparator:
+		switch drag.section {
+		case stackSectionMedia:
+			o.Media = drag.frac
+		case stackSectionConsoleLogs:
+			o.Logs = drag.frac
+		}
+	}
+	if err := r.config.SetRunLayout(o); err != nil {
+		r.logger.Error(fmt.Sprintf("model: failed to save layout: %v", err))
+	}
 }
 
 // isInLeftSidebar checks if mouse position is in the left sidebar region.
@@ -375,8 +483,7 @@ func (r *Run) endAnimating() {
 }
 
 // handleToggleLeftSidebar toggles the left overview sidebar and resolves
-// focus so a collapsing sidebar loses focus and an expanding sidebar
-// gains it when nothing else is focused.
+// focus so a collapsing sidebar loses focus.
 func (r *Run) handleToggleLeftSidebar(msg tea.KeyPressMsg) tea.Cmd {
 	if !r.beginAnimating() {
 		return nil
@@ -388,11 +495,10 @@ func (r *Run) handleToggleLeftSidebar(msg tea.KeyPressMsg) tea.Cmd {
 		r.logger.Error(fmt.Sprintf("model: failed to save left sidebar state: %v", err))
 	}
 
-	r.leftSidebar.UpdateDimensions(r.width, r.rightSidebar.animState.TargetVisible())
-	r.rightSidebar.UpdateDimensions(r.width, leftWillBeVisible)
+	r.updateSidebarDimensions(leftWillBeVisible, r.rightSidebar.animState.TargetVisible())
 	r.leftSidebar.Toggle()
 
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
@@ -411,10 +517,9 @@ func (r *Run) handleToggleRightSidebar(msg tea.KeyPressMsg) tea.Cmd {
 		r.logger.Error(fmt.Sprintf("model: failed to save right sidebar state: %v", err))
 	}
 
-	r.rightSidebar.UpdateDimensions(r.width, r.leftSidebar.animState.TargetVisible())
-	r.leftSidebar.UpdateDimensions(r.width, rightWillBeVisible)
+	r.updateSidebarDimensions(r.leftSidebar.animState.TargetVisible(), rightWillBeVisible)
 	r.rightSidebar.Toggle()
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
@@ -533,7 +638,7 @@ func (r *Run) handleToggleMetricsGrid(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	r.metricsGridAnimState.Toggle()
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	r.updateBottomPaneHeights(
 		r.mediaPane.animState.TargetVisible(), r.consoleLogsPane.animState.TargetVisible())
@@ -689,7 +794,8 @@ func (r *Run) handleSidebarAnimation(msg tea.Msg) []tea.Cmd {
 		}
 
 		r.endAnimating()
-		r.rightSidebar.UpdateDimensions(r.width, r.leftSidebar.animState.TargetVisible())
+		r.rightSidebar.UpdateDimensions(
+			r.width, r.leftSidebar.animState.TargetVisible(), r.config.RunLayout().RightSidebar)
 
 	case RightSidebarAnimationMsg:
 		layout := r.computeViewports()
@@ -700,7 +806,8 @@ func (r *Run) handleSidebarAnimation(msg tea.Msg) []tea.Cmd {
 		}
 
 		r.endAnimating()
-		r.leftSidebar.UpdateDimensions(r.width, r.rightSidebar.animState.TargetVisible())
+		r.leftSidebar.UpdateDimensions(
+			r.width, r.rightSidebar.animState.TargetVisible(), r.config.RunLayout().LeftSidebar)
 	}
 
 	return nil
@@ -723,10 +830,7 @@ func (r *Run) handleToggleMediaPane(msg tea.KeyPressMsg) tea.Cmd {
 
 	r.mediaPane.Toggle()
 	r.updateBottomPaneHeights(mediaWillBeVisible, r.consoleLogsPane.animState.TargetVisible())
-
-	if !mediaWillBeVisible {
-		r.focusMgr.ResolveAfterVisibilityChange()
-	}
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
@@ -754,9 +858,8 @@ func (r *Run) mediaPaneAnimationCmd() tea.Cmd {
 	})
 }
 
-// handleToggleConsoleLogsPane toggles the console logs bottom bar and resolves
-// focus so a collapsing bar loses focus and an expanding bar gains it
-// when nothing else is focused.
+// handleToggleConsoleLogsPane toggles the console logs bottom bar and
+// resolves focus so a collapsing bar loses focus.
 func (r *Run) handleToggleConsoleLogsPane(msg tea.KeyPressMsg) tea.Cmd {
 	if !r.beginAnimating() {
 		return nil
@@ -770,7 +873,7 @@ func (r *Run) handleToggleConsoleLogsPane(msg tea.KeyPressMsg) tea.Cmd {
 
 	r.consoleLogsPane.Toggle()
 	r.updateBottomPaneHeights(r.mediaPane.animState.TargetVisible(), bottomWillBeVisible)
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -163,38 +163,22 @@ func (r *Run) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
 	return false
 }
 
-// applyLayoutDrag resizes the dragged pane(s) to follow the mouse.
+// applyLayoutDrag updates the pending overrides from the mouse position and
+// re-lays the view out from them.
 func (r *Run) applyLayoutDrag(x, y int, layout Layout) {
+	o := &r.drag.overrides
 	switch r.drag.boundary {
 	case dragBoundaryLeftSidebar:
-		r.drag.overrides.LeftSidebar = float64(x+1) / float64(r.width)
-		r.leftSidebar.UpdateDimensions(
-			r.width, r.rightSidebar.animState.TargetVisible(), r.drag.overrides.LeftSidebar)
-
+		o.LeftSidebar = float64(x+1) / float64(r.width)
 	case dragBoundaryRightSidebar:
-		r.drag.overrides.RightSidebar = float64(r.width-x) / float64(r.width)
-		r.rightSidebar.UpdateDimensions(
-			r.width, r.leftSidebar.animState.TargetVisible(), r.drag.overrides.RightSidebar)
-
+		o.RightSidebar = float64(r.width-x) / float64(r.width)
 	case dragBoundarySeparator:
-		resizes := dragSeparator(layout, r.drag.section, y, r.height)
-		if len(resizes) == 0 {
+		if !dragSeparator(o, layout, r.drag.section, y, r.height) {
 			return
-		}
-		for _, rz := range resizes {
-			switch rz.section {
-			case stackSectionMedia:
-				r.mediaPane.SetExpandedHeight(rz.height)
-			case stackSectionConsoleLogs:
-				r.consoleLogsPane.SetExpandedHeight(rz.height)
-			}
-			r.drag.overrides.setSection(rz.section, rz.frac)
 		}
 	}
 	r.drag.dirty = true
-
-	resized := r.computeViewports()
-	r.metricsGrid.UpdateDimensions(resized.mainContentAreaWidth, resized.height)
+	r.applyLayoutConfig()
 }
 
 // handleResetLayout resets the view's pane proportions to the defaults.
@@ -784,7 +768,7 @@ func (r *Run) handleSidebarAnimation(msg tea.Msg) []tea.Cmd {
 
 		r.endAnimating()
 		r.rightSidebar.UpdateDimensions(
-			r.width, r.leftSidebar.animState.TargetVisible(), r.config.RunLayout().RightSidebar)
+			r.width, r.leftSidebar.animState.TargetVisible(), r.layoutOverrides().RightSidebar)
 
 	case RightSidebarAnimationMsg:
 		layout := r.computeViewports()
@@ -796,7 +780,7 @@ func (r *Run) handleSidebarAnimation(msg tea.Msg) []tea.Cmd {
 
 		r.endAnimating()
 		r.leftSidebar.UpdateDimensions(
-			r.width, r.rightSidebar.animState.TargetVisible(), r.config.RunLayout().LeftSidebar)
+			r.width, r.rightSidebar.animState.TargetVisible(), r.layoutOverrides().LeftSidebar)
 	}
 
 	return nil

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -3,6 +3,7 @@ package leet_test
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -62,11 +63,17 @@ func newRunForHandlerTest(t *testing.T) *leet.Run {
 	return r
 }
 
+// seedConsoleLog gives the console logs pane content so it is focusable.
+func seedConsoleLog(r *leet.Run) {
+	r.TestHandleRecordMsg(leet.ConsoleLogMsg{Text: "hello", Time: time.Now()})
+}
+
 // ---- handleSidebarTabNav ----
 
 func TestRun_SidebarTabNav_BothPanelsVisible_CyclesOverviewThenLogs(t *testing.T) {
 	r := newRunForHandlerTest(t)
 	r.TestForceExpandConsoleLogsPane(10)
+	seedConsoleLog(r)
 
 	// Initial state: overview section 0 should be active.
 	sidebar := r.TestGetLeftSidebar()
@@ -99,12 +106,32 @@ func TestRun_SidebarTabNav_BothPanelsVisible_CyclesOverviewThenLogs(t *testing.T
 func TestRun_SidebarTabNav_OnlyLogsVisible(t *testing.T) {
 	r := newRunForHandlerTest(t)
 	r.TestForceExpandConsoleLogsPane(10)
+	seedConsoleLog(r)
 	r.TestForceCollapseLeftSidebar()
 
 	// With overview collapsed, Tab should activate logs.
 	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	require.True(t, r.TestConsoleLogsPaneActive(),
 		"Tab with collapsed overview should still reach logs")
+}
+
+func TestRun_SidebarTabNav_SkipsEmptyLogsPane(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	r.TestForceExpandConsoleLogsPane(10)
+
+	// The logs pane is open but has no content: Tab must skip it and
+	// keep cycling overview sections.
+	sidebar := r.TestGetLeftSidebar()
+	_, lastSec := sidebar.TestFocusableSectionBounds()
+	for r.TestLeftSidebarActiveSectionIdx() < lastSec {
+		r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	}
+	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	require.False(t, r.TestConsoleLogsPaneActive(),
+		"an empty logs pane must not receive focus")
+	require.True(t, r.TestLeftSidebarHasActiveSection(),
+		"focus should wrap back to the overview")
 }
 
 func TestRun_SidebarTabNav_OnlyOverviewVisible(t *testing.T) {
@@ -133,10 +160,112 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 	}, cfg, logger)
 	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
 
+	// Focus is seeded once the first pane gains content.
+	seedConsoleLog(r)
+
 	require.True(t, r.TestConsoleLogsPaneActive(),
 		"the first available pane should receive focus on load")
 	require.False(t, r.TestLeftSidebarHasActiveSection(),
 		"collapsed overview should not appear focused")
+}
+
+// ---- Mouse drag-resize of the sidebars ----
+
+func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	require.Positive(t, right0)
+
+	// Press on the right sidebar's border column, drag 10 columns left
+	// (widening the sidebar), release.
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+
+	_, right1 := r.TestLayoutWidths()
+	require.Equal(t, right0+10, right1, "drag should widen the right sidebar")
+	require.InDelta(t, float64(right0+10)/200.0, cfg.RunLayout().RightSidebar, 1e-9,
+		"released drag should persist the width as a fraction of the terminal")
+
+	// "0" resets the proportions and the persisted overrides.
+	r.Update(tea.KeyPressMsg{Code: '0'})
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
+	_, right2 := r.TestLayoutWidths()
+	require.Equal(t, right0, right2, "reset should restore the default width")
+}
+
+// ---- Esc: unfocus pane first, exit view second ----
+
+func TestRun_EscUnfocusesPane(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	require.True(t, r.HasPaneFocus(), "seeded run should start with pane focus")
+
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	require.False(t, r.HasPaneFocus(), "Esc should clear pane focus")
+	require.False(t, r.TestLeftSidebarHasActiveSection(),
+		"overview sections should be deactivated after Esc")
+}
+
+func TestRun_DataAfterEscDoesNotRestealFocus(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, r.HasPaneFocus())
+
+	// More data arriving must not move focus once the user unfocused.
+	r.TestHandleRecordMsg(leet.SummaryMsg{
+		Summary: []*spb.SummaryRecord{{
+			Update: []*spb.SummaryItem{
+				{NestedKey: []string{"acc"}, ValueJson: "0.9"},
+			},
+		}},
+	})
+	require.False(t, r.HasPaneFocus(),
+		"incoming data must not re-steal focus after Esc")
+}
+
+func TestModel_EscExitsRunViewOnlyWhenUnfocused(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	m := leet.NewModel(leet.ModelParams{
+		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
+		Config:    cfg,
+		Logger:    logger,
+	})
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Seed overview data so focus lands on a pane.
+	require.True(t, m.TestInRunMode())
+	m.TestRunModel().TestHandleRecordMsg(leet.RunMsg{
+		ID:      "abc123",
+		Project: "test-project",
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"lr"}, ValueJson: "0.01"},
+			},
+		},
+	})
+	require.True(t, m.TestRunModel().HasPaneFocus())
+
+	// First Esc unfocuses the pane but stays in the run view.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.True(t, m.TestInRunMode(), "Esc with a focused pane must not exit the view")
+	require.False(t, m.TestRunModel().HasPaneFocus())
+
+	// Second Esc exits to the workspace.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, m.TestInRunMode(), "Esc with no pane focus should exit to workspace")
+	_ = tm
 }
 
 func TestRun_OverviewUpdatesPreserveTabContext(t *testing.T) {

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -2,6 +2,7 @@ package leet_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -200,6 +201,73 @@ func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {
 	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
 	_, right2 := r.TestLayoutWidths()
 	require.Equal(t, right0, right2, "reset should restore the default width")
+}
+
+// TestRun_RenderedSeparatorsAlignWithLayout pins the invariant that mouse
+// hit-testing depends on: the separator rows drawn on screen sit exactly at
+// the rows computeVerticalStackLayout reserves for them. The metrics grid
+// renders header + rows*cellHeight lines, so without padding to the section
+// height, everything below it (and its separators) drifts up by the integer
+// division remainder.
+func TestRun_RenderedSeparatorsAlignWithLayout(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(false)
+	_ = cfg.SetRightSidebarVisible(false)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	// A height where the grid's cell height division leaves a remainder.
+	r.Update(tea.WindowSizeMsg{Width: 120, Height: 52})
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+	})
+
+	metrics, media, _ := r.TestStackHeights()
+	lines := strings.Split(stripANSI(r.View().Content), "\n")
+
+	for _, row := range []int{metrics, metrics + 1 + media} {
+		require.Less(t, row, len(lines))
+		require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
+			"expected a separator at row %d, got %q", row, lines[row])
+	}
+}
+
+func TestRun_DragSeparatorResizesMediaAndLogs(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 100})
+
+	metrics0, media0, logs0 := r.TestStackHeights()
+	require.Positive(t, media0)
+	require.Positive(t, logs0)
+
+	// The separator above logs sits between two fixed panes (media above,
+	// logs below). Drag it down 2 rows: media grows, logs shrinks.
+	left0, _ := r.TestLayoutWidths()
+	x := left0 + 5
+	sepY := metrics0 + 1 + media0 + 1 - 1 // gap row above logs
+	r.Update(tea.MouseClickMsg{X: x, Y: sepY, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
+
+	metrics1, media1, logs1 := r.TestStackHeights()
+	require.Equal(t, media0+2, media1, "pane above the separator should grow")
+	require.Equal(t, logs0-2, logs1, "pane below the separator should shrink")
+	require.Equal(t, metrics0, metrics1, "flex metrics grid should be untouched")
+
+	// Both fractions persist on release.
+	o := cfg.RunLayout()
+	require.InDelta(t, float64(media1)/100.0, o.Media, 1e-9)
+	require.InDelta(t, float64(logs1)/100.0, o.Logs, 1e-9)
 }
 
 // ---- Esc: unfocus pane first, exit view second ----

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -75,32 +75,11 @@ func (s *RunOverviewSidebar) Toggle() {
 	s.animState.Toggle()
 }
 
-// Update handles animation and input updates for the sidebar.
+// Update advances the sidebar's expand/collapse animation.
+//
+// Key input never reaches this method: all sidebar navigation flows through
+// the owning view's FocusManager and key bindings.
 func (s *RunOverviewSidebar) Update(msg tea.Msg) (*RunOverviewSidebar, tea.Cmd) {
-	// Handle key input only when expanded.
-	// TODO: hook up with keybindings.
-	if s.animState.IsExpanded() {
-		if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
-			switch keyMsg.Code {
-			case tea.KeyUp:
-				s.navigateUp()
-			case tea.KeyDown:
-				s.navigateDown()
-			case tea.KeyTab:
-				if keyMsg.Mod == tea.ModShift {
-					s.navigateSection(-1)
-				} else {
-					s.navigateSection(1)
-				}
-			case tea.KeyLeft:
-				s.navigatePageUp()
-			case tea.KeyRight:
-				s.navigatePageDown()
-			}
-		}
-	}
-
-	// Handle animation.
 	if s.animState.IsAnimating() {
 		if complete := s.animState.Update(time.Now()); !complete {
 			cmd := s.animationCmd()
@@ -230,10 +209,15 @@ func (s *RunOverviewSidebar) Sync() {
 	}
 }
 
-// UpdateDimensions updates the sidebar dimensions based on terminal width
-// and the visibility of the sidebar on the opposite side.
-func (s *RunOverviewSidebar) UpdateDimensions(terminalWidth int, oppositeSidebarVisible bool) {
-	s.animState.SetExpanded(expandedSidebarWidth(terminalWidth, oppositeSidebarVisible))
+// UpdateDimensions updates the sidebar dimensions based on terminal width,
+// the visibility of the sidebar on the opposite side, and an optional
+// user-dragged width fraction (0 = default).
+func (s *RunOverviewSidebar) UpdateDimensions(
+	terminalWidth int,
+	oppositeSidebarVisible bool,
+	widthFrac float64,
+) {
+	s.animState.SetExpanded(sidebarWidthFor(terminalWidth, widthFrac, oppositeSidebarVisible))
 }
 
 // Width returns the current width of the sidebar.

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -217,7 +217,7 @@ func (s *RunOverviewSidebar) UpdateDimensions(
 	oppositeSidebarVisible bool,
 	widthFrac float64,
 ) {
-	s.animState.SetExpanded(sidebarWidthFor(terminalWidth, widthFrac, oppositeSidebarVisible))
+	s.animState.SetExpanded(expandedSidebarWidth(terminalWidth, oppositeSidebarVisible, widthFrac))
 }
 
 // Width returns the current width of the sidebar.

--- a/core/internal/leet/runoverviewsidebar_test.go
+++ b/core/internal/leet/runoverviewsidebar_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/require"
 
@@ -102,7 +101,7 @@ func TestSidebar_ConfirmSummaryFilterSelectsSummary(t *testing.T) {
 
 func expandSidebar(t *testing.T, s *leet.RunOverviewSidebar, termWidth int, rightVisible bool) {
 	t.Helper()
-	s.UpdateDimensions(termWidth, rightVisible)
+	s.UpdateDimensions(termWidth, rightVisible, 0)
 	s.Toggle()
 	time.Sleep(leet.AnimationDuration + 20*time.Millisecond)
 	// Drive animation to completion.
@@ -183,26 +182,26 @@ func TestSidebar_Navigation_SectionPageUpDown(t *testing.T) {
 
 	s.Sync()
 
-	// Start in Environment; Tab to Config (navigateSection).
-	s.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	// Start in Environment; move to Config (navigateSection).
+	s.TestNavigateSection(1)
 	key, _ := s.SelectedItem()
 	require.True(t, strings.HasPrefix(key, "alpha.") || strings.HasPrefix(key, "beta."))
 
 	// Height=15 -> 1 item/page; Down moves to next page/next item (navigateDown + navigatePage).
 	_ = s.View(15)
-	s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	s.TestNavigateDown()
 	key2, _ := s.SelectedItem()
 	require.NotEqual(t, key2, key)
 
 	// Page right, then left, then Up; remain in Config.
-	s.Update(tea.KeyPressMsg{Code: tea.KeyRight})
-	s.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
-	s.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	s.TestNavigatePageDown()
+	s.TestNavigatePageUp()
+	s.TestNavigateUp()
 	key3, _ := s.SelectedItem()
 	require.True(t, strings.HasPrefix(key3, "alpha.") || strings.HasPrefix(key3, "beta."))
 
-	// Shift-Tab back to previous section (Environment).
-	s.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	// Step back to the previous section (Environment).
+	s.TestNavigateSection(-1)
 	key4, _ := s.SelectedItem()
 	require.False(t, strings.HasPrefix(key4, "alpha.") || strings.HasPrefix(key4, "beta."))
 }
@@ -405,7 +404,7 @@ func TestSidebar_Pagination_ResizeFromLaterPage(t *testing.T) {
 
 	// Navigate down a few items to force CurrentPage > 0.
 	for range 5 {
-		s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		s.TestNavigateDown()
 	}
 
 	// Larger height -> ItemsPerPage increases. This used to panic.

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -75,6 +75,24 @@ func (r *Run) TestStopHeartbeat() {
 	}
 }
 
+// TestLayoutWidths returns the run view's current sidebar widths.
+func (r *Run) TestLayoutWidths() (left, right int) {
+	l := r.computeViewports()
+	return l.leftSidebarWidth, l.rightSidebarWidth
+}
+
+// TestLayoutWidths returns the workspace's current sidebar widths.
+func (w *Workspace) TestLayoutWidths() (left, right int) {
+	l := w.computeViewports()
+	return l.leftSidebarWidth, l.rightSidebarWidth
+}
+
+// TestInRunMode reports whether the model shows the single-run view.
+func (m *Model) TestInRunMode() bool { return m.mode == viewModeRun }
+
+// TestRunModel returns the single-run sub-model (nil in workspace mode).
+func (m *Model) TestRunModel() *Run { return m.run }
+
 func (s *Symon) TestGrid() *SystemMetricsGrid {
 	return s.grid
 }
@@ -546,6 +564,20 @@ func (w *Workspace) TestConsoleLogs() map[string]*RunConsoleLogs {
 	return w.consoleLogs
 }
 
+// TestSeedConsoleLogs populates console logs for a run and syncs the pane so
+// the console logs region becomes focusable.
+func (w *Workspace) TestSeedConsoleLogs(runKey string, lines ...string) {
+	cl := w.consoleLogs[runKey]
+	if cl == nil {
+		cl = NewRunConsoleLogs()
+		w.consoleLogs[runKey] = cl
+	}
+	for _, line := range lines {
+		cl.ProcessRaw(line, false, time.Now())
+	}
+	w.consoleLogsPane.SetConsoleLogs(cl.Items())
+}
+
 // TestRunOverviewSidebarHasActiveSection reports whether the overview sidebar
 // has an active section.
 func (w *Workspace) TestRunOverviewSidebarHasActiveSection() bool {
@@ -556,6 +588,15 @@ func (w *Workspace) TestRunOverviewSidebarHasActiveSection() bool {
 func (s *RunOverviewSidebar) TestFocusableSectionBounds() (first, last int) {
 	return s.focusableSectionBounds()
 }
+
+// Sidebar navigation helpers for focused unit tests. In production these
+// moves are driven by the owning view's key bindings and FocusManager.
+
+func (s *RunOverviewSidebar) TestNavigateSection(direction int) { s.navigateSection(direction) }
+func (s *RunOverviewSidebar) TestNavigateUp()                   { s.navigateUp() }
+func (s *RunOverviewSidebar) TestNavigateDown()                 { s.navigateDown() }
+func (s *RunOverviewSidebar) TestNavigatePageUp()               { s.navigatePageUp() }
+func (s *RunOverviewSidebar) TestNavigatePageDown()             { s.navigatePageDown() }
 
 // TestSeedRunOverview populates the workspace's overview data for the given
 // run key with sample config, summary, and environment items, then syncs the

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -87,6 +87,18 @@ func (w *Workspace) TestLayoutWidths() (left, right int) {
 	return l.leftSidebarWidth, l.rightSidebarWidth
 }
 
+// TestStackHeights returns the run view's central stack pane heights.
+func (r *Run) TestStackHeights() (metrics, media, logs int) {
+	l := r.computeViewports()
+	return l.height, l.mediaHeight, l.consoleLogsHeight
+}
+
+// TestStackHeights returns the workspace's central stack pane heights.
+func (w *Workspace) TestStackHeights() (metrics, system, media, logs int) {
+	l := w.computeViewports()
+	return l.height, l.systemMetricsHeight, l.mediaHeight, l.consoleLogsHeight
+}
+
 // TestInRunMode reports whether the model shows the single-run view.
 func (m *Model) TestInRunMode() bool { return m.mode == viewModeRun }
 

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -29,6 +29,9 @@ type Workspace struct {
 	// focusMgr is the single source of truth for UI focus state.
 	focusMgr *FocusManager
 
+	// In-progress pane-boundary drag (mouse resize).
+	drag layoutDrag
+
 	// Configuration and key bindings.
 	config *ConfigManager
 	keyMap map[string]func(*Workspace, tea.KeyPressMsg) tea.Cmd
@@ -551,10 +554,12 @@ func (w *Workspace) computeViewports() Layout {
 }
 
 // updateSidebarDimensions tells both sidebars to recalculate their expanded
-// widths given the post-toggle visibility of each side.
+// widths given the post-toggle visibility of each side and any saved layout
+// overrides.
 func (w *Workspace) updateSidebarDimensions(leftVisible, rightVisible bool) {
-	w.runsAnimState.SetExpanded(expandedSidebarWidth(w.width, rightVisible))
-	w.runOverviewSidebar.UpdateDimensions(w.width, leftVisible)
+	o := w.config.WorkspaceLayout()
+	w.runsAnimState.SetExpanded(sidebarWidthFor(w.width, o.LeftSidebar, rightVisible))
+	w.runOverviewSidebar.UpdateDimensions(w.width, leftVisible, o.RightSidebar)
 }
 
 func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisible bool) {
@@ -598,15 +603,16 @@ func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisibl
 		lowerTierH = maxH
 	}
 
+	o := w.config.WorkspaceLayout()
 	each := lowerTierH / lowerCount
 	if sysVisible {
-		w.systemMetricsPane.SetExpandedHeight(each)
+		w.systemMetricsPane.SetExpandedHeight(paneHeightFor(o.System, w.height, each))
 	}
 	if mediaVisible {
-		w.mediaPane.SetExpandedHeight(each)
+		w.mediaPane.SetExpandedHeight(paneHeightFor(o.Media, w.height, each))
 	}
 	if logsVisible {
-		w.consoleLogsPane.SetExpandedHeight(each)
+		w.consoleLogsPane.SetExpandedHeight(paneHeightFor(o.Logs, w.height, each))
 	}
 }
 
@@ -615,77 +621,58 @@ func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisibl
 func (w *Workspace) buildWorkspaceFocusManager() *FocusManager {
 	return NewFocusManager([]FocusRegionDef{
 		{
-			Target:          FocusTargetRunsList,
-			Available:       w.runsFocusAvailable,
-			AvailableTarget: w.runsFocusTargetAvailable,
-			Activate:        w.activateRunsFocus,
-			Deactivate:      w.deactivateRunsFocus,
+			Target:     FocusTargetRunsList,
+			Available:  w.runsFocusAvailable,
+			Activate:   w.activateRunsFocus,
+			Deactivate: w.deactivateRunsFocus,
 		},
 		{
-			Target:          FocusTargetMetricsGrid,
-			Available:       w.metricsGridFocusAvailable,
-			AvailableTarget: w.metricsGridFocusTargetAvailable,
-			Activate:        w.activateMetricsGridFocus,
-			Deactivate:      w.deactivateMetricsGridFocus,
+			Target:     FocusTargetMetricsGrid,
+			Available:  w.metricsGridFocusAvailable,
+			Activate:   w.activateMetricsGridFocus,
+			Deactivate: w.deactivateMetricsGridFocus,
 		},
 		{
-			Target:          FocusTargetSystemMetrics,
-			Available:       w.sysMetricsFocusAvailable,
-			AvailableTarget: w.sysMetricsFocusTargetAvailable,
-			Activate:        w.activateSysMetricsFocus,
-			Deactivate:      w.deactivateSysMetricsFocus,
+			Target:     FocusTargetSystemMetrics,
+			Available:  w.sysMetricsFocusAvailable,
+			Activate:   w.activateSysMetricsFocus,
+			Deactivate: w.deactivateSysMetricsFocus,
 		},
 		{
-			Target:          FocusTargetMedia,
-			Available:       w.mediaFocusAvailable,
-			AvailableTarget: w.mediaFocusTargetAvailable,
-			Activate:        w.activateMediaFocus,
-			Deactivate:      w.deactivateMediaFocus,
+			Target:     FocusTargetMedia,
+			Available:  w.mediaFocusAvailable,
+			Activate:   w.activateMediaFocus,
+			Deactivate: w.deactivateMediaFocus,
 		},
 		{
-			Target:          FocusTargetConsoleLogs,
-			Available:       w.logsFocusAvailable,
-			AvailableTarget: w.logsFocusTargetAvailable,
-			Activate:        w.activateLogsFocus,
-			Deactivate:      w.deactivateLogsFocus,
+			Target:     FocusTargetConsoleLogs,
+			Available:  w.logsFocusAvailable,
+			Activate:   w.activateLogsFocus,
+			Deactivate: w.deactivateLogsFocus,
 		},
 		{
-			Target:          FocusTargetOverview,
-			Available:       w.overviewFocusAvailable,
-			AvailableTarget: w.overviewFocusTargetAvailable,
-			Activate:        w.activateOverviewFocus,
-			Deactivate:      w.deactivateOverviewFocus,
+			Target:     FocusTargetOverview,
+			Available:  w.overviewFocusAvailable,
+			Activate:   w.activateOverviewFocus,
+			Deactivate: w.deactivateOverviewFocus,
 		},
 	})
 }
 
 // ---- Focus availability ----
+//
+// A region is available when its pane's target state is visible and it has
+// content to interact with. Empty panes are skipped by Tab navigation.
 
 func (w *Workspace) runsFocusAvailable() bool {
-	return w.runsAnimState.IsVisible() && len(w.runs.FilteredItems) > 0
-}
-
-func (w *Workspace) runsFocusTargetAvailable() bool {
 	return w.runsAnimState.TargetVisible() && len(w.runs.FilteredItems) > 0
 }
 
 func (w *Workspace) metricsGridFocusAvailable() bool {
-	return w.metricsGridAnimState.IsExpanded() && w.metricsGrid.ChartCount() > 0
-}
-
-func (w *Workspace) metricsGridFocusTargetAvailable() bool {
 	return w.metricsGridAnimState.TargetVisible() && w.metricsGrid.ChartCount() > 0
 }
 
 func (w *Workspace) sysMetricsFocusAvailable() bool {
-	if !w.systemMetricsPane.IsExpanded() {
-		return false
-	}
-	g := w.activeSystemMetricsGrid()
-	return g != nil && g.ChartCount() > 0
-}
-
-func (w *Workspace) sysMetricsFocusTargetAvailable() bool {
 	if !w.systemMetricsPane.animState.TargetVisible() {
 		return false
 	}
@@ -694,27 +681,14 @@ func (w *Workspace) sysMetricsFocusTargetAvailable() bool {
 }
 
 func (w *Workspace) mediaFocusAvailable() bool {
-	return w.mediaPane.IsExpanded() && w.mediaPane.HasData()
-}
-
-func (w *Workspace) mediaFocusTargetAvailable() bool {
 	return w.mediaPane.animState.TargetVisible() && w.mediaPane.HasData()
 }
 
 func (w *Workspace) logsFocusAvailable() bool {
-	return w.consoleLogsPane.IsExpanded()
-}
-
-func (w *Workspace) logsFocusTargetAvailable() bool {
-	return w.consoleLogsPane.animState.TargetVisible()
+	return w.consoleLogsPane.animState.TargetVisible() && w.consoleLogsPane.HasData()
 }
 
 func (w *Workspace) overviewFocusAvailable() bool {
-	firstSec, _ := w.runOverviewSidebar.focusableSectionBounds()
-	return w.runOverviewSidebar.animState.IsExpanded() && firstSec != -1
-}
-
-func (w *Workspace) overviewFocusTargetAvailable() bool {
 	firstSec, _ := w.runOverviewSidebar.focusableSectionBounds()
 	return w.runOverviewSidebar.animState.TargetVisible() && firstSec != -1
 }
@@ -775,7 +749,7 @@ func (w *Workspace) deactivateOverviewFocus() { w.runOverviewSidebar.deactivateA
 // Returns true if the navigation was handled (i.e. we're not at a boundary).
 func (w *Workspace) cycleOverviewSection(direction int) bool {
 	firstSec, lastSec := w.runOverviewSidebar.focusableSectionBounds()
-	if !w.runOverviewSidebar.animState.IsExpanded() || firstSec == -1 {
+	if !w.overviewFocusAvailable() {
 		return false
 	}
 
@@ -792,6 +766,12 @@ func (w *Workspace) cycleOverviewSection(direction int) bool {
 // handleWindowResize handles window resize messages.
 func (w *Workspace) handleWindowResize(width, height int) {
 	w.SetSize(width, height)
+	w.applyLayoutConfig()
+}
+
+// applyLayoutConfig re-derives all pane extents from the terminal size and
+// any saved layout overrides.
+func (w *Workspace) applyLayoutConfig() {
 	w.updateSidebarDimensions(
 		w.runsAnimState.TargetVisible(),
 		w.runOverviewSidebar.animState.TargetVisible(),

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -1051,7 +1051,7 @@ func (w *Workspace) renderMetrics(layout Layout) string {
 
 	// When we have selected runs, render the metrics grid.
 	dims := w.metricsGrid.CalculateChartDimensions(contentWidth, contentHeight)
-	return w.metricsGrid.View(dims)
+	return padStackSection(w.metricsGrid.View(dims), contentWidth, contentHeight)
 }
 
 // renderMetricsEmptyState renders a styled "Metrics" header with a hint message.

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -553,12 +553,21 @@ func (w *Workspace) computeViewports() Layout {
 	}
 }
 
+// layoutOverrides returns the live pane proportions: the in-progress drag's
+// pending values, or the persisted config.
+func (w *Workspace) layoutOverrides() LayoutOverrides {
+	if w.drag.active() {
+		return w.drag.overrides
+	}
+	return w.config.WorkspaceLayout()
+}
+
 // updateSidebarDimensions tells both sidebars to recalculate their expanded
-// widths given the post-toggle visibility of each side and any saved layout
+// widths given the post-toggle visibility of each side and the live layout
 // overrides.
 func (w *Workspace) updateSidebarDimensions(leftVisible, rightVisible bool) {
-	o := w.config.WorkspaceLayout()
-	w.runsAnimState.SetExpanded(sidebarWidthFor(w.width, o.LeftSidebar, rightVisible))
+	o := w.layoutOverrides()
+	w.runsAnimState.SetExpanded(expandedSidebarWidth(w.width, rightVisible, o.LeftSidebar))
 	w.runOverviewSidebar.UpdateDimensions(w.width, leftVisible, o.RightSidebar)
 }
 
@@ -603,7 +612,7 @@ func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisibl
 		lowerTierH = maxH
 	}
 
-	o := w.config.WorkspaceLayout()
+	o := w.layoutOverrides()
 	each := lowerTierH / lowerCount
 	if sysVisible {
 		w.systemMetricsPane.SetExpandedHeight(paneHeightFor(o.System, w.height, each))

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -274,6 +274,44 @@ func TestWorkspace_DragResizesRunsSidebarAndPersists(t *testing.T) {
 	require.Equal(t, left0, left2, "reset should restore the default width")
 }
 
+func TestWorkspace_DragSeparatorResizesBothFixedNeighbors(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetWorkspaceSystemMetricsVisible(true)
+	_ = cfg.SetWorkspaceMediaVisible(true)
+	_ = cfg.SetWorkspaceConsoleLogsVisible(true)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	// Tall terminal so all panes sit above their minimum heights.
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 100})
+
+	metrics0, system0, media0, logs0 := w.TestStackHeights()
+	require.Positive(t, system0)
+	require.Positive(t, media0)
+
+	// The separator above media sits between two fixed panes (system above,
+	// media below). Drag it up 2 rows: system shrinks, media grows, the flex
+	// metrics grid and logs stay put.
+	left0, _ := w.TestLayoutWidths()
+	x := left0 + 5
+	sepY := metrics0 + 1 + system0 + 1 - 1 // gap row above media
+	_ = w.Update(tea.MouseClickMsg{X: x, Y: sepY, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseMotionMsg{X: x, Y: sepY - 2, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: x, Y: sepY - 2, Button: tea.MouseLeft})
+
+	metrics1, system1, media1, logs1 := w.TestStackHeights()
+	require.Equal(t, system0-2, system1, "pane above the separator should shrink")
+	require.Equal(t, media0+2, media1, "pane below the separator should grow")
+	require.Equal(t, metrics0, metrics1, "flex metrics grid should be untouched")
+	require.Equal(t, logs0, logs1, "logs pane should be untouched")
+
+	// Both fractions persist on release.
+	o := cfg.WorkspaceLayout()
+	require.InDelta(t, float64(system1)/100.0, o.System, 1e-9)
+	require.InDelta(t, float64(media1)/100.0, o.Media, 1e-9)
+	require.Zero(t, o.Logs, "untouched panes must not gain overrides")
+}
+
 func TestWorkspace_ClickWithoutMotionDoesNotPersist(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -150,12 +150,15 @@ func newWorkspaceWithPanels(t *testing.T) *leet.Workspace {
 	// computed heights).
 	w.TestSeedRunOverview(runKey)
 
+	// Give the console logs pane content so it is focusable.
+	w.TestSeedConsoleLogs(runKey, "hello from the run")
+
 	return w
 }
 
 // ---- handleToggleConsoleLogsPane ----
 
-func TestWorkspace_ToggleConsoleLogsPane_FocusReturnsToRuns(t *testing.T) {
+func TestWorkspace_ToggleConsoleLogsPane_FocusClears(t *testing.T) {
 	w := newWorkspaceWithPanels(t)
 
 	// Focus logs via Tab until bottom bar is active.
@@ -164,13 +167,13 @@ func TestWorkspace_ToggleConsoleLogsPane_FocusReturnsToRuns(t *testing.T) {
 	}
 	require.Equal(t, testFocusLogs, w.TestCurrentFocusRegion())
 
-	// Collapse bottom bar — focus should return to runs (the next available).
+	// Collapse bottom bar — the focused pane disappeared, so focus clears
+	// rather than jumping to another pane.
 	_ = w.Update(keyRune('4'))
-	_ = w.Update(keyRune(']'))
 	require.False(t, w.TestConsoleLogsPaneActive(),
 		"bottom bar should not be active after collapse")
-	require.True(t, w.TestRunsActive(),
-		"runs list should be focused after collapsing logs")
+	require.Equal(t, int(leet.FocusTargetNone), w.TestCurrentFocusRegion(),
+		"focus should clear when the focused pane is closed")
 }
 
 func TestWorkspace_ToggleConsoleLogsPane_FocusStaysOnRuns(t *testing.T) {
@@ -184,6 +187,107 @@ func TestWorkspace_ToggleConsoleLogsPane_FocusStaysOnRuns(t *testing.T) {
 	_ = w.Update(keyRune('4'))
 	require.True(t, w.TestRunsActive(),
 		"runs focus should be preserved when collapsing bottom bar from runs")
+}
+
+// ---- Esc: home to runs, or clear focus when runs can't take it ----
+
+func TestWorkspace_EscReturnsFocusToRuns(t *testing.T) {
+	w := newWorkspaceWithPanels(t)
+
+	// Focus logs, then Esc home.
+	for w.TestCurrentFocusRegion() != testFocusLogs {
+		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	}
+	_ = w.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	require.Equal(t, testFocusRuns, w.TestCurrentFocusRegion(),
+		"Esc should return focus to the runs list")
+	require.True(t, w.TestRunsActive())
+}
+
+func TestWorkspace_EscClearsFocusWhenRunsHidden(t *testing.T) {
+	w := newWorkspaceWithPanels(t)
+
+	// Focus logs, hide the runs sidebar, then Esc.
+	for w.TestCurrentFocusRegion() != testFocusLogs {
+		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	}
+	_ = w.Update(keyRune('['))
+	require.Equal(t, testFocusLogs, w.TestCurrentFocusRegion())
+
+	_ = w.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	require.Equal(t, int(leet.FocusTargetNone), w.TestCurrentFocusRegion(),
+		"Esc should clear focus when the runs list cannot take it")
+}
+
+// ---- Empty panes are skipped by Tab ----
+
+func TestWorkspace_TabSkipsEmptyLogsPane(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	runKey := "run-20260209_010101-abcdefg"
+	_ = w.Update(leet.WorkspaceRunDirsMsg{RunKeys: []string{runKey}})
+	w.TestForceExpandRunsSidebar()
+	w.TestForceExpandConsoleLogsPane(10)
+
+	// The logs pane is open but empty: a full Tab cycle must never land on it.
+	for range 6 {
+		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+		require.NotEqual(t, testFocusLogs, w.TestCurrentFocusRegion(),
+			"an empty logs pane must not receive focus")
+	}
+}
+
+// ---- Mouse drag-resize of the runs sidebar ----
+
+func TestWorkspace_DragResizesRunsSidebarAndPersists(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	w.TestForceExpandRunsSidebar()
+	w.TestForceExpandOverviewSidebar()
+
+	left0, _ := w.TestLayoutWidths()
+	require.Positive(t, left0)
+
+	// Press on the sidebar's border column, drag 10 columns right, release.
+	_ = w.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseMotionMsg{X: left0 + 9, Y: 5, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: left0 + 9, Y: 5, Button: tea.MouseLeft})
+
+	left1, _ := w.TestLayoutWidths()
+	require.Equal(t, left0+10, left1, "drag should widen the runs sidebar")
+	require.InDelta(t, float64(left0+10)/200.0, cfg.WorkspaceLayout().LeftSidebar, 1e-9,
+		"released drag should persist the width as a fraction of the terminal")
+
+	// "0" resets the proportions and the persisted overrides.
+	_ = w.Update(keyRune('0'))
+	require.Equal(t, leet.LayoutOverrides{}, cfg.WorkspaceLayout())
+	left2, _ := w.TestLayoutWidths()
+	require.Equal(t, left0, left2, "reset should restore the default width")
+}
+
+func TestWorkspace_ClickWithoutMotionDoesNotPersist(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	w.TestForceExpandRunsSidebar()
+
+	left0, _ := w.TestLayoutWidths()
+	_ = w.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+
+	require.Equal(t, leet.LayoutOverrides{}, cfg.WorkspaceLayout(),
+		"a click without motion must not write an override")
 }
 
 // ---- Focus bug: collapsing overview with logs focused ----
@@ -435,8 +539,9 @@ func TestWorkspace_Enter_RequiresRunSelectorActive(t *testing.T) {
 	require.True(t, w.RunSelectorActive(),
 		"run selector should be active with runs focused and items present")
 
-	// Focus logs by expanding bottom bar and tabbing.
+	// Focus logs by expanding and populating the bottom bar, then tabbing.
 	w.TestForceExpandConsoleLogsPane(10)
+	w.TestSeedConsoleLogs(runKey, "hello")
 	for !w.TestConsoleLogsPaneActive() {
 		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	}

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -189,40 +189,22 @@ func (w *Workspace) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
 	return false
 }
 
-// applyLayoutDrag resizes the dragged pane(s) to follow the mouse.
+// applyLayoutDrag updates the pending overrides from the mouse position and
+// re-lays the view out from them.
 func (w *Workspace) applyLayoutDrag(x, y int, layout Layout) {
+	o := &w.drag.overrides
 	switch w.drag.boundary {
 	case dragBoundaryLeftSidebar:
-		w.drag.overrides.LeftSidebar = float64(x+1) / float64(w.width)
-		w.runsAnimState.SetExpanded(sidebarWidthFor(
-			w.width, w.drag.overrides.LeftSidebar,
-			w.runOverviewSidebar.animState.TargetVisible()))
-
+		o.LeftSidebar = float64(x+1) / float64(w.width)
 	case dragBoundaryRightSidebar:
-		w.drag.overrides.RightSidebar = float64(w.width-x) / float64(w.width)
-		w.runOverviewSidebar.UpdateDimensions(
-			w.width, w.runsAnimState.TargetVisible(), w.drag.overrides.RightSidebar)
-
+		o.RightSidebar = float64(w.width-x) / float64(w.width)
 	case dragBoundarySeparator:
-		resizes := dragSeparator(layout, w.drag.section, y, w.height)
-		if len(resizes) == 0 {
+		if !dragSeparator(o, layout, w.drag.section, y, w.height) {
 			return
-		}
-		for _, rz := range resizes {
-			switch rz.section {
-			case stackSectionSystemMetrics:
-				w.systemMetricsPane.SetExpandedHeight(rz.height)
-			case stackSectionMedia:
-				w.mediaPane.SetExpandedHeight(rz.height)
-			case stackSectionConsoleLogs:
-				w.consoleLogsPane.SetExpandedHeight(rz.height)
-			}
-			w.drag.overrides.setSection(rz.section, rz.frac)
 		}
 	}
 	w.drag.dirty = true
-
-	w.recalculateLayout()
+	w.applyLayoutConfig()
 }
 
 // handleResetLayout resets the view's pane proportions to the defaults.

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -107,6 +107,11 @@ func (w *Workspace) handleMouse(msg tea.MouseMsg) tea.Cmd {
 	mouse := msg.Mouse()
 	layout := w.computeViewports()
 
+	// Pane resizing wins over pane-local mouse handling.
+	if w.handleLayoutDrag(msg, layout) {
+		return nil
+	}
+
 	// Clicks in the left sidebar clear all chart focus.
 	if w.runsAnimState.IsVisible() && mouse.X < layout.leftSidebarWidth {
 		w.clearChartFocus()
@@ -148,6 +153,109 @@ func (w *Workspace) handleMouse(msg tea.MouseMsg) tea.Cmd {
 
 	// Separator or status bar area — no chart interaction.
 	return nil
+}
+
+// handleLayoutDrag processes mouse events for pane-boundary resizing.
+// It returns true when the event was consumed by an active or new drag.
+func (w *Workspace) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
+	switch m := msg.(type) {
+	case tea.MouseClickMsg:
+		if m.Button != tea.MouseLeft {
+			return false
+		}
+		drag, ok := boundaryAt(m.X, m.Y, w.width, layout,
+			w.runsAnimState.IsExpanded(), w.runOverviewSidebar.IsExpanded())
+		if !ok || (drag.boundary == dragBoundarySeparator && w.mediaPane.IsFullscreen()) {
+			return false
+		}
+		w.drag = drag
+		return true
+
+	case tea.MouseMotionMsg:
+		if !w.drag.active() || m.Button != tea.MouseLeft {
+			return false
+		}
+		w.applyLayoutDrag(m.X, m.Y, layout)
+		return true
+
+	case tea.MouseReleaseMsg:
+		if !w.drag.active() {
+			return false
+		}
+		w.finishLayoutDrag()
+		return true
+	}
+	return false
+}
+
+// applyLayoutDrag resizes the dragged pane to follow the mouse.
+func (w *Workspace) applyLayoutDrag(x, y int, layout Layout) {
+	switch w.drag.boundary {
+	case dragBoundaryLeftSidebar:
+		w.drag.frac = float64(x+1) / float64(w.width)
+		w.runsAnimState.SetExpanded(sidebarWidthFor(
+			w.width, w.drag.frac, w.runOverviewSidebar.animState.TargetVisible()))
+
+	case dragBoundaryRightSidebar:
+		w.drag.frac = float64(w.width-x) / float64(w.width)
+		w.runOverviewSidebar.UpdateDimensions(
+			w.width, w.runsAnimState.TargetVisible(), w.drag.frac)
+
+	case dragBoundarySeparator:
+		newH, frac, ok := dragSeparatorHeight(layout, w.drag.section, y, w.height)
+		if !ok {
+			return
+		}
+		w.drag.frac = frac
+		switch w.drag.section {
+		case stackSectionSystemMetrics:
+			w.systemMetricsPane.SetExpandedHeight(newH)
+		case stackSectionMedia:
+			w.mediaPane.SetExpandedHeight(newH)
+		case stackSectionConsoleLogs:
+			w.consoleLogsPane.SetExpandedHeight(newH)
+		}
+	}
+
+	w.recalculateLayout()
+}
+
+// handleResetLayout resets the view's pane proportions to the defaults.
+func (w *Workspace) handleResetLayout(tea.KeyPressMsg) tea.Cmd {
+	if err := w.config.SetWorkspaceLayout(LayoutOverrides{}); err != nil {
+		w.logger.Error(fmt.Sprintf("workspace: failed to save layout: %v", err))
+	}
+	w.applyLayoutConfig()
+	return nil
+}
+
+// finishLayoutDrag persists the dragged proportion and ends the drag.
+func (w *Workspace) finishLayoutDrag() {
+	drag := w.drag
+	w.drag = layoutDrag{}
+	if drag.frac == 0 {
+		return // Click without motion: nothing changed.
+	}
+
+	o := w.config.WorkspaceLayout()
+	switch drag.boundary {
+	case dragBoundaryLeftSidebar:
+		o.LeftSidebar = drag.frac
+	case dragBoundaryRightSidebar:
+		o.RightSidebar = drag.frac
+	case dragBoundarySeparator:
+		switch drag.section {
+		case stackSectionSystemMetrics:
+			o.System = drag.frac
+		case stackSectionMedia:
+			o.Media = drag.frac
+		case stackSectionConsoleLogs:
+			o.Logs = drag.frac
+		}
+	}
+	if err := w.config.SetWorkspaceLayout(o); err != nil {
+		w.logger.Error(fmt.Sprintf("workspace: failed to save layout: %v", err))
+	}
 }
 
 func (w *Workspace) handleMetricsMouse(msg tea.MouseMsg, layout Layout) tea.Cmd {
@@ -347,7 +455,7 @@ func (w *Workspace) handleToggleRunsSidebar(msg tea.KeyPressMsg) tea.Cmd {
 
 	w.updateSidebarDimensions(leftWillBeVisible, rightIsVisible)
 	w.runsAnimState.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 
 	return w.runsAnimationCmd()
@@ -363,7 +471,7 @@ func (w *Workspace) handleToggleOverviewSidebar(msg tea.KeyPressMsg) tea.Cmd {
 
 	w.updateSidebarDimensions(leftIsVisible, rightWillBeVisible)
 	w.runOverviewSidebar.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 
 	return w.runOverviewAnimationCmd()
@@ -392,9 +500,7 @@ func (w *Workspace) handleToggleMediaPane(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	w.mediaPane.Toggle()
-	if !mediaWillBeVisible {
-		w.focusMgr.ResolveAfterVisibilityChange()
-	}
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 	return w.mediaPaneAnimationCmd()
 }
@@ -412,7 +518,7 @@ func (w *Workspace) handleToggleConsoleLogsPane(msg tea.KeyPressMsg) tea.Cmd {
 		bottomWillBeVisible,
 	)
 	w.consoleLogsPane.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 
 	return w.consoleLogsPaneAnimationCmd()
@@ -429,7 +535,7 @@ func (w *Workspace) handleToggleSystemMetricsPane(tea.KeyPressMsg) tea.Cmd {
 
 	w.updateBottomPaneHeights(sysWillBeVisible, mediaVisible, logsVisible)
 	w.systemMetricsPane.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 	return w.systemMetricsPaneAnimationCmd()
 }
@@ -938,7 +1044,7 @@ func (w *Workspace) handleToggleMetricsGrid(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	w.metricsGridAnimState.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 
 	w.updateBottomPaneHeights(
 		w.systemMetricsPane.animState.TargetVisible(),
@@ -1217,13 +1323,16 @@ func (w *Workspace) activeSystemMetricsGrid() *SystemMetricsGrid {
 	return w.systemMetrics[cur.Key]
 }
 
-// handleFocusRuns moves focus to the runs list if it's visible.
+// handleFocusRuns moves focus home to the runs list.
 //
-// This gives Esc a natural "return home" feel in workspace mode:
-// wherever focus currently is, Esc snaps it back to the run selector.
+// This gives Esc a natural "return home" feel in workspace mode: wherever
+// focus currently is, Esc snaps it back to the run selector. When the runs
+// list can't take focus (hidden or empty), Esc just clears focus.
 func (w *Workspace) handleFocusRuns(tea.KeyPressMsg) tea.Cmd {
-	if w.runsAnimState.TargetVisible() {
+	if w.runsFocusAvailable() {
 		w.focusMgr.SetTarget(FocusTargetRunsList, 1)
+	} else {
+		w.focusMgr.ClearAll()
 	}
 	return nil
 }

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -168,6 +168,7 @@ func (w *Workspace) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
 		if !ok || (drag.boundary == dragBoundarySeparator && w.mediaPane.IsFullscreen()) {
 			return false
 		}
+		drag.overrides = w.config.WorkspaceLayout()
 		w.drag = drag
 		return true
 
@@ -188,34 +189,38 @@ func (w *Workspace) handleLayoutDrag(msg tea.MouseMsg, layout Layout) bool {
 	return false
 }
 
-// applyLayoutDrag resizes the dragged pane to follow the mouse.
+// applyLayoutDrag resizes the dragged pane(s) to follow the mouse.
 func (w *Workspace) applyLayoutDrag(x, y int, layout Layout) {
 	switch w.drag.boundary {
 	case dragBoundaryLeftSidebar:
-		w.drag.frac = float64(x+1) / float64(w.width)
+		w.drag.overrides.LeftSidebar = float64(x+1) / float64(w.width)
 		w.runsAnimState.SetExpanded(sidebarWidthFor(
-			w.width, w.drag.frac, w.runOverviewSidebar.animState.TargetVisible()))
+			w.width, w.drag.overrides.LeftSidebar,
+			w.runOverviewSidebar.animState.TargetVisible()))
 
 	case dragBoundaryRightSidebar:
-		w.drag.frac = float64(w.width-x) / float64(w.width)
+		w.drag.overrides.RightSidebar = float64(w.width-x) / float64(w.width)
 		w.runOverviewSidebar.UpdateDimensions(
-			w.width, w.runsAnimState.TargetVisible(), w.drag.frac)
+			w.width, w.runsAnimState.TargetVisible(), w.drag.overrides.RightSidebar)
 
 	case dragBoundarySeparator:
-		newH, frac, ok := dragSeparatorHeight(layout, w.drag.section, y, w.height)
-		if !ok {
+		resizes := dragSeparator(layout, w.drag.section, y, w.height)
+		if len(resizes) == 0 {
 			return
 		}
-		w.drag.frac = frac
-		switch w.drag.section {
-		case stackSectionSystemMetrics:
-			w.systemMetricsPane.SetExpandedHeight(newH)
-		case stackSectionMedia:
-			w.mediaPane.SetExpandedHeight(newH)
-		case stackSectionConsoleLogs:
-			w.consoleLogsPane.SetExpandedHeight(newH)
+		for _, rz := range resizes {
+			switch rz.section {
+			case stackSectionSystemMetrics:
+				w.systemMetricsPane.SetExpandedHeight(rz.height)
+			case stackSectionMedia:
+				w.mediaPane.SetExpandedHeight(rz.height)
+			case stackSectionConsoleLogs:
+				w.consoleLogsPane.SetExpandedHeight(rz.height)
+			}
+			w.drag.overrides.setSection(rz.section, rz.frac)
 		}
 	}
+	w.drag.dirty = true
 
 	w.recalculateLayout()
 }
@@ -229,31 +234,14 @@ func (w *Workspace) handleResetLayout(tea.KeyPressMsg) tea.Cmd {
 	return nil
 }
 
-// finishLayoutDrag persists the dragged proportion and ends the drag.
+// finishLayoutDrag persists the dragged proportions and ends the drag.
 func (w *Workspace) finishLayoutDrag() {
 	drag := w.drag
 	w.drag = layoutDrag{}
-	if drag.frac == 0 {
+	if !drag.dirty {
 		return // Click without motion: nothing changed.
 	}
-
-	o := w.config.WorkspaceLayout()
-	switch drag.boundary {
-	case dragBoundaryLeftSidebar:
-		o.LeftSidebar = drag.frac
-	case dragBoundaryRightSidebar:
-		o.RightSidebar = drag.frac
-	case dragBoundarySeparator:
-		switch drag.section {
-		case stackSectionSystemMetrics:
-			o.System = drag.frac
-		case stackSectionMedia:
-			o.Media = drag.frac
-		case stackSectionConsoleLogs:
-			o.Logs = drag.frac
-		}
-	}
-	if err := w.config.SetWorkspaceLayout(o); err != nil {
+	if err := w.config.SetWorkspaceLayout(drag.overrides); err != nil {
 		w.logger.Error(fmt.Sprintf("workspace: failed to save layout: %v", err))
 	}
 }


### PR DESCRIPTION
Description
-----------
Resizing: Drag sidebar border columns or the separator rows between stacked panes to resize them; proportions persist per view in wandb-leet.json (run_layout/workspace_layout) and 0 resets the active view to the golden-ratio defaults. Drags apply live and write config once on release.

Navigation: Focus rules rebuilt around three invariants: a pane is focusable iff visible and non-empty (empty panes are skipped by Tab; console logs previously weren't); focus never moves on its own. It clears when its pane disappears instead of jumping elsewhere, with a one-time seed when a run first loads; Esc steps out one layer (input → pane focus → view), so in the run view it unfocuses before exiting to the workspace, and in the workspace it homes to the runs list only when the list can actually take focus. Simplifies FocusManager (drops AvailableTarget and both resolve variants for one Resolve()) and removes a dead key-handling path in the overview sidebar.