### PR TITLE
fix: wandb login updating system settings even when failing login

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,3 +42,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Registry search `registries(order=...).collections(order=...).versions()` now returns artifact versions in registry and/or collection order. (@ibindlish in https://github.com/wandb/wandb/pull/12154)
 - macOS x86_64 wheels now contain x86_64 builds of the `wandb-xpu` binary and the Rust parquet library, which previously shipped as arm64 and could not run or be loaded on Intel Macs (@dmitryduev in https://github.com/wandb/wandb/pull/12267)
 - `wandb.login(verify=True)` and `wandb login --verify` now verify federated identity (identity token) credentials, which were previously not verified (@dmitryduev in https://github.com/wandb/wandb/pull/12294)
+- `wandb login` and `wandb verify` no longer update the system host settings when failing to login (@jacobromero in https://github.com/wandb/wandb/pull/12332)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -3620,13 +3620,13 @@ def verify(host):
     # TODO: (kdg) Build this all into a WandbVerify object, and clean this up.
     os.environ["WANDB_SILENT"] = "true"
     os.environ["WANDB_PROJECT"] = "verify"
-    api = _get_cling_api()
+    settings = wandb_setup.singleton().settings
     reinit = False
     if host is None:
-        host = api.settings("base_url")
+        host = settings.base_url
         wandb.termlog(f"Default host selected: {host}")
     # if the given host does not match the default host, re-run init
-    elif host != api.settings("base_url"):
+    elif host != settings.base_url:
         reinit = True
 
     tmp_dir = tempfile.mkdtemp()
@@ -3636,8 +3636,7 @@ def verify(host):
     os.chdir(tmp_dir)
     os.environ["WANDB_BASE_URL"] = host
     wandb.login(host=host)
-    if reinit:
-        api = _get_cling_api(reset=True)
+    api = _get_cling_api(reset=reinit)
     if not wandb_verify.check_host(host):
         sys.exit(1)
     if not wandb_verify.check_logged_in(api, host):
@@ -3645,7 +3644,7 @@ def verify(host):
     url_success, url = wandb_verify.check_graphql_put(api, host)
     large_post_success = wandb_verify.check_large_post()
     wandb_verify.check_secure_requests(
-        api.settings("base_url"),
+        settings.base_url,
         "Checking requests to base url",
         "Connections are not made over https. SSL required for secure communications.",
     )

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -97,11 +97,6 @@ def login(
     if host:
         host = host.rstrip("/")
 
-    _update_system_settings(
-        global_settings.read_system_settings(),
-        host=host,
-    )
-
     logged_in, _ = _login(
         key=key,
         relogin=relogin,
@@ -110,6 +105,11 @@ def login(
         timeout=timeout,
         verify=verify,
         referrer=referrer or "models",
+    )
+
+    _update_system_settings(
+        global_settings.read_system_settings(),
+        host=host,
     )
     return logged_in
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Fixes a bug where `wandb verify` can get into a broken state when a bad host name is provided the first time.  
This happens because of two steps,  
First wandb.login was always updating the system settings even if the login failed (such as in the case of a bad hostname).  
The second issue arises from the fact that an `InternalApi` object is created (prior to wandb login), which validates the host name is formatted as a url.

The wandb login makes sense to only update on successful authentication to avoid changing the system settings when some inputs maybe invalid.  
The `IntenralApi` constructed in the `wandb verify` function is initially only used to read system settings prior to the wandb login step, this can be avoiding by using the `wandb_setup.singleton().settings`object,

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

How was this PR tested?

#### Verified that running wandb verify with invalid host does not update the settings file.

```bash
> wandb verify --host localhost:8080
Traceback (most recent call last):
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/bin/wandb", line 6, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/click/core.py", line 1569, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/click/core.py", line 1490, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/click/core.py", line 1970, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/click/core.py", line 1353, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/click/core.py", line 907, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/cli/cli.py", line 3638, in verify
    wandb.login(host=host)
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/sdk/wandb_login.py", line 100, in login
    logged_in, _ = _login(
                   ^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/sdk/wandb_login.py", line 167, in _login
    host_url = wbauth.HostUrl(host)
               ^^^^^^^^^^^^^^^^^^^^
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/sdk/lib/wbauth/host_url.py", line 28, in __init__
    urls.validate_url(url)
  File "/Users/jacob.romero/.pyenv/versions/3.12.9/lib/python3.12/site-packages/wandb/sdk/lib/urls.py", line 26, in validate_url
    _URL_VALIDATOR.validate_python(url)
pydantic_core._pydantic_core.ValidationError: 1 validation error for url['http','https']
  URL scheme should be 'http' or 'https' [type=url_scheme, input_value='localhost:8080', input_type=str]
    For further information visit https://errors.pydantic.dev/2.13/v/url_scheme
```

```bash
> cat ~/.config/wandb/settings
[default]

```

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->