### PR TITLE
chore(artifacts): generate system test GQL payloads with polyfactory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,9 @@ import pytest
 import wandb
 import wandb.util
 from click.testing import CliRunner
+from polyfactory.factories.pydantic_factory import ModelFactory
+from polyfactory.pytest_plugin import register_fixture
+from wandb.apis._generated import ProjectFragment, UserFragment
 from wandb.errors import term
 from wandb.sdk.interface.interface_queue import InterfaceQueue
 from wandb.sdk.lib import filesystem, module, runid, wbauth
@@ -72,11 +75,24 @@ def seed_model_factories(request: pytest.FixtureRequest) -> None:
     and its faker instance are seeded, not the stdlib random module, so
     hypothesis is unaffected.
     """
-    from polyfactory.factories.pydantic_factory import ModelFactory
-
     # Seeding accepts any hashable. Strings seed deterministically across
     # processes, since random.Random does not use the built-in hash() for them.
     ModelFactory.seed_random(request.node.nodeid)
+
+
+# --------------------------------
+# Shared model factories
+# --------------------------------
+
+
+@register_fixture(name="project_fragment_factory")
+class ProjectFragmentFactory(ModelFactory[ProjectFragment]):
+    """Generates valid ProjectFragment instances for stubbed GQL responses."""
+
+
+@register_fixture(name="user_fragment_factory")
+class UserFragmentFactory(ModelFactory[UserFragment]):
+    """Generates valid UserFragment instances for stubbed GQL responses."""
 
 
 # --------------------------------

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 
 import pytest
 import wandb
+from polyfactory.factories.pydantic_factory import ModelFactory
+from polyfactory.pytest_plugin import register_fixture
+from wandb.sdk.artifacts._generated import ArtifactFragment, ArtifactMembershipFragment
 
 from tests.fixtures.wandb_backend_spy import (
     WandbBackendProxy,
@@ -18,6 +21,16 @@ from .backend_fixtures import (
     LocalWandbBackendAddress,
     connect_to_local_wandb_backend,
 )
+
+
+@register_fixture(name="artifact_fragment_factory")
+class ArtifactFragmentFactory(ModelFactory[ArtifactFragment]):
+    """Generates valid ArtifactFragment instances for stubbed GQL responses."""
+
+
+@register_fixture(name="artifact_membership_fragment_factory")
+class ArtifactMembershipFragmentFactory(ModelFactory[ArtifactMembershipFragment]):
+    """Generates valid ArtifactMembershipFragment instances for stubbed GQL responses."""
 
 
 @pytest.fixture(scope="session")

--- a/tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -17,9 +17,7 @@ from wandb.errors import CommError, UnsupportedError
 from wandb.proto import wandb_api_pb2
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.artifacts._generated import (
-    ArtifactFragment,
     ArtifactMembershipByName,
-    ArtifactMembershipFragment,
     FetchOrgInfoFromEntity,
 )
 from wandb.sdk.artifacts._gqlutils import server_supports
@@ -633,6 +631,8 @@ def test_fetch_registry_artifact(
     wandb_backend_spy,
     api,
     mocker,
+    artifact_fragment_factory,
+    artifact_membership_fragment_factory,
     artifact_path,
     resolve_org_entity_name,
     is_registry_project,
@@ -659,49 +659,22 @@ def test_fetch_registry_artifact(
     op_matcher = Matcher(operation=nameof(FetchOrgInfoFromEntity))
     wandb_backend_spy.stub_gql(match=op_matcher, respond=mock_org_entity_info_responder)
 
-    mock_artifact_fragment_data = ArtifactFragment(
-        name="test-collection",  # NOTE: relevant
-        version_index=0,  # NOTE: relevant
-        # ------------------------------------------------------------------------------
-        # NOTE: Remaining artifact fields are placeholders and not as relevant to the test
-        artifact_type={"name": "model"},
-        artifact_sequence={
-            "name": "test-collection",
-            "project": {
-                "name": "orig-project",
-                "entity": {"name": "test-team"},
-            },
-        },
-        id="PLACEHOLDER",
-        description="PLACEHOLDER",
-        tags=[],
-        ttl_duration_seconds=-2,
-        ttl_is_inherited=False,
-        metadata="{}",
-        state="COMMITTED",
-        size=0,
-        digest="FAKE_DIGEST",
-        file_count=0,
-        commit_hash="PLACEHOLDER",
-        created_at="PLACEHOLDER",
-        updated_at=None,
-        history_step=None,
-        # ------------------------------------------------------------------------------
-    ).model_dump()
+    # Only the artifact's presence matters here: Artifact._from_attrs is
+    # mocked above, so the artifact's own fields are never read.
+    mock_artifact_fragment_data = artifact_fragment_factory.build().model_dump()
 
-    mock_membership_fragment_data = ArtifactMembershipFragment(
-        id="PLACEHOLDER",
+    # The fetch reads the collection name and its project/entity names, so pin
+    # those. Everything else is generated.
+    mock_membership_fragment_data = artifact_membership_fragment_factory.build(
         artifact=mock_artifact_fragment_data,
         artifact_collection={
             "__typename": "ArtifactPortfolio",
             "name": "test-collection",
             "project": {
-                "name": "wandb-registry-model",  # NOTE: relevant
-                "entity": {"name": "org-entity-name"},  # NOTE: relevant
+                "name": "wandb-registry-model",
+                "entity": {"name": "org-entity-name"},
             },
         },
-        version_index=1,
-        aliases=[{"id": "PLACEHOLDER", "alias": "my-alias"}],
     ).model_dump()
 
     mock_empty_rsp_data = {"data": {"project": {}}}

--- a/tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -659,22 +659,37 @@ def test_fetch_registry_artifact(
     op_matcher = Matcher(operation=nameof(FetchOrgInfoFromEntity))
     wandb_backend_spy.stub_gql(match=op_matcher, respond=mock_org_entity_info_responder)
 
-    # Only the artifact's presence matters here: Artifact._from_attrs is
-    # mocked above, so the artifact's own fields are never read.
-    mock_artifact_fragment_data = artifact_fragment_factory.build().model_dump()
+    # Pin the fields that carry meaning for this test or must stay consistent
+    # with the membership fragment below. The rest (ids, digests, timestamps,
+    # etc.) are generated.
+    mock_artifact_fragment_data = artifact_fragment_factory.build(
+        version_index=0,
+        artifact_type={"name": "model"},
+        artifact_sequence={
+            "name": "test-collection",
+            "project": {
+                "name": "orig-project",
+                "entity": {"name": "test-team"},
+            },
+        },
+        ttl_duration_seconds=-2,
+        ttl_is_inherited=False,
+        metadata="{}",
+        state="COMMITTED",
+    ).model_dump()
 
-    # The fetch reads the collection name and its project/entity names, so pin
-    # those. Everything else is generated.
     mock_membership_fragment_data = artifact_membership_fragment_factory.build(
         artifact=mock_artifact_fragment_data,
         artifact_collection={
             "__typename": "ArtifactPortfolio",
             "name": "test-collection",
             "project": {
-                "name": "wandb-registry-model",
-                "entity": {"name": "org-entity-name"},
+                "name": "wandb-registry-model",  # NOTE: relevant
+                "entity": {"name": "org-entity-name"},  # NOTE: relevant
             },
         },
+        version_index=1,
+        aliases=[{"id": "PLACEHOLDER", "alias": "my-alias"}],
     ).model_dump()
 
     mock_empty_rsp_data = {"data": {"project": {}}}

--- a/tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -659,14 +659,12 @@ def test_fetch_registry_artifact(
     op_matcher = Matcher(operation=nameof(FetchOrgInfoFromEntity))
     wandb_backend_spy.stub_gql(match=op_matcher, respond=mock_org_entity_info_responder)
 
-    # Pin the fields that carry meaning for this test or must stay consistent
-    # with the membership fragment below. The rest (ids, digests, timestamps,
-    # etc.) are generated.
+    # Set explicit, non-placeholder field values where needed.
     mock_artifact_fragment_data = artifact_fragment_factory.build(
         version_index=0,
         artifact_type={"name": "model"},
         artifact_sequence={
-            "name": "test-collection",
+            "name": "test-source-collection",
             "project": {
                 "name": "orig-project",
                 "entity": {"name": "test-team"},

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -3,31 +3,23 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 import wandb
 import wandb.apis.public
 import wandb.util
-from polyfactory.factories.pydantic_factory import ModelFactory
-from polyfactory.pytest_plugin import register_fixture
 from wandb import Api
-from wandb.apis._generated import ProjectFragment, UserFragment
 from wandb.apis._generated.generate_api_key import GenerateApiKey
 from wandb.apis.public.summary import Summary
 from wandb.errors.errors import CommError
 from wandb.sdk.artifacts._gqlutils import server_supports
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
-
-@register_fixture(name="project_fragment_factory")
-class ProjectFragmentFactory(ModelFactory[ProjectFragment]):
-    """Generates valid ProjectFragment instances for stubbed GQL responses."""
-
-
-@register_fixture(name="user_fragment_factory")
-class UserFragmentFactory(ModelFactory[UserFragment]):
-    """Generates valid UserFragment instances for stubbed GQL responses."""
+if TYPE_CHECKING:
+    from polyfactory.factories.pydantic_factory import ModelFactory
+    from wandb.apis._generated import ProjectFragment, UserFragment
 
 
 @pytest.mark.parametrize(
@@ -516,7 +508,11 @@ def test_runs_from_path(user, wandb_backend_spy):
     assert runs[0].job_type == job_type
 
 
-def test_projects(user, wandb_backend_spy, project_fragment_factory):
+def test_projects(
+    user,
+    wandb_backend_spy,
+    project_fragment_factory: type[ModelFactory[ProjectFragment]],
+):
     num_projects = 2
     # The test only counts the returned projects, so no fragment field needs
     # a specific value.
@@ -1088,7 +1084,10 @@ def test_create_team_exists(wandb_backend_spy):
 
 
 @pytest.fixture
-def stub_search_users(wandb_backend_spy, user_fragment_factory):
+def stub_search_users(
+    wandb_backend_spy,
+    user_fragment_factory: type[ModelFactory[UserFragment]],
+):
     """Fixture to stub a SearchUsers GraphQL query."""
     gql = wandb_backend_spy.gql
 

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -524,8 +524,8 @@ def test_projects(user, wandb_backend_spy, project_fragment_factory):
         "data": {
             "models": {
                 "edges": [
-                    {"node": project_fragment_factory.build().model_dump()}
-                    for _ in range(num_projects)
+                    {"node": project.model_dump()}
+                    for project in project_fragment_factory.batch(num_projects)
                 ],
                 "pageInfo": {
                     "hasNextPage": False,
@@ -1100,14 +1100,17 @@ def stub_search_users(wandb_backend_spy, user_fragment_factory):
     ):
         # The tests read the user's email, api key names, and team names.
         # Everything else is generated.
-        node = user_fragment_factory.build(
+        users = user_fragment_factory.batch(
+            count,
             email=email,
             api_keys={"edges": [{"node": key} for key in api_keys]},
             teams={"edges": [{"node": team} for team in teams]},
-        ).model_dump()
+        )
 
         search_users_spy = gql.Constant(
-            content={"data": {"users": {"edges": [{"node": node}] * count}}}
+            content={
+                "data": {"users": {"edges": [{"node": u.model_dump()} for u in users]}}
+            }
         )
 
         wandb_backend_spy.stub_gql(

--- a/tests/system_tests/test_core/test_public_api.py
+++ b/tests/system_tests/test_core/test_public_api.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 from unittest import mock
 
 import pytest
 import wandb
 import wandb.apis.public
 import wandb.util
+from polyfactory.factories.pydantic_factory import ModelFactory
+from polyfactory.pytest_plugin import register_fixture
 from wandb import Api
 from wandb.apis._generated import ProjectFragment, UserFragment
 from wandb.apis._generated.generate_api_key import GenerateApiKey
@@ -17,6 +18,16 @@ from wandb.apis.public.summary import Summary
 from wandb.errors.errors import CommError
 from wandb.sdk.artifacts._gqlutils import server_supports
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+
+
+@register_fixture(name="project_fragment_factory")
+class ProjectFragmentFactory(ModelFactory[ProjectFragment]):
+    """Generates valid ProjectFragment instances for stubbed GQL responses."""
+
+
+@register_fixture(name="user_fragment_factory")
+class UserFragmentFactory(ModelFactory[UserFragment]):
+    """Generates valid UserFragment instances for stubbed GQL responses."""
 
 
 @pytest.mark.parametrize(
@@ -505,34 +516,16 @@ def test_runs_from_path(user, wandb_backend_spy):
     assert runs[0].job_type == job_type
 
 
-def test_projects(user, wandb_backend_spy):
+def test_projects(user, wandb_backend_spy, project_fragment_factory):
     num_projects = 2
+    # The test only counts the returned projects, so no fragment field needs
+    # a specific value.
     body = {
         "data": {
             "models": {
                 "edges": [
-                    {
-                        "node": ProjectFragment(
-                            id="fake-project-id",
-                            name=f"test_{i}",
-                            entity_name=user,
-                            created_at="2021-01-01T00:00:00Z",
-                            is_benchmark=False,
-                            user=UserFragment(
-                                id="123",
-                                name="test-user",
-                                username="test-user",
-                                email="test-user@example.com",
-                                admin=False,
-                                flags="",
-                                entity="test-entity",
-                                deleted_at=None,
-                                api_keys=None,
-                                teams=None,
-                            ),
-                        ).model_dump(),
-                    }
-                    for i in range(num_projects)
+                    {"node": project_fragment_factory.build().model_dump()}
+                    for _ in range(num_projects)
                 ],
                 "pageInfo": {
                     "hasNextPage": False,
@@ -1094,40 +1087,8 @@ def test_create_team_exists(wandb_backend_spy):
         Api().create_team("test")
 
 
-def fake_search_users_response(
-    email: str,
-    api_keys: dict[str, str],
-    teams: list[str],
-    count: int = 1,
-) -> dict[str, Any]:
-    """Returns a fake response to a SearchUsers GraphQL query."""
-    return {
-        "data": {
-            "users": {
-                "edges": [
-                    {
-                        "node": UserFragment(
-                            id="VXNlcjoxMjM=",
-                            name="fake-name",
-                            username="fake-username",
-                            admin=False,
-                            flags=None,
-                            entity="fake-entity",
-                            deleted_at=None,
-                            email=email,
-                            api_keys={"edges": [{"node": key} for key in api_keys]},
-                            teams={"edges": [{"node": team} for team in teams]},
-                        ).model_dump(),
-                    }
-                ]
-                * count,
-            },
-        },
-    }
-
-
 @pytest.fixture
-def stub_search_users(wandb_backend_spy):
+def stub_search_users(wandb_backend_spy, user_fragment_factory):
     """Fixture to stub a SearchUsers GraphQL query."""
     gql = wandb_backend_spy.gql
 
@@ -1137,13 +1098,16 @@ def stub_search_users(wandb_backend_spy):
         teams: list[str],
         count: int = 1,
     ):
+        # The tests read the user's email, api key names, and team names.
+        # Everything else is generated.
+        node = user_fragment_factory.build(
+            email=email,
+            api_keys={"edges": [{"node": key} for key in api_keys]},
+            teams={"edges": [{"node": team} for team in teams]},
+        ).model_dump()
+
         search_users_spy = gql.Constant(
-            content=fake_search_users_response(
-                email,
-                api_keys,
-                teams,
-                count,
-            )
+            content={"data": {"users": {"edges": [{"node": node}] * count}}}
         )
 
         wandb_backend_spy.stub_gql(

--- a/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
+++ b/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
@@ -8,63 +8,33 @@ from pytest import fixture
 from wandb import Api, Artifact
 from wandb._strutils import nameof
 from wandb.apis.public.registries.registry import Registry
-from wandb.sdk.artifacts._generated import (
-    ArtifactFragment,
-    ArtifactMembershipByName,
-    ArtifactMembershipFragment,
-)
+from wandb.sdk.artifacts._generated import ArtifactMembershipByName
 
 
 @fixture
-def mock_artifact_fragment_data() -> dict[str, Any]:
-    fragment = ArtifactFragment(
-        name="test-collection",  # NOTE: relevant
-        version_index=0,  # NOTE: relevant
-        artifact_type={"name": "model"},
-        artifact_sequence={
-            "name": "test-collection",
-            "project": {
-                "name": "orig-project",
-                "entity": {"name": "test-team"},
-            },
-        },
-        id="PLACEHOLDER",
-        description="PLACEHOLDER",
-        tags=[],
-        ttl_duration_seconds=-2,
-        ttl_is_inherited=False,
-        metadata="{}",
-        state="COMMITTED",
-        size=0,
-        digest="FAKE_DIGEST",
-        file_count=0,
-        commit_hash="PLACEHOLDER",
-        created_at="PLACEHOLDER",
-        updated_at=None,
-        history_step=None,
-    )
-    return fragment.model_dump()
+def mock_artifact_fragment_data(artifact_fragment_factory) -> dict[str, Any]:
+    # Only the artifact's presence matters: Artifact._from_attrs is mocked in
+    # these tests, so the artifact's own fields are never read.
+    return artifact_fragment_factory.build().model_dump()
 
 
 @fixture
 def mock_membership_fragment_data(
+    artifact_membership_fragment_factory,
     mock_artifact_fragment_data: dict[str, Any],
 ) -> dict[str, Any]:
-    fragment = ArtifactMembershipFragment(
-        id="PLACEHOLDER",
+    # The fetch reads the collection name and its project/entity names, so pin
+    # those. Everything else is generated.
+    fragment = artifact_membership_fragment_factory.build(
         artifact=mock_artifact_fragment_data,
-        artifactCollection={
+        artifact_collection={
             "__typename": "ArtifactPortfolio",
-            "name": "test-collection",  # NOTE: relevant
+            "name": "test-collection",
             "project": {
-                "name": "wandb-registry-model",  # NOTE: relevant
-                "entity": {"name": "org-entity-name"},  # NOTE: relevant
+                "name": "wandb-registry-model",
+                "entity": {"name": "org-entity-name"},
             },
         },
-        versionIndex=1,
-        aliases=[
-            {"id": "PLACEHOLDER", "alias": "my-alias"},
-        ],
     )
     return fragment.model_dump()
 

--- a/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
+++ b/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import wandb
@@ -10,17 +10,24 @@ from wandb._strutils import nameof
 from wandb.apis.public.registries.registry import Registry
 from wandb.sdk.artifacts._generated import ArtifactMembershipByName
 
+if TYPE_CHECKING:
+    from polyfactory.factories.pydantic_factory import ModelFactory
+    from wandb.sdk.artifacts._generated import (
+        ArtifactFragment,
+        ArtifactMembershipFragment,
+    )
+
 
 @fixture
-def mock_artifact_fragment_data(artifact_fragment_factory) -> dict[str, Any]:
-    # Pin the fields that carry meaning for these tests or must stay
-    # consistent with the membership fragment below. The rest (ids, digests,
-    # timestamps, etc.) are generated.
+def mock_artifact_fragment_data(
+    artifact_fragment_factory: type[ModelFactory[ArtifactFragment]],
+) -> dict[str, Any]:
+    # Set explicit, non-placeholder field values where needed.
     fragment = artifact_fragment_factory.build(
         version_index=0,
         artifact_type={"name": "model"},
         artifact_sequence={
-            "name": "test-collection",
+            "name": "test-source-collection",
             "project": {
                 "name": "orig-project",
                 "entity": {"name": "test-team"},
@@ -36,7 +43,9 @@ def mock_artifact_fragment_data(artifact_fragment_factory) -> dict[str, Any]:
 
 @fixture
 def mock_membership_fragment_data(
-    artifact_membership_fragment_factory,
+    artifact_membership_fragment_factory: type[
+        ModelFactory[ArtifactMembershipFragment]
+    ],
     mock_artifact_fragment_data: dict[str, Any],
 ) -> dict[str, Any]:
     fragment = artifact_membership_fragment_factory.build(

--- a/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
+++ b/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
@@ -13,9 +13,25 @@ from wandb.sdk.artifacts._generated import ArtifactMembershipByName
 
 @fixture
 def mock_artifact_fragment_data(artifact_fragment_factory) -> dict[str, Any]:
-    # Only the artifact's presence matters: Artifact._from_attrs is mocked in
-    # these tests, so the artifact's own fields are never read.
-    return artifact_fragment_factory.build().model_dump()
+    # Pin the fields that carry meaning for these tests or must stay
+    # consistent with the membership fragment below. The rest (ids, digests,
+    # timestamps, etc.) are generated.
+    fragment = artifact_fragment_factory.build(
+        version_index=0,
+        artifact_type={"name": "model"},
+        artifact_sequence={
+            "name": "test-collection",
+            "project": {
+                "name": "orig-project",
+                "entity": {"name": "test-team"},
+            },
+        },
+        ttl_duration_seconds=-2,
+        ttl_is_inherited=False,
+        metadata="{}",
+        state="COMMITTED",
+    )
+    return fragment.model_dump()
 
 
 @fixture
@@ -23,18 +39,18 @@ def mock_membership_fragment_data(
     artifact_membership_fragment_factory,
     mock_artifact_fragment_data: dict[str, Any],
 ) -> dict[str, Any]:
-    # The fetch reads the collection name and its project/entity names, so pin
-    # those. Everything else is generated.
     fragment = artifact_membership_fragment_factory.build(
         artifact=mock_artifact_fragment_data,
         artifact_collection={
             "__typename": "ArtifactPortfolio",
-            "name": "test-collection",
+            "name": "test-collection",  # NOTE: relevant
             "project": {
-                "name": "wandb-registry-model",
-                "entity": {"name": "org-entity-name"},
+                "name": "wandb-registry-model",  # NOTE: relevant
+                "entity": {"name": "org-entity-name"},  # NOTE: relevant
             },
         },
+        version_index=1,
+        aliases=[{"id": "PLACEHOLDER", "alias": "my-alias"}],
     )
     return fragment.model_dump()
 


### PR DESCRIPTION
Description
-----------

Second PR in the polyfactory stack (base: #12230). Replaces hand-built GraphQL fragment payloads in system tests with factories, so tests pin the fields that carry meaning and generate the rest:

- **`tests/system_tests/conftest.py`**: `ArtifactFragmentFactory` and `ArtifactMembershipFragmentFactory`, registered as fixtures shared by the artifacts and registries test directories.
- **`test_artifacts/test_artifact_public_api.py`** and **`test_registries/test_registry_artifacts_public_api.py`**: the artifact/membership constructions become factory builds. Pinned: everything originally meaningful (sequence/collection/project/entity names, ttl fields, state, metadata, version indexes, aliases). Generated: the original placeholder fields (ids, digests, timestamps, sizes, etc.). This also removes a stale override pydantic was silently discarding: both files passed `name=` to `ArtifactFragment`, which no longer has that field.
- **`test_core/test_public_api.py`**: module-local `ProjectFragmentFactory`/`UserFragmentFactory`. The projects test generates its nodes outright (it only counts them), and `stub_search_users` pins email, api key names, and team names (what the tests assert), absorbing the deleted `fake_search_users_response` helper.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

- No local backend available in this environment, so the full system test run rides on CI. Locally verified instead:
  - The exact payload shapes parse through `ArtifactMembershipByName.model_validate_json` (the SDK's real parse path) and satisfy every field read `Artifact._from_membership` performs, across dozens of seeds.
  - The `UserFragment`/`ProjectFragment` payloads validate and yield the exact values the tests assert (email, api key names, team names).
  - `pytest --collect-only` on the three migrated files: 97 tests collected.
- `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)