### PR TITLE
feat: safely finalize wandb-core resources on Python GC

### DIFF
--- a/tests/unit_tests/test_lib/test_service_finalizer.py
+++ b/tests/unit_tests/test_lib/test_service_finalizer.py
@@ -1,0 +1,38 @@
+from collections.abc import Generator
+from unittest.mock import AsyncMock
+
+import pytest
+from wandb.proto import wandb_server_pb2 as spb
+from wandb.sdk.lib import asyncio_manager
+from wandb.sdk.lib.service.service_finalizer import ServiceFinalizer
+
+
+@pytest.fixture(scope="module")
+def asyncer() -> Generator[asyncio_manager.AsyncioManager]:
+    manager = asyncio_manager.AsyncioManager()
+    manager.start()
+
+    try:
+        yield manager
+    finally:
+        manager.join()
+
+
+class SimpleObject:
+    """A basic object that can be finalized.
+
+    Python does not allow registering a finalizer for a plain `object()`.
+    """
+
+
+def test_service_finalizer_publishes(asyncer: asyncio_manager.AsyncioManager):
+    mock_client = AsyncMock()
+    service_finalizer = ServiceFinalizer(asyncer, mock_client)
+    obj = SimpleObject()
+    request = spb.ServerRequest(request_id="test-request")
+
+    service_finalizer.finalize(obj, request)
+    del obj  # Should finalize synchronously.
+    service_finalizer.close()
+
+    mock_client.publish.assert_awaited_once_with(request)

--- a/tests/unit_tests/test_public_api/test_history.py
+++ b/tests/unit_tests/test_public_api/test_history.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from types import SimpleNamespace
 
 from wandb.apis.public.history import HistoryScan
@@ -34,6 +35,9 @@ class FakeServiceApi:
                 scan_run_history_cleanup=apb.ScanRunHistoryCleanupResponse()
             )
         )
+
+    def finalize(self, *args, **kwargs) -> Callable[[], None]:
+        return lambda: None
 
 
 def history_row(**items):

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -76,6 +76,12 @@ class HistoryScan(Iterator[_RowDict]):
         self.rows: list[_RowDict] = []
         self.keys = keys
 
+        # Clean up resources when the object is GC'ed.
+        self._service_api.finalize(
+            self,
+            _scan_cleanup_request(self._scan_request_id),
+        )
+
     @property
     def max_step(self) -> int:
         """The highest step that can be yielded by this scan."""
@@ -130,3 +136,13 @@ class HistoryScan(Iterator[_RowDict]):
         return {
             item.key: json.loads(item.value_json) for item in history_row.history_items
         }
+
+
+def _scan_cleanup_request(id: int) -> pb.ApiRequest:
+    """Returns a ScanRunHistoryCleanup request for the given ID."""
+    scan_cleanup_request = pb.ScanRunHistoryCleanup(request_id=id)
+    run_history_request = pb.ReadRunHistoryRequest(
+        scan_run_history_cleanup=scan_cleanup_request,
+    )
+
+    return pb.ApiRequest(read_run_history_request=run_history_request)

--- a/wandb/apis/public/service_api.py
+++ b/wandb/apis/public/service_api.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.proto import wandb_server_pb2 as spb
 from wandb.proto.wandb_api_pb2 import (
     ApiRequest,
     ApiResponse,
@@ -58,6 +59,11 @@ class ServiceApi:
         )
         self._api_session = session
 
+        # Clean up service-side resources when this object is GC'ed.
+        cleanup_request = spb.ServerRequest()
+        cleanup_request.api_cleanup_request.api_id = response.api_id
+        service_connection.finalize(self, cleanup_request)
+
         return session
 
     def send_api_request(
@@ -72,6 +78,29 @@ class ServiceApi:
         session = self._get_api_session()
         request.api_id = session.api_id
         return session.connection.api_request(request, timeout=timeout)
+
+    def finalize(
+        self,
+        obj: object,
+        cleanup: ApiRequest,
+    ) -> Callable[[], None]:
+        """Send a cleanup request when the object is garbage collected.
+
+        The request must not reference the object, or else it will never be
+        garbage collected. The request is not guaranteed to be sent before
+        the connection is closed, so any resource it would clean up must also be
+        cleaned up automatically by wandb-core when this API instance is
+        cleaned up.
+
+        Returns:
+            A callback that can be used to send the cleanup request immediately.
+        """
+        session = self._get_api_session()
+
+        cleanup.api_id = session.api_id
+        request = spb.ServerRequest(api_request=cleanup)
+
+        return session.connection.finalize(obj, request)
 
     def execute_graphql(
         self,

--- a/wandb/sdk/lib/service/service_connection.py
+++ b/wandb/sdk/lib/service/service_connection.py
@@ -11,11 +11,12 @@ from wandb.sdk.interface.interface import InterfaceBase
 from wandb.sdk.interface.interface_sock import InterfaceSock
 from wandb.sdk.lib import asyncio_manager
 from wandb.sdk.lib.exit_hooks import ExitHooks
-from wandb.sdk.lib.service.service_client import ServiceClient
 from wandb.sdk.mailbox import HandleAbandonedError, MailboxClosedError
 from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
 
 from . import service_process, service_token
+from .service_client import ServiceClient
+from .service_finalizer import ServiceFinalizer
 
 
 class WandbAttachFailedError(Exception):
@@ -107,6 +108,8 @@ class ServiceConnection:
         """
         self._asyncer = asyncer
         self._client = client
+        self._finalizer = ServiceFinalizer(asyncer, client)
+
         self._proc = proc
         self._torn_down = False
         self._cleanup = cleanup
@@ -192,13 +195,22 @@ class ServiceConnection:
 
         return response.api_init_response
 
-    def api_cleanup_request(self, api_id: str) -> None:
-        """Tells wandb-core to cleanup API resources."""
-        api_cleanup_request = wandb_api_pb2.ServerApiCleanupRequest(
-            api_id=api_id,
-        )
-        request = spb.ServerRequest(api_cleanup_request=api_cleanup_request)
-        self._asyncer.run(lambda: self._client.publish(request))
+    def finalize(
+        self,
+        obj: object,
+        cleanup: spb.ServerRequest,
+    ) -> Callable[[], None]:
+        """Send a cleanup request when the object is garbage collected.
+
+        The request must not reference the object, or else it will never be
+        garbage collected. The request is not guaranteed to be sent before
+        the connection is closed, so any resource it would clean up must also be
+        cleaned up automatically by wandb-core when this connection closes.
+
+        Returns:
+            A callback that can be used to send the cleanup request immediately.
+        """
+        return self._finalizer.finalize(obj, cleanup)
 
     async def sync_status(
         self,
@@ -372,6 +384,7 @@ class ServiceConnection:
             )
             await self._client.close()
 
+        self._finalizer.close()
         self._asyncer.run(publish_teardown_and_close)
 
         return self._proc.join()

--- a/wandb/sdk/lib/service/service_finalizer.py
+++ b/wandb/sdk/lib/service/service_finalizer.py
@@ -1,0 +1,96 @@
+"""Allows Python garbage collection to trigger wandb-core cleanup.
+
+This is tricky to implement correctly and requires a good understanding of
+Python's garbage collection and every line in this file. If done wrong, it can
+cause random deadlocks, and it has in the past. Even if done correctly, it may
+still not work depending on the internals of the Python implementation.
+
+This implementation relies on the SimpleQueue class, whose CPython
+implementation is reentrant, though this is not well documented.
+No guarantees are made about other Pythons.
+
+It is strongly recommended to avoid designs that rely on this.
+Prefer to create stateless APIs or use explicit resource management instead.
+"""
+
+from __future__ import annotations
+
+import functools
+import queue
+import threading
+import weakref
+from collections.abc import Callable
+
+from wandb.proto import wandb_server_pb2 as spb
+from wandb.sdk.lib import asyncio_manager
+from wandb.sdk.lib.service.service_client import ServiceClient
+
+
+class ServiceFinalizer:
+    """Publishes cleanup requests in a daemon thread.
+
+    Cleanup requests are not guaranteed to be published, in particular when the
+    process exits.
+
+    Thread-safe, but not reentrant (so its methods cannot be called inside
+    a finalizer, just like most classes).
+    """
+
+    def __init__(
+        self,
+        asyncer: asyncio_manager.AsyncioManager,
+        client: ServiceClient,
+    ) -> None:
+        self._asyncer = asyncer
+        self._client = client
+
+        self._queue = queue.SimpleQueue[spb.ServerRequest | None]()
+        self._thread = threading.Thread(
+            name="wandb-ServiceFinalizer",
+            target=self._publish_queue,
+            # Daemon because we cannot guarantee that close() is called
+            # before the process exits, so the thread must not block the
+            # process from exiting. This also means that cleanup requests
+            # are not sent at process exit.
+            daemon=True,
+        )
+        self._thread.start()
+
+    def finalize(
+        self,
+        obj: object,
+        cleanup: spb.ServerRequest,
+    ) -> Callable[[], None]:
+        """Publish the cleanup request when the object is garbage collected.
+
+        The request must not hold a reference to the object, or else the
+        finalizer will never run.
+
+        Safe to call after `close()`. Cleanup requests for objects that are
+        garbage collected after `close()` are ignored.
+
+        Returns:
+            A callable finalizer object that can be used to submit the cleanup
+            request (to a queue) immediately. Invoking this after `close()`
+            does nothing. Calls after the first one do nothing.
+        """
+        # If the object is garbage collected after close(), its request will
+        # be added to the queue and ignored. This finalizer prevents the
+        # SimpleQueue (and any requests in it) from being garbage collected.
+        #
+        # SimpleQueue's `put` is designed to be safe to call in a finalizer,
+        # at least in CPython.
+        return weakref.finalize(obj, self._queue.put, cleanup)
+
+    def close(self) -> None:
+        """Flush all cleanup requests and join the thread.
+
+        Safe to call multiple times.
+        """
+        self._queue.put(None)
+        self._thread.join()
+
+    def _publish_queue(self) -> None:
+        """Publish requests in _queue until a None value or an error."""
+        while request := self._queue.get():
+            self._asyncer.run(functools.partial(self._client.publish, request))


### PR DESCRIPTION
Adds a `finalize()` method to `ServiceConnection` and `ServiceApi` to safely publish cleanup requests in object finalizers, and restores the `ServiceApi` and `HistoryScan` finalizers removed in #12215 and #12159.

Works by running a daemon thread throughout the life of a `ServiceConnection` that publishes requests from a `SimpleQueue`, which is safe to add to in a finalizer.

## Testing

I added some debug messages locally and ran a basic script:

```python
import wandb

api = wandb.Api()
run = api.run(...)
scan = run.scan_history()

del scan  # cleans up the scan (according to logs)
del api   # doesn't do anything, kept alive by run
del run   # cleans up the API (according to logs)
```

Testing for deadlocks is very hard, which is why I kept the `service_finalizer.py` file as simple as possible. From recent experience, if there are deadlocks, they will fail our CI somewhat frequently, so we should be on the lookout for that.