### PR TITLE
fix: add use_dot_wandb to client-only settings

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -51,6 +51,7 @@ CLIENT_ONLY_SETTINGS = (
     "max_end_of_run_summary_metrics",
     "reinit",
     "stop_fn",
+    "use_dot_wandb",
     "x_files_dir",
     "x_sync_dir_suffix",
 )


### PR DESCRIPTION
Description
-----------
Sadly missed in https://github.com/wandb/wandb/issues/11017. Seen in the wild: https://weights-biases.sentry.io/issues/7624232170/?project=4504800232407040&query=release%3A%220.28.1%22&referrer=release-issue-stream
