### PR TITLE
test: add unit tests for config_util dict helpers

### DIFF
--- a/tests/unit_tests/test_lib/test_config_util.py
+++ b/tests/unit_tests/test_lib/test_config_util.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from wandb.sdk.lib.config_util import (
+    dict_from_proto_list,
+    dict_no_value_from_proto_list,
+    dict_strip_value_dict,
+)
+
+
+def _item(key, value_json):
+    # These helpers only read .key and .value_json off each proto item.
+    return SimpleNamespace(key=key, value_json=value_json)
+
+
+def test_dict_from_proto_list_wraps_values_with_desc():
+    result = dict_from_proto_list([_item("a", "1"), _item("b", '"x"')])
+    assert result == {
+        "a": {"desc": None, "value": 1},
+        "b": {"desc": None, "value": "x"},
+    }
+
+
+def test_dict_strip_value_dict():
+    config = {"a": {"value": 1, "desc": None}, "b": {"value": 2}}
+    assert dict_strip_value_dict(config) == {"a": 1, "b": 2}
+
+
+def test_dict_no_value_keeps_value_dicts():
+    result = dict_no_value_from_proto_list([_item("a", '{"value": 5}')])
+    assert result == {"a": 5}
+
+
+def test_dict_no_value_skips_non_dict_values():
+    assert dict_no_value_from_proto_list([_item("a", "7")]) == {}
+
+
+def test_dict_no_value_skips_dict_without_value_key():
+    assert dict_no_value_from_proto_list([_item("a", '{"x": 1}')]) == {}


### PR DESCRIPTION
## Description

`wandb.sdk.lib.config_util` has a few small pure helpers for moving config
between proto lists and plain dicts, none of which had test coverage:

- `dict_from_proto_list` - build `{key: {"desc": None, "value": ...}}` from a
  proto list, deserializing each `value_json`
- `dict_strip_value_dict` - collapse `{key: {"value": v, ...}}` down to
  `{key: v}`
- `dict_no_value_from_proto_list` - keep only entries whose JSON value is a
  dict containing a `"value"` key, mapping to that inner value

This adds `tests/unit_tests/test_lib/test_config_util.py` covering the happy
paths plus the two skip branches of `dict_no_value_from_proto_list`
(non-dict value, and dict missing the `"value"` key).

The helpers only read `.key` and `.value_json` off each item, so the tests use
a lightweight stand-in rather than constructing protobufs. No source changes.

## Verification

`pytest tests/unit_tests/test_lib/test_config_util.py` - 5 passed. `ruff check`
/ `ruff format --check` clean.
