### PR TITLE
feat(registries): validate filter fields for registry search paginators

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,3 +26,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - `Api.{create,update}_automation()` now raise `UnsupportedError` instead of `CommError` when the server doesn't support the given automation (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12194)
 - The message format used to communicate between internal processes has slightly changed. If you use `wandb beta core`, restart the service after upgrading `wandb`, as some operations may fail if the SDK and service versions differ. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12374)
 - `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)
+- Registry search methods (`Api.registries()`, `.collections()`, `.versions()`) now validate filter field names, rejecting unsupported field names. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12182)

--- a/tests/system_tests/test_registries/conftest.py
+++ b/tests/system_tests/test_registries/conftest.py
@@ -8,7 +8,6 @@ import wandb
 from pytest import FixtureRequest, fixture, skip
 from pytest_mock import MockerFixture
 from wandb import Api, Artifact
-from wandb.apis.public.registries._utils import fetch_org_entity_from_organization
 from wandb.apis.public.registries.registry import Registry
 from wandb.apis.public.users import User
 from wandb.proto import wandb_internal_pb2 as pb
@@ -66,7 +65,7 @@ def org_entity(org: str, api: Api) -> str:
     if not server_supports(api._service_api, pb.ARTIFACT_REGISTRY_SEARCH):
         skip("Cannot fetch org entity on this server version.")
 
-    return fetch_org_entity_from_organization(api._service_api, org)
+    return api.organization(org).org_entity.name
 
 
 @fixture

--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import wandb
 from pytest import fixture, mark, param, raises
-from wandb import Api, Artifact
+from wandb import Api, Artifact, CommError
 from wandb._strutils import b64decode_ascii
 from wandb.apis.public.registries.registry import Registry
 from wandb.proto import wandb_internal_pb2 as pb
@@ -16,7 +16,6 @@ from wandb.sdk.artifacts._validators import REGISTRY_PREFIX, remove_registry_pre
 
 if TYPE_CHECKING:
     from tests.fixtures.wandb_backend_spy import WandbBackendSpy
-    from tests.fixtures.wandb_backend_spy.gql_match import Responder
 
 
 @fixture
@@ -222,24 +221,18 @@ def test_infer_organization_from_create_load(default_organization, api: Api):
 @mark.usefixtures("skip_if_server_does_not_support_create_registry")
 def test_input_invalid_organizations(default_organization, api: Api):
     """Tests that invalid organization inputs raise errors."""
-    bad_org_name = f"{default_organization}_wrong_organization"
+    invalid = f"{default_organization}_wrong_organization"
 
     registry_name = "test"
-    with raises(
-        ValueError,
-        match=f"Organization entity for {bad_org_name!r} not found.",
-    ):
+    with raises(CommError, match=rf"(?i)organization.*{invalid!r}.*not found"):
         api.create_registry(
             name=registry_name,
             visibility="organization",
-            organization=bad_org_name,
+            organization=invalid,
         )
 
-    with raises(
-        ValueError,
-        match=f"Organization entity for {bad_org_name!r} not found.",
-    ):
-        api.registry(registry_name, f"{default_organization}_wrong_organization")
+    with raises(CommError, match=rf"(?i)organization.*{invalid!r}.*not found"):
+        api.registry(registry_name, organization=invalid)
 
 
 @mark.usefixtures("skip_if_server_does_not_support_create_registry")
@@ -417,8 +410,8 @@ def test_fetch_registries(team: str, org: str, org_entity: str, api: Api):
 
 
 @fixture
-def advanced_features_spy(wandb_backend_spy: WandbBackendSpy) -> Responder:
-    """Report advanced registry search support and capture the org lookup."""
+def enable_advanced_search(wandb_backend_spy: WandbBackendSpy) -> None:
+    """Simulate feature flags that signal advanced registry search features are enabled."""
     gql = wandb_backend_spy.gql
     features = (
         pb.ServerFeature.Name(pb.ARTIFACT_REGISTRY_SEARCH),
@@ -430,35 +423,32 @@ def advanced_features_spy(wandb_backend_spy: WandbBackendSpy) -> Responder:
             content={
                 "data": {
                     "serverInfo": {
-                        "features": [
-                            {"name": feature, "isEnabled": True} for feature in features
-                        ]
+                        "features": [{"name": f, "isEnabled": True} for f in features]
                     }
                 }
             }
         ),
     )
-    advanced_features = gql.once(
-        content={
-            "data": {
-                "organization": {"advancedRegistryFeatures": {"advancedSearch": True}}
-            }
-        }
-    )
+
     wandb_backend_spy.stub_gql(
         gql.Matcher(
             operation="FetchAdvancedRegistryFeatures",
             variables={"organization": "advanced-org"},
         ),
-        advanced_features,
+        gql.Constant(
+            content={
+                "data": {
+                    "organization": {
+                        "advancedRegistryFeatures": {"advancedSearch": True}
+                    }
+                }
+            }
+        ),
     )
-    return advanced_features
 
 
-def test_advanced_feature_response_selects_version_filter_fields(
-    advanced_features_spy: Responder,
-    api: Api,
-):
+@mark.usefixtures(enable_advanced_search.__name__)
+def test_advanced_feature_response_selects_version_filter_fields(api: Api):
     versions = (
         api.registries(organization="advanced-org", filter={"id": "registry-id"})
         .collections(filter={"collection_id": "collection-id"})
@@ -474,7 +464,6 @@ def test_advanced_feature_response_selects_version_filter_fields(
     assert json.loads(versions.variables["artifactFilter"]) == {
         "artifact_created_at": "2026-08-10"
     }
-    assert advanced_features_spy.total_calls > 0
 
 
 @fixture

--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Generator
 from itertools import islice, product
 from unittest.mock import patch
@@ -9,6 +10,7 @@ from pytest import fixture, mark, param, raises
 from wandb import Api, Artifact
 from wandb._strutils import b64decode_ascii
 from wandb.apis.public.registries.registry import Registry
+from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.artifacts._validators import REGISTRY_PREFIX, remove_registry_prefix
 
 
@@ -407,6 +409,65 @@ def test_fetch_registries(team: str, org: str, org_entity: str, api: Api):
     descending = [r.name for r in api.registries(organization=org, order="-name")]
     assert ascending == expected_asc_names
     assert descending == expected_desc_names
+
+
+def test_advanced_feature_response_selects_version_filter_fields(
+    api: Api,
+    wandb_backend_spy,
+):
+    gql = wandb_backend_spy.gql
+    features = [
+        pb.ARTIFACT_REGISTRY_SEARCH,
+        pb.ARTIFACT_COLLECTIONS_FILTERING_SORTING,
+    ]
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="ServerFeaturesQuery"),
+        gql.Constant(
+            content={
+                "data": {
+                    "serverInfo": {
+                        "features": [
+                            {
+                                "name": pb.ServerFeature.Name(feature),
+                                "isEnabled": True,
+                            }
+                            for feature in features
+                        ]
+                    }
+                }
+            }
+        ),
+    )
+    advanced_features = gql.once(
+        content={
+            "data": {
+                "organization": {"advancedRegistryFeatures": {"advancedSearch": True}}
+            }
+        }
+    )
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(
+            operation="FetchAdvancedRegistryFeatures",
+            variables={"organization": "advanced-org"},
+        ),
+        advanced_features,
+    )
+    versions = (
+        api.registries(organization="advanced-org", filter={"id": "registry-id"})
+        .collections(filter={"collection_id": "collection-id"})
+        .versions(filter={"created_at": "2026-08-10"})
+    )
+
+    assert json.loads(versions.variables["registryFilter"]) == {
+        "project_id": "registry-id"
+    }
+    assert json.loads(versions.variables["collectionFilter"]) == {
+        "artifact_collection_id": "collection-id"
+    }
+    assert json.loads(versions.variables["artifactFilter"]) == {
+        "artifact_created_at": "2026-08-10"
+    }
+    assert advanced_features.total_calls == 1
 
 
 @fixture

--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -411,10 +411,9 @@ def test_fetch_registries(team: str, org: str, org_entity: str, api: Api):
     assert descending == expected_desc_names
 
 
-def test_advanced_feature_response_selects_version_filter_fields(
-    api: Api,
-    wandb_backend_spy,
-):
+@fixture
+def advanced_features_spy(wandb_backend_spy):
+    """Report advanced registry search support and capture the org lookup."""
     gql = wandb_backend_spy.gql
     features = [
         pb.ARTIFACT_REGISTRY_SEARCH,
@@ -452,6 +451,13 @@ def test_advanced_feature_response_selects_version_filter_fields(
         ),
         advanced_features,
     )
+    return advanced_features
+
+
+def test_advanced_feature_response_selects_version_filter_fields(
+    advanced_features_spy,
+    api: Api,
+):
     versions = (
         api.registries(organization="advanced-org", filter={"id": "registry-id"})
         .collections(filter={"collection_id": "collection-id"})
@@ -467,7 +473,7 @@ def test_advanced_feature_response_selects_version_filter_fields(
     assert json.loads(versions.variables["artifactFilter"]) == {
         "artifact_created_at": "2026-08-10"
     }
-    assert advanced_features.total_calls == 1
+    assert advanced_features_spy.total_calls > 0
 
 
 @fixture

--- a/tests/system_tests/test_registries/test_registry.py
+++ b/tests/system_tests/test_registries/test_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Generator
 from itertools import islice, product
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import wandb
@@ -12,6 +13,10 @@ from wandb._strutils import b64decode_ascii
 from wandb.apis.public.registries.registry import Registry
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.artifacts._validators import REGISTRY_PREFIX, remove_registry_prefix
+
+if TYPE_CHECKING:
+    from tests.fixtures.wandb_backend_spy import WandbBackendSpy
+    from tests.fixtures.wandb_backend_spy.gql_match import Responder
 
 
 @fixture
@@ -412,13 +417,13 @@ def test_fetch_registries(team: str, org: str, org_entity: str, api: Api):
 
 
 @fixture
-def advanced_features_spy(wandb_backend_spy):
+def advanced_features_spy(wandb_backend_spy: WandbBackendSpy) -> Responder:
     """Report advanced registry search support and capture the org lookup."""
     gql = wandb_backend_spy.gql
-    features = [
-        pb.ARTIFACT_REGISTRY_SEARCH,
-        pb.ARTIFACT_COLLECTIONS_FILTERING_SORTING,
-    ]
+    features = (
+        pb.ServerFeature.Name(pb.ARTIFACT_REGISTRY_SEARCH),
+        pb.ServerFeature.Name(pb.ARTIFACT_COLLECTIONS_FILTERING_SORTING),
+    )
     wandb_backend_spy.stub_gql(
         gql.Matcher(operation="ServerFeaturesQuery"),
         gql.Constant(
@@ -426,11 +431,7 @@ def advanced_features_spy(wandb_backend_spy):
                 "data": {
                     "serverInfo": {
                         "features": [
-                            {
-                                "name": pb.ServerFeature.Name(feature),
-                                "isEnabled": True,
-                            }
-                            for feature in features
+                            {"name": feature, "isEnabled": True} for feature in features
                         ]
                     }
                 }
@@ -455,7 +456,7 @@ def advanced_features_spy(wandb_backend_spy):
 
 
 def test_advanced_feature_response_selects_version_filter_fields(
-    advanced_features_spy,
+    advanced_features_spy: Responder,
     api: Api,
 ):
     versions = (

--- a/tests/unit_tests/test_filters/_strategies.py
+++ b/tests/unit_tests/test_filters/_strategies.py
@@ -70,6 +70,14 @@ def comparison_operands(draw: DrawFn) -> bool | int | float | str:
 
 
 @composite
+def equality_operands(
+    draw: DrawFn,
+) -> bool | int | float | str | list[bool | int | float | str]:
+    """Valid scalar or array operands for equality filters."""
+    return draw(comparison_operands() | lists(comparison_operands()))
+
+
+@composite
 def logical_operands(draw: DrawFn) -> dict[str, Any]:
     """Valid dicts that can be used as the "inner" operand(s) for logical operators."""
     return draw(filter_dicts() | op_dicts())
@@ -86,8 +94,8 @@ gt_dicts = fixed_dictionaries({"$gt": comparison_operands()})
 lt_dicts = fixed_dictionaries({"$lt": comparison_operands()})
 ge_dicts = fixed_dictionaries({"$gte": comparison_operands()})
 le_dicts = fixed_dictionaries({"$lte": comparison_operands()})
-eq_dicts = fixed_dictionaries({"$eq": comparison_operands()})
-ne_dicts = fixed_dictionaries({"$ne": comparison_operands()})
+eq_dicts = fixed_dictionaries({"$eq": equality_operands()})
+ne_dicts = fixed_dictionaries({"$ne": equality_operands()})
 nin_dicts = fixed_dictionaries({"$nin": lists(comparison_operands())})
 in_dicts = fixed_dictionaries({"$in": lists(comparison_operands())})
 

--- a/tests/unit_tests/test_filters/test_filters.py
+++ b/tests/unit_tests/test_filters/test_filters.py
@@ -33,6 +33,7 @@ from ._strategies import (
     comparison_operands,
     contains_dicts,
     eq_dicts,
+    equality_operands,
     exists_dicts,
     filter_dicts,
     ge_dicts,
@@ -115,14 +116,14 @@ def test_lte_from_validated_op(op: Lte):
     assert Lte.model_validate_json(op.model_dump_json()) == op
 
 
-@given(op=builds(Eq, val=comparison_operands()))
+@given(op=builds(Eq, val=equality_operands()))
 def test_eq_from_validated_op(op: Eq):
     assert op.model_dump().keys() == {"$eq"}
     assert Eq.model_validate(op.model_dump()) == op
     assert Eq.model_validate_json(op.model_dump_json()) == op
 
 
-@given(op=builds(Ne, val=comparison_operands()))
+@given(op=builds(Ne, val=equality_operands()))
 def test_ne_from_validated_op(op: Ne):
     assert op.model_dump().keys() == {"$ne"}
     assert Ne.model_validate(op.model_dump()) == op

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Annotated, Any
+
+from pydantic import BaseModel, ValidationError
+from pytest import mark, param, raises
+from wandb._filters import FilterValidator
+from wandb._pydantic import FilterDict
+
+VALID_FIELDS = ("tag", "created_at", "updated_at", "metadata")
+"""Fields considered "valid" for these tests."""
+
+INVALID_FIELD = "bogus"
+"""Field considered "invalid" for these tests."""
+
+
+class ExampleVars(BaseModel):
+    filters: Annotated[FilterDict, FilterValidator(valid=VALID_FIELDS)]
+
+
+@mark.parametrize(
+    "filters",
+    [
+        param({}, id="empty"),
+        param({"tag": "prod"}, id="implicit-eq"),
+        param({"tag": {"$eq": "prod"}}, id="explicit-eq"),
+        param({"tag": {"$regex": "prod"}}, id="regex"),
+        param({"metadata.foo": 1}, id="dotted-subkey"),
+        param({"metadata": {"foo": {"bar": 1}}}, id="nested-subdoc"),
+        param({"$or": [{"tag": "x"}, {"created_at": 1}]}, id="or-predicate"),
+        param({"$and": [{"tag": "x"}, {"created_at": 1}]}, id="and-predicate"),
+        param({"tag": {"$unknownOp": 1}}, id="nested-unknown-operator"),
+        param({"$unknownOp": {"ignored": 1}}, id="root-unknown-operator"),
+        param(
+            {
+                "$and": [
+                    {"tag": "x"},
+                    {"$or": [{"created_at": 1}, {"updated_at": 2}]},
+                ]
+            },
+            id="nested-logical-op",
+        ),
+        param(
+            {
+                "$or": [{"tag": "x"}, {"created_at": 1}],
+                "metadata": {"foo": "bar"},
+            },
+            id="known-mixed-root-predicates",
+        ),
+        param(
+            {
+                "$unknownOp": {"ignored": 1},
+                "tag": "prod",
+            },
+            marks=mark.xfail(
+                reason="Needs to be fixed, fields inside $unknownOp should be ignored",
+                strict=True,
+            ),
+            id="unknown-mixed-root-predicates",
+        ),
+    ],
+)
+def test_valid_filter_unchanged(filters: dict[str, Any]):
+    orig = deepcopy(filters)
+    assert orig == ExampleVars(filters=filters).filters
+
+
+@mark.parametrize(
+    "filters",
+    [
+        param({INVALID_FIELD: 1}, id="root-field"),
+        param({"$and": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="inside-and"),
+        param({"$or": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="inside-or"),
+        param({"$nor": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="inside-nor"),
+        param({"$not": {INVALID_FIELD: 1}}, id="inside-not"),
+        param(
+            {
+                "$and": [
+                    {"tag": "x"},
+                    {"$or": [{"created_at": 1}, {INVALID_FIELD: 2}]},
+                ]
+            },
+            id="inside-nested-predicates",
+        ),
+        param({"$and": {"tag": "x"}}, id="bad-and-op-shape"),
+        param({"$or": {"tag": "x"}}, id="bad-or-op-shape"),
+    ],
+)
+def test_invalid_filter_raises(filters: dict[str, Any]):
+    with raises(ValidationError):
+        ExampleVars(filters=filters)

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Annotated, Any
 
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import TypeAdapter, ValidationError
 from pytest import mark, param, raises
 from wandb._filters import FilterValidator
 from wandb._pydantic import FilterDict
@@ -19,9 +19,16 @@ FIELD_ALIASES = {
     "artifact_metadata": "metadata",
 }
 
-
-class ExampleVars(BaseModel):
-    filters: Annotated[FilterDict, FilterValidator(VALID_FIELDS)]
+FILTER_ADAPTER = TypeAdapter(Annotated[FilterDict, FilterValidator(VALID_FIELDS)])
+ALIASED_FILTER_ADAPTER = TypeAdapter(
+    Annotated[FilterDict, FilterValidator(valid=FIELD_ALIASES)]
+)
+COLLISION_FILTER_ADAPTER = TypeAdapter(
+    Annotated[
+        FilterDict,
+        FilterValidator(valid=FIELD_ALIASES | {"field": "$or"}),
+    ]
+)
 
 
 @mark.parametrize(
@@ -37,15 +44,22 @@ class ExampleVars(BaseModel):
         param({"$or": [{"tag": "x"}, {"created_at": 1}]}, id="or"),
         param({"$nor": [{"tag": "x"}, {"created_at": 1}]}, id="nor"),
         param({"$not": {"tag": "x"}}, id="not"),
-        param({"tag": {"$future": {INVALID_FIELD: 1}}}, id="opaque-field-op"),
+        param({"$and": []}, id="empty-and"),
+        param({"$or": []}, id="empty-or"),
+        param({"$or": [{}]}, id="empty-logical-child"),
+        param({"$not": {}}, id="empty-not"),
         param(
-            {"$future": {INVALID_FIELD: 1}, "tag": "prod"},
+            {"tag": {"$unknownOp": {INVALID_FIELD: 1}}},
+            id="opaque-field-op",
+        ),
+        param(
+            {"$unknownOp": {INVALID_FIELD: 1}, "tag": "prod"},
             id="opaque-root-op",
         ),
         param(
             {
                 "$and": [
-                    {"$future": {INVALID_FIELD: 1}},
+                    {"$unknownOp": {INVALID_FIELD: 1}},
                     {"$or": [{"created_at": 1}, {"updated_at": 2}]},
                 ]
             },
@@ -56,56 +70,61 @@ class ExampleVars(BaseModel):
 def test_valid_filter_unchanged(filters: dict[str, Any]):
     original = deepcopy(filters)
 
-    assert ExampleVars(filters=filters).filters == original
+    assert FILTER_ADAPTER.validate_python(filters) == original
     assert filters == original
 
 
-def test_filter_validator_maps_aliases_in_annotated_field():
-    adapter = TypeAdapter(Annotated[FilterDict, FilterValidator(valid=FIELD_ALIASES)])
-    raw = {
-        "$and": [
-            {"artifact_metadata.owner": "alice"},
+@mark.parametrize(
+    ("raw", "expected"),
+    [
+        param(
             {
-                "$or": [
-                    {"tag": "prod"},
+                "$and": [
+                    {"artifact_metadata.owner": "alice"},
                     {"$not": {"artifact_metadata.team": "ml"}},
                 ]
             },
-            {"$nor": [{"created_at": 1}]},
-        ]
-    }
-
-    assert adapter.validate_python(raw) == {
-        "$and": [
-            {"metadata.owner": "alice"},
             {
-                "$or": [
-                    {"tag": "prod"},
+                "$and": [
+                    {"metadata.owner": "alice"},
                     {"$not": {"metadata.team": "ml"}},
                 ]
             },
-            {"$nor": [{"created_at": 1}]},
-        ]
-    }
+            id="logical-fields",
+        ),
+        param(
+            {
+                "artifact_metadata": [
+                    {"artifact_metadata.owner": "data, not a filter field"}
+                ]
+            },
+            {"metadata": [{"artifact_metadata.owner": "data, not a filter field"}]},
+            id="opaque-field-operand",
+        ),
+        param(
+            {
+                "$unknownOp": {
+                    INVALID_FIELD: 1,
+                    "artifact_metadata.owner": "also opaque",
+                },
+                "artifact_metadata.owner": "alice",
+            },
+            {
+                "$unknownOp": {
+                    INVALID_FIELD: 1,
+                    "artifact_metadata.owner": "also opaque",
+                },
+                "metadata.owner": "alice",
+            },
+            id="opaque-unknown-operator-operand",
+        ),
+    ],
+)
+def test_filter_validator_maps_aliases(raw: dict[str, Any], expected: dict[str, Any]):
+    original = deepcopy(raw)
 
-
-def test_filter_validator_leaves_operands_opaque_when_mapping_fields():
-    adapter = TypeAdapter(Annotated[FilterDict, FilterValidator(valid=FIELD_ALIASES)])
-    field_operand = [{"artifact_metadata.owner": "data, not a filter field"}]
-    unknown_operator_operand = {
-        INVALID_FIELD: 1,
-        "artifact_metadata.owner": "also opaque",
-    }
-
-    assert adapter.validate_python(
-        {
-            "artifact_metadata": field_operand,
-            "$future": unknown_operator_operand,
-        }
-    ) == {
-        "metadata": field_operand,
-        "$future": unknown_operator_operand,
-    }
+    assert ALIASED_FILTER_ADAPTER.validate_python(raw) == expected
+    assert raw == original
 
 
 @mark.parametrize(
@@ -134,11 +153,8 @@ def test_filter_validator_leaves_operands_opaque_when_mapping_fields():
     ],
 )
 def test_filter_validator_rejects_mapping_collisions(raw: dict[str, Any]):
-    aliases = {**FIELD_ALIASES, "field": "$or"}
-    adapter = TypeAdapter(Annotated[FilterDict, FilterValidator(valid=aliases)])
-
     with raises(ValidationError, match="mapping collision"):
-        adapter.validate_python(raw)
+        COLLISION_FILTER_ADAPTER.validate_python(raw)
 
 
 @mark.parametrize(
@@ -160,17 +176,17 @@ def test_filter_validator_rejects_mapping_collisions(raw: dict[str, Any]):
 )
 def test_invalid_filter_field_raises(filters: dict[str, Any]):
     with raises(ValidationError, match="Invalid filter field"):
-        ExampleVars(filters=filters)
+        FILTER_ADAPTER.validate_python(filters)
 
 
 @mark.parametrize(
     "filters",
     [
         param({"$and": {"tag": "x"}}, id="variadic-op-requires-list"),
-        param({"$or": [{}]}, id="logical-child-requires-nonempty-dict"),
-        param({"$not": {}}, id="not-requires-nonempty-dict"),
+        param({"$or": [1]}, id="logical-child-requires-dict"),
+        param({"$not": []}, id="not-requires-dict"),
     ],
 )
 def test_malformed_logical_operator_raises(filters: dict[str, Any]):
     with raises(ValidationError, match=r"must contain|must be"):
-        ExampleVars(filters=filters)
+        FILTER_ADAPTER.validate_python(filters)

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -9,9 +9,10 @@ from wandb._filters import FilterValidator
 from wandb._pydantic import FilterDict
 
 VALID_FIELDS = ("tag", "created_at", "updated_at", "metadata")
-INVALID_FIELD = "bogus"
+INVALID_FIELD1 = "bogus"
+INVALID_FIELD2 = "also_bogus"
 
-FIELD_ALIASES = {
+ALIASED_FIELDS = {
     "tag": "tag",
     "tags": "tag",
     "created_at": "created_at",
@@ -21,8 +22,12 @@ FIELD_ALIASES = {
 }
 
 FILTER_ADAPTER = TypeAdapter(Annotated[FilterDict, FilterValidator(VALID_FIELDS)])
-ALIASED_FILTER_ADAPTER = TypeAdapter(
-    Annotated[FilterDict, FilterValidator(FIELD_ALIASES)]
+ALIASED_ADAPTER = TypeAdapter(Annotated[FilterDict, FilterValidator(ALIASED_FIELDS)])
+TRANSFORM_ADAPTER = TypeAdapter(
+    Annotated[
+        FilterDict,
+        FilterValidator(ALIASED_FIELDS, transforms={"tag": str.upper}),
+    ]
 )
 
 
@@ -41,20 +46,20 @@ ALIASED_FILTER_ADAPTER = TypeAdapter(
         param({"$not": {"tag": "x"}}, id="not"),
         param({"$and": []}, id="empty-and"),
         param({"$or": []}, id="empty-or"),
-        param({"$or": [{}]}, id="empty-logical-child"),
+        param({"$or": [{}]}, id="empty-or-child"),
         param({"$not": {}}, id="empty-not"),
         param(
-            {"tag": {"$unknownOp": {INVALID_FIELD: 1}}},
+            {"tag": {"$unknownOp": {INVALID_FIELD1: 1}}},
             id="opaque-field-op",
         ),
         param(
-            {"$unknownOp": {INVALID_FIELD: 1}, "tag": "prod"},
+            {"$unknownOp": {INVALID_FIELD1: 1}, "tag": "prod"},
             id="opaque-root-op",
         ),
         param(
             {
                 "$and": [
-                    {"$unknownOp": {INVALID_FIELD: 1}},
+                    {"$unknownOp": {INVALID_FIELD1: 1}},
                     {"$or": [{"created_at": 1}, {"updated_at": 2}]},
                 ]
             },
@@ -70,7 +75,7 @@ def test_valid_filter_unchanged(filters: dict[str, Any]):
 
 
 @mark.parametrize(
-    ("raw", "expected"),
+    ("orig", "expected"),
     [
         param(
             {
@@ -90,38 +95,38 @@ def test_valid_filter_unchanged(filters: dict[str, Any]):
             id="logical-fields",
         ),
         param(
-            {
-                "artifact_metadata": [
-                    {"artifact_metadata.owner": "data, not a filter field"}
-                ]
-            },
-            {"metadata": [{"artifact_metadata.owner": "data, not a filter field"}]},
+            {"artifact_metadata": [{"artifact_metadata.inner": "not a filter field"}]},
+            {"metadata": [{"artifact_metadata.inner": "not a filter field"}]},
             id="opaque-field-operand",
         ),
         param(
             {
-                "$unknownOp": {
-                    INVALID_FIELD: 1,
-                    "artifact_metadata.owner": "also opaque",
-                },
+                "$unknownOp": {INVALID_FIELD1: 1, "artifact_metadata.owner": "opaque"},
                 "artifact_metadata.owner": "alice",
             },
             {
-                "$unknownOp": {
-                    INVALID_FIELD: 1,
-                    "artifact_metadata.owner": "also opaque",
-                },
+                "$unknownOp": {INVALID_FIELD1: 1, "artifact_metadata.owner": "opaque"},
                 "metadata.owner": "alice",
             },
             id="opaque-unknown-operator-operand",
         ),
     ],
 )
-def test_filter_validator_maps_aliases(raw: dict[str, Any], expected: dict[str, Any]):
-    original = deepcopy(raw)
+def test_filter_validator_maps_aliases(orig: dict[str, Any], expected: dict[str, Any]):
+    orig_copy = deepcopy(orig)
 
-    assert ALIASED_FILTER_ADAPTER.validate_python(raw) == expected
-    assert raw == original
+    assert ALIASED_ADAPTER.validate_python(orig) == expected
+    assert orig == orig_copy
+
+
+def test_filter_validator_transforms_canonicalized_fields():
+    orig = {"$or": [{"tags": "prod"}, {"tag": "staging"}]}
+    expected = {"$or": [{"tag": "PROD"}, {"tag": "STAGING"}]}
+
+    orig_copy = deepcopy(orig)
+
+    assert TRANSFORM_ADAPTER.validate_python(orig) == expected
+    assert orig == orig_copy
 
 
 @mark.parametrize(
@@ -161,20 +166,21 @@ def test_filter_validator_maps_aliases(raw: dict[str, Any], expected: dict[str, 
 )
 def test_filter_validator_rejects_runtime_collisions(raw: dict[str, Any]):
     with raises(ValidationError, match=r"(?i)duplicate fields"):
-        ALIASED_FILTER_ADAPTER.validate_python(raw)
+        ALIASED_ADAPTER.validate_python(raw)
 
 
 @mark.parametrize(
     "filters",
     [
-        param({INVALID_FIELD: 1}, id="root"),
-        param({"$and": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="logical-child"),
-        param({"$not": {INVALID_FIELD: 1}}, id="not-child"),
+        param({INVALID_FIELD1: 1}, id="root"),
+        param({"$and": [{"tag": "x"}, {INVALID_FIELD1: 1}]}, id="and-child"),
+        param({"$or": [{"tag": "x"}, {INVALID_FIELD1: 1}]}, id="or-child"),
+        param({"$not": {INVALID_FIELD1: 1}}, id="not-child"),
         param(
             {
                 "$and": [
                     {"tag": "x"},
-                    {"$or": [{"created_at": 1}, {INVALID_FIELD: 2}]},
+                    {"$or": [{"created_at": 1}, {INVALID_FIELD1: 2}]},
                 ]
             },
             id="nested-logical-child",
@@ -186,6 +192,14 @@ def test_invalid_filter_field_raises(filters: dict[str, Any]):
         FILTER_ADAPTER.validate_python(filters)
 
 
+def test_invalid_filter_fields_are_all_reported():
+    with raises(
+        ValidationError,
+        match=rf"Invalid filter fields: {INVALID_FIELD2!r}, {INVALID_FIELD1!r}",
+    ):
+        FILTER_ADAPTER.validate_python({INVALID_FIELD1: 1, INVALID_FIELD2: 2})
+
+
 @mark.parametrize(
     "filters",
     [
@@ -195,5 +209,5 @@ def test_invalid_filter_field_raises(filters: dict[str, Any]):
     ],
 )
 def test_malformed_logical_operator_raises(filters: dict[str, Any]):
-    with raises(ValidationError, match=r"must contain|must be"):
+    with raises(ValidationError):
         FILTER_ADAPTER.validate_python(filters)

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from pytest import mark, param, raises
-from wandb._filters import FilterFieldMapper, FilterValidator
+from wandb._filters import FilterValidator
 from wandb._pydantic import FilterDict
 
 VALID_FIELDS = ("tag", "created_at", "updated_at", "metadata")
@@ -89,15 +89,15 @@ def test_filter_validator_maps_aliases_in_annotated_field():
     }
 
 
-def test_filter_field_mapper_leaves_operands_opaque():
-    mapper = FilterFieldMapper(FIELD_ALIASES)
+def test_filter_validator_leaves_operands_opaque_when_mapping_fields():
+    adapter = TypeAdapter(Annotated[FilterDict, FilterValidator(valid=FIELD_ALIASES)])
     field_operand = [{"artifact_metadata.owner": "data, not a filter field"}]
     unknown_operator_operand = {
         INVALID_FIELD: 1,
         "artifact_metadata.owner": "also opaque",
     }
 
-    assert mapper(
+    assert adapter.validate_python(
         {
             "artifact_metadata": field_operand,
             "$future": unknown_operator_operand,
@@ -133,11 +133,12 @@ def test_filter_field_mapper_leaves_operands_opaque():
         ),
     ],
 )
-def test_filter_field_mapper_rejects_collisions(raw: dict[str, Any]):
+def test_filter_validator_rejects_mapping_collisions(raw: dict[str, Any]):
     aliases = {**FIELD_ALIASES, "field": "$or"}
+    adapter = TypeAdapter(Annotated[FilterDict, FilterValidator(valid=aliases)])
 
-    with raises(ValueError, match="mapping collision"):
-        FilterFieldMapper(aliases)(raw)
+    with raises(ValidationError, match="mapping collision"):
+        adapter.validate_python(raw)
 
 
 @mark.parametrize(

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -26,7 +26,7 @@ ALIASED_FILTER_ADAPTER = TypeAdapter(
 COLLISION_FILTER_ADAPTER = TypeAdapter(
     Annotated[
         FilterDict,
-        FilterValidator(valid=FIELD_ALIASES | {"field": "$or"}),
+        FilterValidator(valid=FIELD_ALIASES | {"tags": "tag"}),
     ]
 )
 
@@ -81,12 +81,14 @@ def test_valid_filter_unchanged(filters: dict[str, Any]):
             {
                 "$and": [
                     {"artifact_metadata.owner": "alice"},
+                    {"metadata.promoted": True},
                     {"$not": {"artifact_metadata.team": "ml"}},
                 ]
             },
             {
                 "$and": [
                     {"metadata.owner": "alice"},
+                    {"metadata.promoted": True},
                     {"$not": {"metadata.team": "ml"}},
                 ]
             },
@@ -143,17 +145,27 @@ def test_filter_validator_maps_aliases(raw: dict[str, Any], expected: dict[str, 
             id="nested-dotted-fields",
         ),
         param(
-            {"$or": [{"tag": "prod"}], "field": 1},
-            id="operator-first",
+            {
+                "$or": [
+                    {"tag": "prod", "tags": "OOPS"},  # Collision happens here
+                    {"metadata": "irrelevant"},
+                ]
+            },
+            id="nested-collision-canonical-first",
         ),
         param(
-            {"field": 1, "$or": [{"tag": "prod"}]},
-            id="mapped-field-first",
+            {
+                "$or": [
+                    {"metadata": "irrelevant"},
+                    {"tags": "OOPS", "tag": "prod"},  # Collision happens here
+                ]
+            },
+            id="nested-collision-alias-first",
         ),
     ],
 )
-def test_filter_validator_rejects_mapping_collisions(raw: dict[str, Any]):
-    with raises(ValidationError, match="mapping collision"):
+def test_filter_validator_rejects_runtime_collisions(raw: dict[str, Any]):
+    with raises(ValidationError, match=r"(?i)duplicate fields"):
         COLLISION_FILTER_ADAPTER.validate_python(raw)
 
 

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -3,20 +3,25 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Annotated, Any
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 from pytest import mark, param, raises
-from wandb._filters import FilterValidator
+from wandb._filters import FilterFieldMapper, FilterValidator
 from wandb._pydantic import FilterDict
 
 VALID_FIELDS = ("tag", "created_at", "updated_at", "metadata")
-"""Fields considered "valid" for these tests."""
-
 INVALID_FIELD = "bogus"
-"""Field considered "invalid" for these tests."""
+
+FIELD_ALIASES = {
+    "tag": "tag",
+    "created_at": "created_at",
+    "updated_at": "updated_at",
+    "metadata": "metadata",
+    "artifact_metadata": "metadata",
+}
 
 
 class ExampleVars(BaseModel):
-    filters: Annotated[FilterDict, FilterValidator(valid=VALID_FIELDS)]
+    filters: Annotated[FilterDict, FilterValidator(VALID_FIELDS)]
 
 
 @mark.parametrize(
@@ -24,56 +29,123 @@ class ExampleVars(BaseModel):
     [
         param({}, id="empty"),
         param({"tag": "prod"}, id="implicit-eq"),
+        param({"tag": ["prod", "staging"]}, id="list-valued-equality"),
         param({"tag": {"$eq": "prod"}}, id="explicit-eq"),
-        param({"tag": {"$regex": "prod"}}, id="regex"),
         param({"metadata.foo": 1}, id="dotted-subkey"),
-        param({"metadata": {"foo": {"bar": 1}}}, id="nested-subdoc"),
-        param({"$or": [{"tag": "x"}, {"created_at": 1}]}, id="or-predicate"),
-        param({"$and": [{"tag": "x"}, {"created_at": 1}]}, id="and-predicate"),
-        param({"tag": {"$unknownOp": 1}}, id="nested-unknown-operator"),
-        param({"$unknownOp": {"ignored": 1}}, id="root-unknown-operator"),
+        param({"metadata": {"foo": {"bar": 1}}}, id="nested-subdocument"),
+        param({"$and": [{"tag": "x"}, {"created_at": 1}]}, id="and"),
+        param({"$or": [{"tag": "x"}, {"created_at": 1}]}, id="or"),
+        param({"$nor": [{"tag": "x"}, {"created_at": 1}]}, id="nor"),
+        param({"$not": {"tag": "x"}}, id="not"),
+        param({"tag": {"$future": {INVALID_FIELD: 1}}}, id="opaque-field-op"),
+        param(
+            {"$future": {INVALID_FIELD: 1}, "tag": "prod"},
+            id="opaque-root-op",
+        ),
         param(
             {
                 "$and": [
-                    {"tag": "x"},
+                    {"$future": {INVALID_FIELD: 1}},
                     {"$or": [{"created_at": 1}, {"updated_at": 2}]},
                 ]
             },
-            id="nested-logical-op",
-        ),
-        param(
-            {
-                "$or": [{"tag": "x"}, {"created_at": 1}],
-                "metadata": {"foo": "bar"},
-            },
-            id="known-mixed-root-predicates",
-        ),
-        param(
-            {
-                "$unknownOp": {"ignored": 1},
-                "tag": "prod",
-            },
-            marks=mark.xfail(
-                reason="Needs to be fixed, fields inside $unknownOp should be ignored",
-                strict=True,
-            ),
-            id="unknown-mixed-root-predicates",
+            id="nested-logical-operators",
         ),
     ],
 )
 def test_valid_filter_unchanged(filters: dict[str, Any]):
-    orig = deepcopy(filters)
-    assert orig == ExampleVars(filters=filters).filters
+    original = deepcopy(filters)
+
+    assert ExampleVars(filters=filters).filters == original
+    assert filters == original
+
+
+def test_filter_validator_maps_aliases_in_annotated_field():
+    adapter = TypeAdapter(Annotated[FilterDict, FilterValidator(valid=FIELD_ALIASES)])
+    raw = {
+        "$and": [
+            {"artifact_metadata.owner": "alice"},
+            {
+                "$or": [
+                    {"tag": "prod"},
+                    {"$not": {"artifact_metadata.team": "ml"}},
+                ]
+            },
+            {"$nor": [{"created_at": 1}]},
+        ]
+    }
+
+    assert adapter.validate_python(raw) == {
+        "$and": [
+            {"metadata.owner": "alice"},
+            {
+                "$or": [
+                    {"tag": "prod"},
+                    {"$not": {"metadata.team": "ml"}},
+                ]
+            },
+            {"$nor": [{"created_at": 1}]},
+        ]
+    }
+
+
+def test_filter_field_mapper_leaves_operands_opaque():
+    mapper = FilterFieldMapper(FIELD_ALIASES)
+    field_operand = [{"artifact_metadata.owner": "data, not a filter field"}]
+    unknown_operator_operand = {
+        INVALID_FIELD: 1,
+        "artifact_metadata.owner": "also opaque",
+    }
+
+    assert mapper(
+        {
+            "artifact_metadata": field_operand,
+            "$future": unknown_operator_operand,
+        }
+    ) == {
+        "metadata": field_operand,
+        "$future": unknown_operator_operand,
+    }
+
+
+@mark.parametrize(
+    "raw",
+    [
+        param(
+            {"metadata": 1, "artifact_metadata": 2},
+            id="canonical-name-first",
+        ),
+        param(
+            {"artifact_metadata": 1, "metadata": 2},
+            id="alias-first",
+        ),
+        param(
+            {"$or": [{"metadata.owner": 1, "artifact_metadata.owner": 2}]},
+            id="nested-dotted-fields",
+        ),
+        param(
+            {"$or": [{"tag": "prod"}], "field": 1},
+            id="operator-first",
+        ),
+        param(
+            {"field": 1, "$or": [{"tag": "prod"}]},
+            id="mapped-field-first",
+        ),
+    ],
+)
+def test_filter_field_mapper_rejects_collisions(raw: dict[str, Any]):
+    aliases = {**FIELD_ALIASES, "field": "$or"}
+
+    with raises(ValueError, match="mapping collision"):
+        FilterFieldMapper(aliases)(raw)
 
 
 @mark.parametrize(
     "filters",
     [
-        param({INVALID_FIELD: 1}, id="root-field"),
-        param({"$and": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="inside-and"),
-        param({"$or": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="inside-or"),
-        param({"$nor": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="inside-nor"),
-        param({"$not": {INVALID_FIELD: 1}}, id="inside-not"),
+        param({INVALID_FIELD: 1}, id="root"),
+        param({"$and": [{"tag": "x"}, {INVALID_FIELD: 1}]}, id="logical-child"),
+        param({"$not": {INVALID_FIELD: 1}}, id="not-child"),
         param(
             {
                 "$and": [
@@ -81,12 +153,23 @@ def test_valid_filter_unchanged(filters: dict[str, Any]):
                     {"$or": [{"created_at": 1}, {INVALID_FIELD: 2}]},
                 ]
             },
-            id="inside-nested-predicates",
+            id="nested-logical-child",
         ),
-        param({"$and": {"tag": "x"}}, id="bad-and-op-shape"),
-        param({"$or": {"tag": "x"}}, id="bad-or-op-shape"),
     ],
 )
-def test_invalid_filter_raises(filters: dict[str, Any]):
-    with raises(ValidationError):
+def test_invalid_filter_field_raises(filters: dict[str, Any]):
+    with raises(ValidationError, match="Invalid filter field"):
+        ExampleVars(filters=filters)
+
+
+@mark.parametrize(
+    "filters",
+    [
+        param({"$and": {"tag": "x"}}, id="variadic-op-requires-list"),
+        param({"$or": [{}]}, id="logical-child-requires-nonempty-dict"),
+        param({"$not": {}}, id="not-requires-nonempty-dict"),
+    ],
+)
+def test_malformed_logical_operator_raises(filters: dict[str, Any]):
+    with raises(ValidationError, match=r"must contain|must be"):
         ExampleVars(filters=filters)

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -22,7 +22,7 @@ FIELD_ALIASES = {
 
 FILTER_ADAPTER = TypeAdapter(Annotated[FilterDict, FilterValidator(VALID_FIELDS)])
 ALIASED_FILTER_ADAPTER = TypeAdapter(
-    Annotated[FilterDict, FilterValidator(valid=FIELD_ALIASES)]
+    Annotated[FilterDict, FilterValidator(FIELD_ALIASES)]
 )
 
 

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Annotated, Any
+
+from pydantic import BaseModel, ValidationError
+from pytest import mark, param, raises
+from wandb._filters import FilterValidator
+from wandb._pydantic import FilterDict
+
+
+class _TestVars(BaseModel):
+    filters: Annotated[
+        FilterDict,
+        FilterValidator(valid=("tag", "created_at", "updated_at", "metadata")),
+    ]
+
+
+@mark.parametrize(
+    "filters",
+    [
+        param(
+            {"tag": "prod"},
+            id="valid-implicit-eq",
+        ),
+        param(
+            {"tag": {"$eq": "prod"}},
+            id="valid-explicit-eq",
+        ),
+        param(
+            {"tag": {"$regex": "prod"}},
+            id="valid-regex",
+        ),
+        param(
+            {"metadata.foo": 1},
+            id="valid-dotted-subkey",
+        ),
+        param(
+            {"metadata": {"foo": {"bar": 1}}},
+            id="valid-nested-subdoc",
+        ),
+        param(
+            {"$or": [{"tag": "x"}, {"created_at": 1}]},
+            id="valid-or-predicate",
+        ),
+        param(
+            {"$and": [{"tag": "x"}, {"created_at": 1}]},
+            id="valid-and-predicate",
+        ),
+        param(
+            {"tag": {"$unknownOp": 1}},
+            id="valid-inner-unknown-operator",
+        ),
+        param(
+            {"$unknownOp": {"ignored": 1}},
+            id="valid-root-unknown-operator",
+        ),
+        param(
+            {
+                "$and": [
+                    {"tag": "x"},
+                    {"$or": [{"created_at": 1}, {"updated_at": 2}]},
+                ]
+            },
+            id="valid-nested-logical-op",
+        ),
+        param(
+            {
+                "$or": [{"tag": "x"}, {"created_at": 1}],
+                "metadata": {"foo": "bar"},
+            },
+            id="valid-mixed-root-predicates",
+        ),
+        param(
+            {},
+            id="valid-empty",
+        ),
+    ],
+)
+def test_valid_filter_returned_unchanged(filters: dict[str, Any]):
+    expected = deepcopy(filters)
+    assert expected == _TestVars(filters=filters).filters
+
+
+@mark.parametrize(
+    "filters",
+    [
+        param(
+            {"bogus": 1},
+            id="invalid-root-field",
+        ),
+        param(
+            {"$and": [{"tag": "x"}, {"nope": 1}]},
+            id="invalid-inside-and",
+        ),
+        param(
+            {"$or": [{"tag": "x"}, {"nope": 1}]},
+            id="invalid-inside-or",
+        ),
+        param(
+            {"$nor": [{"tag": "x"}, {"nope": 1}]},
+            id="invalid-inside-nor",
+        ),
+        param(
+            {"$not": {"nope": 1}},
+            id="invalid-inside-not",
+        ),
+        param(
+            {
+                "$and": [
+                    {"tag": "x"},
+                    {"$or": [{"created_at": 1}, {"nope": 2}]},
+                ]
+            },
+            id="invalid-inside-nested-predicates",
+        ),
+        param(
+            {"$and": {"tag": "x"}},
+            id="invalid-root-logical-op-shape",
+        ),
+        param(
+            {
+                "$unknownOp": {"ignored": 1},
+                "tag": "prod",
+            },
+            id="invalid-mixed-root-predicates",
+        ),
+    ],
+)
+def test_unknown_field_raises(filters: dict[str, Any]):
+    with raises(ValidationError):
+        _TestVars(filters=filters)

--- a/tests/unit_tests/test_filters/test_validation.py
+++ b/tests/unit_tests/test_filters/test_validation.py
@@ -13,6 +13,7 @@ INVALID_FIELD = "bogus"
 
 FIELD_ALIASES = {
     "tag": "tag",
+    "tags": "tag",
     "created_at": "created_at",
     "updated_at": "updated_at",
     "metadata": "metadata",
@@ -22,12 +23,6 @@ FIELD_ALIASES = {
 FILTER_ADAPTER = TypeAdapter(Annotated[FilterDict, FilterValidator(VALID_FIELDS)])
 ALIASED_FILTER_ADAPTER = TypeAdapter(
     Annotated[FilterDict, FilterValidator(valid=FIELD_ALIASES)]
-)
-COLLISION_FILTER_ADAPTER = TypeAdapter(
-    Annotated[
-        FilterDict,
-        FilterValidator(valid=FIELD_ALIASES | {"tags": "tag"}),
-    ]
 )
 
 
@@ -166,7 +161,7 @@ def test_filter_validator_maps_aliases(raw: dict[str, Any], expected: dict[str, 
 )
 def test_filter_validator_rejects_runtime_collisions(raw: dict[str, Any]):
     with raises(ValidationError, match=r"(?i)duplicate fields"):
-        COLLISION_FILTER_ADAPTER.validate_python(raw)
+        ALIASED_FILTER_ADAPTER.validate_python(raw)
 
 
 @mark.parametrize(

--- a/tests/unit_tests/test_iterutils.py
+++ b/tests/unit_tests/test_iterutils.py
@@ -1,9 +1,44 @@
+from collections.abc import Hashable, Iterable
 from itertools import repeat, tee
 
 from hypothesis import example, given
-from hypothesis.strategies import integers, iterables, sampled_from
+from hypothesis.strategies import (
+    binary,
+    booleans,
+    dictionaries,
+    floats,
+    integers,
+    iterables,
+    lists,
+    none,
+    recursive,
+    sampled_from,
+    text,
+)
 from pytest import raises
-from wandb._iterutils import one
+from wandb._iterutils import merge_dicts, one
+
+hashables = (
+    none() | booleans() | integers() | floats(allow_nan=False) | text() | binary()
+)
+values = recursive(
+    hashables,
+    lambda children: (
+        lists(children, max_size=5) | dictionaries(hashables, children, max_size=5)
+    ),
+    max_leaves=10,
+)
+
+
+@example(dicts=[])
+@given(dicts=iterables(dictionaries(hashables, values), max_size=10))
+def test_merge_dicts(dicts: Iterable[dict[Hashable, object]]):
+    test_dicts, ref_dicts = tee(dicts)
+    expected: dict[Hashable, object] = {}
+    for d in ref_dicts:
+        expected.update(d)
+
+    assert merge_dicts(test_dicts) == expected
 
 
 @given(iterable=iterables(integers(), min_size=1, max_size=1))

--- a/tests/unit_tests/test_public_api/test_registries_ordered_versions.py
+++ b/tests/unit_tests/test_public_api/test_registries_ordered_versions.py
@@ -8,10 +8,9 @@ from pytest import fixture, raises
 from wandb._strutils import b64encode_ascii
 from wandb.apis.public.registries import _utils
 from wandb.apis.public.registries._utils import (
-    _project_id_from_gql_id,
     advanced_search_enabled,
-    filter_for_registry,
-    registry_filter_for_collection,
+    decode_project_id,
+    registry_filter_for,
 )
 from wandb.apis.public.registries.registries_search import Collections, Registries
 from wandb.apis.public.registries.registry import Registry
@@ -27,56 +26,51 @@ ORG = "test-org"
 REGISTRY_FILTER = {"name": "wandb-registry-test"}
 
 
-def test_filter_for_registry_uses_id(mocker: MockerFixture):
+def test_registry_filter_uses_internal_id(mocker: MockerFixture):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-test"
     registry.internal_id = b64encode_ascii("ProjectInternalId:42")
 
-    assert filter_for_registry(registry) == {"id": 42}
+    assert registry_filter_for(registry) == {"id": 42}
 
 
-def test_registry_filter_for_collection_uses_id(mocker: MockerFixture):
+def test_registry_filter_uses_internal_id_from_collection(mocker: MockerFixture):
     from wandb.apis.public import ArtifactCollection
 
     collection = mocker.Mock(spec=ArtifactCollection)
     collection.project = "wandb-registry-test"
     collection.project_internal_id = b64encode_ascii("ProjectInternalId:42")
 
-    assert registry_filter_for_collection(collection) == {"id": 42}
+    assert registry_filter_for(collection) == {"id": 42}
 
 
-def test_project_id_from_gql_id_decodes_project_internal_id():
+def test_decode_project_id_on_valid_internal_id():
     gql_id = b64encode_ascii("ProjectInternalId:933111")
 
-    assert _project_id_from_gql_id(gql_id) == 933111
+    assert decode_project_id(gql_id) == 933111
 
 
-def test_project_id_from_gql_id_returns_none_for_invalid_id(
-    wandb_caplog: LogCaptureFixture,
-):
+def test_decode_project_id_on_invalid_internal_id(wandb_caplog: LogCaptureFixture):
     with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
-        assert _project_id_from_gql_id("not-a-valid-gql-id") is None
+        assert decode_project_id("not-a-valid-gql-id") is None
 
     assert "Invalid project ID" in wandb_caplog.text
 
 
 def test_filter_for_registry_falls_back_to_name_for_invalid_internal_id(
-    mocker: MockerFixture,
-    wandb_caplog: LogCaptureFixture,
+    mocker: MockerFixture, wandb_caplog: LogCaptureFixture
 ):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-test"
     registry.internal_id = "not-a-valid-gql-id"
 
     with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
-        assert filter_for_registry(registry) == {
-            "name": "wandb-registry-test",
-        }
+        assert registry_filter_for(registry) == {"name": "wandb-registry-test"}
 
     assert "Invalid project ID" in wandb_caplog.text
 
 
-def test_registry_filter_for_collection_falls_back_to_name_for_invalid_internal_id(
+def test_registry_filter_falls_back_to_project_name_for_invalid_internal_id(
     mocker: MockerFixture,
     wandb_caplog: LogCaptureFixture,
 ):
@@ -87,9 +81,7 @@ def test_registry_filter_for_collection_falls_back_to_name_for_invalid_internal_
     collection.project_internal_id = "not-a-valid-gql-id"
 
     with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
-        assert registry_filter_for_collection(collection) == {
-            "name": "wandb-registry-test",
-        }
+        assert registry_filter_for(collection) == {"name": "wandb-registry-test"}
 
     assert "Invalid project ID" in wandb_caplog.text
 
@@ -107,16 +99,14 @@ def test_advanced_search_enabled_returns_false_on_graphql_error(
     assert "Failed to fetch advanced registry features" in wandb_caplog.text
 
 
-def test_filter_for_registry_falls_back_to_name_without_internal_id(
+def test_registry_filter_falls_back_to_name_without_internal_id(
     mocker: MockerFixture,
 ):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-order-test-reg-0"
     registry.internal_id = None
 
-    assert filter_for_registry(registry) == {
-        "name": "wandb-registry-order-test-reg-0",
-    }
+    assert registry_filter_for(registry) == {"name": "wandb-registry-order-test-reg-0"}
 
 
 @fixture

--- a/tests/unit_tests/test_public_api/test_registries_ordered_versions.py
+++ b/tests/unit_tests/test_public_api/test_registries_ordered_versions.py
@@ -13,7 +13,6 @@ from wandb.apis.public.registries._utils import (
     advanced_search_enabled,
     filter_for_registry,
     registry_filter_for_collection,
-    registry_id_filter_key,
 )
 from wandb.apis.public.registries.registries_search import Collections, Registries
 from wandb.apis.public.registries.registry import Registry
@@ -28,56 +27,22 @@ ORG = "test-org"
 REGISTRY_FILTER = {"name": "wandb-registry-test"}
 
 
-@pytest.fixture(autouse=True)
-def clear_registry_filter_caches():
-    advanced_search_enabled.cache_clear()
-
-
-def _mock_advanced_search(service_api, *, enabled: bool) -> None:
-    service_api.feature_enabled.return_value = True
-    response_json = json.dumps(
-        {
-            "organization": {
-                "advancedRegistryFeatures": {"advancedSearch": enabled},
-            }
-        }
-    )
-
-    def execute_graphql(*args, parse, **kwargs):
-        return parse(response_json)
-
-    service_api.execute_graphql.side_effect = execute_graphql
-
-
-@pytest.mark.parametrize(
-    ("enabled", "key"),
-    [(True, "project_id"), (False, "id")],
-    ids=["advanced_search", "non_advanced_search"],
-)
-def test_filter_for_registry_pins_internal_id(service_api, mocker, enabled, key):
-    _mock_advanced_search(service_api, enabled=enabled)
+def test_filter_for_registry_pins_internal_id(mocker):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-test"
     registry.internal_id = b64encode_ascii("ProjectInternalId:42")
 
-    assert filter_for_registry(registry, service_api=service_api, organization=ORG) == {
-        key: 42,
-    }
+    assert filter_for_registry(registry) == {"id": 42}
 
 
-def test_registry_filter_for_collection_pins_internal_id(service_api, mocker):
+def test_registry_filter_for_collection_pins_internal_id(mocker):
     from wandb.apis.public import ArtifactCollection
 
-    _mock_advanced_search(service_api, enabled=True)
     collection = mocker.Mock(spec=ArtifactCollection)
     collection.project = "wandb-registry-test"
     collection.project_internal_id = b64encode_ascii("ProjectInternalId:42")
 
-    assert registry_filter_for_collection(
-        collection, service_api=service_api, organization=ORG
-    ) == {
-        "project_id": 42,
-    }
+    assert registry_filter_for_collection(collection) == {"id": 42}
 
 
 def test_project_id_from_gql_id_decodes_project_internal_id():
@@ -94,25 +59,22 @@ def test_project_id_from_gql_id_returns_none_for_invalid_id(wandb_caplog):
 
 
 def test_filter_for_registry_falls_back_to_name_for_invalid_internal_id(
-    service_api, mocker, wandb_caplog
+    mocker, wandb_caplog
 ):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-test"
     registry.internal_id = "not-a-valid-gql-id"
 
     with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
-        assert filter_for_registry(
-            registry, service_api=service_api, organization=ORG
-        ) == {
+        assert filter_for_registry(registry) == {
             "name": "wandb-registry-test",
         }
 
     assert "Invalid project ID" in wandb_caplog.text
-    service_api.execute_graphql.assert_not_called()
 
 
 def test_registry_filter_for_collection_falls_back_to_name_for_invalid_internal_id(
-    service_api, mocker, wandb_caplog
+    mocker, wandb_caplog
 ):
     from wandb.apis.public import ArtifactCollection
 
@@ -121,9 +83,7 @@ def test_registry_filter_for_collection_falls_back_to_name_for_invalid_internal_
     collection.project_internal_id = "not-a-valid-gql-id"
 
     with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
-        assert registry_filter_for_collection(
-            collection, service_api=service_api, organization=ORG
-        ) == {
+        assert registry_filter_for_collection(collection) == {
             "name": "wandb-registry-test",
         }
 
@@ -140,20 +100,16 @@ def test_advanced_search_enabled_returns_false_on_graphql_error(
         assert advanced_search_enabled(service_api, ORG) is False
 
     assert "Failed to fetch advanced registry features" in wandb_caplog.text
-    assert registry_id_filter_key(service_api, ORG) == "id"
 
 
-def test_filter_for_registry_falls_back_to_name_without_internal_id(
-    service_api, mocker
-):
+def test_filter_for_registry_falls_back_to_name_without_internal_id(mocker):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-order-test-reg-0"
     registry.internal_id = None
 
-    assert filter_for_registry(registry, service_api=service_api, organization=ORG) == {
+    assert filter_for_registry(registry) == {
         "name": "wandb-registry-order-test-reg-0",
     }
-    service_api.execute_graphql.assert_not_called()
 
 
 @pytest.fixture
@@ -163,6 +119,26 @@ def service_api(mocker: MockerFixture) -> MagicMock:
     mock = mocker.Mock(spec=ServiceApi)
     mock.feature_enabled.return_value = True
     return mock
+
+
+@pytest.fixture
+def registry(service_api: MagicMock) -> Registry:
+    registry = Registry(service_api, ORG, entity="entity", name="test")
+    registry._current = registry._current.model_copy(
+        update={"internal_id": b64encode_ascii("ProjectInternalId:42")}
+    )
+    return registry
+
+
+def test_registry_collections_uses_basic_id_filter(
+    service_api: MagicMock,
+    registry: Registry,
+):
+    collections = registry.collections()
+
+    assert json.loads(collections.variables["registryFilter"]) == {"id": 42}
+    service_api.feature_enabled.assert_not_called()
+    service_api.execute_graphql.assert_not_called()
 
 
 def test_registries_versions_with_order_rejects_start(service_api):
@@ -195,16 +171,22 @@ def test_registries_collections_with_order_rejects_start(service_api):
 
 def test_registries_collections_with_registry_order_supports_versions_chain(
     service_api,
+    registry,
+    mocker,
 ):
-    """Test that we can chain versions after collections when querying registries with an order.
-
-    Note that this deliberately only checks for iterability and chainability, not actual results.
-    """
     registries = Registries(
         service_api=service_api,
         organization=ORG,
         filter=REGISTRY_FILTER,
         order="-updated_at",
+    )
+    registries.objects = [registry]
+    registries.last_response = mocker.Mock(has_next=False)
+    load_collection_page = mocker.patch.object(
+        Collections,
+        "_load_page",
+        autospec=True,
+        return_value=False,
     )
 
     collections = registries.collections()
@@ -215,6 +197,11 @@ def test_registries_collections_with_registry_order_supports_versions_chain(
     assert isinstance(registries.versions(), Iterable)
     assert isinstance(collections.versions(), Iterable)
     assert isinstance(registries.collections().versions(), Iterable)
+
+    assert list(collections) == []
+    child = load_collection_page.call_args.args[0]
+    assert json.loads(child.variables["registryFilter"]) == {"id": 42}
+    service_api.feature_enabled.assert_not_called()
 
 
 def test_ordered_chained_queries_reject_cursor_and_length(service_api):

--- a/tests/unit_tests/test_public_api/test_registries_ordered_versions.py
+++ b/tests/unit_tests/test_public_api/test_registries_ordered_versions.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-import pytest
+from pytest import fixture, raises
 from wandb._strutils import b64encode_ascii
 from wandb.apis.public.registries import _utils
 from wandb.apis.public.registries._utils import (
@@ -21,13 +20,14 @@ from wandb.errors import UnsupportedError
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
 ORG = "test-org"
 REGISTRY_FILTER = {"name": "wandb-registry-test"}
 
 
-def test_filter_for_registry_pins_internal_id(mocker):
+def test_filter_for_registry_uses_id(mocker: MockerFixture):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-test"
     registry.internal_id = b64encode_ascii("ProjectInternalId:42")
@@ -35,7 +35,7 @@ def test_filter_for_registry_pins_internal_id(mocker):
     assert filter_for_registry(registry) == {"id": 42}
 
 
-def test_registry_filter_for_collection_pins_internal_id(mocker):
+def test_registry_filter_for_collection_uses_id(mocker: MockerFixture):
     from wandb.apis.public import ArtifactCollection
 
     collection = mocker.Mock(spec=ArtifactCollection)
@@ -51,7 +51,9 @@ def test_project_id_from_gql_id_decodes_project_internal_id():
     assert _project_id_from_gql_id(gql_id) == 933111
 
 
-def test_project_id_from_gql_id_returns_none_for_invalid_id(wandb_caplog):
+def test_project_id_from_gql_id_returns_none_for_invalid_id(
+    wandb_caplog: LogCaptureFixture,
+):
     with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
         assert _project_id_from_gql_id("not-a-valid-gql-id") is None
 
@@ -59,7 +61,8 @@ def test_project_id_from_gql_id_returns_none_for_invalid_id(wandb_caplog):
 
 
 def test_filter_for_registry_falls_back_to_name_for_invalid_internal_id(
-    mocker, wandb_caplog
+    mocker: MockerFixture,
+    wandb_caplog: LogCaptureFixture,
 ):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-test"
@@ -74,7 +77,8 @@ def test_filter_for_registry_falls_back_to_name_for_invalid_internal_id(
 
 
 def test_registry_filter_for_collection_falls_back_to_name_for_invalid_internal_id(
-    mocker, wandb_caplog
+    mocker: MockerFixture,
+    wandb_caplog: LogCaptureFixture,
 ):
     from wandb.apis.public import ArtifactCollection
 
@@ -91,7 +95,8 @@ def test_registry_filter_for_collection_falls_back_to_name_for_invalid_internal_
 
 
 def test_advanced_search_enabled_returns_false_on_graphql_error(
-    service_api, wandb_caplog
+    service_api: MagicMock,
+    wandb_caplog: LogCaptureFixture,
 ):
     service_api.feature_enabled.return_value = True
     service_api.execute_graphql.side_effect = RuntimeError("network down")
@@ -102,7 +107,9 @@ def test_advanced_search_enabled_returns_false_on_graphql_error(
     assert "Failed to fetch advanced registry features" in wandb_caplog.text
 
 
-def test_filter_for_registry_falls_back_to_name_without_internal_id(mocker):
+def test_filter_for_registry_falls_back_to_name_without_internal_id(
+    mocker: MockerFixture,
+):
     registry = mocker.Mock(spec=Registry)
     registry.full_name = "wandb-registry-order-test-reg-0"
     registry.internal_id = None
@@ -112,33 +119,13 @@ def test_filter_for_registry_falls_back_to_name_without_internal_id(mocker):
     }
 
 
-@pytest.fixture
+@fixture
 def service_api(mocker: MockerFixture) -> MagicMock:
     from wandb.apis.public.service_api import ServiceApi
 
     mock = mocker.Mock(spec=ServiceApi)
     mock.feature_enabled.return_value = True
     return mock
-
-
-@pytest.fixture
-def registry(service_api: MagicMock) -> Registry:
-    registry = Registry(service_api, ORG, entity="entity", name="test")
-    registry._current = registry._current.model_copy(
-        update={"internal_id": b64encode_ascii("ProjectInternalId:42")}
-    )
-    return registry
-
-
-def test_registry_collections_uses_basic_id_filter(
-    service_api: MagicMock,
-    registry: Registry,
-):
-    collections = registry.collections()
-
-    assert json.loads(collections.variables["registryFilter"]) == {"id": 42}
-    service_api.feature_enabled.assert_not_called()
-    service_api.execute_graphql.assert_not_called()
 
 
 def test_registries_versions_with_order_rejects_start(service_api):
@@ -149,7 +136,7 @@ def test_registries_versions_with_order_rejects_start(service_api):
         order="-updated_at",
     )
 
-    with pytest.raises(
+    with raises(
         ValueError, match="is not supported when querying versions from registries"
     ):
         registries.versions(start="cursor")
@@ -163,7 +150,7 @@ def test_registries_collections_with_order_rejects_start(service_api):
         order="name",
     )
 
-    with pytest.raises(
+    with raises(
         ValueError, match="is not supported when querying collections from registries"
     ):
         registries.collections(start="cursor")
@@ -171,22 +158,13 @@ def test_registries_collections_with_order_rejects_start(service_api):
 
 def test_registries_collections_with_registry_order_supports_versions_chain(
     service_api,
-    registry,
-    mocker,
 ):
+    """Check interface chainability without fetching results."""
     registries = Registries(
         service_api=service_api,
         organization=ORG,
         filter=REGISTRY_FILTER,
         order="-updated_at",
-    )
-    registries.objects = [registry]
-    registries.last_response = mocker.Mock(has_next=False)
-    load_collection_page = mocker.patch.object(
-        Collections,
-        "_load_page",
-        autospec=True,
-        return_value=False,
     )
 
     collections = registries.collections()
@@ -197,11 +175,6 @@ def test_registries_collections_with_registry_order_supports_versions_chain(
     assert isinstance(registries.versions(), Iterable)
     assert isinstance(collections.versions(), Iterable)
     assert isinstance(registries.collections().versions(), Iterable)
-
-    assert list(collections) == []
-    child = load_collection_page.call_args.args[0]
-    assert json.loads(child.variables["registryFilter"]) == {"id": 42}
-    service_api.feature_enabled.assert_not_called()
 
 
 def test_ordered_chained_queries_reject_cursor_and_length(service_api):
@@ -215,17 +188,17 @@ def test_ordered_chained_queries_reject_cursor_and_length(service_api):
     collections = registries.collections()
     versions = registries.versions()
 
-    with pytest.raises(UnsupportedError, match="cursor"):
+    with raises(UnsupportedError, match="cursor"):
         _ = collections.cursor
-    with pytest.raises(UnsupportedError, match="cursor"):
+    with raises(UnsupportedError, match="cursor"):
         _ = versions.cursor
-    with pytest.raises(UnsupportedError, match="length"):
+    with raises(UnsupportedError, match="length"):
         _ = collections.length
-    with pytest.raises(TypeError, match="len"):
+    with raises(TypeError, match="len"):
         len(collections)
-    with pytest.raises(UnsupportedError, match="__getitem__"):
+    with raises(UnsupportedError, match="__getitem__"):
         _ = collections[0]
-    with pytest.raises(UnsupportedError, match="__getitem__"):
+    with raises(UnsupportedError, match="__getitem__"):
         _ = versions[:1]
 
 
@@ -237,7 +210,7 @@ def test_registries_collections_versions_with_registry_order_rejects_start(servi
         order="-updated_at",
     )
 
-    with pytest.raises(
+    with raises(
         ValueError, match="is not supported when querying versions from registries"
     ):
         registries.collections().versions(start="cursor")
@@ -252,7 +225,7 @@ def test_collections_versions_with_order_rejects_start(service_api):
         order="-updated_at",
     )
 
-    with pytest.raises(
+    with raises(
         ValueError, match="is not supported when querying versions from collections"
     ):
         collections.versions(start="cursor")

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import TYPE_CHECKING
 
 from pytest import fixture, mark, param, raises
-from wandb.apis.public.registries import _utils
 from wandb.apis.public.registries._utils import (
-    advanced_search_enabled,
     prepare_artifact_types_input,
     prepare_registry_filter,
 )
@@ -16,7 +13,6 @@ from wandb.apis.public.registries.registries_search import (
     Registries,
     Versions,
 )
-from wandb.sdk.artifacts._generated import FetchAdvancedRegistryFeatures
 from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 
 if TYPE_CHECKING:
@@ -30,19 +26,13 @@ if TYPE_CHECKING:
 def service_api(mocker: MockerFixture) -> MagicMock:
     from wandb.apis.public.service_api import ServiceApi
 
-    mock = mocker.Mock(spec=ServiceApi)
-    mock.feature_enabled.return_value = False
-    return mock
+    return mocker.Mock(spec=ServiceApi)
 
 
 @fixture
-def enable_advanced_search(service_api: MagicMock) -> None:
-    service_api.feature_enabled.return_value = True
-    service_api.execute_graphql.return_value = (
-        FetchAdvancedRegistryFeatures.model_validate(
-            {"organization": {"advancedRegistryFeatures": {"advancedSearch": True}}}
-        )
-    )
+def disable_advanced_search(service_api: MagicMock) -> None:
+    service_api.feature_enabled.return_value = False
+    service_api.execute_graphql.return_value = None
 
 
 @mark.parametrize(
@@ -174,9 +164,7 @@ def test_prepare_registry_filter(raw, expected):
     assert prepare_registry_filter(raw) == expected
 
 
-def test_basic_paginators_normalize_filters_without_feature_lookup(
-    service_api: MagicMock,
-):
+def test_basic_paginators_normalize_filters(service_api: MagicMock):
     registries = Registries(
         service_api,
         organization="org",
@@ -186,42 +174,35 @@ def test_basic_paginators_normalize_filters_without_feature_lookup(
         service_api,
         organization="org",
         registry_filter={"name": "model"},
-        collection_filter={"collection_id": 2, "tags": "prod"},
+        collection_filter={"collection_id": 2, "tag": "prod"},
     )
 
-    expected_registries_filters = {
-        "filters": {"name": f"{REGISTRY_PREFIX}model", "id": 1},
-    }
-    expected_collections_filters = {
-        "registryFilter": {"name": f"{REGISTRY_PREFIX}model"},
-        "collectionFilter": {"artifact_collection_id": 2, "tag": "prod"},
-    }
+    expected_registries_filter = {"name": f"{REGISTRY_PREFIX}model", "id": 1}
+    expected_registry_filter = {"name": f"{REGISTRY_PREFIX}model"}
+    expected_collection_filter = {"artifact_collection_id": 2, "tag": "prod"}
 
+    assert json.loads(registries.variables["filters"]) == expected_registries_filter
     assert (
-        json.loads(registries.variables["filters"])
-        == expected_registries_filters["filters"]
-    )
-    assert (
-        json.loads(collections.variables["registryFilter"])
-        == expected_collections_filters["registryFilter"]
+        json.loads(collections.variables["registryFilter"]) == expected_registry_filter
     )
     assert (
         json.loads(collections.variables["collectionFilter"])
-        == expected_collections_filters["collectionFilter"]
+        == expected_collection_filter
     )
-    service_api.feature_enabled.assert_not_called()
-    service_api.execute_graphql.assert_not_called()
 
 
-def test_versions_uses_basic_filter_fields(service_api: MagicMock):
+def test_versions_uses_basic_filter_fields(
+    service_api: MagicMock,
+    disable_advanced_search: None,
+):
     versions = Versions(
         service_api,
         organization="org",
         registry_filter={"name": "model", "id": 1},
-        collection_filter={"collection_id": 2, "tags": "prod"},
+        collection_filter={"collection_id": 2, "tag": "prod"},
         artifact_filter={
-            "artifact_metadata.owner": "alice",
-            "version_index": 3,
+            "metadata.owner": "alice",
+            "version": 3,
         },
     )
 
@@ -234,57 +215,6 @@ def test_versions_uses_basic_filter_fields(service_api: MagicMock):
     assert json.loads(gql_vars["registryFilter"]) == expected_registry_filter
     assert json.loads(gql_vars["collectionFilter"]) == expected_collection_filter
     assert json.loads(gql_vars["artifactFilter"]) == expected_artifact_filter
-    service_api.feature_enabled.assert_called_once()
-
-
-def test_versions_rejects_advanced_field_in_basic_mode(service_api: MagicMock):
-    field = "project_id"
-
-    with raises(ValueError, match=rf"Invalid filter field.*{field}"):
-        Versions(service_api, organization="org", registry_filter={field: 1})
-
-
-def test_versions_rejects_basic_field_in_advanced_mode(
-    service_api: MagicMock,
-    enable_advanced_search: None,
-):
-    field = "description"
-
-    with raises(ValueError, match=rf"Invalid filter field.*{field}"):
-        Versions(service_api, organization="org", registry_filter={field: 1})
-
-
-def test_paginators_reject_unknown_filter_fields(
-    service_api: MagicMock,
-):
-    bad_filter = {"not_a_valid_field": 1}
-
-    with raises(ValueError, match="Invalid filter field"):
-        Registries(service_api, organization="org", filter=bad_filter)
-    with raises(ValueError, match="Invalid filter field"):
-        Collections(service_api, organization="org", collection_filter=bad_filter)
-    with raises(ValueError, match="Invalid filter field"):
-        Versions(service_api, organization="org", artifact_filter=bad_filter)
-
-
-def test_advanced_search_disabled_without_server_capability(service_api: MagicMock):
-    service_api.feature_enabled.return_value = False
-
-    assert advanced_search_enabled(service_api, "org") is False
-    service_api.execute_graphql.assert_not_called()
-
-
-def test_advanced_search_error_logs_and_falls_back(
-    service_api: MagicMock,
-    wandb_caplog,
-):
-    service_api.feature_enabled.return_value = True
-    service_api.execute_graphql.side_effect = RuntimeError("network down")
-
-    with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
-        assert advanced_search_enabled(service_api, "org") is False
-
-    assert "Failed to fetch advanced registry features" in wandb_caplog.text
 
 
 @mark.parametrize("cls", [Registries, Collections])

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -189,13 +189,26 @@ def test_basic_paginators_normalize_filters_without_feature_lookup(
         collection_filter={"collection_id": 2, "tags": "prod"},
     )
 
-    expected_registries = {"name": f"{REGISTRY_PREFIX}model", "id": 1}
-    expected_registry = {"name": f"{REGISTRY_PREFIX}model"}
-    expected_collection = {"id": 2, "tag": "prod"}
+    expected_registries_filters = {
+        "filters": {"name": f"{REGISTRY_PREFIX}model", "id": 1},
+    }
+    expected_collections_filters = {
+        "registryFilter": {"name": f"{REGISTRY_PREFIX}model"},
+        "collectionFilter": {"artifact_collection_id": 2, "tag": "prod"},
+    }
 
-    assert json.loads(registries.variables["filters"]) == expected_registries
-    assert json.loads(collections.variables["registryFilter"]) == expected_registry
-    assert json.loads(collections.variables["collectionFilter"]) == expected_collection
+    assert (
+        json.loads(registries.variables["filters"])
+        == expected_registries_filters["filters"]
+    )
+    assert (
+        json.loads(collections.variables["registryFilter"])
+        == expected_collections_filters["registryFilter"]
+    )
+    assert (
+        json.loads(collections.variables["collectionFilter"])
+        == expected_collections_filters["collectionFilter"]
+    )
     service_api.feature_enabled.assert_not_called()
     service_api.execute_graphql.assert_not_called()
 
@@ -212,13 +225,15 @@ def test_versions_uses_basic_filter_fields(service_api: MagicMock):
         },
     )
 
-    expected_registry = {"name": f"{REGISTRY_PREFIX}model", "id": 1}
-    expected_collection = {"id": 2, "tag": "prod"}
-    expected_artifact = {"metadata.owner": "alice", "version": 3}
+    gql_vars = versions.variables
 
-    assert json.loads(versions.variables["registryFilter"]) == expected_registry
-    assert json.loads(versions.variables["collectionFilter"]) == expected_collection
-    assert json.loads(versions.variables["artifactFilter"]) == expected_artifact
+    expected_registry_filter = {"name": f"{REGISTRY_PREFIX}model", "id": 1}
+    expected_collection_filter = {"artifact_collection_id": 2, "tag": "prod"}
+    expected_artifact_filter = {"metadata.owner": "alice", "version": 3}
+
+    assert json.loads(gql_vars["registryFilter"]) == expected_registry_filter
+    assert json.loads(gql_vars["collectionFilter"]) == expected_collection_filter
+    assert json.loads(gql_vars["artifactFilter"]) == expected_artifact_filter
     service_api.feature_enabled.assert_called_once()
 
 

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pytest import fixture, mark, param, raises
 from wandb.apis.public.registries._utils import (
     prepare_artifact_types_input,
     prepare_registry_filter,
 )
-from wandb.apis.public.registries.registries_search import Collections, Registries
+from wandb.apis.public.registries.registries_search import (
+    Collections,
+    Registries,
+    Versions,
+)
 from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 
 if TYPE_CHECKING:
@@ -96,8 +100,12 @@ def test_format_gql_artifact_types_input_error(artifact_types):
                     "$in": [
                         "project1",
                         f"{REGISTRY_PREFIX}project2",
+                    ],
+                    "$or": [
                         {"$regex": "project3"},
-                    ]
+                        {"$eq": "project4"},
+                        {"$eq": f"{REGISTRY_PREFIX}project5"},
+                    ],
                 }
             },
             {
@@ -105,8 +113,12 @@ def test_format_gql_artifact_types_input_error(artifact_types):
                     "$in": [
                         f"{REGISTRY_PREFIX}project1",
                         f"{REGISTRY_PREFIX}project2",
+                    ],
+                    "$or": [
                         {"$regex": "project3"},
-                    ]
+                        {"$eq": f"{REGISTRY_PREFIX}project4"},
+                        {"$eq": f"{REGISTRY_PREFIX}project5"},
+                    ],
                 }
             },
             id="nested-dict",
@@ -123,16 +135,154 @@ def test_prepare_registry_filter(raw, expected):
     assert prepare_registry_filter(raw) == expected
 
 
-def test_registry_filter_is_prepared_and_serialized(service_api: MagicMock):
-    paginator = Registries(
-        service_api=service_api,
-        organization="org",
-        filter={"name": "model"},
-    )
+# TODO: Fix this, overparameterized by AI
+@mark.parametrize(
+    ("cls", "filter_arg", "filter_var", "raw", "expected"),
+    [
+        param(
+            Registries,
+            "filter",
+            "filters",
+            {
+                "name": {
+                    "$in": [
+                        "project1",
+                        f"{REGISTRY_PREFIX}project2",
+                        {"$regex": "project3"},
+                    ]
+                },
+                "description": None,
+                "created_at": 1,
+                "updated_at": {"$gte": "2021-01-01T00:00:00Z"},
+            },
+            {
+                "name": {
+                    "$in": [
+                        f"{REGISTRY_PREFIX}project1",
+                        f"{REGISTRY_PREFIX}project2",
+                        {"$regex": "project3"},
+                    ]
+                },
+                "description": None,
+                "created_at": 1,
+                "updated_at": {"$gte": "2021-01-01T00:00:00Z"},
+            },
+            id="registries-filter",
+        ),
+        param(
+            Collections,
+            "registry_filter",
+            "registryFilter",
+            {"name": "model"},
+            {"name": f"{REGISTRY_PREFIX}model"},
+            id="collections-registry-filter",
+        ),
+        param(
+            Collections,
+            "collection_filter",
+            "collectionFilter",
+            {
+                "name": "collection",
+                "tag": "prod",
+                "description": None,
+                "created_at": 1,
+                "updated_at": 2,
+            },
+            {
+                "name": "collection",
+                "tag": "prod",
+                "description": None,
+                "created_at": 1,
+                "updated_at": 2,
+            },
+            id="collections-collection-filter",
+        ),
+        param(
+            Versions,
+            "registry_filter",
+            "registryFilter",
+            {"name": "model"},
+            {"name": f"{REGISTRY_PREFIX}model"},
+            id="versions-registry-filter",
+        ),
+        param(
+            Versions,
+            "collection_filter",
+            "collectionFilter",
+            {"tag": "prod"},
+            {"tag": "prod"},
+            id="versions-collection-filter",
+        ),
+        param(
+            Versions,
+            "artifact_filter",
+            "artifactFilter",
+            {
+                "tag": "prod",
+                "alias": "latest",
+                "created_at": 1,
+                "updated_at": 2,
+                "metadata.foo": 1,
+            },
+            {
+                "tag": "prod",
+                "alias": "latest",
+                "created_at": 1,
+                "updated_at": 2,
+                "metadata.foo": 1,
+            },
+            id="versions-artifact-filter",
+        ),
+    ],
+)
+def test_paginator_with_valid_filter(
+    service_api: MagicMock,
+    cls: type[Registries | Collections | Versions],
+    filter_arg: str,
+    filter_var: str,
+    raw: dict[str, Any],
+    expected: dict[str, Any],
+):
+    paginator = cls(service_api=service_api, organization="org", **{filter_arg: raw})
+    assert json.loads(paginator.variables[filter_var]) == expected
 
-    assert json.loads(paginator.variables["filters"]) == {
-        "name": f"{REGISTRY_PREFIX}model"
-    }
+
+def test_paginators_with_invalid_filter(service_api: MagicMock):
+    bad_filter = {"not_a_valid_field": 1}
+    expected_msg = r"(?i)invalid filter field"
+
+    # Registries
+    with raises(ValueError, match=expected_msg):
+        Registries(service_api, organization="org", filter=bad_filter)
+
+    # Collections
+    with raises(ValueError, match=expected_msg):
+        Collections(service_api, organization="org", registry_filter=bad_filter)
+    with raises(ValueError, match=expected_msg):
+        Collections(service_api, organization="org", collection_filter=bad_filter)
+    with raises(ValueError, match=expected_msg):
+        Collections(
+            service_api,
+            organization="org",
+            registry_filter=bad_filter,
+            collection_filter=bad_filter,
+        )
+
+    # Versions
+    with raises(ValueError, match=expected_msg):
+        Versions(service_api, organization="org", registry_filter=bad_filter)
+    with raises(ValueError, match=expected_msg):
+        Versions(service_api, organization="org", collection_filter=bad_filter)
+    with raises(ValueError, match=expected_msg):
+        Versions(service_api, organization="org", artifact_filter=bad_filter)
+    with raises(ValueError, match=expected_msg):
+        Versions(
+            service_api,
+            organization="org",
+            registry_filter=bad_filter,
+            collection_filter=bad_filter,
+            artifact_filter=bad_filter,
+        )
 
 
 @mark.parametrize("cls", [Registries, Collections])

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -16,6 +16,7 @@ from wandb.apis.public.registries.registries_search import (
     Registries,
     Versions,
 )
+from wandb.sdk.artifacts._generated import FetchAdvancedRegistryFeatures
 from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
 
 if TYPE_CHECKING:
@@ -29,15 +30,18 @@ if TYPE_CHECKING:
 def service_api(mocker: MockerFixture) -> MagicMock:
     from wandb.apis.public.service_api import ServiceApi
 
-    return mocker.Mock(spec=ServiceApi)
+    mock = mocker.Mock(spec=ServiceApi)
+    mock.feature_enabled.return_value = False
+    return mock
 
 
 @fixture
-def advanced_search_policy(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch(
-        "wandb.apis.public.registries.registries_search.advanced_search_enabled",
-        autospec=True,
-        return_value=False,
+def enable_advanced_search(service_api: MagicMock) -> None:
+    service_api.feature_enabled.return_value = True
+    service_api.execute_graphql.return_value = (
+        FetchAdvancedRegistryFeatures.model_validate(
+            {"organization": {"advancedRegistryFeatures": {"advancedSearch": True}}}
+        )
     )
 
 
@@ -102,16 +106,16 @@ def test_format_gql_artifact_types_input_error(artifact_types):
             id="regex-operand-is-unchanged",
         ),
         param(
-            {"$future": {"name": "opaque"}, "name": "visible"},
+            {"$unknownOp": {"name": "opaque"}, "name": "visible"},
             {
-                "$future": {"name": "opaque"},
+                "$unknownOp": {"name": "opaque"},
                 "name": f"{REGISTRY_PREFIX}visible",
             },
             id="unknown-operator-operand-is-unchanged",
         ),
         param(
-            {"name": {"$future": {"name": "opaque"}}},
-            {"name": {"$future": {"name": "opaque"}}},
+            {"name": {"$unknownOp": {"name": "opaque"}}},
+            {"name": {"$unknownOp": {"name": "opaque"}}},
             id="unknown-name-operator-operand-is-unchanged",
         ),
         param(
@@ -185,25 +189,18 @@ def test_basic_paginators_normalize_filters_without_feature_lookup(
         collection_filter={"collection_id": 2, "tags": "prod"},
     )
 
-    assert json.loads(registries.variables["filters"]) == {
-        "name": f"{REGISTRY_PREFIX}model",
-        "id": 1,
-    }
-    assert json.loads(collections.variables["registryFilter"]) == {
-        "name": f"{REGISTRY_PREFIX}model"
-    }
-    assert json.loads(collections.variables["collectionFilter"]) == {
-        "id": 2,
-        "tag": "prod",
-    }
+    expected_registries = {"name": f"{REGISTRY_PREFIX}model", "id": 1}
+    expected_registry = {"name": f"{REGISTRY_PREFIX}model"}
+    expected_collection = {"id": 2, "tag": "prod"}
+
+    assert json.loads(registries.variables["filters"]) == expected_registries
+    assert json.loads(collections.variables["registryFilter"]) == expected_registry
+    assert json.loads(collections.variables["collectionFilter"]) == expected_collection
     service_api.feature_enabled.assert_not_called()
     service_api.execute_graphql.assert_not_called()
 
 
-def test_versions_uses_basic_filter_fields(
-    service_api: MagicMock,
-    advanced_search_policy: MagicMock,
-):
+def test_versions_uses_basic_filter_fields(service_api: MagicMock):
     versions = Versions(
         service_api,
         organization="org",
@@ -215,35 +212,28 @@ def test_versions_uses_basic_filter_fields(
         },
     )
 
-    assert json.loads(versions.variables["registryFilter"]) == {
-        "name": f"{REGISTRY_PREFIX}model",
-        "id": 1,
-    }
-    assert json.loads(versions.variables["collectionFilter"]) == {
-        "id": 2,
-        "tag": "prod",
-    }
-    assert json.loads(versions.variables["artifactFilter"]) == {
-        "metadata.owner": "alice",
-        "version": 3,
-    }
-    advanced_search_policy.assert_called_once_with(service_api, "org")
+    expected_registry = {"name": f"{REGISTRY_PREFIX}model", "id": 1}
+    expected_collection = {"id": 2, "tag": "prod"}
+    expected_artifact = {"metadata.owner": "alice", "version": 3}
+
+    assert json.loads(versions.variables["registryFilter"]) == expected_registry
+    assert json.loads(versions.variables["collectionFilter"]) == expected_collection
+    assert json.loads(versions.variables["artifactFilter"]) == expected_artifact
+    service_api.feature_enabled.assert_called_once()
 
 
-@mark.parametrize(
-    ("advanced", "field"),
-    [
-        param(False, "project_id", id="advanced-field-in-basic-mode"),
-        param(True, "description", id="basic-field-in-advanced-mode"),
-    ],
-)
-def test_versions_rejects_fields_unsupported_by_search_mode(
+def test_versions_rejects_advanced_field_in_basic_mode(service_api: MagicMock):
+    field = "project_id"
+
+    with raises(ValueError, match=rf"Invalid filter field.*{field}"):
+        Versions(service_api, organization="org", registry_filter={field: 1})
+
+
+def test_versions_rejects_basic_field_in_advanced_mode(
     service_api: MagicMock,
-    advanced_search_policy: MagicMock,
-    advanced: bool,
-    field: str,
+    enable_advanced_search: None,
 ):
-    advanced_search_policy.return_value = advanced
+    field = "description"
 
     with raises(ValueError, match=rf"Invalid filter field.*{field}"):
         Versions(service_api, organization="org", registry_filter={field: 1})
@@ -251,7 +241,6 @@ def test_versions_rejects_fields_unsupported_by_search_mode(
 
 def test_paginators_reject_unknown_filter_fields(
     service_api: MagicMock,
-    advanced_search_policy: MagicMock,
 ):
     bad_filter = {"not_a_valid_field": 1}
 

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
+from pydantic import TypeAdapter
 from pytest import fixture, mark, param, raises
+from wandb._filters import FilterValidator
+from wandb._pydantic import FilterDict
 from wandb.apis.public.registries._utils import (
+    prefix_registry_name,
     prepare_artifact_types_input,
-    prepare_registry_filter,
 )
 from wandb.apis.public.registries.registries_search import (
     Collections,
@@ -20,6 +23,14 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
     from wandb.apis.paginator import RelayPaginator
+
+
+REGISTRY_FILTER_ADAPTER = TypeAdapter(
+    Annotated[
+        FilterDict,
+        FilterValidator(transforms={"name": prefix_registry_name}),
+    ]
+)
 
 
 @fixture
@@ -152,16 +163,11 @@ def test_format_gql_artifact_types_input_error(artifact_types):
             {"name": {"one": {"two": [{"three": f"{REGISTRY_PREFIX}model"}]}}},
             id="deeply-nested-name-operand",
         ),
-        # Non-dict and empty inputs are returned unchanged.
-        param("string", "string", id="non-dict-string"),
         param({}, {}, id="empty-dict"),
-        param(123, 123, id="non-dict-int"),
-        param(None, None, id="None"),
-        param(True, True, id="non-dict-bool"),
     ],
 )
-def test_prepare_registry_filter(raw, expected):
-    assert prepare_registry_filter(raw) == expected
+def test_registry_filter_normalization(raw, expected):
+    assert REGISTRY_FILTER_ADAPTER.validate_python(raw) == expected
 
 
 def test_basic_paginators_normalize_filters(service_api: MagicMock):

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+import logging
+from typing import TYPE_CHECKING
 
 from pytest import fixture, mark, param, raises
+from wandb.apis.public.registries import _utils
 from wandb.apis.public.registries._utils import (
+    advanced_search_enabled,
     prepare_artifact_types_input,
     prepare_registry_filter,
 )
@@ -27,6 +30,15 @@ def service_api(mocker: MockerFixture) -> MagicMock:
     from wandb.apis.public.service_api import ServiceApi
 
     return mocker.Mock(spec=ServiceApi)
+
+
+@fixture
+def advanced_search_policy(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch(
+        "wandb.apis.public.registries.registries_search.advanced_search_enabled",
+        autospec=True,
+        return_value=False,
+    )
 
 
 @mark.parametrize(
@@ -90,6 +102,24 @@ def test_format_gql_artifact_types_input_error(artifact_types):
             id="regex-operand-is-unchanged",
         ),
         param(
+            {"$future": {"name": "opaque"}, "name": "visible"},
+            {
+                "$future": {"name": "opaque"},
+                "name": f"{REGISTRY_PREFIX}visible",
+            },
+            id="unknown-operator-operand-is-unchanged",
+        ),
+        param(
+            {"name": {"$future": {"name": "opaque"}}},
+            {"name": {"$future": {"name": "opaque"}}},
+            id="unknown-name-operator-operand-is-unchanged",
+        ),
+        param(
+            {"metadata": {"name": "not-a-registry-name"}},
+            {"metadata": {"name": "not-a-registry-name"}},
+            id="nested-name-in-another-field-is-unchanged",
+        ),
+        param(
             {"id": 1, "name": "model", "description": None},
             {"id": 1, "name": f"{REGISTRY_PREFIX}model", "description": None},
             id="mixed-fields-and-types",
@@ -123,6 +153,11 @@ def test_format_gql_artifact_types_input_error(artifact_types):
             },
             id="nested-dict",
         ),
+        param(
+            {"name": {"one": {"two": [{"three": "model"}]}}},
+            {"name": {"one": {"two": [{"three": f"{REGISTRY_PREFIX}model"}]}}},
+            id="deeply-nested-name-operand",
+        ),
         # Non-dict and empty inputs are returned unchanged.
         param("string", "string", id="non-dict-string"),
         param({}, {}, id="empty-dict"),
@@ -135,154 +170,117 @@ def test_prepare_registry_filter(raw, expected):
     assert prepare_registry_filter(raw) == expected
 
 
-# TODO: Fix this, overparameterized by AI
+def test_basic_paginators_normalize_filters_without_feature_lookup(
+    service_api: MagicMock,
+):
+    registries = Registries(
+        service_api,
+        organization="org",
+        filter={"name": "model", "id": 1},
+    )
+    collections = Collections(
+        service_api,
+        organization="org",
+        registry_filter={"name": "model"},
+        collection_filter={"collection_id": 2, "tags": "prod"},
+    )
+
+    assert json.loads(registries.variables["filters"]) == {
+        "name": f"{REGISTRY_PREFIX}model",
+        "id": 1,
+    }
+    assert json.loads(collections.variables["registryFilter"]) == {
+        "name": f"{REGISTRY_PREFIX}model"
+    }
+    assert json.loads(collections.variables["collectionFilter"]) == {
+        "id": 2,
+        "tag": "prod",
+    }
+    service_api.feature_enabled.assert_not_called()
+    service_api.execute_graphql.assert_not_called()
+
+
+def test_versions_uses_basic_filter_fields(
+    service_api: MagicMock,
+    advanced_search_policy: MagicMock,
+):
+    versions = Versions(
+        service_api,
+        organization="org",
+        registry_filter={"name": "model", "id": 1},
+        collection_filter={"collection_id": 2, "tags": "prod"},
+        artifact_filter={
+            "artifact_metadata.owner": "alice",
+            "version_index": 3,
+        },
+    )
+
+    assert json.loads(versions.variables["registryFilter"]) == {
+        "name": f"{REGISTRY_PREFIX}model",
+        "id": 1,
+    }
+    assert json.loads(versions.variables["collectionFilter"]) == {
+        "id": 2,
+        "tag": "prod",
+    }
+    assert json.loads(versions.variables["artifactFilter"]) == {
+        "metadata.owner": "alice",
+        "version": 3,
+    }
+    advanced_search_policy.assert_called_once_with(service_api, "org")
+
+
 @mark.parametrize(
-    ("cls", "filter_arg", "filter_var", "raw", "expected"),
+    ("advanced", "field"),
     [
-        param(
-            Registries,
-            "filter",
-            "filters",
-            {
-                "name": {
-                    "$in": [
-                        "project1",
-                        f"{REGISTRY_PREFIX}project2",
-                        {"$regex": "project3"},
-                    ]
-                },
-                "description": None,
-                "created_at": 1,
-                "updated_at": {"$gte": "2021-01-01T00:00:00Z"},
-            },
-            {
-                "name": {
-                    "$in": [
-                        f"{REGISTRY_PREFIX}project1",
-                        f"{REGISTRY_PREFIX}project2",
-                        {"$regex": "project3"},
-                    ]
-                },
-                "description": None,
-                "created_at": 1,
-                "updated_at": {"$gte": "2021-01-01T00:00:00Z"},
-            },
-            id="registries-filter",
-        ),
-        param(
-            Collections,
-            "registry_filter",
-            "registryFilter",
-            {"name": "model"},
-            {"name": f"{REGISTRY_PREFIX}model"},
-            id="collections-registry-filter",
-        ),
-        param(
-            Collections,
-            "collection_filter",
-            "collectionFilter",
-            {
-                "name": "collection",
-                "tag": "prod",
-                "description": None,
-                "created_at": 1,
-                "updated_at": 2,
-            },
-            {
-                "name": "collection",
-                "tag": "prod",
-                "description": None,
-                "created_at": 1,
-                "updated_at": 2,
-            },
-            id="collections-collection-filter",
-        ),
-        param(
-            Versions,
-            "registry_filter",
-            "registryFilter",
-            {"name": "model"},
-            {"name": f"{REGISTRY_PREFIX}model"},
-            id="versions-registry-filter",
-        ),
-        param(
-            Versions,
-            "collection_filter",
-            "collectionFilter",
-            {"tag": "prod"},
-            {"tag": "prod"},
-            id="versions-collection-filter",
-        ),
-        param(
-            Versions,
-            "artifact_filter",
-            "artifactFilter",
-            {
-                "tag": "prod",
-                "alias": "latest",
-                "created_at": 1,
-                "updated_at": 2,
-                "metadata.foo": 1,
-            },
-            {
-                "tag": "prod",
-                "alias": "latest",
-                "created_at": 1,
-                "updated_at": 2,
-                "metadata.foo": 1,
-            },
-            id="versions-artifact-filter",
-        ),
+        param(False, "project_id", id="advanced-field-in-basic-mode"),
+        param(True, "description", id="basic-field-in-advanced-mode"),
     ],
 )
-def test_paginator_with_valid_filter(
+def test_versions_rejects_fields_unsupported_by_search_mode(
     service_api: MagicMock,
-    cls: type[Registries | Collections | Versions],
-    filter_arg: str,
-    filter_var: str,
-    raw: dict[str, Any],
-    expected: dict[str, Any],
+    advanced_search_policy: MagicMock,
+    advanced: bool,
+    field: str,
 ):
-    paginator = cls(service_api=service_api, organization="org", **{filter_arg: raw})
-    assert json.loads(paginator.variables[filter_var]) == expected
+    advanced_search_policy.return_value = advanced
+
+    with raises(ValueError, match=rf"Invalid filter field.*{field}"):
+        Versions(service_api, organization="org", registry_filter={field: 1})
 
 
-def test_paginators_with_invalid_filter(service_api: MagicMock):
+def test_paginators_reject_unknown_filter_fields(
+    service_api: MagicMock,
+    advanced_search_policy: MagicMock,
+):
     bad_filter = {"not_a_valid_field": 1}
-    expected_msg = r"(?i)invalid filter field"
 
-    # Registries
-    with raises(ValueError, match=expected_msg):
+    with raises(ValueError, match="Invalid filter field"):
         Registries(service_api, organization="org", filter=bad_filter)
-
-    # Collections
-    with raises(ValueError, match=expected_msg):
-        Collections(service_api, organization="org", registry_filter=bad_filter)
-    with raises(ValueError, match=expected_msg):
+    with raises(ValueError, match="Invalid filter field"):
         Collections(service_api, organization="org", collection_filter=bad_filter)
-    with raises(ValueError, match=expected_msg):
-        Collections(
-            service_api,
-            organization="org",
-            registry_filter=bad_filter,
-            collection_filter=bad_filter,
-        )
-
-    # Versions
-    with raises(ValueError, match=expected_msg):
-        Versions(service_api, organization="org", registry_filter=bad_filter)
-    with raises(ValueError, match=expected_msg):
-        Versions(service_api, organization="org", collection_filter=bad_filter)
-    with raises(ValueError, match=expected_msg):
+    with raises(ValueError, match="Invalid filter field"):
         Versions(service_api, organization="org", artifact_filter=bad_filter)
-    with raises(ValueError, match=expected_msg):
-        Versions(
-            service_api,
-            organization="org",
-            registry_filter=bad_filter,
-            collection_filter=bad_filter,
-            artifact_filter=bad_filter,
-        )
+
+
+def test_advanced_search_disabled_without_server_capability(service_api: MagicMock):
+    service_api.feature_enabled.return_value = False
+
+    assert advanced_search_enabled(service_api, "org") is False
+    service_api.execute_graphql.assert_not_called()
+
+
+def test_advanced_search_error_logs_and_falls_back(
+    service_api: MagicMock,
+    wandb_caplog,
+):
+    service_api.feature_enabled.return_value = True
+    service_api.execute_graphql.side_effect = RuntimeError("network down")
+
+    with wandb_caplog.at_level(logging.WARNING, logger=_utils.__name__):
+        assert advanced_search_enabled(service_api, "org") is False
+
+    assert "Failed to fetch advanced registry features" in wandb_caplog.text
 
 
 @mark.parametrize("cls", [Registries, Collections])

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -119,7 +119,7 @@ def test_format_gql_artifact_types_input_error(artifact_types):
         param(True, True, id="non-dict-bool"),
     ],
 )
-def test_prepare_registry_filter(raw, expected):
+def test_prepare_registry_filter(service_api: MagicMock, raw, expected):
     assert prepare_registry_filter(raw) == expected
 
 
@@ -133,6 +133,74 @@ def test_registry_filter_is_prepared_and_serialized(service_api: MagicMock):
     assert json.loads(paginator.variables["filters"]) == {
         "name": f"{REGISTRY_PREFIX}model"
     }
+
+
+@mark.parametrize(
+    ("raw", "expected"),
+    [
+        param(
+            {"name": "model"},
+            {"name": f"{REGISTRY_PREFIX}model"},
+            id="bare-name-is-prefixed",
+        ),
+        param(
+            {"name": f"{REGISTRY_PREFIX}model"},
+            {"name": f"{REGISTRY_PREFIX}model"},
+            id="prefixed-name-is-unchanged",
+        ),
+        param(
+            {"$or": [{"name": "model1"}, {"description": "prod"}]},
+            {"$or": [{"name": f"{REGISTRY_PREFIX}model1"}, {"description": "prod"}]},
+            id="nested-list",
+        ),
+        param(
+            {"name": {"$regex": "model.*"}},
+            {"name": {"$regex": "model.*"}},
+            id="regex-operand-is-unchanged",
+        ),
+        param(
+            {
+                "updated_at": {"$gte": "2021-01-01T00:00:00Z"},
+                "name": "model",
+                "description": None,
+            },
+            {
+                "updated_at": {"$gte": "2021-01-01T00:00:00Z"},
+                "name": f"{REGISTRY_PREFIX}model",
+                "description": None,
+            },
+            id="mixed-fields-and-types",
+        ),
+        param(
+            {
+                "name": {
+                    "$in": [
+                        "project1",
+                        f"{REGISTRY_PREFIX}project2",
+                        {"$regex": "project3"},
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "$in": [
+                        f"{REGISTRY_PREFIX}project1",
+                        f"{REGISTRY_PREFIX}project2",
+                        {"$regex": "project3"},
+                    ]
+                }
+            },
+            id="nested-dict",
+        ),
+        # Non-dict and empty inputs are returned unchanged.
+        param({}, {}, id="empty-dict"),
+        param(None, None, id="None"),
+    ],
+)
+def test_prepare_registry_filter_on_paginator(service_api: MagicMock, raw, expected):
+    """Check that the filter is correctly prepared on instantiating a Registries paginator."""
+    paginator = Registries(service_api=service_api, organization="org", filter=raw)
+    assert paginator.filter == expected
 
 
 @mark.parametrize("cls", [Registries, Collections])

--- a/wandb/_filters/__init__.py
+++ b/wandb/_filters/__init__.py
@@ -21,9 +21,11 @@ from .operators import (
     Regex,
     Size,
 )
+from .validation import FilterValidator
 
 __all__ = [
     "BaseOp",
+    "FilterValidator",
     "And",
     "Or",
     "Nor",

--- a/wandb/_filters/__init__.py
+++ b/wandb/_filters/__init__.py
@@ -1,5 +1,5 @@
 from .expressions import FIELD_REGEX, FilterableField, FilterExpr, MongoLikeFilter
-from .filterutils import simplify_expr, transform_fields
+from .filterutils import simplify_expr
 from .operators import (
     All,
     And,
@@ -47,7 +47,6 @@ __all__ = [
     "FilterableField",
     "FilterExpr",
     "MongoLikeFilter",
-    "transform_fields",
     "simplify_expr",
     "FIELD_REGEX",
 ]

--- a/wandb/_filters/__init__.py
+++ b/wandb/_filters/__init__.py
@@ -1,5 +1,5 @@
 from .expressions import FIELD_REGEX, FilterableField, FilterExpr, MongoLikeFilter
-from .filterutils import simplify_expr
+from .filterutils import FilterFieldMapper, FilterFieldTransformer, simplify_expr
 from .operators import (
     All,
     And,
@@ -47,6 +47,8 @@ __all__ = [
     "FilterableField",
     "FilterExpr",
     "MongoLikeFilter",
+    "FilterFieldTransformer",
+    "FilterFieldMapper",
     "simplify_expr",
     "FIELD_REGEX",
 ]

--- a/wandb/_filters/__init__.py
+++ b/wandb/_filters/__init__.py
@@ -1,5 +1,5 @@
 from .expressions import FIELD_REGEX, FilterableField, FilterExpr, MongoLikeFilter
-from .filterutils import FilterFieldMapper, FilterFieldTransformer, simplify_expr
+from .filterutils import FilterFieldTransformer, simplify_expr
 from .operators import (
     All,
     And,
@@ -48,7 +48,6 @@ __all__ = [
     "FilterExpr",
     "MongoLikeFilter",
     "FilterFieldTransformer",
-    "FilterFieldMapper",
     "simplify_expr",
     "FIELD_REGEX",
 ]

--- a/wandb/_filters/__init__.py
+++ b/wandb/_filters/__init__.py
@@ -1,5 +1,5 @@
 from .expressions import FIELD_REGEX, FilterableField, FilterExpr, MongoLikeFilter
-from .filterutils import FilterFieldTransformer, simplify_expr
+from .filterutils import simplify_expr, transform_fields
 from .operators import (
     All,
     And,
@@ -47,7 +47,7 @@ __all__ = [
     "FilterableField",
     "FilterExpr",
     "MongoLikeFilter",
-    "FilterFieldTransformer",
+    "transform_fields",
     "simplify_expr",
     "FIELD_REGEX",
 ]

--- a/wandb/_filters/expressions.py
+++ b/wandb/_filters/expressions.py
@@ -99,10 +99,10 @@ class FilterableField:
     def gte(self, value: Scalar, /) -> FilterExpr:
         return FilterExpr(field=self._name, op=Gte(val=value))
 
-    def ne(self, value: Scalar, /) -> FilterExpr:
+    def ne(self, value: Scalar | Iterable[Scalar], /) -> FilterExpr:
         return FilterExpr(field=self._name, op=Ne(val=value))
 
-    def eq(self, value: Scalar, /) -> FilterExpr:
+    def eq(self, value: Scalar | Iterable[Scalar], /) -> FilterExpr:
         return FilterExpr(field=self._name, op=Eq(val=value))
 
     def in_(self, values: Iterable[Scalar], /) -> FilterExpr:

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -6,8 +6,10 @@ don't expose as instance methods on filter types for now.
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Callable, Iterator
 from functools import singledispatch
+from operator import itemgetter
 from typing import Any, cast
 
 from typing_extensions import assert_never
@@ -39,23 +41,34 @@ def transform_fields(
     aliases: dict[str, str] | None = None,
     operand_transforms: dict[str, Callable[[Any], Any]] | None = None,
 ) -> dict[str, Any]:
-    """Return a copy of ``raw`` with ordinary filter fields transformed.
+    """Return a copy of `raw` with ordinary filter fields transformed.
 
-    If supplied, ``aliases`` maps accepted field roots to their canonical names.
-    ``operand_transforms`` maps exact field names to transformations of their opaque
-    operands. Recognized logical operators are traversed; unknown operators and
-    ordinary field operands are otherwise left untouched.
+    Args:
+        raw: The filter dict to transform.
+        aliases: Maps accepted top-level field names to their canonical names.
+        operand_transforms: Maps exact field names to callable transformations
+            on their inner operands.
+
+    Returns:
+        A copy of `raw` with ordinary filter fields transformed.
+
+    Raises:
+        ValueError: If `aliases` maps multiple aliases to the same canonical name.
     """
-    items = tuple(
+    new_items = tuple(
         _transform_item(*kv, aliases=aliases, operand_transforms=operand_transforms)
         for kv in raw.items()
     )
-    result = dict(items)
+    result = dict(new_items)
 
     # Alias definitions are intentionally many-to-one. A collision is invalid
     # only when one filter object uses multiple aliases for the same field.
-    if len(result) != len(items):
-        raise ValueError("Filter field mapping collision.")
+    if len(result) != len(new_items):
+        new_keys = map(itemgetter(0), new_items)
+        dup_keys = {key for key, count in Counter(new_keys).items() if count > 1}
+
+        msg = f"Duplicate fields in normalized filter: {repr_join(sorted(dup_keys))}"
+        raise ValueError(msg)
 
     return result
 
@@ -94,19 +107,17 @@ def _transform_item(
             return key, val
 
         case (str(field), _):
-            root, dot, suffix = field.partition(".")
+            root, sep, suffix = field.partition(".")
             if aliases and not aliases.get(root):
                 msg = f"Invalid filter field {root!r}, must be one of: {repr_join(sorted(aliases))}"
                 raise ValueError(msg)
 
-            new_root = aliases[root] if aliases else root
-            new_val = (
-                func(val) if (func := (operand_transforms or {}).get(field)) else val
-            )
-            return f"{new_root}{dot}{suffix}", new_val
+            new_root = (aliases or {}).get(root) or root
+            new_val = fn(val) if (fn := (operand_transforms or {}).get(field)) else val
+            return f"{new_root}{sep}{suffix}", new_val
 
         case _:
-            assert_never(val)
+            assert_never((key, val))
 
 
 @singledispatch

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -10,8 +10,9 @@ from collections import Counter
 from collections.abc import Callable, Iterator
 from functools import singledispatch
 from operator import itemgetter
-from typing import Any, cast
+from typing import Any, TypeGuard, cast
 
+from pydantic import JsonValue
 from typing_extensions import assert_never
 
 from wandb._strutils import repr_join
@@ -35,8 +36,14 @@ from .operators import (
 )
 
 
+def _is_filter_dict_list(
+    values: list[JsonValue],
+) -> TypeGuard[list[dict[str, JsonValue]]]:
+    return all(isinstance(value, dict) for value in values)
+
+
 def transform_fields(
-    raw: dict[str, Any],
+    raw: dict[str, JsonValue],
     *,
     aliases: dict[str, str] | None = None,
     operand_transforms: dict[str, Callable[[Any], Any]] | None = None,
@@ -75,7 +82,7 @@ def transform_fields(
 
 def _transform_item(
     key: str,
-    val: Any,
+    val: JsonValue,
     *,
     aliases: dict[str, str] | None,
     operand_transforms: dict[str, Callable[[Any], Any]] | None,
@@ -83,7 +90,7 @@ def _transform_item(
     """Transform one filter item, recursively handling logical operands."""
     match key, val:
         case (("$and" | "$or" | "$nor") as op, list(operands)):
-            if not all(isinstance(obj, dict) for obj in operands):
+            if not _is_filter_dict_list(operands):
                 raise ValueError(f"{op} must contain only filter dictionaries.")
             return key, [
                 transform_fields(

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -6,8 +6,9 @@ don't expose as instnace methods on filter types for now.
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import singledispatch
 from itertools import chain
 from typing import TYPE_CHECKING, Any, cast
@@ -68,7 +69,7 @@ def parse_filter(raw: dict[str, Any]) -> MongoLikeFilter:
             assert_never(raw)
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class FilterFieldTransformer:
     """Transform ordinary fields in a raw MongoDB-style filter.
 
@@ -78,81 +79,57 @@ class FilterFieldTransformer:
     """
 
     visit: Callable[[str, Any], tuple[str, Any]] | None = None
-    field_roots: set[str] = field(init=False, default_factory=set)
 
     def transform(self, raw: dict[str, Any]) -> dict[str, Any]:
         """Return a transformed copy of ``raw``."""
-        self.field_roots.clear()
-        return self._transform(raw)
+        items = tuple(self._remap_item(key, value) for key, value in raw.items())
+        result = dict(items)
 
-    def _transform(self, raw: dict[str, Any]) -> dict[str, Any]:
-        """Transform recursively without resetting accumulated field roots."""
-        result: dict[str, Any] = {}
-
-        for key, value in raw.items():
-            mapped_key, mapped_value = self._remap_item(key, value)
-
-            if mapped_key in result:
-                raise ValueError(
-                    f"Filter field mapping collision: {key!r} maps to existing "
-                    f"field {mapped_key!r}."
-                )
-            result[mapped_key] = mapped_value
+        # Alias definitions are intentionally many-to-one. A collision is invalid
+        # only when one filter object uses multiple aliases for the same field.
+        if len(result) != len(items):
+            collision = next(
+                key
+                for key, count in Counter(key for key, _ in items).items()
+                if count > 1
+            )
+            raise ValueError(
+                f"Filter field mapping collision: multiple fields map to {collision!r}."
+            )
 
         return result
 
     def _remap_item(self, key: str, value: Any) -> tuple[str, Any]:
         """Remap one filter item, recursively handling logical operands."""
         match key, value:
-            case (("$and" | "$or" | "$nor") as operator, list() as operands):
-                mapped_operands: list[dict[str, Any]] = []
-                for operand in operands:
-                    match operand:
-                        case dict() as child if child:
-                            mapped_operands.append(self._transform(child))
-                        case _:
-                            raise ValueError(
-                                f"{operator} must contain only non-empty filter "
-                                "dictionaries."
-                            )
-                return key, mapped_operands
+            case (("$and" | "$or" | "$nor") as operator, list(operands)):
+                if not all(
+                    isinstance(operand, dict) and operand for operand in operands
+                ):
+                    raise ValueError(
+                        f"{operator} must contain only non-empty filter dictionaries."
+                    )
+                return key, [self.transform(operand) for operand in operands]
 
             case (("$and" | "$or" | "$nor") as operator, _):
                 raise ValueError(
                     f"{operator} must contain a list of filter dictionaries."
                 )
 
-            case ("$not", dict() as operand) if operand:
-                return key, self._transform(operand)
+            case ("$not", dict(operand)) if operand:
+                return key, self.transform(operand)
 
             case ("$not", _):
                 raise ValueError("$not must contain a non-empty filter dictionary.")
 
-            case (str() as operator, _) if operator.startswith("$"):
+            case (str(operator), _) if operator.startswith("$"):
                 return key, value
 
-            case (str() as field, _):
-                self.field_roots.add(field.partition(".")[0])
+            case (str(field), _):
                 return self.visit(field, value) if self.visit else (field, value)
 
             case _:
                 raise ValueError("Filter field names must be strings.")
-
-
-@dataclass(slots=True)
-class FilterFieldMapper:
-    """Map accepted field aliases to canonical field names."""
-
-    alias_to_field: dict[str, str]
-
-    def __call__(self, raw: dict[str, Any]) -> dict[str, Any]:
-        """Return a transformed copy of ``raw``."""
-        return FilterFieldTransformer(self._map_field).transform(raw)
-
-    def _map_field(self, field: str, operand: Any) -> tuple[str, Any]:
-        root, separator, suffix = field.partition(".")
-        mapped_root = self.alias_to_field.get(root, root)
-        return f"{mapped_root}{separator}{suffix}", operand
 
 
 def iter_fields(expr: MongoLikeFilter) -> Iterator[str]:

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -1,23 +1,21 @@
 """Helpers for parsing and transforming MongoDB expressions.
 
 If a function is defined here, it's an internal helper that we deliberately
-don't expose as instnace methods on filter types for now.
+don't expose as instance methods on filter types for now.
 """
 
 from __future__ import annotations
 
-from collections import Counter
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
 from functools import singledispatch
-from itertools import chain
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from typing_extensions import assert_never
 
+from wandb._strutils import repr_join
+
 from .expressions import FilterExpr, MongoLikeFilter
 from .operators import (
-    And,
     BaseVariadicLogicalOp,
     Eq,
     Exists,
@@ -30,120 +28,85 @@ from .operators import (
     Nor,
     Not,
     NotIn,
+    Op,
     Or,
 )
 
-if TYPE_CHECKING:
-    from .operators import LogicalChild
 
+def transform_fields(
+    raw: dict[str, Any],
+    *,
+    aliases: dict[str, str] | None = None,
+    operand_transforms: dict[str, Callable[[Any], Any]] | None = None,
+) -> dict[str, Any]:
+    """Return a copy of ``raw`` with ordinary filter fields transformed.
 
-def parse_filter(raw: dict[str, Any]) -> MongoLikeFilter:
-    """Parse a raw MongoDB-style filter dict into a typed MongoDB filter expression."""
-    match raw:
-        case dict() if len(raw) < 1:
-            return raw
-        case dict() if len(raw) > 1:  # Multiple root predicates imply "$and".
-            return And(exprs=(parse_filter({k: v}) for k, v in raw.items()))
-
-        # Below this, we're guaranteed a length-1 dict, so we can drop length guards.
-        case {"$and": exprs}:
-            return And(exprs=map(parse_filter, exprs))
-        case {"$or": exprs}:
-            return Or(exprs=map(parse_filter, exprs))
-        case {"$nor": exprs}:
-            return Nor(exprs=map(parse_filter, exprs))
-        case {"$not": expr}:
-            return Not(expr=parse_filter(expr))
-
-        case dict():
-            ((key, val),) = raw.items()
-
-            if key.startswith("$"):
-                return raw  # Unknown operator dict
-            if isinstance(val, dict):
-                return FilterExpr.model_validate(raw)
-
-            # Implicit $eq, e.g. {"field": "value"} -> {"field": {"$eq": "value"}}
-            return FilterExpr(field=key, op=Eq(val=val))
-        case _:
-            assert_never(raw)
-
-
-@dataclass(frozen=True, slots=True)
-class FilterFieldTransformer:
-    """Transform ordinary fields in a raw MongoDB-style filter.
-
-    ``visit`` receives each ordinary field and its opaque operand. The filter
-    grammar controls traversal: recognized logical operators are visited, while
-    unknown operators and field operands are not inspected.
+    If supplied, ``aliases`` maps accepted field roots to their canonical names.
+    ``operand_transforms`` maps exact field names to transformations of their opaque
+    operands. Recognized logical operators are traversed; unknown operators and
+    ordinary field operands are otherwise left untouched.
     """
+    items = tuple(
+        _transform_item(*kv, aliases=aliases, operand_transforms=operand_transforms)
+        for kv in raw.items()
+    )
+    result = dict(items)
 
-    visit: Callable[[str, Any], tuple[str, Any]] | None = None
+    # Alias definitions are intentionally many-to-one. A collision is invalid
+    # only when one filter object uses multiple aliases for the same field.
+    if len(result) != len(items):
+        raise ValueError("Filter field mapping collision.")
 
-    def transform(self, raw: dict[str, Any]) -> dict[str, Any]:
-        """Return a transformed copy of ``raw``."""
-        items = tuple(self._remap_item(key, value) for key, value in raw.items())
-        result = dict(items)
+    return result
 
-        # Alias definitions are intentionally many-to-one. A collision is invalid
-        # only when one filter object uses multiple aliases for the same field.
-        if len(result) != len(items):
-            collision = next(
-                key
-                for key, count in Counter(key for key, _ in items).items()
-                if count > 1
-            )
-            raise ValueError(
-                f"Filter field mapping collision: multiple fields map to {collision!r}."
-            )
 
-        return result
-
-    def _remap_item(self, key: str, value: Any) -> tuple[str, Any]:
-        """Remap one filter item, recursively handling logical operands."""
-        match key, value:
-            case (("$and" | "$or" | "$nor") as operator, list(operands)):
-                if not all(
-                    isinstance(operand, dict) and operand for operand in operands
-                ):
-                    raise ValueError(
-                        f"{operator} must contain only non-empty filter dictionaries."
-                    )
-                return key, [self.transform(operand) for operand in operands]
-
-            case (("$and" | "$or" | "$nor") as operator, _):
-                raise ValueError(
-                    f"{operator} must contain a list of filter dictionaries."
+def _transform_item(
+    key: str,
+    val: Any,
+    *,
+    aliases: dict[str, str] | None,
+    operand_transforms: dict[str, Callable[[Any], Any]] | None,
+) -> tuple[str, Any]:
+    """Transform one filter item, recursively handling logical operands."""
+    match key, val:
+        case (("$and" | "$or" | "$nor") as op, list(operands)):
+            if not all(isinstance(obj, dict) for obj in operands):
+                raise ValueError(f"{op} must contain only filter dictionaries.")
+            return key, [
+                transform_fields(
+                    obj, aliases=aliases, operand_transforms=operand_transforms
                 )
+                for obj in operands
+            ]
 
-            case ("$not", dict(operand)) if operand:
-                return key, self.transform(operand)
+        case (("$and" | "$or" | "$nor") as op, _):
+            raise ValueError(f"{op} must contain a list of filter dictionaries.")
 
-            case ("$not", _):
-                raise ValueError("$not must contain a non-empty filter dictionary.")
+        case ("$not", dict(operand)):
+            return key, transform_fields(
+                operand, aliases=aliases, operand_transforms=operand_transforms
+            )
 
-            case (str(operator), _) if operator.startswith("$"):
-                return key, value
+        case ("$not", _):
+            raise ValueError("$not must contain a filter dictionary.")
 
-            case (str(field), _):
-                return self.visit(field, value) if self.visit else (field, value)
+        case (str(op), _) if op.startswith("$"):
+            return key, val
 
-            case _:
-                raise ValueError("Filter field names must be strings.")
+        case (str(field), _):
+            root, dot, suffix = field.partition(".")
+            if aliases and not aliases.get(root):
+                msg = f"Invalid filter field {root!r}, must be one of: {repr_join(sorted(aliases))}"
+                raise ValueError(msg)
 
+            new_root = aliases[root] if aliases else root
+            new_val = (
+                func(val) if (func := (operand_transforms or {}).get(field)) else val
+            )
+            return f"{new_root}{dot}{suffix}", new_val
 
-def iter_fields(expr: MongoLikeFilter) -> Iterator[str]:
-    """Iterate over the field names referenced in a MongoDB filter.
-
-    Unknown operators are left untouched because their operands may not be filters.
-    """
-    match expr:
-        case FilterExpr(field=field):
-            yield field
-        case And(exprs=exprs) | Or(exprs=exprs) | Nor(exprs=exprs):
-            yield from chain.from_iterable(map(iter_fields, exprs))
-        case Not(expr=expr):
-            yield from iter_fields(expr)
+        case _:
+            assert_never(val)
 
 
 @singledispatch
@@ -207,7 +170,7 @@ def _(op: Not) -> MongoLikeFilter:
 def flatten_inner(
     op: BaseVariadicLogicalOp,
     parent_cls: type[BaseVariadicLogicalOp],
-) -> Iterator[LogicalChild]:
+) -> Iterator[FilterExpr | Op]:
     """Iterates over an `And/Or/Nor` operator's flattened inner expressions."""
     for x in op.exprs:
         yield from (flatten_inner(x, parent_cls) if isinstance(x, parent_cls) else (x,))

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -6,7 +6,8 @@ don't expose as instnace methods on filter types for now.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
 from functools import singledispatch
 from itertools import chain
 from typing import TYPE_CHECKING, Any, cast
@@ -65,6 +66,93 @@ def parse_filter(raw: dict[str, Any]) -> MongoLikeFilter:
             return FilterExpr(field=key, op=Eq(val=val))
         case _:
             assert_never(raw)
+
+
+@dataclass(slots=True)
+class FilterFieldTransformer:
+    """Transform ordinary fields in a raw MongoDB-style filter.
+
+    ``visit`` receives each ordinary field and its opaque operand. The filter
+    grammar controls traversal: recognized logical operators are visited, while
+    unknown operators and field operands are not inspected.
+    """
+
+    visit: Callable[[str, Any], tuple[str, Any]] | None = None
+    field_roots: set[str] = field(init=False, default_factory=set)
+
+    def transform(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Return a transformed copy of ``raw``."""
+        self.field_roots.clear()
+        return self._transform(raw)
+
+    def _transform(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Transform recursively without resetting accumulated field roots."""
+        result: dict[str, Any] = {}
+
+        for key, value in raw.items():
+            mapped_key, mapped_value = self._remap_item(key, value)
+
+            if mapped_key in result:
+                raise ValueError(
+                    f"Filter field mapping collision: {key!r} maps to existing "
+                    f"field {mapped_key!r}."
+                )
+            result[mapped_key] = mapped_value
+
+        return result
+
+    def _remap_item(self, key: str, value: Any) -> tuple[str, Any]:
+        """Remap one filter item, recursively handling logical operands."""
+        match key, value:
+            case (("$and" | "$or" | "$nor") as operator, list() as operands):
+                mapped_operands: list[dict[str, Any]] = []
+                for operand in operands:
+                    match operand:
+                        case dict() as child if child:
+                            mapped_operands.append(self._transform(child))
+                        case _:
+                            raise ValueError(
+                                f"{operator} must contain only non-empty filter "
+                                "dictionaries."
+                            )
+                return key, mapped_operands
+
+            case (("$and" | "$or" | "$nor") as operator, _):
+                raise ValueError(
+                    f"{operator} must contain a list of filter dictionaries."
+                )
+
+            case ("$not", dict() as operand) if operand:
+                return key, self._transform(operand)
+
+            case ("$not", _):
+                raise ValueError("$not must contain a non-empty filter dictionary.")
+
+            case (str() as operator, _) if operator.startswith("$"):
+                return key, value
+
+            case (str() as field, _):
+                self.field_roots.add(field.partition(".")[0])
+                return self.visit(field, value) if self.visit else (field, value)
+
+            case _:
+                raise ValueError("Filter field names must be strings.")
+
+
+@dataclass(slots=True)
+class FilterFieldMapper:
+    """Map accepted field aliases to canonical field names."""
+
+    alias_to_field: dict[str, str]
+
+    def __call__(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Return a transformed copy of ``raw``."""
+        return FilterFieldTransformer(self._map_field).transform(raw)
+
+    def _map_field(self, field: str, operand: Any) -> tuple[str, Any]:
+        root, separator, suffix = field.partition(".")
+        mapped_root = self.alias_to_field.get(root, root)
+        return f"{mapped_root}{separator}{suffix}", operand
 
 
 def iter_fields(expr: MongoLikeFilter) -> Iterator[str]:

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -8,10 +8,14 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from functools import singledispatch
-from typing import cast
+from itertools import chain
+from typing import Any, cast
+
+from typing_extensions import assert_never
 
 from .expressions import FilterExpr, MongoLikeFilter
 from .operators import (
+    And,
     BaseVariadicLogicalOp,
     Eq,
     Exists,
@@ -27,6 +31,53 @@ from .operators import (
     Op,
     Or,
 )
+
+
+def parse_filter(raw: dict[str, Any]) -> MongoLikeFilter:
+    """Parse a raw MongoDB-style filter dict into a typed MongoDB filter expression."""
+    match raw:
+        case dict() if len(raw) < 1:
+            return raw
+        case dict() if len(raw) > 1:
+            # Multiple root predicates imply "$and".
+            return And(exprs=(parse_filter({k: v}) for k, v in raw.items()))
+
+        # Below this, we're guaranteed a length-1 dict, so we can drop length guards.
+        case {"$and": exprs}:
+            return And(exprs=map(parse_filter, exprs))
+        case {"$or": exprs}:
+            return Or(exprs=map(parse_filter, exprs))
+        case {"$nor": exprs}:
+            return Nor(exprs=map(parse_filter, exprs))
+        case {"$not": expr}:
+            return Not(expr=parse_filter(expr))
+
+        case dict():
+            ((key, obj),) = raw.items()
+
+            if key.startswith("$"):
+                return raw  # Unknown operator dict
+            if isinstance(obj, dict):
+                return FilterExpr.model_validate(raw)
+
+            # Implicit $eq, e.g. {"field": "value"} -> {"field": {"$eq": "value"}}
+            return FilterExpr(field=key, op=Eq(val=obj))
+        case _:
+            assert_never(raw)
+
+
+def iter_fields(expr: MongoLikeFilter) -> Iterator[str]:
+    """Iterate over the field names referenced in a MongoDB filter.
+
+    Unknown operators are left untouched because their operands may not be filters.
+    """
+    match expr:
+        case FilterExpr(field=field):
+            yield field
+        case BaseVariadicLogicalOp(exprs=exprs):
+            yield from chain.from_iterable(map(iter_fields, exprs))
+        case Not(expr=expr):
+            yield from iter_fields(expr)
 
 
 @singledispatch

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -6,20 +6,16 @@ don't expose as instance methods on filter types for now.
 
 from __future__ import annotations
 
-from collections import Counter
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from functools import singledispatch
-from operator import itemgetter
-from typing import Any, TypeGuard, cast
+from itertools import chain
 
 from pydantic import JsonValue
-from typing_extensions import assert_never
-
-from wandb._strutils import repr_join
 
 from .expressions import FilterExpr, MongoLikeFilter
 from .operators import (
-    BaseVariadicLogicalOp,
+    KEY_TO_OP,
+    And,
     Eq,
     Exists,
     Gt,
@@ -31,100 +27,41 @@ from .operators import (
     Nor,
     Not,
     NotIn,
-    Op,
     Or,
 )
 
 
-def _is_filter_dict_list(
-    values: list[JsonValue],
-) -> TypeGuard[list[dict[str, JsonValue]]]:
-    return all(isinstance(value, dict) for value in values)
+def parse_filter(raw: dict[str, JsonValue]) -> MongoLikeFilter:
+    """Parse a raw MongoDB-style filter, leaving unknown operators opaque."""
+    match list(raw.items()):
+        case []:
+            return raw
+        case [(k, _)] if op_cls := KEY_TO_OP.get(k):
+            return op_cls.model_validate(raw)
+        case [(k, _)] if k.startswith("$"):
+            # This looks like an unrecognized operator, so leave it opaque.
+            return raw
+        case [(k, dict())]:
+            return FilterExpr.model_validate(raw)
+        case [(k, v)]:
+            # An ordinary non-dict operand implies an equality expression.
+            return FilterExpr.model_validate({k: {"$eq": v}})
+        case items:  # Multiple root predicates imply "$and".
+            return And.model_validate({"$and": [{k: v} for k, v in items]})
 
 
-def transform_fields(
-    raw: dict[str, JsonValue],
-    *,
-    aliases: dict[str, str] | None = None,
-    operand_transforms: dict[str, Callable[[Any], Any]] | None = None,
-) -> dict[str, Any]:
-    """Return a copy of `raw` with ordinary filter fields transformed.
+def iter_fields(expr: MongoLikeFilter) -> Iterator[str]:
+    """Iterate over the field names referenced in a MongoDB filter.
 
-    Args:
-        raw: The filter dict to transform.
-        aliases: Maps accepted top-level field names to their canonical names.
-        operand_transforms: Maps exact field names to callable transformations
-            on their inner operands.
-
-    Returns:
-        A copy of `raw` with ordinary filter fields transformed.
-
-    Raises:
-        ValueError: If `aliases` maps multiple aliases to the same canonical name.
+    Unknown operators are left untouched because their operands may not be filters.
     """
-    new_items = tuple(
-        _transform_item(*kv, aliases=aliases, operand_transforms=operand_transforms)
-        for kv in raw.items()
-    )
-    result = dict(new_items)
-
-    # Alias definitions are intentionally many-to-one. A collision is invalid
-    # only when one filter object uses multiple aliases for the same field.
-    if len(result) != len(new_items):
-        new_keys = map(itemgetter(0), new_items)
-        dup_keys = {key for key, count in Counter(new_keys).items() if count > 1}
-
-        msg = f"Duplicate fields in normalized filter: {repr_join(sorted(dup_keys))}"
-        raise ValueError(msg)
-
-    return result
-
-
-def _transform_item(
-    key: str,
-    val: JsonValue,
-    *,
-    aliases: dict[str, str] | None,
-    operand_transforms: dict[str, Callable[[Any], Any]] | None,
-) -> tuple[str, Any]:
-    """Transform one filter item, recursively handling logical operands."""
-    match key, val:
-        case (("$and" | "$or" | "$nor") as op, list(operands)):
-            if not _is_filter_dict_list(operands):
-                raise ValueError(f"{op} must contain only filter dictionaries.")
-            return key, [
-                transform_fields(
-                    obj, aliases=aliases, operand_transforms=operand_transforms
-                )
-                for obj in operands
-            ]
-
-        case (("$and" | "$or" | "$nor") as op, _):
-            raise ValueError(f"{op} must contain a list of filter dictionaries.")
-
-        case ("$not", dict(operand)):
-            return key, transform_fields(
-                operand, aliases=aliases, operand_transforms=operand_transforms
-            )
-
-        case ("$not", _):
-            raise ValueError("$not must contain a filter dictionary.")
-
-        case (str(op), _) if op.startswith("$"):
-            return key, val
-
-        case (str(field), _):
-            root, sep, suffix = field.partition(".")
-            if aliases and not aliases.get(root):
-                msg = f"Invalid filter field {root!r}, must be one of: {repr_join(sorted(aliases))}"
-                raise ValueError(msg)
-
-            new_root = (aliases or {}).get(root) or root
-            new_val = fn(val) if (fn := (operand_transforms or {}).get(field)) else val
-            return f"{new_root}{sep}{suffix}", new_val
-
-        case _:
-            assert_never((key, val))
+    match expr:
+        case FilterExpr(field=field):
+            yield field
+        case And(exprs=exprs) | Or(exprs=exprs) | Nor(exprs=exprs):
+            yield from chain.from_iterable(map(iter_fields, exprs))
+        case Not(expr=expr):
+            yield from iter_fields(expr)
 
 
 @singledispatch
@@ -133,36 +70,35 @@ def simplify_expr(expr: MongoLikeFilter) -> MongoLikeFilter:
     return expr  # default implementation is a no-op
 
 
-# singledispatch on the abstract parent dispatches to all And/Or/Nor subclasses
-@simplify_expr.register
-def _(op: BaseVariadicLogicalOp) -> MongoLikeFilter:  # type: ignore[misc]
+@simplify_expr.register(And)
+@simplify_expr.register(Or)
+@simplify_expr.register(Nor)
+def _(op: And | Or | Nor) -> MongoLikeFilter:
     """Simplify an `And/Or/Nor` operator by removing and unnesting redundant expressions.
 
-    This will flatten the operator's inner expressions and simplify them recursively,
-    e.g.:
+    This will flatten the inner expressions and simplify recursively:
     - `And(op1, And(op2, ...)) -> And(op1, op2, ...)`
     - `Or(op1, Or(op2, ...)) -> Or(op1, op2, ...)`
 
-    Note that unnested empty operators are preserved, e.g.
+    Unnested empty operators are preserved:
     - `And() -> And()`
     - `Or() -> Or()`
 
-    However, nested empty operators are flattened, e.g.:
+    Nested empty operators are flattened:
     - `And(And(), And()) -> And()`
     - `Or(Or(), Or()) -> Or()`
 
-    Single inner expressions are unnested, e.g.:
+    Single inner expressions are unnested:
     - `And(a) -> a`
     - `Or(a) -> a`
     """
     cls = type(op)
     # Flatten and simplify the operator's inner expressions.
-    if len(exprs := [simplify_expr(x) for x in flatten_inner(op, cls)]) == 1:
-        return exprs[0]  # Unnest single inner expressions.
-    # cls is always one of And/Or/Nor — concrete subclasses of BaseVariadicLogicalOp
-    # that *are* in the MongoLikeFilter union, but type checkers can't see this
-    # through the abstract `type(op)` capture.
-    return cast(MongoLikeFilter, cls(exprs=exprs))
+    match exprs := [simplify_expr(x) for x in flatten_inner(op, cls)]:
+        case [only_child]:  # Unnest single inner expressions.
+            return only_child
+        case _:
+            return cls(exprs=exprs)
 
 
 @simplify_expr.register
@@ -186,9 +122,9 @@ def _(op: Not) -> MongoLikeFilter:
 
 
 def flatten_inner(
-    op: BaseVariadicLogicalOp,
-    parent_cls: type[BaseVariadicLogicalOp],
-) -> Iterator[FilterExpr | Op]:
+    op: And | Or | Nor,
+    parent_cls: type[And | Or | Nor],
+) -> Iterator[MongoLikeFilter]:
     """Iterates over an `And/Or/Nor` operator's flattened inner expressions."""
     for x in op.exprs:
-        yield from (flatten_inner(x, parent_cls) if isinstance(x, parent_cls) else (x,))
+        yield from (flatten_inner(x, parent_cls) if type(x) is parent_cls else (x,))

--- a/wandb/_filters/filterutils.py
+++ b/wandb/_filters/filterutils.py
@@ -8,10 +8,14 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from functools import singledispatch
-from typing import cast
+from itertools import chain
+from typing import TYPE_CHECKING, Any, cast
+
+from typing_extensions import assert_never
 
 from .expressions import FilterExpr, MongoLikeFilter
 from .operators import (
+    And,
     BaseVariadicLogicalOp,
     Eq,
     Exists,
@@ -24,9 +28,57 @@ from .operators import (
     Nor,
     Not,
     NotIn,
-    Op,
     Or,
 )
+
+if TYPE_CHECKING:
+    from .operators import LogicalChild
+
+
+def parse_filter(raw: dict[str, Any]) -> MongoLikeFilter:
+    """Parse a raw MongoDB-style filter dict into a typed MongoDB filter expression."""
+    match raw:
+        case dict() if len(raw) < 1:
+            return raw
+        case dict() if len(raw) > 1:  # Multiple root predicates imply "$and".
+            return And(exprs=(parse_filter({k: v}) for k, v in raw.items()))
+
+        # Below this, we're guaranteed a length-1 dict, so we can drop length guards.
+        case {"$and": exprs}:
+            return And(exprs=map(parse_filter, exprs))
+        case {"$or": exprs}:
+            return Or(exprs=map(parse_filter, exprs))
+        case {"$nor": exprs}:
+            return Nor(exprs=map(parse_filter, exprs))
+        case {"$not": expr}:
+            return Not(expr=parse_filter(expr))
+
+        case dict():
+            ((key, val),) = raw.items()
+
+            if key.startswith("$"):
+                return raw  # Unknown operator dict
+            if isinstance(val, dict):
+                return FilterExpr.model_validate(raw)
+
+            # Implicit $eq, e.g. {"field": "value"} -> {"field": {"$eq": "value"}}
+            return FilterExpr(field=key, op=Eq(val=val))
+        case _:
+            assert_never(raw)
+
+
+def iter_fields(expr: MongoLikeFilter) -> Iterator[str]:
+    """Iterate over the field names referenced in a MongoDB filter.
+
+    Unknown operators are left untouched because their operands may not be filters.
+    """
+    match expr:
+        case FilterExpr(field=field):
+            yield field
+        case And(exprs=exprs) | Or(exprs=exprs) | Nor(exprs=exprs):
+            yield from chain.from_iterable(map(iter_fields, exprs))
+        case Not(expr=expr):
+            yield from iter_fields(expr)
 
 
 @singledispatch
@@ -90,7 +142,7 @@ def _(op: Not) -> MongoLikeFilter:
 def flatten_inner(
     op: BaseVariadicLogicalOp,
     parent_cls: type[BaseVariadicLogicalOp],
-) -> Iterator[FilterExpr | Op]:
+) -> Iterator[LogicalChild]:
     """Iterates over an `And/Or/Nor` operator's flattened inner expressions."""
     for x in op.exprs:
         yield from (flatten_inner(x, parent_cls) if isinstance(x, parent_cls) else (x,))

--- a/wandb/_filters/operators.py
+++ b/wandb/_filters/operators.py
@@ -4,21 +4,27 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final, get_args
+from typing import TYPE_CHECKING, Annotated, Any, TypeAlias, TypeVar, final
 
-from pydantic import ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from pydantic import (
+    AfterValidator,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 from typing_extensions import Self, override
 
 from wandb._pydantic import GQLBase
-from wandb._strutils import nameof
+from wandb._strutils import nameof, repr_join
 
 if TYPE_CHECKING:
     from .expressions import FilterExpr
 
 # for type annotations
 Scalar = StrictStr | StrictInt | StrictFloat | StrictBool
-# for runtime type checks
-ScalarTypes: tuple[type, ...] = tuple(t.__origin__ for t in get_args(Scalar))
 
 # See: https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol
 RichReprResult: TypeAlias = Iterable[
@@ -53,7 +59,7 @@ class SupportsBitwiseLogicalOps:
     # Subclasses widen the return to their operator-specific inverse
     # (e.g. `Lt -> Gte`); the parent type must cover all those cases so
     # the overrides don't trip Liskov return-type checks.
-    def __invert__(self) -> Op | FilterExpr:
+    def __invert__(self) -> LogicalChild:
         """Implements default `~` behavior: `~a -> Not(a)`."""
         return Not(expr=self)
 
@@ -73,7 +79,7 @@ class BaseOp(GQLBase, SupportsBitwiseLogicalOps, ABC):
         Note that BaseModels implement `__iter__()`:
           https://docs.pydantic.dev/latest/concepts/serialization/#iterating-over-models
         """
-        return f"{nameof(type(self))}({', '.join(repr(v) for _, v in self)})"
+        return f"{nameof(type(self))}({repr_join(v for _, v in self)})"
 
     def __rich_repr__(self) -> RichReprResult:
         """Returns the operator's rich repr, if pretty-printing via `rich`.
@@ -85,8 +91,8 @@ class BaseOp(GQLBase, SupportsBitwiseLogicalOps, ABC):
 
 
 # Base type for logical operators that take a variable number of expressions.
-class BaseVariadicLogicalOp(BaseOp, ABC):
-    exprs: TupleOf[FilterExpr | Op]
+class VariadicLogicalOp(BaseOp, ABC):
+    exprs: TupleOf[LogicalChild]
 
     @classmethod
     def wrap(cls, expr: Any) -> Self:
@@ -99,13 +105,13 @@ class BaseVariadicLogicalOp(BaseOp, ABC):
 # https://www.mongodb.com/docs/manual/reference/operator/query/nor/
 # https://www.mongodb.com/docs/manual/reference/operator/query/not/
 @final
-class And(BaseVariadicLogicalOp):
-    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$and")
+class And(VariadicLogicalOp):
+    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$and")
 
 
 @final
-class Or(BaseVariadicLogicalOp):
-    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$or")
+class Or(VariadicLogicalOp):
+    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$or")
 
     @override
     def __invert__(self) -> Nor:
@@ -114,8 +120,8 @@ class Or(BaseVariadicLogicalOp):
 
 
 @final
-class Nor(BaseVariadicLogicalOp):
-    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$nor")
+class Nor(VariadicLogicalOp):
+    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$nor")
 
     @override
     def __invert__(self) -> Or:
@@ -125,10 +131,10 @@ class Nor(BaseVariadicLogicalOp):
 
 @final
 class Not(BaseOp):
-    expr: FilterExpr | Op = Field(alias="$not")
+    expr: LogicalChild = Field(alias="$not")
 
     @override
-    def __invert__(self) -> FilterExpr | Op:
+    def __invert__(self) -> LogicalChild:
         """Implements `~Not(a) -> a`."""
         return self.expr
 
@@ -184,7 +190,7 @@ class Gte(BaseOp):
 
 @final
 class Eq(BaseOp):
-    val: Scalar = Field(alias="$eq")
+    val: Scalar | TupleOf[Scalar] = Field(alias="$eq")
 
     @override
     def __invert__(self) -> Ne:
@@ -194,7 +200,7 @@ class Eq(BaseOp):
 
 @final
 class Ne(BaseOp):
-    val: Scalar = Field(alias="$ne")
+    val: Scalar | TupleOf[Scalar] = Field(alias="$ne")
 
     @override
     def __invert__(self) -> Eq:
@@ -226,7 +232,7 @@ class NotIn(BaseOp):
 # https://www.mongodb.com/docs/manual/reference/operator/query/exists/
 @final
 class Exists(BaseOp):
-    val: bool = Field(alias="$exists")
+    val: StrictBool = Field(alias="$exists")
 
     @override
     def __invert__(self) -> Exists:
@@ -265,27 +271,6 @@ class Size(BaseOp):
 # ------------------------------------------------------------------------------
 # Convenience helpers, constants, and utils for supported MongoDB operators
 # ------------------------------------------------------------------------------
-KEY_TO_OP: dict[str, type[BaseOp]] = {
-    "$and": And,
-    "$or": Or,
-    "$nor": Nor,
-    "$not": Not,
-    "$lt": Lt,
-    "$gt": Gt,
-    "$lte": Lte,
-    "$gte": Gte,
-    "$eq": Eq,
-    "$ne": Ne,
-    "$in": In,
-    "$nin": NotIn,
-    "$exists": Exists,
-    "$regex": Regex,
-    "$contains": Contains,
-    "$size": Size,
-    "$all": All,
-}
-
-
 # Known, implemented MongoDB operators for type annotations.
 Op = (
     And
@@ -306,3 +291,39 @@ Op = (
     | Size
     | All
 )
+
+KEY_TO_OP: dict[str, type[Op]] = {
+    "$and": And,
+    "$or": Or,
+    "$nor": Nor,
+    "$not": Not,
+    "$lt": Lt,
+    "$gt": Gt,
+    "$lte": Lte,
+    "$gte": Gte,
+    "$eq": Eq,
+    "$ne": Ne,
+    "$in": In,
+    "$nin": NotIn,
+    "$exists": Exists,
+    "$regex": Regex,
+    "$contains": Contains,
+    "$size": Size,
+    "$all": All,
+}
+
+
+def parse_logical_child(value: Any) -> Any:
+    """Parse a dict after Pydantic validates the logical-child union."""
+    if isinstance(value, dict):
+        from .filterutils import parse_filter
+
+        return parse_filter(value)
+    return value
+
+
+LogicalChild: TypeAlias = Annotated[
+    "FilterExpr | Op | dict[str, Any]",
+    AfterValidator(parse_logical_child),
+]
+"""Recognized and opaque operands of logical operators."""

--- a/wandb/_filters/operators.py
+++ b/wandb/_filters/operators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final, get_args
 
 from pydantic import ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 from typing_extensions import Self, override
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
     from .expressions import FilterExpr
 
 # for type annotations
-Scalar = StrictStr | StrictInt | StrictFloat | StrictBool | None
+Scalar = StrictStr | StrictInt | StrictFloat | StrictBool
+# for runtime type checks
+ScalarTypes: tuple[type, ...] = tuple(t.__origin__ for t in get_args(Scalar))
 
 # See: https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol
 RichReprResult: TypeAlias = Iterable[
@@ -84,7 +86,7 @@ class BaseOp(GQLBase, SupportsBitwiseLogicalOps, ABC):
 
 # Base type for logical operators that take a variable number of expressions.
 class BaseVariadicLogicalOp(BaseOp, ABC):
-    exprs: TupleOf[LogicalChild]
+    exprs: TupleOf[FilterExpr | Op]
 
     @classmethod
     def wrap(cls, expr: Any) -> Self:
@@ -98,12 +100,12 @@ class BaseVariadicLogicalOp(BaseOp, ABC):
 # https://www.mongodb.com/docs/manual/reference/operator/query/not/
 @final
 class And(BaseVariadicLogicalOp):
-    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$and")
+    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$and")
 
 
 @final
 class Or(BaseVariadicLogicalOp):
-    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$or")
+    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$or")
 
     @override
     def __invert__(self) -> Nor:
@@ -113,7 +115,7 @@ class Or(BaseVariadicLogicalOp):
 
 @final
 class Nor(BaseVariadicLogicalOp):
-    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$nor")
+    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$nor")
 
     @override
     def __invert__(self) -> Or:
@@ -123,10 +125,10 @@ class Nor(BaseVariadicLogicalOp):
 
 @final
 class Not(BaseOp):
-    expr: LogicalChild = Field(alias="$not")
+    expr: FilterExpr | Op = Field(alias="$not")
 
     @override
-    def __invert__(self) -> LogicalChild:
+    def __invert__(self) -> FilterExpr | Op:
         """Implements `~Not(a) -> a`."""
         return self.expr
 
@@ -284,6 +286,7 @@ KEY_TO_OP: dict[str, type[BaseOp]] = {
 }
 
 
+# Known, implemented MongoDB operators for type annotations.
 Op = (
     And
     | Or
@@ -303,7 +306,3 @@ Op = (
     | Size
     | All
 )
-"""Type hint for known, implemented MongoDB operator types."""
-
-LogicalChild: TypeAlias = "FilterExpr | Op"
-"""Type hint for valid operands of logical operators."""

--- a/wandb/_filters/operators.py
+++ b/wandb/_filters/operators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final, get_args
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final
 
 from pydantic import ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 from typing_extensions import Self, override
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
     from .expressions import FilterExpr
 
 # for type annotations
-Scalar = StrictStr | StrictInt | StrictFloat | StrictBool
-# for runtime type checks
-ScalarTypes: tuple[type, ...] = tuple(t.__origin__ for t in get_args(Scalar))
+Scalar = StrictStr | StrictInt | StrictFloat | StrictBool | None
 
 # See: https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol
 RichReprResult: TypeAlias = Iterable[
@@ -86,7 +84,7 @@ class BaseOp(GQLBase, SupportsBitwiseLogicalOps, ABC):
 
 # Base type for logical operators that take a variable number of expressions.
 class BaseVariadicLogicalOp(BaseOp, ABC):
-    exprs: TupleOf[FilterExpr | Op]
+    exprs: TupleOf[LogicalChild]
 
     @classmethod
     def wrap(cls, expr: Any) -> Self:
@@ -100,12 +98,12 @@ class BaseVariadicLogicalOp(BaseOp, ABC):
 # https://www.mongodb.com/docs/manual/reference/operator/query/not/
 @final
 class And(BaseVariadicLogicalOp):
-    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$and")
+    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$and")
 
 
 @final
 class Or(BaseVariadicLogicalOp):
-    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$or")
+    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$or")
 
     @override
     def __invert__(self) -> Nor:
@@ -115,7 +113,7 @@ class Or(BaseVariadicLogicalOp):
 
 @final
 class Nor(BaseVariadicLogicalOp):
-    exprs: TupleOf[FilterExpr | Op] = Field(default=(), alias="$nor")
+    exprs: TupleOf[LogicalChild] = Field(default=(), alias="$nor")
 
     @override
     def __invert__(self) -> Or:
@@ -125,10 +123,10 @@ class Nor(BaseVariadicLogicalOp):
 
 @final
 class Not(BaseOp):
-    expr: FilterExpr | Op = Field(alias="$not")
+    expr: LogicalChild = Field(alias="$not")
 
     @override
-    def __invert__(self) -> FilterExpr | Op:
+    def __invert__(self) -> LogicalChild:
         """Implements `~Not(a) -> a`."""
         return self.expr
 
@@ -286,7 +284,6 @@ KEY_TO_OP: dict[str, type[BaseOp]] = {
 }
 
 
-# Known, implemented MongoDB operators for type annotations.
 Op = (
     And
     | Or
@@ -306,3 +303,7 @@ Op = (
     | Size
     | All
 )
+"""Type hint for known, implemented MongoDB operator types."""
+
+LogicalChild: TypeAlias = "FilterExpr | Op"
+"""Type hint for valid operands of logical operators."""

--- a/wandb/_filters/operators.py
+++ b/wandb/_filters/operators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final, get_args
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final
 
 from pydantic import ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 from typing_extensions import Self, override
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
     from .expressions import FilterExpr
 
 # for type annotations
-Scalar = StrictStr | StrictInt | StrictFloat | StrictBool
-# for runtime type checks
-ScalarTypes: tuple[type, ...] = tuple(t.__origin__ for t in get_args(Scalar))
+Scalar = StrictStr | StrictInt | StrictFloat | StrictBool | None
 
 # See: https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol
 RichReprResult: TypeAlias = Iterable[

--- a/wandb/_filters/validation.py
+++ b/wandb/_filters/validation.py
@@ -2,36 +2,27 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic import GetCoreSchemaHandler, ValidationInfo
+from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema
-from pydantic_core.core_schema import with_info_after_validator_function
+from pydantic_core.core_schema import no_info_after_validator_function
 
 from .filterutils import transform_fields
-
-AliasResolver = Callable[[ValidationInfo], dict[str, str]]
 
 
 @dataclass(frozen=True, slots=True)
 class FilterValidator:
     """Pydantic metadata that validates and normalizes filter field names."""
 
-    valid: Collection[str] | None = None
+    valid: frozenset[str] | None = None
     """Allowed names, or aliases mapped to canonical serialized names."""
-
-    alias_resolver: AliasResolver | None = None
-    """Resolve accepted-to-canonical aliases from Pydantic validation context."""
 
     aliases: tuple[tuple[str, str], ...] = field(init=False, default=())
     """Immutable accepted-to-canonical aliases derived from ``valid``."""
 
     def __post_init__(self) -> None:
-        if self.valid and self.alias_resolver:
-            raise ValueError("Specify either valid or alias_resolver, not both.")
-
         # Empty collections are treated as None (no restrictions on valid names)
         if isinstance(valid := self.valid, dict):
             aliases = tuple(sorted(valid.items()))
@@ -45,10 +36,7 @@ class FilterValidator:
     def __get_pydantic_core_schema__(
         self, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
-        return with_info_after_validator_function(self.validate, handler(source_type))
+        return no_info_after_validator_function(self.validate, handler(source_type))
 
-    def validate(self, raw: dict[str, Any], info: ValidationInfo) -> dict[str, Any]:
-        aliases = (
-            resolve(info) if (resolve := self.alias_resolver) else dict(self.aliases)
-        )
-        return transform_fields(raw, aliases=aliases or None)
+    def validate(self, raw: dict[str, Any]) -> dict[str, Any]:
+        return transform_fields(raw, aliases=dict(self.aliases) or None)

--- a/wandb/_filters/validation.py
+++ b/wandb/_filters/validation.py
@@ -12,7 +12,7 @@ from pydantic_core.core_schema import with_info_after_validator_function
 
 from wandb._strutils import repr_join
 
-from .filterutils import FilterFieldMapper, FilterFieldTransformer
+from .filterutils import FilterFieldTransformer
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,11 +59,13 @@ class FilterValidator:
             aliases = dict(self._aliases)
             allowed = self.valid
 
-        transformer = FilterFieldTransformer()
-        transformer.transform(raw)
+        def validate_and_map(field: str, operand: Any) -> tuple[str, Any]:
+            root, separator, suffix = field.partition(".")
+            if allowed and root not in allowed:
+                msg = f"Invalid filter field {root!r}, must be one of: {repr_join(sorted(allowed))}"
+                raise ValueError(msg)
 
-        if allowed and (invalid := transformer.field_roots.difference(allowed)):
-            msg = f"Invalid filter field(s) {repr_join(sorted(invalid))}, must be one of: {repr_join(sorted(allowed))}"
-            raise ValueError(msg)
+            mapped_root = aliases.get(root, root)
+            return f"{mapped_root}{separator}{suffix}", operand
 
-        return FilterFieldMapper(aliases)(raw) if aliases else raw
+        return FilterFieldTransformer(validate_and_map).transform(raw)

--- a/wandb/_filters/validation.py
+++ b/wandb/_filters/validation.py
@@ -2,43 +2,68 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable, Collection
+from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic import GetCoreSchemaHandler
+from pydantic import GetCoreSchemaHandler, ValidationInfo
 from pydantic_core import CoreSchema
-from pydantic_core.core_schema import no_info_after_validator_function
+from pydantic_core.core_schema import with_info_after_validator_function
 
 from wandb._strutils import repr_join
 
-from .filterutils import iter_fields, parse_filter
+from .filterutils import FilterFieldMapper, FilterFieldTransformer
 
 
 @dataclass(frozen=True, slots=True)
 class FilterValidator:
-    """Pydantic metadata that validates a MongoDB-style filter dict."""
+    """Pydantic metadata that validates and normalizes filter field names."""
 
-    valid: frozenset[str] | None = None
-    """The allowed field names. If None, all fields are allowed."""
+    valid: Collection[str] | None = None
+    """Allowed names, or aliases mapped to canonical serialized names."""
+
+    resolve: Callable[[ValidationInfo], dict[str, str]] | None = field(
+        default=None,
+        kw_only=True,
+        repr=False,
+    )
+    """Resolve an alias policy from Pydantic validation context."""
+
+    _aliases: tuple[tuple[str, str], ...] = field(
+        init=False,
+        default=(),
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
+        if self.valid is not None and self.resolve is not None:
+            raise ValueError("Specify either valid or resolve, not both.")
+
         # Empty collections are treated as None (no restrictions on valid names)
-        valid = frozenset(valid) if (valid := self.valid) else None
+        if isinstance(valid := self.valid, dict):
+            object.__setattr__(self, "_aliases", tuple(sorted(valid.items())))
+        valid = frozenset(valid) if valid else None
         object.__setattr__(self, "valid", valid)
 
     def __get_pydantic_core_schema__(
         self, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
-        return no_info_after_validator_function(self.validate, handler(source_type))
+        return with_info_after_validator_function(self.validate, handler(source_type))
 
-    def validate(self, raw: dict[str, Any]) -> dict[str, Any]:
-        parsed = parse_filter(raw)
+    def validate(self, raw: dict[str, Any], info: ValidationInfo) -> dict[str, Any]:
+        allowed: Collection[str] | None
+        if self.resolve is not None:
+            aliases = self.resolve(info)
+            allowed = frozenset(aliases) if aliases else None
+        else:
+            aliases = dict(self._aliases)
+            allowed = self.valid
 
-        if valid := self.valid:
-            # Check only root keys for dotted paths, e.g. "metadata.foo" -> "metadata"
-            names = set(s.split(".")[0] for s in iter_fields(parsed))
-            if invalid := names.difference(valid):
-                msg = f"Invalid filter field(s) {repr_join(sorted(invalid))}, must be one of: {repr_join(sorted(valid))}"
-                raise ValueError(msg)
+        transformer = FilterFieldTransformer()
+        transformer.transform(raw)
 
-        return raw  # Preserve the original dict so long as it's valid
+        if allowed and (invalid := transformer.field_roots.difference(allowed)):
+            msg = f"Invalid filter field(s) {repr_join(sorted(invalid))}, must be one of: {repr_join(sorted(allowed))}"
+            raise ValueError(msg)
+
+        return FilterFieldMapper(aliases)(raw) if aliases else raw

--- a/wandb/_filters/validation.py
+++ b/wandb/_filters/validation.py
@@ -1,0 +1,44 @@
+"""Reusable validators for MongoDB-style filter dicts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import CoreSchema
+from pydantic_core.core_schema import no_info_after_validator_function
+
+from wandb._strutils import repr_join
+
+from .filterutils import iter_fields, parse_filter
+
+
+@dataclass(frozen=True, slots=True)
+class FilterValidator:
+    """Pydantic metadata that validates a MongoDB-style filter dict."""
+
+    valid: frozenset[str] | None = None
+    """The allowed field names. If None, all fields are allowed."""
+
+    def __post_init__(self) -> None:
+        # Empty collections are treated as None (no restrictions on valid names)
+        valid = frozenset(valid) if (valid := self.valid) else None
+        object.__setattr__(self, "valid", valid)
+
+    def __get_pydantic_core_schema__(
+        self, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return no_info_after_validator_function(self.validate, handler(source_type))
+
+    def validate(self, raw: dict[str, Any]) -> dict[str, Any]:
+        parsed = parse_filter(raw)
+
+        if valid := self.valid:
+            # Check only root keys for dotted paths, e.g. "metadata.foo" -> "metadata"
+            names = set(s.split(".")[0] for s in iter_fields(parsed))
+            if invalid := names.difference(valid):
+                msg = f"Invalid filter field(s) {repr_join(sorted(invalid))}, must be one of: {repr_join(sorted(valid))}"
+                raise ValueError(msg)
+
+        return raw  # Preserve the original dict so long as it's valid

--- a/wandb/_filters/validation.py
+++ b/wandb/_filters/validation.py
@@ -1,0 +1,43 @@
+"""Reusable validators for MongoDB-style filter dicts."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import CoreSchema
+from pydantic_core.core_schema import no_info_after_validator_function
+
+from wandb._strutils import repr_join
+
+from .filterutils import iter_fields, parse_filter
+
+
+@dataclass(frozen=True, slots=True)
+class FilterValidator:
+    """Pydantic metadata that validates a MongoDB-style filter dict."""
+
+    valid: Collection[str] | None = None
+    """The allowed field names. If None, all fields are allowed."""
+
+    def __post_init__(self) -> None:
+        if valid := self.valid:
+            object.__setattr__(self, "valid", frozenset(valid))
+
+    def __get_pydantic_core_schema__(
+        self, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return no_info_after_validator_function(self.validate, handler(source_type))
+
+    def validate(self, arg: dict[str, Any]) -> dict[str, Any]:
+        if valid := self.valid:
+            # For dotted paths, check only the top-level name.
+            #   e.g. "metadata.foo" -> "metadata"
+            seen = set(s.split(".")[0] for s in iter_fields(parse_filter(arg)))
+            if invalid := seen.difference(valid):
+                msg = f"Invalid filter field(s) {repr_join(sorted(invalid))}, must be one of: {repr_join(sorted(valid))}"
+                raise ValueError(msg)
+
+        return arg

--- a/wandb/_filters/validation.py
+++ b/wandb/_filters/validation.py
@@ -2,36 +2,65 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import KW_ONLY, dataclass, field
+from operator import itemgetter
+from types import MappingProxyType
+from typing import Any, TypeAlias
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema
 from pydantic_core.core_schema import no_info_after_validator_function
+from typing_extensions import assert_never
 
-from .filterutils import transform_fields
+from wandb._strutils import repr_join
+
+from .filterutils import iter_fields, parse_filter
+
+FieldName: TypeAlias = str
+OperandTransform: TypeAlias = Callable[[Any], Any]
 
 
 @dataclass(frozen=True, slots=True)
 class FilterValidator:
     """Pydantic metadata that validates and normalizes filter field names."""
 
-    valid: frozenset[str] | None = None
+    valid: frozenset[FieldName] | None = None
     """Allowed names, or aliases mapped to canonical serialized names."""
 
-    aliases: tuple[tuple[str, str], ...] = field(init=False, default=())
-    """Immutable accepted-to-canonical aliases derived from ``valid``."""
+    _: KW_ONLY
+
+    transforms: MappingProxyType[FieldName, OperandTransform] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    """Canonical field names and transformations for their operands."""
+
+    aliases: MappingProxyType[FieldName, FieldName] = field(init=False)
+    """Read-only accepted-to-canonical aliases derived from ``valid``."""
 
     def __post_init__(self) -> None:
         # Empty collections are treated as None (no restrictions on valid names)
-        if isinstance(valid := self.valid, dict):
-            aliases = tuple(sorted(valid.items()))
-        else:
-            aliases = tuple((name, name) for name in sorted(valid or ()))
-        object.__setattr__(self, "aliases", aliases)
+        match self.valid:
+            case dict(valid):
+                aliases = dict(valid)
+            case valid:
+                aliases = {name: name for name in sorted(valid or ())}
+        object.__setattr__(self, "aliases", MappingProxyType(aliases))
 
         valid = frozenset(valid) if valid else None
         object.__setattr__(self, "valid", valid)
+        object.__setattr__(self, "transforms", MappingProxyType(dict(self.transforms)))
+
+    def __hash__(self) -> int:
+        # Mapping proxies are immutable but unhashable, so hash their contents.
+        return hash(
+            (
+                self.valid,
+                frozenset(self.aliases.items()),
+                frozenset(self.transforms.items()),
+            )
+        )
 
     def __get_pydantic_core_schema__(
         self, source_type: Any, handler: GetCoreSchemaHandler
@@ -39,4 +68,49 @@ class FilterValidator:
         return no_info_after_validator_function(self.validate, handler(source_type))
 
     def validate(self, raw: dict[str, Any]) -> dict[str, Any]:
-        return transform_fields(raw, aliases=dict(self.aliases) or None)
+        parsed = parse_filter(raw)
+        if valid := self.valid:
+            invalid = {
+                root
+                for field in iter_fields(parsed)
+                if (root := field.partition(".")[0]) not in valid
+            }
+            if invalid:
+                msg = f"Invalid filter fields: {repr_join(sorted(invalid))}; must be one of: {repr_join(sorted(valid))}"
+                raise ValueError(msg)
+
+        return self.transform(raw)
+
+    def transform(self, raw: dict[str, Any]) -> dict[str, Any]:
+        new_items = tuple(self._transform_item(item) for item in raw.items())
+        new_dict = dict(new_items)
+
+        # Alias definitions are intentionally many-to-one. A collision is invalid
+        # only when one filter object uses multiple aliases for the same field.
+        if len(new_dict) != len(new_items):
+            new_keys = map(itemgetter(0), new_items)
+            dup_keys = {key for key, count in Counter(new_keys).items() if count > 1}
+            msg = f"Duplicate fields: {repr_join(sorted(dup_keys))}"
+            raise ValueError(msg)
+
+        return new_dict
+
+    def _transform_item(self, item: tuple[str, Any]) -> tuple[str, Any]:
+        match item:
+            case (("$and" | "$or" | "$nor") as key, list(children)):
+                return key, list(map(self.transform, children))
+
+            case ("$not" as key, dict(child)):
+                return key, self.transform(child)
+
+            case (str(op), _) if op.startswith("$"):
+                return item
+
+            case (str(field), val):
+                root, sep, suffix = field.partition(".")
+                field = f"{self.aliases.get(root) or root}{sep}{suffix}"
+                val = fn(val) if (fn := self.transforms.get(field)) else val
+                return field, val
+
+            case _:
+                assert_never(item)

--- a/wandb/_filters/validation.py
+++ b/wandb/_filters/validation.py
@@ -10,9 +10,9 @@ from pydantic import GetCoreSchemaHandler, ValidationInfo
 from pydantic_core import CoreSchema
 from pydantic_core.core_schema import with_info_after_validator_function
 
-from wandb._strutils import repr_join
+from .filterutils import transform_fields
 
-from .filterutils import FilterFieldTransformer
+AliasResolver = Callable[[ValidationInfo], dict[str, str]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,26 +22,23 @@ class FilterValidator:
     valid: Collection[str] | None = None
     """Allowed names, or aliases mapped to canonical serialized names."""
 
-    resolve: Callable[[ValidationInfo], dict[str, str]] | None = field(
-        default=None,
-        kw_only=True,
-        repr=False,
-    )
-    """Resolve an alias policy from Pydantic validation context."""
+    alias_resolver: AliasResolver | None = None
+    """Resolve accepted-to-canonical aliases from Pydantic validation context."""
 
-    _aliases: tuple[tuple[str, str], ...] = field(
-        init=False,
-        default=(),
-        repr=False,
-    )
+    aliases: tuple[tuple[str, str], ...] = field(init=False, default=())
+    """Immutable accepted-to-canonical aliases derived from ``valid``."""
 
     def __post_init__(self) -> None:
-        if self.valid is not None and self.resolve is not None:
-            raise ValueError("Specify either valid or resolve, not both.")
+        if self.valid and self.alias_resolver:
+            raise ValueError("Specify either valid or alias_resolver, not both.")
 
         # Empty collections are treated as None (no restrictions on valid names)
         if isinstance(valid := self.valid, dict):
-            object.__setattr__(self, "_aliases", tuple(sorted(valid.items())))
+            aliases = tuple(sorted(valid.items()))
+        else:
+            aliases = tuple((name, name) for name in sorted(valid or ()))
+        object.__setattr__(self, "aliases", aliases)
+
         valid = frozenset(valid) if valid else None
         object.__setattr__(self, "valid", valid)
 
@@ -51,21 +48,7 @@ class FilterValidator:
         return with_info_after_validator_function(self.validate, handler(source_type))
 
     def validate(self, raw: dict[str, Any], info: ValidationInfo) -> dict[str, Any]:
-        allowed: Collection[str] | None
-        if self.resolve is not None:
-            aliases = self.resolve(info)
-            allowed = frozenset(aliases) if aliases else None
-        else:
-            aliases = dict(self._aliases)
-            allowed = self.valid
-
-        def validate_and_map(field: str, operand: Any) -> tuple[str, Any]:
-            root, separator, suffix = field.partition(".")
-            if allowed and root not in allowed:
-                msg = f"Invalid filter field {root!r}, must be one of: {repr_join(sorted(allowed))}"
-                raise ValueError(msg)
-
-            mapped_root = aliases.get(root, root)
-            return f"{mapped_root}{separator}{suffix}", operand
-
-        return FilterFieldTransformer(validate_and_map).transform(raw)
+        aliases = (
+            resolve(info) if (resolve := self.alias_resolver) else dict(self.aliases)
+        )
+        return transform_fields(raw, aliases=aliases or None)

--- a/wandb/_iterutils.py
+++ b/wandb/_iterutils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Hashable, Iterable
+from collections.abc import Hashable, Iterable, Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 if TYPE_CHECKING:
@@ -28,6 +28,11 @@ def unique_list(iterable: Iterable[HashableT]) -> list[HashableT]:
     """Return a deduplicated list of items from the given iterable, preserving order."""
     # Trick for O(1) uniqueness check that maintains order
     return list(dict.fromkeys(iterable))
+
+
+def merge_dicts(dicts: Iterable[Mapping[HashableT, T]]) -> dict[HashableT, T]:
+    """Merge mappings in iteration order, with later values taking precedence."""
+    return {k: v for d in dicts for k, v in d.items()}
 
 
 def one(

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -31,7 +31,6 @@ from wandb._iterutils import one
 from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public.registries import Registries, Registry
-from wandb.apis.public.registries._utils import fetch_org_entity_from_organization
 from wandb.apis.public.service_api import ServiceApi
 from wandb.apis.public.utils import (
     PathType,
@@ -2086,14 +2085,10 @@ class Api:
         organization = organization or fetch_org_from_settings_or_entity(
             self.settings, self.default_entity
         )
-        org_entity = fetch_org_entity_from_organization(
-            self._service_api,
-            organization,
-        )
         registry = Registry(
             self._service_api,
             organization,
-            org_entity,
+            self.organization(organization).org_entity.name,
             name,
         )
         registry.load()

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -114,8 +114,16 @@ Note: "advanced" fields are only relevant when passing a filter to a Versions pa
 COLLECTIONS_FILTER_FIELDS = SearchFields(
     fields=(
         SearchField.from_shared("artifact_collection_id", "collection_id", "id"),
-        SearchField.from_shared("name", "collection_name", "artifact_collection_name"),
-        SearchField.from_shared("tag", "tags"),
+        SearchField(
+            basic=_FieldNames("name"),
+            advanced=_FieldNames(
+                "name", aliases=("collection_name", "artifact_collection_name")
+            ),
+        ),
+        SearchField(
+            basic=_FieldNames("tag"),
+            advanced=_FieldNames("tag", aliases=("tags",)),
+        ),
         # Only supported in "basic" search
         SearchField(
             basic=_FieldNames("description"),
@@ -142,10 +150,22 @@ VERSIONS_FILTER_FIELDS = SearchFields(
             basic=_FieldNames("id"),
             advanced=_FieldNames("artifact_id", aliases=["id"]),
         ),
-        SearchField.from_shared("version", "version_index"),
-        SearchField.from_shared("tag", "tags"),
-        SearchField.from_shared("alias", "aliases"),
-        SearchField.from_shared("metadata", "artifact_metadata"),
+        SearchField(
+            basic=_FieldNames("version"),
+            advanced=_FieldNames("version", aliases=("version_index",)),
+        ),
+        SearchField(
+            basic=_FieldNames("tag"),
+            advanced=_FieldNames("tag", aliases=("tags",)),
+        ),
+        SearchField(
+            basic=_FieldNames("alias"),
+            advanced=_FieldNames("alias", aliases=("aliases",)),
+        ),
+        SearchField(
+            basic=_FieldNames("metadata"),
+            advanced=_FieldNames("metadata", aliases=("artifact_metadata",)),
+        ),
         SearchField(
             basic=_FieldNames("created_at"),
             advanced=_FieldNames("artifact_created_at", aliases=["created_at"]),

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -1,191 +1,141 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection
-from dataclasses import dataclass
+from collections.abc import Collection, Iterable
+from contextlib import suppress
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, TypeVar, overload
+from typing import TYPE_CHECKING, Any
 
 from pydantic.dataclasses import dataclass as pydantic_dataclass
-from typing_extensions import Self
+from typing_extensions import assert_never
 
-from wandb._filters import transform_fields
 from wandb._filters.operators import KEY_TO_OP
+from wandb._iterutils import merge_dicts
 from wandb._strutils import b64decode_ascii, ensureprefix, repr_join
 from wandb.proto import wandb_internal_pb2 as pb
 
 if TYPE_CHECKING:
-    from wandb.apis.public import ArtifactCollection
-    from wandb.apis.public.registries.registry import Registry
+    from wandb.apis.public import ArtifactCollection, Registry
     from wandb.apis.public.service_api import ServiceApi
 
 logger = logging.getLogger(__name__)
 
 
-T = TypeVar("T")
-
-
 @pydantic_dataclass(frozen=True, slots=True)
-class _FieldNames:
-    canonical: str  #: The canonical name of the field.
+class SearchField:
+    name: str  #: The canonical name of the field.
     aliases: tuple[str, ...] = ()  #: Accepted aliases for the field.
 
 
-@pydantic_dataclass(frozen=True, slots=True)
-class SearchField:
-    """Canonical and accepted filter field names for basic and advanced search.
-
-    In each sequence, the CANONICAL name comes first. Remaining names, if any,
-    are acceptable aliases.
-
-    A `None` value means the field is unsupported in that search mode.
-    """
-
-    basic: _FieldNames | None
-    advanced: _FieldNames | None
-
-    def __post_init__(self) -> None:
-        if not (self.basic or self.advanced):
-            raise ValueError("A filter field must support at least one search mode.")
-
-    @classmethod
-    def from_shared(cls, name: str, *aliases: str) -> Self:
-        """Defines a filter field for either search mode with the same allowed aliases."""
-        return cls(
-            basic=_FieldNames(name, aliases=aliases),
-            advanced=_FieldNames(name, aliases=aliases),
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class SearchFields:
-    """Filter-field aliases for one registry search surface."""
-
-    fields: tuple[SearchField, ...]
-
-    def advanced_aliases(self) -> dict[str, str]:
-        # Be sure to include the canonical name in the map
-        return {
-            alias: names.canonical
-            for field in self.fields
-            if (names := field.advanced)
-            for alias in (names.canonical, *names.aliases)
-        }
-
-    def basic_aliases(self) -> dict[str, str]:
-        # Be sure to include the canonical name in the map
-        return {
-            alias: names.canonical
-            for field in self.fields
-            if (names := field.basic)
-            for alias in (names.canonical, *names.aliases)
-        }
-
-
-REGISTRIES_FILTER_FIELDS = SearchFields(
-    fields=(
-        SearchField(
-            basic=_FieldNames("id"),
-            advanced=_FieldNames("project_id", aliases=["id"]),
-        ),
-        SearchField.from_shared("name"),
-        SearchField.from_shared("entity_id"),
-        # Only supported in "basic" search
-        SearchField(
-            basic=_FieldNames("description"),
-            advanced=None,
-        ),
-        SearchField(
-            basic=_FieldNames("created_at"),
-            advanced=None,
-        ),
-        SearchField(
-            basic=_FieldNames("updated_at"),
-            advanced=None,
-        ),
+def merge_alias_maps(fields: Iterable[SearchField]) -> dict[str, str]:
+    """Returns a combined map of all accepted field aliases -> canonical name."""
+    # Don't forget to allow the canonical name itself
+    return merge_dicts(
+        {alias: f.name for alias in (f.name, *f.aliases)} for f in fields
     )
-)
-"""Defines allowed field names in registry filters.
 
-Note: "advanced" fields are only relevant when passing a filter to a Versions paginator.
+
+# ------------------------------------------------------------------------------
+
+
+BASIC_REGISTRIES_FILTER_FIELDS = (
+    SearchField("id"),
+    SearchField("name"),
+    SearchField("entity_id"),
+    SearchField("description"),  # Only supported in "basic" search
+    SearchField("created_at"),  # Only supported in "basic" search
+    SearchField("updated_at"),  # Only supported in "basic" search
+)
+"""Defines allowed Registries filter fields for "basic" search.
+
+This is relevant for REGISTRY filters passed to:
+- Registries(...) ALWAYS, as advanced search applies to versions queries.
+- Versions(...) ONLY in "basic" search mode.
 """
 
-COLLECTIONS_FILTER_FIELDS = SearchFields(
-    fields=(
-        SearchField.from_shared("artifact_collection_id", "collection_id", "id"),
-        SearchField(
-            basic=_FieldNames("name"),
-            advanced=_FieldNames(
-                "name", aliases=("collection_name", "artifact_collection_name")
-            ),
-        ),
-        SearchField(
-            basic=_FieldNames("tag"),
-            advanced=_FieldNames("tag", aliases=("tags",)),
-        ),
-        # Only supported in "basic" search
-        SearchField(
-            basic=_FieldNames("description"),
-            advanced=None,
-        ),
-        SearchField(
-            basic=_FieldNames("created_at"),
-            advanced=None,
-        ),
-        SearchField(
-            basic=_FieldNames("updated_at"),
-            advanced=None,
-        ),
-    )
+ADVANCED_REGISTRIES_FILTER_FIELDS = (
+    SearchField("project_id", aliases=["id"]),
+    SearchField("name"),
+    SearchField("entity_id"),
 )
-"""Defines allowed field names in artifact collection filters.
+"""Defines allowed Registries filter fields for "advanced" search.
 
-Note: "advanced" fields are only relevant when passing a filter to a Versions paginator.
+This is relevant for REGISTRY filters passed to:
+- Versions(...) ONLY in "advanced" search mode
 """
 
-VERSIONS_FILTER_FIELDS = SearchFields(
-    fields=(
-        SearchField(
-            basic=_FieldNames("id"),
-            advanced=_FieldNames("artifact_id", aliases=["id"]),
-        ),
-        SearchField(
-            basic=_FieldNames("version"),
-            advanced=_FieldNames("version", aliases=("version_index",)),
-        ),
-        SearchField(
-            basic=_FieldNames("tag"),
-            advanced=_FieldNames("tag", aliases=("tags",)),
-        ),
-        SearchField(
-            basic=_FieldNames("alias"),
-            advanced=_FieldNames("alias", aliases=("aliases",)),
-        ),
-        SearchField(
-            basic=_FieldNames("metadata"),
-            advanced=_FieldNames("metadata", aliases=("artifact_metadata",)),
-        ),
-        SearchField(
-            basic=_FieldNames("created_at"),
-            advanced=_FieldNames("artifact_created_at", aliases=["created_at"]),
-        ),
-        # Only supported in "basic" search
-        SearchField(
-            basic=_FieldNames("updated_at"),
-            advanced=None,
-        ),
-        # Only supported in "advanced" search
-        SearchField(
-            basic=None,
-            advanced=_FieldNames("artifact_size"),
-        ),
-    )
-)
-"""Defines allowed field names in artifact version filters.
+# ------------------------------------------------------------------------------
 
-Note: "advanced" fields are only relevant when passing the filter to a Versions paginator.
+BASIC_COLLECTIONS_FILTER_FIELDS = (
+    SearchField("artifact_collection_id", aliases=["collection_id", "id"]),
+    SearchField("name"),
+    SearchField("tag"),
+    SearchField("description"),  # Only supported in "basic" search
+    SearchField("created_at"),  # Only supported in "basic" search
+    SearchField("updated_at"),  # Only supported in "basic" search
+)
+"""Defines allowed Collections filter fields for "basic" search.
+
+This is relevant for COLLECTION filters passed to:
+- Collections(...) ALWAYS, as advanced search applies to versions queries.
+- Versions(...) ONLY in "basic" search mode
 """
+
+ADVANCED_COLLECTIONS_FILTER_FIELDS = (
+    SearchField("artifact_collection_id", aliases=["collection_id", "id"]),
+    SearchField("name", aliases=["collection_name", "artifact_collection_name"]),
+    SearchField("tag", aliases=["tags"]),
+)
+"""Defines allowed Collections filter fields for "advanced" search.
+
+This is relevant for COLLECTION filters passed to:
+- Versions(...) ONLY in "advanced" search mode
+"""
+
+# ------------------------------------------------------------------------------
+
+BASIC_VERSIONS_FILTER_FIELDS = (
+    SearchField("id"),
+    SearchField("version"),
+    SearchField("tag"),
+    SearchField("alias"),
+    SearchField("metadata"),
+    SearchField("created_at"),
+    SearchField("updated_at"),  # Only supported in "basic" search
+)
+"""Defines allowed Versions filter fields for "basic" search.
+
+This is relevant for VERSION filters passed to:
+- Versions(...) ONLY in "basic" search mode
+"""
+
+ADVANCED_VERSIONS_FILTER_FIELDS = (
+    SearchField("artifact_id", aliases=["id"]),
+    SearchField("version", aliases=["version_index"]),
+    SearchField("tag", aliases=["tags"]),
+    SearchField("alias", aliases=["aliases"]),
+    SearchField("metadata", aliases=["artifact_metadata"]),
+    SearchField("artifact_created_at", aliases=["created_at"]),
+    SearchField("artifact_size"),  # Only supported in "advanced" search
+)
+"""Defines allowed Versions filter fields for "advanced" search.
+
+This is relevant for VERSION filters passed to:
+- Versions(...) ONLY in "advanced" search mode
+"""
+
+# ------------------------------------------------------------------------------
+
+BASIC_REGISTRIES_FILTER_ALIASES = merge_alias_maps(BASIC_REGISTRIES_FILTER_FIELDS)
+BASIC_COLLECTIONS_FILTER_ALIASES = merge_alias_maps(BASIC_COLLECTIONS_FILTER_FIELDS)
+BASIC_VERSIONS_FILTER_ALIASES = merge_alias_maps(BASIC_VERSIONS_FILTER_FIELDS)
+
+ADVANCED_REGISTRIES_FILTER_ALIASES = merge_alias_maps(ADVANCED_REGISTRIES_FILTER_FIELDS)
+ADVANCED_COLLECTIONS_FILTER_ALIASES = merge_alias_maps(
+    ADVANCED_COLLECTIONS_FILTER_FIELDS
+)
+ADVANCED_VERSIONS_FILTER_ALIASES = merge_alias_maps(ADVANCED_VERSIONS_FILTER_FIELDS)
 
 
 class Visibility(str, Enum):
@@ -276,90 +226,38 @@ def prefix_registry_name(operand: Any) -> Any:
             return operand
 
 
-@overload
-def prepare_registry_filter(query: str) -> str: ...
-@overload
-def prepare_registry_filter(query: dict[str, Any]) -> dict[str, Any]: ...
-@overload
-def prepare_registry_filter(query: list[T] | tuple[T, ...]) -> list[T]: ...
-@overload
-def prepare_registry_filter(query: T) -> T: ...
+def decode_project_id(gql_id: str) -> int | None:
+    """Returns the int project ID from a base64-encoded GraphQL ID, or None if invalid."""
+    with suppress(ValueError, UnicodeDecodeError):
+        match b64decode_ascii(gql_id).split(":"):
+            case ["ProjectInternalId" | "Project", idx] if idx.isdigit():
+                return int(idx)
+            case _:
+                pass
+
+    logger.warning(f"Invalid project ID: {gql_id!r}")
+    return None
 
 
-def prepare_registry_filter(query: Any) -> Any:
-    """Normalize a registry filter as a JSON-serializable GraphQL input.
+def registry_filter_for(obj: Registry | ArtifactCollection) -> dict[str, Any]:
+    """Returns a filter for Registry objects derived from a registry-related object."""
+    from wandb.apis.public import ArtifactCollection, Registry
 
-    Prepend the registry prefix to ``name`` operands, excluding regex operands
-    and opaque unknown-operator subtrees.
+    match obj:
+        case Registry(internal_id=str(b64_id)) if int_id := decode_project_id(b64_id):
+            return {"id": int_id}
+        case Registry(full_name=name):
+            return {"name": name}
 
-    EX: {"name": "model"} -> {"name": "wandb-registry-model"}
-    """
-    match query:
-        case dict():
-            return transform_fields(
-                query,
-                operand_transforms={"name": prefix_registry_name},
-            )
-        case list() | tuple():
-            return [prepare_registry_filter(value) for value in query]
+        case ArtifactCollection(project_internal_id=str(b64_id)) if (
+            int_id := decode_project_id(b64_id)
+        ):
+            return {"id": int_id}
+        case ArtifactCollection(project=name):
+            return {"name": name}
+
         case _:
-            return query
-
-
-@lru_cache(maxsize=10)
-def fetch_org_entity_from_organization(
-    service_api: ServiceApi, organization: str
-) -> str:
-    """Fetch the org entity from the organization.
-
-    Args:
-        service_api: The service API instance to use for querying W&B.
-        organization (str): The organization to fetch the org entity for.
-    """
-    from wandb.sdk.artifacts._generated import FETCH_ORGANIZATION_GQL, FetchOrganization
-
-    gql_op = FETCH_ORGANIZATION_GQL
-    gql_vars = {"org": organization}
-    try:
-        data = service_api.execute_graphql(gql_op, variables=gql_vars)
-    except Exception as e:
-        msg = f"Error fetching org entity for organization: {organization!r}"
-        raise ValueError(msg) from e
-
-    result = FetchOrganization.model_validate(data)
-    if (
-        not (org := result.organization)
-        or not (org_entity := org.org_entity)
-        or not (org_name := org_entity.name)
-    ):
-        raise ValueError(f"Organization entity for {organization!r} not found.")
-
-    return org_name
-
-
-def _project_id_from_gql_id(gql_id: str) -> int | None:
-    try:
-        decoded = b64decode_ascii(gql_id)
-    except (ValueError, UnicodeDecodeError):
-        logger.warning("Invalid project ID: %r", gql_id)
-        return None
-
-    match decoded.split(":"):
-        case ["Project", idx] if idx.isdigit():
-            return int(idx)
-        case ["ProjectInternalId", idx] if idx.isdigit():
-            return int(idx)
-        case _:
-            logger.warning("Invalid project ID: %r", gql_id)
-            return None
-
-
-def filter_for_registry(registry: Registry) -> dict[str, Any]:
-    if (project_encoded_id := registry.internal_id) and (
-        project_id := _project_id_from_gql_id(project_encoded_id)
-    ):
-        return {"id": project_id}
-    return {"name": registry.full_name}
+            assert_never(obj)
 
 
 @lru_cache(maxsize=10)
@@ -394,14 +292,4 @@ def advanced_search_enabled(service_api: ServiceApi, organization: str) -> bool:
     if not (org := result.organization):
         logger.warning("Organization %r not found.", organization)
         return False
-    return bool(
-        (features := org.advanced_registry_features) and features.advanced_search
-    )
-
-
-def registry_filter_for_collection(collection: ArtifactCollection) -> dict[str, Any]:
-    if (project_encoded_id := collection.project_internal_id) and (
-        project_id := _project_id_from_gql_id(project_encoded_id)
-    ):
-        return {"id": project_id}
-    return {"name": collection.project}
+    return bool((feats := org.advanced_registry_features) and feats.advanced_search)

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -5,16 +5,13 @@ from collections.abc import Collection
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from operator import attrgetter
-from typing import TYPE_CHECKING, Annotated, Any, Final, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
-from pydantic import BeforeValidator, ValidationInfo
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from typing_extensions import Self
 
 from wandb._filters import transform_fields
 from wandb._filters.operators import KEY_TO_OP
-from wandb._iterutils import always_list
 from wandb._strutils import b64decode_ascii, ensureprefix, repr_join
 from wandb.proto import wandb_internal_pb2 as pb
 
@@ -28,121 +25,151 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-ADVANCED_SEARCH_CTX_KEY: Final[str] = "advanced_search_enabled"
-"""Pydantic validation context key signaling that advanced search is enabled."""
+
+@pydantic_dataclass(frozen=True, slots=True)
+class _FieldNames:
+    name: str  #: The canonical name of the field.
+    aliases: tuple[str, ...] = ()  #: Accepted aliases for the field.
+
+
+class SearchMode(str, Enum):
+    BASIC = "basic"
+    ADVANCED = "advanced"
 
 
 @pydantic_dataclass(frozen=True, slots=True)
 class SearchField:
     """Canonical and accepted filter field names for basic and advanced search.
 
-    Each tuple contains the canonical name first, followed by accepted aliases.
-    ``None`` means the field is unsupported in that mode.
+    In each sequence, the CANONICAL name comes first. Remaining names, if any,
+    are acceptable aliases.
+
+    A `None` value means the field is unsupported in that search mode.
     """
 
-    basic: Annotated[tuple[str, ...], BeforeValidator(always_list)] | None = None
-    advanced: Annotated[tuple[str, ...], BeforeValidator(always_list)] | None = None
+    basic: _FieldNames | None
+    advanced: _FieldNames | None
 
     def __post_init__(self) -> None:
         if not (self.basic or self.advanced):
             raise ValueError("A filter field must support at least one search mode.")
 
     @classmethod
-    def basic_only(cls, canonical: str, *aliases: str) -> Self:
-        """Defines a field supported in basic search only."""
-        return cls(basic=(canonical, *aliases), advanced=None)
-
-    @classmethod
-    def advanced_only(cls, canonical: str, *aliases: str) -> Self:
-        """Defines a field supported in advanced search only."""
-        return cls(basic=None, advanced=(canonical, *aliases))
-
-    @classmethod
-    def shared(cls, canonical: str, *aliases: str) -> Self:
-        """Defines a field supported in both search modes with the same canonical name."""
-        return cls(basic=(canonical, *aliases), advanced=(canonical, *aliases))
+    def from_shared(cls, name: str, *aliases: str) -> Self:
+        """Defines a filter field for either search mode with the same allowed aliases."""
+        return cls(
+            basic=_FieldNames(name, aliases=aliases),
+            advanced=_FieldNames(name, aliases=aliases),
+        )
 
 
 @dataclass(frozen=True, slots=True)
-class VersionsFilterFields:
-    """Filter-field aliases for each Versions filter argument."""
+class SearchFields:
+    """Filter-field aliases for one registry search surface."""
 
-    registry_fields: tuple[SearchField, ...]
-    collection_fields: tuple[SearchField, ...]
-    artifact_fields: tuple[SearchField, ...]
+    fields: tuple[SearchField, ...]
 
-    def resolve_aliases(self, info: ValidationInfo) -> dict[str, str]:
-        """Resolve aliases for the model field and search mode being validated."""
-        context = info.context if isinstance(info.context, dict) else {}
-        return self.aliases_for(
-            info.field_name,
-            advanced=bool(context.get(ADVANCED_SEARCH_CTX_KEY)),
-        )
-
-    def aliases_for(self, name: str, *, advanced: bool = False) -> dict[str, str]:
-        """Map accepted aliases to canonical names for one filter and mode."""
-        match name:
-            case "registry_filter":
-                fields = self.registry_fields
-            case "collection_filter":
-                fields = self.collection_fields
-            case "artifact_filter":
-                fields = self.artifact_fields
+    def aliases(self, mode: SearchMode) -> dict[str, str]:
+        """Returns a map of (accepted alias) -> (canonical name) for one search mode."""
+        match SearchMode(mode):
+            case SearchMode.BASIC:
+                names_by_field = (f.basic for f in self.fields)
+            case SearchMode.ADVANCED:
+                names_by_field = (f.advanced for f in self.fields)
             case _:
-                raise ValueError(f"Unknown Versions filter argument: {name!r}.")
+                raise ValueError(f"Invalid search mode: {mode!r}")
 
-        aliases_per_field = map(attrgetter("advanced" if advanced else "basic"), fields)
         return {
-            alias: aliases[0]
-            for aliases in aliases_per_field
-            if aliases
-            for alias in aliases
+            alias: names.name
+            for names in names_by_field
+            if names
+            for alias in (names.name, *names.aliases)
         }
 
 
-VERSIONS_FILTER_FIELDS = VersionsFilterFields(
-    registry_fields=(
-        SearchField.shared("name"),
+REGISTRIES_FILTER_FIELDS = SearchFields(
+    fields=(
         SearchField(
-            basic=("id",),
-            advanced=("project_id", "id"),
+            basic=_FieldNames("id"),
+            advanced=_FieldNames("project_id", aliases=["id"]),
         ),
-        SearchField.shared("entity_id"),
-        SearchField.basic_only("description"),
-        SearchField.basic_only("created_at"),
-        SearchField.basic_only("updated_at"),
-    ),
-    collection_fields=(
-        SearchField.shared("name", "collection_name", "artifact_collection_name"),
+        SearchField.from_shared("name"),
+        SearchField.from_shared("entity_id"),
+        # Only supported in "basic" search
         SearchField(
-            basic=("id", "collection_id", "artifact_collection_id"),
-            advanced=("artifact_collection_id", "id", "collection_id"),
+            basic=_FieldNames("description"),
+            advanced=None,
         ),
-        SearchField.shared("tag", "tags"),
-        SearchField.basic_only("description"),
-        SearchField.basic_only("created_at"),
-        SearchField.basic_only("updated_at"),
-    ),
-    artifact_fields=(
         SearchField(
-            basic=("id",),
-            advanced=("artifact_id", "id"),
+            basic=_FieldNames("created_at"),
+            advanced=None,
         ),
-        SearchField.shared("version", "version_index"),
-        SearchField.shared("tag", "tags"),
-        SearchField.shared("alias", "aliases"),
-        SearchField.shared("metadata", "artifact_metadata"),
         SearchField(
-            basic=("created_at",),
-            advanced=("artifact_created_at", "created_at"),
+            basic=_FieldNames("updated_at"),
+            advanced=None,
         ),
-        SearchField.basic_only("updated_at"),
-        SearchField.advanced_only("acm_created_at"),
-        SearchField.advanced_only("acm_updated_at"),
-        SearchField.advanced_only("artifact_size"),
-        SearchField.advanced_only("artifact_file_count"),
-    ),
+    )
 )
+"""Defines allowed field names in registry filters.
+
+Note: "advanced" fields are only relevant when passing a filter to a Versions paginator.
+"""
+
+COLLECTIONS_FILTER_FIELDS = SearchFields(
+    fields=(
+        SearchField.from_shared("artifact_collection_id", "collection_id", "id"),
+        SearchField.from_shared("name", "collection_name", "artifact_collection_name"),
+        SearchField.from_shared("tag", "tags"),
+        # Only supported in "basic" search
+        SearchField(
+            basic=_FieldNames("description"),
+            advanced=None,
+        ),
+        SearchField(
+            basic=_FieldNames("created_at"),
+            advanced=None,
+        ),
+        SearchField(
+            basic=_FieldNames("updated_at"),
+            advanced=None,
+        ),
+    )
+)
+"""Defines allowed field names in artifact collection filters.
+
+Note: "advanced" fields are only relevant when passing a filter to a Versions paginator.
+"""
+
+VERSIONS_FILTER_FIELDS = SearchFields(
+    fields=(
+        SearchField(
+            basic=_FieldNames("id"),
+            advanced=_FieldNames("artifact_id", aliases=["id"]),
+        ),
+        SearchField.from_shared("version", "version_index"),
+        SearchField.from_shared("tag", "tags"),
+        SearchField.from_shared("alias", "aliases"),
+        SearchField.from_shared("metadata", "artifact_metadata"),
+        SearchField(
+            basic=_FieldNames("created_at"),
+            advanced=_FieldNames("artifact_created_at", aliases=["created_at"]),
+        ),
+        # Only supported in "basic" search
+        SearchField(
+            basic=_FieldNames("updated_at"),
+            advanced=None,
+        ),
+        # Only supported in "advanced" search
+        SearchField(
+            basic=None,
+            advanced=_FieldNames("artifact_size"),
+        ),
+    )
+)
+"""Defines allowed field names in artifact version filters.
+
+Note: "advanced" fields are only relevant when passing the filter to a Versions paginator.
+"""
 
 
 class Visibility(str, Enum):

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -2,14 +2,22 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Collection
+from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Final, TypeVar, overload
 
+from pydantic import ValidationInfo
+from pydantic.dataclasses import dataclass as pydantic_dataclass
+
+from wandb._filters import FilterFieldTransformer
+from wandb._filters.operators import KEY_TO_OP
 from wandb._strutils import b64decode_ascii, ensureprefix, repr_join
 from wandb.proto import wandb_internal_pb2 as pb
 
 _logger = logging.getLogger(__name__)
+
+ADVANCED_SEARCH_CTX_KEY: Final[str] = "advanced_search_enabled"
 
 if TYPE_CHECKING:
     from wandb.apis.public import ArtifactCollection
@@ -18,6 +26,112 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
+
+
+@pydantic_dataclass(frozen=True, slots=True)
+class FilterFieldAlias:
+    """Canonical and accepted filter field names for basic and advanced search.
+
+    Each tuple contains the canonical name first, followed by accepted aliases.
+    ``None`` means the field is unsupported in that mode.
+    """
+
+    basic: tuple[str, ...] | None = None
+    advanced: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not (self.basic or self.advanced):
+            raise ValueError("A filter field must support at least one search mode.")
+
+
+@dataclass(frozen=True, slots=True)
+class VersionsFilterFields:
+    """Field-name policies for each Versions filter argument."""
+
+    registry_filter: tuple[FilterFieldAlias, ...]
+    collection_filter: tuple[FilterFieldAlias, ...]
+    artifact_filter: tuple[FilterFieldAlias, ...]
+
+    def resolve(self, info: ValidationInfo) -> dict[str, str]:
+        """Resolve aliases for the model field and search mode being validated."""
+        if (name := info.field_name) is None:
+            raise ValueError("A Versions filter policy requires a model field name.")
+
+        context = info.context if isinstance(info.context, dict) else {}
+        return self.for_filter(
+            name,
+            advanced=bool(context.get(ADVANCED_SEARCH_CTX_KEY)),
+        )
+
+    def for_filter(self, name: str, *, advanced: bool) -> dict[str, str]:
+        """Return the field-name policy for a Versions filter argument."""
+        match name:
+            case "registry_filter":
+                fields = self.registry_filter
+            case "collection_filter":
+                fields = self.collection_filter
+            case "artifact_filter":
+                fields = self.artifact_filter
+            case _:
+                raise ValueError(f"Unknown Versions filter argument: {name!r}.")
+
+        aliases_by_field = (
+            field.advanced if advanced else field.basic for field in fields
+        )
+        return {
+            alias: aliases[0]
+            for aliases in aliases_by_field
+            if aliases
+            for alias in aliases
+        }
+
+
+VERSIONS_FILTER_FIELDS = VersionsFilterFields(
+    registry_filter=(
+        FilterFieldAlias(basic=("name",), advanced=("name",)),
+        FilterFieldAlias(basic=("id",), advanced=("project_id", "id")),
+        FilterFieldAlias(basic=("entity_id",), advanced=("entity_id",)),
+        FilterFieldAlias(basic=("description",)),
+        FilterFieldAlias(basic=("created_at",)),
+        FilterFieldAlias(basic=("updated_at",)),
+    ),
+    collection_filter=(
+        FilterFieldAlias(
+            basic=("name", "collection_name", "artifact_collection_name"),
+            advanced=("name", "collection_name", "artifact_collection_name"),
+        ),
+        FilterFieldAlias(
+            basic=("id", "collection_id", "artifact_collection_id"),
+            advanced=("artifact_collection_id", "id", "collection_id"),
+        ),
+        FilterFieldAlias(basic=("tag", "tags"), advanced=("tag", "tags")),
+        FilterFieldAlias(basic=("description",)),
+        FilterFieldAlias(basic=("created_at",)),
+        FilterFieldAlias(basic=("updated_at",)),
+    ),
+    artifact_filter=(
+        FilterFieldAlias(basic=("id",), advanced=("artifact_id", "id")),
+        FilterFieldAlias(
+            basic=("version", "version_index"),
+            advanced=("version", "version_index"),
+        ),
+        FilterFieldAlias(basic=("tag", "tags"), advanced=("tag", "tags")),
+        FilterFieldAlias(basic=("alias", "aliases"), advanced=("alias", "aliases")),
+        FilterFieldAlias(
+            basic=("metadata", "artifact_metadata"),
+            advanced=("metadata", "artifact_metadata"),
+        ),
+        FilterFieldAlias(
+            basic=("created_at",),
+            advanced=("artifact_created_at", "created_at"),
+        ),
+        FilterFieldAlias(basic=("updated_at",)),
+        FilterFieldAlias(advanced=("acm_created_at",)),
+        FilterFieldAlias(advanced=("acm_updated_at",)),
+        FilterFieldAlias(advanced=("artifact_size",)),
+        FilterFieldAlias(advanced=("artifact_file_count",)),
+    ),
+)
 
 
 class Visibility(str, Enum):
@@ -86,31 +200,55 @@ def prepare_artifact_types_input(
 
 
 @overload
-def prepare_registry_filter(query: str, path=...) -> str: ...
+def prepare_registry_filter(query: str) -> str: ...
 @overload
-def prepare_registry_filter(query: dict[str, Any], path=...) -> dict[str, Any]: ...
+def prepare_registry_filter(query: dict[str, Any]) -> dict[str, Any]: ...
 @overload
-def prepare_registry_filter(query: list[T] | tuple[T], path=...) -> list[T]: ...
+def prepare_registry_filter(query: list[T] | tuple[T, ...]) -> list[T]: ...
 @overload
-def prepare_registry_filter(query: T, path=...) -> T: ...
+def prepare_registry_filter(query: T) -> T: ...
 
 
-def prepare_registry_filter(query: Any, path: tuple[int | str, ...] = ()) -> Any:
+def prefix_registry_name(operand: Any) -> Any:
+    """Prefix strings in a registry-name operand, except regexes and unknown ops."""
+    from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
+
+    match operand:
+        case str() as txt:
+            return ensureprefix(txt, REGISTRY_PREFIX)
+        case dict() as dct:
+            return {
+                key: (
+                    value
+                    if key == "$regex" or (key.startswith("$") and key not in KEY_TO_OP)
+                    else prefix_registry_name(value)
+                )
+                for key, value in dct.items()
+            }
+        case list() | tuple() as seq:
+            return [prefix_registry_name(value) for value in seq]
+        case _:
+            return operand
+
+
+def prepare_registry_filter(query: Any) -> Any:
     """Normalize a registry filter as a JSON-serializable GraphQL input.
 
-    Recursively prepend the registry prefix under "name" keys, excluding regex ops.
+    Prepend the registry prefix to ``name`` operands, excluding regex operands
+    and opaque unknown-operator subtrees.
 
     EX: {"name": "model"} -> {"name": "wandb-registry-model"}
     """
-    from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
-
     match query:
-        case str() as txt if "name" in path and "$regex" not in path:
-            return ensureprefix(txt, REGISTRY_PREFIX)
-        case dict() as dct:
-            return {k: prepare_registry_filter(v, (*path, k)) for k, v in dct.items()}
-        case list() | tuple() as seq:
-            return [prepare_registry_filter(v, (*path, i)) for i, v in enumerate(seq)]
+        case dict():
+            return FilterFieldTransformer(
+                lambda field, operand: (
+                    field,
+                    prefix_registry_name(operand) if field == "name" else operand,
+                )
+            ).transform(query)
+        case list() | tuple():
+            return [prepare_registry_filter(value) for value in query]
         case _:
             return query
 
@@ -184,15 +322,15 @@ def advanced_search_enabled(service_api: ServiceApi, organization: str) -> bool:
     ``ARTIFACT_COLLECTIONS_FILTERING_SORTING``. We use that feature flag as a proxy
     to avoid querying an endpoint that does not exist on older servers.
     """
-    if not service_api.feature_enabled(pb.ARTIFACT_COLLECTIONS_FILTERING_SORTING):
-        return False
-
-    from wandb.sdk.artifacts._generated import (
-        FETCH_ADVANCED_REGISTRY_FEATURES_GQL,
-        FetchAdvancedRegistryFeatures,
-    )
-
     try:
+        if not service_api.feature_enabled(pb.ARTIFACT_COLLECTIONS_FILTERING_SORTING):
+            return False
+
+        from wandb.sdk.artifacts._generated import (
+            FETCH_ADVANCED_REGISTRY_FEATURES_GQL,
+            FetchAdvancedRegistryFeatures,
+        )
+
         result = service_api.execute_graphql(
             FETCH_ADVANCED_REGISTRY_FEATURES_GQL,
             variables={"organization": organization},
@@ -209,8 +347,7 @@ def advanced_search_enabled(service_api: ServiceApi, organization: str) -> bool:
         _logger.warning("Organization %r not found.", organization)
         return False
     return bool(
-        org.advanced_registry_features
-        and org.advanced_registry_features.advanced_search
+        (features := org.advanced_registry_features) and features.advanced_search
     )
 
 

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -5,131 +5,142 @@ from collections.abc import Collection
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Final, TypeVar, overload
+from operator import attrgetter
+from typing import TYPE_CHECKING, Annotated, Any, Final, TypeVar, overload
 
-from pydantic import ValidationInfo
+from pydantic import BeforeValidator, ValidationInfo
 from pydantic.dataclasses import dataclass as pydantic_dataclass
+from typing_extensions import Self
 
-from wandb._filters import FilterFieldTransformer
+from wandb._filters import transform_fields
 from wandb._filters.operators import KEY_TO_OP
+from wandb._iterutils import always_list
 from wandb._strutils import b64decode_ascii, ensureprefix, repr_join
 from wandb.proto import wandb_internal_pb2 as pb
-
-_logger = logging.getLogger(__name__)
-
-ADVANCED_SEARCH_CTX_KEY: Final[str] = "advanced_search_enabled"
 
 if TYPE_CHECKING:
     from wandb.apis.public import ArtifactCollection
     from wandb.apis.public.registries.registry import Registry
     from wandb.apis.public.service_api import ServiceApi
 
+logger = logging.getLogger(__name__)
+
 
 T = TypeVar("T")
 
+ADVANCED_SEARCH_CTX_KEY: Final[str] = "advanced_search_enabled"
+"""Pydantic validation context key signaling that advanced search is enabled."""
+
 
 @pydantic_dataclass(frozen=True, slots=True)
-class FilterFieldAlias:
+class SearchField:
     """Canonical and accepted filter field names for basic and advanced search.
 
     Each tuple contains the canonical name first, followed by accepted aliases.
     ``None`` means the field is unsupported in that mode.
     """
 
-    basic: tuple[str, ...] | None = None
-    advanced: tuple[str, ...] | None = None
+    basic: Annotated[tuple[str, ...], BeforeValidator(always_list)] | None = None
+    advanced: Annotated[tuple[str, ...], BeforeValidator(always_list)] | None = None
 
     def __post_init__(self) -> None:
         if not (self.basic or self.advanced):
             raise ValueError("A filter field must support at least one search mode.")
 
+    @classmethod
+    def basic_only(cls, canonical: str, *aliases: str) -> Self:
+        """Defines a field supported in basic search only."""
+        return cls(basic=(canonical, *aliases), advanced=None)
+
+    @classmethod
+    def advanced_only(cls, canonical: str, *aliases: str) -> Self:
+        """Defines a field supported in advanced search only."""
+        return cls(basic=None, advanced=(canonical, *aliases))
+
+    @classmethod
+    def shared(cls, canonical: str, *aliases: str) -> Self:
+        """Defines a field supported in both search modes with the same canonical name."""
+        return cls(basic=(canonical, *aliases), advanced=(canonical, *aliases))
+
 
 @dataclass(frozen=True, slots=True)
 class VersionsFilterFields:
-    """Field-name policies for each Versions filter argument."""
+    """Filter-field aliases for each Versions filter argument."""
 
-    registry_filter: tuple[FilterFieldAlias, ...]
-    collection_filter: tuple[FilterFieldAlias, ...]
-    artifact_filter: tuple[FilterFieldAlias, ...]
+    registry_fields: tuple[SearchField, ...]
+    collection_fields: tuple[SearchField, ...]
+    artifact_fields: tuple[SearchField, ...]
 
-    def resolve(self, info: ValidationInfo) -> dict[str, str]:
+    def resolve_aliases(self, info: ValidationInfo) -> dict[str, str]:
         """Resolve aliases for the model field and search mode being validated."""
-        if (name := info.field_name) is None:
-            raise ValueError("A Versions filter policy requires a model field name.")
-
         context = info.context if isinstance(info.context, dict) else {}
-        return self.for_filter(
-            name,
+        return self.aliases_for(
+            info.field_name,
             advanced=bool(context.get(ADVANCED_SEARCH_CTX_KEY)),
         )
 
-    def for_filter(self, name: str, *, advanced: bool) -> dict[str, str]:
-        """Return the field-name policy for a Versions filter argument."""
+    def aliases_for(self, name: str, *, advanced: bool = False) -> dict[str, str]:
+        """Map accepted aliases to canonical names for one filter and mode."""
         match name:
             case "registry_filter":
-                fields = self.registry_filter
+                fields = self.registry_fields
             case "collection_filter":
-                fields = self.collection_filter
+                fields = self.collection_fields
             case "artifact_filter":
-                fields = self.artifact_filter
+                fields = self.artifact_fields
             case _:
                 raise ValueError(f"Unknown Versions filter argument: {name!r}.")
 
-        aliases_by_field = (
-            field.advanced if advanced else field.basic for field in fields
-        )
+        aliases_per_field = map(attrgetter("advanced" if advanced else "basic"), fields)
         return {
             alias: aliases[0]
-            for aliases in aliases_by_field
+            for aliases in aliases_per_field
             if aliases
             for alias in aliases
         }
 
 
 VERSIONS_FILTER_FIELDS = VersionsFilterFields(
-    registry_filter=(
-        FilterFieldAlias(basic=("name",), advanced=("name",)),
-        FilterFieldAlias(basic=("id",), advanced=("project_id", "id")),
-        FilterFieldAlias(basic=("entity_id",), advanced=("entity_id",)),
-        FilterFieldAlias(basic=("description",)),
-        FilterFieldAlias(basic=("created_at",)),
-        FilterFieldAlias(basic=("updated_at",)),
-    ),
-    collection_filter=(
-        FilterFieldAlias(
-            basic=("name", "collection_name", "artifact_collection_name"),
-            advanced=("name", "collection_name", "artifact_collection_name"),
+    registry_fields=(
+        SearchField.shared("name"),
+        SearchField(
+            basic=("id",),
+            advanced=("project_id", "id"),
         ),
-        FilterFieldAlias(
+        SearchField.shared("entity_id"),
+        SearchField.basic_only("description"),
+        SearchField.basic_only("created_at"),
+        SearchField.basic_only("updated_at"),
+    ),
+    collection_fields=(
+        SearchField.shared("name", "collection_name", "artifact_collection_name"),
+        SearchField(
             basic=("id", "collection_id", "artifact_collection_id"),
             advanced=("artifact_collection_id", "id", "collection_id"),
         ),
-        FilterFieldAlias(basic=("tag", "tags"), advanced=("tag", "tags")),
-        FilterFieldAlias(basic=("description",)),
-        FilterFieldAlias(basic=("created_at",)),
-        FilterFieldAlias(basic=("updated_at",)),
+        SearchField.shared("tag", "tags"),
+        SearchField.basic_only("description"),
+        SearchField.basic_only("created_at"),
+        SearchField.basic_only("updated_at"),
     ),
-    artifact_filter=(
-        FilterFieldAlias(basic=("id",), advanced=("artifact_id", "id")),
-        FilterFieldAlias(
-            basic=("version", "version_index"),
-            advanced=("version", "version_index"),
+    artifact_fields=(
+        SearchField(
+            basic=("id",),
+            advanced=("artifact_id", "id"),
         ),
-        FilterFieldAlias(basic=("tag", "tags"), advanced=("tag", "tags")),
-        FilterFieldAlias(basic=("alias", "aliases"), advanced=("alias", "aliases")),
-        FilterFieldAlias(
-            basic=("metadata", "artifact_metadata"),
-            advanced=("metadata", "artifact_metadata"),
-        ),
-        FilterFieldAlias(
+        SearchField.shared("version", "version_index"),
+        SearchField.shared("tag", "tags"),
+        SearchField.shared("alias", "aliases"),
+        SearchField.shared("metadata", "artifact_metadata"),
+        SearchField(
             basic=("created_at",),
             advanced=("artifact_created_at", "created_at"),
         ),
-        FilterFieldAlias(basic=("updated_at",)),
-        FilterFieldAlias(advanced=("acm_created_at",)),
-        FilterFieldAlias(advanced=("acm_updated_at",)),
-        FilterFieldAlias(advanced=("artifact_size",)),
-        FilterFieldAlias(advanced=("artifact_file_count",)),
+        SearchField.basic_only("updated_at"),
+        SearchField.advanced_only("acm_created_at"),
+        SearchField.advanced_only("acm_updated_at"),
+        SearchField.advanced_only("artifact_size"),
+        SearchField.advanced_only("artifact_file_count"),
     ),
 )
 
@@ -199,6 +210,29 @@ def prepare_artifact_types_input(
     return None
 
 
+def prefix_registry_name(operand: Any) -> Any:
+    """Prefix strings in a registry-name operand, except regexes and unknown ops."""
+    from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
+
+    match operand:
+        case str(txt):
+            return ensureprefix(txt, REGISTRY_PREFIX)
+        case dict(dct):
+            return {
+                k: (
+                    v
+                    if isinstance(k, str)
+                    and (k == "$regex" or (k.startswith("$") and k not in KEY_TO_OP))
+                    else prefix_registry_name(v)
+                )
+                for k, v in dct.items()
+            }
+        case list(seq) | tuple(seq):
+            return [prefix_registry_name(value) for value in seq]
+        case _:
+            return operand
+
+
 @overload
 def prepare_registry_filter(query: str) -> str: ...
 @overload
@@ -207,28 +241,6 @@ def prepare_registry_filter(query: dict[str, Any]) -> dict[str, Any]: ...
 def prepare_registry_filter(query: list[T] | tuple[T, ...]) -> list[T]: ...
 @overload
 def prepare_registry_filter(query: T) -> T: ...
-
-
-def prefix_registry_name(operand: Any) -> Any:
-    """Prefix strings in a registry-name operand, except regexes and unknown ops."""
-    from wandb.sdk.artifacts._validators import REGISTRY_PREFIX
-
-    match operand:
-        case str() as txt:
-            return ensureprefix(txt, REGISTRY_PREFIX)
-        case dict() as dct:
-            return {
-                key: (
-                    value
-                    if key == "$regex" or (key.startswith("$") and key not in KEY_TO_OP)
-                    else prefix_registry_name(value)
-                )
-                for key, value in dct.items()
-            }
-        case list() | tuple() as seq:
-            return [prefix_registry_name(value) for value in seq]
-        case _:
-            return operand
 
 
 def prepare_registry_filter(query: Any) -> Any:
@@ -241,12 +253,10 @@ def prepare_registry_filter(query: Any) -> Any:
     """
     match query:
         case dict():
-            return FilterFieldTransformer(
-                lambda field, operand: (
-                    field,
-                    prefix_registry_name(operand) if field == "name" else operand,
-                )
-            ).transform(query)
+            return transform_fields(
+                query,
+                operand_transforms={"name": prefix_registry_name},
+            )
         case list() | tuple():
             return [prepare_registry_filter(value) for value in query]
         case _:
@@ -288,7 +298,7 @@ def _project_id_from_gql_id(gql_id: str) -> int | None:
     try:
         decoded = b64decode_ascii(gql_id)
     except (ValueError, UnicodeDecodeError):
-        _logger.warning("Invalid project ID: %r", gql_id)
+        logger.warning("Invalid project ID: %r", gql_id)
         return None
 
     match decoded.split(":"):
@@ -297,7 +307,7 @@ def _project_id_from_gql_id(gql_id: str) -> int | None:
         case ["ProjectInternalId", idx] if idx.isdigit():
             return int(idx)
         case _:
-            _logger.warning("Invalid project ID: %r", gql_id)
+            logger.warning("Invalid project ID: %r", gql_id)
             return None
 
 
@@ -337,14 +347,14 @@ def advanced_search_enabled(service_api: ServiceApi, organization: str) -> bool:
             parse=FetchAdvancedRegistryFeatures.model_validate_json,
         )
     except Exception:
-        _logger.warning(
+        logger.warning(
             "Failed to fetch advanced registry features for organization: %r",
             organization,
         )
         return False
 
     if not (org := result.organization):
-        _logger.warning("Organization %r not found.", organization)
+        logger.warning("Organization %r not found.", organization)
         return False
     return bool(
         (features := org.advanced_registry_features) and features.advanced_search

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -28,13 +28,8 @@ T = TypeVar("T")
 
 @pydantic_dataclass(frozen=True, slots=True)
 class _FieldNames:
-    name: str  #: The canonical name of the field.
+    canonical: str  #: The canonical name of the field.
     aliases: tuple[str, ...] = ()  #: Accepted aliases for the field.
-
-
-class SearchMode(str, Enum):
-    BASIC = "basic"
-    ADVANCED = "advanced"
 
 
 @pydantic_dataclass(frozen=True, slots=True)
@@ -69,21 +64,22 @@ class SearchFields:
 
     fields: tuple[SearchField, ...]
 
-    def aliases(self, mode: SearchMode) -> dict[str, str]:
-        """Returns a map of (accepted alias) -> (canonical name) for one search mode."""
-        match SearchMode(mode):
-            case SearchMode.BASIC:
-                names_by_field = (f.basic for f in self.fields)
-            case SearchMode.ADVANCED:
-                names_by_field = (f.advanced for f in self.fields)
-            case _:
-                raise ValueError(f"Invalid search mode: {mode!r}")
-
+    def advanced_aliases(self) -> dict[str, str]:
+        # Be sure to include the canonical name in the map
         return {
-            alias: names.name
-            for names in names_by_field
-            if names
-            for alias in (names.name, *names.aliases)
+            alias: names.canonical
+            for field in self.fields
+            if (names := field.advanced)
+            for alias in (names.canonical, *names.aliases)
+        }
+
+    def basic_aliases(self) -> dict[str, str]:
+        # Be sure to include the canonical name in the map
+        return {
+            alias: names.canonical
+            for field in self.fields
+            if (names := field.basic)
+            for alias in (names.canonical, *names.aliases)
         }
 
 
@@ -338,16 +334,11 @@ def _project_id_from_gql_id(gql_id: str) -> int | None:
             return None
 
 
-def filter_for_registry(
-    registry: Registry,
-    *,
-    service_api: ServiceApi,
-    organization: str,
-) -> dict[str, Any]:
+def filter_for_registry(registry: Registry) -> dict[str, Any]:
     if (project_encoded_id := registry.internal_id) and (
         project_id := _project_id_from_gql_id(project_encoded_id)
     ):
-        return {registry_id_filter_key(service_api, organization): project_id}
+        return {"id": project_id}
     return {"name": registry.full_name}
 
 
@@ -388,21 +379,9 @@ def advanced_search_enabled(service_api: ServiceApi, organization: str) -> bool:
     )
 
 
-def registry_id_filter_key(service_api: ServiceApi, organization: str) -> str:
-    """Return the registry project filter key for the organization's search backend."""
-    if advanced_search_enabled(service_api, organization):
-        return "project_id"
-    return "id"
-
-
-def registry_filter_for_collection(
-    collection: ArtifactCollection,
-    *,
-    service_api: ServiceApi,
-    organization: str,
-) -> dict[str, Any]:
+def registry_filter_for_collection(collection: ArtifactCollection) -> dict[str, Any]:
     if (project_encoded_id := collection.project_internal_id) and (
         project_id := _project_id_from_gql_id(project_encoded_id)
     ):
-        return {registry_id_filter_key(service_api, organization): project_id}
+        return {"id": project_id}
     return {"name": collection.project}

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -16,8 +16,10 @@ from wandb.apis.paginator import Paginator, RelayPaginator, SizedRelayPaginator
 from wandb.errors import UnsupportedError
 
 from ._utils import (
-    ADVANCED_SEARCH_CTX_KEY,
+    COLLECTIONS_FILTER_FIELDS,
+    REGISTRIES_FILTER_FIELDS,
     VERSIONS_FILTER_FIELDS,
+    SearchMode,
     advanced_search_enabled,
     filter_for_registry,
     prepare_registry_filter,
@@ -41,27 +43,34 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
 
 
-# Type annotations for `filter` arguments that always use Basic search fields.
+# Type annotations for Basic search filters.
 _RegistryFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(
-        valid=VERSIONS_FILTER_FIELDS.aliases_for("registry_filter", advanced=False)
-    ),
+    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.aliases(mode=SearchMode.BASIC)),
     AfterValidator(prepare_registry_filter),
 ]
 _CollectionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(
-        valid=VERSIONS_FILTER_FIELDS.aliases_for("collection_filter", advanced=False)
-    ),
+    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.aliases(mode=SearchMode.BASIC)),
 ]
-_VersionFilter: TypeAlias = Annotated[
+_BasicArtifactFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(alias_resolver=VERSIONS_FILTER_FIELDS.resolve_aliases),
+    FilterValidator(valid=VERSIONS_FILTER_FIELDS.aliases(mode=SearchMode.BASIC)),
 ]
-_VersionRegistryFilter: TypeAlias = Annotated[
-    _VersionFilter,
+
+# Type annotations for advanced-search filters passed to `Versions`.
+_AdvancedRegistryFilter: TypeAlias = Annotated[
+    FilterDict,
+    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.aliases(mode=SearchMode.ADVANCED)),
     AfterValidator(prepare_registry_filter),
+]
+_AdvancedCollectionFilter: TypeAlias = Annotated[
+    FilterDict,
+    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.aliases(mode=SearchMode.ADVANCED)),
+]
+_AdvancedArtifactFilter: TypeAlias = Annotated[
+    FilterDict,
+    FilterValidator(valid=VERSIONS_FILTER_FIELDS.aliases(mode=SearchMode.ADVANCED)),
 ]
 
 # Type annotations for `order` arguments.
@@ -108,15 +117,28 @@ class _CollectionsVars(PaginatorVars):
     per_page: PositiveInt = 100
 
 
-class _VersionsVars(PaginatorVars):
-    """Validated GraphQL variables for a `Versions` paginator."""
+class _VersionsVarsBase(PaginatorVars):
+    """Validated GraphQL variables shared by `Versions` search modes."""
 
     organization: str
 
-    registry_filter: _VersionRegistryFilter | None = None
-    collection_filter: _VersionFilter | None = None
-    artifact_filter: _VersionFilter | None = None
     per_page: PositiveInt = 100
+
+
+class _BasicVersionsVars(_VersionsVarsBase):
+    """Validated GraphQL variables for Basic `Versions` search."""
+
+    registry_filter: _RegistryFilter | None = None
+    collection_filter: _CollectionFilter | None = None
+    artifact_filter: _BasicArtifactFilter | None = None
+
+
+class _AdvancedVersionsVars(_VersionsVarsBase):
+    """Validated GraphQL variables for Advanced `Versions` search."""
+
+    registry_filter: _AdvancedRegistryFilter | None = None
+    collection_filter: _AdvancedCollectionFilter | None = None
+    artifact_filter: _AdvancedArtifactFilter | None = None
 
 
 class VersionsIterator(Protocol):
@@ -502,19 +524,17 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
 
             type(self).QUERY = REGISTRY_VERSIONS_GQL
 
-        args = _VersionsVars.model_validate(
-            {
-                "organization": organization,
-                "registry_filter": registry_filter,
-                "collection_filter": collection_filter,
-                "artifact_filter": artifact_filter,
-                "per_page": per_page,
-            },
-            context={
-                ADVANCED_SEARCH_CTX_KEY: advanced_search_enabled(
-                    service_api, organization
-                )
-            },
+        vars_type = (
+            _AdvancedVersionsVars
+            if advanced_search_enabled(service_api, organization)
+            else _BasicVersionsVars
+        )
+        args = vars_type(
+            organization=organization,
+            registry_filter=registry_filter,
+            collection_filter=collection_filter,
+            artifact_filter=artifact_filter,
+            per_page=per_page,
         )
 
         self.organization = args.organization

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -10,6 +10,7 @@ from pydantic import AfterValidator, PositiveInt, ValidationError
 from typing_extensions import Never, override
 
 from wandb._analytics import tracked
+from wandb._filters import FilterValidator
 from wandb._pydantic import FilterDict, OrderValidator, PaginatorVars
 from wandb.apis.paginator import Paginator, RelayPaginator, SizedRelayPaginator
 from wandb.errors import UnsupportedError
@@ -40,10 +41,17 @@ if TYPE_CHECKING:
 # Type annotations for `filter` arguments.
 _RegistryFilter: TypeAlias = Annotated[
     FilterDict,
+    FilterValidator(valid=("name", "description", "created_at", "updated_at")),
     AfterValidator(prepare_registry_filter),
 ]
-_CollectionFilter: TypeAlias = FilterDict
-_VersionFilter: TypeAlias = FilterDict
+_CollectionFilter: TypeAlias = Annotated[
+    FilterDict,
+    FilterValidator(valid=("name", "tag", "description", "created_at", "updated_at")),
+]
+_VersionFilter: TypeAlias = Annotated[
+    FilterDict,
+    FilterValidator(valid=("tag", "alias", "created_at", "updated_at", "metadata")),
+]
 
 # Type annotations for `order` arguments.
 _RegistryOrder: TypeAlias = Annotated[

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -10,6 +10,7 @@ from pydantic import AfterValidator, PositiveInt, ValidationError
 from typing_extensions import Never, override
 
 from wandb._analytics import tracked
+from wandb._filters import FilterValidator
 from wandb._pydantic import FilterDict, OrderValidator, PaginatorVars
 from wandb.apis.paginator import Paginator, RelayPaginator, SizedRelayPaginator
 from wandb.errors import UnsupportedError
@@ -36,10 +37,17 @@ if TYPE_CHECKING:
 # Type annotations for `filter` arguments.
 _RegistryFilter: TypeAlias = Annotated[
     FilterDict,
+    FilterValidator(valid=("name", "description", "created_at", "updated_at")),
     AfterValidator(prepare_registry_filter),
 ]
-_CollectionFilter: TypeAlias = FilterDict
-_VersionFilter: TypeAlias = FilterDict
+_CollectionFilter: TypeAlias = Annotated[
+    FilterDict,
+    FilterValidator(valid=("name", "tag", "description", "created_at", "updated_at")),
+]
+_VersionFilter: TypeAlias = Annotated[
+    FilterDict,
+    FilterValidator(valid=("tag", "alias", "created_at", "updated_at", "metadata")),
+]
 
 # Type annotations for `order` arguments.
 _RegistryOrder: TypeAlias = Annotated[

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -16,6 +16,9 @@ from wandb.apis.paginator import Paginator, RelayPaginator, SizedRelayPaginator
 from wandb.errors import UnsupportedError
 
 from ._utils import (
+    ADVANCED_SEARCH_CTX_KEY,
+    VERSIONS_FILTER_FIELDS,
+    advanced_search_enabled,
     filter_for_registry,
     prepare_registry_filter,
     registry_filter_for_collection,
@@ -38,19 +41,30 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
 
 
-# Type annotations for `filter` arguments.
+# Type annotations for `filter` arguments that always use the basic policy.
+_BASIC_REGISTRY_FILTER_ALIASES = VERSIONS_FILTER_FIELDS.for_filter(
+    "registry_filter", advanced=False
+)
+_BASIC_COLLECTION_FILTER_ALIASES = VERSIONS_FILTER_FIELDS.for_filter(
+    "collection_filter", advanced=False
+)
+
 _RegistryFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=("name", "description", "created_at", "updated_at")),
+    FilterValidator(valid=_BASIC_REGISTRY_FILTER_ALIASES),
     AfterValidator(prepare_registry_filter),
 ]
 _CollectionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=("name", "tag", "description", "created_at", "updated_at")),
+    FilterValidator(valid=_BASIC_COLLECTION_FILTER_ALIASES),
 ]
 _VersionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=("tag", "alias", "created_at", "updated_at", "metadata")),
+    FilterValidator(resolve=VERSIONS_FILTER_FIELDS.resolve),
+]
+_VersionRegistryFilter: TypeAlias = Annotated[
+    _VersionFilter,
+    AfterValidator(prepare_registry_filter),
 ]
 
 # Type annotations for `order` arguments.
@@ -102,8 +116,8 @@ class _VersionsVars(PaginatorVars):
 
     organization: str
 
-    registry_filter: _RegistryFilter | None = None
-    collection_filter: _CollectionFilter | None = None
+    registry_filter: _VersionRegistryFilter | None = None
+    collection_filter: _VersionFilter | None = None
     artifact_filter: _VersionFilter | None = None
     per_page: PositiveInt = 100
 
@@ -242,7 +256,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
     @tracked
     def versions(
         self,
-        filter: _VersionFilter | None = None,
+        filter: FilterDict | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> VersionsIterator:
@@ -381,7 +395,7 @@ class Collections(
     @tracked
     def versions(
         self,
-        filter: _VersionFilter | None = None,
+        filter: FilterDict | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ) -> VersionsIterator:
@@ -480,9 +494,9 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
         self,
         service_api: ServiceApi,
         organization: str,
-        registry_filter: _RegistryFilter | None = None,
-        collection_filter: _CollectionFilter | None = None,
-        artifact_filter: _VersionFilter | None = None,
+        registry_filter: FilterDict | None = None,
+        collection_filter: FilterDict | None = None,
+        artifact_filter: FilterDict | None = None,
         per_page: PositiveInt = 100,
         start: str | None = None,
     ):
@@ -491,12 +505,19 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
 
             type(self).QUERY = REGISTRY_VERSIONS_GQL
 
-        args = _VersionsVars(
-            organization=organization,
-            registry_filter=registry_filter,
-            collection_filter=collection_filter,
-            artifact_filter=artifact_filter,
-            per_page=per_page,
+        args = _VersionsVars.model_validate(
+            {
+                "organization": organization,
+                "registry_filter": registry_filter,
+                "collection_filter": collection_filter,
+                "artifact_filter": artifact_filter,
+                "per_page": per_page,
+            },
+            context={
+                ADVANCED_SEARCH_CTX_KEY: advanced_search_enabled(
+                    service_api, organization
+                )
+            },
         )
 
         self.organization = args.organization

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -41,26 +41,23 @@ if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
 
 
-# Type annotations for `filter` arguments that always use the basic policy.
-_BASIC_REGISTRY_FILTER_ALIASES = VERSIONS_FILTER_FIELDS.for_filter(
-    "registry_filter", advanced=False
-)
-_BASIC_COLLECTION_FILTER_ALIASES = VERSIONS_FILTER_FIELDS.for_filter(
-    "collection_filter", advanced=False
-)
-
+# Type annotations for `filter` arguments that always use Basic search fields.
 _RegistryFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=_BASIC_REGISTRY_FILTER_ALIASES),
+    FilterValidator(
+        valid=VERSIONS_FILTER_FIELDS.aliases_for("registry_filter", advanced=False)
+    ),
     AfterValidator(prepare_registry_filter),
 ]
 _CollectionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=_BASIC_COLLECTION_FILTER_ALIASES),
+    FilterValidator(
+        valid=VERSIONS_FILTER_FIELDS.aliases_for("collection_filter", advanced=False)
+    ),
 ]
 _VersionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(resolve=VERSIONS_FILTER_FIELDS.resolve),
+    FilterValidator(alias_resolver=VERSIONS_FILTER_FIELDS.resolve_aliases),
 ]
 _VersionRegistryFilter: TypeAlias = Annotated[
     _VersionFilter,

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 from itertools import chain
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Protocol, TypeAlias, TypeVar
 
-from pydantic import AfterValidator, PositiveInt, ValidationError
+from pydantic import PositiveInt, ValidationError
 from typing_extensions import Never, override
 
 from wandb._analytics import tracked
@@ -16,13 +16,15 @@ from wandb.apis.paginator import Paginator, RelayPaginator, SizedRelayPaginator
 from wandb.errors import UnsupportedError
 
 from ._utils import (
-    COLLECTIONS_FILTER_FIELDS,
-    REGISTRIES_FILTER_FIELDS,
-    VERSIONS_FILTER_FIELDS,
+    ADVANCED_COLLECTIONS_FILTER_ALIASES,
+    ADVANCED_REGISTRIES_FILTER_ALIASES,
+    ADVANCED_VERSIONS_FILTER_ALIASES,
+    BASIC_COLLECTIONS_FILTER_ALIASES,
+    BASIC_REGISTRIES_FILTER_ALIASES,
+    BASIC_VERSIONS_FILTER_ALIASES,
     advanced_search_enabled,
-    filter_for_registry,
-    prepare_registry_filter,
-    registry_filter_for_collection,
+    prefix_registry_name,
+    registry_filter_for,
 )
 
 if TYPE_CHECKING:
@@ -43,33 +45,41 @@ if TYPE_CHECKING:
 
 
 # Type annotations for Basic search filters.
-_RegistryFilter: TypeAlias = Annotated[
+_BasicRegistryFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.basic_aliases()),
-    AfterValidator(prepare_registry_filter),
+    FilterValidator(
+        valid=BASIC_REGISTRIES_FILTER_ALIASES,
+        transforms={"name": prefix_registry_name},
+    ),
 ]
-_CollectionFilter: TypeAlias = Annotated[
+_BasicCollectionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.basic_aliases()),
+    FilterValidator(valid=BASIC_COLLECTIONS_FILTER_ALIASES),
 ]
-_BasicArtifactFilter: TypeAlias = Annotated[
+_BasicVersionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=VERSIONS_FILTER_FIELDS.basic_aliases()),
+    FilterValidator(valid=BASIC_VERSIONS_FILTER_ALIASES),
 ]
+
+# Shorter names for filters that always use Basic search.
+_RegistryFilter: TypeAlias = _BasicRegistryFilter
+_CollectionFilter: TypeAlias = _BasicCollectionFilter
 
 # Type annotations for advanced-search filters passed to `Versions`.
 _AdvancedRegistryFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.advanced_aliases()),
-    AfterValidator(prepare_registry_filter),
+    FilterValidator(
+        valid=ADVANCED_REGISTRIES_FILTER_ALIASES,
+        transforms={"name": prefix_registry_name},
+    ),
 ]
 _AdvancedCollectionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.advanced_aliases()),
+    FilterValidator(valid=ADVANCED_COLLECTIONS_FILTER_ALIASES),
 ]
-_AdvancedArtifactFilter: TypeAlias = Annotated[
+_AdvancedVersionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=VERSIONS_FILTER_FIELDS.advanced_aliases()),
+    FilterValidator(valid=ADVANCED_VERSIONS_FILTER_ALIASES),
 ]
 
 # Type annotations for `order` arguments.
@@ -116,28 +126,26 @@ class _CollectionsVars(PaginatorVars):
     per_page: PositiveInt = 100
 
 
-class _VersionsVarsBase(PaginatorVars):
-    """Validated GraphQL variables shared by `Versions` search modes."""
-
-    organization: str
-
-    per_page: PositiveInt = 100
-
-
-class _BasicVersionsVars(_VersionsVarsBase):
+class _BasicVersionsVars(PaginatorVars):
     """Validated GraphQL variables for Basic `Versions` search."""
 
-    registry_filter: _RegistryFilter | None = None
-    collection_filter: _CollectionFilter | None = None
-    artifact_filter: _BasicArtifactFilter | None = None
+    organization: str
+    per_page: PositiveInt = 100
+
+    registry_filter: _BasicRegistryFilter | None = None
+    collection_filter: _BasicCollectionFilter | None = None
+    artifact_filter: _BasicVersionFilter | None = None
 
 
-class _AdvancedVersionsVars(_VersionsVarsBase):
+class _AdvancedVersionsVars(PaginatorVars):
     """Validated GraphQL variables for Advanced `Versions` search."""
+
+    organization: str
+    per_page: PositiveInt = 100
 
     registry_filter: _AdvancedRegistryFilter | None = None
     collection_filter: _AdvancedCollectionFilter | None = None
-    artifact_filter: _AdvancedArtifactFilter | None = None
+    artifact_filter: _AdvancedVersionFilter | None = None
 
 
 class VersionsIterator(Protocol):
@@ -249,7 +257,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
                     Collections(
                         service_api=self._service_api,
                         organization=self.organization,
-                        registry_filter=filter_for_registry(reg),
+                        registry_filter=registry_filter_for(reg),
                         collection_filter=filter,
                         order=order,
                         per_page=per_page,
@@ -297,7 +305,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
                 Versions(
                     service_api=self._service_api,
                     organization=self.organization,
-                    registry_filter=filter_for_registry(reg),
+                    registry_filter=registry_filter_for(reg),
                     artifact_filter=filter,
                     per_page=per_page,
                 )
@@ -434,7 +442,7 @@ class Collections(
                     organization=self.organization,
                     artifact_filter=filter,
                     per_page=per_page,
-                    registry_filter=registry_filter_for_collection(coll),
+                    registry_filter=registry_filter_for(coll),
                     collection_filter={"name": coll.name} if coll.name else {},
                 )
                 for coll in self
@@ -511,12 +519,12 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
 
             type(self).QUERY = REGISTRY_VERSIONS_GQL
 
-        vars_type = (
+        args_cls = (
             _AdvancedVersionsVars
             if advanced_search_enabled(service_api, organization)
             else _BasicVersionsVars
         )
-        args = vars_type(
+        args = args_cls(
             organization=organization,
             registry_filter=registry_filter,
             collection_filter=collection_filter,
@@ -656,7 +664,7 @@ class _OrderedCollections(_ChainedPaginators["ArtifactCollection"]):
             Versions(
                 service_api=self._service_api,
                 organization=self.organization,
-                registry_filter=registry_filter_for_collection(col),
+                registry_filter=registry_filter_for(col),
                 collection_filter={"name": col.name} if col.name else {},
                 artifact_filter=filter,
                 per_page=per_page,

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -19,7 +19,6 @@ from ._utils import (
     COLLECTIONS_FILTER_FIELDS,
     REGISTRIES_FILTER_FIELDS,
     VERSIONS_FILTER_FIELDS,
-    SearchMode,
     advanced_search_enabled,
     filter_for_registry,
     prepare_registry_filter,
@@ -46,31 +45,31 @@ if TYPE_CHECKING:
 # Type annotations for Basic search filters.
 _RegistryFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.aliases(mode=SearchMode.BASIC)),
+    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.basic_aliases()),
     AfterValidator(prepare_registry_filter),
 ]
 _CollectionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.aliases(mode=SearchMode.BASIC)),
+    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.basic_aliases()),
 ]
 _BasicArtifactFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=VERSIONS_FILTER_FIELDS.aliases(mode=SearchMode.BASIC)),
+    FilterValidator(valid=VERSIONS_FILTER_FIELDS.basic_aliases()),
 ]
 
 # Type annotations for advanced-search filters passed to `Versions`.
 _AdvancedRegistryFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.aliases(mode=SearchMode.ADVANCED)),
+    FilterValidator(valid=REGISTRIES_FILTER_FIELDS.advanced_aliases()),
     AfterValidator(prepare_registry_filter),
 ]
 _AdvancedCollectionFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.aliases(mode=SearchMode.ADVANCED)),
+    FilterValidator(valid=COLLECTIONS_FILTER_FIELDS.advanced_aliases()),
 ]
 _AdvancedArtifactFilter: TypeAlias = Annotated[
     FilterDict,
-    FilterValidator(valid=VERSIONS_FILTER_FIELDS.aliases(mode=SearchMode.ADVANCED)),
+    FilterValidator(valid=VERSIONS_FILTER_FIELDS.advanced_aliases()),
 ]
 
 # Type annotations for `order` arguments.
@@ -250,11 +249,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
                     Collections(
                         service_api=self._service_api,
                         organization=self.organization,
-                        registry_filter=filter_for_registry(
-                            reg,
-                            service_api=self._service_api,
-                            organization=self.organization,
-                        ),
+                        registry_filter=filter_for_registry(reg),
                         collection_filter=filter,
                         order=order,
                         per_page=per_page,
@@ -302,11 +297,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
                 Versions(
                     service_api=self._service_api,
                     organization=self.organization,
-                    registry_filter=filter_for_registry(
-                        reg,
-                        service_api=self._service_api,
-                        organization=self.organization,
-                    ),
+                    registry_filter=filter_for_registry(reg),
                     artifact_filter=filter,
                     per_page=per_page,
                 )
@@ -443,11 +434,7 @@ class Collections(
                     organization=self.organization,
                     artifact_filter=filter,
                     per_page=per_page,
-                    registry_filter=registry_filter_for_collection(
-                        coll,
-                        service_api=self._service_api,
-                        organization=self.organization,
-                    ),
+                    registry_filter=registry_filter_for_collection(coll),
                     collection_filter={"name": coll.name} if coll.name else {},
                 )
                 for coll in self
@@ -669,11 +656,7 @@ class _OrderedCollections(_ChainedPaginators["ArtifactCollection"]):
             Versions(
                 service_api=self._service_api,
                 organization=self.organization,
-                registry_filter=registry_filter_for_collection(
-                    col,
-                    service_api=self._service_api,
-                    organization=self.organization,
-                ),
+                registry_filter=registry_filter_for_collection(col),
                 collection_filter={"name": col.name} if col.name else {},
                 artifact_filter=filter,
                 per_page=per_page,

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -224,9 +224,7 @@ class Registry:
         return Collections(
             service_api=self._service_api,
             organization=self.organization,
-            registry_filter=filter_for_registry(
-                self, service_api=self._service_api, organization=self.organization
-            ),
+            registry_filter=filter_for_registry(self),
             collection_filter=filter,
             order=order,
             per_page=per_page,
@@ -252,9 +250,7 @@ class Registry:
         return Versions(
             service_api=self._service_api,
             organization=self.organization,
-            registry_filter=filter_for_registry(
-                self, service_api=self._service_api, organization=self.organization
-            ),
+            registry_filter=filter_for_registry(self),
             collection_filter=None,
             artifact_filter=filter,
             per_page=per_page,

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -22,12 +22,7 @@ from ._members import (
     UserMember,
     parse_member_ids,
 )
-from ._utils import (
-    Visibility,
-    fetch_org_entity_from_organization,
-    filter_for_registry,
-    prepare_artifact_types_input,
-)
+from ._utils import Visibility, prepare_artifact_types_input, registry_filter_for
 from .registries_search import Collections, Versions
 
 if TYPE_CHECKING:
@@ -224,7 +219,7 @@ class Registry:
         return Collections(
             service_api=self._service_api,
             organization=self.organization,
-            registry_filter=filter_for_registry(self),
+            registry_filter=registry_filter_for(self),
             collection_filter=filter,
             order=order,
             per_page=per_page,
@@ -250,7 +245,7 @@ class Registry:
         return Versions(
             service_api=self._service_api,
             organization=self.organization,
-            registry_filter=filter_for_registry(self),
+            registry_filter=registry_filter_for(self),
             collection_filter=None,
             artifact_filter=filter,
             per_page=per_page,
@@ -302,9 +297,7 @@ class Registry:
             f"Failed to create registry {name!r} in organization {organization!r}."
         )
 
-        # TODO: Avoid reaching into Api internals once registry creation has a
-        # dedicated wandb-core API request.
-        org_entity = fetch_org_entity_from_organization(api._service_api, organization)
+        org_entity = api.organization(organization).org_entity.name
         gql_input = UpsertModelInput(
             description=description,
             entity_name=org_entity,


### PR DESCRIPTION
*This description was AI-generated, then reviewed and revised by the author.*

Description
-----------

- [WB-37926](https://coreweave.atlassian.net/browse/WB-37926)

PR adds allowed field validation for registry search paginator `filter` arguments so invalid field names fail at construction time with a clear error.

- Introduces reusable `FilterValidator` in `wandb/_filters` on top of the generic filter helpers from #12181, plus `parse_filter` and `iter_fields` to walk MongoDB filter dicts, including nested `$and`, `$or`, `$nor`, and `$not` predicates. Dotted paths like `metadata.foo` are checked against the root field name.
- Wires validators into registry, collection, and version search paginators with allowlists for each entity (`name`, `description`, `created_at`, `updated_at`, plus `tag`, `alias`, and `metadata` where applicable).
- Operator names are not allowlisted here. Unknown field operators and an unknown operator used as the sole top-level predicate are left unchanged; an unknown root operator mixed with other predicates is rejected.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

Added `tests/unit_tests/test_filters/test_validation.py` covering valid filters (implicit and explicit operators, dotted and nested subdocs, logical predicates, empty dict) and rejection of disallowed fields at the root and inside nested predicates. Also expanded `tests/unit_tests/test_registries/test_utils.py` to cover registry filter preparation when constructing a `Registries` paginator.


[WB-37926]: https://coreweave.atlassian.net/browse/WB-37926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
