### PR TITLE
chore: force code saving for git tests to reduce flakiness

### DIFF
--- a/tests/system_tests/test_core/test_git.py
+++ b/tests/system_tests/test_core/test_git.py
@@ -54,9 +54,12 @@ def test_create_git_diff(user, wandb_backend_spy, setup_repo_with_remote):
     run_git(base_repo_path, "add", "file2.txt")
 
     with wandb.init(
-        settings=wandb.Settings(root_dir=str(base_repo_path)),
+        settings=wandb.Settings(
+            root_dir=str(base_repo_path),
+            save_code=True,
+        ),
     ) as run:
-        pass
+        assert run.settings.save_code is True
 
     with wandb_backend_spy.freeze() as snapshot:
         assert "diff.patch" in snapshot.uploaded_files(run_id=run.id)
@@ -83,9 +86,12 @@ def test_create_git_diff_from_upstream(
     remote_head = run_git(remote_repo_path, "rev-parse", "HEAD")
 
     with wandb.init(
-        settings=wandb.Settings(root_dir=str(base_repo_path)),
+        settings=wandb.Settings(
+            root_dir=str(base_repo_path),
+            save_code=True,
+        ),
     ) as run:
-        pass
+        assert run.settings.save_code is True
 
     with wandb_backend_spy.freeze() as snapshot:
         assert f"diff_{remote_head}.patch" in snapshot.uploaded_files(run_id=run.id)
@@ -122,9 +128,10 @@ def test_create_git_diff__finds_most_recent_ancestor(
         settings=wandb.Settings(
             root_dir=str(base_repo_path),
             disable_git_fork_point=False,
+            save_code=True,
         ),
     ) as run:
-        pass
+        assert run.settings.save_code is True
 
     with wandb_backend_spy.freeze() as snapshot:
         base_branch_head = run_git(base_repo_path, "rev-parse", "feature1")
@@ -172,9 +179,10 @@ def test_create_git_diff__upstream_with_fork_point_disabled(
         settings=wandb.Settings(
             root_dir=str(base_repo_path),
             disable_git_fork_point=True,
+            save_code=True,
         ),
     ) as run:
-        pass
+        assert run.settings.save_code is True
 
     with wandb_backend_spy.freeze() as snapshot:
         uploaded = snapshot.uploaded_files(run_id=run.id)
@@ -196,9 +204,10 @@ def test_create_git_diff__detached_head_no_upstream_diff(
         settings=wandb.Settings(
             root_dir=str(base_repo_path),
             disable_git_fork_point=False,
+            save_code=True,
         ),
     ) as run:
-        pass
+        assert run.settings.save_code is True
 
     with wandb_backend_spy.freeze() as snapshot:
         uploaded = snapshot.uploaded_files(run_id=run.id)
@@ -227,9 +236,10 @@ def test_create_git_diff__no_upstream_fork_point_disabled(
         settings=wandb.Settings(
             root_dir=str(base_repo_path),
             disable_git_fork_point=True,
+            save_code=True,
         ),
     ) as run:
-        pass
+        assert run.settings.save_code is True
 
     with wandb_backend_spy.freeze() as snapshot:
         uploaded = snapshot.uploaded_files(run_id=run.id)
@@ -262,9 +272,10 @@ def test_create_git_diff__no_tracking_branches_in_repo(
         settings=wandb.Settings(
             root_dir=str(repo_path),
             disable_git_fork_point=False,
+            save_code=True,
         ),
     ) as run:
-        pass
+        assert run.settings.save_code is True
 
     with wandb_backend_spy.freeze() as snapshot:
         uploaded = snapshot.uploaded_files(run_id=run.id)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

The git tests have been flaky, a possible issue to this occurs when the initializing a run, the code queries the `save_code` flag from the backend. This could possibly timeout, leaving this setting to default to false. When `save_code` is false then no diff files are generated.

This PR explicitly sets the `save_code` setting to `True`, in the event that the viewer query for the `save_code` flag fails or times out, the user supplied setting is used.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- Modified one of the flaky tests (prior to the changes) `tests/system_tests/test_core/test_git.py::test_create_git_diff` with
```python
# Simulate the viewer query timing out before it can load user flags.
monkeypatch.setattr(
    "wandb.sdk.lib.server.Server.query_with_timeout",
    lambda self, timeout=5: None,
)
```

This would always fail with the similar error
```
FAILED tests/system_tests/test_core/test_git.py::test_create_git_diff - AssertionError: assert 'diff.patch' in {'wandb-summary.json', 'config.yaml', 'requirements.txt', 'wandb-metadata.json'}
 +  where {'wandb-summary.json', 'config.yaml', 'requirements.txt', 'wandb-metadata.json'} = uploaded_files(run_id='6ovb9vmm')
 +    where uploaded_files = <tests.fixtures.wandb_backend_spy.spy.WandbBackendSnapshot object at 0x10b1d1220>.uploaded_files
 +    and   '6ovb9vmm' = <wandb.sdk.wandb_run.Run object at 0x10b122570>.id
```

- Modifying with `code_save=True` makes the test pass.

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
