### PR TITLE
chore: don't log FileStream heartbeats

### DIFF
--- a/core/internal/filestream/filestreamimpl.go
+++ b/core/internal/filestream/filestreamimpl.go
@@ -149,7 +149,11 @@ func (fs *fileStream) send(
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	fs.logRequestSummary(data)
+	shouldLogStartAndEnd := !data.IsHeartbeat()
+	if shouldLogStartAndEnd {
+		fs.logRequestSummary(data)
+	}
+
 	resp, err := fs.apiClient.Do(req)
 
 	switch {
@@ -173,9 +177,11 @@ func (fs *fileStream) send(
 		)
 
 	default:
-		// Log after sending to record that the backend responded and should
-		// have the data in the request.
-		fs.logger.Info("filestream: request sent", "status", resp.Status)
+		if shouldLogStartAndEnd {
+			// Log after sending to record that the backend responded and should
+			// have the data in the request.
+			fs.logger.Info("filestream: request sent", "status", resp.Status)
+		}
 	}
 
 	defer func(Body io.ReadCloser) {

--- a/core/internal/filestream/filestreamrequest.go
+++ b/core/internal/filestream/filestreamrequest.go
@@ -99,7 +99,7 @@ func (r *FileStreamRequest) Merge(next *FileStreamRequest) {
 // [FileStreamRequest] can be thought of as the "idealized" request;
 // it is what we wish the API looked like.
 type FileStreamRequestJSON struct {
-	Files      map[string]offsetAndContent `json:"files,omitempty"`
+	Files      map[string]OffsetAndContent `json:"files,omitempty"`
 	Uploaded   []string                    `json:"uploaded,omitempty"`
 	Preempting *bool                       `json:"preempting,omitempty"`
 
@@ -107,8 +107,18 @@ type FileStreamRequestJSON struct {
 	ExitCode *int32 `json:"exitcode,omitempty"`
 }
 
-// offsetAndContent is a run of lines to update in a filestream file.
-type offsetAndContent struct {
+// IsHeartbeat is true if this is a "heartbeat" request containing no data.
+func (r *FileStreamRequestJSON) IsHeartbeat() bool {
+	return r != nil &&
+		len(r.Files) == 0 &&
+		len(r.Uploaded) == 0 &&
+		r.Preempting == nil &&
+		r.Complete == nil &&
+		r.ExitCode == nil
+}
+
+// OffsetAndContent is a run of lines to update in a filestream file.
+type OffsetAndContent struct {
 	Offset  int      `json:"offset"`
 	Content []string `json:"content"`
 }

--- a/core/internal/filestream/filestreamrequest_test.go
+++ b/core/internal/filestream/filestreamrequest_test.go
@@ -134,3 +134,29 @@ func TestExitCode_MergeIgnoresIfNotComplete(t *testing.T) {
 	assert.True(t, req1.Complete)
 	assert.EqualValues(t, 111, req1.ExitCode)
 }
+
+func TestIsHeartbeat(t *testing.T) {
+	someBool := true
+	someInt := int32(0)
+	testCases := []struct {
+		Name        string
+		Request     *FileStreamRequestJSON
+		IsHeartbeat bool
+	}{
+		{"nil", nil, false},
+		{"empty", &FileStreamRequestJSON{}, true},
+		// A few important cases. There's no way to test that the
+		// implementation exhaustively checks all fields.
+		{"with Complete", &FileStreamRequestJSON{Complete: &someBool}, false},
+		{"with ExitCode", &FileStreamRequestJSON{ExitCode: &someInt}, false},
+		{"with Files", &FileStreamRequestJSON{Files: map[string]OffsetAndContent{
+			"some-file": {},
+		}}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.Equal(t, tc.IsHeartbeat, tc.Request.IsHeartbeat())
+		})
+	}
+}

--- a/core/internal/filestream/filestreamstate.go
+++ b/core/internal/filestream/filestreamstate.go
@@ -297,10 +297,10 @@ type requestJSONBuilder struct {
 	ApproxSizeBytes, MaxSizeBytes int
 	HasMore                       bool
 
-	HistoryChunk      offsetAndContent
-	EventsChunk       offsetAndContent
-	SummaryChunk      offsetAndContent
-	ConsoleLinesChunk offsetAndContent
+	HistoryChunk      OffsetAndContent
+	EventsChunk       OffsetAndContent
+	SummaryChunk      OffsetAndContent
+	ConsoleLinesChunk OffsetAndContent
 
 	Uploaded   []string
 	Preempting bool
@@ -325,7 +325,7 @@ func (b *requestJSONBuilder) TryAddSize(n int) bool {
 // Build returns the JSON value to upload.
 func (x *requestJSONBuilder) Build() *FileStreamRequestJSON {
 	json := &FileStreamRequestJSON{}
-	json.Files = make(map[string]offsetAndContent)
+	json.Files = make(map[string]OffsetAndContent)
 
 	if len(x.HistoryChunk.Content) > 0 {
 		json.Files[HistoryFileName] = x.HistoryChunk


### PR DESCRIPTION
Stops logging `filestream: sending request` and `filestream: request sent` for heartbeats, which overwhelm the log file in long runs and aren't very useful.