### PR TITLE
feat(leet): mouse-drag pane resizing, 0 resets

### DIFF
--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -98,6 +98,10 @@ func (d *paneDragger) handleMouse(msg tea.MouseMsg, layout Layout, t dragTargets
 		}
 		drag, ok := boundaryAt(m.X, m.Y, t.width, layout, t.leftExpanded, t.rightExpanded)
 		if !ok || (drag.boundary == dragBoundarySeparator && t.mediaFullscreen) {
+			// A stale latch survives when the matching release never
+			// reached this view (help overlay, view switch); any new
+			// press that misses a boundary clears it.
+			d.drag = layoutDrag{}
 			return false
 		}
 		drag.overrides = d.saved()
@@ -115,6 +119,10 @@ func (d *paneDragger) handleMouse(msg tea.MouseMsg, layout Layout, t dragTargets
 		if !d.drag.active() {
 			return false
 		}
+		// Legacy X10 mouse encoding reports every release as MouseNone.
+		if m.Button != tea.MouseLeft && m.Button != tea.MouseNone {
+			return false
+		}
 		d.finish()
 		return true
 	}
@@ -129,17 +137,29 @@ func (d *paneDragger) apply(x, y int, layout Layout, t dragTargets) {
 	switch d.drag.boundary {
 	case dragBoundaryLeftSidebar:
 		maxW := t.width - layout.rightSidebarWidth - mainDragMinWidth
+		if maxW < sidebarDragMinWidth {
+			return // No legal width at this terminal size.
+		}
 		w := clamp(x+1, sidebarDragMinWidth, maxW)
 		o.LeftSidebar = float64(w) / float64(t.width)
 	case dragBoundaryRightSidebar:
 		maxW := t.width - layout.leftSidebarWidth - mainDragMinWidth
+		if maxW < sidebarDragMinWidth {
+			return // No legal width at this terminal size.
+		}
 		w := clamp(t.width-x, sidebarDragMinWidth, maxW)
 		o.RightSidebar = float64(w) / float64(t.width)
 	case dragBoundarySeparator:
+		if t.mediaFullscreen {
+			return // Fullscreen entered mid-drag hides the stack.
+		}
 		if !dragSeparator(o, layout, d.drag.section, y, t.height) {
 			return
 		}
 	}
+	// Live values obey the same bounds as the persisted config, so the
+	// layout cannot snap when the drag is released and re-derived.
+	normalizeLayoutOverrides(o)
 	d.drag.dirty = true
 	d.relayout()
 }
@@ -156,8 +176,10 @@ func (d *paneDragger) finish() {
 	}
 }
 
-// reset restores and persists the view's default pane proportions.
+// reset restores and persists the view's default pane proportions,
+// cancelling any in-flight drag so its release cannot overwrite the reset.
 func (d *paneDragger) reset() {
+	d.drag = layoutDrag{}
 	if err := d.persist(LayoutOverrides{}); err != nil {
 		d.logger.Error(fmt.Sprintf("leet: failed to save layout: %v", err))
 	}

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -1,0 +1,269 @@
+package leet
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+// Mouse-drag pane resizing.
+//
+// A left-click exactly on a sidebar's border column or on the separator row
+// above a stacked pane latches a drag. Mouse motion resizes the pane live;
+// release persists the new proportion (a fraction of the terminal dimension)
+// to the per-view LayoutOverrides in wandb-leet.json. The "0" key resets a
+// view's overrides to the golden-ratio defaults.
+//
+// The run and workspace views share this state machine through paneDragger;
+// each view wires in its own config accessors and re-layout hook.
+
+// dragBoundary identifies a draggable layout boundary.
+type dragBoundary int
+
+const (
+	dragBoundaryNone dragBoundary = iota
+	dragBoundaryLeftSidebar
+	dragBoundaryRightSidebar
+	dragBoundarySeparator
+)
+
+// layoutDrag tracks an in-progress boundary drag.
+//
+// overrides accumulates the view's pending layout fractions as the mouse
+// moves (a separator drag between two fixed panes updates two of them) and
+// is persisted once on mouse release. section is set for separator drags.
+type layoutDrag struct {
+	boundary  dragBoundary
+	section   stackSectionID
+	overrides LayoutOverrides
+	dirty     bool
+}
+
+func (d layoutDrag) active() bool { return d.boundary != dragBoundaryNone }
+
+// setSection records a stacked pane's height fraction.
+func (o *LayoutOverrides) setSection(id stackSectionID, frac float64) {
+	switch id {
+	case stackSectionSystemMetrics:
+		o.System = frac
+	case stackSectionMedia:
+		o.Media = frac
+	case stackSectionConsoleLogs:
+		o.Logs = frac
+	}
+}
+
+// dragTargets describes which boundaries are draggable for one mouse event:
+// the terminal size, whether each sidebar is stably expanded (a drag never
+// fights an animation), and whether the media pane is fullscreen (which
+// hides the separators).
+type dragTargets struct {
+	width, height               int
+	leftExpanded, rightExpanded bool
+	mediaFullscreen             bool
+}
+
+// paneDragger owns mouse-drag pane resizing for one view.
+//
+// saved/persist read and write the view's LayoutOverrides in the config;
+// relayout re-derives the view's pane extents (the view's applyLayoutConfig,
+// which reads live overrides back through overrides()).
+type paneDragger struct {
+	drag layoutDrag
+
+	saved    func() LayoutOverrides
+	persist  func(LayoutOverrides) error
+	relayout func()
+	logger   *observability.CoreLogger
+}
+
+// overrides returns the live pane proportions: the in-progress drag's
+// pending values, or the persisted config.
+func (d *paneDragger) overrides() LayoutOverrides {
+	if d.drag.active() {
+		return d.drag.overrides
+	}
+	return d.saved()
+}
+
+// handleMouse processes a mouse event for pane-boundary resizing. It returns
+// true when the event was consumed by an active or new drag.
+func (d *paneDragger) handleMouse(msg tea.MouseMsg, layout Layout, t dragTargets) bool {
+	switch m := msg.(type) {
+	case tea.MouseClickMsg:
+		if m.Button != tea.MouseLeft {
+			return false
+		}
+		drag, ok := boundaryAt(m.X, m.Y, t.width, layout, t.leftExpanded, t.rightExpanded)
+		if !ok || (drag.boundary == dragBoundarySeparator && t.mediaFullscreen) {
+			return false
+		}
+		drag.overrides = d.saved()
+		d.drag = drag
+		return true
+
+	case tea.MouseMotionMsg:
+		if !d.drag.active() || m.Button != tea.MouseLeft {
+			return false
+		}
+		d.apply(m.X, m.Y, layout, t)
+		return true
+
+	case tea.MouseReleaseMsg:
+		if !d.drag.active() {
+			return false
+		}
+		d.finish()
+		return true
+	}
+	return false
+}
+
+// apply updates the pending overrides from the mouse position and re-lays
+// the view out from them. Sidebar drags are clamped so the main content
+// column keeps its minimum width against the opposite sidebar.
+func (d *paneDragger) apply(x, y int, layout Layout, t dragTargets) {
+	o := &d.drag.overrides
+	switch d.drag.boundary {
+	case dragBoundaryLeftSidebar:
+		maxW := t.width - layout.rightSidebarWidth - mainDragMinWidth
+		w := clamp(x+1, sidebarDragMinWidth, maxW)
+		o.LeftSidebar = float64(w) / float64(t.width)
+	case dragBoundaryRightSidebar:
+		maxW := t.width - layout.leftSidebarWidth - mainDragMinWidth
+		w := clamp(t.width-x, sidebarDragMinWidth, maxW)
+		o.RightSidebar = float64(w) / float64(t.width)
+	case dragBoundarySeparator:
+		if !dragSeparator(o, layout, d.drag.section, y, t.height) {
+			return
+		}
+	}
+	d.drag.dirty = true
+	d.relayout()
+}
+
+// finish persists the dragged proportions and ends the drag.
+func (d *paneDragger) finish() {
+	drag := d.drag
+	d.drag = layoutDrag{}
+	if !drag.dirty {
+		return // Click without motion: nothing changed.
+	}
+	if err := d.persist(drag.overrides); err != nil {
+		d.logger.Error(fmt.Sprintf("leet: failed to save layout: %v", err))
+	}
+}
+
+// reset restores and persists the view's default pane proportions.
+func (d *paneDragger) reset() {
+	if err := d.persist(LayoutOverrides{}); err != nil {
+		d.logger.Error(fmt.Sprintf("leet: failed to save layout: %v", err))
+	}
+	d.relayout()
+}
+
+// stackGeom describes one visible section of the central vertical stack.
+type stackGeom struct {
+	id   stackSectionID
+	y    int
+	h    int
+	minH int
+}
+
+// stackGeometry returns the visible central-column sections in top-to-bottom
+// order. Sections with zero height (hidden, or absent in this view) are
+// omitted, so the same code serves both the run and workspace layouts.
+func stackGeometry(layout Layout) []stackGeom {
+	all := []stackGeom{
+		{stackSectionMetrics, 0, layout.height, minFlexMetricsHeight},
+		{stackSectionSystemMetrics, layout.systemMetricsY,
+			layout.systemMetricsHeight, systemMetricsPaneMinHeight},
+		{stackSectionMedia, layout.mediaY, layout.mediaHeight, mediaPaneMinHeight},
+		{stackSectionConsoleLogs, layout.consoleLogsY,
+			layout.consoleLogsHeight, ConsoleLogsPaneMinHeight},
+	}
+	visible := all[:0]
+	for _, g := range all {
+		if g.h > 0 {
+			visible = append(visible, g)
+		}
+	}
+	return visible
+}
+
+// boundaryAt hit-tests a mouse position against the draggable boundaries:
+// the sidebars' border columns and the separator rows of the central stack.
+//
+// Sidebar borders are only draggable when the sidebar is stably expanded so
+// a drag never fights an animation.
+func boundaryAt(
+	x, y, width int,
+	layout Layout,
+	leftExpanded, rightExpanded bool,
+) (layoutDrag, bool) {
+	if y >= layout.totalContentAreaHeight {
+		return layoutDrag{}, false
+	}
+
+	if layout.leftSidebarWidth > 0 && leftExpanded &&
+		x == layout.leftSidebarWidth-1 {
+		return layoutDrag{boundary: dragBoundaryLeftSidebar}, true
+	}
+	if layout.rightSidebarWidth > 0 && rightExpanded &&
+		x == width-layout.rightSidebarWidth {
+		return layoutDrag{boundary: dragBoundaryRightSidebar}, true
+	}
+
+	// Separator rows span the central column only.
+	if x < layout.leftSidebarWidth || x >= width-layout.rightSidebarWidth {
+		return layoutDrag{}, false
+	}
+	sections := stackGeometry(layout)
+	for i := 1; i < len(sections); i++ {
+		if y == sections[i].y-1 {
+			return layoutDrag{
+				boundary: dragBoundarySeparator,
+				section:  sections[i].id,
+			}, true
+		}
+	}
+	return layoutDrag{}, false
+}
+
+// dragSeparator records in o the pane fractions for dragging the separator
+// above section to row y, clamped so both neighbors keep their minimum
+// heights. It reports whether o was updated.
+//
+// The pane below the separator keeps its bottom anchored. When the pane
+// above is another fixed pane, its fraction is updated too so the boundary
+// lands exactly on the mouse row; when it is the flex metrics section, the
+// flex absorbs the change instead.
+func dragSeparator(
+	o *LayoutOverrides,
+	layout Layout,
+	section stackSectionID,
+	y, terminalHeight int,
+) bool {
+	sections := stackGeometry(layout)
+	for i := 1; i < len(sections); i++ {
+		if sections[i].id != section {
+			continue
+		}
+		prev, sec := sections[i-1], sections[i]
+		bottom := sec.y + sec.h
+		lo, hi := prev.y+prev.minH, bottom-1-sec.minH
+		if lo > hi {
+			return false
+		}
+		y = clamp(y, lo, hi)
+
+		o.setSection(sec.id, float64(bottom-y-1)/float64(terminalHeight))
+		if prev.id != stackSectionMetrics {
+			o.setSection(prev.id, float64(y-prev.y)/float64(terminalHeight))
+		}
+		return true
+	}
+	return false
+}

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -215,8 +215,21 @@ func stackGeometry(layout Layout) []stackGeom {
 	return visible
 }
 
+// sidebarGrabTolerance widens each sidebar border's mouse target to the
+// adjacent column on either side. Terminals report cell-quantized mouse
+// coordinates, so a one-column target makes grabbing the border a matter
+// of sub-cell luck.
+const sidebarGrabTolerance = 1
+
+// nearColumn reports whether x is within sidebarGrabTolerance of col.
+func nearColumn(x, col int) bool {
+	d := x - col
+	return -sidebarGrabTolerance <= d && d <= sidebarGrabTolerance
+}
+
 // boundaryAt hit-tests a mouse position against the draggable boundaries:
-// the sidebars' border columns and the separator rows of the central stack.
+// the sidebars' border columns (with one column of tolerance either side)
+// and the separator rows of the central stack.
 //
 // Sidebar borders are only draggable when the sidebar is stably expanded so
 // a drag never fights an animation.
@@ -230,11 +243,11 @@ func boundaryAt(
 	}
 
 	if layout.leftSidebarWidth > 0 && leftExpanded &&
-		x == layout.leftSidebarWidth-1 {
+		nearColumn(x, layout.leftSidebarWidth-1) {
 		return layoutDrag{boundary: dragBoundaryLeftSidebar}, true
 	}
 	if layout.rightSidebarWidth > 0 && rightExpanded &&
-		x == width-layout.rightSidebarWidth {
+		nearColumn(x, width-layout.rightSidebarWidth) {
 		return layoutDrag{boundary: dragBoundaryRightSidebar}, true
 	}
 

--- a/core/internal/leet/dragresize_test.go
+++ b/core/internal/leet/dragresize_test.go
@@ -1,0 +1,144 @@
+package leet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testRunLayout mirrors a single-run view: metrics (flex) on top, media and
+// console logs stacked below, one separator row above each fixed pane.
+//
+//	y 0..29  metrics (30)
+//	y 30     separator
+//	y 31..50 media (20)
+//	y 51     separator
+//	y 52..61 logs (10)
+func testRunLayout() Layout {
+	return Layout{
+		leftSidebarWidth:       40,
+		mainContentAreaWidth:   100,
+		rightSidebarWidth:      60,
+		totalContentAreaHeight: 62,
+		height:                 30,
+		mediaY:                 31,
+		mediaHeight:            20,
+		consoleLogsY:           52,
+		consoleLogsHeight:      10,
+	}
+}
+
+func TestBoundaryAtSidebarBorders(t *testing.T) {
+	layout := testRunLayout()
+	const width = 200
+
+	// Left sidebar border column is the sidebar's last column.
+	drag, ok := boundaryAt(39, 5, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundaryLeftSidebar, drag.boundary)
+
+	// Right sidebar border column is its first column.
+	drag, ok = boundaryAt(width-60, 5, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundaryRightSidebar, drag.boundary)
+
+	// One column off is a miss.
+	_, ok = boundaryAt(38, 5, width, layout, true, true)
+	require.False(t, ok)
+	_, ok = boundaryAt(width-59, 5, width, layout, true, true)
+	require.False(t, ok)
+
+	// A collapsed/animating sidebar is not draggable.
+	_, ok = boundaryAt(39, 5, width, layout, false, true)
+	require.False(t, ok)
+
+	// The status bar area is off limits.
+	_, ok = boundaryAt(39, layout.totalContentAreaHeight, width, layout, true, true)
+	require.False(t, ok)
+}
+
+func TestBoundaryAtStackSeparators(t *testing.T) {
+	layout := testRunLayout()
+	const width = 200
+
+	// Separator above media.
+	drag, ok := boundaryAt(100, layout.mediaY-1, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundarySeparator, drag.boundary)
+	require.Equal(t, stackSectionMedia, drag.section)
+
+	// Separator above console logs.
+	drag, ok = boundaryAt(100, layout.consoleLogsY-1, width, layout, true, true)
+	require.True(t, ok)
+	require.Equal(t, dragBoundarySeparator, drag.boundary)
+	require.Equal(t, stackSectionConsoleLogs, drag.section)
+
+	// Separator rows are only draggable within the central column.
+	_, ok = boundaryAt(10, layout.mediaY-1, width, layout, true, true)
+	require.False(t, ok)
+	_, ok = boundaryAt(width-30, layout.mediaY-1, width, layout, true, true)
+	require.False(t, ok)
+
+	// Non-separator rows in the central column are misses.
+	_, ok = boundaryAt(100, layout.mediaY, width, layout, true, true)
+	require.False(t, ok)
+}
+
+// frac converts a pane extent to its terminal-dimension fraction.
+func frac(size, terminalSize int) float64 {
+	return float64(size) / float64(terminalSize)
+}
+
+func TestDragSeparatorBelowFlexResizesOnePane(t *testing.T) {
+	layout := testRunLayout()
+	const termH = 63 // content + status bar
+
+	// The pane above the media separator is the flex metrics grid, so only
+	// media resizes; dragging up by 5 rows grows it by 5.
+	var o LayoutOverrides
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, layout.mediaY-1-5, termH))
+	require.Equal(t, LayoutOverrides{Media: frac(layout.mediaHeight+5, termH)}, o)
+
+	// Dragging down by 5 shrinks media by 5.
+	o = LayoutOverrides{}
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, layout.mediaY-1+5, termH))
+	require.Equal(t, LayoutOverrides{Media: frac(layout.mediaHeight-5, termH)}, o)
+}
+
+func TestDragSeparatorBetweenFixedPanesResizesBoth(t *testing.T) {
+	layout := testRunLayout()
+	const termH = 63
+
+	// Media (fixed) sits above the console logs separator: dragging down by
+	// 3 rows grows media by 3 and shrinks logs by 3.
+	var o LayoutOverrides
+	require.True(t,
+		dragSeparator(&o, layout, stackSectionConsoleLogs, layout.consoleLogsY-1+3, termH))
+	require.Equal(t, LayoutOverrides{
+		Media: frac(layout.mediaHeight+3, termH),
+		Logs:  frac(layout.consoleLogsHeight-3, termH),
+	}, o)
+}
+
+func TestDragSeparatorClamps(t *testing.T) {
+	layout := testRunLayout()
+	const termH = 63
+
+	// Dragging far down clamps at the pane's min height.
+	var o LayoutOverrides
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, 1000, termH))
+	require.Equal(t, LayoutOverrides{Media: frac(mediaPaneMinHeight, termH)}, o)
+
+	// Dragging far up clamps so the section above keeps its min height.
+	o = LayoutOverrides{}
+	require.True(t, dragSeparator(&o, layout, stackSectionMedia, 0, termH))
+	mediaBottom := layout.mediaY + layout.mediaHeight
+	require.Equal(t,
+		LayoutOverrides{Media: frac(mediaBottom-minFlexMetricsHeight-1, termH)}, o)
+
+	// Unknown or top-most sections are not draggable.
+	o = LayoutOverrides{}
+	require.False(t, dragSeparator(&o, layout, stackSectionMetrics, 10, termH))
+	require.False(t, dragSeparator(&o, layout, stackSectionSystemMetrics, 10, termH))
+	require.Equal(t, LayoutOverrides{}, o)
+}

--- a/core/internal/leet/dragresize_test.go
+++ b/core/internal/leet/dragresize_test.go
@@ -32,20 +32,26 @@ func TestBoundaryAtSidebarBorders(t *testing.T) {
 	layout := testRunLayout()
 	const width = 200
 
-	// Left sidebar border column is the sidebar's last column.
-	drag, ok := boundaryAt(39, 5, width, layout, true, true)
-	require.True(t, ok)
-	require.Equal(t, dragBoundaryLeftSidebar, drag.boundary)
+	// The left sidebar's border is its last column; the border column and
+	// one column either side latch (mouse coordinates are cell-quantized,
+	// so a one-column target is luck-based).
+	for _, x := range []int{38, 39, 40} {
+		drag, ok := boundaryAt(x, 5, width, layout, true, true)
+		require.True(t, ok, "x=%d", x)
+		require.Equal(t, dragBoundaryLeftSidebar, drag.boundary)
+	}
 
-	// Right sidebar border column is its first column.
-	drag, ok = boundaryAt(width-60, 5, width, layout, true, true)
-	require.True(t, ok)
-	require.Equal(t, dragBoundaryRightSidebar, drag.boundary)
+	// The right sidebar's border is its first column, same tolerance.
+	for _, x := range []int{width - 61, width - 60, width - 59} {
+		drag, ok := boundaryAt(x, 5, width, layout, true, true)
+		require.True(t, ok, "x=%d", x)
+		require.Equal(t, dragBoundaryRightSidebar, drag.boundary)
+	}
 
-	// One column off is a miss.
-	_, ok = boundaryAt(38, 5, width, layout, true, true)
+	// Two columns off is a miss.
+	_, ok := boundaryAt(37, 5, width, layout, true, true)
 	require.False(t, ok)
-	_, ok = boundaryAt(width-59, 5, width, layout, true, true)
+	_, ok = boundaryAt(width-58, 5, width, layout, true, true)
 	require.False(t, ok)
 
 	// A collapsed/animating sidebar is not draggable.

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -75,6 +75,15 @@ func RunKeyBindings() []BindingCategory[Run] {
 					Description: "Toggle console logs panel",
 					Handler:     (*Run).handleToggleConsoleLogsPane,
 				},
+				{
+					Keys:        []string{"drag border/separator"},
+					Description: "Resize panes with the mouse",
+				},
+				{
+					Keys:        []string{"0"},
+					Description: "Reset pane sizes to defaults",
+					Handler:     (*Run).handleResetLayout,
+				},
 			},
 		},
 		{
@@ -272,6 +281,15 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 					Keys:        []string{"4"},
 					Description: "Toggle console logs panel",
 					Handler:     (*Workspace).handleToggleConsoleLogsPane,
+				},
+				{
+					Keys:        []string{"drag border/separator"},
+					Description: "Resize panes with the mouse",
+				},
+				{
+					Keys:        []string{"0"},
+					Description: "Reset pane sizes to defaults",
+					Handler:     (*Workspace).handleResetLayout,
 				},
 			},
 		},

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -85,6 +85,9 @@ type Run struct {
 	// receives data. After that, focus only ever changes on user action.
 	focusSeeded bool
 
+	// drag owns in-progress pane-boundary resizing (mouse drag).
+	drag paneDragger
+
 	// UI components.
 	metricsGridAnimState *AnimatedValue
 	metricsGrid          *MetricsGrid
@@ -164,6 +167,12 @@ func NewRun(
 		logger:               logger,
 	}
 	run.focusMgr = run.buildRunFocusManager()
+	run.drag = paneDragger{
+		saved:    cfg.RunLayout,
+		persist:  cfg.SetRunLayout,
+		relayout: run.applyLayoutConfig,
+		logger:   logger,
+	}
 	return run
 }
 
@@ -276,9 +285,10 @@ func (r *Run) applyLayoutConfig() {
 	r.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
 }
 
-// layoutOverrides returns the view's saved pane proportions.
+// layoutOverrides returns the live pane proportions: the in-progress drag's
+// pending values, or the persisted config.
 func (r *Run) layoutOverrides() LayoutOverrides {
-	return r.config.RunLayout()
+	return r.drag.overrides()
 }
 
 // updateSidebarDimensions re-derives both sidebars' expanded widths from the

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -113,6 +113,11 @@ func (r *Run) handleMouseMsg(msg tea.MouseMsg) tea.Cmd {
 
 	layout := r.computeViewports()
 
+	// Pane resizing wins over pane-local mouse handling.
+	if r.drag.handleMouse(msg, layout, r.dragTargets()) {
+		return nil
+	}
+
 	if r.isInLeftSidebar(msg, layout) {
 		return r.handleLeftSidebarMouse()
 	}
@@ -122,6 +127,23 @@ func (r *Run) handleMouseMsg(msg tea.MouseMsg) tea.Cmd {
 	}
 
 	return r.handleMainContentMouse(msg, layout)
+}
+
+// dragTargets reports which layout boundaries a mouse event may grab.
+func (r *Run) dragTargets() dragTargets {
+	return dragTargets{
+		width:           r.width,
+		height:          r.height,
+		leftExpanded:    r.leftSidebar.IsExpanded(),
+		rightExpanded:   r.rightSidebar.animState.IsExpanded(),
+		mediaFullscreen: r.mediaPane.IsFullscreen(),
+	}
+}
+
+// handleResetLayout resets the view's pane proportions to the defaults.
+func (r *Run) handleResetLayout(tea.KeyPressMsg) tea.Cmd {
+	r.drag.reset()
+	return nil
 }
 
 // isInLeftSidebar checks if mouse position is in the left sidebar region.

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -630,3 +630,122 @@ func TestRun_StackOverridesNeverOverflowFrame(t *testing.T) {
 			"overridden fixed panes must not squeeze the metrics section out (h=%d)", height)
 	}
 }
+
+// Regression: '0' pressed mid-drag used to be silently overwritten when the
+// release persisted the pre-reset drag values.
+func TestRun_ZeroKeyMidDragWins(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.KeyPressMsg{Code: '0'})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout(),
+		"the reset must win over the in-flight drag")
+	_, right1 := r.TestLayoutWidths()
+	require.Equal(t, right0, right1, "the layout must return to the default")
+}
+
+// Regression: a release of a different button used to end (and persist) a
+// left-button drag mid-gesture.
+func TestRun_RightReleaseDoesNotEndLeftDrag(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseRight})
+	require.Zero(t, cfg.RunLayout().RightSidebar,
+		"a right-button release must not persist the drag")
+
+	// The drag is still live and the left release persists it once.
+	r.Update(tea.MouseMotionMsg{X: borderX - 20, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 20, Y: 5, Button: tea.MouseLeft})
+	require.InDelta(t, float64(right0+20)/200.0, cfg.RunLayout().RightSidebar, 1e-9)
+}
+
+// Regression: a drag whose release never reached the view (swallowed by the
+// help overlay or a view switch) stayed latched, and any later left-button
+// motion resized the pane and persisted garbage.
+func TestRun_MissedClickClearsStaleDragLatch(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	// Latch a drag; the matching release is never delivered.
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+
+	// A later unrelated click-drag over the main content must not resize.
+	r.Update(tea.MouseClickMsg{X: 30, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: 60, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: 60, Y: 5, Button: tea.MouseLeft})
+
+	_, right1 := r.TestLayoutWidths()
+	require.Equal(t, right0, right1, "a stale latch must not resurrect as a drag")
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
+}
+
+// Regression: live drag values were unclamped while the persisted config was
+// clamped to [MinLayoutFrac, MaxLayoutFrac], so the pane snapped at the next
+// relayout after release. What you drag is what persists.
+func TestRun_DragExtremePersistsWhatYouSee(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+	_ = cfg.SetRightSidebarVisible(false)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 300, Height: 60})
+
+	left0, _ := r.TestLayoutWidths()
+	r.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: 294, Y: 5, Button: tea.MouseLeft})
+	liveLeft, _ := r.TestLayoutWidths()
+
+	r.Update(tea.MouseReleaseMsg{X: 294, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.WindowSizeMsg{Width: 300, Height: 60})
+	persistedLeft, _ := r.TestLayoutWidths()
+
+	require.Equal(t, liveLeft, persistedLeft,
+		"the layout must not snap when the drag is released")
+	require.LessOrEqual(t, cfg.RunLayout().LeftSidebar, leet.MaxLayoutFrac)
+}
+
+// Terminals without SGR mouse support (legacy X10 encoding) report every
+// release as MouseNone; such a release must still end and persist the drag.
+func TestRun_LegacyMouseReleaseEndsDrag(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseNone})
+
+	require.InDelta(t, float64(right0+10)/200.0, cfg.RunLayout().RightSidebar, 1e-9,
+		"an X10-encoded release must persist the drag")
+}

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -186,6 +186,94 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 		"collapsed overview should not appear focused")
 }
 
+// ---- Mouse drag-resize ----
+
+func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	require.Positive(t, right0)
+
+	// Press on the right sidebar's border column, drag 10 columns left
+	// (widening the sidebar), release.
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+
+	_, right1 := r.TestLayoutWidths()
+	require.Equal(t, right0+10, right1, "drag should widen the right sidebar")
+	require.InDelta(t, float64(right0+10)/200.0, cfg.RunLayout().RightSidebar, 1e-9,
+		"released drag should persist the width as a fraction of the terminal")
+
+	// "0" resets the proportions and the persisted overrides.
+	r.Update(tea.KeyPressMsg{Code: '0'})
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
+	_, right2 := r.TestLayoutWidths()
+	require.Equal(t, right0, right2, "reset should restore the default width")
+}
+
+func TestRun_DragSidebarKeepsMainColumnUsable(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Drag the left sidebar border all the way into the right sidebar.
+	left0, _ := r.TestLayoutWidths()
+	r.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: 195, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: 195, Y: 5, Button: tea.MouseLeft})
+
+	// The main content column keeps its minimum width; the sidebars never
+	// overlap it or each other.
+	left1, right1 := r.TestLayoutWidths()
+	require.GreaterOrEqual(t, 200-left1-right1, 24,
+		"dragging a sidebar must leave room for the main content column")
+}
+
+func TestRun_DragSeparatorResizesMediaAndLogs(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 100})
+
+	metrics0, media0, logs0 := r.TestStackHeights()
+	require.Positive(t, media0)
+	require.Positive(t, logs0)
+
+	// The separator above logs sits between two fixed panes (media above,
+	// logs below). Drag it down 2 rows: media grows, logs shrinks.
+	left0, _ := r.TestLayoutWidths()
+	x := left0 + 5
+	sepY := metrics0 + 1 + media0 + 1 - 1 // gap row above logs
+	r.Update(tea.MouseClickMsg{X: x, Y: sepY, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
+
+	metrics1, media1, logs1 := r.TestStackHeights()
+	require.Equal(t, media0+2, media1, "pane above the separator should grow")
+	require.Equal(t, logs0-2, logs1, "pane below the separator should shrink")
+	require.Equal(t, metrics0, metrics1, "flex metrics grid should be untouched")
+
+	// Both fractions persist on release.
+	o := cfg.RunLayout()
+	require.InDelta(t, float64(media1)/100.0, o.Media, 1e-9)
+	require.InDelta(t, float64(logs1)/100.0, o.Logs, 1e-9)
+}
+
 // ---- Esc: unfocus pane first, exit view second ----
 
 func TestRun_EscUnfocusesPane(t *testing.T) {

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -189,13 +189,10 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 // ---- Mouse drag-resize ----
 
 func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetLeftSidebarVisible(true)
-	_ = cfg.SetRightSidebarVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	r, cfg := newTestRun(t, 200, 60, func(c *leet.ConfigManager) {
+		_ = c.SetLeftSidebarVisible(true)
+		_ = c.SetRightSidebarVisible(true)
+	})
 
 	_, right0 := r.TestLayoutWidths()
 	require.Positive(t, right0)
@@ -220,13 +217,10 @@ func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {
 }
 
 func TestRun_DragSidebarKeepsMainColumnUsable(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetLeftSidebarVisible(true)
-	_ = cfg.SetRightSidebarVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	r, _ := newTestRun(t, 200, 60, func(c *leet.ConfigManager) {
+		_ = c.SetLeftSidebarVisible(true)
+		_ = c.SetRightSidebarVisible(true)
+	})
 
 	// Drag the left sidebar border all the way into the right sidebar.
 	left0, _ := r.TestLayoutWidths()
@@ -239,39 +233,6 @@ func TestRun_DragSidebarKeepsMainColumnUsable(t *testing.T) {
 	left1, right1 := r.TestLayoutWidths()
 	require.GreaterOrEqual(t, 200-left1-right1, 24,
 		"dragging a sidebar must leave room for the main content column")
-}
-
-func TestRun_DragSeparatorResizesMediaAndLogs(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetMediaVisible(true)
-	_ = cfg.SetConsoleLogsVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 100})
-
-	metrics0, media0, logs0 := r.TestStackHeights()
-	require.Positive(t, media0)
-	require.Positive(t, logs0)
-
-	// The separator above logs sits between two fixed panes (media above,
-	// logs below). Drag it down 2 rows: media grows, logs shrinks.
-	left0, _ := r.TestLayoutWidths()
-	x := left0 + 5
-	sepY := metrics0 + 1 + media0 + 1 - 1 // gap row above logs
-	r.Update(tea.MouseClickMsg{X: x, Y: sepY, Button: tea.MouseLeft})
-	r.Update(tea.MouseMotionMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
-	r.Update(tea.MouseReleaseMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
-
-	metrics1, media1, logs1 := r.TestStackHeights()
-	require.Equal(t, media0+2, media1, "pane above the separator should grow")
-	require.Equal(t, logs0-2, logs1, "pane below the separator should shrink")
-	require.Equal(t, metrics0, metrics1, "flex metrics grid should be untouched")
-
-	// Both fractions persist on release.
-	o := cfg.RunLayout()
-	require.InDelta(t, float64(media1)/100.0, o.Media, 1e-9)
-	require.InDelta(t, float64(logs1)/100.0, o.Logs, 1e-9)
 }
 
 // ---- Esc: unfocus pane first, exit view second ----
@@ -634,12 +595,9 @@ func TestRun_StackOverridesNeverOverflowFrame(t *testing.T) {
 // Regression: '0' pressed mid-drag used to be silently overwritten when the
 // release persisted the pre-reset drag values.
 func TestRun_ZeroKeyMidDragWins(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetRightSidebarVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	r, cfg := newTestRun(t, 200, 60, func(c *leet.ConfigManager) {
+		_ = c.SetRightSidebarVisible(true)
+	})
 
 	_, right0 := r.TestLayoutWidths()
 	borderX := 200 - right0
@@ -657,12 +615,9 @@ func TestRun_ZeroKeyMidDragWins(t *testing.T) {
 // Regression: a release of a different button used to end (and persist) a
 // left-button drag mid-gesture.
 func TestRun_RightReleaseDoesNotEndLeftDrag(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetRightSidebarVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	r, cfg := newTestRun(t, 200, 60, func(c *leet.ConfigManager) {
+		_ = c.SetRightSidebarVisible(true)
+	})
 
 	_, right0 := r.TestLayoutWidths()
 	borderX := 200 - right0
@@ -682,12 +637,9 @@ func TestRun_RightReleaseDoesNotEndLeftDrag(t *testing.T) {
 // help overlay or a view switch) stayed latched, and any later left-button
 // motion resized the pane and persisted garbage.
 func TestRun_MissedClickClearsStaleDragLatch(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetRightSidebarVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	r, cfg := newTestRun(t, 200, 60, func(c *leet.ConfigManager) {
+		_ = c.SetRightSidebarVisible(true)
+	})
 
 	_, right0 := r.TestLayoutWidths()
 	borderX := 200 - right0
@@ -708,13 +660,10 @@ func TestRun_MissedClickClearsStaleDragLatch(t *testing.T) {
 // clamped to [MinLayoutFrac, MaxLayoutFrac], so the pane snapped at the next
 // relayout after release. What you drag is what persists.
 func TestRun_DragExtremePersistsWhatYouSee(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetLeftSidebarVisible(true)
-	_ = cfg.SetRightSidebarVisible(false)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 300, Height: 60})
+	r, cfg := newTestRun(t, 300, 60, func(c *leet.ConfigManager) {
+		_ = c.SetLeftSidebarVisible(true)
+		_ = c.SetRightSidebarVisible(false)
+	})
 
 	left0, _ := r.TestLayoutWidths()
 	r.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
@@ -733,12 +682,9 @@ func TestRun_DragExtremePersistsWhatYouSee(t *testing.T) {
 // Terminals without SGR mouse support (legacy X10 encoding) report every
 // release as MouseNone; such a release must still end and persist the drag.
 func TestRun_LegacyMouseReleaseEndsDrag(t *testing.T) {
-	logger := observability.NewNoOpLogger()
-	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
-	_ = cfg.SetRightSidebarVisible(true)
-
-	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
-	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	r, cfg := newTestRun(t, 200, 60, func(c *leet.ConfigManager) {
+		_ = c.SetRightSidebarVisible(true)
+	})
 
 	_, right0 := r.TestLayoutWidths()
 	borderX := 200 - right0

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -170,6 +170,94 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 		"collapsed overview should not appear focused")
 }
 
+// ---- Mouse drag-resize ----
+
+func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	require.Positive(t, right0)
+
+	// Press on the right sidebar's border column, drag 10 columns left
+	// (widening the sidebar), release.
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+
+	_, right1 := r.TestLayoutWidths()
+	require.Equal(t, right0+10, right1, "drag should widen the right sidebar")
+	require.InDelta(t, float64(right0+10)/200.0, cfg.RunLayout().RightSidebar, 1e-9,
+		"released drag should persist the width as a fraction of the terminal")
+
+	// "0" resets the proportions and the persisted overrides.
+	r.Update(tea.KeyPressMsg{Code: '0'})
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
+	_, right2 := r.TestLayoutWidths()
+	require.Equal(t, right0, right2, "reset should restore the default width")
+}
+
+func TestRun_DragSidebarKeepsMainColumnUsable(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	// Drag the left sidebar border all the way into the right sidebar.
+	left0, _ := r.TestLayoutWidths()
+	r.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: 195, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: 195, Y: 5, Button: tea.MouseLeft})
+
+	// The main content column keeps its minimum width; the sidebars never
+	// overlap it or each other.
+	left1, right1 := r.TestLayoutWidths()
+	require.GreaterOrEqual(t, 200-left1-right1, 24,
+		"dragging a sidebar must leave room for the main content column")
+}
+
+func TestRun_DragSeparatorResizesMediaAndLogs(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetMediaVisible(true)
+	_ = cfg.SetConsoleLogsVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 100})
+
+	metrics0, media0, logs0 := r.TestStackHeights()
+	require.Positive(t, media0)
+	require.Positive(t, logs0)
+
+	// The separator above logs sits between two fixed panes (media above,
+	// logs below). Drag it down 2 rows: media grows, logs shrinks.
+	left0, _ := r.TestLayoutWidths()
+	x := left0 + 5
+	sepY := metrics0 + 1 + media0 + 1 - 1 // gap row above logs
+	r.Update(tea.MouseClickMsg{X: x, Y: sepY, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: x, Y: sepY + 2, Button: tea.MouseLeft})
+
+	metrics1, media1, logs1 := r.TestStackHeights()
+	require.Equal(t, media0+2, media1, "pane above the separator should grow")
+	require.Equal(t, logs0-2, logs1, "pane below the separator should shrink")
+	require.Equal(t, metrics0, metrics1, "flex metrics grid should be untouched")
+
+	// Both fractions persist on release.
+	o := cfg.RunLayout()
+	require.InDelta(t, float64(media1)/100.0, o.Media, 1e-9)
+	require.InDelta(t, float64(logs1)/100.0, o.Logs, 1e-9)
+}
+
 // ---- Esc: unfocus pane first, exit view second ----
 
 func TestRun_EscUnfocusesPane(t *testing.T) {

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -679,3 +679,122 @@ func TestRun_StackOverridesNeverOverflowFrame(t *testing.T) {
 			"overridden fixed panes must not squeeze the metrics section out (h=%d)", height)
 	}
 }
+
+// Regression: '0' pressed mid-drag used to be silently overwritten when the
+// release persisted the pre-reset drag values.
+func TestRun_ZeroKeyMidDragWins(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.KeyPressMsg{Code: '0'})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout(),
+		"the reset must win over the in-flight drag")
+	_, right1 := r.TestLayoutWidths()
+	require.Equal(t, right0, right1, "the layout must return to the default")
+}
+
+// Regression: a release of a different button used to end (and persist) a
+// left-button drag mid-gesture.
+func TestRun_RightReleaseDoesNotEndLeftDrag(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseRight})
+	require.Zero(t, cfg.RunLayout().RightSidebar,
+		"a right-button release must not persist the drag")
+
+	// The drag is still live and the left release persists it once.
+	r.Update(tea.MouseMotionMsg{X: borderX - 20, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 20, Y: 5, Button: tea.MouseLeft})
+	require.InDelta(t, float64(right0+20)/200.0, cfg.RunLayout().RightSidebar, 1e-9)
+}
+
+// Regression: a drag whose release never reached the view (swallowed by the
+// help overlay or a view switch) stayed latched, and any later left-button
+// motion resized the pane and persisted garbage.
+func TestRun_MissedClickClearsStaleDragLatch(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	// Latch a drag; the matching release is never delivered.
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+
+	// A later unrelated click-drag over the main content must not resize.
+	r.Update(tea.MouseClickMsg{X: 30, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: 60, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: 60, Y: 5, Button: tea.MouseLeft})
+
+	_, right1 := r.TestLayoutWidths()
+	require.Equal(t, right0, right1, "a stale latch must not resurrect as a drag")
+	require.Equal(t, leet.LayoutOverrides{}, cfg.RunLayout())
+}
+
+// Regression: live drag values were unclamped while the persisted config was
+// clamped to [MinLayoutFrac, MaxLayoutFrac], so the pane snapped at the next
+// relayout after release. What you drag is what persists.
+func TestRun_DragExtremePersistsWhatYouSee(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetLeftSidebarVisible(true)
+	_ = cfg.SetRightSidebarVisible(false)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 300, Height: 60})
+
+	left0, _ := r.TestLayoutWidths()
+	r.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: 294, Y: 5, Button: tea.MouseLeft})
+	liveLeft, _ := r.TestLayoutWidths()
+
+	r.Update(tea.MouseReleaseMsg{X: 294, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.WindowSizeMsg{Width: 300, Height: 60})
+	persistedLeft, _ := r.TestLayoutWidths()
+
+	require.Equal(t, liveLeft, persistedLeft,
+		"the layout must not snap when the drag is released")
+	require.LessOrEqual(t, cfg.RunLayout().LeftSidebar, leet.MaxLayoutFrac)
+}
+
+// Terminals without SGR mouse support (legacy X10 encoding) report every
+// release as MouseNone; such a release must still end and persist the drag.
+func TestRun_LegacyMouseReleaseEndsDrag(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetRightSidebarVisible(true)
+
+	r := leet.NewRun(&leet.RunParams{RunFile: "testdata/fake.wandb"}, cfg, logger)
+	r.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	_, right0 := r.TestLayoutWidths()
+	borderX := 200 - right0
+	r.Update(tea.MouseClickMsg{X: borderX, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseMotionMsg{X: borderX - 10, Y: 5, Button: tea.MouseLeft})
+	r.Update(tea.MouseReleaseMsg{X: borderX - 10, Y: 5, Button: tea.MouseNone})
+
+	require.InDelta(t, float64(right0+10)/200.0, cfg.RunLayout().RightSidebar, 1e-9,
+		"an X10-encoded release must persist the drag")
+}

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -75,10 +75,28 @@ func (r *Run) TestStopHeartbeat() {
 	}
 }
 
+// TestLayoutWidths returns the run view's current sidebar widths.
+func (r *Run) TestLayoutWidths() (left, right int) {
+	l := r.computeViewports()
+	return l.leftSidebarWidth, l.rightSidebarWidth
+}
+
+// TestLayoutWidths returns the workspace's current sidebar widths.
+func (w *Workspace) TestLayoutWidths() (left, right int) {
+	l := w.computeViewports()
+	return l.leftSidebarWidth, l.rightSidebarWidth
+}
+
 // TestStackHeights returns the run view's central stack pane heights.
 func (r *Run) TestStackHeights() (metrics, media, logs int) {
 	l := r.computeViewports()
 	return l.height, l.mediaHeight, l.consoleLogsHeight
+}
+
+// TestStackHeights returns the workspace's central stack pane heights.
+func (w *Workspace) TestStackHeights() (metrics, system, media, logs int) {
+	l := w.computeViewports()
+	return l.height, l.systemMetricsHeight, l.mediaHeight, l.consoleLogsHeight
 }
 
 // TestInRunMode reports whether the model shows the single-run view.

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -29,6 +29,9 @@ type Workspace struct {
 	// focusMgr is the single source of truth for UI focus state.
 	focusMgr *FocusManager
 
+	// drag owns in-progress pane-boundary resizing (mouse drag).
+	drag paneDragger
+
 	// Configuration and key bindings.
 	config *ConfigManager
 	keyMap map[string]func(*Workspace, tea.KeyPressMsg) tea.Cmd
@@ -178,6 +181,12 @@ func NewWorkspace(
 		runsFilterIndex:     make(map[string]WorkspaceRunFilterData),
 	}
 	w.focusMgr = w.buildWorkspaceFocusManager()
+	w.drag = paneDragger{
+		saved:    cfg.WorkspaceLayout,
+		persist:  cfg.SetWorkspaceLayout,
+		relayout: w.applyLayoutConfig,
+		logger:   logger,
+	}
 	// The runs list starts focused by default.
 	w.focusMgr.SetTarget(FocusTargetRunsList, 1)
 	return w
@@ -553,9 +562,10 @@ func (w *Workspace) computeViewports() Layout {
 	}
 }
 
-// layoutOverrides returns the view's saved pane proportions.
+// layoutOverrides returns the live pane proportions: the in-progress drag's
+// pending values, or the persisted config.
 func (w *Workspace) layoutOverrides() LayoutOverrides {
-	return w.config.WorkspaceLayout()
+	return w.drag.overrides()
 }
 
 // updateSidebarDimensions tells both sidebars to recalculate their expanded

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -328,6 +328,41 @@ func TestWorkspace_ClickWithoutMotionDoesNotPersist(t *testing.T) {
 		"a click without motion must not write an override")
 }
 
+// Regression (#12289 review): after dragging the overview sidebar until the
+// main column hits its minimum width, the border must stay grabbable — and
+// a one-column near-miss must latch too, since terminals quantize mouse
+// coordinates to cells and a one-column target is luck-based.
+func TestWorkspace_MaxedSidebarStaysDraggable(t *testing.T) {
+	const width = 170
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: width, Height: 60})
+	w.TestForceExpandRunsSidebar()
+	w.TestForceExpandOverviewSidebar()
+
+	// Drag the overview border all the way left: it stops where the main
+	// column hits its minimum width (24 cols).
+	_, right0 := w.TestLayoutWidths()
+	_ = w.Update(tea.MouseClickMsg{X: width - right0, Y: 20, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseMotionMsg{X: 0, Y: 20, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: 0, Y: 20, Button: tea.MouseLeft})
+
+	left1, right1 := w.TestLayoutWidths()
+	require.Equal(t, width-left1-24, right1,
+		"the sidebar should stop where the main column hits its minimum")
+
+	// Re-grab one column off the border (a typical near-miss) and shrink.
+	borderX := width - right1
+	_ = w.Update(tea.MouseClickMsg{X: borderX + 1, Y: 20, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseMotionMsg{X: borderX + 10, Y: 20, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: borderX + 10, Y: 20, Button: tea.MouseLeft})
+
+	_, right2 := w.TestLayoutWidths()
+	require.Equal(t, right1-10, right2, "a maxed sidebar must stay draggable")
+}
+
 // ---- Focus bug: collapsing overview with logs focused ----
 
 func TestWorkspace_CollapseOverview_FocusStaysOnLogs(t *testing.T) {

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -243,6 +243,91 @@ func TestWorkspace_TabSkipsEmptyLogsPane(t *testing.T) {
 	}
 }
 
+// ---- Mouse drag-resize of the runs sidebar ----
+
+func TestWorkspace_DragResizesRunsSidebarAndPersists(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	w.TestForceExpandRunsSidebar()
+	w.TestForceExpandOverviewSidebar()
+
+	left0, _ := w.TestLayoutWidths()
+	require.Positive(t, left0)
+
+	// Press on the sidebar's border column, drag 10 columns right, release.
+	_ = w.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseMotionMsg{X: left0 + 9, Y: 5, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: left0 + 9, Y: 5, Button: tea.MouseLeft})
+
+	left1, _ := w.TestLayoutWidths()
+	require.Equal(t, left0+10, left1, "drag should widen the runs sidebar")
+	require.InDelta(t, float64(left0+10)/200.0, cfg.WorkspaceLayout().LeftSidebar, 1e-9,
+		"released drag should persist the width as a fraction of the terminal")
+
+	// "0" resets the proportions and the persisted overrides.
+	_ = w.Update(keyRune('0'))
+	require.Equal(t, leet.LayoutOverrides{}, cfg.WorkspaceLayout())
+	left2, _ := w.TestLayoutWidths()
+	require.Equal(t, left0, left2, "reset should restore the default width")
+}
+
+func TestWorkspace_DragSeparatorResizesBothFixedNeighbors(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetWorkspaceSystemMetricsVisible(true)
+	_ = cfg.SetWorkspaceMediaVisible(true)
+	_ = cfg.SetWorkspaceConsoleLogsVisible(true)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	// Tall terminal so all panes sit above their minimum heights.
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 100})
+
+	metrics0, system0, media0, logs0 := w.TestStackHeights()
+	require.Positive(t, system0)
+	require.Positive(t, media0)
+
+	// The separator above media sits between two fixed panes (system above,
+	// media below). Drag it up 2 rows: system shrinks, media grows, the flex
+	// metrics grid and logs stay put.
+	left0, _ := w.TestLayoutWidths()
+	x := left0 + 5
+	sepY := metrics0 + 1 + system0 + 1 - 1 // gap row above media
+	_ = w.Update(tea.MouseClickMsg{X: x, Y: sepY, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseMotionMsg{X: x, Y: sepY - 2, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: x, Y: sepY - 2, Button: tea.MouseLeft})
+
+	metrics1, system1, media1, logs1 := w.TestStackHeights()
+	require.Equal(t, system0-2, system1, "pane above the separator should shrink")
+	require.Equal(t, media0+2, media1, "pane below the separator should grow")
+	require.Equal(t, metrics0, metrics1, "flex metrics grid should be untouched")
+	require.Equal(t, logs0, logs1, "logs pane should be untouched")
+
+	// Both fractions persist on release.
+	o := cfg.WorkspaceLayout()
+	require.InDelta(t, float64(system1)/100.0, o.System, 1e-9)
+	require.InDelta(t, float64(media1)/100.0, o.Media, 1e-9)
+	require.Zero(t, o.Logs, "untouched panes must not gain overrides")
+}
+
+func TestWorkspace_ClickWithoutMotionDoesNotPersist(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	w.TestForceExpandRunsSidebar()
+
+	left0, _ := w.TestLayoutWidths()
+	_ = w.Update(tea.MouseClickMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+	_ = w.Update(tea.MouseReleaseMsg{X: left0 - 1, Y: 5, Button: tea.MouseLeft})
+
+	require.Equal(t, leet.LayoutOverrides{}, cfg.WorkspaceLayout(),
+		"a click without motion must not write an override")
+}
+
 // ---- Focus bug: collapsing overview with logs focused ----
 
 func TestWorkspace_CollapseOverview_FocusStaysOnLogs(t *testing.T) {

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -107,6 +107,11 @@ func (w *Workspace) handleMouse(msg tea.MouseMsg) tea.Cmd {
 	mouse := msg.Mouse()
 	layout := w.computeViewports()
 
+	// Pane resizing wins over pane-local mouse handling.
+	if w.drag.handleMouse(msg, layout, w.dragTargets()) {
+		return nil
+	}
+
 	// Clicks in the left sidebar clear all chart focus.
 	if w.runsAnimState.IsVisible() && mouse.X < layout.leftSidebarWidth {
 		w.clearChartFocus()
@@ -147,6 +152,23 @@ func (w *Workspace) handleMouse(msg tea.MouseMsg) tea.Cmd {
 	}
 
 	// Separator or status bar area — no chart interaction.
+	return nil
+}
+
+// dragTargets reports which layout boundaries a mouse event may grab.
+func (w *Workspace) dragTargets() dragTargets {
+	return dragTargets{
+		width:           w.width,
+		height:          w.height,
+		leftExpanded:    w.runsAnimState.IsExpanded(),
+		rightExpanded:   w.runOverviewSidebar.IsExpanded(),
+		mediaFullscreen: w.mediaPane.IsFullscreen(),
+	}
+}
+
+// handleResetLayout resets the view's pane proportions to the defaults.
+func (w *Workspace) handleResetLayout(tea.KeyPressMsg) tea.Cmd {
+	w.drag.reset()
 	return nil
 }
 


### PR DESCRIPTION
Description
-----------
Drag a sidebar's border column or the separator row above a stacked pane to resize it. Drags apply live and persist once on mouse release to the per-view layout overrides; `0` resets the active view to the golden-ratio defaults.

A single `paneDragger` state machine (latch on click, apply on motion, persist on release). Sidebar borders are draggable only when stably expanded so a drag never fights an animation, and sidebar drags are clamped so the main column keeps its minimum width against the opposite sidebar. A click without motion writes nothing.

Separator drags anchor the lower pane's bottom edge; between two fixed panes both fractions update so the boundary lands exactly on the mouse row, and next to the flex metrics grid the flex absorbs the change.