### PR TITLE
feat: new `wandb clean` command

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,9 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+## Added
+- Added the `wandb clean` command, which replaces `wandb sync --clean` (@timoffex in https://github.com/wandb/wandb/pull/12238)
+
 ## Changed
 - Hardened argument handling in `wandb launch` for the local-process resource so that job-supplied values are always shell-quoted (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12220)
 - The launch agent now restricts a job's git source URL to https/ssh remotes and pins git's protocol allowlist when fetching it and updating submodules (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12221)

--- a/tests/system_tests/test_core/test_wandb_clean_full.py
+++ b/tests/system_tests/test_core/test_wandb_clean_full.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+import wandb
+from click.testing import CliRunner
+from wandb.cli import cli
+from wandb.cli.clean import clean
+
+
+@pytest.mark.usefixtures("user")  # for syncing and the online run
+def test_cleans_expected_runs(runner: CliRunner):
+    """An integration test for wandb clean, wandb sync and online logging."""
+    with wandb.init(mode="offline") as unsynced_run:
+        pass
+    with wandb.init(mode="online") as online_run:
+        pass
+    with wandb.init(mode="offline") as synced_run:
+        pass
+    runner.invoke(cli.sync, synced_run.settings.sync_dir)
+
+    result = runner.invoke(clean, input="y")
+
+    assert os.path.exists(unsynced_run.settings.sync_dir)
+    assert not os.path.exists(synced_run.settings.sync_dir)
+    assert not os.path.exists(online_run.settings.sync_dir)
+    assert "Found 2 synced run(s)." in result.output
+    assert online_run.id in result.output
+    assert synced_run.id in result.output
+    assert unsynced_run.id not in result.output

--- a/tests/unit_tests/test_wandb_clean.py
+++ b/tests/unit_tests/test_wandb_clean.py
@@ -1,0 +1,101 @@
+import pathlib
+from typing import NoReturn
+
+import pytest
+from click.testing import CliRunner
+from wandb.cli.clean import clean
+
+
+@pytest.fixture
+def wandb_dir(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> pathlib.Path:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("WANDB_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _mkrun(path: pathlib.Path, synced: bool = False) -> None:
+    path.mkdir(parents=True)
+    if synced:
+        (path / "run.wandb.synced").touch()
+
+
+@pytest.mark.usefixtures("wandb_dir")
+def test_empty_wandb_dir(runner: CliRunner):
+    result = runner.invoke(clean)
+
+    assert result.exit_code == 1
+    assert result.output.splitlines() == [
+        "wandb: ERROR No wandb directory found.",
+    ]
+
+
+def test_bad_wandb_dir(wandb_dir: pathlib.Path, runner: CliRunner):
+    (wandb_dir / "wandb").touch()
+
+    result = runner.invoke(clean)
+
+    assert result.exit_code == 1
+    assert result.output.splitlines() == [
+        "wandb: ERROR Not a directory: 'wandb'",
+    ]
+
+
+def test_counts_unsynced_runs(wandb_dir: pathlib.Path, runner: CliRunner):
+    wb = wandb_dir / "wandb"
+    _mkrun(wb / "offline-run-20260101_010101-abc")
+    _mkrun(wb / "offline-run-20260101_202020-xyz")
+
+    result = runner.invoke(clean)
+
+    assert result.exit_code == 0
+    assert result.output.splitlines() == [
+        "wandb: Found no synced runs, 2 unsynced.",
+    ]
+
+
+def test_finds_synced_runs(wandb_dir: pathlib.Path, runner: CliRunner):
+    wb = wandb_dir / "wandb"
+    _mkrun(wb / "offline-run-20260101_010101-1")
+    _mkrun(wb / "offline-run-20260101_202020-2")
+    _mkrun(wb / "offline-run-20260101_333000-3", synced=True)
+    _mkrun(wb / "run-20260101_000444-4")
+
+    result = runner.invoke(clean, input="y")
+    lines = result.output.splitlines()
+
+    assert result.exit_code == 0
+    assert lines[0] == "wandb: Found 2 synced run(s)."
+    assert set(lines[1:3]) == set(
+        [
+            "wandb:   wandb/offline-run-20260101_333000-3",
+            "wandb:   wandb/run-20260101_000444-4",
+        ]
+    )
+    assert lines[3] == "wandb: Are you sure you want to remove 2 run(s)? [y/n] y"
+
+
+def test_reports_rmtree_errors(
+    wandb_dir: pathlib.Path,
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def raise_os_error(*args, **kwargs) -> NoReturn:
+        err = OSError()
+        err.strerror = "something went wrong"
+        raise err
+
+    _mkrun(wandb_dir / "wandb" / "run-20260101-123456-abc")
+    monkeypatch.setattr("shutil.rmtree", raise_os_error)
+
+    result = runner.invoke(clean, input="y")
+
+    assert result.exit_code == 1
+    assert result.output.splitlines() == [
+        "wandb: Found 1 synced run(s).",
+        "wandb:   wandb/run-20260101-123456-abc",
+        "wandb: Are you sure you want to remove 1 run(s)? [y/n] y",
+        "wandb: ERROR Failed to remove 'wandb/run-20260101-123456-abc': something went wrong",
+    ]

--- a/wandb/cli/clean.py
+++ b/wandb/cli/clean.py
@@ -1,0 +1,112 @@
+"""Implements `wandb clean`."""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import shutil
+
+import click
+
+from wandb.errors import term
+from wandb.sdk import wandb_setup
+
+
+@click.command()
+@click.pass_context
+def clean(ctx: click.Context) -> None:
+    """Remove synced run data.
+
+    Cleans up the wandb folder, as determined by settings. Usually, this is
+    the "wandb" or ".wandb" folder in the current working directory, or
+    in the directory specified by the WANDB_DIR environment variable if that
+    is set.
+
+    This removes all online runs and any offline runs that have been synced
+    with `wandb sync`.
+    """
+    settings = wandb_setup.singleton().settings
+    wandb_dir = pathlib.Path(settings.wandb_dir)
+
+    # Prefer to print paths relative to the current working directory.
+    cwd = pathlib.Path.cwd()
+    if wandb_dir.is_relative_to(cwd):
+        wandb_dir = wandb_dir.relative_to(cwd)
+
+    # Check that the wandb directory is correctly configured.
+    try:
+        if not wandb_dir.exists():
+            term.termerror("No wandb directory found.")
+            ctx.exit(1)
+        if not wandb_dir.is_dir():
+            term.termerror(f"Not a directory: {str(wandb_dir)!r}")
+            ctx.exit(1)
+    except PermissionError:
+        term.termerror(f"Permission error accessing {str(wandb_dir)!r}")
+        ctx.exit(1)
+
+    result = _examine_wandb_directory(wandb_dir)
+
+    if not result.synced_runs:
+        term.termlog(f"Found no synced runs, {result.unsynced} unsynced.")
+        ctx.exit(0)
+
+    term.termlog(f"Found {len(result.synced_runs)} synced run(s).")
+    for path in result.synced_runs:
+        term.termlog(f"  {path}")
+    if not term.confirm(
+        f"Are you sure you want to remove {len(result.synced_runs)} run(s)?",
+    ):
+        ctx.exit(1)
+
+    exit_code = 0
+    for path in result.synced_runs:
+        try:
+            shutil.rmtree(path)
+        except OSError as e:
+            errstr = f": {e.strerror}" if e.strerror else ""
+            term.termerror(f"Failed to remove {str(path)!r}{errstr}")
+            exit_code = 1
+
+    ctx.exit(exit_code)
+
+
+@dataclasses.dataclass()
+class _WandbDirResult:
+    """A description of the contents of the wandb folder."""
+
+    synced_runs: list[pathlib.Path]
+    """Folders of online or synced runs."""
+
+    unsynced: int = 0
+    """Count of unsynced runs."""
+
+
+def _examine_wandb_directory(wandb_dir: pathlib.Path) -> _WandbDirResult:
+    """Check the wandb folder for runs to clean.
+
+    Args:
+        wandb_dir: The path to the wandb folder to examine.
+    """
+    result = _WandbDirResult(synced_runs=[])
+
+    for online_run in wandb_dir.glob("run-*"):
+        if not online_run.is_dir():
+            term.termwarn(f"Not a directory: {online_run}")
+            continue
+
+        result.synced_runs.append(online_run)
+
+    for offline_run in wandb_dir.glob("offline-run-*"):
+        if not offline_run.is_dir():
+            term.termwarn(f"Not a directory: {offline_run}")
+            continue
+
+        synced_marker_count = len(list(offline_run.glob("*.wandb.synced")))
+        if synced_marker_count != 1:
+            result.unsynced += 1
+            continue  # Not synced yet, or invalid if >1 marker file.
+
+        result.synced_runs.append(offline_run)
+
+    return result

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -44,6 +44,7 @@ from wandb.sdk.lib import filesystem, settings_file
 from wandb.sync import TFEVENT_SUBSTRING, SyncManager, get_run_from_path, get_runs
 
 from .beta import beta
+from .clean import clean
 from .leet import leet
 
 
@@ -3778,3 +3779,4 @@ def purge_cache(
 
 cli.add_command(beta)
 cli.add_command(leet)
+cli.add_command(clean)


### PR DESCRIPTION
Creates the `wandb clean` command which will replace `wandb sync --clean`.

Will implement `--clean-old-hours` and `--clean-force` options separately.

The reason not to bundle this with `wandb sync` is that many sync options are meaningless or confusing in the context of cleaning. Options like `--replace-tags`, `--entity` and `--project` cannot be given an alternate meaning, and options like `--skip-synced / --no-skip-synced` would need a different default (when syncing, you want to skip synced files by default; when cleaning, you want to clean synced files by default). Then other, cleaning-specific options need prefixes to avoid clashing with sync options, for example `--clean-force` and `--clean-old-hours`.