### PR TITLE
fix(sdk): generate valid API keys for system tests

### DIFF
--- a/tests/system_tests/backend_fixtures.py
+++ b/tests/system_tests/backend_fixtures.py
@@ -171,7 +171,10 @@ class BackendFixtureFactory:
 
     def make_user(self, name: str | None = None, admin: bool = False) -> str:
         """Create a new user and return their username."""
-        name = name or (f"user_{self.worker_id}-{random_string(length=40)}")
+        name = name or (
+            f"user_{self.worker_id}-"
+            f"{random_string(alphabet=digits + 'abcdef', length=40)}"
+        )
 
         self.send_cmds(
             UserCmd("up", username=name, admin=admin),


### PR DESCRIPTION
## Description

Core PR [wandb/core#49062](https://github.com/wandb/core/pull/49062) tightened legacy API-key recognition to an optional prefix followed by exactly 40 hexadecimal characters.

The SDK system-test fixture uses its generated username as `WANDB_API_KEY`, but the 40-character suffix was generated from lowercase letters and digits. Those keys now fall through authentication and make server-backed SDK tests fail with `user is not logged in` or `Invalid credentials`.

Generate only the API-key suffix from lowercase hexadecimal characters. Other random fixture names keep their existing alphabet.
