### PR TITLE
feat(sweeps): optuna optimizer implementation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -611,6 +611,7 @@ def mypy_report(session: nox.Session) -> None:
         "types-tqdm",
         "-e .[eval-table]",
         "-e .[sweeps]",
+        "-e .[optuna]",
     )
 
     path = "mypy-results"

--- a/noxfile.py
+++ b/noxfile.py
@@ -611,6 +611,7 @@ def mypy_report(session: nox.Session) -> None:
         "types-six",
         "types-tqdm",
         "-e .[eval-table]",
+        "-e .[optuna]",
     )
 
     path = "mypy-results"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ media = [
     "rdkit",
 ]
 sweeps = ["sweeps>=0.2.0"]
+optuna = ["optuna>=4.0.0"]
 launch = [
     "wandb[aws]",
     "awscli",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ media = [
     "rdkit",
 ]
 sweeps = ["sweeps>=0.2.0"]
+optuna = ["optuna>=4.0.0"]
 launch = [
     "wandb[aws]",
     "awscli",

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -36,3 +36,4 @@ hypothesis>=6.131.7
 hypothesis-fspaths
 
 .[sweeps]
+.[optuna]

--- a/tests/unit_tests/test_optuna_scheduler.py
+++ b/tests/unit_tests/test_optuna_scheduler.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import optuna
+import pytest
+from wandb.apis.public import Sweep
+from wandb.sdk.sweeps.scheduler.optuna import (
+    OptunaDeclarativeOptimizer,
+    OptunaImperativeOptimizer,
+    OptunaOptions,
+    create_study_from_sweep_config,
+    create_sweep,
+    create_sweep_from_config,
+    resume_sweep,
+)
+from wandb.sdk.sweeps.scheduler.scheduler import (
+    Executor,
+    InMemoryScheduler,
+    WBAgentExecutor,
+)
+
+from tests.unit_tests.test_sweep_scheduler import make_scheduler_grid_sweep
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+
+DEFAULT_CONFIG = {"metric": {"name": "loss", "goal": "minimize"}, "parameters": {}}
+
+
+@pytest.fixture
+def sweep() -> Sweep:
+    return make_scheduler_grid_sweep(config=DEFAULT_CONFIG)
+
+
+@pytest.fixture
+def study() -> optuna.Study:
+    return optuna.create_study(direction="minimize")
+
+
+@pytest.fixture(autouse=True)
+def mock_scheduler_api() -> Any:
+    """`InMemoryScheduler.__init__` calls `Api()`; keep it from hitting the network."""
+    with patch("wandb.sdk.sweeps.scheduler.scheduler.Api", return_value=MagicMock()):
+        yield
+
+
+class TestResumeSweep:
+    def test_builds_declarative_optimizer_and_default_scheduler(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        distributions = {"x": optuna.distributions.FloatDistribution(0.0, 1.0)}
+
+        result = resume_sweep(
+            sweep, options=OptunaOptions(study=study, distributions=distributions)
+        )
+
+        assert isinstance(result, InMemoryScheduler)
+        assert isinstance(result._optimizer, OptunaDeclarativeOptimizer)
+        assert result._optimizer.study is study
+        assert result._optimizer.distributions is distributions
+        assert result._optimizer._sweep is sweep
+        assert result._sweep is sweep
+        # No poll/batch/executor given: defaults from `OptunaOptions()`.
+        assert result._poll_interval_s == OptunaOptions().poll_interval_s
+        assert result._batch_size == OptunaOptions().batch_size
+        assert isinstance(result._executor, WBAgentExecutor)
+
+    def test_builds_imperative_optimizer(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        def trial_constructor(trial: optuna.Trial) -> dict[str, Any]:
+            return {"x": trial.suggest_float("x", 0.0, 1.0)}
+
+        result = resume_sweep(
+            sweep, options=OptunaOptions(study=study, search_space=trial_constructor)
+        )
+
+        assert isinstance(result._optimizer, OptunaImperativeOptimizer)
+        assert result._optimizer.trial_constructor is trial_constructor
+
+    def test_resolves_sweep_given_as_path_string(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        api = MagicMock()
+        api.sweep.return_value = sweep
+        with patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api):
+            result = resume_sweep(
+                "test_entity/test_project/test_sweep",
+                options=OptunaOptions(study=study, distributions={}),
+            )
+
+        api.sweep.assert_called_once_with("test_entity/test_project/test_sweep")
+        assert result._sweep is sweep
+
+    def test_uses_given_scheduler_options(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        executor = MagicMock(spec=Executor)
+
+        result = resume_sweep(
+            sweep,
+            options=OptunaOptions(
+                study=study,
+                distributions={},
+                poll_interval_s=1.5,
+                batch_size=3,
+                executor=executor,
+            ),
+        )
+
+        assert result._poll_interval_s == 1.5
+        assert result._batch_size == 3
+        assert result._executor is executor
+
+    def test_requires_a_study(self, sweep: Sweep) -> None:
+        with pytest.raises(ValueError, match="study"):
+            resume_sweep(sweep, options=OptunaOptions(distributions={}))
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {},
+            {"distributions": {}, "search_space": lambda trial: {}},
+        ],
+        ids=["neither", "both"],
+    )
+    def test_requires_exactly_one_of_distributions_or_search_space(
+        self, study: optuna.Study, sweep: Sweep, extra: dict[str, Any]
+    ) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            resume_sweep(sweep, options=OptunaOptions(study=study, **extra))
+
+    def test_forwards_the_terminator_to_the_optimizer(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        terminator = MagicMock()
+
+        result = resume_sweep(
+            sweep,
+            options=OptunaOptions(study=study, distributions={}, terminator=terminator),
+        )
+
+        assert result._optimizer._terminator is terminator
+
+
+class TestCreateSweep:
+    def test_declarative_path_builds_sweep_and_delegates(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        distributions = {"lr": optuna.distributions.FloatDistribution(0.0, 1.0)}
+        api = MagicMock()
+        api.sweep.return_value = sweep
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ) as mock_wandb_sweep,
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep(
+                "test_entity",
+                "test_project",
+                "loss",
+                program_path="train.py",
+                options=OptunaOptions(study=study, distributions=distributions),
+            )
+
+        mock_wandb_sweep.assert_called_once_with(
+            {
+                "metric": {"name": "loss", "goal": "minimize"},
+                "parameters": {
+                    "lr": {"distribution": "uniform", "min": 0.0, "max": 1.0}
+                },
+                "scheduler": {"engine": "optuna"},
+                "program": "train.py",
+            },
+            entity="test_entity",
+            project="test_project",
+        )
+        api.sweep.assert_called_once_with("test_entity/test_project/test_sweep")
+        assert isinstance(result, InMemoryScheduler)
+        assert isinstance(result._optimizer, OptunaDeclarativeOptimizer)
+        assert result._optimizer.distributions is distributions
+        assert result._sweep is sweep
+
+    def test_imperative_path_discovers_space_and_keeps_the_constructor(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        """Regression test: the discovered space must not overwrite the
+        constructor that `resume_sweep` needs to build the imperative
+        optimizer -- `create_sweep` used to shadow its `search_space`
+        parameter with the discovered distributions dict before forwarding
+        it, silently swapping the callable for a dict.
+        """
+
+        def trial_constructor(trial: optuna.Trial) -> dict[str, Any]:
+            return {"lr": trial.suggest_float("lr", 0.0, 1.0)}
+
+        api = MagicMock()
+        api.sweep.return_value = sweep
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ) as mock_wandb_sweep,
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep(
+                "test_entity",
+                "test_project",
+                "loss",
+                options=OptunaOptions(study=study, search_space=trial_constructor),
+            )
+
+        # The space `_spy_search_space` discovered by really running
+        # `trial_constructor` made it into the sweep the server was asked to
+        # create.
+        sent_config = mock_wandb_sweep.call_args[0][0]
+        assert sent_config["parameters"] == {
+            "lr": {"distribution": "uniform", "min": 0.0, "max": 1.0}
+        }
+        # But the optimizer that drives the rest of the sweep keeps the
+        # original callable, not that discovered dict.
+        assert isinstance(result._optimizer, OptunaImperativeOptimizer)
+        assert result._optimizer.trial_constructor is trial_constructor
+
+    def test_requires_a_study(self) -> None:
+        with pytest.raises(ValueError, match="study"):
+            create_sweep(
+                "test_entity",
+                "test_project",
+                "loss",
+                options=OptunaOptions(distributions={}),
+            )
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {},
+            {"distributions": {}, "search_space": lambda trial: {}},
+        ],
+        ids=["neither", "both"],
+    )
+    def test_requires_exactly_one_of_distributions_or_search_space(
+        self, study: optuna.Study, extra: dict[str, Any]
+    ) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            create_sweep(
+                "test_entity",
+                "test_project",
+                "loss",
+                options=OptunaOptions(study=study, **extra),
+            )
+
+    def test_forwards_the_terminator_to_the_optimizer(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        terminator = MagicMock()
+        api = MagicMock()
+        api.sweep.return_value = sweep
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ),
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep(
+                "test_entity",
+                "test_project",
+                "loss",
+                options=OptunaOptions(
+                    study=study, distributions={}, terminator=terminator
+                ),
+            )
+
+        assert result._optimizer._terminator is terminator
+
+
+class TestCreateStudyFromSweepConfig:
+    def test_creates_single_objective_study_from_metric(self) -> None:
+        study = create_study_from_sweep_config(
+            {"metric": {"name": "loss", "goal": "maximize"}}
+        )
+
+        assert study.direction == optuna.study.StudyDirection.MAXIMIZE
+
+    def test_creates_multi_objective_study_from_metrics(self) -> None:
+        study = create_study_from_sweep_config(
+            {
+                "metrics": [
+                    {"name": "loss", "goal": "minimize"},
+                    {"name": "accuracy", "goal": "maximize"},
+                ]
+            }
+        )
+
+        assert [d.name.lower() for d in study.directions] == ["minimize", "maximize"]
+
+    def test_multi_objective_study_passes_validation(self) -> None:
+        metrics_config = {
+            "metrics": [
+                {"name": "loss", "goal": "minimize"},
+                {"name": "accuracy", "goal": "maximize"},
+            ],
+            "parameters": {},
+        }
+        study = create_study_from_sweep_config(metrics_config)
+        sweep = make_scheduler_grid_sweep(config=metrics_config)
+
+        OptunaDeclarativeOptimizer(study, {}, sweep)
+
+
+class TestBuildOptunaScheduler:
+    def test_creates_multi_objective_study_from_metrics_config(self) -> None:
+        from wandb.cli import cli
+
+        config = {
+            "metrics": [
+                {"name": "loss", "goal": "minimize"},
+                {"name": "accuracy", "goal": "maximize"},
+            ],
+            "parameters": {"lr": {"min": 0.0, "max": 1.0}},
+            "scheduler": {"engine": "optuna"},
+        }
+        sweep = make_scheduler_grid_sweep(config=config)
+        scheduler = MagicMock()
+        with patch(
+            "wandb.sdk.sweeps.scheduler.optuna.resume_sweep", return_value=scheduler
+        ) as resume_sweep:
+            result = cli._build_optuna_scheduler(
+                sweep, config, config["scheduler"], poll_interval=5.0, batch_size=10
+            )
+
+        resume_sweep.assert_called_once()
+        options = resume_sweep.call_args.kwargs["options"]
+        assert [d.name.lower() for d in options.study.directions] == [
+            "minimize",
+            "maximize",
+        ]
+        assert result is scheduler
+
+
+class TestCreateSweepFromConfig:
+    CONFIG = {
+        "metric": {"name": "loss", "goal": "minimize"},
+        "parameters": {"lr": {"min": 0.0, "max": 1.0}},
+    }
+
+    def test_builds_sweep_and_declarative_optimizer_from_config(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        api = MagicMock()
+        api.sweep.return_value = sweep
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ) as mock_wandb_sweep,
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep_from_config(
+                self.CONFIG,
+                "test_entity",
+                "test_project",
+                options=OptunaOptions(study=study),
+            )
+
+        mock_wandb_sweep.assert_called_once_with(
+            self.CONFIG, entity="test_entity", project="test_project"
+        )
+        api.sweep.assert_called_once_with("test_entity/test_project/test_sweep")
+
+        assert isinstance(result, InMemoryScheduler)
+        assert isinstance(result._optimizer, OptunaDeclarativeOptimizer)
+        assert result._optimizer.study is study
+        assert result._optimizer.distributions == {
+            "lr": optuna.distributions.FloatDistribution(0.0, 1.0)
+        }
+        assert result._sweep is sweep
+        assert result._poll_interval_s == OptunaOptions().poll_interval_s
+        assert result._batch_size == OptunaOptions().batch_size
+        assert isinstance(result._executor, WBAgentExecutor)
+
+    def test_creates_a_study_from_the_configs_goal_when_none_given(self) -> None:
+        maximize_config = {
+            "metric": {"name": "loss", "goal": "maximize"},
+            "parameters": {},
+        }
+        api = MagicMock()
+        api.sweep.return_value = make_scheduler_grid_sweep(config=maximize_config)
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ),
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep_from_config(
+                maximize_config, "test_entity", "test_project"
+            )
+
+        assert result._optimizer.study.direction == optuna.study.StudyDirection.MAXIMIZE
+
+    def test_creates_multi_objective_study_from_metrics_when_none_given(self) -> None:
+        metrics_config = {
+            "metrics": [
+                {"name": "loss", "goal": "minimize"},
+                {"name": "accuracy", "goal": "maximize"},
+            ],
+            "parameters": {},
+        }
+        api = MagicMock()
+        api.sweep.return_value = make_scheduler_grid_sweep(config=metrics_config)
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ),
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep_from_config(
+                metrics_config, "test_entity", "test_project"
+            )
+
+        assert [d.name.lower() for d in result._optimizer.study.directions] == [
+            "minimize",
+            "maximize",
+        ]
+
+    def test_uses_given_scheduler_options(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        executor = MagicMock(spec=Executor)
+        api = MagicMock()
+        api.sweep.return_value = sweep
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ),
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep_from_config(
+                self.CONFIG,
+                "test_entity",
+                "test_project",
+                options=OptunaOptions(
+                    study=study,
+                    poll_interval_s=2.5,
+                    batch_size=7,
+                    executor=executor,
+                ),
+            )
+
+        assert result._poll_interval_s == 2.5
+        assert result._batch_size == 7
+        assert result._executor is executor
+
+    def test_forwards_the_terminator_to_the_optimizer(
+        self, study: optuna.Study, sweep: Sweep
+    ) -> None:
+        terminator = MagicMock()
+        api = MagicMock()
+        api.sweep.return_value = sweep
+        with (
+            patch(
+                "wandb.sdk.sweeps.scheduler.optuna.wandb_sweep",
+                return_value="test_sweep",
+            ),
+            patch("wandb.sdk.sweeps.scheduler.optuna.Api", return_value=api),
+        ):
+            result = create_sweep_from_config(
+                self.CONFIG,
+                "test_entity",
+                "test_project",
+                options=OptunaOptions(study=study, terminator=terminator),
+            )
+
+        assert result._optimizer._terminator is terminator

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -376,7 +376,7 @@ class OptunaOptimizerAcceptanceTests(OptimizerAcceptanceTests):
             pruner=optuna.pruners.MedianPruner(n_startup_trials=0, n_warmup_steps=0),
         )
 
-    def test_prune_run_hyperband_stops_worst_running_run(
+    def test_prune_runs_hyperband_stops_worst_running_run(
         self, optimizer: Optimizer
     ) -> None:
         suggestions = optimizer.ask_n_runs(3)
@@ -406,8 +406,11 @@ class OptunaOptimizerAcceptanceTests(OptimizerAcceptanceTests):
         optimizer.tell_run(suggestions[1].run_id, worst_running)
         optimizer.tell_run(suggestions[2].run_id, better_running)
 
-        assert optimizer.prune_run(suggestions[1].run_id, worst_running)
-        assert not optimizer.prune_run(suggestions[2].run_id, better_running)
+        pruned = optimizer.prune_runs(
+            [suggestions[1].run_id, suggestions[2].run_id],
+            [worst_running, better_running],
+        )
+        assert pruned == [suggestions[1].run_id]
 
 
 class TestOptunaDeclarativeOptimizerAcceptance(OptunaOptimizerAcceptanceTests):

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -327,6 +327,156 @@ class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
         return WandbOptimizer(sweep=sweep)
 
 
+def _make_sequential_sampler(optuna_module: Any) -> Any:
+    """A deterministic sampler cycling a categorical param's choices in order.
+
+    Real optuna samplers pick randomly (or per some search strategy), but the
+    shared acceptance tests -- written against `WandbOptimizer`'s
+    deterministic grid search -- assert an exact suggestion order.
+    """
+
+    class _SequentialSampler(optuna_module.samplers.BaseSampler):
+        def infer_relative_search_space(self, study: Any, trial: Any) -> dict:
+            return {}
+
+        def sample_relative(self, study: Any, trial: Any, search_space: dict) -> dict:
+            return {}
+
+        def sample_independent(
+            self, study: Any, trial: Any, param_name: str, param_distribution: Any
+        ) -> Any:
+            choices = list(param_distribution.choices)
+            seen = sum(
+                1
+                for t in study.get_trials(deepcopy=False)
+                if t.number != trial.number and param_name in t.params
+            )
+            return choices[seen % len(choices)]
+
+    return _SequentialSampler()
+
+
+class OptunaOptimizerAcceptanceTests(OptimizerAcceptanceTests):
+    """Shared setup for the Optuna optimizer flavors.
+
+    Overrides the hyperband pruning test: optuna's pruners judge a running
+    trial only against *completed*-trial history, unlike the `sweeps`
+    library's hyperband, which ranks concurrently running trials against each
+    other.
+    """
+
+    @pytest.fixture
+    def study(self) -> Any:
+        import optuna
+
+        optuna.logging.set_verbosity(optuna.logging.WARNING)
+        return optuna.create_study(
+            direction="minimize",
+            sampler=_make_sequential_sampler(optuna),
+            pruner=optuna.pruners.MedianPruner(n_startup_trials=0, n_warmup_steps=0),
+        )
+
+    def test_prune_run_hyperband_stops_worst_running_run(
+        self, optimizer: Optimizer
+    ) -> None:
+        suggestions = optimizer.ask_n_runs(3)
+        assert len(suggestions) == 3
+
+        optimizer.tell_run(
+            suggestions[0].run_id,
+            make_run(
+                suggestions[0],
+                state=RunState.FINISHED,
+                summary={"loss": 6.0},
+                history=[{"loss": 10.0}, {"loss": 6.0}, {"loss": 6.0}],
+            ),
+        )
+        worst_running = make_run(
+            suggestions[1],
+            state=RunState.RUNNING,
+            summary={"loss": 10.0},
+            history=[{"loss": 10.0}, {"loss": 10.0}],
+        )
+        better_running = make_run(
+            suggestions[2],
+            state=RunState.RUNNING,
+            summary={"loss": 5.0},
+            history=[{"loss": 10.0}, {"loss": 5.0}, {"loss": 5.0}],
+        )
+        optimizer.tell_run(suggestions[1].run_id, worst_running)
+        optimizer.tell_run(suggestions[2].run_id, better_running)
+
+        assert optimizer.prune_run(suggestions[1].run_id, worst_running)
+        assert not optimizer.prune_run(suggestions[2].run_id, better_running)
+
+
+class TestOptunaDeclarativeOptimizerAcceptance(OptunaOptimizerAcceptanceTests):
+    @pytest.fixture
+    def optimizer(self, study: Any, sweep: Sweep) -> Optimizer:
+        import optuna
+        from wandb.sdk.sweeps.scheduler.optuna import OptunaDeclarativeOptimizer
+
+        distributions = {
+            "param1": optuna.distributions.CategoricalDistribution([1, 2, 3])
+        }
+        return OptunaDeclarativeOptimizer(study, distributions, sweep)
+
+
+class TestOptunaImperativeOptimizerAcceptance(OptunaOptimizerAcceptanceTests):
+    @pytest.fixture
+    def optimizer(self, study: Any, sweep: Sweep) -> Optimizer:
+        from wandb.sdk.sweeps.scheduler.optuna import OptunaImperativeOptimizer
+
+        def trial_constructor(trial: Any) -> dict[str, Any]:
+            return {"param1": trial.suggest_categorical("param1", [1, 2, 3])}
+
+        return OptunaImperativeOptimizer(study, trial_constructor, sweep)
+
+
+class TestOptunaOptimizerTermination:
+    """`OptunaOptimizer.should_terminate_sweep` and its OptunaHub loading."""
+
+    @pytest.fixture
+    def sweep(self) -> Sweep:
+        return make_scheduler_grid_sweep()
+
+    @pytest.fixture
+    def study(self) -> Any:
+        import optuna
+
+        optuna.logging.set_verbosity(optuna.logging.WARNING)
+        return optuna.create_study(direction="minimize")
+
+    def _make_optimizer(self, study: Any, sweep: Sweep, terminator: Any = None) -> Any:
+        import optuna
+        from wandb.sdk.sweeps.scheduler.optuna import OptunaDeclarativeOptimizer
+
+        distributions = {"param1": optuna.distributions.IntDistribution(1, 3)}
+        return OptunaDeclarativeOptimizer(study, distributions, sweep, terminator)
+
+    def test_no_terminator_never_terminates(self, study: Any, sweep: Sweep) -> None:
+        optimizer = self._make_optimizer(study, sweep)
+        assert optimizer.should_terminate_sweep() is False
+
+    def test_delegates_to_the_configured_terminator(
+        self, study: Any, sweep: Sweep
+    ) -> None:
+        terminator = MagicMock(return_value=True)
+        optimizer = self._make_optimizer(study, sweep, terminator)
+
+        assert optimizer.should_terminate_sweep() is True
+        terminator.assert_called_once_with(study)
+
+    def test_a_falsy_terminator_does_not_terminate(
+        self, study: Any, sweep: Sweep
+    ) -> None:
+        terminator = MagicMock(return_value=False)
+        optimizer = self._make_optimizer(study, sweep, terminator)
+
+        assert optimizer.should_terminate_sweep() is False
+        terminator.assert_called_once_with(study)
+
+
 class LoopDriver:
     """Drive `Scheduler.loop()` from the loop's own progress.
 

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -315,6 +315,156 @@ class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
         return WandbOptimizer(sweep=sweep)
 
 
+def _make_sequential_sampler(optuna_module: Any) -> Any:
+    """A deterministic sampler cycling a categorical param's choices in order.
+
+    Real optuna samplers pick randomly (or per some search strategy), but the
+    shared acceptance tests -- written against `WandbOptimizer`'s
+    deterministic grid search -- assert an exact suggestion order.
+    """
+
+    class _SequentialSampler(optuna_module.samplers.BaseSampler):
+        def infer_relative_search_space(self, study: Any, trial: Any) -> dict:
+            return {}
+
+        def sample_relative(self, study: Any, trial: Any, search_space: dict) -> dict:
+            return {}
+
+        def sample_independent(
+            self, study: Any, trial: Any, param_name: str, param_distribution: Any
+        ) -> Any:
+            choices = list(param_distribution.choices)
+            seen = sum(
+                1
+                for t in study.get_trials(deepcopy=False)
+                if t.number != trial.number and param_name in t.params
+            )
+            return choices[seen % len(choices)]
+
+    return _SequentialSampler()
+
+
+class OptunaOptimizerAcceptanceTests(OptimizerAcceptanceTests):
+    """Shared setup for the Optuna optimizer flavors.
+
+    Overrides the hyperband pruning test: optuna's pruners judge a running
+    trial only against *completed*-trial history, unlike the `sweeps`
+    library's hyperband, which ranks concurrently running trials against each
+    other.
+    """
+
+    @pytest.fixture
+    def study(self) -> Any:
+        import optuna
+
+        optuna.logging.set_verbosity(optuna.logging.WARNING)
+        return optuna.create_study(
+            direction="minimize",
+            sampler=_make_sequential_sampler(optuna),
+            pruner=optuna.pruners.MedianPruner(n_startup_trials=0, n_warmup_steps=0),
+        )
+
+    def test_prune_run_hyperband_stops_worst_running_run(
+        self, optimizer: Optimizer
+    ) -> None:
+        suggestions = optimizer.ask_n_runs(3)
+        assert len(suggestions) == 3
+
+        optimizer.tell_run(
+            suggestions[0].run_id,
+            make_run(
+                suggestions[0],
+                state=RunState.FINISHED,
+                summary={"loss": 6.0},
+                history=[{"loss": 10.0}, {"loss": 6.0}, {"loss": 6.0}],
+            ),
+        )
+        worst_running = make_run(
+            suggestions[1],
+            state=RunState.RUNNING,
+            summary={"loss": 10.0},
+            history=[{"loss": 10.0}, {"loss": 10.0}],
+        )
+        better_running = make_run(
+            suggestions[2],
+            state=RunState.RUNNING,
+            summary={"loss": 5.0},
+            history=[{"loss": 10.0}, {"loss": 5.0}, {"loss": 5.0}],
+        )
+        optimizer.tell_run(suggestions[1].run_id, worst_running)
+        optimizer.tell_run(suggestions[2].run_id, better_running)
+
+        assert optimizer.prune_run(suggestions[1].run_id, worst_running)
+        assert not optimizer.prune_run(suggestions[2].run_id, better_running)
+
+
+class TestOptunaDeclarativeOptimizerAcceptance(OptunaOptimizerAcceptanceTests):
+    @pytest.fixture
+    def optimizer(self, study: Any, sweep: Sweep) -> Optimizer:
+        import optuna
+        from wandb.sdk.sweeps.scheduler.optuna import OptunaDeclarativeOptimizer
+
+        distributions = {
+            "param1": optuna.distributions.CategoricalDistribution([1, 2, 3])
+        }
+        return OptunaDeclarativeOptimizer(study, distributions, sweep)
+
+
+class TestOptunaImperativeOptimizerAcceptance(OptunaOptimizerAcceptanceTests):
+    @pytest.fixture
+    def optimizer(self, study: Any, sweep: Sweep) -> Optimizer:
+        from wandb.sdk.sweeps.scheduler.optuna import OptunaImperativeOptimizer
+
+        def trial_constructor(trial: Any) -> dict[str, Any]:
+            return {"param1": trial.suggest_categorical("param1", [1, 2, 3])}
+
+        return OptunaImperativeOptimizer(study, trial_constructor, sweep)
+
+
+class TestOptunaOptimizerTermination:
+    """`OptunaOptimizer.should_terminate_sweep` and its OptunaHub loading."""
+
+    @pytest.fixture
+    def sweep(self) -> Sweep:
+        return make_scheduler_grid_sweep()
+
+    @pytest.fixture
+    def study(self) -> Any:
+        import optuna
+
+        optuna.logging.set_verbosity(optuna.logging.WARNING)
+        return optuna.create_study(direction="minimize")
+
+    def _make_optimizer(self, study: Any, sweep: Sweep, terminator: Any = None) -> Any:
+        import optuna
+        from wandb.sdk.sweeps.scheduler.optuna import OptunaDeclarativeOptimizer
+
+        distributions = {"param1": optuna.distributions.IntDistribution(1, 3)}
+        return OptunaDeclarativeOptimizer(study, distributions, sweep, terminator)
+
+    def test_no_terminator_never_terminates(self, study: Any, sweep: Sweep) -> None:
+        optimizer = self._make_optimizer(study, sweep)
+        assert optimizer.should_terminate_sweep() is False
+
+    def test_delegates_to_the_configured_terminator(
+        self, study: Any, sweep: Sweep
+    ) -> None:
+        terminator = MagicMock(return_value=True)
+        optimizer = self._make_optimizer(study, sweep, terminator)
+
+        assert optimizer.should_terminate_sweep() is True
+        terminator.assert_called_once_with(study)
+
+    def test_a_falsy_terminator_does_not_terminate(
+        self, study: Any, sweep: Sweep
+    ) -> None:
+        terminator = MagicMock(return_value=False)
+        optimizer = self._make_optimizer(study, sweep, terminator)
+
+        assert optimizer.should_terminate_sweep() is False
+        terminator.assert_called_once_with(study)
+
+
 class LoopDriver:
     """Drive `Scheduler.loop()` from the loop's own progress.
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import getpass
+import importlib.util
 import json
 import logging
 import os
@@ -2231,6 +2232,94 @@ def scheduler(
 _SCHEDULER_MIN_POLL_INTERVAL_S = 5
 
 
+def _load_source_object(source: str, name: str) -> Any:
+    """Import the python file at `source` and return its `name` attribute.
+
+    Used to load a user-defined `search_space` or `optimizer` (trial
+    constructor) function referenced by name from a sweep's scheduler config.
+    """
+    module_name = f"wandb_sweep_source_{pathlib.Path(source).stem}"
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    if spec is None or spec.loader is None:
+        raise ClickException(f"Could not import source file: {source}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    try:
+        return getattr(module, name)
+    except AttributeError:
+        raise ClickException(f"{source} has no attribute {name!r}") from None
+
+
+def _build_optuna_scheduler(
+    sweep,
+    config: dict,
+    scheduler_config: dict,
+    poll_interval: float,
+    batch_size: int,
+):
+    """Build the scheduler for a sweep whose `scheduler.engine` is `optuna`."""
+    # Importing the module lazily surfaces a helpful error when optuna isn't
+    # installed, and keeps the wandb path free of that dependency.
+    from wandb.sdk.sweeps.scheduler import optuna as optuna_scheduler
+
+    optimizer_name = scheduler_config.get("optimizer", "")
+    search_space_name = scheduler_config.get("search_space")
+    source = scheduler_config.get("source", "")
+
+    # Exactly one of search_space / optimizer: the declarative space is built
+    # from the loaded function when given, otherwise the loaded function is
+    # itself the define-by-run trial constructor.
+    search_space = None
+    distributions = None
+    if search_space_name is not None:
+        search_space = _load_source_object(source, search_space_name)
+    else:
+        distributions = optuna_scheduler.search_space_from_sweep_config(
+            config.get("parameters", {})
+        )
+    if optimizer_name:
+        study_fn = _load_source_object(source, optimizer_name)
+        study = study_fn()
+    else:
+        study = optuna_scheduler.create_study_from_sweep_config(config)
+
+    return optuna_scheduler.resume_sweep(
+        sweep,
+        options=optuna_scheduler.OptunaOptions(
+            study=study,
+            distributions=distributions,
+            search_space=search_space,
+            poll_interval_s=poll_interval,
+            batch_size=batch_size,
+        ),
+    )
+
+
+def _build_wandb_scheduler(
+    sweep,
+    scheduler_config: dict,
+    poll_interval: float,
+    batch_size: int,
+):
+    search_space = scheduler_config.get("search_space")
+    optimizer = scheduler_config.get("optimizer")
+    if optimizer is not None:
+        wandb.termwarn("optimizer config is not supported by the wandb engine.")
+    if search_space is not None:
+        wandb.termwarn("search_space config is not supported by the wandb engine.")
+
+    from wandb.sdk.sweeps.scheduler import wandb as wandb_scheduler
+    from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
+
+    return wandb_scheduler.resume_sweep(
+        sweep,
+        options=SchedulerOptions(
+            poll_interval_s=poll_interval,
+            batch_size=batch_size,
+        ),
+    )
+
+
 @cli.command(
     name="sweep-scheduler",
     context_settings=CONTEXT,
@@ -2296,22 +2385,15 @@ def sweep_scheduler(
             "'scheduler': {'engine': wandb} in its config."
         )
     if engine == "wandb":
-        search_space = scheduler_config.get("search_space")
-        optimizer = scheduler_config.get("optimizer")
-        if optimizer is not None:
-            wandb.termwarn("optimizer config is not supported by the wandb engine.")
-        if search_space is not None:
-            wandb.termwarn("search_space config is not supported by the wandb engine.")
-
-        from wandb.sdk.sweeps.scheduler import wandb as wandb_scheduler
-        from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
-
-        scheduler = wandb_scheduler.resume_sweep(
+        scheduler = _build_wandb_scheduler(
             sweep,
-            options=SchedulerOptions(
-                poll_interval_s=poll_interval,
-                batch_size=batch_size,
-            ),
+            scheduler_config,
+            poll_interval,
+            batch_size,
+        )
+    elif engine == "optuna":
+        scheduler = _build_optuna_scheduler(
+            sweep, config, scheduler_config, poll_interval, batch_size
         )
     else:
         raise ClickException(f"Unsupported engine: {engine}")

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2235,9 +2235,15 @@ _SCHEDULER_MIN_POLL_INTERVAL_S = 5
 def _load_source_object(source: str, name: str) -> Any:
     """Import the python file at `source` and return its `name` attribute.
 
-    Used to load a user-defined `search_space` or `optimizer` (trial
-    constructor) function referenced by name from a sweep's scheduler config.
+    Used to load a user-defined `search_space` (define-by-run trial
+    constructor) or `optimizer` (study factory) referenced by name from a
+    sweep's scheduler config.
     """
+    if not source:
+        raise ClickException(
+            f"scheduler.source must name the python file that defines "
+            f"{name!r}, but is missing or empty."
+        )
     module_name = f"wandb_sweep_source_{pathlib.Path(source).stem}"
     spec = importlib.util.spec_from_file_location(module_name, source)
     if spec is None or spec.loader is None:
@@ -2266,9 +2272,11 @@ def _build_optuna_scheduler(
     search_space_name = scheduler_config.get("search_space")
     source = scheduler_config.get("source", "")
 
-    # Exactly one of search_space / optimizer: the declarative space is built
-    # from the loaded function when given, otherwise the loaded function is
-    # itself the define-by-run trial constructor.
+    # `search_space` picks how the parameter space is defined: when given,
+    # the loaded function is the define-by-run trial constructor; otherwise
+    # a declarative parameter space is derived from the sweep's
+    # `parameters`. Independently, `optimizer` names a study factory to
+    # call instead of building the study from the config.
     search_space = None
     distributions = None
     if search_space_name is not None:
@@ -2351,7 +2359,7 @@ def sweep_scheduler(
     """Drive an existing sweep from a local, in-process scheduler.
 
     Create the sweep first with `wandb sweep sweep.yaml`; its config must set
-    `scheduler: {engine: wandb}` so the server leaves the search to
+    `scheduler: {engine: <wandb|optuna>}` so the server leaves the search to
     this scheduler. The scheduler proposes runs, enqueues them, and polls their
     results to drive the optimizer.
     """
@@ -2382,7 +2390,7 @@ def sweep_scheduler(
     if not engine:
         raise ClickException(
             "The sweep scheduler requires a sweep created with "
-            "'scheduler': {'engine': wandb} in its config."
+            "'scheduler': {'engine': <wandb|optuna>} in its config."
         )
     if engine == "wandb":
         scheduler = _build_wandb_scheduler(

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import getpass
+import importlib.util
 import json
 import logging
 import os
@@ -2208,6 +2209,94 @@ def scheduler(
         raise
 
 
+def _load_source_object(source: str, name: str) -> Any:
+    """Import the python file at `source` and return its `name` attribute.
+
+    Used to load a user-defined `search_space` or `optimizer` (trial
+    constructor) function referenced by name from a sweep's scheduler config.
+    """
+    module_name = f"wandb_sweep_source_{pathlib.Path(source).stem}"
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    if spec is None or spec.loader is None:
+        raise ClickException(f"Could not import source file: {source}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    try:
+        return getattr(module, name)
+    except AttributeError:
+        raise ClickException(f"{source} has no attribute {name!r}") from None
+
+
+def _build_optuna_scheduler(
+    sweep,
+    config: dict,
+    scheduler_config: dict,
+    poll_interval: float,
+    batch_size: int,
+):
+    """Build the scheduler for a sweep whose `scheduler.engine` is `optuna`."""
+    # Importing the module lazily surfaces a helpful error when optuna isn't
+    # installed, and keeps the wandb path free of that dependency.
+    from wandb.sdk.sweeps.scheduler import optuna as optuna_scheduler
+
+    optimizer_name = scheduler_config.get("optimizer", "")
+    search_space_name = scheduler_config.get("search_space")
+    source = scheduler_config.get("source", "")
+
+    # Exactly one of search_space / optimizer: the declarative space is built
+    # from the loaded function when given, otherwise the loaded function is
+    # itself the define-by-run trial constructor.
+    search_space = None
+    distributions = None
+    if search_space_name is not None:
+        search_space = _load_source_object(source, search_space_name)
+    else:
+        distributions = optuna_scheduler.search_space_from_sweep_config(
+            config.get("parameters", {})
+        )
+    if optimizer_name:
+        study_fn = _load_source_object(source, optimizer_name)
+        study = study_fn()
+    else:
+        study = optuna_scheduler.create_study_from_sweep_config(config)
+
+    return optuna_scheduler.resume_sweep(
+        sweep,
+        options=optuna_scheduler.OptunaOptions(
+            study=study,
+            distributions=distributions,
+            search_space=search_space,
+            poll_interval_s=poll_interval,
+            batch_size=batch_size,
+        ),
+    )
+
+
+def _build_wandb_scheduler(
+    sweep,
+    scheduler_config: dict,
+    poll_interval: float,
+    batch_size: int,
+):
+    search_space = scheduler_config.get("search_space")
+    optimizer = scheduler_config.get("optimizer")
+    if optimizer is not None:
+        wandb.termwarn("optimizer config is not supported by the sweep scheduler.")
+    if search_space is not None:
+        wandb.termwarn("search_space config is not supported by the sweep scheduler.")
+
+    from wandb.sdk.sweeps.scheduler import wandb as wandb_scheduler
+    from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
+
+    return wandb_scheduler.resume_sweep(
+        sweep,
+        options=SchedulerOptions(
+            poll_interval_s=poll_interval,
+            batch_size=batch_size,
+        ),
+    )
+
+
 @cli.command(
     name="sweep_scheduler",
     context_settings=CONTEXT,
@@ -2269,24 +2358,15 @@ def sweep_scheduler(
             "'scheduler': {'engine': <wandb|optuna|ax>} in its config."
         )
     if engine == "wandb":
-        search_space = scheduler_config.get("search_space")
-        optimizer = scheduler_config.get("optimizer")
-        if optimizer is not None:
-            wandb.termwarn("optimizer config is not supported by the sweep scheduler.")
-        if search_space is not None:
-            wandb.termwarn(
-                "search_space config is not supported by the sweep scheduler."
-            )
-
-        from wandb.sdk.sweeps.scheduler import wandb as wandb_scheduler
-        from wandb.sdk.sweeps.scheduler.scheduler import SchedulerOptions
-
-        scheduler = wandb_scheduler.resume_sweep(
+        scheduler = _build_wandb_scheduler(
             sweep,
-            options=SchedulerOptions(
-                poll_interval_s=poll_interval,
-                batch_size=batch_size,
-            ),
+            scheduler_config,
+            poll_interval,
+            batch_size,
+        )
+    elif engine == "optuna":
+        scheduler = _build_optuna_scheduler(
+            sweep, config, scheduler_config, poll_interval, batch_size
         )
     else:
         raise ClickException(f"Unsupported engine: {engine}")

--- a/wandb/sdk/sweeps/scheduler/optuna.py
+++ b/wandb/sdk/sweeps/scheduler/optuna.py
@@ -173,8 +173,9 @@ def sweep_parameter_to_distribution(
     Inverse of `distribution_to_sweep_parameter`. The mapping, by the spec's
     `distribution` name, is:
 
-    - `categorical` / `constant`, or a bare `value`/`values` spec with no
-      `distribution` key -> `CategoricalDistribution`
+    - `categorical` / `constant`; any spec with `value` (the constant
+      shorthand); or a bare `values` spec with no `distribution` key
+      -> `CategoricalDistribution`
     - `int_uniform` -> `IntDistribution(min, max)`
     - `uniform` -> `FloatDistribution(min, max)`
     - `log_uniform_values` -> `FloatDistribution(min, max, log=True)`
@@ -390,14 +391,24 @@ class OptunaOptimizer(Optimizer):
                 )
 
     def trial_state(self, state: RunState) -> optuna.trial.TrialState:
-        """Map a sweep `RunState` onto the optuna `TrialState` it stands for."""
-        if state in (RunState.RUNNING, RunState.PENDING):
+        """Map a sweep `RunState` onto the optuna `TrialState` it stands for.
+
+        Raises:
+            ValueError: If a new `RunState` member has no mapping here.
+        """
+        if state.is_alive:
+            # RUNNING/PENDING/PREEMPTING/UNKNOWN: still producing results.
             return optuna.trial.TrialState.RUNNING
         if state == RunState.FINISHED:
             return optuna.trial.TrialState.COMPLETE
-        if state in (RunState.FAILED, RunState.CRASHED, RunState.KILLED):
+        if state in (
+            RunState.FAILED,
+            RunState.CRASHED,
+            RunState.KILLED,
+            RunState.PREEMPTED,
+        ):
             return optuna.trial.TrialState.FAIL
-        raise ValueError(f"Unknown trial state: {state}")
+        raise ValueError(f"Unhandled run state: {state}")
 
     @override
     def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
@@ -436,13 +447,15 @@ class OptunaOptimizer(Optimizer):
         also handles the imperative conditional branch) return a trial fixed to
         them. The trial is left RUNNING — not told — so the loop reports its
         intermediate values for pruning and finalizes it via tell_run when the
-        run completes. Returns the trial number to track the run by.
+        run completes.
+
+        Returns:
+            The trial number to track the run by, or None if the study
+            produced no trial for the enqueued params.
         """
         self.study.enqueue_trial(data.config.flat_dict())
-        suggestions = list(self.ask_n_runs(1))
-        if not suggestions:
-            return None
-        return suggestions[0].run_id
+        runs = self.ask_n_runs(1)
+        return runs[0].run_id if runs else None
 
 
 class OptunaDeclarativeOptimizer(OptunaOptimizer):
@@ -641,7 +654,13 @@ def resume_sweep(
     `options.study` is required, and exactly one of `options.distributions`
     (define-and-run) or `options.search_space` (define-by-run) chooses how
     the study samples.
+
+    Raises:
+        ValueError: If `options.study` is missing or `sweep` is an empty
+            string.
     """
+    if isinstance(sweep, str) and not sweep:
+        raise ValueError("sweep path must be non-empty")
     resolved_sweep: Sweep = Api().sweep(sweep) if isinstance(sweep, str) else sweep
     options = options or OptunaOptions()
     if options.study is None:
@@ -664,10 +683,25 @@ def create_sweep(
 ) -> Scheduler:
     """Create a sweep from the study's search space, then attach a scheduler.
 
-    `options.study` is required. Pass exactly one of `options.distributions`
-    (define-and-run) or `options.search_space` (define-by-run); the latter's
-    search space is discovered by running it once to build the sweep.
+    Args:
+        entity: The entity to create the sweep under.
+        project: The project to create the sweep under.
+        metric_name: The metric runs must log; it becomes the sweep's
+            objective metric.
+        program_path: The training program recorded in the sweep config.
+        options: `options.study` is required. Pass exactly one of
+            `options.distributions` (define-and-run) or
+            `options.search_space` (define-by-run); the latter's parameter
+            space is discovered by running it once to build the sweep.
+
+    Raises:
+        ValueError: If `options.study` is missing, the parameter space is
+            given as neither or both of `options.distributions` and
+            `options.search_space`, or `entity`, `project` or
+            `metric_name` is empty.
     """
+    if not entity or not project or not metric_name:
+        raise ValueError("entity, project and metric_name must be non-empty")
     options = options or OptunaOptions()
     if options.study is None:
         raise ValueError("`options.study` is required")
@@ -697,7 +731,19 @@ def create_sweep_from_config(
     `options.distributions`/`options.search_space`. When `options.study` is
     `None`, a study is built from `config["metric"]` or `config["metrics"]`, so
     the caller only needs a sweep config.
+
+    Args:
+        config: The sweep config to create the sweep (and study) from.
+        entity: The entity to create the sweep under.
+        project: The project to create the sweep under.
+        options: Optional study/terminator overrides; the parameter-space
+            options are ignored as described above.
+
+    Raises:
+        ValueError: If `entity` or `project` is empty.
     """
+    if not entity or not project:
+        raise ValueError("entity and project must be non-empty")
     distributions = search_space_from_sweep_config(config.get("parameters", {}))
     options = options or OptunaOptions()
     study = options.study

--- a/wandb/sdk/sweeps/scheduler/optuna.py
+++ b/wandb/sdk/sweeps/scheduler/optuna.py
@@ -1,0 +1,715 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+from typing_extensions import override
+
+from wandb import Api, util
+from wandb import sweep as wandb_sweep
+from wandb.apis.public import Sweep
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
+    Optimizer,
+    Run,
+    RunConfig,
+    RunSuggestion,
+    RunWithMetrics,
+    is_terminal_state,
+)
+from wandb.sdk.sweeps.scheduler.scheduler import (
+    InMemoryScheduler,
+    Scheduler,
+    SchedulerOptions,
+)
+
+if TYPE_CHECKING:
+    # Only used for static type checking, so referencing optuna's types below
+    # doesn't force a real import at runtime for users who never touch this
+    # scheduler.
+    import optuna
+    import optuna.distributions
+    import optuna.trial
+else:
+    optuna = util.get_module(
+        "optuna",
+        required="wandb[optuna] is required to use the Optuna sweep scheduler. "
+        "Please run `pip install wandb[optuna]`.",
+    )
+
+TrialConstructor: TypeAlias = Callable[["optuna.Trial"], dict[str, Any]]
+TerminatorCallback: TypeAlias = Callable[["optuna.Study"], bool]
+
+
+@dataclass
+class OptunaOptions(SchedulerOptions):
+    """Scheduler and optuna settings for building or resuming a sweep.
+
+    `poll_interval_s`, `batch_size` and `executor` are inherited from
+    `SchedulerOptions`.
+
+    `study` is required by `resume_sweep`/`create_sweep`;
+    `create_sweep_from_config` builds one from the config's metric goal(s)
+    when left `None`, and always derives `distributions` from the config
+    itself, ignoring `distributions`/`search_space` here. Pass exactly one
+    of `distributions` (define-and-run) or `search_space` (define-by-run)
+    to choose how `study` samples.
+
+    `terminator` decides when the search itself is exhausted -- e.g.
+    wrapping optuna's or OptunaHub's `Terminator.should_terminate`, or any
+    custom stopping rule. It is the caller's own callback: nothing is
+    loaded or configured on their behalf. The default `None` never
+    terminates early.
+    """
+
+    study: optuna.Study | None = None
+    distributions: dict[str, optuna.distributions.BaseDistribution] | None = None
+    search_space: TrialConstructor | None = None
+    terminator: TerminatorCallback | None = None
+
+
+def distribution_to_sweep_parameter(
+    dist: optuna.distributions.BaseDistribution,
+) -> dict[str, Any]:
+    """Convert an optuna distribution into a W&B sweep parameter spec.
+
+    The returned dict is the value for one entry under a sweep config's
+    `parameters` block (e.g. `{"distribution": "uniform", "min": 0, "max": 1}`).
+
+    Inverse of `sweep_parameter_to_distribution`. The mapping is:
+
+    - `CategoricalDistribution(choices)` -> `{"values": choices}`
+    - `IntDistribution(log=True)` -> `q_log_uniform_values` with `q=step`
+      (W&B has no log-scale int distribution; this samples log-uniform in
+      value space and rounds to multiples of `q`)
+    - `IntDistribution(step != 1)` -> `q_uniform` with `q=step`
+    - `IntDistribution` otherwise -> `int_uniform`
+    - `FloatDistribution(log=True)` -> `log_uniform_values` (optuna forbids
+      `step` together with `log`, so there is no q-variant)
+    - `FloatDistribution(step is not None)` -> `q_uniform` with `q=step`
+    - `FloatDistribution` otherwise -> `uniform`
+
+    Numeric specs carry `min`/`max` from the distribution's `low`/`high`.
+    Any other distribution type raises `TypeError`.
+    """
+    distributions = optuna.distributions
+
+    if isinstance(dist, distributions.CategoricalDistribution):
+        # W&B infers a categorical parameter from a `values` list.
+        return {"values": list(dist.choices)}
+
+    if isinstance(dist, distributions.IntDistribution):
+        if dist.log:
+            # No native int-log in W&B; sample log-uniform in value space and
+            # round to multiples of `step` (defaults to 1).
+            return {
+                "distribution": "q_log_uniform_values",
+                "min": dist.low,
+                "max": dist.high,
+                "q": dist.step,
+            }
+        if dist.step != 1:
+            return {
+                "distribution": "q_uniform",
+                "min": dist.low,
+                "max": dist.high,
+                "q": dist.step,
+            }
+        return {"distribution": "int_uniform", "min": dist.low, "max": dist.high}
+
+    if isinstance(dist, distributions.FloatDistribution):
+        if dist.log:
+            # optuna disallows `step` together with `log`, so no q-variant here.
+            return {
+                "distribution": "log_uniform_values",
+                "min": dist.low,
+                "max": dist.high,
+            }
+        if dist.step is not None:
+            return {
+                "distribution": "q_uniform",
+                "min": dist.low,
+                "max": dist.high,
+                "q": dist.step,
+            }
+        return {"distribution": "uniform", "min": dist.low, "max": dist.high}
+
+    raise TypeError(
+        f"Cannot convert optuna distribution to a sweep parameter: "
+        f"{type(dist).__name__} is not supported."
+    )
+
+
+def _is_int(value: Any) -> bool:
+    # bool is a subclass of int but is never a numeric bound here.
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _infer_distribution_name(parameter: dict[str, Any]) -> str:
+    """Return the sweep distribution W&B infers when the spec names none."""
+    if "min" not in parameter or "max" not in parameter:
+        raise ValueError(
+            f"Cannot infer an optuna distribution from sweep parameter: {parameter!r}"
+        )
+    lo, hi = parameter["min"], parameter["max"]
+    return "int_uniform" if _is_int(lo) and _is_int(hi) else "uniform"
+
+
+def _categorical_distribution(
+    parameter: dict[str, Any],
+) -> optuna.distributions.BaseDistribution:
+    """Build a categorical distribution from `values` or a lone `value`."""
+    if "values" in parameter:
+        return optuna.distributions.CategoricalDistribution(list(parameter["values"]))
+    return optuna.distributions.CategoricalDistribution([parameter["value"]])
+
+
+def sweep_parameter_to_distribution(
+    parameter: dict[str, Any],
+) -> optuna.distributions.BaseDistribution:
+    """Convert a W&B sweep parameter spec into an optuna distribution.
+
+    Inverse of `distribution_to_sweep_parameter`. The mapping, by the spec's
+    `distribution` name, is:
+
+    - `categorical` / `constant`, or a bare `value`/`values` spec with no
+      `distribution` key -> `CategoricalDistribution`
+    - `int_uniform` -> `IntDistribution(min, max)`
+    - `uniform` -> `FloatDistribution(min, max)`
+    - `log_uniform_values` -> `FloatDistribution(min, max, log=True)`
+    - `q_uniform` -> `IntDistribution(min, max, step=q)` when `min`, `max`,
+      and `q` are all integers, else `FloatDistribution(min, max, step=q)`
+    - `q_log_uniform_values` -> `IntDistribution(min, max, log=True, step=q)`
+      (`q` defaults to 1)
+    - a numeric spec with no `distribution` key -> `int_uniform` or `uniform`,
+      inferred from the `min`/`max` types as W&B does
+
+    Sweep distributions with no optuna equivalent (e.g. `normal`, `beta`,
+    `inv_log_uniform`, and exponent-space `log_uniform`) raise `ValueError`.
+    """
+    distributions = optuna.distributions
+
+    # Constant / categorical shorthands: `distribution` is optional in W&B.
+    if (
+        "value" in parameter
+        or "values" in parameter
+        and "distribution" not in parameter
+    ):
+        return _categorical_distribution(parameter)
+
+    # Without an explicit distribution, W&B infers one from min/max.
+    dist = parameter.get("distribution") or _infer_distribution_name(parameter)
+
+    if dist in ("categorical", "constant"):
+        return _categorical_distribution(parameter)
+
+    if dist == "int_uniform":
+        return distributions.IntDistribution(parameter["min"], parameter["max"])
+
+    if dist == "uniform":
+        return distributions.FloatDistribution(parameter["min"], parameter["max"])
+
+    if dist == "log_uniform_values":
+        return distributions.FloatDistribution(
+            parameter["min"], parameter["max"], log=True
+        )
+
+    if dist == "q_uniform":
+        lo, hi, q = parameter["min"], parameter["max"], parameter["q"]
+        # q_uniform is produced from both Int and Float stepped distributions;
+        # pick the int variant only when every bound is integral.
+        if _is_int(lo) and _is_int(hi) and _is_int(q):
+            return distributions.IntDistribution(lo, hi, step=q)
+        return distributions.FloatDistribution(lo, hi, step=q)
+
+    if dist == "q_log_uniform_values":
+        # optuna forbids step+log on floats, so this maps to a log-scale int
+        # space.
+        return distributions.IntDistribution(
+            parameter["min"],
+            parameter["max"],
+            log=True,
+            step=int(parameter.get("q", 1)),
+        )
+
+    raise ValueError(
+        f"Sweep distribution {dist!r} has no optuna equivalent and cannot be converted."
+    )
+
+
+def search_space_from_sweep_config(
+    parameters: dict[str, Any],
+) -> dict[str, optuna.distributions.BaseDistribution]:
+    """Convert a sweep config's `parameters` block into an optuna search space.
+
+    Maps each `name -> spec` entry onto a `name -> distribution` entry.
+    """
+    return {
+        name: sweep_parameter_to_distribution(spec) for name, spec in parameters.items()
+    }
+
+
+def sweep_from_study(
+    study: optuna.Study,
+    search_space: dict[str, optuna.distributions.BaseDistribution],
+    entity: str,
+    project: str,
+    metric_name: str,
+    program_path: str | None = None,
+) -> Sweep:
+    """Create a W&B sweep mirroring an optuna study's space and direction.
+
+    The study's optimization direction is mapped onto the sweep metric's goal
+    (`minimize` / `maximize`); `metric_name` names the metric that runs log and
+    that the optimizer reads back when telling the study. `program_path`, if
+    given, sets the sweep's training program.
+    """
+    if len(study.directions) != 1:
+        raise ValueError(
+            "sweep_from_study only supports single-objective studies; "
+            f"got {len(study.directions)} objectives."
+        )
+
+    config: dict[str, Any] = {
+        "metric": {
+            "name": metric_name,
+            # StudyDirection.MINIMIZE/MAXIMIZE -> "minimize"/"maximize".
+            "goal": study.direction.name.lower(),
+        },
+        "parameters": {
+            name: distribution_to_sweep_parameter(dist)
+            for name, dist in search_space.items()
+        },
+        "scheduler": {
+            "engine": "optuna",
+        },
+    }
+    if program_path is not None:
+        config["program"] = program_path
+
+    sid = wandb_sweep(config, entity=entity, project=project)
+    return Api().sweep(f"{entity}/{project}/{sid}")
+
+
+class OptunaOptimizer(Optimizer):
+    """Base `Optimizer` driving a W&B sweep from an optuna study.
+
+    Subclasses supply the search space, either up front as distributions or by
+    running a define-by-run constructor.
+    """
+
+    @override
+    def __init__(
+        self,
+        study: optuna.Study,
+        sweep: Sweep,
+        terminator: TerminatorCallback | None = None,
+    ):
+        super().__init__(sweep)
+        self.study = study
+        # Live ask()'d trials kept by str(trial.number). The study only
+        # stores frozen trials, which lack report()/should_prune(), so we
+        # must hold the live ones to record intermediate values (and, next,
+        # drive pruning).
+        self.trials: dict[str, optuna.Trial] = {}
+        self._validate_matches_sweep()
+        self._terminator = terminator
+
+    @override
+    def should_terminate_sweep(self) -> bool:
+        """Return True once the caller's `terminator` says the search is done.
+
+        `terminator` is supplied via `OptunaOptions`; the default is `None`,
+        which never terminates early.
+        """
+        return self._terminator is not None and self._terminator(self.study)
+
+    def _validate_matches_sweep(self) -> None:
+        """Fail fast if the study and the sweep disagree on the objective.
+
+        The study's optimization direction(s) must match the sweep metric
+        goal(s), and — when the study declares metric names — its objective
+        names must match the sweep metric names. Otherwise the optimizer would
+        silently search the wrong way or against the wrong metric. The study
+        and sweep are supplied independently (e.g. via `resume_sweep` or a
+        user-provided study factory), so the two can drift; the sweep config is
+        the source of truth.
+        """
+        metrics = self._sweep.config.get("metrics")
+        if metrics is not None:
+            if len(self.study.directions) != len(metrics):
+                raise ValueError(
+                    f"Study has {len(self.study.directions)} objectives but the "
+                    f"sweep config declares {len(metrics)} metrics."
+                )
+            sweep_directions = [
+                str(metric.get("goal", "minimize")).lower() for metric in metrics
+            ]
+            study_directions = [d.name.lower() for d in self.study.directions]
+            if study_directions != sweep_directions:
+                raise ValueError(
+                    f"Study directions {study_directions!r} do not match the "
+                    f"sweep metric goals {sweep_directions!r}; create the study "
+                    f"with directions={sweep_directions!r}."
+                )
+            metric_names = getattr(self.study, "metric_names", None)
+            if metric_names:
+                sweep_names = [metric["name"] for metric in metrics if "name" in metric]
+                if sweep_names and list(metric_names) != sweep_names:
+                    raise ValueError(
+                        f"Study metric names {list(metric_names)!r} do not match "
+                        f"the sweep metric names {sweep_names!r}."
+                    )
+            return
+
+        if len(self.study.directions) != 1:
+            raise ValueError(
+                "OptunaOptimizer only supports single-objective studies; the "
+                f"study has {len(self.study.directions)} objectives."
+            )
+
+        metric = self._sweep.config.get("metric") or {}
+        goal = str(metric.get("goal", "minimize")).lower()
+        study_direction = self.study.direction.name.lower()
+        if study_direction != goal:
+            raise ValueError(
+                f"Study direction {study_direction!r} does not match the sweep "
+                f"metric goal {goal!r}; create the study with direction={goal!r}."
+            )
+
+        # optuna's objective names are optional metadata; validate only when
+        # set.
+        metric_names = getattr(self.study, "metric_names", None)
+        if metric_names:
+            metric_name = self.metric_key()
+            if metric_names[0] != metric_name:
+                raise ValueError(
+                    f"Study metric name {metric_names[0]!r} does not match the "
+                    f"sweep metric name {metric_name!r}."
+                )
+
+    def trial_state(self, state: RunState) -> optuna.trial.TrialState:
+        """Map a sweep `RunState` onto the optuna `TrialState` it stands for."""
+        if state in (RunState.RUNNING, RunState.PENDING):
+            return optuna.trial.TrialState.RUNNING
+        if state == RunState.FINISHED:
+            return optuna.trial.TrialState.COMPLETE
+        if state in (RunState.FAILED, RunState.CRASHED, RunState.KILLED):
+            return optuna.trial.TrialState.FAIL
+        raise ValueError(f"Unknown trial state: {state}")
+
+    @override
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
+        """Report a run's intermediate values and finalize it once terminal."""
+        # run_id is str(trial.number), set in ask_n_runs.
+        trial = self.trials[run_id]
+        for step, row in enumerate(data.history_metrics):
+            value = self.metric_value(row)
+            if value is not None:
+                trial.report(value, step=row.get("_step", step))
+
+        state = self.trial_state(data.state)
+        if state == optuna.trial.TrialState.COMPLETE:
+            self.study.tell(trial, self.metric_value(data.summary_metrics), state=state)
+        elif state == optuna.trial.TrialState.FAIL:
+            self.study.tell(trial, state=state)
+        # RUNNING: only intermediate values are reported; the trial is finalized
+        # later (on completion/failure) or by prune_run.
+
+    @override
+    def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
+        """Return True if the study's pruner says the run should stop early."""
+        # tell_run already reported this poll's intermediate values, so the
+        # study's pruner can decide. On a prune, finalize the trial as PRUNED.
+        trial = self.trials[run_id]
+        if not trial.should_prune():
+            return False
+        self.study.tell(trial, state=optuna.trial.TrialState.PRUNED)
+        return True
+
+    @override
+    def tell_existing_active_run(self, data: Run) -> Any:
+        """Adopt an in-flight run by recreating a live trial for its params.
+
+        Enqueuing the run's params makes the next ask() (via ask_n_runs, which
+        also handles the imperative conditional branch) return a trial fixed to
+        them. The trial is left RUNNING — not told — so the loop reports its
+        intermediate values for pruning and finalizes it via tell_run when the
+        run completes. Returns the trial number to track the run by.
+        """
+        self.study.enqueue_trial(data.config.flat_dict())
+        suggestions = list(self.ask_n_runs(1))
+        if not suggestions:
+            return None
+        return suggestions[0].run_id
+
+
+class OptunaDeclarativeOptimizer(OptunaOptimizer):
+    """Define-and-run: the space is supplied up front as distributions.
+
+    The distributions are known before any trial runs, so the sweep is built
+    directly from them and `ask_n_runs` samples by passing them to `study.ask`.
+    """
+
+    @override
+    def __init__(
+        self,
+        study: optuna.Study,
+        distributions: dict[str, optuna.distributions.BaseDistribution],
+        sweep: Sweep,
+        terminator: TerminatorCallback | None = None,
+    ):
+        self.distributions = distributions
+        super().__init__(study, sweep, terminator)
+
+    @override
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        """Sample `n` trials from the declared distributions."""
+        suggestions = []
+        for _ in range(n):
+            trial = self.study.ask(self.distributions)
+            self.trials[str(trial.number)] = trial
+            suggestions.append(
+                RunSuggestion(
+                    config=RunConfig.from_values(trial.params),
+                    run_id=str(trial.number),
+                )
+            )
+        return suggestions
+
+    @override
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        """Warm-start the study by recording a run as a historical trial.
+
+        The flat search space is known up front, so add_trial() is the lightest
+        faithful path — no extra ask(). Runs whose config doesn't cover the
+        search space are skipped (create_trial requires an exact param match).
+        """
+        if not is_terminal_state(data.state):
+            return
+        trial_state = self.trial_state(data.state)  # COMPLETE or FAIL
+        value = None
+        if trial_state == optuna.trial.TrialState.COMPLETE:
+            value = self.metric_value(data.summary_metrics)
+            if value is None:
+                return  # finished but never logged the objective metric
+        config = data.config.flat_dict()
+        if not all(name in config for name in self.distributions):
+            return
+        params = {name: config[name] for name in self.distributions}
+        self.study.add_trial(
+            optuna.trial.create_trial(
+                params=params,
+                distributions=self.distributions,
+                value=value,
+                state=trial_state,
+            )
+        )
+
+
+class OptunaImperativeOptimizer(OptunaOptimizer):
+    """Define-by-run: the space is discovered by a TrialConstructor.
+
+    The constructor's `trial.suggest_*` calls implicitly define the space. We
+    run it once against a throwaway trial to record the distributions, build the
+    sweep from them, then re-run it for real suggestions in `ask_n_runs`.
+    """
+
+    @override
+    def __init__(
+        self,
+        study: optuna.Study,
+        trial_constructor: TrialConstructor,
+        sweep: Sweep,
+        terminator: TerminatorCallback | None = None,
+    ):
+        self.trial_constructor = trial_constructor
+        super().__init__(study, sweep, terminator)
+
+    @override
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        """Sample `n` trials, running the constructor on each."""
+        suggestions = []
+        for _ in range(n):
+            trial = self.study.ask()
+            # A define-by-run constructor returns the flat {param: value}
+            # mapping.
+            params = self.trial_constructor(trial)
+            self.trials[str(trial.number)] = trial
+            # run_id is str(trial.number), so tell_run can look up the trial.
+            suggestions.append(
+                RunSuggestion(
+                    config=RunConfig.from_values(params), run_id=str(trial.number)
+                )
+            )
+        return suggestions
+
+    @override
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        """Warm-start the study by replaying a run through the constructor.
+
+        Enqueuing the run's params makes the next ask() take the same (possibly
+        conditional) branch, so the recreated trial's distributions match the
+        run; tell_run then finalizes it on the study.
+        """
+        if not is_terminal_state(data.state):
+            return
+        # A finished run with no objective value would make tell_run pass None
+        # to a COMPLETE study.tell(), so skip it.
+        if (
+            data.state == RunState.FINISHED
+            and self.metric_value(data.summary_metrics) is None
+        ):
+            return
+        self.study.enqueue_trial(data.config.flat_dict(), skip_if_exists=True)
+        suggestions = list(self.ask_n_runs(1))
+        if not suggestions:
+            return
+        self.tell_run(suggestions[0].run_id, data)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points.
+#
+# These free functions are the supported way to build a scheduler; callers
+# should not instantiate the optimizer classes directly. Each returns a
+# Scheduler whose `.loop()` drives the sweep. The flavor (define-and-run
+# vs define-by-run) is chosen by which of `distributions` or `search_space`
+# is supplied.
+# ---------------------------------------------------------------------------
+
+
+def create_study_from_sweep_config(config: dict[str, Any]) -> optuna.Study:
+    """Build an optuna study from a sweep config's metric objective(s).
+
+    When `config["metrics"]` is set, a multi-objective study is created with
+    `directions=` derived from each entry's `goal` (default `"minimize"`).
+    Otherwise a single-objective study is created from
+    `config["metric"]["goal"]`.
+    """
+    metrics = config.get("metrics")
+    if metrics is not None:
+        directions = [str(metric.get("goal", "minimize")).lower() for metric in metrics]
+        return optuna.create_study(directions=directions)
+    goal = (config.get("metric") or {}).get("goal", "minimize")
+    return optuna.create_study(direction=goal)
+
+
+def _spy_search_space(
+    study: optuna.Study,
+    trial_constructor: TrialConstructor,
+) -> dict[str, optuna.distributions.BaseDistribution]:
+    """Discover an imperative search space by spying on a throwaway trial.
+
+    The constructor is run against that trial and the distributions its
+    `suggest_*` calls registered are read back.
+
+    A separate in-memory study is used so the real study isn't polluted with the
+    spy trial; we only need `Trial.distributions`, not the sampled values. Note
+    a single spy trial only captures the branch taken for a conditional space.
+    """
+    spy_study = optuna.create_study(directions=study.directions)
+    spy_trial = spy_study.ask()
+    trial_constructor(spy_trial)
+    return spy_trial.distributions
+
+
+def _make_optimizer(
+    study: optuna.Study, sweep: Sweep, options: OptunaOptions
+) -> OptunaOptimizer:
+    if (options.distributions is None) == (options.search_space is None):
+        raise ValueError("provide exactly one of `distributions` or `search_space`")
+    if options.distributions is not None:
+        return OptunaDeclarativeOptimizer(
+            study, options.distributions, sweep, options.terminator
+        )
+    assert options.search_space is not None  # guaranteed by the check above
+    return OptunaImperativeOptimizer(
+        study, options.search_space, sweep, options.terminator
+    )
+
+
+def resume_sweep(
+    sweep: Sweep | str,
+    *,
+    options: OptunaOptions | None = None,
+) -> Scheduler:
+    """Attach a scheduler to a sweep that already exists.
+
+    `sweep` may be a `Sweep` or an "entity/project/sweep_id" path string.
+    `options.study` is required, and exactly one of `options.distributions`
+    (define-and-run) or `options.search_space` (define-by-run) chooses how
+    the study samples.
+    """
+    resolved_sweep: Sweep = Api().sweep(sweep) if isinstance(sweep, str) else sweep
+    options = options or OptunaOptions()
+    if options.study is None:
+        raise ValueError("`options.study` is required")
+    built_optimizer = _make_optimizer(options.study, resolved_sweep, options)
+    return InMemoryScheduler(
+        built_optimizer,
+        resolved_sweep,
+        options,
+    )
+
+
+def create_sweep(
+    entity: str,
+    project: str,
+    metric_name: str,
+    *,
+    program_path: str | None = None,
+    options: OptunaOptions | None = None,
+) -> Scheduler:
+    """Create a sweep from the study's search space, then attach a scheduler.
+
+    `options.study` is required. Pass exactly one of `options.distributions`
+    (define-and-run) or `options.search_space` (define-by-run); the latter's
+    search space is discovered by running it once to build the sweep.
+    """
+    options = options or OptunaOptions()
+    if options.study is None:
+        raise ValueError("`options.study` is required")
+    if (options.distributions is None) == (options.search_space is None):
+        raise ValueError("provide exactly one of `distributions` or `search_space`")
+    if options.distributions is not None:
+        resolved_space = options.distributions
+    else:
+        assert options.search_space is not None  # guaranteed by the check above
+        resolved_space = _spy_search_space(options.study, options.search_space)
+    sweep = sweep_from_study(
+        options.study, resolved_space, entity, project, metric_name, program_path
+    )
+    return resume_sweep(sweep, options=options)
+
+
+def create_sweep_from_config(
+    config: dict[str, Any],
+    entity: str,
+    project: str,
+    *,
+    options: OptunaOptions | None = None,
+) -> Scheduler:
+    """Create the study, the sweep and a scheduler from a sweep config alone.
+
+    The search space is derived from `config["parameters"]`, ignoring
+    `options.distributions`/`options.search_space`. When `options.study` is
+    `None`, a study is built from `config["metric"]` or `config["metrics"]`, so
+    the caller only needs a sweep config.
+    """
+    distributions = search_space_from_sweep_config(config.get("parameters", {}))
+    options = options or OptunaOptions()
+    study = options.study
+    if study is None:
+        study = create_study_from_sweep_config(config)
+    sweep_id = wandb_sweep(config, entity=entity, project=project)
+    sweep = Api().sweep(f"{entity}/{project}/{sweep_id}")
+    optimizer = OptunaDeclarativeOptimizer(
+        study, distributions, sweep, options.terminator
+    )
+    return InMemoryScheduler(
+        optimizer,
+        sweep,
+        options,
+    )

--- a/wandb/sdk/sweeps/scheduler/optuna.py
+++ b/wandb/sdk/sweeps/scheduler/optuna.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+from wandb import Api, util
+from wandb import sweep as wandb_sweep
+from wandb.apis.public import Sweep
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
+    Optimizer,
+    Run,
+    RunConfig,
+    RunSuggestion,
+    RunWithMetrics,
+    is_terminal_state,
+)
+from wandb.sdk.sweeps.scheduler.scheduler import (
+    InMemoryScheduler,
+    Scheduler,
+    SchedulerOptions,
+)
+
+if TYPE_CHECKING:
+    # Only used for static type checking, so referencing optuna's types below
+    # doesn't force a real import at runtime for users who never touch this
+    # scheduler.
+    import optuna
+    import optuna.distributions
+    import optuna.trial
+else:
+    optuna = util.get_module(
+        "optuna",
+        required="wandb[optuna] is required to use the Optuna sweep scheduler. "
+        "Please run `pip install wandb[optuna]`.",
+    )
+
+TrialConstructor: TypeAlias = Callable[["optuna.Trial"], dict[str, Any]]
+TerminatorCallback: TypeAlias = Callable[["optuna.Study"], bool]
+
+
+@dataclass
+class OptunaOptions(SchedulerOptions):
+    """Scheduler and optuna settings for building or resuming a sweep.
+
+    `poll_interval_s`, `batch_size` and `executor` are inherited from
+    `SchedulerOptions`.
+
+    `study` is required by `resume_sweep`/`create_sweep`;
+    `create_sweep_from_config` builds one from the config's metric goal(s)
+    when left `None`, and always derives `distributions` from the config
+    itself, ignoring `distributions`/`search_space` here. Pass exactly one
+    of `distributions` (define-and-run) or `search_space` (define-by-run)
+    to choose how `study` samples.
+
+    `terminator` decides when the search itself is exhausted -- e.g.
+    wrapping optuna's or OptunaHub's `Terminator.should_terminate`, or any
+    custom stopping rule. It is the caller's own callback: nothing is
+    loaded or configured on their behalf. The default `None` never
+    terminates early.
+    """
+
+    study: optuna.Study | None = None
+    distributions: dict[str, optuna.distributions.BaseDistribution] | None = None
+    search_space: TrialConstructor | None = None
+    terminator: TerminatorCallback | None = None
+
+
+def distribution_to_sweep_parameter(
+    dist: optuna.distributions.BaseDistribution,
+) -> dict[str, Any]:
+    """Convert an optuna distribution into a W&B sweep parameter spec.
+
+    The returned dict is the value for one entry under a sweep config's
+    `parameters` block (e.g. `{"distribution": "uniform", "min": 0, "max": 1}`).
+    """
+    distributions = optuna.distributions
+
+    if isinstance(dist, distributions.CategoricalDistribution):
+        # W&B infers a categorical parameter from a `values` list.
+        return {"values": list(dist.choices)}
+
+    if isinstance(dist, distributions.IntDistribution):
+        if dist.log:
+            # No native int-log in W&B; sample log-uniform in value space and
+            # round to multiples of `step` (defaults to 1).
+            return {
+                "distribution": "q_log_uniform_values",
+                "min": dist.low,
+                "max": dist.high,
+                "q": dist.step,
+            }
+        if dist.step != 1:
+            return {
+                "distribution": "q_uniform",
+                "min": dist.low,
+                "max": dist.high,
+                "q": dist.step,
+            }
+        return {"distribution": "int_uniform", "min": dist.low, "max": dist.high}
+
+    if isinstance(dist, distributions.FloatDistribution):
+        if dist.log:
+            # optuna disallows `step` together with `log`, so no q-variant here.
+            return {
+                "distribution": "log_uniform_values",
+                "min": dist.low,
+                "max": dist.high,
+            }
+        if dist.step is not None:
+            return {
+                "distribution": "q_uniform",
+                "min": dist.low,
+                "max": dist.high,
+                "q": dist.step,
+            }
+        return {"distribution": "uniform", "min": dist.low, "max": dist.high}
+
+    raise TypeError(
+        f"Cannot convert optuna distribution to a sweep parameter: "
+        f"{type(dist).__name__} is not supported."
+    )
+
+
+def _is_int(value: Any) -> bool:
+    # bool is a subclass of int but is never a numeric bound here.
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _infer_distribution_name(parameter: dict[str, Any]) -> str:
+    """Return the sweep distribution W&B infers when the spec names none."""
+    if "min" not in parameter or "max" not in parameter:
+        raise ValueError(
+            f"Cannot infer an optuna distribution from sweep parameter: {parameter!r}"
+        )
+    lo, hi = parameter["min"], parameter["max"]
+    return "int_uniform" if _is_int(lo) and _is_int(hi) else "uniform"
+
+
+def _categorical_distribution(
+    parameter: dict[str, Any],
+) -> optuna.distributions.BaseDistribution:
+    """Build a categorical distribution from `values` or a lone `value`."""
+    if "values" in parameter:
+        return optuna.distributions.CategoricalDistribution(list(parameter["values"]))
+    return optuna.distributions.CategoricalDistribution([parameter["value"]])
+
+
+def sweep_parameter_to_distribution(
+    parameter: dict[str, Any],
+) -> optuna.distributions.BaseDistribution:
+    """Convert a W&B sweep parameter spec into an optuna distribution.
+
+    Inverse of `distribution_to_sweep_parameter`. optuna only models float, int
+    and categorical spaces, so sweep distributions without an optuna equivalent
+    (normal, beta, inv_log_uniform, exponent-space log_uniform, ...) raise
+    ValueError.
+    """
+    distributions = optuna.distributions
+
+    # Constant / categorical shorthands: `distribution` is optional in W&B.
+    if (
+        "value" in parameter
+        or "values" in parameter
+        and "distribution" not in parameter
+    ):
+        return _categorical_distribution(parameter)
+
+    # Without an explicit distribution, W&B infers one from min/max.
+    dist = parameter.get("distribution") or _infer_distribution_name(parameter)
+
+    if dist in ("categorical", "constant"):
+        return _categorical_distribution(parameter)
+
+    if dist == "int_uniform":
+        return distributions.IntDistribution(parameter["min"], parameter["max"])
+
+    if dist == "uniform":
+        return distributions.FloatDistribution(parameter["min"], parameter["max"])
+
+    if dist == "log_uniform_values":
+        return distributions.FloatDistribution(
+            parameter["min"], parameter["max"], log=True
+        )
+
+    if dist == "q_uniform":
+        lo, hi, q = parameter["min"], parameter["max"], parameter["q"]
+        # q_uniform is produced from both Int and Float stepped distributions;
+        # pick the int variant only when every bound is integral.
+        if _is_int(lo) and _is_int(hi) and _is_int(q):
+            return distributions.IntDistribution(lo, hi, step=q)
+        return distributions.FloatDistribution(lo, hi, step=q)
+
+    if dist == "q_log_uniform_values":
+        # optuna forbids step+log on floats, so this maps to a log-scale int
+        # space.
+        return distributions.IntDistribution(
+            parameter["min"],
+            parameter["max"],
+            log=True,
+            step=int(parameter.get("q", 1)),
+        )
+
+    raise ValueError(
+        f"Sweep distribution {dist!r} has no optuna equivalent and cannot be converted."
+    )
+
+
+def search_space_from_sweep_config(
+    parameters: dict[str, Any],
+) -> dict[str, optuna.distributions.BaseDistribution]:
+    """Convert a sweep config's `parameters` block into an optuna search space.
+
+    Maps each `name -> spec` entry onto a `name -> distribution` entry.
+    """
+    return {
+        name: sweep_parameter_to_distribution(spec) for name, spec in parameters.items()
+    }
+
+
+def sweep_from_study(
+    study: optuna.Study,
+    search_space: dict[str, optuna.distributions.BaseDistribution],
+    entity: str,
+    project: str,
+    metric_name: str,
+    program_path: str | None = None,
+) -> Sweep:
+    """Create a W&B sweep mirroring an optuna study's space and direction.
+
+    The study's optimization direction is mapped onto the sweep metric's goal
+    (`minimize` / `maximize`); `metric_name` names the metric that runs log and
+    that the optimizer reads back when telling the study. `program_path`, if
+    given, sets the sweep's training program.
+    """
+    if len(study.directions) != 1:
+        raise ValueError(
+            "sweep_from_study only supports single-objective studies; "
+            f"got {len(study.directions)} objectives."
+        )
+
+    config: dict[str, Any] = {
+        "metric": {
+            "name": metric_name,
+            # StudyDirection.MINIMIZE/MAXIMIZE -> "minimize"/"maximize".
+            "goal": study.direction.name.lower(),
+        },
+        "parameters": {
+            name: distribution_to_sweep_parameter(dist)
+            for name, dist in search_space.items()
+        },
+        "scheduler": {
+            "engine": "optuna",
+        },
+    }
+    if program_path is not None:
+        config["program"] = program_path
+
+    sid = wandb_sweep(config, entity=entity, project=project)
+    return Api().sweep(f"{entity}/{project}/{sid}")
+
+
+class OptunaOptimizer(Optimizer):
+    """Base `Optimizer` driving a W&B sweep from an optuna study.
+
+    Subclasses supply the search space, either up front as distributions or by
+    running a define-by-run constructor.
+    """
+
+    def __init__(
+        self,
+        study: optuna.Study,
+        sweep: Sweep,
+        terminator: TerminatorCallback | None = None,
+    ):
+        super().__init__(sweep)
+        self.study = study
+        # Live ask()'d trials kept by str(trial.number). The study only
+        # stores frozen trials, which lack report()/should_prune(), so we
+        # must hold the live ones to record intermediate values (and, next,
+        # drive pruning).
+        self.trials: dict[str, optuna.Trial] = {}
+        self._validate_matches_sweep()
+        self._terminator = terminator
+
+    def should_terminate_sweep(self) -> bool:
+        """Return True once the caller's `terminator` says the search is done.
+
+        `terminator` is supplied via `OptunaOptions`; the default is `None`,
+        which never terminates early.
+        """
+        return self._terminator is not None and self._terminator(self.study)
+
+    def _validate_matches_sweep(self) -> None:
+        """Fail fast if the study and the sweep disagree on the objective.
+
+        The study's optimization direction(s) must match the sweep metric
+        goal(s), and — when the study declares metric names — its objective
+        names must match the sweep metric names. Otherwise the optimizer would
+        silently search the wrong way or against the wrong metric. The study
+        and sweep are supplied independently (e.g. via `resume_sweep` or a
+        user-provided study factory), so the two can drift; the sweep config is
+        the source of truth.
+        """
+        metrics = self._sweep.config.get("metrics")
+        if metrics is not None:
+            if len(self.study.directions) != len(metrics):
+                raise ValueError(
+                    f"Study has {len(self.study.directions)} objectives but the "
+                    f"sweep config declares {len(metrics)} metrics."
+                )
+            sweep_directions = [
+                str(metric.get("goal", "minimize")).lower() for metric in metrics
+            ]
+            study_directions = [d.name.lower() for d in self.study.directions]
+            if study_directions != sweep_directions:
+                raise ValueError(
+                    f"Study directions {study_directions!r} do not match the "
+                    f"sweep metric goals {sweep_directions!r}; create the study "
+                    f"with directions={sweep_directions!r}."
+                )
+            metric_names = getattr(self.study, "metric_names", None)
+            if metric_names:
+                sweep_names = [metric["name"] for metric in metrics if "name" in metric]
+                if sweep_names and list(metric_names) != sweep_names:
+                    raise ValueError(
+                        f"Study metric names {list(metric_names)!r} do not match "
+                        f"the sweep metric names {sweep_names!r}."
+                    )
+            return
+
+        if len(self.study.directions) != 1:
+            raise ValueError(
+                "OptunaOptimizer only supports single-objective studies; the "
+                f"study has {len(self.study.directions)} objectives."
+            )
+
+        metric = self._sweep.config.get("metric") or {}
+        goal = str(metric.get("goal", "minimize")).lower()
+        study_direction = self.study.direction.name.lower()
+        if study_direction != goal:
+            raise ValueError(
+                f"Study direction {study_direction!r} does not match the sweep "
+                f"metric goal {goal!r}; create the study with direction={goal!r}."
+            )
+
+        # optuna's objective names are optional metadata; validate only when
+        # set.
+        metric_names = getattr(self.study, "metric_names", None)
+        if metric_names:
+            metric_name = self.metric_key()
+            if metric_names[0] != metric_name:
+                raise ValueError(
+                    f"Study metric name {metric_names[0]!r} does not match the "
+                    f"sweep metric name {metric_name!r}."
+                )
+
+    def trial_state(self, state: RunState) -> optuna.trial.TrialState:
+        """Map a sweep `RunState` onto the optuna `TrialState` it stands for."""
+        if state in (RunState.RUNNING, RunState.PENDING):
+            return optuna.trial.TrialState.RUNNING
+        if state == RunState.FINISHED:
+            return optuna.trial.TrialState.COMPLETE
+        if state in (RunState.FAILED, RunState.CRASHED, RunState.KILLED):
+            return optuna.trial.TrialState.FAIL
+        raise ValueError(f"Unknown trial state: {state}")
+
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
+        """Report a run's intermediate values and finalize it once terminal."""
+        # run_id is str(trial.number), set in ask_n_runs.
+        trial = self.trials[run_id]
+        for step, row in enumerate(data.history_metrics):
+            value = self.metric_value(row)
+            if value is not None:
+                trial.report(value, step=row.get("_step", step))
+
+        state = self.trial_state(data.state)
+        if state == optuna.trial.TrialState.COMPLETE:
+            self.study.tell(trial, self.metric_value(data.summary_metrics), state=state)
+        elif state == optuna.trial.TrialState.FAIL:
+            self.study.tell(trial, state=state)
+        # RUNNING: only intermediate values are reported; the trial is finalized
+        # later (on completion/failure) or by prune_run.
+
+    def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
+        """Return True if the study's pruner says the run should stop early."""
+        # tell_run already reported this poll's intermediate values, so the
+        # study's pruner can decide. On a prune, finalize the trial as PRUNED.
+        trial = self.trials[run_id]
+        if not trial.should_prune():
+            return False
+        self.study.tell(trial, state=optuna.trial.TrialState.PRUNED)
+        return True
+
+    def tell_existing_active_run(self, data: Run) -> Any:
+        """Adopt an in-flight run by recreating a live trial for its params.
+
+        Enqueuing the run's params makes the next ask() (via ask_n_runs, which
+        also handles the imperative conditional branch) return a trial fixed to
+        them. The trial is left RUNNING — not told — so the loop reports its
+        intermediate values for pruning and finalizes it via tell_run when the
+        run completes. Returns the trial number to track the run by.
+        """
+        self.study.enqueue_trial(data.config.flat_dict())
+        suggestions = list(self.ask_n_runs(1))
+        if not suggestions:
+            return None
+        return suggestions[0].run_id
+
+
+class OptunaDeclarativeOptimizer(OptunaOptimizer):
+    """Define-and-run: the space is supplied up front as distributions.
+
+    The distributions are known before any trial runs, so the sweep is built
+    directly from them and `ask_n_runs` samples by passing them to `study.ask`.
+    """
+
+    def __init__(
+        self,
+        study: optuna.Study,
+        distributions: dict[str, optuna.distributions.BaseDistribution],
+        sweep: Sweep,
+        terminator: TerminatorCallback | None = None,
+    ):
+        self.distributions = distributions
+        super().__init__(study, sweep, terminator)
+
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        """Sample `n` trials from the declared distributions."""
+        suggestions = []
+        for _ in range(n):
+            trial = self.study.ask(self.distributions)
+            self.trials[str(trial.number)] = trial
+            suggestions.append(
+                RunSuggestion(
+                    config=RunConfig.from_values(trial.params),
+                    run_id=str(trial.number),
+                )
+            )
+        return suggestions
+
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        """Warm-start the study by recording a run as a historical trial.
+
+        The flat search space is known up front, so add_trial() is the lightest
+        faithful path — no extra ask(). Runs whose config doesn't cover the
+        search space are skipped (create_trial requires an exact param match).
+        """
+        if not is_terminal_state(data.state):
+            return
+        trial_state = self.trial_state(data.state)  # COMPLETE or FAIL
+        value = None
+        if trial_state == optuna.trial.TrialState.COMPLETE:
+            value = self.metric_value(data.summary_metrics)
+            if value is None:
+                return  # finished but never logged the objective metric
+        config = data.config.flat_dict()
+        if not all(name in config for name in self.distributions):
+            return
+        params = {name: config[name] for name in self.distributions}
+        self.study.add_trial(
+            optuna.trial.create_trial(
+                params=params,
+                distributions=self.distributions,
+                value=value,
+                state=trial_state,
+            )
+        )
+
+
+class OptunaImperativeOptimizer(OptunaOptimizer):
+    """Define-by-run: the space is discovered by a TrialConstructor.
+
+    The constructor's `trial.suggest_*` calls implicitly define the space. We
+    run it once against a throwaway trial to record the distributions, build the
+    sweep from them, then re-run it for real suggestions in `ask_n_runs`.
+    """
+
+    def __init__(
+        self,
+        study: optuna.Study,
+        trial_constructor: TrialConstructor,
+        sweep: Sweep,
+        terminator: TerminatorCallback | None = None,
+    ):
+        self.trial_constructor = trial_constructor
+        super().__init__(study, sweep, terminator)
+
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        """Sample `n` trials, running the constructor on each."""
+        suggestions = []
+        for _ in range(n):
+            trial = self.study.ask()
+            # A define-by-run constructor returns the flat {param: value}
+            # mapping.
+            params = self.trial_constructor(trial)
+            self.trials[str(trial.number)] = trial
+            # run_id is str(trial.number), so tell_run can look up the trial.
+            suggestions.append(
+                RunSuggestion(
+                    config=RunConfig.from_values(params), run_id=str(trial.number)
+                )
+            )
+        return suggestions
+
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        """Warm-start the study by replaying a run through the constructor.
+
+        Enqueuing the run's params makes the next ask() take the same (possibly
+        conditional) branch, so the recreated trial's distributions match the
+        run; tell_run then finalizes it on the study.
+        """
+        if not is_terminal_state(data.state):
+            return
+        # A finished run with no objective value would make tell_run pass None
+        # to a COMPLETE study.tell(), so skip it.
+        if (
+            data.state == RunState.FINISHED
+            and self.metric_value(data.summary_metrics) is None
+        ):
+            return
+        self.study.enqueue_trial(data.config.flat_dict(), skip_if_exists=True)
+        suggestions = list(self.ask_n_runs(1))
+        if not suggestions:
+            return
+        self.tell_run(suggestions[0].run_id, data)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points.
+#
+# These free functions are the supported way to build a scheduler; callers
+# should not instantiate the optimizer classes directly. Each returns a
+# Scheduler whose `.loop()` drives the sweep. The flavor (define-and-run
+# vs define-by-run) is chosen by which of `distributions` or `search_space`
+# is supplied.
+# ---------------------------------------------------------------------------
+
+
+def create_study_from_sweep_config(config: dict[str, Any]) -> optuna.Study:
+    """Build an optuna study from a sweep config's metric objective(s).
+
+    When `config["metrics"]` is set, a multi-objective study is created with
+    `directions=` derived from each entry's `goal` (default `"minimize"`).
+    Otherwise a single-objective study is created from
+    `config["metric"]["goal"]`.
+    """
+    metrics = config.get("metrics")
+    if metrics is not None:
+        directions = [str(metric.get("goal", "minimize")).lower() for metric in metrics]
+        return optuna.create_study(directions=directions)
+    goal = (config.get("metric") or {}).get("goal", "minimize")
+    return optuna.create_study(direction=goal)
+
+
+def _spy_search_space(
+    study: optuna.Study,
+    trial_constructor: TrialConstructor,
+) -> dict[str, optuna.distributions.BaseDistribution]:
+    """Discover an imperative search space by spying on a throwaway trial.
+
+    The constructor is run against that trial and the distributions its
+    `suggest_*` calls registered are read back.
+
+    A separate in-memory study is used so the real study isn't polluted with the
+    spy trial; we only need `Trial.distributions`, not the sampled values. Note
+    a single spy trial only captures the branch taken for a conditional space.
+    """
+    spy_study = optuna.create_study(directions=study.directions)
+    spy_trial = spy_study.ask()
+    trial_constructor(spy_trial)
+    return spy_trial.distributions
+
+
+def _make_optimizer(
+    study: optuna.Study, sweep: Sweep, options: OptunaOptions
+) -> OptunaOptimizer:
+    if (options.distributions is None) == (options.search_space is None):
+        raise ValueError("provide exactly one of `distributions` or `search_space`")
+    if options.distributions is not None:
+        return OptunaDeclarativeOptimizer(
+            study, options.distributions, sweep, options.terminator
+        )
+    assert options.search_space is not None  # guaranteed by the check above
+    return OptunaImperativeOptimizer(
+        study, options.search_space, sweep, options.terminator
+    )
+
+
+def resume_sweep(
+    sweep: Sweep | str,
+    *,
+    options: OptunaOptions | None = None,
+) -> Scheduler:
+    """Attach a scheduler to a sweep that already exists.
+
+    `sweep` may be a `Sweep` or an "entity/project/sweep_id" path string.
+    `options.study` is required, and exactly one of `options.distributions`
+    (define-and-run) or `options.search_space` (define-by-run) chooses how
+    the study samples.
+    """
+    resolved_sweep: Sweep = Api().sweep(sweep) if isinstance(sweep, str) else sweep
+    options = options or OptunaOptions()
+    if options.study is None:
+        raise ValueError("`options.study` is required")
+    built_optimizer = _make_optimizer(options.study, resolved_sweep, options)
+    return InMemoryScheduler(
+        built_optimizer,
+        resolved_sweep,
+        options,
+    )
+
+
+def create_sweep(
+    entity: str,
+    project: str,
+    metric_name: str,
+    *,
+    program_path: str | None = None,
+    options: OptunaOptions | None = None,
+) -> Scheduler:
+    """Create a sweep from the study's search space, then attach a scheduler.
+
+    `options.study` is required. Pass exactly one of `options.distributions`
+    (define-and-run) or `options.search_space` (define-by-run); the latter's
+    search space is discovered by running it once to build the sweep.
+    """
+    options = options or OptunaOptions()
+    if options.study is None:
+        raise ValueError("`options.study` is required")
+    if (options.distributions is None) == (options.search_space is None):
+        raise ValueError("provide exactly one of `distributions` or `search_space`")
+    if options.distributions is not None:
+        resolved_space = options.distributions
+    else:
+        assert options.search_space is not None  # guaranteed by the check above
+        resolved_space = _spy_search_space(options.study, options.search_space)
+    sweep = sweep_from_study(
+        options.study, resolved_space, entity, project, metric_name, program_path
+    )
+    return resume_sweep(sweep, options=options)
+
+
+def create_sweep_from_config(
+    config: dict[str, Any],
+    entity: str,
+    project: str,
+    *,
+    options: OptunaOptions | None = None,
+) -> Scheduler:
+    """Create the study, the sweep and a scheduler from a sweep config alone.
+
+    The search space is derived from `config["parameters"]`, ignoring
+    `options.distributions`/`options.search_space`. When `options.study` is
+    `None`, a study is built from `config["metric"]` or `config["metrics"]`, so
+    the caller only needs a sweep config.
+    """
+    distributions = search_space_from_sweep_config(config.get("parameters", {}))
+    options = options or OptunaOptions()
+    study = options.study
+    if study is None:
+        study = create_study_from_sweep_config(config)
+    sweep_id = wandb_sweep(config, entity=entity, project=project)
+    sweep = Api().sweep(f"{entity}/{project}/{sweep_id}")
+    optimizer = OptunaDeclarativeOptimizer(
+        study, distributions, sweep, options.terminator
+    )
+    return InMemoryScheduler(
+        optimizer,
+        sweep,
+        options,
+    )

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -151,7 +151,7 @@ class WandbOptimizer(Optimizer):
 
         Args:
             run_ids: Optimizer run ids to consider for pruning.
-            runs: Corresponding run metrics from the scheduler's latest poll.
+            runs: Corresponding run metrics from the latest poll.
         """
         if "early_terminate" not in self._sweep.config:
             return []


### PR DESCRIPTION
Description
-----------
- Fixes WB-38287

Implements scheduler: engine: optuna, including support from the CLI.
- allow the CLI to read the file referenced by source:
- handle the search_space and optimizer arguments for users to provide setup functions for the study
- Users may provide custom pruners and samplers when constructing the study in the optimizer: option
- implement create_sweep, resume_sweep, and create_sweep_from_config for users who want to manage the scheduler purely through code without the CLI
- Provide OptunaOptions so that users can specify a Terminator callback from optunahub. Unfortunately, many of the features from OptunaHub are designed to be used with study.optimize()

Testing
-------
- unit tested while importing optuna package
- tested scheduler manually