### PR TITLE
feat(sweeps): create sweep_scheduler package with wandb reference optimizer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,3 +90,4 @@
 /tests/system_tests/test_sweep/                  @wandb/sweeps-launch-team @wandb/sdk-team
 /tests/unit_tests/test_wandb_agent_teardown.py   @wandb/sweeps-launch-team @wandb/sdk-team
 /tests/unit_tests/test_wandb_agent_signals.py    @wandb/sweeps-launch-team @wandb/sdk-team
+/wandb/sdk/sweeps/                               @wandb/sweeps-launch-team @wandb/sdk-team

--- a/noxfile.py
+++ b/noxfile.py
@@ -597,6 +597,7 @@ def mypy_report(session: nox.Session) -> None:
         "platformdirs",
         "pydantic",
         "pycobertura",
+        ".[sandbox]",
         "types-jsonschema",
         "types-openpyxl",
         "types-Pillow",
@@ -609,7 +610,7 @@ def mypy_report(session: nox.Session) -> None:
         "types-six",
         "types-tqdm",
         "-e .[eval-table]",
-        ".[sandbox]",
+        "-e .[sweeps]",
     )
 
     path = "mypy-results"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -495,6 +495,7 @@ module = [
     "ultralytics.*",
     "wandb.vendor.*",
     "opentelemetry.*",
+    "sweeps",
 ]
 ignore_missing_imports = true
 

--- a/requirements/requirements_dev.3.10.darwin.txt
+++ b/requirements/requirements_dev.3.10.darwin.txt
@@ -281,6 +281,7 @@ googleapis-common-protos==1.75.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-http
 graphql-core==3.2.8
     # via
     #   -c requirements/constraints.txt
@@ -406,12 +407,15 @@ json5==0.15.0
     # via jupyterlab-server
 jsonpointer==3.1.1
     # via jsonschema
+jsonref==1.1.0
+    # via sweeps
 jsonschema==4.26.0
     # via
     #   jupyter-events
     #   jupyterlab-server
     #   litellm
     #   nbformat
+    #   sweeps
     #   wandb
 jsonschema-specifications==2025.9.1
     # via jsonschema
@@ -596,6 +600,7 @@ numpy==1.26.4
     #   shapely
     #   soundfile
     #   stable-baselines3
+    #   sweeps
     #   tensorboard
     #   tensorboardx
     #   torchmetrics
@@ -610,6 +615,26 @@ openai==2.46.0
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   litellm
+opentelemetry-api==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   wandb
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via wandb
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   wandb
+opentelemetry-semantic-conventions==0.65b0
+    # via opentelemetry-sdk
 opt-einsum==3.4.0
     # via jax
 optuna==4.9.0
@@ -715,6 +740,7 @@ protobuf==6.33.6
     #   grpcio-status
     #   kfp
     #   kfp-pipeline-spec
+    #   opentelemetry-proto
     #   proto-plus
     #   tensorboard
     #   tensorboardx
@@ -750,6 +776,7 @@ pydantic==2.13.4
     #   google-genai
     #   litellm
     #   openai
+    #   sweeps
     #   wandb
 pydantic-core==2.46.4
     # via pydantic
@@ -831,6 +858,7 @@ pyyaml==6.0.3
     #   optuna
     #   pytorch-lightning
     #   responses
+    #   sweeps
     #   wandb
 pyzmq==27.1.0
     # via
@@ -864,6 +892,7 @@ requests==2.34.2
     #   moto
     #   moviepy
     #   msal
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -901,7 +930,9 @@ s3transfer==0.19.1
     #   awscli
     #   boto3
 scikit-learn==1.7.2
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   sweeps
 scipy==1.15.3
     # via
     #   catboost
@@ -909,6 +940,7 @@ scipy==1.15.3
     #   jaxlib
     #   lightgbm
     #   scikit-learn
+    #   sweeps
     #   xgboost
 send2trash==2.1.0
     # via jupyter-server
@@ -950,6 +982,8 @@ stack-data==0.6.3
     # via ipython
 starlette==0.46.2
     # via fastapi
+sweeps==0.2.0
+    # via wandb
 sympy==1.14.0
     # via torch
 tabulate==0.10.0
@@ -1071,6 +1105,10 @@ typing-extensions==4.16.0
     #   mistune
     #   multidict
     #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
     #   pyjwt
@@ -1106,7 +1144,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.10.linux.txt
+++ b/requirements/requirements_dev.3.10.linux.txt
@@ -296,6 +296,7 @@ googleapis-common-protos==1.75.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-http
 graphql-core==3.2.8
     # via
     #   -c requirements/constraints.txt
@@ -688,6 +689,26 @@ openai==2.46.0
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   litellm
+opentelemetry-api==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   wandb
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via wandb
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   wandb
+opentelemetry-semantic-conventions==0.65b0
+    # via opentelemetry-sdk
 opt-einsum==3.4.0
     # via
     #   jax
@@ -800,6 +821,7 @@ protobuf==6.33.6
     #   grpcio-status
     #   kfp
     #   kfp-pipeline-spec
+    #   opentelemetry-proto
     #   proto-plus
     #   tensorboard
     #   tensorboardx
@@ -952,6 +974,7 @@ requests==2.34.2
     #   moto
     #   moviepy
     #   msal
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -1177,6 +1200,10 @@ typing-extensions==4.16.0
     #   mistune
     #   multidict
     #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   optree
     #   pydantic
     #   pydantic-core
@@ -1214,7 +1241,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.10.windows.txt
+++ b/requirements/requirements_dev.3.10.windows.txt
@@ -297,6 +297,7 @@ googleapis-common-protos==1.75.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-http
 graphql-core==3.2.8
     # via
     #   -c requirements/constraints.txt
@@ -648,6 +649,26 @@ openai==2.46.0
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   litellm
+opentelemetry-api==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   wandb
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via wandb
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   wandb
+opentelemetry-semantic-conventions==0.65b0
+    # via opentelemetry-sdk
 opt-einsum==3.4.0
     # via
     #   jax
@@ -758,6 +779,7 @@ protobuf==6.33.6
     #   grpcio-status
     #   kfp
     #   kfp-pipeline-spec
+    #   opentelemetry-proto
     #   proto-plus
     #   tensorboard
     #   tensorboardx
@@ -914,6 +936,7 @@ requests==2.34.2
     #   moto
     #   moviepy
     #   msal
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -1137,6 +1160,10 @@ typing-extensions==4.16.0
     #   mistune
     #   multidict
     #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   optree
     #   pydantic
     #   pydantic-core
@@ -1174,7 +1201,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -275,6 +275,7 @@ googleapis-common-protos==1.75.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-http
 graphql-core==3.2.8
     # via
     #   -c requirements/constraints.txt
@@ -403,12 +404,15 @@ json5==0.15.0
     # via jupyterlab-server
 jsonpointer==3.1.1
     # via jsonschema
+jsonref==1.1.0
+    # via sweeps
 jsonschema==4.26.0
     # via
     #   jupyter-events
     #   jupyterlab-server
     #   litellm
     #   nbformat
+    #   sweeps
     #   wandb
 jsonschema-specifications==2025.9.1
     # via jsonschema
@@ -594,6 +598,7 @@ numpy==2.3.5
     #   shapely
     #   soundfile
     #   stable-baselines3
+    #   sweeps
     #   tensorboard
     #   tensorboardx
     #   torchmetrics
@@ -608,6 +613,26 @@ openai==2.46.0
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   litellm
+opentelemetry-api==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   wandb
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via wandb
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   wandb
+opentelemetry-semantic-conventions==0.65b0
+    # via opentelemetry-sdk
 opt-einsum==3.4.0
     # via jax
 optuna==4.9.0
@@ -712,6 +737,7 @@ protobuf==6.33.6
     #   grpcio-status
     #   kfp
     #   kfp-pipeline-spec
+    #   opentelemetry-proto
     #   proto-plus
     #   tensorboard
     #   tensorboardx
@@ -747,6 +773,7 @@ pydantic==2.13.4
     #   google-genai
     #   litellm
     #   openai
+    #   sweeps
     #   wandb
 pydantic-core==2.46.4
     # via pydantic
@@ -829,6 +856,7 @@ pyyaml==6.0.3
     #   optuna
     #   pytorch-lightning
     #   responses
+    #   sweeps
     #   wandb
 pyzmq==27.1.0
     # via
@@ -862,6 +890,7 @@ requests==2.34.2
     #   moto
     #   moviepy
     #   msal
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -899,7 +928,9 @@ s3transfer==0.19.1
     #   awscli
     #   boto3
 scikit-learn==1.9.0
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   sweeps
 scipy==1.18.0
     # via
     #   catboost
@@ -907,6 +938,7 @@ scipy==1.18.0
     #   jaxlib
     #   lightgbm
     #   scikit-learn
+    #   sweeps
     #   xgboost
 send2trash==2.1.0
     # via jupyter-server
@@ -948,6 +980,8 @@ stack-data==0.6.3
     # via ipython
 starlette==0.46.2
     # via fastapi
+sweeps==0.2.0
+    # via wandb
 sympy==1.14.0
     # via torch
 tabulate==0.10.0
@@ -1052,6 +1086,10 @@ typing-extensions==4.16.0
     #   lightning
     #   lightning-utilities
     #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
     #   pytorch-lightning
@@ -1084,7 +1122,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -290,6 +290,7 @@ googleapis-common-protos==1.75.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-http
 graphql-core==3.2.8
     # via
     #   -c requirements/constraints.txt
@@ -686,6 +687,26 @@ openai==2.46.0
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   litellm
+opentelemetry-api==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   wandb
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via wandb
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   wandb
+opentelemetry-semantic-conventions==0.65b0
+    # via opentelemetry-sdk
 opt-einsum==3.4.0
     # via
     #   jax
@@ -797,6 +818,7 @@ protobuf==6.33.6
     #   grpcio-status
     #   kfp
     #   kfp-pipeline-spec
+    #   opentelemetry-proto
     #   proto-plus
     #   tensorboard
     #   tensorboardx
@@ -950,6 +972,7 @@ requests==2.34.2
     #   moto
     #   moviepy
     #   msal
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -1158,6 +1181,10 @@ typing-extensions==4.16.0
     #   lightning
     #   lightning-utilities
     #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   optree
     #   pydantic
     #   pydantic-core
@@ -1192,7 +1219,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -291,6 +291,7 @@ googleapis-common-protos==1.75.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-http
 graphql-core==3.2.8
     # via
     #   -c requirements/constraints.txt
@@ -646,6 +647,26 @@ openai==2.46.0
     #   -r requirements/requirements_dev.txt
     #   dspy
     #   litellm
+opentelemetry-api==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   wandb
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via wandb
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   wandb
+opentelemetry-semantic-conventions==0.65b0
+    # via opentelemetry-sdk
 opt-einsum==3.4.0
     # via
     #   jax
@@ -755,6 +776,7 @@ protobuf==6.33.6
     #   grpcio-status
     #   kfp
     #   kfp-pipeline-spec
+    #   opentelemetry-proto
     #   proto-plus
     #   tensorboard
     #   tensorboardx
@@ -912,6 +934,7 @@ requests==2.34.2
     #   moto
     #   moviepy
     #   msal
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -1118,6 +1141,10 @@ typing-extensions==4.16.0
     #   lightning
     #   lightning-utilities
     #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   optree
     #   pydantic
     #   pydantic-core
@@ -1152,7 +1179,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -56,5 +56,4 @@ responses
 ariadne-codegen
 
 .[launch]
-.[sweeps] ; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 .[sandbox]

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -56,7 +56,6 @@ responses
 ariadne-codegen
 
 .[launch]
-.[sweeps] ; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 
 # Sandbox tests need the upstream client, but it only supports Python 3.11+.
 cwsandbox[cli]>=0.20.0; python_version >= '3.11'

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -34,3 +34,5 @@ pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.
 hypothesis>=6.131.7
 
 hypothesis-fspaths
+
+.[sweeps]

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -8,12 +8,12 @@ import pytest
 import yaml
 from wandb.apis.public import Sweep
 from wandb.apis.public.service_api import ServiceApi
-from wandb.sdk.launch.sweeps.scheduler import RunState
-from wandb.sdk.sweep_scheduler.optimizer import (
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
     Optimizer,
     RunConfig,
-    RunEnriched,
     RunSuggestion,
+    RunWithMetrics,
 )
 
 SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
@@ -50,8 +50,8 @@ def make_run(
     state: RunState,
     summary: dict[str, Any],
     history: list[dict[str, Any]] | None = None,
-) -> RunEnriched:
-    return RunEnriched(
+) -> RunWithMetrics:
+    return RunWithMetrics(
         config=suggestion.config,
         state=state,
         wandb_run_id="wandb-run-id",
@@ -76,10 +76,10 @@ class OptimizerAcceptanceTests(abc.ABC):
     def test_next_2_runs_after_tell_1_run(
         self, optimizer: Optimizer, sweep: Sweep
     ) -> None:
-        first_run = next(iter(optimizer.next_n_runs(1)))
+        first_run = next(iter(optimizer.ask_n_runs(1)))
         run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
         optimizer.tell_run(first_run.run_id, run)
-        suggestions = optimizer.next_n_runs(2)
+        suggestions = optimizer.ask_n_runs(2)
         assert len(suggestions) == 2
         assert all(isinstance(s, RunSuggestion) for s in suggestions)
         assert len({s.run_id for s in suggestions}) == 2  # unique ids
@@ -94,7 +94,7 @@ class OptimizerAcceptanceTests(abc.ABC):
         )
         run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
         optimizer.tell_existing_finished_run(run)
-        suggestion = next(iter(optimizer.next_n_runs(1)))
+        suggestion = next(iter(optimizer.ask_n_runs(1)))
         assert suggestion.config["param1"].value == 2
 
     def test_next_run_after_tell_existing_active_run(
@@ -105,13 +105,18 @@ class OptimizerAcceptanceTests(abc.ABC):
         )
         run = make_run(first_run, state=RunState.RUNNING, summary={"loss": 1.0})
         optimizer.tell_existing_active_run(run)
-        suggestion = next(iter(optimizer.next_n_runs(1)))
+        suggestion = next(iter(optimizer.ask_n_runs(1)))
         assert suggestion.config["param1"].value == 2
 
-    def test_prune_run_hyperband_stops_worst_running_run(
+    def test_prune_runs_returns_empty_for_no_candidates(
         self, optimizer: Optimizer
     ) -> None:
-        suggestions = optimizer.next_n_runs(3)
+        assert optimizer.prune_runs([], []) == []
+
+    def test_prune_runs_hyperband_stops_worst_running_run(
+        self, optimizer: Optimizer
+    ) -> None:
+        suggestions = optimizer.ask_n_runs(3)
         assert len(suggestions) == 3
 
         optimizer.tell_run(
@@ -138,13 +143,16 @@ class OptimizerAcceptanceTests(abc.ABC):
         optimizer.tell_run(suggestions[1].run_id, worst_running)
         optimizer.tell_run(suggestions[2].run_id, better_running)
 
-        assert optimizer.prune_run(suggestions[1].run_id, worst_running)
-        assert not optimizer.prune_run(suggestions[2].run_id, better_running)
+        pruned = optimizer.prune_runs(
+            [suggestions[1].run_id, suggestions[2].run_id],
+            [worst_running, better_running],
+        )
+        assert pruned == [suggestions[1].run_id]
 
 
 class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
     @pytest.fixture
     def optimizer(self, sweep: Sweep) -> Optimizer:
-        from wandb.sdk.sweep_scheduler.wandb import WandbOptimizer
+        from wandb.sdk.sweeps.scheduler.wandb import WandbOptimizer
 
         return WandbOptimizer(sweep=sweep)

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import abc
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from wandb.apis.public import Sweep
+from wandb.apis.public.service_api import ServiceApi
+from wandb.sdk.launch.sweeps.scheduler import RunState
+from wandb.sdk.sweep_scheduler.optimizer import (
+    Optimizer,
+    RunConfig,
+    RunEnriched,
+    RunSuggestion,
+)
+
+SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
+    "name": "test-sweep-grid-hyperband",
+    "method": "grid",
+    "early_terminate": {"type": "hyperband", "max_iter": 5, "eta": 2, "s": 2},
+    "metric": {"name": "loss", "goal": "minimize"},
+    "parameters": {"param1": {"values": [1, 2, 3]}},
+}
+
+
+def make_scheduler_grid_sweep() -> Sweep:
+    """Return a grid `Sweep` backed by a no-op `ServiceApi`.
+
+    Passing `attrs` keeps the constructor from issuing a GraphQL load().
+    """
+    service_api = MagicMock(spec=ServiceApi)
+    return Sweep(
+        service_api=service_api,
+        entity="test_entity",
+        project="test_project",
+        sweep_id="test_sweep",
+        attrs={
+            "id": "test_sweep",
+            "name": "test_sweep",
+            "config": yaml.dump(SCHEDULER_GRID_SWEEP_CONFIG),
+        },
+    )
+
+
+def make_run(
+    suggestion: RunSuggestion,
+    *,
+    state: RunState,
+    summary: dict[str, Any],
+    history: list[dict[str, Any]] | None = None,
+) -> RunEnriched:
+    return RunEnriched(
+        config=suggestion.config,
+        state=state,
+        wandb_run_id="wandb-run-id",
+        summary_metrics=summary,
+        history_metrics=history or [],
+    )
+
+
+class OptimizerAcceptanceTests(abc.ABC):
+    """Contract tests every Optimizer implementation must satisfy."""
+
+    @pytest.fixture
+    def sweep(self) -> Sweep:
+        return make_scheduler_grid_sweep()
+
+    @abc.abstractmethod
+    @pytest.fixture
+    def optimizer(self, sweep: Sweep) -> Optimizer:
+        """Return a fresh, configured Optimizer instance."""
+        ...
+
+    def test_next_2_runs_after_tell_1_run(
+        self, optimizer: Optimizer, sweep: Sweep
+    ) -> None:
+        first_run = next(iter(optimizer.next_n_runs(1)))
+        run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
+        optimizer.tell_run(first_run.run_id, run)
+        suggestions = optimizer.next_n_runs(2)
+        assert len(suggestions) == 2
+        assert all(isinstance(s, RunSuggestion) for s in suggestions)
+        assert len({s.run_id for s in suggestions}) == 2  # unique ids
+        assert suggestions[0].config["param1"].value == 2
+        assert suggestions[1].config["param1"].value == 3
+
+    def test_next_run_after_tell_existing_finished_run(
+        self, optimizer: Optimizer, sweep: Sweep
+    ) -> None:
+        first_run = RunSuggestion(
+            config=RunConfig.from_values({"param1": 1}), run_id="run_id"
+        )
+        run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
+        optimizer.tell_existing_finished_run(run)
+        suggestion = next(iter(optimizer.next_n_runs(1)))
+        assert suggestion.config["param1"].value == 2
+
+    def test_next_run_after_tell_existing_active_run(
+        self, optimizer: Optimizer, sweep: Sweep
+    ) -> None:
+        first_run = RunSuggestion(
+            config=RunConfig.from_values({"param1": 1}), run_id="run_id"
+        )
+        run = make_run(first_run, state=RunState.RUNNING, summary={"loss": 1.0})
+        optimizer.tell_existing_active_run(run)
+        suggestion = next(iter(optimizer.next_n_runs(1)))
+        assert suggestion.config["param1"].value == 2
+
+    def test_prune_run_hyperband_stops_worst_running_run(
+        self, optimizer: Optimizer
+    ) -> None:
+        suggestions = optimizer.next_n_runs(3)
+        assert len(suggestions) == 3
+
+        optimizer.tell_run(
+            suggestions[0].run_id,
+            make_run(
+                suggestions[0],
+                state=RunState.FINISHED,
+                summary={"loss": 6.0},
+                history=[{"loss": 10.0}, {"loss": 6.0}, {"loss": 6.0}],
+            ),
+        )
+        worst_running = make_run(
+            suggestions[1],
+            state=RunState.RUNNING,
+            summary={"loss": 10.0},
+            history=[{"loss": 10.0}, {"loss": 10.0}],
+        )
+        better_running = make_run(
+            suggestions[2],
+            state=RunState.RUNNING,
+            summary={"loss": 7.0},
+            history=[{"loss": 10.0}, {"loss": 7.0}, {"loss": 7.0}],
+        )
+        optimizer.tell_run(suggestions[1].run_id, worst_running)
+        optimizer.tell_run(suggestions[2].run_id, better_running)
+
+        assert optimizer.prune_run(suggestions[1].run_id, worst_running)
+        assert not optimizer.prune_run(suggestions[2].run_id, better_running)
+
+
+class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
+    @pytest.fixture
+    def optimizer(self, sweep: Sweep) -> Optimizer:
+        from wandb.sdk.sweep_scheduler.wandb import WandbOptimizer
+
+        return WandbOptimizer(sweep=sweep)

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -8,12 +8,12 @@ import pytest
 import yaml
 from wandb.apis.public import Sweep
 from wandb.apis.public.service_api import ServiceApi
-from wandb.sdk.launch.sweeps.scheduler import RunState
-from wandb.sdk.sweep_scheduler.optimizer import (
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
     Optimizer,
     RunConfig,
-    RunEnriched,
     RunSuggestion,
+    RunWithMetrics,
 )
 
 SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
@@ -50,8 +50,8 @@ def make_run(
     state: RunState,
     summary: dict[str, Any],
     history: list[dict[str, Any]] | None = None,
-) -> RunEnriched:
-    return RunEnriched(
+) -> RunWithMetrics:
+    return RunWithMetrics(
         config=suggestion.config,
         state=state,
         wandb_run_id="wandb-run-id",
@@ -76,10 +76,10 @@ class OptimizerAcceptanceTests(abc.ABC):
     def test_next_2_runs_after_tell_1_run(
         self, optimizer: Optimizer, sweep: Sweep
     ) -> None:
-        first_run = next(iter(optimizer.next_n_runs(1)))
+        first_run = next(iter(optimizer.ask_n_runs(1)))
         run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
         optimizer.tell_run(first_run.run_id, run)
-        suggestions = optimizer.next_n_runs(2)
+        suggestions = optimizer.ask_n_runs(2)
         assert len(suggestions) == 2
         assert all(isinstance(s, RunSuggestion) for s in suggestions)
         assert len({s.run_id for s in suggestions}) == 2  # unique ids
@@ -94,7 +94,7 @@ class OptimizerAcceptanceTests(abc.ABC):
         )
         run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
         optimizer.tell_existing_finished_run(run)
-        suggestion = next(iter(optimizer.next_n_runs(1)))
+        suggestion = next(iter(optimizer.ask_n_runs(1)))
         assert suggestion.config["param1"].value == 2
 
     def test_next_run_after_tell_existing_active_run(
@@ -105,13 +105,13 @@ class OptimizerAcceptanceTests(abc.ABC):
         )
         run = make_run(first_run, state=RunState.RUNNING, summary={"loss": 1.0})
         optimizer.tell_existing_active_run(run)
-        suggestion = next(iter(optimizer.next_n_runs(1)))
+        suggestion = next(iter(optimizer.ask_n_runs(1)))
         assert suggestion.config["param1"].value == 2
 
     def test_prune_run_hyperband_stops_worst_running_run(
         self, optimizer: Optimizer
     ) -> None:
-        suggestions = optimizer.next_n_runs(3)
+        suggestions = optimizer.ask_n_runs(3)
         assert len(suggestions) == 3
 
         optimizer.tell_run(
@@ -145,6 +145,6 @@ class OptimizerAcceptanceTests(abc.ABC):
 class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
     @pytest.fixture
     def optimizer(self, sweep: Sweep) -> Optimizer:
-        from wandb.sdk.sweep_scheduler.wandb import WandbOptimizer
+        from wandb.sdk.sweeps.scheduler.wandb import WandbOptimizer
 
         return WandbOptimizer(sweep=sweep)

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -34,6 +34,10 @@ from wandb.sdk.launch.utils import (
 )
 from wandb.sdk.lib.runid import generate_id
 
+# RunState was moved from this file to sdk.sweeps.
+# Ensure backward-compatible re-export for legacy path.
+from wandb.sdk.sweeps import RunState as RunState
+
 if TYPE_CHECKING:
     import wandb.apis.public as public
     from wandb.apis.internal import Api
@@ -55,32 +59,6 @@ class SchedulerState(Enum):
     FAILED = 5
     STOPPED = 6
     CANCELLED = 7
-
-
-class RunState(Enum):
-    RUNNING = "running", "alive"
-    PENDING = "pending", "alive"
-    PREEMPTING = "preempting", "alive"
-    CRASHED = "crashed", "dead"
-    FAILED = "failed", "dead"
-    KILLED = "killed", "dead"
-    FINISHED = "finished", "dead"
-    PREEMPTED = "preempted", "dead"
-    # unknown when api.get_run_state fails or returns unexpected state
-    # assumed alive, unless we get unknown 2x then move to failed (dead)
-    UNKNOWN = "unknown", "alive"
-
-    def __new__(cls: Any, *args: list, **kwds: Any) -> RunState:
-        obj: RunState = object.__new__(cls)
-        obj._value_ = args[0]
-        return obj
-
-    def __init__(self, _: str, life: str = "unknown") -> None:
-        self._life = life
-
-    @property
-    def is_alive(self) -> bool:
-        return self._life == "alive"
 
 
 @dataclass

--- a/wandb/sdk/sweep_scheduler/optimizer.py
+++ b/wandb/sdk/sweep_scheduler/optimizer.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from wandb.apis.public import Sweep
+from wandb.sdk.launch.sweeps.scheduler import RunState
+
+
+@dataclass
+class ConfigValue:
+    """One hyperparameter in the server's wrapped form: `{"value": <v>}`."""
+
+    value: Any
+
+
+@dataclass
+class RunConfig:
+    """A run's hyperparameters, keyed by parameter name.
+
+    Each value is wrapped so that both the flat form callers think in
+    (`flat_dict`) and the form the server and sweep agent exchange
+    (`wire_dict`) are named rather than passed around as bare dicts.
+    """
+
+    config: dict[str, ConfigValue]
+
+    @classmethod
+    def from_values(cls, values: dict[str, Any]) -> RunConfig:
+        """Build a `RunConfig` from a flat `{param: value}` mapping."""
+        return cls({name: ConfigValue(value=value) for name, value in values.items()})
+
+    def flat_dict(self) -> dict[str, Any]:
+        """The flat `{param: value}` mapping."""
+        return {name: cv.value for name, cv in self.config.items()}
+
+    def wire_dict(self) -> dict[str, dict[str, Any]]:
+        """The server/agent wire form `{param: {"value": v}}`."""
+        return {name: {"value": cv.value} for name, cv in self.config.items()}
+
+    def __getitem__(self, key: str) -> ConfigValue:
+        return self.config[key]
+
+
+@dataclass
+class RunSuggestion:
+    """A run the optimizer proposes, with the id it will track it by.
+
+    `run_id` is the optimizer's own id, not a W&B run id: the run does not
+    exist yet when it is proposed.
+    """
+
+    config: RunConfig
+    run_id: str
+
+
+@dataclass
+class Run:
+    """A sweep run as the optimizer sees it, without its metrics.
+
+    `wandb_run_id` is the id W&B assigned the run, which a scheduler maps back
+    to the `RunSuggestion.run_id` the optimizer handed out.
+    """
+
+    config: RunConfig
+    state: RunState
+    wandb_run_id: str
+
+
+@dataclass
+class RunEnriched(Run):
+    """A `Run` together with the metrics it has reported so far.
+
+    `summary_metrics` is the run's latest summary; `history_metrics` is the
+    sampled per-step history, which early terminators read.
+    """
+
+    summary_metrics: dict[str, Any]
+    history_metrics: list[dict[str, Any]]
+
+
+def is_terminal_state(state: RunState) -> bool:
+    """Return True if the run has stopped (is terminal), else False.
+
+    In-flight states (running/pending/preempting/preempted/unknown) return
+    False. Used to decide whether a run's result can be reported to the
+    optimizer.
+    """
+    return state in (
+        RunState.FINISHED,
+        RunState.FAILED,
+        RunState.CRASHED,
+        RunState.KILLED,
+        RunState.PREEMPTED,
+    )
+
+
+class Optimizer(ABC):
+    """An external optimizer that supports an ask-tell interface.
+
+    Pure search strategy: it proposes runs and ingests their results, holding no
+    scheduling I/O. A `Scheduler` drives it.
+    """
+
+    def __init__(self, sweep: Sweep):
+        self._sweep = sweep
+
+    @abstractmethod
+    def next_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        """Propose up to `n` runs to start next.
+
+        Fewer than `n` may come back when the search space is nearly exhausted
+        or the strategy needs results before proposing more. Returning nothing
+        at all means the search space is exhausted: a scheduler takes it as the
+        end of the sweep and finishes it, so a strategy that is only waiting on
+        results must propose at least one run.
+
+        Args:
+            n: The maximum number of runs to propose.
+        """
+        ...
+
+    @abstractmethod
+    def tell_run(self, run_id: Any, data: RunEnriched) -> None:
+        """Report the latest state and metrics of a run this optimizer proposed.
+
+        Called on each poll while the run is in flight, and once more when it
+        reaches a terminal state.
+
+        Args:
+            run_id: The `RunSuggestion.run_id` this optimizer handed out.
+            data: The run's current state, summary metrics and history.
+        """
+        ...
+
+    def tell_existing_finished_run(self, data: RunEnriched) -> None:
+        """Report a *terminal* run that already existed in the sweep at startup.
+
+        Unlike `tell_run`, there is no optimizer-side run id because the run was
+        not produced by this optimizer's `next_n_runs`. Override to warm-start
+        from prior results; the default is a no-op.
+        """
+        return None
+
+    def tell_existing_active_run(self, data: Run) -> Any:
+        """Adopt an *in-flight* (RUNNING/PENDING) run that existed at startup.
+
+        `data` has no metrics; the next poll reports them via `tell_run`.
+        """
+        return None
+
+    def metric_value(self, metrics: dict[str, Any]) -> Any:
+        """Return the objective value for the sweep's configured metric."""
+        return metrics.get(self.metric_key())
+
+    def metric_key(self) -> str:
+        """Return the name of the sweep's objective metric.
+
+        Raises:
+            ValueError: If the sweep config declares no metric name.
+        """
+        metric = self._sweep.config.get("metric")
+        if not metric or "name" not in metric:
+            raise ValueError(
+                "Sweep config has no metric; cannot determine the objective value."
+            )
+        return metric["name"]
+
+    @property
+    def sweep_name(self) -> str:
+        return self._sweep.name
+
+    def prune_run(self, run_id: Any, data: RunEnriched) -> bool:
+        """Return True if the run should be pruned."""
+        return False
+
+    def should_terminate_sweep(self) -> bool:
+        """Return True if the sweep should be terminated."""
+        return False

--- a/wandb/sdk/sweep_scheduler/wandb.py
+++ b/wandb/sdk/sweep_scheduler/wandb.py
@@ -1,0 +1,170 @@
+"""Reference optimizer backed by the `sweeps` search algorithms."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from wandb import util
+from wandb.apis.public import Sweep
+from wandb.sdk.launch.sweeps.scheduler import RunState
+from wandb.sdk.sweep_scheduler.optimizer import (
+    ConfigValue,
+    Optimizer,
+    Run,
+    RunConfig,
+    RunEnriched,
+    RunSuggestion,
+    is_terminal_state,
+)
+
+sweeps = util.get_module(
+    "sweeps",
+    required="wandb[sweeps] is required to use the wandb sweep scheduler. "
+    "Please run `pip install wandb[sweeps]`.",
+)
+
+
+def _to_sweeps_state(state: RunState) -> Any:
+    """Map the scheduler's `RunState` onto the `sweeps` `RunState` enum."""
+    try:
+        return sweeps.RunState(state.value)
+    except ValueError:
+        return sweeps.RunState.pending
+
+
+class WandbOptimizer(Optimizer):
+    """`Optimizer` driven by the `sweeps` search algorithms.
+
+    The `sweeps` search functions (`grid`/`random`/`bayes` and the hyperband
+    early-terminator) are stateless, so this class keeps the full list of sweep
+    runs in memory.
+    """
+
+    def __init__(self, sweep: Sweep):
+        super().__init__(sweep)
+        # key: run id, value: the SweepRun we hold for it
+        self._runs: dict[str, Any] = {}
+        self._run_counter = 0
+
+    def _new_run_id(self) -> str:
+        run_id = f"{self._sweep.id}-{self._run_counter}"
+        self._run_counter += 1
+        return run_id
+
+    def _record(self, run_id: str, data: RunEnriched) -> Any:
+        """Create and store a SweepRun for `run_id` from `data`."""
+        sweep_run = sweeps.SweepRun(
+            name=run_id,
+            config=data.config.wire_dict(),
+            state=_to_sweeps_state(data.state),
+            summary_metrics=data.summary_metrics or {},
+            history=list(data.history_metrics),
+        )
+        self._runs[run_id] = sweep_run
+        return sweep_run
+
+    def next_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        """Ask the `sweeps` search for up to `n` new runs.
+
+        Args:
+            n: The maximum number of runs to propose.
+        """
+        suggested = sweeps.next_runs(self._sweep.config, list(self._runs.values()), n=n)
+        suggestions: list[RunSuggestion] = []
+        for sweep_run in suggested:
+            # grid search returns None once the search space is exhausted.
+            if sweep_run is None:
+                continue
+            run_id = self._new_run_id()
+            sweep_run.name = run_id
+            # Record it (state defaults to pending) so the next search call and
+            # tell_run can find it.
+            self._runs[run_id] = sweep_run
+            # sweep_run.config is already the wire form RunConfig expects.
+            suggestions.append(
+                RunSuggestion(
+                    config=RunConfig(
+                        {
+                            name: ConfigValue(**param)
+                            for name, param in sweep_run.config.items()
+                        }
+                    ),
+                    run_id=run_id,
+                )
+            )
+        return suggestions
+
+    def tell_run(self, run_id: Any, data: RunEnriched) -> None:
+        """Record a run's latest outcome for the next search call to read.
+
+        Args:
+            run_id: The run id this optimizer handed out.
+            data: The run's current state, summary metrics and history.
+
+        Raises:
+            ValueError: If `run_id` was never proposed by this optimizer.
+        """
+        # "Save to memory" = update the SweepRun the search reads next time.
+        # Keep the config we suggested — `data.config` may be empty (e.g. a
+        # reaped run) — only the outcome (state, metrics, history) is new here.
+        sweep_run = self._runs.get(run_id)
+        if sweep_run is None:
+            raise ValueError(f"Run {run_id} not found")
+        sweep_run.state = _to_sweeps_state(data.state)
+        sweep_run.summary_metrics = data.summary_metrics or {}
+        sweep_run.history = list(data.history_metrics)
+
+    def prune_run(self, run_id: Any, data: RunEnriched) -> bool:
+        """Return True if hyperband says the run should stop early.
+
+        Always False unless the sweep config has an `early_terminate` block.
+
+        Args:
+            run_id: The run id this optimizer handed out.
+            data: The run's current state, summary metrics and history.
+        """
+        if "early_terminate" not in self._sweep.config:
+            return False
+        try:
+            to_stop = sweeps.stop_runs(self._sweep.config, list(self._runs.values()))
+        except Exception:
+            return False
+        return any(run.name == run_id for run in to_stop)
+
+    def should_terminate_sweep(self) -> bool:
+        """Sweeps library does not implement this, so we return False."""
+        return False
+
+    def tell_existing_finished_run(self, data: RunEnriched) -> None:
+        """Add a terminal run that predates this optimizer to its memory.
+
+        The search then treats it as a completed sample. Non-terminal runs are
+        ignored.
+
+        Args:
+            data: The existing run's state, summary metrics and history.
+        """
+        if not is_terminal_state(data.state):
+            return
+        self._record(self._new_run_id(), data)
+
+    def tell_existing_active_run(self, data: Run) -> Any:
+        """Adopt an in-flight run that predates this optimizer.
+
+        Its config is stored so the search counts it as in flight; the next poll
+        refreshes its metrics via `tell_run` before any suggestion reads them.
+
+        Args:
+            data: The existing run's config and state.
+
+        Returns:
+            The optimizer run id to track the run by.
+        """
+        run_id = self._new_run_id()
+        self._runs[run_id] = sweeps.SweepRun(
+            name=run_id,
+            config=data.config.wire_dict(),
+            state=_to_sweeps_state(data.state),
+        )
+        return run_id

--- a/wandb/sdk/sweeps/__init__.py
+++ b/wandb/sdk/sweeps/__init__.py
@@ -1,0 +1,1 @@
+from wandb.sdk.sweeps.run_state import RunState as RunState

--- a/wandb/sdk/sweeps/run_state.py
+++ b/wandb/sdk/sweeps/run_state.py
@@ -19,8 +19,9 @@ class RunState(Enum):
     KILLED = "killed", "dead"
     FINISHED = "finished", "dead"
     PREEMPTED = "preempted", "dead"
-    # unknown when api.get_run_state fails or returns unexpected state
-    # assumed alive, unless we get unknown 2x then move to failed (dead)
+    # unknown when api.get_run_state fails or returns an unexpected state.
+    # Classified alive; the launch scheduler moves a run to FAILED (dead)
+    # itself after two consecutive unknown polls.
     UNKNOWN = "unknown", "alive"
 
     def __new__(cls: Any, *args: list, **kwds: Any) -> RunState:
@@ -29,7 +30,8 @@ class RunState(Enum):
         obj._value_ = args[0]
         return obj
 
-    def __init__(self, _: str, life: str = "unknown") -> None:
+    def __init__(self, value: str, life: str = "unknown") -> None:
+        """Store the life classification; `value` is consumed by `__new__`."""
         self._life = life
 
     @property

--- a/wandb/sdk/sweeps/run_state.py
+++ b/wandb/sdk/sweeps/run_state.py
@@ -1,0 +1,38 @@
+"""The state of a sweep run, shared by the schedulers that drive sweeps."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+__all__ = ["RunState"]
+
+
+class RunState(Enum):
+    """A sweep run's state, paired with whether that state is alive or dead."""
+
+    RUNNING = "running", "alive"
+    PENDING = "pending", "alive"
+    PREEMPTING = "preempting", "alive"
+    CRASHED = "crashed", "dead"
+    FAILED = "failed", "dead"
+    KILLED = "killed", "dead"
+    FINISHED = "finished", "dead"
+    PREEMPTED = "preempted", "dead"
+    # unknown when api.get_run_state fails or returns unexpected state
+    # assumed alive, unless we get unknown 2x then move to failed (dead)
+    UNKNOWN = "unknown", "alive"
+
+    def __new__(cls: Any, *args: list, **kwds: Any) -> RunState:
+        """Use only the first tuple element as the member's value."""
+        obj: RunState = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    def __init__(self, _: str, life: str = "unknown") -> None:
+        self._life = life
+
+    @property
+    def is_alive(self) -> bool:
+        """True while a run in this state may still make progress."""
+        return self._life == "alive"

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -100,8 +100,11 @@ def is_terminal_state(state: RunState) -> bool:
 class Optimizer(ABC):
     """An external optimizer that supports an ask-tell interface.
 
-    A `Scheduler` asks for runs from the optimizer.
-    It then tells the run results back to the optimizer.
+    A scheduler asks the optimizer for runs to start, then tells the run
+    results back to the optimizer as they progress.
+
+    Subclasses may read the protected `_sweep` attribute, the `Sweep`
+    being optimized.
     """
 
     def __init__(self, sweep: Sweep):
@@ -147,7 +150,13 @@ class Optimizer(ABC):
     def tell_existing_active_run(self, data: Run) -> Any:
         """Adopt an *in-flight* (RUNNING/PENDING) run that existed at startup.
 
-        `data` has no metrics; the next poll reports them via `tell_run`.
+        Args:
+            data: The existing run's config and state, without metrics.
+
+        Returns:
+            The optimizer-side run id to track the run by, in which case
+            later polls report its metrics via `tell_run`, or None to
+            leave the run untracked. The default adopts nothing.
         """
         return None
 
@@ -176,22 +185,30 @@ class Optimizer(ABC):
     def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
         """Return True if the run should be pruned.
 
-        Convenience implementation for single-run callers.
-        Subclasses should override `prune_runs` instead.
+        Override to stop single runs early; the default prunes nothing.
+        The default `prune_runs` calls this for each polled run.
+
+        Args:
+            run_id: The `RunSuggestion.run_id` this optimizer handed out.
+            data: The run's current state, summary metrics and history.
         """
         return False
 
     def prune_runs(
-        self, _run_ids: Sequence[str], _runs: Sequence[RunWithMetrics]
+        self, run_ids: Sequence[str], runs: Sequence[RunWithMetrics]
     ) -> Sequence[str]:
         """Return the optimizer run ids that should be pruned.
 
-        Override this method to implement early stopping. The default
-        implementation calls prune_run for each run.
+        Override to decide early stopping across runs as a batch; the
+        default delegates to `prune_run` for each run.
+
+        Args:
+            run_ids: Optimizer run ids to consider for pruning.
+            runs: The corresponding runs' latest state and metrics.
         """
         return [
             run_id
-            for run_id, run in zip(_run_ids, _runs)
+            for run_id, run in zip(run_ids, runs, strict=True)
             if self.prune_run(run_id, run)
         ]
 

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from wandb.apis.public import Sweep
-from wandb.sdk.launch.sweeps.scheduler import RunState
+from wandb.sdk.sweeps.run_state import RunState
 
 
 @dataclass
@@ -70,7 +70,7 @@ class Run:
 
 
 @dataclass
-class RunEnriched(Run):
+class RunWithMetrics(Run):
     """A `Run` together with the metrics it has reported so far.
 
     `summary_metrics` is the run's latest summary; `history_metrics` is the
@@ -100,15 +100,15 @@ def is_terminal_state(state: RunState) -> bool:
 class Optimizer(ABC):
     """An external optimizer that supports an ask-tell interface.
 
-    Pure search strategy: it proposes runs and ingests their results, holding no
-    scheduling I/O. A `Scheduler` drives it.
+    A `Scheduler` asks for runs from the optimizer.
+    It then tells the run results back to the optimizer.
     """
 
     def __init__(self, sweep: Sweep):
         self._sweep = sweep
 
     @abstractmethod
-    def next_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
         """Propose up to `n` runs to start next.
 
         Fewer than `n` may come back when the search space is nearly exhausted
@@ -123,7 +123,7 @@ class Optimizer(ABC):
         ...
 
     @abstractmethod
-    def tell_run(self, run_id: Any, data: RunEnriched) -> None:
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
         """Report the latest state and metrics of a run this optimizer proposed.
 
         Called on each poll while the run is in flight, and once more when it
@@ -135,11 +135,11 @@ class Optimizer(ABC):
         """
         ...
 
-    def tell_existing_finished_run(self, data: RunEnriched) -> None:
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
         """Report a *terminal* run that already existed in the sweep at startup.
 
         Unlike `tell_run`, there is no optimizer-side run id because the run was
-        not produced by this optimizer's `next_n_runs`. Override to warm-start
+        not produced by this optimizer's `ask_n_runs`. Override to warm-start
         from prior results; the default is a no-op.
         """
         return None
@@ -170,11 +170,30 @@ class Optimizer(ABC):
 
     @property
     def sweep_name(self) -> str:
+        """The name of the sweep this optimizer searches."""
         return self._sweep.name
 
-    def prune_run(self, run_id: Any, data: RunEnriched) -> bool:
-        """Return True if the run should be pruned."""
+    def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
+        """Return True if the run should be pruned.
+
+        Convenience implementation for single-run callers.
+        Subclasses should override `prune_runs` instead.
+        """
         return False
+
+    def prune_runs(
+        self, _run_ids: Sequence[str], _runs: Sequence[RunWithMetrics]
+    ) -> Sequence[str]:
+        """Return the optimizer run ids that should be pruned.
+
+        Override this method to implement early stopping. The default
+        implementation calls prune_run for each run.
+        """
+        return [
+            run_id
+            for run_id, run in zip(_run_ids, _runs)
+            if self.prune_run(run_id, run)
+        ]
 
     def should_terminate_sweep(self) -> bool:
         """Return True if the sweep should be terminated."""

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -111,14 +111,15 @@ class Optimizer(ABC):
         self._sweep = sweep
 
     @abstractmethod
-    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion] | None:
         """Propose up to `n` runs to start next.
 
-        Fewer than `n` may come back when the search space is nearly exhausted
-        or the strategy needs results before proposing more. Returning nothing
-        at all means the search space is exhausted: a scheduler takes it as the
-        end of the sweep and finishes it, so a strategy that is only waiting on
-        results must propose at least one run.
+        Fewer than `n` may come back when the search space is nearly
+        exhausted. Returning an empty sequence means the search space is
+        exhausted: a scheduler takes it as the end of the sweep and finishes
+        it. Returning None declines to propose for now (e.g. the strategy
+        needs results from in-flight runs first); the scheduler asks again
+        on a later poll.
 
         Args:
             n: The maximum number of runs to propose.
@@ -185,12 +186,12 @@ class Optimizer(ABC):
     def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
         """Return True if the run should be pruned.
 
-        Override to stop single runs early; the default prunes nothing.
+        Override to stop single runs early, the default prunes nothing.
         The default `prune_runs` calls this for each polled run.
 
         Args:
-            run_id: The `RunSuggestion.run_id` this optimizer handed out.
-            data: The run's current state, summary metrics and history.
+            run_id: The `RunSuggestion.run_id` the optimizer handed out.
+            data: The run's current state, summary and history metrics.
         """
         return False
 
@@ -200,7 +201,7 @@ class Optimizer(ABC):
         """Return the optimizer run ids that should be pruned.
 
         Override to decide early stopping across runs as a batch; the
-        default delegates to `prune_run` for each run.
+        default delegates calls to `prune_run` for each run.
 
         Args:
             run_ids: Optimizer run ids to consider for pruning.

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from wandb.apis.public import Sweep
-from wandb.sdk.launch.sweeps.scheduler import RunState
+from wandb.sdk.sweeps.run_state import RunState
 
 
 @dataclass
@@ -70,7 +70,7 @@ class Run:
 
 
 @dataclass
-class RunEnriched(Run):
+class RunWithMetrics(Run):
     """A `Run` together with the metrics it has reported so far.
 
     `summary_metrics` is the run's latest summary; `history_metrics` is the
@@ -100,15 +100,15 @@ def is_terminal_state(state: RunState) -> bool:
 class Optimizer(ABC):
     """An external optimizer that supports an ask-tell interface.
 
-    Pure search strategy: it proposes runs and ingests their results, holding no
-    scheduling I/O. A `Scheduler` drives it.
+    A `Scheduler` asks for runs from the optimizer.
+    It then tells the run results back to the optimizer.
     """
 
     def __init__(self, sweep: Sweep):
         self._sweep = sweep
 
     @abstractmethod
-    def next_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
         """Propose up to `n` runs to start next.
 
         Fewer than `n` may come back when the search space is nearly exhausted
@@ -123,7 +123,7 @@ class Optimizer(ABC):
         ...
 
     @abstractmethod
-    def tell_run(self, run_id: Any, data: RunEnriched) -> None:
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
         """Report the latest state and metrics of a run this optimizer proposed.
 
         Called on each poll while the run is in flight, and once more when it
@@ -135,11 +135,11 @@ class Optimizer(ABC):
         """
         ...
 
-    def tell_existing_finished_run(self, data: RunEnriched) -> None:
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
         """Report a *terminal* run that already existed in the sweep at startup.
 
         Unlike `tell_run`, there is no optimizer-side run id because the run was
-        not produced by this optimizer's `next_n_runs`. Override to warm-start
+        not produced by this optimizer's `ask_n_runs`. Override to warm-start
         from prior results; the default is a no-op.
         """
         return None
@@ -170,9 +170,10 @@ class Optimizer(ABC):
 
     @property
     def sweep_name(self) -> str:
+        """The name of the sweep this optimizer searches."""
         return self._sweep.name
 
-    def prune_run(self, run_id: Any, data: RunEnriched) -> bool:
+    def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
         """Return True if the run should be pruned."""
         return False
 

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
@@ -20,11 +20,14 @@ from wandb.sdk.sweeps.scheduler.optimizer import (
     is_terminal_state,
 )
 
-sweeps = util.get_module(
-    "sweeps",
-    required="wandb[sweeps] is required to use the wandb sweep scheduler. "
-    "Please run `pip install wandb[sweeps]`.",
-)
+if TYPE_CHECKING:
+    import sweeps
+else:
+    sweeps = util.get_module(
+        "sweeps",
+        required="wandb[sweeps] is required to use the wandb sweep scheduler. "
+        "Please run `pip install wandb[sweeps]`.",
+    )
 
 
 def _to_sweeps_state(state: RunState) -> Any:
@@ -47,7 +50,7 @@ class WandbOptimizer(Optimizer):
     def __init__(self, sweep: Sweep):
         super().__init__(sweep)
         # key: run id, value: the SweepRun we hold for it
-        self._runs: dict[str, Any] = {}
+        self._runs: dict[str, sweeps.SweepRun] = {}
         self._run_counter = 0
 
     def _new_run_id(self) -> str:

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+from typing_extensions import override
+
 from wandb import util
 from wandb.apis.public import Sweep
-from wandb.sdk.launch.sweeps.scheduler import RunState
-from wandb.sdk.sweep_scheduler.optimizer import (
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
     ConfigValue,
     Optimizer,
     Run,
     RunConfig,
-    RunEnriched,
     RunSuggestion,
+    RunWithMetrics,
     is_terminal_state,
 )
 
@@ -41,6 +43,7 @@ class WandbOptimizer(Optimizer):
     runs in memory.
     """
 
+    @override
     def __init__(self, sweep: Sweep):
         super().__init__(sweep)
         # key: run id, value: the SweepRun we hold for it
@@ -52,19 +55,33 @@ class WandbOptimizer(Optimizer):
         self._run_counter += 1
         return run_id
 
-    def _record(self, run_id: str, data: RunEnriched) -> Any:
-        """Create and store a SweepRun for `run_id` from `data`."""
+    def _to_sweep_run(self, run_id: str, data: RunWithMetrics) -> Any:
         sweep_run = sweeps.SweepRun(
             name=run_id,
             config=data.config.wire_dict(),
             state=_to_sweeps_state(data.state),
-            summary_metrics=data.summary_metrics or {},
-            history=list(data.history_metrics),
         )
+        sweep_run.summary_metrics = data.summary_metrics or {}
+        sweep_run.history = list(data.history_metrics)
+        return sweep_run
+
+    def _record(self, run_id: str, data: RunWithMetrics) -> Any:
+        """Create and store a SweepRun for `run_id` from `data`."""
+        sweep_run = self._to_sweep_run(run_id, data)
         self._runs[run_id] = sweep_run
         return sweep_run
 
-    def next_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+    def _sweep_runs_for_stop_runs(
+        self, run_ids: Sequence[str], runs: Sequence[RunWithMetrics]
+    ) -> list[Any]:
+        """Merge in-memory runs with the scheduler's latest poll snapshot."""
+        sweep_runs_by_name = {run.name: run for run in self._runs.values()}
+        for run_id, data in zip(run_ids, runs, strict=True):
+            sweep_runs_by_name[run_id] = self._to_sweep_run(run_id, data)
+        return list(sweep_runs_by_name.values())
+
+    @override
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
         """Ask the `sweeps` search for up to `n` new runs.
 
         Args:
@@ -95,7 +112,8 @@ class WandbOptimizer(Optimizer):
             )
         return suggestions
 
-    def tell_run(self, run_id: Any, data: RunEnriched) -> None:
+    @override
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
         """Record a run's latest outcome for the next search call to read.
 
         Args:
@@ -115,28 +133,37 @@ class WandbOptimizer(Optimizer):
         sweep_run.summary_metrics = data.summary_metrics or {}
         sweep_run.history = list(data.history_metrics)
 
-    def prune_run(self, run_id: Any, data: RunEnriched) -> bool:
-        """Return True if hyperband says the run should stop early.
+    @override
+    def prune_runs(
+        self, run_ids: Sequence[str], runs: Sequence[RunWithMetrics]
+    ) -> Sequence[str]:
+        """Return the runs hyperband says should stop early.
 
-        Always False unless the sweep config has an `early_terminate` block.
+        Returns nothing unless the sweep config has an `early_terminate` block.
 
         Args:
-            run_id: The run id this optimizer handed out.
-            data: The run's current state, summary metrics and history.
+            run_ids: Optimizer run ids to consider for pruning.
+            runs: The corresponding run metrics from the scheduler's latest poll.
         """
         if "early_terminate" not in self._sweep.config:
-            return False
+            return []
         try:
-            to_stop = sweeps.stop_runs(self._sweep.config, list(self._runs.values()))
+            to_stop = sweeps.stop_runs(
+                self._sweep.config,
+                self._sweep_runs_for_stop_runs(run_ids, runs),
+            )
         except Exception:
-            return False
-        return any(run.name == run_id for run in to_stop)
+            return []
+        to_stop_names = {run.name for run in to_stop}
+        return [run_id for run_id in run_ids if run_id in to_stop_names]
 
+    @override
     def should_terminate_sweep(self) -> bool:
         """Sweeps library does not implement this, so we return False."""
         return False
 
-    def tell_existing_finished_run(self, data: RunEnriched) -> None:
+    @override
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
         """Add a terminal run that predates this optimizer to its memory.
 
         The search then treats it as a completed sample. Non-terminal runs are
@@ -149,6 +176,7 @@ class WandbOptimizer(Optimizer):
             return
         self._record(self._new_run_id(), data)
 
+    @override
     def tell_existing_active_run(self, data: Run) -> Any:
         """Adopt an in-flight run that predates this optimizer.
 

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -143,7 +143,7 @@ class WandbOptimizer(Optimizer):
 
         Args:
             run_ids: Optimizer run ids to consider for pruning.
-            runs: The corresponding run metrics from the scheduler's latest poll.
+            runs: Corresponding run metrics from the scheduler's latest poll.
         """
         if "early_terminate" not in self._sweep.config:
             return []

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -7,14 +7,14 @@ from typing import Any
 
 from wandb import util
 from wandb.apis.public import Sweep
-from wandb.sdk.launch.sweeps.scheduler import RunState
-from wandb.sdk.sweep_scheduler.optimizer import (
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
     ConfigValue,
     Optimizer,
     Run,
     RunConfig,
-    RunEnriched,
     RunSuggestion,
+    RunWithMetrics,
     is_terminal_state,
 )
 
@@ -52,7 +52,7 @@ class WandbOptimizer(Optimizer):
         self._run_counter += 1
         return run_id
 
-    def _record(self, run_id: str, data: RunEnriched) -> Any:
+    def _record(self, run_id: str, data: RunWithMetrics) -> Any:
         """Create and store a SweepRun for `run_id` from `data`."""
         sweep_run = sweeps.SweepRun(
             name=run_id,
@@ -64,7 +64,7 @@ class WandbOptimizer(Optimizer):
         self._runs[run_id] = sweep_run
         return sweep_run
 
-    def next_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
         """Ask the `sweeps` search for up to `n` new runs.
 
         Args:
@@ -95,7 +95,7 @@ class WandbOptimizer(Optimizer):
             )
         return suggestions
 
-    def tell_run(self, run_id: Any, data: RunEnriched) -> None:
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
         """Record a run's latest outcome for the next search call to read.
 
         Args:
@@ -115,7 +115,7 @@ class WandbOptimizer(Optimizer):
         sweep_run.summary_metrics = data.summary_metrics or {}
         sweep_run.history = list(data.history_metrics)
 
-    def prune_run(self, run_id: Any, data: RunEnriched) -> bool:
+    def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
         """Return True if hyperband says the run should stop early.
 
         Always False unless the sweep config has an `early_terminate` block.
@@ -136,7 +136,7 @@ class WandbOptimizer(Optimizer):
         """Sweeps library does not implement this, so we return False."""
         return False
 
-    def tell_existing_finished_run(self, data: RunEnriched) -> None:
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
         """Add a terminal run that predates this optimizer to its memory.
 
         The search then treats it as a completed sample. Non-terminal runs are


### PR DESCRIPTION
Description
-----------
- Fixes WB-38196

Create the Optimizer base class as specified in the design, and provide a reference implementation using the wandb/sweeps package. The Optimizer base class uses the ask-and-tell interface of the underlying HPO system.

Of note:

- next_n_runs: returns a sequence of run suggestions 
- tell_run: used to report back on runs created by the optimizer
- tell_existing_finished_run: used to warm start the optimizer on existing sweep data
- tell_existing_active_run: used to trigger the optimizer to create internal runs on existing sweep data

- [x] CHANGELOG N/A


Testing
-------
Unit tested