### PR TITLE
docs(sdk): updates create_team docstring in wandb.apis.public

### DIFF
--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1001,9 +1001,9 @@ class Api:
     def create_team(self, team: str, admin_username: str | None = None) -> Team:
         """Create a new team.
 
-        For SaaS, set the Default API organization in your user settings before
-        calling `create_team()`. This setting determines the organization the
-        new team will belong to.
+        For W&B Multi-tenant Cloud users, set the Default API organization in
+        your user settings before calling `create_team()`. This setting
+        determines the organization the new team will belong to.
 
         Args:
             team: The name of the team.

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1001,8 +1001,12 @@ class Api:
     def create_team(self, team: str, admin_username: str | None = None) -> Team:
         """Create a new team.
 
+        For SaaS, set the Default API organization in your user settings before
+        calling `create_team()`. This setting determines the organization the
+        new team will belong to.
+
         Args:
-            team: The name of the team
+            team: The name of the team.
             admin_username: Username of the admin user of the team.
                 Defaults to the current user.
 

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -1002,8 +1002,8 @@ class Api:
         """Create a new team.
 
         For W&B Multi-tenant Cloud users, set the Default API organization in
-        your user settings before calling `create_team()`. This setting
-        determines the organization the new team will belong to.
+        your user settings in the W&B UI before calling `create_team()`.
+        This setting determines the organization the new team will belong to.
 
         Args:
             team: The name of the team.


### PR DESCRIPTION
Description
-----------

Updates `create_team()` docstring. Mentions that for SaaS folks, they need to set their "Default API organization" in their settings.

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes https://coreweave.atlassian.net/browse/DOCS-2555


What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
