### PR TITLE
feat: add run.sync_dir

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 
 - Added support for gzip compression of filestream requests, reducing network traffic when logging metrics. It is currently opt-in and requires server support: set `x_file_stream_no_gzip=False` in `wandb.Settings` to enable it. Compression will become the default in a future release (@dmitryduev in https://github.com/wandb/wandb/pull/12262)
 - Added a `--term-timeout` flag to `wandb agent` (@nathancy-wandb in https://github.com/wandb/wandb/pull/12246)
+- Added `run.sync_dir` (@timoffex in https://github.com/wandb/wandb/pull/12319)
 
 ## Changed
 

--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -188,7 +188,7 @@ def test_syncs_run(
         run.save(test_file, base_path=test_file.parent)
         run.summary["test_sync_summary"] = "test summary"
 
-    result = runner.invoke(cli.beta, f"sync {run.settings.sync_dir}")
+    result = runner.invoke(cli.beta, f"sync {run.sync_dir}")
 
     lines = result.output.splitlines()
     assert lines[0] == "wandb: Syncing 1 run(s):"
@@ -223,7 +223,7 @@ def test_sync_reports_init_error(
         gql.once(content="fake UpsertBucket error", status=400),
     )
 
-    result = runner.invoke(cli.beta, f"sync {run.settings.sync_dir}")
+    result = runner.invoke(cli.beta, f"sync {run.sync_dir}")
 
     assert "fake UpsertBucket error" in result.output
 
@@ -260,9 +260,9 @@ def test_syncs_resumed_run(
         run2.log({"x": "b"})
     with wandb.init(id=run1.id, resume="must") as run3:
         run3.log({"x": "c"})
-    run1_dir = run1.settings.sync_dir
-    run2_dir = run2.settings.sync_dir
-    run3_dir = run3.settings.sync_dir
+    run1_dir = run1.sync_dir
+    run2_dir = run2.sync_dir
+    run3_dir = run3.sync_dir
     new_id = f"{run1.id}-copy"
 
     # Use --no-skip-online since resuming offline runs is unsupported.
@@ -301,8 +301,8 @@ def test_resyncs_resumed_offline_run_keep_same_steps(
     with wandb.init(mode="offline", id=run1.id, resume="must") as run2:
         run2.log({"x": "b"})
 
-    run1_dir = run1.settings.sync_dir
-    run2_dir = run2.settings.sync_dir
+    run1_dir = run1.sync_dir
+    run2_dir = run2.sync_dir
 
     def resumed_segment_steps(history: dict[int, Any]) -> set[int]:
         return {row["_step"] for row in history.values() if row["x"] == "b"}
@@ -335,7 +335,7 @@ def test_sync_to_other_path(
 
     runner.invoke(
         cli.beta,
-        f"sync -p project2 --id {run.id}-copy {run.settings.sync_dir}",
+        f"sync -p project2 --id {run.id}-copy {run.sync_dir}",
     )
 
     with wandb_backend_spy.freeze() as snapshot:
@@ -361,7 +361,7 @@ def test_sync_overrides(
 
     runner.invoke(
         cli.beta,
-        f"sync {run.settings.sync_dir}"
+        f"sync {run.sync_dir}"
         + " --job-type job-override"
         + " --replace-tags old1=new1,old2=new2,delete=",
     )

--- a/tests/system_tests/test_core/test_wandb_clean_full.py
+++ b/tests/system_tests/test_core/test_wandb_clean_full.py
@@ -16,13 +16,13 @@ def test_cleans_expected_runs(runner: CliRunner):
         pass
     with wandb.init(mode="offline") as synced_run:
         pass
-    runner.invoke(cli.sync, synced_run.settings.sync_dir)
+    runner.invoke(cli.sync, synced_run.sync_dir)
 
     result = runner.invoke(clean, ["--min-hours", "0"], input="y")
 
-    assert os.path.exists(unsynced_run.settings.sync_dir)
-    assert not os.path.exists(synced_run.settings.sync_dir)
-    assert not os.path.exists(online_run.settings.sync_dir)
+    assert os.path.exists(unsynced_run.sync_dir)
+    assert not os.path.exists(synced_run.sync_dir)
+    assert not os.path.exists(online_run.sync_dir)
     assert "Found 2 run(s) to clean." in result.output
     assert online_run.id in result.output
     assert synced_run.id in result.output

--- a/tests/system_tests/test_core/test_wandb_settings.py
+++ b/tests/system_tests/test_core/test_wandb_settings.py
@@ -15,7 +15,7 @@ from wandb import env
 )
 def test_sync_dir(user):
     with wandb.init(settings={"mode": "offline"}) as run:
-        assert run._settings.sync_dir == os.path.realpath(
+        assert run.sync_dir == os.path.realpath(
             os.path.join(".", "wandb", "latest-run")
         )
 

--- a/tests/system_tests/test_functional/sync/test_sync.py
+++ b/tests/system_tests/test_functional/sync/test_sync.py
@@ -59,7 +59,7 @@ def _log_run(inputs: queue.Queue[str], outputs: queue.Queue[str]) -> None:
     """
 
     with wandb.init(mode="offline") as run:
-        outputs.put(run.settings.sync_dir)
+        outputs.put(run.sync_dir)
 
         # Force the run to flush to disk, so that syncing may start.
         run.log({"lots_of_data": "a" * 32 * 1024})

--- a/tests/unit_tests/test_library_public.py
+++ b/tests/unit_tests/test_library_public.py
@@ -229,6 +229,7 @@ SYMBOLS_RUN_OTHER = {
     "start_time",
     "path",
     "dir",
+    "sync_dir",
 }
 
 

--- a/tests/unit_tests/test_wandb_init.py
+++ b/tests/unit_tests/test_wandb_init.py
@@ -65,8 +65,8 @@ def test_avoids_sync_dir_conflict(mocker):
     with wandb.init(mode="offline", id="sync-dir-test") as run3:
         pass
 
-    assert run2.settings.sync_dir == run1.settings.sync_dir + "-1"
-    assert run3.settings.sync_dir == run1.settings.sync_dir + "-2"
+    assert run2.sync_dir == run1.sync_dir + "-1"
+    assert run3.sync_dir == run1.sync_dir + "-2"
 
 
 def test_temp_dir_cleanup_on_exit(tmp_path, monkeypatch):

--- a/tests/unit_tests/test_wandb_run.py
+++ b/tests/unit_tests/test_wandb_run.py
@@ -51,6 +51,7 @@ REFERENCE_ATTRIBUTES = set(
         "summary",
         "sweep_id",
         "sweep_url",
+        "sync_dir",
         "tags",
         "to_html",
         "unwatch",

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -758,8 +758,23 @@ class Run:
     @_log_to_run
     @_attach
     def dir(self) -> str:
-        """The directory where files associated with the run are saved."""
+        """The directory where a run's files are saved.
+
+        This refers to files saved with `run.save()`, including automatically
+        created files for certain data types passed to `run.log()`. For the
+        directory containing all of a run's data, see `run.sync_dir`.
+        """
         return self._settings.files_dir
+
+    @property
+    @_log_to_run
+    @_attach
+    def sync_dir(self) -> str:
+        """The directory containing all of a run's data.
+
+        This can be passed to `wandb sync` to upload or re-upload the run.
+        """
+        return self._settings.sync_dir
 
     @property
     @_log_to_run
@@ -3841,7 +3856,9 @@ class Run:
         self._printer.display(f"Tracking run with wandb version {wandb.__version__}")
 
     def _header_sync_info(self) -> None:
-        sync_location_msg = f"Run data is saved locally in {self._printer.files(self._settings.sync_dir)}"
+        sync_location_msg = (
+            f"Run data is saved locally in {self._printer.files(self.sync_dir)}"
+        )
 
         if self._settings._offline:
             offline_warning = (


### PR DESCRIPTION
Add a `sync_dir` property to the run object to make that more easily accessible.

It's natural to try `run.dir` since we use the phrase "run directory" to refer to the sync folder, and it's unfortunate that `run.dir` isn't `run.files_dir`, but fixing that would require a breaking change.

Inspired by #5764.

WB-24046