### PR TITLE
feat(automations): query entity-scoped automations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Added support for gzip compression of filestream requests, reducing network traffic when logging metrics. It is currently opt-in and requires server support: set `x_file_stream_no_gzip=False` in `wandb.Settings` to enable it. Compression will become the default in a future release (@dmitryduev in https://github.com/wandb/wandb/pull/12262)
 - Added a `--term-timeout` flag to `wandb agent` (@nathancy-wandb in https://github.com/wandb/wandb/pull/12246)
 - Added `run.sync_dir` (@timoffex in https://github.com/wandb/wandb/pull/12319)
+- The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
 
 ## Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Added
+
+- The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
+
 ### Changed
 
 - `Api.{create,update}_automation()` now raise `UnsupportedError` instead of `CommError` when the server doesn't support the given automation (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12194)

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -38,6 +38,7 @@ from wandb.automations._generated import (
 )
 from wandb.automations._inputs import INVALID_INPUT_ACTIONS, INVALID_INPUT_EVENTS
 from wandb.automations.events import InputEvent
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 if TYPE_CHECKING:
     from tests.system_tests.backend_fixtures import (
@@ -101,6 +102,32 @@ def org(
 ) -> Organization:
     """A wandb Organization for tests in this module."""
     return make_module_api().organization(team_and_org.org)
+
+
+@fixture(scope="module")
+def entity_scope_enabled(
+    team_and_org: TeamAndOrgNames,
+    make_module_api: Callable[[], wandb.Api],
+) -> bool:
+    """Whether entity-scoped automations are enabled for the test org.
+
+    Two independent checks gate this feature, and both must pass:
+
+    - The `AUTOMATION_SCOPE_ENTITY` ServerFeature says whether the *server*
+      version supports entity scopes at all.
+    - The `automation_entity_scope` flag in `organization.featureFlags` (this
+      check) says whether the feature is switched on for a specific *org*.
+      If the flag is absent, it's off.
+    """
+    try:
+        flags = make_module_api()._service_api.org_feature_flags(
+            team_and_org.org,
+            "automation_entity_scope",
+        )
+    except WandbApiFailedError:
+        # On older servers that don't expose this query, the feature is off.
+        return False
+    return flags.get("automation_entity_scope") or False
 
 
 @fixture(scope="module")
@@ -189,8 +216,7 @@ def webhook(
 # ---------------------------------------------------------------------------
 # Exclude deprecated events/actions that will not be exposed in the API for programmatic creation
 def valid_input_scopes() -> list[ScopeType]:
-    # return sorted(ScopeType)  # TODO: restore once ENTITY scope is supported
-    return sorted(set(ScopeType) - {ScopeType.ENTITY})
+    return sorted(ScopeType)
 
 
 def valid_input_events() -> list[EventType]:
@@ -211,6 +237,7 @@ def valid_input_actions() -> list[ActionType]:
 @lru_cache
 def invalid_events_and_scopes() -> set[tuple[EventType, ScopeType]]:
     return {
+        (EventType.CREATE_ARTIFACT, ScopeType.ENTITY),
         (EventType.CREATE_ARTIFACT, ScopeType.PROJECT),
         (EventType.RUN_METRIC_THRESHOLD, ScopeType.ARTIFACT_COLLECTION),
         (EventType.RUN_METRIC_CHANGE, ScopeType.ARTIFACT_COLLECTION),
@@ -248,6 +275,12 @@ def scope_type(request: FixtureRequest, module_api: wandb.Api) -> ScopeType:
     """A fixture that parametrizes over all valid scope types."""
     if not scope_enabled(module_api._service_api, scope_type := request.param):
         skip(f"Server does not support scope type: {scope_type!r}")
+
+    # ENTITY scope is additionally gated per-organization on the backend.
+    if scope_type is ScopeType.ENTITY and not request.getfixturevalue(
+        entity_scope_enabled.__name__
+    ):
+        skip("Entity-scoped automations are not enabled for the test organization")
 
     return scope_type
 

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -43,9 +43,13 @@ from wandb.automations._utils import (
     scope_enabled,
 )
 from wandb.automations.events import InputEvent
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 if TYPE_CHECKING:
-    from tests.system_tests.backend_fixtures import BackendFixtureFactory
+    from tests.system_tests.backend_fixtures import (
+        BackendFixtureFactory,
+        TeamAndOrgNames,
+    )
 
 ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
 
@@ -71,8 +75,57 @@ def make_name(worker_id: str) -> Callable[[str], str]:
 
 
 @fixture(scope="module")
-def project(
+def team_and_org(
     module_user: str,
+    backend_fixture_factory: BackendFixtureFactory,
+) -> TeamAndOrgNames:
+    """A test team (entity) and org.
+
+    The module user is a bare user with no organization, so it can't itself be an
+    entity scope: entity-scoped automations require an org-associated entity. We
+    therefore create a real org+team for the user and scope to the team entity.
+    """
+    return backend_fixture_factory.make_team(username=module_user)
+
+
+@fixture(scope="module")
+def team(
+    team_and_org: TeamAndOrgNames,
+    make_module_api: Callable[[], wandb.Api],
+) -> Team:
+    """A wandb Team entity for tests in this module."""
+    team = make_module_api().team(team_and_org.team)
+    # This fixture is module-scoped; load attrs before per-test teardown invalidates the API.
+    _ = team.id
+    return team
+
+
+@fixture(scope="module")
+def entity_scope_enabled(
+    team_and_org: TeamAndOrgNames,
+    make_module_api: Callable[[], wandb.Api],
+) -> bool:
+    """Whether entity-scoped automations are enabled for the test org.
+
+    Two independent checks gate this feature, and both must pass:
+
+    - The `AUTOMATION_SCOPE_ENTITY` ServerFeature says whether the *server*
+      version supports entity scopes at all.
+    - The `automation_entity_scope` flag in `organization.featureFlags` (this
+      check) says whether the feature is switched on for a specific *org*.
+      If the flag is absent, it's off.
+    """
+    try:
+        flags = make_module_api()._service_api.org_feature_flags(team_and_org.org)
+    except WandbApiFailedError:
+        # On older servers that don't expose this query, the feature is off.
+        return False
+    return flags.get("automation_entity_scope") or False
+
+
+@fixture(scope="module")
+def project(
+    team: Team,
     make_module_api: Callable[[], wandb.Api],
     make_name,
 ) -> Project:
@@ -80,17 +133,17 @@ def project(
     # Create the project first if it doesn't exist yet
     name = make_name("test-project")
     api = make_module_api()
-    api.create_project(name=name, entity=module_user)
-    project = api.project(name=name, entity=module_user)
+    api.create_project(name=name, entity=team.name)
+    project = api.project(name=name, entity=team.name)
     # This fixture is module-scoped; load attrs before per-test teardown invalidates the API.
     _ = project.id
     return project
 
 
 @fixture(scope="module")
-def artifact(module_user: str, project: Project, make_name) -> Artifact:
+def artifact(team: Team, project: Project, make_name) -> Artifact:
     name = make_name("test-artifact")
-    with wandb.init(entity=module_user, project=project.name) as run:
+    with wandb.init(entity=team.name, project=project.name) as run:
         artifact = Artifact(name, "dataset")
         logged_artifact = run.log_artifact(artifact)
         return logged_artifact.wait()
@@ -104,23 +157,9 @@ def artifact_collection(
     """A test ArtifactCollection for tests in this module."""
     return (
         make_module_api()
-        .artifact(
-            name=artifact.qualified_name,
-            type=artifact.type,
-        )
+        .artifact(name=artifact.qualified_name, type=artifact.type)
         .collection
     )
-
-
-@fixture(scope="module")
-def team(
-    backend_fixture_factory: BackendFixtureFactory,
-    module_user: str,
-    make_module_api: Callable[[], wandb.Api],
-) -> Team:
-    """A test team entity for tests in this module."""
-    name = backend_fixture_factory.make_team(username=module_user).team
-    return make_module_api().team(name)
 
 
 @fixture(scope="module")
@@ -170,8 +209,7 @@ def webhook(
 # ---------------------------------------------------------------------------
 # Exclude deprecated events/actions that will not be exposed in the API for programmatic creation
 def valid_input_scopes() -> list[ScopeType]:
-    # return sorted(ScopeType)  # TODO: restore once ENTITY scope is supported
-    return sorted(set(ScopeType) - {ScopeType.ENTITY})
+    return sorted(ScopeType)
 
 
 def valid_input_events() -> list[EventType]:
@@ -192,6 +230,7 @@ def valid_input_actions() -> list[ActionType]:
 @lru_cache
 def invalid_events_and_scopes() -> set[tuple[EventType, ScopeType]]:
     return {
+        (EventType.CREATE_ARTIFACT, ScopeType.ENTITY),
         (EventType.CREATE_ARTIFACT, ScopeType.PROJECT),
         (EventType.RUN_METRIC_THRESHOLD, ScopeType.ARTIFACT_COLLECTION),
         (EventType.RUN_METRIC_CHANGE, ScopeType.ARTIFACT_COLLECTION),
@@ -229,6 +268,12 @@ def scope_type(request: FixtureRequest, module_api: wandb.Api) -> ScopeType:
     """A fixture that parametrizes over all valid scope types."""
     if not scope_enabled(module_api._service_api, scope_type := request.param):
         skip(f"Server does not support scope type: {scope_type!r}")
+
+    # ENTITY scope is additionally gated per-organization on the backend.
+    if scope_type is ScopeType.ENTITY and not request.getfixturevalue(
+        entity_scope_enabled.__name__
+    ):
+        skip("Entity-scoped automations are not enabled for the test organization")
 
     return scope_type
 

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -4,7 +4,7 @@ import math
 from collections import deque
 from collections.abc import Callable, Generator
 from itertools import islice
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import wandb
 from pytest import FixtureRequest, fixture, mark, raises, skip
@@ -36,6 +36,9 @@ from wandb.automations.actions import InputAction, SavedNoOpAction, SavedWebhook
 from wandb.automations.events import InputEvent, RunMetricFilter, RunStateFilter
 from wandb.errors.errors import CommError, UnsupportedError
 
+if TYPE_CHECKING:
+    from wandb.apis.public import Team
+
 
 @fixture
 def automation_name(make_name: Callable[[str], str]) -> str:
@@ -43,10 +46,11 @@ def automation_name(make_name: Callable[[str], str]) -> str:
 
 
 @fixture
-def reset_automations(module_api: wandb.Api):
+def reset_automations(module_api: wandb.Api, team: Team):
     """Request this fixture to clear any existing automations before a test."""
+    # All automations in this module are scoped in or under the team entity.
     # There has to be a better way to do this
-    for automation in module_api.automations():
+    for automation in module_api.automations(entity=team.name):
         module_api.delete_automation(automation)
     yield
 
@@ -121,8 +125,10 @@ def test_fetch_slack_integrations(
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_automation(
-    module_user: str,
     module_api: wandb.Api,
+    team: Team,
+    scope,
+    scope_type: ScopeType,
     event,
     action,
     automation_name: str,
@@ -131,22 +137,28 @@ def test_create_automation(
         (event >> action), name=automation_name, description="test description"
     )
 
-    # We should be able to fetch the automation by name (optionally filtering by entity)
     assert created.name == automation_name
 
-    fetched_a = module_api.automation(
-        entity=module_user,
-        name=created.name,
-    )
-    fetched_b = module_api.automation(name=created.name)
+    # The saved scope should identify the object the automation was scoped to.
+    assert created.scope.scope_type is scope_type
+    assert created.scope.id == scope.id
+    assert created.scope.name == scope.name
 
+    # We should be able to fetch the automation by name (optionally filtering by entity)
+    fetched_a = module_api.automation(entity=team.name, name=created.name)
     assert fetched_a == created
-    assert fetched_b == created
+
+    if scope_type is not ScopeType.ENTITY:
+        # Fetching without an entity walks the viewer's projects, which can't
+        # see entity-scoped automations.
+        fetched_b = module_api.automation(name=created.name)
+        assert fetched_b == created
 
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_existing_automation_raises_by_default_if_existing(
     module_api: wandb.Api,
+    team: Team,
     event,
     action,
     automation_name: str,
@@ -159,13 +171,14 @@ def test_create_existing_automation_raises_by_default_if_existing(
         module_api.create_automation((event >> action), name=created.name)
 
     # Fetching the automation by name should return the original automation, unchanged.
-    fetched = module_api.automation(name=created.name)
+    fetched = module_api.automation(entity=team.name, name=created.name)
     assert fetched == created
 
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_existing_automation_fetches_existing_if_requested(
     module_api: wandb.Api,
+    team: Team,
     event,
     action,
     automation_name: str,
@@ -185,7 +198,7 @@ def test_create_existing_automation_fetches_existing_if_requested(
     )
 
     # Fetch the automation by name
-    fetched = module_api.automation(name=created.name)
+    fetched = module_api.automation(entity=team.name, name=created.name)
 
     assert created == existing
     assert existing == fetched
@@ -430,6 +443,7 @@ def test_create_automation_for_run_metric_zscore_event(
 @fixture
 def created_automation(
     module_api: wandb.Api,
+    team: Team,
     reset_automations,
     event,
     action,
@@ -441,46 +455,64 @@ def created_automation(
         name=automation_name,
     )
 
-    fetched = module_api.automation(name=created.name)
+    fetched = module_api.automation(entity=team.name, name=created.name)
 
     assert created.name == fetched.name == automation_name  # Sanity check
     return fetched
 
 
 def test_delete_automation(
-    module_api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api,
+    team: Team,
+    automation_name: str,
+    created_automation: Automation,
 ):
-    assert module_api.automation(name=automation_name) == created_automation
+    assert (
+        module_api.automation(entity=team.name, name=automation_name)
+        == created_automation
+    )
 
     module_api.delete_automation(created_automation)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        module_api.automation(name=automation_name)
+        module_api.automation(entity=team.name, name=automation_name)
 
 
 def test_delete_automation_by_id(
-    module_api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api,
+    team: Team,
+    automation_name: str,
+    created_automation: Automation,
 ):
-    assert module_api.automation(name=automation_name) == created_automation
+    assert (
+        module_api.automation(entity=team.name, name=automation_name)
+        == created_automation
+    )
 
     module_api.delete_automation(created_automation.id)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        module_api.automation(name=automation_name)
+        module_api.automation(entity=team.name, name=automation_name)
 
 
 def test_automation_cannot_be_deleted_again(
-    module_api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api,
+    team: Team,
+    automation_name: str,
+    created_automation: Automation,
 ):
-    assert module_api.automation(name=automation_name) == created_automation
+    assert (
+        module_api.automation(entity=team.name, name=automation_name)
+        == created_automation
+    )
 
     module_api.delete_automation(created_automation)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        module_api.automation(name=automation_name)
+        module_api.automation(entity=team.name, name=automation_name)
 
     # Deleting the automation again (by object or ID) should raise the same error
     with raises(CommError):
@@ -871,9 +903,9 @@ class TestPaginatedAutomations:
     @fixture(scope="class")
     def setup_paginated_automations(
         self,
-        module_user: str,
         make_module_api: Callable[[], wandb.Api],
         webhook: WebhookIntegration,
+        team: Team,
         num_projects: int,
         make_name: Callable[[str], str],
     ):
@@ -895,8 +927,8 @@ class TestPaginatedAutomations:
             project_names, automation_names, strict=True
         ):
             # Create the placeholder project for the automation
-            setup_api.create_project(name=project_name, entity=module_user)
-            project = setup_api.project(name=project_name, entity=module_user)
+            setup_api.create_project(name=project_name, entity=team.name)
+            project = setup_api.project(name=project_name, entity=team.name)
 
             # Create the actual automation
             event = OnLinkArtifact(scope=project)
@@ -921,8 +953,8 @@ class TestPaginatedAutomations:
     def test_paginated_automations(
         self,
         mocker,
-        module_user: str,
         module_api: wandb.Api,
+        team: Team,
         num_projects,
         page_size,
     ):
@@ -930,7 +962,7 @@ class TestPaginatedAutomations:
         client_spy = mocker.spy(module_api._service_api, "execute_graphql")
 
         # Fetch the automations
-        list(module_api.automations(entity=module_user, per_page=page_size))
+        list(module_api.automations(entity=team.name, per_page=page_size))
 
         # Check that the number of GQL requests is at least what we expect from the pagination params
         # Note that a (cached) introspection query may add an extra request the first time this is
@@ -942,23 +974,23 @@ class TestPaginatedAutomations:
     @mark.usefixtures(setup_paginated_automations.__name__)
     def test_paginated_automations_start(
         self,
-        module_user: str,
         module_api: wandb.Api,
-        page_size,
+        team: Team,
+        page_size: int,
     ):
         all_automations = list(
-            module_api.automations(entity=module_user, per_page=page_size)
+            module_api.automations(entity=team.name, per_page=page_size)
         )
         all_ids = [a.id for a in all_automations]
 
-        paginator = module_api.automations(entity=module_user, per_page=page_size)
+        paginator = module_api.automations(entity=team.name, per_page=page_size)
         first_ids = [obj.id for obj in islice(paginator, page_size)]
 
         saved_cursor = paginator.cursor
         assert saved_cursor is not None
 
         resumed_paginator = module_api.automations(
-            entity=module_user, per_page=page_size, start=saved_cursor
+            entity=team.name, per_page=page_size, start=saved_cursor
         )
         remaining_ids = [a.id for a in resumed_paginator]
 

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -127,6 +127,8 @@ def test_fetch_slack_integrations(
 def test_create_automation(
     module_api: wandb.Api,
     team: Team,
+    scope,
+    scope_type: ScopeType,
     event,
     action,
     automation_name: str,
@@ -137,11 +139,20 @@ def test_create_automation(
 
     assert created.name == automation_name
 
-    fetched_a = module_api.automation(entity=team.name, name=created.name)
-    fetched_b = module_api.automation(name=created.name)
+    # The saved scope should identify the object the automation was scoped to.
+    assert created.scope.scope_type is scope_type
+    assert created.scope.id == scope.id
+    assert created.scope.name == scope.name
 
+    # We should be able to fetch the automation by name (optionally filtering by entity)
+    fetched_a = module_api.automation(entity=team.name, name=created.name)
     assert fetched_a == created
-    assert fetched_b == created
+
+    if scope_type is not ScopeType.ENTITY:
+        # Fetching without an entity walks the viewer's projects, which can't
+        # see entity-scoped automations.
+        fetched_b = module_api.automation(name=created.name)
+        assert fetched_b == created
 
 
 @mark.usefixtures(reset_automations.__name__)

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -2379,9 +2379,9 @@ class Api:
                 **kwargs,
             )
         elif entity:
-            # Older servers lack `Entity.triggers`, so fall back to the legacy paginator
-            # that walks the entity's projects.
-            # Entity-scoped automations are a newer feature and don't exist on such servers.
+            # TODO: Remove this project-walking fallback once the minimum supported
+            # server version is v0.83.0 or newer. That release added `Entity.triggers`
+            # (wandb/core#43336).
             return LegacyEntityAutomations(
                 self._service_api,
                 entity=entity,

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -2363,32 +2363,34 @@ class Api:
         automations = api.automations(entity="my-team")
         ```
         """
-        from wandb.apis.public.automations import Automations
-        from wandb.automations._generated import (
-            GET_AUTOMATIONS_LEGACY_GQL,
-            GET_ENTITY_AUTOMATIONS_LEGACY_GQL,
+        from wandb.apis.public.automations import (
+            Automations,
+            EntityAutomations,
+            LegacyEntityAutomations,
         )
 
-        # For now, we need to use different queries depending on whether entity is given
-        variables = {"entity": entity}
-        if entity is None:
-            gql_str = GET_AUTOMATIONS_LEGACY_GQL  # Automations for viewer
-        else:
-            gql_str = GET_ENTITY_AUTOMATIONS_LEGACY_GQL  # Automations for entity
+        kwargs = dict(per_page=per_page, start=start)
 
-        # If needed, rewrite the GraphQL field selection set to omit unsupported fields/fragments/types
-        iterator = Automations(
-            self._service_api,
-            variables=variables,
-            per_page=per_page,
-            start=start,
-            _query=gql_str,
-        )
+        if entity and self._service_api.feature_enabled(pb.QUERY_AUTOMATIONS_ON_ENTITY):
+            return EntityAutomations(
+                self._service_api,
+                entity=entity,
+                filter={"name": name} if name else None,
+                **kwargs,
+            )
+        elif entity:
+            # Older servers lack `Entity.triggers`, so fall back to the legacy paginator
+            # that walks the entity's projects.
+            # Entity-scoped automations are a newer feature and don't exist on such servers.
+            return LegacyEntityAutomations(
+                self._service_api,
+                entity=entity,
+                name=name,
+                **kwargs,
+            )
 
-        # FIXME: this is crude, move this client-side filtering logic into backend
-        if name is not None:
-            return filter(lambda x: x.name == name, iterator)
-        return iterator
+        # Legacy implementation: walk the viewer's projects for visible automations
+        return Automations(self._service_api, name=name, **kwargs)
 
     @normalize_exceptions
     @tracked

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 from pydantic import ValidationError
 from typing_extensions import override
@@ -18,13 +18,19 @@ if TYPE_CHECKING:
         GetAutomationsLegacy,
         GetEntityAutomationsLegacy,
         ProjectTriggersFields,
+        TriggerFields,
     )
 
 
 class _LegacyAutomationsPaginator(
     RelayPaginator["ProjectTriggersFields", "Automation"]
 ):
-    """A lazy iterator of automations found by walking projects."""
+    """A lazy iterator of `Automation` objects for older servers.
+
+    For older servers that don't support direct queries for automations, this
+    walks projects for all automations that are visible to the user.
+    Obviously, this is suboptimal.
+    """
 
     QUERY: ClassVar[str | None] = None  # type: ignore[misc]
     last_response: Connection[ProjectTriggersFields] | None
@@ -41,6 +47,7 @@ class _LegacyAutomationsPaginator(
         from wandb.automations._compat import omit_automation_fragments
 
         self._name = name
+
         super().__init__(
             service_api,
             variables=variables,
@@ -87,47 +94,8 @@ class _LegacyAutomationsPaginator(
                 yield from self._convert(node)
 
 
-class Automations(_LegacyAutomationsPaginator):
-    """A generic legacy automations paginator retained for compatibility."""
-
-    QUERY: str  # type: ignore[misc]
-
-    def __init__(
-        self,
-        service_api: ServiceApi,
-        variables: Mapping[str, Any],
-        per_page: int = 50,
-        *,
-        start: str | None = None,
-        _query: str,
-    ):
-        self.QUERY = _query
-        super().__init__(
-            service_api,
-            variables=variables,
-            per_page=per_page,
-            start=start,
-        )
-
-    @override
-    def _update_response(self) -> None:
-        """Fetch raw response data for the compatibility query."""
-        from wandb._pydantic import Connection
-        from wandb.automations._generated import ProjectTriggersFields
-
-        data: dict[str, Any] = self._execute_query()
-        try:
-            conn = Connection[ProjectTriggersFields].model_validate(
-                data["scope"]["projects"]
-            )
-        except (LookupError, AttributeError, ValidationError) as e:
-            raise ValueError("Unexpected response data") from e
-        else:
-            self.last_response = conn
-
-
 class LegacyAutomations(_LegacyAutomationsPaginator):
-    """A lazy iterator of automations found by walking the viewer's projects."""
+    """A lazy iterator of `Automation` objects, walking the viewer's projects."""
 
     def __init__(
         self,
@@ -143,11 +111,7 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
             type(self).QUERY = GET_AUTOMATIONS_LEGACY_GQL
 
         super().__init__(
-            service_api,
-            variables={},
-            name=name,
-            per_page=per_page,
-            start=start,
+            service_api, variables={}, name=name, per_page=per_page, start=start
         )
 
     @classmethod
@@ -159,7 +123,7 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
 
 
 class LegacyEntityAutomations(_LegacyAutomationsPaginator):
-    """A lazy iterator of an entity's automations found by walking its projects."""
+    """A lazy iterator of an entity's `Automation` objects, walking its projects."""
 
     def __init__(
         self,
@@ -189,3 +153,61 @@ class LegacyEntityAutomations(_LegacyAutomationsPaginator):
         from wandb.automations._generated import GetEntityAutomationsLegacy
 
         return GetEntityAutomationsLegacy
+
+
+class EntityAutomations(RelayPaginator["TriggerFields", "Automation"]):
+    """A lazy iterator of `Automation` objects from an entity."""
+
+    QUERY: ClassVar[str | None] = None  # type: ignore[misc]
+    last_response: Connection[TriggerFields] | None
+
+    def __init__(
+        self,
+        service_api: ServiceApi,
+        entity: str,
+        *,
+        filter: dict[str, Any] | None = None,
+        per_page: int = 50,
+        start: str | None = None,
+    ):
+        from wandb._pydantic import to_json
+        from wandb.automations._compat import omit_automation_fragments
+
+        if self.QUERY is None:
+            from wandb.automations._generated import GET_ENTITY_AUTOMATIONS_GQL
+
+            type(self).QUERY = GET_ENTITY_AUTOMATIONS_GQL
+
+        super().__init__(
+            service_api,
+            variables={
+                "entity": entity,
+                "filters": to_json(f) if (f := filter) else None,
+            },
+            per_page=per_page,
+            start=start,
+            omit_fragments=omit_automation_fragments(service_api),
+        )
+
+    @override
+    def _update_response(self) -> None:
+        """Fetch the raw response data for the current page."""
+        from wandb._pydantic import Connection
+        from wandb.automations._generated import GetEntityAutomations, TriggerFields
+
+        try:
+            res = self._execute_query(parse=GetEntityAutomations.model_validate_json)
+            conn = Connection[TriggerFields].model_validate(res.scope.triggers)  # type: ignore[union-attr]
+        except (LookupError, AttributeError, ValidationError) as e:
+            raise ValueError("Unexpected response data") from e
+        else:
+            self.last_response = conn
+
+    @override
+    def _convert(self, node: TriggerFields) -> Automation:
+        from wandb.automations import Automation
+
+        return Automation.model_validate(node)
+
+
+Automations: TypeAlias = LegacyAutomations  # For now

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 from pydantic import ValidationError
 from typing_extensions import override
@@ -18,13 +18,19 @@ if TYPE_CHECKING:
         GetAutomationsLegacy,
         GetEntityAutomationsLegacy,
         ProjectTriggersFields,
+        TriggerFields,
     )
 
 
 class _LegacyAutomationsPaginator(
     RelayPaginator["ProjectTriggersFields", "Automation"]
 ):
-    """A lazy iterator of automations found by walking projects."""
+    """A lazy iterator of `Automation` objects for older servers.
+
+    For older servers that don't support direct queries for automations, this
+    walks projects for all automations that are visible to the user.
+    Obviously, this is suboptimal.
+    """
 
     QUERY: ClassVar[str | None] = None  # type: ignore[misc]
     last_response: Connection[ProjectTriggersFields] | None
@@ -37,26 +43,17 @@ class _LegacyAutomationsPaginator(
         name: str | None = None,
         per_page: int = 50,
         start: str | None = None,
-        omit_variables: Iterable[str] | None = None,
-        omit_fragments: Iterable[str] | None = None,
-        omit_fields: Iterable[str] | None = None,
-        rename_fields: Mapping[str, str] | None = None,
     ):
-        if omit_fragments is None:
-            from wandb.automations._utils import omit_automation_fragments
-
-            omit_fragments = omit_automation_fragments(service_api)
+        from wandb.automations._utils import omit_automation_fragments
 
         self._name = name
+
         super().__init__(
             service_api,
             variables=variables,
             per_page=per_page,
             start=start,
-            omit_variables=omit_variables,
-            omit_fragments=omit_fragments,
-            omit_fields=omit_fields,
-            rename_fields=rename_fields,
+            omit_fragments=omit_automation_fragments(service_api),
         )
 
     @classmethod
@@ -97,55 +94,8 @@ class _LegacyAutomationsPaginator(
                 yield from self._convert(node)
 
 
-class Automations(_LegacyAutomationsPaginator):
-    """A generic legacy automations paginator retained for compatibility."""
-
-    QUERY: str  # type: ignore[misc]
-
-    def __init__(
-        self,
-        service_api: ServiceApi,
-        variables: Mapping[str, Any],
-        per_page: int = 50,
-        *,
-        start: str | None = None,
-        _query: str,
-        omit_variables: Iterable[str] | None = None,
-        omit_fragments: Iterable[str] | None = None,
-        omit_fields: Iterable[str] | None = None,
-        rename_fields: Mapping[str, str] | None = None,
-    ):
-        self.QUERY = _query
-        super().__init__(
-            service_api,
-            variables=variables,
-            per_page=per_page,
-            start=start,
-            omit_variables=omit_variables,
-            omit_fragments=omit_fragments,
-            omit_fields=omit_fields,
-            rename_fields=rename_fields,
-        )
-
-    @override
-    def _update_response(self) -> None:
-        """Fetch raw response data for the compatibility query."""
-        from wandb._pydantic import Connection
-        from wandb.automations._generated import ProjectTriggersFields
-
-        data: dict[str, Any] = self._execute_query()
-        try:
-            conn = Connection[ProjectTriggersFields].model_validate(
-                data["scope"]["projects"]
-            )
-        except (LookupError, AttributeError, ValidationError) as e:
-            raise ValueError("Unexpected response data") from e
-        else:
-            self.last_response = conn
-
-
 class LegacyAutomations(_LegacyAutomationsPaginator):
-    """A lazy iterator of automations found by walking the viewer's projects."""
+    """A lazy iterator of `Automation` objects, walking the viewer's projects."""
 
     def __init__(
         self,
@@ -161,11 +111,7 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
             type(self).QUERY = GET_AUTOMATIONS_LEGACY_GQL
 
         super().__init__(
-            service_api,
-            variables={},
-            name=name,
-            per_page=per_page,
-            start=start,
+            service_api, variables={}, name=name, per_page=per_page, start=start
         )
 
     @classmethod
@@ -177,7 +123,7 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
 
 
 class LegacyEntityAutomations(_LegacyAutomationsPaginator):
-    """A lazy iterator of an entity's automations found by walking its projects."""
+    """A lazy iterator of an entity's `Automation` objects, walking its projects."""
 
     def __init__(
         self,
@@ -207,3 +153,61 @@ class LegacyEntityAutomations(_LegacyAutomationsPaginator):
         from wandb.automations._generated import GetEntityAutomationsLegacy
 
         return GetEntityAutomationsLegacy
+
+
+class EntityAutomations(RelayPaginator["TriggerFields", "Automation"]):
+    """A lazy iterator of `Automation` objects from an entity."""
+
+    QUERY: ClassVar[str | None] = None  # type: ignore[misc]
+    last_response: Connection[TriggerFields] | None
+
+    def __init__(
+        self,
+        service_api: ServiceApi,
+        entity: str,
+        *,
+        filter: dict[str, Any] | None = None,
+        per_page: int = 50,
+        start: str | None = None,
+    ):
+        from wandb._pydantic import to_json
+        from wandb.automations._utils import omit_automation_fragments
+
+        if self.QUERY is None:
+            from wandb.automations._generated import GET_ENTITY_AUTOMATIONS_GQL
+
+            type(self).QUERY = GET_ENTITY_AUTOMATIONS_GQL
+
+        super().__init__(
+            service_api,
+            variables={
+                "entity": entity,
+                "filters": to_json(f) if (f := filter) else None,
+            },
+            per_page=per_page,
+            start=start,
+            omit_fragments=omit_automation_fragments(service_api),
+        )
+
+    @override
+    def _update_response(self) -> None:
+        """Fetch the raw response data for the current page."""
+        from wandb._pydantic import Connection
+        from wandb.automations._generated import GetEntityAutomations, TriggerFields
+
+        try:
+            res = self._execute_query(parse=GetEntityAutomations.model_validate_json)
+            conn = Connection[TriggerFields].model_validate(res.scope.triggers)  # type: ignore[union-attr]
+        except (LookupError, AttributeError, ValidationError) as e:
+            raise ValueError("Unexpected response data") from e
+        else:
+            self.last_response = conn
+
+    @override
+    def _convert(self, node: TriggerFields) -> Automation:
+        from wandb.automations import Automation
+
+        return Automation.model_validate(node)
+
+
+Automations: TypeAlias = LegacyAutomations  # For now


### PR DESCRIPTION
*This description was AI-generated, then reviewed and revised by the author.*

## JIRA Issue(s)

- https://coreweave.atlassian.net/browse/WB-37082

## Description

PR lets `Api.automations(entity=...)` list automations scoped directly to a named team, as well as automations within that team’s projects.

- Uses `Entity.triggers` with server-side name filtering and cursor pagination when direct entity queries are supported.
- Falls back to the legacy entity project walk on older servers, while viewer-wide queries continue to use the legacy path.
- Gates entity scope coverage with the organization feature flag and runs automation scenarios against an organization-backed team.

Updates `CHANGELOG.unreleased.md` for team and organization automation scopes.

## Testing

System coverage exercises team-backed listing, name filtering, CRUD round trips, pagination, and organization feature gating.