### PR TITLE
chore: set CODEOWNERS for requirements/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,9 @@
 # GitHub configuration
 /.github @wandb/sdk-team
 
+# Python requirements in CI
+/requirements/ @wandb/sdk-team
+
 # Internal helpers: used by multiple teams, any here can approve
 /wandb/_iterutils.py @wandb/sdk-team @wandb/art-reg-team
 /wandb/_strutils.py @wandb/sdk-team @wandb/art-reg-team


### PR DESCRIPTION
Sets @wandb/sdk-team as the code owner for `requirements/`. This has the advantage of notifying us when `.github/workflows/regenerate-requirements.yml` makes its weekly PR.

The SDK team should probably be the default (`*`) owner for the whole repo; I'll consider rewriting the CODEOWNERS file later, after more discussion.