### PR TITLE
feat(leet): escape key steps out one layer at a time

### DIFF
--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -42,7 +42,8 @@ func RunKeyBindings() []BindingCategory[Run] {
 				},
 				{
 					Keys:        []string{"esc"},
-					Description: "Back to workspace (when not filtering/configuring)",
+					Description: "Unfocus pane, then back to workspace",
+					Handler:     (*Run).handleEscape,
 				},
 			},
 		},

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -549,8 +549,13 @@ func buildKeyMap[T any](
 // Bubble Tea has historically reported space as " " in some situations; we want a
 // help-friendly, explicit key name.
 func normalizeKey(key string) string {
-	if key == " " {
+	switch key {
+	case " ":
 		return "space"
+	case "alt+esc", "shift+esc", "ctrl+esc":
+		// The terminal decoder coalesces a fast Esc-Esc mash into a single
+		// alt+esc; any modified Esc still means Esc.
+		return "esc"
 	}
 	return key
 }

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -159,13 +159,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	// Snapshot before sub-models consume the key — a filter's Enter
-	// exits filter mode, so checking after would miss it.
+	// Snapshot before sub-models consume the key — a filter's Enter exits
+	// filter mode and the run's Esc clears pane focus, so checking after
+	// would miss them.
 	awaitingInput := m.isAwaitingUserInput()
+	runHadPaneFocus := m.mode == viewModeRun && m.run != nil && m.run.HasPaneFocus()
 
 	cmds := m.updateSubComponents(msg)
 
-	if cmd := m.handleModeSwitch(msg, awaitingInput); cmd != nil {
+	if cmd := m.handleModeSwitch(msg, awaitingInput, runHadPaneFocus); cmd != nil {
 		return m, cmd
 	}
 
@@ -197,10 +199,11 @@ func (m *Model) updateSubComponents(msg tea.Msg) []tea.Cmd {
 
 // handleModeSwitch checks for Enter/Esc and transitions between views.
 //
-// awaitingInput must be snapshotted before sub-components process the
-// message, because an Enter in filter mode exits the filter and would
-// otherwise fall through to a view switch.
-func (m *Model) handleModeSwitch(msg tea.Msg, awaitingInput bool) tea.Cmd {
+// awaitingInput and runHadPaneFocus must be snapshotted before sub-components
+// process the message: an Enter in filter mode exits the filter, and an Esc
+// with a focused pane clears that focus. Either would otherwise fall through
+// to a view switch on the same key press.
+func (m *Model) handleModeSwitch(msg tea.Msg, awaitingInput, runHadPaneFocus bool) tea.Cmd {
 	keyMsg, ok := msg.(tea.KeyPressMsg)
 	if !ok {
 		return nil
@@ -214,7 +217,8 @@ func (m *Model) handleModeSwitch(msg tea.Msg, awaitingInput bool) tea.Cmd {
 			return m.enterRunView()
 		}
 	case viewModeRun:
-		runCapturesEsc := m.run != nil && m.run.MediaFullscreen()
+		runCapturesEsc := runHadPaneFocus ||
+			(m.run != nil && m.run.MediaFullscreen())
 		if keyMsg.Code == tea.KeyEsc &&
 			!awaitingInput && !runCapturesEsc {
 			return m.exitRunView()

--- a/core/internal/leet/runfocus.go
+++ b/core/internal/leet/runfocus.go
@@ -128,6 +128,9 @@ func (r *Run) deactivateSystemMetricsFocus() {
 }
 
 func (r *Run) deactivateMediaFocus() {
+	// Fullscreen follows focus: once focus leaves the pane, no key path
+	// could exit fullscreen and Esc would be captured forever.
+	r.mediaPane.ExitFullscreen()
 	r.mediaPane.SetActive(false)
 }
 
@@ -159,6 +162,9 @@ func (r *Run) HasPaneFocus() bool {
 // handleEscape clears pane focus. When nothing is focused, the parent model
 // handles Esc by exiting back to the workspace.
 func (r *Run) handleEscape(tea.KeyPressMsg) tea.Cmd {
+	// An explicit unfocus ends the initial-focus seeding era: later data
+	// must not move focus back.
+	r.focusSeeded = true
 	r.focusMgr.ClearAll()
 	return nil
 }

--- a/core/internal/leet/runfocus.go
+++ b/core/internal/leet/runfocus.go
@@ -1,5 +1,7 @@
 package leet
 
+import tea "charm.land/bubbletea/v2"
+
 // buildRunFocusManager constructs the FocusManager for the single-run view.
 //
 // The region order follows the spatial layout so Tab flows naturally:
@@ -147,6 +149,18 @@ func (r *Run) resolveFocusAfterData() {
 		r.focusMgr.Tab(1)
 	}
 	r.focusSeeded = r.focusMgr.Current() != FocusTargetNone
+}
+
+// HasPaneFocus reports whether any pane currently holds focus.
+func (r *Run) HasPaneFocus() bool {
+	return r.focusMgr.Current() != FocusTargetNone
+}
+
+// handleEscape clears pane focus. When nothing is focused, the parent model
+// handles Esc by exiting back to the workspace.
+func (r *Run) handleEscape(tea.KeyPressMsg) tea.Cmd {
+	r.focusMgr.ClearAll()
+	return nil
 }
 
 // ---- Within-region cycling ----

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -216,10 +216,17 @@ func TestRun_DataAfterEscDoesNotRestealFocus(t *testing.T) {
 		"incoming data must not re-steal focus after Esc")
 }
 
-func TestModel_EscExitsRunViewOnlyWhenUnfocused(t *testing.T) {
+// newModelInRunMode builds the top-level model in run mode at 200x60, with
+// config tweaks applied before construction.
+func newModelInRunMode(
+	t *testing.T, tweak func(*leet.ConfigManager),
+) (*leet.Model, tea.Model) {
+	t.Helper()
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-
+	if tweak != nil {
+		tweak(cfg)
+	}
 	m := leet.NewModel(leet.ModelParams{
 		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
 		Config:    cfg,
@@ -227,10 +234,13 @@ func TestModel_EscExitsRunViewOnlyWhenUnfocused(t *testing.T) {
 	})
 	var tm tea.Model = m
 	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
-
-	// Seed overview data so focus lands on a pane.
 	require.True(t, m.TestInRunMode())
-	m.TestRunModel().TestHandleRecordMsg(leet.RunMsg{
+	return m, tm
+}
+
+// seedOverview gives the run overview config data so a pane takes focus.
+func seedOverview(r *leet.Run) {
+	r.TestHandleRecordMsg(leet.RunMsg{
 		ID:      "abc123",
 		Project: "test-project",
 		Config: &spb.ConfigRecord{
@@ -239,6 +249,11 @@ func TestModel_EscExitsRunViewOnlyWhenUnfocused(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestModel_EscExitsRunViewOnlyWhenUnfocused(t *testing.T) {
+	m, tm := newModelInRunMode(t, nil)
+	seedOverview(m.TestRunModel())
 	require.True(t, m.TestRunModel().HasPaneFocus())
 
 	// First Esc unfocuses the pane but stays in the run view.
@@ -414,18 +429,9 @@ func TestRun_StackSectionsAlignWithReservedRows(t *testing.T) {
 // further press was captured by the fullscreen guard with no way out.
 // Fullscreen now follows focus.
 func TestModel_TabWhileMediaFullscreenExitsFullscreen(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetMediaVisible(true)
-
-	m := leet.NewModel(leet.ModelParams{
-		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
-		Config:    cfg,
-		Logger:    logger,
+	m, tm := newModelInRunMode(t, func(c *leet.ConfigManager) {
+		_ = c.SetMediaVisible(true)
 	})
-	var tm tea.Model = m
-	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
-	require.True(t, m.TestInRunMode())
 
 	// Metrics + media data: focus seeds on the metrics grid, media is the
 	// next available region.
@@ -460,24 +466,10 @@ func TestModel_TabWhileMediaFullscreenExitsFullscreen(t *testing.T) {
 // missed it while the model exit was suppressed by the focus snapshot, so the
 // press did nothing.
 func TestModel_ModifiedEscStillPeelsFocus(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetLeftSidebarVisible(true)
-
-	m := leet.NewModel(leet.ModelParams{
-		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
-		Config:    cfg,
-		Logger:    logger,
+	m, tm := newModelInRunMode(t, func(c *leet.ConfigManager) {
+		_ = c.SetLeftSidebarVisible(true)
 	})
-	var tm tea.Model = m
-	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
-	require.True(t, m.TestInRunMode())
-	m.TestRunModel().TestHandleRecordMsg(leet.RunMsg{
-		ID: "abc123", Project: "test-project",
-		Config: &spb.ConfigRecord{Update: []*spb.ConfigItem{
-			{NestedKey: []string{"lr"}, ValueJson: "0.01"},
-		}},
-	})
+	seedOverview(m.TestRunModel())
 	require.True(t, m.TestRunModel().HasPaneFocus())
 
 	_, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc, Mod: tea.ModAlt})
@@ -490,12 +482,9 @@ func TestModel_ModifiedEscStillPeelsFocus(t *testing.T) {
 // Regression: an explicit Esc-unfocus before the one-time focus seed fired
 // used to be overridden by the next incoming record re-seeding focus.
 func TestRun_EscBeforeSeedStopsDataFromStealingFocus(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetMediaVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	r, _ := newTestRun(t, 200, 60, func(c *leet.ConfigManager) {
+		_ = c.SetMediaVisible(true)
+	})
 
 	// Media data arrives via the shared store, not a record, so the seed has
 	// not fired yet; the user tabs in and explicitly unfocuses.

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -408,3 +408,115 @@ func TestRun_StackSectionsAlignWithReservedRows(t *testing.T) {
 		})
 	}
 }
+
+// Regression: Tab while the media pane was fullscreen used to move focus away
+// with fullscreen left on; Esc then cleared the invisible focus once and every
+// further press was captured by the fullscreen guard with no way out.
+// Fullscreen now follows focus.
+func TestModel_TabWhileMediaFullscreenExitsFullscreen(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+
+	m := leet.NewModel(leet.ModelParams{
+		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
+		Config:    cfg,
+		Logger:    logger,
+	})
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	require.True(t, m.TestInRunMode())
+
+	// Metrics + media data: focus seeds on the metrics grid, media is the
+	// next available region.
+	r := m.TestRunModel()
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+		Media: map[string][]leet.MediaPoint{
+			"media/img": {{X: 1, FilePath: "a.png", Format: "png"}},
+		},
+	})
+	require.True(t, r.HasPaneFocus())
+
+	// Tab to the media pane, enter fullscreen, then Tab away.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, r.MediaFullscreen())
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.False(t, r.MediaFullscreen(), "fullscreen must follow focus")
+
+	// Esc still peels one layer at a time: focus, then the view.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.True(t, m.TestInRunMode())
+	require.False(t, r.HasPaneFocus())
+	_, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, m.TestInRunMode())
+}
+
+// Regression: a fast Esc-Esc mash reaches the app as one alt+esc; the keyMap
+// missed it while the model exit was suppressed by the focus snapshot, so the
+// press did nothing.
+func TestModel_ModifiedEscStillPeelsFocus(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+
+	m := leet.NewModel(leet.ModelParams{
+		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
+		Config:    cfg,
+		Logger:    logger,
+	})
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	require.True(t, m.TestInRunMode())
+	m.TestRunModel().TestHandleRecordMsg(leet.RunMsg{
+		ID: "abc123", Project: "test-project",
+		Config: &spb.ConfigRecord{Update: []*spb.ConfigItem{
+			{NestedKey: []string{"lr"}, ValueJson: "0.01"},
+		}},
+	})
+	require.True(t, m.TestRunModel().HasPaneFocus())
+
+	_, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc, Mod: tea.ModAlt})
+	require.False(t, m.TestRunModel().HasPaneFocus(),
+		"a modified Esc must still unfocus the pane")
+	require.True(t, m.TestInRunMode(),
+		"a modified Esc must not also exit the view")
+}
+
+// Regression: an explicit Esc-unfocus before the one-time focus seed fired
+// used to be overridden by the next incoming record re-seeding focus.
+func TestRun_EscBeforeSeedStopsDataFromStealingFocus(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Media data arrives via the shared store, not a record, so the seed has
+	// not fired yet; the user tabs in and explicitly unfocuses.
+	store := leet.NewMediaStore()
+	store.ProcessHistory(leet.HistoryMsg{
+		Media: map[string][]leet.MediaPoint{
+			"media/img": {{X: 1, FilePath: "a.png", Format: "png"}},
+		},
+	})
+	r.SetMediaStore(store)
+	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.True(t, r.HasPaneFocus())
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, r.HasPaneFocus())
+
+	// The first processed record must not move focus back.
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+	})
+	require.False(t, r.HasPaneFocus(),
+		"data after an explicit unfocus must not re-seed focus")
+}

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -186,6 +186,71 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 		"collapsed overview should not appear focused")
 }
 
+// ---- Esc: unfocus pane first, exit view second ----
+
+func TestRun_EscUnfocusesPane(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	require.True(t, r.HasPaneFocus(), "seeded run should start with pane focus")
+
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	require.False(t, r.HasPaneFocus(), "Esc should clear pane focus")
+	require.False(t, r.TestLeftSidebarHasActiveSection(),
+		"overview sections should be deactivated after Esc")
+}
+
+func TestRun_DataAfterEscDoesNotRestealFocus(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, r.HasPaneFocus())
+
+	// More data arriving must not move focus once the user unfocused.
+	r.TestHandleRecordMsg(leet.SummaryMsg{
+		Summary: []*spb.SummaryRecord{{
+			Update: []*spb.SummaryItem{
+				{NestedKey: []string{"acc"}, ValueJson: "0.9"},
+			},
+		}},
+	})
+	require.False(t, r.HasPaneFocus(),
+		"incoming data must not re-steal focus after Esc")
+}
+
+func TestModel_EscExitsRunViewOnlyWhenUnfocused(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	m := leet.NewModel(leet.ModelParams{
+		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
+		Config:    cfg,
+		Logger:    logger,
+	})
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Seed overview data so focus lands on a pane.
+	require.True(t, m.TestInRunMode())
+	m.TestRunModel().TestHandleRecordMsg(leet.RunMsg{
+		ID:      "abc123",
+		Project: "test-project",
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"lr"}, ValueJson: "0.01"},
+			},
+		},
+	})
+	require.True(t, m.TestRunModel().HasPaneFocus())
+
+	// First Esc unfocuses the pane but stays in the run view.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.True(t, m.TestInRunMode(), "Esc with a focused pane must not exit the view")
+	require.False(t, m.TestRunModel().HasPaneFocus())
+
+	// Second Esc exits to the workspace.
+	_, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, m.TestInRunMode(), "Esc with no pane focus should exit to workspace")
+}
+
 func TestRun_OverviewUpdatesPreserveTabContext(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -444,3 +444,115 @@ func TestRun_EmptyMetricsShortSlotStaysAligned(t *testing.T) {
 			"expected a separator at row %d, got %q", row, lines[row])
 	}
 }
+
+// Regression: Tab while the media pane was fullscreen used to move focus away
+// with fullscreen left on; Esc then cleared the invisible focus once and every
+// further press was captured by the fullscreen guard with no way out.
+// Fullscreen now follows focus.
+func TestModel_TabWhileMediaFullscreenExitsFullscreen(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+
+	m := leet.NewModel(leet.ModelParams{
+		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
+		Config:    cfg,
+		Logger:    logger,
+	})
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	require.True(t, m.TestInRunMode())
+
+	// Metrics + media data: focus seeds on the metrics grid, media is the
+	// next available region.
+	r := m.TestRunModel()
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+		Media: map[string][]leet.MediaPoint{
+			"media/img": {{X: 1, FilePath: "a.png", Format: "png"}},
+		},
+	})
+	require.True(t, r.HasPaneFocus())
+
+	// Tab to the media pane, enter fullscreen, then Tab away.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, r.MediaFullscreen())
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.False(t, r.MediaFullscreen(), "fullscreen must follow focus")
+
+	// Esc still peels one layer at a time: focus, then the view.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.True(t, m.TestInRunMode())
+	require.False(t, r.HasPaneFocus())
+	_, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, m.TestInRunMode())
+}
+
+// Regression: a fast Esc-Esc mash reaches the app as one alt+esc; the keyMap
+// missed it while the model exit was suppressed by the focus snapshot, so the
+// press did nothing.
+func TestModel_ModifiedEscStillPeelsFocus(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+
+	m := leet.NewModel(leet.ModelParams{
+		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
+		Config:    cfg,
+		Logger:    logger,
+	})
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	require.True(t, m.TestInRunMode())
+	m.TestRunModel().TestHandleRecordMsg(leet.RunMsg{
+		ID: "abc123", Project: "test-project",
+		Config: &spb.ConfigRecord{Update: []*spb.ConfigItem{
+			{NestedKey: []string{"lr"}, ValueJson: "0.01"},
+		}},
+	})
+	require.True(t, m.TestRunModel().HasPaneFocus())
+
+	_, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc, Mod: tea.ModAlt})
+	require.False(t, m.TestRunModel().HasPaneFocus(),
+		"a modified Esc must still unfocus the pane")
+	require.True(t, m.TestInRunMode(),
+		"a modified Esc must not also exit the view")
+}
+
+// Regression: an explicit Esc-unfocus before the one-time focus seed fired
+// used to be overridden by the next incoming record re-seeding focus.
+func TestRun_EscBeforeSeedStopsDataFromStealingFocus(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Media data arrives via the shared store, not a record, so the seed has
+	// not fired yet; the user tabs in and explicitly unfocuses.
+	store := leet.NewMediaStore()
+	store.ProcessHistory(leet.HistoryMsg{
+		Media: map[string][]leet.MediaPoint{
+			"media/img": {{X: 1, FilePath: "a.png", Format: "png"}},
+		},
+	})
+	r.SetMediaStore(store)
+	r.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.True(t, r.HasPaneFocus())
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, r.HasPaneFocus())
+
+	// The first processed record must not move focus back.
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+	})
+	require.False(t, r.HasPaneFocus(),
+		"data after an explicit unfocus must not re-seed focus")
+}

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -170,6 +170,71 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 		"collapsed overview should not appear focused")
 }
 
+// ---- Esc: unfocus pane first, exit view second ----
+
+func TestRun_EscUnfocusesPane(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	require.True(t, r.HasPaneFocus(), "seeded run should start with pane focus")
+
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	require.False(t, r.HasPaneFocus(), "Esc should clear pane focus")
+	require.False(t, r.TestLeftSidebarHasActiveSection(),
+		"overview sections should be deactivated after Esc")
+}
+
+func TestRun_DataAfterEscDoesNotRestealFocus(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, r.HasPaneFocus())
+
+	// More data arriving must not move focus once the user unfocused.
+	r.TestHandleRecordMsg(leet.SummaryMsg{
+		Summary: []*spb.SummaryRecord{{
+			Update: []*spb.SummaryItem{
+				{NestedKey: []string{"acc"}, ValueJson: "0.9"},
+			},
+		}},
+	})
+	require.False(t, r.HasPaneFocus(),
+		"incoming data must not re-steal focus after Esc")
+}
+
+func TestModel_EscExitsRunViewOnlyWhenUnfocused(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	m := leet.NewModel(leet.ModelParams{
+		RunParams: &leet.RunParams{RunFile: "testdata/fake.wandb"},
+		Config:    cfg,
+		Logger:    logger,
+	})
+	var tm tea.Model = m
+	tm, _ = tm.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Seed overview data so focus lands on a pane.
+	require.True(t, m.TestInRunMode())
+	m.TestRunModel().TestHandleRecordMsg(leet.RunMsg{
+		ID:      "abc123",
+		Project: "test-project",
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"lr"}, ValueJson: "0.01"},
+			},
+		},
+	})
+	require.True(t, m.TestRunModel().HasPaneFocus())
+
+	// First Esc unfocuses the pane but stays in the run view.
+	tm, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.True(t, m.TestInRunMode(), "Esc with a focused pane must not exit the view")
+	require.False(t, m.TestRunModel().HasPaneFocus())
+
+	// Second Esc exits to the workspace.
+	_, _ = tm.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.False(t, m.TestInRunMode(), "Esc with no pane focus should exit to workspace")
+}
+
 func TestRun_OverviewUpdatesPreserveTabContext(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -81,6 +81,12 @@ func (r *Run) TestStackHeights() (metrics, media, logs int) {
 	return l.height, l.mediaHeight, l.consoleLogsHeight
 }
 
+// TestInRunMode reports whether the model shows the single-run view.
+func (m *Model) TestInRunMode() bool { return m.mode == viewModeRun }
+
+// TestRunModel returns the single-run sub-model (nil in workspace mode).
+func (m *Model) TestRunModel() *Run { return m.run }
+
 func (s *Symon) TestGrid() *SystemMetricsGrid {
 	return s.grid
 }

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -741,7 +741,12 @@ func (w *Workspace) deactivateSysMetricsFocus() {
 		w.systemMetricsFocus.Reset()
 	}
 }
-func (w *Workspace) deactivateMediaFocus()    { w.mediaPane.SetActive(false) }
+func (w *Workspace) deactivateMediaFocus() {
+	// Fullscreen follows focus: once focus leaves the pane, no key path
+	// could exit fullscreen and Esc would be captured forever.
+	w.mediaPane.ExitFullscreen()
+	w.mediaPane.SetActive(false)
+}
 func (w *Workspace) deactivateLogsFocus()     { w.consoleLogsPane.SetActive(false) }
 func (w *Workspace) deactivateOverviewFocus() { w.runOverviewSidebar.deactivateAllSections() }
 

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -189,6 +189,38 @@ func TestWorkspace_ToggleConsoleLogsPane_FocusStaysOnRuns(t *testing.T) {
 		"runs focus should be preserved when collapsing bottom bar from runs")
 }
 
+// ---- Esc: home to runs, or clear focus when runs can't take it ----
+
+func TestWorkspace_EscReturnsFocusToRuns(t *testing.T) {
+	w := newWorkspaceWithPanels(t)
+
+	// Focus logs, then Esc home.
+	for w.TestCurrentFocusRegion() != testFocusLogs {
+		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	}
+	_ = w.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	require.Equal(t, testFocusRuns, w.TestCurrentFocusRegion(),
+		"Esc should return focus to the runs list")
+	require.True(t, w.TestRunsActive())
+}
+
+func TestWorkspace_EscClearsFocusWhenRunsHidden(t *testing.T) {
+	w := newWorkspaceWithPanels(t)
+
+	// Focus logs, hide the runs sidebar, then Esc.
+	for w.TestCurrentFocusRegion() != testFocusLogs {
+		_ = w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	}
+	_ = w.Update(keyRune('['))
+	require.Equal(t, testFocusLogs, w.TestCurrentFocusRegion())
+
+	_ = w.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	require.Equal(t, int(leet.FocusTargetNone), w.TestCurrentFocusRegion(),
+		"Esc should clear focus when the runs list cannot take it")
+}
+
 // ---- Empty panes are skipped by Tab ----
 
 func TestWorkspace_TabSkipsEmptyLogsPane(t *testing.T) {

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -1229,13 +1229,16 @@ func (w *Workspace) activeSystemMetricsGrid() *SystemMetricsGrid {
 	return w.systemMetrics[cur.Key]
 }
 
-// handleFocusRuns moves focus to the runs list if it's visible.
+// handleFocusRuns moves focus home to the runs list.
 //
-// This gives Esc a natural "return home" feel in workspace mode:
-// wherever focus currently is, Esc snaps it back to the run selector.
+// This gives Esc a natural "return home" feel in workspace mode: wherever
+// focus currently is, Esc snaps it back to the run selector. When the runs
+// list can't take focus (hidden or empty), Esc just clears focus.
 func (w *Workspace) handleFocusRuns(tea.KeyPressMsg) tea.Cmd {
-	if w.runsAnimState.TargetVisible() {
+	if w.runsFocusAvailable() {
 		w.focusMgr.SetTarget(FocusTargetRunsList, 1)
+	} else {
+		w.focusMgr.ClearAll()
 	}
 	return nil
 }


### PR DESCRIPTION
Description
-----------
Part of the stack replacing #12169.

Esc now peels state back one layer at a time: input mode → pane focus → view.

- **Run view**: with a pane focused, Esc unfocuses it; only an unfocused Esc exits back to the workspace. The model snapshots pane focus before sub-models consume the key so a single press can't both unfocus and exit. An explicit Esc-unfocus also ends the initial-focus seeding era, so later data can't move focus back.
- **Workspace**: Esc homes to the runs list whenever the list is visible (the runs list stays focusable while empty — see the previous PR); when it's hidden, Esc just clears focus.
- **Fullscreen follows focus**: deactivating the media region (Tab away, pane emptied) exits fullscreen, so Esc can always peel the fullscreen layer — previously Tab-away left fullscreen on with no key path out. A fast Esc-Esc mash that the terminal decoder coalesces into one `alt+esc` now folds to `esc` instead of being dropped.