### PR TITLE
chore: wait for PyPI before notifying core

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -523,9 +523,33 @@ jobs:
     if: ${{ inputs.mode != 'test-release' }}
     name: notify wandb/core of release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [pypi-publish]
 
     steps:
+      - name: Wait for release to become visible on PyPI
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          max_attempts=20
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if curl --fail --silent --show-error \
+              --max-time 10 \
+              --output /dev/null \
+              "https://pypi.org/pypi/wandb/${VERSION}/json"; then
+              echo "wandb ${VERSION} is visible on PyPI"
+              exit 0
+            fi
+
+            if [[ "${attempt}" == "${max_attempts}" ]]; then
+              echo "wandb ${VERSION} was not visible on PyPI after ${max_attempts} attempts" >&2
+              exit 1
+            fi
+
+            echo "wandb ${VERSION} is not visible on PyPI yet; retrying in 15 seconds"
+            sleep 15
+          done
+
       - name: Create GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3


### PR DESCRIPTION
Description
-----------

The 0.28.1 release notified `wandb/core` about ten seconds after the final PyPI upload completed. PyPI had not exposed the version to dependency resolvers yet, so the automated core update failed while running `uv add wandb==0.28.1`.

This change makes the release workflow wait for the version-specific PyPI JSON endpoint before dispatching `wandb-sdk-released`. It checks up to 20 times at 15-second intervals and fails without dispatching if the version remains unavailable. The notification job now has a ten-minute timeout.

- [x] Updating `CHANGELOG.unreleased.md` is not applicable because this only changes release automation.

Testing
-------

- `git diff --check`
- Compared `actionlint` results before and after the change. Both report the same six existing findings; this change adds none.
- Confirmed the polling shell passes ShellCheck and returns success for an existing PyPI version and failure for a nonexistent version.
