### PR TITLE
docs(sdk): add reinit option to init docstring

### DIFF
--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -335,6 +335,16 @@ def init(
             switching to offline mode if the user is not logged in.
         reinit: Shorthand for the "reinit" setting. Determines the behavior of
             `wandb.init()` when a run is active.
+        - `"default"`: Use "finish_previous" in notebooks and "return_previous"
+            otherwise.
+        - `"return_previous"`: Return the most recently created run
+            that is not yet finished. This does not update `wandb.run`; see
+            the "create_new" option.
+        - `"finish_previous"`: Finish all active runs, then return a new run.
+        - `"create_new"`: Create a new run without modifying other active runs.
+            Does not update `wandb.run` and top-level functions like `wandb.log`.
+            Because of this, some older integrations that rely on the global run
+            will not work.
         resume: Controls the behavior when resuming a run with the specified `id`.
             Available options are:
         - `"allow"`: If a run with the specified `id` exists, it will resume

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1323,6 +1323,16 @@ def init(  # noqa: C901
             switching to offline mode if the user is not logged in.
         reinit: Shorthand for the "reinit" setting. Determines the behavior of
             `wandb.init()` when a run is active.
+        - `"default"`: Use "finish_previous" in notebooks and "return_previous"
+            otherwise.
+        - `"return_previous"`: Return the most recently created run
+            that is not yet finished. This does not update `wandb.run`; see
+            the "create_new" option.
+        - `"finish_previous"`: Finish all active runs, then return a new run.
+        - `"create_new"`: Create a new run without modifying other active runs.
+            Does not update `wandb.run` and top-level functions like `wandb.log`.
+            Because of this, some older integrations that rely on the global run
+            will not work.
         resume: Controls the behavior when resuming a run with the specified `id`.
             Available options are:
         - `"allow"`: If a run with the specified `id` exists, it will resume


### PR DESCRIPTION
Description
-----------
To the reviewer: Unsure how we should go about documenting the same reinit options across different objects. i.e. One description might get stale?

Alternatively, we could tell users to look at wandb.Settings for available options?

- Related https://coreweave.atlassian.net/browse/DOCS-2510

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
