### PR TITLE
refactor(leet): remove dead key handling in the run overview sidebar

### DIFF
--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -75,32 +75,11 @@ func (s *RunOverviewSidebar) Toggle() {
 	s.animState.Toggle()
 }
 
-// Update handles animation and input updates for the sidebar.
+// Update advances the sidebar's expand/collapse animation.
+//
+// Key input never reaches this method: all sidebar navigation flows through
+// the owning view's FocusManager and key bindings.
 func (s *RunOverviewSidebar) Update(msg tea.Msg) (*RunOverviewSidebar, tea.Cmd) {
-	// Handle key input only when expanded.
-	// TODO: hook up with keybindings.
-	if s.animState.IsExpanded() {
-		if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
-			switch keyMsg.Code {
-			case tea.KeyUp:
-				s.navigateUp()
-			case tea.KeyDown:
-				s.navigateDown()
-			case tea.KeyTab:
-				if keyMsg.Mod == tea.ModShift {
-					s.navigateSection(-1)
-				} else {
-					s.navigateSection(1)
-				}
-			case tea.KeyLeft:
-				s.navigatePageUp()
-			case tea.KeyRight:
-				s.navigatePageDown()
-			}
-		}
-	}
-
-	// Handle animation.
 	if s.animState.IsAnimating() {
 		if complete := s.animState.Update(time.Now()); !complete {
 			cmd := s.animationCmd()

--- a/core/internal/leet/runoverviewsidebar_test.go
+++ b/core/internal/leet/runoverviewsidebar_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/require"
 
@@ -183,26 +182,26 @@ func TestSidebar_Navigation_SectionPageUpDown(t *testing.T) {
 
 	s.Sync()
 
-	// Start in Environment; Tab to Config (navigateSection).
-	s.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	// Start in Environment; move to Config (navigateSection).
+	s.TestNavigateSection(1)
 	key, _ := s.SelectedItem()
 	require.True(t, strings.HasPrefix(key, "alpha.") || strings.HasPrefix(key, "beta."))
 
 	// Height=15 -> 1 item/page; Down moves to next page/next item (navigateDown + navigatePage).
 	_ = s.View(15)
-	s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	s.TestNavigateDown()
 	key2, _ := s.SelectedItem()
 	require.NotEqual(t, key2, key)
 
 	// Page right, then left, then Up; remain in Config.
-	s.Update(tea.KeyPressMsg{Code: tea.KeyRight})
-	s.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
-	s.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	s.TestNavigatePageDown()
+	s.TestNavigatePageUp()
+	s.TestNavigateUp()
 	key3, _ := s.SelectedItem()
 	require.True(t, strings.HasPrefix(key3, "alpha.") || strings.HasPrefix(key3, "beta."))
 
-	// Shift-Tab back to previous section (Environment).
-	s.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	// Step back to the previous section (Environment).
+	s.TestNavigateSection(-1)
 	key4, _ := s.SelectedItem()
 	require.False(t, strings.HasPrefix(key4, "alpha.") || strings.HasPrefix(key4, "beta."))
 }
@@ -405,7 +404,7 @@ func TestSidebar_Pagination_ResizeFromLaterPage(t *testing.T) {
 
 	// Navigate down a few items to force CurrentPage > 0.
 	for range 5 {
-		s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		s.TestNavigateDown()
 	}
 
 	// Larger height -> ItemsPerPage increases. This used to panic.

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -563,6 +563,15 @@ func (s *RunOverviewSidebar) TestFocusableSectionBounds() (first, last int) {
 	return s.focusableSectionBounds()
 }
 
+// Sidebar navigation helpers for focused unit tests. In production these
+// moves are driven by the owning view's key bindings and FocusManager.
+
+func (s *RunOverviewSidebar) TestNavigateSection(direction int) { s.navigateSection(direction) }
+func (s *RunOverviewSidebar) TestNavigateUp()                   { s.navigateUp() }
+func (s *RunOverviewSidebar) TestNavigateDown()                 { s.navigateDown() }
+func (s *RunOverviewSidebar) TestNavigatePageUp()               { s.navigatePageUp() }
+func (s *RunOverviewSidebar) TestNavigatePageDown()             { s.navigatePageDown() }
+
 // TestSeedRunOverview populates the workspace's overview data for the given
 // run key with sample config, summary, and environment items, then syncs the
 // sidebar so that overview sections become focusable.


### PR DESCRIPTION
Description
-----------
Key presses never reach `RunOverviewSidebar.Update`: the run view forwards only non-key UI messages to sidebars (`run.go` filters `tea.KeyPressMsg`), and the workspace never routes messages to it at all. All sidebar navigation flows through the owning view's FocusManager and key bindings.
