### PR TITLE
fix(sdk): increase local-testcontainer sweeps worker concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ executors:
         environment:
           CI: 1
           WANDB_ENABLE_TEST_CONTAINER: true
+          GUNICORN_WORKERS: 9
+          GUNICORN_THREADS: 1
     resource_class: wandb/docker-builder
 
 commands:


### PR DESCRIPTION
Description
-----------
- Fixes WB-36929

test_wandb_agent_full.py takes about 33s to complete locally, and in a busy CI frequently times out and fails the system tests on innocent PRs

- [x] CHANGELOG.unreleased.md Not applicable


Testing
-------
Built a new local-testcontainer on a private image and tested, test_wandb_agent_full takes N seconds