### PR TITLE
fix: shorten long internal artifact names

### DIFF
--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -17,6 +17,7 @@ import responses
 from hypothesis import given
 from hypothesis.strategies import from_regex, text
 from wandb.filesync.step_prepare import ResponsePrepare, StepPrepare
+from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 from wandb.sdk.artifacts._validators import NAME_MAXLEN
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
@@ -407,6 +408,17 @@ def test_invalid_artifact_name(invalid_name):
     """Prevent users from instantiating an artifact with an invalid name."""
     with pytest.raises(ValueError):
         _ = Artifact(invalid_name, type="any")
+
+
+def test_internal_artifact_name_sanitized_to_max_length():
+    """Internal artifact names derived from history keys should not exceed limits."""
+    long_table_artifact_name = f"run-abcdefgh-{'B' * 116}"
+
+    artifact = InternalArtifact(long_table_artifact_name, "run_table")
+
+    assert len(artifact.name) <= NAME_MAXLEN
+    assert artifact.name != long_table_artifact_name
+    assert artifact.name.startswith("run-abcdefgh-")
 
 
 @pytest.mark.parametrize(

--- a/wandb/sdk/artifacts/_internal_artifact.py
+++ b/wandb/sdk/artifacts/_internal_artifact.py
@@ -5,6 +5,7 @@ from base64 import urlsafe_b64encode
 from typing import Any, Final
 from zlib import crc32
 
+from wandb.sdk.artifacts._validators import NAME_MAXLEN
 from wandb.sdk.artifacts.artifact import Artifact
 
 PLACEHOLDER: Final[str] = "PLACEHOLDER"
@@ -13,7 +14,8 @@ PLACEHOLDER: Final[str] = "PLACEHOLDER"
 def sanitize_artifact_name(name: str) -> str:
     """Sanitize the string to satisfy constraints on artifact names."""
     # If the name is already sanitized, don't change it.
-    if (sanitized := re.sub(r"[^a-zA-Z0-9_\-.]+", "", name)) == name:
+    sanitized = re.sub(r"[^a-zA-Z0-9_\-.]+", "", name)
+    if sanitized == name and len(sanitized) <= NAME_MAXLEN:
         return name
 
     # Append a short alphanumeric suffix to maintain uniqueness.
@@ -27,7 +29,8 @@ def sanitize_artifact_name(name: str) -> str:
     crc_bytes = crc.to_bytes(4, byteorder="big")
     suffix = urlsafe_b64encode(crc_bytes).rstrip(b"=").decode("ascii")
 
-    return f"{sanitized}-{suffix}"
+    max_prefix_len = NAME_MAXLEN - len(suffix) - 1
+    return f"{sanitized[:max_prefix_len]}-{suffix}"
 
 
 class InternalArtifact(Artifact):


### PR DESCRIPTION
## Summary
- Truncate sanitized internal artifact names to the artifact name max length.
- Preserve deterministic uniqueness with the existing CRC suffix when sanitization or truncation is needed.
- Add a regression test for a `run-{id}-{key}` table artifact name generated from a 116-character history key.

## Linked issue
Fixes #10266

## Tests
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n wandb-issue-10266 python -m pytest tests/unit_tests/test_artifacts/test_wandb_artifacts.py::test_internal_artifact_name_sanitized_to_max_length tests/unit_tests/test_artifacts/test_wandb_artifacts.py::test_invalid_artifact_name`
- `/Users/gpenacastellanos/miniforge3/condabin/mamba run -n wandb-issue-10266 python - <<'PY' ...` offline reproduction logging a `wandb.Table` with a 116-character key

## Follow-up notes
- No issue milestone is set.
- The fork could not be synced to upstream `main` because the authenticated token lacks the `workflow` scope for upstream workflow-file changes, so the pushed branch is based on the fork main with only this fix commit.