### PR TITLE
chore: improve wandb beta sync skipped messages

### DIFF
--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -191,7 +191,7 @@ def test_syncs_run(
     result = runner.invoke(cli.beta, f"sync {run.settings.sync_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Syncing 1 run(s) (0 skipped):"
+    assert lines[0] == "wandb: Syncing 1 run(s):"
     assert lines[1].endswith(f"run-{run.id}.wandb")
     # More lines possible depending on status updates. Not deterministic.
     assert lines[-1].startswith(f"wandb: [{run.path}] Finished syncing")
@@ -240,7 +240,7 @@ def test_sync_defaults_to_wandb_dir(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, "sync", input="n")
 
     assert result.output.splitlines() == [
-        "wandb: Syncing 5 run(s) (0 skipped):",
+        "wandb: Syncing 5 run(s):",
         f"wandb:   {paths[0]}",
         f"wandb:   {paths[1]}",
         f"wandb:   {paths[2]}",
@@ -354,10 +354,11 @@ def test_skip_synced(
     assert "run-3.wandb" in result.output
 
     if skip_synced:
-        assert "Would sync 2 run(s) (1 skipped)" in result.output
+        assert "Skipped 1 synced run(s)." in result.output
+        assert "Would sync 2 run(s)" in result.output
         assert "run-2.wandb" not in result.output
     else:
-        assert "Would sync 3 run(s) (0 skipped)" in result.output
+        assert "Would sync 3 run(s)" in result.output
         assert "run-2.wandb" in result.output
 
 
@@ -382,10 +383,11 @@ def test_skip_online(
     assert "run-def.wandb" in result.output
 
     if skip_online:
-        assert "Would sync 2 run(s) (1 skipped)" in result.output
+        assert "Skipped 1 online run(s)." in result.output
+        assert "Would sync 2 run(s)" in result.output
         assert "run-xyz.wandb" not in result.output
     else:
-        assert "Would sync 3 run(s) (0 skipped)" in result.output
+        assert "Would sync 3 run(s)" in result.output
         assert "run-xyz.wandb" in result.output
 
 
@@ -402,7 +404,7 @@ def test_merges_symlinks(
     result = runner.invoke(cli.beta, "sync --dry-run .")
 
     assert result.output.splitlines() == [
-        "wandb: Would sync 1 run(s) (0 skipped):",
+        "wandb: Would sync 1 run(s):",
         "wandb:   latest-run/run.wandb",
     ]
 
@@ -415,7 +417,7 @@ def test_sync_wandb_file(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {file}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 1 run(s) (0 skipped):"
+    assert lines[0] == "wandb: Would sync 1 run(s):"
     assert lines[1].endswith("run-abc.wandb")
 
 
@@ -427,7 +429,7 @@ def test_sync_run_directory(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {run_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 1 run(s) (0 skipped):"
+    assert lines[0] == "wandb: Would sync 1 run(s):"
     assert lines[1].endswith("run.wandb")
 
 
@@ -445,7 +447,7 @@ def test_sync_wandb_directory(tmp_path: pathlib.Path, runner: CliRunner):
     result = runner.invoke(cli.beta, f"sync --dry-run {wandb_dir}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 2 run(s) (0 skipped):"
+    assert lines[0] == "wandb: Would sync 2 run(s):"
     assert lines[1].endswith("run-1.wandb")
     assert lines[2].endswith("run-2.wandb")
 
@@ -464,7 +466,7 @@ def test_truncates_printed_paths(
     result = runner.invoke(cli.beta, f"sync --dry-run {tmp_path}")
 
     lines = result.output.splitlines()
-    assert lines[0] == "wandb: Would sync 20 run(s) (0 skipped):"
+    assert lines[0] == "wandb: Would sync 20 run(s):"
     for line in lines[1:6]:
         assert re.fullmatch(r"wandb:   .+/offline-run-\d+/run\.wandb", line)
     assert lines[6] == "wandb:   +15 more (pass --verbose to see all)"
@@ -491,7 +493,7 @@ def test_prints_relative_paths(
     result = runner.invoke(cli.beta, f"sync --dry-run {dir1_cwd} {dir2_not}")
 
     assert result.output.splitlines() == [
-        "wandb: Would sync 2 run(s) (0 skipped):",
+        "wandb: Would sync 2 run(s):",
         *sorted(
             [
                 "wandb:   offline-run-1/run-relative.wandb",

--- a/wandb/cli/beta_sync.py
+++ b/wandb/cli/beta_sync.py
@@ -73,24 +73,23 @@ def sync(
         paths = [pathlib.Path(singleton.settings.wandb_dir)]
         ask_for_confirmation = not skip_confirmation
 
-    wandb_files, skipped = _find_wandb_files(
+    wandb_files = _find_wandb_files(
         paths,
         skip_synced=skip_synced,
         skip_online=skip_online,
         verbose=verbose,
     )
-    skipped_str = f"({skipped} skipped)"
 
     if not wandb_files:
-        term.termlog(f"No runs to sync {skipped_str}.")
+        term.termlog("No runs to sync.")
         return
 
     if dry_run:
-        term.termlog(f"Would sync {len(wandb_files)} run(s) {skipped_str}:")
+        term.termlog(f"Would sync {len(wandb_files)} run(s):")
         _print_sorted_paths(wandb_files, verbose=verbose, root=cwd)
         return
 
-    term.termlog(f"Syncing {len(wandb_files)} run(s) {skipped_str}:")
+    term.termlog(f"Syncing {len(wandb_files)} run(s):")
     _print_sorted_paths(wandb_files, verbose=verbose, root=cwd)
 
     if ask_for_confirmation and not term.confirm("Sync the listed runs?"):
@@ -246,11 +245,13 @@ def _find_wandb_files(
     skip_synced: bool,
     skip_online: bool,
     verbose: bool,
-) -> tuple[set[pathlib.Path], int]:
+) -> set[pathlib.Path]:
     """Finds all unique .wandb files selected by the paths.
 
+    Prints whether any files were skipped.
+
     Returns:
-        The .wandb files to sync and the number of files that were filtered out.
+        The .wandb files to sync.
     """
     unique_files = _to_unique_files(
         [file for path in paths for file in _expand_wandb_files(path)],
@@ -258,19 +259,31 @@ def _find_wandb_files(
     )
 
     filtered_files: set[pathlib.Path] = set()
-    skipped = 0
+    skipped_synced = 0
+    skipped_online = 0
 
     for file in unique_files:
         if skip_synced and _is_synced(file):
-            skipped += 1
+            skipped_synced += 1
             continue
         if skip_online and _is_online(file):
-            skipped += 1
+            skipped_online += 1
             continue
 
         filtered_files.add(file)
 
-    return filtered_files, skipped
+    if skipped_synced:
+        term.termlog(
+            f"Skipped {skipped_synced} synced run(s)."
+            + " Include with --no-skip-synced.",
+        )
+    if skipped_online:
+        term.termlog(
+            f"Skipped {skipped_online} online run(s)."
+            + " Include with --no-skip-online.",
+        )
+
+    return filtered_files
 
 
 def _to_unique_files(

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -615,6 +615,7 @@ def init(ctx, project, entity, reset, mode):
 )
 @click.option(
     "--include-online/--no-include-online",
+    "--no-skip-online/--skip-online",
     is_flag=True,
     default=None,
     help="Include runs created in online mode.",
@@ -627,6 +628,7 @@ def init(ctx, project, entity, reset, mode):
 )
 @click.option(
     "--include-synced/--no-include-synced",
+    "--no-skip-synced/--skip-synced",
     is_flag=True,
     default=None,
     help="Include runs that are already synced.",


### PR DESCRIPTION
Instead of printing:

```
❯ wandb sync wandb/offline-run-20260701_154717-2th5svsr
wandb: Using wandb beta sync. Turn this off with --legacy.
wandb: No runs to sync (1 skipped).
```

Print:

```
❯ wandb sync wandb/offline-run-20260701_154717-2th5svsr
wandb: Using wandb beta sync. Turn this off with --legacy.
wandb: Skipped 1 synced run(s). Include with --no-skip-synced.
wandb: No runs to sync.
```

Added the `--no-skip-synced` and `--no-skip-online` aliases to the legacy `--include-synced` and `--include-online` options so that the printed message is valid both for `wandb sync` and `wandb beta sync`.