### PR TITLE
docs(sdk): lazydoc cleaning

### DIFF
--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -33,7 +33,7 @@ __all__ = (
     "Video",
     "Audio",
     "Table",
-    "EvalTable",
+    "EvalTable",  # doc:exclude
     "Html",
     "box3d",
     "Object3D",

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -33,7 +33,7 @@ __all__ = (
     "Video",
     "Audio",
     "Table",
-    "EvalTable",
+    "EvalTable", # doc:exclude
     "Html",
     "box3d",
     "Object3D",

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -33,7 +33,7 @@ __all__ = (
     "Video",
     "Audio",
     "Table",
-    "EvalTable", # doc:exclude
+    "EvalTable",  # doc:exclude
     "Html",
     "box3d",
     "Object3D",

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -33,7 +33,7 @@ __all__ = (
     "Video",
     "Audio",
     "Table",
-    "EvalTable",  # doc:exclude
+    "EvalTable",
     "Html",
     "box3d",
     "Object3D",

--- a/wandb/__init__.template.pyi
+++ b/wandb/__init__.template.pyi
@@ -33,7 +33,7 @@ __all__ = (
     "Video",
     "Audio",
     "Table",
-    "EvalTable",
+    "EvalTable",  # doc:exclude
     "Html",
     "box3d",
     "Object3D",

--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -159,10 +159,7 @@ class SizedPaginator(Paginator[_WandbT], Sized, ABC):
 
 
 class RelayPaginator(Paginator[_WandbT], Generic[_NodeT, _WandbT], ABC):
-    """A Paginator for GQL relay-style nodes parsed via Pydantic.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """A Paginator for GQL relay-style nodes parsed via Pydantic."""
 
     last_response: Connection[_NodeT] | None
 
@@ -224,10 +221,7 @@ class RelayPaginator(Paginator[_WandbT], Generic[_NodeT, _WandbT], ABC):
 
 
 class SizedRelayPaginator(RelayPaginator[_NodeT, _WandbT], Sized, ABC):
-    """A Paginator for GQL nodes parsed via Pydantic, with a known total count.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """A Paginator for GQL nodes parsed via Pydantic, with a known total count."""
 
     last_response: Connection[_NodeT] | None
 

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -35,7 +35,7 @@ __all__ = (
     "Reports",
     "Run",
     "Runs",
-    "AgentRuns",
+    "AgentRuns", # doc:exclude
     "Sweep",
     "Member",
     "Team",

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -10,7 +10,7 @@ __all__ = (
     "ArtifactTypes",
     "DownloadHistoryResult",
     "RunArtifacts",
-    "Automations", # doc:exclude
+    "Automations",  # doc:exclude
     "File",
     "Files",
     "HistoryScan",  # doc:exclude
@@ -35,7 +35,7 @@ __all__ = (
     "Reports",
     "Run",
     "Runs",
-    "AgentRuns", # doc:exclude
+    "AgentRuns",  # doc:exclude
     "Sweep",
     "Member",
     "Team",

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -10,7 +10,7 @@ __all__ = (
     "ArtifactTypes",
     "DownloadHistoryResult",
     "RunArtifacts",
-    "Automations",
+    "Automations", # doc:exclude
     "File",
     "Files",
     "HistoryScan",  # doc:exclude

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -67,10 +67,7 @@ def _run_artifacts_mode_to_gql() -> dict[Literal["logged", "used"], str]:
 
 
 class _ArtifactCollectionAliases(RelayPaginator["ArtifactAliasFragment", str]):
-    """An internal iterator of collection alias names.
-
-    <!-- lazydoc-ignore-init: internal -->
-    """
+    """An internal iterator of collection alias names."""
 
     QUERY: ClassVar[str | None] = None
     last_response: Connection[ArtifactAliasFragment] | None

--- a/wandb/apis/public/artifacts.py
+++ b/wandb/apis/public/artifacts.py
@@ -202,7 +202,7 @@ class ArtifactType:
     def load(self) -> ArtifactTypeFragment:
         """Load the artifact type attributes from W&B.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         from wandb.sdk.artifacts._generated import (
             PROJECT_ARTIFACT_TYPE_GQL,
@@ -592,7 +592,7 @@ class ArtifactCollection:
     ) -> ArtifactCollectionFragment:
         """Fetch and return the validated artifact collection data from W&B.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         from wandb.sdk.artifacts._generated import (
             PROJECT_ARTIFACT_COLLECTION_GQL,
@@ -953,7 +953,7 @@ class Artifacts(SizedRelayPaginator["ArtifactFragment", "Artifact"]):
     def convert_objects(self) -> list[Artifact]:
         """Convert the raw response data into a list of wandb.Artifact objects.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if (conn := self.last_response) is None:
             return []

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -18,10 +18,7 @@ if TYPE_CHECKING:
 
 
 class Automations(RelayPaginator["ProjectTriggersFields", "Automation"]):
-    """A lazy iterator of `Automation` objects.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """A lazy iterator of `Automation` objects."""
 
     QUERY: str  # Must be set per-instance
     last_response: Connection[ProjectTriggersFields] | None

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -171,7 +171,7 @@ class Files(SizedPaginator["File"]):
         """
         Returns total number of files.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             self._load_page()
@@ -187,7 +187,7 @@ class Files(SizedPaginator["File"]):
     def more(self) -> bool:
         """Returns whether there are more files to fetch.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             return True
@@ -202,7 +202,7 @@ class Files(SizedPaginator["File"]):
     def cursor(self) -> str | None:
         """Returns the cursor position for pagination of file results.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             return None
@@ -220,14 +220,14 @@ class Files(SizedPaginator["File"]):
     def update_variables(self) -> None:
         """Updates the GraphQL query variables for pagination.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         self.variables.update({"fileLimit": self.per_page, "fileCursor": self.cursor})
 
     def convert_objects(self) -> list[File]:
         """Converts GraphQL edges to File objects.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             return []

--- a/wandb/apis/public/history.py
+++ b/wandb/apis/public/history.py
@@ -28,10 +28,7 @@ _RowDict: TypeAlias = dict[str, Any]
 
 
 class HistoryScan(Iterator[_RowDict]):
-    """Iterator for scanning complete run history.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """Iterator for scanning complete run history."""
 
     def __init__(
         self,

--- a/wandb/apis/public/integrations.py
+++ b/wandb/apis/public/integrations.py
@@ -27,10 +27,7 @@ _IntegrationT = TypeVar("_IntegrationT")
 
 
 class _IntegrationsPaginator(RelayPaginator["IntegrationFields", _IntegrationT]):
-    """Shared pagination logic for lazy iterators of entity integrations.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """Shared pagination logic for lazy iterators of entity integrations."""
 
     QUERY: ClassVar[str | None] = None
     last_response: Connection[IntegrationFields] | None
@@ -80,10 +77,7 @@ class Integrations(_IntegrationsPaginator["Integration"]):
 # does not change this. Restricting results to a single type requires
 # a client-side filter.
 class WebhookIntegrations(_IntegrationsPaginator["WebhookIntegration"]):
-    """A lazy iterator of `WebhookIntegration` objects.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """A lazy iterator of `WebhookIntegration` objects."""
 
     def _convert(self, node: IntegrationFields) -> WebhookIntegration | None:
         from wandb.automations import WebhookIntegration
@@ -94,10 +88,7 @@ class WebhookIntegrations(_IntegrationsPaginator["WebhookIntegration"]):
 
 
 class SlackIntegrations(_IntegrationsPaginator["SlackIntegration"]):
-    """A lazy iterator of `SlackIntegration` objects.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """A lazy iterator of `SlackIntegration` objects."""
 
     def _convert(self, node: IntegrationFields) -> SlackIntegration | None:
         from wandb.automations import SlackIntegration

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -122,7 +122,7 @@ class Projects(RelayPaginator["ProjectFragment", "Project"]):
 
         Note: This property is not available for projects.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # For backwards compatibility, even though this isn't a SizedPaginator
         return None
@@ -214,7 +214,7 @@ class Project(Attrs):
     def to_html(self, height: int = 420, hidden: bool = False) -> str:
         """Generate HTML containing an iframe displaying this project.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         url = self.url + "?jupyter=true"
         style = f"border:none;width:100%;height:{height}px;"

--- a/wandb/apis/public/query_generator.py
+++ b/wandb/apis/public/query_generator.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 
 class QueryGenerator:
-    """QueryGenerator is a helper object to write filters for runs.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """QueryGenerator is a helper object to write filters for runs."""
 
     INDIVIDUAL_OP_TO_MONGO = {
         "!=": "$ne",

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -319,10 +319,7 @@ class BetaReport(Attrs):
 
 
 class PythonMongoishQueryGenerator:
-    """Converts Python-style query expressions to MongoDB-style queries for W&B reports.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """Converts Python-style query expressions to MongoDB-style queries for W&B reports."""
 
     SPACER = "----------"
     DECIMAL_SPACER = ";;;"
@@ -535,10 +532,7 @@ class PythonMongoishQueryGenerator:
 
 
 class PanelMetricsHelper:
-    """Converts Python-style query expressions to MongoDB-style queries for W&B reports.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """Converts Python-style query expressions to MongoDB-style queries for W&B reports."""
 
     FRONTEND_NAME_MAPPING = {
         "Step": "_step",

--- a/wandb/apis/public/reports.py
+++ b/wandb/apis/public/reports.py
@@ -93,7 +93,7 @@ class Reports(SizedPaginator["BetaReport"]):
     def _length(self) -> int | None:
         """The number of reports in the project.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # TODO: Add the count the backend
         if not self.last_response:
@@ -105,7 +105,7 @@ class Reports(SizedPaginator["BetaReport"]):
     def more(self) -> bool:
         """Returns whether there are more files to fetch.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             return True
@@ -119,7 +119,7 @@ class Reports(SizedPaginator["BetaReport"]):
     def cursor(self) -> str | None:
         """Returns the cursor position for pagination of file results.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             return None
@@ -432,7 +432,7 @@ class PythonMongoishQueryGenerator:
     def python_to_mongo(self, filterstr):
         """Convert Python expresion to MongoDB filter.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         try:
             tree = ast.parse(self._convert(filterstr), mode="eval")
@@ -454,7 +454,7 @@ class PythonMongoishQueryGenerator:
     def front_to_back(self, name):
         """Convert frontend metric names to backend field names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         name, *rest = name.split(".")
         rest = "." + ".".join(rest) if rest else ""
@@ -471,7 +471,7 @@ class PythonMongoishQueryGenerator:
     def back_to_front(self, name):
         """Convert backend field names to frontend metric names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if name in self.FRONTEND_NAME_MAPPING_REVERSED:
             return self.FRONTEND_NAME_MAPPING_REVERSED[name]
@@ -491,7 +491,7 @@ class PythonMongoishQueryGenerator:
     def pc_front_to_back(self, name):
         """Convert ParallelCoordinatesPlot to backend field names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         name, *rest = name.split(".")
         rest = "." + ".".join(rest) if rest else ""
@@ -511,7 +511,7 @@ class PythonMongoishQueryGenerator:
     def pc_back_to_front(self, name):
         """Convert backend backend field names to ParallelCoordinatesPlot names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if name is None:
             return None
@@ -548,7 +548,7 @@ class PanelMetricsHelper:
     def front_to_back(self, name):
         """Convert frontend metric names to backend field names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if name in self.FRONTEND_NAME_MAPPING:
             return self.FRONTEND_NAME_MAPPING[name]
@@ -557,7 +557,7 @@ class PanelMetricsHelper:
     def back_to_front(self, name):
         """Convert backend field names to frontend metric names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if name in self.FRONTEND_NAME_MAPPING_REVERSED:
             return self.FRONTEND_NAME_MAPPING_REVERSED[name]
@@ -567,7 +567,7 @@ class PanelMetricsHelper:
     def special_front_to_back(self, name):
         """Convert frontend metric names to backend field names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if name is None:
             return name
@@ -597,7 +597,7 @@ class PanelMetricsHelper:
     def special_back_to_front(self, name):
         """Convert backend field names to frontend metric names.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if name is not None:
             kind, rest = name.split(":", 1)

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -478,10 +478,7 @@ class Runs(SizedPaginator["Run"]):
 
 
 class AgentRuns(SizedPaginator["Run"]):
-    """A lazy iterator of `Run` objects for a single sweep agent.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """A lazy iterator of `Run` objects for a single sweep agent."""
 
     def __init__(
         self,

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -254,7 +254,7 @@ class Runs(SizedPaginator["Run"]):
     def _length(self) -> int:
         """Returns the total number of runs.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             self._load_page()
@@ -269,7 +269,7 @@ class Runs(SizedPaginator["Run"]):
     def more(self) -> bool:
         """Returns whether there are more runs to fetch.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             return True
@@ -283,7 +283,7 @@ class Runs(SizedPaginator["Run"]):
     def cursor(self):
         """Returns the cursor position for pagination of runs results.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             return None
@@ -300,7 +300,7 @@ class Runs(SizedPaginator["Run"]):
     def convert_objects(self) -> list[Run]:
         """Converts GraphQL edges to Runs objects.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         objs = []
         if self.last_response is None or self.last_response.get("project") is None:
@@ -1077,7 +1077,7 @@ class Run(Attrs):
     def json_config(self) -> str:
         """Return the run config as a JSON string.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         config = {}
         if "_wandb" in self.rawconfig:

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -144,7 +144,7 @@ class Sweeps(SizedPaginator["Sweep"]):
     def _length(self) -> int:
         """The total number of sweeps in the project.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not self.last_response:
             self._load_page()
@@ -159,7 +159,7 @@ class Sweeps(SizedPaginator["Sweep"]):
     def more(self) -> bool:
         """Returns whether there are more sweeps to fetch.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if (
             self.last_response
@@ -176,7 +176,7 @@ class Sweeps(SizedPaginator["Sweep"]):
     def cursor(self) -> str | None:
         """Returns the cursor for the next page of sweeps.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if (
             self.last_response
@@ -192,7 +192,7 @@ class Sweeps(SizedPaginator["Sweep"]):
     def convert_objects(self) -> list[Sweep]:
         """Converts the last GraphQL response into a list of `Sweep` objects.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         from wandb._pydantic import Connection
         from wandb.apis._generated import SweepFragment
@@ -319,7 +319,7 @@ class Sweep(Attrs):
     def load(self, force: bool = False):
         """Fetch and update sweep data logged to the run from GraphQL database.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if force or not self._attrs:
             if not (

--- a/wandb/apis/public/teams.py
+++ b/wandb/apis/public/teams.py
@@ -180,7 +180,7 @@ class Team(Attrs):
     def load(self, force: bool = False) -> dict[str, Any]:
         """Return members that belong to a team.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         from wandb.apis._generated import GET_TEAM_ENTITY_GQL, GetTeamEntity
 

--- a/wandb/apis/public/users.py
+++ b/wandb/apis/public/users.py
@@ -70,7 +70,7 @@ class User(Attrs):
         Returns:
             A `User` object.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         from wandb.apis._generated import (
             CREATE_USER_FROM_ADMIN_GQL,

--- a/wandb/errors/errors.py
+++ b/wandb/errors/errors.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 
 class Error(Exception):
-    """Base W&B Error.
-
-    <!-- lazydoc-ignore-class: internal -->
-    """
+    """Base W&B Error."""
 
     def __init__(self, message: str, context: dict | None = None) -> None:
         super().__init__(message)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -972,7 +972,7 @@ class Artifact:
     def distributed_id(self) -> str | None:
         """The distributed ID of the artifact.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         return self._distributed_id
 
@@ -984,7 +984,7 @@ class Artifact:
     def incremental(self) -> bool:
         """Boolean flag indicating if the artifact is an incremental artifact.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         return self._incremental
 

--- a/wandb/sdk/data_types/audio.py
+++ b/wandb/sdk/data_types/audio.py
@@ -69,7 +69,7 @@ class Audio(BatchableMedia):
     def get_media_subdir(cls):
         """Get media subdirectory.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         return os.path.join("media", "audio")
 
@@ -77,7 +77,7 @@ class Audio(BatchableMedia):
     def from_json(cls, json_obj, source_artifact):
         """Deserialize JSON object into it's class representation.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         return cls(
             source_artifact.get_entry(json_obj["path"]).download(),
@@ -89,7 +89,7 @@ class Audio(BatchableMedia):
     ):
         """Bind this object to a run.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if self.path_is_reference(self._path):
             raise ValueError(
@@ -101,7 +101,7 @@ class Audio(BatchableMedia):
     def to_json(self, run):
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run)
         json_dict.update(
@@ -115,7 +115,7 @@ class Audio(BatchableMedia):
     def seq_to_json(cls, seq, run, key, step):
         """Convert a sequence of Audio objects to a JSON representation.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         audio_list = list(seq)
 
@@ -156,7 +156,7 @@ class Audio(BatchableMedia):
     def captions(cls, audio_list):
         """Get the captions of the audio files.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         captions = [a._caption for a in audio_list]
         if all(c is None for c in captions):
@@ -167,7 +167,7 @@ class Audio(BatchableMedia):
     def resolve_ref(self):
         """Resolve the reference to the actual file path.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if self.path_is_reference(self._path):
             # this object was already created using a ref:

--- a/wandb/sdk/data_types/audio.py
+++ b/wandb/sdk/data_types/audio.py
@@ -69,7 +69,7 @@ class Audio(BatchableMedia):
     def get_media_subdir(cls):
         """Get media subdirectory.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         return os.path.join("media", "audio")
 
@@ -77,7 +77,7 @@ class Audio(BatchableMedia):
     def from_json(cls, json_obj, source_artifact):
         """Deserialize JSON object into it's class representation.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         return cls(
             source_artifact.get_entry(json_obj["path"]).download(),
@@ -115,7 +115,7 @@ class Audio(BatchableMedia):
     def seq_to_json(cls, seq, run, key, step):
         """Convert a sequence of Audio objects to a JSON representation.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         audio_list = list(seq)
 
@@ -156,7 +156,7 @@ class Audio(BatchableMedia):
     def captions(cls, audio_list):
         """Get the captions of the audio files.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         captions = [a._caption for a in audio_list]
         if all(c is None for c in captions):

--- a/wandb/sdk/data_types/eval_table.py
+++ b/wandb/sdk/data_types/eval_table.py
@@ -265,7 +265,7 @@ class EvalTable(Table):
     ) -> None:
         """Bind this object to a run.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # TODO: Remove when weave adds support for offline mode
         if run.offline:
@@ -284,7 +284,7 @@ class EvalTable(Table):
     def to_json(self, run_or_artifact: Any) -> dict[str, Any]:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if isinstance(run_or_artifact, wandb.Artifact):
             raise TypeError("EvalTable cannot be logged to a wandb.Artifact.")

--- a/wandb/sdk/data_types/eval_table.py
+++ b/wandb/sdk/data_types/eval_table.py
@@ -125,7 +125,6 @@ class EvalTable(Table):
 
     Note: EvalTable is a work-in-progress and is NOT yet officially released or
     supported.
-    <!-- lazydoc-ignore-class: internal -->
     """
 
     _log_type = "eval-table"

--- a/wandb/sdk/data_types/graph.py
+++ b/wandb/sdk/data_types/graph.py
@@ -309,7 +309,7 @@ class Graph(Media):
     def get_media_subdir(cls):
         """Get media subdirectory.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         return os.path.join("media", "graph")
 
@@ -368,7 +368,7 @@ class Graph(Media):
         This method is not supported for Keras 3.0.0 and above.
         Requires a refactor.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         graph = cls()
         # Shamelessly copied (then modified) from keras/keras/utils/layer_utils.py

--- a/wandb/sdk/data_types/graph.py
+++ b/wandb/sdk/data_types/graph.py
@@ -293,7 +293,7 @@ class Graph(Media):
     def bind_to_run(self, *args, **kwargs):
         """Bind this object to a run.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         data = self._to_graph_json()
         tmp_path = os.path.join(MEDIA_TMP.name, runid.generate_id() + ".graph.json")
@@ -316,7 +316,7 @@ class Graph(Media):
     def to_json(self, run):
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run)
         json_dict["_type"] = self._log_type
@@ -328,7 +328,7 @@ class Graph(Media):
     def pprint(self):
         """Pretty print the graph.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         for edge in self.edges:
             pprint.pprint(edge.attributes)  # noqa: T203
@@ -338,7 +338,7 @@ class Graph(Media):
     def add_node(self, node=None, **node_kwargs):
         """Add a node to the graph.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if node is None:
             node = Node(**node_kwargs)
@@ -354,7 +354,7 @@ class Graph(Media):
     def add_edge(self, from_node, to_node):
         """Add an edge to the graph.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         edge = Edge(from_node, to_node)
         self.edges.append(edge)

--- a/wandb/sdk/data_types/histogram.py
+++ b/wandb/sdk/data_types/histogram.py
@@ -97,7 +97,7 @@ class Histogram(WBValue):
     def to_json(self, run: LocalRun | Artifact | None = None) -> dict:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         return {"_type": self._log_type, "values": self.histogram, "bins": self.bins}
 

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -92,7 +92,7 @@ class Html(BatchableMedia):
     def inject_head(self) -> None:
         """Inject a <head> tag into the HTML.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         join = ""
         if "<head>" in self.html:
@@ -121,7 +121,7 @@ class Html(BatchableMedia):
     def to_json(self, run_or_artifact: LocalRun | Artifact) -> dict:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run_or_artifact)
         json_dict["_type"] = self._log_type

--- a/wandb/sdk/data_types/html.py
+++ b/wandb/sdk/data_types/html.py
@@ -114,7 +114,7 @@ class Html(BatchableMedia):
     def get_media_subdir(cls: type[Html]) -> str:
         """Get media subdirectory.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         return os.path.join("media", "html")
 
@@ -131,7 +131,7 @@ class Html(BatchableMedia):
     def from_json(cls: type[Html], json_obj: dict, source_artifact: Artifact) -> Html:
         """Deserialize a JSON object into it's class representation.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         return cls(source_artifact.get_entry(json_obj["path"]).download(), inject=False)
 
@@ -145,7 +145,7 @@ class Html(BatchableMedia):
     ) -> dict:
         """Convert a sequence of HTML objects to a JSON representation.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         base_path = os.path.join(run.dir, cls.get_media_subdir())
         filesystem.mkdir_exists_ok(base_path)

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -508,7 +508,7 @@ class Image(BatchableMedia):
     ) -> None:
         """Bind this object to a run.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # For Images, we are going to avoid copying the image file to the run.
         # We should make this common functionality for all media types, but that
@@ -550,7 +550,7 @@ class Image(BatchableMedia):
     def to_json(self, run_or_artifact: wandb.Run | Artifact) -> dict:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run_or_artifact)
         json_dict["_type"] = Image._log_type
@@ -608,7 +608,7 @@ class Image(BatchableMedia):
     ) -> str:
         """Guess what type of image the np.array is representing.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # TODO: do we want to support dimensions being at the beginning of the array?
         ndims = data.ndim
@@ -808,7 +808,7 @@ class Image(BatchableMedia):
     def to_data_array(self) -> list[Any]:
         """Convert to data array.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         res = []
         if self.image is not None:

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -456,7 +456,7 @@ class Image(BatchableMedia):
     def from_json(cls: type[Image], json_obj: dict, source_artifact: Artifact) -> Image:
         """Factory method to create an Audio object from a JSON object.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         classes: Classes | None = None
         if json_obj.get("classes") is not None:
@@ -494,7 +494,7 @@ class Image(BatchableMedia):
     def get_media_subdir(cls: type[Image]) -> str:
         """Get media subdirectory.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         return os.path.join("media", "images")
 
@@ -647,7 +647,7 @@ class Image(BatchableMedia):
     ) -> dict:
         """Convert a sequence of Image objects to a JSON representation.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         if TYPE_CHECKING:
             seq = cast(Sequence["Image"], seq)
@@ -724,7 +724,7 @@ class Image(BatchableMedia):
     ) -> list[dict | None] | bool:
         """Collect all masks from a list of images.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         all_mask_groups: list[dict | None] = []
         for image in images:
@@ -751,7 +751,7 @@ class Image(BatchableMedia):
     ) -> list[dict | None] | bool:
         """Collect all boxes from a list of images.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         all_box_groups: list[dict | None] = []
         for image in images:
@@ -774,7 +774,7 @@ class Image(BatchableMedia):
     ) -> bool | Sequence[str | None]:
         """Get captions from a list of images.
 
-        "<!-- lazydoc-ignore-classmethod: internal -->
+        "<!-- lazydoc-ignore -->
         """
         return cls.captions(images)
 

--- a/wandb/sdk/data_types/molecule.py
+++ b/wandb/sdk/data_types/molecule.py
@@ -119,7 +119,7 @@ class Molecule(BatchableMedia):
             mmff_optimize_molecule_max_iterations: (int)
                 Number of iterations to use in rdkit.Chem.AllChem.MMFFOptimizeMolecule
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         rdkit_chem = util.get_module(
             "rdkit.Chem",
@@ -186,7 +186,7 @@ class Molecule(BatchableMedia):
             mmff_optimize_molecule_max_iterations: Number of iterations to
                 use in rdkit.Chem.AllChem.MMFFOptimizeMolecule.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         rdkit_chem = util.get_module(
             "rdkit.Chem",
@@ -207,7 +207,7 @@ class Molecule(BatchableMedia):
     def get_media_subdir(cls: type[Molecule]) -> str:
         """Get media subdirectory.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         return os.path.join("media", "molecule")
 
@@ -230,7 +230,7 @@ class Molecule(BatchableMedia):
     ) -> dict:
         """Convert a sequence of Molecule objects to a JSON representation.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         seq = list(seq)
 

--- a/wandb/sdk/data_types/molecule.py
+++ b/wandb/sdk/data_types/molecule.py
@@ -214,7 +214,7 @@ class Molecule(BatchableMedia):
     def to_json(self, run_or_artifact: LocalRun | Artifact) -> dict:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run_or_artifact)
         json_dict["_type"] = self._log_type

--- a/wandb/sdk/data_types/object_3d.py
+++ b/wandb/sdk/data_types/object_3d.py
@@ -394,7 +394,7 @@ class Object3D(BatchableMedia):
             file_type (str): Specifies the data format passed to `data_or_path`. Required when `data_or_path` is a
                 `TextIO` stream. This parameter is ignored if a file path is provided. The type is taken from the file extension.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         # if file_type is not None and file_type not in cls.SUPPORTED_TYPES:
         #     raise ValueError(
@@ -419,7 +419,7 @@ class Object3D(BatchableMedia):
         [[x y z r g b], ...]  # nx6 where is rgb is color.
         ```
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         if not util.is_numpy_array(data):
             raise ValueError("`data` must be a numpy array")
@@ -455,7 +455,7 @@ class Object3D(BatchableMedia):
                 visualization. Can be used to indicate directionality of bounding boxes. Defaults to None.
             point_cloud_type ("lidar/beta"): At this time, only the "lidar/beta" type is supported. Defaults to "lidar/beta".
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         if point_cloud_type not in cls.SUPPORTED_POINT_CLOUD_TYPES:
             raise ValueError("Point cloud type not supported")
@@ -478,7 +478,7 @@ class Object3D(BatchableMedia):
     def get_media_subdir(cls: type[Object3D]) -> str:
         """Get media subdirectory.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         return os.path.join("media", "object3D")
 
@@ -509,7 +509,7 @@ class Object3D(BatchableMedia):
     ) -> dict:
         """Convert a sequence of Audio objects to a JSON representation.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         seq = list(seq)
 

--- a/wandb/sdk/data_types/object_3d.py
+++ b/wandb/sdk/data_types/object_3d.py
@@ -485,7 +485,7 @@ class Object3D(BatchableMedia):
     def to_json(self, run_or_artifact: LocalRun | Artifact) -> dict:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run_or_artifact)
         json_dict["_type"] = Object3D._log_type

--- a/wandb/sdk/data_types/plotly.py
+++ b/wandb/sdk/data_types/plotly.py
@@ -91,7 +91,7 @@ class Plotly(Media):
     def to_json(self, run_or_artifact: LocalRun | Artifact) -> dict:
         """Convert the Plotly object to a JSON representation.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run_or_artifact)
         json_dict["_type"] = self._log_type

--- a/wandb/sdk/data_types/plotly.py
+++ b/wandb/sdk/data_types/plotly.py
@@ -44,7 +44,7 @@ class Plotly(Media):
     ) -> Image | Plotly:
         """Create a Plotly object from a Plotly figure or a matplotlib artist.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         if util.is_matplotlib_typename(util.get_full_typename(val)):
             if util.matplotlib_contains_images(val):
@@ -84,7 +84,7 @@ class Plotly(Media):
     def get_media_subdir(cls: type[Plotly]) -> str:
         """Returns the media subdirectory for Plotly plots.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         return os.path.join("media", "plotly")
 

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -705,7 +705,7 @@ class Table(Media):
     def get_media_subdir(cls):
         """Get media subdirectory.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         return os.path.join("media", "table")
 
@@ -717,7 +717,7 @@ class Table(Media):
     ) -> Table:
         """Deserialize JSON object into it's class representation.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         data: list[InputRow] = []
         column_types = None

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -337,7 +337,7 @@ class Table(Media):
         Should be overridden by subclasses if they implement different logic to
         determine whether a table has been logged.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         return self._run is not None or self._artifact_target is not None
 
@@ -687,7 +687,7 @@ class Table(Media):
     def bind_to_run(self, *args, **kwargs):
         """Bind this object to a run.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # We set `warn=False` since Tables will now always be logged to both
         # files and artifacts. The file limit will never practically matter and
@@ -804,7 +804,7 @@ class Table(Media):
     def to_json(self, run_or_artifact: Any) -> dict[str, Any]:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run_or_artifact)
 
@@ -920,7 +920,7 @@ class Table(Media):
             will automatically build a relationship between the tables
         row: The data of the row.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         for ndx in range(len(self.data)):
             index = _TableIndex(ndx)
@@ -931,7 +931,7 @@ class Table(Media):
     def set_pk(self, col_name: ColumnKey) -> None:
         """Set primary key type for Table object.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # TODO: Docs
         assert col_name in self.columns
@@ -941,7 +941,7 @@ class Table(Media):
     def set_fk(self, col_name: ColumnKey, table: Table, table_col: str) -> None:
         """Set foreign key type for Table object.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # TODO: Docs
         assert col_name in self.columns
@@ -1151,7 +1151,7 @@ class Table(Media):
     def index_ref(self, index: int) -> _TableIndex:
         """Gets a reference of the index of a row in the table.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         assert index < len(self.data)
         _index = _TableIndex(index)

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -217,7 +217,7 @@ class Video(BatchableMedia):
     def get_media_subdir(cls: type[Video]) -> str:
         """Get media subdirectory for video files.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         return os.path.join("media", "videos")
 
@@ -282,7 +282,7 @@ class Video(BatchableMedia):
     ) -> dict:
         """Convert a sequence of Video objects to a JSON representation.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore -->
         """
         base_path = os.path.join(run.dir, cls.get_media_subdir())
         filesystem.mkdir_exists_ok(base_path)

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -188,7 +188,7 @@ class Video(BatchableMedia):
     def encode(self, fps: int = 4) -> None:
         """Encode the video data to a file.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # import ImageSequenceClip from the appropriate MoviePy module
         mpy = util.get_module(
@@ -224,7 +224,7 @@ class Video(BatchableMedia):
     def to_json(self, run_or_artifact: LocalRun | Artifact) -> dict:
         """Returns the JSON representation expected by the backend.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         json_dict = super().to_json(run_or_artifact)
         json_dict["_type"] = self._log_type

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -895,7 +895,7 @@ class Run:
     def starting_step(self) -> int:
         """The first step of the run.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         return self._starting_step
 
@@ -977,7 +977,7 @@ class Run:
 
         Name of the W&B project associated with the run.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         deprecation.warn_and_record_deprecation(
             feature=Deprecated(run__project_name=True),
@@ -1003,7 +1003,7 @@ class Run:
         URL of the W&B project associated with the run, if there is one.
         Offline runs do not have a project URL.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         deprecation.warn_and_record_deprecation(
             feature=Deprecated(run__get_project_url=True),
@@ -1139,7 +1139,7 @@ class Run:
         The URL of the sweep associated with the run, if there is one.
         Offline runs do not have a sweep URL.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         deprecation.warn_and_record_deprecation(
             feature=Deprecated(run__get_sweep_url=True),
@@ -1168,7 +1168,7 @@ class Run:
 
         URL of the W&B run, if there is one. Offline runs do not have a URL.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         deprecation.warn_and_record_deprecation(
             feature=Deprecated(run__get_url=True),
@@ -1315,7 +1315,7 @@ class Run:
         If the run is being displayed in a VSCode notebook,
         the string representation of the run is returned instead.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if ipython.in_vscode_notebook():
             import html

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1022,7 +1022,7 @@ class Settings(BaseModel, validate_assignment=True):
 
         This is a compatibility layer to handle previous versions of the settings.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         new_values = {}
         for key in values:
@@ -1078,7 +1078,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_api_key(cls, value):
         """Validate the API key.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is not None and (len(value) > len(value.strip())):
             raise UsageError("API key cannot start or end with whitespace")
@@ -1089,7 +1089,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_base_url(cls, value):
         """Validate the base URL.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         urls.validate_url(value)
         # wandb.ai-specific checks
@@ -1107,7 +1107,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_code_dir(cls, value):
         """Validate the code directory.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1119,7 +1119,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_console(cls, value, values):
         """Validate the console capture method.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value != "auto":
             return value
@@ -1131,7 +1131,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_console_chunk_max_bytes(cls, value):
         """Validate the console_chunk_max_bytes value.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value < 0:
             raise ValueError("console_chunk_max_bytes must be non-negative")
@@ -1143,7 +1143,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_console_chunk_max_seconds(cls, value):
         """Validate the console_chunk_max_seconds value.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value < 0:
             raise ValueError("console_chunk_max_seconds must be non-negative")
@@ -1155,7 +1155,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_executable(cls, value):
         """Validate the Python executable path.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1174,7 +1174,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_file_stream_max_line_bytes(cls, value):
         """Validate the maximum line length for filestream JSONL files.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is not None and value < 1:
             raise ValueError("File stream max line bytes must be greater than 0")
@@ -1185,7 +1185,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_files_dir(cls, value):
         """Validate the files directory.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1197,7 +1197,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_fork_from(cls, value, values) -> RunMoment | None:
         """Validate the fork_from field.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         run_moment = cls._runmoment_preprocessor(value)
 
@@ -1220,7 +1220,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_http_proxy(cls, value):
         """Validate the HTTP proxy.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is None:
             return None
@@ -1232,7 +1232,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_https_proxy(cls, value):
         """Validate the HTTPS proxy.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is None:
             return None
@@ -1244,7 +1244,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_ignore_globs(cls, value):
         """Validate the ignore globs.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         return tuple(value) if not isinstance(value, tuple) else value
 
@@ -1253,7 +1253,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_program(cls, value):
         """Validate the program path.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1265,7 +1265,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_program_abspath(cls, value):
         """Validate the absolute program path.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1277,7 +1277,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_program_relpath(cls, value):
         """Validate the relative program path.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1289,7 +1289,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_project(cls, value, values):
         """Validate the project name.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is None:
             return None
@@ -1310,7 +1310,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_resume(cls, value):
         """Validate the resume behavior.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is False:
             return None
@@ -1323,7 +1323,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_resume_from(cls, value, values) -> RunMoment | None:
         """Validate the resume_from field.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         run_moment = cls._runmoment_preprocessor(value)
 
@@ -1344,7 +1344,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_root_dir(cls, value):
         """Validate the root directory.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1356,7 +1356,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_run_id(cls, value, values):
         """Validate the run ID.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is None:
             return None
@@ -1379,7 +1379,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_settings_system(cls, value):
         """Validate the system settings file path.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is None:
             return None
@@ -1393,7 +1393,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_service_wait(cls, value):
         """Validate the service wait time.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value < 0:
             raise UsageError("Service wait time cannot be negative")
@@ -1404,7 +1404,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_start_method(cls, value):
         """Validate the start method for subprocesses.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is None:
             return value
@@ -1426,7 +1426,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_stats_gpu_device_ids(cls, value):
         """Validate the GPU device IDs.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1437,7 +1437,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_stats_neuron_monitor_config_path(cls, value):
         """Validate the path to the neuron-monitor config file.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1449,7 +1449,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_open_metrics_endpoints(cls, value):
         """Validate the OpenMetrics endpoints.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1460,7 +1460,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_open_metrics_filters(cls, value):
         """Validate the OpenMetrics filters.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1471,7 +1471,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_open_metrics_http_headers(cls, value):
         """Validate the OpenMetrics HTTP headers.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1482,7 +1482,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_sampling_interval(cls, value):
         """Validate the stats sampling interval.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value < 0.1:
             raise UsageError("Stats sampling interval cannot be less than 0.1 seconds")
@@ -1493,7 +1493,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_sweep_id(cls, value):
         """Validate the sweep ID.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         if value is None:
             return None
@@ -1515,7 +1515,7 @@ class Settings(BaseModel, validate_assignment=True):
         - Converts single string values to tuple format
         - Preserves None values
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
 
         Args:
             value: A string, list, tuple, or None representing tags
@@ -1565,7 +1565,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_sweep_param_path(cls, value):
         """Validate the sweep parameter path.
 
-        <!-- lazydoc-ignore-classmethod: internal -->
+        <!-- lazydoc-ignore-->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -300,7 +300,7 @@ class Settings(BaseModel, validate_assignment=True):
     heartbeat_seconds: int = 30
     """Interval in seconds between heartbeat signals sent to the W&B servers.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     host: str | None = None
@@ -373,7 +373,7 @@ class Settings(BaseModel, validate_assignment=True):
     launch: bool = False
     """Flag to indicate if the run is being launched through W&B Launch.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     launch_config_path: str | None = None
@@ -460,7 +460,7 @@ class Settings(BaseModel, validate_assignment=True):
     """Indication from the server about the state of the run.
 
     This is different from resume, a user provided flag.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     root_dir: str = Field(default_factory=lambda: os.path.abspath(os.getcwd()))
@@ -522,13 +522,13 @@ class Settings(BaseModel, validate_assignment=True):
     show_colors: bool | None = None
     """Whether to use colored output in the console.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     show_emoji: bool | None = None
     """Whether to show emoji in the console output.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     show_errors: bool = True
@@ -547,7 +547,7 @@ class Settings(BaseModel, validate_assignment=True):
     """Method to use for starting subprocesses.
 
     This is deprecated and will be removed in a future release.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     stop_on_fatal_error: bool = False
@@ -572,7 +572,7 @@ class Settings(BaseModel, validate_assignment=True):
     summary_warnings: int = 5
     """Maximum number of summary warnings to display.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     sweep_id: str | None = None
@@ -608,7 +608,7 @@ class Settings(BaseModel, validate_assignment=True):
     x_cli_only_mode: bool = False
     """Flag to indicate that the SDK is running in CLI-only mode.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_disable_meta: bool = False
@@ -620,19 +620,19 @@ class Settings(BaseModel, validate_assignment=True):
     x_disable_viewer: bool = False
     """Flag to disable the early viewer query.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_disable_machine_info: bool = False
     """Flag to disable automatic machine info collection.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_executable: str | None = None
     """Path to the Python executable.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_extra_http_headers: dict[str, str] | None = None
@@ -644,19 +644,19 @@ class Settings(BaseModel, validate_assignment=True):
     Its purpose is to prevent HTTP requests from failing due to
     containing too much data. This number is approximate:
     requests will be slightly larger.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_stream_max_line_bytes: int | None = None
     """Maximum line length for filestream JSONL files.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_stream_transmit_interval: float | None = None
     """Interval in seconds between filestream transmissions.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     # Filestream retry client configuration.
@@ -664,25 +664,25 @@ class Settings(BaseModel, validate_assignment=True):
     x_file_stream_retry_max: int | None = None
     """Max number of retries for filestream operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_stream_retry_wait_min_seconds: float | None = None
     """Minimum wait time between retries for filestream operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_stream_retry_wait_max_seconds: float | None = None
     """Maximum wait time between retries for filestream operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_stream_timeout_seconds: float | None = None
     """Timeout in seconds for individual filestream HTTP requests.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     # file transfer retry client configuration
@@ -690,25 +690,25 @@ class Settings(BaseModel, validate_assignment=True):
     x_file_transfer_retry_max: int | None = None
     """Max number of retries for file transfer operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_transfer_retry_wait_min_seconds: float | None = None
     """Minimum wait time between retries for file transfer operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_transfer_retry_wait_max_seconds: float | None = None
     """Maximum wait time between retries for file transfer operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_file_transfer_timeout_seconds: float | None = None
     """Timeout in seconds for individual file transfer HTTP requests.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_files_dir: str | None = None
@@ -717,21 +717,21 @@ class Settings(BaseModel, validate_assignment=True):
     DEPRECATED, DO NOT USE. This private setting is not respected by wandb-core
     but will continue to work for some legacy Python code.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_flow_control_custom: bool | None = None
     """Flag indicating custom flow control for filestream.
 
     TODO: Not implemented in wandb-core.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_flow_control_disabled: bool | None = None
     """Flag indicating flow control is disabled for filestream.
 
     TODO: Not implemented in wandb-core.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     # graphql retry client configuration
@@ -739,49 +739,49 @@ class Settings(BaseModel, validate_assignment=True):
     x_graphql_retry_max: int | None = None
     """Max number of retries for GraphQL operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_graphql_retry_wait_min_seconds: float | None = None
     """Minimum wait time between retries for GraphQL operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_graphql_retry_wait_max_seconds: float | None = None
     """Maximum wait time between retries for GraphQL operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_graphql_timeout_seconds: float | None = None
     """Timeout in seconds for individual GraphQL requests.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_internal_check_process: float = 8.0
     """Interval for internal process health checks in seconds.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_jupyter_name: str | None = None
     """Name of the Jupyter notebook.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_jupyter_path: str | None = None
     """Path to the Jupyter notebook.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_jupyter_root: str | None = None
     """Root directory of the Jupyter notebook.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_label: str | None = None
@@ -794,26 +794,26 @@ class Settings(BaseModel, validate_assignment=True):
     x_live_policy_rate_limit: int | None = None
     """Rate limit for live policy updates in seconds.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_live_policy_wait_time: int | None = None
     """Wait time between live policy updates in seconds.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_log_level: int = logging.INFO
     """Logging level for internal operations.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_network_buffer: int | None = None
     """Size of the network buffer used in flow control.
 
     TODO: Not implemented in wandb-core.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_primary: bool = Field(
@@ -831,13 +831,13 @@ class Settings(BaseModel, validate_assignment=True):
 
     This is deprecated and will be removed in a future release.
     Please use `http_proxy` and `https_proxy` instead.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_runqueue_item_id: str | None = None
     """ID of the Launch run queue item being processed.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_save_requirements: bool = True
@@ -853,13 +853,13 @@ class Settings(BaseModel, validate_assignment=True):
     """Flag to delegate glob matching of metrics in define_metric to the server.
 
     If the server does not support this, the client will perform the glob matching.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_service_transport: str | None = None
     """Transport method for communication with the wandb service.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_service_wait: float = 30.0
@@ -878,13 +878,13 @@ class Settings(BaseModel, validate_assignment=True):
     x_start_time: float | None = None
     """The start time of the run in seconds since the Unix epoch.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_stats_pid: int = os.getpid()
     """PID of the process that started the wandb-core process to collect system stats for.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_stats_sampling_interval: float = Field(default=15.0)
@@ -894,7 +894,7 @@ class Settings(BaseModel, validate_assignment=True):
     """Path to the default config file for the neuron-monitor tool.
 
     This is used to monitor AWS Trainium devices.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_stats_dcgm_exporter: str | None = None
@@ -909,7 +909,7 @@ class Settings(BaseModel, validate_assignment=True):
     Examples:
      - `http://localhost:9400/api/v1/query?query=DCGM_FI_DEV_GPU_TEMP{node="l1337", cluster="globular"}`.
      - TODO: `http://192.168.0.1:9400/metrics`.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_stats_open_metrics_endpoints: dict[str, str] | None = None
@@ -966,14 +966,14 @@ class Settings(BaseModel, validate_assignment=True):
     """Number of system metric samples to buffer in memory in the wandb-core process.
 
     Can be accessed via run._system_metrics.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_stats_coreweave_metadata_base_url: str = "http://169.254.169.254"
     """The scheme and hostname for contacting the CoreWeave metadata server.
 
     Only accessible from within a CoreWeave cluster.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_stats_coreweave_metadata_endpoint: str = "/api/v2/cloud-init/meta-data"
@@ -981,7 +981,7 @@ class Settings(BaseModel, validate_assignment=True):
 
     This must not include the schema and hostname prefix.
     Only accessible from within a CoreWeave cluster.
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_stats_track_process_tree: bool = False
@@ -998,7 +998,7 @@ class Settings(BaseModel, validate_assignment=True):
     x_sync: bool = False
     """Flag to indicate whether we are syncing a run from the transaction log.
 
-    <!-- lazydoc-ignore-class-attributes -->
+    <!-- lazydoc-ignore -->
     """
 
     x_sync_dir_suffix: str = ""

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1022,7 +1022,7 @@ class Settings(BaseModel, validate_assignment=True):
 
         This is a compatibility layer to handle previous versions of the settings.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         new_values = {}
         for key in values:
@@ -1038,7 +1038,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_mutual_exclusion_of_branching_args(self) -> Self:
         """Check if `fork_from`, `resume`, and `resume_from` are mutually exclusive.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if (
             sum(o is not None for o in [self.fork_from, self.resume, self.resume_from])
@@ -1054,7 +1054,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_skip_transaction_log(self):
         """Validate x_skip_transaction_log.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if self._offline and self.x_skip_transaction_log:
             raise ValueError("Cannot skip transaction log in offline mode")
@@ -1078,7 +1078,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_api_key(cls, value):
         """Validate the API key.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is not None and (len(value) > len(value.strip())):
             raise UsageError("API key cannot start or end with whitespace")
@@ -1089,7 +1089,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_base_url(cls, value):
         """Validate the base URL.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         urls.validate_url(value)
         # wandb.ai-specific checks
@@ -1107,7 +1107,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_code_dir(cls, value):
         """Validate the code directory.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1119,7 +1119,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_console(cls, value, values):
         """Validate the console capture method.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value != "auto":
             return value
@@ -1131,7 +1131,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_console_chunk_max_bytes(cls, value):
         """Validate the console_chunk_max_bytes value.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value < 0:
             raise ValueError("console_chunk_max_bytes must be non-negative")
@@ -1143,7 +1143,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_console_chunk_max_seconds(cls, value):
         """Validate the console_chunk_max_seconds value.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value < 0:
             raise ValueError("console_chunk_max_seconds must be non-negative")
@@ -1155,7 +1155,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_executable(cls, value):
         """Validate the Python executable path.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1174,7 +1174,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_file_stream_max_line_bytes(cls, value):
         """Validate the maximum line length for filestream JSONL files.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is not None and value < 1:
             raise ValueError("File stream max line bytes must be greater than 0")
@@ -1185,7 +1185,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_files_dir(cls, value):
         """Validate the files directory.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1197,7 +1197,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_fork_from(cls, value, values) -> RunMoment | None:
         """Validate the fork_from field.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         run_moment = cls._runmoment_preprocessor(value)
 
@@ -1220,7 +1220,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_http_proxy(cls, value):
         """Validate the HTTP proxy.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is None:
             return None
@@ -1232,7 +1232,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_https_proxy(cls, value):
         """Validate the HTTPS proxy.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is None:
             return None
@@ -1244,7 +1244,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_ignore_globs(cls, value):
         """Validate the ignore globs.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         return tuple(value) if not isinstance(value, tuple) else value
 
@@ -1253,7 +1253,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_program(cls, value):
         """Validate the program path.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1265,7 +1265,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_program_abspath(cls, value):
         """Validate the absolute program path.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1277,7 +1277,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_program_relpath(cls, value):
         """Validate the relative program path.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1289,7 +1289,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_project(cls, value, values):
         """Validate the project name.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is None:
             return None
@@ -1310,7 +1310,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_resume(cls, value):
         """Validate the resume behavior.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is False:
             return None
@@ -1323,7 +1323,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_resume_from(cls, value, values) -> RunMoment | None:
         """Validate the resume_from field.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         run_moment = cls._runmoment_preprocessor(value)
 
@@ -1344,7 +1344,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_root_dir(cls, value):
         """Validate the root directory.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1356,7 +1356,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_run_id(cls, value, values):
         """Validate the run ID.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is None:
             return None
@@ -1379,7 +1379,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_settings_system(cls, value):
         """Validate the system settings file path.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is None:
             return None
@@ -1393,7 +1393,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_service_wait(cls, value):
         """Validate the service wait time.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value < 0:
             raise UsageError("Service wait time cannot be negative")
@@ -1404,7 +1404,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_start_method(cls, value):
         """Validate the start method for subprocesses.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is None:
             return value
@@ -1426,7 +1426,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_stats_gpu_device_ids(cls, value):
         """Validate the GPU device IDs.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1437,7 +1437,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_x_stats_neuron_monitor_config_path(cls, value):
         """Validate the path to the neuron-monitor config file.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1449,7 +1449,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_open_metrics_endpoints(cls, value):
         """Validate the OpenMetrics endpoints.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1460,7 +1460,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_open_metrics_filters(cls, value):
         """Validate the OpenMetrics filters.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1471,7 +1471,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_open_metrics_http_headers(cls, value):
         """Validate the OpenMetrics HTTP headers.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if isinstance(value, str):
             return json.loads(value)
@@ -1482,7 +1482,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_stats_sampling_interval(cls, value):
         """Validate the stats sampling interval.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value < 0.1:
             raise UsageError("Stats sampling interval cannot be less than 0.1 seconds")
@@ -1493,7 +1493,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_sweep_id(cls, value):
         """Validate the sweep ID.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         if value is None:
             return None
@@ -1515,7 +1515,7 @@ class Settings(BaseModel, validate_assignment=True):
         - Converts single string values to tuple format
         - Preserves None values
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
 
         Args:
             value: A string, list, tuple, or None representing tags
@@ -1565,7 +1565,7 @@ class Settings(BaseModel, validate_assignment=True):
     def validate_sweep_param_path(cls, value):
         """Validate the sweep parameter path.
 
-        <!-- lazydoc-ignore-->
+        <!-- lazydoc-ignore -->
         """
         # TODO: add native support for pathlib.Path
         if isinstance(value, pathlib.Path):
@@ -1867,7 +1867,7 @@ class Settings(BaseModel, validate_assignment=True):
         Updating the settings files does not update this Settings instance
         and vice versa.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         local_settings = pathlib.Path(self.settings_workspace)
 
@@ -1887,7 +1887,7 @@ class Settings(BaseModel, validate_assignment=True):
         If settings files contain invalid settings, prints and suppresses
         the error.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         system_settings = self.read_system_settings()
 
@@ -1936,7 +1936,7 @@ class Settings(BaseModel, validate_assignment=True):
     def update_from_env_vars(self, environ: dict[str, Any]):
         """Update settings from environment variables.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         env_prefix: str = "WANDB_"
         private_env_prefix: str = env_prefix + "_"
@@ -1979,7 +1979,7 @@ class Settings(BaseModel, validate_assignment=True):
     def update_from_system_environment(self):
         """Update settings from the system environment.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         # For code saving, only allow env var override if value from server is true, or
         # if no preference was specified.
@@ -2045,7 +2045,7 @@ class Settings(BaseModel, validate_assignment=True):
     def infer_git_root(self) -> None:
         """Infer the git root from the root_dir setting using GitRepo.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         if self.git_root is not None or self.disable_git:
             return
@@ -2063,7 +2063,7 @@ class Settings(BaseModel, validate_assignment=True):
     def update_from_dict(self, settings: dict[str, Any]) -> None:
         """Update settings from a dictionary.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         for key, value in dict(settings).items():
             if value is not None:
@@ -2072,7 +2072,7 @@ class Settings(BaseModel, validate_assignment=True):
     def update_from_settings(self, settings: Settings) -> None:
         """Update settings from another instance of `Settings`.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         d = {field: getattr(settings, field) for field in settings.model_fields_set}
         if d:
@@ -2083,7 +2083,7 @@ class Settings(BaseModel, validate_assignment=True):
     def to_proto(self) -> wandb_settings_pb2.Settings:
         """Generate a protobuf representation of the settings.
 
-        <!-- lazydoc-ignore: internal -->
+        <!-- lazydoc-ignore -->
         """
         settings_proto = wandb_settings_pb2.Settings()
         for k, v in self.model_dump(exclude_none=True).items():


### PR DESCRIPTION
Description
-----------
Reduces the number of internal "lazydoc" comments from 6 -> 2. We are keeping the following:

Remove `__init__` definitions (e.g. `ArtifactFiles`):  
```text
<!-- lazydoc-ignore-init: internal -->
```

For everything else:

```
<!-- lazydoc-ignore -->
```

Note: To remove a Class, add `# docs: exclude` to it's appropriate `__init__.py` file. E.g.

```python 
    "Object3D",
    "Molecule",
    "Histogram",
    "ArtifactTTL",  # doc:exclude
    "log_artifact",  # doc:exclude
    "use_artifact",  # doc:exclude
```

Why?
Too many internal comment options were confusing. Which led to incorrect usage. 

Ticket: https://coreweave.atlassian.net/browse/DOCS-2924

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [X] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
