### PR TITLE
chore: add a dependency cooldown to requirements/generate.sh

### DIFF
--- a/requirements/generate.sh
+++ b/requirements/generate.sh
@@ -47,6 +47,7 @@ function platform_python_name() {
 # Compiles requirements for a Python version ($1) and platform ($2).
 function compile() {
     uv pip compile "${PIP_COMPILE_ARGS[@]}" \
+        --exclude-newer "1w" \
         --python-version "$1" \
         --python-platform "$(platform_python_name $2)" \
         requirements/requirements_dev.txt \


### PR DESCRIPTION
Ensures updated versions of Python packages used in CI are at least a week old. The job runs weekly, so our packages are going to be at least a week out of date normally, and a cooldown makes it a little less scary to upgrade things.