### PR TITLE
fix(automations): fix generated entity fragments failing min server version checks

### DIFF
--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -150,7 +150,8 @@ def webhook(
 # ---------------------------------------------------------------------------
 # Exclude deprecated events/actions that will not be exposed in the API for programmatic creation
 def valid_input_scopes() -> list[ScopeType]:
-    return sorted(ScopeType)
+    # return sorted(ScopeType)  # TODO: restore once ENTITY scope is supported
+    return sorted(set(ScopeType) - {ScopeType.ENTITY})
 
 
 def valid_input_events() -> list[EventType]:
@@ -204,9 +205,12 @@ def pytest_collection_modifyitems(config, items):
 
 
 @fixture(params=valid_input_scopes(), ids=lambda x: f"scope={x.value}")
-def scope_type(request: FixtureRequest) -> ScopeType:
+def scope_type(request: FixtureRequest, module_api: wandb.Api) -> ScopeType:
     """A fixture that parametrizes over all valid scope types."""
-    return request.param
+    if not module_api._supports_automation(scope=(scope_type := request.param)):
+        skip(f"Server does not support scope type: {scope_type!r}")
+
+    return scope_type
 
 
 @fixture(params=valid_input_events(), ids=lambda x: f"event={x.value}")
@@ -216,10 +220,7 @@ def event_type(
     module_api: wandb.Api,
 ) -> EventType:
     """A fixture that parametrizes over all valid event types."""
-
-    event_type = request.param
-
-    if not module_api._supports_automation(event=event_type):
+    if not module_api._supports_automation(event=(event_type := request.param)):
         skip(f"Server does not support event type: {event_type!r}")
 
     if (event_type, scope_type) in invalid_events_and_scopes():
@@ -234,9 +235,7 @@ def action_type(
     module_api: wandb.Api,
 ) -> ActionType:
     """A fixture that parametrizes over all valid action types."""
-    action_type = request.param
-
-    if not module_api._supports_automation(action=action_type):
+    if not module_api._supports_automation(action=(action_type := request.param)):
         skip(f"Server does not support action type: {action_type!r}")
 
     return action_type

--- a/tests/unit_tests/test_automations/conftest.py
+++ b/tests/unit_tests/test_automations/conftest.py
@@ -149,7 +149,8 @@ def project(mock_client: Mock) -> Project:
 
 # Exclude deprecated scope/event/action types from those expected to be exposed for valid behavior
 def valid_scopes() -> list[ScopeType]:
-    return sorted(set(ScopeType))
+    # return sorted(set(ScopeType))  # TODO: restore once ENTITY scope is supported
+    return sorted(set(ScopeType) - {ScopeType.ENTITY})
 
 
 def valid_input_events() -> list[EventType]:
@@ -164,6 +165,7 @@ def valid_input_actions() -> list[ActionType]:
 @cache
 def invalid_events_and_scopes() -> set[tuple[EventType, ScopeType]]:
     return {
+        (EventType.CREATE_ARTIFACT, ScopeType.ENTITY),
         (EventType.CREATE_ARTIFACT, ScopeType.PROJECT),
         (EventType.RUN_METRIC_THRESHOLD, ScopeType.ARTIFACT_COLLECTION),
         (EventType.RUN_METRIC_CHANGE, ScopeType.ARTIFACT_COLLECTION),

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
         EventType,
         Integration,
         NewAutomation,
+        ScopeType,
         SlackIntegration,
         WebhookIntegration,
     )
@@ -2260,6 +2261,7 @@ class Api:
     def _supports_automation(
         self,
         *,
+        scope: ScopeType | None = None,
         event: EventType | None = None,
         action: ActionType | None = None,
     ) -> bool:
@@ -2267,8 +2269,14 @@ class Api:
         from wandb.automations._utils import (
             ALWAYS_SUPPORTED_ACTIONS,
             ALWAYS_SUPPORTED_EVENTS,
+            ALWAYS_SUPPORTED_SCOPES,
         )
 
+        supports_scope = (
+            (scope is None)
+            or (scope in ALWAYS_SUPPORTED_SCOPES)
+            or self._service_api.feature_enabled(f"AUTOMATION_SCOPE_{scope.value}")
+        )
         supports_event = (
             (event is None)
             or (event in ALWAYS_SUPPORTED_EVENTS)
@@ -2279,7 +2287,7 @@ class Api:
             or (action in ALWAYS_SUPPORTED_ACTIONS)
             or self._service_api.feature_enabled(f"AUTOMATION_ACTION_{action.value}")
         )
-        return supports_event and supports_action
+        return supports_event and supports_action and supports_scope
 
     def _omitted_automation_fragments(self) -> set[str]:
         """Returns the names of unsupported automation-related fragments.
@@ -2305,8 +2313,9 @@ class Api:
                 }
                 ```
         """
-        from wandb.automations import ActionType
+        from wandb.automations import ActionType, ScopeType
         from wandb.automations._generated import (
+            EntityScopeFields,
             GenericWebhookActionFields,
             NoOpActionFields,
             NotificationActionFields,
@@ -2315,19 +2324,29 @@ class Api:
 
         # Note: we can't currently define this as a constant outside the method
         # and still keep it nearby in this module, because it relies on pydantic v2-only imports
-        fragment_names: dict[ActionType, str] = {
+        scope_fragment_names: dict[ScopeType, str] = {
+            ScopeType.ENTITY: nameof(EntityScopeFields),
+        }
+        action_fragment_names: dict[ActionType, str] = {
             ActionType.NO_OP: nameof(NoOpActionFields),
             ActionType.QUEUE_JOB: nameof(QueueJobActionFields),
             ActionType.NOTIFICATION: nameof(NotificationActionFields),
             ActionType.GENERIC_WEBHOOK: nameof(GenericWebhookActionFields),
         }
 
-        return set(
+        omitted_scope_fragments = set(
+            name
+            for scope in ScopeType
+            if (not self._supports_automation(scope=scope))
+            and (name := scope_fragment_names.get(scope))
+        )
+        omitted_action_fragments = set(
             name
             for action in ActionType
             if (not self._supports_automation(action=action))
-            and (name := fragment_names.get(action))
+            and (name := action_fragment_names.get(action))
         )
+        return omitted_scope_fragments | omitted_action_fragments
 
     @tracked
     def automation(

--- a/wandb/automations/_utils.py
+++ b/wandb/automations/_utils.py
@@ -52,6 +52,14 @@ While we forbid new/edited automations from assigning these action types,
 they're defined so that we can still parse existing automations that may use them.
 """
 
+ALWAYS_SUPPORTED_SCOPES: Final[Collection[ScopeType]] = frozenset(
+    {
+        ScopeType.ARTIFACT_COLLECTION,
+        ScopeType.PROJECT,
+    }
+)
+"""Scope types that should be supported by all current, non-EOL server versions."""
+
 ALWAYS_SUPPORTED_EVENTS: Final[Collection[EventType]] = frozenset(
     {
         EventType.CREATE_ARTIFACT,

--- a/wandb/automations/scopes.py
+++ b/wandb/automations/scopes.py
@@ -22,6 +22,7 @@ class ScopeType(LenientStrEnum):
 
     PROJECT = "PROJECT"
     ARTIFACT_COLLECTION = "ARTIFACT_COLLECTION"
+    ENTITY = "ENTITY"
 
 
 class _BaseScope(GQLBase):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fixes failing `system-tests-min-server-version-linux-3.13` CI job due to changes introduced in https://github.com/wandb/wandb/pull/12206

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Existing tests must pass -- especially the `system-tests-min-server-version-linux-3.13` check.

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
