### PR TITLE
docs(sdk): fix table example code formatting

### DIFF
--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -1173,15 +1173,20 @@ class Table(Media):
             fn: A function which accepts an index and row dict, and returns a dict
                 representing new columns for that row, keyed by the new column names.
 
-        Example:
-            table = wandb.Table(columns=["x", "y"], data=[[3, 1], [4, 6]])
-            table.add_computed_columns(
-                lambda ndx, row: {"diff": row["x"] - row["y"]}
-            )
+        Examples:
+        
+        In the callback:
+        - `ndx` is an integer representing the index of the row.
+        - `row` is a dictionary keyed by existing columns.
 
-            In the callback:
-            - `ndx` is an integer representing the index of the row.
-            - `row` is a dictionary keyed by existing columns.
+        ```python
+        import wandb
+
+        table = wandb.Table(columns=["x", "y"], data=[[3, 1], [4, 6]])
+        table.add_computed_columns(
+            lambda ndx, row: {"diff": row["x"] - row["y"]}
+        )
+        ```
         """
         new_columns: dict[str, list[Any]] = {}
         for ndx, row in self.iterrows():

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -1174,7 +1174,6 @@ class Table(Media):
                 representing new columns for that row, keyed by the new column names.
 
         Examples:
-        
         In the callback:
         - `ndx` is an integer representing the index of the row.
         - `row` is a dictionary keyed by existing columns.
@@ -1183,9 +1182,7 @@ class Table(Media):
         import wandb
 
         table = wandb.Table(columns=["x", "y"], data=[[3, 1], [4, 6]])
-        table.add_computed_columns(
-            lambda ndx, row: {"diff": row["x"] - row["y"]}
-        )
+        table.add_computed_columns(lambda ndx, row: {"diff": row["x"] - row["y"]})
         ```
         """
         new_columns: dict[str, list[Any]] = {}


### PR DESCRIPTION
Description
-----------

Example code in `Tables.add_computed_columns` docstring was not wrapped with triple tick marks. 

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
