### PR TITLE
refactor: avoid capturing cancellation/timeout errors in wandb sync

### DIFF
--- a/core/internal/runsync/errors.go
+++ b/core/internal/runsync/errors.go
@@ -1,6 +1,7 @@
 package runsync
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -61,21 +62,35 @@ func FirstSyncError(logger *observability.CoreLogger, errs ...error) error {
 // LogSyncFailure logs and possibly captures an error that prevents sync
 // from succeeding.
 func LogSyncFailure(logger *observability.CoreLogger, err error) {
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		logger.Error(err.Error())
+		return
+	}
+
 	if syncErr, ok := err.(*SyncError); ok && syncErr.UserText != "" {
 		logger.Error(syncErr.Error())
-	} else {
-		// Any other errors are captured as they are unexpected
-		// and don't have helpful user text.
-		//
-		// If you're here from Sentry, please figure out where
-		// the error happens and wrap it in a SyncError with
-		// proper UserText. Or fix it so it can't happen.
-		logger.CaptureError(err)
+		return
 	}
+
+	// Any other errors are captured as they are unexpected
+	// and don't have helpful user text.
+	//
+	// If you're here from Sentry, please figure out where
+	// the error happens and wrap it in a SyncError with
+	// proper UserText. Or fix it so it can't happen.
+	logger.CaptureError(err)
 }
 
 // ToUserText returns user-facing text for the error, which may be a SyncError.
 func ToUserText(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "Cancelled." // we generally use "Cancelled", not "Canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "Timed out."
+	}
+
 	syncErr, ok := err.(*SyncError)
 	if !ok || syncErr.UserText == "" {
 		return fmt.Sprintf("Internal error: %v", err)

--- a/core/internal/runsync/errors_test.go
+++ b/core/internal/runsync/errors_test.go
@@ -1,6 +1,7 @@
 package runsync_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -28,6 +29,18 @@ func TestToUserText_SyncErrorWithoutUserText(t *testing.T) {
 	userText := ToUserText(err)
 
 	assert.Equal(t, "Internal error: internal text", userText)
+}
+
+func TestToUserText_Cancelled(t *testing.T) {
+	userText := ToUserText(context.Canceled)
+
+	assert.Equal(t, "Cancelled.", userText)
+}
+
+func TestToUserText_Timeout(t *testing.T) {
+	userText := ToUserText(context.DeadlineExceeded)
+
+	assert.Equal(t, "Timed out.", userText)
 }
 
 func TestToUserText_UnknownError(t *testing.T) {


### PR DESCRIPTION
Prevent Ctrl+C during `wandb beta sync` from logging to Sentry.

In terms of design, I think it's right to bubble up `context.Canceled` and `context.DeadlineExceeded`, and it matches the convention of writing:

```go
select {
...
case <-ctx.Done():
	return ctx.Err()  // not wrapped
}
```

But this isn't a perfect solution because it conflicts with the convention of using `%v` by default when wrapping errors using `fmt.Errorf`:

```go
err := otherpackage.SomeImplementationDetail(ctx, ...)
if err != nil {
	// This hides Canceled and DeadlineExceeded, but using %w is wrong for
	// other errors that aren't part of this function's interface.
	return fmt.Errorf("mypackage: couldn't do thing: %v", err)
}
```

I think an error framework like in #11347 could handle this. I could pick up that PR again later.