### PR TITLE
refactor: make internal/api retry logging unconditional

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -142,8 +142,6 @@ func NewClient(opts ClientOptions) RetryableClient {
 	retryableHTTP.RetryWaitMax = opts.RetryWaitMax
 	retryableHTTP.HTTPClient.Timeout = opts.NonRetryTimeout
 	retryableHTTP.PrepareRetry = opts.PrepareRetry
-
-	// Set the retry policy with debug logging if possible.
 	retryableHTTP.CheckRetry = withRetryObservation(
 		opts.RetryPolicy,
 		opts.Logger,

--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -52,7 +52,7 @@ type RetryableClient interface {
 // clientImpl implements the RetryableClient interface.
 type clientImpl struct {
 	retryableHTTP RetryableClient // underlying HTTP client
-	logger        *slog.Logger
+	logger        *slog.Logger    // never nil
 }
 
 type ClientOptions struct {
@@ -128,6 +128,12 @@ func NewClient(opts ClientOptions) RetryableClient {
 	if opts.BaseURL == nil {
 		panic("api: nil BaseURL")
 	}
+	if opts.RetryPolicy == nil {
+		opts.RetryPolicy = retryablehttp.DefaultRetryPolicy
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.DiscardHandler)
+	}
 
 	retryableHTTP := retryablehttp.NewClient()
 	retryableHTTP.Backoff = clients.ExponentialBackoffWithJitter
@@ -138,22 +144,16 @@ func NewClient(opts ClientOptions) RetryableClient {
 	retryableHTTP.PrepareRetry = opts.PrepareRetry
 
 	// Set the retry policy with debug logging if possible.
-	retryPolicy := opts.RetryPolicy
-	if retryPolicy == nil {
-		retryPolicy = retryablehttp.DefaultRetryPolicy
-	}
-	if opts.Logger != nil {
-		retryPolicy = withRetryLogging(retryPolicy, opts.Logger)
-	}
-	retryableHTTP.CheckRetry = retryPolicy
+	retryableHTTP.CheckRetry = withRetryObservation(
+		opts.RetryPolicy,
+		opts.Logger,
+	)
 
 	// Let the client log debug messages.
-	if opts.Logger != nil {
-		retryableHTTP.Logger = slog.NewLogLogger(
-			opts.Logger.Handler(),
-			slog.LevelDebug,
-		)
-	}
+	retryableHTTP.Logger = slog.NewLogLogger(
+		opts.Logger.Handler(),
+		slog.LevelDebug,
+	)
 
 	// Set the Proxy function on the HTTP client.
 	transport := &http.Transport{

--- a/core/internal/api/logging.go
+++ b/core/internal/api/logging.go
@@ -18,7 +18,7 @@ func (client *clientImpl) logFinalResponseOnError(
 	req *retryablehttp.Request,
 	resp *http.Response,
 ) {
-	if resp.StatusCode < 400 || client.logger == nil {
+	if resp.StatusCode < 400 {
 		return
 	}
 
@@ -32,8 +32,11 @@ func (client *clientImpl) logFinalResponseOnError(
 	)
 }
 
-// Wraps a RetryPolicy to log retries.
-func withRetryLogging(
+// withRetryObservation wraps a retry policy to log retries.
+//
+// The resulting CheckRetry function always invokes the given policy
+// and acts based on its outcome.
+func withRetryObservation(
 	policy retryablehttp.CheckRetry,
 	logger *slog.Logger,
 ) retryablehttp.CheckRetry {
@@ -47,42 +50,44 @@ func withRetryLogging(
 			err = newErr
 		}
 
-		if willRetry {
-			switch {
-			case resp == nil && err == nil:
-				logger.Error("api: retrying HTTP request, no error or response")
-
-			case err != nil:
-				logger.Info("api: retrying error", "error", err)
-				wboperation.Get(ctx).MarkRetryingError(err)
-
-			case resp.StatusCode >= 400:
-				bodyFirstKB, err := readResponseBodyUpToLimit(resp, 1024)
-
-				var bodyToLog string
-				if err == nil {
-					bodyToLog = string(bodyFirstKB)
-				} else {
-					bodyToLog = fmt.Sprintf("error reading body: %v", err)
-				}
-
-				logger.Info(
-					"api: retrying HTTP error",
-					"status", resp.StatusCode,
-					"url", resp.Request.URL.String(),
-					"body", bodyToLog,
-				)
-
-				// TODO: Report the attempt number & time to next retry.
-				wboperation.Get(ctx).MarkRetryingHTTPError(
-					resp.StatusCode,
-					resp.Status,
-					ErrorFromWBResponse(bodyFirstKB),
-				)
-			}
+		if !willRetry {
+			return false, err
 		}
 
-		return willRetry, err
+		switch {
+		case resp == nil && err == nil:
+			logger.Error("api: retrying HTTP request, no error or response")
+
+		case err != nil:
+			logger.Info("api: retrying error", "error", err)
+			wboperation.Get(ctx).MarkRetryingError(err)
+
+		case resp.StatusCode >= 400:
+			bodyFirstKB, err := readResponseBodyUpToLimit(resp, 1024)
+
+			var bodyToLog string
+			if err == nil {
+				bodyToLog = string(bodyFirstKB)
+			} else {
+				bodyToLog = fmt.Sprintf("error reading body: %v", err)
+			}
+
+			logger.Info(
+				"api: retrying HTTP error",
+				"status", resp.StatusCode,
+				"url", resp.Request.URL.String(),
+				"body", bodyToLog,
+			)
+
+			// TODO: Report the attempt number & time to next retry.
+			wboperation.Get(ctx).MarkRetryingHTTPError(
+				resp.StatusCode,
+				resp.Status,
+				ErrorFromWBResponse(bodyFirstKB),
+			)
+		}
+
+		return true, err
 	}
 }
 

--- a/core/internal/api/logging.go
+++ b/core/internal/api/logging.go
@@ -40,6 +40,9 @@ func withRetryObservation(
 	policy retryablehttp.CheckRetry,
 	logger *slog.Logger,
 ) retryablehttp.CheckRetry {
+	if policy == nil {
+		panic("api: withRetryLogging: nil policy")
+	}
 	if logger == nil {
 		panic("api: withRetryLogging: nil logger")
 	}


### PR DESCRIPTION
Calls withRetryLogging unconditionally, since the logic added by PR #12216 depends on it happening.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>