### PR TITLE
fix(sdk): fix mypy errors from IPython 9.16 type annotations

### DIFF
--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -159,11 +159,15 @@ class WandBMagics(Magics):
         if cell is None:
             return
 
+        ipython = IPython.get_ipython()
+        if ipython is None:
+            return
+
         if not displayed:
             _current_cell_wandb_magic = _WandbCellMagicState(height=height)
 
         try:
-            IPython.get_ipython().run_cell(cell)
+            ipython.run_cell(cell)
         finally:
             _current_cell_wandb_magic = None
 
@@ -179,7 +183,8 @@ def notebook_metadata_from_jupyter_servers_and_kernel_id():
         from IPython import get_ipython
 
         ipython = get_ipython()
-        if ipython is not None:
+        # The kernel attribute only exists when running under ipykernel.
+        if ipython is not None and hasattr(ipython, "kernel"):
             notebook_path = ipython.kernel.shell.user_ns.get("__vsc_ipynb_file__")
             if notebook_path:
                 return {
@@ -428,7 +433,7 @@ class Notebook:
             )
             return
         # TODO: some tests didn't patch ipython properly?
-        if self.shell is None:
+        if self.shell is None or self.shell.history_manager is None:
             return
         cells = []
         hist = list(self.shell.history_manager.get_range(output=True))

--- a/wandb/sdk/lib/ipython.py
+++ b/wandb/sdk/lib/ipython.py
@@ -32,24 +32,23 @@ def _get_python_type() -> PythonType:
         from IPython import get_ipython  # type: ignore
 
         # Calling get_ipython can cause an ImportError
-        if get_ipython() is None:
-            return "python"
+        ipython = get_ipython()
     except ImportError:
+        return "python"
+    if ipython is None:
         return "python"
 
     # jupyter-based environments (e.g. jupyter itself, colab, kaggle, etc) have a connection file
     ip_kernel_app_connection_file = (
-        (get_ipython().config.get("IPKernelApp", {}) or {})
-        .get("connection_file", "")
-        .lower()
+        (ipython.config.get("IPKernelApp", {}) or {}).get("connection_file", "").lower()
     ) or (
-        (get_ipython().config.get("ColabKernelApp", {}) or {})
+        (ipython.config.get("ColabKernelApp", {}) or {})
         .get("connection_file", "")
         .lower()
     )
 
     if (
-        ("terminal" in get_ipython().__module__)
+        ("terminal" in ipython.__module__)
         or ("jupyter" not in ip_kernel_app_connection_file)
         or ("spyder" in sys.modules)
     ):
@@ -81,7 +80,9 @@ def in_vscode_notebook() -> bool:
         return False
 
     ipython = get_ipython()
-    if not ipython:
+
+    # The kernel attribute only exists when running under ipykernel.
+    if not ipython or not hasattr(ipython, "kernel"):
         return False
 
     return ipython.kernel.shell.user_ns.get("__vsc_ipynb_file__") is not None

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -626,8 +626,6 @@ class _WandbInit:
     def _jupyter_teardown(self) -> None:
         """Teardown hooks and display saving, called with wandb.finish."""
         assert self.notebook
-        ipython = self.notebook.shell
-
         if self.run:
             self.notebook.save_history(self.run)
 
@@ -636,6 +634,10 @@ class _WandbInit:
             res = self.run.log_code(root=None)
             self._logger.info("saved code and history: %s", res)
         self._logger.info("cleaning up jupyter logic")
+
+        ipython = self.notebook.shell
+        if ipython is None:
+            return
 
         ipython.events.unregister("pre_run_cell", self._pre_run_cell_hook)
         ipython.events.unregister("post_run_cell", self._post_run_cell_hook)
@@ -647,6 +649,8 @@ class _WandbInit:
         """Add hooks, and session history saving."""
         self.notebook = wandb.jupyter.Notebook(settings)
         ipython = self.notebook.shell
+        if ipython is None:
+            return
 
         # Monkey patch ipython publish to capture displayed outputs
         if not hasattr(ipython.display_pub, "_orig_publish"):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes https://coreweave.atlassian.net/browse/WB-38214

IPython 9.16 added type annotations to its core API — notably`get_ipython()` now returns `InteractiveShell | None` (previously untyped, i.e. `Any`), and `history_manager` is typed as optional. Since the `mypy-report` nox session installs `ipython` unpinned, mypy started reporting 16 missing-`None`-handling errors in our Jupyter integration.

Fix the code rather than pinning IPython: `None`-check `get_ipython()`/`notebook.shell` before use, guard `ipython.kernel` with `hasattr` (it's set dynamically by ipykernel, not declared on `InteractiveShell`), and skip history saving when `history_manager` is unset.

Only behavior change: paths that would have raised `AttributeError` when no shell (or no `history_manager`) was available now no-op instead, as they should not have been crashing `wandb.init()`/`finish()` anyway.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
  - no update needed; test fix only

Testing
-------
- [x] Now passes `code-check` test.

Current failing test examples:
https://app.circleci.com/pipelines/github/wandb/wandb/66651/workflows/46749622-e937-444f-8bdd-3ff440606028/jobs/1707109
https://app.circleci.com/pipelines/github/wandb/wandb/66649/workflows/883ef768-07c1-4b1e-9716-5c21e9abf6f4/jobs/1707085


<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
