### PR TITLE
chore: add requirements/constraints.txt

### DIFF
--- a/.github/workflows/regenerate-requirements.yml
+++ b/.github/workflows/regenerate-requirements.yml
@@ -37,3 +37,7 @@ jobs:
             If CI fails because of a bug in a dependency, update
             `requirements/requirements_dev.txt` and rerun the action. Consider
             filing a bug for the dependency.
+
+            If there are security or license issues in some upgraded packages,
+            consider adding pins in `requirements/constraints.txt` and
+            rerunning the action.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,15 @@
+# This file provides constraints in addition to requirements_dev.txt
+# without directly depending on the listed packages. This is used to
+# constrain indirect dependencies that have security or licence issues.
+#
+# Add constraints here and rerun `generate.sh -U` when socket.dev reports
+# issues with a dependency upgrade.
+#
+# Try to occasionally remove these constraints to see if issues are fixed.
+
+aiohttp==3.13.5
+cryptography==46.0.7
+google-auth==2.52.0
+graphql-core==3.2.8
+polars-runtime-32==1.40.1
+pywinpty==3.0.3

--- a/requirements/generate.sh
+++ b/requirements/generate.sh
@@ -50,6 +50,7 @@ function compile() {
         --exclude-newer "1w" \
         --python-version "$1" \
         --python-platform "$(platform_python_name $2)" \
+        --constraints requirements/constraints.txt \
         requirements/requirements_dev.txt \
         -o "requirements/requirements_dev.$1.$2.txt" \
         >/dev/null  # https://github.com/astral-sh/uv/issues/3701


### PR DESCRIPTION
Adds a constraints file which we can use to constrain the upgrades done by `requirements/generate.sh` when `socket.dev` reports security or license problems.

I picked the initial constraints based on https://socket.dev/dashboard/org/wandb/diff-scan/ccf729a9-1b28-4cb1-ade0-5a75fd7d9fde?tab=dependencies&insights=0