### PR TITLE
chore: remove unused Auth.as_requests_auth

### DIFF
--- a/tests/unit_tests/test_lib/test_auth.py
+++ b/tests/unit_tests/test_lib/test_auth.py
@@ -1,6 +1,5 @@
 import pathlib
 import textwrap
-from unittest.mock import Mock
 
 import pytest
 from wandb.errors import AuthenticationError
@@ -136,49 +135,6 @@ def test_reads_netrc(
     mock_wandb_log.assert_logged(
         f"[test] Loaded credentials for https://example.com from {netrc}"
     )
-
-
-def test_api_key_as_requests_auth():
-    auth = AuthApiKey(host="https://test", api_key="test" * 10)
-    requests_auth = auth.as_requests_auth()
-
-    request = Mock()
-    request.headers = {}
-
-    requests_auth(request)
-
-    assert "Authorization" in request.headers
-    assert request.headers["Authorization"].startswith("Basic ")
-
-
-def test_identity_token_as_requests_auth(tmp_path: pathlib.Path, monkeypatch):
-    token_file = tmp_path / "token.jwt"
-    token_file.write_text("test.jwt.token")
-    credentials_file = tmp_path / "credentials.json"
-
-    auth = AuthIdentityTokenFile(
-        host="https://test",
-        path=str(token_file),
-        credentials_file=str(credentials_file),
-    )
-
-    # Mock credentials.access_token to return a test token
-    from wandb.sdk.lib import credentials
-
-    monkeypatch.setattr(
-        credentials,
-        "access_token",
-        lambda base_url, token_path, creds_path: "test_access_token",
-    )
-
-    requests_auth = auth.as_requests_auth()
-
-    request = Mock()
-    request.headers = {}
-
-    requests_auth(request)
-
-    assert request.headers["Authorization"] == "Bearer test_access_token"
 
 
 def test_jwt_bypasses_validation():

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 
 import pytest
 import wandb
-from pytest_mock import MockerFixture
 from wandb import Api
 from wandb.apis import internal
 from wandb.apis._generated import ProjectFragment, UserFragment
@@ -494,19 +493,3 @@ def test_project_load__raises_error(monkeypatch):
 
     with pytest.raises(ValueError):
         project._load()
-
-
-@pytest.mark.usefixtures("skip_verify_login")
-def test_api_does_not_use_requests_auth(mocker: MockerFixture):
-    """Test that Api() does not build requests auth for the service API."""
-    mock_auth = wbauth.AuthApiKey(
-        host=wbauth.HostUrl("https://api.wandb.ai"),
-        api_key="a" * 40,
-    )
-    mocker.spy(mock_auth, "as_requests_auth")
-
-    mocker.patch.object(wbauth, "authenticate_session", return_value=mock_auth)
-
-    Api()
-
-    mock_auth.as_requests_auth.assert_not_called()

--- a/wandb/sdk/lib/wbauth/auth.py
+++ b/wandb/sdk/lib/wbauth/auth.py
@@ -4,8 +4,6 @@ import abc
 import dataclasses
 import pathlib
 
-import requests
-import requests.auth
 from typing_extensions import final, override
 
 from wandb.errors import AuthenticationError
@@ -33,22 +31,6 @@ class Auth(abc.ABC):
     def host(self) -> HostUrl:
         """The W&B server for which the credentials are valid."""
         return self._host
-
-    @abc.abstractmethod
-    def as_requests_auth(self) -> requests.auth.AuthBase:
-        """Return a requests-compatible auth handler for this credential.
-
-        Returns a callable that implements the requests library's AuthBase
-        interface. This can be passed directly to requests.Session.auth for
-        automatic authentication on each request.
-
-        For token-based auth (e.g., identity tokens), the returned handler
-        will automatically refresh expired tokens on each request.
-
-        Returns:
-            A requests.auth.AuthBase instance that applies this credential
-            to HTTP requests.
-        """
 
     @final
     @override
@@ -88,29 +70,6 @@ class AuthApiKey(Auth):
     def api_key(self) -> str:
         """The API key."""
         return self._api_key
-
-    @override
-    def as_requests_auth(self) -> requests.auth.AuthBase:
-        """Return a requests auth handler using HTTP Basic Auth.
-
-        Returns:
-            An auth handler that sets the Authorization header with
-            Basic auth using "api" as the username and the API key
-            as the password.
-        """
-        return requests.auth.HTTPBasicAuth("api", self._api_key)
-
-
-class _IdentityTokenAuth(requests.auth.AuthBase):
-    """Requests auth handler for identity token (JWT) authentication."""
-
-    def __init__(self, auth: AuthIdentityTokenFile) -> None:
-        self._auth = auth
-
-    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
-        token = self._auth.fetch_access_token()
-        r.headers["Authorization"] = f"Bearer {token}"
-        return r
 
 
 @final
@@ -170,20 +129,6 @@ class AuthIdentityTokenFile(Auth):
         """
         base_url = str(self.host.url)
         return credentials.access_token(base_url, self.path, self.credentials_path)
-
-    @override
-    def as_requests_auth(self) -> requests.auth.AuthBase:
-        """Return a requests auth handler using Bearer token authentication.
-
-        The returned handler calls fetch_access_token() on each request,
-        ensuring that expired tokens are automatically refreshed.
-
-        Returns:
-            An auth handler that sets the Authorization header with
-            a Bearer token fetched (and refreshed as needed) from the
-            identity token file.
-        """
-        return _IdentityTokenAuth(self)
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Description
-----------
Removes Auth.as_requests_auth() and its implementations - dead code since Public API GraphQL moved to wandb-core (#11818), which removed the last production caller.