### PR TITLE
fix(sdk): stub MarkRunFilesUploaded mutation in directory-traversal upload test

### DIFF
--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -1466,6 +1466,10 @@ def test_run_upload_file_with_directory_traversal(
         gql.Matcher(operation="RunFiles"),
         gql.Constant(content=runs_files_gql_body),
     )
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="MarkRunFilesUploaded"),
+        gql.Constant(content={"data": {"markRunFilesUploaded": {"success": True}}}),
+    )
     mock_push = mock.MagicMock()
     monkeypatch.setattr(wandb.sdk.internal.internal_api.Api, "push", mock_push)
     tmp_path.joinpath("root").mkdir()


### PR DESCRIPTION
## Summary

- A system test was failing with `wandb.errors.errors.CommError: entity test not found during markRunFilesUploaded`.
- #12138 added a call in `Run.upload_file()` that fires a real `markRunFilesUploaded` GraphQL mutation via wandb-core after pushing the file. This test fakes the run through stubbed `Run`/`RunFiles` GraphQL responses and a mocked `InternalApi.push`, but never stubbed the new mutation, so it hit the real local test server for a nonexistent `test/test/test` entity/project/run and errored.
- This stubs `MarkRunFilesUploaded` the same way `RunFiles` is already stubbed in this test.

## Fixes

JIRA [WB-37392](https://coreweave.atlassian.net/browse/WB-37392).

## Test plan

- [x] Applied the same `gql.Matcher`/`gql.Constant` stubbing pattern already used for `RunFiles` in this test.
- [x] Run the system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[WB-37392]: https://coreweave.atlassian.net/browse/WB-37392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ