### PR TITLE
chore: add --upgrade-package option to requirements/generate.sh

### DIFF
--- a/requirements/generate.sh
+++ b/requirements/generate.sh
@@ -5,9 +5,16 @@ set -e
 function print_help() {
     echo "Usage: generate.sh [--upgrade]"
     echo
-    echo "Pass --upgrade to upgrade all requirements."
+    echo "Pass --upgrade or -U to upgrade all requirements."
+    echo "Pass --upgrade-package <package> or -P to upgrade specific packages."
+    echo "  Upgrading specific packages can be desirable if some upgrades"
+    echo "  have security or license issues. It is preferred to use this"
+    echo "  mechanism instead of adding pins in the requirements file."
     echo
-    echo "Otherwise, this will apply any new requirements_dev.txt constraints"
+    echo "  Unfortunately, uv does not provide an '--upgrade-except' option yet:"
+    echo "  https://github.com/astral-sh/uv/issues/7177"
+    echo
+    echo "By default, this will apply any new requirements_dev.txt constraints"
     echo "while trying to preserve any currently pinned versions."
 }
 
@@ -16,8 +23,18 @@ PIP_COMPILE_ARGS=()
 # Parse arguments.
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        --upgrade)
+        --upgrade|-U)
             PIP_COMPILE_ARGS+=( "--upgrade" )
+            ;;
+
+        --upgrade-package|-P)
+            if [[ "$#" -lt 2 ]]; then
+                echo "The --upgrade-package / -P option requires an argument."
+                exit 1
+            fi
+
+            PIP_COMPILE_ARGS+=( "--upgrade-package" "$2" )
+            shift  # Pop the extra argument.
             ;;
 
         --help)


### PR DESCRIPTION
Adds `--upgrade-package` or `-P` as an option to `requirements/generate.sh` to upgrade specific packages instead of everything as with `--upgrade`. The option names match `uv pip compile` options. This makes it easier to upgrade packages when some packages have security or license issues.