### PR TITLE
fix(leet): align rendered stack sections with their reserved layout rows

### DIFF
--- a/core/internal/leet/flexlayout.go
+++ b/core/internal/leet/flexlayout.go
@@ -1,6 +1,10 @@
 package leet
 
-import "charm.land/lipgloss/v2"
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
 
 // stackSectionID identifies a vertically stacked pane in the main content area.
 type stackSectionID int
@@ -129,9 +133,17 @@ func filterNonEmptySections(sections []string) []string {
 	return filtered
 }
 
+// placeMainColumn pads or crops content to exactly width x height. Mouse
+// hit-testing maps screen rows to sections via computeVerticalStackLayout,
+// so rendered content must never spill past its reserved rows —
+// lipgloss.Place pads short content but never crops tall content (e.g. the
+// metrics grid's minimum chart height in a short section).
 func placeMainColumn(width, height int, content string) string {
 	if width <= 0 || height <= 0 {
 		return ""
+	}
+	if lines := strings.Split(content, "\n"); len(lines) > height {
+		content = strings.Join(lines[:height], "\n")
 	}
 	return lipgloss.Place(width, height, lipgloss.Left, lipgloss.Top, content)
 }

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -355,7 +355,13 @@ func (r *Run) renderMainView() string {
 					renderMetricsEmptyState(w, layout.height, "No scalar metrics logged."))
 			} else {
 				dims := r.metricsGrid.CalculateChartDimensions(w, layout.height)
-				sections = append(sections, r.metricsGrid.View(dims))
+				// Pad the grid (header + rows*cellHeight lines, short of
+				// layout.height by the integer-division remainder) to its
+				// reserved height so the sections below sit exactly at the
+				// rows computeVerticalStackLayout reserves for them. Mouse
+				// hit-testing maps screen rows to sections via that layout.
+				sections = append(sections,
+					placeMainColumn(w, layout.height, r.metricsGrid.View(dims)))
 			}
 		}
 

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -63,6 +63,22 @@ func newRunForHandlerTest(t *testing.T) *leet.Run {
 	return r
 }
 
+// newTestRun builds an unseeded Run at the given terminal size, with config
+// tweaks applied before construction.
+func newTestRun(
+	t *testing.T, width, height int, tweak func(*leet.ConfigManager),
+) (*leet.Run, *leet.ConfigManager) {
+	t.Helper()
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	if tweak != nil {
+		tweak(cfg)
+	}
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	return r, cfg
+}
+
 // ---- handleSidebarTabNav ----
 
 func TestRun_SidebarTabNav_BothPanelsVisible_CyclesOverviewThenLogs(t *testing.T) {
@@ -251,101 +267,49 @@ func mustSelectedItem(t *testing.T, sidebar *leet.RunOverviewSidebar) string {
 	return key
 }
 
-// TestRun_RenderedSeparatorsAlignWithLayout pins the invariant that mouse
+// TestRun_StackSectionsAlignWithReservedRows pins the invariant that mouse
 // hit-testing depends on: the separator rows drawn on screen sit exactly at
-// the rows computeVerticalStackLayout reserves for them. The metrics grid
-// renders header + rows*cellHeight lines, so without padding to the section
-// height, everything below it (and its separators) drifts up by the integer
-// division remainder.
-func TestRun_RenderedSeparatorsAlignWithLayout(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetLeftSidebarVisible(false)
-	_ = cfg.SetRightSidebarVisible(false)
-	_ = cfg.SetMediaVisible(true)
-	_ = cfg.SetConsoleLogsVisible(true)
+// the rows computeVerticalStackLayout reserves for them, and the frame never
+// grows taller than the terminal. The metrics section must pad a short
+// render (integer-division remainder) and crop a tall one (grid minimum or
+// empty-state hint taller than the slot — lipgloss.Place never crops).
+func TestRun_StackSectionsAlignWithReservedRows(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		height     int
+		hasMetrics bool
+	}{
+		{"grid height leaves a division remainder", 52, true},
+		{"grid minimum is taller than its slot", 20, true},
+		{"empty-state hint is taller than its slot", 17, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := newTestRun(t, 120, tc.height, func(c *leet.ConfigManager) {
+				_ = c.SetLeftSidebarVisible(false)
+				_ = c.SetRightSidebarVisible(false)
+				_ = c.SetMediaVisible(true)
+				_ = c.SetConsoleLogsVisible(true)
+			})
+			r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+			if tc.hasMetrics {
+				r.TestHandleRecordMsg(leet.HistoryMsg{
+					Metrics: map[string]leet.MetricData{
+						"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+					},
+				})
+			}
 
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	// A height where the grid's cell height division leaves a remainder.
-	r.Update(tea.WindowSizeMsg{Width: 120, Height: 52})
-	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
-	r.TestHandleRecordMsg(leet.HistoryMsg{
-		Metrics: map[string]leet.MetricData{
-			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
-		},
-	})
+			metrics, media, _ := r.TestStackHeights()
+			require.Positive(t, metrics)
+			lines := strings.Split(stripANSI(r.View().Content), "\n")
+			require.LessOrEqual(t, len(lines), tc.height,
+				"the rendered frame must never be taller than the terminal")
 
-	metrics, media, _ := r.TestStackHeights()
-	lines := strings.Split(stripANSI(r.View().Content), "\n")
-
-	for _, row := range []int{metrics, metrics + 1 + media} {
-		require.Less(t, row, len(lines))
-		require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
-			"expected a separator at row %d, got %q", row, lines[row])
-	}
-}
-
-// Regression: when the metrics slot is shorter than the grid's minimum
-// render height, the grid used to render past its reservation (lipgloss
-// Place never crops), pushing every section below off its layout row and
-// the status bar off-screen.
-func TestRun_ShortMetricsSlotStaysAligned(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetLeftSidebarVisible(false)
-	_ = cfg.SetRightSidebarVisible(false)
-	_ = cfg.SetMediaVisible(true)
-	_ = cfg.SetConsoleLogsVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	// A height where the reserved metrics slot is below the grid's minimum
-	// render height (header + one bordered chart cell).
-	r.Update(tea.WindowSizeMsg{Width: 120, Height: 20})
-	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
-	r.TestHandleRecordMsg(leet.HistoryMsg{
-		Metrics: map[string]leet.MetricData{
-			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
-		},
-	})
-
-	metrics, media, _ := r.TestStackHeights()
-	require.Positive(t, metrics)
-	lines := strings.Split(stripANSI(r.View().Content), "\n")
-	require.LessOrEqual(t, len(lines), 20,
-		"the rendered frame must never be taller than the terminal")
-
-	for _, row := range []int{metrics, metrics + 1 + media} {
-		require.Less(t, row, len(lines))
-		require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
-			"expected a separator at row %d, got %q", row, lines[row])
-	}
-}
-
-// Same invariant for the metrics empty state: its three-line hint must crop
-// to a shorter reservation instead of shifting the sections below.
-func TestRun_EmptyMetricsShortSlotStaysAligned(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetLeftSidebarVisible(false)
-	_ = cfg.SetRightSidebarVisible(false)
-	_ = cfg.SetMediaVisible(true)
-	_ = cfg.SetConsoleLogsVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	// No scalar metrics logged: the empty-state hint renders into a slot
-	// shorter than its three lines.
-	r.Update(tea.WindowSizeMsg{Width: 120, Height: 17})
-	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
-
-	metrics, media, _ := r.TestStackHeights()
-	require.Positive(t, metrics)
-	lines := strings.Split(stripANSI(r.View().Content), "\n")
-	require.LessOrEqual(t, len(lines), 17,
-		"the rendered frame must never be taller than the terminal")
-
-	for _, row := range []int{metrics, metrics + 1 + media} {
-		require.Less(t, row, len(lines))
-		require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
-			"expected a separator at row %d, got %q", row, lines[row])
+			for _, row := range []int{metrics, metrics + 1 + media} {
+				require.Less(t, row, len(lines))
+				require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
+					"expected a separator at row %d, got %q", row, lines[row])
+			}
+		})
 	}
 }

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -284,3 +284,68 @@ func TestRun_RenderedSeparatorsAlignWithLayout(t *testing.T) {
 			"expected a separator at row %d, got %q", row, lines[row])
 	}
 }
+
+// Regression: when the metrics slot is shorter than the grid's minimum
+// render height, the grid used to render past its reservation (lipgloss
+// Place never crops), pushing every section below off its layout row and
+// the status bar off-screen.
+func TestRun_ShortMetricsSlotStaysAligned(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(false)
+	_ = cfg.SetRightSidebarVisible(false)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	// A height where the reserved metrics slot is below the grid's minimum
+	// render height (header + one bordered chart cell).
+	r.Update(tea.WindowSizeMsg{Width: 120, Height: 20})
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+	})
+
+	metrics, media, _ := r.TestStackHeights()
+	require.Positive(t, metrics)
+	lines := strings.Split(stripANSI(r.View().Content), "\n")
+	require.LessOrEqual(t, len(lines), 20,
+		"the rendered frame must never be taller than the terminal")
+
+	for _, row := range []int{metrics, metrics + 1 + media} {
+		require.Less(t, row, len(lines))
+		require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
+			"expected a separator at row %d, got %q", row, lines[row])
+	}
+}
+
+// Same invariant for the metrics empty state: its three-line hint must crop
+// to a shorter reservation instead of shifting the sections below.
+func TestRun_EmptyMetricsShortSlotStaysAligned(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(false)
+	_ = cfg.SetRightSidebarVisible(false)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	// No scalar metrics logged: the empty-state hint renders into a slot
+	// shorter than its three lines.
+	r.Update(tea.WindowSizeMsg{Width: 120, Height: 17})
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+
+	metrics, media, _ := r.TestStackHeights()
+	require.Positive(t, metrics)
+	lines := strings.Split(stripANSI(r.View().Content), "\n")
+	require.LessOrEqual(t, len(lines), 17,
+		"the rendered frame must never be taller than the terminal")
+
+	for _, row := range []int{metrics, metrics + 1 + media} {
+		require.Less(t, row, len(lines))
+		require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
+			"expected a separator at row %d, got %q", row, lines[row])
+	}
+}

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -2,6 +2,7 @@ package leet_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -248,4 +249,38 @@ func mustSelectedItem(t *testing.T, sidebar *leet.RunOverviewSidebar) string {
 	key, _ := sidebar.SelectedItem()
 	require.NotEmpty(t, key)
 	return key
+}
+
+// TestRun_RenderedSeparatorsAlignWithLayout pins the invariant that mouse
+// hit-testing depends on: the separator rows drawn on screen sit exactly at
+// the rows computeVerticalStackLayout reserves for them. The metrics grid
+// renders header + rows*cellHeight lines, so without padding to the section
+// height, everything below it (and its separators) drifts up by the integer
+// division remainder.
+func TestRun_RenderedSeparatorsAlignWithLayout(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(false)
+	_ = cfg.SetRightSidebarVisible(false)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	// A height where the grid's cell height division leaves a remainder.
+	r.Update(tea.WindowSizeMsg{Width: 120, Height: 52})
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+	})
+
+	metrics, media, _ := r.TestStackHeights()
+	lines := strings.Split(stripANSI(r.View().Content), "\n")
+
+	for _, row := range []int{metrics, metrics + 1 + media} {
+		require.Less(t, row, len(lines))
+		require.True(t, strings.HasPrefix(strings.TrimSpace(lines[row]), "———"),
+			"expected a separator at row %d, got %q", row, lines[row])
+	}
 }

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -75,6 +75,12 @@ func (r *Run) TestStopHeartbeat() {
 	}
 }
 
+// TestStackHeights returns the run view's central stack pane heights.
+func (r *Run) TestStackHeights() (metrics, media, logs int) {
+	l := r.computeViewports()
+	return l.height, l.mediaHeight, l.consoleLogsHeight
+}
+
 func (s *Symon) TestGrid() *SystemMetricsGrid {
 	return s.grid
 }

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -1089,7 +1089,9 @@ func renderMetricsEmptyState(width, height int, hint string) string {
 	header := mediaPaneHeaderStyle.Render("Metrics")
 	hintText := mediaTilePlaceholderStyle.Render(hint)
 	content := lipgloss.JoinVertical(lipgloss.Left, header, "", hintText)
-	content = lipgloss.Place(innerW, height, lipgloss.Left, lipgloss.Top, content)
+	// placeMainColumn rather than lipgloss.Place: the three-line hint must
+	// also crop to a shorter reservation, like every stack section.
+	content = placeMainColumn(innerW, height, content)
 	return lipgloss.NewStyle().Padding(0, ContentPadding).Render(content)
 }
 

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -1072,9 +1072,12 @@ func (w *Workspace) renderMetrics(layout Layout) string {
 		return renderMetricsEmptyState(contentWidth, contentHeight, "No scalar metrics logged.")
 	}
 
-	// When we have selected runs, render the metrics grid.
+	// When we have selected runs, render the metrics grid, padded to its
+	// reserved height so the sections below sit exactly at the rows
+	// computeVerticalStackLayout reserves for them (mouse hit-testing maps
+	// screen rows to sections via that layout).
 	dims := w.metricsGrid.CalculateChartDimensions(contentWidth, contentHeight)
-	return w.metricsGrid.View(dims)
+	return placeMainColumn(contentWidth, contentHeight, w.metricsGrid.View(dims))
 }
 
 // renderMetricsEmptyState renders a styled "Metrics" header with a hint message.


### PR DESCRIPTION
Description
-----------
The metrics grid renders `header + rows*cellHeight` lines, which integer division leaves short of the height `computeVerticalStackLayout` reserves for the section. Everything rendered below it then drifts up by the remainder, so mouse hit-testing, which maps screen rows to sections via the layout, misses. Pad the grid to its reserved height (reusing `placeMainColumn`) in both the run and workspace views.
