### PR TITLE
refactor: improve wandb.init() timeout message further

### DIFF
--- a/core/internal/api/retryerror.go
+++ b/core/internal/api/retryerror.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"fmt"
+)
+
+// RetryError is returned from a client initialized using this package
+// when a request retry fails.
+//
+// It contains information about the error that was being retried,
+// allowing the caller to construct better error messages.
+type RetryError struct {
+	Inner      error
+	LastStatus string
+}
+
+func (err *RetryError) Error() string {
+	return fmt.Sprintf(
+		"%s\nwhile retrying: %s",
+		err.Inner.Error(), err.LastStatus)
+}
+
+func (err *RetryError) Unwrap() error {
+	return err.Inner
+}

--- a/core/internal/api/send.go
+++ b/core/internal/api/send.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -20,7 +18,11 @@ func (client *clientImpl) Do(req *retryablehttp.Request) (*http.Response, error)
 	wboperation.Get(req.Context()).ClearError()
 
 	if err != nil {
-		return nil, enhanceContextError(err, lastRetriedError(req.Context()))
+		if lastStatus := lastRetriedError(req.Context()); lastStatus != "" {
+			return nil, &RetryError{Inner: err, LastStatus: lastStatus}
+		} else {
+			return nil, err
+		}
 	}
 
 	// This is a bug that happens with retryablehttp sometimes.
@@ -30,24 +32,4 @@ func (client *clientImpl) Do(req *retryablehttp.Request) (*http.Response, error)
 
 	client.logFinalResponseOnError(req, resp)
 	return resp, nil
-}
-
-// enhanceContextError adds the message of the most recently retried error
-// to context cancellation and timeout errors.
-func enhanceContextError(finalErr error, lastRetriedErr string) error {
-	if lastRetriedErr == "" {
-		return finalErr
-	}
-
-	if !errors.Is(finalErr, context.Canceled) &&
-		!errors.Is(finalErr, context.DeadlineExceeded) {
-		return finalErr
-	}
-
-	// Use Join to preserve the fact that this is a cancellation or timeout,
-	// so that callers can check it.
-	return errors.Join(
-		finalErr,
-		fmt.Errorf("last status: %s", lastRetriedErr),
-	)
 }

--- a/core/internal/runupserter/runupdateerror.go
+++ b/core/internal/runupserter/runupdateerror.go
@@ -63,9 +63,20 @@ func fromGQLError(gqlError *graphql.HTTPError) *RunUpdateError {
 }
 
 func fromTimeout(err error) *RunUpdateError {
+	const timeoutSettingHint = "" +
+		"Consider increasing the init_timeout setting:" +
+		"\n  wandb.init(settings=wandb.Settings(init_timeout=...))"
+
+	var userMessage string
+	if retryErr, ok := errors.AsType[*api.RetryError](err); ok {
+		userMessage = fmt.Sprintf("Timed out while retrying: %s", retryErr.LastStatus)
+	} else {
+		userMessage = fmt.Sprintf("Timed out initializing run: %s", err.Error())
+	}
+
 	return &RunUpdateError{
 		Cause:       err,
-		UserMessage: fmt.Sprintf("Timed out initializing run: %s", err.Error()),
+		UserMessage: fmt.Sprintf("%s\n%s", userMessage, timeoutSettingHint),
 		Code:        spb.ErrorInfo_COMMUNICATION,
 	}
 }

--- a/core/internal/runupserter/runupdateerror_test.go
+++ b/core/internal/runupserter/runupdateerror_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
+	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/runbranch"
 	"github.com/wandb/wandb/core/internal/runupserter"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
@@ -65,7 +66,7 @@ func Test_ToRunUpdateError_GQLError_Empty(t *testing.T) {
 	assert.Contains(t, runUpdateError.UserMessage, "<no message>")
 }
 
-func Test_ToRunUpdateError_Timeout(t *testing.T) {
+func Test_ToRunUpdateError_RawTimeout(t *testing.T) {
 	err := fmt.Errorf("some extra info: %w", context.DeadlineExceeded)
 
 	result := runupserter.ToRunUpdateError(err)
@@ -73,9 +74,31 @@ func Test_ToRunUpdateError_Timeout(t *testing.T) {
 	runUpdateError := result.(*runupserter.RunUpdateError)
 	assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
 	assert.Equal(t,
-		"Timed out initializing run: some extra info: context deadline exceeded",
+		"Timed out initializing run: some extra info: context deadline exceeded"+
+			"\nConsider increasing the init_timeout setting:"+
+			"\n  wandb.init(settings=wandb.Settings(init_timeout=...))",
 		runUpdateError.UserMessage)
 	assert.Equal(t,
 		"some extra info: context deadline exceeded",
+		runUpdateError.Error())
+}
+
+func Test_ToRunUpdateError_EnhancedTimeout(t *testing.T) {
+	err := &api.RetryError{
+		Inner:      context.DeadlineExceeded,
+		LastStatus: "HTTP 500: oops",
+	}
+
+	result := runupserter.ToRunUpdateError(err)
+
+	runUpdateError := result.(*runupserter.RunUpdateError)
+	assert.Equal(t, spb.ErrorInfo_COMMUNICATION, runUpdateError.Code)
+	assert.Equal(t,
+		"Timed out while retrying: HTTP 500: oops"+
+			"\nConsider increasing the init_timeout setting:"+
+			"\n  wandb.init(settings=wandb.Settings(init_timeout=...))",
+		runUpdateError.UserMessage)
+	assert.Equal(t,
+		"context deadline exceeded\nwhile retrying: HTTP 500: oops",
 		runUpdateError.Error())
 }

--- a/tests/system_tests/test_core/test_wandb_init.py
+++ b/tests/system_tests/test_core/test_wandb_init.py
@@ -27,8 +27,9 @@ def test_init_timeout__prints_retry_err(wandb_backend_spy: WandbBackendSpy):
     with pytest.raises(
         CommError,
         match=re.escape("""\
-Timed out initializing run: context deadline exceeded
-last status: HTTP 500: test test test"""),
+Timed out while retrying: HTTP 500: test test test
+Consider increasing the init_timeout setting:
+  wandb.init(settings=wandb.Settings(init_timeout=...))"""),
     ):
         # Give it just enough time to reach UpsertBucket and retry once.
         with wandb.init(settings=wandb.Settings(init_timeout=2)):

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -30,7 +30,7 @@ import wandb
 import wandb.env
 from wandb import env, trigger
 from wandb.analytics import get_sentry
-from wandb.errors import CommError, Error, UsageError
+from wandb.errors import Error, UsageError
 from wandb.errors.links import url_registry
 from wandb.errors.util import ProtobufErrorHandler
 from wandb.integration import sagemaker, weave
@@ -939,33 +939,24 @@ class _WandbInit:
             f"communicating run to backend with {timeout} second timeout",
         )
 
-        run_init_handle = interface.deliver_run(run)
-
-        try:
-            with progress.progress_printer(
-                run_printer,
-                default_text="Waiting for wandb.init()...",
-            ) as progress_printer:
-                result = wait_with_progress(
-                    run_init_handle,
-                    timeout=timeout + _INIT_TIMEOUT_GRACE_SECONDS,
-                    display_progress=functools.partial(
-                        progress.loop_printing_operation_stats,
-                        progress_printer,
-                        interface,
-                    ),
-                )
-
-        except TimeoutError:
-            # The backend didn't respond with the underlying error before
-            # the grace period expired. This may either be an issue with
-            # the W&B server (a CommError) or a bug in the SDK (an Error).
-            # We cannot distinguish between the two causes here.
-            raise CommError(
-                f"Run initialization has timed out after {timeout} sec."
-                + " Please try increasing the timeout with the `init_timeout`"
-                + " setting: `wandb.init(settings=wandb.Settings(init_timeout=120))`."
-            ) from None
+        with progress.progress_printer(
+            run_printer,
+            default_text="Waiting for wandb.init()...",
+        ) as progress_printer:
+            result = wait_with_progress(
+                interface.deliver_run(run),
+                # We expect the service process to respect the init timeout
+                # setting and promptly return a `run_result.error` on timeout.
+                #
+                # If the grace period expires, we treat that like an SDK bug
+                # and don't give special treatment to the exception.
+                timeout=timeout + _INIT_TIMEOUT_GRACE_SECONDS,
+                display_progress=functools.partial(
+                    progress.loop_printing_operation_stats,
+                    progress_printer,
+                    interface,
+                ),
+            )
 
         assert result.run_result
 


### PR DESCRIPTION
Makes the `wandb.init()` timeout message clearer, restoring the `init_timeout` setting hint and improving the format.

WB-31493, WB-23319

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>