### PR TITLE
fix(launch): validate git source URLs and pin protocol allowlist in agent fetch

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,4 +16,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Changed
 - Hardened argument handling in `wandb launch` for the local-process resource so that job-supplied values are always shell-quoted (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12220)
-- The launch agent now validates a job's git source URL and pins git's protocol allowlist when fetching it and updating submodules (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/XXXXX)
+- The launch agent now restricts a job's git source URL to https/ssh remotes and pins git's protocol allowlist when fetching it and updating submodules (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12221)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,3 +16,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Changed
 - Hardened argument handling in `wandb launch` for the local-process resource so that job-supplied values are always shell-quoted (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12220)
+- The launch agent now validates a job's git source URL and pins git's protocol allowlist when fetching it and updating submodules (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/XXXXX)

--- a/tests/unit_tests/test_launch/test_git_reference.py
+++ b/tests/unit_tests/test_launch/test_git_reference.py
@@ -6,12 +6,27 @@ import pathlib
 import subprocess
 
 import pytest
+from wandb.sdk.launch import git_reference as git_reference_module
 from wandb.sdk.launch.errors import LaunchError
 from wandb.sdk.launch.git_reference import GitReference
 
 
 def run_git(cwd: pathlib.Path, *args: str) -> str:
     return subprocess.check_output(["git", *args], cwd=cwd, text=True).strip()
+
+
+@pytest.fixture
+def uri_recorder(monkeypatch) -> list[tuple[str, ...]]:
+    """Record the args of every ``run_git`` call while still calling through."""
+    calls: list[tuple[str, ...]] = []
+    real_run_git = git_reference_module.run_git
+
+    def spy(*args: str, **kwargs):
+        calls.append(args)
+        return real_run_git(*args, **kwargs)
+
+    monkeypatch.setattr(git_reference_module, "run_git", spy)
+    return calls
 
 
 @pytest.fixture
@@ -91,3 +106,83 @@ def test_fetch_no_default_branch_raises_launch_error(source_repo, tmp_path):
 
     with pytest.raises(LaunchError, match="Unable to determine branch or commit"):
         ref.fetch(str(tmp_path / "dst"))
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "ext::sh -c 'touch /tmp/pwned'",
+        "EXT::sh -c 'touch /tmp/pwned'",
+        "fd::17/foo",
+        "file:///tmp/evil.git",
+        "-u./payload",
+        "--upload-pack=touch /tmp/pwned",
+    ],
+)
+def test_fetch_rejects_dangerous_uri(uri, tmp_path):
+    """Command-executing transports and option-like remotes are refused."""
+    ref = GitReference(uri)
+
+    with pytest.raises(LaunchError, match="Refusing to fetch git remote"):
+        ref.fetch(str(tmp_path / "dst"))
+
+
+def test_fetch_dangerous_uri_runs_no_git(uri_recorder, tmp_path):
+    """A rejected URI is refused before any git process is spawned."""
+    ref = GitReference("ext::sh -c 'touch /tmp/pwned'")
+
+    with pytest.raises(LaunchError):
+        ref.fetch(str(tmp_path / "dst"))
+
+    assert uri_recorder == []
+
+
+def test_fetch_blocked_submodule_raises_launch_error(source_repo, tmp_path):
+    """A submodule over a forbidden transport is blocked and reported cleanly."""
+    # Point a submodule at a file:// URL; our protocol allowlist refuses it.
+    evil = tmp_path / "evil"
+    subprocess.run(
+        ["git", "init", "--initial-branch", "main", evil],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    run_git(evil, "config", "user.name", "test")
+    run_git(evil, "config", "user.email", "test@test.com")
+    (evil / "payload").write_text("x\n")
+    run_git(evil, "add", "payload")
+    run_git(evil, "commit", "--no-verify", "--no-gpg-sign", "-m", "evil")
+    run_git(
+        source_repo,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        f"file://{evil}",
+        "sub",
+    )
+    run_git(
+        source_repo, "commit", "--no-verify", "--no-gpg-sign", "-m", "add submodule"
+    )
+
+    ref = GitReference(str(source_repo))
+
+    with pytest.raises(LaunchError, match="Unable to update submodules"):
+        ref.fetch(str(tmp_path / "dst"))
+
+
+def test_fetch_hardens_transports(source_repo, tmp_path, uri_recorder):
+    """The fetch and recursive-submodule calls pin the protocol allowlist."""
+    ref = GitReference(str(source_repo))
+
+    ref.fetch(str(tmp_path / "dst"))
+
+    fetch_calls = [args for args in uri_recorder if "fetch" in args]
+    submodule_calls = [args for args in uri_recorder if "submodule" in args]
+
+    assert fetch_calls, "expected a git fetch"
+    assert all("protocol.ext.allow=never" in args for args in fetch_calls)
+
+    assert submodule_calls, "expected a git submodule update"
+    for args in submodule_calls:
+        assert "protocol.file.allow=never" in args
+        assert "protocol.ext.allow=never" in args

--- a/tests/unit_tests/test_launch/test_git_reference.py
+++ b/tests/unit_tests/test_launch/test_git_reference.py
@@ -30,6 +30,22 @@ def uri_recorder(monkeypatch) -> list[tuple[str, ...]]:
 
 
 @pytest.fixture
+def allow_local(monkeypatch) -> None:
+    """Let behavior tests fetch from local fixtures.
+
+    Production only allows https/ssh remotes and pins ``protocol.file.allow=never``,
+    so exercising the real fetch/checkout logic against a local repo requires
+    relaxing both the scheme allowlist and the file-transport hardening.
+    """
+    monkeypatch.setattr(git_reference_module, "_validate_uri", lambda uri: None)
+    monkeypatch.setattr(
+        git_reference_module,
+        "_PROTOCOL_HARDENING",
+        ("-c", "protocol.file.allow=always"),
+    )
+
+
+@pytest.fixture
 def source_repo(tmp_path: pathlib.Path) -> pathlib.Path:
     """A local git repo with a `main` branch and a `feature` branch."""
     path = tmp_path / "source"
@@ -52,7 +68,7 @@ def source_repo(tmp_path: pathlib.Path) -> pathlib.Path:
     return path
 
 
-def test_fetch_default_branch(source_repo, tmp_path):
+def test_fetch_default_branch(source_repo, tmp_path, allow_local):
     dst_dir = tmp_path / "dst"
     ref = GitReference(str(source_repo))
 
@@ -64,7 +80,7 @@ def test_fetch_default_branch(source_repo, tmp_path):
     assert ref.commit_hash == run_git(source_repo, "rev-parse", "main")
 
 
-def test_fetch_branch(source_repo, tmp_path):
+def test_fetch_branch(source_repo, tmp_path, allow_local):
     dst_dir = tmp_path / "dst"
     ref = GitReference(str(source_repo), "feature")
 
@@ -74,7 +90,7 @@ def test_fetch_branch(source_repo, tmp_path):
     assert (dst_dir / "feature.py").exists()
 
 
-def test_fetch_commit_hash(source_repo, tmp_path):
+def test_fetch_commit_hash(source_repo, tmp_path, allow_local):
     dst_dir = tmp_path / "dst"
     commit = run_git(source_repo, "rev-parse", "main")
     ref = GitReference(str(source_repo), commit)
@@ -85,14 +101,14 @@ def test_fetch_commit_hash(source_repo, tmp_path):
     assert not (dst_dir / "feature.py").exists()
 
 
-def test_fetch_bad_remote_raises_launch_error(tmp_path):
+def test_fetch_bad_remote_raises_launch_error(tmp_path, allow_local):
     ref = GitReference(str(tmp_path / "does-not-exist"))
 
     with pytest.raises(LaunchError, match="Unable to fetch"):
         ref.fetch(str(tmp_path / "dst"))
 
 
-def test_fetch_without_git_raises_launch_error(tmp_path, monkeypatch):
+def test_fetch_without_git_raises_launch_error(tmp_path, allow_local, monkeypatch):
     monkeypatch.setenv("GIT_PYTHON_GIT_EXECUTABLE", "git-not-found")
     ref = GitReference(str(tmp_path / "source"))
 
@@ -100,7 +116,9 @@ def test_fetch_without_git_raises_launch_error(tmp_path, monkeypatch):
         ref.fetch(str(tmp_path / "dst"))
 
 
-def test_fetch_no_default_branch_raises_launch_error(source_repo, tmp_path):
+def test_fetch_no_default_branch_raises_launch_error(
+    source_repo, tmp_path, allow_local
+):
     run_git(source_repo, "branch", "-m", "main", "trunk")
     ref = GitReference(str(source_repo))
 
@@ -111,53 +129,111 @@ def test_fetch_no_default_branch_raises_launch_error(source_repo, tmp_path):
 @pytest.mark.parametrize(
     "uri",
     [
-        "ext::sh -c 'touch /tmp/pwned'",
-        "EXT::sh -c 'touch /tmp/pwned'",
-        "fd::17/foo",
-        "file:///tmp/evil.git",
-        "-u./payload",
-        "--upload-pack=touch /tmp/pwned",
+        "https://github.com/wandb/launch-jobs",
+        "https://github.com/wandb/launch-jobs.git",
+        "ssh://git@github.com/wandb/launch-jobs.git",
+        "git@github.com:wandb/launch-jobs.git",
+        "git@host.example.com:group/sub/repo.git",
     ],
 )
-def test_fetch_rejects_dangerous_uri(uri, tmp_path):
-    """Command-executing transports and option-like remotes are refused."""
-    ref = GitReference(uri)
+def test_validate_uri_allows_supported_remotes(uri):
+    """https, ssh, and scp-like git@host:path remotes are permitted."""
+    git_reference_module._validate_uri(uri)  # does not raise
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "file:///tmp/some/repo.git",
+        "ext::sh -c 'echo hi'",
+        "EXT::sh -c 'echo hi'",
+        "fd::17/foo",
+        "git://github.com/wandb/launch-jobs.git",
+        "http://github.com/wandb/launch-jobs.git",
+        "/tmp/local/repo",
+        ".",
+        "./relative/repo",
+        "-u./x",
+        "--upload-pack=echo",
+        "-x@host:path",
+    ],
+)
+def test_validate_uri_rejects_everything_else(uri):
+    """file/ext/fd/git/http, bare paths, and option-like remotes are refused."""
+    with pytest.raises(LaunchError, match="Refusing to fetch git remote"):
+        git_reference_module._validate_uri(uri)
+
+
+def test_fetch_rejected_uri_runs_no_git(uri_recorder, tmp_path):
+    """A rejected remote is refused before any git process is spawned."""
+    ref = GitReference("ext::sh -c 'echo hi'")
 
     with pytest.raises(LaunchError, match="Refusing to fetch git remote"):
-        ref.fetch(str(tmp_path / "dst"))
-
-
-def test_fetch_dangerous_uri_runs_no_git(uri_recorder, tmp_path):
-    """A rejected URI is refused before any git process is spawned."""
-    ref = GitReference("ext::sh -c 'touch /tmp/pwned'")
-
-    with pytest.raises(LaunchError):
         ref.fetch(str(tmp_path / "dst"))
 
     assert uri_recorder == []
 
 
-def test_fetch_blocked_submodule_raises_launch_error(source_repo, tmp_path):
-    """A submodule over a forbidden transport is blocked and reported cleanly."""
-    # Point a submodule at a file:// URL; our protocol allowlist refuses it.
-    evil = tmp_path / "evil"
+def test_protocol_hardening_pins_file_and_ext():
+    """The hardening applied to git commands denies the file and ext transports."""
+    assert git_reference_module._PROTOCOL_HARDENING == (
+        "-c",
+        "protocol.file.allow=never",
+        "-c",
+        "protocol.ext.allow=never",
+    )
+
+
+def test_fetch_hardens_fetch_and_submodule(monkeypatch, tmp_path):
+    """fetch() pins the protocol allowlist on both the fetch and submodule calls."""
+    monkeypatch.setattr(git_reference_module, "_validate_uri", lambda uri: None)
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        git_reference_module, "run_git", lambda *a, **k: calls.append(a) or ""
+    )
+
+    GitReference("https://example.com/o/r.git").fetch(str(tmp_path / "dst"))
+
+    fetch_calls = [a for a in calls if "fetch" in a]
+    submodule_calls = [a for a in calls if "submodule" in a]
+    assert fetch_calls, "expected a git fetch"
+    assert submodule_calls, "expected a git submodule update"
+    for group in (fetch_calls, submodule_calls):
+        for args in group:
+            assert "protocol.file.allow=never" in args
+            assert "protocol.ext.allow=never" in args
+
+
+def test_fetch_blocked_submodule_raises_launch_error(
+    source_repo, tmp_path, monkeypatch
+):
+    """A submodule over the file transport is blocked and reported cleanly."""
+    monkeypatch.setattr(git_reference_module, "_validate_uri", lambda uri: None)
+    # Allow the top-level local fetch (user context) while keeping the recursive
+    # submodule fetch restricted, mirroring the production file.allow=never
+    # posture for recursion.
+    monkeypatch.setattr(
+        git_reference_module, "_PROTOCOL_HARDENING", ("-c", "protocol.file.allow=user")
+    )
+
+    submodule_src = tmp_path / "submodule_src"
     subprocess.run(
-        ["git", "init", "--initial-branch", "main", evil],
+        ["git", "init", "--initial-branch", "main", submodule_src],
         check=True,
         stdout=subprocess.DEVNULL,
     )
-    run_git(evil, "config", "user.name", "test")
-    run_git(evil, "config", "user.email", "test@test.com")
-    (evil / "payload").write_text("x\n")
-    run_git(evil, "add", "payload")
-    run_git(evil, "commit", "--no-verify", "--no-gpg-sign", "-m", "evil")
+    run_git(submodule_src, "config", "user.name", "test")
+    run_git(submodule_src, "config", "user.email", "test@test.com")
+    (submodule_src / "data").write_text("x\n")
+    run_git(submodule_src, "add", "data")
+    run_git(submodule_src, "commit", "--no-verify", "--no-gpg-sign", "-m", "init")
     run_git(
         source_repo,
         "-c",
         "protocol.file.allow=always",
         "submodule",
         "add",
-        f"file://{evil}",
+        f"file://{submodule_src}",
         "sub",
     )
     run_git(
@@ -168,21 +244,3 @@ def test_fetch_blocked_submodule_raises_launch_error(source_repo, tmp_path):
 
     with pytest.raises(LaunchError, match="Unable to update submodules"):
         ref.fetch(str(tmp_path / "dst"))
-
-
-def test_fetch_hardens_transports(source_repo, tmp_path, uri_recorder):
-    """The fetch and recursive-submodule calls pin the protocol allowlist."""
-    ref = GitReference(str(source_repo))
-
-    ref.fetch(str(tmp_path / "dst"))
-
-    fetch_calls = [args for args in uri_recorder if "fetch" in args]
-    submodule_calls = [args for args in uri_recorder if "submodule" in args]
-
-    assert fetch_calls, "expected a git fetch"
-    assert all("protocol.ext.allow=never" in args for args in fetch_calls)
-
-    assert submodule_calls, "expected a git submodule update"
-    for args in submodule_calls:
-        assert "protocol.file.allow=never" in args
-        assert "protocol.ext.allow=never" in args

--- a/tests/unit_tests/test_launch/test_runner/conftest.py
+++ b/tests/unit_tests/test_launch/test_runner/conftest.py
@@ -74,7 +74,7 @@ def clean_monitor():
     LaunchKubernetesMonitor._instance = None
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clean_agent():
     LaunchAgent._instance = None
     yield

--- a/wandb/sdk/launch/git_reference.py
+++ b/wandb/sdk/launch/git_reference.py
@@ -16,6 +16,51 @@ SUFFIX_GIT = ".git"
 
 GIT_COMMIT_REGEX = re.compile(r"[0-9a-f]{40}")
 
+# Transports that let a remote URL execute an arbitrary command or read
+# arbitrary local files. These are never legitimate for a launch job's source
+# repository, and a remote is attacker-controlled data (it is read back from a
+# job artifact and replayed to every agent that pops the queue). Reject them
+# before any git process sees the URL.
+_DISALLOWED_URI_PREFIXES = ("ext::", "fd::", "file://")
+
+# Force git to refuse the local-file and ext transports for the fetches it
+# performs, including the recursive submodule fetches. This closes the
+# malicious-submodule RCE class (e.g. CVE-2024-32002) even on host git binaries
+# that predate the upstream default of protocol.file.allow=user, and blocks the
+# ext:: command transport as defense in depth if the prefix check above is ever
+# bypassed. `submodule update --recursive` is passed explicitly, so
+# `submodule.recurse=false` would not help here; the protocol allowlist is what
+# gates the dangerous transports.
+_FETCH_PROTOCOL_ARGS = ("-c", "protocol.ext.allow=never")
+_SUBMODULE_PROTOCOL_ARGS = (
+    "-c",
+    "protocol.file.allow=never",
+    "-c",
+    "protocol.ext.allow=never",
+)
+
+
+def _validate_uri(uri: str) -> None:
+    """Reject remote URLs that git would treat as a command or an option.
+
+    Raises:
+        LaunchError: If the URI uses a command-executing transport or looks
+            like a command-line option (argument injection).
+    """
+    stripped = uri.strip()
+    if stripped.startswith("-"):
+        raise LaunchError(
+            f"Refusing to fetch git remote that looks like a command-line "
+            f"option: {uri!r}"
+        )
+    lowered = stripped.lower()
+    for prefix in _DISALLOWED_URI_PREFIXES:
+        if lowered.startswith(prefix):
+            raise LaunchError(
+                f"Refusing to fetch git remote using a disallowed transport "
+                f"({prefix!r}): {uri!r}"
+            )
+
 
 class ReferenceType(IntEnum):
     BRANCH = 1
@@ -42,12 +87,13 @@ class GitReference:
 
     def fetch(self, dst_dir: str) -> None:
         """Fetch the repo into dst_dir and refine githubref based on what we learn."""
+        _validate_uri(self.uri)
         try:
             run_git("init", dst_dir)
             self.path = os.path.abspath(dst_dir)
-            run_git("remote", "add", "origin", self.uri, cwd=dst_dir)
+            run_git("remote", "add", "origin", "--", self.uri, cwd=dst_dir)
             # We fetch the origin so that we have branch and tag references
-            run_git("fetch", "origin", cwd=dst_dir)
+            run_git(*_FETCH_PROTOCOL_ARGS, "fetch", "origin", cwd=dst_dir)
         except GitCommandError as e:
             raise LaunchError(
                 f"Unable to fetch from git remote repository {self.url}:\n{e}"
@@ -74,7 +120,19 @@ class GitReference:
             self._checkout_branch(dst_dir, default_branch, f"origin/{default_branch}")
 
         self.commit_hash = run_git("rev-parse", "HEAD", cwd=dst_dir).strip()
-        run_git("submodule", "update", "--init", "--recursive", cwd=dst_dir)
+        try:
+            run_git(
+                *_SUBMODULE_PROTOCOL_ARGS,
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+                cwd=dst_dir,
+            )
+        except GitCommandError as e:
+            raise LaunchError(
+                f"Unable to update submodules for git repository {self.url}:\n{e}"
+            )
 
     def _ref_exists(self, dst_dir: str, ref: str) -> bool:
         try:

--- a/wandb/sdk/launch/git_reference.py
+++ b/wandb/sdk/launch/git_reference.py
@@ -16,23 +16,21 @@ SUFFIX_GIT = ".git"
 
 GIT_COMMIT_REGEX = re.compile(r"[0-9a-f]{40}")
 
-# Transports that let a remote URL execute an arbitrary command or read
-# arbitrary local files. These are never legitimate for a launch job's source
-# repository, and a remote is attacker-controlled data (it is read back from a
-# job artifact and replayed to every agent that pops the queue). Reject them
-# before any git process sees the URL.
-_DISALLOWED_URI_PREFIXES = ("ext::", "fd::", "file://")
+# Launch jobs specify their source as a git remote. Restrict that remote to the
+# transports a git repository is served over -- https://, ssh://, and the
+# scp-like git@host:path form -- via a positive allowlist. Other values
+# (file://, ext::, fd::, git://, http://, bare local paths, and values that git
+# would read as a command-line option) are rejected before the remote is handed
+# to git.
+_SCP_LIKE_REMOTE = re.compile(r"^[\w.+-]+@[\w.-]+:.+", re.ASCII)
 
-# Force git to refuse the local-file and ext transports for the fetches it
-# performs, including the recursive submodule fetches. This closes the
-# malicious-submodule RCE class (e.g. CVE-2024-32002) even on host git binaries
-# that predate the upstream default of protocol.file.allow=user, and blocks the
-# ext:: command transport as defense in depth if the prefix check above is ever
-# bypassed. `submodule update --recursive` is passed explicitly, so
-# `submodule.recurse=false` would not help here; the protocol allowlist is what
-# gates the dangerous transports.
-_FETCH_PROTOCOL_ARGS = ("-c", "protocol.ext.allow=never")
-_SUBMODULE_PROTOCOL_ARGS = (
+# Pin git's protocol allowlist on every fetch, including the recursive submodule
+# fetches, so only the intended transports are used -- including for submodule
+# URLs declared in .gitmodules -- even on host git that predates the upstream
+# protocol.file.allow=user default. `submodule update --recursive` is passed
+# explicitly, so `submodule.recurse=false` would not apply here; the
+# protocol.*.allow settings are what constrain the transports.
+_PROTOCOL_HARDENING = (
     "-c",
     "protocol.file.allow=never",
     "-c",
@@ -41,25 +39,30 @@ _SUBMODULE_PROTOCOL_ARGS = (
 
 
 def _validate_uri(uri: str) -> None:
-    """Reject remote URLs that git would treat as a command or an option.
+    """Restrict a git remote to the supported transports.
+
+    Only ``https://``, ``ssh://``, and scp-like ``git@host:path`` remotes are
+    permitted.
 
     Raises:
-        LaunchError: If the URI uses a command-executing transport or looks
-            like a command-line option (argument injection).
+        LaunchError: If the remote is not one of the supported transports.
     """
     stripped = uri.strip()
+    # A leading "-" would be read by git as a command-line flag, and can also
+    # slip past the scp-like check below, so reject it explicitly.
     if stripped.startswith("-"):
         raise LaunchError(
-            f"Refusing to fetch git remote that looks like a command-line "
-            f"option: {uri!r}"
+            f"Refusing to fetch git remote {uri!r}: only https://, ssh://, and "
+            f"git@host:path remotes are allowed."
         )
-    lowered = stripped.lower()
-    for prefix in _DISALLOWED_URI_PREFIXES:
-        if lowered.startswith(prefix):
-            raise LaunchError(
-                f"Refusing to fetch git remote using a disallowed transport "
-                f"({prefix!r}): {uri!r}"
-            )
+    if stripped.lower().startswith((PREFIX_HTTPS, "ssh://")) or _SCP_LIKE_REMOTE.match(
+        stripped
+    ):
+        return
+    raise LaunchError(
+        f"Refusing to fetch git remote {uri!r}: only https://, ssh://, and "
+        f"git@host:path remotes are allowed."
+    )
 
 
 class ReferenceType(IntEnum):
@@ -93,7 +96,7 @@ class GitReference:
             self.path = os.path.abspath(dst_dir)
             run_git("remote", "add", "origin", "--", self.uri, cwd=dst_dir)
             # We fetch the origin so that we have branch and tag references
-            run_git(*_FETCH_PROTOCOL_ARGS, "fetch", "origin", cwd=dst_dir)
+            run_git(*_PROTOCOL_HARDENING, "fetch", "origin", cwd=dst_dir)
         except GitCommandError as e:
             raise LaunchError(
                 f"Unable to fetch from git remote repository {self.url}:\n{e}"
@@ -122,7 +125,7 @@ class GitReference:
         self.commit_hash = run_git("rev-parse", "HEAD", cwd=dst_dir).strip()
         try:
             run_git(
-                *_SUBMODULE_PROTOCOL_ARGS,
+                *_PROTOCOL_HARDENING,
                 "submodule",
                 "update",
                 "--init",


### PR DESCRIPTION
Description
-----------
- Resolves https://coreweave.atlassian.net/browse/VULNMGMT-2140
- Prevent unconditional fetching of git submodules when launching git jobs by passing the following flags: `-c protocol.file.allow=never` and `-c protocol.ext.allow=never`
- Additionally only allow git sources from `https://`, `ssh://` or `git@host:`

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
- Added unit tests
- Attempted to launch [a malicious job](https://wandb.ai/wandb/nicpun-launch-test/jobs/QXJ0aWZhY3RDb2xsZWN0aW9uOjExNzU0ODA2OTc=/version_details/latest) and verified that it [failed](https://wandb.ai/wandb/launch/agents/TGF1bmNoQWdlbnQ6NjkyMDE=/logs) with:
```
ERROR launch: Error running job: Refusing to fetch git remote using a disallowed transport ('ext::'): "ext::sh -c 'touch /tmp/pwned_from_agent; echo PWNED'"
```
Launch agent image: `wandb/launch-agent-dev:VULNMGMT-2140-1` (https://github.com/wandb/wandb/actions/runs/29525242635)