### PR TITLE
refactor(leet): focus clears instead of wandering

### DIFF
--- a/core/internal/leet/focusmanager.go
+++ b/core/internal/leet/focusmanager.go
@@ -17,13 +17,10 @@ const (
 type FocusRegionDef struct {
 	Target FocusTarget
 
-	// Available reports whether the region is currently focusable for normal
-	// navigation.
+	// Available reports whether the region is currently focusable: its pane
+	// is logically visible (target state, so an expanding pane counts and a
+	// collapsing one does not) and has content to interact with.
 	Available func() bool
-
-	// AvailableTarget reports whether the region should be considered focusable
-	// immediately after a visibility toggle. When nil, Available is used.
-	AvailableTarget func() bool
 
 	Activate   func(direction int)
 	Deactivate func()
@@ -31,9 +28,10 @@ type FocusRegionDef struct {
 
 // FocusManager is the single source of truth for which UI component holds focus.
 //
-// It tracks one FocusTarget at a time, supports Tab cycling through available
-// regions, and resolves focus after visibility changes. All focus state changes
-// flow through this manager.
+// It tracks one FocusTarget at a time and supports Tab cycling through
+// available regions. Focus never moves on its own: it changes only through
+// Tab, mouse adoption, or explicit SetTarget calls, and Resolve clears it
+// when the focused region disappears.
 type FocusManager struct {
 	current FocusTarget
 	regions []FocusRegionDef
@@ -143,56 +141,22 @@ func (fm *FocusManager) TabWithinOrAdvance(direction int, withinFn func(int) boo
 	fm.Tab(direction)
 }
 
-// ResolveAfterAvailabilityChange keeps the current focus when it is still
-// available. Otherwise, it activates the first currently available region.
-// If none are available, it clears focus.
-func (fm *FocusManager) ResolveAfterAvailabilityChange() {
-	fm.resolve(fm.regionAvailable)
-}
-
-// ResolveAfterVisibilityChange checks whether the current target is still
-// available under the target visibility state after a toggle. If not, it
-// activates the first region that will be available in the target state. If
-// none are available, it clears focus.
-func (fm *FocusManager) ResolveAfterVisibilityChange() {
-	fm.resolve(fm.regionAvailableForResolve)
+// Resolve clears focus when the focused region is no longer available
+// (its pane was closed, emptied, or squeezed out). It never moves focus
+// to another region.
+func (fm *FocusManager) Resolve() {
+	if fm.current == FocusTargetNone {
+		return
+	}
+	idx := fm.indexOf(fm.current)
+	if idx != -1 && fm.regionAvailable(&fm.regions[idx]) {
+		return
+	}
+	fm.ClearAll()
 }
 
 func (fm *FocusManager) regionAvailable(r *FocusRegionDef) bool {
 	return r.Available != nil && r.Available()
-}
-
-func (fm *FocusManager) regionAvailableForResolve(r *FocusRegionDef) bool {
-	if r.AvailableTarget != nil {
-		return r.AvailableTarget()
-	}
-	return fm.regionAvailable(r)
-}
-
-func (fm *FocusManager) resolve(isAvailable func(*FocusRegionDef) bool) {
-	if fm.current != FocusTargetNone {
-		for i := range fm.regions {
-			if fm.regions[i].Target != fm.current {
-				continue
-			}
-			if isAvailable(&fm.regions[i]) {
-				return
-			}
-			break
-		}
-	}
-
-	for i := range fm.regions {
-		if !isAvailable(&fm.regions[i]) {
-			continue
-		}
-		fm.deactivateAll()
-		fm.current = fm.regions[i].Target
-		fm.regions[i].Activate(1)
-		return
-	}
-
-	fm.ClearAll()
 }
 
 func (fm *FocusManager) deactivateAll() {

--- a/core/internal/leet/focusmanager.go
+++ b/core/internal/leet/focusmanager.go
@@ -19,7 +19,8 @@ type FocusRegionDef struct {
 
 	// Available reports whether the region is currently focusable: its pane
 	// is logically visible (target state, so an expanding pane counts and a
-	// collapsing one does not) and has content to interact with.
+	// collapsing one does not) and, for data panes, has content to interact
+	// with.
 	Available func() bool
 
 	Activate   func(direction int)

--- a/core/internal/leet/focusmanager_test.go
+++ b/core/internal/leet/focusmanager_test.go
@@ -8,37 +8,82 @@ import (
 	"github.com/wandb/wandb/core/internal/leet"
 )
 
-func TestFocusManagerResolveAfterVisibilityChangeUsesTargetAvailability(t *testing.T) {
-	currentOverviewVisible := true
-	targetOverviewVisible := true
-	overviewActive := false
-	logsActive := false
-
-	fm := leet.NewFocusManager([]leet.FocusRegionDef{
+// newTwoRegionFocusManager builds a manager with an overview and a logs
+// region whose availability is controlled by the returned pointers.
+func newTwoRegionFocusManager(
+	overviewAvailable, logsAvailable *bool,
+	overviewActive, logsActive *bool,
+) *leet.FocusManager {
+	return leet.NewFocusManager([]leet.FocusRegionDef{
 		{
-			Target:          leet.FocusTargetOverview,
-			Available:       func() bool { return currentOverviewVisible },
-			AvailableTarget: func() bool { return targetOverviewVisible },
-			Activate:        func(int) { overviewActive = true },
-			Deactivate:      func() { overviewActive = false },
+			Target:     leet.FocusTargetOverview,
+			Available:  func() bool { return *overviewAvailable },
+			Activate:   func(int) { *overviewActive = true },
+			Deactivate: func() { *overviewActive = false },
 		},
 		{
-			Target:          leet.FocusTargetConsoleLogs,
-			Available:       func() bool { return true },
-			AvailableTarget: func() bool { return true },
-			Activate:        func(int) { logsActive = true },
-			Deactivate:      func() { logsActive = false },
+			Target:     leet.FocusTargetConsoleLogs,
+			Available:  func() bool { return *logsAvailable },
+			Activate:   func(int) { *logsActive = true },
+			Deactivate: func() { *logsActive = false },
 		},
 	})
+}
+
+func TestFocusManagerResolveKeepsAvailableFocus(t *testing.T) {
+	overviewAvailable, logsAvailable := true, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
 
 	fm.SetTarget(leet.FocusTargetOverview, 1)
+	fm.Resolve()
+
 	require.True(t, fm.IsTarget(leet.FocusTargetOverview))
 	require.True(t, overviewActive)
+}
 
-	targetOverviewVisible = false
-	fm.ResolveAfterVisibilityChange()
+func TestFocusManagerResolveClearsUnavailableFocus(t *testing.T) {
+	overviewAvailable, logsAvailable := true, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
+
+	fm.SetTarget(leet.FocusTargetOverview, 1)
+	require.True(t, overviewActive)
+
+	// The focused region disappears: focus clears rather than jumping to
+	// another region.
+	overviewAvailable = false
+	fm.Resolve()
+
+	require.True(t, fm.IsTarget(leet.FocusTargetNone))
+	require.False(t, overviewActive)
+	require.False(t, logsActive)
+}
+
+func TestFocusManagerResolveIsNoOpWhenNothingFocused(t *testing.T) {
+	overviewAvailable, logsAvailable := true, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
+
+	fm.Resolve()
+
+	require.True(t, fm.IsTarget(leet.FocusTargetNone))
+	require.False(t, overviewActive)
+	require.False(t, logsActive)
+}
+
+func TestFocusManagerTabSkipsUnavailableRegions(t *testing.T) {
+	overviewAvailable, logsAvailable := false, true
+	var overviewActive, logsActive bool
+	fm := newTwoRegionFocusManager(
+		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
+
+	fm.Tab(1)
 
 	require.True(t, fm.IsTarget(leet.FocusTargetConsoleLogs))
-	require.False(t, overviewActive)
 	require.True(t, logsActive)
+	require.False(t, overviewActive)
 }

--- a/core/internal/leet/focusmanager_test.go
+++ b/core/internal/leet/focusmanager_test.go
@@ -62,19 +62,6 @@ func TestFocusManagerResolveClearsUnavailableFocus(t *testing.T) {
 	require.False(t, logsActive)
 }
 
-func TestFocusManagerResolveIsNoOpWhenNothingFocused(t *testing.T) {
-	overviewAvailable, logsAvailable := true, true
-	var overviewActive, logsActive bool
-	fm := newTwoRegionFocusManager(
-		&overviewAvailable, &logsAvailable, &overviewActive, &logsActive)
-
-	fm.Resolve()
-
-	require.True(t, fm.IsTarget(leet.FocusTargetNone))
-	require.False(t, overviewActive)
-	require.False(t, logsActive)
-}
-
 func TestFocusManagerTabSkipsUnavailableRegions(t *testing.T) {
 	overviewAvailable, logsAvailable := false, true
 	var overviewActive, logsActive bool

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -81,6 +81,10 @@ type Run struct {
 	focusMgr *FocusManager
 	focus    *Focus
 
+	// focusSeeded is set once initial focus lands on the first pane that
+	// receives data. After that, focus only ever changes on user action.
+	focusSeeded bool
+
 	// UI components.
 	metricsGridAnimState *AnimatedValue
 	metricsGrid          *MetricsGrid
@@ -262,7 +266,7 @@ func (r *Run) handleWindowResize(msg tea.WindowSizeMsg) {
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
-	r.focusMgr.ResolveAfterAvailabilityChange()
+	r.focusMgr.Resolve()
 }
 
 // isUIMsg returns true for messages that should flow to child view models.

--- a/core/internal/leet/runfocus.go
+++ b/core/internal/leet/runfocus.go
@@ -11,86 +11,63 @@ package leet
 func (r *Run) buildRunFocusManager() *FocusManager {
 	return NewFocusManager([]FocusRegionDef{
 		{
-			Target:          FocusTargetOverview,
-			Available:       r.overviewFocusAvailable,
-			AvailableTarget: r.overviewFocusTargetAvailable,
-			Activate:        r.activateOverviewFocus,
-			Deactivate:      r.deactivateOverviewFocus,
+			Target:     FocusTargetOverview,
+			Available:  r.overviewFocusAvailable,
+			Activate:   r.activateOverviewFocus,
+			Deactivate: r.deactivateOverviewFocus,
 		},
 		{
-			Target:          FocusTargetMetricsGrid,
-			Available:       r.metricsGridFocusAvailable,
-			AvailableTarget: r.metricsGridFocusTargetAvailable,
-			Activate:        r.activateMetricsGridFocus,
-			Deactivate:      r.deactivateMetricsGridFocus,
+			Target:     FocusTargetMetricsGrid,
+			Available:  r.metricsGridFocusAvailable,
+			Activate:   r.activateMetricsGridFocus,
+			Deactivate: r.deactivateMetricsGridFocus,
 		},
 		{
-			Target:          FocusTargetMedia,
-			Available:       r.mediaFocusAvailable,
-			AvailableTarget: r.mediaFocusTargetAvailable,
-			Activate:        r.activateMediaFocus,
-			Deactivate:      r.deactivateMediaFocus,
+			Target:     FocusTargetMedia,
+			Available:  r.mediaFocusAvailable,
+			Activate:   r.activateMediaFocus,
+			Deactivate: r.deactivateMediaFocus,
 		},
 		{
-			Target:          FocusTargetConsoleLogs,
-			Available:       r.logsFocusAvailable,
-			AvailableTarget: r.logsFocusTargetAvailable,
-			Activate:        r.activateLogsFocus,
-			Deactivate:      r.deactivateLogsFocus,
+			Target:     FocusTargetConsoleLogs,
+			Available:  r.logsFocusAvailable,
+			Activate:   r.activateLogsFocus,
+			Deactivate: r.deactivateLogsFocus,
 		},
 		{
-			Target:          FocusTargetSystemMetrics,
-			Available:       r.systemMetricsFocusAvailable,
-			AvailableTarget: r.systemMetricsFocusTargetAvailable,
-			Activate:        r.activateSystemMetricsFocus,
-			Deactivate:      r.deactivateSystemMetricsFocus,
+			Target:     FocusTargetSystemMetrics,
+			Available:  r.systemMetricsFocusAvailable,
+			Activate:   r.activateSystemMetricsFocus,
+			Deactivate: r.deactivateSystemMetricsFocus,
 		},
 	})
 }
 
 // ---- Availability ----
+//
+// A region is available when its pane's target state is visible and it has
+// content to interact with. Empty panes are skipped by Tab navigation.
 
 func (r *Run) overviewFocusAvailable() bool {
-	firstSec, _ := r.leftSidebar.focusableSectionBounds()
-	return r.leftSidebar.animState.IsExpanded() && firstSec != -1
-}
-
-func (r *Run) overviewFocusTargetAvailable() bool {
 	firstSec, _ := r.leftSidebar.focusableSectionBounds()
 	return r.leftSidebar.animState.TargetVisible() && firstSec != -1
 }
 
 func (r *Run) metricsGridFocusAvailable() bool {
-	return r.metricsGridAnimState.IsExpanded() && r.metricsGrid.ChartCount() > 0
-}
-
-func (r *Run) metricsGridFocusTargetAvailable() bool {
 	return r.metricsGridAnimState.TargetVisible() && r.metricsGrid.ChartCount() > 0
 }
 
 func (r *Run) systemMetricsFocusAvailable() bool {
-	return r.rightSidebar.IsVisible() && r.rightSidebar.metricsGrid.ChartCount() > 0
-}
-
-func (r *Run) systemMetricsFocusTargetAvailable() bool {
 	return r.rightSidebar.animState.TargetVisible() &&
 		r.rightSidebar.metricsGrid.ChartCount() > 0
 }
 
 func (r *Run) mediaFocusAvailable() bool {
-	return r.mediaPane.IsExpanded() && r.mediaPane.HasData()
-}
-
-func (r *Run) mediaFocusTargetAvailable() bool {
 	return r.mediaPane.animState.TargetVisible() && r.mediaPane.HasData()
 }
 
 func (r *Run) logsFocusAvailable() bool {
-	return r.consoleLogsPane.IsExpanded()
-}
-
-func (r *Run) logsFocusTargetAvailable() bool {
-	return r.consoleLogsPane.animState.TargetVisible()
+	return r.consoleLogsPane.animState.TargetVisible() && r.consoleLogsPane.HasData()
 }
 
 // ---- Activate ----
@@ -156,13 +133,29 @@ func (r *Run) deactivateLogsFocus() {
 	r.consoleLogsPane.SetActive(false)
 }
 
+// resolveFocusAfterData keeps focus consistent as data streams in.
+//
+// The first time any region becomes available, focus is seeded there so
+// keyboard navigation works immediately after load. From then on, incoming
+// data never moves focus; it is only cleared if the focused pane disappears.
+func (r *Run) resolveFocusAfterData() {
+	if r.focusSeeded {
+		r.focusMgr.Resolve()
+		return
+	}
+	if r.focusMgr.Current() == FocusTargetNone {
+		r.focusMgr.Tab(1)
+	}
+	r.focusSeeded = r.focusMgr.Current() != FocusTargetNone
+}
+
 // ---- Within-region cycling ----
 
 // cycleRunOverviewSection tries to move within overview sections.
 // Returns true if the navigation was handled (i.e. we're not at a boundary).
 func (r *Run) cycleRunOverviewSection(direction int) bool {
 	firstSec, lastSec := r.leftSidebar.focusableSectionBounds()
-	if !r.leftSidebar.animState.IsExpanded() || firstSec == -1 {
+	if !r.overviewFocusAvailable() {
 		return false
 	}
 

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -17,7 +17,7 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 	defer func() {
 		r.logger.Debug(fmt.Sprintf("perf: processRecordMsg(%T) took %s", msg, time.Since(start)))
 	}()
-	defer r.focusMgr.ResolveAfterAvailabilityChange()
+	defer r.resolveFocusAfterData()
 
 	switch msg := msg.(type) {
 	case RunMsg:
@@ -56,6 +56,9 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 	case ConsoleLogMsg:
 		r.logger.Debug("model: processing ConsoleLogMsg")
 		r.consoleLogs.ProcessRaw(msg.Text, msg.IsStderr, msg.Time)
+		// Keep the pane's data (and thus focus availability) current
+		// without waiting for the next render.
+		r.consoleLogsPane.SetConsoleLogs(r.consoleLogs.Items())
 
 	case FileCompleteMsg:
 		r.logger.Debug("model: processing FileCompleteMsg - file is complete!")
@@ -375,8 +378,7 @@ func (r *Run) endAnimating() {
 }
 
 // handleToggleLeftSidebar toggles the left overview sidebar and resolves
-// focus so a collapsing sidebar loses focus and an expanding sidebar
-// gains it when nothing else is focused.
+// focus so a collapsing sidebar loses focus.
 func (r *Run) handleToggleLeftSidebar(msg tea.KeyPressMsg) tea.Cmd {
 	if !r.beginAnimating() {
 		return nil
@@ -392,7 +394,7 @@ func (r *Run) handleToggleLeftSidebar(msg tea.KeyPressMsg) tea.Cmd {
 	r.rightSidebar.UpdateDimensions(r.width, leftWillBeVisible)
 	r.leftSidebar.Toggle()
 
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
@@ -414,7 +416,7 @@ func (r *Run) handleToggleRightSidebar(msg tea.KeyPressMsg) tea.Cmd {
 	r.rightSidebar.UpdateDimensions(r.width, r.leftSidebar.animState.TargetVisible())
 	r.leftSidebar.UpdateDimensions(r.width, rightWillBeVisible)
 	r.rightSidebar.Toggle()
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
@@ -533,7 +535,7 @@ func (r *Run) handleToggleMetricsGrid(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	r.metricsGridAnimState.Toggle()
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	r.updateBottomPaneHeights(
 		r.mediaPane.animState.TargetVisible(), r.consoleLogsPane.animState.TargetVisible())
@@ -724,9 +726,7 @@ func (r *Run) handleToggleMediaPane(msg tea.KeyPressMsg) tea.Cmd {
 	r.mediaPane.Toggle()
 	r.updateBottomPaneHeights(mediaWillBeVisible, r.consoleLogsPane.animState.TargetVisible())
 
-	if !mediaWillBeVisible {
-		r.focusMgr.ResolveAfterVisibilityChange()
-	}
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
@@ -754,9 +754,8 @@ func (r *Run) mediaPaneAnimationCmd() tea.Cmd {
 	})
 }
 
-// handleToggleConsoleLogsPane toggles the console logs bottom bar and resolves
-// focus so a collapsing bar loses focus and an expanding bar gains it
-// when nothing else is focused.
+// handleToggleConsoleLogsPane toggles the console logs bottom bar and
+// resolves focus so a collapsing bar loses focus.
 func (r *Run) handleToggleConsoleLogsPane(msg tea.KeyPressMsg) tea.Cmd {
 	if !r.beginAnimating() {
 		return nil
@@ -770,7 +769,7 @@ func (r *Run) handleToggleConsoleLogsPane(msg tea.KeyPressMsg) tea.Cmd {
 
 	r.consoleLogsPane.Toggle()
 	r.updateBottomPaneHeights(r.mediaPane.animState.TargetVisible(), bottomWillBeVisible)
-	r.focusMgr.ResolveAfterVisibilityChange()
+	r.focusMgr.Resolve()
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -79,11 +80,17 @@ func newTestRun(
 	return r, cfg
 }
 
+// seedConsoleLog gives the console logs pane content so it is focusable.
+func seedConsoleLog(r *leet.Run) {
+	r.TestHandleRecordMsg(leet.ConsoleLogMsg{Text: "hello", Time: time.Now()})
+}
+
 // ---- handleSidebarTabNav ----
 
 func TestRun_SidebarTabNav_BothPanelsVisible_CyclesOverviewThenLogs(t *testing.T) {
 	r := newRunForHandlerTest(t)
 	r.TestForceExpandConsoleLogsPane(10)
+	seedConsoleLog(r)
 
 	// Initial state: overview section 0 should be active.
 	sidebar := r.TestGetLeftSidebar()
@@ -116,12 +123,32 @@ func TestRun_SidebarTabNav_BothPanelsVisible_CyclesOverviewThenLogs(t *testing.T
 func TestRun_SidebarTabNav_OnlyLogsVisible(t *testing.T) {
 	r := newRunForHandlerTest(t)
 	r.TestForceExpandConsoleLogsPane(10)
+	seedConsoleLog(r)
 	r.TestForceCollapseLeftSidebar()
 
 	// With overview collapsed, Tab should activate logs.
 	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	require.True(t, r.TestConsoleLogsPaneActive(),
 		"Tab with collapsed overview should still reach logs")
+}
+
+func TestRun_SidebarTabNav_SkipsEmptyLogsPane(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	r.TestForceExpandConsoleLogsPane(10)
+
+	// The logs pane is open but has no content: Tab must skip it and
+	// keep cycling overview sections.
+	sidebar := r.TestGetLeftSidebar()
+	_, lastSec := sidebar.TestFocusableSectionBounds()
+	for r.TestLeftSidebarActiveSectionIdx() < lastSec {
+		r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	}
+	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	require.False(t, r.TestConsoleLogsPaneActive(),
+		"an empty logs pane must not receive focus")
+	require.True(t, r.TestLeftSidebarHasActiveSection(),
+		"focus should wrap back to the overview")
 }
 
 func TestRun_SidebarTabNav_OnlyOverviewVisible(t *testing.T) {
@@ -149,6 +176,9 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 		RunFile: "testdata/fake.wandb",
 	}, cfg, logger)
 	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Focus is seeded once the first pane gains content.
+	seedConsoleLog(r)
 
 	require.True(t, r.TestConsoleLogsPaneActive(),
 		"the first available pane should receive focus on load")

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -63,11 +64,17 @@ func newRunForHandlerTest(t *testing.T) *leet.Run {
 	return r
 }
 
+// seedConsoleLog gives the console logs pane content so it is focusable.
+func seedConsoleLog(r *leet.Run) {
+	r.TestHandleRecordMsg(leet.ConsoleLogMsg{Text: "hello", Time: time.Now()})
+}
+
 // ---- handleSidebarTabNav ----
 
 func TestRun_SidebarTabNav_BothPanelsVisible_CyclesOverviewThenLogs(t *testing.T) {
 	r := newRunForHandlerTest(t)
 	r.TestForceExpandConsoleLogsPane(10)
+	seedConsoleLog(r)
 
 	// Initial state: overview section 0 should be active.
 	sidebar := r.TestGetLeftSidebar()
@@ -100,12 +107,32 @@ func TestRun_SidebarTabNav_BothPanelsVisible_CyclesOverviewThenLogs(t *testing.T
 func TestRun_SidebarTabNav_OnlyLogsVisible(t *testing.T) {
 	r := newRunForHandlerTest(t)
 	r.TestForceExpandConsoleLogsPane(10)
+	seedConsoleLog(r)
 	r.TestForceCollapseLeftSidebar()
 
 	// With overview collapsed, Tab should activate logs.
 	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	require.True(t, r.TestConsoleLogsPaneActive(),
 		"Tab with collapsed overview should still reach logs")
+}
+
+func TestRun_SidebarTabNav_SkipsEmptyLogsPane(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	r.TestForceExpandConsoleLogsPane(10)
+
+	// The logs pane is open but has no content: Tab must skip it and
+	// keep cycling overview sections.
+	sidebar := r.TestGetLeftSidebar()
+	_, lastSec := sidebar.TestFocusableSectionBounds()
+	for r.TestLeftSidebarActiveSectionIdx() < lastSec {
+		r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	}
+	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	require.False(t, r.TestConsoleLogsPaneActive(),
+		"an empty logs pane must not receive focus")
+	require.True(t, r.TestLeftSidebarHasActiveSection(),
+		"focus should wrap back to the overview")
 }
 
 func TestRun_SidebarTabNav_OnlyOverviewVisible(t *testing.T) {
@@ -133,6 +160,9 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 		RunFile: "testdata/fake.wandb",
 	}, cfg, logger)
 	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Focus is seeded once the first pane gains content.
+	seedConsoleLog(r)
 
 	require.True(t, r.TestConsoleLogsPaneActive(),
 		"the first available pane should receive focus on load")

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -552,6 +552,20 @@ func (w *Workspace) TestConsoleLogs() map[string]*RunConsoleLogs {
 	return w.consoleLogs
 }
 
+// TestSeedConsoleLogs populates console logs for a run and syncs the pane so
+// the console logs region becomes focusable.
+func (w *Workspace) TestSeedConsoleLogs(runKey string, lines ...string) {
+	cl := w.consoleLogs[runKey]
+	if cl == nil {
+		cl = NewRunConsoleLogs()
+		w.consoleLogs[runKey] = cl
+	}
+	for _, line := range lines {
+		cl.ProcessRaw(line, false, time.Now())
+	}
+	w.consoleLogsPane.SetConsoleLogs(cl.Items())
+}
+
 // TestRunOverviewSidebarHasActiveSection reports whether the overview sidebar
 // has an active section.
 func (w *Workspace) TestRunOverviewSidebarHasActiveSection() bool {

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -658,11 +658,15 @@ func (w *Workspace) buildWorkspaceFocusManager() *FocusManager {
 
 // ---- Focus availability ----
 //
-// A region is available when its pane's target state is visible and it has
-// content to interact with. Empty panes are skipped by Tab navigation.
+// A data pane is available when its target state is visible and it has
+// content to interact with; empty panes are skipped by Tab navigation.
+// The runs list is the one exception (see runsFocusAvailable).
 
+// The runs list is the workspace's home surface: it stays focusable while
+// visible even when empty, so focus survives the empty-list windows during
+// startup and no-match filters.
 func (w *Workspace) runsFocusAvailable() bool {
-	return w.runsAnimState.TargetVisible() && len(w.runs.FilteredItems) > 0
+	return w.runsAnimState.TargetVisible()
 }
 
 func (w *Workspace) metricsGridFocusAvailable() bool {

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -618,77 +618,58 @@ func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisibl
 func (w *Workspace) buildWorkspaceFocusManager() *FocusManager {
 	return NewFocusManager([]FocusRegionDef{
 		{
-			Target:          FocusTargetRunsList,
-			Available:       w.runsFocusAvailable,
-			AvailableTarget: w.runsFocusTargetAvailable,
-			Activate:        w.activateRunsFocus,
-			Deactivate:      w.deactivateRunsFocus,
+			Target:     FocusTargetRunsList,
+			Available:  w.runsFocusAvailable,
+			Activate:   w.activateRunsFocus,
+			Deactivate: w.deactivateRunsFocus,
 		},
 		{
-			Target:          FocusTargetMetricsGrid,
-			Available:       w.metricsGridFocusAvailable,
-			AvailableTarget: w.metricsGridFocusTargetAvailable,
-			Activate:        w.activateMetricsGridFocus,
-			Deactivate:      w.deactivateMetricsGridFocus,
+			Target:     FocusTargetMetricsGrid,
+			Available:  w.metricsGridFocusAvailable,
+			Activate:   w.activateMetricsGridFocus,
+			Deactivate: w.deactivateMetricsGridFocus,
 		},
 		{
-			Target:          FocusTargetSystemMetrics,
-			Available:       w.sysMetricsFocusAvailable,
-			AvailableTarget: w.sysMetricsFocusTargetAvailable,
-			Activate:        w.activateSysMetricsFocus,
-			Deactivate:      w.deactivateSysMetricsFocus,
+			Target:     FocusTargetSystemMetrics,
+			Available:  w.sysMetricsFocusAvailable,
+			Activate:   w.activateSysMetricsFocus,
+			Deactivate: w.deactivateSysMetricsFocus,
 		},
 		{
-			Target:          FocusTargetMedia,
-			Available:       w.mediaFocusAvailable,
-			AvailableTarget: w.mediaFocusTargetAvailable,
-			Activate:        w.activateMediaFocus,
-			Deactivate:      w.deactivateMediaFocus,
+			Target:     FocusTargetMedia,
+			Available:  w.mediaFocusAvailable,
+			Activate:   w.activateMediaFocus,
+			Deactivate: w.deactivateMediaFocus,
 		},
 		{
-			Target:          FocusTargetConsoleLogs,
-			Available:       w.logsFocusAvailable,
-			AvailableTarget: w.logsFocusTargetAvailable,
-			Activate:        w.activateLogsFocus,
-			Deactivate:      w.deactivateLogsFocus,
+			Target:     FocusTargetConsoleLogs,
+			Available:  w.logsFocusAvailable,
+			Activate:   w.activateLogsFocus,
+			Deactivate: w.deactivateLogsFocus,
 		},
 		{
-			Target:          FocusTargetOverview,
-			Available:       w.overviewFocusAvailable,
-			AvailableTarget: w.overviewFocusTargetAvailable,
-			Activate:        w.activateOverviewFocus,
-			Deactivate:      w.deactivateOverviewFocus,
+			Target:     FocusTargetOverview,
+			Available:  w.overviewFocusAvailable,
+			Activate:   w.activateOverviewFocus,
+			Deactivate: w.deactivateOverviewFocus,
 		},
 	})
 }
 
 // ---- Focus availability ----
+//
+// A region is available when its pane's target state is visible and it has
+// content to interact with. Empty panes are skipped by Tab navigation.
 
 func (w *Workspace) runsFocusAvailable() bool {
-	return w.runsAnimState.IsVisible() && len(w.runs.FilteredItems) > 0
-}
-
-func (w *Workspace) runsFocusTargetAvailable() bool {
 	return w.runsAnimState.TargetVisible() && len(w.runs.FilteredItems) > 0
 }
 
 func (w *Workspace) metricsGridFocusAvailable() bool {
-	return w.metricsGridAnimState.IsExpanded() && w.metricsGrid.ChartCount() > 0
-}
-
-func (w *Workspace) metricsGridFocusTargetAvailable() bool {
 	return w.metricsGridAnimState.TargetVisible() && w.metricsGrid.ChartCount() > 0
 }
 
 func (w *Workspace) sysMetricsFocusAvailable() bool {
-	if !w.systemMetricsPane.IsExpanded() {
-		return false
-	}
-	g := w.activeSystemMetricsGrid()
-	return g != nil && g.ChartCount() > 0
-}
-
-func (w *Workspace) sysMetricsFocusTargetAvailable() bool {
 	if !w.systemMetricsPane.animState.TargetVisible() {
 		return false
 	}
@@ -697,27 +678,14 @@ func (w *Workspace) sysMetricsFocusTargetAvailable() bool {
 }
 
 func (w *Workspace) mediaFocusAvailable() bool {
-	return w.mediaPane.IsExpanded() && w.mediaPane.HasData()
-}
-
-func (w *Workspace) mediaFocusTargetAvailable() bool {
 	return w.mediaPane.animState.TargetVisible() && w.mediaPane.HasData()
 }
 
 func (w *Workspace) logsFocusAvailable() bool {
-	return w.consoleLogsPane.IsExpanded()
-}
-
-func (w *Workspace) logsFocusTargetAvailable() bool {
-	return w.consoleLogsPane.animState.TargetVisible()
+	return w.consoleLogsPane.animState.TargetVisible() && w.consoleLogsPane.HasData()
 }
 
 func (w *Workspace) overviewFocusAvailable() bool {
-	firstSec, _ := w.runOverviewSidebar.focusableSectionBounds()
-	return w.runOverviewSidebar.animState.IsExpanded() && firstSec != -1
-}
-
-func (w *Workspace) overviewFocusTargetAvailable() bool {
 	firstSec, _ := w.runOverviewSidebar.focusableSectionBounds()
 	return w.runOverviewSidebar.animState.TargetVisible() && firstSec != -1
 }
@@ -778,7 +746,7 @@ func (w *Workspace) deactivateOverviewFocus() { w.runOverviewSidebar.deactivateA
 // Returns true if the navigation was handled (i.e. we're not at a boundary).
 func (w *Workspace) cycleOverviewSection(direction int) bool {
 	firstSec, lastSec := w.runOverviewSidebar.focusableSectionBounds()
-	if !w.runOverviewSidebar.animState.IsExpanded() || firstSec == -1 {
+	if !w.overviewFocusAvailable() {
 		return false
 	}
 

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -856,3 +856,45 @@ func TestWorkspace_RunsFilter_TagsAndNotes(t *testing.T) {
 	require.Nil(t, w.Update(tea.KeyPressMsg{Code: tea.KeyEnter}))
 	require.Equal(t, []string{run2}, w.TestFilteredRunKeys())
 }
+
+// Regression: with no runs yet, toggling an unrelated pane used to clear the
+// seeded runs-list focus for good (the runs list was "unavailable" while
+// empty and nothing ever re-seeded it), leaving keyboard navigation dead
+// once runs appeared.
+func TestWorkspace_ToggleWithEmptyRunsListKeepsFocus(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	require.Equal(t, int(leet.FocusTargetRunsList), w.TestCurrentFocusRegion(),
+		"runs list starts focused")
+
+	// Toggle the media pane while the runs list is still empty.
+	_ = w.Update(keyRune('3'))
+
+	require.Equal(t, int(leet.FocusTargetRunsList), w.TestCurrentFocusRegion(),
+		"toggling an unrelated pane must not clear runs-list focus")
+}
+
+// Regression: when an externally deleted run dir empties the focused data
+// pane, the run-key snapshot must clear focus from it — and availability
+// must be evaluated against the freshly synced pane state, not the dropped
+// run's leftovers (panes are normally re-pointed only during View).
+func TestWorkspace_DroppedRunClearsFocusFromEmptiedPane(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetWorkspaceConsoleLogsVisible(true)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	_ = w.Update(leet.WorkspaceRunDirsMsg{RunKeys: []string{"run-a"}})
+	w.TestSeedConsoleLogs("run-a", "hello")
+	w.TestSetFocusTarget(int(leet.FocusTargetConsoleLogs))
+	require.Equal(t, int(leet.FocusTargetConsoleLogs), w.TestCurrentFocusRegion())
+
+	// The run's directory disappears; the pane it fed is now empty.
+	_ = w.Update(leet.WorkspaceRunDirsMsg{RunKeys: nil})
+	require.Equal(t, int(leet.FocusTargetNone), w.TestCurrentFocusRegion(),
+		"focus must not stay on a pane emptied by a dropped run")
+}

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -150,12 +150,15 @@ func newWorkspaceWithPanels(t *testing.T) *leet.Workspace {
 	// computed heights).
 	w.TestSeedRunOverview(runKey)
 
+	// Give the console logs pane content so it is focusable.
+	w.TestSeedConsoleLogs(runKey, "hello from the run")
+
 	return w
 }
 
 // ---- handleToggleConsoleLogsPane ----
 
-func TestWorkspace_ToggleConsoleLogsPane_FocusReturnsToRuns(t *testing.T) {
+func TestWorkspace_ToggleConsoleLogsPane_FocusClears(t *testing.T) {
 	w := newWorkspaceWithPanels(t)
 
 	// Focus logs via Tab until bottom bar is active.
@@ -164,13 +167,13 @@ func TestWorkspace_ToggleConsoleLogsPane_FocusReturnsToRuns(t *testing.T) {
 	}
 	require.Equal(t, testFocusLogs, w.TestCurrentFocusRegion())
 
-	// Collapse bottom bar — focus should return to runs (the next available).
+	// Collapse bottom bar — the focused pane disappeared, so focus clears
+	// rather than jumping to another pane.
 	_ = w.Update(keyRune('4'))
-	_ = w.Update(keyRune(']'))
 	require.False(t, w.TestConsoleLogsPaneActive(),
 		"bottom bar should not be active after collapse")
-	require.True(t, w.TestRunsActive(),
-		"runs list should be focused after collapsing logs")
+	require.Equal(t, int(leet.FocusTargetNone), w.TestCurrentFocusRegion(),
+		"focus should clear when the focused pane is closed")
 }
 
 func TestWorkspace_ToggleConsoleLogsPane_FocusStaysOnRuns(t *testing.T) {
@@ -184,6 +187,28 @@ func TestWorkspace_ToggleConsoleLogsPane_FocusStaysOnRuns(t *testing.T) {
 	_ = w.Update(keyRune('4'))
 	require.True(t, w.TestRunsActive(),
 		"runs focus should be preserved when collapsing bottom bar from runs")
+}
+
+// ---- Empty panes are skipped by Tab ----
+
+func TestWorkspace_TabSkipsEmptyLogsPane(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	runKey := "run-20260209_010101-abcdefg"
+	_ = w.Update(leet.WorkspaceRunDirsMsg{RunKeys: []string{runKey}})
+	w.TestForceExpandRunsSidebar()
+	w.TestForceExpandConsoleLogsPane(10)
+
+	// The logs pane is open but empty: a full Tab cycle must never land on it.
+	for range 6 {
+		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+		require.NotEqual(t, testFocusLogs, w.TestCurrentFocusRegion(),
+			"an empty logs pane must not receive focus")
+	}
 }
 
 // ---- Focus bug: collapsing overview with logs focused ----
@@ -435,8 +460,9 @@ func TestWorkspace_Enter_RequiresRunSelectorActive(t *testing.T) {
 	require.True(t, w.RunSelectorActive(),
 		"run selector should be active with runs focused and items present")
 
-	// Focus logs by expanding bottom bar and tabbing.
+	// Focus logs by expanding and populating the bottom bar, then tabbing.
 	w.TestForceExpandConsoleLogsPane(10)
+	w.TestSeedConsoleLogs(runKey, "hello")
 	for !w.TestConsoleLogsPaneActive() {
 		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	}

--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -380,6 +380,12 @@ func (w *Workspace) applyRunKeys(runKeys []string) {
 		w.restoreRunCursor(prevCursorKey)
 	}
 	w.syncRunsPage()
+
+	// Dropped runs may have emptied the focused pane. Availability reads
+	// the panes' own state, which is normally re-pointed at the cursor run
+	// during View — sync first so Resolve sees the post-drop state.
+	w.syncCurrentRunContext()
+	w.focusMgr.Resolve()
 }
 
 func (w *Workspace) setRunItems(runKeys []string) {

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -347,7 +347,7 @@ func (w *Workspace) handleToggleRunsSidebar(msg tea.KeyPressMsg) tea.Cmd {
 
 	w.updateSidebarDimensions(leftWillBeVisible, rightIsVisible)
 	w.runsAnimState.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 
 	return w.runsAnimationCmd()
@@ -363,7 +363,7 @@ func (w *Workspace) handleToggleOverviewSidebar(msg tea.KeyPressMsg) tea.Cmd {
 
 	w.updateSidebarDimensions(leftIsVisible, rightWillBeVisible)
 	w.runOverviewSidebar.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 
 	return w.runOverviewAnimationCmd()
@@ -392,9 +392,7 @@ func (w *Workspace) handleToggleMediaPane(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	w.mediaPane.Toggle()
-	if !mediaWillBeVisible {
-		w.focusMgr.ResolveAfterVisibilityChange()
-	}
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 	return w.mediaPaneAnimationCmd()
 }
@@ -412,7 +410,7 @@ func (w *Workspace) handleToggleConsoleLogsPane(msg tea.KeyPressMsg) tea.Cmd {
 		bottomWillBeVisible,
 	)
 	w.consoleLogsPane.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 
 	return w.consoleLogsPaneAnimationCmd()
@@ -429,7 +427,7 @@ func (w *Workspace) handleToggleSystemMetricsPane(tea.KeyPressMsg) tea.Cmd {
 
 	w.updateBottomPaneHeights(sysWillBeVisible, mediaVisible, logsVisible)
 	w.systemMetricsPane.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 	w.recalculateLayout()
 	return w.systemMetricsPaneAnimationCmd()
 }
@@ -949,7 +947,7 @@ func (w *Workspace) handleToggleMetricsGrid(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	w.metricsGridAnimState.Toggle()
-	w.focusMgr.ResolveAfterVisibilityChange()
+	w.focusMgr.Resolve()
 
 	w.updateBottomPaneHeights(
 		w.systemMetricsPane.animState.TargetVisible(),


### PR DESCRIPTION
Description
-----------
Part of the stack replacing #12169.

Rebuild focus availability around two invariants:

- **A data pane is focusable iff it is logically visible and non-empty.** Availability uses the pane's target state (an expanding pane counts, a collapsing one doesn't) and requires content; empty panes are skipped by Tab. Console logs previously took focus even when empty. One deliberate exception: **the workspace runs list stays focusable while visible even when empty** — it is the workspace's home surface, and requiring content meant any Resolve() during the empty-list window (pane toggle at startup, no-match filter) cleared the seeded focus with nothing ever restoring it, leaving j/k/Enter dead once runs appeared.
- **Focus never moves on its own.** It clears when its pane disappears instead of jumping to another pane, with a one-time seed when a run first receives data so keyboard navigation works immediately after load. The workspace also resolves focus when externally deleted run dirs empty the focused pane.

This collapses `FocusManager`'s `AvailableTarget` and both `ResolveAfter*` variants into a single clear-only `Resolve()`, and drops the per-region `IsExpanded`/`TargetVisible` predicate pairs for one predicate each.

Behavior change: collapsing a focused pane now clears focus instead of teleporting it to the runs list.