### PR TITLE
feat(sweeps): sweeps_scheduler CLI that suggests runs with external optimizers

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,8 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
 - The automations API now supports creating and editing automations whose scope is a `Registry` object (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10867)
+- New `wandb sweep_scheduler` command to support driving a sweep by suggesting new runs locally. Designed to integrate with
+third party hyperparameter optimization frameworks. Replaces local controller functionality (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/12336)
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,8 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Added support for gzip compression of filestream requests, reducing network traffic when logging metrics. It is currently opt-in and requires server support: set `x_file_stream_no_gzip=False` in `wandb.Settings` to enable it. Compression will become the default in a future release (@dmitryduev in https://github.com/wandb/wandb/pull/12262)
 - Added a `--term-timeout` flag to `wandb agent` (@nathancy-wandb in https://github.com/wandb/wandb/pull/12246)
 - Added `run.sync_dir` (@timoffex in https://github.com/wandb/wandb/pull/12319)
+- New `wandb sweep_scheduler` command to support driving a sweep by suggesting new runs locally. Designed to integrate with
+third party hyperparameter optimization frameworks. Replaces local controller functionality (@kmikowicz-wandb in https://github.com/wandb/wandb/pull/12336)
 
 ## Changed
 

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -1219,7 +1219,7 @@ def test_sweep_scheduler_cli_resolves_full_sweep_path(runner: CliRunner) -> None
     assert result.exit_code == 0, result.output
     mocks.public_api.sweep.assert_called_once_with("entity/project/sweep-1")
     mocks.resume_sweep.assert_called_once_with(
-        sweep, options=SchedulerOptions(poll_interval_s=5.0, batch_size=10)
+        sweep, options=SchedulerOptions(poll_interval_s=10.0, batch_size=10)
     )
     mocks.scheduler.loop.assert_called_once()
 

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -12,8 +12,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
+from click.testing import CliRunner
 from wandb.apis.public import Sweep, SweepState
 from wandb.apis.public.service_api import ServiceApi
+from wandb.cli import cli
 from wandb.errors import CommError
 from wandb.proto.wandb_api_pb2 import ApiErrorResponse
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
@@ -46,10 +48,12 @@ SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
 }
 
 
-def make_scheduler_grid_sweep() -> Sweep:
+def make_scheduler_grid_sweep(config: dict[str, Any] | None = None) -> Sweep:
     """Return a grid `Sweep` backed by a no-op `ServiceApi`.
 
-    Passing `attrs` keeps the constructor from issuing a GraphQL load().
+    Passing `attrs` keeps the constructor from issuing a GraphQL load(). A
+    custom `config` overrides the default grid config, e.g. to drive
+    `Sweep.config["scheduler"]` variants without hand-rolling a mock.
     """
     service_api = MagicMock(spec=ServiceApi)
     sweep = Sweep(
@@ -60,7 +64,9 @@ def make_scheduler_grid_sweep() -> Sweep:
         attrs={
             "id": "test_sweep",
             "name": "test_sweep",
-            "config": yaml.dump(SCHEDULER_GRID_SWEEP_CONFIG),
+            "config": yaml.dump(
+                SCHEDULER_GRID_SWEEP_CONFIG if config is None else config
+            ),
         },
     )
     sweep.finish = MagicMock()  # type: ignore[attr-defined]
@@ -1164,3 +1170,158 @@ class TestInMemorySchedulerAcceptance(SchedulerAcceptanceTests):
         assert mock_api.runs.call_count == 3  # one active poll, two warm-start
         for call in mock_api.runs.call_args_list:
             assert call.kwargs["lazy"] is False
+
+
+@dataclass
+class CliSchedulerMocks:
+    """Collaborators `sweep_scheduler` talks to, patched for one test."""
+
+    public_api: MagicMock
+    scheduler: MagicMock
+    resume_sweep: MagicMock
+    login: MagicMock
+
+
+@contextlib.contextmanager
+def _cli_scheduler_context(
+    sweep: Sweep, *, authenticated: bool = True
+) -> Iterator[CliSchedulerMocks]:
+    public_api = MagicMock()
+    public_api.sweep.return_value = sweep
+    scheduler = MagicMock()
+
+    with (
+        patch.object(
+            cli,
+            "_get_cling_api",
+            return_value=MagicMock(is_authenticated=authenticated),
+        ),
+        patch.object(cli, "PublicApi", return_value=public_api),
+        patch.object(cli, "login") as login,
+        patch(
+            "wandb.sdk.sweeps.scheduler.wandb.resume_sweep",
+            return_value=scheduler,
+        ) as resume_sweep,
+    ):
+        yield CliSchedulerMocks(
+            public_api=public_api,
+            scheduler=scheduler,
+            resume_sweep=resume_sweep,
+            login=login,
+        )
+
+
+def test_sweep_scheduler_cli_resolves_full_sweep_path(runner: CliRunner) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    mocks.public_api.sweep.assert_called_once_with("entity/project/sweep-1")
+    mocks.resume_sweep.assert_called_once_with(
+        sweep, options=SchedulerOptions(poll_interval_s=5.0, batch_size=10)
+    )
+    mocks.scheduler.loop.assert_called_once()
+
+
+def test_sweep_scheduler_cli_builds_path_from_entity_and_project(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(
+            cli.sweep_scheduler,
+            ["--entity", "my-entity", "--project", "my-project", "sweep-1"],
+        )
+
+    assert result.exit_code == 0, result.output
+    mocks.public_api.sweep.assert_called_once_with("my-entity/my-project/sweep-1")
+
+
+def test_sweep_scheduler_cli_passes_batch_size_and_poll_interval(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(
+            cli.sweep_scheduler,
+            ["--batch-size", "7", "--poll-interval", "15.0", "entity/project/sweep-1"],
+        )
+
+    assert result.exit_code == 0, result.output
+    mocks.resume_sweep.assert_called_once_with(
+        sweep, options=SchedulerOptions(poll_interval_s=15.0, batch_size=7)
+    )
+
+
+def test_sweep_scheduler_cli_requires_engine_config(runner: CliRunner) -> None:
+    sweep = make_scheduler_grid_sweep(config={})
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code != 0
+    assert "requires a sweep created with" in result.output
+    mocks.resume_sweep.assert_not_called()
+
+
+def test_sweep_scheduler_cli_rejects_unsupported_engine(runner: CliRunner) -> None:
+    sweep = make_scheduler_grid_sweep(
+        config={**SCHEDULER_GRID_SWEEP_CONFIG, "scheduler": {"engine": "unknown"}}
+    )
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code != 0
+    assert "Unsupported engine: unknown" in result.output
+    mocks.resume_sweep.assert_not_called()
+
+
+def test_sweep_scheduler_cli_warns_when_optimizer_configured(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep(
+        config={
+            **SCHEDULER_GRID_SWEEP_CONFIG,
+            "scheduler": {"engine": "wandb", "optimizer": "make_optimizer"},
+        }
+    )
+    with _cli_scheduler_context(sweep) as mocks, patch("wandb.termwarn") as termwarn:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    assert any(
+        "optimizer config is not supported" in call.args[0]
+        for call in termwarn.call_args_list
+    )
+    mocks.scheduler.loop.assert_called_once()
+
+
+def test_sweep_scheduler_cli_warns_when_search_space_configured(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep(
+        config={
+            **SCHEDULER_GRID_SWEEP_CONFIG,
+            "scheduler": {"engine": "wandb", "search_space": "unknown"},
+        }
+    )
+    with _cli_scheduler_context(sweep) as mocks, patch("wandb.termwarn") as termwarn:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    assert any(
+        "search_space config is not supported" in call.args[0]
+        for call in termwarn.call_args_list
+    )
+    mocks.scheduler.loop.assert_called_once()
+
+
+def test_sweep_scheduler_cli_triggers_login_when_unauthenticated(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep, authenticated=False) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    mocks.login.assert_called_once_with(no_offline=True)

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -11,8 +11,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
+from click.testing import CliRunner
 from wandb.apis.public import Sweep, SweepState
 from wandb.apis.public.service_api import ServiceApi
+from wandb.cli import cli
 from wandb.errors import CommError
 from wandb.proto.wandb_api_pb2 import ApiErrorResponse
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
@@ -30,8 +32,8 @@ from wandb.sdk.sweeps.scheduler.scheduler import (
     Executor,
     InMemoryScheduler,
     Scheduler,
-    _ShutdownMonitor,
     SchedulerOptions,
+    _ShutdownMonitor,
 )
 
 SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
@@ -44,10 +46,12 @@ SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
 }
 
 
-def make_scheduler_grid_sweep() -> Sweep:
+def make_scheduler_grid_sweep(config: dict[str, Any] | None = None) -> Sweep:
     """Return a grid `Sweep` backed by a no-op `ServiceApi`.
 
-    Passing `attrs` keeps the constructor from issuing a GraphQL load().
+    Passing `attrs` keeps the constructor from issuing a GraphQL load(). A
+    custom `config` overrides the default grid config, e.g. to drive
+    `Sweep.config["scheduler"]` variants without hand-rolling a mock.
     """
     service_api = MagicMock(spec=ServiceApi)
     sweep = Sweep(
@@ -58,7 +62,9 @@ def make_scheduler_grid_sweep() -> Sweep:
         attrs={
             "id": "test_sweep",
             "name": "test_sweep",
-            "config": yaml.dump(SCHEDULER_GRID_SWEEP_CONFIG),
+            "config": yaml.dump(
+                SCHEDULER_GRID_SWEEP_CONFIG if config is None else config
+            ),
         },
     )
     sweep.finish = MagicMock()  # type: ignore[attr-defined]
@@ -1120,3 +1126,158 @@ class TestInMemorySchedulerAcceptance(SchedulerAcceptanceTests):
         assert mock_api.runs.call_count == 3  # one active poll, two warm-start
         for call in mock_api.runs.call_args_list:
             assert call.kwargs["lazy"] is False
+
+
+@dataclass
+class CliSchedulerMocks:
+    """Collaborators `sweep_scheduler` talks to, patched for one test."""
+
+    public_api: MagicMock
+    scheduler: MagicMock
+    resume_sweep: MagicMock
+    login: MagicMock
+
+
+@contextlib.contextmanager
+def _cli_scheduler_context(
+    sweep: Sweep, *, authenticated: bool = True
+) -> Iterator[CliSchedulerMocks]:
+    public_api = MagicMock()
+    public_api.sweep.return_value = sweep
+    scheduler = MagicMock()
+
+    with (
+        patch.object(
+            cli,
+            "_get_cling_api",
+            return_value=MagicMock(is_authenticated=authenticated),
+        ),
+        patch.object(cli, "PublicApi", return_value=public_api),
+        patch.object(cli, "login") as login,
+        patch(
+            "wandb.sdk.sweeps.scheduler.wandb.resume_sweep",
+            return_value=scheduler,
+        ) as resume_sweep,
+    ):
+        yield CliSchedulerMocks(
+            public_api=public_api,
+            scheduler=scheduler,
+            resume_sweep=resume_sweep,
+            login=login,
+        )
+
+
+def test_sweep_scheduler_cli_resolves_full_sweep_path(runner: CliRunner) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    mocks.public_api.sweep.assert_called_once_with("entity/project/sweep-1")
+    mocks.resume_sweep.assert_called_once_with(
+        sweep, options=SchedulerOptions(poll_interval_s=5.0, batch_size=10)
+    )
+    mocks.scheduler.loop.assert_called_once()
+
+
+def test_sweep_scheduler_cli_builds_path_from_entity_and_project(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(
+            cli.sweep_scheduler,
+            ["--entity", "my-entity", "--project", "my-project", "sweep-1"],
+        )
+
+    assert result.exit_code == 0, result.output
+    mocks.public_api.sweep.assert_called_once_with("my-entity/my-project/sweep-1")
+
+
+def test_sweep_scheduler_cli_passes_batch_size_and_poll_interval(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(
+            cli.sweep_scheduler,
+            ["--batch-size", "7", "--poll-interval", "2.5", "entity/project/sweep-1"],
+        )
+
+    assert result.exit_code == 0, result.output
+    mocks.resume_sweep.assert_called_once_with(
+        sweep, options=SchedulerOptions(poll_interval_s=2.5, batch_size=7)
+    )
+
+
+def test_sweep_scheduler_cli_requires_engine_config(runner: CliRunner) -> None:
+    sweep = make_scheduler_grid_sweep(config={})
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code != 0
+    assert "requires a sweep created with" in result.output
+    mocks.resume_sweep.assert_not_called()
+
+
+def test_sweep_scheduler_cli_rejects_unsupported_engine(runner: CliRunner) -> None:
+    sweep = make_scheduler_grid_sweep(
+        config={**SCHEDULER_GRID_SWEEP_CONFIG, "scheduler": {"engine": "unknown"}}
+    )
+    with _cli_scheduler_context(sweep) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code != 0
+    assert "Unsupported engine: unknown" in result.output
+    mocks.resume_sweep.assert_not_called()
+
+
+def test_sweep_scheduler_cli_warns_when_optimizer_configured(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep(
+        config={
+            **SCHEDULER_GRID_SWEEP_CONFIG,
+            "scheduler": {"engine": "wandb", "optimizer": "make_optimizer"},
+        }
+    )
+    with _cli_scheduler_context(sweep) as mocks, patch("wandb.termwarn") as termwarn:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    assert any(
+        "optimizer config is not supported" in call.args[0]
+        for call in termwarn.call_args_list
+    )
+    mocks.scheduler.loop.assert_called_once()
+
+
+def test_sweep_scheduler_cli_warns_when_search_space_configured(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep(
+        config={
+            **SCHEDULER_GRID_SWEEP_CONFIG,
+            "scheduler": {"engine": "wandb", "search_space": "unknown"},
+        }
+    )
+    with _cli_scheduler_context(sweep) as mocks, patch("wandb.termwarn") as termwarn:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    assert any(
+        "search_space config is not supported" in call.args[0]
+        for call in termwarn.call_args_list
+    )
+    mocks.scheduler.loop.assert_called_once()
+
+
+def test_sweep_scheduler_cli_triggers_login_when_unauthenticated(
+    runner: CliRunner,
+) -> None:
+    sweep = make_scheduler_grid_sweep()
+    with _cli_scheduler_context(sweep, authenticated=False) as mocks:
+        result = runner.invoke(cli.sweep_scheduler, ["entity/project/sweep-1"])
+
+    assert result.exit_code == 0, result.output
+    mocks.login.assert_called_once_with(no_offline=True)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2226,11 +2226,15 @@ def scheduler(
         raise
 
 
+# The scheduler's own poll loop already backs off, but polling more often
+# than this just burns API quota without fresher run data.
+_SCHEDULER_MIN_POLL_INTERVAL_S = 5
+
+
 @cli.command(
     name="sweep-scheduler",
     context_settings=CONTEXT,
-    help="Run a local scheduler that drives a sweep with an external optimizer "
-    "(Experimental).",
+    help="Run a local scheduler that suggests a sweep's runs (Experimental).",
 )
 @click.option("--entity", "-e", default=None, help="Entity that owns the sweep.")
 @click.option("--project", "-p", default=None, help="Project that owns the sweep.")
@@ -2258,7 +2262,7 @@ def sweep_scheduler(
     """Drive an existing sweep from a local, in-process scheduler.
 
     Create the sweep first with `wandb sweep sweep.yaml`; its config must set
-    `scheduler: {engine: <wandb|optuna|ax>}` so the server leaves the search to
+    `scheduler: {engine: wandb}` so the server leaves the search to
     this scheduler. The scheduler proposes runs, enqueues them, and polls their
     results to drive the optimizer.
     """
@@ -2267,8 +2271,10 @@ def sweep_scheduler(
         wandb.termlog("Login to W&B to use the sweep scheduler feature")
         click.get_current_context().invoke(login, no_offline=True)
 
-    if poll_interval < 5:
-        wandb.termerror("poll_interval must be at least 5 seconds")
+    if poll_interval < _SCHEDULER_MIN_POLL_INTERVAL_S:
+        wandb.termerror(
+            f"--poll-interval must be at least {_SCHEDULER_MIN_POLL_INTERVAL_S} seconds"
+        )
         sys.exit(1)
     # Resolve the sweep the user already created with `wandb sweep`.
     if "/" in sweep_id:
@@ -2287,17 +2293,15 @@ def sweep_scheduler(
     if not engine:
         raise ClickException(
             "The sweep scheduler requires a sweep created with "
-            "'scheduler': {'engine': <wandb|optuna|ax>} in its config."
+            "'scheduler': {'engine': wandb} in its config."
         )
     if engine == "wandb":
         search_space = scheduler_config.get("search_space")
         optimizer = scheduler_config.get("optimizer")
         if optimizer is not None:
-            wandb.termwarn("optimizer config is not supported by the sweep scheduler.")
+            wandb.termwarn("optimizer config is not supported by the wandb engine.")
         if search_space is not None:
-            wandb.termwarn(
-                "search_space config is not supported by the sweep scheduler."
-            )
+            wandb.termwarn("search_space config is not supported by the wandb engine.")
 
         from wandb.sdk.sweeps.scheduler import wandb as wandb_scheduler
         from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1306,6 +1306,11 @@ def sweep(
 
     styled_path = click.style(f"wandb agent {sweep_path}", fg="yellow")
     wandb.termlog(f"Run sweep agent with: {styled_path}")
+    if config is not None and config.get("scheduler") is not None:
+        styled_scheduler = click.style(
+            f"wandb sweep-scheduler {sweep_path}", fg="yellow"
+        )
+        wandb.termlog(f"Run scheduler with {styled_scheduler}")
     if controller:
         wandb.termlog("Starting wandb controller...")
         from wandb import controller as wandb_controller
@@ -2219,6 +2224,98 @@ def scheduler(
         telemetry_recorder.exception(e)
         get_sentry().exception(e)
         raise
+
+
+@cli.command(
+    name="sweep-scheduler",
+    context_settings=CONTEXT,
+    help="Run a local scheduler that drives a sweep with an external optimizer "
+    "(Experimental).",
+)
+@click.option("--entity", "-e", default=None, help="Entity that owns the sweep.")
+@click.option("--project", "-p", default=None, help="Project that owns the sweep.")
+@click.option(
+    "--batch-size",
+    default=10,
+    type=int,
+    help="Number of runs to keep in flight at once.",
+)
+@click.option(
+    "--poll-interval",
+    default=10.0,
+    type=float,
+    help="Seconds to wait between polls of the sweep's runs.",
+)
+@click.argument("sweep_id")
+@display_error
+def sweep_scheduler(
+    entity,
+    project,
+    batch_size,
+    poll_interval,
+    sweep_id,
+):
+    """Drive an existing sweep from a local, in-process scheduler.
+
+    Create the sweep first with `wandb sweep sweep.yaml`; its config must set
+    `scheduler: {engine: <wandb|optuna|ax>}` so the server leaves the search to
+    this scheduler. The scheduler proposes runs, enqueues them, and polls their
+    results to drive the optimizer.
+    """
+    api = _get_cling_api()
+    if not api.is_authenticated:
+        wandb.termlog("Login to W&B to use the sweep scheduler feature")
+        click.get_current_context().invoke(login, no_offline=True)
+
+    if poll_interval < 5:
+        wandb.termerror("poll_interval must be at least 5 seconds")
+        sys.exit(1)
+    # Resolve the sweep the user already created with `wandb sweep`.
+    if "/" in sweep_id:
+        sweep_path = sweep_id
+    elif entity and project:
+        sweep_path = f"{entity}/{project}/{sweep_id}"
+    else:
+        sweep_path = sweep_id
+    sweep = PublicApi().sweep(sweep_path)
+
+    # The local scheduler only drives sweeps that opted out of server-side
+    # search, which the `scheduler.engine` block records.
+    config = sweep.config or {}
+    scheduler_config = config.get("scheduler") or {}
+    engine = scheduler_config.get("engine")
+    if not engine:
+        raise ClickException(
+            "The sweep scheduler requires a sweep created with "
+            "'scheduler': {'engine': <wandb|optuna|ax>} in its config."
+        )
+    if engine == "wandb":
+        search_space = scheduler_config.get("search_space")
+        optimizer = scheduler_config.get("optimizer")
+        if optimizer is not None:
+            wandb.termwarn("optimizer config is not supported by the sweep scheduler.")
+        if search_space is not None:
+            wandb.termwarn(
+                "search_space config is not supported by the sweep scheduler."
+            )
+
+        from wandb.sdk.sweeps.scheduler import wandb as wandb_scheduler
+        from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
+
+        scheduler = wandb_scheduler.resume_sweep(
+            sweep,
+            options=SchedulerOptions(
+                poll_interval_s=poll_interval,
+                batch_size=batch_size,
+            ),
+        )
+    else:
+        raise ClickException(f"Unsupported engine: {engine}")
+
+    wandb.termlog(
+        f"Starting sweep scheduler for {sweep.name} with the {engine} engine 🧹"
+    )
+    scheduler.loop()
 
 
 @cli.group(help="Commands for managing and viewing W&B jobs.")

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1303,6 +1303,11 @@ def sweep(
 
     styled_path = click.style(f"wandb agent {sweep_path}", fg="yellow")
     wandb.termlog(f"Run sweep agent with: {styled_path}")
+    if config is not None and config.get("scheduler") is not None:
+        styled_scheduler = click.style(
+            f"wandb sweep_scheduler {sweep_path}", fg="yellow"
+        )
+        wandb.termlog(f"Run scheduler with {styled_scheduler}")
     if controller:
         wandb.termlog("Starting wandb controller...")
         from wandb import controller as wandb_controller
@@ -2201,6 +2206,95 @@ def scheduler(
     except Exception as e:
         get_sentry().exception(e)
         raise
+
+
+@cli.command(
+    name="sweep_scheduler",
+    context_settings=CONTEXT,
+    help="Run a local scheduler that drives a sweep with an external optimizer "
+    "(Experimental).",
+)
+@click.option("--entity", "-e", default=None, help="Entity that owns the sweep.")
+@click.option("--project", "-p", default=None, help="Project that owns the sweep.")
+@click.option(
+    "--batch-size",
+    default=10,
+    type=int,
+    help="Number of runs to keep in flight at once.",
+)
+@click.option(
+    "--poll-interval",
+    default=5.0,
+    type=float,
+    help="Seconds to wait between polls of the sweep's runs.",
+)
+@click.argument("sweep_id")
+@display_error
+def sweep_scheduler(
+    entity,
+    project,
+    batch_size,
+    poll_interval,
+    sweep_id,
+):
+    """Drive an existing sweep from a local, in-process scheduler.
+
+    Create the sweep first with `wandb sweep sweep.yaml`; its config must set
+    `scheduler: {engine: <wandb|optuna|ax>}` so the server leaves the search to
+    this scheduler. The scheduler proposes runs, enqueues them, and polls their
+    results to drive the optimizer.
+    """
+    api = _get_cling_api()
+    if not api.is_authenticated:
+        wandb.termlog("Login to W&B to use the sweep scheduler feature")
+        click.get_current_context().invoke(login, no_offline=True)
+
+    # Resolve the sweep the user already created with `wandb sweep`.
+    if "/" in sweep_id:
+        sweep_path = sweep_id
+    elif entity and project:
+        sweep_path = f"{entity}/{project}/{sweep_id}"
+    else:
+        sweep_path = sweep_id
+    sweep = PublicApi().sweep(sweep_path)
+
+    # The local scheduler only drives sweeps that opted out of server-side
+    # search, which the `scheduler.engine` block records.
+    config = sweep.config or {}
+    scheduler_config = config.get("scheduler") or {}
+    engine = scheduler_config.get("engine")
+    if not engine:
+        raise ClickException(
+            "The sweep scheduler requires a sweep created with "
+            "'scheduler': {'engine': <wandb|optuna|ax>} in its config."
+        )
+    if engine == "wandb":
+        search_space = scheduler_config.get("search_space")
+        optimizer = scheduler_config.get("optimizer")
+        if optimizer is not None:
+            wandb.termwarn("optimizer config is not supported by the sweep scheduler.")
+        if search_space is not None:
+            wandb.termwarn(
+                "search_space config is not supported by the sweep scheduler."
+            )
+
+        from wandb.sdk.sweeps.scheduler import wandb as wandb_scheduler
+        from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
+
+        scheduler = wandb_scheduler.resume_sweep(
+            sweep,
+            options=SchedulerOptions(
+                poll_interval_s=poll_interval,
+                batch_size=batch_size,
+            ),
+        )
+    else:
+        raise ClickException(f"Unsupported engine: {engine}")
+
+    wandb.termlog(
+        f"Starting sweep scheduler for {sweep.name} with the {engine} engine 🧹"
+    )
+    scheduler.loop()
 
 
 @cli.group(help="Commands for managing and viewing W&B jobs.")

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -56,11 +56,11 @@ class RunSuggestion:
     run_id: str
 
     def __post_init__(self) -> None:
-        # A define-by-run `trial_constructor` naturally returns the flat
-        # `{param: value}` mapping from `trial.params`; accept that and
-        # normalize it to a `RunConfig` here so every suggestion the executor
-        # sees can be serialized the same way (`config.model_dump()`),
-        # regardless of which optimizer (or user constructor) built it.
+        # Optimizers built on third-party frameworks naturally produce the
+        # flat `{param: value}` mapping; accept that and normalize it to a
+        # `RunConfig` here so every suggestion the executor sees serializes
+        # the same way (`config.wire_dict()`), regardless of which optimizer
+        # built it.
         if not isinstance(self.config, RunConfig):
             self.config = RunConfig.from_values(self.config)
 

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -55,6 +55,15 @@ class RunSuggestion:
     config: RunConfig
     run_id: str
 
+    def __post_init__(self) -> None:
+        # A define-by-run `trial_constructor` naturally returns the flat
+        # `{param: value}` mapping from `trial.params`; accept that and
+        # normalize it to a `RunConfig` here so every suggestion the executor
+        # sees can be serialized the same way (`config.model_dump()`),
+        # regardless of which optimizer (or user constructor) built it.
+        if not isinstance(self.config, RunConfig):
+            self.config = RunConfig.from_values(self.config)
+
 
 @dataclass
 class Run:


### PR DESCRIPTION
Description
-----------
- Fixes WB-38287

Adds a new `wandb sweep_scheduler` command to the CLI. The command takes a single argument in the form of a fully qualified sweep ID of `entity/project/sweep` format, or `sweep_name` requiring extra options for entity and project. This matches the existing behavior of the agent command. This new command builds and starts a scheduler and optimizer for the user that schedules and monitors the execution of sweep runs.

Users will be automatically given the command string to use the sweep scheduler when they create a sweep with the
scheduler: config key, similar to how we give them a pasteable command for the wandb agent.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Manually tested, and includes unit tests for creating a new scheduler with the wandb reference implementation.
