### PR TITLE
feat: make `wandb sync --clean` error out and suggest `wandb clean`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,18 +14,26 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+## Notable Changes
+
+The `wandb sync --clean` command now exits with code 1 and prints a hint to use `wandb clean`, which is the replacement.
+
 ## Added
-- Added the `wandb clean` command, which replaces `wandb sync --clean` (@timoffex in https://github.com/wandb/wandb/pull/12238)
+
 - Added support for gzip compression of filestream requests, reducing network traffic when logging metrics. It is currently opt-in and requires server support: set `x_file_stream_no_gzip=False` in `wandb.Settings` to enable it. Compression will become the default in a future release (@dmitryduev in https://github.com/wandb/wandb/pull/12262)
 
 ## Changed
+
+- The new `wandb clean` command replaces `wandb sync --clean` (@timoffex in https://github.com/wandb/wandb/pull/12238)
 - Hardened argument handling in `wandb launch` for the local-process resource so that job-supplied values are always shell-quoted (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12220)
 - The launch agent now restricts a job's git source URL to https/ssh remotes and pins git's protocol allowlist when fetching it and updating submodules (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12221)
 - Response parsing is now faster for many `wandb.Api` operations, including artifact and registry queries (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12213)
 
 ## Removed
+
 - Releases no longer include 32-bit Windows (`win32`) wheels; use 64-bit Python on Windows (@dmitryduev in https://github.com/wandb/wandb/pull/12267)
 
 ## Fixed
+
 - Registry search `registries(order=...).collections(order=...).versions()` now returns artifact versions in registry and/or collection order.  (@ibindlish in https://github.com/wandb/wandb/pull/12154)
 - macOS x86_64 wheels now contain x86_64 builds of the `wandb-xpu` binary and the Rust parquet library, which previously shipped as arm64 and could not run or be loaded on Intel Macs (@dmitryduev in https://github.com/wandb/wandb/pull/12267)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,4 +1,3 @@
-import datetime
 import getpass
 import importlib
 import netrc
@@ -106,44 +105,6 @@ def test_login_invalid_key_arg(runner, dummy_api_key):
         invalid_key = "test-" + dummy_api_key[:-5]
         result = runner.invoke(cli.login, [invalid_key])
         assert "API key must have 40+ characters, has 35." in result.output
-
-
-@pytest.mark.usefixtures("patch_apikey")
-def test_sync_gc(runner):
-    with runner.isolated_filesystem():
-        if not os.path.isdir("wandb"):
-            os.mkdir("wandb")
-        d1 = datetime.datetime.now()
-        d2 = d1 - datetime.timedelta(hours=3)
-        run1 = d1.strftime("run-%Y%m%d_%H%M%S-abcd")
-        run2 = d2.strftime("run-%Y%m%d_%H%M%S-efgh")
-        run1_dir = os.path.join("wandb", run1)
-        run2_dir = os.path.join("wandb", run2)
-        os.mkdir(run1_dir)
-        with open(os.path.join(run1_dir, "run-abcd.wandb"), "w") as f:
-            f.write("")
-        with open(os.path.join(run1_dir, "run-abcd.wandb.synced"), "w") as f:
-            f.write("")
-        os.mkdir(run2_dir)
-        with open(os.path.join(run2_dir, "run-efgh.wandb"), "w") as f:
-            f.write("")
-        with open(os.path.join(run2_dir, "run-efgh.wandb.synced"), "w") as f:
-            f.write("")
-        assert (
-            runner.invoke(
-                cli.sync, ["--clean", "--clean-old-hours", "2"], input="y\n"
-            ).exit_code
-        ) == 0
-
-        assert os.path.exists(run1_dir)
-        assert not os.path.exists(run2_dir)
-        assert (
-            runner.invoke(
-                cli.sync, ["--clean", "--clean-old-hours", "0"], input="y\n"
-            ).exit_code
-            == 0
-        )
-        assert not os.path.exists(run1_dir)
 
 
 def test_docker_run_digest(runner, docker, monkeypatch):

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import getpass
 import json
 import logging
@@ -41,7 +40,7 @@ from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.launch.sweeps.scheduler import Scheduler
 from wandb.sdk.lib import filesystem, settings_file
-from wandb.sync import TFEVENT_SUBSTRING, SyncManager, get_run_from_path, get_runs
+from wandb.sync import TFEVENT_SUBSTRING, SyncManager, get_runs
 
 from .beta import beta
 from .clean import clean
@@ -646,24 +645,22 @@ def init(ctx, project, entity, reset, mode):
     default=False,
     help="(legacy only) Sync all unsynced runs in the local wandb directory.",
 )
-@click.option(
+@click.option(  # TODO: Remove wandb sync --clean completely.
     "--clean",
     is_flag=True,
     default=False,
-    help="(legacy only) Delete local data for runs that are already synced.",
+    help="Removed. Use `wandb clean`.",
 )
-@click.option(
+@click.option(  # TODO: Remove wandb sync --clean-old-hours completely.
     "--clean-old-hours",
-    default=24,
-    help="""Delete only synced runs older than this many
-    hours (use with --clean).""",
-    type=int,
+    default=None,
+    help="Removed. Use `wandb clean`.",
 )
-@click.option(
+@click.option(  # TODO: Remove wandb sync --clean-force completely.
     "--clean-force",
     is_flag=True,
     default=False,
-    help="Skip the confirmation prompt if --clean is specified.",
+    help="Removed. Use `wandb clean`.",
 )
 @click.option("--ignore", hidden=True)
 @click.option(
@@ -717,7 +714,7 @@ def sync(
     ignore: str | None,
     show: int,
     clean: bool,
-    clean_old_hours: int,
+    clean_old_hours: int | None,
     clean_force: bool,
     append: bool,
     skip_console: bool,
@@ -770,13 +767,11 @@ def sync(
 
         $ wandb sync --sync-all
 
-    To delete local data for runs that have already been synced:
+    Use `wandb clean` to delete local data for runs that have been synced. See
 
-        $ wandb sync --clean
+        $ wandb clean --help
 
-    To delete synced runs older than 48 hours without a confirmation prompt:
-
-        $ wandb sync --clean --clean-old-hours 48 --clean-force
+    for more info.
     """
     # Use `wandb beta sync` if possible.
     if (
@@ -816,6 +811,9 @@ def sync(
             parallelism=5,  # same default as wandb beta sync
         )
         return
+
+    if clean or clean_old_hours or clean_force:
+        raise ClickException("Use `wandb clean` instead of `wandb sync --clean`")
 
     # Print out deprecations for legacy options, especially if they prevent
     # us from rerouting through `wandb beta sync`.
@@ -897,7 +895,7 @@ def sync(
         else:
             wandb.termlog("No runs to be synced.")
         if synced:
-            clean_cmd = click.style("wandb sync --clean", fg="yellow")
+            clean_cmd = click.style("wandb clean", fg="yellow")
             wandb.termlog(
                 f"NOTE: use {clean_cmd} to delete {len(synced)} synced runs from local directory."
             )
@@ -948,60 +946,8 @@ def sync(
             sync_tb = sync_tensorboard if sync_tensorboard is not None else False
             _sync_path(sync_items, sync_tb)
 
-    def _clean():
-        if path:
-            runs = list(map(get_run_from_path, path))
-            if not clean_force:
-                click.confirm(
-                    click.style(
-                        f"Are you sure you want to remove {len(runs)} runs?",
-                        bold=True,
-                    ),
-                    abort=True,
-                )
-            for run in runs:
-                shutil.rmtree(run.path)
-            click.echo(click.style("Success!", fg="green"))
-            return
-        runs = get_runs(
-            include_online=include_online if include_online is not None else True,
-            include_offline=include_offline if include_offline is not None else True,
-            include_synced=include_synced if include_synced is not None else True,
-            include_unsynced=False,
-            exclude_globs=exclude_globs,
-            include_globs=include_globs,
-        )
-        since = datetime.datetime.now() - datetime.timedelta(hours=clean_old_hours)
-        old_runs = [run for run in runs if run.datetime < since]
-        old_runs.sort(key=lambda _run: _run.datetime)
-        if old_runs:
-            click.echo(
-                f"Found {len(runs)} runs, {len(old_runs)} are older than {clean_old_hours} hours"
-            )
-            for run in old_runs:
-                click.echo(run.path)
-            if not clean_force:
-                click.confirm(
-                    click.style(
-                        f"Are you sure you want to remove {len(old_runs)} runs?",
-                        bold=True,
-                    ),
-                    abort=True,
-                )
-            for run in old_runs:
-                shutil.rmtree(run.path)
-            click.echo(click.style("Success!", fg="green"))
-        else:
-            click.echo(
-                click.style(
-                    f"No runs older than {clean_old_hours} hours found", fg="red"
-                )
-            )
-
     if sync_all:
         _sync_all()
-    elif clean:
-        _clean()
     elif path:
         # When syncing a specific path, default to syncing tensorboard
         sync_tb = sync_tensorboard if sync_tensorboard is not None else True


### PR DESCRIPTION
Removes `wandb sync --clean`, since `wandb clean` is now a complete replacement.

I considered doing a more gradual deprecation, but since it's an interactive command, removing it won't be very disruptive as long as it prints a suggestion for what to use instead.

I searched for all mentions of `--clean` in the code to make sure the docs are also updated.