### PR TITLE
refactor: parse GQL errors in internal/api

### DIFF
--- a/core/internal/api/gqlerrors.go
+++ b/core/internal/api/gqlerrors.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Khan/genqlient/graphql"
+)
+
+// MaybeGQLErrorResponse parses and returns the GraphQL error messages from
+// the HTTP response body, if it looks like a GraphQL error response.
+func MaybeGQLErrorResponse(responseBody []byte) string {
+	var gqlResponse graphql.Response
+	err := json.Unmarshal(responseBody, &gqlResponse)
+	if err != nil {
+		return ""
+	}
+
+	return FormatGQLErrors(gqlResponse)
+}
+
+// FormatGQLErrors formats the error messages in a graphql.Response.
+//
+// Returns the empty string if there are no errors.
+func FormatGQLErrors(response graphql.Response) string {
+	switch {
+	case len(response.Errors) < 1:
+		return ""
+
+	case len(response.Errors) == 1:
+		return response.Errors[0].Message
+
+	default:
+		var messages []string
+		for _, err := range response.Errors {
+			messages = append(messages, err.Message)
+		}
+		joinedMessages := strings.Join(messages, "; ")
+		return fmt.Sprintf("[%s]", joinedMessages)
+	}
+}

--- a/core/internal/api/gqlerrors_test.go
+++ b/core/internal/api/gqlerrors_test.go
@@ -1,0 +1,60 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/wandb/wandb/core/internal/api"
+)
+
+func Test_FormatGQLErrors_GQLError_One(t *testing.T) {
+	response := graphql.Response{
+		Errors: gqlerror.List{
+			{Message: "gql error message"},
+		},
+	}
+
+	result := api.FormatGQLErrors(response)
+
+	assert.Equal(t, "gql error message", result)
+}
+
+func Test_FormatGQLErrors_GQLError_Many(t *testing.T) {
+	response := graphql.Response{
+		Errors: gqlerror.List{
+			{Message: "gql 1"},
+			{Message: "gql 2"},
+		},
+	}
+
+	result := api.FormatGQLErrors(response)
+
+	assert.Equal(t, "[gql 1; gql 2]", result)
+}
+
+func Test_FormatGQLErrors_GQLError_None(t *testing.T) {
+	response := graphql.Response{}
+
+	result := api.FormatGQLErrors(response)
+
+	assert.Empty(t, result)
+}
+
+func Test_MaybeGQLErrorResponse(t *testing.T) {
+	result := api.MaybeGQLErrorResponse([]byte(`
+		{"errors": [
+			{"message": "err 1"},
+			{"message": "err 2"}
+		]}`))
+
+	assert.Equal(t, "[err 1; err 2]", result)
+}
+
+func Test_MaybeGQLErrorResponse_Incomplete(t *testing.T) {
+	result := api.MaybeGQLErrorResponse([]byte(`{"errors": [`))
+
+	assert.Empty(t, result)
+}

--- a/core/internal/api/logging.go
+++ b/core/internal/api/logging.go
@@ -71,7 +71,12 @@ func withRetryObservation(
 
 			var bodyToLog string
 			if err == nil {
-				bodyToLog = string(bodyFirstKB)
+				gqlErrors := MaybeGQLErrorResponse(bodyFirstKB)
+				if gqlErrors != "" {
+					bodyToLog = gqlErrors
+				} else {
+					bodyToLog = string(bodyFirstKB)
+				}
 			} else {
 				bodyToLog = fmt.Sprintf("error reading body: %v", err)
 			}

--- a/core/internal/runupserter/runupdateerror.go
+++ b/core/internal/runupserter/runupdateerror.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Khan/genqlient/graphql"
 
+	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/runbranch"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -45,21 +45,7 @@ func fromRunBranchError(runBranchError *runbranch.BranchError) *RunUpdateError {
 }
 
 func fromGQLError(gqlError *graphql.HTTPError) *RunUpdateError {
-	var userMessage string
-
-	switch {
-	case len(gqlError.Response.Errors) == 0:
-		userMessage = gqlError.Error()
-	case len(gqlError.Response.Errors) == 1:
-		userMessage = gqlError.Response.Errors[0].Message
-	default:
-		var messages []string
-		for _, err := range gqlError.Response.Errors {
-			messages = append(messages, err.Message)
-		}
-		joinedMessages := strings.Join(messages, "; ")
-		userMessage = fmt.Sprintf("[%s]", joinedMessages)
-	}
+	userMessage := api.FormatGQLErrors(gqlError.Response)
 
 	if userMessage == "" {
 		// An empty UserMessage is treated like "no error" by the client.

--- a/core/internal/runupserter/runupdateerror_test.go
+++ b/core/internal/runupserter/runupdateerror_test.go
@@ -32,7 +32,7 @@ func Test_ToRunUpdateError_BranchError(t *testing.T) {
 	assert.Equal(t, spb.ErrorInfo_UNSUPPORTED, runUpdateError.Code)
 }
 
-func Test_ToRunUpdateError_GQLError_One(t *testing.T) {
+func Test_ToRunUpdateError_GQLError(t *testing.T) {
 	err := &graphql.HTTPError{
 		StatusCode: 400,
 		Response: graphql.Response{
@@ -48,38 +48,6 @@ func Test_ToRunUpdateError_GQLError_One(t *testing.T) {
 	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
 	assert.Equal(t, "gql error message", runUpdateError.UserMessage)
 	assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
-}
-
-func Test_ToRunUpdateError_GQLError_Many(t *testing.T) {
-	err := &graphql.HTTPError{
-		StatusCode: 400,
-		Response: graphql.Response{
-			Errors: gqlerror.List{
-				{Message: "gql 1"},
-				{Message: "gql 2"},
-			},
-		},
-	}
-
-	result := runupserter.ToRunUpdateError(err)
-
-	runUpdateError := result.(*runupserter.RunUpdateError)
-	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
-	assert.Equal(t, "[gql 1; gql 2]", runUpdateError.UserMessage)
-	assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
-}
-
-func Test_ToRunUpdateError_GQLError_None(t *testing.T) {
-	err := &graphql.HTTPError{
-		StatusCode: 400,
-		Response:   graphql.Response{}, // no GQL errors (unusual)
-	}
-
-	result := runupserter.ToRunUpdateError(err)
-
-	runUpdateError := result.(*runupserter.RunUpdateError)
-	assert.ErrorContains(t, runUpdateError, "400") // from HTTPError.Error()
-	assert.Contains(t, runUpdateError.UserMessage, "400")
 }
 
 func Test_ToRunUpdateError_GQLError_Empty(t *testing.T) {

--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -28,7 +28,7 @@ def test_init_timeout__prints_retry_err(wandb_backend_spy: WandbBackendSpy):
         CommError,
         match=re.escape("""\
 Timed out initializing run: context deadline exceeded
-last status: HTTP 500: {"errors": [{"message": "test test test"}]}"""),
+last status: HTTP 500: test test test"""),
     ):
         # Give it just enough time to reach UpsertBucket and retry once.
         with wandb.init(settings=wandb.Settings(init_timeout=2)):


### PR DESCRIPTION
Makes `internal/api` parse errors out of GQL response bodies to improve logging and `wboperation` messages.

This also improves the `wandb.init()` timeout error message over what was added in #12216 (see `test_wandb_init.py`).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>