### PR TITLE
feat(leet): persisted per-view pane layout overrides

### DIFF
--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -40,6 +40,9 @@ const (
 	// Chart grid size constraints.
 	MinGridSize, MaxGridSize = 1, 9
 
+	// Layout override fractions are clamped to this range when set.
+	MinLayoutFrac, MaxLayoutFrac = 0.05, 0.9
+
 	ColorModePerPlot   = "per_plot"   // Each chart gets next color
 	ColorModePerSeries = "per_series" // All charts use base color, multi-series differentiate
 
@@ -90,6 +93,11 @@ type Config struct {
 
 	// SymonGrid is the dimensions for the standalone system monitor chart grid.
 	SymonGrid GridConfig `json:"symon_grid" leet:"desc=standalone system metrics grid"`
+
+	// Mouse-dragged pane proportions per view. Managed by drag-resize and
+	// the "0" reset key, not the config editor.
+	RunLayout       LayoutOverrides `json:"run_layout,omitzero"       leet:"-"`
+	WorkspaceLayout LayoutOverrides `json:"workspace_layout,omitzero" leet:"-"`
 
 	// ColorScheme is the color scheme to display the main metrics.
 	ColorScheme string `json:"color_scheme" leet:"desc=Palette for main run metrics charts (and run list colors).,options=colorSchemes"`
@@ -147,6 +155,20 @@ type Config struct {
 type GridConfig struct {
 	Rows int `json:"rows" leet:"min=1,max=9"`
 	Cols int `json:"cols" leet:"min=1,max=9"`
+}
+
+// LayoutOverrides stores user-adjusted pane proportions for one view,
+// set by dragging pane boundaries with the mouse.
+//
+// Each value is a fraction of the terminal width (sidebars) or height
+// (stacked panes). Zero means "use the built-in default". The JSON schema
+// matches leet-rs so both implementations can share wandb-leet.json.
+type LayoutOverrides struct {
+	LeftSidebar  float64 `json:"left_sidebar,omitempty"`
+	RightSidebar float64 `json:"right_sidebar,omitempty"`
+	System       float64 `json:"system,omitempty"`
+	Media        float64 `json:"media,omitempty"`
+	Logs         float64 `json:"logs,omitempty"`
 }
 
 // ConfigManager manages application configuration with thread-safe access
@@ -316,6 +338,20 @@ func (cm *ConfigManager) normalizeConfig() {
 	if cm.config.StartupMode != StartupModeWorkspaceLatest &&
 		cm.config.StartupMode != StartupModeSingleRunLatest {
 		cm.config.StartupMode = DefaultStartupMode
+	}
+
+	normalizeLayoutOverrides(&cm.config.RunLayout)
+	normalizeLayoutOverrides(&cm.config.WorkspaceLayout)
+}
+
+// normalizeLayoutOverrides clamps set (non-zero) fractions to a sane range.
+func normalizeLayoutOverrides(o *LayoutOverrides) {
+	for _, f := range []*float64{
+		&o.LeftSidebar, &o.RightSidebar, &o.System, &o.Media, &o.Logs,
+	} {
+		if *f != 0 {
+			*f = min(max(*f, MinLayoutFrac), MaxLayoutFrac)
+		}
 	}
 }
 
@@ -558,6 +594,38 @@ func (cm *ConfigManager) SetSymonCols(cols int) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config.SymonGrid.Cols = cols
+	return cm.save()
+}
+
+// RunLayout returns the single-run view's layout overrides.
+func (cm *ConfigManager) RunLayout() LayoutOverrides {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.config.RunLayout
+}
+
+// SetRunLayout sets and persists the single-run view's layout overrides.
+func (cm *ConfigManager) SetRunLayout(o LayoutOverrides) error {
+	normalizeLayoutOverrides(&o)
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.config.RunLayout = o
+	return cm.save()
+}
+
+// WorkspaceLayout returns the workspace view's layout overrides.
+func (cm *ConfigManager) WorkspaceLayout() LayoutOverrides {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.config.WorkspaceLayout
+}
+
+// SetWorkspaceLayout sets and persists the workspace view's layout overrides.
+func (cm *ConfigManager) SetWorkspaceLayout(o LayoutOverrides) error {
+	normalizeLayoutOverrides(&o)
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.config.WorkspaceLayout = o
 	return cm.save()
 }
 

--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -261,13 +262,13 @@ func (cm *ConfigManager) loadOrCreateConfig() error {
 		return err
 	}
 
-	if err := json.Unmarshal(data, &cm.config); err != nil {
-		return err
-	}
+	err = json.Unmarshal(data, &cm.config)
 
+	// Unmarshal decodes what it can before failing, and the caller keeps
+	// the partial config, so normalize even on error.
 	cm.normalizeConfig()
 
-	return nil
+	return err
 }
 
 // normalizeConfig ensures all config values are within valid ranges.
@@ -345,11 +346,15 @@ func (cm *ConfigManager) normalizeConfig() {
 }
 
 // normalizeLayoutOverrides clamps set (non-zero) fractions to a sane range.
+// NaN would defeat the clamp (min/max propagate it) and later poison every
+// config save (encoding/json rejects NaN), so it resets to the default.
 func normalizeLayoutOverrides(o *LayoutOverrides) {
 	for _, f := range []*float64{
 		&o.LeftSidebar, &o.RightSidebar, &o.System, &o.Media, &o.Logs,
 	} {
-		if *f != 0 {
+		if math.IsNaN(*f) {
+			*f = 0
+		} else if *f != 0 {
 			*f = min(max(*f, MinLayoutFrac), MaxLayoutFrac)
 		}
 	}

--- a/core/internal/leet/config_test.go
+++ b/core/internal/leet/config_test.go
@@ -83,6 +83,46 @@ func TestConfig_SetLeftSidebarVisible_AffectsModelOnStartup(t *testing.T) {
 	require.True(t, model.TestLeftSidebarVisible())
 }
 
+func TestConfig_SetRunLayout_PersistsAndReloads(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	path := filepath.Join(t.TempDir(), "config.json")
+	cfg := leet.NewConfigManager(path, logger)
+
+	want := leet.LayoutOverrides{LeftSidebar: 0.3, Media: 0.25}
+	require.NoError(t, cfg.SetRunLayout(want))
+	require.Equal(t, want, cfg.RunLayout())
+
+	// A fresh manager reads the same overrides back from disk.
+	reloaded := leet.NewConfigManager(path, logger)
+	require.Equal(t, want, reloaded.RunLayout())
+	require.Equal(t, leet.LayoutOverrides{}, reloaded.WorkspaceLayout())
+}
+
+func TestConfig_SetWorkspaceLayout_ClampsFractions(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	require.NoError(t, cfg.SetWorkspaceLayout(leet.LayoutOverrides{
+		LeftSidebar: 0.001, // below the minimum
+		Logs:        1.5,   // above the maximum
+	}))
+
+	got := cfg.WorkspaceLayout()
+	require.Equal(t, leet.MinLayoutFrac, got.LeftSidebar)
+	require.Equal(t, leet.MaxLayoutFrac, got.Logs)
+	// Unset fractions stay zero ("use default") rather than being clamped.
+	require.Zero(t, got.Media)
+}
+
+func TestConfig_SetRunLayout_ZeroValueResets(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{RightSidebar: 0.4}))
+	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{}))
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
+}
+
 func TestConfig_SetTagColorScheme_Persists(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	path := filepath.Join(t.TempDir(), "config.json")

--- a/core/internal/leet/config_test.go
+++ b/core/internal/leet/config_test.go
@@ -116,15 +116,6 @@ func TestConfig_SetWorkspaceLayout_ClampsFractions(t *testing.T) {
 	require.Zero(t, got.Media)
 }
 
-func TestConfig_SetRunLayout_ZeroValueResets(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-
-	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{RightSidebar: 0.4}))
-	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{}))
-	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
-}
-
 func TestConfig_SetTagColorScheme_Persists(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	path := filepath.Join(t.TempDir(), "config.json")

--- a/core/internal/leet/config_test.go
+++ b/core/internal/leet/config_test.go
@@ -1,6 +1,8 @@
 package leet_test
 
 import (
+	"math"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -169,4 +171,32 @@ func TestConfig_SetFrenchFriesColorScheme_Persists(t *testing.T) {
 
 	cfg2 := leet.NewConfigManager(path, logger)
 	require.Equal(t, "cividis", cfg2.Snapshot().FrenchFriesColorScheme)
+}
+
+// Regression: a config file where one unrelated field fails to decode used to
+// skip normalization entirely, letting out-of-range override fractions
+// through unclamped.
+func TestConfig_PartialDecodeStillClampsOverrides(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"run_layout":{"media":5.0},"color_scheme":123}`), 0o644))
+
+	cfg := leet.NewConfigManager(path, logger)
+	require.LessOrEqual(t, cfg.RunLayout().Media, leet.MaxLayoutFrac,
+		"fractions must be clamped even when another field fails to decode")
+}
+
+// NaN would defeat the clamp and poison every subsequent save (encoding/json
+// rejects NaN); it resets to the default instead.
+func TestConfig_SetRunLayoutRejectsNaN(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	path := filepath.Join(t.TempDir(), "config.json")
+	cfg := leet.NewConfigManager(path, logger)
+
+	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{Media: math.NaN()}))
+	require.Zero(t, cfg.RunLayout().Media)
+
+	// Later unrelated saves keep working.
+	require.NoError(t, cfg.SetLeftSidebarVisible(false))
 }

--- a/core/internal/leet/flexlayout.go
+++ b/core/internal/leet/flexlayout.go
@@ -132,6 +132,51 @@ func expandedSidebarWidth(terminalWidth int, oppositeVisible bool, frac float64)
 	return clamp(int(float64(terminalWidth)*ratio), SidebarMinWidth, SidebarMaxWidth)
 }
 
+// minFlexMetricsHeight is the shortest the flex metrics section can be
+// squeezed to by the fixed panes below it.
+const minFlexMetricsHeight = 5
+
+// fitSidebarFractions clamps sidebar override fractions so both expanded
+// sidebars together leave the main content column its minimum width. Only
+// overridden (non-zero) fractions are adjusted; the golden-ratio defaults
+// already fit jointly.
+func fitSidebarFractions(
+	width int,
+	leftVisible, rightVisible bool,
+	leftFrac, rightFrac float64,
+) (float64, float64) {
+	if width <= 0 || !leftVisible || !rightVisible ||
+		(leftFrac <= 0 && rightFrac <= 0) {
+		return leftFrac, rightFrac
+	}
+
+	leftW := expandedSidebarWidth(width, true, leftFrac)
+	rightW := expandedSidebarWidth(width, true, rightFrac)
+	total := width - mainDragMinWidth
+	if leftW+rightW <= total {
+		return leftFrac, rightFrac
+	}
+
+	newLeft, newRight := leftW, rightW
+	switch {
+	case rightFrac <= 0: // Only the left override can shrink.
+		newLeft = total - rightW
+	case leftFrac <= 0: // Only the right override can shrink.
+		newRight = total - leftW
+	default: // Shrink both, proportionally.
+		newLeft = leftW * total / (leftW + rightW)
+		newRight = total - newLeft
+	}
+
+	if leftFrac > 0 {
+		leftFrac = float64(max(newLeft, sidebarDragMinWidth)) / float64(width)
+	}
+	if rightFrac > 0 {
+		rightFrac = float64(max(newRight, sidebarDragMinWidth)) / float64(width)
+	}
+	return leftFrac, rightFrac
+}
+
 // paneHeightFor returns a stacked pane's expanded height for the given
 // override fraction of the terminal height, or the fallback default when no
 // override is set. The pane's own SetExpandedHeight enforces its minimum.
@@ -140,6 +185,47 @@ func paneHeightFor(frac float64, terminalHeight, fallback int) int {
 		return fallback
 	}
 	return int(math.Round(float64(terminalHeight) * frac))
+}
+
+// fitStackHeights lowers the fixed stacked panes' heights to fit budget so
+// overridden panes cannot crowd out the flex metrics section or overflow
+// the stack. Each pane gives up slack above its own minimum, proportionally
+// — the panes re-inflate anything below their minimums, which would
+// silently undo a plain proportional scale. When even the minimums exceed
+// the budget the panes keep their minimums (tiny-terminal degradation the
+// renderer crops).
+func fitStackHeights(heights, minimums []int, budget int) {
+	sum, slack := 0, 0
+	for i := range heights {
+		sum += heights[i]
+		slack += max(heights[i]-minimums[i], 0)
+	}
+	over := sum - max(budget, 0)
+	if over <= 0 {
+		return
+	}
+	if over >= slack {
+		for i := range heights {
+			heights[i] = min(heights[i], minimums[i])
+		}
+		return
+	}
+
+	left := over
+	for i := range heights {
+		cut := over * max(heights[i]-minimums[i], 0) / slack
+		heights[i] -= cut
+		left -= cut
+	}
+	// Integer-division dust: take the remainder from panes with slack.
+	for i := range heights {
+		if left == 0 {
+			break
+		}
+		cut := min(left, max(heights[i]-minimums[i], 0))
+		heights[i] -= cut
+		left -= cut
+	}
 }
 
 // sidebarContentWidth returns the width available for text content inside a

--- a/core/internal/leet/flexlayout.go
+++ b/core/internal/leet/flexlayout.go
@@ -1,6 +1,7 @@
 package leet
 
 import (
+	"math"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -102,12 +103,43 @@ func (l verticalStackLayout) Y(id stackSectionID) int {
 	return l.Sections[id].Y
 }
 
-func expandedSidebarWidth(terminalWidth int, oppositeVisible bool) int {
+const (
+	// sidebarDragMinWidth is the narrowest a sidebar override can make it.
+	// Deliberately smaller than SidebarMinWidth so users can shrink
+	// sidebars below the default clamp.
+	sidebarDragMinWidth = 20
+
+	// mainDragMinWidth is the narrowest the main content column can be
+	// squeezed to by a sidebar override.
+	mainDragMinWidth = 24
+)
+
+// expandedSidebarWidth returns a sidebar's expanded width: a user-dragged
+// fraction of the terminal width when set (non-zero), or the golden-ratio
+// default. Dragged widths may go below the default minimum but always leave
+// room for the main content column.
+func expandedSidebarWidth(terminalWidth int, oppositeVisible bool, frac float64) int {
+	if frac > 0 {
+		maxW := max(terminalWidth-mainDragMinWidth, sidebarDragMinWidth)
+		w := int(math.Round(float64(terminalWidth) * frac))
+		return clamp(w, sidebarDragMinWidth, maxW)
+	}
+
 	ratio := SidebarWidthRatio
 	if oppositeVisible {
 		ratio = SidebarWidthRatioBoth
 	}
 	return clamp(int(float64(terminalWidth)*ratio), SidebarMinWidth, SidebarMaxWidth)
+}
+
+// paneHeightFor returns a stacked pane's expanded height for the given
+// override fraction of the terminal height, or the fallback default when no
+// override is set. The pane's own SetExpandedHeight enforces its minimum.
+func paneHeightFor(frac float64, terminalHeight, fallback int) int {
+	if frac <= 0 {
+		return fallback
+	}
+	return int(math.Round(float64(terminalHeight) * frac))
 }
 
 // sidebarContentWidth returns the width available for text content inside a

--- a/core/internal/leet/flexlayout_test.go
+++ b/core/internal/leet/flexlayout_test.go
@@ -25,3 +25,59 @@ func TestPaneHeightFor(t *testing.T) {
 	require.Equal(t, 17, paneHeightFor(0, 60, 17))
 	require.Equal(t, 30, paneHeightFor(0.5, 60, 17))
 }
+
+func TestFitSidebarFractions(t *testing.T) {
+	// Jointly valid overrides pass through unchanged.
+	l, r := fitSidebarFractions(200, true, true, 0.3, 0.3)
+	require.Equal(t, 0.3, l)
+	require.Equal(t, 0.3, r)
+
+	// Defaults are never adjusted.
+	l, r = fitSidebarFractions(200, true, true, 0, 0)
+	require.Zero(t, l)
+	require.Zero(t, r)
+
+	// A lone override shrinks against the opposite default width.
+	l, r = fitSidebarFractions(200, true, true, 0.9, 0)
+	require.Zero(t, r)
+	lw := expandedSidebarWidth(200, true, l)
+	rw := expandedSidebarWidth(200, true, 0)
+	require.LessOrEqual(t, lw+rw, 200-mainDragMinWidth)
+
+	// Two fat overrides shrink to fit jointly.
+	l, r = fitSidebarFractions(200, true, true, 0.9, 0.9)
+	lw = expandedSidebarWidth(200, true, l)
+	rw = expandedSidebarWidth(200, true, r)
+	require.LessOrEqual(t, lw+rw, 200-mainDragMinWidth)
+
+	// A hidden side leaves the other side's override alone.
+	l, r = fitSidebarFractions(200, true, false, 0.9, 0.9)
+	require.Equal(t, 0.9, l)
+	require.Equal(t, 0.9, r)
+}
+
+func TestFitStackHeights(t *testing.T) {
+	// Within budget: untouched.
+	h := []int{10, 10}
+	fitStackHeights(h, []int{3, 3}, 30)
+	require.Equal(t, []int{10, 10}, h)
+
+	// Over budget: shrunk to exactly the budget, never below the minimums.
+	// The pane floors would re-inflate anything below them, so the fit must
+	// land on values SetExpandedHeight will keep.
+	h = []int{12, 12}
+	fitStackHeights(h, []int{10, 3}, 16)
+	require.Equal(t, 16, h[0]+h[1])
+	require.GreaterOrEqual(t, h[0], 10)
+	require.GreaterOrEqual(t, h[1], 3)
+
+	// Even the minimums exceed the budget: fall back to the minimums.
+	h = []int{25, 25}
+	fitStackHeights(h, []int{10, 3}, 5)
+	require.Equal(t, []int{10, 3}, h)
+
+	// Invisible panes (zero height) contribute nothing and stay zero.
+	h = []int{0, 25}
+	fitStackHeights(h, []int{10, 3}, 12)
+	require.Equal(t, []int{0, 12}, h)
+}

--- a/core/internal/leet/flexlayout_test.go
+++ b/core/internal/leet/flexlayout_test.go
@@ -1,0 +1,27 @@
+package leet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandedSidebarWidth(t *testing.T) {
+	// No override: golden-ratio default.
+	require.Equal(t, 76, expandedSidebarWidth(200, false, 0)) // 200 * 0.382
+	require.Equal(t, 47, expandedSidebarWidth(200, true, 0))  // 200 * 0.236
+
+	// Override fraction of terminal width.
+	require.Equal(t, 50, expandedSidebarWidth(200, false, 0.25))
+
+	// Overrides can go below the default minimum, but not the drag minimum.
+	require.Equal(t, sidebarDragMinWidth, expandedSidebarWidth(200, false, 0.05))
+
+	// The main content column keeps its minimum width.
+	require.Equal(t, 200-mainDragMinWidth, expandedSidebarWidth(200, false, 0.99))
+}
+
+func TestPaneHeightFor(t *testing.T) {
+	require.Equal(t, 17, paneHeightFor(0, 60, 17))
+	require.Equal(t, 30, paneHeightFor(0.5, 60, 17))
+}

--- a/core/internal/leet/rightsidebar.go
+++ b/core/internal/leet/rightsidebar.go
@@ -46,10 +46,15 @@ func NewRightSidebar(
 	}
 }
 
-// UpdateDimensions updates the right sidebar dimensions based on terminal width
-// and the visibility of the left sidebar.
-func (rs *RightSidebar) UpdateDimensions(terminalWidth int, leftSidebarVisible bool) {
-	rs.animState.SetExpanded(expandedSidebarWidth(terminalWidth, leftSidebarVisible))
+// UpdateDimensions updates the right sidebar dimensions based on terminal
+// width, the visibility of the left sidebar, and an optional user-dragged
+// width fraction (0 = default).
+func (rs *RightSidebar) UpdateDimensions(
+	terminalWidth int,
+	leftSidebarVisible bool,
+	widthFrac float64,
+) {
+	rs.animState.SetExpanded(expandedSidebarWidth(terminalWidth, leftSidebarVisible, widthFrac))
 
 	if gridWidth := sidebarContentWidth(rs.animState.Value()); gridWidth > 0 {
 		rs.metricsGrid.Resize(gridWidth, defaultSystemMetricsGridHeight)

--- a/core/internal/leet/rightsidebar_test.go
+++ b/core/internal/leet/rightsidebar_test.go
@@ -13,7 +13,7 @@ import (
 
 func expandRightSidebar(t *testing.T, rs *leet.RightSidebar, termWidth int, leftVisible bool) {
 	t.Helper()
-	rs.UpdateDimensions(termWidth, leftVisible)
+	rs.UpdateDimensions(termWidth, leftVisible, 0)
 	rs.Toggle()
 	time.Sleep(leet.AnimationDuration + 20*time.Millisecond)
 	rs.Update(leet.RightSidebarAnimationMsg{})
@@ -110,7 +110,7 @@ func TestRightSidebar_Update_ReturnsAnimationCmdWhileAnimating(t *testing.T) {
 	rs := leet.NewRightSidebar(cfg, &leet.Focus{}, logger)
 
 	// Start expansion; immediately update -> should get a continuation command.
-	rs.UpdateDimensions(120, false)
+	rs.UpdateDimensions(120, false, 0)
 	rs.Toggle()
 	_, cmd := rs.Update(leet.RightSidebarAnimationMsg{})
 	require.NotNil(t, cmd, "expected a continuation command while animating")

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -258,15 +258,36 @@ func (r *Run) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // handleWindowResize handles window resize messages.
 func (r *Run) handleWindowResize(msg tea.WindowSizeMsg) {
 	r.width, r.height = msg.Width, msg.Height
+	r.applyLayoutConfig()
+	r.focusMgr.Resolve()
+}
 
-	r.leftSidebar.UpdateDimensions(msg.Width, r.rightSidebar.animState.TargetVisible())
-	r.rightSidebar.UpdateDimensions(msg.Width, r.leftSidebar.animState.TargetVisible())
+// applyLayoutConfig re-derives all pane extents from the terminal size and
+// any saved layout overrides.
+func (r *Run) applyLayoutConfig() {
+	r.updateSidebarDimensions(
+		r.leftSidebar.animState.TargetVisible(),
+		r.rightSidebar.animState.TargetVisible(),
+	)
 	r.updateBottomPaneHeights(
 		r.mediaPane.animState.TargetVisible(), r.consoleLogsPane.animState.TargetVisible())
 
 	layout := r.computeViewports()
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
-	r.focusMgr.Resolve()
+}
+
+// layoutOverrides returns the view's saved pane proportions.
+func (r *Run) layoutOverrides() LayoutOverrides {
+	return r.config.RunLayout()
+}
+
+// updateSidebarDimensions re-derives both sidebars' expanded widths from the
+// terminal width, the given post-toggle visibility of each side, and the
+// layout overrides.
+func (r *Run) updateSidebarDimensions(leftVisible, rightVisible bool) {
+	o := r.layoutOverrides()
+	r.leftSidebar.UpdateDimensions(r.width, rightVisible, o.LeftSidebar)
+	r.rightSidebar.UpdateDimensions(r.width, leftVisible, o.RightSidebar)
 }
 
 // isUIMsg returns true for messages that should flow to child view models.
@@ -694,12 +715,13 @@ func (r *Run) updateBottomPaneHeights(mediaVisible, logsVisible bool) {
 		lowerTierH = maxH
 	}
 
+	o := r.layoutOverrides()
 	each := lowerTierH / lowerCount
 	if mediaVisible {
-		r.mediaPane.SetExpandedHeight(each)
+		r.mediaPane.SetExpandedHeight(paneHeightFor(o.Media, r.height, each))
 	}
 	if logsVisible {
-		r.consoleLogsPane.SetExpandedHeight(each)
+		r.consoleLogsPane.SetExpandedHeight(paneHeightFor(o.Logs, r.height, each))
 	}
 }
 

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -286,8 +286,10 @@ func (r *Run) layoutOverrides() LayoutOverrides {
 // layout overrides.
 func (r *Run) updateSidebarDimensions(leftVisible, rightVisible bool) {
 	o := r.layoutOverrides()
-	r.leftSidebar.UpdateDimensions(r.width, rightVisible, o.LeftSidebar)
-	r.rightSidebar.UpdateDimensions(r.width, leftVisible, o.RightSidebar)
+	left, right := fitSidebarFractions(
+		r.width, leftVisible, rightVisible, o.LeftSidebar, o.RightSidebar)
+	r.leftSidebar.UpdateDimensions(r.width, rightVisible, left)
+	r.rightSidebar.UpdateDimensions(r.width, leftVisible, right)
 }
 
 // isUIMsg returns true for messages that should flow to child view models.
@@ -717,11 +719,27 @@ func (r *Run) updateBottomPaneHeights(mediaVisible, logsVisible bool) {
 
 	o := r.layoutOverrides()
 	each := lowerTierH / lowerCount
+	heights := []int{
+		paneHeightFor(o.Media, r.height, each),
+		paneHeightFor(o.Logs, r.height, each),
+	}
+	budget := maxH
+	if metricsVisible {
+		budget = maxH - minFlexMetricsHeight
+	}
+	if !mediaVisible {
+		heights[0] = 0
+	}
+	if !logsVisible {
+		heights[1] = 0
+	}
+	fitStackHeights(heights,
+		[]int{mediaPaneMinHeight, ConsoleLogsPaneMinHeight}, budget)
 	if mediaVisible {
-		r.mediaPane.SetExpandedHeight(paneHeightFor(o.Media, r.height, each))
+		r.mediaPane.SetExpandedHeight(heights[0])
 	}
 	if logsVisible {
-		r.consoleLogsPane.SetExpandedHeight(paneHeightFor(o.Logs, r.height, each))
+		r.consoleLogsPane.SetExpandedHeight(heights[1])
 	}
 }
 

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -390,8 +390,7 @@ func (r *Run) handleToggleLeftSidebar(msg tea.KeyPressMsg) tea.Cmd {
 		r.logger.Error(fmt.Sprintf("model: failed to save left sidebar state: %v", err))
 	}
 
-	r.leftSidebar.UpdateDimensions(r.width, r.rightSidebar.animState.TargetVisible())
-	r.rightSidebar.UpdateDimensions(r.width, leftWillBeVisible)
+	r.updateSidebarDimensions(leftWillBeVisible, r.rightSidebar.animState.TargetVisible())
 	r.leftSidebar.Toggle()
 
 	r.focusMgr.Resolve()
@@ -413,8 +412,7 @@ func (r *Run) handleToggleRightSidebar(msg tea.KeyPressMsg) tea.Cmd {
 		r.logger.Error(fmt.Sprintf("model: failed to save right sidebar state: %v", err))
 	}
 
-	r.rightSidebar.UpdateDimensions(r.width, r.leftSidebar.animState.TargetVisible())
-	r.leftSidebar.UpdateDimensions(r.width, rightWillBeVisible)
+	r.updateSidebarDimensions(r.leftSidebar.animState.TargetVisible(), rightWillBeVisible)
 	r.rightSidebar.Toggle()
 	r.focusMgr.Resolve()
 
@@ -691,7 +689,8 @@ func (r *Run) handleSidebarAnimation(msg tea.Msg) []tea.Cmd {
 		}
 
 		r.endAnimating()
-		r.rightSidebar.UpdateDimensions(r.width, r.leftSidebar.animState.TargetVisible())
+		r.rightSidebar.UpdateDimensions(
+			r.width, r.leftSidebar.animState.TargetVisible(), r.layoutOverrides().RightSidebar)
 
 	case RightSidebarAnimationMsg:
 		layout := r.computeViewports()
@@ -702,7 +701,8 @@ func (r *Run) handleSidebarAnimation(msg tea.Msg) []tea.Cmd {
 		}
 
 		r.endAnimating()
-		r.leftSidebar.UpdateDimensions(r.width, r.rightSidebar.animState.TargetVisible())
+		r.leftSidebar.UpdateDimensions(
+			r.width, r.rightSidebar.animState.TargetVisible(), r.layoutOverrides().LeftSidebar)
 	}
 
 	return nil

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -509,3 +509,38 @@ func TestRun_EscBeforeSeedStopsDataFromStealingFocus(t *testing.T) {
 	require.False(t, r.HasPaneFocus(),
 		"data after an explicit unfocus must not re-seed focus")
 }
+
+// Regression: individually legal pane-height overrides (media 0.5 + logs 0.5)
+// used to overflow the terminal vertically, pushing the status bar off-screen
+// and desyncing mouse hit-testing from the rendered rows.
+func TestRun_StackOverridesNeverOverflowFrame(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+	_ = cfg.SetLeftSidebarVisible(false)
+	_ = cfg.SetRightSidebarVisible(false)
+	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{Media: 0.5, Logs: 0.5}))
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+	})
+
+	// The short terminal exercises the interplay with the panes' own
+	// minimum heights, which re-inflate a naive proportional fit.
+	for _, height := range []int{50, 24} {
+		r.Update(tea.WindowSizeMsg{Width: 120, Height: height})
+
+		lines := strings.Split(r.View().Content, "\n")
+		require.LessOrEqual(t, len(lines), height,
+			"the rendered frame must never be taller than the terminal (h=%d)", height)
+
+		metrics, _, _ := r.TestStackHeights()
+		require.GreaterOrEqual(t, metrics, 5, // minFlexMetricsHeight
+			"overridden fixed panes must not squeeze the metrics section out (h=%d)", height)
+	}
+}

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -556,3 +556,38 @@ func TestRun_EscBeforeSeedStopsDataFromStealingFocus(t *testing.T) {
 	require.False(t, r.HasPaneFocus(),
 		"data after an explicit unfocus must not re-seed focus")
 }
+
+// Regression: individually legal pane-height overrides (media 0.5 + logs 0.5)
+// used to overflow the terminal vertically, pushing the status bar off-screen
+// and desyncing mouse hit-testing from the rendered rows.
+func TestRun_StackOverridesNeverOverflowFrame(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+	_ = cfg.SetLeftSidebarVisible(false)
+	_ = cfg.SetRightSidebarVisible(false)
+	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{Media: 0.5, Logs: 0.5}))
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
+	r.TestHandleRecordMsg(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"loss": {X: []float64{1, 2}, Y: []float64{0.5, 0.4}},
+		},
+	})
+
+	// The short terminal exercises the interplay with the panes' own
+	// minimum heights, which re-inflate a naive proportional fit.
+	for _, height := range []int{50, 24} {
+		r.Update(tea.WindowSizeMsg{Width: 120, Height: height})
+
+		lines := strings.Split(r.View().Content, "\n")
+		require.LessOrEqual(t, len(lines), height,
+			"the rendered frame must never be taller than the terminal (h=%d)", height)
+
+		metrics, _, _ := r.TestStackHeights()
+		require.GreaterOrEqual(t, metrics, 5, // minFlexMetricsHeight
+			"overridden fixed panes must not squeeze the metrics section out (h=%d)", height)
+	}
+}

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -514,15 +514,13 @@ func TestRun_EscBeforeSeedStopsDataFromStealingFocus(t *testing.T) {
 // used to overflow the terminal vertically, pushing the status bar off-screen
 // and desyncing mouse hit-testing from the rendered rows.
 func TestRun_StackOverridesNeverOverflowFrame(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetMediaVisible(true)
-	_ = cfg.SetConsoleLogsVisible(true)
-	_ = cfg.SetLeftSidebarVisible(false)
-	_ = cfg.SetRightSidebarVisible(false)
-	require.NoError(t, cfg.SetRunLayout(leet.LayoutOverrides{Media: 0.5, Logs: 0.5}))
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r, _ := newTestRun(t, 120, 50, func(c *leet.ConfigManager) {
+		_ = c.SetMediaVisible(true)
+		_ = c.SetConsoleLogsVisible(true)
+		_ = c.SetLeftSidebarVisible(false)
+		_ = c.SetRightSidebarVisible(false)
+		require.NoError(t, c.SetRunLayout(leet.LayoutOverrides{Media: 0.5, Logs: 0.5}))
+	})
 	r.TestHandleRecordMsg(leet.RunMsg{ID: "abc123", Project: "test-project"})
 	r.TestHandleRecordMsg(leet.HistoryMsg{
 		Metrics: map[string]leet.MetricData{

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -209,10 +209,15 @@ func (s *RunOverviewSidebar) Sync() {
 	}
 }
 
-// UpdateDimensions updates the sidebar dimensions based on terminal width
-// and the visibility of the sidebar on the opposite side.
-func (s *RunOverviewSidebar) UpdateDimensions(terminalWidth int, oppositeSidebarVisible bool) {
-	s.animState.SetExpanded(expandedSidebarWidth(terminalWidth, oppositeSidebarVisible))
+// UpdateDimensions updates the sidebar dimensions based on terminal width,
+// the visibility of the sidebar on the opposite side, and an optional
+// user-dragged width fraction (0 = default).
+func (s *RunOverviewSidebar) UpdateDimensions(
+	terminalWidth int,
+	oppositeSidebarVisible bool,
+	widthFrac float64,
+) {
+	s.animState.SetExpanded(expandedSidebarWidth(terminalWidth, oppositeSidebarVisible, widthFrac))
 }
 
 // Width returns the current width of the sidebar.

--- a/core/internal/leet/runoverviewsidebar_test.go
+++ b/core/internal/leet/runoverviewsidebar_test.go
@@ -101,7 +101,7 @@ func TestSidebar_ConfirmSummaryFilterSelectsSummary(t *testing.T) {
 
 func expandSidebar(t *testing.T, s *leet.RunOverviewSidebar, termWidth int, rightVisible bool) {
 	t.Helper()
-	s.UpdateDimensions(termWidth, rightVisible)
+	s.UpdateDimensions(termWidth, rightVisible, 0)
 	s.Toggle()
 	time.Sleep(leet.AnimationDuration + 20*time.Millisecond)
 	// Drive animation to completion.

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -563,8 +563,10 @@ func (w *Workspace) layoutOverrides() LayoutOverrides {
 // overrides.
 func (w *Workspace) updateSidebarDimensions(leftVisible, rightVisible bool) {
 	o := w.layoutOverrides()
-	w.runsAnimState.SetExpanded(expandedSidebarWidth(w.width, rightVisible, o.LeftSidebar))
-	w.runOverviewSidebar.UpdateDimensions(w.width, leftVisible, o.RightSidebar)
+	left, right := fitSidebarFractions(
+		w.width, leftVisible, rightVisible, o.LeftSidebar, o.RightSidebar)
+	w.runsAnimState.SetExpanded(expandedSidebarWidth(w.width, rightVisible, left))
+	w.runOverviewSidebar.UpdateDimensions(w.width, leftVisible, right)
 }
 
 func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisible bool) {
@@ -610,14 +612,35 @@ func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisibl
 
 	o := w.layoutOverrides()
 	each := lowerTierH / lowerCount
+	heights := []int{
+		paneHeightFor(o.System, w.height, each),
+		paneHeightFor(o.Media, w.height, each),
+		paneHeightFor(o.Logs, w.height, each),
+	}
+	budget := maxH
+	if metricsVisible {
+		budget = maxH - minFlexMetricsHeight
+	}
+	if !sysVisible {
+		heights[0] = 0
+	}
+	if !mediaVisible {
+		heights[1] = 0
+	}
+	if !logsVisible {
+		heights[2] = 0
+	}
+	fitStackHeights(heights, []int{
+		systemMetricsPaneMinHeight, mediaPaneMinHeight, ConsoleLogsPaneMinHeight,
+	}, budget)
 	if sysVisible {
-		w.systemMetricsPane.SetExpandedHeight(paneHeightFor(o.System, w.height, each))
+		w.systemMetricsPane.SetExpandedHeight(heights[0])
 	}
 	if mediaVisible {
-		w.mediaPane.SetExpandedHeight(paneHeightFor(o.Media, w.height, each))
+		w.mediaPane.SetExpandedHeight(heights[1])
 	}
 	if logsVisible {
-		w.consoleLogsPane.SetExpandedHeight(paneHeightFor(o.Logs, w.height, each))
+		w.consoleLogsPane.SetExpandedHeight(heights[2])
 	}
 }
 

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -553,11 +553,18 @@ func (w *Workspace) computeViewports() Layout {
 	}
 }
 
+// layoutOverrides returns the view's saved pane proportions.
+func (w *Workspace) layoutOverrides() LayoutOverrides {
+	return w.config.WorkspaceLayout()
+}
+
 // updateSidebarDimensions tells both sidebars to recalculate their expanded
-// widths given the post-toggle visibility of each side.
+// widths given the post-toggle visibility of each side and the layout
+// overrides.
 func (w *Workspace) updateSidebarDimensions(leftVisible, rightVisible bool) {
-	w.runsAnimState.SetExpanded(expandedSidebarWidth(w.width, rightVisible))
-	w.runOverviewSidebar.UpdateDimensions(w.width, leftVisible)
+	o := w.layoutOverrides()
+	w.runsAnimState.SetExpanded(expandedSidebarWidth(w.width, rightVisible, o.LeftSidebar))
+	w.runOverviewSidebar.UpdateDimensions(w.width, leftVisible, o.RightSidebar)
 }
 
 func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisible bool) {
@@ -601,15 +608,16 @@ func (w *Workspace) updateBottomPaneHeights(sysVisible, mediaVisible, logsVisibl
 		lowerTierH = maxH
 	}
 
+	o := w.layoutOverrides()
 	each := lowerTierH / lowerCount
 	if sysVisible {
-		w.systemMetricsPane.SetExpandedHeight(each)
+		w.systemMetricsPane.SetExpandedHeight(paneHeightFor(o.System, w.height, each))
 	}
 	if mediaVisible {
-		w.mediaPane.SetExpandedHeight(each)
+		w.mediaPane.SetExpandedHeight(paneHeightFor(o.Media, w.height, each))
 	}
 	if logsVisible {
-		w.consoleLogsPane.SetExpandedHeight(each)
+		w.consoleLogsPane.SetExpandedHeight(paneHeightFor(o.Logs, w.height, each))
 	}
 }
 
@@ -772,6 +780,12 @@ func (w *Workspace) cycleOverviewSection(direction int) bool {
 // handleWindowResize handles window resize messages.
 func (w *Workspace) handleWindowResize(width, height int) {
 	w.SetSize(width, height)
+	w.applyLayoutConfig()
+}
+
+// applyLayoutConfig re-derives all pane extents from the terminal size and
+// any saved layout overrides.
+func (w *Workspace) applyLayoutConfig() {
 	w.updateSidebarDimensions(
 		w.runsAnimState.TargetVisible(),
 		w.runOverviewSidebar.animState.TargetVisible(),


### PR DESCRIPTION
Description
-----------
Part of the stack replacing #12169.

Add `LayoutOverrides` to the config: per-view fractions of the terminal size for the sidebars and the stacked panes (system/media/logs), stored under `run_layout` / `workspace_layout` in `wandb-leet.json`. Zero means "use the built-in default"; set values are clamped on load and write. The JSON schema matches leet-rs so both implementations share the file.

Sidebar widths and stacked-pane heights now flow through the overrides (`expandedSidebarWidth` gains a fraction parameter; pane heights go through `paneHeightFor`), and each view re-derives its layout from config in one place, `applyLayoutConfig`. The fields are hidden from the config editor (`leet:"-"`).

Overrides are also **clamped jointly**, not just per pane: `fitSidebarFractions` shrinks overridden sidebar fractions so both sidebars leave the main column its minimum width, and `fitStackHeights` scales the fixed stacked panes to a budget that always leaves the flex metrics section its minimum height — hand-edited configs like two 0.9 sidebars or media 0.5 + logs 0.5 can no longer overflow the terminal. Config load is hardened for the same reason: values are normalized even when an unrelated field fails to decode (`json.Unmarshal` partially decodes before erroring), and NaN — which defeats min/max clamps and would poison every subsequent save — resets to the default.

Mouse drag-resize lands on top of this in the next PR of the stack.