### PR TITLE
chore(sdk): generate public API test payloads with polyfactory

### DIFF
--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 import pytest
 import wandb
 from polyfactory.factories.pydantic_factory import ModelFactory
-from polyfactory.pytest_plugin import register_fixture
 from pytest_mock import MockerFixture
 from wandb import Api
 from wandb.apis import internal
@@ -18,11 +17,6 @@ from wandb.sdk import wandb_login
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.lib import wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
-
-
-@register_fixture(name="project_fragment_factory")
-class ProjectFragmentFactory(ModelFactory[ProjectFragment]):
-    """Generates valid ProjectFragment instances for stubbed GQL responses."""
 
 
 def test_api_auto_login_no_tty():
@@ -404,7 +398,10 @@ def test_artifact_from_id_uses_service_api(monkeypatch):
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_project_id_lazy_load(monkeypatch, project_fragment_factory):
+def test_project_id_lazy_load(
+    monkeypatch: pytest.MonkeyPatch,
+    project_fragment_factory: type[ModelFactory[ProjectFragment]],
+):
     from wandb.apis._generated import GetProject
 
     api = wandb.Api()
@@ -420,6 +417,12 @@ def test_project_id_lazy_load(monkeypatch, project_fragment_factory):
                     entity_name="test-entity",
                     created_at="2021-01-01T00:00:00Z",
                     is_benchmark=False,
+                    user={
+                        "name": "test-user",
+                        "username": "test-user",
+                        "email": "test-user@example.com",
+                        "entity": "test-entity",
+                    },
                 ).model_dump(),
             }
         )

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -6,16 +6,23 @@ from unittest.mock import MagicMock
 
 import pytest
 import wandb
+from polyfactory.factories.pydantic_factory import ModelFactory
+from polyfactory.pytest_plugin import register_fixture
 from pytest_mock import MockerFixture
 from wandb import Api
 from wandb.apis import internal
-from wandb.apis._generated import ProjectFragment, UserFragment
+from wandb.apis._generated import ProjectFragment
 from wandb.errors import UsageError
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.sdk import wandb_login
 from wandb.sdk.artifacts.artifact_download_logger import ArtifactDownloadLogger
 from wandb.sdk.lib import wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+
+
+@register_fixture(name="project_fragment_factory")
+class ProjectFragmentFactory(ModelFactory[ProjectFragment]):
+    """Generates valid ProjectFragment instances for stubbed GQL responses."""
 
 
 def test_api_auto_login_no_tty():
@@ -397,33 +404,22 @@ def test_artifact_from_id_uses_service_api(monkeypatch):
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_project_id_lazy_load(monkeypatch):
+def test_project_id_lazy_load(monkeypatch, project_fragment_factory):
     from wandb.apis._generated import GetProject
 
     api = wandb.Api()
     # execute_graphql now parses the response into the pydantic model itself
     # (via parse=), so its return value is the already-parsed result.
+    # Set explicit, non-placeholder field values where needed.
     mock_execute = MagicMock(
         return_value=GetProject.model_validate(
             {
-                "project": ProjectFragment(
+                "project": project_fragment_factory.build(
                     id="123",
                     name="test-project",
                     entity_name="test-entity",
                     created_at="2021-01-01T00:00:00Z",
                     is_benchmark=False,
-                    user=UserFragment(
-                        id="123",
-                        name="test-user",
-                        username="test-user",
-                        email="test-user@example.com",
-                        admin=False,
-                        flags="",
-                        entity="test-entity",
-                        deleted_at=None,
-                        api_keys=None,
-                        teams=None,
-                    ),
                 ).model_dump(),
             }
         )

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -18,7 +18,7 @@ class LightweightRunFragmentFactory(ModelFactory[LightweightRunFragment]):
 
 
 @pytest.fixture
-def mock_service_api(mocker: MockerFixture) -> mock.MagicMock:
+def service_api(mocker: MockerFixture) -> mock.MagicMock:
     """A mocked ServiceApi to prevent real API calls."""
     return mocker.MagicMock(spec=ServiceApi)
 
@@ -68,13 +68,13 @@ def test_upload_file_skips_notification_when_unsupported(mocker, tmp_path):
     service_api.send_api_request.assert_not_called()
 
 
-def test_stop_sends_stop_run_request(mock_service_api: mock.MagicMock):
+def test_stop_sends_stop_run_request(service_api: mock.MagicMock):
     """stop() sends a StopRunRequest with the run's storage ID."""
-    mock_service_api.send_api_request.return_value = apb.ApiResponse(
+    service_api.send_api_request.return_value = apb.ApiResponse(
         stop_run_response=apb.StopRunResponse()
     )
     run = Run(
-        service_api=mock_service_api,
+        service_api=service_api,
         entity="entity",
         project="project",
         run_id="run-id",
@@ -83,8 +83,8 @@ def test_stop_sends_stop_run_request(mock_service_api: mock.MagicMock):
 
     run.stop()
 
-    mock_service_api.send_api_request.assert_called_once()
-    request = mock_service_api.send_api_request.call_args.args[0]
+    service_api.send_api_request.assert_called_once()
+    request = service_api.send_api_request.call_args.args[0]
     assert request.WhichOneof("request") == "stop_run_request"
     assert request.stop_run_request.storage_id == "run-node-id"
 
@@ -136,10 +136,10 @@ def test_create_run_with_dictionary_attrs_already_parsed(field, value):
 
 def test_run_metadata_downloads_through_service_api(
     mocker: MockerFixture,
-    mock_service_api: mock.MagicMock,
+    service_api: mock.MagicMock,
 ):
     run = Run(
-        service_api=mock_service_api,
+        service_api=service_api,
         entity="entity",
         project="project",
         run_id="run-id",
@@ -153,10 +153,10 @@ def test_run_metadata_downloads_through_service_api(
             f.write(b'{"os":"Linux"}')
         return apb.ApiResponse(download_file_response=apb.DownloadFileResponse())
 
-    mock_service_api.send_api_request.side_effect = send_api_request
+    service_api.send_api_request.side_effect = send_api_request
 
     assert run.metadata == {"os": "Linux"}
-    request = mock_service_api.send_api_request.call_args.args[0].download_file_request
+    request = service_api.send_api_request.call_args.args[0].download_file_request
     assert request.url == "https://files.example/wandb-metadata.json"
     assert request.size == 17
 
@@ -249,13 +249,13 @@ def full_response(lightweight_attrs: dict[str, Any]) -> dict[str, Any]:
 def test_lazy_run_config_triggers_full_load(
     lightweight_attrs: dict[str, Any],
     full_response: dict[str, Any],
-    mock_service_api: mock.MagicMock,
+    service_api: mock.MagicMock,
 ):
     """run.config on a lazy run should trigger load_full_data and return config."""
-    mock_service_api.execute_graphql.return_value = full_response
+    service_api.execute_graphql.return_value = full_response
 
     run = Run(
-        service_api=mock_service_api,
+        service_api=service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
@@ -272,17 +272,17 @@ def test_lazy_run_config_triggers_full_load(
     assert run._full_data_loaded is True
     assert config == {"learning_rate": 0.001, "batch_size": 32}
     assert "_wandb" not in config
-    mock_service_api.execute_graphql.assert_called_once()
+    service_api.execute_graphql.assert_called_once()
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_lazy_run_user_accessible_without_full_load(
     lightweight_attrs: dict[str, Any],
-    mock_service_api: mock.MagicMock,
+    service_api: mock.MagicMock,
 ):
     """run.user should work on lazy runs without triggering a full data load."""
     run = Run(
-        service_api=mock_service_api,
+        service_api=service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
@@ -296,11 +296,11 @@ def test_lazy_run_user_accessible_without_full_load(
     assert run._full_data_loaded is False
 
 
-def test_run_url_encodes_spaces_in_project_name(mock_service_api: mock.MagicMock):
-    mock_service_api.app_url = "https://wandb.ai/"
+def test_run_url_encodes_spaces_in_project_name(service_api: mock.MagicMock):
+    service_api.app_url = "https://wandb.ai/"
 
     run = Run(
-        service_api=mock_service_api,
+        service_api=service_api,
         entity="my-entity",
         project="My Project",
         run_id="12345",
@@ -325,17 +325,15 @@ def _make_sweep_graphql_response(sweep_name: str) -> dict:
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_sweep_property_loads_from_api(
     lightweight_attrs: dict[str, Any],
-    mock_service_api: mock.MagicMock,
+    service_api: mock.MagicMock,
 ):
     """Accessing run.sweep should fetch and return a Sweep from the API."""
     sweep_name = "test-sweep"
     lightweight_attrs["sweepName"] = sweep_name
-    mock_service_api.execute_graphql.return_value = _make_sweep_graphql_response(
-        sweep_name
-    )
+    service_api.execute_graphql.return_value = _make_sweep_graphql_response(sweep_name)
 
     run = Run(
-        service_api=mock_service_api,
+        service_api=service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
@@ -343,7 +341,7 @@ def test_sweep_property_loads_from_api(
         lazy=True,
     )
 
-    mock_service_api.execute_graphql.assert_not_called()
+    service_api.execute_graphql.assert_not_called()
 
     sweep = run.sweep
 
@@ -351,22 +349,21 @@ def test_sweep_property_loads_from_api(
     assert sweep.name == sweep_name
     assert sweep.entity == "test-entity"
     assert sweep.project == "test-project"
-    mock_service_api.execute_graphql.assert_called_once()
+    service_api.execute_graphql.assert_called_once()
     assert (
-        mock_service_api.execute_graphql.call_args.kwargs["variables"]["name"]
-        == sweep_name
+        service_api.execute_graphql.call_args.kwargs["variables"]["name"] == sweep_name
     )
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
 def test_lazy_run_missing_raises(
     lightweight_attrs: dict[str, Any],
-    mock_service_api: mock.MagicMock,
+    service_api: mock.MagicMock,
 ):
-    mock_service_api.execute_graphql.return_value = {"project": {"run": None}}
+    service_api.execute_graphql.return_value = {"project": {"run": None}}
 
     run = Run(
-        service_api=mock_service_api,
+        service_api=service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -3,9 +3,15 @@ from unittest import mock
 
 import pytest
 import wandb
+from polyfactory.factories.pydantic_factory import ModelFactory
+from wandb.apis._generated import LightweightRunFragment
 from wandb.apis.public.runs import Run, RunNotFoundError
 from wandb.apis.public.sweeps import Sweep
 from wandb.proto import wandb_api_pb2 as apb
+
+
+class LightweightRunFragmentFactory(ModelFactory[LightweightRunFragment]):
+    """Generates valid LightweightRunFragment instances for stubbed responses."""
 
 
 def _make_upload_run(mocker, *, feature_enabled: bool):
@@ -193,26 +199,18 @@ def test_create_run_with_control_characters(field, value, expected):
         assert getattr(run, field) == expected
 
 
-def _make_lightweight_attrs():
-    """Attrs matching LIGHTWEIGHT_RUN_FRAGMENT (no config/summary/system)."""
-    return {
-        "id": "abc123storeid",
-        "tags": [],
-        "name": "run-abc123",
-        "displayName": "happy-fox-42",
-        "sweepName": None,
-        "state": "finished",
-        "group": None,
-        "jobType": None,
-        "commit": None,
-        "readOnly": False,
-        "createdAt": "2026-03-24T01:00:00Z",
-        "heartbeatAt": "2026-03-24T02:00:00Z",
-        "description": "",
-        "notes": "",
-        "historyLineCount": 100,
-        "user": {"name": "testuser", "username": "testuser"},
-    }
+@pytest.fixture
+def lightweight_attrs() -> dict:
+    """Attrs matching LIGHTWEIGHT_RUN_FRAGMENT (no config/summary/system).
+
+    Set explicit, non-placeholder field values where needed.
+    """
+    return LightweightRunFragmentFactory.build(
+        name="run-abc123",
+        state="finished",
+        sweep_name=None,
+        user={"name": "testuser", "username": "testuser"},
+    ).model_dump()
 
 
 def _make_full_response(lightweight_attrs):
@@ -237,10 +235,10 @@ def _make_full_response(lightweight_attrs):
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_lazy_run_config_triggers_full_load():
+def test_lazy_run_config_triggers_full_load(lightweight_attrs):
     """run.config on a lazy run should trigger load_full_data and return config."""
     service_api = mock.MagicMock()
-    lightweight = _make_lightweight_attrs()
+    lightweight = lightweight_attrs
     service_api.execute_graphql.return_value = _make_full_response(lightweight)
 
     run = Run(
@@ -265,10 +263,10 @@ def test_lazy_run_config_triggers_full_load():
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_lazy_run_user_accessible_without_full_load():
+def test_lazy_run_user_accessible_without_full_load(lightweight_attrs):
     """run.user should work on lazy runs without triggering a full data load."""
     service_api = mock.MagicMock()
-    lightweight = _make_lightweight_attrs()
+    lightweight = lightweight_attrs
 
     run = Run(
         service_api=service_api,
@@ -313,10 +311,10 @@ def _make_sweep_graphql_response(sweep_name: str) -> dict:
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_sweep_property_loads_from_api():
+def test_sweep_property_loads_from_api(lightweight_attrs):
     """Accessing run.sweep should fetch and return a Sweep from the API."""
     service_api = mock.MagicMock()
-    lightweight = _make_lightweight_attrs()
+    lightweight = lightweight_attrs
     sweep_name = "test-sweep"
     lightweight["sweepName"] = sweep_name
     service_api.execute_graphql.return_value = _make_sweep_graphql_response(sweep_name)
@@ -345,7 +343,7 @@ def test_sweep_property_loads_from_api():
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_lazy_run_missing_raises():
+def test_lazy_run_missing_raises(lightweight_attrs):
     service_api = mock.MagicMock()
     service_api.execute_graphql.return_value = {"project": {"run": None}}
 
@@ -354,7 +352,7 @@ def test_lazy_run_missing_raises():
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
-        attrs=dict(_make_lightweight_attrs()),
+        attrs=dict(lightweight_attrs),
         lazy=True,
     )
 

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -1,11 +1,14 @@
 import json
+from typing import Any
 from unittest import mock
 
 import pytest
 import wandb
 from polyfactory.factories.pydantic_factory import ModelFactory
+from pytest_mock import MockerFixture
 from wandb.apis._generated import LightweightRunFragment
 from wandb.apis.public.runs import Run, RunNotFoundError
+from wandb.apis.public.service_api import ServiceApi
 from wandb.apis.public.sweeps import Sweep
 from wandb.proto import wandb_api_pb2 as apb
 
@@ -14,8 +17,14 @@ class LightweightRunFragmentFactory(ModelFactory[LightweightRunFragment]):
     """Generates valid LightweightRunFragment instances for stubbed responses."""
 
 
-def _make_upload_run(mocker, *, feature_enabled: bool):
-    service_api = mocker.MagicMock()
+@pytest.fixture
+def mock_service_api(mocker: MockerFixture) -> mock.MagicMock:
+    """A mocked ServiceApi to prevent real API calls."""
+    return mocker.MagicMock(spec=ServiceApi)
+
+
+def _make_upload_run(mocker: MockerFixture, *, feature_enabled: bool):
+    service_api = mocker.MagicMock(spec=ServiceApi)
     service_api.feature_enabled.return_value = feature_enabled
     run = Run(
         service_api=service_api,
@@ -59,14 +68,13 @@ def test_upload_file_skips_notification_when_unsupported(mocker, tmp_path):
     service_api.send_api_request.assert_not_called()
 
 
-def test_stop_sends_stop_run_request(mocker):
+def test_stop_sends_stop_run_request(mock_service_api: mock.MagicMock):
     """stop() sends a StopRunRequest with the run's storage ID."""
-    service_api = mocker.MagicMock()
-    service_api.send_api_request.return_value = apb.ApiResponse(
+    mock_service_api.send_api_request.return_value = apb.ApiResponse(
         stop_run_response=apb.StopRunResponse()
     )
     run = Run(
-        service_api=service_api,
+        service_api=mock_service_api,
         entity="entity",
         project="project",
         run_id="run-id",
@@ -75,8 +83,8 @@ def test_stop_sends_stop_run_request(mocker):
 
     run.stop()
 
-    service_api.send_api_request.assert_called_once()
-    request = service_api.send_api_request.call_args.args[0]
+    mock_service_api.send_api_request.assert_called_once()
+    request = mock_service_api.send_api_request.call_args.args[0]
     assert request.WhichOneof("request") == "stop_run_request"
     assert request.stop_run_request.storage_id == "run-node-id"
 
@@ -126,10 +134,12 @@ def test_create_run_with_dictionary_attrs_already_parsed(field, value):
         assert getattr(run, field) == value
 
 
-def test_run_metadata_downloads_through_service_api(mocker):
-    service_api = mocker.MagicMock()
+def test_run_metadata_downloads_through_service_api(
+    mocker: MockerFixture,
+    mock_service_api: mock.MagicMock,
+):
     run = Run(
-        service_api=service_api,
+        service_api=mock_service_api,
         entity="entity",
         project="project",
         run_id="run-id",
@@ -143,10 +153,10 @@ def test_run_metadata_downloads_through_service_api(mocker):
             f.write(b'{"os":"Linux"}')
         return apb.ApiResponse(download_file_response=apb.DownloadFileResponse())
 
-    service_api.send_api_request.side_effect = send_api_request
+    mock_service_api.send_api_request.side_effect = send_api_request
 
     assert run.metadata == {"os": "Linux"}
-    request = service_api.send_api_request.call_args.args[0].download_file_request
+    request = mock_service_api.send_api_request.call_args.args[0].download_file_request
     assert request.url == "https://files.example/wandb-metadata.json"
     assert request.size == 17
 
@@ -200,7 +210,7 @@ def test_create_run_with_control_characters(field, value, expected):
 
 
 @pytest.fixture
-def lightweight_attrs() -> dict:
+def lightweight_attrs() -> dict[str, Any]:
     """Attrs matching LIGHTWEIGHT_RUN_FRAGMENT (no config/summary/system).
 
     Set explicit, non-placeholder field values where needed.
@@ -213,7 +223,8 @@ def lightweight_attrs() -> dict:
     ).model_dump()
 
 
-def _make_full_response(lightweight_attrs):
+@pytest.fixture
+def full_response(lightweight_attrs: dict[str, Any]) -> dict[str, Any]:
     """Server response for a single-run query with RUN_FRAGMENT."""
     return {
         "project": {
@@ -235,18 +246,20 @@ def _make_full_response(lightweight_attrs):
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_lazy_run_config_triggers_full_load(lightweight_attrs):
+def test_lazy_run_config_triggers_full_load(
+    lightweight_attrs: dict[str, Any],
+    full_response: dict[str, Any],
+    mock_service_api: mock.MagicMock,
+):
     """run.config on a lazy run should trigger load_full_data and return config."""
-    service_api = mock.MagicMock()
-    lightweight = lightweight_attrs
-    service_api.execute_graphql.return_value = _make_full_response(lightweight)
+    mock_service_api.execute_graphql.return_value = full_response
 
     run = Run(
-        service_api=service_api,
+        service_api=mock_service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
-        attrs=dict(lightweight),
+        attrs=lightweight_attrs,
         lazy=True,
     )
 
@@ -259,21 +272,21 @@ def test_lazy_run_config_triggers_full_load(lightweight_attrs):
     assert run._full_data_loaded is True
     assert config == {"learning_rate": 0.001, "batch_size": 32}
     assert "_wandb" not in config
-    service_api.execute_graphql.assert_called_once()
+    mock_service_api.execute_graphql.assert_called_once()
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_lazy_run_user_accessible_without_full_load(lightweight_attrs):
+def test_lazy_run_user_accessible_without_full_load(
+    lightweight_attrs: dict[str, Any],
+    mock_service_api: mock.MagicMock,
+):
     """run.user should work on lazy runs without triggering a full data load."""
-    service_api = mock.MagicMock()
-    lightweight = lightweight_attrs
-
     run = Run(
-        service_api=service_api,
+        service_api=mock_service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
-        attrs=dict(lightweight),
+        attrs=lightweight_attrs,
         lazy=True,
     )
 
@@ -283,12 +296,11 @@ def test_lazy_run_user_accessible_without_full_load(lightweight_attrs):
     assert run._full_data_loaded is False
 
 
-def test_run_url_encodes_spaces_in_project_name():
-    service_api = mock.MagicMock()
-    service_api.app_url = "https://wandb.ai/"
+def test_run_url_encodes_spaces_in_project_name(mock_service_api: mock.MagicMock):
+    mock_service_api.app_url = "https://wandb.ai/"
 
     run = Run(
-        service_api=service_api,
+        service_api=mock_service_api,
         entity="my-entity",
         project="My Project",
         run_id="12345",
@@ -311,24 +323,27 @@ def _make_sweep_graphql_response(sweep_name: str) -> dict:
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_sweep_property_loads_from_api(lightweight_attrs):
+def test_sweep_property_loads_from_api(
+    lightweight_attrs: dict[str, Any],
+    mock_service_api: mock.MagicMock,
+):
     """Accessing run.sweep should fetch and return a Sweep from the API."""
-    service_api = mock.MagicMock()
-    lightweight = lightweight_attrs
     sweep_name = "test-sweep"
-    lightweight["sweepName"] = sweep_name
-    service_api.execute_graphql.return_value = _make_sweep_graphql_response(sweep_name)
+    lightweight_attrs["sweepName"] = sweep_name
+    mock_service_api.execute_graphql.return_value = _make_sweep_graphql_response(
+        sweep_name
+    )
 
     run = Run(
-        service_api=service_api,
+        service_api=mock_service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
-        attrs=dict(lightweight),
+        attrs=lightweight_attrs,
         lazy=True,
     )
 
-    service_api.execute_graphql.assert_not_called()
+    mock_service_api.execute_graphql.assert_not_called()
 
     sweep = run.sweep
 
@@ -336,23 +351,26 @@ def test_sweep_property_loads_from_api(lightweight_attrs):
     assert sweep.name == sweep_name
     assert sweep.entity == "test-entity"
     assert sweep.project == "test-project"
-    service_api.execute_graphql.assert_called_once()
+    mock_service_api.execute_graphql.assert_called_once()
     assert (
-        service_api.execute_graphql.call_args.kwargs["variables"]["name"] == sweep_name
+        mock_service_api.execute_graphql.call_args.kwargs["variables"]["name"]
+        == sweep_name
     )
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_lazy_run_missing_raises(lightweight_attrs):
-    service_api = mock.MagicMock()
-    service_api.execute_graphql.return_value = {"project": {"run": None}}
+def test_lazy_run_missing_raises(
+    lightweight_attrs: dict[str, Any],
+    mock_service_api: mock.MagicMock,
+):
+    mock_service_api.execute_graphql.return_value = {"project": {"run": None}}
 
     run = Run(
-        service_api=service_api,
+        service_api=mock_service_api,
         entity="test-entity",
         project="test-project",
         run_id="run-abc123",
-        attrs=dict(lightweight_attrs),
+        attrs=lightweight_attrs,
         lazy=True,
     )
 


### PR DESCRIPTION
Description
-----------

Fourth and final PR in the polyfactory stack (base: #12233). Migrates the public API unit test payloads:

- **`test_runs.py`**: `_make_lightweight_attrs()` hand-wrote a 16 key camelCase dict mirroring `LIGHTWEIGHT_RUN_FRAGMENT` key by key — the same shape that drifted silently in the artifact tests. It becomes a `lightweight_attrs` fixture built from a module-local `LightweightRunFragmentFactory`, pinning only `name` (consistent with the run id), `state`, `sweep_name=None`, and the `user` name the tests assert. The full response helper is now a `full_response` fixture, and a `mock_service_api` fixture provides `MagicMock(spec=ServiceApi)` for the service API mocks in this file.
- **`test_public_api.py`**: the hand-filled `ProjectFragment` becomes a build from the shared `project_fragment_factory` fixture (defined in the root `tests/conftest.py` by the base PR, reused by the system tests), pinning the asserted fields (`id`, `created_at`, `is_benchmark`), the project/entity names, and the user's identity fields.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

- `pytest tests/unit_tests/test_public_api -n 4`: 66 passed.
- A 50 seed sweep driving the real code paths (`Run` lazy load and config parse, `GetProject` validation) with factory-built payloads, confirming no generated optional field (e.g. `read_only`) changes behavior if per-test seeds shift.
- `ruff check` and `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)