### PR TITLE
feat(sweeps): scheduler implementation for sweeps

### DIFF
--- a/tests/system_tests/test_sweep/test_wandb_sdk_sweep_scheduler.py
+++ b/tests/system_tests/test_sweep/test_wandb_sdk_sweep_scheduler.py
@@ -1,0 +1,39 @@
+"""System tests for the wandb.sdk.sweeps.scheduler reference scheduler."""
+
+from typing import Any
+from unittest.mock import patch
+
+from wandb.apis.public import SweepState
+from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
+from wandb.sdk.sweeps.scheduler.wandb import create_sweep_from_config
+
+SWEEP_CONFIG_GRID_SINGLE: dict[str, Any] = {
+    "name": "test-scheduler-grid-single",
+    "method": "grid",
+    "metric": {"name": "loss", "goal": "minimize"},
+    "parameters": {"param1": {"values": [1]}},
+    "scheduler": {"engine": "wandb"},
+}
+
+
+def test_loop_finishes_sweep_when_optimizer_should_terminate(user) -> None:
+    """When the optimizer requests termination, loop() marks the sweep FINISHED."""
+    project = "test-scheduler-terminate-sweep"
+
+    scheduler = create_sweep_from_config(
+        SWEEP_CONFIG_GRID_SINGLE,
+        entity=user,
+        project=project,
+        options=SchedulerOptions(
+            poll_interval_s=0.2,
+            batch_size=1,
+        ),
+    )
+    with patch.object(
+        scheduler._optimizer,
+        "should_terminate_sweep",
+        return_value=True,
+    ):
+        scheduler.loop()
+
+    assert scheduler.sweep_state() == SweepState.FINISHED

--- a/tests/system_tests/test_sweep/test_wandb_sdk_sweep_scheduler.py
+++ b/tests/system_tests/test_sweep/test_wandb_sdk_sweep_scheduler.py
@@ -1,0 +1,39 @@
+"""System tests for the wandb.sdk.sweeps.scheduler reference scheduler."""
+
+from typing import Any
+from unittest.mock import patch
+
+from wandb.apis.public import SweepState
+from wandb.sdk.sweeps.scheduler.wandb import create_sweep_from_config
+from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
+
+SWEEP_CONFIG_GRID_SINGLE: dict[str, Any] = {
+    "name": "test-scheduler-grid-single",
+    "method": "grid",
+    "metric": {"name": "loss", "goal": "minimize"},
+    "parameters": {"param1": {"values": [1]}},
+    "scheduler": {"engine": "wandb"},
+}
+
+
+def test_loop_finishes_sweep_when_optimizer_should_terminate(user) -> None:
+    """When the optimizer requests termination, loop() marks the sweep FINISHED."""
+    project = "test-scheduler-terminate-sweep"
+
+    scheduler = create_sweep_from_config(
+        SWEEP_CONFIG_GRID_SINGLE,
+        entity=user,
+        project=project,
+        options=SchedulerOptions(
+            poll_interval_s=0.2,
+            batch_size=1,
+        ),
+    )
+    with patch.object(
+        scheduler._optimizer,
+        "should_terminate_sweep",
+        return_value=True,
+    ):
+        scheduler.loop()
+
+    assert scheduler.sweep_state() == SweepState.FINISHED

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -5,6 +5,7 @@ import contextlib
 import signal
 import threading
 from collections.abc import Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -688,6 +689,7 @@ class SchedulerAcceptanceTests(abc.ABC):
         sweep.finish.assert_not_called()  # type: ignore[attr-defined]
         executor.schedule.assert_not_called()
         assert len(scheduler.in_flight_runs()) == 0
+
     def test_loop_exits_when_cancelled_without_calling_optimizer(
         self,
         scheduler: Scheduler,
@@ -696,12 +698,15 @@ class SchedulerAcceptanceTests(abc.ABC):
         mock_api: MagicMock,
     ) -> None:
         optimizer_called = threading.Event()
-        optimizer_finished = threading.Event()
+        release_optimizer = threading.Event()
         warm_start_runs_calls = 2
 
         def blocking_next_n(n: int) -> list[RunSuggestion]:
             optimizer_called.set()
-            optimizer_finished.wait(timeout=1.0)
+            # Block until the test releases it, so the loop must exit while
+            # the optimizer is still working. The pytest timeout is the
+            # backstop if the loop never exits.
+            release_optimizer.wait()
             return make_suggestions(n)
 
         optimizer.ask_n_runs_mock.side_effect = blocking_next_n
@@ -718,31 +723,29 @@ class SchedulerAcceptanceTests(abc.ABC):
         driver = LoopDriver(
             scheduler, SweepState.RUNNING, exit_state=SweepState.CANCELED
         )
-        loop_done = threading.Event()
 
         def run_loop() -> None:
-            try:
-                with driver.driving():
-                    scheduler.loop()
-            finally:
-                loop_done.set()
+            with driver.driving():
+                scheduler.loop()
 
-        loop_thread = threading.Thread(target=run_loop)
-        loop_thread.start()
-
-        # Cancel only once the optimizer is known to be working, so the loop has
-        # to notice the transition while blocked on `ask_n_runs` rather than at
-        # some particular state query.
-        assert optimizer_called.wait(timeout=2.0)
-        driver.state = SweepState.CANCELED
-
-        assert loop_done.wait(timeout=2.0)
-        loop_thread.join(timeout=2.0)
+        try:
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(run_loop)
+                # Cancel only once the optimizer is known to be working, so the
+                # loop has to notice the transition while blocked on
+                # `ask_n_runs` rather than at some particular state query.
+                optimizer_called.wait()
+                driver.state = SweepState.CANCELED
+                # Re-raises anything the loop raised, including guarded_runs's
+                # AssertionError.
+                future.result()
+        finally:
+            # Unblock the optimizer's fetch thread before asserting.
+            release_optimizer.set()
 
         optimizer.ask_n_runs_mock.assert_called_once()
-        # The loop left without waiting for the blocked optimizer, so nothing it
-        # would eventually suggest was scheduled.
-        assert not optimizer_finished.is_set()
+        # The loop left without waiting for the blocked optimizer, so nothing
+        # it would eventually suggest was scheduled.
         executor.schedule.assert_not_called()
         assert len(scheduler.in_flight_runs()) == 0
         assert mock_api.runs.call_count == warm_start_runs_calls

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import abc
 import contextlib
 import signal
+import threading
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -26,7 +28,9 @@ from wandb.sdk.sweeps.scheduler.optimizer import (
 from wandb.sdk.sweeps.scheduler.scheduler import (
     _MAX_CONSECUTIVE_ERRORS,
     Executor,
+    InMemoryScheduler,
     Scheduler,
+    SchedulerOptions,
     _LoopControl,
     _ShutdownMonitor,
 )
@@ -76,6 +80,65 @@ def make_run(
         wandb_run_id=wandb_run_id,
         summary_metrics=summary,
         history_metrics=history or [],
+    )
+
+
+@dataclass
+class RemoteRun:
+    """A sweep run as fetched from the W&B API.
+
+    Carries the fields `InMemoryScheduler` reads from `wandb.apis.public.Run`
+    when polling or warm-starting.
+    """
+
+    id: str
+    state: str
+    config: dict[str, Any]
+    summary_metrics: dict[str, Any] = field(default_factory=dict)
+    storage_id: str = ""
+    history_metrics: list[dict[str, Any]] = field(default_factory=list)
+    history_error: Exception | None = None
+
+    def __post_init__(self) -> None:
+        if not self.storage_id:
+            self.storage_id = self.id
+
+    def history(
+        self,
+        keys: list[str] | None = None,
+        samples: int | None = None,
+        pandas: bool = False,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Return sampled history rows, like `wandb.apis.public.Run.history`.
+
+        `history_error` stands in for that per-run query failing.
+        """
+        if self.history_error is not None:
+            raise self.history_error
+        return list(self.history_metrics)
+
+
+def make_remote_run(
+    run_id: str,
+    state: RunState | str,
+    config: dict[str, Any],
+    summary: dict[str, Any] | None = None,
+    *,
+    storage_id: str | None = None,
+    history: list[dict[str, Any]] | None = None,
+    history_error: Exception | None = None,
+) -> RemoteRun:
+    """Build a `RemoteRun` for tests or stubs of `Api.runs()` results."""
+    state_str = state.value if isinstance(state, RunState) else state
+    return RemoteRun(
+        id=run_id,
+        state=state_str,
+        config=config,
+        summary_metrics=summary or {},
+        storage_id=storage_id or "",
+        history_metrics=history or [],
+        history_error=history_error,
     )
 
 
@@ -370,6 +433,216 @@ class SchedulerAcceptanceTests(abc.ABC):
         assert "wandb-opt-0" in scheduler.in_flight_runs()
         optimizer.ask_n_runs_mock.assert_called_once_with(batch_size - 1)
 
+    def test_schedule_then_poll_one_finished(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+        batch_size: int,
+    ) -> None:
+        with patch.object(scheduler, "sweep_state", return_value=SweepState.RUNNING):
+            scheduler._schedule_suggestions()
+        assert len(scheduler.in_flight_runs()) == batch_size
+
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "wandb-opt-0",
+                RunState.FINISHED,
+                {"param1": 1},
+                {"loss": 1.0},
+            ),
+            make_remote_run(
+                "wandb-opt-1",
+                RunState.RUNNING,
+                {"param1": 2},
+                {"loss": 2.0},
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        tell_calls = {
+            call.args[0]: call.args[1]
+            for call in optimizer.tell_run_mock.call_args_list
+        }
+        assert tell_calls["opt-0"].state == RunState.FINISHED
+        assert tell_calls["opt-0"].wandb_run_id == "wandb-opt-0"
+        assert tell_calls["opt-0"].summary_metrics == {"loss": 1.0}
+        assert tell_calls["opt-1"].state == RunState.RUNNING
+        assert tell_calls["opt-1"].wandb_run_id == "wandb-opt-1"
+        assert tell_calls["opt-1"].summary_metrics == {"loss": 2.0}
+        assert len(scheduler.in_flight_runs()) == batch_size - 1
+        assert "wandb-opt-1" in scheduler.in_flight_runs()
+
+    def test_warm_start_adopts_existing_runs(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        finished = make_remote_run(
+            "existing-finished",
+            RunState.FINISHED,
+            {"param1": 1},
+            {"loss": 0.5},
+        )
+        active = make_remote_run(
+            "existing-active",
+            RunState.RUNNING,
+            {"param1": 2},
+            {"loss": 1.0},
+        )
+
+        def runs_side_effect(
+            path: str,
+            filters: dict[str, Any],
+            per_page: int = 50,
+            lazy: bool = False,
+        ) -> list[RemoteRun]:
+            state_filter = filters.get("state")
+            if state_filter is not None:
+                states = state_filter["$in"]
+                if RunState.FINISHED.value in states:
+                    return [finished]
+                if RunState.RUNNING.value in states:
+                    return [active]
+            return []
+
+        mock_api.runs.side_effect = runs_side_effect
+
+        scheduler._warm_start()
+
+        optimizer.tell_existing_finished_run_mock.assert_called_once()
+        finished_arg = optimizer.tell_existing_finished_run_mock.call_args[0][0]
+        assert finished_arg.wandb_run_id == "existing-finished"
+        assert finished_arg.state == RunState.FINISHED
+
+        optimizer.tell_existing_active_run_mock.assert_called_once()
+        active_arg = optimizer.tell_existing_active_run_mock.call_args[0][0]
+        assert active_arg.wandb_run_id == "existing-active"
+        assert active_arg.state == RunState.RUNNING
+
+        assert len(scheduler.in_flight_runs()) == 1
+        assert "existing-active" in scheduler.in_flight_runs()
+
+    def test_warm_start_raises_when_api_runs_fails(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        mock_api.runs.side_effect = RuntimeError("api unavailable")
+
+        with pytest.raises(RuntimeError, match="api unavailable"):
+            scheduler._warm_start()
+
+        optimizer.tell_existing_finished_run_mock.assert_not_called()
+        optimizer.tell_existing_active_run_mock.assert_not_called()
+        assert len(scheduler.in_flight_runs()) == 0
+
+    def test_poll_handles_deleted_runs(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        scheduler.push_in_flight_run("run-1", "opt-1")
+        scheduler.push_in_flight_run("run-2", "opt-2")
+        assert len(scheduler.in_flight_runs()) == 3
+
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-2",
+                RunState.RUNNING,
+                {"param1": 3},
+                {"loss": 3.0},
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        assert optimizer.tell_run_mock.call_count == 3
+        deleted_calls = [
+            call
+            for call in optimizer.tell_run_mock.call_args_list
+            if call[0][1].state == RunState.FAILED
+        ]
+        assert len(deleted_calls) == 2
+        deleted_ids = {call[0][0] for call in deleted_calls}
+        assert deleted_ids == {"opt-0", "opt-1"}
+
+        assert len(scheduler.in_flight_runs()) == 1
+        assert "run-2" in scheduler.in_flight_runs()
+
+    def test_prune_active_runs(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_internal_api: MagicMock,
+    ) -> None:
+        prune_suggestion = RunSuggestion(
+            config=RunConfig.from_values({"param1": 1}), run_id="opt-prune"
+        )
+        keep_suggestion = RunSuggestion(
+            config=RunConfig.from_values({"param1": 2}), run_id="opt-keep"
+        )
+        scheduler.push_in_flight_run("run-prune", "opt-prune")
+        scheduler.push_in_flight_run("run-keep", "opt-keep")
+
+        active = [
+            make_run(
+                prune_suggestion,
+                state=RunState.RUNNING,
+                summary={"loss": 10.0},
+                wandb_run_id="run-prune",
+                history=[{"loss": 10.0}, {"loss": 10.0}],
+            ),
+            make_run(
+                keep_suggestion,
+                state=RunState.RUNNING,
+                summary={"loss": 1.0},
+                wandb_run_id="run-keep",
+                history=[{"loss": 10.0}, {"loss": 1.0}],
+            ),
+        ]
+
+        optimizer.prune_runs_mock.return_value = ["opt-prune"]
+
+        if isinstance(scheduler, InMemoryScheduler):
+            scheduler._storage_ids["run-prune"] = "storage-prune"
+
+        scheduler._prune_active_runs(active)
+
+        optimizer.prune_runs_mock.assert_called_once_with(
+            ["opt-prune", "opt-keep"],
+            active,
+        )
+        assert "run-prune" not in scheduler.in_flight_runs()
+        assert "run-keep" in scheduler.in_flight_runs()
+
+    def test_loop_does_nothing_when_paused(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        executor: MagicMock,
+        mock_api: MagicMock,
+        mock_internal_api: MagicMock,
+    ) -> None:
+        # Stay paused for two full iterations, then let the sweep finish so the
+        # loop exits on its own.
+        driver = LoopDriver(scheduler, SweepState.PAUSED, max_iterations=2)
+        with driver.driving():
+            scheduler.loop()
+
+        assert driver.iterations == 2
+        assert len(scheduler.in_flight_runs()) == 0
+        executor.schedule.assert_not_called()
+        optimizer.ask_n_runs_mock.assert_not_called()
+        optimizer.tell_run_mock.assert_not_called()
+        assert mock_api.runs.call_count <= 2  # warm-start queries only
+        mock_internal_api.stop_run.assert_not_called()
+
     def test_loop_finishes_sweep_when_optimizer_is_exhausted(
         self,
         scheduler: Scheduler,
@@ -415,6 +688,64 @@ class SchedulerAcceptanceTests(abc.ABC):
         sweep.finish.assert_not_called()  # type: ignore[attr-defined]
         executor.schedule.assert_not_called()
         assert len(scheduler.in_flight_runs()) == 0
+    def test_loop_exits_when_cancelled_without_calling_optimizer(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        executor: MagicMock,
+        mock_api: MagicMock,
+    ) -> None:
+        optimizer_called = threading.Event()
+        optimizer_finished = threading.Event()
+        warm_start_runs_calls = 2
+
+        def blocking_next_n(n: int) -> list[RunSuggestion]:
+            optimizer_called.set()
+            optimizer_finished.wait(timeout=1.0)
+            return make_suggestions(n)
+
+        optimizer.ask_n_runs_mock.side_effect = blocking_next_n
+
+        def guarded_runs(*args: Any, **kwargs: Any) -> list[RemoteRun]:
+            if optimizer_called.is_set():
+                raise AssertionError(
+                    "scheduler fetched run state while optimizer was working"
+                )
+            return []
+
+        mock_api.runs.side_effect = guarded_runs
+
+        driver = LoopDriver(
+            scheduler, SweepState.RUNNING, exit_state=SweepState.CANCELED
+        )
+        loop_done = threading.Event()
+
+        def run_loop() -> None:
+            try:
+                with driver.driving():
+                    scheduler.loop()
+            finally:
+                loop_done.set()
+
+        loop_thread = threading.Thread(target=run_loop)
+        loop_thread.start()
+
+        # Cancel only once the optimizer is known to be working, so the loop has
+        # to notice the transition while blocked on `ask_n_runs` rather than at
+        # some particular state query.
+        assert optimizer_called.wait(timeout=2.0)
+        driver.state = SweepState.CANCELED
+
+        assert loop_done.wait(timeout=2.0)
+        loop_thread.join(timeout=2.0)
+
+        optimizer.ask_n_runs_mock.assert_called_once()
+        # The loop left without waiting for the blocked optimizer, so nothing it
+        # would eventually suggest was scheduled.
+        assert not optimizer_finished.is_set()
+        executor.schedule.assert_not_called()
+        assert len(scheduler.in_flight_runs()) == 0
+        assert mock_api.runs.call_count == warm_start_runs_calls
 
     def test_loop_exits_when_sweep_state_not_found(
         self,
@@ -670,3 +1001,163 @@ class SchedulerAcceptanceTests(abc.ABC):
 
         assert driver.iterations == 1
         assert call_order == ["poll", "prune", "reap", "schedule"]
+
+
+class TestInMemorySchedulerAcceptance(SchedulerAcceptanceTests):
+    @pytest.fixture
+    def mock_api(self) -> Iterator[MagicMock]:
+        api = MagicMock()
+        api.runs.return_value = []
+        with patch("wandb.sdk.sweeps.scheduler.scheduler.Api", return_value=api):
+            yield api
+
+    @pytest.fixture
+    def mock_internal_api(self) -> Iterator[MagicMock]:
+        internal_api = MagicMock()
+        internal_api.stop_run.return_value = True
+        with patch(
+            "wandb.sdk.sweeps.scheduler.scheduler.InternalApi",
+            return_value=internal_api,
+        ):
+            yield internal_api
+
+    @pytest.fixture
+    def scheduler(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        executor: MagicMock,
+        mock_api: MagicMock,
+        batch_size: int,
+    ) -> InMemoryScheduler:
+        return InMemoryScheduler(
+            optimizer=optimizer,
+            sweep=sweep,
+            options=SchedulerOptions(
+                poll_interval_s=0,
+                batch_size=batch_size,
+                executor=executor,
+            ),
+        )
+
+    def test_poll_skips_unreadable_run_and_keeps_the_rest(
+        self,
+        scheduler: InMemoryScheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        """One run's metrics failing must not cost the whole poll."""
+        scheduler.push_in_flight_run("run-ok", "opt-ok")
+        scheduler.push_in_flight_run("run-bad", "opt-bad")
+        mock_api.runs.return_value = [
+            make_remote_run("run-ok", RunState.RUNNING, {"param1": 1}, {"loss": 1.0}),
+            make_remote_run(
+                "run-bad",
+                RunState.RUNNING,
+                {"param1": 2},
+                history_error=CommError("history query failed"),
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        told = {call.args[0] for call in optimizer.tell_run_mock.call_args_list}
+        assert told == {"opt-ok"}
+        # Still on the server, so it stays in flight instead of being failed.
+        assert "run-bad" in scheduler.in_flight_runs()
+        assert scheduler.unreadable_run_ids() == frozenset({"run-bad"})
+
+    def test_poll_reaps_deleted_run_but_not_unreadable_one(
+        self,
+        scheduler: InMemoryScheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        """Absent from the server is failed; present but unreadable is not."""
+        scheduler.push_in_flight_run("run-deleted", "opt-deleted")
+        scheduler.push_in_flight_run("run-bad", "opt-bad")
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-bad",
+                RunState.RUNNING,
+                {"param1": 2},
+                history_error=CommError("history query failed"),
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        failed = {
+            call.args[0]
+            for call in optimizer.tell_run_mock.call_args_list
+            if call.args[1].state == RunState.FAILED
+        }
+        assert failed == {"opt-deleted"}
+        assert "run-deleted" not in scheduler.in_flight_runs()
+        assert "run-bad" in scheduler.in_flight_runs()
+
+    def test_failed_poll_keeps_the_storage_ids_pruning_needs(
+        self,
+        scheduler: InMemoryScheduler,
+        mock_api: MagicMock,
+        mock_internal_api: MagicMock,
+    ) -> None:
+        """A failed poll must not strand in-flight runs with no way to stop them."""
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-0",
+                RunState.RUNNING,
+                {"param1": 1},
+                {"loss": 1.0},
+                storage_id="storage-0",
+            ),
+        ]
+        scheduler._poll_active_runs()
+
+        mock_api.runs.side_effect = api_error(503)
+        with pytest.raises(WandbApiFailedError):
+            scheduler._poll_active_runs()
+
+        # The last good poll's ids survive, so the run is still stoppable.
+        assert scheduler.stop_run("run-0")
+        mock_internal_api.stop_run.assert_called_once_with("storage-0")
+
+    def test_poll_forgets_storage_ids_when_nothing_is_in_flight(
+        self,
+        scheduler: InMemoryScheduler,
+        mock_api: MagicMock,
+    ) -> None:
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-0",
+                RunState.FINISHED,
+                {"param1": 1},
+                {"loss": 1.0},
+                storage_id="storage-0",
+            ),
+        ]
+        scheduler._poll_active_runs()
+        assert not scheduler.in_flight_runs()
+
+        scheduler.fetch_active_runs()
+
+        assert not scheduler.stop_run("run-0")
+        assert scheduler.unreadable_run_ids() == frozenset()
+
+    def test_every_run_query_prefetches_config_and_summary_metrics(
+        self,
+        scheduler: InMemoryScheduler,
+        mock_api: MagicMock,
+    ) -> None:
+        """Lazily loaded runs would cost a query per run on first access."""
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        mock_api.runs.return_value = []
+
+        scheduler.fetch_active_runs()
+        scheduler._warm_start()
+
+        assert mock_api.runs.call_count == 3  # one active poll, two warm-start
+        for call in mock_api.runs.call_args_list:
+            assert call.kwargs["lazy"] is False

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import abc
 import contextlib
 import signal
+import threading
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -26,8 +28,10 @@ from wandb.sdk.sweeps.scheduler.optimizer import (
 from wandb.sdk.sweeps.scheduler.scheduler import (
     _MAX_CONSECUTIVE_ERRORS,
     Executor,
+    InMemoryScheduler,
     Scheduler,
     _ShutdownMonitor,
+    SchedulerOptions,
 )
 
 SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
@@ -75,6 +79,65 @@ def make_run(
         wandb_run_id=wandb_run_id,
         summary_metrics=summary,
         history_metrics=history or [],
+    )
+
+
+@dataclass
+class RemoteRun:
+    """A sweep run as fetched from the W&B API.
+
+    Carries the fields `InMemoryScheduler` reads from `wandb.apis.public.Run`
+    when polling or warm-starting.
+    """
+
+    id: str
+    state: str
+    config: dict[str, Any]
+    summary_metrics: dict[str, Any] = field(default_factory=dict)
+    storage_id: str = ""
+    history_metrics: list[dict[str, Any]] = field(default_factory=list)
+    history_error: Exception | None = None
+
+    def __post_init__(self) -> None:
+        if not self.storage_id:
+            self.storage_id = self.id
+
+    def history(
+        self,
+        keys: list[str] | None = None,
+        samples: int | None = None,
+        pandas: bool = False,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Return sampled history rows, like `wandb.apis.public.Run.history`.
+
+        `history_error` stands in for that per-run query failing.
+        """
+        if self.history_error is not None:
+            raise self.history_error
+        return list(self.history_metrics)
+
+
+def make_remote_run(
+    run_id: str,
+    state: RunState | str,
+    config: dict[str, Any],
+    summary: dict[str, Any] | None = None,
+    *,
+    storage_id: str | None = None,
+    history: list[dict[str, Any]] | None = None,
+    history_error: Exception | None = None,
+) -> RemoteRun:
+    """Build a `RemoteRun` for tests or stubs of `Api.runs()` results."""
+    state_str = state.value if isinstance(state, RunState) else state
+    return RemoteRun(
+        id=run_id,
+        state=state_str,
+        config=config,
+        summary_metrics=summary or {},
+        storage_id=storage_id or "",
+        history_metrics=history or [],
+        history_error=history_error,
     )
 
 
@@ -359,6 +422,216 @@ class SchedulerAcceptanceTests(abc.ABC):
         assert "wandb-opt-0" in scheduler.in_flight_runs()
         optimizer.ask_n_runs_mock.assert_called_once_with(batch_size - 1)
 
+    def test_schedule_then_poll_one_finished(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+        batch_size: int,
+    ) -> None:
+        with patch.object(scheduler, "sweep_state", return_value=SweepState.RUNNING):
+            scheduler._schedule_suggestions()
+        assert len(scheduler.in_flight_runs()) == batch_size
+
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "wandb-opt-0",
+                RunState.FINISHED,
+                {"param1": 1},
+                {"loss": 1.0},
+            ),
+            make_remote_run(
+                "wandb-opt-1",
+                RunState.RUNNING,
+                {"param1": 2},
+                {"loss": 2.0},
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        tell_calls = {
+            call.args[0]: call.args[1]
+            for call in optimizer.tell_run_mock.call_args_list
+        }
+        assert tell_calls["opt-0"].state == RunState.FINISHED
+        assert tell_calls["opt-0"].wandb_run_id == "wandb-opt-0"
+        assert tell_calls["opt-0"].summary_metrics == {"loss": 1.0}
+        assert tell_calls["opt-1"].state == RunState.RUNNING
+        assert tell_calls["opt-1"].wandb_run_id == "wandb-opt-1"
+        assert tell_calls["opt-1"].summary_metrics == {"loss": 2.0}
+        assert len(scheduler.in_flight_runs()) == batch_size - 1
+        assert "wandb-opt-1" in scheduler.in_flight_runs()
+
+    def test_warm_start_adopts_existing_runs(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        finished = make_remote_run(
+            "existing-finished",
+            RunState.FINISHED,
+            {"param1": 1},
+            {"loss": 0.5},
+        )
+        active = make_remote_run(
+            "existing-active",
+            RunState.RUNNING,
+            {"param1": 2},
+            {"loss": 1.0},
+        )
+
+        def runs_side_effect(
+            path: str,
+            filters: dict[str, Any],
+            per_page: int = 50,
+            lazy: bool = False,
+        ) -> list[RemoteRun]:
+            state_filter = filters.get("state")
+            if state_filter is not None:
+                states = state_filter["$in"]
+                if RunState.FINISHED.value in states:
+                    return [finished]
+                if RunState.RUNNING.value in states:
+                    return [active]
+            return []
+
+        mock_api.runs.side_effect = runs_side_effect
+
+        scheduler._warm_start()
+
+        optimizer.tell_existing_finished_run_mock.assert_called_once()
+        finished_arg = optimizer.tell_existing_finished_run_mock.call_args[0][0]
+        assert finished_arg.wandb_run_id == "existing-finished"
+        assert finished_arg.state == RunState.FINISHED
+
+        optimizer.tell_existing_active_run_mock.assert_called_once()
+        active_arg = optimizer.tell_existing_active_run_mock.call_args[0][0]
+        assert active_arg.wandb_run_id == "existing-active"
+        assert active_arg.state == RunState.RUNNING
+
+        assert len(scheduler.in_flight_runs()) == 1
+        assert "existing-active" in scheduler.in_flight_runs()
+
+    def test_warm_start_raises_when_api_runs_fails(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        mock_api.runs.side_effect = RuntimeError("api unavailable")
+
+        with pytest.raises(RuntimeError, match="api unavailable"):
+            scheduler._warm_start()
+
+        optimizer.tell_existing_finished_run_mock.assert_not_called()
+        optimizer.tell_existing_active_run_mock.assert_not_called()
+        assert len(scheduler.in_flight_runs()) == 0
+
+    def test_poll_handles_deleted_runs(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        scheduler.push_in_flight_run("run-1", "opt-1")
+        scheduler.push_in_flight_run("run-2", "opt-2")
+        assert len(scheduler.in_flight_runs()) == 3
+
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-2",
+                RunState.RUNNING,
+                {"param1": 3},
+                {"loss": 3.0},
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        assert optimizer.tell_run_mock.call_count == 3
+        deleted_calls = [
+            call
+            for call in optimizer.tell_run_mock.call_args_list
+            if call[0][1].state == RunState.FAILED
+        ]
+        assert len(deleted_calls) == 2
+        deleted_ids = {call[0][0] for call in deleted_calls}
+        assert deleted_ids == {"opt-0", "opt-1"}
+
+        assert len(scheduler.in_flight_runs()) == 1
+        assert "run-2" in scheduler.in_flight_runs()
+
+    def test_prune_active_runs(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        mock_internal_api: MagicMock,
+    ) -> None:
+        prune_suggestion = RunSuggestion(
+            config=RunConfig.from_values({"param1": 1}), run_id="opt-prune"
+        )
+        keep_suggestion = RunSuggestion(
+            config=RunConfig.from_values({"param1": 2}), run_id="opt-keep"
+        )
+        scheduler.push_in_flight_run("run-prune", "opt-prune")
+        scheduler.push_in_flight_run("run-keep", "opt-keep")
+
+        active = [
+            make_run(
+                prune_suggestion,
+                state=RunState.RUNNING,
+                summary={"loss": 10.0},
+                wandb_run_id="run-prune",
+                history=[{"loss": 10.0}, {"loss": 10.0}],
+            ),
+            make_run(
+                keep_suggestion,
+                state=RunState.RUNNING,
+                summary={"loss": 1.0},
+                wandb_run_id="run-keep",
+                history=[{"loss": 10.0}, {"loss": 1.0}],
+            ),
+        ]
+
+        optimizer.prune_run_mock.side_effect = lambda run_id, data: (
+            run_id == "opt-prune"
+        )
+
+        if isinstance(scheduler, InMemoryScheduler):
+            scheduler._storage_ids["run-prune"] = "storage-prune"
+
+        scheduler._prune_active_runs(active)
+
+        optimizer.prune_run_mock.assert_any_call("opt-prune", active[0])
+        optimizer.prune_run_mock.assert_any_call("opt-keep", active[1])
+        assert "run-prune" not in scheduler.in_flight_runs()
+        assert "run-keep" in scheduler.in_flight_runs()
+
+    def test_loop_does_nothing_when_paused(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        executor: MagicMock,
+        mock_api: MagicMock,
+        mock_internal_api: MagicMock,
+    ) -> None:
+        # Stay paused for two full iterations, then let the sweep finish so the
+        # loop exits on its own.
+        driver = LoopDriver(scheduler, SweepState.PAUSED, max_iterations=2)
+        with driver.driving():
+            scheduler.loop()
+
+        assert driver.iterations == 2
+        assert len(scheduler.in_flight_runs()) == 0
+        executor.schedule.assert_not_called()
+        optimizer.ask_n_runs_mock.assert_not_called()
+        optimizer.tell_run_mock.assert_not_called()
+        assert mock_api.runs.call_count <= 2  # warm-start queries only
+        mock_internal_api.stop_run.assert_not_called()
+
     def test_loop_finishes_sweep_when_optimizer_is_exhausted(
         self,
         scheduler: Scheduler,
@@ -381,6 +654,65 @@ class SchedulerAcceptanceTests(abc.ABC):
         sweep.finish.assert_called_once()  # type: ignore[attr-defined]
         executor.schedule.assert_not_called()
         assert len(scheduler.in_flight_runs()) == 0
+
+    def test_loop_exits_when_cancelled_without_calling_optimizer(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        executor: MagicMock,
+        mock_api: MagicMock,
+    ) -> None:
+        optimizer_called = threading.Event()
+        optimizer_finished = threading.Event()
+        warm_start_runs_calls = 2
+
+        def blocking_next_n(n: int) -> list[RunSuggestion]:
+            optimizer_called.set()
+            optimizer_finished.wait(timeout=1.0)
+            return make_suggestions(n)
+
+        optimizer.ask_n_runs_mock.side_effect = blocking_next_n
+
+        def guarded_runs(*args: Any, **kwargs: Any) -> list[RemoteRun]:
+            if optimizer_called.is_set():
+                raise AssertionError(
+                    "scheduler fetched run state while optimizer was working"
+                )
+            return []
+
+        mock_api.runs.side_effect = guarded_runs
+
+        driver = LoopDriver(
+            scheduler, SweepState.RUNNING, exit_state=SweepState.CANCELED
+        )
+        loop_done = threading.Event()
+
+        def run_loop() -> None:
+            try:
+                with driver.driving():
+                    scheduler.loop()
+            finally:
+                loop_done.set()
+
+        loop_thread = threading.Thread(target=run_loop)
+        loop_thread.start()
+
+        # Cancel only once the optimizer is known to be working, so the loop has
+        # to notice the transition while blocked on `ask_n_runs` rather than at
+        # some particular state query.
+        assert optimizer_called.wait(timeout=2.0)
+        driver.state = SweepState.CANCELED
+
+        assert loop_done.wait(timeout=2.0)
+        loop_thread.join(timeout=2.0)
+
+        optimizer.ask_n_runs_mock.assert_called_once()
+        # The loop left without waiting for the blocked optimizer, so nothing it
+        # would eventually suggest was scheduled.
+        assert not optimizer_finished.is_set()
+        executor.schedule.assert_not_called()
+        assert len(scheduler.in_flight_runs()) == 0
+        assert mock_api.runs.call_count == warm_start_runs_calls
 
     def test_loop_exits_when_sweep_state_not_found(
         self,
@@ -628,3 +960,163 @@ class SchedulerAcceptanceTests(abc.ABC):
 
         assert driver.iterations == 1
         assert call_order == ["poll", "prune", "reap", "schedule"]
+
+
+class TestInMemorySchedulerAcceptance(SchedulerAcceptanceTests):
+    @pytest.fixture
+    def mock_api(self) -> Iterator[MagicMock]:
+        api = MagicMock()
+        api.runs.return_value = []
+        with patch("wandb.sdk.sweeps.scheduler.scheduler.Api", return_value=api):
+            yield api
+
+    @pytest.fixture
+    def mock_internal_api(self) -> Iterator[MagicMock]:
+        internal_api = MagicMock()
+        internal_api.stop_run.return_value = True
+        with patch(
+            "wandb.sdk.sweeps.scheduler.scheduler.InternalApi",
+            return_value=internal_api,
+        ):
+            yield internal_api
+
+    @pytest.fixture
+    def scheduler(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        executor: MagicMock,
+        mock_api: MagicMock,
+        batch_size: int,
+    ) -> InMemoryScheduler:
+        return InMemoryScheduler(
+            optimizer=optimizer,
+            sweep=sweep,
+            options=SchedulerOptions(
+                poll_interval_s=0,
+                batch_size=batch_size,
+                executor=executor,
+            ),
+        )
+
+    def test_poll_skips_unreadable_run_and_keeps_the_rest(
+        self,
+        scheduler: InMemoryScheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        """One run's metrics failing must not cost the whole poll."""
+        scheduler.push_in_flight_run("run-ok", "opt-ok")
+        scheduler.push_in_flight_run("run-bad", "opt-bad")
+        mock_api.runs.return_value = [
+            make_remote_run("run-ok", RunState.RUNNING, {"param1": 1}, {"loss": 1.0}),
+            make_remote_run(
+                "run-bad",
+                RunState.RUNNING,
+                {"param1": 2},
+                history_error=CommError("history query failed"),
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        told = {call.args[0] for call in optimizer.tell_run_mock.call_args_list}
+        assert told == {"opt-ok"}
+        # Still on the server, so it stays in flight instead of being failed.
+        assert "run-bad" in scheduler.in_flight_runs()
+        assert scheduler.unreadable_run_ids() == frozenset({"run-bad"})
+
+    def test_poll_reaps_deleted_run_but_not_unreadable_one(
+        self,
+        scheduler: InMemoryScheduler,
+        optimizer: MockOptimizer,
+        mock_api: MagicMock,
+    ) -> None:
+        """Absent from the server is failed; present but unreadable is not."""
+        scheduler.push_in_flight_run("run-deleted", "opt-deleted")
+        scheduler.push_in_flight_run("run-bad", "opt-bad")
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-bad",
+                RunState.RUNNING,
+                {"param1": 2},
+                history_error=CommError("history query failed"),
+            ),
+        ]
+
+        scheduler._poll_active_runs()
+
+        failed = {
+            call.args[0]
+            for call in optimizer.tell_run_mock.call_args_list
+            if call.args[1].state == RunState.FAILED
+        }
+        assert failed == {"opt-deleted"}
+        assert "run-deleted" not in scheduler.in_flight_runs()
+        assert "run-bad" in scheduler.in_flight_runs()
+
+    def test_failed_poll_keeps_the_storage_ids_pruning_needs(
+        self,
+        scheduler: InMemoryScheduler,
+        mock_api: MagicMock,
+        mock_internal_api: MagicMock,
+    ) -> None:
+        """A failed poll must not strand in-flight runs with no way to stop them."""
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-0",
+                RunState.RUNNING,
+                {"param1": 1},
+                {"loss": 1.0},
+                storage_id="storage-0",
+            ),
+        ]
+        scheduler._poll_active_runs()
+
+        mock_api.runs.side_effect = api_error(503)
+        with pytest.raises(WandbApiFailedError):
+            scheduler._poll_active_runs()
+
+        # The last good poll's ids survive, so the run is still stoppable.
+        assert scheduler.stop_run("run-0")
+        mock_internal_api.stop_run.assert_called_once_with("storage-0")
+
+    def test_poll_forgets_storage_ids_when_nothing_is_in_flight(
+        self,
+        scheduler: InMemoryScheduler,
+        mock_api: MagicMock,
+    ) -> None:
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        mock_api.runs.return_value = [
+            make_remote_run(
+                "run-0",
+                RunState.FINISHED,
+                {"param1": 1},
+                {"loss": 1.0},
+                storage_id="storage-0",
+            ),
+        ]
+        scheduler._poll_active_runs()
+        assert not scheduler.in_flight_runs()
+
+        scheduler.fetch_active_runs()
+
+        assert not scheduler.stop_run("run-0")
+        assert scheduler.unreadable_run_ids() == frozenset()
+
+    def test_every_run_query_prefetches_config_and_summary_metrics(
+        self,
+        scheduler: InMemoryScheduler,
+        mock_api: MagicMock,
+    ) -> None:
+        """Lazily loaded runs would cost a query per run on first access."""
+        scheduler.push_in_flight_run("run-0", "opt-0")
+        mock_api.runs.return_value = []
+
+        scheduler.fetch_active_runs()
+        scheduler._warm_start()
+
+        assert mock_api.runs.call_count == 3  # one active poll, two warm-start
+        for call in mock_api.runs.call_args_list:
+            assert call.kwargs["lazy"] is False

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -305,7 +305,8 @@ class Sweep(Attrs):
         id (str): Sweep ID
         project (str): The name of the project the sweep belongs to
         config (dict): Dictionary containing the sweep configuration
-        state (str): The state of the sweep, as reported by the server.
+        state (SweepState): The state of the sweep, re-fetched from the
+            server on each access.
         expected_run_count (int): The number of expected runs for the sweep
     """
 
@@ -447,8 +448,14 @@ class Sweep(Attrs):
 
     @property
     def state(self) -> SweepState:
-        """The state of the sweep."""
-        self.load(force=True)  # reading a changing property
+        """The sweep's current state, re-fetched from the server.
+
+        Each access issues a query so the value tracks a running sweep.
+
+        Raises:
+            SweepNotFoundError: If the sweep no longer exists.
+        """
+        self.load(force=True)
         return SweepState(self._attrs.get("state"))
 
     @classmethod

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -445,6 +445,12 @@ class Sweep(Attrs):
         """
         return self._attrs.get("displayName") or self.config.get("name") or self.id
 
+    @property
+    def state(self) -> SweepState:
+        """The state of the sweep."""
+        self.load(force=True)  # reading a changing property
+        return SweepState(self._attrs.get("state"))
+
     @classmethod
     def get(
         cls,

--- a/wandb/sdk/sweeps/scheduler/scheduler.py
+++ b/wandb/sdk/sweeps/scheduler/scheduler.py
@@ -15,7 +15,8 @@ from typing import Any, TypeVar
 from typing_extensions import override
 
 from wandb import termerror, termlog, termwarn
-from wandb.apis.public import Sweep, SweepState
+from wandb.apis.internal import InternalApi
+from wandb.apis.public import Api, Sweep, SweepState
 from wandb.sdk.sweeps.run_state import RunState
 from wandb.sdk.sweeps.scheduler.failure_policy import Disposition, classify
 from wandb.sdk.sweeps.scheduler.optimizer import (
@@ -31,6 +32,8 @@ from wandb.wandb_agent import TERMINATING_SIGNALS, ShutdownSignal
 _RunT = TypeVar("_RunT", bound=Run)
 _T = TypeVar("_T")
 
+# Run states that can be adopted and kept driving at warm-start.
+_ADOPTABLE_STATES = [RunState.RUNNING.value, RunState.PENDING.value]
 # Terminal states, derived from `is_terminal_state` so the two stay in sync.
 _TERMINAL_STATES = [s.value for s in RunState if is_terminal_state(s)]
 
@@ -55,6 +58,8 @@ _MAX_SLOWDOWN_S = 60.0
 # Consecutive failed polls to absorb before giving up on the sweep. Rate
 # limiting doesn't count toward this.
 _MAX_CONSECUTIVE_ERRORS = 10
+
+_WARM_START_PAGE_SIZE = 200
 
 
 class _LoopControl(enum.Enum):
@@ -713,3 +718,159 @@ class Scheduler(ABC):
                 )
                 continue
             yield built
+
+
+class InMemoryScheduler(Scheduler):
+    """Track in-flight runs in memory and observe them by polling `Api.runs`."""
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        options: SchedulerOptions | None = None,
+    ):
+        super().__init__(optimizer, sweep, options)
+        self._api = Api()
+        # Key: wandb run id, Value: optimizer run id
+        self._in_flight: dict[str, Any] = {}
+        # wandb run id -> storage id, captured on fetch so stop_run can target
+        # it.
+        self._storage_ids: dict[str, str] = {}
+        # Runs the last fetch saw on the server but could not build.
+        self._unreadable_run_ids: frozenset[str] = frozenset()
+
+    def in_flight_runs(self) -> Mapping[str, Any]:
+        """The in-memory {wandb_run_id: optimizer_run_id} map."""
+        return self._in_flight
+
+    def pop_in_flight_run(self, wandb_run_id: str) -> Any:
+        """Remove `wandb_run_id` from the map; return its optimizer id."""
+        return self._in_flight.pop(wandb_run_id, None)
+
+    def push_in_flight_run(self, wandb_run_id: str, optimizer_run_id: Any) -> None:
+        """Add a run to the in-flight set.
+
+        Raises:
+            ValueError: If `wandb_run_id` is already in flight.
+        """
+        if wandb_run_id in self._in_flight:
+            raise ValueError(f"Run {wandb_run_id} is already in flight")
+        self._in_flight[wandb_run_id] = optimizer_run_id
+
+    def fetch_existing_finished_runs(self) -> Iterable[RunWithMetrics]:
+        """Query the sweep's terminal runs, with their summary metrics."""
+        runs = self._sweep_runs(
+            {"state": {"$in": _TERMINAL_STATES}}, per_page=_WARM_START_PAGE_SIZE
+        )
+        return self._build_runs(
+            runs,
+            lambda run: RunWithMetrics(
+                config=RunConfig.from_values(run.config),
+                state=RunState(run.state),
+                wandb_run_id=run.id,
+                summary_metrics=run.summary_metrics,
+                history_metrics=[],
+            ),
+        )
+
+    def fetch_existing_unfinished_runs(self) -> Iterable[Run]:
+        """Query the sweep's RUNNING/PENDING runs, without metrics."""
+        runs = self._sweep_runs(
+            {"state": {"$in": _ADOPTABLE_STATES}}, per_page=_WARM_START_PAGE_SIZE
+        )
+        return self._build_runs(
+            runs,
+            lambda run: Run(
+                config=RunConfig.from_values(run.config),
+                state=RunState(run.state),
+                wandb_run_id=run.id,
+            ),
+        )
+
+    def fetch_active_runs(self) -> Iterable[RunWithMetrics]:
+        """Re-query tracked in-flight runs with fresh state and metrics."""
+        if not self._in_flight:
+            self._storage_ids = {}
+            self._unreadable_run_ids = frozenset()
+            return []
+        # `Api.runs` caches results by (path, filters); with a stable in-flight
+        # set the filter is identical every poll, so without flushing we'd get
+        # back the same cached Run objects with stale state/history forever
+        self._api.flush()
+        runs = self._sweep_runs({"name": {"$in": list(self._in_flight)}})
+        # Each run's config, summary and history cost their own queries, so
+        # build through `_build_runs`: one unreadable run is skipped with a
+        # warning rather than aborting the whole poll.
+        seen: set[str] = set()
+        storage_ids: dict[str, str] = {}
+        builder = self._active_run_builder(seen, storage_ids)
+        active = list(self._build_runs(runs, builder))
+        # Swap in only once the query succeeded: clearing up front would
+        # leave a failed page fetch with a half-built map, and `stop_run` would
+        # silently refuse to prune the rest.
+        self._storage_ids = storage_ids
+        self._unreadable_run_ids = frozenset(seen - storage_ids.keys())
+        return active
+
+    def _active_run_builder(
+        self,
+        seen: set[str],
+        storage_ids: dict[str, str],
+    ) -> Callable[[Any], RunWithMetrics]:
+        """Build a `RunWithMetrics`, recording what the poll saw as it goes.
+
+        Args:
+            seen: Collects the id of every run the server returned, whether or
+                not it could be built.
+            storage_ids: Collects {run id: storage id} for the runs that built,
+                for `stop_run` to target.
+        """
+
+        def build(run: Any) -> RunWithMetrics:
+            # Before building: a run that fails to read is still on the server.
+            seen.add(run.id)
+            data = RunWithMetrics(
+                config=RunConfig.from_values(run.config),
+                state=RunState(run.state),
+                wandb_run_id=run.id,
+                summary_metrics=run.summary_metrics,
+                history_metrics=run.history(
+                    keys=[self._optimizer.metric_key()], samples=20, pandas=False
+                ),
+            )
+            storage_ids[run.id] = run.storage_id
+            return data
+
+        return build
+
+    @override
+    def unreadable_run_ids(self) -> frozenset[str]:
+        """W&B run ids the last poll saw but could not build."""
+        return self._unreadable_run_ids
+
+    def sweep_state(self) -> SweepState:
+        """The sweep's state, re-read from the server."""
+        return self._sweep.state
+
+    def stop_run(self, wandb_run_id: str) -> bool:
+        """Ask the server to stop the run; True if it was accepted."""
+        storage_id = self._storage_ids.get(wandb_run_id)
+        if storage_id is None:
+            return False
+        res = bool(InternalApi().stop_run(storage_id))
+        if res:
+            self._storage_ids.pop(wandb_run_id)
+        return res
+
+    def _sweep_runs(self, filters: dict[str, Any], per_page: int = 50) -> Iterable[Any]:
+        """Query the sweep's runs, with config and summary metrics prefetched.
+
+        `lazy=False` fetches the full run fragment per page,
+        so reading `config` or `summary_metrics` off a result is free.
+        """
+        return self._api.runs(
+            path=f"{self._sweep.entity}/{self._sweep.project}",
+            filters={"sweep": self._sweep.id, **filters},
+            per_page=per_page,
+            lazy=False,
+        )

--- a/wandb/sdk/sweeps/scheduler/scheduler.py
+++ b/wandb/sdk/sweeps/scheduler/scheduler.py
@@ -61,6 +61,13 @@ _MAX_CONSECUTIVE_ERRORS = 10
 
 _WARM_START_PAGE_SIZE = 200
 
+# Runs per page when polling the sweep's in-flight runs.
+_RUNS_PAGE_SIZE = 50
+
+# Sampled history points fetched per run each poll; this is the history the
+# optimizer's early-stopping decisions see.
+_HISTORY_SAMPLES = 20
+
 
 class _LoopControl(enum.Enum):
     CONTINUE = enum.auto()
@@ -739,14 +746,17 @@ class InMemoryScheduler(Scheduler):
         # Runs the last fetch saw on the server but could not build.
         self._unreadable_run_ids: frozenset[str] = frozenset()
 
+    @override
     def in_flight_runs(self) -> Mapping[str, Any]:
         """The in-memory {wandb_run_id: optimizer_run_id} map."""
         return self._in_flight
 
+    @override
     def pop_in_flight_run(self, wandb_run_id: str) -> Any:
         """Remove `wandb_run_id` from the map; return its optimizer id."""
         return self._in_flight.pop(wandb_run_id, None)
 
+    @override
     def push_in_flight_run(self, wandb_run_id: str, optimizer_run_id: Any) -> None:
         """Add a run to the in-flight set.
 
@@ -757,6 +767,7 @@ class InMemoryScheduler(Scheduler):
             raise ValueError(f"Run {wandb_run_id} is already in flight")
         self._in_flight[wandb_run_id] = optimizer_run_id
 
+    @override
     def fetch_existing_finished_runs(self) -> Iterable[RunWithMetrics]:
         """Query the sweep's terminal runs, with their summary metrics."""
         runs = self._sweep_runs(
@@ -773,6 +784,7 @@ class InMemoryScheduler(Scheduler):
             ),
         )
 
+    @override
     def fetch_existing_unfinished_runs(self) -> Iterable[Run]:
         """Query the sweep's RUNNING/PENDING runs, without metrics."""
         runs = self._sweep_runs(
@@ -787,6 +799,7 @@ class InMemoryScheduler(Scheduler):
             ),
         )
 
+    @override
     def fetch_active_runs(self) -> Iterable[RunWithMetrics]:
         """Re-query tracked in-flight runs with fresh state and metrics."""
         if not self._in_flight:
@@ -835,7 +848,9 @@ class InMemoryScheduler(Scheduler):
                 wandb_run_id=run.id,
                 summary_metrics=run.summary_metrics,
                 history_metrics=run.history(
-                    keys=[self._optimizer.metric_key()], samples=20, pandas=False
+                    keys=[self._optimizer.metric_key()],
+                    samples=_HISTORY_SAMPLES,
+                    pandas=False,
                 ),
             )
             storage_ids[run.id] = run.storage_id
@@ -848,10 +863,12 @@ class InMemoryScheduler(Scheduler):
         """W&B run ids the last poll saw but could not build."""
         return self._unreadable_run_ids
 
+    @override
     def sweep_state(self) -> SweepState:
         """The sweep's state, re-read from the server."""
         return self._sweep.state
 
+    @override
     def stop_run(self, wandb_run_id: str) -> bool:
         """Ask the server to stop the run; True if it was accepted."""
         storage_id = self._storage_ids.get(wandb_run_id)
@@ -862,7 +879,9 @@ class InMemoryScheduler(Scheduler):
             self._storage_ids.pop(wandb_run_id)
         return res
 
-    def _sweep_runs(self, filters: dict[str, Any], per_page: int = 50) -> Iterable[Any]:
+    def _sweep_runs(
+        self, filters: dict[str, Any], per_page: int = _RUNS_PAGE_SIZE
+    ) -> Iterable[Any]:
         """Query the sweep's runs, with config and summary metrics prefetched.
 
         `lazy=False` fetches the full run fragment per page,

--- a/wandb/sdk/sweeps/scheduler/scheduler.py
+++ b/wandb/sdk/sweeps/scheduler/scheduler.py
@@ -11,8 +11,11 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
+from typing_extensions import override
+
 from wandb import termerror, termlog, termwarn
-from wandb.apis.public import Sweep, SweepState
+from wandb.apis.internal import InternalApi
+from wandb.apis.public import Api, Sweep, SweepState
 from wandb.sdk.sweeps.run_state import RunState
 from wandb.sdk.sweeps.scheduler.failure_policy import Disposition, classify
 from wandb.sdk.sweeps.scheduler.optimizer import (
@@ -28,6 +31,8 @@ from wandb.wandb_agent import TERMINATING_SIGNALS, ShutdownSignal
 _RunT = TypeVar("_RunT", bound=Run)
 _T = TypeVar("_T")
 
+# Run states that can be adopted and kept driving at warm-start.
+_ADOPTABLE_STATES = [RunState.RUNNING.value, RunState.PENDING.value]
 # Terminal states, derived from `is_terminal_state` so the two stay in sync.
 _TERMINAL_STATES = [s.value for s in RunState if is_terminal_state(s)]
 
@@ -52,6 +57,8 @@ _MAX_SLOWDOWN_S = 60.0
 # Consecutive failed polls to absorb before giving up on the sweep. Rate
 # limiting doesn't count toward this.
 _MAX_CONSECUTIVE_ERRORS = 10
+
+_WARM_START_PAGE_SIZE = 200
 
 
 class Executor(ABC):
@@ -683,3 +690,159 @@ class Scheduler(ABC):
                 )
                 continue
             yield built
+
+
+class InMemoryScheduler(Scheduler):
+    """Track in-flight runs in memory and observe them by polling `Api.runs`."""
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        options: SchedulerOptions | None = None,
+    ):
+        super().__init__(optimizer, sweep, options)
+        self._api = Api()
+        # Key: wandb run id, Value: optimizer run id
+        self._in_flight: dict[str, Any] = {}
+        # wandb run id -> storage id, captured on fetch so stop_run can target
+        # it.
+        self._storage_ids: dict[str, str] = {}
+        # Runs the last fetch saw on the server but could not build.
+        self._unreadable_run_ids: frozenset[str] = frozenset()
+
+    def in_flight_runs(self) -> Mapping[str, Any]:
+        """The in-memory {wandb_run_id: optimizer_run_id} map."""
+        return self._in_flight
+
+    def pop_in_flight_run(self, wandb_run_id: str) -> Any:
+        """Remove `wandb_run_id` from the map; return its optimizer id."""
+        return self._in_flight.pop(wandb_run_id, None)
+
+    def push_in_flight_run(self, wandb_run_id: str, optimizer_run_id: Any) -> None:
+        """Add a run to the in-flight set.
+
+        Raises:
+            ValueError: If `wandb_run_id` is already in flight.
+        """
+        if wandb_run_id in self._in_flight:
+            raise ValueError(f"Run {wandb_run_id} is already in flight")
+        self._in_flight[wandb_run_id] = optimizer_run_id
+
+    def fetch_existing_finished_runs(self) -> Iterable[RunWithMetrics]:
+        """Query the sweep's terminal runs, with their summary metrics."""
+        runs = self._sweep_runs(
+            {"state": {"$in": _TERMINAL_STATES}}, per_page=_WARM_START_PAGE_SIZE
+        )
+        return self._build_runs(
+            runs,
+            lambda run: RunWithMetrics(
+                config=RunConfig.from_values(run.config),
+                state=RunState(run.state),
+                wandb_run_id=run.id,
+                summary_metrics=run.summary_metrics,
+                history_metrics=[],
+            ),
+        )
+
+    def fetch_existing_unfinished_runs(self) -> Iterable[Run]:
+        """Query the sweep's RUNNING/PENDING runs, without metrics."""
+        runs = self._sweep_runs(
+            {"state": {"$in": _ADOPTABLE_STATES}}, per_page=_WARM_START_PAGE_SIZE
+        )
+        return self._build_runs(
+            runs,
+            lambda run: Run(
+                config=RunConfig.from_values(run.config),
+                state=RunState(run.state),
+                wandb_run_id=run.id,
+            ),
+        )
+
+    def fetch_active_runs(self) -> Iterable[RunWithMetrics]:
+        """Re-query tracked in-flight runs with fresh state and metrics."""
+        if not self._in_flight:
+            self._storage_ids = {}
+            self._unreadable_run_ids = frozenset()
+            return []
+        # `Api.runs` caches results by (path, filters); with a stable in-flight
+        # set the filter is identical every poll, so without flushing we'd get
+        # back the same cached Run objects with stale state/history forever
+        self._api.flush()
+        runs = self._sweep_runs({"name": {"$in": list(self._in_flight)}})
+        # Each run's config, summary and history cost their own queries, so
+        # build through `_build_runs`: one unreadable run is skipped with a
+        # warning rather than aborting the whole poll.
+        seen: set[str] = set()
+        storage_ids: dict[str, str] = {}
+        builder = self._active_run_builder(seen, storage_ids)
+        active = list(self._build_runs(runs, builder))
+        # Swap in only once the query succeeded: clearing up front would
+        # leave a failed page fetch with a half-built map, and `stop_run` would
+        # silently refuse to prune the rest.
+        self._storage_ids = storage_ids
+        self._unreadable_run_ids = frozenset(seen - storage_ids.keys())
+        return active
+
+    def _active_run_builder(
+        self,
+        seen: set[str],
+        storage_ids: dict[str, str],
+    ) -> Callable[[Any], RunWithMetrics]:
+        """Build a `RunWithMetrics`, recording what the poll saw as it goes.
+
+        Args:
+            seen: Collects the id of every run the server returned, whether or
+                not it could be built.
+            storage_ids: Collects {run id: storage id} for the runs that built,
+                for `stop_run` to target.
+        """
+
+        def build(run: Any) -> RunWithMetrics:
+            # Before building: a run that fails to read is still on the server.
+            seen.add(run.id)
+            data = RunWithMetrics(
+                config=RunConfig.from_values(run.config),
+                state=RunState(run.state),
+                wandb_run_id=run.id,
+                summary_metrics=run.summary_metrics,
+                history_metrics=run.history(
+                    keys=[self._optimizer.metric_key()], samples=20, pandas=False
+                ),
+            )
+            storage_ids[run.id] = run.storage_id
+            return data
+
+        return build
+
+    @override
+    def unreadable_run_ids(self) -> frozenset[str]:
+        """W&B run ids the last poll saw but could not build."""
+        return self._unreadable_run_ids
+
+    def sweep_state(self) -> SweepState:
+        """The sweep's state, re-read from the server."""
+        return self._sweep.state
+
+    def stop_run(self, wandb_run_id: str) -> bool:
+        """Ask the server to stop the run; True if it was accepted."""
+        storage_id = self._storage_ids.get(wandb_run_id)
+        if storage_id is None:
+            return False
+        res = bool(InternalApi().stop_run(storage_id))
+        if res:
+            self._storage_ids.pop(wandb_run_id)
+        return res
+
+    def _sweep_runs(self, filters: dict[str, Any], per_page: int = 50) -> Iterable[Any]:
+        """Query the sweep's runs, with config and summary metrics prefetched.
+
+        `lazy=False` fetches the full run fragment per page,
+        so reading `config` or `summary_metrics` off a result is free.
+        """
+        return self._api.runs(
+            path=f"{self._sweep.entity}/{self._sweep.project}",
+            filters={"sweep": self._sweep.id, **filters},
+            per_page=per_page,
+            lazy=False,
+        )

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -222,7 +222,23 @@ def create_sweep_from_config(
     *,
     options: SchedulerOptions | None = None,
 ) -> Scheduler:
-    """Create a W&B sweep from `config` and attach a wandb scheduler."""
+    """Create a W&B sweep from `config` and attach a wandb scheduler.
+
+    Args:
+        config: The sweep config; `scheduler.engine` must be `"wandb"`.
+        entity: The entity to create the sweep under.
+        project: The project to create the sweep under.
+        options: How the scheduler drives the sweep; see `SchedulerOptions`.
+
+    Returns:
+        A scheduler whose `loop()` drives the new sweep.
+
+    Raises:
+        ValueError: If `config` does not select the wandb engine, or if
+            `entity` or `project` is empty.
+    """
+    if not entity or not project:
+        raise ValueError("entity and project must be non-empty")
     if (
         "scheduler" not in config
         or "engine" not in config["scheduler"]
@@ -248,9 +264,19 @@ def resume_sweep(
 ) -> Scheduler:
     """Attach a reference scheduler to a sweep that already exists.
 
-    `sweep` may be a `Sweep` or an `"entity/project/sweep_id"` path string; its
-    search `method`/`parameters` are read off the sweep itself.
+    Args:
+        sweep: The sweep whose search `method`/`parameters` to drive, as a
+            `Sweep` or an `"entity/project/sweep_id"` path string.
+        options: How the scheduler drives the sweep; see `SchedulerOptions`.
+
+    Returns:
+        A scheduler whose `loop()` drives the sweep.
+
+    Raises:
+        ValueError: If `sweep` is an empty string.
     """
+    if isinstance(sweep, str) and not sweep:
+        raise ValueError("sweep path must be non-empty")
     resolved: Sweep = Api().sweep(sweep) if isinstance(sweep, str) else sweep
     optimizer = WandbOptimizer(resolved)
     return InMemoryScheduler(

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -7,11 +7,10 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
-from wandb import util
+from wandb import Api, util
 from wandb.apis.public import Sweep
 from wandb.sdk.sweeps.run_state import RunState
 from wandb.sdk.sweeps.scheduler.optimizer import (
-    ConfigValue,
     Optimizer,
     Run,
     RunConfig,
@@ -19,6 +18,12 @@ from wandb.sdk.sweeps.scheduler.optimizer import (
     RunWithMetrics,
     is_terminal_state,
 )
+from wandb.sdk.sweeps.scheduler.scheduler import (
+    InMemoryScheduler,
+    Scheduler,
+    SchedulerOptions,
+)
+from wandb.sdk.wandb_sweep import sweep as wandb_sweep
 
 if TYPE_CHECKING:
     import sweeps
@@ -101,12 +106,13 @@ class WandbOptimizer(Optimizer):
             # Record it (state defaults to pending) so the next search call and
             # tell_run can find it.
             self._runs[run_id] = sweep_run
-            # sweep_run.config is already the wire form RunConfig expects.
+            # `sweeps` hands back the wire form ({param: {"value": v}}); unwrap
+            # it into the flat mapping `RunConfig.from_values` takes.
             suggestions.append(
                 RunSuggestion(
-                    config=RunConfig(
+                    config=RunConfig.from_values(
                         {
-                            name: ConfigValue(**param)
+                            name: param["value"]
                             for name, param in sweep_run.config.items()
                         }
                     ),
@@ -126,7 +132,6 @@ class WandbOptimizer(Optimizer):
         Raises:
             ValueError: If `run_id` was never proposed by this optimizer.
         """
-        # "Save to memory" = update the SweepRun the search reads next time.
         # Keep the config we suggested — `data.config` may be empty (e.g. a
         # reaped run) — only the outcome (state, metrics, history) is new here.
         sweep_run = self._runs.get(run_id)
@@ -199,3 +204,57 @@ class WandbOptimizer(Optimizer):
             state=_to_sweeps_state(data.state),
         )
         return run_id
+
+
+# ---------------------------------------------------------------------------
+# Public entry points.
+#
+# These free functions are the supported way to build a scheduler; callers
+# should not instantiate `WandbOptimizer` directly. Each returns a scheduler
+# whose `.loop()` drives the sweep.
+# ---------------------------------------------------------------------------
+
+
+def create_sweep_from_config(
+    config: dict[str, Any],
+    entity: str,
+    project: str,
+    *,
+    options: SchedulerOptions | None = None,
+) -> Scheduler:
+    """Create a W&B sweep from `config` and attach a wandb scheduler."""
+    if (
+        "scheduler" not in config
+        or "engine" not in config["scheduler"]
+        or config["scheduler"]["engine"] != "wandb"
+    ):
+        raise ValueError(
+            "config must have a 'scheduler' key with 'engine' subkey set to 'wandb'"
+        )
+    sweep_id = wandb_sweep(config, entity=entity, project=project)
+    sweep = Api().sweep(f"{entity}/{project}/{sweep_id}")
+    optimizer = WandbOptimizer(sweep)
+    return InMemoryScheduler(
+        optimizer,
+        sweep,
+        options,
+    )
+
+
+def resume_sweep(
+    sweep: Sweep | str,
+    *,
+    options: SchedulerOptions | None = None,
+) -> Scheduler:
+    """Attach a reference scheduler to a sweep that already exists.
+
+    `sweep` may be a `Sweep` or an `"entity/project/sweep_id"` path string; its
+    search `method`/`parameters` are read off the sweep itself.
+    """
+    resolved: Sweep = Api().sweep(sweep) if isinstance(sweep, str) else sweep
+    optimizer = WandbOptimizer(resolved)
+    return InMemoryScheduler(
+        optimizer,
+        resolved,
+        options,
+    )

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
-from wandb import util
+from wandb import Api, util
 from wandb.apis.public import Sweep
 from wandb.sdk.sweeps.run_state import RunState
 from wandb.sdk.sweeps.scheduler.optimizer import (
-    ConfigValue,
     Optimizer,
     Run,
     RunConfig,
@@ -17,6 +16,13 @@ from wandb.sdk.sweeps.scheduler.optimizer import (
     RunWithMetrics,
     is_terminal_state,
 )
+from wandb.sdk.sweeps.scheduler.scheduler import (
+    Executor,
+    InMemoryScheduler,
+    Scheduler,
+    SchedulerOptions,
+)
+from wandb.sdk.wandb_sweep import sweep as wandb_sweep
 
 sweeps = util.get_module(
     "sweeps",
@@ -81,12 +87,13 @@ class WandbOptimizer(Optimizer):
             # Record it (state defaults to pending) so the next search call and
             # tell_run can find it.
             self._runs[run_id] = sweep_run
-            # sweep_run.config is already the wire form RunConfig expects.
+            # `sweeps` hands back the wire form ({param: {"value": v}}); unwrap
+            # it into the flat mapping `RunConfig.from_values` takes.
             suggestions.append(
                 RunSuggestion(
-                    config=RunConfig(
+                    config=RunConfig.from_values(
                         {
-                            name: ConfigValue(**param)
+                            name: param["value"]
                             for name, param in sweep_run.config.items()
                         }
                     ),
@@ -105,7 +112,6 @@ class WandbOptimizer(Optimizer):
         Raises:
             ValueError: If `run_id` was never proposed by this optimizer.
         """
-        # "Save to memory" = update the SweepRun the search reads next time.
         # Keep the config we suggested — `data.config` may be empty (e.g. a
         # reaped run) — only the outcome (state, metrics, history) is new here.
         sweep_run = self._runs.get(run_id)
@@ -168,3 +174,57 @@ class WandbOptimizer(Optimizer):
             state=_to_sweeps_state(data.state),
         )
         return run_id
+
+
+# ---------------------------------------------------------------------------
+# Public entry points.
+#
+# These free functions are the supported way to build a scheduler; callers
+# should not instantiate `WandbOptimizer` directly. Each returns a scheduler
+# whose `.loop()` drives the sweep.
+# ---------------------------------------------------------------------------
+
+
+def create_sweep_from_config(
+    config: dict[str, Any],
+    entity: str,
+    project: str,
+    *,
+    options: SchedulerOptions | None = None,
+) -> Scheduler:
+    """Create a W&B sweep from `config` and attach a wandb scheduler."""
+    if (
+        "scheduler" not in config
+        or "engine" not in config["scheduler"]
+        or config["scheduler"]["engine"] != "wandb"
+    ):
+        raise ValueError(
+            "config must have a 'scheduler' key with 'engine' subkey set to 'wandb'"
+        )
+    sweep_id = wandb_sweep(config, entity=entity, project=project)
+    sweep = Api().sweep(f"{entity}/{project}/{sweep_id}")
+    optimizer = WandbOptimizer(sweep)
+    return InMemoryScheduler(
+        optimizer,
+        sweep,
+        options,
+    )
+
+
+def resume_sweep(
+    sweep: Sweep | str,
+    *,
+    options: SchedulerOptions | None = None,
+) -> Scheduler:
+    """Attach a reference scheduler to a sweep that already exists.
+
+    `sweep` may be a `Sweep` or an `"entity/project/sweep_id"` path string; its
+    search `method`/`parameters` are read off the sweep itself.
+    """
+    resolved: Sweep = Api().sweep(sweep) if isinstance(sweep, str) else sweep
+    optimizer = WandbOptimizer(resolved)
+    return InMemoryScheduler(
+        optimizer,
+        resolved,
+        options,
+    )


### PR DESCRIPTION
Description
-----------
- Fixes WB-38287

Implement InMemoryScheduler which stores a list of active run_ids to poll using the Wandb API. It uses the storage_ids dict and unreadable_runs set to keep track of run IDs from the optimizer and certain runs which are malformed from the backend.

- Added create_sweep_from_config and resume_sweep entrypoints for the wandb reference implementation as helper methods for running local schedulers.

- [x] CHANGELOG.unreleased.md N/A


Testing
-------
Added many unit tests covering warm start, polling, api errors, graceful shutdown behavior, ensuring state is updated correctly based on the Api().runs() responses
