### PR TITLE
chore(sdk): directly parse pydantic types faster via `model_validate_json`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,3 +17,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ## Changed
 - Hardened argument handling in `wandb launch` for the local-process resource so that job-supplied values are always shell-quoted (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12220)
 - The launch agent now restricts a job's git source URL to https/ssh remotes and pins git's protocol allowlist when fetching it and updating submodules (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12221)
+- Response parsing is now faster for many `wandb.Api` operations, including artifact and registry queries (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12213)

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -366,8 +366,6 @@ def test_artifact_from_id_uses_service_api(monkeypatch):
 
     artifact_id = "test-artifact-id"
     artifact_instance_cache.pop(artifact_id, None)
-    service_api = MagicMock()
-    service_api.execute_graphql.return_value = {}
     artifact = SimpleNamespace(
         artifact_sequence=SimpleNamespace(
             name="dataset",
@@ -378,11 +376,10 @@ def test_artifact_from_id_uses_service_api(monkeypatch):
         ),
         version_index=3,
     )
-    monkeypatch.setattr(
-        ArtifactByID,
-        "model_validate",
-        MagicMock(return_value=SimpleNamespace(artifact=artifact)),
-    )
+    # execute_graphql now parses the response into the pydantic model itself
+    # (via parse=), so its return value is the already-parsed result.
+    service_api = MagicMock()
+    service_api.execute_graphql.return_value = SimpleNamespace(artifact=artifact)
     from_attrs = MagicMock(return_value="artifact")
     monkeypatch.setattr(Artifact, "_from_attrs", from_attrs)
 
@@ -391,6 +388,7 @@ def test_artifact_from_id_uses_service_api(monkeypatch):
     service_api.execute_graphql.assert_called_once_with(
         ARTIFACT_BY_ID_GQL,
         variables={"id": artifact_id},
+        parse=ArtifactByID.model_validate_json,
     )
     path, src_art, actual_service_api = from_attrs.call_args.args
     assert path.to_str() == "entity/project/dataset:v3"

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -398,29 +398,35 @@ def test_artifact_from_id_uses_service_api(monkeypatch):
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_project_id_lazy_load(monkeypatch):
+    from wandb.apis._generated import GetProject
+
     api = wandb.Api()
+    # execute_graphql now parses the response into the pydantic model itself
+    # (via parse=), so its return value is the already-parsed result.
     mock_execute = MagicMock(
-        return_value={
-            "project": ProjectFragment(
-                id="123",
-                name="test-project",
-                entity_name="test-entity",
-                created_at="2021-01-01T00:00:00Z",
-                is_benchmark=False,
-                user=UserFragment(
+        return_value=GetProject.model_validate(
+            {
+                "project": ProjectFragment(
                     id="123",
-                    name="test-user",
-                    username="test-user",
-                    email="test-user@example.com",
-                    admin=False,
-                    flags="",
-                    entity="test-entity",
-                    deleted_at=None,
-                    api_keys=None,
-                    teams=None,
-                ),
-            ).model_dump(),
-        }
+                    name="test-project",
+                    entity_name="test-entity",
+                    created_at="2021-01-01T00:00:00Z",
+                    is_benchmark=False,
+                    user=UserFragment(
+                        id="123",
+                        name="test-user",
+                        username="test-user",
+                        email="test-user@example.com",
+                        admin=False,
+                        flags="",
+                        entity="test-entity",
+                        deleted_at=None,
+                        api_keys=None,
+                        teams=None,
+                    ),
+                ).model_dump(),
+            }
+        )
     )
     monkeypatch.setattr(
         wandb.apis.public.api.ServiceApi,

--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator, Mapping, Sized
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sized
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, overload
 
 import wandb
@@ -10,6 +11,8 @@ from wandb._strutils import nameof
 if TYPE_CHECKING:
     from wandb._pydantic import Connection
     from wandb.apis.public.service_api import ServiceApi
+
+_T = TypeVar("_T")
 
 _WandbT = TypeVar("_WandbT")
 """Generic type variable for a W&B object."""
@@ -77,11 +80,12 @@ class Paginator(Iterator[_WandbT], ABC):
         """Update the query variables for the next page fetch."""
         self.variables.update({"perPage": self.per_page, "cursor": self.cursor})
 
-    def _execute_query(self) -> Any:
+    def _execute_query(self, parse: Callable[[str], _T] = json.loads) -> _T:
         """Run self.QUERY with the paginator's compat options."""
         return self._service_api.execute_graphql(
             self.QUERY,
             variables=self.variables,
+            parse=parse,
             omit_variables=self._omit_variables,
             omit_fragments=self._omit_fragments,
             omit_fields=self._omit_fields,

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -679,8 +679,10 @@ class Api:
         from wandb.apis._generated import GET_DEFAULT_ENTITY_GQL, GetDefaultEntity
 
         if self._default_entity is None:
-            data = self._service_api.execute_graphql(GET_DEFAULT_ENTITY_GQL)
-            result = GetDefaultEntity.model_validate(data)
+            result = self._service_api.execute_graphql(
+                GET_DEFAULT_ENTITY_GQL,
+                parse=GetDefaultEntity.model_validate_json,
+            )
             if (viewer := result.viewer) and (entity := viewer.entity):
                 self._default_entity = entity
         return self._default_entity
@@ -698,8 +700,10 @@ class Api:
         from .users import User
 
         if self._viewer is None:
-            data = self._service_api.execute_graphql(GET_VIEWER_GQL)
-            result = GetViewer.model_validate(data)
+            result = self._service_api.execute_graphql(
+                GET_VIEWER_GQL,
+                parse=GetViewer.model_validate_json,
+            )
             if (viewer := result.viewer) is None:
                 msg = "Unable to fetch user data from W&B, please verify your API key is valid."
                 raise ValueError(msg)
@@ -1049,11 +1053,11 @@ class Api:
                 non_org_entity=self.settings.get("entity") or self.default_entity,
             )
 
-        gql_op = FETCH_ORGANIZATION_GQL
-        gql_vars = {"org": org_name}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-
-        result = FetchOrganization.model_validate(data)
+        result = self._service_api.execute_graphql(
+            FETCH_ORGANIZATION_GQL,
+            variables={"org": org_name},
+            parse=FetchOrganization.model_validate_json,
+        )
         if (org := result.organization) is None:
             raise ValueError(f"Organization {org_name!r} not found.")
         return Organization(self._service_api, **org.model_dump())
@@ -1074,11 +1078,11 @@ class Api:
 
         from .users import User
 
-        data = self._service_api.execute_graphql(
+        result = self._service_api.execute_graphql(
             SEARCH_USERS_GQL,
-            {"query": username_or_email},
+            variables={"query": username_or_email},
+            parse=SearchUsers.model_validate_json,
         )
-        result = SearchUsers.model_validate(data)
         if not (conn := result.users) or not (edges := conn.edges):
             return None
         if len(edges) > 1:
@@ -1102,11 +1106,11 @@ class Api:
 
         from .users import User
 
-        data = self._service_api.execute_graphql(
+        result = self._service_api.execute_graphql(
             SEARCH_USERS_GQL,
-            {"query": username_or_email},
+            variables={"query": username_or_email},
+            parse=SearchUsers.model_validate_json,
         )
-        result = SearchUsers.model_validate(data)
         if not ((conn := result.users) and (edges := conn.edges)):
             return []
         return [
@@ -2534,6 +2538,7 @@ class Api:
                 CREATE_AUTOMATION_GQL,
                 variables=variables,
                 omit_fragments=omit_fragments,
+                parse=CreateAutomation.model_validate_json,
             )
         except WandbApiFailedError as e:
             status = _api_error_status(e)
@@ -2546,18 +2551,15 @@ class Api:
                     f"Automation {name!r} exists. Unable to create another with the same name."
                 ) from None
             raise
-
-        try:
-            result = CreateAutomation.model_validate(data).result
         except ValidationError as e:
             msg = f"Invalid response while creating automation {name!r}"
             raise RuntimeError(msg) from e
 
-        if (result is None) or (result.trigger is None):
+        if not (result := data.result) or not (trigger := result.trigger):
             msg = f"Empty response while creating automation {name!r}"
             raise RuntimeError(msg)
 
-        return Automation.model_validate(result.trigger)
+        return Automation.model_validate(trigger)
 
     @normalize_exceptions
     @tracked
@@ -2655,6 +2657,7 @@ class Api:
                 UPDATE_AUTOMATION_GQL,
                 variables=variables,
                 omit_fragments=self._omitted_automation_fragments(),
+                parse=UpdateAutomation.model_validate_json,
             )
         except WandbApiFailedError as e:
             status = _api_error_status(e)
@@ -2670,18 +2673,15 @@ class Api:
             # Not a (known) recoverable API error
             wandb.termerror(f"Got API error: {e}")
             raise
-
-        try:
-            result = UpdateAutomation.model_validate(data).result
         except ValidationError as e:
             msg = f"Invalid response while updating automation {name!r}"
             raise RuntimeError(msg) from e
 
-        if (result is None) or (result.trigger is None):
+        if not (result := data.result) or not (trigger := result.trigger):
             msg = f"Empty response while updating automation {name!r}"
             raise RuntimeError(msg)
 
-        return Automation.model_validate(result.trigger)
+        return Automation.model_validate(trigger)
 
     @normalize_exceptions
     @tracked
@@ -2698,22 +2698,22 @@ class Api:
         from wandb.automations._utils import extract_id
 
         id_ = extract_id(obj)
-        mutation = DELETE_AUTOMATION_GQL
-        variables = {"id": id_}
-
-        data = self._service_api.execute_graphql(mutation, variables=variables)
 
         try:
-            result = DeleteAutomation.model_validate(data).result
+            data = self._service_api.execute_graphql(
+                DELETE_AUTOMATION_GQL,
+                variables={"id": id_},
+                parse=DeleteAutomation.model_validate_json,
+            )
         except ValidationError as e:
             msg = f"Invalid response while deleting automation {id_!r}"
             raise RuntimeError(msg) from e
 
-        if result is None:
+        if not (result := data.result):
             msg = f"Empty response while deleting automation {id_!r}"
             raise RuntimeError(msg)
 
-        if not result.success:
+        if not (success := result.success):
             raise RuntimeError(f"Failed to delete automation: {id_!r}")
 
-        return result.success
+        return success

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -98,8 +98,9 @@ class _ArtifactCollectionAliases(RelayPaginator["ArtifactAliasFragment", str]):
             ArtifactCollectionAliases,
         )
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = ArtifactCollectionAliases.model_validate(data)
+        result = self._execute_query(
+            parse=ArtifactCollectionAliases.model_validate_json
+        )
 
         # Extract the inner `*Connection` result for faster/easier access.
         if not ((coll := result.artifact_collection) and (conn := coll.aliases)):
@@ -147,8 +148,7 @@ class ArtifactTypes(RelayPaginator["ArtifactTypeFragment", "ArtifactType"]):
         from wandb.sdk.artifacts._generated import ProjectArtifactTypes
         from wandb.sdk.artifacts._models.pagination import ArtifactTypeConnection
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = ProjectArtifactTypes.model_validate(data)
+        result = self._execute_query(parse=ProjectArtifactTypes.model_validate_json)
 
         # Extract the inner `*Connection` result for faster/easier access.
         if not ((proj := result.project) and (conn := proj.artifact_types)):
@@ -213,11 +213,13 @@ class ArtifactType:
             ProjectArtifactType,
         )
 
-        gql_op = PROJECT_ARTIFACT_TYPE_GQL
-        gql_vars = {"entity": self.entity, "project": self.project, "type": self.type}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = ProjectArtifactType.model_validate(data)
-        if not ((proj := result.project) and (artifact_type := proj.artifact_type)):
+        data = self._service_api.execute_graphql(
+            PROJECT_ARTIFACT_TYPE_GQL,
+            {"entity": self.entity, "project": self.project, "type": self.type},
+            parse=ProjectArtifactType.model_validate_json,
+        )
+
+        if not ((proj := data.project) and (artifact_type := proj.artifact_type)):
             raise ValueError(f"Could not find artifact type {self.type!r}")
         return ArtifactTypeFragment.model_validate(artifact_type)
 
@@ -353,8 +355,9 @@ class ArtifactCollections(
         from wandb.sdk.artifacts._generated import ArtifactTypeArtifactCollections
         from wandb.sdk.artifacts._models.pagination import ArtifactCollectionConnection
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = ArtifactTypeArtifactCollections.model_validate(data)
+        result = self._execute_query(
+            parse=ArtifactTypeArtifactCollections.model_validate_json
+        )
 
         # Extract the inner `*Connection` result for faster/easier access.
         if not (
@@ -453,13 +456,12 @@ class ProjectArtifactCollections(
             ProjectArtifactCollectionConnection,
         )
 
-        data = self._execute_query()
-        result = ProjectArtifactCollections.model_validate(data)
-
+        result = self._execute_query(
+            parse=ProjectArtifactCollections.model_validate_json
+        )
         # Extract the inner `*Connection` result for faster/easier access.
         if not ((proj := result.project) and (conn := proj.artifact_collections)):
             raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
-
         self.last_response = ProjectArtifactCollectionConnection.model_validate(conn)
 
     def _convert(self, node: ArtifactCollectionFragment) -> ArtifactCollection | None:
@@ -600,10 +602,11 @@ class ArtifactCollection:
             ProjectArtifactCollection,
         )
 
-        gql_op = PROJECT_ARTIFACT_COLLECTION_GQL
-        gql_vars = {"entity": entity, "project": project, "type": type_, "name": name}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = ProjectArtifactCollection.model_validate(data)
+        result = self._service_api.execute_graphql(
+            PROJECT_ARTIFACT_COLLECTION_GQL,
+            {"entity": entity, "project": project, "type": type_, "name": name},
+            parse=ProjectArtifactCollection.model_validate_json,
+        )
         if not (
             result.project
             and (proj := result.project)
@@ -643,13 +646,13 @@ class ArtifactCollection:
 
         termlog(f"Changing artifact collection type of {old_type!r} to {new_type!r}")
 
-        gql_op = UPDATE_ARTIFACT_SEQUENCE_TYPE_GQL
         gql_input = MoveArtifactSequenceInput(
             artifact_sequence_id=self.id,
             destination_artifact_type_name=new_type,
         )
         self._service_api.execute_graphql(
-            gql_op, variables={"input": gql_input.model_dump()}
+            UPDATE_ARTIFACT_SEQUENCE_TYPE_GQL,
+            variables={"input": gql_input.model_dump()},
         )
         self._saved.type = new_type
         self._current.type = new_type
@@ -911,8 +914,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     def _update_response(self) -> None:
         from wandb.sdk.artifacts._generated import ArtifactFragment, ProjectArtifacts
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = ProjectArtifacts.model_validate(data)
+        result = self._execute_query(parse=ProjectArtifacts.model_validate_json)
 
         # Extract the inner `*Connection` result for faster/easier access.
         if not (
@@ -1071,10 +1073,9 @@ class ArtifactFiles(SizedRelayPaginator["FileFragment", "File"]):
         from wandb.sdk.artifacts._generated import ArtifactMembershipFiles
         from wandb.sdk.artifacts._models.pagination import ArtifactFileConnection
 
-        data = self._execute_query()
+        result = self._execute_query(parse=ArtifactMembershipFiles.model_validate_json)
 
         # Extract the inner `*Connection` result for faster/easier access.
-        result = ArtifactMembershipFiles.model_validate(data)
         conn = result.project.artifact_collection.artifact_membership.files
 
         if conn is None:

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -57,7 +57,7 @@ class Automations(RelayPaginator["ProjectTriggersFields", "Automation"]):
         from wandb._pydantic import Connection
         from wandb.automations._generated import ProjectTriggersFields
 
-        data = self._execute_query()
+        data: dict[str, Any] = self._execute_query()
         try:
             conn_data = data["scope"]["projects"]
             conn = Connection[ProjectTriggersFields].model_validate(conn_data)

--- a/wandb/apis/public/integrations.py
+++ b/wandb/apis/public/integrations.py
@@ -57,8 +57,7 @@ class _IntegrationsPaginator(RelayPaginator["IntegrationFields", _IntegrationT])
         from wandb._pydantic import Connection
         from wandb.automations._generated import IntegrationsByEntity
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = IntegrationsByEntity.model_validate(data)
+        result = self._execute_query(parse=IntegrationsByEntity.model_validate_json)
         if not ((entity := result.entity) and (conn := entity.integrations)):
             raise ValueError("Unexpected response data")
         self.last_response = Connection.model_validate(conn)

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -111,8 +111,7 @@ class Projects(RelayPaginator["ProjectFragment", "Project"]):
         from wandb._pydantic import Connection
         from wandb.apis._generated import GetProjects, ProjectFragment
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = GetProjects.model_validate(data)
+        result = self._execute_query(parse=GetProjects.model_validate_json)
         if not (conn := result.models):
             raise ValueError(f"Unable to parse {nameof(type(self))!r} response data")
         self.last_response = Connection[ProjectFragment].model_validate(conn)
@@ -176,11 +175,15 @@ class Project(Attrs):
 
         gql_vars = {"name": self.name, "entity": self.entity}
         try:
-            data = self._service_api.execute_graphql(GET_PROJECT_GQL, gql_vars)
+            data = self._service_api.execute_graphql(
+                GET_PROJECT_GQL,
+                variables=gql_vars,
+                parse=GetProject.model_validate_json,
+            )
         except WandbApiFailedError as e:
             raise ValueError(f"Unable to fetch project ID: {gql_vars!r}") from e
 
-        project = GetProject.model_validate(data).project
+        project = data.project
         self._attrs = project.model_dump() if project else {}
         self._is_loaded = True
 

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -138,8 +138,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         from wandb.sdk.artifacts._generated import FetchRegistries
         from wandb.sdk.artifacts._models.pagination import RegistryConnection
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = FetchRegistries.model_validate(data)
+        result = self._execute_query(parse=FetchRegistries.model_validate_json)
         if not ((org := result.organization) and (org_entity := org.org_entity)):
             raise ValueError(
                 f"Organization {self.organization!r} not found. Please verify the organization name is correct."
@@ -242,8 +241,7 @@ class Collections(
         from wandb.sdk.artifacts._generated import RegistryCollections
         from wandb.sdk.artifacts._models.pagination import RegistryCollectionConnection
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = RegistryCollections.model_validate(data)
+        result = self._execute_query(parse=RegistryCollections.model_validate_json)
         if not ((org := result.organization) and (org_entity := org.org_entity)):
             raise ValueError(
                 f"Organization {self.organization!r} not found. Please verify the organization name is correct."
@@ -334,8 +332,7 @@ class Versions(RelayPaginator["ArtifactMembershipFragment", "Artifact"]):
         from wandb.sdk.artifacts._generated import RegistryVersions
         from wandb.sdk.artifacts._models.pagination import ArtifactMembershipConnection
 
-        data = self._service_api.execute_graphql(self.QUERY, variables=self.variables)
-        result = RegistryVersions.model_validate(data)
+        result = self._execute_query(parse=RegistryVersions.model_validate_json)
         if not ((org := result.organization) and (org_entity := org.org_entity)):
             raise ValueError(
                 f"Organization {self.organization!r} not found. Please verify the organization name is correct."

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -307,11 +307,15 @@ class Registry:
             data = api._service_api.execute_graphql(
                 UPSERT_REGISTRY_GQL,
                 {"input": gql_input.model_dump()},
+                parse=UpsertRegistry.model_validate_json,
             )
-            result = UpsertRegistry.model_validate(data).upsert_model
         except Exception as e:
             raise ValueError(failed_msg) from e
-        if not (result and result.inserted and (registry_project := result.project)):
+        if not (
+            (result := data.upsert_model)
+            and result.inserted
+            and (registry_project := result.project)
+        ):
             raise ValueError(failed_msg)
 
         return cls(
@@ -329,14 +333,15 @@ class Registry:
 
         failed_msg = f"Failed to delete registry {self.name!r} in organization {self.organization!r}"
 
-        gql_op = DELETE_REGISTRY_GQL
-        gql_vars = {"id": self.id}
         try:
-            data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-            result = DeleteRegistry.model_validate(data).delete_model
+            data = self._service_api.execute_graphql(
+                DELETE_REGISTRY_GQL,
+                variables={"id": self.id},
+                parse=DeleteRegistry.model_validate_json,
+            )
         except Exception as e:
             raise ValueError(failed_msg) from e
-        if not (result and result.success):
+        if not ((result := data.delete_model) and result.success):
             raise ValueError(failed_msg)
 
     @tracked
@@ -349,11 +354,12 @@ class Registry:
             f" {self.organization!r}."
         )
 
-        gql_op = FETCH_REGISTRY_GQL
-        gql_vars = {"name": self.full_name, "entity": self.entity}
         try:
-            data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-            result = FetchRegistry.model_validate(data)
+            result = self._service_api.execute_graphql(
+                FETCH_REGISTRY_GQL,
+                variables={"name": self.full_name, "entity": self.entity},
+                parse=FetchRegistry.model_validate_json,
+            )
         except Exception as e:
             raise ValueError(failed_msg) from e
 
@@ -398,7 +404,6 @@ class Registry:
         old_project_name = validate_project_name(self._saved.full_name)
         new_project_name = validate_project_name(self._current.full_name)
 
-        upsert_op = UPSERT_REGISTRY_GQL
         upsert_input = UpsertModelInput(
             description=self.description,
             entity_name=self.entity,
@@ -407,14 +412,16 @@ class Registry:
             allow_all_artifact_types_in_registry=self.allow_all_artifact_types,
             artifact_types=prepare_artifact_types_input(new_artifact_types),
         )
-        upsert_vars = {"input": upsert_input.model_dump()}
         try:
-            data = self._service_api.execute_graphql(upsert_op, variables=upsert_vars)
-            result = UpsertRegistry.model_validate(data).upsert_model
+            data = self._service_api.execute_graphql(
+                UPSERT_REGISTRY_GQL,
+                variables={"input": upsert_input.model_dump()},
+                parse=UpsertRegistry.model_validate_json,
+            )
         except Exception as e:
             raise ValueError(failed_msg) from e
 
-        if result and result.inserted:
+        if (result := data.upsert_model) and result.inserted:
             # This should only trigger if `_saved_name` was modified unexpectedly.
             wandb.termlog(
                 f"Created registry {self.name!r} in organization {self.organization!r} on save"
@@ -427,16 +434,19 @@ class Registry:
 
         # Update the name of the registry if it has changed
         if old_project_name != new_project_name:
-            rename_op = RENAME_REGISTRY_GQL
             rename_input = RenameProjectInput(
                 entity_name=self.entity,
                 old_project_name=old_project_name,
                 new_project_name=new_project_name,
             )
-            rename_vars = {"input": rename_input.model_dump()}
-            data = self._service_api.execute_graphql(rename_op, variables=rename_vars)
-            result = RenameRegistry.model_validate(data).rename_project
-            if not (result and (registry_project := result.project)):
+            data = self._service_api.execute_graphql(
+                RENAME_REGISTRY_GQL,
+                variables={"input": rename_input.model_dump()},
+                parse=RenameRegistry.model_validate_json,
+            )
+            if not (
+                (result := data.rename_project) and (registry_project := result.project)
+            ):
                 raise ValueError(failed_msg)
 
             if result.inserted:
@@ -456,11 +466,11 @@ class Registry:
             RegistryUserMembers,
         )
 
-        gql_op = REGISTRY_USER_MEMBERS_GQL
-        gql_vars = {"project": self.full_name, "entity": self.entity}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = RegistryUserMembers.model_validate(data)
-
+        result = self._service_api.execute_graphql(
+            REGISTRY_USER_MEMBERS_GQL,
+            variables={"project": self.full_name, "entity": self.entity},
+            parse=RegistryUserMembers.model_validate_json,
+        )
         if not (project := result.project):
             raise ValueError(f"Failed to fetch user members for registry {self.name!r}")
 
@@ -484,11 +494,11 @@ class Registry:
             RegistryTeamMembers,
         )
 
-        gql_op = REGISTRY_TEAM_MEMBERS_GQL
-        gql_vars = {"project": self.full_name, "entity": self.entity}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = RegistryTeamMembers.model_validate(data)
-
+        result = self._service_api.execute_graphql(
+            REGISTRY_TEAM_MEMBERS_GQL,
+            variables={"project": self.full_name, "entity": self.entity},
+            parse=RegistryTeamMembers.model_validate_json,
+        )
         if not (project := result.project):
             raise ValueError(f"Failed to fetch team members for registry {self.name!r}")
 
@@ -550,15 +560,15 @@ class Registry:
             )
         user_ids, team_ids = parse_member_ids(members)
 
-        gql_op = CREATE_REGISTRY_MEMBERS_GQL
         gql_input = CreateProjectMembersInput(
             user_ids=user_ids, team_ids=team_ids, project_id=self.id
         )
-        gql_vars = {"input": gql_input.model_dump()}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = CreateRegistryMembers.model_validate(data).result
-
-        if not (result and result.success):
+        data = self._service_api.execute_graphql(
+            CREATE_REGISTRY_MEMBERS_GQL,
+            variables={"input": gql_input.model_dump()},
+            parse=CreateRegistryMembers.model_validate_json,
+        )
+        if not ((result := data.result) and result.success):
             raise ValueError(f"Failed to add members to registry {self.name!r}")
         return self
 
@@ -607,15 +617,15 @@ class Registry:
             )
         user_ids, team_ids = parse_member_ids(members)
 
-        gql_op = DELETE_REGISTRY_MEMBERS_GQL
         gql_input = DeleteProjectMembersInput(
             user_ids=user_ids, team_ids=team_ids, project_id=self.id
         )
-        gql_vars = {"input": gql_input.model_dump()}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = DeleteRegistryMembers.model_validate(data).result
-
-        if not (result and result.success):
+        data = self._service_api.execute_graphql(
+            DELETE_REGISTRY_MEMBERS_GQL,
+            variables={"input": gql_input.model_dump()},
+            parse=DeleteRegistryMembers.model_validate_json,
+        )
+        if not ((result := data.result) and result.success):
             raise ValueError(f"Failed to remove members from registry {self.name!r}")
         return self
 
@@ -681,11 +691,12 @@ class Registry:
         else:
             assert_never(id_.kind)
 
-        gql_vars = {"input": gql_input.model_dump()}
-        data = self._service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = result_cls.model_validate(data).result
-
-        if not (result and result.success):
+        data = self._service_api.execute_graphql(
+            gql_op,
+            variables={"input": gql_input.model_dump()},
+            parse=result_cls.model_validate_json,
+        )
+        if not ((result := data.result) and result.success):
             raise ValueError(
                 f"Failed to update member {member!r} role to {role!r} in registry {self.name!r}"
             )

--- a/wandb/apis/public/service_api.py
+++ b/wandb/apis/public/service_api.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto import wandb_server_pb2 as spb
@@ -22,6 +22,9 @@ from wandb.sdk.lib.service.service_connection import (
 from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
 
 _logger = logging.getLogger(__name__)
+
+
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
@@ -108,11 +111,12 @@ class ServiceApi:
         variables: Mapping[str, Any] | None = None,
         timeout: float | None = None,
         *,
+        parse: Callable[[str], _T] = json.loads,
         omit_variables: Iterable[str] | None = None,
         omit_fragments: Iterable[str] | None = None,
         omit_fields: Iterable[str] | None = None,
         rename_fields: Mapping[str, str] | None = None,
-    ) -> Any:
+    ) -> _T:
         """Execute a GraphQL operation through the wandb-core sidecar.
 
         The query is sent to wandb-core, which performs the network round-trip
@@ -125,6 +129,9 @@ class ServiceApi:
                 on the wire.
             timeout: Optional timeout in seconds for waiting on wandb-core.
                 On timeout, the request is cancelled on a best-effort basis.
+            parse: Callable used to deserialize the JSON response data.
+                Its must accept a (JSON) string as input. Its output will be
+                returned from this method. Defaults to `json.loads`.
             omit_variables: Variable names ($var) to strip from the query
                 server-side before forwarding to the backend. Use this to
                 drop variables that the deployed server version does not
@@ -145,21 +152,21 @@ class ServiceApi:
                 non-successful HTTP status codes, and GraphQL `errors`
                 returned by the server.
         """
-        request = ApiRequest(
+        req = ApiRequest(
             graphql_request=GraphQLRequest(
                 query=query,
                 variables_json=json.dumps(variables or {}),
-                omit_variables=list(omit_variables) if omit_variables else None,
-                omit_fragments=list(omit_fragments) if omit_fragments else None,
-                omit_fields=list(omit_fields) if omit_fields else None,
-                rename_fields=dict(rename_fields) if rename_fields else None,
+                omit_variables=omit_variables,
+                omit_fragments=omit_fragments,
+                omit_fields=omit_fields,
+                rename_fields=rename_fields,
             )
         )
-        response = self.send_api_request(
-            request,
-            timeout=timeout if timeout is not None else self._timeout,
+        resp = self.send_api_request(
+            req,
+            timeout=self._timeout if timeout is None else timeout,
         )
-        return json.loads(response.graphql_response.data_json)
+        return parse(resp.graphql_response.data_json)
 
     async def send_api_request_async(
         self,

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -132,12 +132,12 @@ class Sweeps(SizedPaginator["Sweep"]):
         # On servers that don't support the `filters` argument, strip it from the
         # query so that listing sweeps still works.
         omit_variables = None if self._supports_filtering else ["filters"]
-        data = self._service_api.execute_graphql(
+        self.last_response = self._service_api.execute_graphql(
             self.QUERY,
             variables=self.variables,
             omit_variables=omit_variables,
+            parse=GetSweeps.model_validate_json,
         )
-        self.last_response = GetSweeps.model_validate(data)
 
     @property
     @override
@@ -488,11 +488,11 @@ class Sweep(Attrs):
             "entity": self.entity,
             "project": self.project,
         }
-        data = self._service_api.execute_graphql(
+        parsed = self._service_api.execute_graphql(
             GET_SWEEP_AGENTS_GQL,
             variables=variables,
+            parse=GetSweepAgents.model_validate_json,
         )
-        parsed = GetSweepAgents.model_validate(data)
         if not parsed.project or not parsed.project.sweep:
             return []
         return [

--- a/wandb/apis/public/teams.py
+++ b/wandb/apis/public/teams.py
@@ -185,11 +185,11 @@ class Team(Attrs):
         from wandb.apis._generated import GET_TEAM_ENTITY_GQL, GetTeamEntity
 
         if force or not self._attrs:
-            data = self._service_api.execute_graphql(
+            result = self._service_api.execute_graphql(
                 GET_TEAM_ENTITY_GQL,
-                {"name": self.name},
+                variables={"name": self.name},
+                parse=GetTeamEntity.model_validate_json,
             )
-            result = GetTeamEntity.model_validate(data)
             self._attrs = entity.model_dump() if (entity := result.entity) else {}
             self._attrs["members"] = [
                 Member(self._service_api, self.name, member)

--- a/wandb/apis/public/teams.py
+++ b/wandb/apis/public/teams.py
@@ -47,12 +47,12 @@ class Member(Attrs):
             data = self._service_api.execute_graphql(
                 DELETE_INVITE_GQL,
                 {"id": self.id, "entity": self.team},
+                parse=DeleteInvite.model_validate_json,
             )
         except WandbApiFailedError:
             return False
         else:
-            result = DeleteInvite.model_validate(data).result
-            return (result is not None) and result.success
+            return ((result := data.result) is not None) and result.success
 
     def __repr__(self):
         return f"<Member {self.name} ({self.account_type})>"

--- a/wandb/apis/public/users.py
+++ b/wandb/apis/public/users.py
@@ -80,9 +80,9 @@ class User(Attrs):
         data = api._service_api.execute_graphql(
             CREATE_USER_FROM_ADMIN_GQL,
             {"email": email, "admin": admin},
+            parse=CreateUserFromAdmin.model_validate_json,
         )
-        result = CreateUserFromAdmin.model_validate(data).result
-        if not (result and (user := result.user)):
+        if not ((result := data.result) and (user := result.user)):
             raise ValueError(f"Failed to create user {email!r}.")
         return cls(api._service_api, user.model_dump(), api_key=api.api_key)
 
@@ -152,12 +152,12 @@ class User(Attrs):
 
         try:
             # We must make this call using credentials from the original user
-            gql_op = GENERATE_API_KEY_GQL
             data = self._service_api.execute_graphql(
-                gql_op,
+                GENERATE_API_KEY_GQL,
                 {"description": description},
+                parse=GenerateApiKey.model_validate_json,
             )
-            key_fragment = GenerateApiKey.model_validate(data).result.api_key
+            key_fragment = data.result.api_key
             self._attrs["apiKeys"]["edges"].append({"node": key_fragment.model_dump()})
         except (WandbApiFailedError, AttributeError):
             return None

--- a/wandb/sdk/artifacts/_gqlutils.py
+++ b/wandb/sdk/artifacts/_gqlutils.py
@@ -23,9 +23,12 @@ def org_info_from_entity(
     """Returns the organization info for a given entity."""
     from ._generated import FETCH_ORG_INFO_FROM_ENTITY_GQL, FetchOrgInfoFromEntity
 
-    gql_op = FETCH_ORG_INFO_FROM_ENTITY_GQL
-    data = service_api.execute_graphql(gql_op, variables={"entity": entity})
-    return FetchOrgInfoFromEntity.model_validate(data).entity
+    result = service_api.execute_graphql(
+        FETCH_ORG_INFO_FROM_ENTITY_GQL,
+        variables={"entity": entity},
+        parse=FetchOrgInfoFromEntity.model_validate_json,
+    )
+    return result.entity
 
 
 @lru_cache(maxsize=16)
@@ -35,7 +38,10 @@ def _server_features(service_api: ServiceApi) -> dict[str, bool]:
     Results are cached per service API instance.
     """
     try:
-        response = service_api.execute_graphql(SERVER_FEATURES_QUERY_GQL)
+        result = service_api.execute_graphql(
+            SERVER_FEATURES_QUERY_GQL,
+            parse=ServerFeaturesQuery.model_validate_json,
+        )
     except Exception as e:
         # Unfortunately we currently have to match on the text of the error message,
         # as the `gql` client raises `Exception` rather than a more specific error.
@@ -43,7 +49,6 @@ def _server_features(service_api: ServiceApi) -> dict[str, bool]:
             return {}
         raise
 
-    result = ServerFeaturesQuery.model_validate(response)
     if (server_info := result.server_info) and (features := server_info.features):
         return {feat.name: feat.is_enabled for feat in features if feat}
     return {}
@@ -177,11 +182,11 @@ def is_project_read_only(
     """Return whether *project* is read-only for the caller, or None if invisible."""
     from wandb.apis._generated import IS_PROJECT_READ_ONLY_GQL, IsProjectReadOnly
 
-    data = service_api.execute_graphql(
+    result = service_api.execute_graphql(
         IS_PROJECT_READ_ONLY_GQL,
         variables={"entity": entity, "project": project},
+        parse=IsProjectReadOnly.model_validate_json,
     )
-    result = IsProjectReadOnly.model_validate(data)
     if not (result and (proj := result.project)):
         return None
     return proj.read_only

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -267,11 +267,11 @@ class Artifact:
         if cached_artifact := artifact_instance_cache.get(artifact_id):
             return cached_artifact
 
-        data = service_api.execute_graphql(
+        result = service_api.execute_graphql(
             ARTIFACT_BY_ID_GQL,
             variables={"id": artifact_id},
+            parse=ArtifactByID.model_validate_json,
         )
-        result = ArtifactByID.model_validate(data)
         if (artifact := result.artifact) is None:
             return None
 
@@ -294,10 +294,11 @@ class Artifact:
             ArtifactMembershipByName,
         )
 
-        gql_op = ARTIFACT_MEMBERSHIP_BY_NAME_GQL
-        gql_vars = {"entity": path.prefix, "project": path.project, "name": path.name}
-        data = service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = ArtifactMembershipByName.model_validate(data)
+        result = service_api.execute_graphql(
+            ARTIFACT_MEMBERSHIP_BY_NAME_GQL,
+            {"entity": path.prefix, "project": path.project, "name": path.name},
+            parse=ArtifactMembershipByName.model_validate_json,
+        )
 
         if not (project := result.project):
             msg = f"project {path.project!r} not found under entity {path.prefix!r}"
@@ -1020,10 +1021,11 @@ class Artifact:
             raise RuntimeError("Client not initialized for artifact queries")
 
         # From the GraphQL API, get the (expiring) directUrl for downloading the manifest.
-        gql_op = FETCH_ARTIFACT_MANIFEST_GQL
-        gql_vars = {"id": self.id}
-        data = client.execute_graphql(gql_op, variables=gql_vars)
-        result = FetchArtifactManifest.model_validate(data)
+        result = client.execute_graphql(
+            FETCH_ARTIFACT_MANIFEST_GQL,
+            variables={"id": self.id},
+            parse=FetchArtifactManifest.model_validate_json,
+        )
 
         # Now fetch the actual manifest contents from the directUrl.
         if (artifact := result.artifact) and (manifest := artifact.current_manifest):
@@ -1235,9 +1237,11 @@ class Artifact:
         if (client := self._service_api) is None:
             raise RuntimeError("Client not initialized for artifact queries")
 
-        gql_op = ARTIFACT_BY_ID_GQL
-        data = client.execute_graphql(gql_op, variables={"id": artifact_id})
-        result = ArtifactByID.model_validate(data)
+        result = client.execute_graphql(
+            ARTIFACT_BY_ID_GQL,
+            variables={"id": artifact_id},
+            parse=ArtifactByID.model_validate_json,
+        )
 
         if not (artifact := result.artifact):
             raise ValueError(f"Unable to fetch artifact with id: {artifact_id!r}")
@@ -1269,7 +1273,6 @@ class Artifact:
         if not skip_update_artifact:
             old_tags, new_tags = set(self._saved_tags), set(self.tags)
 
-            gql_op = UPDATE_ARTIFACT_GQL
             gql_input = UpdateArtifactInput(
                 artifact_id=self.id,
                 description=self.description,
@@ -1282,11 +1285,13 @@ class Artifact:
                     {"tagName": t} for t in validate_tags(old_tags - new_tags)
                 ],
             )
-            gql_vars = {"input": gql_input.model_dump()}
-            data = client.execute_graphql(gql_op, variables=gql_vars)
+            data = client.execute_graphql(
+                UPDATE_ARTIFACT_GQL,
+                variables={"input": gql_input.model_dump()},
+                parse=UpdateArtifact.model_validate_json,
+            )
 
-            result = UpdateArtifact.model_validate(data).result
-            if not (result and (artifact := result.artifact)):
+            if not ((result := data.result) and (artifact := result.artifact)):
                 raise ValueError("Unable to parse updateArtifact response")
             self._assign_attrs(artifact)
 
@@ -2178,10 +2183,12 @@ class Artifact:
                 "cursor": cursor,
                 "perPage": per_page,
             }
-            data = self._service_api.execute_graphql(
-                query, variables=gql_vars, timeout=60
+            membership_result = self._service_api.execute_graphql(
+                query,
+                variables=gql_vars,
+                timeout=60,
+                parse=GetArtifactMembershipFileUrls.model_validate_json,
             )
-            membership_result = GetArtifactMembershipFileUrls.model_validate(data)
 
             if not (
                 (project := membership_result.project)
@@ -2473,11 +2480,11 @@ class Artifact:
             variables=gql_vars,
             omit_variables=omit_variables,
             omit_fields=omit_fields,
+            parse=LinkArtifact.model_validate_json,
         )
-        result = LinkArtifact.model_validate(data).result
 
         # Newer server versions can return artifactMembership directly in the response
-        if result and (membership := result.artifact_membership):
+        if (result := data.result) and (membership := result.artifact_membership):
             return self._from_membership(
                 membership,
                 target=target,
@@ -2543,10 +2550,11 @@ class Artifact:
         if (service_api := self._service_api) is None:
             raise RuntimeError("Client not initialized for artifact queries")
 
-        query = ARTIFACT_USED_BY_GQL
-        gql_vars = {"id": self.id}
-        data = service_api.execute_graphql(query, variables=gql_vars)
-        result = ArtifactUsedBy.model_validate(data)
+        result = service_api.execute_graphql(
+            ARTIFACT_USED_BY_GQL,
+            variables={"id": self.id},
+            parse=ArtifactUsedBy.model_validate_json,
+        )
 
         if (
             (artifact := result.artifact)
@@ -2586,10 +2594,11 @@ class Artifact:
         if (service_api := self._service_api) is None:
             raise RuntimeError("Client not initialized for artifact queries")
 
-        gql_op = ARTIFACT_CREATED_BY_GQL
-        gql_vars = {"id": self.id}
-        data = service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = ArtifactCreatedBy.model_validate(data)
+        result = service_api.execute_graphql(
+            ARTIFACT_CREATED_BY_GQL,
+            variables={"id": self.id},
+            parse=ArtifactCreatedBy.model_validate_json,
+        )
 
         if (
             (artifact := result.artifact)
@@ -2624,10 +2633,11 @@ class Artifact:
 
         name = name if (":" in name) else f"{name}:latest"
 
-        gql_op = ARTIFACT_TYPE_GQL
-        gql_vars = {"entity": entity_name, "project": project_name, "name": name}
-        data = service_api.execute_graphql(gql_op, variables=gql_vars)
-        result = ArtifactType.model_validate(data)
+        result = service_api.execute_graphql(
+            ARTIFACT_TYPE_GQL,
+            {"entity": entity_name, "project": project_name, "name": name},
+            parse=ArtifactType.model_validate_json,
+        )
         if (project := result.project) and (artifact := project.artifact):
             return artifact.artifact_type.name
         return None
@@ -2665,10 +2675,11 @@ class Artifact:
         if (service_api := self._service_api) is None:
             raise ValueError("Client is not initialized")
 
-        data = service_api.execute_graphql(
-            FETCH_LINKED_ARTIFACTS_GQL, variables={"artifactID": self.id}
+        result = service_api.execute_graphql(
+            FETCH_LINKED_ARTIFACTS_GQL,
+            variables={"artifactID": self.id},
+            parse=FetchLinkedArtifacts.model_validate_json,
         )
-        result = FetchLinkedArtifacts.model_validate(data)
 
         if not (
             (artifact := result.artifact)


### PR DESCRIPTION
## Description

- Fixes https://coreweave.atlassian.net/browse/WB-37451

The internal `ServiceApi.execute_graphql(...)` method now takes an optional `parse` callable to deserialize the response, defaulting to `json.loads`. Callers can pass a pydantic model's `model_validate_json`, decoding the response in one step instead of `json.loads(...)` then `model_validate(...)`. This skips the intermediate Python object and is typically ~2x faster, though the speedup varies with the model definition and payload (see [pydantic's performance docs](https://pydantic.dev/docs/validation/latest/concepts/performance/#in-general-use-model_validate_json-not-model_validatejsonloads)).

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

No intended behavioral changes. Existing tests cover the affected paths.
