### PR TITLE
feat: wandb clean --force

### DIFF
--- a/tests/unit_tests/test_wandb_clean.py
+++ b/tests/unit_tests/test_wandb_clean.py
@@ -53,6 +53,18 @@ def test_bad_wandb_dir(wandb_dir: pathlib.Path, runner: CliRunner):
     ]
 
 
+def test_force_skips_confirmation(wandb_dir: pathlib.Path, runner: CliRunner):
+    wb = wandb_dir / "wandb"
+    run = wb / "run-20260101_123456-oldrun"
+    _mkrun(run)
+
+    # Would fail without input.
+    result = runner.invoke(clean.clean, ["--force"])
+
+    assert result.exit_code == 0
+    assert not run.exists()
+
+
 @pytest.mark.usefixtures("now_20260805_3pm")
 def test_counts_skipped_runs(wandb_dir: pathlib.Path, runner: CliRunner):
     wb = wandb_dir / "wandb"
@@ -90,6 +102,7 @@ def test_finds_synced_runs(wandb_dir: pathlib.Path, runner: CliRunner):
         ]
     )
     assert lines[4] == "wandb: Are you sure you want to remove 2 run(s)? [y/n] y"
+    assert lines[5] == "wandb: Success."
 
 
 def test_reports_rmtree_errors(
@@ -113,4 +126,5 @@ def test_reports_rmtree_errors(
         "wandb:   wandb/run-20260101-123456-abc",
         "wandb: Are you sure you want to remove 1 run(s)? [y/n] y",
         "wandb: ERROR Failed to remove 'wandb/run-20260101-123456-abc': something went wrong",
+        "wandb: WARNING Some runs may not have been removed.",
     ]

--- a/wandb/cli/clean.py
+++ b/wandb/cli/clean.py
@@ -24,7 +24,13 @@ _DATETIME_NOW = datetime.now
     help="Minimum run age in hours for deletion (default 24).",
     default=24,
 )
-def clean(ctx: click.Context, min_hours: int) -> None:
+@click.option(
+    "--force",
+    help="Skip the confirmation prompt.",
+    is_flag=True,
+    default=False,
+)
+def clean(ctx: click.Context, min_hours: int, force: bool) -> None:
     """Remove synced run data.
 
     Cleans up the wandb folder, as determined by settings. Usually, this is
@@ -71,7 +77,8 @@ def clean(ctx: click.Context, min_hours: int) -> None:
     term.termlog(f"Found {len(result.runs_to_clean)} synced run(s).")
     for path in result.runs_to_clean:
         term.termlog(f"  {path}")
-    if not term.confirm(
+
+    if not force and not term.confirm(
         f"Are you sure you want to remove {len(result.runs_to_clean)} run(s)?",
     ):
         ctx.exit(1)
@@ -84,6 +91,11 @@ def clean(ctx: click.Context, min_hours: int) -> None:
             errstr = f": {e.strerror}" if e.strerror else ""
             term.termerror(f"Failed to remove {str(path)!r}{errstr}")
             exit_code = 1
+
+    if exit_code == 0:
+        term.termlog("Success.")
+    else:
+        term.termwarn("Some runs may not have been removed.")
 
     ctx.exit(exit_code)
 


### PR DESCRIPTION
Adds the `--force` option to skip confirmation prompts, like `wandb sync --clean --clean-force`.