### PR TITLE
feat(sweeps): add a --term-timeout flag to sweeps agent, which automatically kills runs which are unresponsive to forwarded shutdown signals.

### DIFF
--- a/tests/system_tests/test_sweep/test_wandb_agent.py
+++ b/tests/system_tests/test_sweep/test_wandb_agent.py
@@ -175,6 +175,105 @@ def _write_signal_parent_script(path: Path) -> Path:
     return script
 
 
+def _write_ignore_signals_child_script(path: Path) -> Path:
+    # A child that ignores SIGINT and SIGTERM, so it survives both the forwarded
+    # shutdown signal and a polite SIGTERM. Only SIGKILL can end it -- which is
+    # exactly the escalation we want to assert once the term_timeout budget
+    # expires.
+    script = path / "child_ignore_signals.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import signal
+            import time
+
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+            while True:
+                time.sleep(0.1)
+            """
+        ).strip()
+    )
+    return script
+
+
+def _write_term_timeout_parent_script(path: Path) -> Path:
+    """Similar to _write_signal_parent_script, but drives a real Agent (which
+    manages the AgentProcess lifecycle) instead of using AgentProcess directly."""
+
+    script = path / "parent_term_timeout.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import os
+            import queue
+            import signal
+            import sys
+            import threading
+            import time
+
+            from wandb.wandb_agent import Agent
+
+            child_script = sys.argv[1]
+            term_timeout = int(sys.argv[2])
+
+            class _StubApi:
+                def sweep(self, sweep_id, spec):
+                    return None
+
+                def register_agent(self, host, sweep_id=None):
+                    return {"id": "agent-1"}
+
+                def agent_heartbeat(self, agent_id, spec, run_status):
+                    return []
+
+            # Seed agent command queue to run the child script
+            command_queue = queue.Queue()
+            command_queue.put(
+                {
+                    "type": "run",
+                    "run_id": "run-1",
+                    "program": child_script,
+                    "args": {},
+                    "resp_queue": queue.Queue(),
+                }
+            )
+
+            agent = Agent(
+                _StubApi(),
+                command_queue,
+                sweep_id="sweep-1",
+                term_timeout=term_timeout,
+                forward_signals=True,
+            )
+
+            # Send a SIGINT after 1 second. This is eaten by then child process but
+            # puts the Agent into the tier 1 waiting state.
+            threading.Timer(1.0, lambda: os.kill(os.getpid(), signal.SIGINT)).start()
+
+            start = time.monotonic()
+            agent.run()
+            elapsed = time.monotonic() - start
+
+            procs = list(agent._run_processes.values())
+            child = procs[0]
+
+            returncode = child.wait(timeout=5)
+            if returncode != -signal.SIGKILL:
+                sys.exit(2)
+
+            # We expect that the child terminated roughly around the term_timeout time
+            if elapsed > term_timeout * 2:
+                sys.exit(3)
+            if elapsed < term_timeout * 0.5:
+                sys.exit(4)
+            """
+        ).strip()
+    )
+    return script
+
+
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="POSIX signals required for this test"
 )
@@ -201,6 +300,42 @@ def test_agent_process_forwards_signals_end_to_end(tmp_path):
     assert result.returncode == 0, f"stderr:\n{result.stderr}"
     assert marker.exists()
     assert marker.read_text().strip() == str(int(signal.SIGTERM))
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="POSIX signals required for this test"
+)
+def test_agent_term_timeout_escalates_to_sigkill(tmp_path):
+    """Checks that a child that ignores signals past `term_timeout` is
+    escalated straight to SIGKILL rather than re-sent a polite SIGTERM."""
+
+    child_script = _write_ignore_signals_child_script(tmp_path)
+    parent_script = _write_term_timeout_parent_script(tmp_path)
+    term_timeout = 3
+
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        f"{repo_root}{os.pathsep}{env['PYTHONPATH']}"
+        if "PYTHONPATH" in env and env["PYTHONPATH"]
+        else str(repo_root)
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(parent_script),
+            str(child_script),
+            str(term_timeout),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+        timeout=60,
+    )
+
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
 
 def test_agent_cli_exit_code_on_sweep_not_found(runner, user):

--- a/tests/unit_tests/test_wandb_agent_signals.py
+++ b/tests/unit_tests/test_wandb_agent_signals.py
@@ -1,5 +1,6 @@
 import os
 import signal
+import subprocess
 from unittest import mock
 
 import pytest
@@ -285,6 +286,108 @@ def test_agent_run_third_shutdown_signal_escalates_to_kill(monkeypatch):
     agent._run_processes["run-1"] = run_process
 
     agent.run()
+
+    run_process.terminate.assert_called_once()
+    run_process.kill.assert_called_once()
+
+
+def test_agent_run_term_timeout_expiry_escalates_straight_to_kill(monkeypatch):
+    """Tests that when a child process runs past the term_timeout, Tier 1
+    raises a timeoutExpired and we escalate straight to Tier 3 SIGKILL."""
+
+    api = mock.Mock()
+    api.sweep.return_value = {"config": ""}
+    api.register_agent.return_value = {"id": "agent-1"}
+    api.agent_heartbeat.side_effect = wandb_agent.ShutdownSignal(signal.SIGTERM)
+
+    monkeypatch.setattr(wandb_agent.util, "read_many_from_queue", lambda *a, **kw: [])
+
+    agent = wandb_agent.Agent(
+        api=api,
+        queue=mock.Mock(),
+        sweep_id="sweep-1",
+        term_timeout=5,
+        forward_signals=True,
+    )
+
+    run_process = mock.Mock()
+    run_process.poll.return_value = None
+
+    run_process.wait.side_effect = subprocess.TimeoutExpired(cmd="child", timeout=5)
+    agent._run_processes["run-1"] = run_process
+
+    agent.run()
+
+    assert run_process.wait.call_count == 1
+    wait_timeout = run_process.wait.call_args.kwargs["timeout"]
+    assert wait_timeout is not None
+    assert 0 <= wait_timeout <= 5
+
+    assert agent._immediately_kill_children is True
+    run_process.terminate.assert_not_called()
+    run_process.kill.assert_called_once()
+
+
+def test_agent_run_term_timeout_ignored_without_forward_signals(monkeypatch):
+    """Test that term_timeout only applies when forward_signals is also set."""
+    api = mock.Mock()
+    api.sweep.return_value = {"config": ""}
+    api.register_agent.return_value = {"id": "agent-1"}
+    api.agent_heartbeat.side_effect = wandb_agent.ShutdownSignal(signal.SIGTERM)
+
+    monkeypatch.setattr(wandb_agent.util, "read_many_from_queue", lambda *a, **kw: [])
+
+    agent = wandb_agent.Agent(
+        api=api,
+        queue=mock.Mock(),
+        sweep_id="sweep-1",
+        term_timeout=5,
+        forward_signals=False,
+    )
+
+    run_process = mock.Mock()
+    run_process.poll.side_effect = [None, 0]
+    run_process.wait.return_value = 0
+    agent._run_processes["run-1"] = run_process
+
+    agent.run()
+
+    assert run_process.wait.call_args.kwargs["timeout"] is None
+    assert agent._immediately_kill_children is False
+    run_process.terminate.assert_not_called()
+    run_process.kill.assert_not_called()
+
+
+def test_agent_run_term_timeout_in_tier2_escalates_to_kill(monkeypatch):
+    """Checks that the tier 2 wait also obeys term_timeout."""
+    api = mock.Mock()
+    api.sweep.return_value = {"config": ""}
+    api.register_agent.return_value = {"id": "agent-1"}
+    api.agent_heartbeat.side_effect = wandb_agent.ShutdownSignal(signal.SIGTERM)
+
+    monkeypatch.setattr(wandb_agent.util, "read_many_from_queue", lambda *a, **kw: [])
+
+    agent = wandb_agent.Agent(
+        api=api,
+        queue=mock.Mock(),
+        sweep_id="sweep-1",
+        term_timeout=5,
+        forward_signals=True,
+    )
+
+    run_process = mock.Mock()
+    run_process.poll.return_value = None
+    run_process.wait.side_effect = [
+        wandb_agent.ShutdownSignal(signal.SIGTERM),
+        subprocess.TimeoutExpired(cmd="child", timeout=5),
+    ]
+    agent._run_processes["run-1"] = run_process
+
+    agent.run()
+
+    tier2_timeout = run_process.wait.call_args_list[1].kwargs["timeout"]
+    assert tier2_timeout is not None
+    assert 0 <= tier2_timeout <= 5
 
     run_process.terminate.assert_called_once()
     run_process.kill.assert_called_once()

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2143,9 +2143,19 @@ def launch_agent(
     help="""Forward signals (e.g. SIGINT/SIGTERM) to child runs so they can
     shut down cleanly.""",
 )
+@click.option(
+    "--term-timeout",
+    "-t",
+    default=None,
+    type=int,
+    help="""Time (in seconds) after receiving a terminating signal (e.g. SIGINT
+    /SIGTERM) to force-terminate child runs which have not finished since
+    receiving the initial forwarded signal. Does nothing if --forward-signals is
+    not set.""",
+)
 @click.argument("sweep_id")
 @display_error
-def agent(ctx, project, entity, count, forward_signals, sweep_id):
+def agent(ctx, project, entity, count, forward_signals, term_timeout, sweep_id):
     """Start a sweep agent.
 
     Poll the W&B server for hyperparameter configurations from
@@ -2191,6 +2201,7 @@ def agent(ctx, project, entity, count, forward_signals, sweep_id):
             project=project,
             count=count,
             forward_signals=forward_signals,
+            term_timeout=term_timeout,
         )
     # TODO: handle other errors with correct exit codes
     except SweepNotFoundError:

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -205,17 +205,25 @@ class AgentProcess:
             pass
         return
 
-    def wait(self):
+    def wait(self, timeout: float | None = None):
+        start = time.monotonic()
+
         if self._popen:
             # if on windows, wait() will block and we won't be able to interrupt
             if platform.system() == "Windows":
                 while True:
-                    p = self._popen.poll()
+                    if timeout is not None and time.monotonic() - start > timeout:
+                        p = self._popen.wait(timeout=0)
+                    else:
+                        p = self._popen.poll()
+
                     if p is not None:
                         return p
+
                     time.sleep(1)
-            return self._popen.wait()
-        return self._proc.join()
+
+            return self._popen.wait(timeout=timeout)
+        return self._proc.join(timeout=timeout)
 
     def kill(self):
         if self._popen:
@@ -260,6 +268,7 @@ class Agent:
         in_jupyter=None,
         count=None,
         forward_signals=False,
+        term_timeout: int | None = None,
     ):
         self._api = api
         self._queue = queue
@@ -284,6 +293,10 @@ class Agent:
             self.MAX_INITIAL_FAILURES
         )
         self._forward_signals = forward_signals
+        self._term_timeout = term_timeout
+        # if children do not gracefully exit after _term_timeout, this flag is set to
+        # true, which skips Tier 2 signals and goes straight for a SIGKILL.
+        self._immediately_kill_children = False
         self._sweep_not_found = False
         if self._report_interval is None:
             raise AgentError("Invalid agent report interval")
@@ -309,6 +322,20 @@ class Agent:
             self._failed >= self._finished
             and self._max_initial_failures <= self._failed
         )
+
+    def _wait_for_processes_with_term_timeout(self):
+        start_time = time.monotonic()
+
+        for _, run_process in self._run_processes.items():
+            if self._forward_signals and self._term_timeout:
+                remaining_time = max(
+                    0,
+                    self._term_timeout - (time.monotonic() - start_time),
+                )
+            else:
+                remaining_time = None
+
+            run_process.wait(timeout=remaining_time)
 
     def run(self):  # noqa: C901
         # TODO: catch exceptions, handle errors, show validation warnings, and make more generic
@@ -442,8 +469,15 @@ class Agent:
                             f"{exc.label} received. Waiting for runs to end. "
                             f"Send {exc.label} again to terminate."
                         )
-                    for _, run_process in self._run_processes.items():
-                        run_process.wait()
+
+                    try:
+                        self._wait_for_processes_with_term_timeout()
+                    except subprocess.TimeoutExpired:
+                        self._immediately_kill_children = True
+                        wandb.termlog(
+                            f"Child runs took longer than {self._term_timeout} seconds to end. Attempting to kill them."
+                        )
+
                 except KeyboardInterrupt as kb:
                     raise ShutdownSignal(signal.SIGINT) from kb
             except ShutdownSignal:
@@ -451,6 +485,9 @@ class Agent:
         finally:
             try:
                 try:
+                    if self._immediately_kill_children:
+                        raise ShutdownSignal(signal.SIGINT)
+
                     # If Tier 1's wait() returned cleanly, the runs have
                     # already exited and there's nothing to terminate. Skip
                     # Tier 2 messaging and operations.
@@ -464,8 +501,14 @@ class Agent:
                                 run_process.terminate()
                             except OSError:
                                 pass  # if process is already dead
-                        for _, run_process in self._run_processes.items():
-                            run_process.wait()
+
+                        # For simplicity, this resets the term_timeout clock, so
+                        # possible to wait up to 2*term_timeout for a SIGKILL if the
+                        # user/orchestrator sends a second shutdown signal right before
+                        # the first term_timeout clock expires.
+                        self._wait_for_processes_with_term_timeout()
+                except subprocess.TimeoutExpired:
+                    raise ShutdownSignal(signal.SIGINT)
                 except KeyboardInterrupt as kb:
                     raise ShutdownSignal(signal.SIGINT) from kb
             except ShutdownSignal:
@@ -687,6 +730,7 @@ def run_agent(
     project=None,
     count=None,
     forward_signals=False,
+    term_timeout: int | None = None,
 ):
     from wandb.apis import InternalApi
     from wandb.sdk.launch.sweeps import utils as sweep_utils
@@ -730,6 +774,7 @@ def run_agent(
             in_jupyter=in_jupyter,
             count=count,
             forward_signals=forward_signals,
+            term_timeout=term_timeout,
         )
         agent.run()
     finally:
@@ -744,6 +789,7 @@ def agent(
     project: str | None = None,
     count: int | None = None,
     forward_signals: bool = False,
+    term_timeout: int | None = None,
 ) -> None:
     """Start one or more sweep agents.
 
@@ -786,6 +832,7 @@ def agent(
             project=project,
             count=count,
             forward_signals=forward_signals,
+            term_timeout=term_timeout,
         )
     finally:
         _INSTANCES -= 1


### PR DESCRIPTION
- **Add --term-timeout flag to cli and thread through wandb_agent**
- **Write unit and system tests for --term-timeout flag**

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
