### PR TITLE
feat(automations): add entity automation scopes

### DIFF
--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, TypeAlias
 import wandb
 from pytest import FixtureRequest, fixture, skip
 from wandb import Artifact
-from wandb.apis.public import ArtifactCollection, Project, Team
+from wandb.apis.public import ArtifactCollection, Organization, Project, Team
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -41,7 +41,7 @@ from wandb.automations.events import InputEvent
 if TYPE_CHECKING:
     from tests.system_tests.backend_fixtures import BackendFixtureFactory
 
-ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team
+ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
 
 
 def random_string(chars: str = ascii_lowercase + digits, n: int = 12) -> str:
@@ -164,8 +164,8 @@ def webhook(
 # ---------------------------------------------------------------------------
 # Exclude deprecated events/actions that will not be exposed in the API for programmatic creation
 def valid_input_scopes() -> list[ScopeType]:
-    return sorted(ScopeType)
-    # return sorted(set(ScopeType) - {ScopeType.ENTITY})
+    # return sorted(ScopeType)  # TODO: restore once ENTITY scope is supported
+    return sorted(set(ScopeType) - {ScopeType.ENTITY})
 
 
 def valid_input_events() -> list[EventType]:

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -4,12 +4,12 @@ import secrets
 from collections.abc import Callable, Generator
 from functools import lru_cache
 from string import ascii_lowercase, digits
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 import wandb
 from pytest import FixtureRequest, fixture, skip
 from wandb import Artifact
-from wandb.apis.public import ArtifactCollection, Project
+from wandb.apis.public import ArtifactCollection, Project, Team
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -38,7 +38,10 @@ from wandb.automations._generated import (
 from wandb.automations._utils import INVALID_INPUT_ACTIONS, INVALID_INPUT_EVENTS
 from wandb.automations.events import InputEvent
 
-ScopableWandbType: TypeAlias = ArtifactCollection | Project
+if TYPE_CHECKING:
+    from tests.system_tests.backend_fixtures import BackendFixtureFactory
+
+ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team
 
 
 def random_string(chars: str = ascii_lowercase + digits, n: int = 12) -> str:
@@ -104,6 +107,17 @@ def artifact_collection(
 
 
 @fixture(scope="module")
+def team(
+    backend_fixture_factory: BackendFixtureFactory,
+    module_user: str,
+    make_module_api: Callable[[], wandb.Api],
+) -> Team:
+    """A test team entity for tests in this module."""
+    name = backend_fixture_factory.make_team(username=module_user).team
+    return make_module_api().team(name)
+
+
+@fixture(scope="module")
 def make_webhook_integration(
     make_module_api: Callable[[], wandb.Api],
 ) -> Callable[[str, str, str], WebhookIntegration]:
@@ -150,8 +164,8 @@ def webhook(
 # ---------------------------------------------------------------------------
 # Exclude deprecated events/actions that will not be exposed in the API for programmatic creation
 def valid_input_scopes() -> list[ScopeType]:
-    # return sorted(ScopeType)  # TODO: restore once ENTITY scope is supported
-    return sorted(set(ScopeType) - {ScopeType.ENTITY})
+    return sorted(ScopeType)
+    # return sorted(set(ScopeType) - {ScopeType.ENTITY})
 
 
 def valid_input_events() -> list[EventType]:
@@ -246,6 +260,7 @@ def scope(request: FixtureRequest, scope_type: ScopeType) -> ScopableWandbType:
     scope2fixture: dict[ScopeType, str] = {
         ScopeType.ARTIFACT_COLLECTION: artifact_collection.__name__,
         ScopeType.PROJECT: project.__name__,
+        ScopeType.ENTITY: team.__name__,
     }
     # We want to request the fixture dynamically, hence the request.getfixturevalue workaround
     return request.getfixturevalue(scope2fixture[scope_type])

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -43,17 +43,16 @@ def automation_name(make_name: Callable[[str], str]) -> str:
 
 @fixture
 def reset_automations(module_api: wandb.Api):
-    """Request this fixture to remove any saved automations both before and after the test."""
+    """Request this fixture to clear any existing automations before a test."""
     # There has to be a better way to do this
     for automation in module_api.automations():
         module_api.delete_automation(automation)
     yield
-    for automation in module_api.automations():
-        module_api.delete_automation(automation)
 
 
 # ------------------------------------------------------------------------------
-def test_no_initial_automations(module_api: wandb.Api, reset_automations):
+@mark.usefixtures(reset_automations.__name__)
+def test_no_initial_automations(module_api: wandb.Api):
     """No automations should be fetched by the API prior to creating any."""
     assert list(module_api.automations()) == []
 

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -33,7 +33,6 @@ from wandb.automations._filters.run_metrics import ChangeDir
 from wandb.automations._filters.run_states import ReportedRunState, StateFilter
 from wandb.automations.actions import InputAction, SavedNoOpAction, SavedWebhookAction
 from wandb.automations.events import InputEvent, RunMetricFilter, RunStateFilter
-from wandb.automations.scopes import ArtifactCollectionScopeTypes
 from wandb.errors.errors import CommError
 
 
@@ -755,7 +754,7 @@ class TestUpdateAutomation:
 
         updated_scope = new_automation.scope
 
-        assert isinstance(updated_scope, ArtifactCollectionScopeTypes)
+        assert updated_scope.scope_type is ScopeType.ARTIFACT_COLLECTION
         assert updated_scope.id == artifact_collection.id
         assert updated_scope.name == artifact_collection.name
 

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -139,20 +139,8 @@ def test_create_automation(
     )
     fetched_b = module_api.automation(name=created.name)
 
-    # NOTE: On older server versions, the ID returned returned by create_automation()
-    # seems to have an (encoded) index that's off by 1, vs. the ID returned by
-    # automation().
-    # This seems fixed on newer servers.  Use server support for the `RUN_METRIC_THRESHOLD`
-    # event to determine if this is a "newer" server.
-    assert fetched_a.id == fetched_b.id  # these should at least be the same
-
-    is_older_server = not module_api._supports_automation(
-        event=EventType.RUN_METRIC_THRESHOLD
-    )
-    exclude = {"id"} if is_older_server else None
-
-    assert fetched_a.model_dump(exclude=exclude) == created.model_dump(exclude=exclude)
-    assert fetched_b.model_dump(exclude=exclude) == created.model_dump(exclude=exclude)
+    assert fetched_a == created
+    assert fetched_b == created
 
 
 @mark.usefixtures(reset_automations.__name__)
@@ -169,19 +157,9 @@ def test_create_existing_automation_raises_by_default_if_existing(
     with raises(CommError):
         module_api.create_automation((event >> action), name=created.name)
 
-    # Fetching the automation by name should return the original automation,
-    # unchanged.
+    # Fetching the automation by name should return the original automation, unchanged.
     fetched = module_api.automation(name=created.name)
-
-    # NOTE: On older server versions, the ID returned has an encoded index that's off by 1.
-    # This seems fixed on newer servers.  Use RUN_METRIC_THRESHOLD support as a proxy for identifying
-    # newer servers.
-    is_older_server = not module_api._supports_automation(
-        event=EventType.RUN_METRIC_THRESHOLD
-    )
-    exclude = {"id"} if is_older_server else None
-
-    assert fetched.model_dump(exclude=exclude) == created.model_dump(exclude=exclude)
+    assert fetched == created
 
 
 @mark.usefixtures(reset_automations.__name__)
@@ -208,16 +186,8 @@ def test_create_existing_automation_fetches_existing_if_requested(
     # Fetch the automation by name
     fetched = module_api.automation(name=created.name)
 
-    # NOTE: On older server versions, the ID returned has an encoded index that's off by 1.
-    # This seems fixed on newer servers.  Use RUN_METRIC_THRESHOLD support as a proxy for identifying
-    # newer servers.
-    is_older_server = not module_api._supports_automation(
-        event=EventType.RUN_METRIC_THRESHOLD
-    )
-    exclude = {"id"} if is_older_server else None
-
-    assert created.model_dump(exclude=exclude) == existing.model_dump(exclude=exclude)
-    assert existing.model_dump(exclude=exclude) == fetched.model_dump(exclude=exclude)
+    assert created == existing
+    assert existing == fetched
 
     assert created.description is None
     assert existing.description is None
@@ -484,7 +454,6 @@ def created_automation(
         name=automation_name,
     )
 
-    # Fetch the automation by name (avoids the off-by-1 index issue on older servers)
     fetched = module_api.automation(name=created.name)
 
     assert created.name == fetched.name == automation_name  # Sanity check
@@ -539,18 +508,6 @@ def test_delete_automation_raises_on_invalid_id(module_api: wandb.Api):
         module_api.delete_automation("invalid-automation-id")
 
 
-@fixture
-def skip_if_edit_automations_not_supported_on_server(module_api: wandb.Api):
-    # HACK: Use NO_OP as a proxy for whether the server is "new enough"
-    #
-    # FIXME: We need a better way to check this in the absence of
-    # - a prior server feature flag
-    # - use of GraphQL introspection queries
-    if not module_api._supports_automation(action=ActionType.NO_OP):
-        skip("Server does not support editing automations")
-
-
-@mark.usefixtures(skip_if_edit_automations_not_supported_on_server.__name__)
 class TestUpdateAutomation:
     @fixture
     def action_type(self) -> ActionType:
@@ -963,9 +920,8 @@ class TestPaginatedAutomations:
                 description="test description",
             )
 
-            # Refetch (to avoid the off-by-1 index issue on older servers) and retain for later cleanup
-            refetched_id = setup_api.automation(name=created.name).id
-            created_automation_ids.append(refetched_id)
+            # Retain the automation ID for later cleanup.
+            created_automation_ids.append(created.id)
 
         yield
 

--- a/tests/unit_tests/test_automations/conftest.py
+++ b/tests/unit_tests/test_automations/conftest.py
@@ -10,7 +10,7 @@ from hypothesis import settings
 from pytest import FixtureRequest, fixture, skip
 from pytest_mock import MockerFixture
 from wandb._strutils import b64encode_ascii
-from wandb.apis.public import ArtifactCollection, Project
+from wandb.apis.public import ArtifactCollection, Organization, Project, Team
 from wandb.automations import (
     ActionType,
     ArtifactEvent,
@@ -47,7 +47,7 @@ settings.register_profile("default", max_examples=100)
 settings.load_profile("default")
 
 
-ScopableWandbType: TypeAlias = ArtifactCollection | Project
+ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +147,53 @@ def project(mock_client: Mock) -> Project:
     )
 
 
+@fixture(scope="session")
+def team(mock_client: Mock) -> Team:
+    """A simulated `Team` (team entity) that could be returned by `wandb.Api`.
+
+    Typically fetched via `Api.team()`.
+
+    For unit-testing purposes, this has been heavily mocked.
+    Tests relying on real `wandb.Api` calls should live in system tests.
+    """
+    name = "test-team-entity"
+    return Team(
+        service_api=mock_client,
+        name=name,
+        attrs={
+            "__typename": "Entity",
+            "id": make_graphql_id(prefix="Entity"),
+            "name": name,
+            "entityType": "team",
+        },
+    )
+
+
+@fixture(scope="session")
+def org(mock_client: Mock) -> Organization:
+    """A simulated `Organization` with a mock org entity.
+
+    Typically fetched via `Api.organization()`.
+
+    For unit-testing purposes, this has been heavily mocked.
+    Tests relying on real `wandb.Api` calls should live in system tests.
+    """
+    name = "test-org"
+    return Organization(
+        mock_client,
+        **{
+            "id": make_graphql_id(prefix="Organization"),
+            "name": name,
+            "orgEntity": {
+                "__typename": "Entity",
+                "id": make_graphql_id(prefix="Entity"),
+                "name": f"{name}-entity",
+                "entityType": "organization",
+            },
+        },
+    )
+
+
 # Exclude deprecated scope/event/action types from those expected to be exposed for valid behavior
 def valid_scopes() -> list[ScopeType]:
     # return sorted(set(ScopeType))  # TODO: restore once ENTITY scope is supported
@@ -205,6 +252,7 @@ def scope(request: FixtureRequest, scope_type: ScopeType) -> ScopableWandbType:
     scope2fixture: dict[ScopeType, str] = {
         ScopeType.ARTIFACT_COLLECTION: artifact_collection.__name__,
         ScopeType.PROJECT: project.__name__,
+        ScopeType.ENTITY: team.__name__,
     }
     return request.getfixturevalue(scope2fixture[scope_type])
 

--- a/tests/unit_tests/test_automations/test_scopes.py
+++ b/tests/unit_tests/test_automations/test_scopes.py
@@ -1,10 +1,23 @@
-from pydantic import BaseModel
-from pytest import mark
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
+from pytest import mark, raises
 from wandb._strutils import nameof
-from wandb.apis.public import ArtifactCollection, Project
-from wandb.automations import ArtifactCollectionScope, ProjectScope, ScopeType
+from wandb.automations import (
+    ArtifactCollectionScope,
+    EntityScope,
+    ProjectScope,
+    ScopeType,
+)
 from wandb.automations._generated import TriggerScopeType
-from wandb.automations.scopes import ArtifactCollectionScopeTypes, AutomationScope
+from wandb.automations.scopes import AutomationScope
+
+if TYPE_CHECKING:
+    from unittest.mock import Mock
+
+    from wandb.apis.public import ArtifactCollection, Organization, Project, Team
 
 
 class HasScope(BaseModel):
@@ -17,6 +30,10 @@ class HasCollectionScope(HasScope):
 
 class HasProjectScope(HasScope):
     scope: ProjectScope
+
+
+class HasEntityScope(HasScope):
+    scope: EntityScope
 
 
 def test_public_scope_type_enum_is_subset_of_generated():
@@ -39,27 +56,98 @@ def test_scope_can_validate_from_wandb_artifact_collection(
 
     validated = model_cls(scope=artifact_collection)
 
-    # ArtifactCollectionScope is defined as a Union type, so isinstance() checks won't work
-    # prior to python 3.10.  We need to check against a tuple of the unioned types.
-    # See:
-    # - https://docs.python.org/3/library/stdtypes.html#union-type
-    # - https://peps.python.org/pep-0604/
-
-    assert isinstance(validated.scope, ArtifactCollectionScopeTypes)
-    assert validated.scope.scope_type == ScopeType.ARTIFACT_COLLECTION
+    assert validated.scope.scope_type is ScopeType.ARTIFACT_COLLECTION
     assert validated.scope.id == artifact_collection.id
     assert validated.scope.name == artifact_collection.name
 
 
 @mark.parametrize("model_cls", (HasProjectScope, HasScope), ids=nameof)
 def test_scope_can_validate_from_wandb_project(
-    project: Project,
-    model_cls: type[HasScope],
+    project: Project, model_cls: type[HasScope]
 ):
     """Check that we can parse an automation scope from a pre-existing `Project` type."""
 
     validated = model_cls(scope=project)
-    assert isinstance(validated.scope, ProjectScope)
-    assert validated.scope.scope_type == ScopeType.PROJECT
+    assert validated.scope.scope_type is ScopeType.PROJECT
     assert validated.scope.id == project.id
     assert validated.scope.name == project.name
+
+
+@mark.parametrize("model_cls", (HasEntityScope, HasScope), ids=nameof)
+def test_scope_can_validate_from_wandb_team(team: Team, model_cls: type[HasScope]):
+    """Check that we can parse an automation scope from a pre-existing `Team` (team entity)."""
+
+    validated = model_cls(scope=team)
+    assert validated.scope.scope_type is ScopeType.ENTITY
+    assert validated.scope.entity_type == "team"
+    assert validated.scope.id == team.id
+    assert validated.scope.name == team.name
+
+
+@mark.parametrize("model_cls", (HasEntityScope, HasScope), ids=nameof)
+def test_scope_can_validate_from_wandb_org(
+    org: Organization, model_cls: type[HasScope]
+):
+    """Check that an org-scoped automation scope resolves to the org's (non-team) entity."""
+
+    # The org's entity is inferred from the org on any field that accepts an entity scope.
+    # The actual org entity can also be passed directly (it would be weird if this didn't work).
+    for scope_arg in (org, org.org_entity):
+        validated = model_cls(scope=scope_arg)
+        assert validated.scope.scope_type is ScopeType.ENTITY
+        assert validated.scope.entity_type == "organization"
+        assert validated.scope.id == org.org_entity.id
+        assert validated.scope.name == org.org_entity.name
+
+
+def test_entity_scope_uses_entity_type_as_discriminator():
+    team_entity_data = {
+        "__typename": "Entity",
+        "id": "Entity:1",
+        "name": "team-entity",
+        "entityType": "team",
+    }
+    org_entity_data = {
+        "__typename": "Entity",
+        "id": "Entity:2",
+        "name": "org-entity",
+        "entityType": "organization",
+    }
+    team_scope = HasEntityScope(scope=team_entity_data).scope
+    org_scope = HasEntityScope(scope=org_entity_data).scope
+
+    assert team_scope.entity_type == "team"
+    assert org_scope.entity_type == "organization"
+
+
+@mark.parametrize("model_cls", (HasEntityScope, HasScope), ids=nameof)
+def test_personal_entity_scope_is_not_allowed(model_cls: type[HasScope]):
+    personal_entity_data = {
+        "__typename": "Entity",
+        "id": "Entity:1",
+        "name": "personal-entity",
+        "entityType": "personal",
+    }
+
+    with raises(ValidationError):
+        model_cls(scope=personal_entity_data)
+
+
+def test_organization_uses_org_entity_type_as_discriminator(mock_client: Mock):
+    from wandb.apis.public import Organization
+
+    org_data = {
+        "id": "Organization:1",
+        "name": "test-org",
+        "orgEntity": {
+            "__typename": "Entity",
+            "id": "Entity:1",
+            "name": "test-org",
+            "entityType": "organization",
+        },
+    }
+    org = Organization(mock_client, **org_data)
+    assert org.org_entity.entity_type == "organization"
+
+    entity_scope = HasEntityScope(scope=org).scope
+    assert entity_scope.entity_type == "organization"

--- a/tools/local_wandb_server.py
+++ b/tools/local_wandb_server.py
@@ -380,6 +380,10 @@ def _start_container(*, name: str) -> _WandbContainerPorts:
         "--detach",
         *["--pull", pull],
         *["-e", "WANDB_ENABLE_TEST_CONTAINER=true"],
+        # ------------------------------------------------------------------------------
+        # TODO: replace with more durable solution after verifying
+        *["-e", "GORILLA_GATE_AUTOMATION_ENTITY_SCOPE=true"],
+        # ------------------------------------------------------------------------------
         *["--name", name],
         *["--volume", f"{name}-vol:/vol"],
         # Expose ports to the host.

--- a/tools/local_wandb_server.py
+++ b/tools/local_wandb_server.py
@@ -380,10 +380,6 @@ def _start_container(*, name: str) -> _WandbContainerPorts:
         "--detach",
         *["--pull", pull],
         *["-e", "WANDB_ENABLE_TEST_CONTAINER=true"],
-        # ------------------------------------------------------------------------------
-        # TODO: replace with more durable solution after verifying
-        *["-e", "GORILLA_GATE_AUTOMATION_ENTITY_SCOPE=true"],
-        # ------------------------------------------------------------------------------
         *["--name", name],
         *["--volume", f"{name}-vol:/vol"],
         # Expose ports to the host.

--- a/wandb/automations/__init__.py
+++ b/wandb/automations/__init__.py
@@ -20,13 +20,23 @@ from .events import (
     RunStateFilter,
 )
 from .integrations import Integration, SlackIntegration, WebhookIntegration
-from .scopes import ArtifactCollectionScope, ProjectScope, ScopeType
+from .scopes import (
+    ArtifactCollectionScope,
+    EntityScope,
+    OrgScope,
+    ProjectScope,
+    ScopeType,
+    TeamScope,
+)
 
 __all__ = [
     # Scopes
     "ScopeType",  # doc:exclude
     "ArtifactCollectionScope",  # doc:exclude
     "ProjectScope",  # doc:exclude
+    "OrgScope",  # doc:exclude
+    "TeamScope",  # doc:exclude
+    "EntityScope",  # doc:exclude
     # Events
     "EventType",  # doc:exclude
     "OnAddArtifactAlias",

--- a/wandb/automations/_validators.py
+++ b/wandb/automations/_validators.py
@@ -71,17 +71,30 @@ def upper_if_str(v: Any) -> Any:
 # ----------------------------------------------------------------------------
 def parse_scope(v: Any) -> Any:
     """Convert eligible objects (including wandb types) to an automation scope."""
-    from wandb.apis.public import ArtifactCollection, Project
+    from wandb.apis.public import ArtifactCollection, Organization, Project, Team
 
-    from .scopes import ProjectScope, _ArtifactPortfolioScope, _ArtifactSequenceScope
+    from .scopes import (
+        OrgScope,
+        ProjectScope,
+        TeamScope,
+        _ArtifactPortfolioScope,
+        _ArtifactSequenceScope,
+    )
 
     match v:
         case Project():
             return ProjectScope.model_validate(v)
+
         case ArtifactCollection() if v.is_sequence():
             return _ArtifactSequenceScope.model_validate(v)
         case ArtifactCollection():
             return _ArtifactPortfolioScope.model_validate(v)
+
+        case Team():
+            return TeamScope.model_validate(v)
+        case Organization(org_entity=org_entity):
+            return OrgScope.model_validate(org_entity)
+
         case _:
             return v
 

--- a/wandb/automations/events.py
+++ b/wandb/automations/events.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args
 
-from pydantic import AfterValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Discriminator, Field
 
 from wandb._pydantic import GQLBase, model_validator, pydantic_isinstance
 from wandb._strutils import nameof
@@ -23,11 +23,12 @@ from ._validators import (
     JsonEncoded,
     LenientStrEnum,
     ensure_json,
+    parse_scope,
     wrap_mutation_event_filter,
     wrap_run_filter,
 )
 from .actions import InputAction, InputActionTypes, SavedActionTypes
-from .scopes import ArtifactCollectionScope, AutomationScope, ProjectScope
+from .scopes import ArtifactCollectionScope, AutomationScope, EntityScope, ProjectScope
 
 if TYPE_CHECKING:
     from .automations import NewAutomation
@@ -360,8 +361,12 @@ class OnCreateArtifact(_BaseMutationEventInput):
 # ------------------------------------------------------------------------------
 # Events that trigger on run conditions
 class _BaseRunEventInput(_BaseEventInput):
-    scope: ProjectScope
-    """The scope of the event: must be a project."""
+    scope: Annotated[
+        ProjectScope | EntityScope,
+        BeforeValidator(parse_scope),
+        Discriminator("typename__"),
+    ]
+    """The scope of the event: must be a project or a team/org entity."""
 
 
 class OnRunMetric(_BaseRunEventInput):

--- a/wandb/automations/scopes.py
+++ b/wandb/automations/scopes.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, TypeAlias, get_args
+from typing import Annotated, Literal
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Discriminator, Field
 
 from wandb._pydantic import GQLBase
 
 from ._generated import (
     ArtifactPortfolioScopeFields,
     ArtifactSequenceScopeFields,
+    EntityScopeFields,
     ProjectScopeFields,
 )
 from ._validators import LenientStrEnum, parse_scope
@@ -30,13 +31,13 @@ class _BaseScope(GQLBase):
 
 
 class _ArtifactSequenceScope(_BaseScope, ArtifactSequenceScopeFields):
-    """An automation scope defined by a specific `ArtifactSequence`."""
+    """A scope defined by an `ArtifactSequence`."""
 
     scope_type: Literal[ScopeType.ARTIFACT_COLLECTION] = ScopeType.ARTIFACT_COLLECTION
 
 
 class _ArtifactPortfolioScope(_BaseScope, ArtifactPortfolioScopeFields):
-    """Automation scope defined by an `ArtifactPortfolio` (e.g. a registry collection)."""
+    """A scope defined by an `ArtifactPortfolio`, usually a registry collection."""
 
     scope_type: Literal[ScopeType.ARTIFACT_COLLECTION] = ScopeType.ARTIFACT_COLLECTION
 
@@ -45,33 +46,57 @@ class _ArtifactPortfolioScope(_BaseScope, ArtifactPortfolioScopeFields):
 ArtifactCollectionScope = Annotated[
     _ArtifactSequenceScope | _ArtifactPortfolioScope,
     BeforeValidator(parse_scope),
-    Field(discriminator="typename__"),
+    Discriminator("typename__"),
 ]
-"""An automation scope defined by a specific `ArtifactCollection`."""
+"""Type hint for a scope defined by an `ArtifactCollection`."""
 
 # for runtime type checks
-ArtifactCollectionScopeTypes: tuple[type, ...] = get_args(
-    ArtifactCollectionScope.__origin__  # type: ignore[attr-defined]
-)
+ArtifactCollectionScopeTypes = ArtifactCollectionScope.__origin__  # type: ignore[attr-defined]
 
 
 class ProjectScope(_BaseScope, ProjectScopeFields):
-    """An automation scope defined by a specific `Project`."""
+    """A scope defined by a `Project`."""
 
     scope_type: Literal[ScopeType.PROJECT] = ScopeType.PROJECT
 
 
-# for type annotations
-AutomationScope: TypeAlias = Annotated[
-    _ArtifactSequenceScope | _ArtifactPortfolioScope | ProjectScope,
+class TeamScope(_BaseScope, EntityScopeFields):
+    """A scope defined by a team `Entity`."""
+
+    scope_type: Literal[ScopeType.ENTITY] = ScopeType.ENTITY
+    entity_type: Literal["team"] = "team"
+
+
+class OrgScope(_BaseScope, EntityScopeFields):
+    """A scope defined by an org `Entity`."""
+
+    scope_type: Literal[ScopeType.ENTITY] = ScopeType.ENTITY
+    entity_type: Literal["organization"] = "organization"
+
+
+EntityScope = Annotated[
+    TeamScope | OrgScope,
     BeforeValidator(parse_scope),
-    Field(discriminator="typename__"),
+    Discriminator("entity_type"),
 ]
+"""Type hint for a scope defined by a team or org `Entity`."""
+
+
+AutomationScope = Annotated[
+    _ArtifactSequenceScope | _ArtifactPortfolioScope | ProjectScope | EntityScope,
+    BeforeValidator(parse_scope),
+    Discriminator("typename__"),
+]
+"""Type hint for any allowed scope for an automation."""
+
 # for runtime type checks
-AutomationScopeTypes: tuple[type, ...] = get_args(AutomationScope.__origin__)  # type: ignore[attr-defined]
+AutomationScopeTypes = AutomationScope.__origin__  # type: ignore[attr-defined]
 
 __all__ = [
     "ScopeType",
     "ArtifactCollectionScope",
     "ProjectScope",
+    "TeamScope",
+    "OrgScope",
+    "EntityScope",
 ]


### PR DESCRIPTION
Description
-----------
- Fixes: [WB-37080](https://coreweave.atlassian.net/browse/WB-37080)

Adds runtime support for entity automation scopes on top of the generated schema support. Entity scopes let automation definitions target a whole team or organization entity, alongside the existing project and artifact collection scopes.

What the PR does:
- Adds `ScopeType.ENTITY`, `EntityScope`, `TeamScope`, and `OrgScope`.
- Teaches automation scope parsing to accept `Team` and `Organization`, using the organization backing entity for organization scopes.
- Allows run events to target either a project or an entity scope.
- Gates entity scope support through the server feature flag and omits `EntityScopeFields` for older servers.

Usage:
```python
api = wandb.Api()

team = api.team("my-team")
api.create_automation(
    OnRunMetric(scope=team, filter=RunEvent.metric("loss").avg(window=5) > 0.1) >> DoNothing(),
    name="team-alert",
)

org = api.organization("my-org")
api.create_automation(
    OnRunMetric(scope=org, filter=RunEvent.metric("loss").avg(window=5) > 0.1) >> DoNothing(),
    name="org-alert",
)
```

Stack context:
- Builds on the generated schema support in the codegen PR.
- Enables the query behavior PR to list automations scoped directly to teams and organizations.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Added unit coverage in `tests/unit_tests/test_automations/test_scopes.py` for team and organization entity scopes.


[WB-37080]: https://coreweave.atlassian.net/browse/WB-37080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ