### PR TITLE
chore: remove internal_api usage from wandb_login

### DIFF
--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -111,8 +111,8 @@ def test_login_sets_api_base_url():
 
 def test_login_invalid_key(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
-        "wandb.apis.internal.Api.validate_api_key",
-        lambda self: False,
+        "wandb.sdk.wandb_login.ServiceApi.execute_graphql",
+        lambda self, *_args, **_kwargs: {"viewer": None},
     )
     wandb.ensure_configured()
 

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -61,10 +61,6 @@ class Api:
     def default_entity(self):
         return self.api.default_entity
 
-    def validate_api_key(self) -> bool:
-        """Returns whether the API key stored on initialization is valid."""
-        return self.api.validate_api_key()
-
     def file_current(self, *args):
         return self.api.file_current(*args)
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -361,11 +361,6 @@ class Api:
             timeout=self.HTTP_TIMEOUT,
         )
 
-    def validate_api_key(self) -> bool:
-        """Returns whether the API key stored on initialization is valid."""
-        res = self.execute("query { viewer { id } }")
-        return res is not None and res["viewer"] is not None
-
     def set_current_run_id(self, run_id: str) -> None:
         self._current_run_id = run_id
 

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -5,6 +5,8 @@ This authenticates your machine to log data to your account.
 
 from __future__ import annotations
 
+from typing import Any
+
 import click
 
 import wandb
@@ -299,7 +301,9 @@ def _verify_login(key: str, base_url: str) -> None:
     )
 
     try:
-        result = service_api.execute_graphql("query { viewer { id } }")
+        result: dict[str, Any] = service_api.execute_graphql(
+            "query { viewer { id } }",
+        )
         is_api_key_valid = result is not None and result["viewer"] is not None
     except ConnectionError as e:
         raise AuthenticationError(

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 import click
 
 import wandb
+from wandb import env
+from wandb.apis.public.service_api import ServiceApi
 from wandb.errors import AuthenticationError, term
 from wandb.sdk import wandb_setup
 from wandb.sdk.lib import settings_file, wbauth
 from wandb.sdk.lib.deprecation import UNSET, DoNotSet
-
-from ..apis import InternalApi
 
 
 def login(
@@ -290,13 +290,17 @@ def _find_or_prompt_for_key(
 def _verify_login(key: str, base_url: str) -> None:
     from requests.exceptions import ConnectionError
 
-    api = InternalApi(
-        api_key=key,
-        default_settings={"base_url": base_url},
+    settings = wandb_setup.singleton().settings.model_copy()
+    settings.base_url = base_url
+    settings.api_key = key
+    service_api = ServiceApi(
+        settings=settings,
+        timeout=env.get_http_timeout(10),
     )
 
     try:
-        is_api_key_valid = api.validate_api_key()
+        result = service_api.execute_graphql("query { viewer { id } }")
+        is_api_key_valid = result is not None and result["viewer"] is not None
     except ConnectionError as e:
         raise AuthenticationError(
             f"Unable to connect to {base_url} to verify API token."


### PR DESCRIPTION
- Fixes: WB-37026

## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Many places in the code base still rely on `internal_api` for simple one off tasks (usually a graphql query). Most of these one off code paths can now be accomplished with simpler primatives that have been added to the code.

This PR is one of the first steps to uncouple the internal api from our code. The `verify_api_key` is simply a wrapper for a graphql query. Which we can call the service_api directly to execute the graphql request.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

How was this PR tested?

Repro script from WB-37026

Set ~/.config/wandb/settings, base_url = https://api.wandb.ai

```python
import wandb

api = wandb.Api(
    overrides={"base_url": "https://api.qa.wandb.ai"},
    api_key="{API_KEY}",
)
```

- previously this would fail, because of how `default_settings` worked in the internal_api.
- Now this passes

### Additionally tested

```bash
❯ wandb login --relogin --host=https://api.wandb.ai --verify
wandb: Logging into https://api.wandb.ai. (Learn how to deploy a W&B server locally: https://wandb.me/wandb-server)
wandb: Create a new API key at: https://wandb.ai/authorize?ref=models
wandb: Store your API key securely and do not share it.
wandb: Paste your API key and hit enter:
wandb: Appending key for api.wandb.ai to your netrc file: /Users/jacob.romero/.netrc
wandb: Currently logged in as: jacob-romero (jacobromerotest) to https://api.wandb.ai. Use `wandb login --relogin` to force relogin
```



<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->