### PR TITLE
fix: missing unlock in runfiles and a lock held too long

### DIFF
--- a/core/internal/runfiles/uploader.go
+++ b/core/internal/runfiles/uploader.go
@@ -3,6 +3,7 @@ package runfiles
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -223,6 +224,7 @@ func (u *uploader) Finish() {
 	// Mark as isFinished to prevent new operations.
 	u.stateMu.Lock()
 	if u.isFinished {
+		u.stateMu.Unlock()
 		return
 	}
 	u.isFinished = true
@@ -237,8 +239,9 @@ func (u *uploader) Finish() {
 
 	// Wait for all file uploads to complete.
 	u.stateMu.Lock()
-	defer u.stateMu.Unlock()
-	for _, file := range u.knownFiles {
+	knownFiles := maps.Clone(u.knownFiles)
+	u.stateMu.Unlock()
+	for _, file := range knownFiles {
 		file.Finish()
 	}
 }


### PR DESCRIPTION
* Unlock `stateMu` in the `Finish()` early exit
* Clone `knownFiles` before iterating to avoid holding the lock while calling `file.Finish()`, which is a potentially long operation

The first one could only have been triggered by calling `Finish()` twice, which `Sender` avoids because it doesn't process Exit records more than once. The second one could have potentially caused unnecessary synchronization, but also only in buggy conditions (like if a new file was saved while an exit record was being processed).