### PR TITLE
refactor: include last retried error in timeout/cancellation error in internal/api

### DIFF
--- a/core/internal/api/logging.go
+++ b/core/internal/api/logging.go
@@ -63,6 +63,7 @@ func withRetryObservation(
 
 		case err != nil:
 			logger.Info("api: retrying error", "error", err)
+			setLastRetriedError(ctx, err.Error())
 			wboperation.Get(ctx).MarkRetryingError(err)
 
 		case resp.StatusCode >= 400:
@@ -81,6 +82,11 @@ func withRetryObservation(
 				"url", resp.Request.URL.String(),
 				"body", bodyToLog,
 			)
+
+			setLastRetriedError(ctx,
+				fmt.Sprintf("HTTP %d: %s",
+					resp.StatusCode,
+					bodyToLog))
 
 			// TODO: Report the attempt number & time to next retry.
 			wboperation.Get(ctx).MarkRetryingHTTPError(

--- a/core/internal/api/retryobserver.go
+++ b/core/internal/api/retryobserver.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+)
+
+type retryObserverKey struct{}
+
+// retryObserver tracks the errors retried by retryablehttp.
+//
+// It is only meant to be used during the execution of a single request,
+// in a single goroutine, so it is not lock-protected.
+type retryObserver struct {
+	// lastRetriedError is a string representation of the most recently
+	// retried error, if any.
+	lastRetriedError string
+}
+
+// withRetryObserver returns a new context in which retried errors can be
+// tracked.
+func withRetryObserver(ctx context.Context) context.Context {
+	return context.WithValue(ctx, retryObserverKey{}, &retryObserver{})
+}
+
+// setLastRetriedError records the most recent error being retried,
+// if a retry observer is available.
+func setLastRetriedError(ctx context.Context, desc string) {
+	observer, ok := ctx.Value(retryObserverKey{}).(*retryObserver)
+	if !ok {
+		return
+	}
+
+	observer.lastRetriedError = desc
+}
+
+// lastRetriedError returns a description of the last error retried, if any,
+// by the current HTTP request.
+func lastRetriedError(ctx context.Context) string {
+	observer, ok := ctx.Value(retryObserverKey{}).(*retryObserver)
+	if !ok {
+		return ""
+	}
+
+	return observer.lastRetriedError
+}

--- a/core/internal/api/retryobserver_test.go
+++ b/core/internal/api/retryobserver_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryObserver(t *testing.T) {
+	ctx := withRetryObserver(context.Background())
+
+	setLastRetriedError(ctx, "some error")
+
+	assert.Equal(t, "some error", lastRetriedError(ctx))
+}
+
+func TestNoRetryObserver(t *testing.T) {
+	ctx := context.Background()
+
+	assert.NotPanics(t, func() { setLastRetriedError(ctx, "some error") })
+	assert.Empty(t, lastRetriedError(ctx))
+}

--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -11,17 +13,15 @@ import (
 
 // Do implements RetryableClient.Do.
 func (client *clientImpl) Do(req *retryablehttp.Request) (*http.Response, error) {
+	// Track retried errors to provide a better error message at the end.
+	req = req.WithContext(withRetryObserver(req.Context()))
+
 	resp, err := client.retryableHTTP.Do(req)
+	wboperation.Get(req.Context()).ClearError()
 
 	if err != nil {
-		// Keep the operation's error status: it identifies the error that
-		// was being retried, which is usually more specific than the final
-		// error. In particular, when the request is cancelled by a deadline
-		// during a retry backoff, `err` is a bare context error.
-		return nil, err
+		return nil, enhanceContextError(err, lastRetriedError(req.Context()))
 	}
-
-	wboperation.Get(req.Context()).ClearError()
 
 	// This is a bug that happens with retryablehttp sometimes.
 	if resp == nil {
@@ -30,4 +30,24 @@ func (client *clientImpl) Do(req *retryablehttp.Request) (*http.Response, error)
 
 	client.logFinalResponseOnError(req, resp)
 	return resp, nil
+}
+
+// enhanceContextError adds the message of the most recently retried error
+// to context cancellation and timeout errors.
+func enhanceContextError(finalErr error, lastRetriedErr string) error {
+	if lastRetriedErr == "" {
+		return finalErr
+	}
+
+	if !errors.Is(finalErr, context.Canceled) &&
+		!errors.Is(finalErr, context.DeadlineExceeded) {
+		return finalErr
+	}
+
+	// Use Join to preserve the fact that this is a cancellation or timeout,
+	// so that callers can check it.
+	return errors.Join(
+		finalErr,
+		fmt.Errorf("last status: %s", lastRetriedErr),
+	)
 }

--- a/core/internal/runupserter/runupdateerror.go
+++ b/core/internal/runupserter/runupdateerror.go
@@ -1,7 +1,6 @@
 package runupserter
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -9,7 +8,6 @@ import (
 	"github.com/Khan/genqlient/graphql"
 
 	"github.com/wandb/wandb/core/internal/runbranch"
-	"github.com/wandb/wandb/core/internal/wboperation"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -68,33 +66,6 @@ func fromGQLError(gqlError *graphql.HTTPError) *RunUpdateError {
 
 	return &RunUpdateError{
 		Cause:       gqlError,
-		UserMessage: userMessage,
-		Code:        spb.ErrorInfo_COMMUNICATION,
-	}
-}
-
-// explainInitTimeout enhances errors caused by reaching the client's init
-// timeout during run initialization.
-//
-// If the error is the operation's context reaching its deadline, it is
-// converted to a RunUpdateError whose message includes the operation's
-// error status—usually the error that was being retried. Other errors,
-// including nil, are returned unchanged.
-func explainInitTimeout(
-	err error,
-	operation *wboperation.WandbOperation,
-) error {
-	if !errors.Is(err, context.DeadlineExceeded) {
-		return err
-	}
-
-	userMessage := "Timed out while creating the run."
-	if status := operation.ErrorStatus(); status != "" {
-		userMessage = fmt.Sprintf("%s Last status: %s.", userMessage, status)
-	}
-
-	return &RunUpdateError{
-		Cause:       err,
 		UserMessage: userMessage,
 		Code:        spb.ErrorInfo_COMMUNICATION,
 	}

--- a/core/internal/runupserter/runupdateerror.go
+++ b/core/internal/runupserter/runupdateerror.go
@@ -1,6 +1,7 @@
 package runupserter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -26,6 +27,10 @@ func ToRunUpdateError(err error) error {
 
 	if gqlError, ok := errors.AsType[*graphql.HTTPError](err); ok {
 		return fromGQLError(gqlError)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fromTimeout(err)
 	}
 
 	return err
@@ -67,6 +72,14 @@ func fromGQLError(gqlError *graphql.HTTPError) *RunUpdateError {
 	return &RunUpdateError{
 		Cause:       gqlError,
 		UserMessage: userMessage,
+		Code:        spb.ErrorInfo_COMMUNICATION,
+	}
+}
+
+func fromTimeout(err error) *RunUpdateError {
+	return &RunUpdateError{
+		Cause:       err,
+		UserMessage: fmt.Sprintf("Timed out initializing run: %s", err.Error()),
 		Code:        spb.ErrorInfo_COMMUNICATION,
 	}
 }

--- a/core/internal/runupserter/runupdateerror_test.go
+++ b/core/internal/runupserter/runupdateerror_test.go
@@ -1,7 +1,9 @@
 package runupserter_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/Khan/genqlient/graphql"
@@ -93,4 +95,19 @@ func Test_ToRunUpdateError_GQLError_Empty(t *testing.T) {
 	runUpdateError := result.(*runupserter.RunUpdateError)
 	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
 	assert.Contains(t, runUpdateError.UserMessage, "<no message>")
+}
+
+func Test_ToRunUpdateError_Timeout(t *testing.T) {
+	err := fmt.Errorf("some extra info: %w", context.DeadlineExceeded)
+
+	result := runupserter.ToRunUpdateError(err)
+
+	runUpdateError := result.(*runupserter.RunUpdateError)
+	assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
+	assert.Equal(t,
+		"Timed out initializing run: some extra info: context deadline exceeded",
+		runUpdateError.UserMessage)
+	assert.Equal(t,
+		"some extra info: context deadline exceeded",
+		runUpdateError.Error())
 }

--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -199,7 +199,7 @@ func InitRun(
 		err := upserter.updateMetadataForResume(ctx, params.Settings.GetResume())
 
 		if err != nil {
-			return nil, ToRunUpdateError(explainInitTimeout(err, operation))
+			return nil, ToRunUpdateError(err)
 		}
 
 	case branchPoint != nil && branchPoint.GetRun() == runRecord.RunId:
@@ -207,7 +207,7 @@ func InitRun(
 		err := upserter.updateMetadataForRewind(ctx, branchPoint)
 
 		if err != nil {
-			return nil, ToRunUpdateError(explainInitTimeout(err, operation))
+			return nil, ToRunUpdateError(err)
 		}
 
 	case branchPoint != nil && branchPoint.GetRun() != "":
@@ -243,7 +243,7 @@ func InitRun(
 	)
 
 	if err != nil {
-		return nil, ToRunUpdateError(explainInitTimeout(err, operation))
+		return nil, ToRunUpdateError(err)
 	}
 
 	// Fill some metadata based on the server response.

--- a/core/internal/runupserter/runupserter_test.go
+++ b/core/internal/runupserter/runupserter_test.go
@@ -184,7 +184,7 @@ func TestInitRun_UpsertError(t *testing.T) {
 	assert.Equal(t, "Everything is broken", runUpdateError.UserMessage)
 }
 
-func TestInitRun_InitTimeout_ReportsTimeout(t *testing.T) {
+func TestInitRun_InitTimeout(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		mockClient := gqlmock.NewMockClient()
 		params := testParams(t)
@@ -197,12 +197,7 @@ func TestInitRun_InitTimeout_ReportsTimeout(t *testing.T) {
 		upserter, err := runupserter.InitRun(runRecord(&spb.RunRecord{}), params)
 
 		assert.Nil(t, upserter)
-		var runUpdateError *runupserter.RunUpdateError
-		require.ErrorAs(t, err, &runUpdateError)
-		assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
-		assert.Contains(t,
-			runUpdateError.UserMessage,
-			"Timed out while creating the run")
+		assert.ErrorContains(t, err, "context deadline exceeded")
 	})
 }
 

--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pathlib import Path
 from unittest import mock
 
@@ -7,6 +8,30 @@ import pytest
 import wandb
 from wandb.errors import AuthenticationError, CommError
 from wandb.sdk.lib import runid
+
+from tests.fixtures.wandb_backend_spy import WandbBackendSpy
+
+
+def test_init_timeout__prints_retry_err(wandb_backend_spy: WandbBackendSpy):
+    # Set up UpsertBucket to return HTTP 500, which is retryable.
+    gql = wandb_backend_spy.gql
+    wandb_backend_spy.stub_gql(
+        gql.Matcher(operation="UpsertBucket"),
+        gql.Constant(
+            # GQL-like error response.
+            content={"errors": [{"message": "test test test"}]},
+            status=500,
+        ),
+    )
+
+    with pytest.raises(
+        match=re.escape("""\
+Error initializing run: context deadline exceeded
+last status: HTTP 500: {"errors": [{"message": "test test test"}]}""")
+    ):
+        # Give it just enough time to reach UpsertBucket and retry once.
+        with wandb.init(settings=wandb.Settings(init_timeout=2)):
+            pass
 
 
 def test_upsert_bucket_409(wandb_backend_spy):

--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -25,9 +25,10 @@ def test_init_timeout__prints_retry_err(wandb_backend_spy: WandbBackendSpy):
     )
 
     with pytest.raises(
+        CommError,
         match=re.escape("""\
-Error initializing run: context deadline exceeded
-last status: HTTP 500: {"errors": [{"message": "test test test"}]}""")
+Timed out initializing run: context deadline exceeded
+last status: HTTP 500: {"errors": [{"message": "test test test"}]}"""),
     ):
         # Give it just enough time to reach UpsertBucket and retry once.
         with wandb.init(settings=wandb.Settings(init_timeout=2)):


### PR DESCRIPTION
Makes `internal/api` track the errors it retries and add their messages to context cancellation and timeout errors.

This replaces the `WandbOperation.ErrorStatus()` method added in #12216 and simplifies the `runupserter` logic. This improves error messages for all calls made through the `internal/api` HTTP client.

The error message is a little less user-friendly as a result, but that can be fixed separately. It was previously

```
Timed out while creating a run. Last status: retrying HTTP 500: {"errors": ...}
```

and now it is

```
Error initializing run: context deadline exceeded
last status: HTTP 500: {"errors": ...}
```

(with the newline). Note that since #12216, the error no longer includes a hint about the `init_timeout` setting, which we'll also want to fix.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>