### PR TITLE
fix: remove incorrect finalizer from HistoryScan

### DIFF
--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -11,16 +11,13 @@ Note:
 
 from __future__ import annotations
 
-import contextlib
 import json
-import weakref
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from typing_extensions import Self
 
 from wandb.proto import wandb_api_pb2 as pb
-from wandb.sdk.mailbox.mailbox import MailboxClosedError
 
 if TYPE_CHECKING:
     from . import runs
@@ -79,19 +76,6 @@ class HistoryScan(Iterator[_RowDict]):
         self.rows: list[_RowDict] = []
         self.keys = keys
 
-        # Add cleanup hook to clean up resources in wandb-core
-        # when this scan object is deleted.
-        #
-        # Using weakref.finalize ensures that references to objects needed during cleanup
-        # are not garbage collected before being used.
-        # see: https://docs.python.org/3/library/weakref.html#comparing-finalizers-with-del-methods
-        weakref.finalize(
-            self,
-            self.cleanup,
-            self._service_api,
-            self._scan_request_id,
-        )
-
     @property
     def max_step(self) -> int:
         """The highest step that can be yielded by this scan."""
@@ -146,17 +130,3 @@ class HistoryScan(Iterator[_RowDict]):
         return {
             item.key: json.loads(item.value_json) for item in history_row.history_items
         }
-
-    @staticmethod
-    def cleanup(service_api: ServiceApi, request_id: int) -> None:
-        scan_run_history_cleanup = pb.ScanRunHistoryCleanup(
-            request_id=request_id,
-        )
-        scan_run_history_cleanup_request = pb.ReadRunHistoryRequest(
-            scan_run_history_cleanup=scan_run_history_cleanup
-        )
-
-        with contextlib.suppress(ConnectionResetError, MailboxClosedError):
-            service_api.send_api_request(
-                pb.ApiRequest(read_run_history_request=scan_run_history_cleanup_request)
-            )


### PR DESCRIPTION
Removes the `weakref.finalize` call in `HistoryScan` for the same reason as in #12159.