### PR TITLE
feat: wandb clean --min-hours

### DIFF
--- a/tests/system_tests/test_core/test_wandb_clean_full.py
+++ b/tests/system_tests/test_core/test_wandb_clean_full.py
@@ -18,7 +18,7 @@ def test_cleans_expected_runs(runner: CliRunner):
         pass
     runner.invoke(cli.sync, synced_run.settings.sync_dir)
 
-    result = runner.invoke(clean, input="y")
+    result = runner.invoke(clean, ["--min-hours", "0"], input="y")
 
     assert os.path.exists(unsynced_run.settings.sync_dir)
     assert not os.path.exists(synced_run.settings.sync_dir)

--- a/tests/unit_tests/test_wandb_clean.py
+++ b/tests/unit_tests/test_wandb_clean.py
@@ -1,9 +1,10 @@
 import pathlib
+from datetime import datetime
 from typing import NoReturn
 
 import pytest
 from click.testing import CliRunner
-from wandb.cli.clean import clean
+from wandb.cli import clean
 
 
 @pytest.fixture
@@ -16,6 +17,15 @@ def wandb_dir(
     return tmp_path
 
 
+@pytest.fixture
+def now_20260805_3pm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        clean,
+        "_DATETIME_NOW",
+        lambda: datetime(2026, 8, 5, 15, 0, 0),
+    )
+
+
 def _mkrun(path: pathlib.Path, synced: bool = False) -> None:
     path.mkdir(parents=True)
     if synced:
@@ -24,7 +34,7 @@ def _mkrun(path: pathlib.Path, synced: bool = False) -> None:
 
 @pytest.mark.usefixtures("wandb_dir")
 def test_empty_wandb_dir(runner: CliRunner):
-    result = runner.invoke(clean)
+    result = runner.invoke(clean.clean)
 
     assert result.exit_code == 1
     assert result.output.splitlines() == [
@@ -35,7 +45,7 @@ def test_empty_wandb_dir(runner: CliRunner):
 def test_bad_wandb_dir(wandb_dir: pathlib.Path, runner: CliRunner):
     (wandb_dir / "wandb").touch()
 
-    result = runner.invoke(clean)
+    result = runner.invoke(clean.clean)
 
     assert result.exit_code == 1
     assert result.output.splitlines() == [
@@ -43,16 +53,20 @@ def test_bad_wandb_dir(wandb_dir: pathlib.Path, runner: CliRunner):
     ]
 
 
-def test_counts_unsynced_runs(wandb_dir: pathlib.Path, runner: CliRunner):
+@pytest.mark.usefixtures("now_20260805_3pm")
+def test_counts_skipped_runs(wandb_dir: pathlib.Path, runner: CliRunner):
     wb = wandb_dir / "wandb"
-    _mkrun(wb / "offline-run-20260101_010101-abc")
-    _mkrun(wb / "offline-run-20260101_202020-xyz")
+    _mkrun(wb / "offline-run-20260101_010101-unsynced1")
+    _mkrun(wb / "offline-run-20260101_202020-unsynced2")
+    _mkrun(wb / "run-20260805_140000-1hour")
+    _mkrun(wb / "run-20260805_120000-3hours")
 
-    result = runner.invoke(clean)
+    result = runner.invoke(clean.clean, ["--min-hours", "2"], input="n")
 
-    assert result.exit_code == 0
-    assert result.output.splitlines() == [
-        "wandb: Found no synced runs, 2 unsynced.",
+    assert result.output.splitlines()[:3] == [
+        "wandb: Skipping 1 run(s) created fewer than 2 hours ago.",
+        "wandb: Skipping 2 unsynced run(s).",
+        "wandb: Found 1 synced run(s).",
     ]
 
 
@@ -63,18 +77,19 @@ def test_finds_synced_runs(wandb_dir: pathlib.Path, runner: CliRunner):
     _mkrun(wb / "offline-run-20260101_333000-3", synced=True)
     _mkrun(wb / "run-20260101_000444-4")
 
-    result = runner.invoke(clean, input="y")
+    result = runner.invoke(clean.clean, input="y")
     lines = result.output.splitlines()
 
     assert result.exit_code == 0
-    assert lines[0] == "wandb: Found 2 synced run(s)."
-    assert set(lines[1:3]) == set(
+    assert lines[0] == "wandb: Skipping 2 unsynced run(s)."
+    assert lines[1] == "wandb: Found 2 synced run(s)."
+    assert set(lines[2:4]) == set(
         [
             "wandb:   wandb/offline-run-20260101_333000-3",
             "wandb:   wandb/run-20260101_000444-4",
         ]
     )
-    assert lines[3] == "wandb: Are you sure you want to remove 2 run(s)? [y/n] y"
+    assert lines[4] == "wandb: Are you sure you want to remove 2 run(s)? [y/n] y"
 
 
 def test_reports_rmtree_errors(
@@ -90,7 +105,7 @@ def test_reports_rmtree_errors(
     _mkrun(wandb_dir / "wandb" / "run-20260101-123456-abc")
     monkeypatch.setattr("shutil.rmtree", raise_os_error)
 
-    result = runner.invoke(clean, input="y")
+    result = runner.invoke(clean.clean, input="y")
 
     assert result.exit_code == 1
     assert result.output.splitlines() == [

--- a/wandb/cli/clean.py
+++ b/wandb/cli/clean.py
@@ -4,17 +4,27 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
+import re
 import shutil
+from datetime import datetime
 
 import click
 
 from wandb.errors import term
 from wandb.sdk import wandb_setup
 
+# Patched in tests.
+_DATETIME_NOW = datetime.now
+
 
 @click.command()
 @click.pass_context
-def clean(ctx: click.Context) -> None:
+@click.option(
+    "--min-hours",
+    help="Minimum run age in hours for deletion (default 24).",
+    default=24,
+)
+def clean(ctx: click.Context, min_hours: int) -> None:
     """Remove synced run data.
 
     Cleans up the wandb folder, as determined by settings. Usually, this is
@@ -45,22 +55,29 @@ def clean(ctx: click.Context) -> None:
         term.termerror(f"Permission error accessing {str(wandb_dir)!r}")
         ctx.exit(1)
 
-    result = _examine_wandb_directory(wandb_dir)
+    result = _examine_wandb_directory(wandb_dir, min_hours=min_hours)
 
-    if not result.synced_runs:
-        term.termlog(f"Found no synced runs, {result.unsynced} unsynced.")
+    if result.too_young:
+        term.termlog(
+            f"Skipping {result.too_young} run(s) created fewer than"
+            + f" {min_hours} hours ago.",
+        )
+    if result.unsynced:
+        term.termlog(f"Skipping {result.unsynced} unsynced run(s).")
+    if not result.runs_to_clean:
+        term.termlog("Found no runs to clean up.")
         ctx.exit(0)
 
-    term.termlog(f"Found {len(result.synced_runs)} synced run(s).")
-    for path in result.synced_runs:
+    term.termlog(f"Found {len(result.runs_to_clean)} synced run(s).")
+    for path in result.runs_to_clean:
         term.termlog(f"  {path}")
     if not term.confirm(
-        f"Are you sure you want to remove {len(result.synced_runs)} run(s)?",
+        f"Are you sure you want to remove {len(result.runs_to_clean)} run(s)?",
     ):
         ctx.exit(1)
 
     exit_code = 0
-    for path in result.synced_runs:
+    for path in result.runs_to_clean:
         try:
             shutil.rmtree(path)
         except OSError as e:
@@ -75,27 +92,40 @@ def clean(ctx: click.Context) -> None:
 class _WandbDirResult:
     """A description of the contents of the wandb folder."""
 
-    synced_runs: list[pathlib.Path]
-    """Folders of online or synced runs."""
+    runs_to_clean: list[pathlib.Path]
+    """Folders of online or synced runs that are old enough for deletion."""
+
+    too_young: int = 0
+    """Count of synced runs that are filtered out due to age."""
 
     unsynced: int = 0
     """Count of unsynced runs."""
 
 
-def _examine_wandb_directory(wandb_dir: pathlib.Path) -> _WandbDirResult:
+def _examine_wandb_directory(
+    wandb_dir: pathlib.Path,
+    *,
+    min_hours: int,
+) -> _WandbDirResult:
     """Check the wandb folder for runs to clean.
 
     Args:
         wandb_dir: The path to the wandb folder to examine.
+        min_hours: Minimum age in hours.
     """
-    result = _WandbDirResult(synced_runs=[])
+    result = _WandbDirResult(runs_to_clean=[])
+    now = _DATETIME_NOW()
 
     for online_run in wandb_dir.glob("run-*"):
         if not online_run.is_dir():
             term.termwarn(f"Not a directory: {online_run}")
             continue
 
-        result.synced_runs.append(online_run)
+        if (age := _run_age_hours(now, online_run.name)) and age < min_hours:
+            result.too_young += 1
+            continue
+
+        result.runs_to_clean.append(online_run)
 
     for offline_run in wandb_dir.glob("offline-run-*"):
         if not offline_run.is_dir():
@@ -107,6 +137,29 @@ def _examine_wandb_directory(wandb_dir: pathlib.Path) -> _WandbDirResult:
             result.unsynced += 1
             continue  # Not synced yet, or invalid if >1 marker file.
 
-        result.synced_runs.append(offline_run)
+        if (age := _run_age_hours(now, offline_run.name)) and age < min_hours:
+            result.too_young += 1
+            continue
+
+        result.runs_to_clean.append(offline_run)
 
     return result
+
+
+def _run_age_hours(now: datetime, run_folder_name: str) -> int | None:
+    # Required for the subtraction below.
+    # strptime with our format returns a naive datetime.
+    assert not now.tzinfo, "Requires a naive datetime."
+
+    run_timestamp_re = re.compile(r"\d{8}_\d{6}")
+    match = run_timestamp_re.search(run_folder_name)
+    if not match:
+        return None
+
+    try:
+        run_datetime = datetime.strptime(match.group(0), "%Y%m%d_%H%M%S")
+    except ValueError:
+        return None
+
+    time_delta = now - run_datetime
+    return int(time_delta.total_seconds() / 3600)


### PR DESCRIPTION
Adds the `--min-hours` option to `wandb clean`, mimicking `wandb sync --clean --clean-old-hours`.