### PR TITLE
chore(sdk): handle Authenticate API requests in wandb-core

### DIFF
--- a/core/api/graphql/query_viewer.graphql
+++ b/core/api/graphql/query_viewer.graphql
@@ -3,6 +3,8 @@ query Viewer{
     viewer {
         id
         entity
+        username
+        email
         flags
         teams {
             edges {

--- a/core/internal/api/credentials.go
+++ b/core/internal/api/credentials.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -111,8 +112,11 @@ func NewOAuth2CredentialProvider(
 		baseURL:             baseURL,
 		credentialsFilePath: credentialsFilePath,
 		tokenMu:             &sync.RWMutex{},
-		identityToken:       string(identityToken),
-		logger:              logger,
+		// Strip surrounding whitespace, like the trailing newline written
+		// by `echo` and most editors, which would otherwise be sent as
+		// part of the token.
+		identityToken: strings.TrimSpace(string(identityToken)),
+		logger:        logger,
 	}, nil
 }
 
@@ -296,12 +300,12 @@ func (c *oauth2CredentialProvider) trySaveCredentialsToFile(credentials Credenti
 // an access token from the authorization server using the JWT Bearer flow defined
 // in OAuth RFC 7523. The access token is then returned with its expiration time.
 func (c *oauth2CredentialProvider) fetchAccessToken() (accessTokenInfo, error) {
-	url := fmt.Sprintf("%s/oidc/token", c.baseURL)
+	tokenURL := fmt.Sprintf("%s/oidc/token", c.baseURL)
 	data := fmt.Sprintf(
 		"grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=%s",
-		c.identityToken,
+		url.QueryEscape(c.identityToken),
 	)
-	req, err := http.NewRequest("POST", url, strings.NewReader(data))
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data))
 	if err != nil {
 		return accessTokenInfo{}, err
 	}

--- a/core/internal/api/credentials_test.go
+++ b/core/internal/api/credentials_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -135,6 +136,44 @@ func TestNewOAuth2CredentialProvider(t *testing.T) {
 	assert.Equal(t, token, data.Credentials[server.URL].AccessToken)
 	assert.Equal(t, time.Now().UTC().Add(expiresIn).Round(time.Hour),
 		time.Time(data.Credentials[server.URL].ExpiresAt).Round(time.Hour))
+}
+
+func TestNewOAuth2CredentialProvider_TrimsTokenWhitespace(t *testing.T) {
+	// Token files are often created with `echo` or an editor and end with
+	// a newline, which must not become part of the token exchange request.
+	tokenFile, err := os.CreateTemp(t.TempDir(), "jwt.txt")
+	require.NoError(t, err)
+	_, err = tokenFile.WriteString("id-token\n")
+	require.NoError(t, err)
+	require.NoError(t, tokenFile.Close())
+
+	credentialsFile := filepath.Join(t.TempDir(), "credentials.json")
+
+	server := authServer("fake-token", time.Hour)
+	defer server.Close()
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: server.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile.Name()},
+		CredentialsFile:   &wrapperspb.StringValue{Value: credentialsFile},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t,
+		credentialProvider,
+		exampleGetRequest(t),
+	)
+	require.NoError(t, err)
+
+	exchanges := server.Requests()
+	require.Len(t, exchanges, 1)
+	assert.Equal(t,
+		"grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=id-token",
+		string(exchanges[0].Body))
 }
 
 func TestNewOAuth2CredentialProvider_RefreshesToken(t *testing.T) {

--- a/core/internal/gql/gql_gen.go
+++ b/core/internal/gql/gql_gen.go
@@ -1656,10 +1656,12 @@ func (v *ViewerResponse) GetViewer() *ViewerViewerUser { return v.Viewer }
 
 // ViewerViewerUser includes the requested fields of the GraphQL type User.
 type ViewerViewerUser struct {
-	Id     string                                 `json:"id"`
-	Entity *string                                `json:"entity"`
-	Flags  *string                                `json:"flags"`
-	Teams  *ViewerViewerUserTeamsEntityConnection `json:"teams"`
+	Id       string                                 `json:"id"`
+	Entity   *string                                `json:"entity"`
+	Username *string                                `json:"username"`
+	Email    *string                                `json:"email"`
+	Flags    *string                                `json:"flags"`
+	Teams    *ViewerViewerUserTeamsEntityConnection `json:"teams"`
 }
 
 // GetId returns ViewerViewerUser.Id, and is useful for accessing the field via an interface.
@@ -1667,6 +1669,12 @@ func (v *ViewerViewerUser) GetId() string { return v.Id }
 
 // GetEntity returns ViewerViewerUser.Entity, and is useful for accessing the field via an interface.
 func (v *ViewerViewerUser) GetEntity() *string { return v.Entity }
+
+// GetUsername returns ViewerViewerUser.Username, and is useful for accessing the field via an interface.
+func (v *ViewerViewerUser) GetUsername() *string { return v.Username }
+
+// GetEmail returns ViewerViewerUser.Email, and is useful for accessing the field via an interface.
+func (v *ViewerViewerUser) GetEmail() *string { return v.Email }
 
 // GetFlags returns ViewerViewerUser.Flags, and is useful for accessing the field via an interface.
 func (v *ViewerViewerUser) GetFlags() *string { return v.Flags }
@@ -3557,6 +3565,8 @@ query Viewer {
 	viewer {
 		id
 		entity
+		username
+		email
 		flags
 		teams {
 			edges {

--- a/core/internal/wbapi/authhandler.go
+++ b/core/internal/wbapi/authhandler.go
@@ -18,8 +18,7 @@ func NewAuthHandler(graphqlClient graphql.Client) *AuthHandler {
 	return &AuthHandler{graphqlClient: graphqlClient}
 }
 
-// HandleAuthenticate verifies the API instance's credentials and identifies
-// the authenticated user.
+// HandleAuthenticate verifies the account credentials.
 //
 // The credentials come from the settings used to initialize the API
 // instance: an API key, or an identity token file when using federated

--- a/core/internal/wbapi/authhandler.go
+++ b/core/internal/wbapi/authhandler.go
@@ -1,0 +1,80 @@
+package wbapi
+
+import (
+	"context"
+
+	"github.com/Khan/genqlient/graphql"
+
+	"github.com/wandb/wandb/core/internal/gql"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// AuthHandler responds to AuthenticateRequests.
+type AuthHandler struct {
+	graphqlClient graphql.Client
+}
+
+func NewAuthHandler(graphqlClient graphql.Client) *AuthHandler {
+	return &AuthHandler{graphqlClient: graphqlClient}
+}
+
+// HandleAuthenticate verifies the API instance's credentials and identifies
+// the authenticated user.
+//
+// The credentials come from the settings used to initialize the API
+// instance: an API key, or an identity token file when using federated
+// identity. Both are applied by the credential provider attached to the
+// GraphQL client, so this handler works the same for either method.
+func (h *AuthHandler) HandleAuthenticate(
+	ctx context.Context,
+	request *spb.AuthenticateRequest,
+) *spb.ApiResponse {
+	data, err := gql.Viewer(ctx, h.graphqlClient)
+
+	// The credentials are valid exactly if the server resolved a viewer.
+	//
+	// Field-level GraphQL errors (like a failing resolver for one of the
+	// requested fields) do not invalidate the credentials, so partial data
+	// is accepted as long as the viewer itself is present. Any field,
+	// including the entity, may be null for unusual accounts and old
+	// server versions.
+	if data == nil || data.GetViewer() == nil {
+		if err != nil {
+			message, status := graphqlErrorInfo(err)
+			return apiErrorResponse(message, status)
+		}
+		return apiErrorResponse(
+			"invalid credentials: the server did not recognize an account"+
+				" for the configured credentials",
+			0,
+		)
+	}
+
+	viewer := data.GetViewer()
+	response := &spb.AuthenticateResponse{}
+	if entity := viewer.GetEntity(); entity != nil {
+		response.DefaultEntity = *entity
+	}
+	if username := viewer.GetUsername(); username != nil {
+		response.Username = *username
+	}
+	if email := viewer.GetEmail(); email != nil {
+		response.Email = *email
+	}
+	if flags := viewer.GetFlags(); flags != nil {
+		response.FlagsJson = *flags
+	}
+	if teams := viewer.GetTeams(); teams != nil {
+		for _, edge := range teams.GetEdges() {
+			if node := edge.GetNode(); node != nil {
+				response.Teams = append(response.Teams, node.GetName())
+			}
+		}
+	}
+
+	return &spb.ApiResponse{
+		Response: &spb.ApiResponse_AuthenticateResponse{
+			AuthenticateResponse: response,
+		},
+	}
+}

--- a/core/internal/wbapi/authhandler_test.go
+++ b/core/internal/wbapi/authhandler_test.go
@@ -1,0 +1,128 @@
+package wbapi_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/internal/wbapi"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestAuthenticateReturnsViewerInfo(t *testing.T) {
+	client := &fakeGQLClient{
+		respMap: map[string]any{
+			"viewer": map[string]any{
+				"id":       "user-node-id",
+				"entity":   "myentity",
+				"username": "myuser",
+				"email":    "me@example.com",
+				"flags":    `{"code_saving_enabled": true}`,
+				"teams": map[string]any{
+					"edges": []any{
+						map[string]any{"node": map[string]any{"name": "team1"}},
+						map[string]any{"node": map[string]any{"name": "team2"}},
+					},
+				},
+			},
+		},
+	}
+	handler := wbapi.NewAuthHandler(client)
+
+	response := handler.HandleAuthenticate(
+		context.Background(),
+		&spb.AuthenticateRequest{},
+	)
+
+	authResponse := response.GetAuthenticateResponse()
+	require.NotNil(t, authResponse)
+	require.True(t, client.called)
+	assert.Equal(t, "Viewer", client.gotReq.OpName)
+	assert.Equal(t, "myentity", authResponse.GetDefaultEntity())
+	assert.Equal(t, "myuser", authResponse.GetUsername())
+	assert.Equal(t, "me@example.com", authResponse.GetEmail())
+	assert.Equal(t, `{"code_saving_enabled": true}`, authResponse.GetFlagsJson())
+	assert.Equal(t, []string{"team1", "team2"}, authResponse.GetTeams())
+}
+
+func TestAuthenticateNullEntityIsAccepted(t *testing.T) {
+	// Unusual accounts and old server versions may return a viewer with
+	// null fields; the credentials are still valid.
+	client := &fakeGQLClient{
+		respMap: map[string]any{
+			"viewer": map[string]any{
+				"id":       "user-node-id",
+				"username": "myuser",
+			},
+		},
+	}
+	handler := wbapi.NewAuthHandler(client)
+
+	response := handler.HandleAuthenticate(
+		context.Background(),
+		&spb.AuthenticateRequest{},
+	)
+
+	authResponse := response.GetAuthenticateResponse()
+	require.NotNil(t, authResponse)
+	assert.Equal(t, "", authResponse.GetDefaultEntity())
+	assert.Equal(t, "myuser", authResponse.GetUsername())
+}
+
+func TestAuthenticatePartialDataIsAccepted(t *testing.T) {
+	// Field-level GraphQL errors don't invalidate the credentials when the
+	// viewer itself resolved; genqlient returns partial data plus an error.
+	client := &fakeGQLClient{
+		err: errors.New("resolver for field 'teams' failed"),
+		respMap: map[string]any{
+			"viewer": map[string]any{
+				"id":     "user-node-id",
+				"entity": "myentity",
+			},
+		},
+	}
+	handler := wbapi.NewAuthHandler(client)
+
+	response := handler.HandleAuthenticate(
+		context.Background(),
+		&spb.AuthenticateRequest{},
+	)
+
+	authResponse := response.GetAuthenticateResponse()
+	require.NotNil(t, authResponse)
+	assert.Equal(t, "myentity", authResponse.GetDefaultEntity())
+}
+
+func TestAuthenticateNullViewerIsError(t *testing.T) {
+	client := &fakeGQLClient{
+		respMap: map[string]any{"viewer": nil},
+	}
+	handler := wbapi.NewAuthHandler(client)
+
+	response := handler.HandleAuthenticate(
+		context.Background(),
+		&spb.AuthenticateRequest{},
+	)
+
+	apiError := response.GetApiErrorResponse()
+	require.NotNil(t, apiError)
+	assert.Contains(t, apiError.GetMessage(), "invalid credentials")
+}
+
+func TestAuthenticateReturnsError(t *testing.T) {
+	client := &fakeGQLClient{err: errors.New("boom")}
+	handler := wbapi.NewAuthHandler(client)
+
+	response := handler.HandleAuthenticate(
+		context.Background(),
+		&spb.AuthenticateRequest{},
+	)
+
+	apiError := response.GetApiErrorResponse()
+	require.NotNil(t, apiError)
+	assert.Contains(t, apiError.GetMessage(), "boom")
+	assert.Equal(t, int32(0), apiError.GetHttpStatus()) // non-HTTP error
+}

--- a/core/internal/wbapi/runfileshandler_test.go
+++ b/core/internal/wbapi/runfileshandler_test.go
@@ -14,8 +14,12 @@ import (
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
-// fakeGQLClient records the request it receives and returns a canned result or
-// error.
+// fakeGQLClient records the request it receives and returns a canned result
+// and/or error.
+//
+// Setting both respMap and err models genqlient's behavior for a response
+// with partial data and GraphQL errors: data is populated and a non-nil
+// error is returned.
 type fakeGQLClient struct {
 	err     error
 	called  bool
@@ -30,14 +34,11 @@ func (c *fakeGQLClient) MakeRequest(
 ) error {
 	c.called = true
 	c.gotReq = req
-	if c.err != nil {
-		return c.err
-	}
 	if c.respMap != nil {
 		raw, _ := json.Marshal(c.respMap)
 		_ = json.Unmarshal(raw, resp.Data)
 	}
-	return nil
+	return c.err
 }
 
 func TestMarkRunFilesUploadedRunsMutation(t *testing.T) {

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -34,6 +34,7 @@ type WandbAPI struct {
 
 	settings *settings.Settings
 
+	authHandler          *AuthHandler
 	featuresHandler      *FeaturesHandler
 	fileTransferHandler  *FileTransferHandler
 	graphqlHandler       *GraphQLHandler
@@ -99,6 +100,7 @@ func New(
 		semaphore: make(chan struct{}, maxConcurrency),
 		settings:  s,
 
+		authHandler:          NewAuthHandler(graphqlClient),
 		featuresHandler:      NewFeaturesHandler(featureProvider),
 		fileTransferHandler:  NewFileTransferHandler(fileTransferManager),
 		graphqlHandler:       NewGraphQLHandler(graphqlClient),
@@ -173,6 +175,8 @@ func (p *WandbAPI) HandleRequest(
 	defer func() { <-p.semaphore }()
 
 	switch req := request.Request.(type) {
+	case *spb.ApiRequest_AuthenticateRequest:
+		return p.authHandler.HandleAuthenticate(ctx, req.AuthenticateRequest)
 	case *spb.ApiRequest_FeaturesRequest:
 		return p.featuresHandler.HandleRequest(ctx, req.FeaturesRequest)
 	case *spb.ApiRequest_DownloadFileRequest:
@@ -189,5 +193,9 @@ func (p *WandbAPI) HandleRequest(
 		return p.runHistoryApiHandler.HandleRequest(ctx, req.ReadRunHistoryRequest)
 	}
 
-	return nil
+	// Unknown request types happen when a newer client attaches to an older
+	// wandb-core. Returning an error instead of nil (no response) saves the
+	// client from waiting for a response that will never come.
+	return apiErrorResponse(
+		fmt.Sprintf("unsupported API request type: %T", request.Request), 0)
 }

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -191,11 +191,7 @@ func (p *WandbAPI) HandleRequest(
 		return p.graphqlHandler.HandleRequest(ctx, req.GraphqlRequest)
 	case *spb.ApiRequest_ReadRunHistoryRequest:
 		return p.runHistoryApiHandler.HandleRequest(ctx, req.ReadRunHistoryRequest)
+	default:
+		return apiErrorResponse(fmt.Sprintf("unsupported API request type: %T", request.Request), 0)
 	}
-
-	// Unknown request types happen when a newer client attaches to an older
-	// wandb-core. Returning an error instead of nil (no response) saves the
-	// client from waiting for a response that will never come.
-	return apiErrorResponse(
-		fmt.Sprintf("unsupported API request type: %T", request.Request), 0)
 }

--- a/core/internal/wbapi/wbapi_test.go
+++ b/core/internal/wbapi/wbapi_test.go
@@ -1,0 +1,61 @@
+package wbapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestHandleRequestUnknownTypeIsError(t *testing.T) {
+	// A newer client attached to an older wandb-core sends request types
+	// this version doesn't know; they must get an error response instead
+	// of no response (which would make the client wait until its timeout).
+	api := &WandbAPI{
+		semaphore: make(chan struct{}, 1),
+	}
+
+	response := api.HandleRequest(
+		context.Background(),
+		"request-id",
+		&spb.ApiRequest{},
+	)
+
+	apiError := response.GetApiErrorResponse()
+	if apiError == nil {
+		t.Fatal("expected API error response")
+	}
+	if !strings.Contains(apiError.GetMessage(), "unsupported API request") {
+		t.Fatalf("expected unsupported request error, got %q", apiError.GetMessage())
+	}
+}
+
+func TestHandleRequestReturnsWhenCancelledWaitingForConcurrency(t *testing.T) {
+	api := &WandbAPI{
+		semaphore: make(chan struct{}, 1),
+	}
+	api.semaphore <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan *spb.ApiResponse, 1)
+	go func() {
+		done <- api.HandleRequest(ctx, "request-id", &spb.ApiRequest{})
+	}()
+
+	cancel()
+
+	select {
+	case response := <-done:
+		apiError := response.GetApiErrorResponse()
+		if apiError == nil {
+			t.Fatal("expected API error response")
+		}
+		if !strings.Contains(apiError.GetMessage(), "context canceled") {
+			t.Fatalf("expected context cancellation error, got %q", apiError.GetMessage())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HandleRequest did not return after context cancellation")
+	}
+}

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -524,7 +524,14 @@ func (nc *Connection) handleAuthenticateImpl(
 	)
 
 	data, err := gql.Viewer(ctx, graphqlClient)
-	if err != nil || data == nil || data.GetViewer() == nil || data.GetViewer().GetEntity() == nil {
+
+	// Field-level GraphQL errors (like a failing resolver for one of the
+	// requested fields) do not invalidate the credentials, so partial data
+	// is accepted as long as the viewer and its entity were resolved.
+	if data == nil || data.GetViewer() == nil || data.GetViewer().GetEntity() == nil {
+		if err != nil {
+			slog.Debug("handleAuthenticate: viewer query failed", "error", err)
+		}
 		return &spb.ServerAuthenticateResponse{
 			ErrorStatus: "Invalid credentials",
 		}

--- a/core/pkg/server/connection_authenticate_test.go
+++ b/core/pkg/server/connection_authenticate_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func viewerBackend(t *testing.T, response string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(response))
+		}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestHandleAuthenticateAcceptsPartialErrors(t *testing.T) {
+	// Field-level GraphQL errors (here: a failing email resolver) must not
+	// invalidate credentials when the viewer and its entity were resolved.
+	backend := viewerBackend(t,
+		`{
+			"data": {"viewer": {"id": "id", "entity": "myentity"}},
+			"errors": [{"message": "email resolver failed"}]
+		}`)
+
+	nc := &Connection{}
+	response := nc.handleAuthenticateImpl(
+		context.Background(),
+		&spb.ServerAuthenticateRequest{
+			ApiKey:  "X",
+			BaseUrl: backend.URL,
+		},
+	)
+
+	if response.GetErrorStatus() != "" {
+		t.Fatalf("expected success, got error status %q", response.GetErrorStatus())
+	}
+	if response.GetDefaultEntity() != "myentity" {
+		t.Fatalf("expected entity, got %q", response.GetDefaultEntity())
+	}
+}
+
+func TestHandleAuthenticateNullViewerIsInvalid(t *testing.T) {
+	backend := viewerBackend(t, `{"data": {"viewer": null}}`)
+
+	nc := &Connection{}
+	response := nc.handleAuthenticateImpl(
+		context.Background(),
+		&spb.ServerAuthenticateRequest{
+			ApiKey:  "X",
+			BaseUrl: backend.URL,
+		},
+	)
+
+	if response.GetErrorStatus() == "" {
+		t.Fatal("expected an error status for a null viewer")
+	}
+}


### PR DESCRIPTION
Description
-----------
Part 2/5 of stack #12296.

Adds an `AuthHandler` to `core/internal/wbapi` that serves `AuthenticateRequest` by running the `Viewer` GraphQL query. Works identically for API keys and identity token files (federated identity). The `Viewer` query now also selects `username` and `email`, which the response includes along with the default entity, teams, and user flags.

Credentials are considered valid exactly if the server resolves a viewer: null fields (including the entity) and field-level GraphQL errors with partial data are accepted, matching how permissive verification was before this stack (unusual accounts and old server versions may omit fields). 

Also fixes two pre-existing bugs in the OAuth2 credential provider that the new verification path would otherwise inherit: the identity token file is stripped of surrounding whitespace (a trailing newline from `echo` or an editor used to be sent as part of the token and rejected), and the assertion is URL-encoded in the token exchange request.

An alternative was to extend the connection-level `ServerAuthenticateRequest` used by the experimental C# client, but that message is API-key-only and its handler is already marked for deprecation in favor of the API-instance workflow used here.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

