### PR TITLE
fix(sdk): harden Azure file transfers

### DIFF
--- a/core/internal/filetransfer/file_transfer_azure.go
+++ b/core/internal/filetransfer/file_transfer_azure.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -26,7 +24,8 @@ import (
 )
 
 const (
-	maxAzureWorkers = 500
+	maxAzureWorkers = 32
+	azureBlockSize  = 4 * 1024 * 1024
 	// Azure blob storage urls have the following format:
 	// https://<storage-account-name>.blob.core.windows.net/<container-name>/<blob-name>
 	azureScheme = "https"
@@ -255,16 +254,9 @@ func (ft *AzureFileTransfer) uploadBlob(
 	task *DefaultUploadTask,
 	requestBody io.Reader,
 ) (*http.Response, error) {
-	clientOptions := blockblob.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Retry: policy.RetryOptions{
-				MaxRetries: 0,
-			},
-		},
-	}
 	blockBlobClient := ft.blockBlobClient
 	if blockBlobClient == nil {
-		client, err := blockblob.NewClientWithNoCredential(task.Url, &clientOptions)
+		client, err := blockblob.NewClientWithNoCredential(task.Url, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -273,7 +265,7 @@ func (ft *AzureFileTransfer) uploadBlob(
 
 	uploadOptions := blockblob.UploadStreamOptions{
 		Concurrency: 4,
-		BlockSize:   4 * 1024,
+		BlockSize:   azureBlockSize,
 		HTTPHeaders: &blob.HTTPHeaders{},
 	}
 
@@ -288,7 +280,11 @@ func (ft *AzureFileTransfer) uploadBlob(
 		uploadOptions.HTTPHeaders.BlobContentType = &contentType
 	}
 
-	resp, err := blockBlobClient.UploadStream(context.Background(), requestBody, &uploadOptions)
+	ctx := task.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resp, err := blockBlobClient.UploadStream(ctx, requestBody, &uploadOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -570,6 +566,17 @@ func (ft *AzureFileTransfer) downloadBlobToFile(
 	if err != nil {
 		return fmt.Errorf("unable to create destination file %s: %w", localPath, err)
 	}
+	defer func() {
+		if err := destination.Close(); err != nil {
+			ft.logger.CaptureError(
+				fmt.Errorf(
+					"azure file transfer: download: error closing file %s: %w",
+					localPath,
+					err,
+				),
+			)
+		}
+	}()
 
 	// If version ID is specified, use the blob client to download the blob
 	_, ok := task.VersionIDString()

--- a/core/internal/filetransfer/file_transfer_azure_test.go
+++ b/core/internal/filetransfer/file_transfer_azure_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 )
 
+type testContextKey string
+
 // the mockAzureClients mock the azure client with the following containers/blobs:
 // account/container
 // |
@@ -296,6 +298,7 @@ type mockAzureBlockBlobClient struct {
 	t               *testing.T
 	contentExpected []byte
 	headers         map[string]string
+	contextExpected context.Context
 	shouldFail      bool
 }
 
@@ -307,6 +310,9 @@ func (m mockAzureBlockBlobClient) UploadStream(
 	if m.shouldFail {
 		return blockblob.UploadStreamResponse{}, fmt.Errorf("upload failed")
 	}
+	assert.Equal(m.t, m.contextExpected, ctx)
+	assert.Equal(m.t, int64(4*1024*1024), options.BlockSize)
+	assert.Equal(m.t, 4, options.Concurrency)
 	bodyBytes, err := io.ReadAll(body)
 	assert.NoError(m.t, err)
 	assert.Equal(m.t, m.contentExpected, bodyBytes)
@@ -330,6 +336,11 @@ func TestAzureFileTransfer_Upload(t *testing.T) {
 	mockAzureBlockBlobClient := mockAzureBlockBlobClient{
 		t:               t,
 		contentExpected: contentExpected,
+		contextExpected: context.WithValue(
+			context.Background(),
+			testContextKey("test-key"),
+			"test-value",
+		),
 		headers: map[string]string{
 			"Content-MD5":  contentMD5,
 			"Content-Type": "text/plain",
@@ -359,6 +370,7 @@ func TestAzureFileTransfer_Upload(t *testing.T) {
 		Path:    filename,
 		Url:     "https://account.blob.core.windows.net/container/test-upload-file.txt",
 		Headers: headers,
+		Context: mockAzureBlockBlobClient.contextExpected,
 	}
 
 	// Performing the upload

--- a/core/internal/filetransfer/task_default_test.go
+++ b/core/internal/filetransfer/task_default_test.go
@@ -32,3 +32,14 @@ func TestParseHeaders(t *testing.T) {
 		assert.ErrorContains(t, err, `["no-colon" "also bad"]`)
 	})
 }
+
+func TestDefaultUploadTask_RequiresAzureUploadUsesBackendHeader(t *testing.T) {
+	task := &filetransfer.DefaultUploadTask{
+		Url: "https://account.blob.core.windows.net/container/blob?user-delegation-sas",
+		Headers: http.Header{
+			"X-Ms-Blob-Type": {"BlockBlob"},
+		},
+	}
+
+	assert.True(t, task.RequiresAzureUpload())
+}


### PR DESCRIPTION
## Azure transfer changes

Azure uploads now use the task context, a 4 MiB block size, and the Azure SDK's retry policy. Reference-prefix downloads are capped at 32 workers and close each destination file.

Managed uploads still use the signed URL and headers returned by the W&B backend. The client never handles an account credential, so account-key and user-delegation SAS URLs follow the same code path. A routing test covers signed URLs marked with `x-ms-blob-type`.

Reference artifacts are separate. They continue to use `DefaultAzureCredential`.

## Checks

- `go test ./internal/filetransfer -count=1`
- `go vet ./internal/filetransfer`

Jira: WB-38010
